### PR TITLE
[Doc] docs(variables): update en, zh, ja documentation

### DIFF
--- a/docs/ja/sql-reference/System_variable.md
+++ b/docs/ja/sql-reference/System_variable.md
@@ -183,6 +183,14 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 
 セッションで割り当てられたロールをアクティブにしたい場合は、[SET ROLE](sql-statements/account-management/SET_DEFAULT_ROLE.md) コマンドを使用してください。
 
+### array_low_cardinality_optimize
+
+* **スコープ**: Session
+* **説明**: オプティマイザが array&lt;varchar&gt; カラムを low-cardinality（辞書ベース）のデコードおよび関連最適化の対象として検討するかどうかを制御します。有効にすると、オプティマイザの low-cardinality ルール（例: `DecodeCollector`）は辞書カラムを定義し、型が `varchar` または `array&lt;varchar&gt;` の式に対して辞書デコードを適用することがあります。無効にすると、スカラーの `varchar` カラムのみが対象となり、`array&lt;varchar&gt;` 型はこれらの low-cardinality 最適化によって無視されます。この変数は配列サポートの判定に `DecodeCollector.supportAndEnabledLowCardinality(...)` によって読み取られ、`SessionVariable` の getter/setter を介して公開されます。
+* **デフォルト**: `true`
+* **タイプ**: boolean
+* **導入バージョン**: v3.3.0, v3.4.0, v3.5.0
+
 ### auto_increment_increment
 
 MySQL クライアント互換性のために使用されます。実際の用途はありません。
@@ -249,6 +257,22 @@ MySQL クライアント互換性のために使用されます。実際の用�
 * **説明**: オプティマイザで JSON v2 のパス書き換えを有効にするかどうか。有効にすると、JSON 関数（`get_json_*` など）を Flat JSON のサブカラムへの直接アクセスに書き換え、述語プッシュダウン、カラムプルーニング、辞書最適化を有効化します。
 * **デフォルト**: true
 * **データ型**: Boolean
+
+### cbo_max_reorder_node_use_dp
+
+* **説明**: コストベースオプティマイザ（CBO）が DP（動的計画法）join-reorder アルゴリズムを含めるかを制御するセッションスコープの上限です。オプティマイザは join 入力数（MultiJoinNode.atoms.size()）をこの値と比較し、`multiJoinNode.getAtoms().size() <= cbo_max_reorder_node_use_dp` かつ `cbo_enable_dp_join_reorder` が有効な場合にのみ DP reorder を実行または追加します。JoinReorderFactory.createJoinReorderAdaptive（候補アルゴリズムに JoinReorderDP を追加するため）および ReorderJoinRule.transform/rewrite（メモにプランをコピーするときに JoinReorderDP を実行するか決定するため）で使用されます。デフォルト値の 10 は実用的な性能のカットオフを反映しています（コード内コメント: "10 table join reorder takes more than 100ms"）。この設定はオプティマイザの実行時間（DP は高コスト）と大規模な multi-join クエリに対するプラン品質のトレードオフを調整するためにチューニングしてください。`cbo_enable_dp_join_reorder` および 貪欲法の閾値 `cbo_max_reorder_node_use_greedy` と相互作用します。比較は包含比較（`<=`）です。
+* **スコープ**: セッション
+* **デフォルト**: `10`
+* **データタイプ**: long
+* **導入バージョン**: `v3.2.0`
+
+### cbo_max_reorder_node_use_exhaustive
+
+* **スコープ**: セッション
+* **説明**: CBO における join-reorder アルゴリズム選択の閾値を制御します。オプティマイザはクエリ内の inner/cross join ノードをカウントし、その数がこの値より大きい場合、プランナは transform ベースの（より積極的な）reorder パスを取ります：CTE 統計の収集を強制し、ReorderJoinRule.transform および関連する可換性ルールを呼び出します。カウントがこの値以下の場合、プランナはより安価な join-transformation ルールを適用します（特定の semi/anti-join ケースでは INNER_JOIN_LEFT_ASSCOM_RULE を追加することがあります）。このセッション変数はオプティマイザ（`SPMOptimizer`, `QueryOptimizer`）で参照され、セッションレベルでは `setMaxTransformReorderJoins` を介して設定できます。
+* **デフォルト**: `4`
+* **データタイプ**: int
+* **導入バージョン**: v3.2.0
 
 ### cbo_max_reorder_node_use_greedy
 
@@ -334,6 +358,14 @@ MySQL クライアント互換性のために使用されます。実際の用�
 * **単位**: Seconds
 * **導入バージョン**: v3.5.1
 
+### default_authentication_plugin
+
+* **スコープ**: Session
+* **説明**: このセッションのデフォルトの MySQL 認証プラグイン名を指定するセッションスコープの変数です。SessionVariable.defaultAuthenticationPlugin として格納され、サーバーがデフォルトの認証プラグインを告知または使用する必要がある場合（ハンドシェイク時やプラグインが指定されていない場合など）に、StarRocks の MySQL プロトコル互換レイヤーで使用されます。サーバーがサポートする標準的な MySQL 認証プラグイン識別子（例: `mysql_native_password`, `caching_sha2_password`）を受け付けます。この変数はセッション動作にのみ影響し、永続的なユーザーアカウントの認証構成は別途管理されます。関連するセッション変数 `authentication_policy` を参照してください。
+* **デフォルト**: `mysql_native_password`
+* **データタイプ**: String
+* **導入バージョン**: -
+
 ### default_rowset_type (global)
 
 コンピューティングノードのストレージエンジンで使用されるデフォルトのストレージ形式を設定するために使用されます。現在サポートされているストレージ形式は `alpha` と `beta` です。
@@ -347,6 +379,14 @@ MySQL クライアント互換性のために使用されます。実際の用�
 * **デフォルト**: lz4_frame
 * **導入バージョン**: v3.0
 
+### default_tmp_storage_engine
+
+* **説明**: セッション変数で、テンポラリテーブル（明示的な `CREATE TEMPORARY TABLE` およびエンジンによって作成される内部/暗黙のテンポラリテーブル）のデフォルトのストレージエンジンを制御します。`SessionVariable.java` に `@VariableMgr.VarAttr` アノテーションで宣言されており、主に MySQL 8.0 互換性のために存在し、MySQL ライクな動作を期待するクライアントやツールがセッションごとに一時テーブルのエンジンを確認または変更できるようにします。この値を変更すると、メモリバックエンドとディスクバックエンドなど、異なるエンジンを尊重するストレージ層でのテンポラリテーブルデータの保存/管理方法に影響します。
+* **スコープ**: Session
+* **デフォルト**: `InnoDB`
+* **データタイプ**: String
+* **導入バージョン**: v3.4.2, v3.5.0
+
 ### disable_colocate_join
 
 * **説明**: Colocation Join を有効にするかどうかを制御するために使用されます。デフォルト値は `false` で、機能が有効です。この機能が無効になっている場合、クエリプランニングは Colocation Join を実行しようとしません。
@@ -359,6 +399,14 @@ MySQL クライアント互換性のために使用されます。実際の用�
 * **デフォルト**: `false`
 * **データタイプ**: boolean
 * **導入バージョン**: v3.2.0
+
+### disable_spill_to_local_disk
+
+* **説明**: セッションで `true` に設定すると、FE は BE に対してローカルディスクへのスピルを無効にし、代わりにリモートストレージへのスピルに依存するよう指示します（リモートスピルが構成されている場合）。このフラグは `enable_spill` = `true`、`enable_spill_to_remote_storage` = `true`、かつ有効な `spill_storage_volume` が FE によって検出されている場合にのみ意味を持ちます。値は TSpillToRemoteStorageOptions（BE に送信）に `disable_spill_to_local_disk` としてシリアライズされます。リモートスピルが構成されていないか、指定されたストレージボリュームが解決できない場合、この設定は効果を持ちません。注意して使用してください：ローカルディスクへのスピルを無効化するとネットワーク I/O とレイテンシが増加し、信頼性・高性能なリモートストレージを必要とします。
+* **スコープ**: Session
+* **デフォルト**: false
+* **データ型**: boolean
+* **導入バージョン**: v3.3.0, v3.4.0, v3.5.0
 
 ### div_precision_increment
 
@@ -489,6 +537,14 @@ StarRocks は 2 種類の RF を提供します：ローカル RF とグロー�
 * **デフォルト**: false、つまりこの機能は無効です。
 * **導入バージョン**: v3.1.4
 
+### enable_incremental_mv
+
+* **説明**: セッションフラグで、サーバーが増分リフレッシュを使用するマテリアライズドビューに対してプランを生成し、インメモリのプランを保持するかを制御します。有効にすると、`MaterializedViewAnalyzer.planMVQuery` はリフレッシュスキームが `IncrementalRefreshSchemeDesc` である create-MV ステートメントに対して処理を行います：ビュークエリの論理・物理プランを構築し、セッションの `enableMVPlanner` フラグを設定します（`setMVPlanner(true)`）。無効にすると、増分リフレッシュ MV のプラン作成はスキップされます。`SessionVariable` の `isEnableIncrementalRefreshMV()` および `setEnableIncrementalRefreshMv(boolean)` からアクセス可能です。
+* **スコープ**: セッション（接続ごと）
+* **デフォルト**: `false`
+* **データ型**: boolean
+* **導入バージョン**: v3.2.0
+
 ### enable_insert_partial_update
 
 * **説明**：主キーテーブルに対するINSERTステートメントの部分更新を有効化するかどうか。この項目が `true`（デフォルト）に設定されている場合、INSERT ステートメントで指定された列がサブセット（テーブル内のすべての非生成列の数より少ない）であるとき、システムは部分更新を実行し、指定された列のみを更新しながら他の列の既存値を保持します。`false` に設定すると、システムは既存の値を保持する代わりに、指定されていない列に対してデフォルト値を使用します。この機能は、主キーテーブルの特定の列を更新する際に他の列の値に影響を与えない場合に特に有用です。
@@ -512,6 +568,17 @@ StarRocks は 2 種類の RF を提供します：ローカル RF とグロー�
 * **スコープ**: Session
 * **説明**: 有効にすると、FE はロードジョブのランタイムプロファイルの収集を要求し、ロード完了後にロードコーディネータがプロファイルを収集/エクスポートします。ストリームロードの場合、FE は `TQueryOptions.enable_profile = true` を設定し、`stream_load_profile_collect_threshold_second` からの `load_profile_collect_second` をバックエンドに渡します。コーディネータは条件に応じてプロファイル収集を呼び出します（StreamLoadTask.collectProfile() を参照）。実際の振る舞いは、このセッション変数と宛先テーブルのテーブルレベルプロパティ `enable_load_profile` の論理 OR です。収集はさらに `load_profile_collect_interval_second`（FE 側のサンプリング間隔）によって制御され、頻繁な収集を回避します。セッションフラグは `SessionVariable.isEnableLoadProfile()` を介して読み取られ、`setEnableLoadProfile(...)` で接続ごとに設定できます。
 * **デフォルト**: `false`
+* **データ型**: boolean
+* **導入バージョン**: v3.2.0
+
+### enable_local_shuffle_agg
+
+* **説明**: プランナーとコストモデルが、二相／グローバルシャッフル集約の代わりにローカルシャッフルを用いた単一フェーズのローカル集約プラン（Scan -> LocalShuffle -> OnePhaseAgg）を生成することを許可するかを制御します。有効（デフォルト）の場合、オプティマイザとコストモデルは次を行います：
+  - Scan と Global Agg の間の SHUFFLE 交換を、単一バックエンド兼コンピュートノードのクラスタでローカルシャッフル + ワンフェーズ集約に置き換えることを許可する（`PruneShuffleDistributionNodeRule` と `EnforceAndCostTask` を参照）、
+  - その単一ノードのケースでネットワークコストを無視してワンフェーズプランを優先させる（`CostModel`）。
+  置換は `enable_pipeline_engine` が有効でクラスタが単一のバックエンド＋コンピュートノードである場合にのみ検討されます。プランナーは安全でないケース（例：DISTINCT 集約、検出されたデータスキュー、欠落または不明なカラム統計、結合のような複数入力オペレータ、その他のセマンティック制約）ではローカルシャッフル変換を却下します。いくつかのコードパス（INSERT/UPDATE/DELETE のプランナーや MaterializedViewOptimizer）は、一時的にこのセッションフラグを無効化します。これは非クエリシンクや特定のリライトが driver 単位の scan アサインを要求し、ローカルシャッフルでは利用できないためです。
+* **スコープ**: セッション
+* **デフォルト**: `true`
 * **データ型**: boolean
 * **導入バージョン**: v3.2.0
 
@@ -873,12 +940,6 @@ MySQL クライアント互換性のために使用されます。実際の用�
 
 MySQL クライアント互換性のために使用されます。実際の用途はありません。
 
-### interpolate_passthrough
-
-* **説明**: 特定の演算子に対して local-exchange-passthrough を追加するかどうか。現在サポートされている演算子には streaming aggregates などがある。local-exchange を追加すると、データの偏りが計算に与える影響を軽減できるが、メモリ使用量がわずかに増加する。
-* **デフォルト**: true
-* **導入バージョン**: v3.2
-
 ### io_tasks_per_scan_operator
 
 * **説明**: スキャンオペレーターによって発行される同時 I/O タスクの数。この値を増やすと、HDFS や S3 などのリモートストレージシステムにアクセスする際のレイテンシーが高い場合に役立ちます。ただし、値が大きいとメモリ消費が増加します。
@@ -940,6 +1001,14 @@ MySQL クライアント互換性のために使用されます。実際の用�
   * `false`：データレイクのクエリで低基数最適化を無効にします。
 * **導入バージョン**: v3.5.0
 
+### low_cardinality_optimize_v2
+
+* **スコープ**: Session
+* **説明**: オプティマイザが適用する low-cardinality 最適化のどのリライトを選択するかを制御するセッションレベルの boolean。`true` の場合、オプティマイザは `LowCardinalityRewriteRule` によって実装された新しい V2 リライト（`DecodeCollector` / `DecodeRewriter` を使用して low-cardinality な VARCHAR カラムをエンコード/デコード）を試行します。`false` の場合、オプティマイザは `AddDecodeNodeForDictStringRule` によって実装されたレガシーなリライトにフォールバックします。どちらのリライトを実行する場合でも `enableLowCardinalityOptimize` が有効である必要があり、`enableLowCardinalityOptimize` が無効な場合は low-cardinality のリライトは実行されません。この変数は適切な変換を選択するためにオプティマイザのツリー書き換え経路でチェックされます。
+* **デフォルト**: `true`
+* **タイプ**: boolean
+* **導入バージョン**: v3.3.0, v3.4.0, v3.5.0
+
 ### lower_case_table_names (global)
 
 MySQL クライアント互換性のために使用されます。実際の用途はありません。StarRocks のテーブル名は大文字小文字を区別します。
@@ -966,6 +1035,18 @@ MySQL クライアント互換性のために使用されます。実際の用�
 * **デフォルト**: 33554432 (32 MB)。クライアントが "PacketTooBigException" を報告する場合、この値を増やすことができます。
 * **単位**: バイト
 * **データ型**: Int
+
+### max_pipeline_dop
+
+* **スコープ**: Session
+* **説明**: パイプラインエンジンの degree-of-parallelism (DOP) に対するセッションごとの上限。動作:
+  * `enable_pipeline_engine` が有効で `pipeline_dop` が明示的に設定されていない（0 以下ではない）場合にのみ適用されます。`pipeline_dop` が 0 より大きい場合、この変数は無視され `pipeline_dop` が直接使用されます。
+  * `pipeline_dop` が 0 以下（アダプティブ/デフォルトモード）のとき、実際の実行 DOP は min(`max_pipeline_dop`, BackendResourceStat が返すバックエンドのデフォルト DOP) として計算されます。パイプラインの sink に対しては同じロジックで sink のデフォルト DOP が使用されます。
+  * `max_pipeline_dop` が 0 以下の場合、追加の上限は適用されずバックエンドのデフォルト DOP が使用されます。
+  * 目的: コア数が非常に多いマシンでスケジューリングによる負荷増を回避するため、自動計算された並列度に上限をかけること。
+* **デフォルト**: `64`
+* **データ型**: int
+* **導入バージョン**: v3.2.0
 
 ### max_pushdown_conditions_per_column
 
@@ -1352,6 +1433,14 @@ GROUP BY の最初のフェーズの事前集計モードを指定するため�
 ### tx_isolation
 
 MySQL クライアント互換性のために使用されます。実際の用途はありません。エイリアスは `transaction_isolation` です。
+
+### tx_visible_wait_timeout
+
+* **説明**: コミット済みトランザクションが可視（公開）になるまでサーバが待機する時間（秒単位）を制御するセッションスコープのタイムアウトです。`StmtExecutor` および `TransactionStmtExecutor` のコミットフローで使用されるミリ秒単位の publish 待機時間はこの値に1000を掛けて算出されます。可視待機が期限切れになると、トランザクションは COMMITTED と扱われますがまだ VISIBLE ではないと見なされます。マテリアライズドビューのリフレッシュロジック（`MVTaskRunProcessor`）は、可視性を事実上無期限に待つために一時的にこの変数を `Long.MAX_VALUE / 1000` に設定し、リフレッシュ後に元の値を復元します。`enable_sync_publish` が有効な場合、この変数は無視され、publish 待機はジョブのデッドラインから派生されます。
+* **スコープ**: Session
+* **デフォルト**: `10`
+* **データ型**: long
+* **導入バージョン**: v3.2.0
 
 ### use_compute_nodes
 

--- a/docs/zh/sql-reference/System_variable.md
+++ b/docs/zh/sql-reference/System_variable.md
@@ -183,7 +183,7 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 ### array_low_cardinality_optimize
 
 * **作用域**: Session
-* **描述**: 控制优化器是否将 array&lt;varchar&gt; 列纳入低基数（基于字典）的解码及相关优化的考虑范围。启用时，优化器的低基数规则（例如 `DecodeCollector`）可能会定义字典列，并将字典解码应用于类型为 `varchar` 或 `array&lt;varchar&gt;` 的表达式。禁用时，仅标量 `varchar` 列有资格参与，`array&lt;varchar&gt;` 类型会被这些低基数优化忽略。该变量由 `DecodeCollector.supportAndEnabledLowCardinality(...)` 读取以控制对数组的支持，并通过 `SessionVariable` 的 getter/setter 方法暴露。
+* **描述**: 控制优化器是否将 ARRAY&lt;VARCHAR&gt; 列纳入低基数（基于字典）的解码及相关优化的考虑范围。启用时，优化器的低基数规则（例如 `DecodeCollector`）可能会定义字典列，并将字典解码应用于类型为 VARCHAR 或 ARRAY&lt;VARCHAR&gt; 的表达式。禁用时，仅标量 VARCHAR 列有资格参与，ARRAY&lt;VARCHAR&gt; 类型会被这些低基数优化忽略。该变量由 `DecodeCollector.supportAndEnabledLowCardinality(...)` 读取以控制对数组的支持，并通过 `SessionVariable` 的 getter/setter 方法暴露。
 * **默认值**: `true`
 * **数据类型**: boolean
 * **引入版本**: v3.3.0, v3.4.0, v3.5.0
@@ -259,16 +259,16 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 
 ### cbo_max_reorder_node_use_dp
 
-* **描述**: 会话级限制，用于控制成本基准优化器（CBO）何时包含 DP（dynamic programming，动态规划）连接重排序算法。优化器将连接输入数量（MultiJoinNode.atoms.size()）与此值比较，只有在 `multiJoinNode.getAtoms().size() <= cbo_max_reorder_node_use_dp` 且启用了 `cbo_enable_dp_join_reorder` 时才运行或添加 DP 重排序。用于 JoinReorderFactory.createJoinReorderAdaptive（将 JoinReorderDP 添加到候选算法）以及 ReorderJoinRule.transform/rewrite（在将计划复制到 memo 时决定是否执行 JoinReorderDP）。默认值 10 反映了一个实际性能的截止点（代码注释："10 table join reorder takes more than 100ms"）。可通过调优该值在优化器运行时长（DP 开销较大）与对更大多表连接查询潜在计划质量之间进行权衡。该设置与 `cbo_enable_dp_join_reorder` 和贪心阈值 `cbo_max_reorder_node_use_greedy` 交互。比较为包含等号（`<=`）。
-* **范围**: 会话
+* **描述**: 会话级限制，用于控制 CBO 何时包含 DP（dynamic programming，动态规划）连接重排序算法。优化器将连接输入数量（MultiJoinNode.atoms.size()）与此值比较，只有在 `multiJoinNode.getAtoms().size()` 小于等于 `cbo_max_reorder_node_use_dp` 且启用了 `cbo_enable_dp_join_reorder` 时才运行或添加 DP 重排序。用于 将 JoinReorderDP 添加到候选算法以及在将计划复制到 memo 时决定是否执行 JoinReorderDP。默认值 10 反映了一个实际性能的截止点。可通过调优该值在优化器运行时长（DP 开销较大）与对更大多表连接查询潜在计划质量之间进行权衡。该设置与 `cbo_enable_dp_join_reorder` 和贪心阈值 `cbo_max_reorder_node_use_greedy` 交互。比较为包含等号（`<=`）。
+* **范围**: Session
 * **默认值**: `10`
 * **数据类型**: long
-* **引入版本**: `v3.2.0`
+* **引入版本**: v3.2.0
 
 ### cbo_max_reorder_node_use_exhaustive
 
-* **范围**: 会话
-* **描述**: 控制 CBO 中连接重排序算法选择的阈值。优化器会统计查询中的内/交叉连接节点数量；当该计数大于此值时，planner 会走基于变换（更激进）的重排序路径：强制收集 CTE 统计信息并调用 ReorderJoinRule.transform 及相关的交换律规则。 当计数小于或等于此值时，planner 应用开销较小的连接变换规则（并且在某些半/反连接情况下可能会添加 INNER_JOIN_LEFT_ASSCOM_RULE）。优化器（`SPMOptimizer`, `QueryOptimizer`）会读取此会话变量，并且可以通过 `setMaxTransformReorderJoins` 在会话级别设置。
+* **范围**: Session
+* **描述**: 控制 CBO 中 Join 重排序算法选择的阈值。优化器会统计查询中的内/交叉连接节点数量；当该计数大于此值时，planner 会走基于变换（更激进）的重排序路径：强制收集 CTE 统计信息并调用 ReorderJoinRule.transform 及相关的交换律规则。 当计数小于或等于此值时，planner 应用开销较小的连接变换规则（并且在某些半/反连接情况下可能会添加 INNER_JOIN_LEFT_ASSCOM_RULE）。优化器（`SPMOptimizer`, `QueryOptimizer`）会读取此会话变量，并且可以通过 `setMaxTransformReorderJoins` 在会话级别设置。
 * **默认值**: `4`
 * **数据类型**: int
 * **引入版本**: v3.2.0
@@ -398,8 +398,8 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 
 ### disable_spill_to_local_disk
 
-* **描述**: 当会话中设置为 `true` 时，FE 将指示 BE 禁用本地磁盘溢写（spilling to local disk），并改为依赖远程存储溢写（如果配置了远程溢写）。该标志仅在 `enable_spill` = `true`、`enable_spill_to_remote_storage` = `true` 且 FE 提供并找到有效的 `spill_storage_volume` 时才有意义。该值会以 `disable_spill_to_local_disk` 的字段序列化到 TSpillToRemoteStorageOptions（发送给 BE）。如果未配置远程溢写或无法解析所命名的存储卷，则此设置无效。谨慎使用：禁用本地磁盘溢写可能会增加网络 I/O 和延迟，并要求远程存储具有可靠性和良好性能。
-* **范围**: 会话
+* **描述**: 当会话中设置为 `true` 时，FE 将指示 BE 禁用本地磁盘落盘（spilling to local disk），并改为依赖远程存储落盘（如果配置了远程溢写）。该标志仅在 `enable_spill` 为 `true`、`enable_spill_to_remote_storage` 为 `true` 且 FE 提供并找到有效的 `spill_storage_volume` 时才有意义。如果未配置远程溢写或无法解析所命名的存储卷，则此设置无效。谨慎使用：禁用本地磁盘落盘可能会增加网络 I/O 和延迟，并要求远程存储具有可靠性和良好性能。
+* **范围**: Session
 * **默认值**: `false`
 * **数据类型**: boolean
 * **引入版本**: v3.3.0, v3.4.0, v3.5.0
@@ -536,8 +536,8 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 
 ### enable_incremental_mv
 
-* **描述**: 会话标志，用于控制服务器是否会为使用增量刷新（incremental refresh）的物化视图规划并保留内存中的计划。当启用时，`MaterializedViewAnalyzer.planMVQuery` 会对刷新方案为 `IncrementalRefreshSchemeDesc` 的 create-MV 语句继续执行：它会为视图查询构建逻辑和物理计划并设置会话的 `enableMVPlanner` 标志（`setMVPlanner(true)`）。禁用时，增量刷新 MV 的规划将被跳过。可通过 `SessionVariable` 中的 `isEnableIncrementalRefreshMV()` 和 `setEnableIncrementalRefreshMv(boolean)` 访问。
-* **范围**: 会话（每连接）
+* **描述**: 会话变量，用于控制服务器是否会为使用增量刷新（incremental refresh）的物化视图规划并保留内存中的计划。当启用时，对于刷新方案为增量刷新的物化视图创建语句，系统会为视图查询构建逻辑和物理计划并设置会话的 `enableMVPlanner` 标志（`setMVPlanner(true)`）。禁用时，增量刷新物化视图的规划将被跳过。
+* **范围**: Session（每连接）
 * **默认值**: `false`
 * **数据类型**: boolean
 * **引入版本**: v3.2.0
@@ -574,7 +574,7 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
   - 允许在单 backend+compute-node 集群中将 Scan 与 Global Agg 之间的 SHUFFLE exchange 替换为本地 shuffle + 单阶段聚合（参见 `PruneShuffleDistributionNodeRule` 和 `EnforceAndCostTask`），
   - 在该单节点场景下让成本模型忽略 SHUFFLE 的网络成本以偏好单阶段计划（`CostModel`）。
   仅在 `enable_pipeline_engine` 启用且集群为单个 backend+compute 节点时考虑替换。规划器在不安全的情况下仍会拒绝本地 shuffle 转换（例如 DISTINCT 聚合、检测到的数据倾斜、缺失/未知的列统计、多输入算子如 joins 或其他语义限制）。某些代码路径（INSERT/UPDATE/DELETE 的 planner 和 MaterializedViewOptimizer）会临时禁用该会话标志，因为非查询的 sink 或某些重写需要按 driver 分配扫描，而本地 shuffle 无法使用这种分配。
-* **范围**: 会话
+* **范围**: Session
 * **默认值**: `true`
 * **数据类型**: boolean
 * **引入版本**: v3.2.0
@@ -1016,7 +1016,7 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 ### low_cardinality_optimize_v2
 
 * **作用域**: Session
-* **描述**: 会话级布尔值，用于选择优化器应用哪种低基数（low-cardinality）优化重写。为 `true` 时，优化器将尝试由 `LowCardinalityRewriteRule` 实现的新版 V2 重写（使用 `DecodeCollector` / `DecodeRewriter` 对低基数 VARCHAR 列进行编码/解码）。为 `false` 时，优化器回退到由 `AddDecodeNodeForDictStringRule` 实现的旧版重写。执行任一重写还需要 `enableLowCardinalityOptimize` 被启用；如果 `enableLowCardinalityOptimize` 被禁用，则不执行任何低基数重写。该变量在优化器的树重写路径中被检查以选择合适的转换。
+* **描述**: 会话级变量，用于选择优化器应用哪种低基数（low-cardinality）优化重写。为 `true` 时，优化器将尝试由 `LowCardinalityRewriteRule` 实现的新版 Skew Join V2 重写（使用 `DecodeCollector` / `DecodeRewriter` 对低基数 VARCHAR 列进行编码/解码）。为 `false` 时，优化器回退到由 `AddDecodeNodeForDictStringRule` 实现的旧版重写。执行任一重写还需要 `enableLowCardinalityOptimize` 被启用；如果 `enableLowCardinalityOptimize` 被禁用，则不执行任何低基数重写。该变量在优化器的树重写路径中被检查以选择合适的转换。
 * **默认值**: `true`
 * **数据类型**: boolean
 * **引入版本**: v3.3.0, v3.4.0, v3.5.0
@@ -1050,7 +1050,7 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 
 ### max_pipeline_dop
 
-* **范围**: 会话
+* **范围**: Session
 * **描述**: 每会话的 pipeline 引擎并行度（DOP）上限。行为：
   * 仅在 `enable_pipeline_engine` 启用且未显式设置 `pipeline_dop`（大于 0）时生效。如果 `pipeline_dop` 大于 0 则忽略此变量并直接使用 `pipeline_dop`。
   * 当 `pipeline_dop` 小于或等于 0（自适应/默认模式）时，执行的实际 DOP 计算为 min(`max_pipeline_dop`, BackendResourceStat 返回的后端默认 DOP)。对于 pipeline sinks，同样的逻辑使用 sink 的默认 DOP。
@@ -1458,7 +1458,7 @@ set sql_mode = 'PIPES_AS_CONCAT,ERROR_IF_OVERFLOW,GROUP_CONCAT_LEGACY';
 
 ### tx_visible_wait_timeout
 
-* **描述**: 会话范围的超时时间（秒），控制服务器在提交事务后等待该事务变为可见（published）再继续处理的最长时间。该值乘以 1000 用于计算 StmtExecutor 和 TransactionStmtExecutor 的提交流程中以毫秒为单位的 publish 等待时间。如果可见等待超时，事务将被视为已 COMMITTED 但尚未 VISIBLE。物化视图刷新逻辑（`MVTaskRunProcessor`）会临时将此变量设置为 `Long.MAX_VALUE / 1000` 以有效地无限期等待可见性，并在刷新后恢复原值。当启用 `enable_sync_publish` 时，该变量被忽略，因为 publish 等待时间将由作业截止时间推导。
+* **描述**: 会话范围的超时时间（秒），控制服务器在提交事务后等待该事务变为可见（published）再继续处理的最长时间。如果可见等待超时，事务将被视为已 COMMITTED 但尚未 VISIBLE。物化视图刷新逻辑（`MVTaskRunProcessor`）会临时将此变量设置为 `Long.MAX_VALUE / 1000` 以有效地无限期等待可见性，并在刷新后恢复原值。当启用 `enable_sync_publish` 时，该变量被忽略，因为 publish 等待时间将由作业截止时间推导。
 * **范围**: Session
 * **默认值**: `10`
 * **类型**: long

--- a/docs/zh/sql-reference/System_variable.md
+++ b/docs/zh/sql-reference/System_variable.md
@@ -180,6 +180,14 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 
 如果要在当前会话中激活一个角色，可以使用 [SET ROLE](sql-statements/account-management/SET_ROLE.md)。
 
+### array_low_cardinality_optimize
+
+* **作用域**: Session
+* **描述**: 控制优化器是否将 array&lt;varchar&gt; 列纳入低基数（基于字典）的解码及相关优化的考虑范围。启用时，优化器的低基数规则（例如 `DecodeCollector`）可能会定义字典列，并将字典解码应用于类型为 `varchar` 或 `array&lt;varchar&gt;` 的表达式。禁用时，仅标量 `varchar` 列有资格参与，`array&lt;varchar&gt;` 类型会被这些低基数优化忽略。该变量由 `DecodeCollector.supportAndEnabledLowCardinality(...)` 读取以控制对数组的支持，并通过 `SessionVariable` 的 getter/setter 方法暴露。
+* **默认值**: `true`
+* **数据类型**: boolean
+* **引入版本**: v3.3.0, v3.4.0, v3.5.0
+
 ### auto_increment_increment
 
 * 描述：用于兼容 MySQL 客户端。无实际作用。
@@ -248,6 +256,22 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * 描述：是否在优化器中启用 JSON v2 路径改写。开启后，会将 JSON 函数（如 `get_json_*`）改写为直接访问 Flat JSON 子列，从而启用谓词下推、列裁剪以及字典优化。
 * 默认值：true
 * 类型：Boolean
+
+### cbo_max_reorder_node_use_dp
+
+* **描述**: 会话级限制，用于控制成本基准优化器（CBO）何时包含 DP（dynamic programming，动态规划）连接重排序算法。优化器将连接输入数量（MultiJoinNode.atoms.size()）与此值比较，只有在 `multiJoinNode.getAtoms().size() <= cbo_max_reorder_node_use_dp` 且启用了 `cbo_enable_dp_join_reorder` 时才运行或添加 DP 重排序。用于 JoinReorderFactory.createJoinReorderAdaptive（将 JoinReorderDP 添加到候选算法）以及 ReorderJoinRule.transform/rewrite（在将计划复制到 memo 时决定是否执行 JoinReorderDP）。默认值 10 反映了一个实际性能的截止点（代码注释："10 table join reorder takes more than 100ms"）。可通过调优该值在优化器运行时长（DP 开销较大）与对更大多表连接查询潜在计划质量之间进行权衡。该设置与 `cbo_enable_dp_join_reorder` 和贪心阈值 `cbo_max_reorder_node_use_greedy` 交互。比较为包含等号（`<=`）。
+* **范围**: 会话
+* **默认值**: `10`
+* **数据类型**: long
+* **引入版本**: `v3.2.0`
+
+### cbo_max_reorder_node_use_exhaustive
+
+* **范围**: 会话
+* **描述**: 控制 CBO 中连接重排序算法选择的阈值。优化器会统计查询中的内/交叉连接节点数量；当该计数大于此值时，planner 会走基于变换（更激进）的重排序路径：强制收集 CTE 统计信息并调用 ReorderJoinRule.transform 及相关的交换律规则。 当计数小于或等于此值时，planner 应用开销较小的连接变换规则（并且在某些半/反连接情况下可能会添加 INNER_JOIN_LEFT_ASSCOM_RULE）。优化器（`SPMOptimizer`, `QueryOptimizer`）会读取此会话变量，并且可以通过 `setMaxTransformReorderJoins` 在会话级别设置。
+* **默认值**: `4`
+* **数据类型**: int
+* **引入版本**: v3.2.0
 
 ### cbo_max_reorder_node_use_greedy
 
@@ -332,6 +356,14 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 - 单位：秒
 - 引入版本：v3.5.1
 
+### default_authentication_plugin
+
+* **范围**: Session
+* **描述**: 会话范围的变量，指定本会话的默认 MySQL 认证插件名称。它以 SessionVariable.defaultAuthenticationPlugin 的形式存储，并由 StarRocks 的 MySQL 协议兼容层在服务器需要通告或使用默认认证插件时使用（例如在握手期间或未指定插件时）。接受服务器支持的标准 MySQL 认证插件标识（例如 `mysql_native_password`、`caching_sha2_password`）。此变量仅影响会话行为；持久化的用户账号认证配置由其他机制单独管理。参见相关会话变量 `authentication_policy`。
+* **默认值**: `mysql_native_password`
+* **类型**: String
+* **引入版本**: -
+
 ### default_rowset_type (global)
 
 全局变量，仅支持全局生效。用于设置计算节点存储引擎默认的存储格式。当前支持的存储格式包括：alpha/beta。
@@ -342,6 +374,14 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * 默认值：lz4_frame
 * 类型：String
 * 引入版本：v3.0
+
+### default_tmp_storage_engine
+
+* **描述**: 会话变量，用于控制临时表的默认存储引擎（包括显式的 `CREATE TEMPORARY TABLE` 以及引擎创建的内部/隐式临时表）。在 `SessionVariable.java` 中以 `@VariableMgr.VarAttr` 注解声明，主要用于 MySQL 8.0 的兼容性，以便期望 MySQL 行为的客户端和工具可以在每个会话级别查看或更改临时表引擎。更改此值会影响在不同引擎下（例如基于内存 vs 基于磁盘的引擎）如何在存储层上存放/管理临时表数据。
+* **范围**: Session
+* **默认值**: `InnoDB`
+* **类型**: String
+* **引入版本**: v3.4.2, v3.5.0
 
 ### disable_colocate_join
 
@@ -355,6 +395,14 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * **默认值**: `false`
 * **数据类型**: boolean
 * **引入版本**: v3.2.0
+
+### disable_spill_to_local_disk
+
+* **描述**: 当会话中设置为 `true` 时，FE 将指示 BE 禁用本地磁盘溢写（spilling to local disk），并改为依赖远程存储溢写（如果配置了远程溢写）。该标志仅在 `enable_spill` = `true`、`enable_spill_to_remote_storage` = `true` 且 FE 提供并找到有效的 `spill_storage_volume` 时才有意义。该值会以 `disable_spill_to_local_disk` 的字段序列化到 TSpillToRemoteStorageOptions（发送给 BE）。如果未配置远程溢写或无法解析所命名的存储卷，则此设置无效。谨慎使用：禁用本地磁盘溢写可能会增加网络 I/O 和延迟，并要求远程存储具有可靠性和良好性能。
+* **范围**: 会话
+* **默认值**: `false`
+* **数据类型**: boolean
+* **引入版本**: v3.3.0, v3.4.0, v3.5.0
 
 ### div_precision_increment
 
@@ -486,6 +534,14 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * 默认值：false，表示不开启。
 * 引入版本：v3.1.4
 
+### enable_incremental_mv
+
+* **描述**: 会话标志，用于控制服务器是否会为使用增量刷新（incremental refresh）的物化视图规划并保留内存中的计划。当启用时，`MaterializedViewAnalyzer.planMVQuery` 会对刷新方案为 `IncrementalRefreshSchemeDesc` 的 create-MV 语句继续执行：它会为视图查询构建逻辑和物理计划并设置会话的 `enableMVPlanner` 标志（`setMVPlanner(true)`）。禁用时，增量刷新 MV 的规划将被跳过。可通过 `SessionVariable` 中的 `isEnableIncrementalRefreshMV()` 和 `setEnableIncrementalRefreshMv(boolean)` 访问。
+* **范围**: 会话（每连接）
+* **默认值**: `false`
+* **数据类型**: boolean
+* **引入版本**: v3.2.0
+
 ### enable_insert_partial_update
 
 * **描述**：是否为主键表的 INSERT 语句启用部分更新（Partial Update）。当设置为 `true`（默认）时，如果 INSERT 语句只指定了部分列（少于表中所有非生成列），系统会执行部分更新，即仅更新指定列，并保留其他列的现有值。当设置为 `false` 时，系统会对未指定的列使用默认值，而不是保留已有值。此功能特别适用于对主键表的特定列进行更新，而不影响其他列的值。
@@ -509,6 +565,17 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * **作用域**: Session
 * **描述**: 启用后，FE 会请求收集 load 作业的运行时 profile，load 协调器将在 load 完成后收集/导出该 profile。对于 stream load，FE 会设置 `TQueryOptions.enable_profile = true` 并将 `load_profile_collect_second`（来自 `stream_load_profile_collect_threshold_second`）传递给 backends；协调器随后有条件地调用 profile 收集（参见 StreamLoadTask.collectProfile()）。实际行为是此会话变量与目标表上的表级属性 `enable_load_profile` 的逻辑 OR；采集还受 `load_profile_collect_interval_second`（FE 端采样间隔）的限制以避免频繁采集。会话标志通过 `SessionVariable.isEnableLoadProfile()` 读取，并且可以通过 `setEnableLoadProfile(...)` 按连接设置。
 * **默认值**: `false`
+* **数据类型**: boolean
+* **引入版本**: v3.2.0
+
+### enable_local_shuffle_agg
+
+* **描述**: 控制 planner 和 cost model 是否可以生成使用本地 shuffle 的单阶段局部聚合计划（Scan -> LocalShuffle -> OnePhaseAgg），而不是两阶段/全局 shuffle 聚合。启用时（默认），优化器和成本模型会：
+  - 允许在单 backend+compute-node 集群中将 Scan 与 Global Agg 之间的 SHUFFLE exchange 替换为本地 shuffle + 单阶段聚合（参见 `PruneShuffleDistributionNodeRule` 和 `EnforceAndCostTask`），
+  - 在该单节点场景下让成本模型忽略 SHUFFLE 的网络成本以偏好单阶段计划（`CostModel`）。
+  仅在 `enable_pipeline_engine` 启用且集群为单个 backend+compute 节点时考虑替换。规划器在不安全的情况下仍会拒绝本地 shuffle 转换（例如 DISTINCT 聚合、检测到的数据倾斜、缺失/未知的列统计、多输入算子如 joins 或其他语义限制）。某些代码路径（INSERT/UPDATE/DELETE 的 planner 和 MaterializedViewOptimizer）会临时禁用该会话标志，因为非查询的 sink 或某些重写需要按 driver 分配扫描，而本地 shuffle 无法使用这种分配。
+* **范围**: 会话
+* **默认值**: `true`
 * **数据类型**: boolean
 * **引入版本**: v3.2.0
 
@@ -882,12 +949,6 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * 单位：秒
 * 类型：Int
 
-### interpolate_passthrough
-
-* 描述：是否为某些算子添加 local-exchang-passthrough。当前支持算子包括 Streaming Aggregates 等。添加 local-exchange-passthrough 会降低数据倾斜的影响，但是会稍微增加内存使用。
-* 默认值：true
-* 引入版本：v3.2
-
 ### io_tasks_per_scan_operator
 
 * 每个 Scan 算子能同时下发的 I/0 任务的数量。如果使用远端存储系统（比如 HDFS 或 S3）且时延较长，可以增加该值。但是值过大会增加内存消耗。
@@ -952,6 +1013,14 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
   * `false`: 在数据湖查询中禁用低基数优化。
 * 引入版本：v3.5.0
 
+### low_cardinality_optimize_v2
+
+* **作用域**: Session
+* **描述**: 会话级布尔值，用于选择优化器应用哪种低基数（low-cardinality）优化重写。为 `true` 时，优化器将尝试由 `LowCardinalityRewriteRule` 实现的新版 V2 重写（使用 `DecodeCollector` / `DecodeRewriter` 对低基数 VARCHAR 列进行编码/解码）。为 `false` 时，优化器回退到由 `AddDecodeNodeForDictStringRule` 实现的旧版重写。执行任一重写还需要 `enableLowCardinalityOptimize` 被启用；如果 `enableLowCardinalityOptimize` 被禁用，则不执行任何低基数重写。该变量在优化器的树重写路径中被检查以选择合适的转换。
+* **默认值**: `true`
+* **数据类型**: boolean
+* **引入版本**: v3.3.0, v3.4.0, v3.5.0
+
 ### lower_case_table_names (global)
 
 用于兼容 MySQL 客户端，无实际作用。StarRocks 中的表名是大小写敏感的。
@@ -978,6 +1047,18 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * 默认值：33554432 (32 MB)
 * 单位：Byte
 * 类型：Int
+
+### max_pipeline_dop
+
+* **范围**: 会话
+* **描述**: 每会话的 pipeline 引擎并行度（DOP）上限。行为：
+  * 仅在 `enable_pipeline_engine` 启用且未显式设置 `pipeline_dop`（大于 0）时生效。如果 `pipeline_dop` 大于 0 则忽略此变量并直接使用 `pipeline_dop`。
+  * 当 `pipeline_dop` 小于或等于 0（自适应/默认模式）时，执行的实际 DOP 计算为 min(`max_pipeline_dop`, BackendResourceStat 返回的后端默认 DOP)。对于 pipeline sinks，同样的逻辑使用 sink 的默认 DOP。
+  * 如果 `max_pipeline_dop` 小于或等于 0，则不施加额外上限，使用后端默认 DOP。
+  * 目的：通过对自动计算的并行度设置上限，避免在核数非常大的机器上调度带来的负面开销。
+* **默认值**: `64`
+* **数据类型**: int
+* **引入版本**: v3.2.0
 
 ### max_pushdown_conditions_per_column
 
@@ -1374,6 +1455,14 @@ set sql_mode = 'PIPES_AS_CONCAT,ERROR_IF_OVERFLOW,GROUP_CONCAT_LEGACY';
 ### tx_isolation
 
 用于兼容 MySQL 客户端，无实际作用。别名 `transaction_isolation`。
+
+### tx_visible_wait_timeout
+
+* **描述**: 会话范围的超时时间（秒），控制服务器在提交事务后等待该事务变为可见（published）再继续处理的最长时间。该值乘以 1000 用于计算 StmtExecutor 和 TransactionStmtExecutor 的提交流程中以毫秒为单位的 publish 等待时间。如果可见等待超时，事务将被视为已 COMMITTED 但尚未 VISIBLE。物化视图刷新逻辑（`MVTaskRunProcessor`）会临时将此变量设置为 `Long.MAX_VALUE / 1000` 以有效地无限期等待可见性，并在刷新后恢复原值。当启用 `enable_sync_publish` 时，该变量被忽略，因为 publish 等待时间将由作业截止时间推导。
+* **范围**: Session
+* **默认值**: `10`
+* **类型**: long
+* **引入版本**: v3.2.0
 
 ### use_compute_nodes
 


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:  

    EXECUTION SUMMARY
    Document Type: variables
    Duration: 3901.17 seconds
    Command: /home/seaven/documents/workspace/DocsAgent/src/docsagent/main.py -g -t variables --force_search_code -tv -l 100 --pr
    Arguments:
      ├─ ci: False
      ├─ force_search_code: True
      ├─ generate: True
      ├─ include_miss_usage: False
      ├─ limit: 100
      ├─ meta: False
      ├─ name: None
      ├─ pr: True
      ├─ track_version: True
      ├─ type: variables
      ├─ without_llm: False
    
    ITEM EXTRACTION:
      ├─ Items from meta files: 501
      ├─ Items from code parsing: 0
      └─ Total unique items: 0
    
    DOCUMENT GENERATION:
      ├─ EN: 68 documents
      ├─ JA: 10 documents
      ├─ ZH: 10 documents
      └─ Total: 88 documents
    
    AGENT INVOCATIONS:
      ├─ VariableDocAgent: 68 calls
      ├─ TranslationAgent_zh: 10 calls
      ├─ TranslationAgent_ja: 10 calls
      └─ Total: 88 calls
    
    TOOL INVOCATIONS:
      ├─ read_file: 205 calls
      ├─ search_code: 44 calls
      └─ Total: 249 calls
    
    GENERATED ITEMS:
      ├─ Total: 68 items
      ├─ maxBucketsPerBeToUseBalancerAssignment
      ├─ adaptiveDopMaxBlockRowsPerDriverSeq
      ├─ adaptiveDopMaxOutputAmplificationFactor
      ├─ enableGatherFragmentLocalityOptimization
      ├─ runtimeFilterScanWaitTime
      ├─ tabletInternalParallelMode
      ├─ maxExecMemByte
      ├─ chunkSize
      ├─ useCorrelatedJoinEstimate
      ├─ useNthExecPlan
      ├─ cboCTERuseRatio
      ├─ cboCTEMaxLimit
      ├─ cboCTEForceReuseLimitWithoutOrderBy
      ├─ preferCTERewrite
      ├─ cboPruneSubfield
      ├─ cboPruneJsonSubfieldDepth
      ├─ cboUseHistogramEvaluateListPartition
      ├─ enableSQLDigest
      ├─ cboUseDBLock
      ├─ optimizeDistinctAggOverFramedWindow
      ├─ enableConnectorSinkGlobalShuffle
      ├─ enableIcebergSinkGlobalShuffle
      ├─ enableConnectorSinkSpill
      ├─ connectorSinkSpillMemLimitThreshold
      ├─ enableExecutionOnly
      ├─ profileTimeout
      ├─ enableAsyncProfile
      ├─ resourceGroupId
      ├─ spillableOperatorMask
      ├─ spillMemTableSize
      ├─ spillMemTableNum
      ├─ spillMemLimitThreshold
      ├─ spillOperatorMinBytes
      ├─ spillOperatorMaxBytes
      ├─ spillRandRatio
      ├─ spillEnableCompaction
      ├─ enableAggSpillPreaggregation
      ├─ spillPartitionWiseAggPartitionNum
      ├─ spillPartitionWiseAggSkewElimination
      ├─ enableSpillBufferRead
      ├─ maxSpillReadBufferBytesPerDriver
      ├─ spillHashJoinProbeOpMaxBytes
      ├─ maxUKFKJoinReorderScaleRatio
      ├─ maxUKFKJoinReorderFKRows
      ├─ enablePruneColumnAfterIndexFilter
      ├─ cboMaxReorderNode
      ├─ cboEnableDPJoinReorder
      ├─ cboEnableGreedyJoinReorder
      ├─ cboDebugAliveBackendNumber
      ├─ transactionVisibleWaitTimeout
      ├─ forceScheduleLocal
      ├─ broadcastRowCountLimit
      ├─ broadcastRightTableScaleFactor
      ├─ queryDebugOptions
      ├─ enableQueryDump
      ├─ alwaysCollectDict
      ├─ alwaysCollectDictOnLake
      ├─ enableLowCardinalityOptimizeForJoin
      ├─ useLowCardinalityOptimizeV2
      ├─ enableArrayLowCardinalityOptimize
      ├─ enableRewriteGroupingSetsToUnionAll
      ├─ enablePartitionLevelCardinalityEstimation
      ├─ enableOptimizerSkewJoinByQueryRewrite
      ├─ enableOptimizerSkewJoinByBroadCastSkewValues
      ├─ newPlannerAggStage
      ├─ enableCostBasedMultiStageAgg
      ├─ transmissionCompressionType
      └─ rpcHttpMinSize
    
    TRANSLATED ITEMS:
      ├─ Total: 100 items
      ├─ maxUKFKJoinReorderScaleRatio
      ├─ cboMaxReorderNodeUseDP
      ├─ enableConnectorSinkGlobalShuffle
      ├─ profileTimeout
      ├─ enableEliminateAgg
      ├─ collationConnection
      ├─ enableLocalShuffleAgg
      ├─ enablePruneColumnAfterIndexFilter
      ├─ collationDatabase
      ├─ enableSharedScan
      ├─ maxSpillReadBufferBytesPerDriver
      ├─ useNthExecPlan
      ├─ connectorSinkSpillMemLimitThreshold
      ├─ cboCTERuseRatio
      ├─ preferCTERewrite
      ├─ resourceGroupId
      ├─ enableSpillBufferRead
      ├─ newPlannerAggStage
      ├─ transmissionCompressionType
      ├─ runtimeFilterScanWaitTime
      ├─ queryDeliveryTimeoutS
      ├─ enableIncrementalRefreshMV
      ├─ maxPipelineDop
      ├─ usePageCache
      ├─ maxExecMemByte
      ├─ spillPartitionWiseAggPartitionNum
      ├─ skipPageCache
      ├─ enableRewriteGroupingSetsToUnionAll
      ├─ defaultStorageEngine
      ├─ largeInPredicateThreshold
      ├─ spillPartitionWiseAggSkewElimination
      ├─ cboEnableGreedyJoinReorder
      ├─ enableUKFKJoinReorder
      ├─ rpcHttpMinSize
      ├─ cboPruneSubfield
      ├─ decimalOverflowToDouble
      ├─ spillMemTableSize
      ├─ enableAggSpillPreaggregation
      ├─ disableColocateSet
      ├─ enableExecutionOnly
      ├─ splitTopNAggLimit
      ├─ enableConnectorSinkSpill
      ├─ queryDebugOptions
      ├─ enableLowCardinalityOptimizeForJoin
      ├─ defaultTmpStorageEngine
      ├─ enablePartitionLevelCardinalityEstimation
      ├─ spillOperatorMinBytes
      ├─ enableLambdaPushdown
      ├─ disableSpillToLocalDisk
      ├─ forceScheduleLocal
      ├─ adaptiveDopMaxBlockRowsPerDriverSeq
      ├─ cboPruneJsonSubfieldDepth
      ├─ enableCostBasedMultiStageAgg
      ├─ spillableOperatorMask
      ├─ maxParallelScanInstanceNum
      ├─ enableOptimizerSkewJoinByBroadCastSkewValues
      ├─ maxUKFKJoinReorderFKRows
      ├─ enableAsyncProfile
      ├─ transactionVisibleWaitTimeout
      ├─ enableQueryDump
      ├─ cboCTEForceReuseLimitWithoutOrderBy
      ├─ cboEnableDPJoinReorder
      ├─ enableLargeInPredicate
      ├─ alwaysCollectDictOnLake
      ├─ spillEnableCompaction
      ├─ broadcastRowCountLimit
      ├─ maxBucketsPerBeToUseBalancerAssignment
      ├─ useLowCardinalityOptimizeV2
      ├─ enableSplitTopNAgg
      ├─ alwaysCollectDict
      ├─ enableOptimizerSkewJoinByQueryRewrite
      ├─ enableSQLDigest
      ├─ spillMemTableNum
      ├─ cboUseDBLock
      ├─ spillOperatorMaxBytes
      ├─ spillPartitionWiseAgg
      ├─ transactionIsolation
      ├─ joinLateMaterialization
      ├─ cboUseHistogramEvaluateListPartition
      ├─ cboMaxReorderNodeUseExhaustive
      ├─ adaptiveDopMaxOutputAmplificationFactor
      ├─ enableArrayLowCardinalityOptimize
      ├─ cboPruneJsonSubfield
      ├─ spillRevocableMaxBytes
      ├─ cboDebugAliveBackendNumber
      ├─ enableFilterUnusedColumnsInScanStage
      ├─ enableGatherFragmentLocalityOptimization
      ├─ authenticationPolicy
      ├─ spillMemLimitThreshold
      ├─ defaultAuthenticationPlugin
      ├─ optimizeDistinctAggOverFramedWindow
      ├─ spillRandRatio
      ├─ cboCTEMaxLimit
      ├─ tabletInternalParallelMode
      ├─ spillHashJoinProbeOpMaxBytes
      ├─ cboMaxReorderNode
      ├─ chunkSize
      ├─ broadcastRightTableScaleFactor
      ├─ useCorrelatedJoinEstimate
      └─ enableIcebergSinkGlobalShuffle
    

This Pr is generated by [DocsAgent](https://github.com/StarRocks/DocsAgent)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Major refresh of `System_variable.md` in English/Japanese/Chinese.
> 
> - Adds/expands many optimizer/execution variables: `array_low_cardinality_optimize`, `cbo_enable_low_cardinality_optimize_for_join`, `low_cardinality_optimize_v2`, `broadcast_row_limit`, skew-join toggles (`enable_optimize_skew_join_v1/v2`), `enable_cost_based_multi_stage_agg`, `new_planner_agg_stage`, `enable_rewrite_groupingsets_to_union_all`, join reorder thresholds, predicate reorder, distinct-over-window, SplitTopN Agg, etc.
> - Documents additional runtime/system toggles: `enable_local_shuffle_agg`, `enable_incremental_mv`, `enable_query_dump`, `force_schedule_local`, `transmission_compression_type`, `tx_visible_wait_timeout`, `max_pipeline_dop`, `default_authentication_plugin`, `default_tmp_storage_engine`, spill-related flags (e.g., `disable_spill_to_local_disk`), cache/page-skip options, and other per-session limits/caps.
> - Clarifies scopes/defaults/introduced versions and enriches descriptions for existing entries.
> - Removes deprecated `interpolate_passthrough` section in all locales.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0277757c42e30bb4180187c5ba8b4bc2ab4ecfd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->