### PR TITLE
[Enhancement] Record the time taken to write to the client

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -29,7 +29,7 @@ public class Tracers {
     }
 
     public enum Module {
-        NONE, ALL, BASE, OPTIMIZER, SCHEDULER, ANALYZE, MV, EXTERNAL, PARSER
+        NONE, ALL, BASE, OPTIMIZER, SCHEDULER, CLIENT, ANALYZE, MV, EXTERNAL, PARSER
     }
 
     private static final Tracer EMPTY_TRACER = new Tracer() {
@@ -121,6 +121,7 @@ public class Tracers {
             tracers.moduleMask |= 1 << Module.BASE.ordinal();
             tracers.moduleMask |= 1 << Module.EXTERNAL.ordinal();
             tracers.moduleMask |= 1 << Module.SCHEDULER.ordinal();
+            tracers.moduleMask |= 1 << Module.CLIENT.ordinal();
             tracers.moduleMask |= 1 << Module.MV.ordinal();
 
             tracers.modeMask |= 1 << Mode.TIMER.ordinal();

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -133,6 +133,8 @@ public class AuditEvent {
     public long bigQueryLogScanRowsThreshold = -1;
     @AuditField(value = "SpilledBytes", ignore_zero = true)
     public long spilledBytes = -1;
+    @AuditField(value = "writeClientTimeMs", ignore_zero = true)
+    public long writeClientTimeMs = -1;
     @AuditField(value = "Warehouse")
     public String warehouse = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
     @AuditField(value = "CNGroup")
@@ -331,6 +333,11 @@ public class AuditEvent {
             } else {
                 auditEvent.spilledBytes += spilledBytes;
             }
+            return this;
+        }
+
+        public AuditEventBuilder setWriteClientTimeMs(long writeClientTimeMs) {
+            auditEvent.writeClientTimeMs = writeClientTimeMs;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1589,7 +1589,7 @@ public class StmtExecutor {
                     // For some language driver, getting error packet after fields packet will be recognized as a success result
                     // so We need to send fields after first batch arrived
                     if (!isSendFields) {
-                        sendFields(colNames, outputExprs);
+                        responseFields(colNames, outputExprs);
                         isSendFields = true;
                     }
                     if (!isProxy && channel.isSendBufferNull()) {
@@ -1601,13 +1601,7 @@ public class StmtExecutor {
                         channel.initBuffer(bufferSize + 8);
                     }
 
-                    for (ByteBuffer row : batch.getBatch().getRows()) {
-                        if (isProxy) {
-                            proxyResultBuffer.add(row);
-                        } else {
-                            channel.sendOnePacket(row);
-                        }
-                    }
+                    responseRowBatch(batch, channel);
                 }
                 if (batch.getBatch() != null) {
                     context.updateReturnRows(batch.getBatch().getRows().size());
@@ -1615,12 +1609,31 @@ public class StmtExecutor {
             } while (!batch.isEos());
 
             if (!isSendFields && !isOutfileQuery && !isExplainAnalyze && !isPlanAdvisorAnalyze && !isArrowFlight) {
-                sendFields(colNames, outputExprs);
+                responseFields(colNames, outputExprs);
             }
+            final Long res = Tracers.getSpecifiedTimer("clientResponse").map(Timer::getTotalTime).orElse(0L);
+            context.getAuditEventBuilder().setWriteClientTimeMs(res);
         }
 
         processQueryStatisticsFromResult(batch, execPlan, isOutfileQuery);
         GlobalStateMgr.getCurrentState().getQueryHistoryMgr().addQueryHistory(context, execPlan);
+    }
+    private void responseRowBatch(RowBatch batch, MysqlChannel channel) throws IOException {
+        try (final Timer ignore = Tracers.watchScope(Tracers.Module.CLIENT, "clientResponse")) {
+            for (ByteBuffer row : batch.getBatch().getRows()) {
+                if (isProxy) {
+                    proxyResultBuffer.add(row);
+                } else {
+                    channel.sendOnePacket(row);
+                }
+            }
+        }
+    }
+
+    private void responseFields(List<String> colNames, List<Expr> exprs) throws IOException {
+        try (final Timer ignore = Tracers.watchScope(Tracers.Module.CLIENT, "clientResponse")) {
+            sendFields(colNames, exprs);
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/plugin/AuditEventTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/plugin/AuditEventTest.java
@@ -75,7 +75,7 @@ public class AuditEventTest {
         Assertions.assertEquals("customQueryId", event.customQueryId);
         Assertions.assertEquals("test_cngroup", event.cnGroup);
         Assertions.assertEquals("50.0%", event.cacheHitRatio);
-        Assertions.assertEquals(1000, event.writeClientTimeMs);
+        Assertions.assertEquals(100, event.writeClientTimeMs);
         Assertions.assertEquals((float) 50, event.getCacheMissRatio());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/plugin/AuditEventTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/plugin/AuditEventTest.java
@@ -34,6 +34,7 @@ public class AuditEventTest {
                 .setBigQueryLogCPUSecondThreshold(1)
                 .setCatalog("catalog")
                 .setQueryId("queryId")
+                .setWriteClientTimeMs(100)
                 .setStmtId(123)
                 .setStmt("stmt")
                 .setDigest("digest")
@@ -74,6 +75,7 @@ public class AuditEventTest {
         Assertions.assertEquals("customQueryId", event.customQueryId);
         Assertions.assertEquals("test_cngroup", event.cnGroup);
         Assertions.assertEquals("50.0%", event.cacheHitRatio);
+        Assertions.assertEquals(1000, event.writeClientTimeMs);
         Assertions.assertEquals((float) 50, event.getCacheMissRatio());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

If the client encounters an exception and fails to close successfully, this will prevent the frontend from writing data to the client. We have added the time taken to write to the client in the profile and timer to explicitly identify such scenarios.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit timing for client write latency and surfaces it in audit/a profile outputs.
> 
> - Introduces `CLIENT` module in `Tracers` and enables it when profile is on
> - Wraps sending result fields/rows in `StmtExecutor` with `Tracers.watchScope(… "clientResponse")` via new `responseFields`/`responseRowBatch`
> - Captures `clientResponse` total time and sets `AuditEvent.writeClientTimeMs`
> - Adds `writeClientTimeMs` field and `setWriteClientTimeMs` builder method in `AuditEvent`; updates unit test
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02c19060b01e8196ec6feeb18e1730de52098dae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->