### PR TITLE
[BugFix] Fix NPE in Iceberg metadata table query due to missing Configuration propagation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
@@ -196,10 +196,8 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
     }
 
     public FileIO getWrappedIO() {
-        if (wrappedIO instanceof HadoopConfigurable) {
-            Configuration configuration = conf != null ? conf.get() : new Configuration();
-            ((HadoopConfigurable) wrappedIO).setConf(configuration);
-        }
+        Configuration configuration = conf != null ? conf.get() : new Configuration();
+        wrappedIO.setConf(configuration);
         return wrappedIO;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
@@ -126,6 +126,10 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
         wrappedIO = new ResolvingFileIO();
         wrappedIO.initialize(properties);
 
+        if (conf != null) {
+            wrappedIO.setConf(conf.get());
+        }
+
         if (ENABLE_DISK_CACHE) {
             this.fileContentCache = TwoLevelCacheHolder.INSTANCE;
         } else {
@@ -155,6 +159,9 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
     @Override
     public void setConf(Configuration conf) {
         this.conf = new SerializableConfiguration(conf)::get;
+        if (wrappedIO != null) {
+            wrappedIO.setConf(conf);
+        }
     }
 
     @Override
@@ -196,8 +203,6 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
     }
 
     public FileIO getWrappedIO() {
-        Configuration configuration = conf != null ? conf.get() : new Configuration();
-        wrappedIO.setConf(configuration);
         return wrappedIO;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
@@ -196,6 +196,10 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
     }
 
     public FileIO getWrappedIO() {
+        if (wrappedIO instanceof HadoopConfigurable) {
+            Configuration configuration = conf != null ? conf.get() : new Configuration();
+            ((HadoopConfigurable) wrappedIO).setConf(configuration);
+        }
         return wrappedIO;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
@@ -159,4 +159,26 @@ public class IcebergCachingFileIOTest {
             });
         });
     }
+
+    @Test
+    public void testWrappedIOConfigurationPropagationWithoutSetConf() {
+        IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO();
+        Map<String, String> properties = new HashMap<>();
+        properties.put("iceberg.catalog.type", "rest");
+        cachingFileIO.initialize(properties);
+
+        FileIO wrappedIO = cachingFileIO.getWrappedIO();
+        Assertions.assertTrue(wrappedIO instanceof HadoopConfigurable);
+
+        HadoopConfigurable hadoopConfigurable = (HadoopConfigurable) wrappedIO;
+        Assertions.assertDoesNotThrow(() -> {
+            hadoopConfigurable.serializeConfWith(confToSerialize -> {
+                Assertions.assertNotNull(confToSerialize);
+                int size = confToSerialize.size();
+                Map<String, String> confAsMap = new HashMap<>(size);
+                confToSerialize.forEach(entry -> confAsMap.put(entry.getKey(), entry.getValue()));
+                return (SerializableSupplier<Configuration>) () -> confToSerialize;
+            });
+        });
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
@@ -17,7 +17,10 @@ package com.starrocks.connector.iceberg.io;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.hadoop.HadoopConfigurable;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.util.SerializableSupplier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -132,5 +135,28 @@ public class IcebergCachingFileIOTest {
         Assertions.assertEquals(accessToken, token);
         Assertions.assertEquals(ACCESS_TOKEN_PROVIDER_IMPL,
                 configuration.get("fs.gs.auth.access.token.provider.impl"));
+    }
+
+    @Test
+    public void testWrappedIOConfigurationPropagation() {
+        IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO();
+        Map<String, String> properties = new HashMap<>();
+        properties.put("iceberg.catalog.type", "hive");
+        cachingFileIO.initialize(properties);
+
+        Configuration conf = new Configuration();
+        conf.set("test.key", "test.value");
+        cachingFileIO.setConf(conf);
+
+        FileIO wrappedIO = cachingFileIO.getWrappedIO();
+        Assertions.assertTrue(wrappedIO instanceof HadoopConfigurable);
+
+        HadoopConfigurable hadoopConfigurable = (HadoopConfigurable) wrappedIO;
+        Assertions.assertDoesNotThrow(() -> {
+            hadoopConfigurable.serializeConfWith(confToSerialize -> {
+                Assertions.assertNotNull(confToSerialize);
+                return (SerializableSupplier<Configuration>) () -> confToSerialize;
+            });
+        });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
@@ -160,25 +160,4 @@ public class IcebergCachingFileIOTest {
         });
     }
 
-    @Test
-    void testWrappedIOConfigurationPropagationWithoutSetConf() {
-        IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO();
-        Map<String, String> properties = new HashMap<>();
-        properties.put("iceberg.catalog.type", "rest");
-        cachingFileIO.initialize(properties);
-
-        FileIO wrappedIO = cachingFileIO.getWrappedIO();
-        Assertions.assertTrue(wrappedIO instanceof HadoopConfigurable);
-
-        HadoopConfigurable hadoopConfigurable = (HadoopConfigurable) wrappedIO;
-        Assertions.assertDoesNotThrow(() -> {
-            hadoopConfigurable.serializeConfWith(confToSerialize -> {
-                Assertions.assertNotNull(confToSerialize);
-                int size = confToSerialize.size();
-                Map<String, String> confAsMap = new HashMap<>(size);
-                confToSerialize.forEach(entry -> confAsMap.put(entry.getKey(), entry.getValue()));
-                return (SerializableSupplier<Configuration>) () -> confToSerialize;
-            });
-        });
-    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
@@ -138,7 +138,7 @@ public class IcebergCachingFileIOTest {
     }
 
     @Test
-    public void testWrappedIOConfigurationPropagation() {
+    void testWrappedIOConfigurationPropagation() {
         IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO();
         Map<String, String> properties = new HashMap<>();
         properties.put("iceberg.catalog.type", "hive");
@@ -161,7 +161,7 @@ public class IcebergCachingFileIOTest {
     }
 
     @Test
-    public void testWrappedIOConfigurationPropagationWithoutSetConf() {
+    void testWrappedIOConfigurationPropagationWithoutSetConf() {
         IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO();
         Map<String, String> properties = new HashMap<>();
         properties.put("iceberg.catalog.type", "rest");


### PR DESCRIPTION
## Why I'm doing:

When querying Iceberg metadata tables (history, snapshots, refs, etc.),
NPE occurs with message: "Cannot invoke Configuration.size() because conf is null".

This happens because:
1. `IcebergCachingFileIO.getWrappedIO()` returns `ResolvingFileIO` without Configuration set
2. When `SerializableTable` serializes the FileIO, it calls `serializeConfWith()`
3. `SerializableConfSupplier` constructor calls `conf.size()` on null Configuration
  
## What I'm doing:

Fix `getWrappedIO()` to propagate Configuration to wrappedIO before returning.
- If `conf` is set via `setConf()`, use it
- If `conf` is null (e.g., REST catalog), use default `new Configuration()`


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes missing Hadoop `Configuration` propagation to the underlying `ResolvingFileIO`, preventing NPE during metadata table operations.
> 
> - In `IcebergCachingFileIO.initialize`, if `conf` is already set, forward it to `wrappedIO`
> - In `setConf`, also forward the config to `wrappedIO` when it exists
> - Adds `testWrappedIOConfigurationPropagation` to verify `HadoopConfigurable.serializeConfWith` works and no NPE occurs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb2649854f40a618a9c616ba02e4af3956db90f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->