### PR TITLE
[BugFix] incorrect optimization transformation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java
@@ -226,6 +226,12 @@ public class RewriteSimpleAggToHDFSScanRule extends TransformationRule {
             return false;
         }
 
+        // add check for column mapping
+        if (!scanOperator.getColRefToColumnMetaMap().keySet()
+                .containsAll(groupingKeys)) {
+            return false;
+        }
+
         // no materialized column in predicate of aggregation
         if (hasMaterializedColumnInPredicate(scanOperator, aggregationOperator.getPredicate())) {
             return false;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -103,6 +103,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         mockDataCacheTable();
         mockPartitionTable();
         mockView();
+        mockPartUnionViewItem();
         mockSubfieldTable();
         mockFileSplitTable();
     }
@@ -864,6 +865,131 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         mockTables.put(lineItemPar.getTableName(),
                 new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(lineItemPar, MOCKED_HIVE_CATALOG_NAME),
                         partitionNames, (long) rowCount, columnStatisticMap, remoteFileInfos));
+    }
+
+    public static void mockPartUnionViewItem() {
+        MOCK_TABLE_MAP.putIfAbsent(MOCKED_TPCH_DB_NAME, new CaseInsensitiveMap<>());
+        Map<String, HiveTableInfo> mockTables = MOCK_TABLE_MAP.get(MOCKED_TPCH_DB_NAME);
+
+        {
+            List<FieldSchema> cols = Lists.newArrayList();
+            cols.add(new FieldSchema("l_orderkey", "int", null));
+            StorageDescriptor sd =
+                    new StorageDescriptor(cols, "", MAPRED_PARQUET_INPUT_FORMAT_CLASS,
+                            "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                            Maps.newHashMap());
+
+            Table lineItemPar = new Table("lineitem_par1", MOCKED_TPCH_DB_NAME, null, 0, 0, 0, sd,
+                    ImmutableList.of(new FieldSchema("l_shipdate", "Date", null)), Maps.newHashMap(),
+                    null, null, "EXTERNAL_TABLE");
+
+            Column partitionColumn = new Column("l_shipdate", DateType.DATE);
+
+            List<PartitionKey> lineitemPartitionKeyList = Lists.newArrayList();
+            lineitemPartitionKeyList.add(
+                    new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 1)), ImmutableList.of(PrimitiveType.DATE)));
+            lineitemPartitionKeyList.add(
+                    new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 2)), ImmutableList.of(PrimitiveType.DATE)));
+
+            List<String> partitionNames = Lists.newArrayList();
+            partitionNames.addAll(
+                    ImmutableList.of("l_shipdate=" + HiveMetaClient.PARTITION_NULL_VALUE, "l_shipdate=1998-01-01",
+                            "l_shipdate=1998-01-02"));
+
+            List<String> partitionColumnNames = ImmutableList.of("l_shipdate");
+
+            double rowCount = 600037902;
+            double avgNumPerPartition = rowCount / partitionNames.size();
+            Map<String, HivePartitionStats> hivePartitionStatsMap = Maps.newHashMap();
+
+            ColumnStatistic partitionColumnStats =
+                    getPartitionColumnStatistic(partitionColumn, lineitemPartitionKeyList, partitionColumnNames,
+                            hivePartitionStatsMap, avgNumPerPartition, rowCount);
+
+            List<RemoteFileInfo> remoteFileInfos = Lists.newArrayList();
+            partitionNames.forEach(
+                    k -> remoteFileInfos.add(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null)));
+
+            List<String> colNames = cols.stream().map(FieldSchema::getName).collect(Collectors.toList());
+            Map<String, ColumnStatistic> columnStatisticMap =
+                    colNames.stream().collect(Collectors.toMap(Function.identity(), col -> ColumnStatistic.unknown()));
+            columnStatisticMap.put("l_shipdate", partitionColumnStats);
+
+            mockTables.put(lineItemPar.getTableName(),
+                    new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(lineItemPar, MOCKED_HIVE_CATALOG_NAME),
+                            partitionNames, (long) rowCount, columnStatisticMap, remoteFileInfos));
+        }
+
+        {
+            List<FieldSchema> cols = Lists.newArrayList();
+            cols.add(new FieldSchema("l_orderkey", "int", null));
+            StorageDescriptor sd =
+                    new StorageDescriptor(cols, "", MAPRED_PARQUET_INPUT_FORMAT_CLASS,
+                            "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                            Maps.newHashMap());
+
+            Table lineItemPar = new Table("lineitem_par2", MOCKED_TPCH_DB_NAME, null, 0, 0, 0, sd,
+                    ImmutableList.of(new FieldSchema("l_shipdate", "Date", null)), Maps.newHashMap(),
+                    null, null, "EXTERNAL_TABLE");
+
+            Column partitionColumn = new Column("l_shipdate", DateType.DATE);
+
+            List<PartitionKey> lineitemPartitionKeyList = Lists.newArrayList();
+            lineitemPartitionKeyList.add(
+                    new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 3)), ImmutableList.of(PrimitiveType.DATE)));
+            lineitemPartitionKeyList.add(
+                    new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 4)), ImmutableList.of(PrimitiveType.DATE)));
+            lineitemPartitionKeyList.add(
+                    new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 5)), ImmutableList.of(PrimitiveType.DATE)));
+
+            List<String> partitionNames = Lists.newArrayList();
+            partitionNames.addAll(
+                    ImmutableList.of("l_shipdate=" + HiveMetaClient.PARTITION_NULL_VALUE,
+                            "l_shipdate=1998-01-03", "l_shipdate=1998-01-04", "l_shipdate=1998-01-05"));
+
+            List<String> partitionColumnNames = ImmutableList.of("l_shipdate");
+
+            double rowCount = 600037902;
+            double avgNumPerPartition = rowCount / partitionNames.size();
+            Map<String, HivePartitionStats> hivePartitionStatsMap = Maps.newHashMap();
+
+            ColumnStatistic partitionColumnStats =
+                    getPartitionColumnStatistic(partitionColumn, lineitemPartitionKeyList, partitionColumnNames,
+                            hivePartitionStatsMap, avgNumPerPartition, rowCount);
+
+            List<RemoteFileInfo> remoteFileInfos = Lists.newArrayList();
+            partitionNames.forEach(
+                    k -> remoteFileInfos.add(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null)));
+
+            List<String> colNames = cols.stream().map(FieldSchema::getName).collect(Collectors.toList());
+            Map<String, ColumnStatistic> columnStatisticMap =
+                    colNames.stream().collect(Collectors.toMap(Function.identity(), col -> ColumnStatistic.unknown()));
+            columnStatisticMap.put("l_shipdate", partitionColumnStats);
+
+            mockTables.put(lineItemPar.getTableName(),
+                    new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(lineItemPar, MOCKED_HIVE_CATALOG_NAME),
+                            partitionNames, (long) rowCount, columnStatisticMap, remoteFileInfos));
+        }
+
+        List<FieldSchema> cols = Lists.newArrayList();
+        cols.add(new FieldSchema("l_orderkey", "int", null));
+        cols.add(new FieldSchema("l_shipdate", "string", null));
+
+        StorageDescriptor sd =
+                new StorageDescriptor(cols, "", MAPRED_PARQUET_INPUT_FORMAT_CLASS,
+                        "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                        Maps.newHashMap());
+
+        Table hmsView6 =
+                new Table("customer_union_view", MOCKED_TPCH_DB_NAME, null, 0, 0, 0,
+                        sd, Lists.newArrayList(), Maps.newHashMap(),
+                        null,
+                        "select l_orderkey, l_shipdate from lineitem_par1 where l_shipdate <= '1998-01-02' " +
+                                "union all " +
+                                "select l_orderkey, l_shipdate from lineitem_par2 where l_shipdate >= '1998-01-03'",
+                        "VIRTUAL_VIEW");
+        HiveView view6 = HiveMetastoreApiConverter.toHiveView(hmsView6, MOCKED_HIVE_CATALOG_NAME);
+        mockTables.put(hmsView6.getTableName(), new HiveTableInfo(view6));
     }
 
     public static void mockLineItemWithMultiPartitionColumns() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
@@ -130,6 +130,20 @@ public class HiveScanTest extends ConnectorPlanTestBase {
                 assertNotContains(plan, "___count___");
             }
         }
+
+        // negative cases, because customer_union_view is a view.
+        {
+            String[] sqlString = {
+                    "select l_shipdate, count(*) from hive0.tpch.customer_union_view where l_shipdate = '1998-01-02' group by 1",
+                    "select count(*) from hive0.tpch.customer_union_view",
+            };
+            for (int i = 0; i < sqlString.length; i++) {
+                String sql = sqlString[i];
+                String plan = getFragmentPlan(sql);
+                assertNotContains(plan, "___count___");
+                assertNotContains(plan, "ifnull");
+            }
+        }
         connectContext.getSessionVariable().setEnableRewriteSimpleAggToHdfsScan(false);
     }
 


### PR DESCRIPTION
patch doesn't fix transformation, just disable it for now

## Why I'm doing:

we have hive view on top of 2 different tables
planner do some slot_id remapping during parsing of view with `union all`

https://github.com/StarRocks/starrocks/blob/main/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java#L380-L381

later in check we just validate names in 
https://github.com/StarRocks/starrocks/blob/main/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToHDFSScanRule.java#L222-L227

because `scanOperator.getPartitionColumns()` return `Strings` we compare it with `groupingKeys ColumnRefOperator.getName`

but the same name doesn't mean the same ColumnRefOperator, they can have same name but different id's

`l_shipdate` have different columnrefs for grouping and for logical scan

<img width="1201" height="873" alt="view error" src="https://github.com/user-attachments/assets/726133f0-dd85-43f1-b3f1-455d4e1d3f12" />

so `check` pass and we do transformation 

in `buildAggScanOperator`

scanOperator have original ColumnRefOperator's name and ids
```
for (ColumnRefOperator c : scanOperator.getColRefToColumnMetaMap().keySet()) 
```

but `aggregationOperator.getGroupingKeys()` return remapped ColumnRefOperator's (same name, different ids)
```
LogicalAggregationOperator newAggOperator = new LogicalAggregationOperator(aggregationOperator.getType(),
                aggregationOperator.getGroupingKeys(), newAggCalls);
```

later when you will try to access to statistics in 
https://github.com/StarRocks/starrocks/blob/main/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java#L1037-L1038

you will get error like (correct name, but id different)
```
[42000][1064] only found column statistics: {713: ___count___, 175: datadate, 176: hour}, but missing statistic of col: 709: datadate.
```

because for ColumnRefOperator equality you have to have the same id's

```
private final Map<ColumnRefOperator, ColumnStatistic> columnStatistics;
```

i don't know how safe will be use `name` comparison to find correct rows during transformation, so just disable optimization if logical scan doesn't have all required columnrefs

## What I'm doing:
update check to validate scan operator contain all require output columns refs

Fixes #66731

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents incorrect rewrite when grouping keys share names but differ in ColumnRef IDs.
> 
> - Update `RewriteSimpleAggToHDFSScanRule.check` to require `scanOperator.getColRefToColumnMetaMap().keySet()` contains all aggregation `groupingKeys` (in addition to partition-name check)
> - Extend test metadata: add mocked `lineitem_par1`, `lineitem_par2`, and `customer_union_view` (union all) in `MockedHiveMetadata`
> - Add negative cases in `HiveScanTest` asserting no `___count___`/`ifnull` for queries on `hive0.tpch.customer_union_view`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87b8145af059abf1957b5fac118629745ebbf7c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->