### PR TITLE
[BugFix] fix MulticastSinkOperator stuck in OUTPUT_FULL state

### DIFF
--- a/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
+++ b/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
@@ -263,6 +263,11 @@ void MemLimitedChunkQueue::close_consumer(int32_t consumer_index) {
     }
 }
 
+bool MemLimitedChunkQueue::is_all_source_finished() const {
+    std::shared_lock l(_mutex);
+    return _opened_source_number == 0;
+}
+
 void MemLimitedChunkQueue::open_producer() {
     std::unique_lock l(_mutex);
     _opened_sink_number++;

--- a/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.h
+++ b/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.h
@@ -151,6 +151,7 @@ public:
     void open_producer();
 
     void close_producer();
+    bool is_all_source_finished() const;
 
     void enter_release_memory_mode();
 
@@ -184,7 +185,7 @@ private:
     }
 
     RuntimeState* _state = nullptr;
-    std::shared_mutex _mutex;
+    mutable std::shared_mutex _mutex;
     // an empty chunk, only keep meta
     ChunkPtr _chunk_builder;
     Block* _head = nullptr;

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange.cpp
@@ -170,6 +170,11 @@ void InMemoryMultiCastLocalExchanger::close_sink_operator() {
     _opened_sink_number--;
 }
 
+bool InMemoryMultiCastLocalExchanger::is_all_sources_finished() const {
+    std::unique_lock l(_mutex);
+    return _opened_source_number == 0;
+}
+
 void InMemoryMultiCastLocalExchanger::_closer_consumer(int32_t mcast_consumer_index) {
     Cell* now = _progress[mcast_consumer_index];
     now = now->next;

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange.h
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange.h
@@ -67,6 +67,9 @@ public:
     virtual void open_sink_operator() = 0;
     virtual void close_sink_operator() = 0;
 
+    // Short-Cicuit indicates if the SourceOperator finished, the SinkOperator can also finish immediately
+    virtual bool is_short_circuit() const { return false; }
+
     virtual bool releaseable() const { return false; }
     virtual void enter_release_memory_mode() {}
 
@@ -91,6 +94,7 @@ public:
     void close_source_operator(int32_t mcast_consumer_index) override;
     void open_sink_operator() override;
     void close_sink_operator() override;
+    bool is_short_circuit() const override { return _opened_source_number == 0; }
 
 #ifndef BE_TEST
 private:

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange.h
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange.h
@@ -67,8 +67,8 @@ public:
     virtual void open_sink_operator() = 0;
     virtual void close_sink_operator() = 0;
 
-    // Short-Cicuit indicates if the SourceOperator finished, the SinkOperator can also finish immediately
-    virtual bool is_short_circuit() const { return false; }
+    // indicates if all SourceOperator finished
+    virtual bool is_all_sources_finished() const { return false; }
 
     virtual bool releaseable() const { return false; }
     virtual void enter_release_memory_mode() {}
@@ -94,7 +94,7 @@ public:
     void close_source_operator(int32_t mcast_consumer_index) override;
     void open_sink_operator() override;
     void close_sink_operator() override;
-    bool is_short_circuit() const override { return _opened_source_number == 0; }
+    bool is_all_sources_finished() const override;
 
 #ifndef BE_TEST
 private:
@@ -145,6 +145,7 @@ public:
     void close_source_operator(int32_t mcast_consumer_index) override;
     void open_sink_operator() override;
     void close_sink_operator() override;
+    bool is_all_sources_finished() const override;
     bool releaseable() const override { return true; }
     void enter_release_memory_mode() override;
 

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.h
@@ -36,7 +36,7 @@ public:
 
     bool need_input() const override;
 
-    bool is_finished() const override { return _is_finished || _exchanger->is_short_circuit(); }
+    bool is_finished() const override { return _is_finished || _exchanger->is_all_sources_finished(); }
 
     Status set_finishing(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.h
@@ -36,7 +36,7 @@ public:
 
     bool need_input() const override;
 
-    bool is_finished() const override { return _is_finished; }
+    bool is_finished() const override { return _is_finished || _exchanger->is_short_circuit(); }
 
     Status set_finishing(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/exchange/spillable_multi_cast_local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/spillable_multi_cast_local_exchange.cpp
@@ -94,6 +94,10 @@ void SpillableMultiCastLocalExchanger::close_sink_operator() {
     _queue->close_producer();
 }
 
+bool SpillableMultiCastLocalExchanger::is_all_sources_finished() const {
+    return _queue->is_all_source_finished();
+}
+
 void SpillableMultiCastLocalExchanger::enter_release_memory_mode() {
     _queue->enter_release_memory_mode();
 }

--- a/be/src/exec/pipeline/exchange/split_local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/split_local_exchange.cpp
@@ -167,4 +167,9 @@ void SplitLocalExchanger::close_sink_operator() {
     _opened_sink_number--;
 }
 
+bool SplitLocalExchanger::is_all_sources_finished() const {
+    std::unique_lock l(_mutex);
+    return _opened_source_number == 0;
+}
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/split_local_exchange.h
+++ b/be/src/exec/pipeline/exchange/split_local_exchange.h
@@ -43,6 +43,7 @@ public:
     void close_source_operator(int32_t consumer_index) override;
     void open_sink_operator() override;
     void close_sink_operator() override;
+    bool is_all_sources_finished() const override;
 
 private:
     // one input chunk will be split into _num_consumers chunks by _split_expr_ctxs and saved in _buffer

--- a/test/sql/test_spill/R/test_spill_mcast_hang
+++ b/test/sql/test_spill/R/test_spill_mcast_hang
@@ -1,0 +1,50 @@
+-- name: test_spill_mcast_hang
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode='force';
+-- result:
+-- !result
+set spillable_operator_mask = 32;
+-- result:
+-- !result
+set cbo_cte_reuse = true;
+-- result:
+-- !result
+set cbo_cte_reuse_rate = 0;
+-- result:
+-- !result
+CREATE TABLE t_hang (
+    k1 INT,
+    v1 INT
+) DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t_hang select generate_series, generate_series from TABLE(generate_series(1, 1000000));
+-- result:
+-- !result
+with cte as (
+    select * from t_hang
+)
+select count(*) from (select * from cte limit 1) t1
+union all
+select count(*) from (select * from cte limit 1) t2;
+-- result:
+1
+1
+-- !result
+with cte as (
+    select * from t_hang limit 200000
+)
+select max(cnt) from (select k1, count(*) as cnt from cte group by k1 order by k1 limit 10) r1
+union all
+select max(cnt) from (select v1, count(*) as cnt from cte group by v1 order by v1 limit 10) r2;
+-- result:
+1
+1
+-- !result
+drop table t_hang;
+-- result:
+-- !result

--- a/test/sql/test_spill/T/test_spill_mcast_hang
+++ b/test/sql/test_spill/T/test_spill_mcast_hang
@@ -1,0 +1,32 @@
+-- name: test_spill_mcast_hang
+set enable_spill=true;
+set spill_mode='force';
+set spillable_operator_mask = 32;
+set cbo_cte_reuse = true;
+set cbo_cte_reuse_rate = 0;
+
+CREATE TABLE t_hang (
+    k1 INT,
+    v1 INT
+) DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES('replication_num' = '1');
+
+insert into t_hang select generate_series, generate_series from TABLE(generate_series(1, 1000000));
+
+with cte as (
+    select * from t_hang
+)
+select count(*) from (select * from cte limit 1) t1
+union all
+select count(*) from (select * from cte limit 1) t2;
+
+with cte as (
+    select * from t_hang limit 200000
+)
+select max(cnt) from (select k1, count(*) as cnt from cte group by k1 order by k1 limit 10) r1
+union all
+select max(cnt) from (select v1, count(*) as cnt from cte group by v1 order by v1 limit 10) r2;
+
+drop table t_hang;
+


### PR DESCRIPTION
## Why I'm doing:

example sql:
```sql
set cbo_cte_reuse = true;
set cbo_cte_reuse_rate = 0;

with cte as (
	select * from table limit 2000000
) 
select k1, min(c1) from cte group by k1
union all
select k1, min(c2) from cte group by k1
```

```
    "queries_in_workgroup": [
        {
            "query_id": "d668e65c-dfec-11f0-bd33-00163e1bdf0b",
            "fragments": [
                {
                    "fragment_id": "d668e65c-dfec-11f0-bd33-00163e1bdf13",
                    "fragment_status": "OK",
                    "drivers": [
                        {
                            "driver_id": 1,
                            "state": "OUTPUT_FULL",
                            "driver_desc": "query_id=d668e65c-dfec-11f0-bd33-00163e1bdf0b fragment_id=d668e65c-dfec-11f0-bd33-00163e1bdf13 driver=driver_1_1 addr=0x1528cec29d10, status=OUTPUT_FULL, operator-chain: [exchange_source_1_0x1528cec27f10(O) { has_output:true} -> limit_1_0x15291f2b3110(O) -> multi_cast_local_exchange_sink_1_0x15290e0d8f90(O)]"
                        }
                    ]
                }
            ]
        }
    ]
```

In a query plan such as `multi-cast -> limit`, the completion of the source operator should also trigger the completion of the sink operator; otherwise, it may remain in the `OUTPUT_FULL` state indefinitely.

One practical query is `ANALYZE SAMPLE <table>`, as it produces a CTE query similar to the one mentioned above.

<img width="695" height="683" alt="image" src="https://github.com/user-attachments/assets/42898935-7fc6-4007-a98d-0828cc1275b6" />




## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents multicast sink from hanging when upstream sources (e.g., after a `limit`) complete by short‑circuiting sink completion.
> 
> - Adds `is_short_circuit()` to `MultiCastLocalExchanger` and uses it in sink `is_finished()`
> - Implements short‑circuit in `InMemoryMultiCastLocalExchanger` (`_opened_source_number == 0`)
> - No behavior changes elsewhere; header-only updates to exchanger and sink operator
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0923f6651fa18c58c9d8d1296abe61b772338743. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->