### PR TITLE
[BugFix] avoid publish compaction crash when input rowset not found

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1316,6 +1316,11 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
     // then get the max src rssid, to solve conflict between write and compaction
     auto input_rowset = std::find_if(metadata.rowsets().begin(), metadata.rowsets().end(),
                                      [&](const RowsetMetadata& r) { return r.id() == max_rowset_id; });
+    if (input_rowset == metadata.rowsets().end()) {
+        LOG(ERROR) << "cannot find input rowset in tablet metadata, rowset_id: " << max_rowset_id
+                   << ", meta : " << metadata.ShortDebugString();
+        return Status::InternalError("cannot find input rowset in tablet metadata");
+    }
     uint32_t max_src_rssid = max_rowset_id + input_rowset->segments_size() - 1;
     std::map<uint32_t, size_t> segment_id_to_add_dels;
 

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -1713,6 +1713,62 @@ TEST_P(LakePrimaryKeyCompactionTest, test_concurrent_compaction_and_publish) {
     ASSERT_EQ(kChunkSize, read(version));
 }
 
+TEST_P(LakePrimaryKeyCompactionTest, test_publish_compaction_with_invalid_rowset_id) {
+    auto chunk0 = generate_data(kChunkSize, 0);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+
+    for (int i = 0; i < 3; i++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    ASSERT_EQ(kChunkSize, read(version));
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(metadata->rowsets_size(), 3);
+
+    auto txn_id = next_id();
+    TxnLogPB txn_log;
+    txn_log.set_tablet_id(tablet_id);
+    txn_log.set_txn_id(txn_id);
+    auto* op_compaction = txn_log.mutable_op_compaction();
+
+    op_compaction->add_input_rowsets(0);
+    op_compaction->add_input_rowsets(1);
+    op_compaction->add_input_rowsets(999);
+
+    auto* output_rowset = op_compaction->mutable_output_rowset();
+    output_rowset->set_num_rows(kChunkSize);
+    output_rowset->set_data_size(1024);
+    output_rowset->add_segments("fake_segment.dat");
+    output_rowset->add_segment_size(1024);
+
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    auto res = publish_single_version(tablet_id, version + 1, txn_id);
+    EXPECT_TRUE(res.status().is_internal_error());
+    EXPECT_TRUE(res.status().message().find("cannot find input rowset in tablet metadata") != std::string::npos);
+}
+
 INSTANTIATE_TEST_SUITE_P(
         LakePrimaryKeyCompactionTest, LakePrimaryKeyCompactionTest,
         ::testing::Values(CompactionParam{HORIZONTAL_COMPACTION, 5, false},

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -1766,7 +1766,6 @@ TEST_P(LakePrimaryKeyCompactionTest, test_publish_compaction_with_invalid_rowset
 
     auto res = publish_single_version(tablet_id, version + 1, txn_id);
     EXPECT_TRUE(res.status().is_internal_error());
-    EXPECT_TRUE(res.status().message().find("cannot find input rowset in tablet metadata") != std::string::npos);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
## Why I'm doing:
Return an error if the input rowset is not found during compaction publish to prevent invalid pointer access. This scenario may occur when compaction transactions within the same partition are executed concurrently.

## What I'm doing:
This pull request improves error handling in the primary compaction publishing process and adds a new unit test to ensure robustness against invalid input. The most important changes are:

**Error Handling Improvements:**
* Added a check in `UpdateManager::publish_primary_compaction` (in `update_manager.cpp`) to return an internal error if an input rowset ID specified in the compaction operation cannot be found in the tablet metadata, along with detailed error logging.

**Testing Enhancements:**
* Added a new test case `test_publish_compaction_with_invalid_rowset_id` in `primary_key_compaction_task_test.cpp` to verify that the system correctly identifies and handles cases where a compaction operation references a non-existent rowset ID, ensuring the error is reported as expected.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents invalid memory access during primary-key compaction publish by validating compaction inputs.
> 
> - Add check in `publish_primary_compaction` (in `update_manager.cpp`) to log and return `InternalError` when an input rowset ID is not found in tablet metadata
> - New test `test_publish_compaction_with_invalid_rowset_id` (in `primary_key_compaction_task_test.cpp`) builds a compaction txn with a nonexistent rowset and asserts the error and message
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d92f45e42f86bd005c11801cf06fcbaaf97bd24f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->