### PR TITLE
[BugFix] Fix refresh delta lake table not effective

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/CachingDeltaLakeMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/CachingDeltaLakeMetastore.java
@@ -118,6 +118,9 @@ public class CachingDeltaLakeMetastore extends CachingMetastore implements IDelt
     }
 
     public DeltaLakeSnapshot getCachedSnapshot(DatabaseTableName databaseTableName) {
+        if (ConnectContext.get() != null && ConnectContext.get().getCommand() == MysqlCommand.COM_QUERY) {
+            lastAccessTimeMap.put(databaseTableName, System.currentTimeMillis());
+        }
         return get(tableSnapshotCache, databaseTableName);
     }
 
@@ -137,10 +140,6 @@ public class CachingDeltaLakeMetastore extends CachingMetastore implements IDelt
 
     @Override
     public Table getTable(String dbName, String tableName) {
-        if (ConnectContext.get() != null && ConnectContext.get().getCommand() == MysqlCommand.COM_QUERY) {
-            DatabaseTableName databaseTableName = DatabaseTableName.of(dbName, tableName);
-            lastAccessTimeMap.put(databaseTableName, System.currentTimeMillis());
-        }
         DeltaLakeSnapshot snapshot = getCachedSnapshot(DatabaseTableName.of(dbName, tableName));
         return DeltaUtils.convertDeltaSnapshotToSRTable(getCatalogName(), snapshot);
     }
@@ -160,21 +159,23 @@ public class CachingDeltaLakeMetastore extends CachingMetastore implements IDelt
         DatabaseTableName databaseTableName = DatabaseTableName.of(dbName, tblName);
         tableNameLockMap.putIfAbsent(databaseTableName, dbName + "_" + tblName + "_lock");
         synchronized (tableNameLockMap.get(databaseTableName)) {
-            Table newDeltaLakeTable;
+            DeltaLakeSnapshot newSnapshot;
             try {
-                newDeltaLakeTable = loadTable(databaseTableName);
+                newSnapshot = getLatestSnapshot(dbName, tblName);
             } catch (StarRocksConnectorException e) {
                 Throwable cause = e.getCause();
                 if (cause instanceof InvocationTargetException &&
                         ((InvocationTargetException) cause).getTargetException() instanceof NoSuchObjectException) {
+                    LOG.error("Failed to refresh table {}.{}: table does not exist", dbName, tblName, e);
                     invalidateTable(dbName, tblName);
                     throw new StarRocksConnectorException(e.getMessage() + ", invalidated cache.");
                 } else {
+                    LOG.error("Failed to refresh table {}.{}", dbName, tblName, e);
                     throw e;
                 }
             }
 
-            tableCache.put(databaseTableName, newDeltaLakeTable);
+            tableSnapshotCache.put(databaseTableName, newSnapshot);
         }
     }
 
@@ -197,16 +198,32 @@ public class CachingDeltaLakeMetastore extends CachingMetastore implements IDelt
             }
         }
         refreshTable(dbName, tblName, true);
-        Set<DatabaseTableName> cachedTableName = tableCache.asMap().keySet();
+        Set<DatabaseTableName> cachedTableName = tableSnapshotCache.asMap().keySet();
         lastAccessTimeMap.keySet().retainAll(cachedTableName);
         LOG.info("Refresh table {}.{} in background", dbName, tblName);
     }
 
+    @Override
+    public boolean isTablePresent(DatabaseTableName tableName) {
+        return tableSnapshotCache.getIfPresent(tableName) != null;
+    }
+
+    @Override
     public void invalidateAll() {
         super.invalidateAll();
+        tableSnapshotCache.invalidateAll();
         if (delegate instanceof DeltaLakeMetastore) {
             ((DeltaLakeMetastore) delegate).invalidateAll();
         }
+        lastAccessTimeMap.clear();
+    }
+
+    @Override
+    public synchronized void invalidateTable(String dbName, String tableName) {
+        super.invalidateTable(dbName, tableName);
+        DatabaseTableName databaseTableName = DatabaseTableName.of(dbName, tableName);
+        tableSnapshotCache.invalidate(databaseTableName);
+        lastAccessTimeMap.remove(databaseTableName);
     }
 
     @Override
@@ -215,14 +232,14 @@ public class CachingDeltaLakeMetastore extends CachingMetastore implements IDelt
                 .stream()
                 .limit(MEMORY_META_SAMPLES)
                 .collect(Collectors.toList());
-        List<Object> tableSamples = tableCache.asMap().values()
+        List<Object> tableSamples = tableSnapshotCache.asMap().values()
                 .stream()
                 .limit(MEMORY_META_SAMPLES)
                 .collect(Collectors.toList());
 
         List<Pair<List<Object>, Long>> samples = delegate.getSamples();
         samples.add(Pair.create(dbSamples, databaseCache.size()));
-        samples.add(Pair.create(tableSamples, tableCache.size()));
+        samples.add(Pair.create(tableSamples, tableSnapshotCache.size()));
         return samples;
     }
 
@@ -230,7 +247,7 @@ public class CachingDeltaLakeMetastore extends CachingMetastore implements IDelt
     public Map<String, Long> estimateCount() {
         Map<String, Long> delegateCount = Maps.newHashMap(delegate.estimateCount());
         delegateCount.put("databaseCache", databaseCache.size());
-        delegateCount.put("tableCache", tableCache.size());
+        delegateCount.put("tableCache", tableSnapshotCache.size());
         return delegateCount;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -154,6 +154,9 @@ public class DeltaLakeScanNode extends ScanNode {
             output.append(prefix).append("MIN/MAX PREDICATES: ").append(
                     explainExpr(scanNodePredicates.getMinMaxConjuncts())).append("\n");
         }
+        output.append(prefix).append(String.format("TABLE VERSION: %s",
+                deltaLakeTable.getDeltaSnapshot().getVersion(deltaLakeTable.getDeltaEngine())));
+        output.append("\n");
 
         output.append(prefix).append(String.format("cardinality=%s", cardinality));
         output.append("\n");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/CachingDeltaLakeMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/CachingDeltaLakeMetastoreTest.java
@@ -27,6 +27,8 @@ import com.starrocks.connector.hive.HiveMetastore;
 import com.starrocks.connector.hive.HiveMetastoreTest;
 import com.starrocks.connector.hive.IHiveMetastore;
 import com.starrocks.connector.metastore.MetastoreTable;
+import com.starrocks.mysql.MysqlCommand;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.SemanticException;
 import io.delta.kernel.Operation;
 import io.delta.kernel.Snapshot;
@@ -48,6 +50,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -226,7 +229,7 @@ public class CachingDeltaLakeMetastoreTest {
     public void testRefreshTable() {
         new Expectations(metastore) {
             {
-                metastore.getTable(anyString, "notExistTbl");
+                metastore.getLatestSnapshot(anyString, "notExistTbl");
                 minTimes = 0;
                 Throwable targetException = new NoSuchObjectException("no such obj");
                 Throwable e = new InvocationTargetException(targetException);
@@ -270,6 +273,135 @@ public class CachingDeltaLakeMetastoreTest {
     }
 
     @Test
+    public void testInvalidateAll() {
+        new MockUp<CachingDeltaLakeMetastore>() {
+            @mockit.Mock
+            public DeltaLakeSnapshot getCachedSnapshot(DatabaseTableName databaseTableName) {
+                return new DeltaLakeSnapshot("db1", "table1", null, null,
+                        new MetastoreTable("db1", "table1", "s3://bucket/path/to/table",
+                                123));
+            }
+        };
+
+        new MockUp<DeltaUtils>() {
+            @mockit.Mock
+            public DeltaLakeTable convertDeltaSnapshotToSRTable(String catalog, DeltaLakeSnapshot snapshot) {
+                return new DeltaLakeTable(1, "delta0", "db1", "table1",
+                        Lists.newArrayList(), Lists.newArrayList("ts"), null, null,
+                        new MetastoreTable("db1", "table1", "s3://bucket/path/to/table",
+                                123));
+            }
+        };
+
+        CachingDeltaLakeMetastore cachingDeltaLakeMetastore =
+                CachingDeltaLakeMetastore.createCatalogLevelInstance(metastore, executor, expireAfterWriteSec,
+                        refreshAfterWriteSec, 100);
+
+        // First access to populate cache
+        cachingDeltaLakeMetastore.getTable("db1", "table1");
+        Assertions.assertFalse(cachingDeltaLakeMetastore.estimateCount().isEmpty());
+
+        // Invalidate all
+        cachingDeltaLakeMetastore.invalidateAll();
+
+        // After invalidate all, caches should be cleared
+        Map<String, Long> count = cachingDeltaLakeMetastore.estimateCount();
+        Assertions.assertTrue(count.containsKey("tableCache"));
+        Assertions.assertEquals(0L, count.get("tableCache"));
+    }
+
+    @Test
+    public void testInvalidateTable() {
+        new MockUp<CachingDeltaLakeMetastore>() {
+            @mockit.Mock
+            public DeltaLakeSnapshot getCachedSnapshot(DatabaseTableName databaseTableName) {
+                return new DeltaLakeSnapshot("db1", "table1", null, null,
+                        new MetastoreTable("db1", "table1", "s3://bucket/path/to/table",
+                                123));
+            }
+        };
+
+        new MockUp<DeltaUtils>() {
+            @mockit.Mock
+            public DeltaLakeTable convertDeltaSnapshotToSRTable(String catalog, DeltaLakeSnapshot snapshot) {
+                return new DeltaLakeTable(1, "delta0", "db1", "table1",
+                        Lists.newArrayList(), Lists.newArrayList("ts"), null, null,
+                        new MetastoreTable("db1", "table1", "s3://bucket/path/to/table",
+                                123));
+            }
+        };
+
+        CachingDeltaLakeMetastore cachingDeltaLakeMetastore =
+                CachingDeltaLakeMetastore.createCatalogLevelInstance(metastore, executor, expireAfterWriteSec,
+                        refreshAfterWriteSec, 100);
+
+        // Access table to populate cache
+        Table table = cachingDeltaLakeMetastore.getTable("db1", "table1");
+        Assertions.assertNotNull(table);
+
+        // Invalidate specific table
+        cachingDeltaLakeMetastore.invalidateTable("db1", "table1");
+
+        Map<String, Long> count = cachingDeltaLakeMetastore.estimateCount();
+        Assertions.assertTrue(count.containsKey("tableCache"));
+        Assertions.assertEquals(0L, count.get("tableCache"));
+    }
+
+    @Test
+    public void testGetCachedSnapshot() {
+        new MockUp<ConnectContext>() {
+            @mockit.Mock
+            public static ConnectContext get() {
+                ConnectContext context = new ConnectContext();
+                context.setCommand(MysqlCommand.COM_QUERY);
+                return context;
+            }
+        };
+
+        DeltaLakeSnapshot snapshot = new DeltaLakeSnapshot("db1", "table1", null, null,
+                new MetastoreTable("db1", "table1", "s3://bucket/path/to/table", 123));
+
+        new MockUp<CachingDeltaLakeMetastore>() {
+            @mockit.Mock
+            public DeltaLakeSnapshot getCachedSnapshot(DatabaseTableName databaseTableName) {
+                return snapshot;
+            }
+        };
+
+        CachingDeltaLakeMetastore cachingDeltaLakeMetastore =
+                CachingDeltaLakeMetastore.createCatalogLevelInstance(metastore, executor, expireAfterWriteSec,
+                        refreshAfterWriteSec, 100);
+
+        DeltaLakeSnapshot result = cachingDeltaLakeMetastore.getCachedSnapshot(DatabaseTableName.of("db1", "table1"));
+        Assertions.assertEquals(snapshot, result);
+    }
+
+    @Test
+    public void testRefreshTableUsesSnapshotCache() {
+        DeltaLakeSnapshot snapshot = new DeltaLakeSnapshot("db1", "table1", null, null,
+                new MetastoreTable("db1", "table1", "s3://bucket/path/to/table", 123));
+
+        new MockUp<DeltaLakeMetastore>() {
+            @mockit.Mock
+            public DeltaLakeSnapshot getLatestSnapshot(String dbName, String tableName) {
+                return snapshot;
+            }
+        };
+
+        CachingDeltaLakeMetastore cachingDeltaLakeMetastore =
+                new CachingDeltaLakeMetastore(metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000);
+
+        // This should not throw exception and should use snapshot cache
+        try {
+            cachingDeltaLakeMetastore.refreshTable("db1", "table1", true);
+            // If we reach here, refresh succeeded
+            Assertions.assertTrue(true);
+        } catch (Exception e) {
+            Assertions.fail("Refresh table should succeed");
+        }
+    }
+
+    @Test
     public void testCacheMemoryUsage() {
         new MockUp<CachingDeltaLakeMetastore>() {
             @mockit.Mock
@@ -301,5 +433,35 @@ public class CachingDeltaLakeMetastoreTest {
         Assertions.assertFalse(cachingDeltaLakeMetastore.estimateCount().isEmpty());
         Assertions.assertTrue(cachingDeltaLakeMetastore.estimateCount().containsKey("databaseCache"));
         Assertions.assertTrue(cachingDeltaLakeMetastore.estimateCount().containsKey("tableCache"));
+    }
+
+    @Test
+    public void testInvalidateTableUsesSnapshotCache() {
+        DeltaLakeSnapshot snapshot = new DeltaLakeSnapshot("db1", "table1", null, null,
+                new MetastoreTable("db1", "table1", "s3://bucket/path/to/table", 123));
+
+        new MockUp<DeltaLakeMetastore>() {
+            @mockit.Mock
+            public DeltaLakeSnapshot getLatestSnapshot(String dbName, String tableName) {
+                return snapshot;
+            }
+        };
+
+        CachingDeltaLakeMetastore cachingDeltaLakeMetastore =
+                new CachingDeltaLakeMetastore(metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000);
+
+        // Refresh table to populate snapshot cache
+        cachingDeltaLakeMetastore.refreshTable("db1", "table1", true);
+
+        Map<String, Long> count = cachingDeltaLakeMetastore.estimateCount();
+        Assertions.assertTrue(count.containsKey("tableCache"));
+        Assertions.assertEquals(1L, count.get("tableCache"));
+
+        // Now invalidate the table
+        cachingDeltaLakeMetastore.invalidateTable("db1", "table1");
+
+        count = cachingDeltaLakeMetastore.estimateCount();
+        Assertions.assertTrue(count.containsKey("tableCache"));
+        Assertions.assertEquals(0L, count.get("tableCache"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeCacheUpdateProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeCacheUpdateProcessorTest.java
@@ -73,9 +73,9 @@ public class DeltaLakeCacheUpdateProcessorTest {
             }
         };
 
-        new MockUp<CachingDeltaLakeMetastore>() {
+        new MockUp<DeltaLakeMetastore>() {
             @mockit.Mock
-            public DeltaLakeSnapshot getCachedSnapshot(DatabaseTableName databaseTableName) {
+            public DeltaLakeSnapshot getLatestSnapshot(String dbName, String tableName) {
                 return new DeltaLakeSnapshot("db1", "table1", null, null,
                         new MetastoreTable("db1", "table1", "s3://bucket/path/to/table",
                                 123));
@@ -113,15 +113,6 @@ public class DeltaLakeCacheUpdateProcessorTest {
                 connectContext.getCommand();
                 result = MysqlCommand.COM_QUERY;
                 minTimes = 0;
-            }
-        };
-
-        new MockUp<CachingDeltaLakeMetastore>() {
-            @mockit.Mock
-            public DeltaLakeSnapshot getCachedSnapshot(DatabaseTableName databaseTableName) {
-                return new DeltaLakeSnapshot("db1", "table1", null, null,
-                        new MetastoreTable("db1", "table1", "s3://bucket/path/to/table",
-                                123));
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/DeltaLakeScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/DeltaLakeScanNodeTest.java
@@ -16,16 +16,21 @@ package com.starrocks.planner;
 
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.connector.CatalogConnector;
+import com.starrocks.connector.delta.DeltaLakeEngine;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TExplainLevel;
+import io.delta.kernel.Snapshot;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DeltaLakeScanNodeTest {
     @Test
@@ -80,5 +85,49 @@ public class DeltaLakeScanNodeTest {
         DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(0), desc, "Delta Scan Node");
         Assertions.assertFalse(scanNode.getNodeExplainString("", TExplainLevel.NORMAL).contains("partitions"));
         Assertions.assertTrue(scanNode.getNodeExplainString("", TExplainLevel.VERBOSE).contains("partitions"));
+    }
+
+    @Test
+    public void testNodeExplainContainsVersion(@Mocked GlobalStateMgr globalStateMgr, @Mocked CatalogConnector connector,
+                                               @Mocked DeltaLakeTable table, @Mocked Snapshot snapshot,
+                                               @Mocked DeltaLakeEngine engine) {
+        String catalogName = "delta0";
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.
+                buildCloudConfigurationForStorage(new HashMap<>());
+
+        new Expectations() {{
+                GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalogName);
+                result = connector;
+                minTimes = 0;
+
+                connector.getMetadata().getCloudConfiguration();
+                result = cloudConfiguration;
+                minTimes = 0;
+
+                table.getCatalogName();
+                result = catalogName;
+                minTimes = 0;
+
+                table.getName();
+                result = "table0";
+                minTimes = 0;
+
+                table.getDeltaSnapshot();
+                result = snapshot;
+                minTimes = 0;
+
+                table.getDeltaEngine();
+                result = engine;
+                minTimes = 0;
+
+                snapshot.getVersion(engine);
+                result = 123L;
+                minTimes = 0;
+            }};
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(table);
+        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(0), desc, "Delta Scan Node");
+        String explainString = scanNode.getNodeExplainString("", TExplainLevel.NORMAL);
+        assertThat(explainString, containsString("TABLE VERSION: 123"));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
after refresh delta lake table, still query the old snapshot

## What I'm doing:
This pull request refactors the caching logic for Delta Lake table metadata in the `CachingDeltaLakeMetastore` class, consolidating the use of table snapshot caching, improving cache invalidation methods, and enhancing test coverage. It also adds the table version to the explain output for Delta Lake scan nodes. The most important changes are grouped below:

**Delta Lake Metastore Caching Improvements:**

* Refactored `CachingDeltaLakeMetastore` to use `tableSnapshotCache` consistently instead of the old `tableCache`, updating all related methods and sample/estimate reporting to reference the snapshot cache. This ensures that the cache always reflects the latest table snapshot state. [[1]](diffhunk://#diff-0cb3be4b0dd854881b05e16a521d3d999d2a2b3861607a14223416333c627a50L163-R178) [[2]](diffhunk://#diff-0cb3be4b0dd854881b05e16a521d3d999d2a2b3861607a14223416333c627a50L200-R226) [[3]](diffhunk://#diff-0cb3be4b0dd854881b05e16a521d3d999d2a2b3861607a14223416333c627a50L218-R250)
* Improved cache invalidation logic by overriding and updating `invalidateAll` and `invalidateTable` to clear both the snapshot cache and the access time map, ensuring consistency and preventing stale cache entries.
* Added a new `isTablePresent` method to check for the presence of a table in the snapshot cache.

**Behavioral and Functional Adjustments:**

* Updated the cache access time tracking to only update on `COM_QUERY` commands, ensuring more accurate cache usage statistics. [[1]](diffhunk://#diff-0cb3be4b0dd854881b05e16a521d3d999d2a2b3861607a14223416333c627a50R121-R123) [[2]](diffhunk://#diff-0cb3be4b0dd854881b05e16a521d3d999d2a2b3861607a14223416333c627a50L140-L143)
* Modified the refresh logic to use `getLatestSnapshot` instead of loading the full table, aligning refreshes with the snapshot-based caching strategy.


**Planner and Explain Output:**

* Enhanced the `DeltaLakeScanNode` explain string to include the table version, improving query plan transparency.
* Added a test to verify that the explain output contains the table version.

These changes modernize the caching layer for Delta Lake metadata, improve reliability and maintainability, and provide better observability through both code and tests.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes Delta Lake metadata caching and improves observability.
> 
> - Switches all table metadata caching to `tableSnapshotCache` and updates usages in refresh (`refreshTable` now calls `getLatestSnapshot`), background refresh, samples, and `estimateCount`
> - Refines cache lifecycle: adds `isTablePresent`, updates `invalidateAll`/`invalidateTable` to clear snapshot cache and `lastAccessTimeMap`, and records access time only on `COM_QUERY` in `getCachedSnapshot`
> - Adds error logging on refresh failures and cleans up stale entries during background refresh
> - Enhances `DeltaLakeScanNode` explain output to include `TABLE VERSION`, improving plan transparency
> - Updates and adds unit tests to cover snapshot-based refresh/invalidate paths, access tracking, and explain output
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e243b37be46d3ab5a0e24ce487ef3d04f4f011c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->