### PR TITLE
[Enhancement] Support delete iceberg plan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnector.java
@@ -20,6 +20,7 @@ import com.starrocks.connector.metadata.TableMetaConnector;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -73,5 +74,10 @@ public class CatalogConnector implements Connector {
         } else {
             return normalConnector.getClass().getSimpleName();
         }
+    }
+
+    @Override
+    public Set<OperationType> supportedOperations() {
+        return normalConnector.supportedOperations();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/Connector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/Connector.java
@@ -19,9 +19,11 @@ import com.starrocks.connector.config.ConnectorConfig;
 import com.starrocks.memory.MemoryTrackable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface Connector extends MemoryTrackable {
     /**
@@ -57,5 +59,18 @@ public interface Connector extends MemoryTrackable {
 
     default List<Pair<List<Object>, Long>> getSamples() {
         return new ArrayList<>();
+    }
+
+    /**
+     * Returns the set of operations supported by this connector.
+     * This allows connectors to declare which operations (DELETE, ALTER, etc.) they support.
+     * An empty set means no operations are supported.
+     * To support specific operations, connectors must override this method and return
+     * a set containing the supported OperationType values.
+     *
+     * @return a set of operation types that this connector supports
+     */
+    default Set<OperationType> supportedOperations() {
+        return Collections.emptySet();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/LazyConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/LazyConnector.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class LazyConnector implements Connector {
     private static final Logger LOG = LogManager.getLogger(LazyConnector.class);
@@ -111,5 +112,11 @@ public class LazyConnector implements Connector {
         } else {
             return LazyConnector.class.getSimpleName();
         }
+    }
+
+    @Override
+    public Set<OperationType> supportedOperations() {
+        initIfNeeded();
+        return delegate.supportedOperations();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/OperationType.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import java.util.Set;
+
+/**
+ * Enum for catalog operations to ensure type safety and easy management.
+ * This enum defines the various operations that can be performed on external catalogs.
+ */
+public enum OperationType {
+    /** ALTER operations including add/drop columns, modify table properties */
+    ALTER("ALTER"),
+
+    /** DELETE operations for deleting data from tables */
+    DELETE("DELETE"),
+
+    /** CREATE TABLE LIKE operations */
+    CREATE_TABLE_LIKE("CREATE TABLE LIKE");
+
+    private final String displayName;
+
+    OperationType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     * Get the display name for this operation type.
+     * @return the display name suitable for error messages
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Convert a display name back to an OperationType.
+     * @param displayName the display name to convert
+     * @return the corresponding OperationType or null if not found
+     */
+    public static OperationType fromDisplayName(String displayName) {
+        for (OperationType type : values()) {
+            if (type.displayName.equals(displayName)) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Create a Set from multiple OperationType objects.
+     * @param types the operation types to include in the set
+     * @return an unmodifiable Set containing the specified operation types
+     */
+    public static Set<OperationType> setOf(OperationType... types) {
+        return Set.of(types);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
@@ -18,6 +18,7 @@ import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.OperationType;
 import com.starrocks.connector.RemoteFileIO;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
@@ -26,6 +27,7 @@ import com.starrocks.server.GlobalStateMgr;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public class HiveConnector implements Connector {
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
@@ -96,5 +98,11 @@ public class HiveConnector implements Connector {
         metadataFactory.getCacheUpdateProcessor().ifPresent(HiveCacheUpdateProcessor::invalidateAll);
         GlobalStateMgr.getCurrentState().getMetastoreEventsProcessor().unRegisterCacheUpdateProcessor(catalogName);
         GlobalStateMgr.getCurrentState().getConnectorTableMetadataProcessor().unRegisterCacheUpdateProcessor(catalogNameType);
+    }
+
+    @Override
+    public Set<OperationType> supportedOperations() {
+        // Hive connector supports ALTER operations
+        return OperationType.setOf(OperationType.ALTER);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnector.java
@@ -19,6 +19,7 @@ import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.OperationType;
 import com.starrocks.connector.RemoteFileIO;
 import com.starrocks.connector.hive.CatalogNameType;
 import com.starrocks.connector.hive.IHiveMetastore;
@@ -28,6 +29,7 @@ import com.starrocks.server.GlobalStateMgr;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class HudiConnector implements Connector {
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
@@ -78,5 +80,11 @@ public class HudiConnector implements Connector {
     public void shutdown() {
         internalMgr.shutdown();
         GlobalStateMgr.getCurrentState().getConnectorTableMetadataProcessor().unRegisterCacheUpdateProcessor(catalogNameType);
+    }
+
+    @Override
+    public Set<OperationType> supportedOperations() {
+        // Hudi connector supports ALTER operations
+        return OperationType.setOf(OperationType.ALTER);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -22,6 +22,7 @@ import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.OperationType;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.glue.IcebergGlueCatalog;
 import com.starrocks.connector.iceberg.hadoop.IcebergHadoopCatalog;
@@ -41,6 +42,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ICEBERG_CATALOG_TYPE;
@@ -172,5 +174,11 @@ public class IcebergConnector implements Connector {
     @Override
     public List<Pair<List<Object>, Long>> getSamples() {
         return icebergNativeCatalog.getSamples();
+    }
+
+    @Override
+    public Set<OperationType> supportedOperations() {
+        // Iceberg connector supports ALTER and DELETE operations
+        return OperationType.setOf(OperationType.ALTER, OperationType.DELETE);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -16,7 +16,13 @@ package com.starrocks.connector.iceberg;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.connector.CatalogConnector;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudConfigurationFactory;
+import com.starrocks.credential.CloudType;
 import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TExprMinMaxValue;
 import com.starrocks.thrift.TExprNodeType;
 import org.apache.iceberg.Schema;
@@ -194,5 +200,34 @@ public final class IcebergUtil {
         String tableLocation = table.location();
         return table.properties().getOrDefault(TableProperties.WRITE_DATA_LOCATION,
                 String.format("%s/data", LocationUtil.stripTrailingSlash(tableLocation)));
+    }
+
+    public static CloudConfiguration getVendedCloudConfiguration(String catalogName, IcebergTable icebergTable) {
+        CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalogName);
+        Preconditions.checkState(connector != null,
+                String.format("connector of catalog %s should not be null", catalogName));
+
+        // Try to get vended credentials from loadTable response
+        CloudConfiguration vendedCredentialsCloudConfiguration = CloudConfigurationFactory.
+                buildCloudConfigurationForVendedCredentials(icebergTable.getNativeTable().io().properties(),
+                        icebergTable.getNativeTable().location());
+        if (vendedCredentialsCloudConfiguration.getCloudType() != CloudType.DEFAULT) {
+            return vendedCredentialsCloudConfiguration;
+        }
+        
+        // Try to get credentials from catalog config (/v1/config response).
+        // This is used as fallback when STS is unavailable (e.g., Apache Polaris without STS).
+        CloudConfiguration catalogConfigCloudConfiguration = CloudConfigurationFactory.
+                buildCloudConfigurationForVendedCredentials(connector.getMetadata().getCatalogProperties(),
+                        icebergTable.getNativeTable().location());
+        if (catalogConfigCloudConfiguration.getCloudType() != CloudType.DEFAULT) {
+            return catalogConfigCloudConfiguration;
+        }
+
+        // Fall back to user-provided catalog credentials
+        CloudConfiguration cloudConfiguration = connector.getMetadata().getCloudConfiguration();
+        Preconditions.checkState(cloudConfiguration != null,
+                String.format("cloudConfiguration of catalog %s should not be null", catalogName));
+        return cloudConfiguration;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -32,6 +32,7 @@ import com.starrocks.connector.iceberg.IcebergGetRemoteFilesParams;
 import com.starrocks.connector.iceberg.IcebergMORParams;
 import com.starrocks.connector.iceberg.IcebergRemoteSourceTrigger;
 import com.starrocks.connector.iceberg.IcebergTableMORParams;
+import com.starrocks.connector.iceberg.IcebergUtil;
 import com.starrocks.connector.iceberg.QueueIcebergRemoteFileInfoSource;
 import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.credential.CloudConfiguration;
@@ -197,33 +198,7 @@ public class IcebergScanNode extends ScanNode {
             return;
         }
 
-        // Try to get vended credentials from loadTable response
-        CloudConfiguration vendedCredentialsCloudConfiguration = CloudConfigurationFactory.
-                buildCloudConfigurationForVendedCredentials(icebergTable.getNativeTable().io().properties(),
-                        icebergTable.getNativeTable().location());
-        if (vendedCredentialsCloudConfiguration.getCloudType() != CloudType.DEFAULT) {
-            cloudConfiguration = vendedCredentialsCloudConfiguration;
-            return;
-        }
-
-        CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalogName);
-        Preconditions.checkState(connector != null,
-                String.format("connector of catalog %s should not be null", catalogName));
-
-        // Try to get credentials from catalog config (/v1/config response).
-        // This is used as fallback when STS is unavailable (e.g., Apache Polaris without STS).
-        CloudConfiguration catalogConfigCloudConfiguration = CloudConfigurationFactory.
-                buildCloudConfigurationForVendedCredentials(connector.getMetadata().getCatalogProperties(),
-                        icebergTable.getNativeTable().location());
-        if (catalogConfigCloudConfiguration.getCloudType() != CloudType.DEFAULT) {
-            cloudConfiguration = catalogConfigCloudConfiguration;
-            return;
-        }
-
-        // Fall back to user-provided catalog credentials
-        cloudConfiguration = connector.getMetadata().getCloudConfiguration();
-        Preconditions.checkState(cloudConfiguration != null,
-                String.format("cloudConfiguration of catalog %s should not be null", catalogName));
+        cloudConfiguration = IcebergUtil.getVendedCloudConfiguration(catalogName, icebergTable);
     }
 
     public void setCloudConfiguration(CloudConfiguration cloudConfiguration) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -14,9 +14,11 @@
 
 package com.starrocks.sql;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.TableName;
@@ -25,6 +27,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.load.Load;
 import com.starrocks.planner.DataSink;
 import com.starrocks.planner.DescriptorTable;
+import com.starrocks.planner.IcebergDeleteSink;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.SlotDescriptor;
@@ -34,12 +37,17 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Optimizer;
 import com.starrocks.sql.optimizer.OptimizerFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.DistributionProperty;
+import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.plan.ExecPlan;
@@ -56,15 +64,62 @@ public class DeletePlanner {
             // so just return empty plan here
             return null;
         }
+
+        return planDelete(deleteStatement, session);
+    }
+
+    /**
+     * Main method to plan delete operations for different table types
+     */
+    private ExecPlan planDelete(DeleteStmt deleteStatement, ConnectContext session) {
+        // Get table to determine delete strategy
+        com.starrocks.catalog.Table table = deleteStatement.getTable();
+
+        // Transform logical plan
         QueryRelation query = deleteStatement.getQueryStatement().getQueryRelation();
         List<String> colNames = query.getColumnOutputNames();
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
         LogicalPlan logicalPlan = new RelationTransformer(columnRefFactory, session).transform(query);
 
+        // Determine physical properties based on table type
+        PhysicalPropertySet requiredProperty;
+        if (table instanceof IcebergTable) {
+            // For Iceberg, create shuffled property based on partitioning
+            List<ColumnRefOperator> outputColumns = logicalPlan.getOutputColumn();
+            requiredProperty = createShuffleProperty((IcebergTable) table, outputColumns);
+        } else {
+            // For other tables, use default empty property
+            requiredProperty = new PhysicalPropertySet();
+        }
+
+        // Optimize logical plan, create physical plan, setup sink and configure pipeline
+        return createDeletePlan(
+                deleteStatement,
+                logicalPlan,
+                columnRefFactory,
+                session,
+                requiredProperty,
+                colNames,
+                table
+        );
+    }
+
+    /**
+     * Creates complete delete plan including optimization, sink setup and pipeline configuration
+     */
+    private ExecPlan createDeletePlan(
+            DeleteStmt deleteStatement,
+            LogicalPlan logicalPlan,
+            ColumnRefFactory columnRefFactory,
+            ConnectContext session,
+            PhysicalPropertySet requiredProperty,
+            List<String> colNames,
+            com.starrocks.catalog.Table table) {
         // TODO: remove forceDisablePipeline when all the operators support pipeline engine.
         boolean isEnablePipeline = session.getSessionVariable().isEnablePipelineEngine();
-        boolean canUsePipeline = isEnablePipeline && DataSink.canTableSinkUsePipeline(deleteStatement.getTable());
+        boolean canUsePipeline = isEnablePipeline && DataSink.canTableSinkUsePipeline(table);
         boolean forceDisablePipeline = isEnablePipeline && !canUsePipeline;
+
         boolean prevIsEnableLocalShuffleAgg = session.getSessionVariable().isEnableLocalShuffleAgg();
         try {
             if (forceDisablePipeline) {
@@ -73,83 +128,183 @@ public class DeletePlanner {
             // Non-query must use the strategy assign scan ranges per driver sequence, which local shuffle agg cannot use.
             session.getSessionVariable().setEnableLocalShuffleAgg(false);
 
+            // Optimize logical plan and create physical plan
             Optimizer optimizer = OptimizerFactory.create(OptimizerFactory.initContext(session, columnRefFactory));
             OptExpression optimizedPlan = optimizer.optimize(
                     logicalPlan.getRoot(),
-                    new PhysicalPropertySet(),
+                    requiredProperty,
                     new ColumnRefSet(logicalPlan.getOutputColumn()));
             ExecPlan execPlan = PlanFragmentBuilder.createPhysicalPlan(optimizedPlan, session,
                     logicalPlan.getOutputColumn(), columnRefFactory,
                     colNames, TResultSinkType.MYSQL_PROTOCAL, false);
-            DescriptorTable descriptorTable = execPlan.getDescTbl();
-            TupleDescriptor olapTuple = descriptorTable.createTupleDescriptor();
 
-            OlapTable table = (OlapTable) deleteStatement.getTable();
-            for (Column column : table.getBaseSchema()) {
-                if (column.isKey() || column.isNameWithPrefix(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)) {
-                    SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
-                    slotDescriptor.setIsMaterialized(true);
-                    slotDescriptor.setType(column.getType());
-                    slotDescriptor.setColumn(column);
-                    slotDescriptor.setIsNullable(column.isAllowNull());
-                } else {
-                    continue;
-                }
-            }
-            SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
-            slotDescriptor.setIsMaterialized(true);
-            slotDescriptor.setType(IntegerType.TINYINT);
-            slotDescriptor.setColumn(new Column(Load.LOAD_OP_COLUMN, IntegerType.TINYINT));
-            slotDescriptor.setIsNullable(false);
-            olapTuple.computeMemLayout();
-
-            List<Long> partitionIds = Lists.newArrayList();
-            for (Partition partition : table.getPartitions()) {
-                partitionIds.add(partition.getId());
-            }
-            DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds, table.writeQuorum(),
-                    table.enableReplicatedStorage(), false, false,
-                    session.getCurrentComputeResource());
-            execPlan.getFragments().get(0).setSink(dataSink);
-            if (session.getTxnId() != 0) {
-                ((OlapTableSink) dataSink).setIsMultiStatementsTxn(true);
-            }
-
-            // if sink is OlapTableSink Assigned to Be execute this sql [cn execute OlapTableSink will crash]
-            session.getSessionVariable().setPreferComputeNode(false);
-            session.getSessionVariable().setUseComputeNodes(0);
-            OlapTableSink olapTableSink = (OlapTableSink) dataSink;
-            TableName catalogDbTable = deleteStatement.getTableName();
-            Database db = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                    .getDb(session, catalogDbTable.getCatalog(), catalogDbTable.getDb());
-            try {
-                olapTableSink.init(session.getExecutionId(), deleteStatement.getTxnId(), db.getId(), session.getExecTimeout());
-                olapTableSink.complete();
-            } catch (StarRocksException e) {
-                throw new SemanticException(e.getMessage());
-            }
-
-            if (canUsePipeline) {
-                PlanFragment sinkFragment = execPlan.getFragments().get(0);
-                if (session.getSessionVariable().getEnableAdaptiveSinkDop()) {
-                    long warehouseId = session.getCurrentComputeResource().getWarehouseId();
-                    sinkFragment.setPipelineDop(session.getSessionVariable().getSinkDegreeOfParallelism(warehouseId));
-                } else {
-                    sinkFragment.setPipelineDop(session.getSessionVariable().getParallelExecInstanceNum());
-                }
-                sinkFragment.setHasOlapTableSink();
-                sinkFragment.setForceSetTableSinkDop();
-                sinkFragment.setForceAssignScanRangesPerDriverSeq();
-                sinkFragment.disableRuntimeAdaptiveDop();
+            // Create sink based on table type
+            if (table instanceof IcebergTable) {
+                setupIcebergDeleteSink(execPlan, colNames, (IcebergTable) table, session);
+            } else if (table instanceof OlapTable) {
+                setupOlapTableSink(execPlan, deleteStatement, session);
             } else {
-                execPlan.getFragments().get(0).setPipelineDop(1);
+                throw new SemanticException("Unsupported table type for delete: " + table.getType());
             }
+
+            // Configure pipeline for the sink
+            configurePipelineSink(execPlan, session, table, canUsePipeline);
+
             return execPlan;
         } finally {
             session.getSessionVariable().setEnableLocalShuffleAgg(prevIsEnableLocalShuffleAgg);
             if (forceDisablePipeline) {
                 session.getSessionVariable().setEnablePipelineEngine(true);
             }
+        }
+    }
+
+    /**
+     *
+     * @param icebergTable  The Iceberg table
+     * @param outputColumns Output columns from the logical plan (includes virtual columns + partition columns)
+     * @return PhysicalPropertySet with shuffle requirement or empty property
+     */
+    private PhysicalPropertySet createShuffleProperty(IcebergTable icebergTable,
+                                                      List<ColumnRefOperator> outputColumns) {
+        // Check if table is partitioned
+        if (!icebergTable.isPartitioned()) {
+            // No shuffle for non-partitioned tables
+            return new PhysicalPropertySet();
+        }
+
+        List<String> partitionColNames = icebergTable.getPartitionColumnNames();
+        List<Integer> partitionColumnIDs = Lists.newArrayList();
+        for (String partCol : partitionColNames) {
+            boolean found = false;
+            for (ColumnRefOperator outputCol : outputColumns) {
+                if (outputCol.getName().equalsIgnoreCase(partCol)) {
+                    found = true;
+                    partitionColumnIDs.add(outputCol.getId());
+                    break;
+                }
+            }
+            if (!found) {
+                // Partition column not in output, cannot shuffle
+                return new PhysicalPropertySet();
+            }
+        }
+
+        // Create HASH distribution spec
+        HashDistributionDesc distributionDesc = new HashDistributionDesc(
+                partitionColumnIDs,
+                HashDistributionDesc.SourceType.SHUFFLE_AGG
+        );
+
+        DistributionProperty distributionProperty = DistributionProperty.createProperty(
+                DistributionSpec.createHashDistributionSpec(distributionDesc));
+
+        return new PhysicalPropertySet(distributionProperty);
+    }
+
+    /**
+     * Sets up OLAP table sink for delete operations
+     */
+    private void setupOlapTableSink(ExecPlan execPlan, DeleteStmt deleteStatement, ConnectContext session) {
+        DescriptorTable descriptorTable = execPlan.getDescTbl();
+        TupleDescriptor olapTuple = descriptorTable.createTupleDescriptor();
+
+        OlapTable table = (OlapTable) deleteStatement.getTable();
+        for (Column column : table.getBaseSchema()) {
+            if (column.isKey() || column.isNameWithPrefix(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)) {
+                SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
+                slotDescriptor.setIsMaterialized(true);
+                slotDescriptor.setType(column.getType());
+                slotDescriptor.setColumn(column);
+                slotDescriptor.setIsNullable(column.isAllowNull());
+            }
+        }
+        SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);
+        slotDescriptor.setIsMaterialized(true);
+        slotDescriptor.setType(IntegerType.TINYINT);
+        slotDescriptor.setColumn(new Column(Load.LOAD_OP_COLUMN, IntegerType.TINYINT));
+        slotDescriptor.setIsNullable(false);
+        olapTuple.computeMemLayout();
+
+        List<Long> partitionIds = Lists.newArrayList();
+        for (Partition partition : table.getPartitions()) {
+            partitionIds.add(partition.getId());
+        }
+        DataSink dataSink = new OlapTableSink(table, olapTuple, partitionIds, table.writeQuorum(),
+                table.enableReplicatedStorage(), false, false,
+                session.getCurrentComputeResource());
+        execPlan.getFragments().get(0).setSink(dataSink);
+        if (session.getTxnId() != 0) {
+            ((OlapTableSink) dataSink).setIsMultiStatementsTxn(true);
+        }
+
+        // if sink is OlapTableSink Assigned to Be execute this sql [cn execute OlapTableSink will crash]
+        session.getSessionVariable().setPreferComputeNode(false);
+        session.getSessionVariable().setUseComputeNodes(0);
+        OlapTableSink olapTableSink = (OlapTableSink) dataSink;
+        TableName catalogDbTable = deleteStatement.getTableName();
+        Database db = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getDb(session, catalogDbTable.getCatalog(), catalogDbTable.getDb());
+        try {
+            olapTableSink.init(session.getExecutionId(), deleteStatement.getTxnId(), db.getId(),
+                    session.getExecTimeout());
+            olapTableSink.complete();
+        } catch (StarRocksException e) {
+            throw new SemanticException(e.getMessage());
+        }
+    }
+
+    /**
+     * Sets up Iceberg delete sink for delete operations
+     */
+    private void setupIcebergDeleteSink(ExecPlan execPlan, List<String> colNames,
+                                        IcebergTable icebergTable, ConnectContext session) {
+        DescriptorTable descriptorTable = execPlan.getDescTbl();
+        TupleDescriptor mergeTuple = descriptorTable.createTupleDescriptor();
+
+        List<Expr> outputExprs = execPlan.getOutputExprs();
+        Preconditions.checkArgument(colNames.size() == outputExprs.size(),
+                "output column size mismatch");
+        for (int index = 0; index < colNames.size(); ++index) {
+            SlotDescriptor slot = descriptorTable.addSlotDescriptor(mergeTuple);
+            slot.setIsMaterialized(true);
+            slot.setType(outputExprs.get(index).getType());
+            slot.setColumn(new Column(colNames.get(index), outputExprs.get(index).getType()));
+            slot.setIsNullable(outputExprs.get(index).isNullable());
+        }
+        mergeTuple.computeMemLayout();
+
+        // Initialize IcebergDeleteSink
+        descriptorTable.addReferencedTable(icebergTable);
+        DataSink dataSink = new IcebergDeleteSink(
+                icebergTable,
+                mergeTuple,
+                session.getSessionVariable()
+        );
+        execPlan.getFragments().get(0).setSink(dataSink);
+    }
+
+    /**
+     * Configures pipeline for sink fragment
+     */
+    private void configurePipelineSink(ExecPlan execPlan, ConnectContext session,
+                                       com.starrocks.catalog.Table table, boolean canUsePipeline) {
+        PlanFragment sinkFragment = execPlan.getFragments().get(0);
+        if (canUsePipeline) {
+            if (session.getSessionVariable().getEnableAdaptiveSinkDop()) {
+                long warehouseId = session.getCurrentComputeResource().getWarehouseId();
+                sinkFragment.setPipelineDop(session.getSessionVariable().getSinkDegreeOfParallelism(warehouseId));
+            } else {
+                sinkFragment.setPipelineDop(session.getSessionVariable().getParallelExecInstanceNum());
+            }
+            sinkFragment.setForceSetTableSinkDop();
+            sinkFragment.setForceAssignScanRangesPerDriverSeq();
+            sinkFragment.disableRuntimeAdaptiveDop();
+            if (table instanceof OlapTable) {
+                sinkFragment.setHasOlapTableSink();
+            }
+        } else {
+            execPlan.getFragments().get(0).setPipelineDop(1);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.connector.OperationType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterClause;
@@ -41,7 +42,7 @@ public class AlterTableStatementAnalyzer {
     public static void analyze(AlterTableStmt statement, ConnectContext context) {
         TableName tbl = statement.getTbl();
         tbl.normalization(context);
-        MetaUtils.checkNotSupportCatalog(tbl.getCatalog(), "ALTER");
+        MetaUtils.checkNotSupportCatalog(tbl.getCatalog(), OperationType.ALTER);
 
         List<AlterClause> alterClauseList = statement.getAlterClauseList();
         if (alterClauseList == null || alterClauseList.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableLikeAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableLikeAnalyzer.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.connector.OperationType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
@@ -40,7 +41,7 @@ public class CreateTableLikeAnalyzer {
         String tableName = stmt.getTableName();
         FeNameFormat.checkTableName(tableName);
 
-        MetaUtils.checkNotSupportCatalog(existedDbTbl.getCatalog(), "CREATE TABLE LIKE");
+        MetaUtils.checkNotSupportCatalog(existedDbTbl.getCatalog(), OperationType.CREATE_TABLE_LIKE);
         Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, existedDbTbl.getCatalog(),
                 existedDbTbl.getDb(), existedDbTbl.getTbl());
         if (table == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DeleteAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DeleteAnalyzer.java
@@ -18,12 +18,14 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.connector.OperationType;
 import com.starrocks.load.Load;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -194,11 +196,72 @@ public class DeleteAnalyzer {
         properties.put(LoadStmt.TIMEOUT_PROPERTY, String.valueOf(session.getSessionVariable().getInsertTimeoutS()));
     }
 
+    /**
+     * Analyze Iceberg table delete statement.
+     * For Iceberg delete, we convert:
+     *   DELETE FROM table WHERE condition
+     * to:
+     *   INSERT INTO iceberg_delete_sink
+     *   SELECT _file, _pos FROM table WHERE condition
+     */
+    private static void analyzeIcebergTable(DeleteStmt deleteStatement, Table table, ConnectContext session) {
+        deleteStatement.setTable(table);
+
+        if (deleteStatement.getWherePredicate() == null) {
+            throw new SemanticException("Delete must specify where clause to prevent full table delete");
+        }
+        if (deleteStatement.getPartitionNames() != null) {
+            throw new SemanticException("Delete for Iceberg table do not support specifying partitions",
+                    deleteStatement.getPartitionNames().getPos());
+        }
+        if (deleteStatement.getUsingRelations() != null) {
+            throw new SemanticException("Delete for Iceberg table do not support `using` clause");
+        }
+        if (deleteStatement.getCommonTableExpressions() != null) {
+            throw new SemanticException("Delete for Iceberg table do not support `with` clause");
+        }
+
+        // Create select list: SELECT _file, _pos, partition_col1, partition_col2, ...
+        SelectList selectList = new SelectList();
+        // Add _file column
+        SlotRef filePathColumn = new SlotRef(deleteStatement.getTableName(), IcebergTable.FILE_PATH);
+        selectList.addItem(new SelectListItem(filePathColumn, IcebergTable.FILE_PATH));
+
+        // Add _pos column
+        SlotRef posColumn = new SlotRef(deleteStatement.getTableName(), IcebergTable.ROW_POSITION);
+        selectList.addItem(new SelectListItem(posColumn, IcebergTable.ROW_POSITION));
+
+        // Add partition columns for shuffle
+        List<Column> partitionColumns = table.getPartitionColumns();
+        for (Column partitionCol : partitionColumns) {
+            SlotRef partitionColumnRef = new SlotRef(deleteStatement.getTableName(), partitionCol.getName());
+            selectList.addItem(new SelectListItem(partitionColumnRef, partitionCol.getName()));
+        }
+
+        // Create table relation with WHERE predicate
+        TableRelation tableRelation = new TableRelation(deleteStatement.getTableName());
+        SelectRelation selectRelation = new SelectRelation(
+                selectList,
+                tableRelation,
+                deleteStatement.getWherePredicate(),
+                null,
+                null
+        );
+
+        // Create query statement
+        QueryStatement queryStatement = new QueryStatement(selectRelation);
+        queryStatement.setIsExplain(deleteStatement.isExplain(), deleteStatement.getExplainLevel());
+
+        // Analyze the query statement
+        new QueryAnalyzer(session).analyze(queryStatement);
+        deleteStatement.setQueryStatement(queryStatement);
+    }
+
     public static void analyze(DeleteStmt deleteStatement, ConnectContext session) {
         analyzeProperties(deleteStatement, session);
 
         TableName tableName = deleteStatement.getTableName();
-        MetaUtils.checkNotSupportCatalog(tableName.getCatalog(), "DELETE");
+        MetaUtils.checkNotSupportCatalog(tableName.getCatalog(), OperationType.DELETE);
         Database db = GlobalStateMgr.getCurrentState().getMetadataMgr()
                 .getDb(session, tableName.getCatalog(), tableName.getDb());
         if (db == null) {
@@ -210,6 +273,12 @@ public class DeleteAnalyzer {
             String msg = String.format("The data of '%s' cannot be deleted because it is a materialized view," +
                     "and the data of materialized view must be consistent with the base table.", tableName.getTbl());
             throw new SemanticException(msg, tableName.getPos());
+        }
+
+        // Handle Iceberg table delete
+        if (table instanceof IcebergTable) {
+            analyzeIcebergTable(deleteStatement, table, session);
+            return;
         }
 
         if (!(table instanceof OlapTable && ((OlapTable) table).getKeysType() == KeysType.PRIMARY_KEYS)) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -155,6 +155,12 @@ public class MockIcebergMetadata implements ConnectorMetadata {
                 new Column("data", StringType.STRING, true),
                 new Column("date", StringType.STRING, true));
 
+        ImmutableList.Builder<Column> builder = ImmutableList.builder();
+        builder.addAll(schemas);
+        builder.add(new Column(IcebergTable.FILE_PATH, StringType.STRING, true));
+        builder.add(new Column(IcebergTable.ROW_POSITION, IntegerType.BIGINT, true));
+        schemas = builder.build();
+
         Schema schema =
                 new Schema(required(3, "id", Types.IntegerType.get()),
                         required(4, "data", Types.StringType.get()),
@@ -187,6 +193,12 @@ public class MockIcebergMetadata implements ConnectorMetadata {
 
         for (String tblName : PARTITION_TABLE_NAMES) {
             List<Column> columns = getPartitionedTableSchema(tblName);
+            ImmutableList.Builder<Column> builder = ImmutableList.builder();
+            builder.addAll(columns);
+            builder.add(new Column(IcebergTable.FILE_PATH, StringType.STRING, true));
+            builder.add(new Column(IcebergTable.ROW_POSITION, IntegerType.BIGINT, true));
+            columns = builder.build();
+
             MockIcebergTable icebergTable = getPartitionIcebergTable(tblName, columns);
             Map<String, ColumnStatistic> columnStatisticMap;
             List<String> colNames = columns.stream().map(Column::getName).collect(Collectors.toList());

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergDeleteSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergDeleteSinkTest.java
@@ -1,0 +1,181 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.connector.iceberg.IcebergUtil;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.thrift.TDataSink;
+import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TIcebergTableSink;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.*;
+
+public class IcebergDeleteSinkTest {
+
+    private MockedStatic<IcebergUtil> mockedIcebergUtil;
+
+    @BeforeEach
+    public void setUp() {
+        // Mock the static method
+        mockedIcebergUtil = mockStatic(IcebergUtil.class);
+        CloudConfiguration mockCloudConfig = mock(CloudConfiguration.class);
+
+        // Mock toThrift method to avoid NPE during test
+        doAnswer(invocation -> {
+            com.starrocks.thrift.TCloudConfiguration tConfig = invocation.getArgument(0);
+            tConfig.setCloud_type(com.starrocks.thrift.TCloudType.AWS);
+            return null;
+        }).when(mockCloudConfig).toThrift(any(com.starrocks.thrift.TCloudConfiguration.class));
+
+        when(IcebergUtil.getVendedCloudConfiguration(anyString(), any(IcebergTable.class)))
+                .thenReturn(mockCloudConfig);
+        when(IcebergUtil.getVendedCloudConfiguration(isNull(), any(IcebergTable.class)))
+                .thenReturn(mockCloudConfig);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        // Close the static mock
+        if (mockedIcebergUtil != null) {
+            mockedIcebergUtil.close();
+        }
+    }
+
+    @Test
+    public void testValidDeleteTuple() {
+        // Create a valid tuple descriptor with _file and _pos columns
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0), "DeleteTuple");
+
+        // Add _file column (STRING type)
+        Column fileColumn = new Column(IcebergTable.FILE_PATH, VarcharType.VARCHAR);
+        SlotDescriptor fileSlot = new SlotDescriptor(new SlotId(0), desc);
+        fileSlot.setColumn(fileColumn);
+        desc.addSlot(fileSlot);
+
+        // Add _pos column (BIGINT type)
+        Column posColumn = new Column(IcebergTable.ROW_POSITION, IntegerType.BIGINT);
+        SlotDescriptor posSlot = new SlotDescriptor(new SlotId(1), desc);
+        posSlot.setColumn(posColumn);
+        desc.addSlot(posSlot);
+
+        // Mock IcebergTable
+        IcebergTable icebergTable = mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTable = mock(org.apache.iceberg.Table.class);
+        when(icebergTable.getNativeTable()).thenReturn(nativeTable);
+        when(nativeTable.location()).thenReturn("/tmp/iceberg");
+
+        // Should not throw exception
+        IcebergDeleteSink sink = new IcebergDeleteSink(icebergTable, desc, new SessionVariable());
+        assertNotNull(sink);
+    }
+
+    @Test
+    public void testMissingFileColumn() {
+        // Create a tuple descriptor without _file column
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0), "DeleteTuple");
+
+        // Add only _pos column
+        Column posColumn = new Column(IcebergTable.ROW_POSITION, IntegerType.BIGINT);
+        SlotDescriptor posSlot = new SlotDescriptor(new SlotId(0), desc);
+        posSlot.setColumn(posColumn);
+        desc.addSlot(posSlot);
+
+        // Mock IcebergTable
+        IcebergTable icebergTable = mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTable = mock(org.apache.iceberg.Table.class);
+        when(icebergTable.getNativeTable()).thenReturn(nativeTable);
+        when(nativeTable.location()).thenReturn("/tmp/iceberg");
+
+        // Should throw exception
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> new IcebergDeleteSink(icebergTable, desc, new SessionVariable()));
+        assertTrue(exception.getMessage().contains("_file"));
+    }
+
+    @Test
+    public void testThriftSerialization() {
+        // Create a valid tuple descriptor
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0), "DeleteTuple");
+
+        Column fileColumn = new Column(IcebergTable.FILE_PATH, VarcharType.VARCHAR);
+        SlotDescriptor fileSlot = new SlotDescriptor(new SlotId(0), desc);
+        fileSlot.setColumn(fileColumn);
+        desc.addSlot(fileSlot);
+
+        Column posColumn = new Column(IcebergTable.ROW_POSITION, IntegerType.BIGINT);
+        SlotDescriptor posSlot = new SlotDescriptor(new SlotId(1), desc);
+        posSlot.setColumn(posColumn);
+        desc.addSlot(posSlot);
+
+        // Mock IcebergTable
+        IcebergTable icebergTable = mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTable = mock(org.apache.iceberg.Table.class);
+        when(icebergTable.getNativeTable()).thenReturn(nativeTable);
+        when(nativeTable.location()).thenReturn("hdfs://localhost:9000/iceberg");
+        when(icebergTable.getUUID()).thenReturn("iceberg_catalog.db.table");
+
+        IcebergDeleteSink sink = new IcebergDeleteSink(icebergTable, desc, new SessionVariable());
+
+        // Check thrift serialization
+        TDataSink tDataSink = sink.toThrift();
+        assertNotNull(tDataSink);
+        assertTrue(tDataSink.isSetIceberg_table_sink());
+
+        TIcebergTableSink icebergSink = tDataSink.getIceberg_table_sink();
+        assertEquals("hdfs://localhost:9000/iceberg", icebergSink.getLocation());
+        assertEquals("parquet", icebergSink.getFile_format());
+        assertFalse(icebergSink.isIs_static_partition_sink());
+    }
+
+    @Test
+    public void testGetExplainString() {
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0), "DeleteTuple");
+
+        Column fileColumn = new Column(IcebergTable.FILE_PATH, VarcharType.VARCHAR);
+        SlotDescriptor fileSlot = new SlotDescriptor(new SlotId(0), desc);
+        fileSlot.setColumn(fileColumn);
+        desc.addSlot(fileSlot);
+
+        Column posColumn = new Column(IcebergTable.ROW_POSITION, IntegerType.BIGINT);
+        SlotDescriptor posSlot = new SlotDescriptor(new SlotId(1), desc);
+        posSlot.setColumn(posColumn);
+        desc.addSlot(posSlot);
+
+        // Mock IcebergTable
+        IcebergTable icebergTable = mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTable = mock(org.apache.iceberg.Table.class);
+        when(icebergTable.getNativeTable()).thenReturn(nativeTable);
+        when(nativeTable.location()).thenReturn("/tmp/iceberg");
+        when(icebergTable.getUUID()).thenReturn("iceberg_catalog.db.table");
+
+        IcebergDeleteSink sink = new IcebergDeleteSink(icebergTable, desc, new SessionVariable());
+
+        String explainString = sink.getExplainString("", TExplainLevel.NORMAL);
+        assertTrue(explainString.contains("ICEBERG DELETE SINK"));
+        assertTrue(explainString.contains("iceberg_catalog.db.table"));
+        assertTrue(explainString.contains("/tmp/iceberg"));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -1325,6 +1325,8 @@ public class IcebergScanNodeTest {
 
     @Test
     public void testSetupCloudCredentialVendedCredentialsPriority(
+            @Mocked GlobalStateMgr globalStateMgr,
+            @Mocked CatalogConnector connector,
             @Mocked IcebergTable table,
             @Mocked org.apache.iceberg.Table nativeTable,
             @Mocked org.apache.iceberg.io.FileIO fileIO,
@@ -1338,6 +1340,10 @@ public class IcebergScanNodeTest {
         vendedCredentials.put("client.region", "eu-west-1");
 
         new Expectations() {{
+            GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalogName);
+            result = connector;
+            minTimes = 0;
+
             table.getCatalogName();
             result = catalogName;
             minTimes = 0;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DeleteAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DeleteAnalyzerTest.java
@@ -1,0 +1,160 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.DeleteStmt;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+
+import static com.starrocks.sql.plan.ConnectorPlanTestBase.newFolder;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DeleteAnalyzerTest {
+
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @TempDir
+    public static File temp;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+        ConnectorPlanTestBase.mockAllCatalogs(connectContext, newFolder(temp, "junit").toURI().toString());
+    }
+
+    @Test
+    public void testIcebergDeleteBasic() {
+        String sql = "DELETE FROM iceberg0.unpartitioned_db.t0 WHERE id = 1";
+        DeleteStmt deleteStmt = (DeleteStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        assertDoesNotThrow(() -> DeleteAnalyzer.analyze(deleteStmt, connectContext));
+
+        assertNotNull(deleteStmt.getTable());
+        assertTrue(deleteStmt.getTable() instanceof IcebergTable);
+        assertNotNull(deleteStmt.getQueryStatement());
+    }
+
+    @Test
+    public void testIcebergDeleteWithoutWhereClause() {
+        String sql = "DELETE FROM iceberg0.unpartitioned_db.t0";
+        DeleteStmt deleteStmt = (DeleteStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> DeleteAnalyzer.analyze(deleteStmt, connectContext));
+        assertTrue(exception.getMessage().contains("Delete must specify where clause"));
+    }
+
+    @Test
+    public void testIcebergDeleteWithPartition() {
+        String sql = "DELETE FROM iceberg0.partitioned_db.t1 PARTITION(p_date = '2023-01-01') WHERE id = 1";
+        DeleteStmt deleteStmt = (DeleteStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> DeleteAnalyzer.analyze(deleteStmt, connectContext));
+        assertTrue(exception.getMessage().contains("Delete for Iceberg table do not support specifying partitions"));
+    }
+
+    @Test
+    public void testIcebergDeleteWithUsingClause() {
+        String sql = "DELETE FROM iceberg0.unpartitioned_db.t0 USING other_table WHERE t0.id = other_table.id";
+        DeleteStmt deleteStmt = (DeleteStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> DeleteAnalyzer.analyze(deleteStmt, connectContext));
+        assertTrue(exception.getMessage().contains("Delete for Iceberg table do not support `using` clause"));
+    }
+
+    @Test
+    public void testIcebergDeleteWithCTEs() {
+        String sql = "WITH cte AS (SELECT id FROM iceberg0.unpartitioned_db.t0) DELETE FROM iceberg0.unpartitioned_db.t0 " +
+                "WHERE id IN (SELECT id FROM cte)";
+        DeleteStmt deleteStmt = (DeleteStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> DeleteAnalyzer.analyze(deleteStmt, connectContext));
+        assertTrue(exception.getMessage().contains("Delete for Iceberg table do not support `with` clause"));
+    }
+
+    @Test
+    public void testIcebergDeleteConvertsToSelectFileAndPos() {
+        String sql = "DELETE FROM iceberg0.unpartitioned_db.t0 WHERE id = 1";
+        DeleteStmt deleteStmt = (DeleteStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        DeleteAnalyzer.analyze(deleteStmt, connectContext);
+
+        QueryStatement queryStmt = deleteStmt.getQueryStatement();
+        assertNotNull(queryStmt);
+
+        QueryRelation queryRelation = queryStmt.getQueryRelation();
+        assertInstanceOf(SelectRelation.class, queryRelation);
+
+        SelectRelation selectRelation = (SelectRelation) queryRelation;
+        assertNotNull(selectRelation.getSelectList());
+
+        // Check that select list contains _file and _pos columns
+        boolean hasFileColumn = false;
+        boolean hasPosColumn = false;
+
+        for (int i = 0; i < selectRelation.getSelectList().getItems().size(); i++) {
+            String alias = selectRelation.getSelectList().getItems().get(i).getAlias();
+            if (IcebergTable.FILE_PATH.equals(alias)) {
+                hasFileColumn = true;
+            }
+            if (IcebergTable.ROW_POSITION.equals(alias)) {
+                hasPosColumn = true;
+            }
+        }
+
+        assertTrue(hasFileColumn, "Select list should contain _file column");
+        assertTrue(hasPosColumn, "Select list should contain _pos column");
+    }
+
+    @Test
+    public void testUnsupportedCatalogDelete() {
+        String sql = "DELETE FROM hive0.`partitioned_db`.`lineitem_par` WHERE l_orderkey = 1";
+        DeleteStmt deleteStmt = (DeleteStmt) SqlParser.parse(
+                sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> DeleteAnalyzer.analyze(deleteStmt, connectContext));
+        assertTrue(exception.getMessage().contains("doesn't support"));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
@@ -384,7 +384,7 @@ public class ConnectorPlanTestBase extends PlanTestBase {
         metadataMgr.registerMockedMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME, mockIcebergMetadata);
     }
 
-    private static File newFolder(File root, String... subDirs) throws IOException {
+    public static File newFolder(File root, String... subDirs) throws IOException {
         String subFolder = String.join("/", subDirs);
         File result = new File(root, subFolder);
         if (!result.mkdirs()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DeletePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DeletePlanTest.java
@@ -15,32 +15,98 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TPartitionType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
 public class DeletePlanTest extends PlanTestBase {
     @BeforeAll
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
+        ConnectorPlanTestBase.mockCatalog(connectContext, MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME);
     }
 
     @Test
     public void testDelete() throws Exception {
-        String explainString = getDeleteExecPlan("delete from tprimary where pk = 1");
-        Assertions.assertTrue(explainString.contains("PREDICATES: 1: pk = 1"));
+        String explainString = getDeleteExecPlanString("delete from tprimary where pk = 1");
+        assertTrue(explainString.contains("PREDICATES: 1: pk = 1"));
 
         testExplain("explain delete from tprimary where pk = 1");
         testExplain("explain verbose delete from tprimary where pk = 1");
         testExplain("explain costs delete from tprimary where pk = 1");
+    }
+
+    @Test
+    public void testIcebergDeleteWithMultipleConditions() throws Exception {
+        // Test DELETE with multiple WHERE conditions
+        String[] deleteStatements = {
+                "delete from iceberg0.unpartitioned_db.t0 where id = 1",
+                "delete from iceberg0.unpartitioned_db.t0 where id > 100",
+                "delete from iceberg0.unpartitioned_db.t0 where id between 10 and 100",
+                "delete from iceberg0.unpartitioned_db.t0 where data like '%test%'"
+        };
+
+        for (String sql : deleteStatements) {
+            String explainString = getDeleteExecPlanString(sql);
+            assertNotNull(explainString, "Explain plan should not be null for SQL: " + sql);
+            assertTrue(explainString.contains("ICEBERG DELETE SINK"));
+        }
+    }
+
+    @Test
+    public void testPartitionedIcebergTableDelete() throws Exception {
+        // Test DELETE on partitioned Iceberg tables
+        String[] deleteStatements = {
+                "delete from iceberg0.partitioned_db.t1 where id = 1",
+                "delete from iceberg0.partitioned_db.t1 where `date` = '2023-01-01'",
+                "delete from iceberg0.partitioned_db.t1 where id > 100 and `date` >= '2023-01-01'"
+        };
+
+        for (String sql : deleteStatements) {
+            ExecPlan execPlan = getDeleteExecPlan(sql);
+
+            assertNotNull(execPlan);
+            assertNotNull(execPlan.getFragments());
+            assertFalse(execPlan.getFragments().isEmpty());
+            assertSame(TPartitionType.HASH_PARTITIONED, execPlan.getFragments().get(1).getOutputPartition().getType());
+        }
+    }
+
+    @Test
+    public void testIcebergDeleteWithSubquery() throws Exception {
+        // Test DELETE with subquery (like: DELETE WHERE id IN (SELECT id FROM other_table))
+        String sql = "delete from iceberg0.unpartitioned_db.t0 where id in (select id from iceberg0.partitioned_db.t1)";
+        String explainString = getDeleteExecPlanString(sql);
+        assertTrue(explainString.contains("ICEBERG DELETE SINK"));
+    }
+
+    @Test
+    public void testIcebergDeleteOutputColumns() throws Exception {
+        // Test that DELETE returns _file and _pos columns for Iceberg position delete
+        String sql = "delete from iceberg0.unpartitioned_db.t0 where id = 1";
+        ExecPlan execPlan = getDeleteExecPlan(sql);
+
+        assertNotNull(execPlan);
+        assertNotNull(execPlan.getOutputExprs());
+        assertTrue(execPlan.getOutputExprs().size() >= 2, "Should output _file and _pos");
+        assertTrue(execPlan.getOutputExprs().get(0).debugString().contains("_file"));
+        assertTrue(execPlan.getOutputExprs().get(1).debugString().contains("_pos"));
     }
 
     private void testExplain(String explainStmt) throws Exception {
@@ -51,10 +117,10 @@ public class DeletePlanTest extends PlanTestBase {
                 com.starrocks.sql.parser.SqlParser.parse(explainStmt, connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statements.get(0));
         stmtExecutor.execute();
-        Assertions.assertEquals(connectContext.getState().getStateType(), QueryState.MysqlStateType.EOF);
+        Assertions.assertEquals(QueryState.MysqlStateType.EOF, connectContext.getState().getStateType());
     }
 
-    private static String getDeleteExecPlan(String originStmt) throws Exception {
+    private static ExecPlan getDeleteExecPlan(String originStmt) throws Exception {
         connectContext.setQueryId(UUIDUtil.genUUID());
         connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
         connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
@@ -62,9 +128,11 @@ public class DeletePlanTest extends PlanTestBase {
                 com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable().getSqlMode())
                         .get(0);
         connectContext.getDumpInfo().setOriginStmt(originStmt);
-        ExecPlan execPlan = new StatementPlanner().plan(statementBase, connectContext);
+        return StatementPlanner.plan(statementBase, connectContext);
+    }
 
-        String ret = execPlan.getExplainString(TExplainLevel.NORMAL);
-        return ret;
+    private static String getDeleteExecPlanString(String originStmt) throws Exception {
+        ExecPlan execPlan = getDeleteExecPlan(originStmt);
+        return execPlan.getExplainString(TExplainLevel.NORMAL);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 public class HiveScanTest extends ConnectorPlanTestBase {
@@ -175,14 +174,5 @@ public class HiveScanTest extends ConnectorPlanTestBase {
             }
         }
         connectContext.getSessionVariable().setEnableRewriteSimpleAggToHdfsScan(false);
-    }
-
-    private static File newFolder(File root, String... subDirs) throws IOException {
-        String subFolder = String.join("/", subDirs);
-        File result = new File(root, subFolder);
-        if (!result.mkdirs()) {
-            throw new IOException("Couldn't create folders " + root);
-        }
-        return result;
     }
 }

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -59,7 +59,8 @@ enum TDataSinkType {
     DICTIONARY_CACHE_SINK,
     MULTI_OLAP_TABLE_SINK,
     SPLIT_DATA_STREAM_SINK,
-    NOOP_SINK
+    NOOP_SINK,
+    ICEBERG_DELETE_SINK
 }
 
 enum TResultSinkType {


### PR DESCRIPTION
## Why I'm doing:
#66944
## What I'm doing:
This pull request introduces support for operation capability discovery in connectors and adds infrastructure for Iceberg table DELETE operations. The main changes include extending the connector interface to declare supported operations, implementing this for several connectors, and adding a new `IcebergDeleteSink` class. Additionally, there is a refactor to centralize cloud credential resolution logic for Iceberg tables.

**Connector extensibility and operation support:**
- Added a new `supportedOperations()` method to the `Connector` interface, allowing connectors to declare which operations (e.g., ALTER, DELETE) they support. Default implementation returns an empty set. (`Connector.java`, `CatalogConnector.java`, `LazyConnector.java`) [[1]](diffhunk://#diff-c84ab59235175e5d13d276315c23affb0bcc7e3a9a76a071ecbe5564c8d8b8eaR63-R75) [[2]](diffhunk://#diff-ff6890f9e1695cefd7b84e9a18732e29b4095317d9d5d2a22745c7aad1881684R78-R82) [[3]](diffhunk://#diff-d747619da6f5e25d91fc2f3940b6d503ad8d5587b3dc0b94af630a6845e4be2bR116-R121)
- Implemented `supportedOperations()` in specific connectors:
    - `HiveConnector` and `HudiConnector` now declare support for the ALTER operation. (`HiveConnector.java`, `HudiConnector.java`) [[1]](diffhunk://#diff-0f3787aa1bf8f6659406a8b0ef453302d40480239e991cc63e4654fbfb3d035eR102-R107) [[2]](diffhunk://#diff-592c5447bdb1d0087945b228a264713f845452b721900f1644e138cdeac3ea94R84-R89)
    - `IcebergConnector` declares support for both ALTER and DELETE operations. (`IcebergConnector.java`)

**Iceberg table DELETE support:**
- Introduced the new `IcebergDeleteSink` class, enabling writing position delete files for Iceberg tables. This class validates required columns and handles cloud configuration for the sink. (`IcebergDeleteSink.java`)

**Cloud credential management refactor:**
- Centralized and refactored the logic for resolving cloud credentials for Iceberg tables into a new utility method `IcebergUtil.getVendedCloudConfiguration()`, and updated `IcebergScanNode` to use this method. (`IcebergUtil.java`, `IcebergScanNode.java`) [[1]](diffhunk://#diff-04eb30820b9afffe2106e018f6f987eec0fe38f3724581a6c19566e7624dfe26R204-R232) [[2]](diffhunk://#diff-57afce8c17b2c88789de3fe9d5be2ff6008a9ce67e80382e67851bae1d75c897L200-R201)

These changes lay the groundwork for more granular feature enablement in connectors and enable DELETE support for Iceberg tables.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Iceberg DELETE support and connector operation capabilities**
> 
> - New `OperationType` enum and `Connector.supportedOperations()` API; implemented for Hive/Hudi (ALTER) and Iceberg (ALTER, DELETE)
> - Enforce per-catalog operation support in analyzers (`MetaUtils.checkNotSupportCatalog`) for `ALTER`, `DELETE`, and `CREATE TABLE LIKE`
> - Add `IcebergDeleteSink` and wire up DELETE planning: `DeleteAnalyzer` rewrites to select `_file`, `_pos` (+ partitions), `DeletePlanner` builds sink and hash-shuffle on partitions
> - Centralize Iceberg cloud credential resolution in `IcebergUtil.getVendedCloudConfiguration()`; refactor `IcebergScanNode`/`IcebergTableSink` to use it
> - Extend Thrift with `ICEBERG_DELETE_SINK`
> - Add/adjust tests for Iceberg delete path and credential selection; minor utilities/test fixes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ecb44bffc201e6e0ead1cf445ca10e1efeab561. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->