### PR TITLE
[BugFix] Fix merge commit latency metrics overflow

### DIFF
--- a/docs/en/administration/management/monitoring/metrics.md
+++ b/docs/en/administration/management/monitoring/metrics.md
@@ -1893,6 +1893,24 @@ All transaction metrics share the following labels:
 - Type: Instantaneous
 - Description: Total bytes of data held by pending merge commit tasks.
 
+#### merge_commit_send_rpc_total
+
+- Unit: Count
+- Type: Cumulative
+- Description: RPC requests sent to FE for starting merge commit operations.
+
+#### merge_commit_register_pipe_total
+
+- Unit: Count
+- Type: Cumulative
+- Description: Stream load pipes registered for merge commit operations.
+
+#### merge_commit_unregister_pipe_total
+
+- Unit: Count
+- Type: Cumulative
+- Description: Stream load pipes unregistered from merge commit operations.
+
 Latency metrics expose percentile series such as `merge_commit_request_latency_99` and `merge_commit_request_latency_90`, reported in microseconds. The end-to-end latency obeys:
 
 `merge_commit_request = merge_commit_pending + merge_commit_wait_plan + merge_commit_append_pipe + merge_commit_wait_finish`

--- a/docs/en/administration/management/monitoring/metrics.md
+++ b/docs/en/administration/management/monitoring/metrics.md
@@ -1919,30 +1919,30 @@ Latency metrics expose percentile series such as `merge_commit_request_latency_9
 
 #### merge_commit_request
 
-- Unit: us
+- Unit: microsecond
 - Type: Summary
 - Description: End-to-end processing latency for merge commit requests.
 
 #### merge_commit_pending
 
-- Unit: us
+- Unit: microsecond
 - Type: Summary
 - Description: Time merge commit tasks spend waiting in the pending queue before execution.
 
 #### merge_commit_wait_plan
 
-- Unit: us
+- Unit: microsecond
 - Type: Summary
 - Description: Combined latency for the RPC request and waiting for the stream load pipe to become available.
 
 #### merge_commit_append_pipe
 
-- Unit: us
+- Unit: microsecond
 - Type: Summary
 - Description: Time spent appending data to the stream load pipe during merge commit.
 
 #### merge_commit_wait_finish
 
-- Unit: us
+- Unit: microsecond
 - Type: Summary
 - Description: Time spent waiting for merge commit load operations to finish.

--- a/docs/en/administration/management/monitoring/metrics.md
+++ b/docs/en/administration/management/monitoring/metrics.md
@@ -1854,3 +1854,77 @@ All transaction metrics share the following labels:
 - Unit: ms
 - Type: Summary
 - Description: The final acknowledgment latency, from when the `publish` task finishes to the final `finish` time when the transaction is marked as `VISIBLE`. This metric includes any final steps or acknowledgments required.
+
+### Merge Commit BE Metrics
+
+#### merge_commit_request_total
+
+- Unit: Count
+- Type: Cumulative
+- Description: Total number of merge commit requests received by BE.
+
+#### merge_commit_request_bytes
+
+- Unit: Bytes
+- Type: Cumulative
+- Description: Total bytes of data received across merge commit requests.
+
+#### merge_commit_success_total
+
+- Unit: Count
+- Type: Cumulative
+- Description: Merge commit requests that finished successfully.
+
+#### merge_commit_fail_total
+
+- Unit: Count
+- Type: Cumulative
+- Description: Merge commit requests that failed.
+
+#### merge_commit_pending_total
+
+- Unit: Count
+- Type: Instantaneous
+- Description: Merge commit tasks currently waiting in the execution queue.
+
+#### merge_commit_pending_bytes
+
+- Unit: Bytes
+- Type: Instantaneous
+- Description: Total bytes of data held by pending merge commit tasks.
+
+Latency metrics expose percentile series such as `merge_commit_request_latency_99` and `merge_commit_request_latency_90`, reported in microseconds. The end-to-end latency obeys:
+
+`merge_commit_request = merge_commit_pending + merge_commit_wait_plan + merge_commit_append_pipe + merge_commit_wait_finish`
+
+> **Note**: Before v3.4.11, v3.5.12, and v4.0.4, these latency metrics were reported in nanoseconds.
+
+#### merge_commit_request
+
+- Unit: us
+- Type: Summary
+- Description: End-to-end processing latency for merge commit requests.
+
+#### merge_commit_pending
+
+- Unit: us
+- Type: Summary
+- Description: Time merge commit tasks spend waiting in the pending queue before execution.
+
+#### merge_commit_wait_plan
+
+- Unit: us
+- Type: Summary
+- Description: Combined latency for the RPC request and waiting for the stream load pipe to become available.
+
+#### merge_commit_append_pipe
+
+- Unit: us
+- Type: Summary
+- Description: Time spent appending data to the stream load pipe during merge commit.
+
+#### merge_commit_wait_finish
+
+- Unit: us
+- Type: Summary
+- Description: Time spent waiting for merge commit load operations to finish.

--- a/docs/ja/administration/management/monitoring/metrics.md
+++ b/docs/ja/administration/management/monitoring/metrics.md
@@ -1849,3 +1849,97 @@ StarRocks クラスタのモニタリングサービスの構築方法につい�
 - 単位: ms
 - タイプ: Summary
 - 説明: 最終的な確認遅延。`publish` タスクが完了してから、トランザクションが `VISIBLE` としてマークされる最終的な `finish` 時点までの時間。このメトリックには、必要な最終的なステップや確認が含まれます。
+
+### Merge Commit メトリクス
+
+これらのメトリクスは、等型バッチ書き込み経路での merge commit 処理を追跡します。
+
+#### merge_commit_request_total
+
+- 単位: Count
+- タイプ: Cumulative
+- 説明: BE が受信した merge commit リクエストの総数。
+
+#### merge_commit_request_bytes
+
+- 単位: Bytes
+- タイプ: Cumulative
+- 説明: merge commit リクエストで受信したデータ総量。
+
+#### merge_commit_success_total
+
+- 単位: Count
+- タイプ: Cumulative
+- 説明: 正常に完了した merge commit リクエスト数。
+
+#### merge_commit_fail_total
+
+- 単位: Count
+- タイプ: Cumulative
+- 説明: 失敗した merge commit リクエスト数。
+
+#### merge_commit_pending_total
+
+- 単位: Count
+- タイプ: Instantaneous
+- 説明: 実行キューで待機している merge commit タスク数。
+
+#### merge_commit_pending_bytes
+
+- 単位: Bytes
+- タイプ: Instantaneous
+- 説明: 待機中の merge commit タスクが保持するデータ総量。
+
+#### merge_commit_send_rpc_total
+
+- 単位: Count
+- タイプ: Cumulative
+- 説明: merge commit を開始するために送信した RPC リクエスト数。
+
+#### merge_commit_register_pipe_total
+
+- 単位: Count
+- タイプ: Cumulative
+- 説明: merge commit 用に登録された stream load pipe の数。
+
+#### merge_commit_unregister_pipe_total
+
+- 単位: Count
+- タイプ: Cumulative
+- 説明: merge commit 用に登録解除された stream load pipe の数。
+
+レイテンシメトリクスは、`merge_commit_request_latency_99` や `merge_commit_request_latency_90` などのパーセンタイル系列をマイクロ秒単位で出力します。エンドツーエンドのレイテンシは以下の式に従います：
+
+`merge_commit_request = merge_commit_pending + merge_commit_wait_plan + merge_commit_append_pipe + merge_commit_wait_finish`
+
+> **注意**: v3.4.11、v3.5.12、および v4.0.4 より前のバージョンでは、これらのレイテンシメトリクスはナノ秒単位で報告されていました。
+
+#### merge_commit_request
+
+- 単位: us
+- タイプ: Summary
+- 説明: merge commit リクエストのエンドツーエンド処理レイテンシ。
+
+#### merge_commit_pending
+
+- 単位: us
+- タイプ: Summary
+- 説明: 実行前に pending キューで待機する時間。
+
+#### merge_commit_wait_plan
+
+- 単位: us
+- タイプ: Summary
+- 説明: RPC リクエストと stream load pipe が利用可能になるまでの待機を合わせた時間。
+
+#### merge_commit_append_pipe
+
+- 単位: us
+- タイプ: Summary
+- 説明: merge commit 中に stream load pipe へデータを追加する時間。
+
+#### merge_commit_wait_finish
+
+- 単位: us
+- タイプ: Summary
+- 説明: merge commit のロード操作が完了するまで待機する時間。

--- a/docs/ja/administration/management/monitoring/metrics.md
+++ b/docs/ja/administration/management/monitoring/metrics.md
@@ -1916,30 +1916,30 @@ StarRocks クラスタのモニタリングサービスの構築方法につい�
 
 #### merge_commit_request
 
-- 単位: us
+- 単位: microsecond
 - タイプ: Summary
 - 説明: merge commit リクエストのエンドツーエンド処理レイテンシ。
 
 #### merge_commit_pending
 
-- 単位: us
+- 単位: microsecond
 - タイプ: Summary
 - 説明: 実行前に pending キューで待機する時間。
 
 #### merge_commit_wait_plan
 
-- 単位: us
+- 単位: microsecond
 - タイプ: Summary
 - 説明: RPC リクエストと stream load pipe が利用可能になるまでの待機を合わせた時間。
 
 #### merge_commit_append_pipe
 
-- 単位: us
+- 単位: microsecond
 - タイプ: Summary
 - 説明: merge commit 中に stream load pipe へデータを追加する時間。
 
 #### merge_commit_wait_finish
 
-- 単位: us
+- 単位: microsecond
 - タイプ: Summary
 - 説明: merge commit のロード操作が完了するまで待機する時間。

--- a/docs/zh/administration/management/monitoring/metrics.md
+++ b/docs/zh/administration/management/monitoring/metrics.md
@@ -1851,3 +1851,97 @@ displayed_sidebar: docs
 - 单位：毫秒
 - 类型：Summary
 - 描述：事务最终确认的延迟，从发布任务完成到事务被标记为 `VISIBLE` 的最终 `finish` 时间。这包括任何最终步骤或所需的确认。
+
+### Merge Commit 指标
+
+这些指标用于跟踪等型批量写入路径中的 merge commit 操作。
+
+#### merge_commit_request_total
+
+- 单位：个
+- 类型：累积值
+- 描述：BE 收到的 merge commit 请求总数。
+
+#### merge_commit_request_bytes
+
+- 单位：字节
+- 类型：累积值
+- 描述：所有 merge commit 请求接收的数据总量。
+
+#### merge_commit_success_total
+
+- 单位：个
+- 类型：累积值
+- 描述：成功完成的 merge commit 请求数。
+
+#### merge_commit_fail_total
+
+- 单位：个
+- 类型：累积值
+- 描述：失败的 merge commit 请求数。
+
+#### merge_commit_pending_total
+
+- 单位：个
+- 类型：瞬时值
+- 描述：当前等待执行的 merge commit 任务数量。
+
+#### merge_commit_pending_bytes
+
+- 单位：字节
+- 类型：瞬时值
+- 描述：当前等待执行的 merge commit 任务持有的数据总量。
+
+#### merge_commit_send_rpc_total
+
+- 单位：个
+- 类型：累积值
+- 描述：用于启动 merge commit 的 RPC 请求数。
+
+#### merge_commit_register_pipe_total
+
+- 单位：个
+- 类型：累积值
+- 描述：为 merge commit 注册的 stream load pipe 数量。
+
+#### merge_commit_unregister_pipe_total
+
+- 单位：个
+- 类型：累积值
+- 描述：为 merge commit 取消注册的 stream load pipe 数量。
+
+延迟指标会输出百分位序列，例如 `merge_commit_request_latency_99` 和 `merge_commit_request_latency_90`，单位为微秒。端到端延迟遵循以下公式：
+
+`merge_commit_request = merge_commit_pending + merge_commit_wait_plan + merge_commit_append_pipe + merge_commit_wait_finish`
+
+> **注意**：在 v3.4.11、v3.5.12 和 v4.0.4 之前，这些延迟指标的单位为纳秒。
+
+#### merge_commit_request
+
+- 单位：微秒
+- 类型：Summary
+- 描述：merge commit 请求的端到端处理延迟。
+
+#### merge_commit_pending
+
+- 单位：微秒
+- 类型：Summary
+- 描述：merge commit 任务在执行前等待的时间。
+
+#### merge_commit_wait_plan
+
+- 单位：微秒
+- 类型：Summary
+- 描述：RPC 请求与等待 stream load pipe 可用的合计耗时。
+
+#### merge_commit_append_pipe
+
+- 单位：微秒
+- 类型：Summary
+- 描述：向 stream load pipe 追加数据的耗时。
+
+#### merge_commit_wait_finish
+
+- 单位：微秒
+- 类型：Summary
+- 描述：等待 merge commit 导入完成的耗时。


### PR DESCRIPTION
## Why I'm doing:

Merge commit latency metrics use bvar `LatencyRecorder`, and the unit is nanoseconds, but if the latency is larger than 2 seconds, the bvar will report overflow as the following

<img width="931" height="402" alt="image" src="https://github.com/user-attachments/assets/c04c7e1f-a61e-45d4-8d52-63cca130db26" />


The reason is that although `LatencyRecorder` accepts `int64_t` as input (https://github.com/apache/brpc/blob/master/src/bvar/latency_recorder.h#L100
), but it actually uses `IntRecorder` to store the latency as int (https://github.com/apache/brpc/blob/master/src/bvar/latency_recorder.h#L54), so the allowed latency in nanosecond is `2147483647` (about 2.1s)

```
class LatencyRecorder : public detail::LatencyRecorderBase {
public:
    // Record the latency.
    LatencyRecorder& operator<<(int64_t latency);
```

```
class LatencyRecorderBase {
public:
    explicit LatencyRecorderBase(time_t window_size);
    time_t window_size() const { return _latency_window.window_size(); }
protected:
    IntRecorder _latency;
```

## What I'm doing:
bvar does not provide other recorders to support `int64_t`. For merge commit latency, it's not necessary to use nanosecond precision, so just change the latency unit to microsecond, and the max latency can be 35.8 minutes which should be enough. 

Note changing metric unit introduces behavior change, and add the document to explain it


Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [X] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes overflow in merge-commit latency metrics by switching from nanoseconds to microseconds and documenting the change.
> 
> - Replace `g_mc_*_latency_ns` with `g_mc_*_latency_us` in `isomorphic_batch_write.cpp`, add `NS_TO_US` conversions, and update logs/recorders accordingly
> - No functional logic changes to write flow; only metric units and names updated
> - Add "Merge Commit BE Metrics" docs (EN/JA/ZH): new counters described; latency metrics now reported in microseconds with note about pre-v3.4.11/v3.5.12/v4.0.4 behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 126d8f710b1ade86e7f11d3bd574196453a81a84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->