### PR TITLE
[Enhancement] Support default values for complex types (ARRAY, MAP, STRUCT)

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -218,10 +218,15 @@ void run_drop_tablet_task(const std::shared_ptr<DropTabletAgentTaskRequest>& age
 }
 
 void run_create_tablet_task(const std::shared_ptr<CreateTabletAgentTaskRequest>& agent_task_req, ExecEnv* exec_env) {
-    const auto& create_tablet_req = agent_task_req->task_req;
+    TCreateTabletReq create_tablet_req = agent_task_req->task_req;
     TFinishTaskRequest finish_task_request;
     TStatusCode::type status_code = TStatusCode::OK;
     std::vector<std::string> error_msgs;
+
+    Status preprocess_status = preprocess_default_expr_for_tcolumns(create_tablet_req.tablet_schema.columns);
+    if (!preprocess_status.ok()) {
+        LOG(WARNING) << "Failed to preprocess default_expr in CREATE TABLE: " << preprocess_status.to_string();
+    }
 
     auto tablet_type = create_tablet_req.tablet_type;
     Status create_status;
@@ -633,6 +638,12 @@ void run_update_schema_task(const std::shared_ptr<UpdateSchemaTaskRequest>& agen
     for (auto uid : tcolumn_param.sort_key_uid) {
         pcolumn_param.add_sort_key_uid(uid);
     }
+
+    Status preprocess_status = preprocess_default_expr_for_tcolumns(tcolumn_param.columns);
+    if (!preprocess_status.ok()) {
+        LOG(WARNING) << "Failed to preprocess default_expr in UPDATE_SCHEMA task: " << preprocess_status;
+    }
+
     Status st;
     for (auto& tcolumn : tcolumn_param.columns) {
         uint32_t col_unique_id = tcolumn.col_unique_id;

--- a/be/src/exec/olap_meta_scanner.cpp
+++ b/be/src/exec/olap_meta_scanner.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include "exec/olap_meta_scan_node.h"
+#include "storage/metadata_util.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet.h"
 #include "storage/tablet_manager.h"
@@ -62,8 +63,14 @@ Status OlapMetaScanner::_init_meta_reader_params() {
     if (_reader_params.tablet_schema == nullptr) {
         if (_parent->_meta_scan_node.__isset.columns && !_parent->_meta_scan_node.columns.empty() &&
             (_parent->_meta_scan_node.columns[0].col_unique_id >= 0)) {
-            _reader_params.tablet_schema =
-                    TabletSchema::copy(*_tablet->tablet_schema(), _parent->_meta_scan_node.columns);
+            auto columns_copy = _parent->_meta_scan_node.columns;
+            Status preprocess_status = preprocess_default_expr_for_tcolumns(columns_copy);
+            if (!preprocess_status.ok()) {
+                LOG(WARNING) << "Failed to preprocess default_expr in OlapMetaScanner: "
+                             << preprocess_status.to_string();
+            }
+
+            _reader_params.tablet_schema = TabletSchema::copy(*_tablet->tablet_schema(), columns_copy);
         } else {
             _reader_params.tablet_schema = _tablet->tablet_schema();
         }

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -42,11 +42,11 @@
 #include "storage/chunk_helper.h"
 #include "storage/column_predicate_rewriter.h"
 #include "storage/index/vector/vector_search_option.h"
+#include "storage/metadata_util.h"
 #include "storage/predicate_parser.h"
 #include "storage/projection_iterator.h"
 #include "storage/runtime_range_pruner.hpp"
 #include "storage/storage_engine.h"
-#include "storage/tablet_index.h"
 #include "types/logical_type.h"
 #include "util/json.h"
 #include "util/runtime_profile.h"
@@ -635,8 +635,13 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
         if (_scan_node->thrift_olap_scan_node().__isset.columns_desc &&
             !_scan_node->thrift_olap_scan_node().columns_desc.empty() &&
             _scan_node->thrift_olap_scan_node().columns_desc[0].col_unique_id >= 0) {
-            _tablet_schema =
-                    TabletSchema::copy(*_tablet->tablet_schema(), _scan_node->thrift_olap_scan_node().columns_desc);
+            auto columns_desc_copy = _scan_node->thrift_olap_scan_node().columns_desc;
+            Status preprocess_status = preprocess_default_expr_for_tcolumns(columns_desc_copy);
+            if (!preprocess_status.ok()) {
+                LOG(WARNING) << "Failed to preprocess default_expr in olap_chunk_source: "
+                             << preprocess_status.to_string();
+            }
+            _tablet_schema = TabletSchema::copy(*_tablet->tablet_schema(), columns_desc_copy);
         } else {
             _tablet_schema = _tablet->tablet_schema();
         }

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -18,6 +18,7 @@
 #include "column/chunk.h"
 #include "exprs/expr.h"
 #include "runtime/mem_pool.h"
+#include "storage/metadata_util.h"
 #include "storage/tablet_schema.h"
 #include "types/constexpr.h"
 #include "util/string_parser.hpp"
@@ -169,7 +170,15 @@ Status OlapTableSchemaParam::init(const TOlapTableSchemaParam& tschema, RuntimeS
 
         if (t_index.__isset.column_param) {
             auto col_param = _obj_pool.add(new OlapTableColumnParam());
-            for (auto& tcolumn_desc : t_index.column_param.columns) {
+            std::vector<TColumn> columns_copy = t_index.column_param.columns;
+            Status preprocess_status = preprocess_default_expr_for_tcolumns(columns_copy);
+            if (!preprocess_status.ok()) {
+                LOG(WARNING) << "Failed to preprocess default_expr in OlapTableSchemaParam::init: "
+                             << preprocess_status.to_string();
+                columns_copy = t_index.column_param.columns;
+            }
+
+            for (auto& tcolumn_desc : columns_copy) {
                 TabletColumn* tc = _obj_pool.add(new TabletColumn());
                 tc->init_from_thrift(tcolumn_desc);
                 col_param->columns.emplace_back(tc);

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -401,7 +401,6 @@ struct CastToString {
 
 StatusOr<ColumnPtr> cast_nested_to_json(const ColumnPtr& column, bool allow_throw_exception);
 
-// cast column[idx] to coresponding json type.
-StatusOr<std::string> cast_type_to_json_str(const ColumnPtr& column, int idx);
+StatusOr<std::string> cast_type_to_json_str(const ColumnPtr& column, int idx, bool unindexed_struct = false);
 
 } // namespace starrocks

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -336,7 +336,14 @@ Status SchemaChangeHandler::do_process_alter_tablet(const TAlterTabletReqV2& req
 
     TabletSchemaCSPtr base_schema;
     if (!request.columns.empty() && request.columns[0].col_unique_id >= 0) {
-        base_schema = TabletSchema::copy(*(base_tablet.get_schema()), request.columns);
+        auto columns_copy = request.columns;
+
+        Status preprocess_status = preprocess_default_expr_for_tcolumns(columns_copy);
+        if (!preprocess_status.ok()) {
+            LOG(WARNING) << "Failed to preprocess default_expr in Lake SchemaChange: " << preprocess_status.to_string();
+        }
+
+        base_schema = TabletSchema::copy(*(base_tablet.get_schema()), columns_copy);
     } else {
         base_schema = base_tablet.get_schema();
     }

--- a/be/src/storage/metadata_util.h
+++ b/be/src/storage/metadata_util.h
@@ -22,7 +22,6 @@
 #include "common/status.h"
 #include "gen_cpp/Types_types.h"
 #include "olap_common.h"
-#include "types/logical_type.h"
 
 namespace starrocks {
 
@@ -57,5 +56,9 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& t_schema, uint32_t nex
 void convert_to_new_version(TColumn* tcolumn);
 
 Status t_column_to_pb_column(int32_t unique_id, const TColumn& t_column, ColumnPB* column_pb);
+
+StatusOr<std::string> convert_default_expr_to_json_string(const TExpr& t_expr);
+
+Status preprocess_default_expr_for_tcolumns(std::vector<TColumn>& columns);
 
 } // namespace starrocks

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -768,7 +768,7 @@ StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::_create_merge_struct_ite
                 const TypeInfoPtr& type_info = get_type_info(*sub_column);
                 auto default_value_iter = std::make_unique<DefaultValueColumnIterator>(
                         sub_column->has_default_value(), sub_column->default_value(), sub_column->is_nullable(),
-                        type_info, sub_column->length(), num_rows());
+                        type_info, sub_column->length(), num_rows(), child_paths[i]);
                 ColumnIteratorOptions iter_opts;
                 RETURN_IF_ERROR(default_value_iter->init(iter_opts));
                 field_iters.emplace_back(std::move(default_value_iter));

--- a/be/src/storage/rowset/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/default_value_column_iterator.cpp
@@ -41,10 +41,10 @@
 #include "runtime/decimalv3.h"
 #include "storage/range.h"
 #include "storage/types.h"
-#include "util/json.h"
 #include "types/array_type_info.h"
 #include "types/map_type_info.h"
 #include "types/struct_type_info.h"
+#include "util/json.h"
 #include "util/json_converter.h"
 #include "util/mem_util.hpp"
 #include "velocypack/Builder.h"
@@ -459,7 +459,6 @@ Status DefaultValueColumnIterator::next_batch(const SparseRange<>& range, Column
     }
     if (_is_default_value_null) {
         [[maybe_unused]] bool ok = dst->append_nulls(to_read);
-        _current_rowid = range.end();
         DCHECK(ok) << "cannot append null to non-nullable column";
     } else {
         if (_type_info->type() == TYPE_OBJECT || _type_info->type() == TYPE_HLL ||
@@ -472,9 +471,9 @@ Status DefaultValueColumnIterator::next_batch(const SparseRange<>& range, Column
             [[maybe_unused]] auto ret = dst->append_strings(slices);
         } else {
             dst->append_value_multiple_times(_mem_value, to_read);
-            _current_rowid = range.end();
         }
     }
+    _current_rowid = range.end();
     if (_may_contain_deleted_row) {
         dst->set_delete_state(DEL_PARTIAL_SATISFIED);
     }

--- a/be/src/storage/rowset/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/default_value_column_iterator.cpp
@@ -34,16 +34,300 @@
 
 #include "storage/rowset/default_value_column_iterator.h"
 
+#include "column/array_column.h"
 #include "column/column.h"
+#include "column/column_builder.h"
+#include "column/datum.h"
+#include "runtime/decimalv3.h"
 #include "storage/range.h"
 #include "storage/types.h"
 #include "util/json.h"
+#include "types/array_type_info.h"
+#include "types/map_type_info.h"
+#include "types/struct_type_info.h"
+#include "util/json_converter.h"
 #include "util/mem_util.hpp"
+#include "velocypack/Builder.h"
+#include "velocypack/Iterator.h"
 
 namespace starrocks {
 
+class VPackToDatumCaster {
+public:
+    VPackToDatumCaster(const vpack::Slice& json_slice, const TypeInfo* type_info, MemPool* mem_pool)
+            : _json_slice(json_slice), _type_info(type_info), _mem_pool(mem_pool) {}
+
+    StatusOr<Datum> cast() {
+        LogicalType target_type = _type_info->type();
+
+        if (target_type == TYPE_ARRAY) return cast_array();
+        if (target_type == TYPE_MAP) return cast_map();
+        if (target_type == TYPE_STRUCT) return cast_struct();
+        if (target_type == TYPE_JSON) return cast_json();
+
+        return cast_primitive_dispatch(target_type);
+    }
+
+private:
+    StatusOr<Datum> cast_primitive_dispatch(LogicalType target_type) {
+        switch (target_type) {
+        case TYPE_BOOLEAN:
+            return cast_primitive<TYPE_BOOLEAN>();
+        case TYPE_TINYINT:
+            return cast_primitive<TYPE_TINYINT>();
+        case TYPE_SMALLINT:
+            return cast_primitive<TYPE_SMALLINT>();
+        case TYPE_INT:
+            return cast_primitive<TYPE_INT>();
+        case TYPE_BIGINT:
+            return cast_primitive<TYPE_BIGINT>();
+        case TYPE_LARGEINT:
+            return cast_primitive<TYPE_LARGEINT>();
+        case TYPE_FLOAT:
+            return cast_primitive<TYPE_FLOAT>();
+        case TYPE_DOUBLE:
+            return cast_primitive<TYPE_DOUBLE>();
+        case TYPE_DATE:
+            return cast_primitive<TYPE_DATE>();
+        case TYPE_DATETIME:
+            return cast_primitive<TYPE_DATETIME>();
+        case TYPE_VARCHAR:
+        case TYPE_CHAR:
+            return cast_string();
+        case TYPE_DECIMAL32:
+            return cast_decimal<int32_t>();
+        case TYPE_DECIMAL64:
+            return cast_decimal<int64_t>();
+        case TYPE_DECIMAL128:
+            return cast_decimal<int128_t>();
+        case TYPE_DECIMAL256:
+            return cast_decimal<int256_t>();
+        default:
+            return Status::NotSupported(fmt::format("Unsupported type for default value: {}", target_type));
+        }
+    }
+
+    template <LogicalType TYPE>
+    StatusOr<Datum> cast_primitive() {
+        ColumnBuilder<TYPE> builder(1);
+        Status st = cast_vpjson_to<TYPE, false>(_json_slice, builder);
+        RETURN_IF_ERROR(st);
+        auto col = builder.build(false);
+
+        Datum result;
+        if constexpr (TYPE == TYPE_BOOLEAN) {
+            result.set<bool>(col->get(0).get_int8() != 0);
+        } else if constexpr (TYPE == TYPE_TINYINT) {
+            result.set_int8(col->get(0).get_int8());
+        } else if constexpr (TYPE == TYPE_SMALLINT) {
+            result.set_int16(col->get(0).get_int16());
+        } else if constexpr (TYPE == TYPE_INT) {
+            result.set_int32(col->get(0).get_int32());
+        } else if constexpr (TYPE == TYPE_BIGINT) {
+            result.set_int64(col->get(0).get_int64());
+        } else if constexpr (TYPE == TYPE_LARGEINT) {
+            result.set_int128(col->get(0).get_int128());
+        } else if constexpr (TYPE == TYPE_FLOAT) {
+            result.set_float(col->get(0).get_float());
+        } else if constexpr (TYPE == TYPE_DOUBLE) {
+            result.set_double(col->get(0).get_double());
+        } else if constexpr (TYPE == TYPE_DATE) {
+            result.set_date(col->get(0).get_date());
+        } else if constexpr (TYPE == TYPE_DATETIME) {
+            result.set_timestamp(col->get(0).get_timestamp());
+        }
+        return result;
+    }
+
+    StatusOr<Datum> cast_string() {
+        ColumnBuilder<TYPE_VARCHAR> builder(1);
+        Status st = cast_vpjson_to<TYPE_VARCHAR, false>(_json_slice, builder);
+        RETURN_IF_ERROR(st);
+        auto col = builder.build(false);
+        Slice temp_slice = col->get(0).get_slice();
+
+        char* string_buffer = reinterpret_cast<char*>(_mem_pool->allocate(temp_slice.size));
+        if (UNLIKELY(string_buffer == nullptr)) {
+            return Status::InternalError("Mem usage has exceed the limit of BE");
+        }
+        memory_copy(string_buffer, temp_slice.data, temp_slice.size);
+
+        Datum result;
+        result.set_slice(Slice(string_buffer, temp_slice.size));
+        return result;
+    }
+
+    template <typename DecimalType>
+    StatusOr<Datum> cast_decimal() {
+        std::string str_value;
+        if (_json_slice.isString()) {
+            vpack::ValueLength len;
+            const char* str = _json_slice.getStringUnchecked(len);
+            str_value.assign(str, len);
+        } else if (_json_slice.isNumber()) {
+            vpack::Options options = vpack::Options::Defaults;
+            options.singleLinePrettyPrint = true;
+            str_value = _json_slice.toJson(&options);
+        } else {
+            return Status::InvalidArgument("DECIMAL value must be string or number in JSON");
+        }
+
+        int precision = _type_info->precision();
+        int scale = _type_info->scale();
+
+        DecimalType decimal_value;
+        bool overflow = DecimalV3Cast::from_string<DecimalType>(&decimal_value, precision, scale, str_value.c_str(),
+                                                                str_value.size());
+
+        if (overflow) {
+            return Status::InvalidArgument(fmt::format("Failed to parse DECIMAL from: {}", str_value));
+        }
+
+        Datum result;
+        result.set<DecimalType>(decimal_value);
+        return result;
+    }
+
+    StatusOr<Datum> cast_array() {
+        if (!_json_slice.isArray()) {
+            Datum result;
+            result.set_null();
+            return result;
+        }
+
+        auto element_type_info = get_item_type_info(_type_info);
+
+        DatumArray datum_array;
+        for (const auto& element : vpack::ArrayIterator(_json_slice)) {
+            VPackToDatumCaster element_caster(element, element_type_info.get(), _mem_pool);
+            ASSIGN_OR_RETURN(auto element_datum, element_caster.cast());
+            datum_array.push_back(std::move(element_datum));
+        }
+
+        Datum result;
+        result.set_array(datum_array);
+        return result;
+    }
+
+    StatusOr<Datum> cast_map() {
+        if (!_json_slice.isObject()) {
+            Datum result;
+            result.set_null();
+            return result;
+        }
+
+        if (_json_slice.length() == 0) {
+            DatumMap datum_map;
+            Datum result;
+            result.set<DatumMap>(datum_map);
+            return result;
+        }
+
+        auto key_type_info = get_key_type_info(_type_info);
+        auto value_type_info = get_value_type_info(_type_info);
+
+        DatumMap datum_map;
+        // Use sequential iteration (true) to preserve field order
+        for (const auto& pair : vpack::ObjectIterator(_json_slice, true)) {
+            std::string key_str = pair.key.copyString();
+            vpack::Builder key_builder;
+            key_builder.add(vpack::Value(key_str));
+            vpack::Slice key_slice = key_builder.slice();
+
+            VPackToDatumCaster key_caster(key_slice, key_type_info.get(), _mem_pool);
+            ASSIGN_OR_RETURN(auto key_datum, key_caster.cast());
+            DatumKey datum_key = key_datum.convert2DatumKey();
+
+            VPackToDatumCaster value_caster(pair.value, value_type_info.get(), _mem_pool);
+            ASSIGN_OR_RETURN(auto value_datum, value_caster.cast());
+
+            datum_map[datum_key] = std::move(value_datum);
+        }
+
+        Datum result;
+        result.set<DatumMap>(datum_map);
+        return result;
+    }
+
+    StatusOr<Datum> cast_struct() {
+        const auto& field_types = get_struct_field_types(_type_info);
+
+        if (_json_slice.isArray()) {
+            DatumStruct datum_struct;
+            size_t field_idx = 0;
+
+            for (const auto& element : vpack::ArrayIterator(_json_slice)) {
+                if (field_idx >= field_types.size()) {
+                    break;
+                }
+
+                VPackToDatumCaster field_caster(element, field_types[field_idx].get(), _mem_pool);
+                ASSIGN_OR_RETURN(auto field_datum, field_caster.cast());
+                datum_struct.push_back(std::move(field_datum));
+                field_idx++;
+            }
+
+            while (field_idx < field_types.size()) {
+                Datum null_datum;
+                null_datum.set_null();
+                datum_struct.push_back(null_datum);
+                field_idx++;
+            }
+
+            Datum result;
+            result.set<DatumStruct>(datum_struct);
+            return result;
+
+        } else if (_json_slice.isObject()) {
+            DatumStruct datum_struct;
+            size_t field_idx = 0;
+
+            // Use sequential iteration (true) to preserve field order
+            for (const auto& pair : vpack::ObjectIterator(_json_slice, true)) {
+                std::string_view key_name = pair.key.stringView();
+                if (field_idx >= field_types.size()) {
+                    break;
+                }
+
+                VPackToDatumCaster field_caster(pair.value, field_types[field_idx].get(), _mem_pool);
+                ASSIGN_OR_RETURN(auto field_datum, field_caster.cast());
+                datum_struct.push_back(std::move(field_datum));
+                field_idx++;
+            }
+
+            while (field_idx < field_types.size()) {
+                Datum null_datum;
+                null_datum.set_null();
+                datum_struct.push_back(null_datum);
+                field_idx++;
+            }
+
+            Datum result;
+            result.set<DatumStruct>(datum_struct);
+            return result;
+        } else {
+            Datum result;
+            result.set_null();
+            return result;
+        }
+    }
+
+    StatusOr<Datum> cast_json() {
+        JsonValue* json_value = new JsonValue(_json_slice);
+        Datum result;
+        result.set_json(json_value);
+        return result;
+    }
+
+private:
+    const vpack::Slice& _json_slice;
+    const TypeInfo* _type_info;
+    MemPool* _mem_pool;
+};
+
 Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
     _opts = opts;
+
     // be consistent with segment v1
     // if _has_default_value, we should create default column iterator for this column, and
     // "NULL" is a special default value which means the default value is null.
@@ -52,7 +336,12 @@ Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
             DCHECK(_is_nullable);
             _is_default_value_null = true;
         } else {
-            _type_size = _type_info->size();
+            if (_type_info->type() == TYPE_ARRAY || _type_info->type() == TYPE_MAP ||
+                _type_info->type() == TYPE_STRUCT) {
+                _type_size = sizeof(Datum);
+            } else {
+                _type_size = _type_info->size();
+            }
             _mem_value = reinterpret_cast<void*>(_pool.allocate(static_cast<int64_t>(_type_size)));
             if (UNLIKELY(_mem_value == nullptr)) {
                 return Status::InternalError("Mem usage has exceed the limit of BE");
@@ -99,8 +388,26 @@ Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
                 }
             } else if (_type_info->type() == TYPE_ARRAY || _type_info->type() == TYPE_MAP ||
                        _type_info->type() == TYPE_STRUCT) {
-                // @todo: need support complex type literal
-                return Status::NotSupported("Array/Map/Struct default type is unsupported");
+                auto json_or = JsonValue::parse_json_or_string(Slice(_default_value));
+                if (!json_or.ok()) {
+                    LOG(ERROR) << "Failed to parse complex type default value as JSON: '" << _default_value
+                               << "', type: " << _type_info->type() << ", error: " << json_or.status()
+                               << ", treating as NULL";
+                    _is_default_value_null = true;
+                } else {
+                    vpack::Slice json_slice = json_or.value().to_vslice();
+
+                    VPackToDatumCaster caster(json_slice, _type_info.get(), &_pool);
+                    auto datum_or = caster.cast();
+                    if (!datum_or.ok()) {
+                        LOG(ERROR) << "Failed to convert complex type default value to Datum: '" << _default_value
+                                   << "', type: " << _type_info->type() << ", error: " << datum_or.status()
+                                   << ", treating as NULL";
+                        _is_default_value_null = true;
+                    } else {
+                        new (_mem_value) Datum(std::move(datum_or.value()));
+                    }
+                }
             } else {
                 RETURN_IF_ERROR(_type_info->from_string(_mem_value, _default_value));
             }
@@ -165,8 +472,8 @@ Status DefaultValueColumnIterator::next_batch(const SparseRange<>& range, Column
             [[maybe_unused]] auto ret = dst->append_strings(slices);
         } else {
             dst->append_value_multiple_times(_mem_value, to_read);
+            _current_rowid = range.end();
         }
-        _current_rowid = range.end();
     }
     if (_may_contain_deleted_row) {
         dst->set_delete_state(DEL_PARTIAL_SATISFIED);

--- a/be/src/storage/rowset/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/default_value_column_iterator.cpp
@@ -89,7 +89,6 @@ static void _project_default_datum_by_path_if_needed(Datum* datum, const TypeInf
         }
 
         if (type_info->type() == TYPE_MAP) {
-            // MAP paths are represented similarly with a single child (INDEX/ALL) applied to values.
             const ColumnAccessPath* value_path = nullptr;
             if (path->children().size() == 1) {
                 auto* p = path->children()[0].get();

--- a/be/src/storage/rowset/default_value_column_iterator.h
+++ b/be/src/storage/rowset/default_value_column_iterator.h
@@ -40,6 +40,7 @@
 
 namespace starrocks {
 
+class ColumnAccessPath;
 class TypeInfo;
 using TypeInfoPtr = std::shared_ptr<TypeInfo>;
 
@@ -47,14 +48,16 @@ using TypeInfoPtr = std::shared_ptr<TypeInfo>;
 class DefaultValueColumnIterator final : public ColumnIterator {
 public:
     DefaultValueColumnIterator(bool has_default_value, std::string default_value, bool is_nullable,
-                               TypeInfoPtr type_info, size_t schema_length, ordinal_t num_rows)
+                               TypeInfoPtr type_info, size_t schema_length, ordinal_t num_rows,
+                               const ColumnAccessPath* path = nullptr)
             : _has_default_value(has_default_value),
               _default_value(std::move(default_value)),
               _is_nullable(is_nullable),
               _type_info(std::move(type_info)),
               _schema_length(schema_length),
               _pool(),
-              _num_rows(num_rows) {}
+              _num_rows(num_rows),
+              _path(path) {}
 
     Status init(const ColumnIteratorOptions& opts) override;
 
@@ -114,6 +117,11 @@ private:
     ordinal_t _current_rowid = 0;
     ordinal_t _num_rows = 0;
     bool _may_contain_deleted_row = false;
+
+    // Optional: used when scan prunes subfields (e.g. only read /struct_col/subfield).
+    // For missing columns filled by default value, we need this to project STRUCT default datums
+    // to match the pruned column shape.
+    const ColumnAccessPath* _path = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -502,7 +502,7 @@ StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator_or_defaul
         const TypeInfoPtr& type_info = get_type_info(column);
         auto default_value_iter = std::make_unique<DefaultValueColumnIterator>(
                 column.has_default_value(), column.default_value(), column.is_nullable(), type_info, column.length(),
-                num_rows());
+                num_rows(), path);
         ColumnIteratorOptions iter_opts;
         RETURN_IF_ERROR(default_value_iter->init(iter_opts));
         return default_value_iter;

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -50,15 +50,14 @@
 #include "storage/convert_helper.h"
 #include "storage/memtable.h"
 #include "storage/memtable_rowset_writer_sink.h"
+#include "storage/metadata_util.h"
 #include "storage/rowset/rowset_factory.h"
-#include "storage/rowset/rowset_id_generator.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet.h"
 #include "storage/tablet_manager.h"
 #include "storage/tablet_meta_manager.h"
 #include "storage/tablet_updates.h"
 #include "util/failpoint/fail_point.h"
-#include "util/unaligned_access.h"
 
 namespace starrocks {
 
@@ -724,7 +723,14 @@ Status SchemaChangeHandler::_do_process_alter_tablet(const TAlterTabletReqV2& re
     // Create a new tablet schema, should merge with dropped columns in light schema change
     TabletSchemaCSPtr base_tablet_schema;
     if (!request.columns.empty() && request.columns[0].col_unique_id >= 0) {
-        base_tablet_schema = TabletSchema::copy(*base_tablet->tablet_schema(), request.columns);
+        auto columns_copy = request.columns;
+
+        Status preprocess_status = preprocess_default_expr_for_tcolumns(columns_copy);
+        if (!preprocess_status.ok()) {
+            LOG(WARNING) << "Failed to preprocess default_expr in SchemaChange: " << preprocess_status.to_string();
+        }
+
+        base_tablet_schema = TabletSchema::copy(*base_tablet->tablet_schema(), columns_copy);
     } else {
         base_tablet_schema = base_tablet->tablet_schema();
     }

--- a/be/src/types/struct_type_info.h
+++ b/be/src/types/struct_type_info.h
@@ -20,4 +20,6 @@ namespace starrocks {
 
 TypeInfoPtr get_struct_type_info(std::vector<TypeInfoPtr> field_types);
 
+const std::vector<TypeInfoPtr>& get_struct_field_types(const TypeInfo* type_info);
+
 } // namespace starrocks

--- a/be/src/util/json_converter.h
+++ b/be/src/util/json_converter.h
@@ -18,6 +18,8 @@
 #include "column/type_traits.h"
 #include "common/compiler_util.h"
 #include "common/statusor.h"
+#include "runtime/decimalv3.h"
+#include "types/timestamp_value.h"
 #ifdef __APPLE__
 #include "simdjson.h"
 #else
@@ -186,6 +188,50 @@ static Status cast_vpjson_to(const vpack::Slice& slice, ColumnBuilder<ResultType
 
                 result.append(Slice(str));
             }
+        }
+        if constexpr (ResultType == TYPE_DATE) {
+            if (LIKELY(slice.isString())) {
+                vpack::ValueLength len;
+                const char* str = slice.getStringUnchecked(len);
+                DateValue dv;
+                if (dv.from_string(str, len)) {
+                    result.append(dv);
+                } else {
+                    if constexpr (AllowThrowException) {
+                        return Status::JsonFormatError(
+                                fmt::format("cast from JSON({}) to DATE failed", std::string(str, len)));
+                    }
+                    result.append_null();
+                }
+            } else {
+                if constexpr (AllowThrowException) {
+                    return Status::JsonFormatError("cast from JSON to DATE failed: not a string");
+                }
+                result.append_null();
+            }
+            return Status::OK();
+        }
+        if constexpr (ResultType == TYPE_DATETIME) {
+            if (LIKELY(slice.isString())) {
+                vpack::ValueLength len;
+                const char* str = slice.getStringUnchecked(len);
+                TimestampValue tv;
+                if (tv.from_string(str, len)) {
+                    result.append(tv);
+                } else {
+                    if constexpr (AllowThrowException) {
+                        return Status::JsonFormatError(
+                                fmt::format("cast from JSON({}) to DATETIME failed", std::string(str, len)));
+                    }
+                    result.append_null();
+                }
+            } else {
+                if constexpr (AllowThrowException) {
+                    return Status::JsonFormatError("cast from JSON to DATETIME failed: not a string");
+                }
+                result.append_null();
+            }
+            return Status::OK();
         }
     } catch (const vpack::Exception& e) {
         if constexpr (AllowThrowException) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1127,7 +1127,17 @@ public class SchemaChangeHandler extends AlterHandler {
             fastSchemaEvolution = false;
         }
 
-        if (newColumn.getDefaultValue() != null && newColumn.getDefaultExpr() != null) {
+        if (newColumn.getDefaultExpr() != null && newColumn.getDefaultExpr().hasExprObject()) {
+            if (!fastSchemaEvolution) {
+                throw new DdlException(
+                        "Complex type (ARRAY/MAP/STRUCT) default values require fast schema evolution. " +
+                                "Table '" + olapTable.getName() + "' has fast_schema_evolution=false. " +
+                                "This property can only be set during table creation and cannot be modified later.");
+            }
+        }
+
+        if (newColumn.getDefaultValue() != null && newColumn.getDefaultExpr() != null
+                && newColumn.getDefaultExpr().getExpr() != null) {
             fastSchemaEvolution = false;
         }
         if (newColumn.getDefaultExpr() != null && newColumn.getDefaultValueType() == Column.DefaultValueType.CONST) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -46,13 +46,19 @@ import com.starrocks.persist.ColumnIdExpr;
 import com.starrocks.persist.ExpressionSerializedObject;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonPreProcessable;
+import com.starrocks.planner.expression.ExprToThrift;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
+import com.starrocks.sql.analyzer.ColumnDefAnalyzer;
 import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.IndexDef;
+import com.starrocks.sql.ast.expression.ArrayExpr;
+import com.starrocks.sql.ast.expression.CastExpr;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprToSql;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.MapExpr;
 import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.StringLiteral;
@@ -68,6 +74,8 @@ import com.starrocks.type.Type;
 import com.starrocks.type.TypeSerializer;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.text.translate.UnicodeUnescaper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -86,6 +94,7 @@ import static com.starrocks.common.util.DateUtils.DATE_TIME_FORMATTER;
  * This class represents the column-related metadata.
  */
 public class Column implements Writable, GsonPreProcessable, GsonPostProcessable {
+    private static final Logger LOG = LogManager.getLogger(Column.class);
 
     public static final String CAN_NOT_CHANGE_DEFAULT_VALUE = "Can not change default value";
     public static final int COLUMN_UNIQUE_ID_INIT_VALUE = -1;
@@ -248,7 +257,12 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
                 // for default value is null or default value is not set the defaultExpr = null
                 this.defaultExpr = null;
             } else {
-                this.defaultExpr = new DefaultExpr(ExprToSql.toSql(defaultValueDef.expr), defaultValueDef.hasArguments);
+                boolean isExprObject = isComplexTypeExpression(defaultValueDef.expr);
+                if (isExprObject) {
+                    this.defaultExpr = new DefaultExpr(defaultValueDef.expr);
+                } else {
+                    this.defaultExpr = new DefaultExpr(ExprToSql.toSql(defaultValueDef.expr), defaultValueDef.hasArguments);
+                }
             }
         }
         this.isAutoIncrement = false;
@@ -288,17 +302,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     }
 
     public ColumnDef toColumnDef(Table table) {
-        ColumnDef.DefaultValueDef defaultDef = null;
-        if (defaultValue == null) {
-            if (defaultExpr != null) {
-                defaultDef = new ColumnDef.DefaultValueDef(true, defaultExpr.obtainExpr());
-            } else {
-                defaultDef = new ColumnDef.DefaultValueDef(false, null);
-            }
-        } else {
-            defaultDef = new ColumnDef.DefaultValueDef(true, new StringLiteral(defaultValue));
-        }
-        ColumnDef.DefaultValueDef defaultValueDef = null;
+        ColumnDef.DefaultValueDef defaultValueDef;
         if (defaultValue != null) {
             defaultValueDef = new ColumnDef.DefaultValueDef(true, new StringLiteral(defaultValue));
         } else {
@@ -411,6 +415,9 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     }
 
     public String getDefaultValue() {
+        if (this.defaultValue == null && this.defaultExpr != null && this.defaultExpr.hasExprObject()) {
+            return this.defaultExpr.toSql();
+        }
         return this.defaultValue;
     }
 
@@ -472,7 +479,12 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         tColumn.setIs_key(this.isKey);
         tColumn.setIs_allow_null(this.isAllowNull);
         tColumn.setIs_auto_increment(this.isAutoIncrement);
-        tColumn.setDefault_value(this.defaultValue);
+        if (this.defaultExpr != null && this.defaultExpr.getExprObject() != null) {
+            tColumn.setDefault_expr(ExprToThrift.treeToThrift(this.defaultExpr.getExprObject()));
+        } else if (this.defaultValue != null && !this.defaultValue.isEmpty()) {
+            tColumn.setDefault_value(this.defaultValue);
+        }
+
         // The define expr does not need to be serialized here for now.
         // At present, only serialized(analyzed) define expr is directly used when creating a materialized view.
         // It will not be used here, but through another structure `TAlterMaterializedViewParam`.
@@ -671,7 +683,9 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         if (defaultExpr == null && isAutoIncrement) {
             sb.append("AUTO_INCREMENT ");
         } else if (defaultExpr != null) {
-            if (isValidDefaultTimeFunction(defaultExpr.getExpr())) {
+            if (defaultExpr.hasExprObject()) {
+                sb.append("DEFAULT ").append(defaultExpr.toSql()).append(" ");
+            } else if (isValidDefaultTimeFunction(defaultExpr.getExpr())) {
                 // compatible with mysql
                 if (defaultExpr.hasArgs()) {
                     sb.append("DEFAULT ").append(defaultExpr.getExpr()).append(" ");
@@ -700,13 +714,15 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
 
     public enum DefaultValueType {
         NULL,       // default value is not set or default value is null
-        CONST,      // const expr e.g. default "1"
+        CONST,      // const expr e.g. default "1" or [1, 2, 3]
         VARY        // variable expr e.g. uuid() function
     }
 
     public DefaultValueType getDefaultValueType() {
         if (defaultExpr != null) {
             if (isEmptyDefaultTimeFunction(defaultExpr)) {
+                return DefaultValueType.CONST;
+            } else if (defaultExpr.hasExprObject()) {
                 return DefaultValueType.CONST;
             } else {
                 return DefaultValueType.VARY;
@@ -756,6 +772,10 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
                 LocalDateTime localDateTime = Instant.ofEpochMilli(currentTimestamp)
                         .atZone(TimeUtils.getTimeZone().toZoneId()).toLocalDateTime();
                 return localDateTime.format(DATE_TIME_FORMATTER);
+            } else if (defaultExpr.hasExprObject()) {
+                // For expr object type default expressions, return null
+                // The actual default value will be evaluated in BE from TExpr
+                return null;
             }
         }
 
@@ -776,6 +796,9 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
                 }
                 return "CURRENT_TIMESTAMP";
             } else {
+                if (defaultExpr.hasExprObject()) {
+                    return defaultExpr.toSql();
+                }
                 if (extras != null) {
                     extras.add("DEFAULT_GENERATED");
                 }
@@ -804,7 +827,9 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
                         .append("\" ");
             }
         } else {
-            if (isValidDefaultTimeFunction(defaultExpr.getExpr())) {
+            if (defaultExpr.hasExprObject()) {
+                sb.append("DEFAULT ").append(defaultExpr.toSql()).append(" ");
+            } else if (isValidDefaultTimeFunction(defaultExpr.getExpr())) {
                 // compatible with mysql
                 if (defaultExpr.hasArgs()) {
                     sb.append("DEFAULT ").append(defaultExpr.getExpr()).append(" ");
@@ -933,6 +958,15 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         if (this.aggStateDesc != null) {
             this.type.setAggStateDesc(this.aggStateDesc);
         }
+        if (defaultExpr != null && defaultExpr.hasExprObject() && defaultExpr.getExprObject() != null) {
+            try {
+                Expr validatedExpr = ColumnDefAnalyzer.validateComplexTypeDefaultValue(
+                        type, defaultExpr.getExprObject(), true);
+                defaultExpr.setExprObject(validatedExpr);
+            } catch (Exception e) {
+                LOG.warn("Failed to re-validate complex default expression for column {}: {}", name, e.getMessage());
+            }
+        }
     }
 
     @Override
@@ -985,4 +1019,20 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return this.aggStateDesc;
     }
 
+    private static boolean isComplexTypeExpression(Expr expr) {
+        Expr unwrapped = expr;
+        if (expr instanceof CastExpr) {
+            unwrapped = expr.getChild(0);
+        }
+
+        if (unwrapped instanceof ArrayExpr || unwrapped instanceof MapExpr) {
+            return true;
+        }
+
+        if (unwrapped instanceof FunctionCallExpr) {
+            String functionName = ((FunctionCallExpr) unwrapped).getFunctionName();
+            return "row".equalsIgnoreCase(functionName);
+        }
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -481,7 +481,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         tColumn.setIs_auto_increment(this.isAutoIncrement);
         if (this.defaultExpr != null && this.defaultExpr.getExprObject() != null) {
             tColumn.setDefault_expr(ExprToThrift.treeToThrift(this.defaultExpr.getExprObject()));
-        } else if (this.defaultValue != null && !this.defaultValue.isEmpty()) {
+        } else if (this.defaultValue != null) {
             tColumn.setDefault_value(this.defaultValue);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DefaultExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DefaultExpr.java
@@ -16,29 +16,54 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.persist.gson.GsonPostProcessable;
+import com.starrocks.persist.gson.GsonPreProcessable;
+import com.starrocks.qe.SqlModeHelper;
+import com.starrocks.sql.ast.expression.ArrayExpr;
+import com.starrocks.sql.ast.expression.CastExpr;
 import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.ExprToSql;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.FunctionParams;
 import com.starrocks.sql.ast.expression.IntLiteral;
+import com.starrocks.sql.ast.expression.MapExpr;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.Type;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class DefaultExpr {
+public class DefaultExpr implements GsonPreProcessable, GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(DefaultExpr.class);
+
     @SerializedName("expr")
     private String expr;
-    private boolean hasArguments;
+
+    private final boolean hasArguments;
+
+    @SerializedName("serializedExpr")
+    private String serializedExpr;
+
+    private Expr exprObject;
 
     public DefaultExpr(String expr, boolean hasArguments) {
         this.expr = expr;
         this.hasArguments = hasArguments;
+        this.exprObject = null;
+        this.serializedExpr = null;
+    }
+
+    public DefaultExpr(Expr exprObject) {
+        this.expr = null;
+        this.hasArguments = false;
+        this.exprObject = exprObject;
     }
 
     public String getExpr() {
@@ -53,12 +78,42 @@ public class DefaultExpr {
         return hasArguments;
     }
 
+    public boolean hasExprObject() {
+        return exprObject != null || serializedExpr != null;
+    }
+
+    public Expr getExprObject() {
+        return exprObject;
+    }
+
+    public void setExprObject(Expr exprObject) {
+        this.exprObject = exprObject;
+    }
+
+    @Override
+    public void gsonPreProcess() throws IOException {
+        if (exprObject != null) {
+            serializedExpr = ExprToSql.toSql(exprObject);
+        }
+    }
+
+    @Override
+    public void gsonPostProcess() throws IOException {
+        if (serializedExpr != null && !serializedExpr.isEmpty()) {
+            try {
+                exprObject = SqlParser.parseSqlToExpr(serializedExpr, SqlModeHelper.MODE_DEFAULT);
+            } catch (Exception e) {
+                LOG.warn("Failed to restore expr object from SQL: {}", serializedExpr, e);
+            }
+        }
+    }
+
     public static boolean isValidDefaultFunction(String expr) {
         String[] defaultfunctions = {
-            "current_timestamp\\([0-6]?\\)",
-            "now\\([0-6]?\\)",
-            "uuid\\(\\)",
-            "uuid_numeric\\(\\)"
+                "current_timestamp\\([0-6]?\\)",
+                "now\\([0-6]?\\)",
+                "uuid\\(\\)",
+                "uuid_numeric\\(\\)"
         };
 
         String combinedPattern = String.format("^(%s)$", String.join("|", defaultfunctions));
@@ -70,8 +125,8 @@ public class DefaultExpr {
 
     public static boolean isValidDefaultTimeFunction(String expr) {
         String[] defaultfunctions = {
-            "current_timestamp\\([0-6]?\\)",
-            "now\\([0-6]?\\)"
+                "current_timestamp\\([0-6]?\\)",
+                "now\\([0-6]?\\)"
         };
 
         String combinedPattern = String.format("^(%s)$", String.join("|", defaultfunctions));
@@ -82,11 +137,17 @@ public class DefaultExpr {
     }
 
     public static boolean isEmptyDefaultTimeFunction(DefaultExpr expr) {
-        return isValidDefaultTimeFunction(expr.getExpr()) && !expr.hasArgs();
+        return expr.getExprObject() == null && expr.getExpr() != null &&
+                isValidDefaultTimeFunction(expr.getExpr()) && !expr.hasArgs();
     }
 
     public Expr obtainExpr() {
-        if (isValidDefaultFunction(expr)) {
+        if (exprObject != null) {
+            return exprObject;
+        }
+
+        // Legacy: handle simple function expressions like now()
+        if (expr != null && isValidDefaultFunction(expr)) {
             String functionName = expr.replaceAll("\\(.*\\)", "");
 
             Pattern pattern = Pattern.compile("\\(([^)]+)\\)");
@@ -110,5 +171,79 @@ public class DefaultExpr {
             return functionCallExpr;
         }
         return null;
+    }
+
+    private static Expr removeAllCastExprs(Expr expr) {
+        if (expr instanceof CastExpr) {
+            Expr unwrapped = expr.getChild(0);
+            return removeAllCastExprs(unwrapped);
+        }
+
+        if (expr instanceof MapExpr mapExpr) {
+            boolean anyChanged = false;
+            List<Expr> newChildren = new ArrayList<>();
+            for (Expr child : mapExpr.getChildren()) {
+                Expr newChild = removeAllCastExprs(child);
+                newChildren.add(newChild);
+                if (newChild != child) {
+                    anyChanged = true;
+                }
+            }
+            if (!anyChanged) {
+                return mapExpr;
+            }
+            return new MapExpr(mapExpr.getType(), newChildren, mapExpr.getPos());
+        }
+
+        if (expr instanceof ArrayExpr arrayExpr) {
+            boolean anyChanged = false;
+            List<Expr> newChildren = new ArrayList<>();
+            for (Expr child : arrayExpr.getChildren()) {
+                Expr newChild = removeAllCastExprs(child);
+                newChildren.add(newChild);
+                if (newChild != child) {
+                    anyChanged = true;
+                }
+            }
+            if (!anyChanged) {
+                return arrayExpr;
+            }
+            return new ArrayExpr(arrayExpr.getType(), newChildren, arrayExpr.getPos());
+        }
+
+        if (expr instanceof FunctionCallExpr funcExpr) {
+            String funcName = funcExpr.getFunctionName();
+            if ("row".equalsIgnoreCase(funcName)) {
+                boolean anyChanged = false;
+                List<Expr> newChildren = new ArrayList<>();
+                for (Expr child : funcExpr.getChildren()) {
+                    Expr newChild = removeAllCastExprs(child);
+                    newChildren.add(newChild);
+                    if (newChild != child) {
+                        anyChanged = true;
+                    }
+                }
+                if (!anyChanged) {
+                    return funcExpr;
+                }
+                FunctionCallExpr newFuncExpr = new FunctionCallExpr(funcName, newChildren);
+                newFuncExpr.setType(funcExpr.getType());
+                newFuncExpr.setFn(funcExpr.getFn());
+                return newFuncExpr;
+            }
+        }
+
+        return expr;
+    }
+
+    public String toSql() {
+        if (exprObject != null) {
+            Expr exprWithoutCast = removeAllCastExprs(exprObject);
+            return ExprToSql.toSql(exprWithoutCast);
+        }
+        if (serializedExpr != null) {
+            return serializedExpr;
+        }
+        return expr;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -70,6 +70,7 @@ import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.ast.ValuesRelation;
+import com.starrocks.sql.ast.expression.CastExpr;
 import com.starrocks.sql.ast.expression.DefaultValueExpr;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.LiteralExpr;
@@ -682,7 +683,15 @@ public class InsertPlanner {
                     if (defaultValueType == Column.DefaultValueType.NULL || targetColumn.isAutoIncrement()) {
                         scalarOperator = ConstantOperator.createNull(targetColumn.getType());
                     } else if (defaultValueType == Column.DefaultValueType.CONST) {
-                        scalarOperator = ConstantOperator.createVarchar(targetColumn.calculatedDefaultValue());
+                        if (targetColumn.getDefaultExpr() != null && targetColumn.getDefaultExpr().hasExprObject()) {
+                            Expr expr = targetColumn.getDefaultExpr().obtainExpr();
+                            if (!expr.getType().equals(targetColumn.getType())) {
+                                expr = new CastExpr(targetColumn.getType(), expr);
+                            }
+                            scalarOperator = SqlToScalarOperatorTranslator.translate(expr);
+                        } else {
+                            scalarOperator = ConstantOperator.createVarchar(targetColumn.calculatedDefaultValue());
+                        }
                     } else if (defaultValueType == Column.DefaultValueType.VARY) {
                         if (isValidDefaultFunction(targetColumn.getDefaultExpr().getExpr())) {
                             scalarOperator = SqlToScalarOperatorTranslator.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -683,7 +683,7 @@ public class InsertPlanner {
                     if (defaultValueType == Column.DefaultValueType.NULL || targetColumn.isAutoIncrement()) {
                         scalarOperator = ConstantOperator.createNull(targetColumn.getType());
                     } else if (defaultValueType == Column.DefaultValueType.CONST) {
-                        if (targetColumn.getDefaultExpr() != null && targetColumn.getDefaultExpr().hasExprObject()) {
+                        if (targetColumn.getDefaultExpr() != null && targetColumn.getDefaultExpr().getExprObject() != null) {
                             Expr expr = targetColumn.getDefaultExpr().obtainExpr();
                             if (!expr.getType().equals(targetColumn.getType())) {
                                 expr = new CastExpr(targetColumn.getType(), expr);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1742,6 +1742,20 @@ public class AnalyzerUtils {
         return type;
     }
 
+    public static void replaceNullTypeInExprTree(Expr expr) {
+        for (Expr child : expr.getChildren()) {
+            replaceNullTypeInExprTree(child);
+        }
+
+        Type currentType = expr.getType();
+        if (currentType != null) {
+            Type hackedType = replaceNullType2Boolean(currentType);
+            if (!currentType.equals(hackedType)) {
+                expr.setType(hackedType);
+            }
+        }
+    }
+
     public static void checkNondeterministicFunction(ParseNode node) {
         new AstTraverser<Void, Void>() {
             @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
@@ -27,15 +27,23 @@ import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.ColumnDef;
+import com.starrocks.sql.ast.expression.ArrayExpr;
+import com.starrocks.sql.ast.expression.CastExpr;
 import com.starrocks.sql.ast.expression.DecimalLiteral;
 import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.ExprCastFunction;
+import com.starrocks.sql.ast.expression.ExprToSql;
 import com.starrocks.sql.ast.expression.FloatLiteral;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.FunctionParams;
+import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.LiteralExprFactory;
+import com.starrocks.sql.ast.expression.MapExpr;
+import com.starrocks.sql.ast.expression.MaxLiteral;
 import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.ast.expression.TypeDef;
+import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.type.AggStateDesc;
 import com.starrocks.type.PrimitiveType;
@@ -177,7 +185,10 @@ public class ColumnDefAnalyzer {
 
         if (defaultValueDef.isSet && defaultValueDef.expr != null) {
             try {
-                validateDefaultValue(type, defaultValueDef.expr);
+                Expr validatedExpr = validateDefaultValue(type, defaultValueDef.expr);
+                if (validatedExpr != defaultValueDef.expr) {
+                    defaultValueDef.expr = validatedExpr;
+                }
             } catch (AnalysisException e) {
                 throw new AnalysisException(String.format("Invalid default value for '%s': %s", name, e.getMessage()));
             }
@@ -218,12 +229,15 @@ public class ColumnDefAnalyzer {
         return type;
     }
 
-    public static void validateDefaultValue(Type type, Expr defaultExpr) throws AnalysisException {
+    public static Expr validateDefaultValue(Type type, Expr defaultExpr) throws AnalysisException {
         if (defaultExpr instanceof StringLiteral) {
             String defaultValue = ((StringLiteral) defaultExpr).getValue();
             Preconditions.checkNotNull(defaultValue);
+            // For complex types with string literals, they should be handled as expressions
             if (type.isComplexType()) {
-                throw new AnalysisException(String.format("Default value for complex type '%s' not supported", type));
+                throw new AnalysisException(
+                        String.format("Default value for complex type '%s' requires expression syntax (e.g., [], map{}, row())",
+                                type));
             }
             ScalarType scalarType = (ScalarType) type;
             // check if default value is valid. if not, some literal constructor will throw AnalysisException
@@ -285,6 +299,11 @@ public class ColumnDefAnalyzer {
         } else if (defaultExpr instanceof FunctionCallExpr) {
             FunctionCallExpr functionCallExpr = (FunctionCallExpr) defaultExpr;
             String functionName = functionCallExpr.getFunctionName();
+            // for struct type default value
+            if ("row".equalsIgnoreCase(functionName)) {
+                return validateComplexTypeDefaultValue(type, defaultExpr, false);
+            }
+
             boolean supported = isValidDefaultFunction(functionName + "()");
 
             if (!supported) {
@@ -311,9 +330,107 @@ public class ColumnDefAnalyzer {
             }
         } else if (defaultExpr instanceof NullLiteral) {
             // nothing to check
+        } else if (defaultExpr instanceof ArrayExpr || defaultExpr instanceof MapExpr) {
+            return validateComplexTypeDefaultValue(type, defaultExpr, false);
         } else {
             throw new AnalysisException(String.format("Unsupported expr %s for default value", defaultExpr));
         }
+
+        return defaultExpr;
+    }
+
+    public static Expr validateComplexTypeDefaultValue(Type columnType, Expr defaultExpr,
+                                                       boolean allowOuterCast)
+            throws AnalysisException {
+        validateComplexTypeDefaultExpressionForm(defaultExpr, allowOuterCast);
+
+        try {
+            ExpressionAnalyzer.analyzeExpressionIgnoreSlot(defaultExpr, ConnectContext.get());
+        } catch (Exception e) {
+            throw new AnalysisException(
+                    "Failed to analyze default value expression: " + e.getMessage(), e);
+        }
+
+        Type exprType = defaultExpr.getType();
+        if (exprType == null) {
+            throw new AnalysisException("Cannot determine type of default value expression");
+        }
+
+        AnalyzerUtils.replaceNullTypeInExprTree(defaultExpr);
+        exprType = defaultExpr.getType();
+
+        if (!TypeManager.canCastTo(exprType, columnType)) {
+            throw new AnalysisException(
+                    String.format("Default value type %s cannot be cast to column type %s",
+                            exprType, columnType));
+        }
+
+        if (!exprType.equals(columnType)) {
+            return ExprCastFunction.uncheckedCastTo(defaultExpr, columnType);
+        }
+
+        return defaultExpr;
+    }
+
+    private static void validateComplexTypeDefaultExpressionForm(Expr expr, boolean allowOuterCast)
+            throws AnalysisException {
+        if (expr instanceof CastExpr castExpr) {
+            if (allowOuterCast) {
+                validateComplexTypeDefaultExpressionForm(castExpr.getChild(0), true);
+                return;
+            } else {
+                throw new AnalysisException(
+                        "CAST expression is not allowed in complex type default value. " +
+                                "Type conversion will be handled automatically. " +
+                                "Expression: " + ExprToSql.toSql(expr));
+            }
+        }
+
+        // TODO(stephen): support null default value on subfield
+        if (expr instanceof NullLiteral || expr instanceof MaxLiteral) {
+            throw new AnalysisException(
+                    "NULL literal is not supported in complex type default value. " +
+                            "Only constant expressions (literals, arrays, maps, and row()) are allowed.");
+        }
+
+        if (expr instanceof LiteralExpr) {
+            return;
+        }
+
+        if (expr instanceof ArrayExpr arrayExpr) {
+            for (Expr child : arrayExpr.getChildren()) {
+                validateComplexTypeDefaultExpressionForm(child, allowOuterCast);
+            }
+            return;
+        }
+
+        if (expr instanceof MapExpr mapExpr) {
+            for (Expr child : mapExpr.getChildren()) {
+                validateComplexTypeDefaultExpressionForm(child, allowOuterCast);
+            }
+            return;
+        }
+
+        if (expr instanceof FunctionCallExpr funcExpr) {
+            String funcName = funcExpr.getFnName().toString();
+
+            if (!"row".equalsIgnoreCase(funcName)) {
+                throw new AnalysisException(
+                        String.format("Function '%s' is not supported in complex type default value. " +
+                                        "Only constant expressions (literals, arrays, maps, and row()) are allowed.",
+                                funcName));
+            }
+
+            for (Expr child : funcExpr.getChildren()) {
+                validateComplexTypeDefaultExpressionForm(child, allowOuterCast);
+            }
+            return;
+        }
+
+        throw new AnalysisException(
+                String.format("Expression type '%s' is not supported in complex type default value. " +
+                        "Only constant expressions (literals, arrays, maps, and row()) are allowed. " +
+                        "Expression: %s", expr.getClass().getSimpleName(), ExprToSql.toSql(expr)));
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1196,6 +1196,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                 String functionName = defaultDescContext.qualifiedName().getText().toLowerCase();
                 defaultValueDef = new ColumnDef.DefaultValueDef(true,
                         new FunctionCallExpr(functionName, new ArrayList<>()));
+            } else if (defaultDescContext.expression() != null) {
+                Expr defaultExpr = (Expr) visit(defaultDescContext.expression());
+                defaultValueDef = new ColumnDef.DefaultValueDef(true, defaultExpr);
             }
         }
         final com.starrocks.sql.parser.StarRocksParser.GeneratedColumnDescContext generatedColumnDescContext =

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -730,4 +730,142 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
                     exception.getMessage());
         }
     }
+
+    @Test
+    public void testAlterTableAddComplexTypeDefaultValue() throws Exception {
+        String createTableStmt = "CREATE TABLE test.test_complex_default (\n" +
+                "id INT NOT NULL,\n" +
+                "name STRING\n" +
+                ") DUPLICATE KEY(id)\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "    'replication_num' = '1',\n" +
+                "    'fast_schema_evolution' = 'true'\n" +
+                ");";
+        createTable(createTableStmt);
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) db.getTable("test_complex_default");
+        Assertions.assertNotNull(table);
+        Assertions.assertEquals(2, table.getBaseSchema().size());
+
+        String alterSql1 = "ALTER TABLE test.test_complex_default ADD COLUMN arr ARRAY<INT> DEFAULT [1, 2, 3]";
+        AlterTableStmt alterStmt1 = (AlterTableStmt) parseAndAnalyzeStmt(alterSql1);
+        Assertions.assertDoesNotThrow(() -> {
+            SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+            handler.process(alterStmt1.getAlterClauseList(), db, table);
+        });
+
+        jobSize++;
+        Assertions.assertEquals(3, table.getBaseSchema().size());
+        Column arrCol = table.getColumn("arr");
+        Assertions.assertNotNull(arrCol);
+        Assertions.assertTrue(arrCol.getType().isArrayType());
+        Assertions.assertNotNull(arrCol.getDefaultExpr());
+
+        String alterSql2 = "ALTER TABLE test.test_complex_default ADD COLUMN mp MAP<STRING, INT> DEFAULT map{'k1': 1, 'k2': 2}";
+        AlterTableStmt alterStmt2 = (AlterTableStmt) parseAndAnalyzeStmt(alterSql2);
+        Assertions.assertDoesNotThrow(() -> {
+            SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+            handler.process(alterStmt2.getAlterClauseList(), db, table);
+        });
+
+        jobSize++;
+        Assertions.assertEquals(4, table.getBaseSchema().size());
+        Column mpCol = table.getColumn("mp");
+        Assertions.assertNotNull(mpCol);
+        Assertions.assertTrue(mpCol.getType().isMapType());
+        Assertions.assertNotNull(mpCol.getDefaultExpr());
+
+        String alterSql3 = "ALTER TABLE test.test_complex_default ADD COLUMN st STRUCT<id INT, name STRING> " +
+                "DEFAULT row(1, 'test')";
+        AlterTableStmt alterStmt3 = (AlterTableStmt) parseAndAnalyzeStmt(alterSql3);
+        Assertions.assertDoesNotThrow(() -> {
+            SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+            handler.process(alterStmt3.getAlterClauseList(), db, table);
+        });
+
+        jobSize++;
+        Assertions.assertEquals(5, table.getBaseSchema().size());
+        Column stCol = table.getColumn("st");
+        Assertions.assertNotNull(stCol);
+        Assertions.assertTrue(stCol.getType().isStructType());
+        Assertions.assertNotNull(stCol.getDefaultExpr());
+
+        String alterSql4 = "ALTER TABLE test.test_complex_default ADD COLUMN" +
+                " nested_arr ARRAY<STRUCT<id INT, tags ARRAY<STRING>>> DEFAULT [row(1, ['a', 'b']), row(2, ['c', 'd'])]";
+        AlterTableStmt alterStmt4 = (AlterTableStmt) parseAndAnalyzeStmt(alterSql4);
+        Assertions.assertDoesNotThrow(() -> {
+            SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+            handler.process(alterStmt4.getAlterClauseList(), db, table);
+        });
+
+        jobSize++;
+        Assertions.assertEquals(6, table.getBaseSchema().size());
+        Column nestedCol = table.getColumn("nested_arr");
+        Assertions.assertNotNull(nestedCol);
+        Assertions.assertTrue(nestedCol.getType().isArrayType());
+        Assertions.assertNotNull(nestedCol.getDefaultExpr());
+    }
+
+    @Test
+    public void testAlterTableComplexTypeRequiresFastSchemaEvolution() throws Exception {
+        String createTableStmt = "CREATE TABLE test.test_complex_no_fast (\n" +
+                "id INT NOT NULL,\n" +
+                "name STRING\n" +
+                ") DUPLICATE KEY(id)\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "    'replication_num' = '1',\n" +
+                "    'fast_schema_evolution' = 'false'\n" +
+                ");";
+        createTable(createTableStmt);
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) db.getTable("test_complex_no_fast");
+        Assertions.assertNotNull(table);
+
+        String alterSql = "ALTER TABLE test.test_complex_no_fast ADD COLUMN arr ARRAY<INT> DEFAULT [1, 2, 3]";
+        AlterTableStmt alterStmt = (AlterTableStmt) parseAndAnalyzeStmt(alterSql);
+
+        DdlException exception = Assertions.assertThrows(DdlException.class, () -> {
+            SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+            handler.process(alterStmt.getAlterClauseList(), db, table);
+        });
+
+        Assertions.assertTrue(exception.getMessage().contains("Complex type (ARRAY/MAP/STRUCT) " +
+                "default values require fast schema evolution"), exception.getMessage());
+    }
+
+    @Test
+    public void testAlterTableComplexTypeInvalidExpression() throws Exception {
+        String createTableStmt = "CREATE TABLE test.test_complex_invalid (\n" +
+                "id INT NOT NULL\n" +
+                ") DUPLICATE KEY(id)\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "    'replication_num' = '1',\n" +
+                "    'fast_schema_evolution' = 'true'\n" +
+                ");";
+        createTable(createTableStmt);
+
+        String alterSql1 = "ALTER TABLE test.test_complex_invalid ADD COLUMN arr ARRAY<DATETIME> DEFAULT [now()]";
+        SemanticException exception1 = Assertions.assertThrows(SemanticException.class, () ->
+                parseAndAnalyzeStmt(alterSql1));
+        Assertions.assertTrue(exception1.getMessage().contains("Function 'now' is not supported"),
+                exception1.getMessage());
+
+        String alterSql2 = "ALTER TABLE test.test_complex_invalid ADD COLUMN st STRUCT<id INT, name STRING> DEFAULT row(null, " +
+                "'test')";
+        SemanticException exception2 = Assertions.assertThrows(SemanticException.class, () ->
+                parseAndAnalyzeStmt(alterSql2));
+        Assertions.assertTrue(exception2.getMessage().contains("NULL literal is not supported"),
+                exception2.getMessage());
+
+        String alterSql3 = "ALTER TABLE test.test_complex_invalid ADD COLUMN arr2 ARRAY<INT> DEFAULT [1+2, 3*4]";
+        SemanticException exception3 = Assertions.assertThrows(SemanticException.class, () ->
+                parseAndAnalyzeStmt(alterSql3));
+        Assertions.assertTrue(exception3.getMessage().contains("ArithmeticExpr' is not supported"),
+                exception3.getMessage());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateTableStmtTest.java
@@ -297,4 +297,81 @@ public class ShowCreateTableStmtTest {
         Assertions.assertTrue(createTable3.contains("parent1_k1") && createTable3.contains("parent1_k2"),
                 "foreign_key_constraints should include child column names. Got: " + createTable3);
     }
+
+    private String buildComplexTypeTableDdl(String tableName, String columnDef) {
+        return "CREATE TABLE test." + tableName + " (\n" +
+                "  k1 INT,\n" +
+                "  " + columnDef + "\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(k1)\n" +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "  \"replication_num\" = \"1\",\n" +
+                "  \"fast_schema_evolution\" = \"true\"\n" +
+                ");";
+    }
+
+    private void verifyShowCreateTableNoCast(String tableName, String columnDef,
+                                             String expectedFragment) throws Exception {
+        starRocksAssert.withTable(buildComplexTypeTableDdl(tableName, columnDef));
+
+        String showSql = "show create table test." + tableName;
+        ShowCreateTableStmt stmt = (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showSql, ctx);
+        ShowResultSet result = ShowExecutor.execute(stmt, ctx);
+        String output = result.getResultRows().get(0).get(1);
+
+        Assertions.assertTrue(output.contains(expectedFragment),
+                String.format("Expected output to contain '%s'. Got: %s", expectedFragment, output));
+        Assertions.assertFalse(output.contains("CAST"),
+                String.format("Output should not contain CAST. Got: %s", output));
+    }
+
+    @Test
+    public void testComplexTypeDefaultValueRemoveCast() throws Exception {
+        starRocksAssert.withDatabase("test").useDatabase("test");
+
+        verifyShowCreateTableNoCast(
+                "test_array_struct",
+                "k2 ARRAY<STRUCT<id INT, name STRING>> DEFAULT [row(1, 'alice'), row(2, 'bob')]",
+                "DEFAULT [row(1, 'alice'),row(2, 'bob')]"
+        );
+
+        verifyShowCreateTableNoCast(
+                "test_map_struct",
+                "k2 MAP<STRING, STRUCT<id INT, score DOUBLE>> DEFAULT map{'user1': row(1, 95.5), 'user2': row(2, 88.0)}",
+                "row(1, 95.5)"
+        );
+
+        verifyShowCreateTableNoCast(
+                "test_struct_array",
+                "k2 STRUCT<id INT, tags ARRAY<STRING>> DEFAULT row(1, ['tag1', 'tag2', 'tag3'])",
+                "row(1, ['tag1','tag2','tag3'])"
+        );
+
+        verifyShowCreateTableNoCast(
+                "test_struct_nested",
+                "k2 STRUCT<user STRUCT<id INT, name STRING>, meta STRUCT<created_at STRING, updated_at STRING>> " +
+                        "DEFAULT row(row(100, 'admin'), row('2024-01-01', '2024-01-02'))",
+                "row(row(100, 'admin'), row('2024-01-01', '2024-01-02'))"
+        );
+
+        verifyShowCreateTableNoCast(
+                "test_complex_nested",
+                "k2 MAP<INT, STRUCT<id INT, items ARRAY<STRUCT<item_id INT, quantity INT>>>> " +
+                        "DEFAULT map{1: row(100, [row(1, 5), row(2, 3)])}",
+                "row(100, [row(1, 5),row(2, 3)])"
+        );
+
+        verifyShowCreateTableNoCast(
+                "test_array_map_struct",
+                "k2 ARRAY<MAP<STRING, STRUCT<val INT>>> DEFAULT [map{'a': row(1)}, map{'b': row(2)}]",
+                "row(1)"
+        );
+
+        verifyShowCreateTableNoCast(
+                "test_map_array_struct",
+                "k2 MAP<STRING, ARRAY<STRUCT<x INT, y INT>>> DEFAULT map{'point1': [row(1, 2), row(3, 4)]}",
+                "[row(1, 2),row(3, 4)]"
+        );
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -38,6 +40,7 @@ public class CreateTableAnalyzerTest {
 
         FeConstants.runningUnitTest = true;
         UtFrameUtils.createMinStarRocksCluster();
+        AnalyzeTestUtil.init();
         UtFrameUtils.addMockBackend(10002);
         UtFrameUtils.addMockBackend(10003);
         // create connect context
@@ -119,5 +122,363 @@ public class CreateTableAnalyzerTest {
             CreateTableAnalyzer.analyze(createTableStmt, connectContext);
         });
         assertThat(exception.getMessage(), containsString("max_column_number_per_table"));
+        Config.max_column_number_per_table = 10000;
+    }
+
+    private void testValidComplexDefault(String columnDef) {
+        String sql = "CREATE TABLE test_create_table_db.test_complex_default (\n" +
+                "    id INT,\n" +
+                "    " + columnDef + "\n" +
+                ") DUPLICATE KEY(id)\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                "PROPERTIES(\"replication_num\" = \"1\", \"fast_schema_evolution\" = \"true\")";
+
+        analyzeSuccess(sql);
+    }
+
+    private void testInvalidComplexDefault(String columnDef, String expectedErrorMsg) {
+        String sql = "CREATE TABLE test_create_table_db.test_complex_default (\n" +
+                "    id INT,\n" +
+                "    " + columnDef + "\n" +
+                ") DUPLICATE KEY(id)\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                "PROPERTIES(\"replication_num\" = \"1\", \"fast_schema_evolution\" = \"true\")";
+
+        analyzeFail(sql, expectedErrorMsg);
+    }
+
+    @Test
+    public void testValidArrayDefaults() {
+        testValidComplexDefault("c1 ARRAY<INT> DEFAULT [1, 2, 3]");
+        testValidComplexDefault("c2 ARRAY<STRING> DEFAULT ['a', 'b', 'c']");
+        testValidComplexDefault("c3 ARRAY<DOUBLE> DEFAULT [1.1, 2.2, 3.3]");
+        testValidComplexDefault("c4 ARRAY<BOOLEAN> DEFAULT [true, false, true]");
+        testValidComplexDefault("c5 ARRAY<DATE> DEFAULT ['2024-01-01', '2024-12-31']");
+        testValidComplexDefault("c6 ARRAY<DATETIME> DEFAULT ['2024-01-01 10:00:00', '2024-12-31 23:59:59']");
+        testValidComplexDefault("c7 ARRAY<DECIMAL(10,2)> DEFAULT [123.45, 678.90]");
+
+        testValidComplexDefault("c8 ARRAY<ARRAY<INT>> DEFAULT [[1,2], [3,4], [5]]");
+        testValidComplexDefault("c9 ARRAY<ARRAY<STRING>> DEFAULT [['a','b'], ['c','d','e']]");
+        testValidComplexDefault("c10 ARRAY<ARRAY<ARRAY<INT>>> DEFAULT [[[1,2],[3,4]], [[5,6]]]");
+    }
+
+    @Test
+    public void testValidMapDefaults() {
+        testValidComplexDefault("c1 MAP<STRING, INT> DEFAULT map{'k1': 1, 'k2': 2}");
+        testValidComplexDefault("c2 MAP<INT, STRING> DEFAULT map{1: 'one', 2: 'two'}");
+        testValidComplexDefault("c3 MAP<STRING, DOUBLE> DEFAULT map{'price1': 99.99, 'price2': 199.99}");
+        testValidComplexDefault("c4 MAP<STRING, BOOLEAN> DEFAULT map{'flag1': true, 'flag2': false}");
+        testValidComplexDefault("c5 MAP<INT, INT> DEFAULT map{1: 10, 2: 20, 3: 30}");
+    }
+
+    @Test
+    public void testValidStructDefaults() {
+        testValidComplexDefault("c1 STRUCT<id INT, name STRING> DEFAULT row(1, 'test')");
+        testValidComplexDefault("c2 STRUCT<code INT, value DOUBLE, active BOOLEAN> DEFAULT row(100, 95.5, true)");
+        testValidComplexDefault("c3 STRUCT<dt DATE, name STRING> DEFAULT row('2024-01-01', 'event')");
+        testValidComplexDefault("c4 STRUCT<price DECIMAL(10,2), qty INT> DEFAULT row(99.99, 10)");
+
+        testValidComplexDefault("c5 STRUCT<id INT, inner_field STRUCT<code INT, value STRING>> " +
+                "DEFAULT row(1, row(100, 'nested'))");
+        testValidComplexDefault("c6 STRUCT<user STRUCT<id INT, name STRING>, status STRING> " +
+                "DEFAULT row(row(1, 'user1'), 'active')");
+    }
+
+    @Test
+    public void testValidArrayOfStructDefaults() {
+        testValidComplexDefault("c1 ARRAY<STRUCT<id INT, name STRING>> " +
+                "DEFAULT [row(1, 'alice'), row(2, 'bob')]");
+        testValidComplexDefault("c2 ARRAY<STRUCT<code INT, value DOUBLE, flag BOOLEAN>> " +
+                "DEFAULT [row(1, 95.5, true), row(2, 88.8, false)]");
+    }
+
+    @Test
+    public void testValidMapOfStructDefaults() {
+        testValidComplexDefault("c1 MAP<STRING, STRUCT<id INT, score DOUBLE>> " +
+                "DEFAULT map{'user1': row(1, 95.5), 'user2': row(2, 88.8)}");
+        testValidComplexDefault("c2 MAP<INT, STRUCT<name STRING, active BOOLEAN>> " +
+                "DEFAULT map{1: row('item1', true), 2: row('item2', false)}");
+    }
+
+    @Test
+    public void testValidStructWithArrayDefaults() {
+        testValidComplexDefault("c1 STRUCT<id INT, tags ARRAY<STRING>> " +
+                "DEFAULT row(1, ['tag1', 'tag2', 'tag3'])");
+        testValidComplexDefault("c2 STRUCT<user STRING, scores ARRAY<INT>> " +
+                "DEFAULT row('alice', [90, 85, 92])");
+        testValidComplexDefault("c3 STRUCT<id INT, dates ARRAY<DATE>> " +
+                "DEFAULT row(1, ['2024-01-01', '2024-12-31'])");
+    }
+
+    @Test
+    public void testValidStructWithMapDefaults() {
+        testValidComplexDefault("c1 STRUCT<id INT, properties MAP<STRING, INT>> " +
+                "DEFAULT row(1, map{'k1': 10, 'k2': 20})");
+        testValidComplexDefault("c2 STRUCT<name STRING, attrs MAP<STRING, STRING>> " +
+                "DEFAULT row('test', map{'attr1': 'v1', 'attr2': 'v2'})");
+    }
+
+    @Test
+    public void testValidMapWithArrayDefaults() {
+        testValidComplexDefault("c1 MAP<STRING, ARRAY<INT>> " +
+                "DEFAULT map{'scores1': [90, 85, 92], 'scores2': [78, 82, 88]}");
+        testValidComplexDefault("c2 MAP<STRING, ARRAY<STRING>> " +
+                "DEFAULT map{'tags1': ['a', 'b'], 'tags2': ['x', 'y', 'z']}");
+    }
+
+    @Test
+    public void testValidDeeplyNestedDefaults() {
+        // STRUCT<STRUCT<ARRAY>>
+        testValidComplexDefault("c1 STRUCT<id INT, data STRUCT<code INT, value ARRAY<INT>>> " +
+                "DEFAULT row(1, row(100, [1, 2, 3]))");
+
+        // ARRAY<STRUCT<STRUCT>>
+        testValidComplexDefault("c2 ARRAY<STRUCT<id INT, inner_field STRUCT<code INT, name STRING>>> " +
+                "DEFAULT [row(1, row(10, 'test1')), row(2, row(20, 'test2'))]");
+
+        // MAP<K, STRUCT<ARRAY>>
+        testValidComplexDefault("c3 MAP<STRING, STRUCT<id INT, tags ARRAY<STRING>>> " +
+                "DEFAULT map{'k1': row(1, ['a', 'b']), 'k2': row(2, ['c', 'd'])}");
+
+        // STRUCT<MAP<K, ARRAY>>
+        testValidComplexDefault("c4 STRUCT<id INT, data MAP<STRING, ARRAY<INT>>> " +
+                "DEFAULT row(1, map{'scores': [90, 85], 'grades': [80, 75]})");
+    }
+
+    @Test
+    public void testInvalidArithmeticExpressions() {
+        testInvalidComplexDefault(
+                "c1 ARRAY<INT> DEFAULT [1+2, 3*4]",
+                "Expression type 'ArithmeticExpr' is not supported");
+
+        testInvalidComplexDefault(
+                "c2 ARRAY<DOUBLE> DEFAULT [1.0/2.0, 3.0-1.0]",
+                "Expression type 'ArithmeticExpr' is not supported");
+
+        testInvalidComplexDefault(
+                "c3 MAP<STRING, INT> DEFAULT map{'k1': 10+20, 'k2': 30}",
+                "Expression type 'ArithmeticExpr' is not supported");
+
+        testInvalidComplexDefault(
+                "c4 STRUCT<id INT, value INT> DEFAULT row(1+1, 2*2)",
+                "Expression type 'ArithmeticExpr' is not supported");
+    }
+
+    @Test
+    public void testInvalidFunctionCalls() {
+        // Time functions
+        testInvalidComplexDefault(
+                "c1 ARRAY<DATETIME> DEFAULT [now()]",
+                "Function 'now' is not supported");
+
+        testInvalidComplexDefault(
+                "c2 STRUCT<id INT, ts DATETIME> DEFAULT row(1, now())",
+                "Function 'now' is not supported");
+
+        testInvalidComplexDefault(
+                "c3 MAP<STRING, DATETIME> DEFAULT map{'created': current_timestamp()}",
+                "Function 'CURRENT_TIMESTAMP' is not supported");
+
+        // String functions
+        testInvalidComplexDefault(
+                "c4 ARRAY<STRING> DEFAULT [concat('a', 'b')]",
+                "Function 'concat' is not supported");
+
+        testInvalidComplexDefault(
+                "c5 ARRAY<STRING> DEFAULT [upper('test')]",
+                "Function 'upper' is not supported");
+
+        testInvalidComplexDefault(
+                "c6 STRUCT<name STRING, value STRING> DEFAULT row('test', substring('hello', 1, 2))",
+                "Function 'substring' is not supported");
+
+        // Math functions
+        testInvalidComplexDefault(
+                "c7 ARRAY<INT> DEFAULT [abs(-10)]",
+                "Function 'abs' is not supported");
+
+        testInvalidComplexDefault(
+                "c8 ARRAY<DOUBLE> DEFAULT [rand()]",
+                "Function 'rand' is not supported");
+
+        testInvalidComplexDefault(
+                "c9 MAP<STRING, INT> DEFAULT map{'k1': floor(3.14)}",
+                "Function 'floor' is not supported");
+
+        // UUID function
+        testInvalidComplexDefault(
+                "c10 ARRAY<STRING> DEFAULT [uuid()]",
+                "Function 'uuid' is not supported");
+
+        // Conditional functions
+        testInvalidComplexDefault(
+                "c11 ARRAY<INT> DEFAULT [if(true, 10, 20)]",
+                "Function 'if' is not supported");
+
+        testInvalidComplexDefault(
+                "c12 STRUCT<id INT, value STRING> DEFAULT row(1, coalesce(null, 'default'))",
+                "Function 'coalesce' is not supported");
+
+        testInvalidComplexDefault(
+                "c13 MAP<STRING, INT> DEFAULT map{'k1': ifnull(null, 10)}",
+                "Function 'ifnull' is not supported");
+    }
+
+    @Test
+    public void testInvalidCaseAndCastExpressions() {
+        testInvalidComplexDefault(
+                "c1 ARRAY<INT> DEFAULT [CASE WHEN 1=1 THEN 10 ELSE 20 END]",
+                "Expression type 'CaseExpr' is not supported");
+
+        testInvalidComplexDefault(
+                "c2 MAP<STRING, INT> DEFAULT map{'k1': CAST('10' AS INT)}",
+                "CAST expression is not allowed in complex type default value");
+
+        testInvalidComplexDefault(
+                "c3 STRUCT<id INT, value STRING> DEFAULT row(1, CAST(100 AS STRING))",
+                "CAST expression is not allowed in complex type default value");
+    }
+
+    @Test
+    public void testInvalidNestedFunctions() {
+        testInvalidComplexDefault(
+                "c1 ARRAY<STRUCT<id INT, name STRING>> DEFAULT [row(1, upper('test'))]",
+                "Function 'upper' is not supported");
+
+        testInvalidComplexDefault(
+                "c2 STRUCT<id INT, data ARRAY<DATETIME>> DEFAULT row(1, [now()])",
+                "Function 'now' is not supported");
+
+        testInvalidComplexDefault(
+                "c3 MAP<STRING, STRUCT<id INT, value STRING>> " +
+                        "DEFAULT map{'k1': row(1, concat('a', 'b'))}",
+                "Function 'concat' is not supported");
+
+        testInvalidComplexDefault(
+                "c4 STRUCT<outer_field STRUCT<inner_field ARRAY<STRING>>> " +
+                        "DEFAULT row(row([uuid()]))",
+                "Function 'uuid' is not supported");
+    }
+
+    @Test
+    public void testEmptyAndNullValues() {
+        testValidComplexDefault("c1 ARRAY<INT> DEFAULT []");
+        testValidComplexDefault("c2 ARRAY<STRING> DEFAULT []");
+        testValidComplexDefault("c3 ARRAY<ARRAY<INT>> DEFAULT []");
+        testValidComplexDefault("c4 ARRAY<STRUCT<id INT, name STRING>> DEFAULT []");
+
+        testValidComplexDefault("c5 ARRAY<STRING> DEFAULT ['', 'a', '']");
+        testValidComplexDefault("c6 ARRAY<STRING> DEFAULT ['']");
+
+        testValidComplexDefault("c7 MAP<STRING, INT> DEFAULT map{}");
+        testValidComplexDefault("c8 MAP<INT, STRING> DEFAULT map{}");
+
+        testValidComplexDefault("c9 STRUCT<id INT, name STRING> DEFAULT row(1, '')");
+        testValidComplexDefault("c10 STRUCT<name STRING, value STRING> DEFAULT row('', '')");
+
+        testValidComplexDefault("c11 STRUCT<id INT, tags ARRAY<STRING>> DEFAULT row(1, [])");
+        testValidComplexDefault("c12 STRUCT<id INT, attrs MAP<STRING, INT>> DEFAULT row(1, map{})");
+
+        testValidComplexDefault("c13 ARRAY<ARRAY<INT>> DEFAULT [[], [1, 2], []]");
+        testValidComplexDefault("c14 MAP<STRING, ARRAY<INT>> DEFAULT map{'k1': [], 'k2': [1, 2]}");
+        testValidComplexDefault("c15 STRUCT<id INT, data STRUCT<tags ARRAY<STRING>, count INT>> " +
+                "DEFAULT row(1, row([], 0))");
+    }
+
+    @Test
+    public void testNullSubFieldsNotAllowed() {
+        testInvalidComplexDefault(
+                "c1 STRUCT<id INT, name STRING> DEFAULT row(null, 'test')",
+                "NULL literal is not supported in complex type default value");
+
+        testInvalidComplexDefault(
+                "c2 STRUCT<id INT, name STRING> DEFAULT row(1, null)",
+                "NULL literal is not supported in complex type default value");
+
+        testInvalidComplexDefault(
+                "c3 STRUCT<id INT, name STRING, value INT> DEFAULT row(null, null, null)",
+                "NULL literal is not supported in complex type default value");
+
+        testInvalidComplexDefault(
+                "c4 STRUCT<id INT, inner_field STRUCT<code INT, name STRING>> " +
+                        "DEFAULT row(1, row(null, 'test'))",
+                "NULL literal is not supported in complex type default value");
+
+        testInvalidComplexDefault(
+                "c5 ARRAY<INT> DEFAULT [1, null, 3]",
+                "NULL literal is not supported in complex type default value");
+
+        testInvalidComplexDefault(
+                "c6 ARRAY<STRING> DEFAULT ['a', null, 'b']",
+                "NULL literal is not supported in complex type default value");
+
+        testInvalidComplexDefault(
+                "c7 ARRAY<STRUCT<id INT, name STRING>> " +
+                        "DEFAULT [row(1, 'a'), row(null, 'b')]",
+                "NULL literal is not supported in complex type default value");
+
+        testInvalidComplexDefault(
+                "c8 MAP<STRING, INT> DEFAULT map{'k1': 1, 'k2': null}",
+                "NULL literal is not supported in complex type default value");
+
+        testInvalidComplexDefault(
+                "c9 MAP<STRING, STRING> DEFAULT map{'k1': 'v1', 'k2': null}",
+                "NULL literal is not supported in complex type default value");
+
+        testInvalidComplexDefault(
+                "c10 MAP<STRING, INT> DEFAULT map{null: 1, 'k2': 2}",
+                "NULL literal is not supported in complex type default value");
+
+        testInvalidComplexDefault(
+                "c11 MAP<STRING, STRUCT<id INT, value STRING>> " +
+                        "DEFAULT map{'k1': row(1, 'v1'), 'k2': row(null, 'v2')}",
+                "NULL literal is not supported in complex type default value");
+    }
+
+    @Test
+    public void testComplexTypeWithTypeCast() {
+        testValidComplexDefault("c1 ARRAY<INT> DEFAULT [1, 2, 3]");
+        testValidComplexDefault("c2 ARRAY<BIGINT> DEFAULT [100, 200]");
+        testValidComplexDefault("c3 ARRAY<DOUBLE> DEFAULT [1, 2, 3]");
+        testValidComplexDefault("c4 STRUCT<id BIGINT, value DOUBLE> DEFAULT row(1, 2)");
+        testValidComplexDefault("c5 MAP<STRING, BIGINT> DEFAULT map{'k1': 1, 'k2': 2}");
+        testValidComplexDefault("c6 ARRAY<ARRAY<BIGINT>> DEFAULT [[1, 2], [3, 4]]");
+        testValidComplexDefault("c7 STRUCT<id INT, scores ARRAY<DOUBLE>> DEFAULT row(1, [90, 85, 92])");
+    }
+
+    @Test
+    public void testComplexTypeInvalidCast() {
+        testInvalidComplexDefault(
+                "c1 ARRAY<INT> DEFAULT ['not_a_number']",
+                "Invalid number format: not_a_number");
+
+        testInvalidComplexDefault(
+                "c3 MAP<INT, STRING> DEFAULT [123]",
+                "Invalid default value for 'c3': Default value type ARRAY<TINYINT> cannot be cast " +
+                        "to column type MAP<INT,VARCHAR(65533)");
+
+        testInvalidComplexDefault(
+                "c4 STRUCT<id INT, name STRING> DEFAULT row('not_int', 123, 456)",
+                "Invalid default value for 'c4': Default value type struct<col1 varchar, col2 tinyint(4), col3 smallint(6)> " +
+                        "cannot be cast to column type struct<id int(11), name varchar(65533)>");
+
+        testInvalidComplexDefault("c1 ARRAY<STRUCT<id INT>> DEFAULT [row(1, 'extra_field')]", "");
+
+        testInvalidComplexDefault("c2 MAP<STRING, INT> DEFAULT map{'k1'}", "");
+
+        testInvalidComplexDefault("c2 MAP<STRING, INT> DEFAULT '123'", "Invalid default value for 'c2':" +
+                " Default value for complex type 'MAP<VARCHAR(65533),INT>' requires expression syntax (e.g., [], map{}, row())");
+    }
+
+    @Test
+    public void testFastSchemaEvolutionRequired() {
+        String sql = "CREATE TABLE test_create_table_db.test_no_fast_schema (\n" +
+                "    id INT,\n" +
+                "    c1 ARRAY<INT> DEFAULT [1, 2, 3]\n" +
+                ") DUPLICATE KEY(id)\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                "PROPERTIES(\"replication_num\" = \"1\", \"fast_schema_evolution\" = \"false\")";
+
+        analyzeFail(sql, "Complex type (ARRAY/MAP/STRUCT) default values require fast schema evolution");
     }
 }

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -458,7 +458,7 @@ charsetName
     ;
 
 defaultDesc
-    : DEFAULT (string | NULL | CURRENT_TIMESTAMP ('(' (INTEGER_VALUE)? ')')? | '(' qualifiedName '(' ')' ')')
+    : DEFAULT (string | NULL | CURRENT_TIMESTAMP ('(' (INTEGER_VALUE)? ')')? | '(' qualifiedName '(' ')' ')' | expression)
     ;
 
 generatedColumnDesc

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -267,7 +267,11 @@ struct TColumn {
     // For fixed-length column, this value may be ignored by BE when creating a tablet.
     20: optional i32 index_len                 
     // column type. If this field is set, the |column_type| will be ignored.
-    21: optional Types.TTypeDesc type_desc         
+    21: optional Types.TTypeDesc type_desc
+    // Default value expression for complex types (array/map/struct).
+    // If set, BE will evaluate this expression and convert to JSON string for storage.
+    // For simple types, use |default_value| (field 6) instead.
+    22: optional Exprs.TExpr default_expr
 }
 
 // Key information for locating a specific table schema version.

--- a/test/sql/test_default_value/R/test_complex_default_all_paths.sql
+++ b/test/sql/test_default_value/R/test_complex_default_all_paths.sql
@@ -1,4 +1,4 @@
--- name: test_complex_default_all_paths
+-- name: test_complex_default_all_paths @slow
 DROP DATABASE IF EXISTS test_complex_default_db;
 -- result:
 -- !result
@@ -21,11 +21,23 @@ INSERT INTO fast_schema_evolution (id) VALUES (1), (2), (3);
 ALTER TABLE fast_schema_evolution ADD COLUMN arr_col ARRAY<INT> DEFAULT [10, 20, 30];
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE fast_schema_evolution ADD COLUMN map_col MAP<INT, VARCHAR(20)> DEFAULT map{1: 'apple', 2: 'banana'};
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE fast_schema_evolution ADD COLUMN struct_col STRUCT<f1 INT, f2 VARCHAR(20)> DEFAULT row(100, 'hello');
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 SELECT * FROM fast_schema_evolution ORDER BY id;
 -- result:
@@ -46,8 +58,16 @@ INSERT INTO nested_complex (id) VALUES (1), (2);
 ALTER TABLE nested_complex ADD COLUMN nested_array ARRAY<ARRAY<INT>> DEFAULT [[1, 2], [3, 4, 5]];
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE nested_complex ADD COLUMN map_with_array MAP<INT, ARRAY<VARCHAR(20)>> DEFAULT map{1: ['a', 'b'], 2: ['c', 'd']};
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 ALTER TABLE nested_complex ADD COLUMN complex_struct STRUCT<
     id INT, 
@@ -55,6 +75,10 @@ ALTER TABLE nested_complex ADD COLUMN complex_struct STRUCT<
     tags MAP<VARCHAR(20), INT>
 > DEFAULT row(999, [100, 200], map{'k1': 1, 'k2': 2});
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 SELECT * FROM nested_complex ORDER BY id;
 -- result:
@@ -75,12 +99,20 @@ ALTER TABLE map_struct_order ADD COLUMN data MAP<INT, STRUCT<s4 INT, ks ARRAY<IN
 DEFAULT map{1: row(2, [1, 2, 3, 4])};
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE map_struct_order ADD COLUMN complex_data MAP<INT, STRUCT<
     field_b VARCHAR(20),
     field_a INT,
     nested STRUCT<z INT, a VARCHAR(20)>
 >> DEFAULT map{10: row('hello', 100, row(999, 'world'))};
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 SELECT * FROM map_struct_order ORDER BY id;
 -- result:
@@ -100,8 +132,16 @@ INSERT INTO empty_collections (id) VALUES (1), (2);
 ALTER TABLE empty_collections ADD COLUMN empty_arr ARRAY<INT> DEFAULT [];
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE empty_collections ADD COLUMN empty_map MAP<INT, VARCHAR(20)> DEFAULT map{};
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 ALTER TABLE empty_collections ADD COLUMN struct_with_empty STRUCT<
     id INT,
@@ -109,6 +149,10 @@ ALTER TABLE empty_collections ADD COLUMN struct_with_empty STRUCT<
     mp MAP<VARCHAR(20), INT>
 > DEFAULT row(0, [], map{});
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 SELECT * FROM empty_collections ORDER BY id;
 -- result:
@@ -128,29 +172,65 @@ INSERT INTO all_primitive_types (id) VALUES (1);
 ALTER TABLE all_primitive_types ADD COLUMN arr_int ARRAY<INT> DEFAULT [1, 2, 3];
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE all_primitive_types ADD COLUMN arr_bigint ARRAY<BIGINT> DEFAULT [1000000000, 2000000000];
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 ALTER TABLE all_primitive_types ADD COLUMN arr_string ARRAY<VARCHAR(20)> DEFAULT ['hello', 'world'];
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE all_primitive_types ADD COLUMN arr_double ARRAY<DOUBLE> DEFAULT [1.1, 2.2, 3.3];
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 ALTER TABLE all_primitive_types ADD COLUMN arr_bool ARRAY<BOOLEAN> DEFAULT [true, false, true];
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE all_primitive_types ADD COLUMN arr_decimal ARRAY<DECIMAL(10, 2)> DEFAULT [99.99, 199.99, 299.99];
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 ALTER TABLE all_primitive_types ADD COLUMN map_int_str MAP<INT, VARCHAR(20)> DEFAULT map{1: 'one', 2: 'two'};
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE all_primitive_types ADD COLUMN map_str_int MAP<VARCHAR(20), INT> DEFAULT map{'a': 10, 'b': 20};
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE all_primitive_types ADD COLUMN map_str_bool MAP<VARCHAR(20), BOOLEAN> DEFAULT map{'flag1': true, 'flag2': false};
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 ALTER TABLE all_primitive_types ADD COLUMN struct_mixed STRUCT<
     f_int INT,
@@ -161,6 +241,10 @@ ALTER TABLE all_primitive_types ADD COLUMN struct_mixed STRUCT<
     f_decimal DECIMAL(10, 2)
 > DEFAULT row(100, 1000000000, 'text', 99.99, true, 123.45);
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 SELECT * FROM all_primitive_types;
 -- result:
@@ -179,11 +263,23 @@ INSERT INTO nullable_complex (id) VALUES (1), (2);
 ALTER TABLE nullable_complex ADD COLUMN nullable_arr ARRAY<INT> NULL DEFAULT [100, 200];
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE nullable_complex ADD COLUMN nullable_map MAP<INT, VARCHAR(20)> NULL DEFAULT map{1: 'test'};
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE nullable_complex ADD COLUMN nullable_struct STRUCT<f1 INT> NULL DEFAULT row(999);
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 SELECT * FROM nullable_complex ORDER BY id;
 -- result:
@@ -213,14 +309,30 @@ INSERT INTO reorder_test (id, name) VALUES (1, 'alice'), (2, 'bob'), (3, 'charli
 ALTER TABLE reorder_test ADD COLUMN arr ARRAY<INT> DEFAULT [1, 2, 3];
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE reorder_test ADD COLUMN mp MAP<INT, VARCHAR(20)> DEFAULT map{10: 'ten'};
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 ALTER TABLE reorder_test ADD COLUMN st STRUCT<f1 INT, f2 VARCHAR(20)> DEFAULT row(100, 'test');
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
 ALTER TABLE reorder_test ORDER BY (id, mp, st, arr, name);
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 SELECT SLEEP(2);
 -- result:
@@ -294,6 +406,10 @@ SELECT * FROM pk_column_mode ORDER BY order_id;
 -- !result
 ALTER TABLE pk_column_mode ADD COLUMN extras STRUCT<discount DOUBLE, items ARRAY<INT>> DEFAULT row(0.1, [1, 2, 3]);
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
 -- !result
 INSERT INTO pk_column_mode (order_id, product_name) VALUES (4, 'mouse');
 -- result:

--- a/test/sql/test_default_value/R/test_complex_default_all_paths.sql
+++ b/test/sql/test_default_value/R/test_complex_default_all_paths.sql
@@ -1,0 +1,480 @@
+-- name: test_complex_default_all_paths
+DROP DATABASE IF EXISTS test_complex_default_db;
+-- result:
+-- !result
+CREATE DATABASE test_complex_default_db;
+-- result:
+-- !result
+USE test_complex_default_db;
+-- result:
+-- !result
+CREATE TABLE fast_schema_evolution (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO fast_schema_evolution (id) VALUES (1), (2), (3);
+-- result:
+-- !result
+ALTER TABLE fast_schema_evolution ADD COLUMN arr_col ARRAY<INT> DEFAULT [10, 20, 30];
+-- result:
+-- !result
+ALTER TABLE fast_schema_evolution ADD COLUMN map_col MAP<INT, VARCHAR(20)> DEFAULT map{1: 'apple', 2: 'banana'};
+-- result:
+-- !result
+ALTER TABLE fast_schema_evolution ADD COLUMN struct_col STRUCT<f1 INT, f2 VARCHAR(20)> DEFAULT row(100, 'hello');
+-- result:
+-- !result
+SELECT * FROM fast_schema_evolution ORDER BY id;
+-- result:
+1	[10,20,30]	{1:"apple",2:"banana"}	{"f1":100,"f2":"hello"}
+2	[10,20,30]	{1:"apple",2:"banana"}	{"f1":100,"f2":"hello"}
+3	[10,20,30]	{1:"apple",2:"banana"}	{"f1":100,"f2":"hello"}
+-- !result
+CREATE TABLE nested_complex (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO nested_complex (id) VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE nested_complex ADD COLUMN nested_array ARRAY<ARRAY<INT>> DEFAULT [[1, 2], [3, 4, 5]];
+-- result:
+-- !result
+ALTER TABLE nested_complex ADD COLUMN map_with_array MAP<INT, ARRAY<VARCHAR(20)>> DEFAULT map{1: ['a', 'b'], 2: ['c', 'd']};
+-- result:
+-- !result
+ALTER TABLE nested_complex ADD COLUMN complex_struct STRUCT<
+    id INT, 
+    scores ARRAY<INT>, 
+    tags MAP<VARCHAR(20), INT>
+> DEFAULT row(999, [100, 200], map{'k1': 1, 'k2': 2});
+-- result:
+-- !result
+SELECT * FROM nested_complex ORDER BY id;
+-- result:
+1	[[1,2],[3,4,5]]	{1:["a","b"],2:["c","d"]}	{"id":999,"scores":[100,200],"tags":{"k1":1,"k2":2}}
+2	[[1,2],[3,4,5]]	{1:["a","b"],2:["c","d"]}	{"id":999,"scores":[100,200],"tags":{"k1":1,"k2":2}}
+-- !result
+CREATE TABLE map_struct_order (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO map_struct_order (id) VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE map_struct_order ADD COLUMN data MAP<INT, STRUCT<s4 INT, ks ARRAY<INT>>> 
+DEFAULT map{1: row(2, [1, 2, 3, 4])};
+-- result:
+-- !result
+ALTER TABLE map_struct_order ADD COLUMN complex_data MAP<INT, STRUCT<
+    field_b VARCHAR(20),
+    field_a INT,
+    nested STRUCT<z INT, a VARCHAR(20)>
+>> DEFAULT map{10: row('hello', 100, row(999, 'world'))};
+-- result:
+-- !result
+SELECT * FROM map_struct_order ORDER BY id;
+-- result:
+1	{1:{"s4":2,"ks":[1,2,3,4]}}	{10:{"field_b":"hello","field_a":100,"nested":{"z":999,"a":"world"}}}
+2	{1:{"s4":2,"ks":[1,2,3,4]}}	{10:{"field_b":"hello","field_a":100,"nested":{"z":999,"a":"world"}}}
+-- !result
+CREATE TABLE empty_collections (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO empty_collections (id) VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE empty_collections ADD COLUMN empty_arr ARRAY<INT> DEFAULT [];
+-- result:
+-- !result
+ALTER TABLE empty_collections ADD COLUMN empty_map MAP<INT, VARCHAR(20)> DEFAULT map{};
+-- result:
+-- !result
+ALTER TABLE empty_collections ADD COLUMN struct_with_empty STRUCT<
+    id INT,
+    arr ARRAY<INT>,
+    mp MAP<VARCHAR(20), INT>
+> DEFAULT row(0, [], map{});
+-- result:
+-- !result
+SELECT * FROM empty_collections ORDER BY id;
+-- result:
+1	[]	{}	{"id":0,"arr":[],"mp":{}}
+2	[]	{}	{"id":0,"arr":[],"mp":{}}
+-- !result
+CREATE TABLE all_primitive_types (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO all_primitive_types (id) VALUES (1);
+-- result:
+-- !result
+ALTER TABLE all_primitive_types ADD COLUMN arr_int ARRAY<INT> DEFAULT [1, 2, 3];
+-- result:
+-- !result
+ALTER TABLE all_primitive_types ADD COLUMN arr_bigint ARRAY<BIGINT> DEFAULT [1000000000, 2000000000];
+-- result:
+-- !result
+ALTER TABLE all_primitive_types ADD COLUMN arr_string ARRAY<VARCHAR(20)> DEFAULT ['hello', 'world'];
+-- result:
+-- !result
+ALTER TABLE all_primitive_types ADD COLUMN arr_double ARRAY<DOUBLE> DEFAULT [1.1, 2.2, 3.3];
+-- result:
+-- !result
+ALTER TABLE all_primitive_types ADD COLUMN arr_bool ARRAY<BOOLEAN> DEFAULT [true, false, true];
+-- result:
+-- !result
+ALTER TABLE all_primitive_types ADD COLUMN arr_decimal ARRAY<DECIMAL(10, 2)> DEFAULT [99.99, 199.99, 299.99];
+-- result:
+-- !result
+ALTER TABLE all_primitive_types ADD COLUMN map_int_str MAP<INT, VARCHAR(20)> DEFAULT map{1: 'one', 2: 'two'};
+-- result:
+-- !result
+ALTER TABLE all_primitive_types ADD COLUMN map_str_int MAP<VARCHAR(20), INT> DEFAULT map{'a': 10, 'b': 20};
+-- result:
+-- !result
+ALTER TABLE all_primitive_types ADD COLUMN map_str_bool MAP<VARCHAR(20), BOOLEAN> DEFAULT map{'flag1': true, 'flag2': false};
+-- result:
+-- !result
+ALTER TABLE all_primitive_types ADD COLUMN struct_mixed STRUCT<
+    f_int INT,
+    f_bigint BIGINT,
+    f_string VARCHAR(20),
+    f_double DOUBLE,
+    f_bool BOOLEAN,
+    f_decimal DECIMAL(10, 2)
+> DEFAULT row(100, 1000000000, 'text', 99.99, true, 123.45);
+-- result:
+-- !result
+SELECT * FROM all_primitive_types;
+-- result:
+1	[1,2,3]	[1000000000,2000000000]	["hello","world"]	[1.1,2.2,3.3]	[1,0,1]	[99.99,199.99,299.99]	{1:"one",2:"two"}	{"a":10,"b":20}	{"flag1":1,"flag2":0}	{"f_int":100,"f_bigint":1000000000,"f_string":"text","f_double":99.99,"f_bool":1,"f_decimal":123.45}
+-- !result
+CREATE TABLE nullable_complex (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO nullable_complex (id) VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE nullable_complex ADD COLUMN nullable_arr ARRAY<INT> NULL DEFAULT [100, 200];
+-- result:
+-- !result
+ALTER TABLE nullable_complex ADD COLUMN nullable_map MAP<INT, VARCHAR(20)> NULL DEFAULT map{1: 'test'};
+-- result:
+-- !result
+ALTER TABLE nullable_complex ADD COLUMN nullable_struct STRUCT<f1 INT> NULL DEFAULT row(999);
+-- result:
+-- !result
+SELECT * FROM nullable_complex ORDER BY id;
+-- result:
+1	[100,200]	{1:"test"}	{"f1":999}
+2	[100,200]	{1:"test"}	{"f1":999}
+-- !result
+INSERT INTO nullable_complex (id, nullable_arr, nullable_map, nullable_struct) VALUES (3, NULL, NULL, NULL);
+-- result:
+-- !result
+SELECT * FROM nullable_complex ORDER BY id;
+-- result:
+1	[100,200]	{1:"test"}	{"f1":999}
+2	[100,200]	{1:"test"}	{"f1":999}
+3	None	None	None
+-- !result
+CREATE TABLE reorder_test (
+    id INT NOT NULL,
+    name VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO reorder_test (id, name) VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie');
+-- result:
+-- !result
+ALTER TABLE reorder_test ADD COLUMN arr ARRAY<INT> DEFAULT [1, 2, 3];
+-- result:
+-- !result
+ALTER TABLE reorder_test ADD COLUMN mp MAP<INT, VARCHAR(20)> DEFAULT map{10: 'ten'};
+-- result:
+-- !result
+ALTER TABLE reorder_test ADD COLUMN st STRUCT<f1 INT, f2 VARCHAR(20)> DEFAULT row(100, 'test');
+-- result:
+-- !result
+ALTER TABLE reorder_test ORDER BY (id, mp, st, arr, name);
+-- result:
+-- !result
+SELECT SLEEP(2);
+-- result:
+1
+-- !result
+SELECT count(*) FROM reorder_test;
+-- result:
+3
+-- !result
+CREATE TABLE pk_basic_defaults (
+    user_id INT NOT NULL,
+    username VARCHAR(50),
+    scores ARRAY<INT> DEFAULT [80, 90, 85],
+    tags MAP<VARCHAR(20), VARCHAR(20)> DEFAULT map{'status': 'active', 'level': 'basic'},
+    profile STRUCT<age INT, city VARCHAR(20)> DEFAULT row(18, 'Shanghai')
+) PRIMARY KEY(user_id)
+DISTRIBUTED BY HASH(user_id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO pk_basic_defaults (user_id, username) VALUES (1, 'user1');
+-- result:
+-- !result
+INSERT INTO pk_basic_defaults (user_id, username) VALUES (2, 'user2');
+-- result:
+-- !result
+SELECT * FROM pk_basic_defaults ORDER BY user_id;
+-- result:
+1	user1	[80,90,85]	{"level":"basic","status":"active"}	{"age":18,"city":"Shanghai"}
+2	user2	[80,90,85]	{"level":"basic","status":"active"}	{"age":18,"city":"Shanghai"}
+-- !result
+INSERT INTO pk_basic_defaults VALUES 
+    (3, 'user3', [100, 95, 98], map{'status': 'vip', 'level': 'premium'}, row(30, 'Beijing'));
+-- result:
+-- !result
+SELECT * FROM pk_basic_defaults ORDER BY user_id;
+-- result:
+1	user1	[80,90,85]	{"level":"basic","status":"active"}	{"age":18,"city":"Shanghai"}
+2	user2	[80,90,85]	{"level":"basic","status":"active"}	{"age":18,"city":"Shanghai"}
+3	user3	[100,95,98]	{"level":"premium","status":"vip"}	{"age":30,"city":"Beijing"}
+-- !result
+CREATE TABLE pk_column_mode (
+    order_id INT NOT NULL,
+    product_name VARCHAR(50),
+    quantity INT DEFAULT '1',
+    tags ARRAY<VARCHAR(20)> DEFAULT ['new', 'available'],
+    config MAP<VARCHAR(20), INT> DEFAULT map{'priority': 1, 'score': 100},
+    details STRUCT<category VARCHAR(20), rating INT> DEFAULT row('electronics', 5)
+) PRIMARY KEY(order_id)
+DISTRIBUTED BY HASH(order_id) BUCKETS 2
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+SET partial_update_mode = 'column';
+-- result:
+-- !result
+INSERT INTO pk_column_mode (order_id, product_name) VALUES (1, 'laptop');
+-- result:
+-- !result
+INSERT INTO pk_column_mode (order_id, product_name) VALUES (2, 'phone');
+-- result:
+-- !result
+INSERT INTO pk_column_mode (order_id, product_name) VALUES (3, 'tablet');
+-- result:
+-- !result
+SELECT * FROM pk_column_mode ORDER BY order_id;
+-- result:
+1	laptop	1	["new","available"]	{"priority":1,"score":100}	{"category":"electronics","rating":5}
+2	phone	1	["new","available"]	{"priority":1,"score":100}	{"category":"electronics","rating":5}
+3	tablet	1	["new","available"]	{"priority":1,"score":100}	{"category":"electronics","rating":5}
+-- !result
+ALTER TABLE pk_column_mode ADD COLUMN extras STRUCT<discount DOUBLE, items ARRAY<INT>> DEFAULT row(0.1, [1, 2, 3]);
+-- result:
+-- !result
+INSERT INTO pk_column_mode (order_id, product_name) VALUES (4, 'mouse');
+-- result:
+-- !result
+INSERT INTO pk_column_mode (order_id, product_name) VALUES (5, 'keyboard');
+-- result:
+-- !result
+SELECT * FROM pk_column_mode ORDER BY order_id;
+-- result:
+1	laptop	1	["new","available"]	{"priority":1,"score":100}	{"category":"electronics","rating":5}	{"discount":0.1,"items":[1,2,3]}
+2	phone	1	["new","available"]	{"priority":1,"score":100}	{"category":"electronics","rating":5}	{"discount":0.1,"items":[1,2,3]}
+3	tablet	1	["new","available"]	{"priority":1,"score":100}	{"category":"electronics","rating":5}	{"discount":0.1,"items":[1,2,3]}
+4	mouse	1	["new","available"]	{"priority":1,"score":100}	{"category":"electronics","rating":5}	{"discount":0.1,"items":[1,2,3]}
+5	keyboard	1	["new","available"]	{"priority":1,"score":100}	{"category":"electronics","rating":5}	{"discount":0.1,"items":[1,2,3]}
+-- !result
+SET partial_update_mode = 'auto';
+-- result:
+-- !result
+CREATE TABLE pk_row_mode (
+    id INT NOT NULL,
+    name VARCHAR(50),
+    score INT DEFAULT '100',
+    level VARCHAR(20) DEFAULT 'bronze',
+    tags ARRAY<VARCHAR(20)> DEFAULT ['default', 'new'],
+    config MAP<VARCHAR(20), INT> DEFAULT map{'level': 1, 'score': 100},
+    details STRUCT<category VARCHAR(20), active BOOLEAN> DEFAULT row('general', true)
+) PRIMARY KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO pk_row_mode VALUES 
+    (1, 'item1', 500, 'gold', ['premium'], map{'level': 5}, row('special', false));
+-- result:
+-- !result
+SELECT * FROM pk_row_mode ORDER BY id;
+-- result:
+1	item1	500	gold	["premium"]	{"level":5}	{"category":"special","active":0}
+-- !result
+INSERT INTO pk_row_mode (id, name) VALUES (2, 'item2');
+-- result:
+-- !result
+INSERT INTO pk_row_mode (id, name) VALUES (3, 'item3');
+-- result:
+-- !result
+SELECT * FROM pk_row_mode ORDER BY id;
+-- result:
+1	item1	500	gold	["premium"]	{"level":5}	{"category":"special","active":0}
+2	item2	100	bronze	["default","new"]	{"level":1,"score":100}	{"category":"general","active":1}
+3	item3	100	bronze	["default","new"]	{"level":1,"score":100}	{"category":"general","active":1}
+-- !result
+CREATE TABLE pk_nested_complex (
+    id INT NOT NULL,
+    name VARCHAR(50),
+    nested_arr ARRAY<ARRAY<INT>> DEFAULT [[1, 2], [3, 4, 5]],
+    map_with_struct MAP<INT, STRUCT<val INT, description VARCHAR(20)>> DEFAULT map{1: row(100, 'default')},
+    complex_struct STRUCT<id INT, data MAP<VARCHAR(20), ARRAY<INT>>> DEFAULT row(999, map{'scores': [90, 95, 100]})
+) PRIMARY KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+SET partial_update_mode = 'column';
+-- result:
+-- !result
+INSERT INTO pk_nested_complex (id, name) VALUES (1, 'user1');
+-- result:
+-- !result
+INSERT INTO pk_nested_complex (id, name) VALUES (2, 'user2');
+-- result:
+-- !result
+SELECT * FROM pk_nested_complex ORDER BY id;
+-- result:
+1	user1	[[1,2],[3,4,5]]	{1:{"val":100,"description":"default"}}	{"id":999,"data":{"scores":[90,95,100]}}
+2	user2	[[1,2],[3,4,5]]	{1:{"val":100,"description":"default"}}	{"id":999,"data":{"scores":[90,95,100]}}
+-- !result
+SET partial_update_mode = 'auto';
+-- result:
+-- !result
+INSERT INTO pk_nested_complex (id, name) VALUES (3, 'user3');
+-- result:
+-- !result
+SELECT * FROM pk_nested_complex ORDER BY id;
+-- result:
+1	user1	[[1,2],[3,4,5]]	{1:{"val":100,"description":"default"}}	{"id":999,"data":{"scores":[90,95,100]}}
+2	user2	[[1,2],[3,4,5]]	{1:{"val":100,"description":"default"}}	{"id":999,"data":{"scores":[90,95,100]}}
+3	user3	[[1,2],[3,4,5]]	{1:{"val":100,"description":"default"}}	{"id":999,"data":{"scores":[90,95,100]}}
+-- !result
+CREATE TABLE pk_empty_collections (
+    id INT NOT NULL,
+    status VARCHAR(20),
+    empty_arr ARRAY<INT> DEFAULT [],
+    empty_map MAP<INT, VARCHAR(20)> DEFAULT map{},
+    struct_with_empty STRUCT<id INT, arr ARRAY<VARCHAR(20)>, mp MAP<VARCHAR(20), INT>> DEFAULT row(0, [], map{})
+) PRIMARY KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+SET partial_update_mode = 'column';
+-- result:
+-- !result
+INSERT INTO pk_empty_collections (id, status) VALUES (1, 'active');
+-- result:
+-- !result
+INSERT INTO pk_empty_collections (id, status) VALUES (2, 'inactive');
+-- result:
+-- !result
+SELECT * FROM pk_empty_collections ORDER BY id;
+-- result:
+1	active	[]	{}	{"id":0,"arr":[],"mp":{}}
+2	inactive	[]	{}	{"id":0,"arr":[],"mp":{}}
+-- !result
+SET partial_update_mode = 'auto';
+-- result:
+-- !result
+CREATE TABLE pk_multi_complex (
+    id INT NOT NULL,
+    name VARCHAR(50),
+    arr_int ARRAY<INT> DEFAULT [10, 20, 30],
+    arr_str ARRAY<VARCHAR(20)> DEFAULT ['a', 'b', 'c'],
+    map_int_str MAP<INT, VARCHAR(20)> DEFAULT map{1: 'one', 2: 'two'},
+    map_str_int MAP<VARCHAR(20), INT> DEFAULT map{'x': 100, 'y': 200},
+    struct_simple STRUCT<f1 INT, f2 VARCHAR(20)> DEFAULT row(999, 'default'),
+    struct_complex STRUCT<id INT, tags ARRAY<VARCHAR(20)>> DEFAULT row(1, ['tag1', 'tag2'])
+) PRIMARY KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+SET partial_update_mode = 'column';
+-- result:
+-- !result
+INSERT INTO pk_multi_complex (id, name) VALUES (1, 'test1');
+-- result:
+-- !result
+INSERT INTO pk_multi_complex (id, name) VALUES (2, 'test2');
+-- result:
+-- !result
+SELECT * FROM pk_multi_complex ORDER BY id;
+-- result:
+1	test1	[10,20,30]	["a","b","c"]	{1:"one",2:"two"}	{"x":100,"y":200}	{"f1":999,"f2":"default"}	{"id":1,"tags":["tag1","tag2"]}
+2	test2	[10,20,30]	["a","b","c"]	{1:"one",2:"two"}	{"x":100,"y":200}	{"f1":999,"f2":"default"}	{"id":1,"tags":["tag1","tag2"]}
+-- !result
+INSERT INTO pk_multi_complex (id, name, arr_int) VALUES (3, 'test3', [100, 200]);
+-- result:
+-- !result
+SELECT id, name, arr_int, arr_str FROM pk_multi_complex ORDER BY id;
+-- result:
+1	test1	[10,20,30]	["a","b","c"]
+2	test2	[10,20,30]	["a","b","c"]
+3	test3	[100,200]	["a","b","c"]
+-- !result
+SET partial_update_mode = 'auto';
+-- result:
+-- !result
+CREATE TABLE pk_decimal_complex (
+    id INT NOT NULL,
+    name VARCHAR(50),
+    prices ARRAY<DECIMAL(10, 2)> DEFAULT [99.99, 199.99, 299.99],
+    price_map MAP<VARCHAR(20), DECIMAL(10, 2)> DEFAULT map{'min': 10.00, 'max': 1000.00},
+    price_info STRUCT<base DECIMAL(10, 2), tax DECIMAL(5, 2)> DEFAULT row(100.00, 8.25)
+) PRIMARY KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+SET partial_update_mode = 'column';
+-- result:
+-- !result
+INSERT INTO pk_decimal_complex (id, name) VALUES (1, 'product1');
+-- result:
+-- !result
+INSERT INTO pk_decimal_complex (id, name) VALUES (2, 'product2');
+-- result:
+-- !result
+SELECT * FROM pk_decimal_complex ORDER BY id;
+-- result:
+1	product1	[99.99,199.99,299.99]	{"max":1000.00,"min":10.00}	{"base":100.00,"tax":8.25}
+2	product2	[99.99,199.99,299.99]	{"max":1000.00,"min":10.00}	{"base":100.00,"tax":8.25}
+-- !result
+SET partial_update_mode = 'auto';
+-- result:
+-- !result

--- a/test/sql/test_default_value/R/test_complex_default_correctness.sql
+++ b/test/sql/test_default_value/R/test_complex_default_correctness.sql
@@ -1,0 +1,738 @@
+-- name: test_complex_default_correctness
+DROP DATABASE IF EXISTS test_correctness_db;
+-- result:
+-- !result
+CREATE DATABASE test_correctness_db;
+-- result:
+-- !result
+USE test_correctness_db;
+-- result:
+-- !result
+CREATE TABLE array_primitives (id INT) DUPLICATE KEY(id) 
+DISTRIBUTED BY HASH(id) BUCKETS 1 
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO array_primitives VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE array_primitives ADD COLUMN arr_tinyint ARRAY<TINYINT> DEFAULT [1, 2, 127];
+-- result:
+-- !result
+ALTER TABLE array_primitives ADD COLUMN arr_smallint ARRAY<SMALLINT> DEFAULT [100, 200, 32767];
+-- result:
+-- !result
+ALTER TABLE array_primitives ADD COLUMN arr_int ARRAY<INT> DEFAULT [1000, 2000, 2147483647];
+-- result:
+-- !result
+ALTER TABLE array_primitives ADD COLUMN arr_bigint ARRAY<BIGINT> DEFAULT [1000000, 2000000, 9223372036854775807];
+-- result:
+-- !result
+ALTER TABLE array_primitives ADD COLUMN arr_float ARRAY<FLOAT> DEFAULT [1.1, 2.2, 3.3];
+-- result:
+-- !result
+ALTER TABLE array_primitives ADD COLUMN arr_double ARRAY<DOUBLE> DEFAULT [1.123456789, 2.987654321, 3.141592653];
+-- result:
+-- !result
+ALTER TABLE array_primitives ADD COLUMN arr_varchar ARRAY<VARCHAR(50)> DEFAULT ['hello', 'world', '你好世界'];
+-- result:
+-- !result
+ALTER TABLE array_primitives ADD COLUMN arr_char ARRAY<CHAR(10)> DEFAULT ['abc', 'def', 'ghi'];
+-- result:
+-- !result
+ALTER TABLE array_primitives ADD COLUMN arr_bool ARRAY<BOOLEAN> DEFAULT [true, false, true, false];
+-- result:
+-- !result
+ALTER TABLE array_primitives ADD COLUMN arr_decimal32 ARRAY<DECIMAL(9, 2)> DEFAULT [123.45, 678.90, 999.99];
+-- result:
+-- !result
+ALTER TABLE array_primitives ADD COLUMN arr_decimal64 ARRAY<DECIMAL(18, 4)> DEFAULT [12345678.1234, 87654321.4321];
+-- result:
+-- !result
+ALTER TABLE array_primitives ADD COLUMN arr_decimal128 ARRAY<DECIMAL(38, 10)> DEFAULT [1234567890.1234567890, 9876543210.0987654321];
+-- result:
+-- !result
+ALTER TABLE array_primitives ADD COLUMN arr_decimal256 ARRAY<DECIMAL(55, 10)> DEFAULT [1123123234567890123412345678901234.1234567890, 98765432109876.0987654321];
+-- result:
+-- !result
+SELECT * FROM array_primitives ORDER BY id;
+-- result:
+1	[1,2,127]	[100,200,32767]	[1000,2000,2147483647]	[1000000,2000000,9223372036854775807]	[1.1,2.2,3.3]	[1.123456789,2.987654321,3.141592653]	["hello","world","你好世界"]	["abc","def","ghi"]	[1,0,1,0]	[123.45,678.90,999.99]	[12345678.1234,87654321.4321]	[1234567890.1234567890,9876543210.0987654321]	[1123123234567890123412345678901234.1234567890,98765432109876.0987654321]
+2	[1,2,127]	[100,200,32767]	[1000,2000,2147483647]	[1000000,2000000,9223372036854775807]	[1.1,2.2,3.3]	[1.123456789,2.987654321,3.141592653]	["hello","world","你好世界"]	["abc","def","ghi"]	[1,0,1,0]	[123.45,678.90,999.99]	[12345678.1234,87654321.4321]	[1234567890.1234567890,9876543210.0987654321]	[1123123234567890123412345678901234.1234567890,98765432109876.0987654321]
+-- !result
+CREATE TABLE map_types (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO map_types VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE map_types ADD COLUMN map_int_str MAP<INT, VARCHAR(20)> DEFAULT map{1: 'one', 2: 'two', 100: 'hundred'};
+-- result:
+-- !result
+ALTER TABLE map_types ADD COLUMN map_str_int MAP<VARCHAR(20), INT> DEFAULT map{'alice': 25, 'bob': 30, 'charlie': 35};
+-- result:
+-- !result
+ALTER TABLE map_types ADD COLUMN map_int_double MAP<INT, DOUBLE> DEFAULT map{1: 1.1, 2: 2.2, 3: 3.3};
+-- result:
+-- !result
+ALTER TABLE map_types ADD COLUMN map_str_bool MAP<VARCHAR(20), BOOLEAN> DEFAULT map{'active': true, 'disabled': false};
+-- result:
+-- !result
+ALTER TABLE map_types ADD COLUMN map_int_decimal MAP<INT, DECIMAL(10, 2)> DEFAULT map{1: 99.99, 2: 199.99, 3: 299.99};
+-- result:
+-- !result
+SELECT * FROM map_types ORDER BY id;
+-- result:
+1	{1:"one",2:"two",100:"hundred"}	{"alice":25,"bob":30,"charlie":35}	{1:1.1,2:2.2,3:3.3}	{"active":1,"disabled":0}	{1:99.99,2:199.99,3:299.99}
+2	{1:"one",2:"two",100:"hundred"}	{"alice":25,"bob":30,"charlie":35}	{1:1.1,2:2.2,3:3.3}	{"active":1,"disabled":0}	{1:99.99,2:199.99,3:299.99}
+-- !result
+CREATE TABLE struct_field_order (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO struct_field_order VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE struct_field_order ADD COLUMN st1 STRUCT<z INT, a VARCHAR(20)> DEFAULT row(999, 'test');
+-- result:
+-- !result
+ALTER TABLE struct_field_order ADD COLUMN st2 STRUCT<field_c INT, field_b VARCHAR(20), field_a DOUBLE> 
+DEFAULT row(100, 'middle', 3.14);
+-- result:
+-- !result
+ALTER TABLE struct_field_order ADD COLUMN st3 STRUCT<s4 INT, ks ARRAY<INT>> DEFAULT row(2, [1, 2, 3, 4]);
+-- result:
+-- !result
+ALTER TABLE struct_field_order ADD COLUMN st4 STRUCT<
+    zebra INT,
+    apple VARCHAR(20),
+    monkey BOOLEAN,
+    banana DOUBLE
+> DEFAULT row(10, 'fruit', true, 2.5);
+-- result:
+-- !result
+SELECT * FROM struct_field_order ORDER BY id;
+-- result:
+1	{"z":999,"a":"test"}	{"field_c":100,"field_b":"middle","field_a":3.14}	{"s4":2,"ks":[1,2,3,4]}	{"zebra":10,"apple":"fruit","monkey":1,"banana":2.5}
+2	{"z":999,"a":"test"}	{"field_c":100,"field_b":"middle","field_a":3.14}	{"s4":2,"ks":[1,2,3,4]}	{"zebra":10,"apple":"fruit","monkey":1,"banana":2.5}
+-- !result
+CREATE TABLE nested_arrays (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO nested_arrays VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE nested_arrays ADD COLUMN arr2_int ARRAY<ARRAY<INT>> DEFAULT [[1, 2, 3], [4, 5], [6, 7, 8, 9]];
+-- result:
+-- !result
+ALTER TABLE nested_arrays ADD COLUMN arr2_str ARRAY<ARRAY<VARCHAR(20)>> DEFAULT [['a', 'b'], ['c', 'd', 'e'], ['f']];
+-- result:
+-- !result
+ALTER TABLE nested_arrays ADD COLUMN arr3_int ARRAY<ARRAY<ARRAY<INT>>> DEFAULT [[[1, 2], [3]], [[4, 5, 6]], [[7], [8, 9]]];
+-- result:
+-- !result
+ALTER TABLE nested_arrays ADD COLUMN arr2_empty ARRAY<ARRAY<INT>> DEFAULT [[], [1, 2], []];
+-- result:
+-- !result
+SELECT * FROM nested_arrays ORDER BY id;
+-- result:
+1	[[1,2,3],[4,5],[6,7,8,9]]	[["a","b"],["c","d","e"],["f"]]	[[[1,2],[3]],[[4,5,6]],[[7],[8,9]]]	[[],[1,2],[]]
+2	[[1,2,3],[4,5],[6,7,8,9]]	[["a","b"],["c","d","e"],["f"]]	[[[1,2],[3]],[[4,5,6]],[[7],[8,9]]]	[[],[1,2],[]]
+-- !result
+CREATE TABLE array_struct (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO array_struct VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE array_struct ADD COLUMN arr_st1 ARRAY<STRUCT<id INT, name VARCHAR(20)>> 
+DEFAULT [row(1, 'alice'), row(2, 'bob'), row(3, 'charlie')];
+-- result:
+-- !result
+ALTER TABLE array_struct ADD COLUMN arr_st2 ARRAY<STRUCT<score INT, age INT, name VARCHAR(20)>> 
+DEFAULT [row(95, 25, 'student1'), row(88, 26, 'student2')];
+-- result:
+-- !result
+ALTER TABLE array_struct ADD COLUMN arr_st3 ARRAY<STRUCT<id INT, tags ARRAY<VARCHAR(20)>>> 
+DEFAULT [row(1, ['tag1', 'tag2']), row(2, ['tag3', 'tag4', 'tag5'])];
+-- result:
+-- !result
+SELECT * FROM array_struct ORDER BY id;
+-- result:
+1	[{"id":1,"name":"alice"},{"id":2,"name":"bob"},{"id":3,"name":"charlie"}]	[{"score":95,"age":25,"name":"student1"},{"score":88,"age":26,"name":"student2"}]	[{"id":1,"tags":["tag1","tag2"]},{"id":2,"tags":["tag3","tag4","tag5"]}]
+2	[{"id":1,"name":"alice"},{"id":2,"name":"bob"},{"id":3,"name":"charlie"}]	[{"score":95,"age":25,"name":"student1"},{"score":88,"age":26,"name":"student2"}]	[{"id":1,"tags":["tag1","tag2"]},{"id":2,"tags":["tag3","tag4","tag5"]}]
+-- !result
+CREATE TABLE map_array (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO map_array VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE map_array ADD COLUMN mp_arr1 MAP<INT, ARRAY<VARCHAR(20)>> 
+DEFAULT map{1: ['a', 'b', 'c'], 2: ['d', 'e'], 3: ['f', 'g', 'h', 'i']};
+-- result:
+-- !result
+ALTER TABLE map_array ADD COLUMN mp_arr2 MAP<VARCHAR(20), ARRAY<INT>> 
+DEFAULT map{'scores': [90, 85, 92], 'ages': [25, 30, 35]};
+-- result:
+-- !result
+ALTER TABLE map_array ADD COLUMN mp_arr3 MAP<INT, ARRAY<ARRAY<INT>>> 
+DEFAULT map{1: [[1, 2], [3, 4]], 2: [[5], [6, 7, 8]]};
+-- result:
+-- !result
+SELECT * FROM map_array ORDER BY id;
+-- result:
+1	{1:["a","b","c"],2:["d","e"],3:["f","g","h","i"]}	{"ages":[25,30,35],"scores":[90,85,92]}	{1:[[1,2],[3,4]],2:[[5],[6,7,8]]}
+2	{1:["a","b","c"],2:["d","e"],3:["f","g","h","i"]}	{"ages":[25,30,35],"scores":[90,85,92]}	{1:[[1,2],[3,4]],2:[[5],[6,7,8]]}
+-- !result
+CREATE TABLE map_struct (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO map_struct VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE map_struct ADD COLUMN mp_st1 MAP<INT, STRUCT<name VARCHAR(20), age INT>> 
+DEFAULT map{1: row('alice', 25), 2: row('bob', 30)};
+-- result:
+-- !result
+ALTER TABLE map_struct ADD COLUMN mp_st2 MAP<INT, STRUCT<z INT, a VARCHAR(20)>> 
+DEFAULT map{10: row(999, 'test'), 20: row(888, 'demo')};
+-- result:
+-- !result
+ALTER TABLE map_struct ADD COLUMN mp_st3 MAP<INT, STRUCT<s4 INT, ks ARRAY<INT>>> 
+DEFAULT map{1: row(2, [1, 2, 3, 4]), 2: row(5, [10, 20, 30])};
+-- result:
+-- !result
+ALTER TABLE map_struct ADD COLUMN mp_st4 MAP<INT, STRUCT<
+    field_b VARCHAR(20),
+    field_a INT,
+    nested STRUCT<z INT, a VARCHAR(20)>
+>> DEFAULT map{10: row('hello', 100, row(999, 'world'))};
+-- result:
+-- !result
+SELECT * FROM map_struct ORDER BY id;
+-- result:
+1	{1:{"name":"alice","age":25},2:{"name":"bob","age":30}}	{10:{"z":999,"a":"test"},20:{"z":888,"a":"demo"}}	{1:{"s4":2,"ks":[1,2,3,4]},2:{"s4":5,"ks":[10,20,30]}}	{10:{"field_b":"hello","field_a":100,"nested":{"z":999,"a":"world"}}}
+2	{1:{"name":"alice","age":25},2:{"name":"bob","age":30}}	{10:{"z":999,"a":"test"},20:{"z":888,"a":"demo"}}	{1:{"s4":2,"ks":[1,2,3,4]},2:{"s4":5,"ks":[10,20,30]}}	{10:{"field_b":"hello","field_a":100,"nested":{"z":999,"a":"world"}}}
+-- !result
+CREATE TABLE struct_nested (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO struct_nested VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE struct_nested ADD COLUMN st_arr STRUCT<id INT, scores ARRAY<INT>, name VARCHAR(20)> 
+DEFAULT row(1, [90, 85, 95], 'student');
+-- result:
+-- !result
+ALTER TABLE struct_nested ADD COLUMN st_map STRUCT<id INT, attributes MAP<VARCHAR(20), VARCHAR(20)>> 
+DEFAULT row(1, map{'color': 'red', 'size': 'large'});
+-- result:
+-- !result
+ALTER TABLE struct_nested ADD COLUMN st_both STRUCT<
+    tags ARRAY<VARCHAR(20)>,
+    id INT,
+    metadata MAP<VARCHAR(20), INT>
+> DEFAULT row(['tag1', 'tag2'], 100, map{'version': 1, 'priority': 5});
+-- result:
+-- !result
+ALTER TABLE struct_nested ADD COLUMN st_deep STRUCT<
+    name VARCHAR(20),
+    items ARRAY<STRUCT<id INT, value VARCHAR(20)>>
+> DEFAULT row('container', [row(1, 'item1'), row(2, 'item2')]);
+-- result:
+-- !result
+SELECT * FROM struct_nested ORDER BY id;
+-- result:
+1	{"id":1,"scores":[90,85,95],"name":"student"}	{"id":1,"attributes":{"color":"red","size":"large"}}	{"tags":["tag1","tag2"],"id":100,"metadata":{"priority":5,"version":1}}	{"name":"container","items":[{"id":1,"value":"item1"},{"id":2,"value":"item2"}]}
+2	{"id":1,"scores":[90,85,95],"name":"student"}	{"id":1,"attributes":{"color":"red","size":"large"}}	{"tags":["tag1","tag2"],"id":100,"metadata":{"priority":5,"version":1}}	{"name":"container","items":[{"id":1,"value":"item1"},{"id":2,"value":"item2"}]}
+-- !result
+CREATE TABLE three_level_nesting (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO three_level_nesting VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE three_level_nesting ADD COLUMN arr3 ARRAY<ARRAY<ARRAY<INT>>> 
+DEFAULT [[[1, 2], [3]], [[4, 5]]];
+-- result:
+-- !result
+ALTER TABLE three_level_nesting ADD COLUMN arr_map_arr ARRAY<MAP<INT, ARRAY<INT>>> 
+DEFAULT [map{1: [1, 2], 2: [3, 4]}, map{10: [10, 20]}];
+-- result:
+-- !result
+ALTER TABLE three_level_nesting ADD COLUMN map_arr_st MAP<INT, ARRAY<STRUCT<id INT, name VARCHAR(20)>>> 
+DEFAULT map{1: [row(1, 'a'), row(2, 'b')]};
+-- result:
+-- !result
+ALTER TABLE three_level_nesting ADD COLUMN st_map_arr STRUCT<
+    id INT,
+    data MAP<VARCHAR(20), ARRAY<INT>>
+> DEFAULT row(1, map{'scores': [90, 95, 100]});
+-- result:
+-- !result
+ALTER TABLE three_level_nesting ADD COLUMN map_st_arr MAP<INT, STRUCT<
+    name VARCHAR(20),
+    vals ARRAY<INT>
+>> DEFAULT map{1: row('test', [1, 2, 3])};
+-- result:
+-- !result
+SELECT * FROM three_level_nesting ORDER BY id;
+-- result:
+1	[[[1,2],[3]],[[4,5]]]	[{1:[1,2],2:[3,4]},{10:[10,20]}]	{1:[{"id":1,"name":"a"},{"id":2,"name":"b"}]}	{"id":1,"data":{"scores":[90,95,100]}}	{1:{"name":"test","vals":[1,2,3]}}
+2	[[[1,2],[3]],[[4,5]]]	[{1:[1,2],2:[3,4]},{10:[10,20]}]	{1:[{"id":1,"name":"a"},{"id":2,"name":"b"}]}	{"id":1,"data":{"scores":[90,95,100]}}	{1:{"name":"test","vals":[1,2,3]}}
+-- !result
+CREATE TABLE empty_collections (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO empty_collections VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE empty_collections ADD COLUMN arr_empty ARRAY<INT> DEFAULT [];
+-- result:
+-- !result
+ALTER TABLE empty_collections ADD COLUMN map_empty MAP<INT, VARCHAR(20)> DEFAULT map{};
+-- result:
+-- !result
+ALTER TABLE empty_collections ADD COLUMN st_empty_arr STRUCT<id INT, tags ARRAY<VARCHAR(20)>> 
+DEFAULT row(1, []);
+-- result:
+-- !result
+ALTER TABLE empty_collections ADD COLUMN st_empty_map STRUCT<id INT, attrs MAP<VARCHAR(20), INT>> 
+DEFAULT row(1, map{});
+-- result:
+-- !result
+ALTER TABLE empty_collections ADD COLUMN st_all_empty STRUCT<
+    id INT,
+    arr ARRAY<INT>,
+    mp MAP<VARCHAR(20), INT>
+> DEFAULT row(0, [], map{});
+-- result:
+-- !result
+ALTER TABLE empty_collections ADD COLUMN arr_mixed ARRAY<ARRAY<INT>> 
+DEFAULT [[], [1, 2], [], [3, 4, 5]];
+-- result:
+-- !result
+ALTER TABLE empty_collections ADD COLUMN map_empty_arr MAP<INT, ARRAY<VARCHAR(20)>> 
+DEFAULT map{1: [], 2: ['a', 'b'], 3: []};
+-- result:
+-- !result
+SELECT * FROM empty_collections ORDER BY id;
+-- result:
+1	[]	{}	{"id":1,"tags":[]}	{"id":1,"attrs":{}}	{"id":0,"arr":[],"mp":{}}	[[],[1,2],[],[3,4,5]]	{1:[],2:["a","b"],3:[]}
+2	[]	{}	{"id":1,"tags":[]}	{"id":1,"attrs":{}}	{"id":0,"arr":[],"mp":{}}	[[],[1,2],[],[3,4,5]]	{1:[],2:["a","b"],3:[]}
+-- !result
+CREATE TABLE decimal_complex (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO decimal_complex VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE decimal_complex ADD COLUMN arr_dec32 ARRAY<DECIMAL(9, 2)> DEFAULT [99.99, 199.99, 299.99];
+-- result:
+-- !result
+ALTER TABLE decimal_complex ADD COLUMN arr_dec64 ARRAY<DECIMAL(18, 4)> DEFAULT [9999.9999, 19999.9999];
+-- result:
+-- !result
+ALTER TABLE decimal_complex ADD COLUMN arr_dec128 ARRAY<DECIMAL(38, 10)> DEFAULT [123456.1234567890, 654321.0987654321];
+-- result:
+-- !result
+ALTER TABLE decimal_complex ADD COLUMN arr_dec256 ARRAY<DECIMAL(45, 10)> DEFAULT [123456789012.1234567890, 987654321098.0987654321];
+-- result:
+-- !result
+ALTER TABLE decimal_complex ADD COLUMN map_dec MAP<VARCHAR(20), DECIMAL(10, 2)> 
+DEFAULT map{'price': 99.99, 'tax': 8.25, 'total': 108.24};
+-- result:
+-- !result
+ALTER TABLE decimal_complex ADD COLUMN map_dec256 MAP<INT, DECIMAL(45, 10)> 
+DEFAULT map{1: 99999999999.9999999999, 2: 12345678901.1234567890};
+-- result:
+-- !result
+ALTER TABLE decimal_complex ADD COLUMN st_dec STRUCT<
+    amount DECIMAL(10, 2),
+    rate DECIMAL(5, 4),
+    result DECIMAL(15, 6),
+    large DECIMAL(45, 10)
+> DEFAULT row(1000.50, 0.0525, 52.526250, 123456789012.1234567890);
+-- result:
+-- !result
+ALTER TABLE decimal_complex ADD COLUMN arr_st_dec ARRAY<STRUCT<id INT, price DECIMAL(10, 2)>> 
+DEFAULT [row(1, 99.99), row(2, 199.99), row(3, 299.99)];
+-- result:
+-- !result
+SELECT * FROM decimal_complex ORDER BY id;
+-- result:
+1	[99.99,199.99,299.99]	[9999.9999,19999.9999]	[123456.1234567890,654321.0987654321]	[123456789012.1234567890,987654321098.0987654321]	{"price":99.99,"tax":8.25,"total":108.24}	{1:99999999999.9999999999,2:12345678901.1234567890}	{"amount":1000.50,"rate":0.0525,"result":52.526250,"large":123456789012.1234567890}	[{"id":1,"price":99.99},{"id":2,"price":199.99},{"id":3,"price":299.99}]
+2	[99.99,199.99,299.99]	[9999.9999,19999.9999]	[123456.1234567890,654321.0987654321]	[123456789012.1234567890,987654321098.0987654321]	{"price":99.99,"tax":8.25,"total":108.24}	{1:99999999999.9999999999,2:12345678901.1234567890}	{"amount":1000.50,"rate":0.0525,"result":52.526250,"large":123456789012.1234567890}	[{"id":1,"price":99.99},{"id":2,"price":199.99},{"id":3,"price":299.99}]
+-- !result
+CREATE TABLE large_defaults (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO large_defaults VALUES (1);
+-- result:
+-- !result
+ALTER TABLE large_defaults ADD COLUMN large_arr ARRAY<INT> 
+DEFAULT [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+-- result:
+-- !result
+ALTER TABLE large_defaults ADD COLUMN large_map MAP<INT, VARCHAR(20)> 
+DEFAULT map{1: 'one', 2: 'two', 3: 'three', 4: 'four', 5: 'five', 
+            6: 'six', 7: 'seven', 8: 'eight', 9: 'nine', 10: 'ten'};
+-- result:
+-- !result
+ALTER TABLE large_defaults ADD COLUMN large_struct STRUCT<
+    f1 INT, f2 INT, f3 INT, f4 INT, f5 INT,
+    f6 VARCHAR(20), f7 VARCHAR(20), f8 DOUBLE, f9 BOOLEAN, f10 DECIMAL(10, 2)
+> DEFAULT row(1, 2, 3, 4, 5, 'six', 'seven', 8.8, true, 10.50);
+-- result:
+-- !result
+ALTER TABLE large_defaults ADD COLUMN complex_combo MAP<INT, STRUCT<
+    id INT,
+    tags ARRAY<VARCHAR(20)>,
+    scores ARRAY<INT>,
+    metadata MAP<VARCHAR(20), VARCHAR(20)>
+>> DEFAULT map{
+    1: row(100, ['tag1', 'tag2', 'tag3'], [90, 85, 95], map{'type': 'A', 'level': 'high'}),
+    2: row(200, ['tag4', 'tag5'], [80, 88], map{'type': 'B', 'level': 'medium'})
+};
+-- result:
+-- !result
+SELECT * FROM large_defaults;
+-- result:
+1	[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]	{1:"one",2:"two",3:"three",4:"four",5:"five",6:"six",7:"seven",8:"eight",9:"nine",10:"ten"}	{"f1":1,"f2":2,"f3":3,"f4":4,"f5":5,"f6":"six","f7":"seven","f8":8.8,"f9":1,"f10":10.50}	{1:{"id":100,"tags":["tag1","tag2","tag3"],"scores":[90,85,95],"metadata":{"level":"high","type":"A"}},2:{"id":200,"tags":["tag4","tag5"],"scores":[80,88],"metadata":{"level":"medium","type":"B"}}}
+-- !result
+CREATE TABLE special_strings (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO special_strings VALUES (1);
+-- result:
+-- !result
+ALTER TABLE special_strings ADD COLUMN arr_unicode ARRAY<VARCHAR(50)> 
+DEFAULT ['你好', '世界', 'こんにちは', '안녕하세요', '🚀', '⭐'];
+-- result:
+-- !result
+ALTER TABLE special_strings ADD COLUMN arr_special ARRAY<VARCHAR(50)> 
+DEFAULT ['it\'s', 'path\\to\\file', '"quoted"'];
+-- result:
+-- !result
+ALTER TABLE special_strings ADD COLUMN map_unicode MAP<VARCHAR(20), VARCHAR(20)> 
+DEFAULT map{'中文': '测试', 'emoji': '😀🎉'};
+-- result:
+-- !result
+ALTER TABLE special_strings ADD COLUMN st_unicode STRUCT<name VARCHAR(50), description VARCHAR(100)> 
+DEFAULT row('用户名', '这是一个包含中文的描述信息');
+-- result:
+-- !result
+SELECT * FROM special_strings;
+-- result:
+1	["你好","世界","こんにちは","안녕하세요","🚀","⭐"]	["it's","path\\to\\file","\"quoted\""]	{"emoji":"😀🎉","中文":"测试"}	{"name":"用户名","description":"这是一个包含中文的描述信息"}
+-- !result
+CREATE TABLE deep_nesting_1 (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO deep_nesting_1 VALUES (1);
+-- result:
+-- !result
+ALTER TABLE deep_nesting_1 ADD COLUMN arr_st_map_arr ARRAY<STRUCT<
+    id INT,
+    data MAP<INT, ARRAY<INT>>
+>> DEFAULT [
+    row(1, map{10: [1, 2, 3], 20: [4, 5]}),
+    row(2, map{30: [6, 7, 8, 9]})
+];
+-- result:
+-- !result
+ALTER TABLE deep_nesting_1 ADD COLUMN map_st_arr_map MAP<INT, STRUCT<
+    tags ARRAY<VARCHAR(20)>,
+    attrs MAP<VARCHAR(20), INT>
+>> DEFAULT map{
+    1: row(['tag1', 'tag2'], map{'score': 90, 'level': 5}),
+    2: row(['tag3'], map{'score': 85, 'level': 3})
+};
+-- result:
+-- !result
+ALTER TABLE deep_nesting_1 ADD COLUMN st_map_st_arr STRUCT<
+    name VARCHAR(20),
+    data MAP<INT, STRUCT<id INT, vals ARRAY<INT>>>
+> DEFAULT row('test', map{1: row(100, [1, 2, 3]), 2: row(200, [4, 5])});
+-- result:
+-- !result
+SELECT * FROM deep_nesting_1;
+-- result:
+1	[{"id":1,"data":{10:[1,2,3],20:[4,5]}},{"id":2,"data":{30:[6,7,8,9]}}]	{1:{"tags":["tag1","tag2"],"attrs":{"level":5,"score":90}},2:{"tags":["tag3"],"attrs":{"level":3,"score":85}}}	{"name":"test","data":{1:{"id":100,"vals":[1,2,3]},2:{"id":200,"vals":[4,5]}}}
+-- !result
+CREATE TABLE deep_nesting_2 (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO deep_nesting_2 VALUES (1);
+-- result:
+-- !result
+ALTER TABLE deep_nesting_2 ADD COLUMN st_map_arr_map STRUCT<
+    id INT,
+    nested MAP<INT, ARRAY<MAP<VARCHAR(20), INT>>>
+> DEFAULT row(1, map{
+    10: [map{'a': 1, 'b': 2}, map{'c': 3}],
+    20: [map{'d': 4, 'e': 5, 'f': 6}]
+});
+-- result:
+-- !result
+ALTER TABLE deep_nesting_2 ADD COLUMN arr_map_st_map_arr ARRAY<MAP<INT, STRUCT<
+    name VARCHAR(20),
+    data MAP<VARCHAR(20), ARRAY<INT>>
+>>> DEFAULT [
+    map{1: row('item1', map{'scores': [90, 85], 'ages': [25, 30]})},
+    map{2: row('item2', map{'scores': [95, 92, 88]})}
+];
+-- result:
+-- !result
+ALTER TABLE deep_nesting_2 ADD COLUMN map_arr_st_arr_st MAP<INT, ARRAY<STRUCT<
+    id INT,
+    items ARRAY<STRUCT<k VARCHAR(20), v INT>>
+>>> DEFAULT map{
+    1: [row(10, [row('a', 1), row('b', 2)])],
+    2: [row(20, [row('c', 3)]), row(30, [row('d', 4), row('e', 5)])]
+};
+-- result:
+-- !result
+SELECT * FROM deep_nesting_2;
+-- result:
+1	{"id":1,"nested":{10:[{"a":1,"b":2},{"c":3}],20:[{"d":4,"e":5,"f":6}]}}	[{1:{"name":"item1","data":{"ages":[25,30],"scores":[90,85]}}},{2:{"name":"item2","data":{"scores":[95,92,88]}}}]	{1:[{"id":10,"items":[{"k":"a","v":1},{"k":"b","v":2}]}],2:[{"id":20,"items":[{"k":"c","v":3}]},{"id":30,"items":[{"k":"d","v":4},{"k":"e","v":5}]}]}
+-- !result
+CREATE TABLE complex_field_order (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO complex_field_order VALUES (1);
+-- result:
+-- !result
+ALTER TABLE complex_field_order ADD COLUMN arr_st_order ARRAY<STRUCT<
+    zebra INT,
+    apple VARCHAR(20),
+    monkey BOOLEAN,
+    banana ARRAY<INT>
+>> DEFAULT [
+    row(10, 'fruit', true, [1, 2, 3]),
+    row(20, 'animal', false, [4, 5])
+];
+-- result:
+-- !result
+ALTER TABLE complex_field_order ADD COLUMN map_st_nested MAP<INT, STRUCT<
+    outer_z INT,
+    outer_a VARCHAR(20),
+    nested_st STRUCT<inner_y INT, inner_b VARCHAR(20)>
+>> DEFAULT map{
+    1: row(100, 'test', row(200, 'nested'))
+};
+-- result:
+-- !result
+ALTER TABLE complex_field_order ADD COLUMN st_map_st STRUCT<
+    id INT,
+    data MAP<INT, STRUCT<s4 INT, ks ARRAY<INT>, aa VARCHAR(20)>>
+> DEFAULT row(1, map{
+    10: row(2, [1, 2, 3, 4], 'test'),
+    20: row(5, [10, 20], 'demo')
+});
+-- result:
+-- !result
+SELECT * FROM complex_field_order;
+-- result:
+1	[{"zebra":10,"apple":"fruit","monkey":1,"banana":[1,2,3]},{"zebra":20,"apple":"animal","monkey":0,"banana":[4,5]}]	{1:{"outer_z":100,"outer_a":"test","nested_st":{"inner_y":200,"inner_b":"nested"}}}	{"id":1,"data":{10:{"s4":2,"ks":[1,2,3,4],"aa":"test"},20:{"s4":5,"ks":[10,20],"aa":"demo"}}}
+-- !result
+CREATE TABLE mixed_empty_nested (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO mixed_empty_nested VALUES (1);
+-- result:
+-- !result
+ALTER TABLE mixed_empty_nested ADD COLUMN arr3_mixed ARRAY<ARRAY<ARRAY<INT>>> 
+DEFAULT [[[1, 2], []], [[]], [[3], [4, 5]]];
+-- result:
+-- !result
+ALTER TABLE mixed_empty_nested ADD COLUMN map_arr_st_empty MAP<INT, ARRAY<STRUCT<
+    id INT,
+    tags ARRAY<VARCHAR(20)>
+>>> DEFAULT map{
+    1: [row(1, []), row(2, ['tag1', 'tag2'])],
+    2: []
+};
+-- result:
+-- !result
+ALTER TABLE mixed_empty_nested ADD COLUMN st_mixed_empty STRUCT<
+    id INT,
+    empty_arr ARRAY<INT>,
+    empty_map MAP<VARCHAR(20), INT>,
+    non_empty_arr ARRAY<INT>,
+    non_empty_map MAP<VARCHAR(20), INT>
+> DEFAULT row(1, [], map{}, [1, 2], map{'k': 100});
+-- result:
+-- !result
+ALTER TABLE mixed_empty_nested ADD COLUMN arr_map_st_empty ARRAY<MAP<INT, STRUCT<
+    id INT,
+    data ARRAY<INT>
+>>> DEFAULT [
+    map{},
+    map{1: row(10, [1, 2, 3])},
+    map{},
+    map{2: row(20, [])}
+];
+-- result:
+-- !result
+SELECT * FROM mixed_empty_nested;
+-- result:
+1	[[[1,2],[]],[[]],[[3],[4,5]]]	{1:[{"id":1,"tags":[]},{"id":2,"tags":["tag1","tag2"]}],2:[]}	{"id":1,"empty_arr":[],"empty_map":{},"non_empty_arr":[1,2],"non_empty_map":{"k":100}}	[{},{1:{"id":10,"data":[1,2,3]}},{},{2:{"id":20,"data":[]}}]
+-- !result
+CREATE TABLE six_level_nesting (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO six_level_nesting VALUES (1);
+-- result:
+-- !result
+ALTER TABLE six_level_nesting ADD COLUMN level6_1 ARRAY<MAP<INT, STRUCT<
+    id INT,
+    nested ARRAY<MAP<INT, ARRAY<INT>>>
+>>> DEFAULT [
+    map{1: row(100, [map{1: [1, 2]}, map{2: [3, 4]}])}
+];
+-- result:
+-- !result
+ALTER TABLE six_level_nesting ADD COLUMN level6_2 MAP<INT, STRUCT<
+    name VARCHAR(20),
+    data MAP<INT, ARRAY<STRUCT<id INT, vals ARRAY<INT>>>>
+>> DEFAULT map{
+    1: row('test', map{10: [row(1, [1, 2, 3])]})
+};
+-- result:
+-- !result
+ALTER TABLE six_level_nesting ADD COLUMN level6_3 STRUCT<
+    id INT,
+    deep ARRAY<MAP<INT, STRUCT<
+        name VARCHAR(20),
+        data MAP<INT, ARRAY<INT>>
+    >>>
+> DEFAULT row(1, [
+    map{1: row('item', map{10: [1, 2], 20: [3, 4]})}
+]);
+-- result:
+-- !result
+SELECT * FROM six_level_nesting;
+-- result:
+1	[{1:{"id":100,"nested":[{1:[1,2]},{2:[3,4]}]}}]	{1:{"name":"test","data":{10:[{"id":1,"vals":[1,2,3]}]}}}	{"id":1,"deep":[{1:{"name":"item","data":{10:[1,2],20:[3,4]}}}]}
+-- !result
+CREATE TABLE decimal256_nested (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO decimal256_nested VALUES (1);
+-- result:
+-- !result
+ALTER TABLE decimal256_nested ADD COLUMN arr_st_dec256 ARRAY<STRUCT<
+    id INT,
+    amount DECIMAL(45, 10)
+>> DEFAULT [
+    row(1, 12345678901234.1234567890),
+    row(2, 98765432109876.0987654321)
+];
+-- result:
+-- !result
+ALTER TABLE decimal256_nested ADD COLUMN map_st_dec256 MAP<INT, STRUCT<
+    price DECIMAL(45, 10),
+    history ARRAY<DECIMAL(45, 10)>
+>> DEFAULT map{
+    1: row(99999999999.9999999999, [11111111111.1111111111, 22222222222.2222222222])
+};
+-- result:
+-- !result
+ALTER TABLE decimal256_nested ADD COLUMN st_map_arr_dec256 STRUCT<
+    name VARCHAR(20),
+    data MAP<INT, ARRAY<STRUCT<id INT, val DECIMAL(45, 10)>>>
+> DEFAULT row('test', map{
+    1: [row(10, 12345.1234567890), row(20, 67890.0987654321)]
+});
+-- result:
+-- !result
+SELECT * FROM decimal256_nested;
+-- result:
+1	[{"id":1,"amount":12345678901234.1234567890},{"id":2,"amount":98765432109876.0987654321}]	{1:{"price":99999999999.9999999999,"history":[11111111111.1111111111,22222222222.2222222222]}}	{"name":"test","data":{1:[{"id":10,"val":12345.1234567890},{"id":20,"val":67890.0987654321}]}}
+-- !result
+SELECT 
+    id,
+    arr_tinyint[1] AS first_tinyint,
+    arr_tinyint[2] AS second_tinyint,
+    arr_varchar[1] AS first_varchar,
+    arr_decimal256[1] AS first_decimal256
+FROM test_correctness_db.array_primitives
+ORDER BY id;
+-- result:
+1	1	2	hello	1123123234567890123412345678901234.1234567890
+2	1	2	hello	1123123234567890123412345678901234.1234567890
+-- !result
+SELECT
+    id,
+    arr2_int[1] AS first_subarray,
+    arr2_int[1][1] AS first_elem_of_first_subarray,
+    arr2_int[2][2] AS second_elem_of_second_subarray,
+    arr3_int[1][1][1] AS deeply_nested_element
+FROM test_correctness_db.nested_arrays
+ORDER BY id;
+-- result:
+1	[1,2,3]	1	5	1
+2	[1,2,3]	1	5	1
+-- !result
+SELECT
+    id,
+    map_int_str[1] AS value_for_key_1,
+    map_int_str[100] AS value_for_key_100,
+    map_str_int['alice'] AS alice_value,
+    map_int_decimal[2] AS decimal_for_key_2
+FROM test_correctness_db.map_types
+ORDER BY id;
+-- result:
+1	one	hundred	25	199.99
+2	one	hundred	25	199.99
+-- !result
+SELECT
+    id,
+    st1.z AS st1_field_z,
+    st1.a AS st1_field_a,
+    st3.s4 AS st3_field_s4,
+    st3.ks AS st3_field_ks_array,
+    st3.ks[1] AS st3_first_ks_element
+FROM test_correctness_db.struct_field_order
+ORDER BY id;
+-- result:
+1	999	test	2	[1,2,3,4]	1
+2	999	test	2	[1,2,3,4]	1
+-- !result

--- a/test/sql/test_default_value/R/test_complex_default_correctness.sql
+++ b/test/sql/test_default_value/R/test_complex_default_correctness.sql
@@ -736,3 +736,268 @@ ORDER BY id;
 1	999	test	2	[1,2,3,4]	1
 2	999	test	2	[1,2,3,4]	1
 -- !result
+SELECT
+    id,
+    st_arr.id AS struct_id,
+    st_arr.scores AS scores_array,
+    st_arr.scores[1] AS first_score,
+    st_map.attributes['color'] AS color_value,
+    st_deep.items[1].id AS first_item_id,
+    st_deep.items[2].value AS second_item_value
+FROM struct_nested
+ORDER BY id;
+-- result:
+1	1	[90,85,95]	90	red	1	item2
+2	1	[90,85,95]	90	red	1	item2
+-- !result
+SELECT
+    id,
+    arr_st1[1].id AS first_person_id,
+    arr_st1[1].name AS first_person_name,
+    arr_st2[2].score AS second_student_score,
+    arr_st3[1].tags[2] AS first_record_second_tag
+FROM test_correctness_db.array_struct
+ORDER BY id;
+-- result:
+1	1	alice	88	tag2
+2	1	alice	88	tag2
+-- !result
+SELECT
+    id,
+    mp_arr1[1] AS array_for_key_1,
+    mp_arr1[1][2] AS second_elem_of_array_for_key_1,
+    mp_arr2['scores'][1] AS first_score,
+    mp_arr3[1][1][2] AS nested_array_element
+FROM test_correctness_db.map_array
+ORDER BY id;
+-- result:
+1	["a","b","c"]	b	90	2
+2	["a","b","c"]	b	90	2
+-- !result
+SELECT
+    id,
+    mp_st1[1].name AS person_1_name,
+    mp_st1[2].age AS person_2_age,
+    mp_st3[1].s4 AS key_1_s4_value,
+    mp_st3[1].ks[3] AS key_1_ks_third_element,
+    mp_st4[10].nested.z AS nested_struct_z_field
+FROM test_correctness_db.map_struct
+ORDER BY id;
+-- result:
+1	alice	30	2	3	999
+2	alice	30	2	3	999
+-- !result
+SELECT
+    id,
+    arr_st_map_arr[1].data[10][2] AS deep_array_access,
+    map_st_arr_map[1].tags[1] AS map_struct_array_elem,
+    st_map_st_arr.data[1].vals[2] AS struct_map_struct_array_elem,
+    map_arr_st_arr_st[1][1].items[1].k AS very_deep_struct_field
+FROM test_correctness_db.deep_nesting_1, test_correctness_db.deep_nesting_2
+ORDER BY id;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'id' is ambiguous.")
+-- !result
+SELECT
+    id,
+    arr_st_dec256[1].amount AS first_amount,
+    map_st_dec256[1].price AS price_for_key_1,
+    map_st_dec256[1].history[2] AS second_history_value,
+    st_map_arr_dec256.data[1][1].val AS nested_decimal_value
+FROM test_correctness_db.decimal256_nested
+ORDER BY id;
+-- result:
+1	12345678901234.1234567890	99999999999.9999999999	22222222222.2222222222	12345.1234567890
+-- !result
+CREATE TABLE t_ns (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num"="1", "fast_schema_evolution"="true");
+-- result:
+-- !result
+INSERT INTO t_ns VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE t_ns
+ADD COLUMN st_outer STRUCT<
+  k1 INT,
+  mid STRUCT<
+    a INT,
+    sub STRUCT<x INT, y VARCHAR(20)>
+  >,
+  k2 VARCHAR(20)
+>
+DEFAULT row(10, row(1, row(7, 'yy')), 'end');
+-- result:
+-- !result
+SELECT
+  id,
+  st_outer.mid,
+  st_outer.mid.sub
+FROM t_ns
+ORDER BY id;
+-- result:
+1	{"a":1,"sub":{"x":7,"y":"yy"}}	{"x":7,"y":"yy"}
+2	{"a":1,"sub":{"x":7,"y":"yy"}}	{"x":7,"y":"yy"}
+-- !result
+SELECT
+  id,
+  st_outer.mid,
+  st_outer.mid.sub.x
+FROM t_ns
+ORDER BY id;
+-- result:
+1	{"a":1,"sub":{"x":7,"y":"yy"}}	7
+2	{"a":1,"sub":{"x":7,"y":"yy"}}	7
+-- !result
+SELECT
+  id,
+  st_outer.mid.sub
+FROM t_ns
+ORDER BY id;
+-- result:
+1	{"x":7,"y":"yy"}
+2	{"x":7,"y":"yy"}
+-- !result
+SET cbo_prune_subfield=true;
+-- result:
+-- !result
+CREATE TABLE t_prune_mix (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num"="1", "fast_schema_evolution"="true");
+-- result:
+-- !result
+INSERT INTO t_prune_mix VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE t_prune_mix
+ADD COLUMN st_mix STRUCT<
+  sid INT,
+  arr ARRAY<STRUCT<s INT, meta STRUCT<x INT, y VARCHAR(10)>>>,
+  mp MAP<INT, STRUCT<m VARCHAR(10), vals ARRAY<INT>>>,
+  name VARCHAR(10)
+>
+DEFAULT row(
+  1,
+  [row(10, row(7, 'a')), row(20, row(8, 'b'))],
+  map{1: row('v', [1, 2, 3]), 2: row('w', [9])},
+  'n'
+);
+-- result:
+-- !result
+SELECT
+  id,
+  st_mix.arr[1] AS first_elem,
+  st_mix.arr[1].meta.x AS first_elem_meta_x
+FROM t_prune_mix
+ORDER BY id;
+-- result:
+1	{"s":10,"meta":{"x":7,"y":"a"}}	7
+2	{"s":10,"meta":{"x":7,"y":"a"}}	7
+-- !result
+SELECT
+  id,
+  st_mix.arr[2].meta.y AS second_elem_meta_y
+FROM t_prune_mix
+ORDER BY id;
+-- result:
+1	b
+2	b
+-- !result
+SELECT
+  id,
+  st_mix.mp[1].m AS m1,
+  st_mix.mp[1].vals[2] AS mp1_vals_2
+FROM t_prune_mix
+ORDER BY id;
+-- result:
+1	v	2
+2	v	2
+-- !result
+SELECT
+  id,
+  st_mix.mp AS mp_all,
+  st_mix.mp[2].vals AS mp2_vals
+FROM t_prune_mix
+ORDER BY id;
+-- result:
+1	{1:{"m":"v","vals":[1,2,3]},2:{"m":"w","vals":[9]}}	[9]
+2	{1:{"m":"v","vals":[1,2,3]},2:{"m":"w","vals":[9]}}	[9]
+-- !result
+SELECT
+  id,
+  st_mix.name AS name,
+  st_mix.arr[1].s AS first_s
+FROM t_prune_mix
+ORDER BY id;
+-- result:
+1	n	10
+2	n	10
+-- !result
+CREATE TABLE t_prune_arr_mp (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num"="1", "fast_schema_evolution"="true");
+-- result:
+-- !result
+INSERT INTO t_prune_arr_mp VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE t_prune_arr_mp
+ADD COLUMN arr_mp ARRAY<MAP<INT, STRUCT<a INT, b STRUCT<x INT, y VARCHAR(10)>>>>
+DEFAULT [
+  map{1: row(10, row(7, 'aa')), 2: row(20, row(8, 'bb'))}
+];
+-- result:
+-- !result
+SELECT
+  id,
+  arr_mp[1][2].b.y AS y_2
+FROM t_prune_arr_mp
+ORDER BY id;
+-- result:
+1	bb
+2	bb
+-- !result
+SELECT
+  id,
+  arr_mp[1][1] AS v1,
+  arr_mp[1][1].b.x AS v1_b_x
+FROM t_prune_arr_mp
+ORDER BY id;
+-- result:
+1	{"a":10,"b":{"x":7,"y":"aa"}}	7
+2	{"a":10,"b":{"x":7,"y":"aa"}}	7
+-- !result
+CREATE TABLE t_prune_mp_arr (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num"="1", "fast_schema_evolution"="true");
+-- result:
+-- !result
+INSERT INTO t_prune_mp_arr VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE t_prune_mp_arr
+ADD COLUMN mp_arr MAP<VARCHAR(10), ARRAY<STRUCT<id INT, meta STRUCT<p INT, q VARCHAR(10)>>>>
+DEFAULT map{
+  'k': [row(1, row(7, 'qq')), row(2, row(8, 'ww'))]
+};
+-- result:
+-- !result
+SELECT
+  id,
+  mp_arr['k'][2].meta.q AS q2
+FROM t_prune_mp_arr
+ORDER BY id;
+-- result:
+1	ww
+2	ww
+-- !result
+SELECT
+  id,
+  mp_arr['k'][1] AS e1,
+  mp_arr['k'][1].meta.p AS e1_p
+FROM t_prune_mp_arr
+ORDER BY id;
+-- result:
+1	{"id":1,"meta":{"p":7,"q":"qq"}}	7
+2	{"id":1,"meta":{"p":7,"q":"qq"}}	7
+-- !result

--- a/test/sql/test_default_value/R/test_complex_default_correctness.sql
+++ b/test/sql/test_default_value/R/test_complex_default_correctness.sql
@@ -1,4 +1,4 @@
--- name: test_complex_default_correctness
+-- name: test_complex_default_correctness @native
 DROP DATABASE IF EXISTS test_correctness_db;
 -- result:
 -- !result

--- a/test/sql/test_default_value/R/test_varbinary_default.sql
+++ b/test/sql/test_default_value/R/test_varbinary_default.sql
@@ -186,7 +186,7 @@ CREATE TABLE test_varbinary_invalid1 (
 DISTRIBUTED BY HASH(id) BUCKETS 1
 PROPERTIES("replication_num" = "1");
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Invalid default value for \'binary_col\': Type \'VARBINARY\' only supports empty string "" as default value.')
+[REGEX].*Getting analyzing error*
 -- !result
 CREATE TABLE test_varbinary_invalid2 (
     id INT,
@@ -195,7 +195,7 @@ CREATE TABLE test_varbinary_invalid2 (
 DISTRIBUTED BY HASH(id) BUCKETS 1
 PROPERTIES("replication_num" = "1");
 -- result:
-E: (1064, "Getting syntax error at line 3, column 33. Detail message: Unexpected input 'x'CAFE'', the most similar input is {'NULL', 'CURRENT_TIMESTAMP', SINGLE_QUOTED_TEXT, DOUBLE_QUOTED_TEXT, '('}.")
+[REGEX].*Getting analyzing error*
 -- !result
 CREATE TABLE test_varbinary_sized (
     id INT NOT NULL,

--- a/test/sql/test_default_value/T/test_complex_default_all_paths.sql
+++ b/test/sql/test_default_value/T/test_complex_default_all_paths.sql
@@ -1,0 +1,353 @@
+-- name: test_complex_default_all_paths
+-- Comprehensive test for complex type (ARRAY/MAP/STRUCT) default values
+
+DROP DATABASE IF EXISTS test_complex_default_db;
+CREATE DATABASE test_complex_default_db;
+USE test_complex_default_db;
+
+-- ====================================================================================
+-- SECTION 1: ALTER TABLE ADD COLUMN with Complex Type Defaults
+-- ====================================================================================
+
+CREATE TABLE fast_schema_evolution (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO fast_schema_evolution (id) VALUES (1), (2), (3);
+
+ALTER TABLE fast_schema_evolution ADD COLUMN arr_col ARRAY<INT> DEFAULT [10, 20, 30];
+ALTER TABLE fast_schema_evolution ADD COLUMN map_col MAP<INT, VARCHAR(20)> DEFAULT map{1: 'apple', 2: 'banana'};
+ALTER TABLE fast_schema_evolution ADD COLUMN struct_col STRUCT<f1 INT, f2 VARCHAR(20)> DEFAULT row(100, 'hello');
+
+SELECT * FROM fast_schema_evolution ORDER BY id;
+
+-- ====================================================================================
+-- SECTION 2: Nested Complex Types
+-- ====================================================================================
+
+CREATE TABLE nested_complex (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO nested_complex (id) VALUES (1), (2);
+
+ALTER TABLE nested_complex ADD COLUMN nested_array ARRAY<ARRAY<INT>> DEFAULT [[1, 2], [3, 4, 5]];
+ALTER TABLE nested_complex ADD COLUMN map_with_array MAP<INT, ARRAY<VARCHAR(20)>> DEFAULT map{1: ['a', 'b'], 2: ['c', 'd']};
+ALTER TABLE nested_complex ADD COLUMN complex_struct STRUCT<
+    id INT, 
+    scores ARRAY<INT>, 
+    tags MAP<VARCHAR(20), INT>
+> DEFAULT row(999, [100, 200], map{'k1': 1, 'k2': 2});
+
+SELECT * FROM nested_complex ORDER BY id;
+
+-- ====================================================================================
+-- SECTION 3: MAP with STRUCT - Field Order Preservation Test
+-- ====================================================================================
+CREATE TABLE map_struct_order (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO map_struct_order (id) VALUES (1), (2);
+
+ALTER TABLE map_struct_order ADD COLUMN www123 MAP<INT, STRUCT<s4 INT, ks ARRAY<INT>>>
+DEFAULT map{1: row(2, [1, 2, 3, 4])};
+
+ALTER TABLE map_struct_order ADD COLUMN complex_data MAP<INT, STRUCT<
+    field_b VARCHAR(20),
+    field_a INT,
+    nested STRUCT<z INT, a VARCHAR(20)>
+>> DEFAULT map{10: row('hello', 100, row(999, 'world'))};
+
+SELECT * FROM map_struct_order ORDER BY id;
+
+-- ====================================================================================
+-- SECTION 4: Empty Collections
+-- ====================================================================================
+
+CREATE TABLE empty_collections (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO empty_collections (id) VALUES (1), (2);
+
+ALTER TABLE empty_collections ADD COLUMN empty_arr ARRAY<INT> DEFAULT [];
+ALTER TABLE empty_collections ADD COLUMN empty_map MAP<INT, VARCHAR(20)> DEFAULT map{};
+ALTER TABLE empty_collections ADD COLUMN struct_with_empty STRUCT<
+    id INT,
+    arr ARRAY<INT>,
+    mp MAP<VARCHAR(20), INT>
+> DEFAULT row(0, [], map{});
+
+SELECT * FROM empty_collections ORDER BY id;
+
+-- ====================================================================================
+-- SECTION 5: All Primitive Types in Complex Types
+-- ====================================================================================
+
+CREATE TABLE all_primitive_types (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO all_primitive_types (id) VALUES (1);
+
+ALTER TABLE all_primitive_types ADD COLUMN arr_int ARRAY<INT> DEFAULT [1, 2, 3];
+ALTER TABLE all_primitive_types ADD COLUMN arr_bigint ARRAY<BIGINT> DEFAULT [1000000000, 2000000000];
+ALTER TABLE all_primitive_types ADD COLUMN arr_string ARRAY<VARCHAR(20)> DEFAULT ['hello', 'world'];
+ALTER TABLE all_primitive_types ADD COLUMN arr_double ARRAY<DOUBLE> DEFAULT [1.1, 2.2, 3.3];
+ALTER TABLE all_primitive_types ADD COLUMN arr_bool ARRAY<BOOLEAN> DEFAULT [true, false, true];
+ALTER TABLE all_primitive_types ADD COLUMN arr_decimal ARRAY<DECIMAL(10, 2)> DEFAULT [99.99, 199.99, 299.99];
+
+ALTER TABLE all_primitive_types ADD COLUMN map_int_str MAP<INT, VARCHAR(20)> DEFAULT map{1: 'one', 2: 'two'};
+ALTER TABLE all_primitive_types ADD COLUMN map_str_int MAP<VARCHAR(20), INT> DEFAULT map{'a': 10, 'b': 20};
+ALTER TABLE all_primitive_types ADD COLUMN map_str_bool MAP<VARCHAR(20), BOOLEAN> DEFAULT map{'flag1': true, 'flag2': false};
+
+ALTER TABLE all_primitive_types ADD COLUMN struct_mixed STRUCT<
+    f_int INT,
+    f_bigint BIGINT,
+    f_string VARCHAR(20),
+    f_double DOUBLE,
+    f_bool BOOLEAN,
+    f_decimal DECIMAL(10, 2)
+> DEFAULT row(100, 1000000000, 'text', 99.99, true, 123.45);
+
+SELECT * FROM all_primitive_types;
+
+-- ====================================================================================
+-- SECTION 6: Nullable Complex Types
+-- ====================================================================================
+
+CREATE TABLE nullable_complex (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO nullable_complex (id) VALUES (1), (2);
+
+ALTER TABLE nullable_complex ADD COLUMN nullable_arr ARRAY<INT> NULL DEFAULT [100, 200];
+ALTER TABLE nullable_complex ADD COLUMN nullable_map MAP<INT, VARCHAR(20)> NULL DEFAULT map{1: 'test'};
+ALTER TABLE nullable_complex ADD COLUMN nullable_struct STRUCT<f1 INT> NULL DEFAULT row(999);
+
+SELECT * FROM nullable_complex ORDER BY id;
+
+INSERT INTO nullable_complex (id, nullable_arr, nullable_map, nullable_struct) VALUES (3, NULL, NULL, NULL);
+SELECT * FROM nullable_complex ORDER BY id;
+
+-- ====================================================================================
+-- SECTION 7: REORDER COLUMNS with Complex Type Defaults
+-- ====================================================================================
+
+CREATE TABLE reorder_test (
+    id INT NOT NULL,
+    name VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO reorder_test (id, name) VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie');
+
+ALTER TABLE reorder_test ADD COLUMN arr ARRAY<INT> DEFAULT [1, 2, 3];
+ALTER TABLE reorder_test ADD COLUMN mp MAP<INT, VARCHAR(20)> DEFAULT map{10: 'ten'};
+ALTER TABLE reorder_test ADD COLUMN st STRUCT<f1 INT, f2 VARCHAR(20)> DEFAULT row(100, 'test');
+
+ALTER TABLE reorder_test ORDER BY (id, mp, st, arr, name);
+
+SELECT SLEEP(2);
+
+SELECT count(*) FROM reorder_test;
+
+-- ====================================================================================
+-- SECTION 8: PRIMARY KEY Table - INSERT with Partial Columns
+-- ====================================================================================
+
+CREATE TABLE pk_basic_defaults (
+    user_id INT NOT NULL,
+    username VARCHAR(50),
+    scores ARRAY<INT> DEFAULT [80, 90, 85],
+    tags MAP<VARCHAR(20), VARCHAR(20)> DEFAULT map{'status': 'active', 'level': 'basic'},
+    profile STRUCT<age INT, city VARCHAR(20)> DEFAULT row(18, 'Shanghai')
+) PRIMARY KEY(user_id)
+DISTRIBUTED BY HASH(user_id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO pk_basic_defaults (user_id, username) VALUES (1, 'user1');
+INSERT INTO pk_basic_defaults (user_id, username) VALUES (2, 'user2');
+
+SELECT * FROM pk_basic_defaults ORDER BY user_id;
+
+INSERT INTO pk_basic_defaults VALUES 
+    (3, 'user3', [100, 95, 98], map{'status': 'vip', 'level': 'premium'}, row(30, 'Beijing'));
+
+SELECT * FROM pk_basic_defaults ORDER BY user_id;
+
+-- ====================================================================================
+-- SECTION 9: PRIMARY KEY Table - Column Mode Partial Update
+-- ====================================================================================
+
+CREATE TABLE pk_column_mode (
+    order_id INT NOT NULL,
+    product_name VARCHAR(50),
+    quantity INT DEFAULT '1',
+    tags ARRAY<VARCHAR(20)> DEFAULT ['new', 'available'],
+    config MAP<VARCHAR(20), INT> DEFAULT map{'priority': 1, 'score': 100},
+    details STRUCT<category VARCHAR(20), rating INT> DEFAULT row('electronics', 5)
+) PRIMARY KEY(order_id)
+DISTRIBUTED BY HASH(order_id) BUCKETS 2
+PROPERTIES("replication_num" = "1");
+
+SET partial_update_mode = 'column';
+
+INSERT INTO pk_column_mode (order_id, product_name) VALUES (1, 'laptop');
+INSERT INTO pk_column_mode (order_id, product_name) VALUES (2, 'phone');
+INSERT INTO pk_column_mode (order_id, product_name) VALUES (3, 'tablet');
+
+SELECT * FROM pk_column_mode ORDER BY order_id;
+
+ALTER TABLE pk_column_mode ADD COLUMN extras STRUCT<discount DOUBLE, items ARRAY<INT>> DEFAULT row(0.1, [1, 2, 3]);
+
+INSERT INTO pk_column_mode (order_id, product_name) VALUES (4, 'mouse');
+INSERT INTO pk_column_mode (order_id, product_name) VALUES (5, 'keyboard');
+
+SELECT * FROM pk_column_mode ORDER BY order_id;
+
+SET partial_update_mode = 'auto';
+
+-- ====================================================================================
+-- SECTION 10: PRIMARY KEY Table - Row Mode Partial Update
+-- ====================================================================================
+
+CREATE TABLE pk_row_mode (
+    id INT NOT NULL,
+    name VARCHAR(50),
+    score INT DEFAULT '100',
+    level VARCHAR(20) DEFAULT 'bronze',
+    tags ARRAY<VARCHAR(20)> DEFAULT ['default', 'new'],
+    config MAP<VARCHAR(20), INT> DEFAULT map{'level': 1, 'score': 100},
+    details STRUCT<category VARCHAR(20), active BOOLEAN> DEFAULT row('general', true)
+) PRIMARY KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO pk_row_mode VALUES 
+    (1, 'item1', 500, 'gold', ['premium'], map{'level': 5}, row('special', false));
+
+SELECT * FROM pk_row_mode ORDER BY id;
+
+INSERT INTO pk_row_mode (id, name) VALUES (2, 'item2');
+INSERT INTO pk_row_mode (id, name) VALUES (3, 'item3');
+
+SELECT * FROM pk_row_mode ORDER BY id;
+
+-- ====================================================================================
+-- SECTION 11: PRIMARY KEY Table - Nested Complex Types
+-- ====================================================================================
+
+CREATE TABLE pk_nested_complex (
+    id INT NOT NULL,
+    name VARCHAR(50),
+    nested_arr ARRAY<ARRAY<INT>> DEFAULT [[1, 2], [3, 4, 5]],
+    map_with_struct MAP<INT, STRUCT<val INT, description VARCHAR(20)>> DEFAULT map{1: row(100, 'default')},
+    complex_struct STRUCT<id INT, data MAP<VARCHAR(20), ARRAY<INT>>> DEFAULT row(999, map{'scores': [90, 95, 100]})
+) PRIMARY KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+SET partial_update_mode = 'column';
+
+INSERT INTO pk_nested_complex (id, name) VALUES (1, 'user1');
+INSERT INTO pk_nested_complex (id, name) VALUES (2, 'user2');
+
+SELECT * FROM pk_nested_complex ORDER BY id;
+
+SET partial_update_mode = 'auto';
+
+INSERT INTO pk_nested_complex (id, name) VALUES (3, 'user3');
+
+SELECT * FROM pk_nested_complex ORDER BY id;
+
+-- ====================================================================================
+-- SECTION 12: PRIMARY KEY Table - Empty Collections
+-- ====================================================================================
+
+CREATE TABLE pk_empty_collections (
+    id INT NOT NULL,
+    status VARCHAR(20),
+    empty_arr ARRAY<INT> DEFAULT [],
+    empty_map MAP<INT, VARCHAR(20)> DEFAULT map{},
+    struct_with_empty STRUCT<id INT, arr ARRAY<VARCHAR(20)>, mp MAP<VARCHAR(20), INT>> DEFAULT row(0, [], map{})
+) PRIMARY KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+SET partial_update_mode = 'column';
+
+INSERT INTO pk_empty_collections (id, status) VALUES (1, 'active');
+INSERT INTO pk_empty_collections (id, status) VALUES (2, 'inactive');
+
+SELECT * FROM pk_empty_collections ORDER BY id;
+
+SET partial_update_mode = 'auto';
+
+-- ====================================================================================
+-- SECTION 13: PRIMARY KEY Table - Multiple Complex Types
+-- ====================================================================================
+
+CREATE TABLE pk_multi_complex (
+    id INT NOT NULL,
+    name VARCHAR(50),
+    arr_int ARRAY<INT> DEFAULT [10, 20, 30],
+    arr_str ARRAY<VARCHAR(20)> DEFAULT ['a', 'b', 'c'],
+    map_int_str MAP<INT, VARCHAR(20)> DEFAULT map{1: 'one', 2: 'two'},
+    map_str_int MAP<VARCHAR(20), INT> DEFAULT map{'x': 100, 'y': 200},
+    struct_simple STRUCT<f1 INT, f2 VARCHAR(20)> DEFAULT row(999, 'default'),
+    struct_complex STRUCT<id INT, tags ARRAY<VARCHAR(20)>> DEFAULT row(1, ['tag1', 'tag2'])
+) PRIMARY KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+SET partial_update_mode = 'column';
+
+INSERT INTO pk_multi_complex (id, name) VALUES (1, 'test1');
+INSERT INTO pk_multi_complex (id, name) VALUES (2, 'test2');
+
+SELECT * FROM pk_multi_complex ORDER BY id;
+
+INSERT INTO pk_multi_complex (id, name, arr_int) VALUES (3, 'test3', [100, 200]);
+
+SELECT id, name, arr_int, arr_str FROM pk_multi_complex ORDER BY id;
+
+SET partial_update_mode = 'auto';
+
+-- ====================================================================================
+-- SECTION 14: PRIMARY KEY Table - DECIMAL Types
+-- ====================================================================================
+
+CREATE TABLE pk_decimal_complex (
+    id INT NOT NULL,
+    name VARCHAR(50),
+    prices ARRAY<DECIMAL(10, 2)> DEFAULT [99.99, 199.99, 299.99],
+    price_map MAP<VARCHAR(20), DECIMAL(10, 2)> DEFAULT map{'min': 10.00, 'max': 1000.00},
+    price_info STRUCT<base DECIMAL(10, 2), tax DECIMAL(5, 2)> DEFAULT row(100.00, 8.25)
+) PRIMARY KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+SET partial_update_mode = 'column';
+
+INSERT INTO pk_decimal_complex (id, name) VALUES (1, 'product1');
+INSERT INTO pk_decimal_complex (id, name) VALUES (2, 'product2');
+
+SELECT * FROM pk_decimal_complex ORDER BY id;
+
+SET partial_update_mode = 'auto';

--- a/test/sql/test_default_value/T/test_complex_default_correctness.sql
+++ b/test/sql/test_default_value/T/test_complex_default_correctness.sql
@@ -1,0 +1,572 @@
+-- name: test_complex_default_correctness
+
+DROP DATABASE IF EXISTS test_correctness_db;
+CREATE DATABASE test_correctness_db;
+USE test_correctness_db;
+
+-- ====================================================================================
+-- Section 1: ARRAY with Various Primitive Types
+-- ====================================================================================
+
+CREATE TABLE array_primitives (id INT) DUPLICATE KEY(id) 
+DISTRIBUTED BY HASH(id) BUCKETS 1 
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO array_primitives VALUES (1), (2);
+
+ALTER TABLE array_primitives ADD COLUMN arr_tinyint ARRAY<TINYINT> DEFAULT [1, 2, 127];
+ALTER TABLE array_primitives ADD COLUMN arr_smallint ARRAY<SMALLINT> DEFAULT [100, 200, 32767];
+ALTER TABLE array_primitives ADD COLUMN arr_int ARRAY<INT> DEFAULT [1000, 2000, 2147483647];
+ALTER TABLE array_primitives ADD COLUMN arr_bigint ARRAY<BIGINT> DEFAULT [1000000, 2000000, 9223372036854775807];
+ALTER TABLE array_primitives ADD COLUMN arr_float ARRAY<FLOAT> DEFAULT [1.1, 2.2, 3.3];
+ALTER TABLE array_primitives ADD COLUMN arr_double ARRAY<DOUBLE> DEFAULT [1.123456789, 2.987654321, 3.141592653];
+ALTER TABLE array_primitives ADD COLUMN arr_varchar ARRAY<VARCHAR(50)> DEFAULT ['hello', 'world', '你好世界'];
+ALTER TABLE array_primitives ADD COLUMN arr_char ARRAY<CHAR(10)> DEFAULT ['abc', 'def', 'ghi'];
+ALTER TABLE array_primitives ADD COLUMN arr_bool ARRAY<BOOLEAN> DEFAULT [true, false, true, false];
+ALTER TABLE array_primitives ADD COLUMN arr_decimal32 ARRAY<DECIMAL(9, 2)> DEFAULT [123.45, 678.90, 999.99];
+ALTER TABLE array_primitives ADD COLUMN arr_decimal64 ARRAY<DECIMAL(18, 4)> DEFAULT [12345678.1234, 87654321.4321];
+ALTER TABLE array_primitives ADD COLUMN arr_decimal128 ARRAY<DECIMAL(38, 10)> DEFAULT [1234567890.1234567890, 9876543210.0987654321];
+ALTER TABLE array_primitives ADD COLUMN arr_decimal256 ARRAY<DECIMAL(55, 10)> DEFAULT [1123123234567890123412345678901234.1234567890, 98765432109876.0987654321];
+
+SELECT * FROM array_primitives ORDER BY id;
+
+-- ====================================================================================
+-- Section 2: MAP with Various Key-Value Type Combinations
+-- ====================================================================================
+
+CREATE TABLE map_types (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO map_types VALUES (1), (2);
+
+ALTER TABLE map_types ADD COLUMN map_int_str MAP<INT, VARCHAR(20)> DEFAULT map{1: 'one', 2: 'two', 100: 'hundred'};
+ALTER TABLE map_types ADD COLUMN map_str_int MAP<VARCHAR(20), INT> DEFAULT map{'alice': 25, 'bob': 30, 'charlie': 35};
+ALTER TABLE map_types ADD COLUMN map_int_double MAP<INT, DOUBLE> DEFAULT map{1: 1.1, 2: 2.2, 3: 3.3};
+ALTER TABLE map_types ADD COLUMN map_str_bool MAP<VARCHAR(20), BOOLEAN> DEFAULT map{'active': true, 'disabled': false};
+ALTER TABLE map_types ADD COLUMN map_int_decimal MAP<INT, DECIMAL(10, 2)> DEFAULT map{1: 99.99, 2: 199.99, 3: 299.99};
+
+SELECT * FROM map_types ORDER BY id;
+
+-- ====================================================================================
+-- Section 3: STRUCT with Field Order Preservation (Non-Alphabetical)
+-- ====================================================================================
+
+CREATE TABLE struct_field_order (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO struct_field_order VALUES (1), (2);
+
+ALTER TABLE struct_field_order ADD COLUMN st1 STRUCT<z INT, a VARCHAR(20)> DEFAULT row(999, 'test');
+ALTER TABLE struct_field_order ADD COLUMN st2 STRUCT<field_c INT, field_b VARCHAR(20), field_a DOUBLE> 
+DEFAULT row(100, 'middle', 3.14);
+ALTER TABLE struct_field_order ADD COLUMN st3 STRUCT<s4 INT, ks ARRAY<INT>> DEFAULT row(2, [1, 2, 3, 4]);
+ALTER TABLE struct_field_order ADD COLUMN st4 STRUCT<
+    zebra INT,
+    apple VARCHAR(20),
+    monkey BOOLEAN,
+    banana DOUBLE
+> DEFAULT row(10, 'fruit', true, 2.5);
+
+SELECT * FROM struct_field_order ORDER BY id;
+
+-- ====================================================================================
+-- Section 4: Nested ARRAY (2-level and 3-level)
+-- ====================================================================================
+
+CREATE TABLE nested_arrays (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO nested_arrays VALUES (1), (2);
+
+ALTER TABLE nested_arrays ADD COLUMN arr2_int ARRAY<ARRAY<INT>> DEFAULT [[1, 2, 3], [4, 5], [6, 7, 8, 9]];
+ALTER TABLE nested_arrays ADD COLUMN arr2_str ARRAY<ARRAY<VARCHAR(20)>> DEFAULT [['a', 'b'], ['c', 'd', 'e'], ['f']];
+ALTER TABLE nested_arrays ADD COLUMN arr3_int ARRAY<ARRAY<ARRAY<INT>>> DEFAULT [[[1, 2], [3]], [[4, 5, 6]], [[7], [8, 9]]];
+ALTER TABLE nested_arrays ADD COLUMN arr2_empty ARRAY<ARRAY<INT>> DEFAULT [[], [1, 2], []];
+
+SELECT * FROM nested_arrays ORDER BY id;
+
+-- ====================================================================================
+-- Section 5: ARRAY<STRUCT> with Various Struct Definitions
+-- ====================================================================================
+
+CREATE TABLE array_struct (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO array_struct VALUES (1), (2);
+
+ALTER TABLE array_struct ADD COLUMN arr_st1 ARRAY<STRUCT<id INT, name VARCHAR(20)>> 
+DEFAULT [row(1, 'alice'), row(2, 'bob'), row(3, 'charlie')];
+ALTER TABLE array_struct ADD COLUMN arr_st2 ARRAY<STRUCT<score INT, age INT, name VARCHAR(20)>> 
+DEFAULT [row(95, 25, 'student1'), row(88, 26, 'student2')];
+ALTER TABLE array_struct ADD COLUMN arr_st3 ARRAY<STRUCT<id INT, tags ARRAY<VARCHAR(20)>>> 
+DEFAULT [row(1, ['tag1', 'tag2']), row(2, ['tag3', 'tag4', 'tag5'])];
+
+SELECT * FROM array_struct ORDER BY id;
+
+-- ====================================================================================
+-- Section 6: MAP<K, ARRAY<V>> Combinations
+-- ====================================================================================
+
+CREATE TABLE map_array (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO map_array VALUES (1), (2);
+
+ALTER TABLE map_array ADD COLUMN mp_arr1 MAP<INT, ARRAY<VARCHAR(20)>> 
+DEFAULT map{1: ['a', 'b', 'c'], 2: ['d', 'e'], 3: ['f', 'g', 'h', 'i']};
+
+ALTER TABLE map_array ADD COLUMN mp_arr2 MAP<VARCHAR(20), ARRAY<INT>> 
+DEFAULT map{'scores': [90, 85, 92], 'ages': [25, 30, 35]};
+
+ALTER TABLE map_array ADD COLUMN mp_arr3 MAP<INT, ARRAY<ARRAY<INT>>> 
+DEFAULT map{1: [[1, 2], [3, 4]], 2: [[5], [6, 7, 8]]};
+
+SELECT * FROM map_array ORDER BY id;
+
+-- ====================================================================================
+-- Section 7: MAP<K, STRUCT> with Field Order Preservation
+-- ====================================================================================
+
+CREATE TABLE map_struct (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO map_struct VALUES (1), (2);
+
+ALTER TABLE map_struct ADD COLUMN mp_st1 MAP<INT, STRUCT<name VARCHAR(20), age INT>> 
+DEFAULT map{1: row('alice', 25), 2: row('bob', 30)};
+ALTER TABLE map_struct ADD COLUMN mp_st2 MAP<INT, STRUCT<z INT, a VARCHAR(20)>> 
+DEFAULT map{10: row(999, 'test'), 20: row(888, 'demo')};
+ALTER TABLE map_struct ADD COLUMN mp_st3 MAP<INT, STRUCT<s4 INT, ks ARRAY<INT>>> 
+DEFAULT map{1: row(2, [1, 2, 3, 4]), 2: row(5, [10, 20, 30])};
+ALTER TABLE map_struct ADD COLUMN mp_st4 MAP<INT, STRUCT<
+    field_b VARCHAR(20),
+    field_a INT,
+    nested STRUCT<z INT, a VARCHAR(20)>
+>> DEFAULT map{10: row('hello', 100, row(999, 'world'))};
+
+SELECT * FROM map_struct ORDER BY id;
+
+-- ====================================================================================
+-- Section 8: STRUCT with Nested ARRAY and MAP
+-- ====================================================================================
+
+CREATE TABLE struct_nested (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO struct_nested VALUES (1), (2);
+
+ALTER TABLE struct_nested ADD COLUMN st_arr STRUCT<id INT, scores ARRAY<INT>, name VARCHAR(20)> 
+DEFAULT row(1, [90, 85, 95], 'student');
+ALTER TABLE struct_nested ADD COLUMN st_map STRUCT<id INT, attributes MAP<VARCHAR(20), VARCHAR(20)>> 
+DEFAULT row(1, map{'color': 'red', 'size': 'large'});
+ALTER TABLE struct_nested ADD COLUMN st_both STRUCT<
+    tags ARRAY<VARCHAR(20)>,
+    id INT,
+    metadata MAP<VARCHAR(20), INT>
+> DEFAULT row(['tag1', 'tag2'], 100, map{'version': 1, 'priority': 5});
+ALTER TABLE struct_nested ADD COLUMN st_deep STRUCT<
+    name VARCHAR(20),
+    items ARRAY<STRUCT<id INT, value VARCHAR(20)>>
+> DEFAULT row('container', [row(1, 'item1'), row(2, 'item2')]);
+
+SELECT * FROM struct_nested ORDER BY id;
+
+-- ====================================================================================
+-- Section 9: Three-Level Nesting Combinations
+-- ====================================================================================
+
+CREATE TABLE three_level_nesting (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO three_level_nesting VALUES (1), (2);
+
+ALTER TABLE three_level_nesting ADD COLUMN arr3 ARRAY<ARRAY<ARRAY<INT>>> 
+DEFAULT [[[1, 2], [3]], [[4, 5]]];
+ALTER TABLE three_level_nesting ADD COLUMN arr_map_arr ARRAY<MAP<INT, ARRAY<INT>>> 
+DEFAULT [map{1: [1, 2], 2: [3, 4]}, map{10: [10, 20]}];
+ALTER TABLE three_level_nesting ADD COLUMN map_arr_st MAP<INT, ARRAY<STRUCT<id INT, name VARCHAR(20)>>> 
+DEFAULT map{1: [row(1, 'a'), row(2, 'b')]};
+ALTER TABLE three_level_nesting ADD COLUMN st_map_arr STRUCT<
+    id INT,
+    data MAP<VARCHAR(20), ARRAY<INT>>
+> DEFAULT row(1, map{'scores': [90, 95, 100]});
+ALTER TABLE three_level_nesting ADD COLUMN map_st_arr MAP<INT, STRUCT<
+    name VARCHAR(20),
+    vals ARRAY<INT>
+>> DEFAULT map{1: row('test', [1, 2, 3])};
+
+SELECT * FROM three_level_nesting ORDER BY id;
+
+-- ====================================================================================
+-- Section 10: Empty Collections and Mixed Empty/Non-Empty
+-- ====================================================================================
+
+CREATE TABLE empty_collections (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO empty_collections VALUES (1), (2);
+
+ALTER TABLE empty_collections ADD COLUMN arr_empty ARRAY<INT> DEFAULT [];
+ALTER TABLE empty_collections ADD COLUMN map_empty MAP<INT, VARCHAR(20)> DEFAULT map{};
+ALTER TABLE empty_collections ADD COLUMN st_empty_arr STRUCT<id INT, tags ARRAY<VARCHAR(20)>> 
+DEFAULT row(1, []);
+ALTER TABLE empty_collections ADD COLUMN st_empty_map STRUCT<id INT, attrs MAP<VARCHAR(20), INT>> 
+DEFAULT row(1, map{});
+ALTER TABLE empty_collections ADD COLUMN st_all_empty STRUCT<
+    id INT,
+    arr ARRAY<INT>,
+    mp MAP<VARCHAR(20), INT>
+> DEFAULT row(0, [], map{});
+ALTER TABLE empty_collections ADD COLUMN arr_mixed ARRAY<ARRAY<INT>> 
+DEFAULT [[], [1, 2], [], [3, 4, 5]];
+ALTER TABLE empty_collections ADD COLUMN map_empty_arr MAP<INT, ARRAY<VARCHAR(20)>> 
+DEFAULT map{1: [], 2: ['a', 'b'], 3: []};
+
+SELECT * FROM empty_collections ORDER BY id;
+
+-- ====================================================================================
+-- Section 11: DECIMAL Types in Complex Structures
+-- ====================================================================================
+
+CREATE TABLE decimal_complex (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO decimal_complex VALUES (1), (2);
+
+ALTER TABLE decimal_complex ADD COLUMN arr_dec32 ARRAY<DECIMAL(9, 2)> DEFAULT [99.99, 199.99, 299.99];
+ALTER TABLE decimal_complex ADD COLUMN arr_dec64 ARRAY<DECIMAL(18, 4)> DEFAULT [9999.9999, 19999.9999];
+ALTER TABLE decimal_complex ADD COLUMN arr_dec128 ARRAY<DECIMAL(38, 10)> DEFAULT [123456.1234567890, 654321.0987654321];
+ALTER TABLE decimal_complex ADD COLUMN arr_dec256 ARRAY<DECIMAL(45, 10)> DEFAULT [123456789012.1234567890, 987654321098.0987654321];
+ALTER TABLE decimal_complex ADD COLUMN map_dec MAP<VARCHAR(20), DECIMAL(10, 2)> 
+DEFAULT map{'price': 99.99, 'tax': 8.25, 'total': 108.24};
+ALTER TABLE decimal_complex ADD COLUMN map_dec256 MAP<INT, DECIMAL(45, 10)> 
+DEFAULT map{1: 99999999999.9999999999, 2: 12345678901.1234567890};
+ALTER TABLE decimal_complex ADD COLUMN st_dec STRUCT<
+    amount DECIMAL(10, 2),
+    rate DECIMAL(5, 4),
+    result DECIMAL(15, 6),
+    large DECIMAL(45, 10)
+> DEFAULT row(1000.50, 0.0525, 52.526250, 123456789012.1234567890);
+ALTER TABLE decimal_complex ADD COLUMN arr_st_dec ARRAY<STRUCT<id INT, price DECIMAL(10, 2)>> 
+DEFAULT [row(1, 99.99), row(2, 199.99), row(3, 299.99)];
+
+SELECT * FROM decimal_complex ORDER BY id;
+
+-- ====================================================================================
+-- Section 12: Large and Complex Default Values
+-- ====================================================================================
+
+CREATE TABLE large_defaults (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO large_defaults VALUES (1);
+
+ALTER TABLE large_defaults ADD COLUMN large_arr ARRAY<INT> 
+DEFAULT [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+ALTER TABLE large_defaults ADD COLUMN large_map MAP<INT, VARCHAR(20)> 
+DEFAULT map{1: 'one', 2: 'two', 3: 'three', 4: 'four', 5: 'five', 
+            6: 'six', 7: 'seven', 8: 'eight', 9: 'nine', 10: 'ten'};
+ALTER TABLE large_defaults ADD COLUMN large_struct STRUCT<
+    f1 INT, f2 INT, f3 INT, f4 INT, f5 INT,
+    f6 VARCHAR(20), f7 VARCHAR(20), f8 DOUBLE, f9 BOOLEAN, f10 DECIMAL(10, 2)
+> DEFAULT row(1, 2, 3, 4, 5, 'six', 'seven', 8.8, true, 10.50);
+ALTER TABLE large_defaults ADD COLUMN complex_combo MAP<INT, STRUCT<
+    id INT,
+    tags ARRAY<VARCHAR(20)>,
+    scores ARRAY<INT>,
+    metadata MAP<VARCHAR(20), VARCHAR(20)>
+>> DEFAULT map{
+    1: row(100, ['tag1', 'tag2', 'tag3'], [90, 85, 95], map{'type': 'A', 'level': 'high'}),
+    2: row(200, ['tag4', 'tag5'], [80, 88], map{'type': 'B', 'level': 'medium'})
+};
+
+SELECT * FROM large_defaults;
+
+-- ====================================================================================
+-- Section 13: Special Characters and Unicode in Strings
+-- ====================================================================================
+
+CREATE TABLE special_strings (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO special_strings VALUES (1);
+
+ALTER TABLE special_strings ADD COLUMN arr_unicode ARRAY<VARCHAR(50)> 
+DEFAULT ['你好', '世界', 'こんにちは', '안녕하세요', '🚀', '⭐'];
+ALTER TABLE special_strings ADD COLUMN arr_special ARRAY<VARCHAR(50)> 
+DEFAULT ['it\'s', 'path\\to\\file', '"quoted"'];
+ALTER TABLE special_strings ADD COLUMN map_unicode MAP<VARCHAR(20), VARCHAR(20)> 
+DEFAULT map{'中文': '测试', 'emoji': '😀🎉'};
+ALTER TABLE special_strings ADD COLUMN st_unicode STRUCT<name VARCHAR(50), description VARCHAR(100)> 
+DEFAULT row('用户名', '这是一个包含中文的描述信息');
+
+SELECT * FROM special_strings;
+
+-- ====================================================================================
+-- Section 14: Deep Nesting - ARRAY in MAP in STRUCT in ARRAY
+-- ====================================================================================
+
+CREATE TABLE deep_nesting_1 (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO deep_nesting_1 VALUES (1);
+
+ALTER TABLE deep_nesting_1 ADD COLUMN arr_st_map_arr ARRAY<STRUCT<
+    id INT,
+    data MAP<INT, ARRAY<INT>>
+>> DEFAULT [
+    row(1, map{10: [1, 2, 3], 20: [4, 5]}),
+    row(2, map{30: [6, 7, 8, 9]})
+];
+ALTER TABLE deep_nesting_1 ADD COLUMN map_st_arr_map MAP<INT, STRUCT<
+    tags ARRAY<VARCHAR(20)>,
+    attrs MAP<VARCHAR(20), INT>
+>> DEFAULT map{
+    1: row(['tag1', 'tag2'], map{'score': 90, 'level': 5}),
+    2: row(['tag3'], map{'score': 85, 'level': 3})
+};
+ALTER TABLE deep_nesting_1 ADD COLUMN st_map_st_arr STRUCT<
+    name VARCHAR(20),
+    data MAP<INT, STRUCT<id INT, vals ARRAY<INT>>>
+> DEFAULT row('test', map{1: row(100, [1, 2, 3]), 2: row(200, [4, 5])});
+
+SELECT * FROM deep_nesting_1;
+
+-- ====================================================================================
+-- Section 15: Deep Nesting - MAP in ARRAY in MAP in STRUCT
+-- ====================================================================================
+
+CREATE TABLE deep_nesting_2 (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO deep_nesting_2 VALUES (1);
+
+ALTER TABLE deep_nesting_2 ADD COLUMN st_map_arr_map STRUCT<
+    id INT,
+    nested MAP<INT, ARRAY<MAP<VARCHAR(20), INT>>>
+> DEFAULT row(1, map{
+    10: [map{'a': 1, 'b': 2}, map{'c': 3}],
+    20: [map{'d': 4, 'e': 5, 'f': 6}]
+});
+ALTER TABLE deep_nesting_2 ADD COLUMN arr_map_st_map_arr ARRAY<MAP<INT, STRUCT<
+    name VARCHAR(20),
+    data MAP<VARCHAR(20), ARRAY<INT>>
+>>> DEFAULT [
+    map{1: row('item1', map{'scores': [90, 85], 'ages': [25, 30]})},
+    map{2: row('item2', map{'scores': [95, 92, 88]})}
+];
+ALTER TABLE deep_nesting_2 ADD COLUMN map_arr_st_arr_st MAP<INT, ARRAY<STRUCT<
+    id INT,
+    items ARRAY<STRUCT<k VARCHAR(20), v INT>>
+>>> DEFAULT map{
+    1: [row(10, [row('a', 1), row('b', 2)])],
+    2: [row(20, [row('c', 3)]), row(30, [row('d', 4), row('e', 5)])]
+};
+
+SELECT * FROM deep_nesting_2;
+
+-- ====================================================================================
+-- Section 16: Complex Nesting with Non-Alphabetical Field Orders
+-- ====================================================================================
+
+CREATE TABLE complex_field_order (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO complex_field_order VALUES (1);
+
+ALTER TABLE complex_field_order ADD COLUMN arr_st_order ARRAY<STRUCT<
+    zebra INT,
+    apple VARCHAR(20),
+    monkey BOOLEAN,
+    banana ARRAY<INT>
+>> DEFAULT [
+    row(10, 'fruit', true, [1, 2, 3]),
+    row(20, 'animal', false, [4, 5])
+];
+ALTER TABLE complex_field_order ADD COLUMN map_st_nested MAP<INT, STRUCT<
+    outer_z INT,
+    outer_a VARCHAR(20),
+    nested_st STRUCT<inner_y INT, inner_b VARCHAR(20)>
+>> DEFAULT map{
+    1: row(100, 'test', row(200, 'nested'))
+};
+ALTER TABLE complex_field_order ADD COLUMN st_map_st STRUCT<
+    id INT,
+    data MAP<INT, STRUCT<s4 INT, ks ARRAY<INT>, aa VARCHAR(20)>>
+> DEFAULT row(1, map{
+    10: row(2, [1, 2, 3, 4], 'test'),
+    20: row(5, [10, 20], 'demo')
+});
+
+SELECT * FROM complex_field_order;
+
+-- ====================================================================================
+-- Section 17: Mixed Empty and Non-Empty in Deep Nesting
+-- ====================================================================================
+
+CREATE TABLE mixed_empty_nested (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO mixed_empty_nested VALUES (1);
+
+ALTER TABLE mixed_empty_nested ADD COLUMN arr3_mixed ARRAY<ARRAY<ARRAY<INT>>> 
+DEFAULT [[[1, 2], []], [[]], [[3], [4, 5]]];
+ALTER TABLE mixed_empty_nested ADD COLUMN map_arr_st_empty MAP<INT, ARRAY<STRUCT<
+    id INT,
+    tags ARRAY<VARCHAR(20)>
+>>> DEFAULT map{
+    1: [row(1, []), row(2, ['tag1', 'tag2'])],
+    2: []
+};
+ALTER TABLE mixed_empty_nested ADD COLUMN st_mixed_empty STRUCT<
+    id INT,
+    empty_arr ARRAY<INT>,
+    empty_map MAP<VARCHAR(20), INT>,
+    non_empty_arr ARRAY<INT>,
+    non_empty_map MAP<VARCHAR(20), INT>
+> DEFAULT row(1, [], map{}, [1, 2], map{'k': 100});
+ALTER TABLE mixed_empty_nested ADD COLUMN arr_map_st_empty ARRAY<MAP<INT, STRUCT<
+    id INT,
+    data ARRAY<INT>
+>>> DEFAULT [
+    map{},
+    map{1: row(10, [1, 2, 3])},
+    map{},
+    map{2: row(20, [])}
+];
+
+SELECT * FROM mixed_empty_nested;
+
+-- ====================================================================================
+-- Section 18: All Combinations - ARRAY/MAP/STRUCT (6 levels)
+-- ====================================================================================
+
+CREATE TABLE six_level_nesting (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO six_level_nesting VALUES (1);
+
+ALTER TABLE six_level_nesting ADD COLUMN level6_1 ARRAY<MAP<INT, STRUCT<
+    id INT,
+    nested ARRAY<MAP<INT, ARRAY<INT>>>
+>>> DEFAULT [
+    map{1: row(100, [map{1: [1, 2]}, map{2: [3, 4]}])}
+];
+ALTER TABLE six_level_nesting ADD COLUMN level6_2 MAP<INT, STRUCT<
+    name VARCHAR(20),
+    data MAP<INT, ARRAY<STRUCT<id INT, vals ARRAY<INT>>>>
+>> DEFAULT map{
+    1: row('test', map{10: [row(1, [1, 2, 3])]})
+};
+
+-- 6-level: STRUCT<ARRAY<MAP<INT, STRUCT<MAP<INT, ARRAY<INT>>>>>>
+ALTER TABLE six_level_nesting ADD COLUMN level6_3 STRUCT<
+    id INT,
+    deep ARRAY<MAP<INT, STRUCT<
+        name VARCHAR(20),
+        data MAP<INT, ARRAY<INT>>
+    >>>
+> DEFAULT row(1, [
+    map{1: row('item', map{10: [1, 2], 20: [3, 4]})}
+]);
+
+SELECT * FROM six_level_nesting;
+
+-- ====================================================================================
+-- Section 19: DECIMAL256 in Complex Nesting
+-- ====================================================================================
+
+CREATE TABLE decimal256_nested (id INT) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+INSERT INTO decimal256_nested VALUES (1);
+
+-- ARRAY<STRUCT<DECIMAL256>>
+ALTER TABLE decimal256_nested ADD COLUMN arr_st_dec256 ARRAY<STRUCT<
+    id INT,
+    amount DECIMAL(45, 10)
+>> DEFAULT [
+    row(1, 12345678901234.1234567890),
+    row(2, 98765432109876.0987654321)
+];
+
+-- MAP<INT, STRUCT<DECIMAL256, ARRAY<DECIMAL256>>>
+ALTER TABLE decimal256_nested ADD COLUMN map_st_dec256 MAP<INT, STRUCT<
+    price DECIMAL(45, 10),
+    history ARRAY<DECIMAL(45, 10)>
+>> DEFAULT map{
+    1: row(99999999999.9999999999, [11111111111.1111111111, 22222222222.2222222222])
+};
+
+-- STRUCT<MAP<INT, ARRAY<STRUCT<DECIMAL256>>>>
+ALTER TABLE decimal256_nested ADD COLUMN st_map_arr_dec256 STRUCT<
+    name VARCHAR(20),
+    data MAP<INT, ARRAY<STRUCT<id INT, val DECIMAL(45, 10)>>>
+> DEFAULT row('test', map{
+    1: [row(10, 12345.1234567890), row(20, 67890.0987654321)]
+});
+
+SELECT * FROM decimal256_nested;
+
+-- ====================================================================================
+-- Section 20: Accessing Sub-Elements and Fields from Default Values
+-- ====================================================================================
+
+-- Access ARRAY elements
+SELECT 
+    id,
+    arr_tinyint[1] AS first_tinyint,
+    arr_tinyint[2] AS second_tinyint,
+    arr_varchar[1] AS first_varchar,
+    arr_decimal256[1] AS first_decimal256
+FROM test_correctness_db.array_primitives
+ORDER BY id;
+
+-- Access nested ARRAY elements
+SELECT
+    id,
+    arr2_int[1] AS first_subarray,
+    arr2_int[1][1] AS first_elem_of_first_subarray,
+    arr2_int[2][2] AS second_elem_of_second_subarray,
+    arr3_int[1][1][1] AS deeply_nested_element
+FROM test_correctness_db.nested_arrays
+ORDER BY id;
+
+-- Access MAP values by key
+SELECT
+    id,
+    map_int_str[1] AS value_for_key_1,
+    map_int_str[100] AS value_for_key_100,
+    map_str_int['alice'] AS alice_value,
+    map_int_decimal[2] AS decimal_for_key_2
+FROM test_correctness_db.map_types
+ORDER BY id;
+
+-- Access STRUCT fields
+SELECT
+    id,
+    st1.z AS st1_field_z,
+    st1.a AS st1_field_a,
+    st3.s4 AS st3_field_s4,
+    st3.ks AS st3_field_ks_array,
+    st3.ks[1] AS st3_first_ks_element
+FROM test_correctness_db.struct_field_order
+ORDER BY id;


### PR DESCRIPTION
## Why I'm doing:

Currently, StarRocks only supports default values for primitive types (INT, VARCHAR, etc.). Complex types like ARRAY, MAP, and STRUCT do not support default values, which limits user flexibility when defining table schemas with nested data structures.

## What I'm doing:

This PR adds support for default values for complex types (ARRAY, MAP, STRUCT) in StarRocks.

### 1. Syntax

StarRocks uses the following syntax for complex type default values:

- **ARRAY**: Use square brackets `[]`
  ```sql
  ARRAY<INT> DEFAULT [1, 2, 3]
  ARRAY<VARCHAR(20)> DEFAULT ['a', 'b', 'c']
  ```

- **MAP**: Use `map{}`
  ```sql
  MAP<VARCHAR(20), INT> DEFAULT map{'key1': 100, 'key2': 200}
  MAP<INT, VARCHAR(20)> DEFAULT map{1: 'value1', 2: 'value2'}
  ```

- **STRUCT**: Use `row()`
  ```sql
  STRUCT<id INT, name VARCHAR(20)> DEFAULT row(1, 'alice')
  STRUCT<a INT, b VARCHAR(20), c DOUBLE> DEFAULT row(10, 'test', 3.14)
  ```

**CREATE TABLE Example:**

```sql
CREATE TABLE complex_defaults (
    id BIGINT,
    -- Simple types with defaults
    simple_int INT DEFAULT '0',
    simple_str VARCHAR(20) DEFAULT 'default',
    simple_bool BOOLEAN DEFAULT '1',
    simple_date DATE DEFAULT '2026-01-01',
    
    -- ARRAY types with various types
    arr_int ARRAY<INT> DEFAULT [1, 2, 3],
    arr_str ARRAY<VARCHAR(20)> DEFAULT ['a', 'b', 'c'],
    arr_bool ARRAY<BOOLEAN> DEFAULT [1, 0, 1],
    arr_date ARRAY<DATE> DEFAULT ['2024-01-01', '2024-06-01', '2024-12-31'],
    arr_datetime ARRAY<DATETIME> DEFAULT ['2024-01-01 10:00:00', '2024-12-31 23:59:59'],
    arr_empty ARRAY<INT> DEFAULT [],
    
    -- MAP types with various value types
    map_str_int MAP<VARCHAR(20), INT> DEFAULT map{'count': 100, 'total': 200},
    map_str_bool MAP<VARCHAR(20), BOOLEAN> DEFAULT map{'active': 1, 'deleted': 0},
    map_str_date MAP<VARCHAR(20), DATE> DEFAULT map{'start': '2024-01-01', 'end': '2024-12-31'},
    map_str_datetime MAP<VARCHAR(20), DATETIME> DEFAULT map{'created': '2024-01-01 10:00:00', 'updated': '2024-06-01 15:30:00'},
    map_empty MAP<VARCHAR(20), INT> DEFAULT map{},
    
    -- STRUCT types with mixed field types
    struct_simple STRUCT<id INT, name VARCHAR(20), active BOOLEAN> DEFAULT row(1, 'alice', 1),
    struct_multi STRUCT<
        id INT, 
        name VARCHAR(20), 
        created_date DATE, 
        updated_time DATETIME,
        is_valid BOOLEAN
    > DEFAULT row(10, 'test', '2024-01-01', '2024-01-01 12:00:00', 1),
    
    -- Nested types with various types
    arr_nested ARRAY<STRUCT<id INT, active BOOLEAN, tags ARRAY<VARCHAR(20)>>> 
        DEFAULT [row(1, 1, ['tag1', 'tag2']), row(2, 0, ['tag3'])],
    map_nested MAP<INT, STRUCT<name VARCHAR(20), join_date DATE, is_member BOOLEAN>> 
        DEFAULT map{1: row('alice', '2024-01-01', 1), 2: row('bob', '2024-06-01', 0)},
    struct_nested STRUCT<
        items ARRAY<INT>, 
        flags ARRAY<BOOLEAN>,
        dates MAP<VARCHAR(20), DATE>,
        status STRUCT<active BOOLEAN, created DATE>
    > DEFAULT row([1, 2, 3], [1, 0], map{'start': '2024-01-01', 'end': '2024-12-31'}, row(1, '2024-01-01')),
    
    -- Empty nested collections
    struct_with_empty STRUCT<
        id INT, 
        active BOOLEAN,
        tags ARRAY<VARCHAR(20)>, 
        attrs MAP<VARCHAR(20), INT>
    > DEFAULT row(0, 0, [], map{})
) properties("replication_num" = "1");
```

**ALTER TABLE Examples:**

```sql
-- Simple ARRAY
ALTER TABLE t ADD COLUMN arr ARRAY<INT> DEFAULT [1, 2, 3];

-- Simple MAP
ALTER TABLE t ADD COLUMN config MAP<VARCHAR(20), INT> DEFAULT map{'timeout': 30, 'retry': 3};

-- Simple STRUCT
ALTER TABLE t ADD COLUMN user_info STRUCT<id INT, name VARCHAR(20), age INT> DEFAULT row(1, 'default_user', 18);

-- Nested types
ALTER TABLE t ADD COLUMN nested_arr ARRAY<ARRAY<INT>> DEFAULT [[1, 2], [3, 4]];
ALTER TABLE t ADD COLUMN nested_map MAP<INT, STRUCT<id INT, name VARCHAR(20)>> 
    DEFAULT map{1: row(1, 'alice'), 2: row(2, 'bob')};
ALTER TABLE t ADD COLUMN nested_struct STRUCT<items ARRAY<INT>, metadata MAP<VARCHAR(20), INT>> 
    DEFAULT row([1, 2, 3], map{'count': 3, 'version': 1});

-- Empty collections
ALTER TABLE t ADD COLUMN empty_arr ARRAY<INT> DEFAULT [];
ALTER TABLE t ADD COLUMN empty_map MAP<VARCHAR(20), INT> DEFAULT map{};
```

### 2. Limitations

1. **Literal Values Only**: Default expressions must contain only literal values. Functions (including `CAST`) and expressions are **NOT** supported.
   
   ```sql
   -- ✅ Valid: literal values
   ALTER TABLE t ADD COLUMN arr ARRAY<INT> DEFAULT [1, 2, 3];
   
   -- ❌ Invalid: CAST function not allowed
   ALTER TABLE t ADD COLUMN arr ARRAY<INT> DEFAULT CAST('[1,2,3]' AS ARRAY<INT>);
   
   -- ❌ Invalid: function calls not allowed
   ALTER TABLE t ADD COLUMN arr ARRAY<INT> DEFAULT array_concat([1, 2], [3, 4]);
   ```

2. **Fast Schema Evolution Required**: Complex type default values are **only supported when table property `fast_schema_evolution` is `true`** (which is the default for new tables).
   
   ```sql
   -- ✅ Works: fast_schema_evolution is true by default
   CREATE TABLE t (id INT) PROPERTIES("fast_schema_evolution" = "true");
   ALTER TABLE t ADD COLUMN arr ARRAY<INT> DEFAULT [1, 2, 3];  -- Success
   
   -- ❌ Fails: fast_schema_evolution is false
   CREATE TABLE t (id INT) PROPERTIES("fast_schema_evolution" = "false");
   ALTER TABLE t ADD COLUMN arr ARRAY<INT> DEFAULT [1, 2, 3];  -- Error
   ```

### 3. Implementation Details

#### 3.1 Frontend (FE)

- **Expression Parsing**: FE parses complex type literals (`[]`, `map{}`, `row()`) into expression trees (`ArrayExpr`, `MapExpr`, `FunctionCallExpr`)
- **Expression Analysis**: The parsed expression goes through `analyze()` phase
  - Type inference and validation
  - **May automatically add CAST expressions** for type compatibility
- **Validation**: 
  - User input must contain only literal values (no explicit CAST, no functions)
  - After analysis, internal CAST expressions are allowed (added by analyzer)
  - Validates type compatibility between default value and column type
  - Checks `fast_schema_evolution` property before allowing complex type default values
- **Persistence**: 
  - `Column.defaultExpr`: Stores the **analyzed** expression (may contain CAST)
    - Serialized to SQL string via `Expr.toSql()` and persisted to FE metadata (EditLog/Image)
    - Example: Original `[1, 2, 3]` → after analysis → `[CAST(1 AS BIGINT), CAST(2 AS BIGINT), CAST(3 AS BIGINT)]`
    - Re-parsed after FE restart via `gsonPostProcess()` to reconstruct the `Expr` object
  - `Column.defaultValue`: Transient field, NOT persisted in FE
- **SHOW CREATE TABLE Handling**: To display SQL consistent with user's original input:
  - `SHOW CREATE TABLE` / `DESC` use `validateComplexTypeDefaultExpressionForm()` to strip auto-added CAST expressions
  - This ensures displayed SQL matches what the user originally wrote
  - Example: Internally stored `[CAST(1 AS BIGINT), ...]` → displayed as `[1, 2, 3]`
- **Thrift Serialization**: When sending schema to BE, FE serializes the **analyzed** expression tree (with CASTs) to Thrift format:
  - `TColumn.default_expr`: The complete analyzed expression tree serialized as `TExpr` (Thrift format)
  - FE sends the full expression tree structure, **not JSON string**
- **Schema Propagation Paths**: FE sends schema to BE through multiple paths:
  - DDL operations: via `TCreateTabletReq`, `TAlterTabletReqV2`
  - DML operations (INSERT/UPDATE): via `TOlapTableSchemaParam` in `OlapTableSink`

#### 3.2 Backend (BE)

- **Expression to JSON Conversion**: BE receives `TExpr` (Thrift expression tree) from FE via `TColumn.default_expr`
  - `preprocess_default_expr_for_tcolumns()` function converts `TExpr` to JSON string
  - This conversion happens when BE first receives the schema (DDL/DML paths)
  - Example: `TExpr` (ArrayExpr with [1,2,3]) → evaluates to JSON string `"[1,2,3]"`
  - The JSON string is stored in `TColumn.default_value` for later use
- **Protobuf Persistence**: BE persists the **JSON string** in `TabletSchemaPB.ColumnPB.default_value`
  - Stored in tablet metadata files on disk
  - Ensures BE can provide default values after restart without re-evaluating expressions
  - Only the JSON string is persisted, not the original `TExpr`
- **Runtime JSON Parsing**: When providing default values during query execution:
  1. `DefaultValueColumnIterator::init()` reads JSON string from `_default_value` (loaded from TabletSchema)
  2. Parses JSON string using VelocyPack: `JsonValue::parse_json_or_string()` → `vpack::Slice`
  3. Converts VPack slice to `Datum` using `VPackToDatumCaster`
- **VPackToDatumCaster**: Recursively converts VPack JSON slices to `Datum` objects:
  - Template-based implementation (`cast_primitive<TYPE>()`, `cast_decimal<DecimalType>()`) eliminates code duplication
  - Dedicated methods for each complex type (`cast_array()`, `cast_map()`, `cast_struct()`)
  - Handles nested structures with arbitrary depth
  - Preserves field order for MAP and STRUCT using sequential iteration (`ObjectIterator(slice, true)`)
- **DefaultValueColumnIterator**: Provides default `Datum` values during query execution:
  - **Segment scan**: When reading old data files that don't contain newly added columns
  - **Partial updates**: Both column mode (`rowset_column_update_state.cpp`) and row mode (`tablet_updates.cpp`)
  - **Schema change**: When materialized columns require default values
 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables default values for complex types end-to-end, covering DDL/DML paths and query execution.
> 
> - FE: parse DEFAULT complex literals (`[]`, `map{}`, `row()`), validate literals-only, require `fast_schema_evolution=true`, serialize analyzed expr to Thrift (`TColumn.default_expr`), strip analyzer CASTs in SHOW CREATE; InsertPlanner uses expr when present
> - Thrift: add `default_expr` to `TColumn`
> - BE: convert `TExpr` default to JSON via `preprocess_default_expr_for_tcolumns` and persist as `default_value`; wire into create/alter/schema-scan paths
> - Runtime: `DefaultValueColumnIterator` now materializes ARRAY/MAP/STRUCT defaults from JSON (via `VPackToDatumCaster`) and projects by `ColumnAccessPath`; `cast_type_to_json_str` supports ordered/unindexed structs
> - Touch points: agent tasks, meta/olap scanners, pipeline scan, schema change (lake + classic), rowset readers/segment
> - Tests: extensive SQL/FE UTs for syntax, SHOW CREATE, fast schema evolution checks, nested types, and correctness
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20fa8e305960b5085b3b4a07d01337e9a3fd357f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->