### PR TITLE
[Refactor] Simplify cloud configuration retrieval in IcebergScanNode and IcebergTableSink

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -16,7 +16,13 @@ package com.starrocks.connector.iceberg;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.connector.CatalogConnector;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudConfigurationFactory;
+import com.starrocks.credential.CloudType;
 import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TExprMinMaxValue;
 import com.starrocks.thrift.TExprNodeType;
 import org.apache.iceberg.Schema;
@@ -194,5 +200,34 @@ public final class IcebergUtil {
         String tableLocation = table.location();
         return table.properties().getOrDefault(TableProperties.WRITE_DATA_LOCATION,
                 String.format("%s/data", LocationUtil.stripTrailingSlash(tableLocation)));
+    }
+
+    public static CloudConfiguration getVendedCloudConfiguration(String catalogName, IcebergTable icebergTable) {
+        CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalogName);
+        Preconditions.checkState(connector != null,
+                String.format("connector of catalog %s should not be null", catalogName));
+
+        // Try to get vended credentials from loadTable response
+        CloudConfiguration vendedCredentialsCloudConfiguration = CloudConfigurationFactory.
+                buildCloudConfigurationForVendedCredentials(icebergTable.getNativeTable().io().properties(),
+                        icebergTable.getNativeTable().location());
+        if (vendedCredentialsCloudConfiguration.getCloudType() != CloudType.DEFAULT) {
+            return vendedCredentialsCloudConfiguration;
+        }
+
+        // Try to get credentials from catalog config (/v1/config response).
+        // This is used as fallback when STS is unavailable (e.g., Apache Polaris without STS).
+        CloudConfiguration catalogConfigCloudConfiguration = CloudConfigurationFactory.
+                buildCloudConfigurationForVendedCredentials(connector.getMetadata().getCatalogProperties(),
+                        icebergTable.getNativeTable().location());
+        if (catalogConfigCloudConfiguration.getCloudType() != CloudType.DEFAULT) {
+            return catalogConfigCloudConfiguration;
+        }
+
+        // Fall back to user-provided catalog credentials
+        CloudConfiguration cloudConfiguration = connector.getMetadata().getCloudConfiguration();
+        Preconditions.checkState(cloudConfiguration != null,
+                String.format("cloudConfiguration of catalog %s should not be null", catalogName));
+        return cloudConfiguration;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -19,7 +19,6 @@ import com.google.common.base.Preconditions;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.connector.BucketProperty;
-import com.starrocks.connector.CatalogConnector;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.RemoteFileInfo;
@@ -32,11 +31,10 @@ import com.starrocks.connector.iceberg.IcebergGetRemoteFilesParams;
 import com.starrocks.connector.iceberg.IcebergMORParams;
 import com.starrocks.connector.iceberg.IcebergRemoteSourceTrigger;
 import com.starrocks.connector.iceberg.IcebergTableMORParams;
+import com.starrocks.connector.iceberg.IcebergUtil;
 import com.starrocks.connector.iceberg.QueueIcebergRemoteFileInfoSource;
 import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.credential.CloudConfiguration;
-import com.starrocks.credential.CloudConfigurationFactory;
-import com.starrocks.credential.CloudType;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.plan.HDFSScanNodePredicates;
@@ -197,33 +195,7 @@ public class IcebergScanNode extends ScanNode {
             return;
         }
 
-        // Try to get vended credentials from loadTable response
-        CloudConfiguration vendedCredentialsCloudConfiguration = CloudConfigurationFactory.
-                buildCloudConfigurationForVendedCredentials(icebergTable.getNativeTable().io().properties(),
-                        icebergTable.getNativeTable().location());
-        if (vendedCredentialsCloudConfiguration.getCloudType() != CloudType.DEFAULT) {
-            cloudConfiguration = vendedCredentialsCloudConfiguration;
-            return;
-        }
-
-        CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalogName);
-        Preconditions.checkState(connector != null,
-                String.format("connector of catalog %s should not be null", catalogName));
-
-        // Try to get credentials from catalog config (/v1/config response).
-        // This is used as fallback when STS is unavailable (e.g., Apache Polaris without STS).
-        CloudConfiguration catalogConfigCloudConfiguration = CloudConfigurationFactory.
-                buildCloudConfigurationForVendedCredentials(connector.getMetadata().getCatalogProperties(),
-                        icebergTable.getNativeTable().location());
-        if (catalogConfigCloudConfiguration.getCloudType() != CloudType.DEFAULT) {
-            cloudConfiguration = catalogConfigCloudConfiguration;
-            return;
-        }
-
-        // Fall back to user-provided catalog credentials
-        cloudConfiguration = connector.getMetadata().getCloudConfiguration();
-        Preconditions.checkState(cloudConfiguration != null,
-                String.format("cloudConfiguration of catalog %s should not be null", catalogName));
+        cloudConfiguration = IcebergUtil.getVendedCloudConfiguration(catalogName, icebergTable);
     }
 
     public void setCloudConfiguration(CloudConfiguration cloudConfiguration) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -1325,6 +1325,8 @@ public class IcebergScanNodeTest {
 
     @Test
     public void testSetupCloudCredentialVendedCredentialsPriority(
+            @Mocked GlobalStateMgr globalStateMgr,
+            @Mocked CatalogConnector connector,
             @Mocked IcebergTable table,
             @Mocked org.apache.iceberg.Table nativeTable,
             @Mocked org.apache.iceberg.io.FileIO fileIO,
@@ -1338,6 +1340,10 @@ public class IcebergScanNodeTest {
         vendedCredentials.put("client.region", "eu-west-1");
 
         new Expectations() {{
+            GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalogName);
+            result = connector;
+            minTimes = 0;
+
             table.getCatalogName();
             result = catalogName;
             minTimes = 0;


### PR DESCRIPTION
## Why I'm doing:
#66944
## What I'm doing:
This pull request refactors how cloud credentials are obtained for Iceberg operations, centralizing the logic into a new utility method and updating its usage across relevant classes. This improves maintainability and ensures consistent credential handling. The most important changes are:

**Cloud credential retrieval logic:**

* Added a new method `getVendedCloudConfiguration` to `IcebergUtil` that encapsulates the logic for fetching cloud credentials, prioritizing vended credentials, then catalog config, and finally user-provided credentials.
* Updated both `IcebergScanNode` and `IcebergTableSink` to use the new `IcebergUtil.getVendedCloudConfiguration` method instead of duplicating credential-fetching logic. [[1]](diffhunk://#diff-57afce8c17b2c88789de3fe9d5be2ff6008a9ce67e80382e67851bae1d75c897L200-R198) [[2]](diffhunk://#diff-14f5a318e021ec451fb61b3806913468b2d096ae5a0b22010507fe383f742f1aL69-R64)


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
