### PR TITLE
[Enhancement] add running slow query metric

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -75,6 +75,7 @@ import com.starrocks.monitor.jvm.JvmStats;
 import com.starrocks.proto.PKafkaOffsetProxyRequest;
 import com.starrocks.proto.PKafkaOffsetProxyResult;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.scheduler.slot.BaseSlotManager;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -517,6 +518,15 @@ public final class MetricRepo {
             }
         };
         STARROCKS_METRIC_REGISTER.addMetric(totalTabletCount);
+
+        GaugeMetric<Long> runningSlowQueriesCount = new GaugeMetric<Long>(
+                "running_slow_query", MetricUnit.NOUNIT, "counter running slow query") {
+            @Override
+            public Long getValue() {
+                return QeProcessorImpl.INSTANCE.runningSlowQueries();
+            }
+        };
+        STARROCKS_METRIC_REGISTER.addMetric(runningSlowQueriesCount);
 
         // 2. counter
         COUNTER_REQUEST_ALL = new LongCounterMetric("request_total", MetricUnit.REQUESTS, "total request");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -141,6 +141,11 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
         long slowCount = 0;
         long now = System.currentTimeMillis();
         for (Map.Entry<TUniqueId, QueryInfo> entry : coordinatorMap.entrySet()) {
+            final QueryInfo info = entry.getValue();
+            final ConnectContext context = info.getConnectContext();
+            if (info.sql == null || context == null) {
+                continue;
+            }
             if (now - entry.getValue().getStartExecTime() > Config.qe_slow_log_ms) {
                 slowCount ++;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -141,7 +141,7 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
         long slowCount = 0;
         long now = System.currentTimeMillis();
         for (Map.Entry<TUniqueId, QueryInfo> entry : coordinatorMap.entrySet()) {
-            if (now - entry.getValue().getStartExecTime() >= Config.qe_slow_log_ms) {
+            if (now - entry.getValue().getStartExecTime() > Config.qe_slow_log_ms) {
                 slowCount ++;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -137,6 +137,17 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
         }
     }
 
+    public long runningSlowQueries() {
+        long slowCount = 0;
+        long now = System.currentTimeMillis();
+        for (Map.Entry<TUniqueId, QueryInfo> entry : coordinatorMap.entrySet()) {
+            if (now - entry.getValue().getStartExecTime() >= Config.qe_slow_log_ms) {
+                slowCount ++;
+            }
+        }
+        return slowCount;
+    }
+
     @Override
     public void monitorQuery(TUniqueId queryId, long expireTime) {
         monitorQueryMap.put(queryId, expireTime);
@@ -365,7 +376,7 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
 
         private boolean isMVJob = false;
 
-        // from Export, Pull load, Insert 
+        // from Export, Pull load, Insert
         public QueryInfo(Coordinator coord) {
             this(null, null, coord);
         }


### PR DESCRIPTION
## Why I'm doing:
Add the `starrocks_fe_running_slow_query` metric, which allows monitoring and alerting when slow queries occur in the cluster
## What I'm doing:

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a FE metric to monitor in-flight slow queries.
> 
> - Adds `running_slow_query` gauge in `MetricRepo` that reports the current count of slow-running queries
> - Implements `QeProcessorImpl.runningSlowQueries()` to count active queries whose runtime exceeds `Config.qe_slow_log_ms`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8270ca116e106a0849be9b134af0c0d85fc17f61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->