### PR TITLE
[Enhancement] Prioritize using the "compression_codec" table property in connector sink modules.

### DIFF
--- a/docs/en/data_source/catalog/hive_catalog.md
+++ b/docs/en/data_source/catalog/hive_catalog.md
@@ -38,7 +38,9 @@ To ensure successful SQL workloads on your Hive cluster, your StarRocks cluster 
   - Parquet and ORC files support the following compression formats: NO_COMPRESSION, SNAPPY, LZ4, ZSTD, and GZIP.
   - Textfile files support the NO_COMPRESSION compression format.
 
-  You can use the session variable [`connector_sink_compression_codec`](../../sql-reference/System_variable.md#connector_sink_compression_codec) to specify the compression algorithm used for sinking data to Hive tables.
+  You can use the table property [`compression_codec`](../../data_source/catalog/hive_catalog.md#properties) or the system variable [`connector_sink_compression_codec`](../../sql-reference/System_variable.md#connector_sink_compression_codec) to specify the compression algorithm used for sinking data to Hive tables.
+
+  When writing to a Hive table, if the table's properties include a compression codec, StarRocks will preferentially use that algorithm to compress the written data. Otherwise, it will use the compression algorithm set in the system variable `connector_sink_compression_codec`.
 
 ## Integration preparations
 
@@ -1021,7 +1023,7 @@ The following table describes a few key properties.
 | ----------------- | ------------------------------------------------------------ |
 | location          | The file path in which you want to create the managed table. When you use HMS as metastore, you do not need to specify the `location` parameter, because StarRocks will create the table in the default file path of the current Hive catalog. When you use AWS Glue as metadata service:<ul><li>If you have specified the `location` parameter for the database in which you want to create the table, you do not need to specify the `location` parameter for the table. As such, the table defaults to the file path of the database to which it belongs. </li><li>If you have not specified the `location` for the database in which you want to create the table, you must specify the `location` parameter for the table.</li></ul> |
 | file_format       | The file format of the managed table. Supported file formats are Parquet, ORC, and Textfile. ORC and Textfile formats are supported from v3.3 onwards. Valid values: `parquet`, `orc`, and `textfile`. Default value: `parquet`. |
-| compression_codec | The compression algorithm used for the managed table. This property is deprecated in v3.2.3, since which version the compression algorithm used for sinking data to Hive tables is uniformly controlled by the session variable [connector_sink_compression_codec](../../sql-reference/System_variable.md#connector_sink_compression_codec). |
+| compression_codec | The compression algorithm used for the managed table.        |
 
 ### Examples
 
@@ -1068,7 +1070,7 @@ Note that sinking data to external tables is disabled by default. To sink data t
 :::note
 
 - You can grant and revoke privileges by using [GRANT](../../sql-reference/sql-statements/account-management/GRANT.md) and [REVOKE](../../sql-reference/sql-statements/account-management/REVOKE.md).
-- You can use the session variable [connector_sink_compression_codec](../../sql-reference/System_variable.md#connector_sink_compression_codec) to specify the compression algorithm used for sinking data to Hive tables.
+- You can use the table property [`compression_codec`](../../data_source/catalog/hive_catalog.md#properties) or the system variable [`connector_sink_compression_codec`](../../sql-reference/System_variable.md#connector_sink_compression_codec) to specify the compression algorithm used for sinking data to Hive tables. StarRocks will prioritize using the compression codec specified in the table property.
 
 :::
 

--- a/docs/en/data_source/catalog/iceberg/iceberg_catalog.md
+++ b/docs/en/data_source/catalog/iceberg/iceberg_catalog.md
@@ -1433,7 +1433,7 @@ Description: The file format of the Iceberg table. Only the Parquet format is su
 
 ###### compression_codec
 
-Description: The compression algorithm used for the Iceberg table. The supported compression algorithms are SNAPPY, GZIP, ZSTD, and LZ4. Default value: `gzip`. This property is deprecated in v3.2.3, since which version the compression algorithm used for sinking data to Iceberg tables is uniformly controlled by the session variable [connector_sink_compression_codec](../../../sql-reference/System_variable.md#connector_sink_compression_codec).
+Description: The compression algorithm used for the Iceberg table. The supported compression algorithms are SNAPPY, GZIP, ZSTD, and LZ4. Default value: `zstd`.
 
 ---
 

--- a/docs/en/sql-reference/System_variable.md
+++ b/docs/en/sql-reference/System_variable.md
@@ -350,9 +350,9 @@ Used for MySQL client compatibility. No practical usage.
 ### connector_sink_compression_codec
 
 * **Description**: Specifies the compression algorithm used for writing data into Hive tables or Iceberg tables, or exporting data with Files(). This parameter only takes effect in the following situations:
-  * The `compression_codec` property is not exist in the Hive tables.
-  * The `compression_codec` and `write.parquet.compression-codec` property are not exist in the Iceberg tables.
-  * The `compression` property is not set when `INSERT INTO FILES`.
+  * The `compression_codec` property does not exist in the Hive tables.
+  * The `compression_codec` and `write.parquet.compression-codec` properties do not exist in the Iceberg tables.
+  * The `compression` property is not set for `INSERT INTO FILES`.
 * **Valid values**: `uncompressed`, `snappy`, `lz4`, `zstd`, and `gzip`.
 * **Default**: uncompressed
 * **Data type**: String

--- a/docs/en/sql-reference/System_variable.md
+++ b/docs/en/sql-reference/System_variable.md
@@ -349,7 +349,10 @@ Used for MySQL client compatibility. No practical usage.
 
 ### connector_sink_compression_codec
 
-* **Description**: Specifies the compression algorithm used for writing data into Hive tables or Iceberg tables, or exporting data with Files().
+* **Description**: Specifies the compression algorithm used for writing data into Hive tables or Iceberg tables, or exporting data with Files(). This parameter only takes effect in the following situations:
+  * The `compression_codec` property is not exist in the Hive tables.
+  * The `compression_codec` and `write.parquet.compression-codec` property are not exist in the Iceberg tables.
+  * The `compression` property is not set when `INSERT INTO FILES`.
 * **Valid values**: `uncompressed`, `snappy`, `lz4`, `zstd`, and `gzip`.
 * **Default**: uncompressed
 * **Data type**: String

--- a/docs/en/sql-reference/System_variable.md
+++ b/docs/en/sql-reference/System_variable.md
@@ -351,7 +351,7 @@ Used for MySQL client compatibility. No practical usage.
 
 * **Description**: Specifies the compression algorithm used for writing data into Hive tables or Iceberg tables, or exporting data with Files(). This parameter only takes effect in the following situations:
   * The `compression_codec` property does not exist in the Hive tables.
-  * The `compression_codec` and `write.parquet.compression-codec` properties do not exist in the Iceberg tables.
+  * The `write.parquet.compression-codec` properties do not exist in the Iceberg tables.
   * The `compression` property is not set for `INSERT INTO FILES`.
 * **Valid values**: `uncompressed`, `snappy`, `lz4`, `zstd`, and `gzip`.
 * **Default**: uncompressed

--- a/docs/ja/data_source/catalog/hive_catalog.md
+++ b/docs/ja/data_source/catalog/hive_catalog.md
@@ -38,7 +38,9 @@ Hive クラスターでの SQL ワークロードを成功させるためには�
   - Parquet および ORC ファイルは、以下の圧縮形式をサポートしています：NO_COMPRESSION、SNAPPY、LZ4、ZSTD、GZIP。
   - Textfile ファイルは、NO_COMPRESSION 圧縮形式をサポートしています。
 
-  Hive テーブルへのデータのシンクに使用する圧縮アルゴリズムを指定するために、セッション変数 [`connector_sink_compression_codec`](../../sql-reference/System_variable.md#connector_sink_compression_codec) を使用できます。
+  テーブルプロパティ [`compression_codec`](../../data_source/catalog/hive_catalog.md#properties) またはシステム変数 [`connector_sink_compression_codec`](../../sql-reference/System_variable.md#connector_sink_compression_codec) を使用して、Hive テーブルへのデータシンクに使用する圧縮アルゴリズムを指定できます。
+
+  Hive テーブルへの書き込み時、テーブルのプロパティに圧縮コーデックが含まれている場合、StarRocks は書き込みデータの圧縮にそのアルゴリズムを優先的に使用します。そうでない場合、システム変数 `connector_sink_compression_codec` で設定された圧縮アルゴリズムが使用されます。
 
 ## 統合準備
 
@@ -1021,7 +1023,7 @@ PARTITION BY (par_col1[, par_col2...])
 | ----------------- | ------------------------------------------------------------ |
 | location          | 管理テーブルを作成したいファイルパスです。HMS をメタストアとして使用する場合、`location` パラメータを指定する必要はありません。StarRocks は現在の Hive catalog のデフォルトファイルパスにテーブルを作成します。AWS Glue をメタデータサービスとして使用する場合：<ul><li>テーブルを作成したいデータベースに対して `location` パラメータを指定した場合、テーブルに対して `location` パラメータを指定する必要はありません。このように、テーブルは所属するデータベースのファイルパスにデフォルト設定されます。</li><li>テーブルを作成したいデータベースに対して `location` を指定していない場合、テーブルに対して `location` パラメータを指定する必要があります。</li></ul> |
 | file_format       | 管理テーブルのファイル形式です。サポートされているファイル形式は Parquet、ORC、Textfile です。ORC および Textfile 形式は v3.3 以降でサポートされています。 有効な値：`parquet`、`orc`、`textfile`。 デフォルト値：`parquet`。 |
-| compression_codec | 管理テーブルに使用される圧縮アルゴリズムです。このプロパティは v3.2.3 で非推奨となり、そのバージョン以降、Hive テーブルへのデータのシンクに使用される圧縮アルゴリズムはセッション変数 [connector_sink_compression_codec](../../sql-reference/System_variable.md#connector_sink_compression_codec) によって一元的に制御されます。 |
+| compression_codec | 管理テーブルに使用される圧縮アルゴリズムです。                       |
 
 ### 例
 
@@ -1068,7 +1070,7 @@ StarRocks の内部テーブルと同様に、Hive テーブル（管理テー�
 :::note
 
 - [GRANT](../../sql-reference/sql-statements/account-management/GRANT.md) および [REVOKE](../../sql-reference/sql-statements/account-management/REVOKE.md) を使用して権限を付与および取り消すことができます。
-- Hive テーブルへのデータのシンクに使用する圧縮アルゴリズムを指定するために、セッション変数 [connector_sink_compression_codec](../../sql-reference/System_variable.md#connector_sink_compression_codec) を使用できます。
+- テーブルプロパティ [`compression_codec`](../../data_source/catalog/hive_catalog.md#properties) またはシステム変数 [`connector_sink_compression_codec`](../../sql-reference/System_variable.md# connector_sink_compression_codec) を使用して、Hive テーブルへのデータシンクに適用する圧縮アルゴリズムを指定できます。StarRocks はテーブルプロパティで指定された圧縮コーデックを優先的に使用します。
 
 :::
 

--- a/docs/ja/data_source/catalog/iceberg/iceberg_catalog.md
+++ b/docs/ja/data_source/catalog/iceberg/iceberg_catalog.md
@@ -1431,7 +1431,7 @@ ORDER BY (column_name [sort_direction] [nulls_order], ...)
 
 ###### compression_codec
 
-説明: Iceberg テーブルに使用される圧縮アルゴリズム。サポートされている圧縮アルゴリズムは SNAPPY、GZIP、ZSTD、および LZ4 です。デフォルト値: `gzip`。このプロパティは v3.2.3 で非推奨となり、それ以降のバージョンでは Iceberg テーブルにデータをシンクするために使用される圧縮アルゴリズムはセッション変数 [connector_sink_compression_codec](../../../sql-reference/System_variable.md#connector_sink_compression_codec) によって一元的に制御されます。
+説明: Iceberg テーブルに使用される圧縮アルゴリズム。サポートされている圧縮アルゴリズムは SNAPPY、GZIP、ZSTD、および LZ4 です。デフォルト値: `zstd`。
 
 ---
 

--- a/docs/ja/sql-reference/System_variable.md
+++ b/docs/ja/sql-reference/System_variable.md
@@ -302,7 +302,7 @@ MySQL クライアント互換性のために使用されます。実際の用�
 
 * **説明**: Hive テーブルまたは Iceberg テーブルにデータを書き込む際、または Files() でデータをエクスポートする際に使用される圧縮アルゴリズムを指定します。このパラメータは、以下の状況でのみ有効になります：
   * Hive テーブルに `compression_codec` プロパティが存在しない場合。
-  * Iceberg テーブルに `compression_codec` および `write.parquet.compression-codec` プロパティが存在しない場合。
+  * Iceberg テーブルに `write.parquet.compression-codec` プロパティが存在しない場合。
   * `INSERT INTO FILES` に対して `compression` プロパティが設定されていない場合。
 * **有効な値**: `uncompressed`, `snappy`, `lz4`, `zstd`, および `gzip`。
 * **デフォルト**: uncompressed

--- a/docs/ja/sql-reference/System_variable.md
+++ b/docs/ja/sql-reference/System_variable.md
@@ -300,7 +300,10 @@ MySQL クライアント互換性のために使用されます。実際の用�
 
 ### connector_sink_compression_codec
 
-* **説明**: Hive テーブルまたは Iceberg テーブルにデータを書き込む際、または Files() でデータをエクスポートする際に使用される圧縮アルゴリズムを指定します。
+* **説明**: Hive テーブルまたは Iceberg テーブルにデータを書き込む際、または Files() でデータをエクスポートする際に使用される圧縮アルゴリズムを指定します。このパラメータは、以下の状況でのみ有効になります：
+  * Hive テーブルに `compression_codec` プロパティが存在しない場合。
+  * Iceberg テーブルに `compression_codec` および `write.parquet.compression-codec` プロパティが存在しない場合。
+  * `INSERT INTO FILES` に対して `compression` プロパティが設定されていない場合。
 * **有効な値**: `uncompressed`, `snappy`, `lz4`, `zstd`, および `gzip`。
 * **デフォルト**: uncompressed
 * **データ型**: 文字列

--- a/docs/zh/data_source/catalog/hive_catalog.md
+++ b/docs/zh/data_source/catalog/hive_catalog.md
@@ -38,8 +38,9 @@ Hive Catalog 是一种 External Catalog，自 2.3 版本开始支持。通过 Hi
   - Parquet 和 ORC 文件支持 NO_COMPRESSION、SNAPPY、LZ4、ZSTD 和 GZIP 压缩格式。
   - Textfile 文件支持 NO_COMPRESSION 压缩格式。
 
-  您可以通过table属性 [`compression_codec`](../../data_source/catalog/hive_catalog.md#properties)或者系统变量 [`connector_sink_compression_codec`](../../sql-reference/System_variable.md#connector_sink_compression_codec)来设置写入到 Hive 表时的压缩算法。
-  在写入hive table时，如果该表的属性中包含了compression codec，StarRocks优先使用该算法对写入数据进行压缩。否则，使用系统变量 connector_sink_compression_codec 中设置的压缩算法代替。
+  您可以通过表属性 [`compression_codec`](../../data_source/catalog/hive_catalog.md#properties) 或系统变量 [`connector_sink_compression_codec`](../../sql-reference/System_variable.md#connector_sink_compression_codec) 来设置写入到 Hive 表时的压缩算法。
+
+  在写入 Hive 表时，如果该表的属性中包含了 `compression_codec`，StarRocks 优先使用该算法对写入数据进行压缩。否则，使用系统变量 `connector_sink_compression_codec` 中设置的压缩算法代替。
 
 ## 准备工作
 
@@ -1078,7 +1079,7 @@ PARTITION BY (par_col1[, par_col2...])
 :::note
 
 - 您可以通过 [GRANT](../../sql-reference/sql-statements/account-management/GRANT.md) 和 [REVOKE](../../sql-reference/sql-statements/account-management/REVOKE.md) 操作对用户和角色进行权限的赋予和收回。
-- 您可以通过table属性 [`compression_codec`](../../data_source/catalog/hive_catalog.md/#properties)或者系统变量 [`connector_sink_compression_codec`](../../sql-reference/System_variable.md#connector_sink_compression_codec)来设置写入到 Hive 表时的压缩算法。StarRocks会优先选择table属性中指定的compression codec来使用。
+- 您可以通过表属性 [`compression_codec`](../../data_source/catalog/hive_catalog.md/#properties) 或系统变量 [`connector_sink_compression_codec`](../../sql-reference/System_variable.md#connector_sink_compression_codec) 来设置写入到 Hive 表时的压缩算法。StarRocks 会优先选择表属性中指定的 `compression_codec` 来使用。
 
 :::
 

--- a/docs/zh/data_source/catalog/hive_catalog.md
+++ b/docs/zh/data_source/catalog/hive_catalog.md
@@ -38,7 +38,8 @@ Hive Catalog 是一种 External Catalog，自 2.3 版本开始支持。通过 Hi
   - Parquet 和 ORC 文件支持 NO_COMPRESSION、SNAPPY、LZ4、ZSTD 和 GZIP 压缩格式。
   - Textfile 文件支持 NO_COMPRESSION 压缩格式。
 
-  您可以通过系统变量 [`connector_sink_compression_codec`](../../sql-reference/System_variable.md#connector_sink_compression_codec) 来设置写入到 Hive 表时的压缩算法。
+  您可以通过table属性 [`compression_codec`](../../data_source/catalog/hive_catalog.md#properties)或者系统变量 [`connector_sink_compression_codec`](../../sql-reference/System_variable.md#connector_sink_compression_codec)来设置写入到 Hive 表时的压缩算法。
+  在写入hive table时，如果该表的属性中包含了compression codec，StarRocks优先使用该算法对写入数据进行压缩。否则，使用系统变量 connector_sink_compression_codec 中设置的压缩算法代替。
 
 ## 准备工作
 
@@ -1030,7 +1031,7 @@ PARTITION BY (par_col1[, par_col2...])
 | ----------------- | ------------------------------------------------------------ |
 | location          | Managed Table 所在的文件路径。使用 HMS 作为元数据服务时，您无需指定 `location` 参数。使用 AWS Glue 作为元数据服务时：<ul><li>如果在创建当前数据库时指定了 `location` 参数，那么在当前数据库下建表时不需要再指定 `location` 参数，StarRocks 默认把表建在当前数据库所在的文件路径下。</li><li>如果在创建当前数据库时没有指定 `location` 参数，那么在当前数据库建表时必须指定 `location` 参数。</li></ul> |
 | file_format       | Managed Table 的文件格式。当前支持 Parquet、ORC、Textfile 文件格式，其中 ORC 和 Textfile 文件格式自 3.3 版本起支持。取值范围：`parquet`、`orc`、`textfile`。默认值：`parquet`。 |
-| compression_codec | Managed Table 的压缩格式。该属性自 3.2.3 版本起弃用，此后写入 Hive 表时的压缩算法统一由会话变量 [connector_sink_compression_codec](../../sql-reference/System_variable.md#connector_sink_compression_codec) 控制。 |
+| compression_codec | Managed Table 的压缩格式。                                   |
 
 ### 示例
 
@@ -1077,7 +1078,7 @@ PARTITION BY (par_col1[, par_col2...])
 :::note
 
 - 您可以通过 [GRANT](../../sql-reference/sql-statements/account-management/GRANT.md) 和 [REVOKE](../../sql-reference/sql-statements/account-management/REVOKE.md) 操作对用户和角色进行权限的赋予和收回。
-- 您可以通过会话变量 [connector_sink_compression_codec](../../sql-reference/System_variable.md#connector_sink_compression_codec) 来指定写入 Hive 表时的压缩算法。
+- 您可以通过table属性 [`compression_codec`](../../data_source/catalog/hive_catalog.md/#properties)或者系统变量 [`connector_sink_compression_codec`](../../sql-reference/System_variable.md#connector_sink_compression_codec)来设置写入到 Hive 表时的压缩算法。StarRocks会优先选择table属性中指定的compression codec来使用。
 
 :::
 

--- a/docs/zh/data_source/catalog/iceberg/iceberg_catalog.md
+++ b/docs/zh/data_source/catalog/iceberg/iceberg_catalog.md
@@ -1471,7 +1471,7 @@ ORDER BY (column_name [sort_direction] [nulls_order], ...)
 
 ###### compression_codec
 
-描述：Iceberg 表使用的压缩算法。支持的压缩算法有 SNAPPY、GZIP、ZSTD 和 LZ4。默认值：`gzip`。此属性在 v3.2.3 中已弃用，从该版本开始，导入数据到 Iceberg 表时使用的压缩算法由会话变量 [connector_sink_compression_codec](../../../sql-reference/System_variable.md#connector_sink_compression_codec) 统一控制。
+描述：Iceberg 表使用的压缩算法。支持的压缩算法有 SNAPPY、GZIP、ZSTD 和 LZ4。默认值：`zstd`。
 
 ---
 

--- a/docs/zh/sql-reference/System_variable.md
+++ b/docs/zh/sql-reference/System_variable.md
@@ -299,7 +299,10 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 
 ### connector_sink_compression_codec
 
-* 描述：用于指定写入 Hive 表或 Iceberg 表时以及使用 Files() 导出数据时的压缩算法。有效值：`uncompressed`、`snappy`、`lz4`、`zstd`、`gzip`。
+* 描述：用于指定写入 Hive 表或 Iceberg 表时以及使用 Files() 导出数据时的压缩算法。有效值：`uncompressed`、`snappy`、`lz4`、`zstd`、`gzip`。该参数只在以下情况生效：
+  * Hive表中未指定compression codec属性。
+  * Iceberg的表中未包含`compression_codec`和`write.parquet.compression-codec`属性；
+  * `INSERT INTO FILES`时未设置 `compression`属性。 
 * 默认值：uncompressed
 * 类型：String
 * 引入版本：v3.2.3

--- a/docs/zh/sql-reference/System_variable.md
+++ b/docs/zh/sql-reference/System_variable.md
@@ -301,7 +301,7 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 
 * 描述：用于指定写入 Hive 表或 Iceberg 表时以及使用 Files() 导出数据时的压缩算法。有效值：`uncompressed`、`snappy`、`lz4`、`zstd`、`gzip`。该参数只在以下情况生效：
   * Hive 表中未指定 `compression_codec` 属性。
-  * Iceberg 表中未包含 `compression_codec` 和 `write.parquet.compression-codec` 属性。
+  * Iceberg 表中未包含`write.parquet.compression-codec` 属性。
   * `INSERT INTO FILES` 时未设置 `compression` 属性。 
 * 默认值：uncompressed
 * 类型：String

--- a/docs/zh/sql-reference/System_variable.md
+++ b/docs/zh/sql-reference/System_variable.md
@@ -300,9 +300,9 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 ### connector_sink_compression_codec
 
 * 描述：用于指定写入 Hive 表或 Iceberg 表时以及使用 Files() 导出数据时的压缩算法。有效值：`uncompressed`、`snappy`、`lz4`、`zstd`、`gzip`。该参数只在以下情况生效：
-  * Hive表中未指定compression codec属性。
-  * Iceberg的表中未包含`compression_codec`和`write.parquet.compression-codec`属性；
-  * `INSERT INTO FILES`时未设置 `compression`属性。 
+  * Hive 表中未指定 `compression_codec` 属性。
+  * Iceberg 表中未包含 `compression_codec` 和 `write.parquet.compression-codec` 属性。
+  * `INSERT INTO FILES` 时未设置 `compression` 属性。 
 * 默认值：uncompressed
 * 类型：String
 * 引入版本：v3.2.3

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HiveTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HiveTableSink.java
@@ -68,7 +68,8 @@ public class HiveTableSink extends DataSink {
             this.textFileFormatDesc = Optional.of(toTextFileFormatDesc(hiveTable.getSerdeProperties()));
             this.compressionType = String.valueOf(TCompressionType.NO_COMPRESSION);
         } else {
-            this.compressionType = sessionVariable.getConnectorSinkCompressionCodec();
+            this.compressionType = hiveTable.getProperties().getOrDefault("compression_codec",
+                    sessionVariable.getConnectorSinkCompressionCodec());
         }
 
         this.targetMaxFileSize = sessionVariable.getConnectorSinkTargetMaxFileSize() > 0 ?

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
@@ -29,6 +29,8 @@ import org.apache.iceberg.Table;
 import static com.starrocks.sql.ast.OutFileClause.PARQUET_COMPRESSION_TYPE_MAP;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
+import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
+import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION_DEFAULT;
 
 public class IcebergTableSink extends DataSink {
     public final static int ICEBERG_SINK_MAX_DOP = 32;
@@ -55,7 +57,8 @@ public class IcebergTableSink extends DataSink {
         this.isStaticPartitionSink = isStaticPartitionSink;
         this.fileFormat = nativeTable.properties().getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT)
                 .toLowerCase();
-        this.compressionType = sessionVariable.getConnectorSinkCompressionCodec();
+        this.compressionType = nativeTable.properties().getOrDefault(PARQUET_COMPRESSION,
+                sessionVariable.getConnectorSinkCompressionCodec());
         this.targetMaxFileSize = sessionVariable.getConnectorSinkTargetMaxFileSize() > 0 ?
             sessionVariable.getConnectorSinkTargetMaxFileSize() : 1024L * 1024 * 1024;
         this.targetBranch = targetBranch;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.planner;
 
+import com.google.common.base.Preconditions;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.iceberg.IcebergUtil;
 import com.starrocks.credential.CloudConfiguration;
@@ -30,7 +31,6 @@ import static com.starrocks.sql.ast.OutFileClause.PARQUET_COMPRESSION_TYPE_MAP;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
-import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION_DEFAULT;
 
 public class IcebergTableSink extends DataSink {
     public final static int ICEBERG_SINK_MAX_DOP = 32;
@@ -92,6 +92,7 @@ public class IcebergTableSink extends DataSink {
         tIcebergTableSink.setFile_format(fileFormat);
         tIcebergTableSink.setIs_static_partition_sink(isStaticPartitionSink);
         TCompressionType compression = PARQUET_COMPRESSION_TYPE_MAP.get(compressionType);
+        Preconditions.checkState(compression != null, "compression type not supported");
         tIcebergTableSink.setCompression_type(compression);
         tIcebergTableSink.setTarget_max_file_size(targetMaxFileSize);
         TCloudConfiguration tCloudConfiguration = new TCloudConfiguration();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HiveTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HiveTableSinkTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.toResourceName;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.getStarRocksAssert;
@@ -118,6 +119,107 @@ public class HiveTableSinkTest {
         builder.setStorageFormat(HiveStorageFormat.AVRO);
         ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
                 "Writing to hive table in [AVRO] format is not supported",
-                () ->new HiveTableSink(builder.build(), desc, true, new SessionVariable()));
+                () -> new HiveTableSink(builder.build(), desc, true, new SessionVariable()));
     }
+
+    @Test
+    public void testCompressionFromHiveTableProperty(@Mocked CatalogConnector hiveConnector,
+                                                     @Mocked SessionVariable sessionVariable) {
+        // hiveTable.properties contains compression_codec -> should use it
+        Map<String, String> props = new HashMap<>();
+        props.put("compression_codec", "snappy");
+
+        HiveTable.Builder builder = HiveTable.builder()
+                .setId(1)
+                .setTableName("hive_table")
+                .setCatalogName("hive_catalog")
+                .setHiveDbName("hive_db")
+                .setHiveTableName("hive_table")
+                .setPartitionColumnNames(java.util.Collections.singletonList("p1"))
+                .setDataColumnNames(java.util.Collections.singletonList("c1"))
+                .setFullSchema(java.util.Arrays.asList(new Column("c1", IntegerType.INT), new Column("p1", IntegerType.INT)))
+                .setTableLocation("hdfs://hadoop01:9000/tableLocation")
+                .setProperties(props)
+                .setStorageFormat(HiveStorageFormat.PARQUET)
+                .setCreateTime(System.currentTimeMillis());
+
+        new Expectations() {
+            {
+                CloudConfiguration cloudConfig = new CloudConfiguration();
+                cloudConfig.loadCommonFields(new HashMap<>());
+                hiveConnector.getMetadata().getCloudConfiguration();
+                result = cloudConfig;
+                minTimes = 1;
+            }
+        };
+
+        ConnectorMgr connectorMgr = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getConnectorMgr();
+        new Expectations(connectorMgr) {{
+            connectorMgr.getConnector("hive_catalog");
+            result = hiveConnector;
+            minTimes = 1;
+
+            sessionVariable.getConnectorSinkCompressionCodec();
+            result = "gzip";
+            sessionVariable.getHiveTempStagingDir();
+            result = "/tmp";
+        }};
+
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        HiveTableSink sink = new HiveTableSink(builder.build(), desc, true, sessionVariable);
+        TDataSink tDataSink = sink.toThrift();
+        THiveTableSink tHiveTableSink = tDataSink.getHive_table_sink();
+        Assertions.assertEquals(TCompressionType.SNAPPY, tHiveTableSink.getCompression_type());
+    }
+
+    @Test
+    public void testCompressionFallbackToSessionVariable(@Mocked CatalogConnector hiveConnector,
+                                                         @Mocked SessionVariable sessionVariable) {
+        // hiveTable.properties does NOT contain compression_codec -> should fallback to sessionVariable
+        HiveTable.Builder builder = HiveTable.builder()
+                .setId(2)
+                .setTableName("hive_table2")
+                .setCatalogName("hive_catalog")
+                .setHiveDbName("hive_db")
+                .setHiveTableName("hive_table2")
+                .setPartitionColumnNames(java.util.Collections.singletonList("p1"))
+                .setDataColumnNames(java.util.Collections.singletonList("c1"))
+                .setFullSchema(java.util.Arrays.asList(new Column("c1", IntegerType.INT), new Column("p1", IntegerType.INT)))
+                .setTableLocation("hdfs://hadoop01:9000/tableLocation")
+                .setProperties(new HashMap<>())
+                .setStorageFormat(HiveStorageFormat.PARQUET)
+                .setCreateTime(System.currentTimeMillis());
+
+        new Expectations() {
+            {
+                CloudConfiguration cloudConfig = new CloudConfiguration();
+                cloudConfig.loadCommonFields(new HashMap<>());
+                hiveConnector.getMetadata().getCloudConfiguration();
+                result = cloudConfig;
+                minTimes = 1;
+
+                // session variable returns fallback compression codec and staging dir
+                sessionVariable.getConnectorSinkCompressionCodec();
+                result = "gzip";
+                sessionVariable.getHiveTempStagingDir();
+                result = "/tmp";
+            }
+        };
+
+        ConnectorMgr connectorMgr = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getConnectorMgr();
+        new Expectations(connectorMgr) {
+            {
+                connectorMgr.getConnector("hive_catalog");
+                result = hiveConnector;
+                minTimes = 1;
+            }
+        };
+
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        HiveTableSink sink = new HiveTableSink(builder.build(), desc, true, sessionVariable);
+        TDataSink tDataSink = sink.toThrift();
+        THiveTableSink tHiveTableSink = tDataSink.getHive_table_sink();
+        Assertions.assertEquals(TCompressionType.GZIP, tHiveTableSink.getCompression_type());
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergTableSinkTest.java
@@ -1,0 +1,171 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// language: java
+package com.starrocks.planner;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.connector.CatalogConnector;
+import com.starrocks.connector.ConnectorMgr;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudConfigurationFactory;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TCompressionType;
+import com.starrocks.thrift.TDataSink;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.io.FileIO;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
+
+public class IcebergTableSinkTest {
+
+    @Test
+    public void testCompressionFromNativeTableProperty(@Mocked GlobalStateMgr globalStateMgr, @Mocked ConnectorMgr connectorMgr,
+                                                       @Mocked CatalogConnector connector, @Mocked IcebergTable icebergTable,
+                                                       @Mocked Table nativeTable, @Mocked FileIO fileIO,
+                                                       @Mocked SessionVariable sessionVariable) {
+        // nativeTable.properties contains parquet compression -> should use it
+        Map<String, String> nativeProps = Maps.newHashMap();
+        nativeProps.put(PARQUET_COMPRESSION, "zstd");
+
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(new HashMap<>());
+
+        new Expectations() {
+            {
+                // iceberg table / native table basic
+                icebergTable.getNativeTable();
+                result = nativeTable;
+
+                icebergTable.getCatalogName();
+                result = "catA";
+
+                icebergTable.getId();
+                result = 101L;
+
+                icebergTable.getUUID();
+                result = "uuidA";
+
+                nativeTable.location();
+                result = "s3://bucket/a";
+
+                nativeTable.properties();
+                result = nativeProps;
+
+                nativeTable.io();
+                result = fileIO;
+
+                fileIO.properties();
+                result = new HashMap<String, String>();
+
+                // Global state and connector metadata fallback path
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+
+                globalStateMgr.getConnectorMgr();
+                result = connectorMgr;
+
+                connectorMgr.getConnector("catA");
+                result = connector;
+
+                connector.getMetadata().getCloudConfiguration();
+                result = cc;
+
+                // session variable should not be used for compression in this case, but stub anyway
+                sessionVariable.getConnectorSinkCompressionCodec();
+                result = "gzip";
+
+                sessionVariable.getConnectorSinkTargetMaxFileSize();
+                result = 0L;
+            }
+        };
+
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        IcebergTableSink sink = new IcebergTableSink(icebergTable, desc, false, sessionVariable, null);
+        TDataSink t = sink.toThrift();
+        // compression_type should map "zstd" -> TCompressionType.ZSTD
+        Assertions.assertEquals(TCompressionType.ZSTD, t.getIceberg_table_sink().getCompression_type());
+    }
+
+    @Test
+    public void testCompressionFromSessionVariableFallback(@Mocked GlobalStateMgr globalStateMgr,
+                                                           @Mocked ConnectorMgr connectorMgr, @Mocked CatalogConnector connector,
+                                                           @Mocked IcebergTable icebergTable, @Mocked Table nativeTable,
+                                                           @Mocked FileIO fileIO, @Mocked SessionVariable sessionVariable) {
+        // nativeTable.properties does NOT contain parquet compression -> should fallback to sessionVariable
+        Map<String, String> nativeProps = Maps.newHashMap(); // empty
+
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(new HashMap<>());
+
+        new Expectations() {
+            {
+                icebergTable.getNativeTable();
+                result = nativeTable;
+
+                icebergTable.getCatalogName();
+                result = "catB";
+
+                icebergTable.getId();
+                result = 102L;
+
+                icebergTable.getUUID();
+                result = "uuidB";
+
+                nativeTable.location();
+                result = "s3://bucket/b";
+
+                nativeTable.properties();
+                result = nativeProps;
+
+                nativeTable.io();
+                result = fileIO;
+
+                fileIO.properties();
+                result = new HashMap<String, String>();
+
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+
+                globalStateMgr.getConnectorMgr();
+                result = connectorMgr;
+
+                connectorMgr.getConnector("catB");
+                result = connector;
+
+                connector.getMetadata().getCloudConfiguration();
+                result = cc;
+
+                // session variable provides fallback compression codec
+                sessionVariable.getConnectorSinkCompressionCodec();
+                result = "gzip";
+                sessionVariable.getConnectorSinkTargetMaxFileSize();
+                result = 0L;
+            }
+        };
+
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        IcebergTableSink sink = new IcebergTableSink(icebergTable, desc, false, sessionVariable, null);
+        TDataSink t = sink.toThrift();
+        // fallback "gzip" -> TCompressionType.GZIP
+        Assertions.assertEquals(TCompressionType.GZIP, t.getIceberg_table_sink().getCompression_type());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
From iceberg spec, a write property `write.parquet.compression-codec` of table is used to control the parquet compression codec of the table data, and the default value of the property is `zstd`. 

StarRocks now supports the `compression_codec` when creating iceberg and hive tables, and it will be set to the `write.parquet.compression-codec` property for iceberg native table.

However, when writing iceberg tables, we ignore this property. StarRocks now use the system variable `connector_sink_compression_codec` to control the compression codec of all connector tables, and it's default value is "uncompressed". 

So, by default, when creating an iceberg table in StarRocks, the table property `write.parquet.compression-codec` is `zstd`, while the data written to this table is `uncompressed`, which make users confused.

## What I'm doing:
* Use the `write.parquet.compression-codec` property when writing an iceberg table to follow the iceberg spec.
* If the table does not contain a compression codec property, use the system variable `connector_sink_compression_codec` instead.
* * Similarly, modify the compression logic of hive tables.
* Update the related documents.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prioritizes table-level compression settings when sinking to Hive/Iceberg, with clear fallback to the system variable only if absent.
> 
> - Planner: `HiveTableSink` now uses table `compression_codec` (TEXTFILE remains `NO_COMPRESSION`), else falls back to `connector_sink_compression_codec`; `IcebergTableSink` now uses Iceberg `PARQUET_COMPRESSION` (`write.parquet.compression-codec`) or falls back to session var, with a supported-type check.
> - Tests: Added unit tests for both sinks covering table-property precedence and session fallback.
> - Docs (en/ja/zh): Updated Hive/Iceberg docs to document precedence rules and when `connector_sink_compression_codec` applies; set Iceberg `compression_codec` default to `zstd`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8302e6ceac64501130495bb5bc40d7931de4e180. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->