### PR TITLE
[Feature] Add UTF-8 support for ngram_search functions

### DIFF
--- a/be/src/base/CMakeLists.txt
+++ b/be/src/base/CMakeLists.txt
@@ -71,6 +71,7 @@ ADD_BE_LIB(Base
   string/string_parser.cpp
   string/url_parser.cpp
   string/slice.cpp
+  string/utf8.cpp
   string/utf8_check.cpp
   system/errno.cpp
   time/date_func.cpp

--- a/be/src/base/string/utf8.cpp
+++ b/be/src/base/string/utf8.cpp
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "base/string/utf8.h"
+
+#include <fmt/format.h>
+#include <unicode/ucasemap.h>
+
+#include <memory>
+#include <stdexcept>
+
+namespace starrocks {
+
+struct UCaseMapDeleter {
+    void operator()(UCaseMap* p) const noexcept {
+        if (p != nullptr) {
+            ucasemap_close(p);
+        }
+    }
+};
+
+static UCaseMap* get_case_map() {
+    static std::unique_ptr<UCaseMap, UCaseMapDeleter> case_map = []() {
+        UErrorCode err_code = U_ZERO_ERROR;
+        UCaseMap* map = ucasemap_open("", U_FOLD_CASE_DEFAULT, &err_code);
+        if (U_FAILURE(err_code)) {
+            throw std::runtime_error(fmt::format("Failed to open UCaseMap: {}", u_errorName(err_code)));
+        }
+        return std::unique_ptr<UCaseMap, UCaseMapDeleter>(map);
+    }();
+    return case_map.get();
+}
+
+void utf8_tolower(const char* src, size_t src_len, std::string& dst) {
+    UCaseMap* case_map = get_case_map();
+
+    // Initial buffer size - UTF-8 lowercase can be larger than original (e.g., German ß -> ss)
+    dst.resize(src_len * 2);
+
+    UErrorCode err_code = U_ZERO_ERROR;
+    int32_t result_len = ucasemap_utf8ToLower(case_map, dst.data(), dst.size(), src, src_len, &err_code);
+
+    if (err_code == U_BUFFER_OVERFLOW_ERROR) {
+        err_code = U_ZERO_ERROR;
+        dst.resize(result_len + 1);
+        result_len = ucasemap_utf8ToLower(case_map, dst.data(), dst.size(), src, src_len, &err_code);
+    }
+
+    if (U_FAILURE(err_code)) {
+        throw std::runtime_error(fmt::format("Failed to convert to lowercase: {}", u_errorName(err_code)));
+    }
+    dst.resize(result_len);
+}
+
+} // namespace starrocks

--- a/be/src/base/string/utf8.h
+++ b/be/src/base/string/utf8.h
@@ -181,4 +181,13 @@ static inline size_t incomplete_trailing_utf8_len(const char* data, size_t len) 
     return 0;
 }
 
+// UTF-8 aware tolower using ICU
+// DCHECKs on ICU failure - ICU should always be available
+void utf8_tolower(const char* src, size_t src_len, std::string& dst);
+
+// Convenience overload for std::string
+static inline void utf8_tolower(const std::string& src, std::string& dst) {
+    utf8_tolower(src.data(), src.size(), dst);
+}
+
 } // namespace starrocks

--- a/be/src/exprs/function_call_expr.cpp
+++ b/be/src/exprs/function_call_expr.cpp
@@ -245,15 +245,25 @@ bool VectorizedFunctionCallExpr::ngram_bloom_filter(ExprContext* context, const 
         const auto& needle_column = fn_ctx->get_constant_column(1);
         std::string needle = ColumnHelper::get_const_value<TYPE_VARCHAR>(needle_column).to_string();
 
-        // for case_insensitive, we need to convert needle to lower case
-        if (!reader_options.index_case_sensitive) {
-            std::transform(needle.begin(), needle.end(), needle.begin(),
-                           [](unsigned char c) { return std::tolower(c); });
-        }
-
         if (!simdjson::validate_utf8(needle.data(), needle.size())) {
             index_useful = false;
-        } else if (_fn_desc->name == "LIKE") {
+            ngram_state->initialized = true;
+            ngram_state->index_useful = index_useful;
+            return true;
+        }
+
+        // for case_insensitive, we need to convert needle to lower case
+        if (!reader_options.index_case_sensitive) {
+            std::string lower_needle;
+            if (validate_ascii_fast(needle.data(), needle.size())) {
+                Slice(needle).tolower(lower_needle);
+            } else {
+                utf8_tolower(needle, lower_needle);
+            }
+            needle = std::move(lower_needle);
+        }
+
+        if (_fn_desc->name == "LIKE") {
             index_useful = split_like_string_to_ngram(needle, reader_options, ngram_set);
         } else {
             index_useful = split_normal_string_to_ngram(needle, fn_ctx, reader_options, ngram_set, _fn_desc->name);

--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -67,7 +67,7 @@ struct Ngramstate {
     }
 };
 
-template <bool case_insensitive, bool use_utf_8, class Gram>
+template <bool case_insensitive, bool use_utf_8>
 class NgramFunctionImpl {
 public:
     StatusOr<ColumnPtr> static ngram_search_impl(FunctionContext* context, const Columns& columns) {
@@ -167,6 +167,11 @@ private:
         }
     }
 
+    // Hash one n-gram spanning nbytes bytes at data into the 16-bit ngram-map index.
+    static NgramHash ngram_hash(const char* data, size_t nbytes) {
+        return crc_hash_32(data, nbytes, CRC_HASH_SEEDS::CRC_HASH_SEED1) & 0xffffu;
+    }
+
     // UTF-8 aware tolower - uses shared implementation from base/string/utf8.h
     static void tolower_utf8(const Slice& str, std::string& buf) {
         if (validate_ascii_fast(str.get_data(), str.get_size())) {
@@ -176,7 +181,7 @@ private:
         }
     }
 
-    // ASCII tolower into a caller-owned buffer, used by the non-constant-needle path in non-UTF-8 mode.
+    // ASCII tolower into a caller-owned buffer, used by the case-insensitive non-UTF-8 paths.
     void inline static tolower(const Slice& str, std::string& buf) {
         buf.assign(str.get_data(), str.get_size());
         std::transform(buf.begin(), buf.end(), buf.begin(), [](unsigned char c) { return std::tolower(c); });
@@ -190,8 +195,7 @@ private:
             if constexpr (use_utf_8) {
                 tolower_utf8(needle, buf);
             } else {
-                buf.assign(needle.get_data(), needle.get_size());
-                std::transform(buf.begin(), buf.end(), buf.begin(), [](unsigned char c) { return std::tolower(c); });
+                tolower(needle, buf);
             }
             cur_needle = Slice(buf.c_str(), buf.size());
         }
@@ -215,7 +219,7 @@ private:
                 size_t end = (i + gram_num < num_chars) ? positions[i + gram_num] : len;
                 size_t ngram_bytes = end - start;
 
-                NgramHash cur_hash = crc_hash_32(data + start, ngram_bytes, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
+                NgramHash cur_hash = ngram_hash(data + start, ngram_bytes);
                 map[cur_hash]++;
                 gram_count++;
             }
@@ -224,18 +228,17 @@ private:
             // ASCII mode: iterate by bytes (original behavior)
             size_t i;
             for (i = 0; i + gram_num <= len; i++) {
-                NgramHash cur_hash = crc_hash_32(data + i, gram_num, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
+                NgramHash cur_hash = ngram_hash(data + i, gram_num);
                 map[cur_hash]++;
             }
             return i;
         }
     }
 
-    // Like calculateMapWithNeedle but also populates recover_info with each gram's hash (resized to gram count),
-    // so the caller can restore or clear the needle's map entries when reusing the map across rows. The needle
-    // must already be lowercased for case-insensitive variants (lowercasing is the caller's responsibility).
-    // In UTF-8 mode grams span whole characters; a needle shorter than gram_num characters yields no gram
-    // (returns 0 and empties recover_info).
+    // Like calculateMapWithNeedle but also populates recover_info with each gram's hash (resized to gram count).
+    // Caller must guarantee needle.get_size() >= gram_num and that needle is already lowercased
+    // for case-insensitive variants (lowercasing is the caller's responsibility).
+    // In UTF-8 mode grams span whole characters, so a needle of fewer than gram_num characters yields no gram.
     size_t static calculateMapWithNeedleAndRecoverInfo(std::vector<NgramHash>& map, const Slice& needle,
                                                        size_t gram_num, std::vector<NgramHash>& recover_info) {
         const char* data = needle.get_data();
@@ -257,9 +260,9 @@ private:
             for (size_t i = 0; i < gram_count; i++) {
                 size_t start = positions[i];
                 size_t end = (i + gram_num < num_chars) ? positions[i + gram_num] : len;
-                NgramHash h = crc_hash_32(data + start, end - start, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
-                map[h]++;
-                recover_info[i] = h;
+                NgramHash cur_hash = ngram_hash(data + start, end - start);
+                map[cur_hash]++;
+                recover_info[i] = cur_hash;
             }
             return gram_count;
         } else {
@@ -267,9 +270,9 @@ private:
             size_t gram_count = len - gram_num + 1;
             recover_info.resize(gram_count);
             for (size_t i = 0; i < gram_count; i++) {
-                NgramHash h = crc_hash_32(data + i, gram_num, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
-                map[h]++;
-                recover_info[i] = h;
+                NgramHash cur_hash = ngram_hash(data + i, gram_num);
+                map[cur_hash]++;
+                recover_info[i] = cur_hash;
             }
             return gram_count;
         }
@@ -292,7 +295,7 @@ private:
             for (size_t i = 0; i + gram_num <= num_chars; i++) {
                 size_t start = positions[i];
                 size_t end = (i + gram_num < num_chars) ? positions[i + gram_num] : len;
-                NgramHash cur_hash = crc_hash_32(data + start, end - start, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
+                NgramHash cur_hash = ngram_hash(data + start, end - start);
                 if (map[cur_hash] > 0) {
                     needle_gram_count--;
                     map[cur_hash]--;
@@ -301,7 +304,7 @@ private:
         } else {
             // ASCII mode: iterate by bytes
             for (size_t i = 0; i + gram_num <= len; i++) {
-                NgramHash cur_hash = crc_hash_32(data + i, gram_num, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
+                NgramHash cur_hash = ngram_hash(data + i, gram_num);
                 if (map[cur_hash] > 0) {
                     needle_gram_count--;
                     map[cur_hash]--;
@@ -520,8 +523,7 @@ private:
         // UTF-8 lowering happens inside calculateDistanceWithHaystack; pre-converting here would lower twice.
         std::string buf;
         if constexpr (case_insensitive && !use_utf_8) {
-            buf.assign(haystack.get_data(), haystack.get_size());
-            std::transform(buf.begin(), buf.end(), buf.begin(), [](unsigned char c) { return std::tolower(c); });
+            tolower(haystack, buf);
             cur_haystack = Slice(buf.c_str(), buf.size());
         }
 
@@ -580,7 +582,7 @@ private:
                 size_t end = (i + gram_num < num_chars) ? positions[i + gram_num] : len;
                 size_t ngram_bytes = end - start;
 
-                NgramHash cur_hash = crc_hash_32(data + start, ngram_bytes, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
+                NgramHash cur_hash = ngram_hash(data + start, ngram_bytes);
 
                 if (map[cur_hash] > 0) {
                     needle_gram_count--;
@@ -603,7 +605,7 @@ private:
             // ASCII mode: iterate by bytes (original behavior)
             size_t i;
             for (i = 0; i + gram_num <= len; i++) {
-                NgramHash cur_hash = crc_hash_32(data + i, gram_num, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
+                NgramHash cur_hash = ngram_hash(data + i, gram_num);
                 if (map[cur_hash] > 0) {
                     needle_gram_count--;
                     map[cur_hash]--;
@@ -631,32 +633,32 @@ private:
 StatusOr<ColumnPtr> StringFunctions::ngram_search(FunctionContext* context, const Columns& columns) {
     auto state = reinterpret_cast<Ngramstate*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
     if (state && state->use_utf8) {
-        return NgramFunctionImpl<false, true, char>::ngram_search_impl(context, columns);
+        return NgramFunctionImpl<false, true>::ngram_search_impl(context, columns);
     }
-    return NgramFunctionImpl<false, false, char>::ngram_search_impl(context, columns);
+    return NgramFunctionImpl<false, false>::ngram_search_impl(context, columns);
 }
 
 StatusOr<ColumnPtr> StringFunctions::ngram_search_case_insensitive(FunctionContext* context, const Columns& columns) {
     auto state = reinterpret_cast<Ngramstate*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
     if (state && state->use_utf8) {
-        return NgramFunctionImpl<true, true, char>::ngram_search_impl(context, columns);
+        return NgramFunctionImpl<true, true>::ngram_search_impl(context, columns);
     }
-    return NgramFunctionImpl<true, false, char>::ngram_search_impl(context, columns);
+    return NgramFunctionImpl<true, false>::ngram_search_impl(context, columns);
 }
 
 Status StringFunctions::ngram_search_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
     if (context->state() && context->state()->ngram_search_support_utf8()) {
-        return NgramFunctionImpl<false, true, char>::ngram_search_prepare_impl(context, scope);
+        return NgramFunctionImpl<false, true>::ngram_search_prepare_impl(context, scope);
     }
-    return NgramFunctionImpl<false, false, char>::ngram_search_prepare_impl(context, scope);
+    return NgramFunctionImpl<false, false>::ngram_search_prepare_impl(context, scope);
 }
 
 Status StringFunctions::ngram_search_case_insensitive_prepare(FunctionContext* context,
                                                               FunctionContext::FunctionStateScope scope) {
     if (context->state() && context->state()->ngram_search_support_utf8()) {
-        return NgramFunctionImpl<true, true, char>::ngram_search_prepare_impl(context, scope);
+        return NgramFunctionImpl<true, true>::ngram_search_prepare_impl(context, scope);
     }
-    return NgramFunctionImpl<true, false, char>::ngram_search_prepare_impl(context, scope);
+    return NgramFunctionImpl<true, false>::ngram_search_prepare_impl(context, scope);
 }
 
 Status StringFunctions::ngram_search_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {

--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -449,6 +449,11 @@ private:
     ColumnPtr static haystack_vector_and_needle_const(const ColumnPtr& haystack_column, std::vector<NgramHash>& map,
                                                       FunctionContext* context, size_t gram_num) {
         std::vector<NgramHash> map_restore_helper(MAX_STRING_SIZE, 0);
+        // Hoisted per-row scratch for UTF-8 path: lowered haystack and character offsets.
+        // Default-constructed strings/vectors don't allocate, and clear() preserves capacity,
+        // so the ASCII path pays nothing and the UTF-8 path amortizes after the first row.
+        std::string lower_buf;
+        std::vector<size_t> positions;
 
         NullColumnPtr res_null = nullptr;
         ColumnPtr haystackPtr = nullptr;
@@ -483,7 +488,7 @@ private:
             }
 
             size_t needle_not_overlap_with_haystack = calculateDistanceWithHaystack<true>(
-                    map, cur_haystack_str, map_restore_helper, needle_gram_count, gram_num);
+                    map, cur_haystack_str, map_restore_helper, lower_buf, positions, needle_gram_count, gram_num);
             DCHECK(needle_not_overlap_with_haystack <= needle_gram_count);
 
             // now get the result
@@ -502,6 +507,8 @@ private:
     float static haystack_const_and_needle_const(const Slice& haystack, std::vector<NgramHash>& map,
                                                  FunctionContext* context, size_t gram_num) {
         std::vector<NgramHash> map_restore_helper{};
+        std::string lower_buf;
+        std::vector<size_t> positions;
         // if haystack is too large, we can say they are not similar at all
         if (haystack.get_size() > MAX_STRING_SIZE) {
             return 0;
@@ -522,7 +529,7 @@ private:
         // needle_gram_count may be zero because needle is empty or N is too large for needle
         size_t needle_gram_count = state->needle_gram_count;
         size_t needle_not_overlap_with_haystack = calculateDistanceWithHaystack<false>(
-                map, cur_haystack, map_restore_helper, needle_gram_count, gram_num);
+                map, cur_haystack, map_restore_helper, lower_buf, positions, needle_gram_count, gram_num);
         float result = 1.0f - (needle_not_overlap_with_haystack)*1.0f / std::max(needle_gram_count, (size_t)1);
         DCHECK(needle_not_overlap_with_haystack <= needle_gram_count);
         return result;
@@ -531,14 +538,18 @@ private:
     // traverse haystack's every gram, find whether this gram is in needle or not using gram's hash
     // 16bit hash value may cause hash collision, but because we just calculate the similarity of two string
     // so don't need to be so accurate.
+    // lower_buf and positions are caller-owned scratch buffers reused across rows; only the UTF-8 path
+    // touches them. clear() on entry preserves capacity for the next row.
     template <bool need_recovery_map>
     size_t static calculateDistanceWithHaystack(std::vector<NgramHash>& map, const Slice& haystack,
                                                 [[maybe_unused]] std::vector<NgramHash>& map_restore_helper,
+                                                [[maybe_unused]] std::string& lower_buf,
+                                                [[maybe_unused]] std::vector<size_t>& positions,
                                                 size_t needle_gram_count, size_t gram_num) {
         // For UTF-8 case-insensitive mode in vector processing, we need to convert here
-        std::string lower_buf;
         Slice cur_haystack = haystack;
         if constexpr (case_insensitive && use_utf_8) {
+            lower_buf.clear();
             tolower_utf8(haystack, lower_buf);
             cur_haystack = Slice(lower_buf.c_str(), lower_buf.size());
         }
@@ -548,12 +559,17 @@ private:
 
         if constexpr (use_utf_8) {
             // UTF-8 mode: iterate by characters
-            std::vector<size_t> positions;
             get_utf8_positions(data, len, positions);
 
             size_t num_chars = positions.size();
             if (num_chars < gram_num) {
                 return needle_gram_count;
+            }
+            // Defensive: map_restore_helper is sized in bytes (MAX_STRING_SIZE); character count
+            // could in principle exceed that after ICU folds (e.g. ligatures expanding). Skip
+            // rather than indexing out of bounds.
+            if constexpr (need_recovery_map) {
+                if (num_chars > MAX_STRING_SIZE) return needle_gram_count;
             }
 
             // For UTF-8 mode, we use positions as indices in map_restore_helper

--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -20,6 +20,7 @@
 #include "exprs/function_helper.h"
 #include "exprs/string_functions.h"
 #include "gutil/strings/fastmem.h"
+#include "runtime/runtime_state.h"
 
 namespace starrocks {
 static constexpr size_t MAX_STRING_SIZE = 1 << 15;

--- a/be/src/exprs/ngram.cpp
+++ b/be/src/exprs/ngram.cpp
@@ -14,11 +14,13 @@
 // This file is based on code available under the Apache license here:
 //  https://github.com/ClickHouse/ClickHouse/blob/master/src/Functions/FunctionsStringSimilarity.cpp
 
+#include "base/string/utf8.h"
 #include "column/column_hash.h"
 #include "exprs/function_context.h"
 #include "exprs/function_helper.h"
 #include "exprs/string_functions.h"
 #include "gutil/strings/fastmem.h"
+
 namespace starrocks {
 static constexpr size_t MAX_STRING_SIZE = 1 << 15;
 // uint16[2^16] can almost fit into L2
@@ -41,6 +43,9 @@ struct Ngramstate {
     size_t needle_gram_count = 0;
 
     float result = -1;
+
+    // Flag to indicate whether UTF-8 mode is enabled (set in prepare from template parameter)
+    bool use_utf8 = false;
 
     std::vector<NgramHash>* get_or_create_driver_hashmap() {
         std::thread::id current_thread_id = std::this_thread::get_id();
@@ -85,12 +90,15 @@ public:
             return Status::NotSupported("ngram function's second parameter is larger than 2^15");
         }
 
-        // needle is too small so we can not get even single Ngram, so they are not similar at all
-        if (needle.get_size() < (size_t)gram_num) {
+        auto state = reinterpret_cast<Ngramstate*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+
+        // needle_gram_count was computed in prepare after the case-insensitive
+        // and UTF-8-aware tolower; zero means the needle yields no full n-gram
+        // (e.g. too short, or empty after folding), so similarity is 0.
+        if (state->needle_gram_count == 0) {
             return ColumnHelper::create_const_column<TYPE_DOUBLE>(0, haystack_column->size());
         }
 
-        auto state = reinterpret_cast<Ngramstate*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
         std::vector<NgramHash>* map = state->get_or_create_driver_hashmap();
         if (haystack_column->is_constant()) {
             if (context->is_constant_column(0)) {
@@ -119,6 +127,7 @@ public:
         }
 
         auto* state = new Ngramstate(MAP_SIZE);
+        state->use_utf8 = use_utf_8;
 
         context->set_function_state(scope, state);
 
@@ -148,57 +157,154 @@ public:
     }
 
 private:
-    // for every gram of needle, we calculate its' hash value and store its' frequency in map, and return the number of gram in needle
-    size_t static calculateMapWithNeedle(std::vector<NgramHash>& map, const Slice& needle, size_t gram_num) {
-        size_t needle_length = needle.get_size();
-        NgramHash cur_hash;
-        size_t i;
-        Slice cur_needle(needle.get_data(), needle_length);
-        const char* cur_char_ptr;
-        std::string buf;
-        if constexpr (case_insensitive) {
-            tolower(needle, buf);
-            cur_needle = Slice(buf.c_str(), buf.size());
+    // Get UTF-8 character positions for a string
+    static void get_utf8_positions(const char* data, size_t len, std::vector<size_t>& positions) {
+        positions.clear();
+        for (size_t i = 0; i < len;) {
+            positions.push_back(i);
+            i += UTF8_BYTE_LENGTH_TABLE[static_cast<uint8_t>(data[i])];
         }
-        cur_char_ptr = cur_needle.get_data();
-
-        for (i = 0; i + gram_num <= needle_length; i++) {
-            cur_hash = getAsciiHash(cur_char_ptr + i, gram_num);
-            map[cur_hash]++;
-        }
-
-        return i;
     }
 
-    // Like calculateMapWithNeedle but also populates recover_info with each gram's hash (resized to gram count).
-    // Caller must guarantee needle.get_size() >= gram_num and that needle is already lowercased
-    // for case-insensitive variants (lowercasing is the caller's responsibility).
+    // UTF-8 aware tolower - uses shared implementation from base/string/utf8.h
+    static void tolower_utf8(const Slice& str, std::string& buf) {
+        if (validate_ascii_fast(str.get_data(), str.get_size())) {
+            Slice(str.get_data(), str.get_size()).tolower(buf);
+        } else {
+            utf8_tolower(str.get_data(), str.get_size(), buf);
+        }
+    }
+
+    // ASCII tolower into a caller-owned buffer, used by the non-constant-needle path in non-UTF-8 mode.
+    void inline static tolower(const Slice& str, std::string& buf) {
+        buf.assign(str.get_data(), str.get_size());
+        std::transform(buf.begin(), buf.end(), buf.begin(), [](unsigned char c) { return std::tolower(c); });
+    }
+
+    // for every gram of needle, we calculate its' hash value and store its' frequency in map, and return the number of gram in needle
+    size_t static calculateMapWithNeedle(std::vector<NgramHash>& map, const Slice& needle, size_t gram_num) {
+        Slice cur_needle(needle.get_data(), needle.get_size());
+        std::string buf;
+        if constexpr (case_insensitive) {
+            if constexpr (use_utf_8) {
+                tolower_utf8(needle, buf);
+            } else {
+                buf.assign(needle.get_data(), needle.get_size());
+                std::transform(buf.begin(), buf.end(), buf.begin(), [](unsigned char c) { return std::tolower(c); });
+            }
+            cur_needle = Slice(buf.c_str(), buf.size());
+        }
+
+        const char* data = cur_needle.get_data();
+        size_t len = cur_needle.get_size();
+
+        if constexpr (use_utf_8) {
+            // UTF-8 mode: iterate by characters
+            std::vector<size_t> positions;
+            get_utf8_positions(data, len, positions);
+
+            size_t num_chars = positions.size();
+            if (num_chars < gram_num) {
+                return 0;
+            }
+
+            size_t gram_count = 0;
+            for (size_t i = 0; i + gram_num <= num_chars; i++) {
+                size_t start = positions[i];
+                size_t end = (i + gram_num < num_chars) ? positions[i + gram_num] : len;
+                size_t ngram_bytes = end - start;
+
+                NgramHash cur_hash = crc_hash_32(data + start, ngram_bytes, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
+                map[cur_hash]++;
+                gram_count++;
+            }
+            return gram_count;
+        } else {
+            // ASCII mode: iterate by bytes (original behavior)
+            size_t i;
+            for (i = 0; i + gram_num <= len; i++) {
+                NgramHash cur_hash = crc_hash_32(data + i, gram_num, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
+                map[cur_hash]++;
+            }
+            return i;
+        }
+    }
+
+    // Like calculateMapWithNeedle but also populates recover_info with each gram's hash (resized to gram count),
+    // so the caller can restore or clear the needle's map entries when reusing the map across rows. The needle
+    // must already be lowercased for case-insensitive variants (lowercasing is the caller's responsibility).
+    // In UTF-8 mode grams span whole characters; a needle shorter than gram_num characters yields no gram
+    // (returns 0 and empties recover_info).
     size_t static calculateMapWithNeedleAndRecoverInfo(std::vector<NgramHash>& map, const Slice& needle,
                                                        size_t gram_num, std::vector<NgramHash>& recover_info) {
-        size_t needle_length = needle.get_size();
-        const char* cur_char_ptr = needle.get_data();
+        const char* data = needle.get_data();
+        size_t len = needle.get_size();
 
-        size_t gram_count = needle_length - gram_num + 1;
-        recover_info.resize(gram_count);
-        for (size_t i = 0; i < gram_count; i++) {
-            NgramHash h = getAsciiHash(cur_char_ptr + i, gram_num);
-            map[h]++;
-            recover_info[i] = h;
+        if constexpr (use_utf_8) {
+            // UTF-8 mode: iterate by characters
+            std::vector<size_t> positions;
+            get_utf8_positions(data, len, positions);
+
+            size_t num_chars = positions.size();
+            if (num_chars < gram_num) {
+                recover_info.resize(0);
+                return 0;
+            }
+
+            size_t gram_count = num_chars - gram_num + 1;
+            recover_info.resize(gram_count);
+            for (size_t i = 0; i < gram_count; i++) {
+                size_t start = positions[i];
+                size_t end = (i + gram_num < num_chars) ? positions[i + gram_num] : len;
+                NgramHash h = crc_hash_32(data + start, end - start, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
+                map[h]++;
+                recover_info[i] = h;
+            }
+            return gram_count;
+        } else {
+            // ASCII mode: iterate by bytes
+            size_t gram_count = len - gram_num + 1;
+            recover_info.resize(gram_count);
+            for (size_t i = 0; i < gram_count; i++) {
+                NgramHash h = crc_hash_32(data + i, gram_num, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
+                map[h]++;
+                recover_info[i] = h;
+            }
+            return gram_count;
         }
-        return gram_count;
     }
 
     // Distance calculation that leaves map modified (matched entries are decremented).
     // Caller must invoke recoverNeedleNgramMap or clearNeedleNgramMap before the next use of map.
+    // In UTF-8 mode haystack grams span whole characters, matching the needle grams built above.
     size_t static calculateDistanceWithHaystackWithoutRecoverMap(std::vector<NgramHash>& map, const Slice& haystack,
                                                                  size_t needle_gram_count, size_t gram_num) {
-        size_t haystack_length = haystack.get_size();
-        const char* ptr = haystack.get_data();
-        for (size_t i = 0; i + gram_num <= haystack_length; i++) {
-            NgramHash cur_hash = getAsciiHash(ptr + i, gram_num);
-            if (map[cur_hash] > 0) {
-                needle_gram_count--;
-                map[cur_hash]--;
+        const char* data = haystack.get_data();
+        size_t len = haystack.get_size();
+
+        if constexpr (use_utf_8) {
+            // UTF-8 mode: iterate by characters
+            std::vector<size_t> positions;
+            get_utf8_positions(data, len, positions);
+
+            size_t num_chars = positions.size();
+            for (size_t i = 0; i + gram_num <= num_chars; i++) {
+                size_t start = positions[i];
+                size_t end = (i + gram_num < num_chars) ? positions[i + gram_num] : len;
+                NgramHash cur_hash = crc_hash_32(data + start, end - start, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
+                if (map[cur_hash] > 0) {
+                    needle_gram_count--;
+                    map[cur_hash]--;
+                }
+            }
+        } else {
+            // ASCII mode: iterate by bytes
+            for (size_t i = 0; i + gram_num <= len; i++) {
+                NgramHash cur_hash = crc_hash_32(data + i, gram_num, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
+                if (map[cur_hash] > 0) {
+                    needle_gram_count--;
+                    map[cur_hash]--;
+                }
             }
         }
         return needle_gram_count;
@@ -275,9 +381,14 @@ private:
             Slice cur_haystack_slice = raw_haystack;
             std::string needle_lc_buf, haystack_lc_buf;
             if constexpr (case_insensitive) {
-                tolower(raw_needle, needle_lc_buf);
+                if constexpr (use_utf_8) {
+                    tolower_utf8(raw_needle, needle_lc_buf);
+                    tolower_utf8(raw_haystack, haystack_lc_buf);
+                } else {
+                    tolower(raw_needle, needle_lc_buf);
+                    tolower(raw_haystack, haystack_lc_buf);
+                }
                 cur_needle_slice = Slice(needle_lc_buf.c_str(), needle_lc_buf.size());
-                tolower(raw_haystack, haystack_lc_buf);
                 cur_haystack_slice = Slice(haystack_lc_buf.c_str(), haystack_lc_buf.size());
             }
 
@@ -341,8 +452,6 @@ private:
 
         NullColumnPtr res_null = nullptr;
         ColumnPtr haystackPtr = nullptr;
-        // used in case_insensitive
-        StatusOr<ColumnPtr> lower;
         if (haystack_column->is_nullable()) {
             auto haystack_nullable = ColumnHelper::as_column<NullableColumn>(haystack_column);
             res_null = NullColumn::static_pointer_cast(Column::mutate(haystack_nullable->null_column()));
@@ -350,8 +459,10 @@ private:
         } else {
             haystackPtr = haystack_column;
         }
-        if constexpr (case_insensitive) {
-            // @TODO if ngram supports utf8 in the future, we should use antoher implementation.
+
+        // For case-insensitive ASCII mode, use the fast StringCaseToggleFunction
+        // For UTF-8 mode, we handle case conversion per-string in calculateDistanceWithHaystack
+        if constexpr (case_insensitive && !use_utf_8) {
             haystackPtr = StringCaseToggleFunction<false>::evaluate<TYPE_VARCHAR, TYPE_VARCHAR>(haystackPtr);
         }
 
@@ -398,9 +509,11 @@ private:
 
         Slice cur_haystack(haystack.get_data(), haystack.get_size());
 
+        // UTF-8 lowering happens inside calculateDistanceWithHaystack; pre-converting here would lower twice.
         std::string buf;
-        if constexpr (case_insensitive) {
-            tolower(haystack, buf);
+        if constexpr (case_insensitive && !use_utf_8) {
+            buf.assign(haystack.get_data(), haystack.get_size());
+            std::transform(buf.begin(), buf.end(), buf.begin(), [](unsigned char c) { return std::tolower(c); });
             cur_haystack = Slice(buf.c_str(), buf.size());
         }
 
@@ -415,67 +528,117 @@ private:
         return result;
     }
 
-    // traverse haystack‘s every gram, find whether this gram is in needle or not using gram's hash
+    // traverse haystack's every gram, find whether this gram is in needle or not using gram's hash
     // 16bit hash value may cause hash collision, but because we just calculate the similarity of two string
     // so don't need to be so accurate.
     template <bool need_recovery_map>
     size_t static calculateDistanceWithHaystack(std::vector<NgramHash>& map, const Slice& haystack,
                                                 [[maybe_unused]] std::vector<NgramHash>& map_restore_helper,
                                                 size_t needle_gram_count, size_t gram_num) {
-        size_t haystack_length = haystack.get_size();
-        NgramHash cur_hash;
-        size_t i;
-        const char* ptr = haystack.get_data();
-
-        for (i = 0; i + gram_num <= haystack_length; i++) {
-            cur_hash = getAsciiHash(ptr + i, gram_num);
-            // if this gram is in needle
-            if (map[cur_hash] > 0) {
-                needle_gram_count--;
-                map[cur_hash]--;
-                if constexpr (need_recovery_map) {
-                    map_restore_helper[i] = cur_hash;
-                }
-            }
+        // For UTF-8 case-insensitive mode in vector processing, we need to convert here
+        std::string lower_buf;
+        Slice cur_haystack = haystack;
+        if constexpr (case_insensitive && use_utf_8) {
+            tolower_utf8(haystack, lower_buf);
+            cur_haystack = Slice(lower_buf.c_str(), lower_buf.size());
         }
 
-        if constexpr (need_recovery_map) {
-            for (int j = 0; j < i; j++) {
-                if (map_restore_helper[j]) {
-                    map[map_restore_helper[j]]++;
-                    // reset map_restore_helper
-                    map_restore_helper[j] = 0;
+        const char* data = cur_haystack.get_data();
+        size_t len = cur_haystack.get_size();
+
+        if constexpr (use_utf_8) {
+            // UTF-8 mode: iterate by characters
+            std::vector<size_t> positions;
+            get_utf8_positions(data, len, positions);
+
+            size_t num_chars = positions.size();
+            if (num_chars < gram_num) {
+                return needle_gram_count;
+            }
+
+            // For UTF-8 mode, we use positions as indices in map_restore_helper
+            size_t gram_idx = 0;
+            for (size_t i = 0; i + gram_num <= num_chars; i++, gram_idx++) {
+                size_t start = positions[i];
+                size_t end = (i + gram_num < num_chars) ? positions[i + gram_num] : len;
+                size_t ngram_bytes = end - start;
+
+                NgramHash cur_hash = crc_hash_32(data + start, ngram_bytes, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
+
+                if (map[cur_hash] > 0) {
+                    needle_gram_count--;
+                    map[cur_hash]--;
+                    if constexpr (need_recovery_map) {
+                        map_restore_helper[gram_idx] = cur_hash;
+                    }
+                }
+            }
+
+            if constexpr (need_recovery_map) {
+                for (size_t j = 0; j < gram_idx; j++) {
+                    if (map_restore_helper[j]) {
+                        map[map_restore_helper[j]]++;
+                        map_restore_helper[j] = 0;
+                    }
+                }
+            }
+        } else {
+            // ASCII mode: iterate by bytes (original behavior)
+            size_t i;
+            for (i = 0; i + gram_num <= len; i++) {
+                NgramHash cur_hash = crc_hash_32(data + i, gram_num, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
+                if (map[cur_hash] > 0) {
+                    needle_gram_count--;
+                    map[cur_hash]--;
+                    if constexpr (need_recovery_map) {
+                        map_restore_helper[i] = cur_hash;
+                    }
+                }
+            }
+
+            if constexpr (need_recovery_map) {
+                for (size_t j = 0; j < i; j++) {
+                    if (map_restore_helper[j]) {
+                        map[map_restore_helper[j]]++;
+                        map_restore_helper[j] = 0;
+                    }
                 }
             }
         }
 
         return needle_gram_count;
     }
-
-    void inline static tolower(const Slice& str, std::string& buf) {
-        buf.assign(str.get_data(), str.get_size());
-        std::transform(buf.begin(), buf.end(), buf.begin(), [](unsigned char c) { return std::tolower(c); });
-    }
-
-    static NgramHash getAsciiHash(const Gram* ch, size_t gram_num) {
-        return crc_hash_32(ch, gram_num, CRC_HASH_SEEDS::CRC_HASH_SEED1) & (0xffffu);
-    }
 };
 
+// Wrapper functions that check the UTF-8 flag at runtime and dispatch to the correct implementation
 StatusOr<ColumnPtr> StringFunctions::ngram_search(FunctionContext* context, const Columns& columns) {
+    auto state = reinterpret_cast<Ngramstate*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+    if (state && state->use_utf8) {
+        return NgramFunctionImpl<false, true, char>::ngram_search_impl(context, columns);
+    }
     return NgramFunctionImpl<false, false, char>::ngram_search_impl(context, columns);
 }
 
 StatusOr<ColumnPtr> StringFunctions::ngram_search_case_insensitive(FunctionContext* context, const Columns& columns) {
+    auto state = reinterpret_cast<Ngramstate*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+    if (state && state->use_utf8) {
+        return NgramFunctionImpl<true, true, char>::ngram_search_impl(context, columns);
+    }
     return NgramFunctionImpl<true, false, char>::ngram_search_impl(context, columns);
 }
 
 Status StringFunctions::ngram_search_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+    if (context->state() && context->state()->ngram_search_support_utf8()) {
+        return NgramFunctionImpl<false, true, char>::ngram_search_prepare_impl(context, scope);
+    }
     return NgramFunctionImpl<false, false, char>::ngram_search_prepare_impl(context, scope);
 }
 
 Status StringFunctions::ngram_search_case_insensitive_prepare(FunctionContext* context,
                                                               FunctionContext::FunctionStateScope scope) {
+    if (context->state() && context->state()->ngram_search_support_utf8()) {
+        return NgramFunctionImpl<true, true, char>::ngram_search_prepare_impl(context, scope);
+    }
     return NgramFunctionImpl<true, false, char>::ngram_search_prepare_impl(context, scope);
 }
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -642,6 +642,10 @@ public:
         return _query_options.__isset.lower_upper_support_utf8 && _query_options.lower_upper_support_utf8;
     }
 
+    bool ngram_search_support_utf8() const {
+        return _query_options.__isset.ngram_search_support_utf8 && _query_options.ngram_search_support_utf8;
+    }
+
     bool enable_global_late_materialization() const {
         return _query_options.__isset.enable_global_late_materialization &&
                _query_options.enable_global_late_materialization;

--- a/be/src/storage/rowset/bloom_filter_index_writer.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_writer.cpp
@@ -217,6 +217,9 @@ public:
         for (int i = 0; i < count; ++i) {
             std::vector<size_t> index;
             size_t slice_gram_num = get_utf8_index(*cur_slice, &index);
+            // slice_gram_num can be used to judge if the cur_slice is an ASCII string or not.
+            // If slice_gram_num == cur_slice->get_size(), then it is.
+            bool is_ascii = (slice_gram_num == cur_slice->get_size());
 
             size_t j;
             for (j = 0; j + gram_num <= slice_gram_num; j++) {
@@ -230,9 +233,14 @@ public:
                     if (this->_bf_options.case_sensitive) {
                         _values.insert(get_value<field_type>(&cur_ngram, this->_typeinfo, &this->_type_info_allocator));
                     } else {
-                        // todo::exist two copy of ngram, need to optimize
                         std::string lower_ngram;
-                        Slice lower_ngram_slice = cur_ngram.tolower(lower_ngram);
+                        Slice lower_ngram_slice;
+                        if (is_ascii) {
+                            lower_ngram_slice = cur_ngram.tolower(lower_ngram);
+                        } else {
+                            utf8_tolower(cur_ngram.get_data(), cur_ngram.get_size(), lower_ngram);
+                            lower_ngram_slice = Slice(lower_ngram.data(), lower_ngram.size());
+                        }
                         _values.insert(get_value<field_type>(&lower_ngram_slice, this->_typeinfo,
                                                              &this->_type_info_allocator));
                     }

--- a/be/src/storage/rowset/bloom_filter_index_writer.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_writer.cpp
@@ -215,35 +215,33 @@ public:
         size_t gram_num = this->_bf_options.gram_num;
         const auto* cur_slice = reinterpret_cast<const Slice*>(values);
         for (int i = 0; i < count; ++i) {
-            std::vector<size_t> index;
-            size_t slice_gram_num = get_utf8_index(*cur_slice, &index);
-            // slice_gram_num can be used to judge if the cur_slice is an ASCII string or not.
-            // If slice_gram_num == cur_slice->get_size(), then it is.
-            bool is_ascii = (slice_gram_num == cur_slice->get_size());
+            // For a case-insensitive index, lowercase the whole value once and build ngrams from the
+            // folded copy. The reader lowercases the whole needle before splitting it, so the writer
+            // must split in the same order: folding each ngram after slicing would disagree with the
+            // reader for context-dependent or length-changing case mappings (e.g. Turkish 'İ').
+            Slice value = *cur_slice;
+            std::string lower_buf;
+            if (!this->_bf_options.case_sensitive) {
+                if (validate_ascii_fast(value.get_data(), value.get_size())) {
+                    value.tolower(lower_buf);
+                } else {
+                    utf8_tolower(value.get_data(), value.get_size(), lower_buf);
+                }
+                value = Slice(lower_buf.data(), lower_buf.size());
+            }
 
-            size_t j;
-            for (j = 0; j + gram_num <= slice_gram_num; j++) {
+            std::vector<size_t> index;
+            size_t slice_gram_num = get_utf8_index(value, &index);
+
+            for (size_t j = 0; j + gram_num <= slice_gram_num; j++) {
                 // find next ngram
-                size_t cur_ngram_length = j + gram_num < slice_gram_num ? index[j + gram_num] - index[j]
-                                                                        : cur_slice->get_size() - index[j];
-                Slice cur_ngram = Slice(cur_slice->data + index[j], cur_ngram_length);
+                size_t cur_ngram_length =
+                        j + gram_num < slice_gram_num ? index[j + gram_num] - index[j] : value.get_size() - index[j];
+                Slice cur_ngram = Slice(value.get_data() + index[j], cur_ngram_length);
 
                 // add this ngram into set
                 if (_values.find(unaligned_load<CppType>(&cur_ngram)) == _values.end()) {
-                    if (this->_bf_options.case_sensitive) {
-                        _values.insert(get_value<field_type>(&cur_ngram, this->_typeinfo, &this->_type_info_allocator));
-                    } else {
-                        std::string lower_ngram;
-                        Slice lower_ngram_slice;
-                        if (is_ascii) {
-                            lower_ngram_slice = cur_ngram.tolower(lower_ngram);
-                        } else {
-                            utf8_tolower(cur_ngram.get_data(), cur_ngram.get_size(), lower_ngram);
-                            lower_ngram_slice = Slice(lower_ngram.data(), lower_ngram.size());
-                        }
-                        _values.insert(get_value<field_type>(&lower_ngram_slice, this->_typeinfo,
-                                                             &this->_type_info_allocator));
-                    }
+                    _values.insert(get_value<field_type>(&cur_ngram, this->_typeinfo, &this->_type_info_allocator));
                 }
             }
             // move to next row

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -162,6 +162,7 @@ set(EXEC_FILES
         ./exprs/encryption_functions_test.cpp
         ./exprs/function_call_expr_test.cpp
         ./exprs/geography_functions_test.cpp
+        ./exprs/ngram_search_test.cpp
         ./exprs/if_expr_test.cpp
         ./exprs/flat_json_functions_test.cpp
         ./exprs/lambda_array_expr_test.cpp

--- a/be/test/exprs/function_call_expr_test.cpp
+++ b/be/test/exprs/function_call_expr_test.cpp
@@ -21,8 +21,10 @@
 
 #include "base/testutil/assert.h"
 #include "butil/time.h"
+#include "column/binary_column.h"
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
+#include "common/bloom_filter.h"
 #include "exprs/cast_expr.h"
 #include "exprs/expr_context.h"
 #include "exprs/expr_executor.h"
@@ -307,6 +309,152 @@ TEST_F(VectorizedFunctionCallExprTest, prepare_close) {
     st = expr_context.open(&_runtime_state);
     ASSERT_TRUE(st.ok());
     expr_context.close(&_runtime_state);
+}
+
+// ---------------------------------------------------------------------------
+// ngram_bloom_filter pushdown helper: validates needle, lowers it via the
+// ICU/ASCII path matching the writer, and probes the bloom filter. These
+// tests cover the index-side reader path for ngram_bf with UTF-8 needles.
+// ---------------------------------------------------------------------------
+
+class NgramBloomFilterPushdownTest : public ::testing::Test {
+protected:
+    static TExprNode make_typed_node(TPrimitiveType::type t) {
+        TExprNode n;
+        n.node_type = TExprNodeType::SLOT_REF;
+        n.num_children = 0;
+        n.type = gen_type_desc(t);
+        return n;
+    }
+
+    TExprNode build_ngram_call_node() {
+        TFunction function;
+        TFunctionName functionName;
+        functionName.__set_function_name("ngram_search_case_insensitive");
+        function.__set_name(functionName);
+        function.__set_binary_type(TFunctionBinaryType::BUILTIN);
+        function.__set_fid(30441);
+        function.__set_has_var_args(false);
+        std::vector<TTypeDesc> arg_types = {
+                gen_type_desc(TPrimitiveType::VARCHAR),
+                gen_type_desc(TPrimitiveType::VARCHAR),
+                gen_type_desc(TPrimitiveType::INT),
+        };
+        function.__set_arg_types(arg_types);
+        function.__set_ret_type(gen_type_desc(TPrimitiveType::DOUBLE));
+
+        TExprNode parent;
+        parent.node_type = TExprNodeType::FUNCTION_CALL;
+        parent.num_children = 3;
+        parent.type = gen_type_desc(TPrimitiveType::DOUBLE);
+        parent.__set_fn(function);
+        return parent;
+    }
+
+    std::unique_ptr<BloomFilter> make_bf_with_cyrillic_lowered_trigrams() {
+        std::unique_ptr<BloomFilter> bf;
+        EXPECT_OK(BloomFilter::create(BLOCK_BLOOM_FILTER, &bf));
+        EXPECT_OK(bf->init(16, 0.05, HashStrategyPB::HASH_MURMUR3_X64_64));
+        // Lowercase Cyrillic character trigrams of "привет" (each char is 2 bytes).
+        bf->add_bytes("при", 6);
+        bf->add_bytes("рив", 6);
+        bf->add_bytes("иве", 6);
+        bf->add_bytes("вет", 6);
+        return bf;
+    }
+
+    RuntimeState _runtime_state;
+};
+
+TEST_F(NgramBloomFilterPushdownTest, MatchUtf8CaseInsensitiveLowersNeedle) {
+    TExprNode varchar_node = make_typed_node(TPrimitiveType::VARCHAR);
+    TExprNode int_node = make_typed_node(TPrimitiveType::INT);
+    TExprNode parent_node = build_ngram_call_node();
+
+    VectorizedFunctionCallExpr expr(parent_node);
+    MockColumnExpr haystack(varchar_node, BinaryColumn::create());
+    MockConstVectorizedExpr<TYPE_VARCHAR> needle(varchar_node, "ПРИВЕТ");
+    MockConstVectorizedExpr<TYPE_INT> gram_num(int_node, 3);
+    expr.add_child(&haystack);
+    expr.add_child(&needle);
+    expr.add_child(&gram_num);
+
+    ExprContext exprContext(&expr);
+    std::vector<ExprContext*> expr_ctxs = {&exprContext};
+    ASSERT_OK(ExprExecutor::prepare(expr_ctxs, &_runtime_state));
+    ASSERT_OK(ExprExecutor::open(expr_ctxs, &_runtime_state));
+
+    auto bf = make_bf_with_cyrillic_lowered_trigrams();
+    NgramBloomFilterReaderOptions opts;
+    opts.index_gram_num = 3;
+    opts.index_case_sensitive = false;
+
+    // Needle "ПРИВЕТ" lowered via utf8_tolower to "привет"; all 4 trigrams hit
+    // the bloom filter, so the helper must report the page as a candidate.
+    EXPECT_TRUE(expr.ngram_bloom_filter(&exprContext, bf.get(), opts));
+
+    ExprExecutor::close(expr_ctxs, &_runtime_state);
+}
+
+TEST_F(NgramBloomFilterPushdownTest, MissUtf8CaseInsensitiveFiltersPage) {
+    TExprNode varchar_node = make_typed_node(TPrimitiveType::VARCHAR);
+    TExprNode int_node = make_typed_node(TPrimitiveType::INT);
+    TExprNode parent_node = build_ngram_call_node();
+
+    VectorizedFunctionCallExpr expr(parent_node);
+    MockColumnExpr haystack(varchar_node, BinaryColumn::create());
+    MockConstVectorizedExpr<TYPE_VARCHAR> needle(varchar_node, "ПОКА");
+    MockConstVectorizedExpr<TYPE_INT> gram_num(int_node, 3);
+    expr.add_child(&haystack);
+    expr.add_child(&needle);
+    expr.add_child(&gram_num);
+
+    ExprContext exprContext(&expr);
+    std::vector<ExprContext*> expr_ctxs = {&exprContext};
+    ASSERT_OK(ExprExecutor::prepare(expr_ctxs, &_runtime_state));
+    ASSERT_OK(ExprExecutor::open(expr_ctxs, &_runtime_state));
+
+    auto bf = make_bf_with_cyrillic_lowered_trigrams();
+    NgramBloomFilterReaderOptions opts;
+    opts.index_gram_num = 3;
+    opts.index_case_sensitive = false;
+
+    // Needle "ПОКА" lowered to "пока" produces trigrams "пок", "ока" — neither
+    // present in the bloom filter that was populated for "привет".
+    EXPECT_FALSE(expr.ngram_bloom_filter(&exprContext, bf.get(), opts));
+
+    ExprExecutor::close(expr_ctxs, &_runtime_state);
+}
+
+TEST_F(NgramBloomFilterPushdownTest, InvalidUtf8NeedleDisablesIndex) {
+    TExprNode varchar_node = make_typed_node(TPrimitiveType::VARCHAR);
+    TExprNode int_node = make_typed_node(TPrimitiveType::INT);
+    TExprNode parent_node = build_ngram_call_node();
+
+    VectorizedFunctionCallExpr expr(parent_node);
+    MockColumnExpr haystack(varchar_node, BinaryColumn::create());
+    // 0xC0 0xC1 are illegal lead bytes in UTF-8.
+    MockConstVectorizedExpr<TYPE_VARCHAR> needle(varchar_node, std::string("\xC0\xC1\xFE", 3));
+    MockConstVectorizedExpr<TYPE_INT> gram_num(int_node, 3);
+    expr.add_child(&haystack);
+    expr.add_child(&needle);
+    expr.add_child(&gram_num);
+
+    ExprContext exprContext(&expr);
+    std::vector<ExprContext*> expr_ctxs = {&exprContext};
+    ASSERT_OK(ExprExecutor::prepare(expr_ctxs, &_runtime_state));
+    ASSERT_OK(ExprExecutor::open(expr_ctxs, &_runtime_state));
+
+    auto bf = make_bf_with_cyrillic_lowered_trigrams();
+    NgramBloomFilterReaderOptions opts;
+    opts.index_gram_num = 3;
+    opts.index_case_sensitive = false;
+
+    // Invalid UTF-8 needle: helper short-circuits with index_useful=false and
+    // returns true so the page is not filtered out by the bloom filter.
+    EXPECT_TRUE(expr.ngram_bloom_filter(&exprContext, bf.get(), opts));
+
+    ExprExecutor::close(expr_ctxs, &_runtime_state);
 }
 
 } // namespace starrocks

--- a/be/test/exprs/ngram_search_test.cpp
+++ b/be/test/exprs/ngram_search_test.cpp
@@ -1,0 +1,210 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "base/testutil/assert.h"
+#include "column/column_helper.h"
+#include "exprs/function_context.h"
+#include "exprs/string_functions.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+
+class NgramSearchTest : public ::testing::Test {
+protected:
+    std::unique_ptr<FunctionContext> make_ctx(bool utf8_enabled, std::unique_ptr<RuntimeState>* state_out) {
+        TQueryOptions query_options;
+        query_options.__set_ngram_search_support_utf8(utf8_enabled);
+        TQueryGlobals query_globals;
+        *state_out = std::make_unique<RuntimeState>(TUniqueId(), query_options, query_globals, nullptr);
+        std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+        ctx->set_runtime_state(state_out->get());
+        return ctx;
+    }
+
+    static Columns build_columns(const std::string& haystack, const std::string& needle, int gram_num) {
+        return {ColumnHelper::create_const_column<TYPE_VARCHAR>(haystack, 1),
+                ColumnHelper::create_const_column<TYPE_VARCHAR>(needle, 1),
+                ColumnHelper::create_const_column<TYPE_INT>(gram_num, 1)};
+    }
+
+    enum Mode { CASE_SENSITIVE, CASE_INSENSITIVE };
+
+    static double eval(FunctionContext* ctx, const Columns& columns, Mode mode) {
+        ctx->set_constant_columns(columns);
+        ColumnPtr result;
+        if (mode == CASE_INSENSITIVE) {
+            EXPECT_OK(StringFunctions::ngram_search_case_insensitive_prepare(ctx, FunctionContext::FRAGMENT_LOCAL));
+            auto r = StringFunctions::ngram_search_case_insensitive(ctx, columns);
+            EXPECT_TRUE(r.ok());
+            result = r.value();
+        } else {
+            EXPECT_OK(StringFunctions::ngram_search_prepare(ctx, FunctionContext::FRAGMENT_LOCAL));
+            auto r = StringFunctions::ngram_search(ctx, columns);
+            EXPECT_TRUE(r.ok());
+            result = r.value();
+        }
+        double v = ColumnHelper::get_const_value<TYPE_DOUBLE>(result);
+        EXPECT_OK(StringFunctions::ngram_search_close(ctx, FunctionContext::FRAGMENT_LOCAL));
+        return v;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Matrix invariant: ASCII input must yield the same result regardless of the
+// ngram_search_support_utf8 toggle. The UTF-8 mode only adds new behavior for
+// non-ASCII input; pure ASCII paths must remain bit-identical.
+// ---------------------------------------------------------------------------
+
+TEST_F(NgramSearchTest, AsciiSensitive_ToggleInvariant) {
+    auto columns_on = build_columns("hello world", "hello", 3);
+    auto columns_off = build_columns("hello world", "hello", 3);
+
+    std::unique_ptr<RuntimeState> s_on;
+    std::unique_ptr<RuntimeState> s_off;
+    auto ctx_on = make_ctx(true, &s_on);
+    auto ctx_off = make_ctx(false, &s_off);
+
+    double v_on = eval(ctx_on.get(), columns_on, CASE_SENSITIVE);
+    double v_off = eval(ctx_off.get(), columns_off, CASE_SENSITIVE);
+    EXPECT_DOUBLE_EQ(v_on, v_off);
+    EXPECT_NEAR(v_on, 1.0, 0.05) << "Substring 'hello' fully covered by 'hello world' ngrams";
+}
+
+TEST_F(NgramSearchTest, AsciiInsensitive_ToggleInvariant) {
+    auto columns_on = build_columns("HELLO WORLD", "hello", 3);
+    auto columns_off = build_columns("HELLO WORLD", "hello", 3);
+
+    std::unique_ptr<RuntimeState> s_on;
+    std::unique_ptr<RuntimeState> s_off;
+    auto ctx_on = make_ctx(true, &s_on);
+    auto ctx_off = make_ctx(false, &s_off);
+
+    double v_on = eval(ctx_on.get(), columns_on, CASE_INSENSITIVE);
+    double v_off = eval(ctx_off.get(), columns_off, CASE_INSENSITIVE);
+    EXPECT_DOUBLE_EQ(v_on, v_off);
+    EXPECT_NEAR(v_on, 1.0, 0.05) << "ASCII case-insensitive match regardless of mode";
+}
+
+// ---------------------------------------------------------------------------
+// utf8=ON: the new behavior. Non-ASCII characters are treated as units,
+// ICU-based lowering produces matching ngrams across case-different strings.
+// ---------------------------------------------------------------------------
+
+TEST_F(NgramSearchTest, Utf8On_CyrillicInsensitive_Match) {
+    std::unique_ptr<RuntimeState> state;
+    auto ctx = make_ctx(true, &state);
+    auto columns = build_columns("ПРИВЕТ", "привет", 3);
+
+    double v = eval(ctx.get(), columns, CASE_INSENSITIVE);
+    EXPECT_NEAR(v, 1.0, 0.05) << "ICU lowering aligns Cyrillic case variants";
+}
+
+TEST_F(NgramSearchTest, Utf8On_CyrillicSensitive_SubstringMatch) {
+    std::unique_ptr<RuntimeState> state;
+    auto ctx = make_ctx(true, &state);
+    auto columns = build_columns("Привет мир", "мир", 3);
+
+    double v = eval(ctx.get(), columns, CASE_SENSITIVE);
+    EXPECT_GT(v, 0.5) << "UTF-8 ngrams find needle as a character substring";
+}
+
+TEST_F(NgramSearchTest, Utf8On_GermanSharpS_Insensitive) {
+    // ICU lowering folds U+1E9E (ẞ) and "SS" toward "ß"/"ss" in a way the byte
+    // path cannot. Compare uppercase vs lowercase variants of "Straße".
+    std::unique_ptr<RuntimeState> state;
+    auto ctx = make_ctx(true, &state);
+    auto columns = build_columns("STRASSE", "strasse", 3);
+
+    double v = eval(ctx.get(), columns, CASE_INSENSITIVE);
+    EXPECT_NEAR(v, 1.0, 0.05);
+}
+
+TEST_F(NgramSearchTest, Utf8On_TurkishCapitalI_ExpandingLowercase_Insensitive) {
+    // Regression: ICU lowers U+0130 ("İ", 1 codepoint) into "i" + U+0307 combining
+    // dot (2 codepoints). A pre-lower length check would see 1 < gram_num=2 and
+    // wrongly return 0; needle_gram_count from prepare is computed post-lower
+    // and yields the valid 2-gram, so the match must be found.
+    std::unique_ptr<RuntimeState> state;
+    auto ctx = make_ctx(true, &state);
+    auto columns = build_columns("i\xCC\x87stanbul", "\xC4\xB0", 2);
+
+    double v = eval(ctx.get(), columns, CASE_INSENSITIVE);
+    EXPECT_NEAR(v, 1.0, 0.05) << "Expanding ICU lowercase must not be cut off by pre-lower length guard";
+}
+
+// ---------------------------------------------------------------------------
+// utf8=OFF: the legacy byte-oriented behavior. We pin it here as a regression
+// guard - it stays broken for case-insensitive Cyrillic, intentionally, so the
+// feature must be opted into. ASCII keeps working.
+// ---------------------------------------------------------------------------
+
+TEST_F(NgramSearchTest, Utf8Off_CyrillicInsensitive_LegacyBroken) {
+    std::unique_ptr<RuntimeState> state;
+    auto ctx = make_ctx(false, &state);
+    auto columns = build_columns("ПРИВЕТ", "привет", 3);
+
+    double v = eval(ctx.get(), columns, CASE_INSENSITIVE);
+    // Byte-wise std::tolower leaves Cyrillic bytes unchanged, so uppercase and
+    // lowercase Cyrillic produce disjoint byte-ngrams and similarity is ~0.
+    EXPECT_LT(v, 0.5) << "Legacy ASCII tolower cannot fold Cyrillic case";
+}
+
+TEST_F(NgramSearchTest, Utf8Off_AsciiSensitive_StillWorks) {
+    std::unique_ptr<RuntimeState> state;
+    auto ctx = make_ctx(false, &state);
+    auto columns = build_columns("hello world", "hello", 3);
+
+    double v = eval(ctx.get(), columns, CASE_SENSITIVE);
+    EXPECT_NEAR(v, 1.0, 0.05);
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases: empty / oversized needle, non-const haystack vector path.
+// ---------------------------------------------------------------------------
+
+TEST_F(NgramSearchTest, Utf8On_EmptyNeedle_Zero) {
+    std::unique_ptr<RuntimeState> state;
+    auto ctx = make_ctx(true, &state);
+    auto columns = build_columns("Привет", "", 3);
+
+    double v = eval(ctx.get(), columns, CASE_SENSITIVE);
+    EXPECT_DOUBLE_EQ(v, 0.0);
+}
+
+TEST_F(NgramSearchTest, Utf8On_HaystackVector_CyrillicInsensitive) {
+    std::unique_ptr<RuntimeState> state;
+    auto ctx = make_ctx(true, &state);
+
+    auto haystack_col = BinaryColumn::create();
+    haystack_col->append("ПРИВЕТ");
+    haystack_col->append("МИР");
+    haystack_col->append("hello");
+    Columns columns{haystack_col, ColumnHelper::create_const_column<TYPE_VARCHAR>("привет", 3),
+                    ColumnHelper::create_const_column<TYPE_INT>(3, 3)};
+    ctx->set_constant_columns(columns);
+
+    ASSERT_OK(StringFunctions::ngram_search_case_insensitive_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL));
+    auto result = StringFunctions::ngram_search_case_insensitive(ctx.get(), columns);
+    ASSERT_TRUE(result.ok());
+    auto v = ColumnHelper::cast_to<TYPE_DOUBLE>(result.value());
+    EXPECT_NEAR(v->get_data()[0], 1.0, 0.05) << "ПРИВЕТ matches привет";
+    EXPECT_LT(v->get_data()[1], 0.5) << "МИР does not match привет";
+    EXPECT_LT(v->get_data()[2], 0.5) << "hello does not match привет";
+    ASSERT_OK(StringFunctions::ngram_search_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL));
+}
+
+} // namespace starrocks

--- a/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
+++ b/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
@@ -457,4 +457,54 @@ TEST_F(BloomFilterIndexReaderWriterTest, test_ngram_utf8_case_sensitive_preserve
     delete reader;
 }
 
+// The reader lowercases the whole needle before splitting it into ngrams, so the writer must do the
+// same: fold the whole value first, then split. For a length-changing case mapping the two orders
+// diverge -- U+0130 (LATIN CAPITAL LETTER I WITH DOT ABOVE) lowercases to 'i' + U+0307 (combining
+// dot above) in the root locale, turning one source character into two. Splitting "Aİ" before
+// folding yields a single 2-char gram that folds to a 4-byte ngram, while the reader, folding
+// first, sees three characters ('a','i',U+0307) and probes the 2-char grams "ai" and "i"+U+0307.
+// Per-ngram folding would never store those, so the index would drop matching pages.
+TEST_F(BloomFilterIndexReaderWriterTest, test_ngram_utf8_case_insensitive_length_changing_fold) {
+    BloomFilterOptions bf_options;
+    bf_options.use_ngram = true;
+    bf_options.gram_num = 2;
+    bf_options.case_sensitive = false;
+
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    const std::string file_name = "bloom_filter_ngram_utf8_fold_order";
+    const std::string fname = kTestDir + "/" + file_name;
+    ColumnIndexMetaPB meta;
+
+    std::string s1 = "Aİ";
+    Slice slices[] = {Slice(s1)};
+
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(fname));
+        std::unique_ptr<BloomFilterIndexWriter> writer;
+        ASSERT_OK(BloomFilterIndexWriter::create(bf_options, type_info, &writer));
+        writer->add_values(slices, 1);
+        ASSERT_OK(writer->flush());
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    std::unique_ptr<RandomAccessFile> rfile;
+    BloomFilterIndexReader* reader = nullptr;
+    std::unique_ptr<BloomFilterIndexIterator> iter;
+    get_bloom_filter_reader_iter(file_name, meta, &rfile, &reader, &iter);
+
+    std::unique_ptr<BloomFilter> bf;
+    ASSERT_OK(iter->read_bloom_filter(0, &bf));
+
+    // utf8_tolower("Aİ") == 'a' 'i' U+0307 (bytes 61 69 cc 87, three characters). These are the
+    // 2-char ngrams the reader probes; the writer must store exactly them.
+    EXPECT_TRUE(bf->test_bytes("\x61\x69", 2));     // "ai"
+    EXPECT_TRUE(bf->test_bytes("\x69\xcc\x87", 3)); // "i" + U+0307
+    // The pre-fix per-ngram path stored the whole gram folded into one 4-byte ngram; fold-before
+    // -split no longer produces it.
+    EXPECT_FALSE(bf->test_bytes("\x61\x69\xcc\x87", 4));
+
+    delete reader;
+}
+
 } // namespace starrocks

--- a/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
+++ b/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
@@ -325,4 +325,136 @@ TEST_F(BloomFilterIndexReaderWriterTest, test_decimal) {
     delete[] val;
 }
 
+// ---------------------------------------------------------------------------
+// Ngram bloom filter index writer with UTF-8 input under case_insensitive
+// indexing must store ICU-lowered ngrams. The byte-wise tolower path used in
+// the ascii branch must remain bit-identical for pure ASCII rows.
+// ---------------------------------------------------------------------------
+
+TEST_F(BloomFilterIndexReaderWriterTest, test_ngram_utf8_case_insensitive) {
+    BloomFilterOptions bf_options;
+    bf_options.use_ngram = true;
+    bf_options.gram_num = 3;
+    bf_options.case_sensitive = false;
+
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    const std::string file_name = "bloom_filter_ngram_utf8";
+    const std::string fname = kTestDir + "/" + file_name;
+    ColumnIndexMetaPB meta;
+
+    std::string s1 = "ПРИВЕТ";
+    Slice slices[] = {Slice(s1)};
+
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(fname));
+        std::unique_ptr<BloomFilterIndexWriter> writer;
+        ASSERT_OK(BloomFilterIndexWriter::create(bf_options, type_info, &writer));
+        writer->add_values(slices, 1);
+        ASSERT_OK(writer->flush());
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    std::unique_ptr<RandomAccessFile> rfile;
+    BloomFilterIndexReader* reader = nullptr;
+    std::unique_ptr<BloomFilterIndexIterator> iter;
+    get_bloom_filter_reader_iter(file_name, meta, &rfile, &reader, &iter);
+
+    std::unique_ptr<BloomFilter> bf;
+    ASSERT_OK(iter->read_bloom_filter(0, &bf));
+
+    // "ПРИВЕТ" -> ICU lowered "привет" -> character trigrams
+    EXPECT_TRUE(bf->test_bytes("при", 6));
+    EXPECT_TRUE(bf->test_bytes("рив", 6));
+    EXPECT_TRUE(bf->test_bytes("иве", 6));
+    EXPECT_TRUE(bf->test_bytes("вет", 6));
+    // uppercase Cyrillic trigrams must not appear: lowering happens in the writer
+    EXPECT_FALSE(bf->test_bytes("ПРИ", 6));
+    EXPECT_FALSE(bf->test_bytes("РИВ", 6));
+
+    delete reader;
+}
+
+TEST_F(BloomFilterIndexReaderWriterTest, test_ngram_ascii_case_insensitive) {
+    BloomFilterOptions bf_options;
+    bf_options.use_ngram = true;
+    bf_options.gram_num = 3;
+    bf_options.case_sensitive = false;
+
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    const std::string file_name = "bloom_filter_ngram_ascii";
+    const std::string fname = kTestDir + "/" + file_name;
+    ColumnIndexMetaPB meta;
+
+    std::string s1 = "HELLO";
+    Slice slices[] = {Slice(s1)};
+
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(fname));
+        std::unique_ptr<BloomFilterIndexWriter> writer;
+        ASSERT_OK(BloomFilterIndexWriter::create(bf_options, type_info, &writer));
+        writer->add_values(slices, 1);
+        ASSERT_OK(writer->flush());
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    std::unique_ptr<RandomAccessFile> rfile;
+    BloomFilterIndexReader* reader = nullptr;
+    std::unique_ptr<BloomFilterIndexIterator> iter;
+    get_bloom_filter_reader_iter(file_name, meta, &rfile, &reader, &iter);
+
+    std::unique_ptr<BloomFilter> bf;
+    ASSERT_OK(iter->read_bloom_filter(0, &bf));
+
+    // ASCII fast-path: Slice::tolower turns "HELLO" into "hello"; trigrams are 3 bytes each.
+    EXPECT_TRUE(bf->test_bytes("hel", 3));
+    EXPECT_TRUE(bf->test_bytes("ell", 3));
+    EXPECT_TRUE(bf->test_bytes("llo", 3));
+    EXPECT_FALSE(bf->test_bytes("HEL", 3));
+    EXPECT_FALSE(bf->test_bytes("LLO", 3));
+
+    delete reader;
+}
+
+TEST_F(BloomFilterIndexReaderWriterTest, test_ngram_utf8_case_sensitive_preserves_case) {
+    BloomFilterOptions bf_options;
+    bf_options.use_ngram = true;
+    bf_options.gram_num = 3;
+    bf_options.case_sensitive = true;
+
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    const std::string file_name = "bloom_filter_ngram_utf8_sensitive";
+    const std::string fname = kTestDir + "/" + file_name;
+    ColumnIndexMetaPB meta;
+
+    std::string s1 = "ПРИВЕТ";
+    Slice slices[] = {Slice(s1)};
+
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(fname));
+        std::unique_ptr<BloomFilterIndexWriter> writer;
+        ASSERT_OK(BloomFilterIndexWriter::create(bf_options, type_info, &writer));
+        writer->add_values(slices, 1);
+        ASSERT_OK(writer->flush());
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    std::unique_ptr<RandomAccessFile> rfile;
+    BloomFilterIndexReader* reader = nullptr;
+    std::unique_ptr<BloomFilterIndexIterator> iter;
+    get_bloom_filter_reader_iter(file_name, meta, &rfile, &reader, &iter);
+
+    std::unique_ptr<BloomFilter> bf;
+    ASSERT_OK(iter->read_bloom_filter(0, &bf));
+
+    // case_sensitive: trigrams are stored as written, no lowering branch is exercised.
+    EXPECT_TRUE(bf->test_bytes("ПРИ", 6));
+    EXPECT_TRUE(bf->test_bytes("РИВ", 6));
+    EXPECT_FALSE(bf->test_bytes("при", 6));
+
+    delete reader;
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1152,6 +1152,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             "topn_back_pressure_throttle_time_upper_bound_ms";
 
     public static final String LOWER_UPPER_SUPPORT_UTF8 = "lower_upper_support_utf8";
+    public static final String NGRAM_SEARCH_SUPPORT_UTF8 = "ngram_search_support_utf8";
 
     public static final String SEMI_JOIN_DEDUPLICATE_MODE = "semi_join_deduplicat_mode";
     public static final String ENABLE_INNER_JOIN_TO_SEMI = "enable_inner_join_to_semi";
@@ -2297,6 +2298,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // In order to be compatible with the previous behavior, the default value is false.
     @VarAttr(name = LOWER_UPPER_SUPPORT_UTF8)
     private boolean lowerUpperSupportUTF8 = false;
+
+    // Enable UTF-8 support for ngram_search and ngram_search_case_insensitive functions.
+    // When enabled, n-grams are computed based on UTF-8 characters instead of bytes.
+    // This allows proper similarity computation for non-ASCII text (e.g., Cyrillic, Chinese).
+    // Default is false for backward compatibility.
+    @VarAttr(name = NGRAM_SEARCH_SUPPORT_UTF8)
+    private boolean ngramSearchSupportUTF8 = false;
 
     // this sv controls whether to create distinct agg below semi join
     // -1 means disable this optimization
@@ -6528,6 +6536,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setEnable_join_runtime_filter_pushdown(enableJoinRuntimeFilterPushDown);
         tResult.setEnable_join_runtime_bitset_filter(enableJoinRuntimeBitsetFilter);
         tResult.setLower_upper_support_utf8(lowerUpperSupportUTF8);
+        tResult.setNgram_search_support_utf8(ngramSearchSupportUTF8);
         tResult.setEnable_global_late_materialization(enableGlobalLateMaterialization);
         tResult.setPipeline_dop(pipelineDop);
         if (pipelineProfileLevel == 2) {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -365,6 +365,7 @@ struct TQueryOptions {
   171: optional bool enable_parquet_reader_page_index;
   
   180: optional bool lower_upper_support_utf8;
+  181: optional bool ngram_search_support_utf8;
 
   190: optional i64 column_view_concat_rows_limit;
   191: optional i64 column_view_concat_bytes_limit;

--- a/test/sql/test_string_functions/T/test_string_functions
+++ b/test/sql/test_string_functions/T/test_string_functions
@@ -237,6 +237,64 @@ select sum(c0) > 500 from (select ngram_search(nation, 'china', 4) as c0 from le
 
 select count(1) from left_table where ngram_search(nation, 'china', 4) > 0;
 
+-- name: test_ngram_search_utf8
+-- Enable UTF-8 support for ngram_search
+set ngram_search_support_utf8 = true;
+
+-- Test with Cyrillic characters (Russian/Tajik names transliteration comparison)
+-- Same name should have high similarity
+select ngram_search('Расулов Сунатулло', 'Расулов Сунатулло', 4);
+select ngram_search('Бабоев Мухаммаджон', 'Бабоев Мухаммаджон', 4);
+
+-- Similar names with minor differences
+select ngram_search('Назаров Назарали', 'Назаров Назар', 4);
+select ngram_search('Акрамов Хусейн', 'Акрамов Хусейн Махмадалиевич', 4);
+
+-- Different names should have low similarity
+select ngram_search('Иванов Иван', 'Петров Петр', 4);
+
+-- Case insensitive UTF-8 test
+select ngram_search_case_insensitive('РАСУЛОВ СУНАТУЛЛО', 'расулов сунатулло', 4);
+select ngram_search_case_insensitive('Акрамов Хусейн', 'АКРАМОВ ХУСЕЙН', 4);
+
+-- Test with Chinese characters
+select ngram_search('北京大学', '北京大学', 4);
+select ngram_search('北京大学', '北京师范大学', 4);
+
+-- Mixed ASCII and UTF-8
+select ngram_search('Hello Мир', 'Hello Мир', 4);
+select ngram_search('Привет World', 'Привет World', 4);
+
+-- Short strings (less than gram_num characters)
+select ngram_search('Ми', 'Мир', 4);
+select ngram_search('北京', '北京大学', 4);
+
+-- Test with column
+CREATE TABLE utf8_names (
+  id INT,
+  name_cyrillic VARCHAR(100),
+  name_latin VARCHAR(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES ('replication_num'='1');
+
+INSERT INTO utf8_names VALUES
+(1, 'Расулов Сунатулло Ашуралиевич', 'Rasulov Sunatullo Ashuralevich'),
+(2, 'Бабоев Мухаммаджон Алиджонович', 'Baboev Mukhammadjon Alidjonovich'),
+(3, 'Акрамов Хусейн Махмадалиевич', 'Akramov Khusein Makhmadalievich'),
+(4, 'Назаров Назарали Захирджонович', 'Nazarov Nazarali Zakhirdjonovich');
+
+-- Search within Cyrillic names
+select id, ngram_search(name_cyrillic, 'Расулов Сунатулло', 4) as similarity
+from utf8_names
+order by similarity desc;
+
+-- Case insensitive search
+select id, ngram_search_case_insensitive(name_cyrillic, 'РАСУЛОВ СУНАТУЛЛО', 4) as similarity
+from utf8_names
+order by similarity desc;
+
 -- name: test_lower_upper_utf8
 create table t (
   id int,


### PR DESCRIPTION
  This patch adds proper UTF-8 character-based n-gram computation for
  ngram_search and ngram_search_case_insensitive functions.

  Previously, n-grams were computed byte-by-byte, which produced incorrect
  results for non-ASCII text (Cyrillic, Chinese, etc.). Now n-grams are
  computed based on UTF-8 characters using the existing UTF8_BYTE_LENGTH_TABLE.

  Changes:
  - Add session variable `ngram_search_support_utf8` (default: false)
  - Add utf8_tolower() utility function using ICU for proper Unicode case folding
  - Fix ngram_search to iterate by UTF-8 characters when enabled
  - Fix bloom filter index writer to use UTF-8 case folding
  - Fix bloom filter query to use UTF-8 case folding

  Note: Bloom filter index already used UTF-8 for n-gram extraction,
  but case-insensitive mode used ASCII tolower. This is now fixed.

## Why I'm doing:

## What I'm doing:

Fixes #67208

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional UTF-8 character–based n-gram processing and Unicode case folding to string similarity and bloom-filter flows.
> 
> - **UTF-8 mode (gated by `ngram_search_support_utf8`)** for `ngram_search` and `ngram_search_case_insensitive`; FE `SessionVariable`, Thrift `TQueryOptions`, and BE `RuntimeState` wiring included
> - **Unicode lowercase via `utf8_tolower` (ICU)**; added `util/utf8.cpp` and integrated into n-gram processing and bloom filter index writer/query paths, with ASCII fast-path preserved
> - **N-gram logic updated** to iterate by UTF-8 characters when enabled; case-insensitive handling adjusted; runtime dispatch via `Ngramstate::use_utf8`
> - **Bloom filter**: LIKE/ngram paths now validate UTF-8 and apply proper case folding for non-ASCII
> - **Tests**: new SQL cases for Cyrillic/Chinese; build updated to compile new UTF-8 utility
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 894c3f2ab94af96cd15bb037a34c06ab6642ade0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->