### PR TITLE
[BugFix] fix compaction profile reports wrong sub task count

### DIFF
--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -125,7 +125,7 @@ void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&
     compact_stat->set_write_segment_bytes(context->stats->write_segment_bytes);
     compact_stat->set_write_time_remote(context->stats->io_ns_write_remote);
     compact_stat->set_in_queue_time_sec(context->stats->in_queue_time_sec);
-    compact_stat->set_sub_task_count(_request->tablet_ids_size());
+    compact_stat->set_sub_task_count(1); // each tablet will have 1 task
     compact_stat->set_total_compact_input_file_size(context->stats->input_file_size);
     if (context->skip_write_txnlog && context->txn_log != nullptr) {
         // context->txn_log could be nullptr if the task is failed before writing txn log.

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionJob.java
@@ -200,10 +200,9 @@ public class CompactionJob {
             if (subStats == null) {
                 continue;
             }
-            int subTaskCount = 0;
             for (CompactStat subStat : subStats) {
                 if (subStat.subTaskCount != null) {
-                    subTaskCount = subStat.subTaskCount;
+                    stat.subTaskCount += subStat.subTaskCount;
                 }
                 if (subStat.readTimeRemote != null) {
                     stat.readTimeRemote += subStat.readTimeRemote;
@@ -233,7 +232,6 @@ public class CompactionJob {
                     stat.writeTimeRemote += subStat.writeTimeRemote;
                 }
             }
-            stat.subTaskCount += subTaskCount;
         }
         return new CompactionProfile(stat).toString();
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

fix wrong `sub task count` in `show proc '/compactions'` when table file_bundling is on

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures accurate `subTaskCount` in compaction profiles (e.g., `show proc '/compactions'`).
> 
> - BE: In `compaction_scheduler.cpp`, set `sub_task_count` to `1` for each tablet task instead of using `request->tablet_ids_size()`
> - FE: In `CompactionJob.getExecutionProfile()`, aggregate `subTaskCount` by summing each `subStat.subTaskCount` directly, removing the separate accumulator that could miscount
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9eec84b0a60210f58bc564a7a33d1890a9e7a0dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->