### PR TITLE
[Enhancement] refactor table support operation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -554,4 +554,10 @@ public class HiveTable extends Table {
                     storageFormat, hiveTableType);
         }
     }
+
+    @Override
+    public Set<TableOperation> getSupportedOperations() {
+        // Hive tables support ALTER and CREATE TABLE LIKE operations
+        return Sets.newHashSet(TableOperation.ALTER, TableOperation.CREATE_TABLE_LIKE);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -557,7 +557,7 @@ public class HiveTable extends Table {
 
     @Override
     public Set<TableOperation> getSupportedOperations() {
-        // Hive tables support ALTER and CREATE TABLE LIKE operations
-        return Sets.newHashSet(TableOperation.ALTER, TableOperation.CREATE_TABLE_LIKE);
+        return Sets.newHashSet(TableOperation.READ, TableOperation.CREATE, TableOperation.INSERT, TableOperation.DROP,
+                TableOperation.ALTER, TableOperation.CREATE_TABLE_LIKE);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -19,6 +19,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
@@ -589,6 +590,11 @@ public class IcebergTable extends Table {
             case ADD_FILES -> AddFilesProcedure.getInstance();
             default -> throw new StarRocksConnectorException("Unsupported table operation %s", op);
         };
+    }
+
+    @Override
+    public Set<TableOperation> getSupportedOperations() {
+        return Sets.newHashSet(TableOperation.ALTER);
     }
 
     public void setIcebergMetricsReporter(IcebergMetricsReporter reporter) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -594,7 +594,8 @@ public class IcebergTable extends Table {
 
     @Override
     public Set<TableOperation> getSupportedOperations() {
-        return Sets.newHashSet(TableOperation.ALTER);
+        return Sets.newHashSet(TableOperation.READ, TableOperation.INSERT, TableOperation.DROP, TableOperation.CREATE,
+                TableOperation.ALTER);
     }
 
     public void setIcebergMetricsReporter(IcebergMetricsReporter reporter) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -3335,4 +3335,9 @@ public class OlapTable extends Table {
         }
         return shardGroupIds;
     }
+
+    @Override
+    public Set<TableOperation> getSupportedOperations() {
+        return Sets.newHashSet(TableOperation.values());
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -844,6 +844,27 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
                 !isConnectorView();
     }
 
+    /**
+     * Get the set of operations supported by this table type.
+     * Subclasses can override this method to define their own supported operations.
+     * By default, tables don't support any operations.
+     *
+     * @return Set of supported operations
+     */
+    public Set<TableOperation> getSupportedOperations() {
+        return Sets.newHashSet();
+    }
+
+    /**
+     * Check if this table supports the specified operation.
+     *
+     * @param operation The operation to check
+     * @return true if the operation is supported, false otherwise
+     */
+    public boolean supportsOperation(TableOperation operation) {
+        return getSupportedOperations().contains(operation);
+    }
+
     public boolean isSupportBackupRestore() {
         return isOlapTableOrMaterializedView() || isOlapView();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -847,12 +847,12 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
     /**
      * Get the set of operations supported by this table type.
      * Subclasses can override this method to define their own supported operations.
-     * By default, tables don't support any operations.
+     * By default, tables support read operations.
      *
      * @return Set of supported operations
      */
     public Set<TableOperation> getSupportedOperations() {
-        return Sets.newHashSet();
+        return Sets.newHashSet(TableOperation.READ);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableOperation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableOperation.java
@@ -27,9 +27,6 @@ public enum TableOperation {
     DROP,
     ALTER,
     CREATE_TABLE_LIKE,
-    RENAME,
-    TRUNCATE,
-    REFRESH,
 
     // Add other operations as needed
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableOperation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableOperation.java
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+/**
+ * Defines the operations that can be performed on tables.
+ * Used by Table classes to declare which operations they support.
+ */
+public enum TableOperation {
+    CREATE,
+    READ,
+    INSERT,
+    UPDATE,
+    DELETE,
+    DROP,
+    ALTER,
+    CREATE_TABLE_LIKE,
+    RENAME,
+    TRUNCATE,
+    REFRESH,
+
+    // Add other operations as needed
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
+import com.starrocks.catalog.TableOperation;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.StarRocksException;
@@ -41,7 +42,6 @@ public class AlterTableStatementAnalyzer {
     public static void analyze(AlterTableStmt statement, ConnectContext context) {
         TableName tbl = statement.getTbl();
         tbl.normalization(context);
-        MetaUtils.checkNotSupportCatalog(tbl.getCatalog(), "ALTER");
 
         List<AlterClause> alterClauseList = statement.getAlterClauseList();
         if (alterClauseList == null || alterClauseList.isEmpty()) {
@@ -66,6 +66,7 @@ public class AlterTableStatementAnalyzer {
         }
 
         Table table = MetaUtils.getSessionAwareTable(context, null, tbl);
+        MetaUtils.checkNotSupportCatalog(table, TableOperation.ALTER);
         if (table.isTemporaryTable()) {
             throw new SemanticException("temporary table doesn't support alter table statement");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableLikeAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableLikeAnalyzer.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
+import com.starrocks.catalog.TableOperation;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.qe.ConnectContext;
@@ -40,12 +41,13 @@ public class CreateTableLikeAnalyzer {
         String tableName = stmt.getTableName();
         FeNameFormat.checkTableName(tableName);
 
-        MetaUtils.checkNotSupportCatalog(existedDbTbl.getCatalog(), "CREATE TABLE LIKE");
         Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, existedDbTbl.getCatalog(),
                 existedDbTbl.getDb(), existedDbTbl.getTbl());
         if (table == null) {
-            throw new SemanticException("Table %s is not found", tableName);
+            throw new SemanticException("Table %s.%s.%s is not found", existedDbTbl.getCatalog(), existedDbTbl.getDb(),
+                    existedDbTbl.getTbl());
         }
+        MetaUtils.checkNotSupportCatalog(table, TableOperation.CREATE_TABLE_LIKE);
 
         List<String> createTableStmt = Lists.newArrayList();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DeleteAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DeleteAnalyzer.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
+import com.starrocks.catalog.TableOperation;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.load.Load;
@@ -198,13 +199,13 @@ public class DeleteAnalyzer {
         analyzeProperties(deleteStatement, session);
 
         TableName tableName = deleteStatement.getTableName();
-        MetaUtils.checkNotSupportCatalog(tableName.getCatalog(), "DELETE");
         Database db = GlobalStateMgr.getCurrentState().getMetadataMgr()
                 .getDb(session, tableName.getCatalog(), tableName.getDb());
         if (db == null) {
             throw new SemanticException("Database %s is not found", tableName.getCatalogAndDb());
         }
         Table table = MetaUtils.getSessionAwareTable(session, null, tableName);
+        MetaUtils.checkNotSupportCatalog(table, TableOperation.DELETE);
 
         if (table instanceof MaterializedView) {
             String msg = String.format("The data of '%s' cannot be deleted because it is a materialized view," +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
+import com.starrocks.catalog.TableOperation;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.util.DebugUtil;
@@ -73,15 +74,27 @@ public class MetaUtils {
         }
     }
 
-    public static void checkNotSupportCatalog(String catalogName, String operation) {
-        if (catalogName == null) {
-            throw new SemanticException("Catalog is null");
-        }
-        if (CatalogMgr.isInternalCatalog(catalogName)) {
-            return;
+    /**
+     * Check if the specified operation is supported on the given table.
+     * Throws SemanticException if the operation is not supported by the table type.
+     * For internal catalog tables, all operations are supported.
+     *
+     * @param table The table to check
+     * @param operation The operation to check
+     * @throws SemanticException if the operation is not supported
+     */
+    public static void checkNotSupportCatalog(Table table, TableOperation operation) {
+        if (table == null) {
+            throw new SemanticException("Table is null");
         }
         if (operation == null) {
-            throw new SemanticException("operation is null");
+            throw new SemanticException("Operation is null");
+        }
+
+        String catalogName = table.getCatalogName();
+        // Internal catalog tables support all operations
+        if (CatalogMgr.isInternalCatalog(catalogName)) {
+            return;
         }
 
         Catalog catalog = GlobalStateMgr.getCurrentState().getCatalogMgr().getCatalogByName(catalogName);
@@ -89,8 +102,9 @@ public class MetaUtils {
             throw new SemanticException("Catalog %s is not found", catalogName);
         }
 
-        if (!operation.equals("ALTER") && catalog.getType().equalsIgnoreCase("iceberg")) {
-            throw new SemanticException("Table of iceberg catalog doesn't support [%s]", operation);
+        if (!table.supportsOperation(operation)) {
+            throw new SemanticException("Table of %s catalog doesn't support [%s]",
+                    table.getType().name(), operation.name());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -92,6 +92,9 @@ public class MetaUtils {
         }
 
         String catalogName = table.getCatalogName();
+        if (catalogName == null) {
+            throw new SemanticException("Catalog is null");
+        }
         // Internal catalog tables support all operations
         if (CatalogMgr.isInternalCatalog(catalogName)) {
             return;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterTableOperationStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterTableOperationStmtTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableOperation;
 import com.starrocks.connector.iceberg.procedure.CherryPickSnapshotProcedure;
 import com.starrocks.connector.iceberg.procedure.ExpireSnapshotsProcedure;
 import com.starrocks.connector.iceberg.procedure.FastForwardProcedure;
@@ -224,6 +225,10 @@ public class AlterTableOperationStmtTest {
                 icebergTable.getPartitionColumnsIncludeTransformed();
                 result = List.of(new Column("k1", IntegerType.INT, true),
                         new Column("partition_date", DateType.DATE, true));
+                minTimes = 0;
+
+                icebergTable.supportsOperation(TableOperation.ALTER);
+                result = true;
                 minTimes = 0;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterTableOperationStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterTableOperationStmtTest.java
@@ -230,6 +230,10 @@ public class AlterTableOperationStmtTest {
                 icebergTable.supportsOperation(TableOperation.ALTER);
                 result = true;
                 minTimes = 0;
+
+                icebergTable.getCatalogName();
+                result = "iceberg_catalog";
+                minTimes = 0;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
@@ -76,6 +76,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -241,10 +242,17 @@ public class DeleteTest {
 
         try {
             Analyzer analyzer = new Analyzer(Analyzer.AnalyzerVisitor.getInstance());
+
             new Expectations() {
                 {
                     globalStateMgr.getAnalyzer();
                     result = analyzer;
+
+                    globalStateMgr.getMetadataMgr().getTemporaryTable((UUID) any, anyString, anyLong, anyString);
+                    result = null;
+
+                    globalStateMgr.getMetadataMgr().getTable((ConnectContext) any, anyString, anyString, anyString);
+                    result = db.getTable(tableId);
                 }
             };
             com.starrocks.sql.analyzer.Analyzer.analyze(deleteStmt, connectContext);
@@ -319,6 +327,12 @@ public class DeleteTest {
                     {
                         globalStateMgr.getAnalyzer();
                         result = analyzer;
+
+                        globalStateMgr.getMetadataMgr().getTemporaryTable((UUID) any, anyString, anyLong, anyString);
+                        result = null;
+
+                        globalStateMgr.getMetadataMgr().getTable((ConnectContext) any, anyString, anyString, anyString);
+                        result = db.getTable(tableId);
                     }
                 };
                 com.starrocks.sql.analyzer.Analyzer.analyze(deleteStmt, connectContext);
@@ -370,6 +384,12 @@ public class DeleteTest {
             {
                 globalStateMgr.getAnalyzer();
                 result = analyzer;
+
+                globalStateMgr.getMetadataMgr().getTemporaryTable((UUID) any, anyString, anyLong, anyString);
+                result = null;
+
+                globalStateMgr.getMetadataMgr().getTable((ConnectContext) any, anyString, anyString, anyString);
+                result = db.getTable(tableId);
             }
         };
         com.starrocks.sql.analyzer.Analyzer.analyze(deleteStmt, connectContext);

--- a/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
@@ -42,6 +42,7 @@ import com.starrocks.qe.QueryStateException;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.sql.ast.PartitionRef;
@@ -74,6 +75,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -161,6 +163,14 @@ public class DeleteHandlerTest {
                 result = db.getTable("test_tbl");
 
                 globalStateMgr.getLocalMetastore().getTable(CatalogMocker.TEST_DB_ID, CatalogMocker.TEST_TBL_ID);
+                minTimes = 0;
+                result = db.getTable("test_tbl");
+
+                globalStateMgr.getMetadataMgr().getTemporaryTable((UUID) any, anyString, anyLong, anyString);
+                minTimes = 0;
+                result = null;
+
+                globalStateMgr.getMetadataMgr().getTable((ConnectContext) any, anyString, anyString, anyString);
                 minTimes = 0;
                 result = db.getTable("test_tbl");
 
@@ -569,7 +579,7 @@ public class DeleteHandlerTest {
     }
 
     @Test
-    public void testRemoveOldOnReplay() throws Exception {
+    public void testRemoveOldOnReplay(@Mocked MetadataMgr metadataMgr) throws Exception {
         new Expectations(globalStateMgr) {
             {
                 globalStateMgr.getLocalMetastore().getDb(1L);
@@ -577,6 +587,23 @@ public class DeleteHandlerTest {
                 result = db;
 
                 globalStateMgr.getLocalMetastore().getTable(anyLong, anyLong);
+                minTimes = 0;
+                result = db.getTable("test_tbl");
+
+                globalStateMgr.getMetadataMgr();
+                minTimes = 0;
+                result = metadataMgr;
+
+            }
+        };
+
+        new Expectations(metadataMgr) {
+            {
+                metadataMgr.getTemporaryTable((UUID) any, anyString, anyLong, anyString);
+                minTimes = 0;
+                result = null;
+
+                metadataMgr.getTable((ConnectContext) any, anyString, anyString, anyString);
                 minTimes = 0;
                 result = db.getTable("test_tbl");
             }


### PR DESCRIPTION
## Why I'm doing:
#66944
## What I'm doing:
This pull request introduces a new mechanism for handling table operation support in the StarRocks codebase. Instead of relying on catalog type checks scattered throughout the code, each `Table` subclass now explicitly declares which operations it supports using a new `TableOperation` enum and related methods. This allows for more granular and extensible operation checks. The pull request also refactors relevant analyzer logic and updates tests accordingly.

**Core Table Operation Support**

- Introduced a new `TableOperation` enum in `TableOperation.java` to represent supported table operations such as `ALTER`, `DELETE`, and `CREATE_TABLE_LIKE`.
- Added `getSupportedOperations()` and `supportsOperation()` methods to the base `Table` class, allowing subclasses to declare and check supported operations. By default, no operations are supported unless overridden.
- Implemented `getSupportedOperations()` in key table subclasses:
  - [`OlapTable`](diffhunk://#diff-171dae9f0bb57d4016183d17e215ac2dba38e31e0902cd331ec11660212eba4bR3531-R3535): supports all operations defined in `TableOperation`.
  - [`HiveTable`](diffhunk://#diff-124224e890a4a9ad6efdad43f7f2f966b962403800c6a9d7cee1ee6544892e46R557-R562): supports `ALTER` and `CREATE_TABLE_LIKE`.
  - [`IcebergTable`](diffhunk://#diff-62955f4651c70b99d1f502bc07103c278a9d80ef7bfb9eba6fa90cafb8d943fbR595-R599): supports only `ALTER`.

**Analyzer and MetaUtils Refactoring**

- Refactored `MetaUtils.checkNotSupportCatalog` to `checkNotSupportCatalog(Table, TableOperation)`, which now checks a table’s supported operations instead of relying on catalog string comparisons.
- Updated analyzers for `ALTER`, `DELETE`, and `CREATE TABLE LIKE` statements to use the new operation support mechanism, ensuring semantic checks are performed based on the actual table instance. [[1]](diffhunk://#diff-e0eba02ceadc8ea9ee288f49583d74c3731cb54c18e9cdc6bc82e579b1e10645L44) [[2]](diffhunk://#diff-e0eba02ceadc8ea9ee288f49583d74c3731cb54c18e9cdc6bc82e579b1e10645R69) [[3]](diffhunk://#diff-7a82262f07752399cb85d489af502c672864b44f028c716e12e23206e2fb6837L43-R50) [[4]](diffhunk://#diff-7a82262f07752399cb85d489af502c672864b44f028c716e12e23206e2fb6837L43-R50) [[5]](diffhunk://#diff-7ba29f27aabfb7b419cd745ab061be3dfe480efc4d2c7ddf9fc550d88f506662L201-R208)

**Test Updates**

- Updated and expanded unit tests to mock the new operation support checks, ensuring correct error messages and behavior when operations are not supported by the table type. 

These changes make operation support more explicit, extensible, and easier to maintain across different table types.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces explicit per-table operation capability and replaces catalog-string checks with type-aware validation.
> 
> - New `TableOperation` enum and base `Table` APIs: `getSupportedOperations()` (default `READ`) and `supportsOperation()`
> - Implemented supported ops in `OlapTable` (all), `HiveTable` (`READ/CREATE/INSERT/DROP/ALTER/CREATE_TABLE_LIKE`), `IcebergTable` (`READ/INSERT/DROP/CREATE/ALTER`)
> - Refactored `MetaUtils.checkNotSupportCatalog` to `checkNotSupportCatalog(Table, TableOperation)` using `table.supportsOperation()`
> - Updated analyzers to use the new mechanism: `ALTER` (`AlterTableStatementAnalyzer`), `DELETE` (`DeleteAnalyzer`), and `CREATE TABLE LIKE` (`CreateTableLikeAnalyzer`), with improved not-found and unsupported error messages
> - Adjusted unit tests to mock `supportsOperation`, MetadataMgr lookups for temporary tables, and new error texts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fa4f3b28d61ad119a48802e1b70c7f9b953f9be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->