### PR TITLE
[BugFix] make query lifetime longer than fragment in report_fragment

### DIFF
--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -634,8 +634,8 @@ void QueryContextManager::collect_query_statistics(const PCollectQueryStatistics
 
 void QueryContextManager::report_fragments(
         const std::vector<PipeLineReportTaskKey>& pipeline_need_report_query_fragment_ids) {
-    std::vector<std::shared_ptr<FragmentContext>> need_report_fragment_context;
     std::vector<std::shared_ptr<QueryContext>> need_report_query_ctx;
+    std::vector<std::shared_ptr<FragmentContext>> need_report_fragment_context;
 
     std::vector<PipeLineReportTaskKey> fragment_context_non_exist;
 

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -313,6 +313,7 @@ private:
     ExecEnv* _exec_env = nullptr;
     TUniqueId _query_id;
     MonotonicStopWatch _lifetime_sw;
+    std::unique_ptr<spill::QuerySpillManager> _spill_manager;
     std::unique_ptr<FragmentContextManager> _fragment_mgr;
     size_t _total_fragments;
     std::atomic<size_t> _num_fragments;
@@ -393,8 +394,6 @@ private:
 
     // STREAM MV
     std::shared_ptr<StreamEpochManager> _stream_epoch_manager;
-
-    std::unique_ptr<spill::QuerySpillManager> _spill_manager;
 
     int64_t _static_query_mem_limit = 0;
     ConnectorScanOperatorMemShareArbitrator* _connector_scan_operator_mem_share_arbitrator = nullptr;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

close https://github.com/StarRocks/StarRocksTest/issues/10776

```
Crash Log: 
==2826==ERROR: AddressSanitizer: heap-use-after-free on address 0x504002a24ab8 at pc 0x000020952ee1 bp 0x2af9b6120b80 sp 0x2af9b6120b78
READ of size 8 at 0x504002a24ab8 thread T329
   #0 0x20952ee0 in starrocks::spill::QuerySpillManager::dec_reserve_bytes(unsigned long) be/src/exec/spill/query_spill_manager.h:55
   #1 0x20951555 in starrocks::spill::OperatorMemoryResourceManager::ResGuard::reset() be/src/exec/spill/operator_mem_resource_manager.cpp:70
   #2 0x1ec0fed7 in starrocks::spill::OperatorMemoryResourceManager::ResGuard::~ResGuard() be/src/exec/spill/operator_mem_resource_manager.h:32
   #3 0x1ec10c51 in starrocks::spill::OperatorMemoryResourceManager::~OperatorMemoryResourceManager() be/src/exec/spill/operator_mem_resource_manager.h:27
   #4 0x1ec10cc4 in starrocks::pipeline::Operator::~Operator() be/src/exec/pipeline/operator.h:50
   #5 0x1ec113ee in starrocks::pipeline::SourceOperator::~SourceOperator() be/src/exec/pipeline/source_operator.h:148
   #6 0x20129ffc in starrocks::pipeline::ExchangeSourceOperator::~ExchangeSourceOperator() be/src/exec/pipeline/exchange/exchange_source_operator.h:30
   #7 0x2012a306 in void std::destroy_at<starrocks::pipeline::ExchangeSourceOperator>(starrocks::pipeline::ExchangeSourceOperator*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:88
   #8 0x2012a2a3 in void std::_Destroy<starrocks::pipeline::ExchangeSourceOperator>(starrocks::pipeline::ExchangeSourceOperator*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:149
   #9 0x2012a0d3 in void std::allocator_traits<std::allocator<void> >::destroy<starrocks::pipeline::ExchangeSourceOperator>(std::allocator<void>&, starrocks::pipeline::ExchangeSourceOperator*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/alloc_traits.h:720
   #10 0x2012a0d3 in std::_Sp_counted_ptr_inplace<starrocks::pipeline::ExchangeSourceOperator, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:616
   #11 0x12283b2d in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:346
   #12 0x12295f13 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1069
   #13 0x1f7b9643 in std::__shared_ptr<starrocks::pipeline::Operator, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1525
   #14 0x1f7b965f in std::shared_ptr<starrocks::pipeline::Operator>::~shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr.h:175
   #15 0x20571e5c in void std::destroy_at<std::shared_ptr<starrocks::pipeline::Operator> >(std::shared_ptr<starrocks::pipeline::Operator>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:88
   #16 0x205701e1 in void std::_Destroy<std::shared_ptr<starrocks::pipeline::Operator> >(std::shared_ptr<starrocks::pipeline::Operator>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:149
   #17 0x2056e6f9 in void std::_Destroy_aux<false>::__destroy<std::shared_ptr<starrocks::pipeline::Operator>*>(std::shared_ptr<starrocks::pipeline::Operator>*, std::shared_ptr<starrocks::pipeline::Operator>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:163
   #18 0x2056c790 in void std::_Destroy<std::shared_ptr<starrocks::pipeline::Operator>*>(std::shared_ptr<starrocks::pipeline::Operator>*, std::shared_ptr<starrocks::pipeline::Operator>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:196
   #19 0x205625ae in void std::_Destroy<std::shared_ptr<starrocks::pipeline::Operator>*, std::shared_ptr<starrocks::pipeline::Operator> >(std::shared_ptr<starrocks::pipeline::Operator>*, std::shared_ptr<starrocks::pipeline::Operator>*, std::allocator<std::shared_ptr<starrocks::pipeline::Operator> >&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/alloc_traits.h:993
   #20 0x205625ae in std::vector<std::shared_ptr<starrocks::pipeline::Operator>, std::allocator<std::shared_ptr<starrocks::pipeline::Operator> > >::~vector() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_vector.h:748
   #21 0x205424af in starrocks::pipeline::PipelineDriver::~PipelineDriver() be/src/exec/pipeline/pipeline_driver.cpp:55
   #22 0x20795724 in void std::destroy_at<starrocks::pipeline::PipelineDriver>(starrocks::pipeline::PipelineDriver*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:88
   #23 0x20795638 in void std::_Destroy<starrocks::pipeline::PipelineDriver>(starrocks::pipeline::PipelineDriver*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:149
   #24 0x20795433 in void std::allocator_traits<std::allocator<void> >::destroy<starrocks::pipeline::PipelineDriver>(std::allocator<void>&, starrocks::pipeline::PipelineDriver*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/alloc_traits.h:720
   #25 0x20795433 in std::_Sp_counted_ptr_inplace<starrocks::pipeline::PipelineDriver, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:616
   #26 0x12283b2d in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:346
   #27 0x12295f13 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1069
   #28 0x1ec115cd in std::__shared_ptr<starrocks::pipeline::PipelineDriver, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1525
   #29 0x1ec115e9 in std::shared_ptr<starrocks::pipeline::PipelineDriver>::~shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr.h:175
   #30 0x1ec4eae5 in void std::destroy_at<std::shared_ptr<starrocks::pipeline::PipelineDriver> >(std::shared_ptr<starrocks::pipeline::PipelineDriver>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:88
   #31 0x1ec4ea7f in void std::_Destroy<std::shared_ptr<starrocks::pipeline::PipelineDriver> >(std::shared_ptr<starrocks::pipeline::PipelineDriver>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:149
   #32 0x1ec4e9a2 in void std::_Destroy_aux<false>::__destroy<std::shared_ptr<starrocks::pipeline::PipelineDriver>*>(std::shared_ptr<starrocks::pipeline::PipelineDriver>*, std::shared_ptr<starrocks::pipeline::PipelineDriver>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:163
   #33 0x1ec4e77f in void std::_Destroy<std::shared_ptr<starrocks::pipeline::PipelineDriver>*>(std::shared_ptr<starrocks::pipeline::PipelineDriver>*, std::shared_ptr<starrocks::pipeline::PipelineDriver>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:196
   #34 0x1ec4e3fa in void std::_Destroy<std::shared_ptr<starrocks::pipeline::PipelineDriver>*, std::shared_ptr<starrocks::pipeline::PipelineDriver> >(std::shared_ptr<starrocks::pipeline::PipelineDriver>*, std::shared_ptr<starrocks::pipeline::PipelineDriver>*, std::allocator<std::shared_ptr<starrocks::pipeline::PipelineDriver> >&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/alloc_traits.h:993
   #35 0x1ec4e3fa in std::vector<std::shared_ptr<starrocks::pipeline::PipelineDriver>, std::allocator<std::shared_ptr<starrocks::pipeline::PipelineDriver> > >::~vector() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_vector.h:748
   #36 0x1ec4e2cb in starrocks::pipeline::Pipeline::~Pipeline() be/src/exec/pipeline/pipeline.h:33
   #37 0x1ec4e306 in void std::destroy_at<starrocks::pipeline::Pipeline>(starrocks::pipeline::Pipeline*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:88
   #38 0x1ec4d83a in void std::_Destroy<starrocks::pipeline::Pipeline>(starrocks::pipeline::Pipeline*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:149
   #39 0x1ec4d211 in void std::allocator_traits<std::allocator<void> >::destroy<starrocks::pipeline::Pipeline>(std::allocator<void>&, starrocks::pipeline::Pipeline*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/alloc_traits.h:720
   #40 0x1ec4d211 in std::_Sp_counted_ptr_inplace<starrocks::pipeline::Pipeline, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:616
   #41 0x12283b2d in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:346
   #42 0x12295f13 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1069
   #43 0x1ec11609 in std::__shared_ptr<starrocks::pipeline::Pipeline, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1525
   #44 0x1ec11625 in std::shared_ptr<starrocks::pipeline::Pipeline>::~shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr.h:175
   #45 0x1ec3e174 in void std::destroy_at<std::shared_ptr<starrocks::pipeline::Pipeline> >(std::shared_ptr<starrocks::pipeline::Pipeline>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:88
   #46 0x20193c54 in void std::_Destroy<std::shared_ptr<starrocks::pipeline::Pipeline> >(std::shared_ptr<starrocks::pipeline::Pipeline>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:149
   #47 0x2018ec47 in void std::_Destroy_aux<false>::__destroy<std::shared_ptr<starrocks::pipeline::Pipeline>*>(std::shared_ptr<starrocks::pipeline::Pipeline>*, std::shared_ptr<starrocks::pipeline::Pipeline>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:163
   #48 0x20188a7b in void std::_Destroy<std::shared_ptr<starrocks::pipeline::Pipeline>*>(std::shared_ptr<starrocks::pipeline::Pipeline>*, std::shared_ptr<starrocks::pipeline::Pipeline>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:196
   #49 0x2017ef86 in void std::_Destroy<std::shared_ptr<starrocks::pipeline::Pipeline>*, std::shared_ptr<starrocks::pipeline::Pipeline> >(std::shared_ptr<starrocks::pipeline::Pipeline>*, std::shared_ptr<starrocks::pipeline::Pipeline>*, std::allocator<std::shared_ptr<starrocks::pipeline::Pipeline> >&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/alloc_traits.h:993
   #50 0x2017ef86 in std::vector<std::shared_ptr<starrocks::pipeline::Pipeline>, std::allocator<std::shared_ptr<starrocks::pipeline::Pipeline> > >::~vector() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_vector.h:748
   #51 0x205798ed in starrocks::pipeline::FragmentContext::~FragmentContext() be/src/exec/pipeline/fragment_context.cpp:57
   #52 0x2019cf2b in void std::destroy_at<starrocks::pipeline::FragmentContext>(starrocks::pipeline::FragmentContext*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:88
   #53 0x2019ce02 in void std::_Destroy<starrocks::pipeline::FragmentContext>(starrocks::pipeline::FragmentContext*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:149
   #54 0x2019c5c7 in void std::allocator_traits<std::allocator<void> >::destroy<starrocks::pipeline::FragmentContext>(std::allocator<void>&, starrocks::pipeline::FragmentContext*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/alloc_traits.h:720
   #55 0x2019c5c7 in std::_Sp_counted_ptr_inplace<starrocks::pipeline::FragmentContext, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:616
   #56 0x12283b2d in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:346
   #57 0x12295f13 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1069
   #58 0x1caf4ff7 in std::__shared_ptr<starrocks::pipeline::FragmentContext, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1525
   #59 0x1caf5013 in std::shared_ptr<starrocks::pipeline::FragmentContext>::~shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr.h:175
   #60 0x205c6e20 in void std::destroy_at<std::shared_ptr<starrocks::pipeline::FragmentContext> >(std::shared_ptr<starrocks::pipeline::FragmentContext>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:88
   #61 0x205c57d3 in void std::_Destroy<std::shared_ptr<starrocks::pipeline::FragmentContext> >(std::shared_ptr<starrocks::pipeline::FragmentContext>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:149
   #62 0x205c23a3 in void std::_Destroy_aux<false>::__destroy<std::shared_ptr<starrocks::pipeline::FragmentContext>*>(std::shared_ptr<starrocks::pipeline::FragmentContext>*, std::shared_ptr<starrocks::pipeline::FragmentContext>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:163
   #63 0x205bdf9e in void std::_Destroy<std::shared_ptr<starrocks::pipeline::FragmentContext>*>(std::shared_ptr<starrocks::pipeline::FragmentContext>*, std::shared_ptr<starrocks::pipeline::FragmentContext>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:196
   #64 0x205b1066 in void std::_Destroy<std::shared_ptr<starrocks::pipeline::FragmentContext>*, std::shared_ptr<starrocks::pipeline::FragmentContext> >(std::shared_ptr<starrocks::pipeline::FragmentContext>*, std::shared_ptr<starrocks::pipeline::FragmentContext>*, std::allocator<std::shared_ptr<starrocks::pipeline::FragmentContext> >&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/alloc_traits.h:993
   #65 0x205b1066 in std::vector<std::shared_ptr<starrocks::pipeline::FragmentContext>, std::allocator<std::shared_ptr<starrocks::pipeline::FragmentContext> > >::~vector() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_vector.h:748
   #66 0x205a7979 in starrocks::pipeline::QueryContextManager::report_fragments(std::vector<starrocks::PipeLineReportTaskKey, std::allocator<starrocks::PipeLineReportTaskKey> > const&) be/src/exec/pipeline/query_context.cpp:745
   #67 0x1cd5039c in starrocks::ProfileReportWorker::_start_report_profile() be/src/runtime/profile_report_worker.cpp:107
   #68 0x1cd5077f in starrocks::ProfileReportWorker::execute() be/src/runtime/profile_report_worker.cpp:114
   #69 0x1cd50b03 in operator() be/src/runtime/profile_report_worker.cpp:128
   #70 0x1cd52c79 in __invoke_impl<void, starrocks::ProfileReportWorker::ProfileReportWorker(starrocks::ExecEnv*)::<lambda()> > /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:61
   #71 0x1cd52c3c in __invoke<starrocks::ProfileReportWorker::ProfileReportWorker(starrocks::ExecEnv*)::<lambda()> > /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:96
   #72 0x1cd52be9 in _M_invoke<0> /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/std_thread.h:301
   #73 0x1cd52bbd in operator() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/std_thread.h:308
   #74 0x1cd52ba1 in _M_run /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/std_thread.h:253
   #75 0x2e32ad3f in execute_native_thread_routine ../../../.././libstdc++-v3/src/c++11/thread.cc:104
   #76 0x1218ef11 in asan_thread_start ../../.././libsanitizer/asan/asan_interceptors.cpp:234
   #77 0x2af8be39fea4 in start_thread (/lib64/libpthread.so.0+0x7ea4) (BuildId: e10cc8f2b932fc3daeda22f8dac5ebb969524e5b)
   #78 0x2af8c0542b0c in clone (/lib64/libc.so.6+0xfeb0c) (BuildId: 1a8fb61bb4614a483833d5334202ab50edda2a25)

0x504002a24ab8 is located 40 bytes inside of 48-byte region [0x504002a24a90,0x504002a24ac0)
freed by thread T329 here:
   #0 0x12227b00 in operator delete(void*) ../../.././libsanitizer/asan/asan_new_delete.cpp:152
   #1 0x205b2157 in std::default_delete<starrocks::spill::QuerySpillManager>::operator()(starrocks::spill::QuerySpillManager*) const (/home/disk1/sr/be/lib/starrocks_be+0x205b2157)
   #2 0x205ae0cc in std::unique_ptr<starrocks::spill::QuerySpillManager, std::default_delete<starrocks::spill::QuerySpillManager> >::~unique_ptr() (/home/disk1/sr/be/lib/starrocks_be+0x205ae0cc)
   #3 0x2059c749 in starrocks::pipeline::QueryContext::~QueryContext() be/src/exec/pipeline/query_context.cpp:90
   #4 0x205d187a in void std::destroy_at<starrocks::pipeline::QueryContext>(starrocks::pipeline::QueryContext*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:88
   #5 0x205d1763 in void std::_Destroy<starrocks::pipeline::QueryContext>(starrocks::pipeline::QueryContext*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:149
   #6 0x205d0b95 in void std::allocator_traits<std::allocator<void> >::destroy<starrocks::pipeline::QueryContext>(std::allocator<void>&, starrocks::pipeline::QueryContext*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/alloc_traits.h:720
   #7 0x205d0b95 in std::_Sp_counted_ptr_inplace<starrocks::pipeline::QueryContext, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:616
   #8 0x1229a321 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:175
   #9 0x12295e57 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use_cold() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:199
   #10 0x12283c7b in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:353
   #11 0x12295f13 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1069
   #12 0x1cc89721 in std::__shared_ptr<starrocks::pipeline::QueryContext, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr_base.h:1525
   #13 0x1cc8973d in std::shared_ptr<starrocks::pipeline::QueryContext>::~shared_ptr() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/shared_ptr.h:175
   #14 0x205c6ab1 in void std::destroy_at<std::shared_ptr<starrocks::pipeline::QueryContext> >(std::shared_ptr<starrocks::pipeline::QueryContext>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:88
   #15 0x205c47fb in void std::_Destroy<std::shared_ptr<starrocks::pipeline::QueryContext> >(std::shared_ptr<starrocks::pipeline::QueryContext>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:149
   #16 0x205c1709 in void std::_Destroy_aux<false>::__destroy<std::shared_ptr<starrocks::pipeline::QueryContext>*>(std::shared_ptr<starrocks::pipeline::QueryContext>*, std::shared_ptr<starrocks::pipeline::QueryContext>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:163
   #17 0x205bcfa8 in void std::_Destroy<std::shared_ptr<starrocks::pipeline::QueryContext>*>(std::shared_ptr<starrocks::pipeline::QueryContext>*, std::shared_ptr<starrocks::pipeline::QueryContext>*) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_construct.h:196
   #18 0x205b028e in void std::_Destroy<std::shared_ptr<starrocks::pipeline::QueryContext>*, std::shared_ptr<starrocks::pipeline::QueryContext> >(std::shared_ptr<starrocks::pipeline::QueryContext>*, std::shared_ptr<starrocks::pipeline::QueryContext>*, std::allocator<std::shared_ptr<starrocks::pipeline::QueryContext> >&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/alloc_traits.h:993
   #19 0x205b028e in std::vector<std::shared_ptr<starrocks::pipeline::QueryContext>, std::allocator<std::shared_ptr<starrocks::pipeline::QueryContext> > >::~vector() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/stl_vector.h:748
   #20 0x205a796a in starrocks::pipeline::QueryContextManager::report_fragments(std::vector<starrocks::PipeLineReportTaskKey, std::allocator<starrocks::PipeLineReportTaskKey> > const&) be/src/exec/pipeline/query_context.cpp:745
   #21 0x1cd5039c in starrocks::ProfileReportWorker::_start_report_profile() be/src/runtime/profile_report_worker.cpp:107
   #22 0x1cd5077f in starrocks::ProfileReportWorker::execute() be/src/runtime/profile_report_worker.cpp:114
   #23 0x1cd50b03 in operator() be/src/runtime/profile_report_worker.cpp:128
   #24 0x1cd52c79 in __invoke_impl<void, starrocks::ProfileReportWorker::ProfileReportWorker(starrocks::ExecEnv*)::<lambda()> > /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:61
   #25 0x1cd52c3c in __invoke<starrocks::ProfileReportWorker::ProfileReportWorker(starrocks::ExecEnv*)::<lambda()> > /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:96
   #26 0x1cd52be9 in _M_invoke<0> /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/std_thread.h:301
   #27 0x1cd52bbd in operator() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/std_thread.h:308
   #28 0x1cd52ba1 in _M_run /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/std_thread.h:253
   #29 0x2e32ad3f in execute_native_thread_routine ../../../.././libstdc++-v3/src/c++11/thread.cc:104

previously allocated by thread T260 here:
   #0 0x122270c8 in operator new(unsigned long) ../../.././libsanitizer/asan/asan_new_delete.cpp:95
   #1 0x205aee66 in std::__detail::_MakeUniq<starrocks::spill::QuerySpillManager>::__single_object std::make_unique<starrocks::spill::QuerySpillManager, starrocks::TUniqueId&, starrocks::spill::GlobalSpillManager*&>(starrocks::TUniqueId&, starrocks::spill::GlobalSpillManager*&) /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/unique_ptr.h:1077
   #2 0x2059eac4 in operator() be/src/exec/pipeline/query_context.cpp:195
   #3 0x205a9e0e in __invoke_impl<void, starrocks::pipeline::QueryContext::init_spill_manager(const starrocks::TQueryOptions&)::<lambda()> > /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:61
   #4 0x205a961e in __invoke<starrocks::pipeline::QueryContext::init_spill_manager(const starrocks::TQueryOptions&)::<lambda()> > /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/bits/invoke.h:96
   #5 0x205a8995 in operator() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/mutex:909
   #6 0x205a9640 in operator() /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/mutex:845
   #7 0x205a9651 in _FUN /opt/rh/gcc-toolset-10/root/usr/include/c++/14.3.0/mutex:845
   #8 0x2af8be39e20a in __pthread_once_slow (/lib64/libpthread.so.0+0x620a) (BuildId: e10cc8f2b932fc3daeda22f8dac5ebb969524e5b)

Thread T329 created by T0 here:
   #0 0x1221e53d in pthread_create ../../.././libsanitizer/asan/asan_interceptors.cpp:245
   #1 0x2e32ae38 in __gthread_create /workspace/gcc/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:676
   #2 0x2e32ae38 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) ../../../.././libstdc++-v3/src/c++11/thread.cc:172
   #3 0x1cd50c37 in starrocks::ProfileReportWorker::ProfileReportWorker(starrocks::ExecEnv*) be/src/runtime/profile_report_worker.cpp:128
   #4 0x1ca05dcd in starrocks::ExecEnv::init(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath> > const&, bool) be/src/runtime/exec_env.cpp:533
   #5 0x1cf0a437 in starrocks::start_be(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath> > const&, bool) be/src/service/service_be/starrocks_be.cpp:131
   #6 0x1227fc1d in main be/src/service/starrocks_main.cpp:266
   #7 0x2af8c0466554 in __libc_start_main (/lib64/libc.so.6+0x22554) (BuildId: 1a8fb61bb4614a483833d5334202ab50edda2a25)

Thread T260 created by T0 here:
   #0 0x1221e53d in pthread_create ../../.././libsanitizer/asan/asan_interceptors.cpp:245
   #1 0x2b003a28 in boost::thread::start_thread_noexcept() libs/thread/src/pthread/thread.cpp:263
   #2 0x1ca34638 in boost::thread::thread<std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>&>(std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>&) /var/local/thirdparty/installed/include/boost/thread/detail/thread.hpp:269
   #3 0x1ca2b1ef in boost::thread* boost::thread_group::create_thread<std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)> >(std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>) /var/local/thirdparty/installed/include/boost/thread/detail/thread_group.hpp:79
   #4 0x1ca227db in starrocks::PriorityThreadPool::new_thread(int) be/src/util/priority_thread_pool.hpp:177
   #5 0x1ca223d4 in starrocks::PriorityThreadPool::PriorityThreadPool(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int, unsigned int) (/home/disk1/sr/be/lib/starrocks_be+0x1ca223d4)
   #6 0x1ca02758 in starrocks::ExecEnv::init(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath> > const&, bool) be/src/runtime/exec_env.cpp:395
   #7 0x1cf0a437 in starrocks::start_be(std::vector<starrocks::StorePath, std::allocator<starrocks::StorePath> > const&, bool) be/src/service/service_be/starrocks_be.cpp:131
   #8 0x1227fc1d in main be/src/service/starrocks_main.cpp:266
   #9 0x2af8c0466554 in __libc_start_main (/lib64/libc.so.6+0x22554) (BuildId: 1a8fb61bb4614a483833d5334202ab50edda2a25)

SUMMARY: AddressSanitizer: heap-use-after-free be/src/exec/spill/query_spill_manager.h:55 in starrocks::spill::QuerySpillManager::dec_reserve_bytes(unsigned long)
Shadow bytes around the buggy address:
 0x504002a24800: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
 0x504002a24880: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
 0x504002a24900: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
 0x504002a24980: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
 0x504002a24a00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x504002a24a80: fa fa fd fd fd fd fd[fd]fa fa fa fa fa fa fa fa
 0x504002a24b00: fa fa 00 00 00 00 00 fa fa fa fa fa fa fa fa fa
 0x504002a24b80: fa fa fa fa fa fa fa fa fa fa 00 00 00 00 00 00
 0x504002a24c00: fa fa fd fd fd fd fd fa fa fa fd fd fd fd fd fa
 0x504002a24c80: fa fa fd fd fd fd fd fa fa fa fa fa fa fa fa fa
 0x504002a24d00: fa fa fa fa fa fa fa fa fa fa fd fd fd fd fd fa
Shadow byte legend (one shadow byte represents 8 application bytes):
 Addressable:           00
 Partially addressable: 01 02 03 04 05 06 07 
 Heap left redzone:       fa
 Freed heap region:       fd
 Stack left redzone:      f1
 Stack mid redzone:       f2
 Stack right redzone:     f3
 Stack after return:      f5
 Stack use after scope:   f8
 Global redzone:          f9
 Global init order:       f6
 Poisoned by user:        f7
 Container overflow:      fc
 Array cookie:            ac
 Intra object redzone:    bb
 ASan internal:           fe
 Left alloca redzone:     ca
 Right alloca redzone:    cb
==2826==ABORTING

```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
