### PR TITLE
[Doc] Release Notes for 3.3.21 and 4.0.3

### DIFF
--- a/docs/.markdownlint.json
+++ b/docs/.markdownlint.json
@@ -2,6 +2,7 @@
   "default": true,
   "MD001": false,
   "MD004": false,
+  "MD005": false,
   "MD007": false,
   "MD009": false,
   "MD010": false,

--- a/docs/en/release_notes/release-3.3.md
+++ b/docs/en/release_notes/release-3.3.md
@@ -11,6 +11,47 @@ displayed_sidebar: docs
 
 :::
 
+## 3.3.21
+
+Release Date: December 25, 2025
+
+### Bug Fixes
+
+The following issues have been fixed:
+
+- Logic errors when the `trim` function handles specific Unicode whitespace characters (for example, `\u1680`) and performance issues caused by reserved memory calculation. [#66428](https://github.com/StarRocks/starrocks/pull/66428) [#66477](https://github.com/StarRocks/starrocks/pull/66477)
+- Foreign key constraints are lost after FE restart due to table loading order. [#66474](https://github.com/StarRocks/starrocks/pull/66474)
+- Security vulnerabilities CVE-2025-66566 and CVE-2025-12183 in `lz4-java`, and potential crashes in upstream. [#66453](https://github.com/StarRocks/starrocks/pull/66453) [#66362](https://github.com/StarRocks/starrocks/pull/66362) [#67075](https://github.com/StarRocks/starrocks/pull/67075)
+- Incorrect results when Join is used with window functions in Group Execution mode. [#66441](https://github.com/StarRocks/starrocks/pull/66441)
+- System continues attempting to fetch metadata for a deleted warehouse, causing `SHOW LOAD` or SQL execution failures. [#66436](https://github.com/StarRocks/starrocks/pull/66436)
+- `PartitionColumnMinMaxRewriteRule` optimization incorrectly returns an empty set instead of NULL when the Scan input for aggregation is fully filtered. [#66356](https://github.com/StarRocks/starrocks/pull/66356)
+- Rowset IDs are not properly released when Rowset Commit or Compaction fails, preventing disk space reclamation. [#66301](https://github.com/StarRocks/starrocks/pull/66301)
+- Missing scan statistics (for example, scanned rows/bytes) in audit logs when a high-selectivity filter causes the Scan to end early (EOS). [#66280](https://github.com/StarRocks/starrocks/pull/66280)
+- BE continues to respond to heartbeats as Alive after entering the crash handling process (for example, SIGSEGV), causing the FE to continue dispatching queries and reporting errors [#66212](https://github.com/StarRocks/starrocks/pull/66212)
+- BE crash caused by multiple calls to `set_collector` of the Runtime Filter due to Local TopN pushdown optimization. [#66199](https://github.com/StarRocks/starrocks/pull/66199)
+- Load task failures caused by un-initialized `rssid` when column-mode Partial Update is used with Conditional Update. [#66139](https://github.com/StarRocks/starrocks/pull/66139)
+- Race condition when submitting drivers in Colocate Execution Group, leading to BE crashes. [#66099](https://github.com/StarRocks/starrocks/pull/66099)
+- `MemoryScratchSinkOperator` remains in a pending state and cannot be cancelled after `RecordBatchQueue` is closed (For example, triggered by SparkSQL Limit), causing queries to hang. [#66041](https://github.com/StarRocks/starrocks/pull/66041)
+- Use-after-free issue caused by a race condition when accessing `_num_pipelines` in the `ExecutionGroup` countdown logic. [#65940](https://github.com/StarRocks/starrocks/pull/65940)
+- Incorrect calculation logic for query error rate monitoring metrics (Internal/Analysis/Timeout error rate), resulting in negative values. [#65891](https://github.com/StarRocks/starrocks/pull/65891)
+- Null Pointer Exception (NPE) caused by unset `ConnectContext` when executing tasks as an LDAP user. [#65843](https://github.com/StarRocks/starrocks/pull/65843)
+- Performance issues where Filesystem Cache lookups for the same Key fail because object reference comparison is used instead of value comparison. [#65823](https://github.com/StarRocks/starrocks/pull/65823)
+- Tablet-related files are not correctly cleaned up after a snapshot load failure due to incorrect status variable checking. [#65709](https://github.com/StarRocks/starrocks/pull/65709)
+- Compression type and level configured in FE are not correctly propagated to BE or persisted during table creation or Schema Change, resulting in default compression settings. [#65673](https://github.com/StarRocks/starrocks/pull/65673)
+- `COM_STMT_EXECUTE` has no audit logs by default, and Profile information is incorrectly merged into the Prepare stage. [#65448](https://github.com/StarRocks/starrocks/pull/65448)
+- Delete Vector CRC32 check failures during cluster upgrade/downgrade scenarios due to version incompatibility. [#65442](https://github.com/StarRocks/starrocks/pull/65442)
+- BE crash caused by improper handling of Nullable properties when `UnionConstSourceOperator` merges Union to Values. [#65429](https://github.com/StarRocks/starrocks/pull/65429)
+- Concurrent load tasks fail during the Commit phase if the target tablet is dropped during an ALTER TABLE operation. [#65396](https://github.com/StarRocks/starrocks/pull/65396)
+- Inaccurate error log information when authentication fails due to incorrect context setting if users are switched in the HTTP SQL interface. [#65371](https://github.com/StarRocks/starrocks/pull/65371)
+- Statistics collection issues after `INSERT OVERWRITE`, including failure to collect statistics for temporary partitions and inaccurate row count statistics at transaction commit preventing collection trigger. [#65327](https://github.com/StarRocks/starrocks/pull/65327), [#65298](https://github.com/StarRocks/starrocks/pull/65298), [#65225](https://github.com/StarRocks/starrocks/pull/65225)
+- `HttpConnectContext` related to SQL is not released in TCP connection reuse scenarios because subsequent non-SQL HTTP requests overwrite the context. [#65203](https://github.com/StarRocks/starrocks/pull/65203)
+- Potential version loss caused by incomplete tablet loading when RocksDB iteration times out during BE startup metadata loading. [#65146](https://github.com/StarRocks/starrocks/pull/65146)
+- BE crash caused by out-of-bounds access when processing compression parameters in the `percentile_approx_weighted` function. [#64838](https://github.com/StarRocks/starrocks/pull/64838)
+- Missing Query Profile logs for queries forwarded from Follower to Leader. [#64395](https://github.com/StarRocks/starrocks/pull/64395)
+- BE crash caused by lax size checks during LZ4 encoding of large string columns during spilling. [#61495](https://github.com/StarRocks/starrocks/pull/61495)
+- `MERGING-EXCHANGE` operator crash caused by Ranking window function optimization generating an empty `ORDER BY` when there is no `PARTITION BY` and `GROUP BY`. [#67081](https://github.com/StarRocks/starrocks/pull/67081)
+- Unstable results or errors in the Low Cardinality column rewrite logic due to dependence on the Set iteration order. [#66724](https://github.com/StarRocks/starrocks/pull/66724)
+
 ## 3.3.20
 
 Release Date: November 18, 2025

--- a/docs/en/release_notes/release-4.0.md
+++ b/docs/en/release_notes/release-4.0.md
@@ -10,6 +10,65 @@ After upgrading StarRocks to v4.0, DO NOT downgrade it directly to v3.5.0 & v3.5
 
 :::
 
+## 4.0.3
+
+Release Date: December 25, 2025
+
+### Downgrade Notes
+
+Before downgrading clusters from v4.0.3 to v3.5.0~v3.5.10, execute the following statement:
+
+```SQL
+SET GLOBAL enable_rewrite_simple_agg_to_meta_scan=false;
+```
+
+### Improvements
+
+- Supports `ORDER BY` clauses for STRUCT data types [#66035](https://github.com/StarRocks/starrocks/pull/66035)
+- Supports creating Iceberg views with properties and displaying properties in the output of `SHOW CREATE VIEW`. [#65938](https://github.com/StarRocks/starrocks/pull/65938)
+- Supports altering Iceberg table partition specs using `ALTER TABLE ADD/DROP PARTITION COLUMN`. [#65922](https://github.com/StarRocks/starrocks/pull/65922)
+- Supports `COUNT/SUM/AVG(DISTINCT)` aggregation over framed windows (for example, `ORDER BY`/`PARTITION BY`) with optimization options. [#65815](https://github.com/StarRocks/starrocks/pull/65815)
+- Optimized CSV parsing performance by using `memchr` for single-character delimiters. [#63715](https://github.com/StarRocks/starrocks/pull/63715)
+- Added an optimizer rule to push down Partial TopN to the Pre-Aggregation phase to reduce network overhead. [#61497](https://github.com/StarRocks/starrocks/pull/61497)
+- Enhanced Data Cache monitoring
+  - Added new metrics for memory/disk quota and usage. [#66168](https://github.com/StarRocks/starrocks/pull/66168)
+  - Added Page Cache statistics to the `api/datacache/stat` HTTP endpoint. [#66240](https://github.com/StarRocks/starrocks/pull/66240)
+  - Added hit rate statistics for native tables. [#66198](https://github.com/StarRocks/starrocks/pull/66198)
+- Optimized Sort and Aggregation operators to support rapid memory release in OOM scenarios. [#66157](https://github.com/StarRocks/starrocks/pull/66157)
+- Added `TableSchemaService` in FE for shared-data clusters to allow CNs to fetch specific schemas on demand. [#66142](https://github.com/StarRocks/starrocks/pull/66142)
+- Optimized Fast Schema Evolution to retain history schemas until all dependent ingestion jobs are finished. [#65799](https://github.com/StarRocks/starrocks/pull/65799)
+- Enhanced `filterPartitionsByTTL` to properly handle NULL partition values to prevent all partitions from being filtered. [#65923](https://github.com/StarRocks/starrocks/pull/65923)
+- Optimized `FusedMultiDistinctState` to clear the associated MemPool upon reset. [#66073](https://github.com/StarRocks/starrocks/pull/66073)
+- Made `ICEBERG_CATALOG_SECURITY` property check case-insensitive in Iceberg REST Catalog. [#66028](https://github.com/StarRocks/starrocks/pull/66028)
+- Added HTTP endpoint `GET /service_id` to retrieve StarOS Service ID in shared-data clusters. [#65816](https://github.com/StarRocks/starrocks/pull/65816)
+- Replaced deprecated `metadata.broker.list` with `bootstrap.servers` in Kafka consumer configurations. [#65437](https://github.com/StarRocks/starrocks/pull/65437)
+- Added FE configuration `lake_enable_fullvacuum` (Default: false) to allow disabling the Full Vacuum Daemon. [#66685](https://github.com/StarRocks/starrocks/pull/66685)
+- Updated lz4 library to v1.10.0. [#67080](https://github.com/StarRocks/starrocks/pull/67080)
+
+### Bug Fixes
+
+The following issues have been fixed:
+
+- `latest_cached_tablet_metadata` could cause versions to be incorrectly skipped during batch Publish. [#66558](https://github.com/StarRocks/starrocks/pull/66558)
+- Potential issues caused by `ClusterSnapshot` relative checks in `CatalogRecycleBin` when running in shared-nothing clusters. [#66501](https://github.com/StarRocks/starrocks/pull/66501)
+- BE crash when writing complex data types (ARRAY/MAP/STRUCT) to Iceberg tables during Spill operations. [#66209](https://github.com/StarRocks/starrocks/pull/66209)
+- Potential hang in Connector Chunk Sink when the writer's initialization or initial write fails. [#65951](https://github.com/StarRocks/starrocks/pull/65951)
+- Connector Chunk Sink bug where `PartitionChunkWriter` initialization failure caused a null pointer dereference during close. [#66097](https://github.com/StarRocks/starrocks/pull/66097)
+- Setting a non-existent system variable would silently succeed instead of reporting an error. [#66022](https://github.com/StarRocks/starrocks/pull/66022)
+- Bundle metadata parsing failure when Data Cache is corrupted. [#66021](https://github.com/StarRocks/starrocks/pull/66021)
+- MetaScan returned NULL instead of 0 for count columns when the result is empty. [#66010](https://github.com/StarRocks/starrocks/pull/66010)
+- `SHOW VERBOSE RESOURCE GROUP ALL` displays NULL instead of `default_mem_pool` for resource groups created in earlier versions. [#65982](https://github.com/StarRocks/starrocks/pull/65982)
+- A `RuntimeException` during query execution after disabling the `flat_json` table configuration. [#65921](https://github.com/StarRocks/starrocks/pull/65921)
+- Type mismatch issue in shared-data clusters caused by rewriting `min`/`max` statistics to MetaScan after Schema Change. [#65911](https://github.com/StarRocks/starrocks/pull/65911)
+- BE crash caused by ranking window optimization when `PARTITION BY` and `ORDER BY` are missing. [#67093](https://github.com/StarRocks/starrocks/pull/67093)
+- Incorrect `can_use_bf` check when merging runtime filters, which could lead to wrong results or crashes. [#67062](https://github.com/StarRocks/starrocks/pull/67062)
+- Pushing down runtime bitset filters into nested OR predicates causes incorrect results. [#67061](https://github.com/StarRocks/starrocks/pull/67061)
+- Potential data race and data loss issues caused by write or flush operations after the DeltaWriter has finished. [#66966](https://github.com/StarRocks/starrocks/pull/66966)
+- Execution error caused by mismatched nullable properties when rewriting simple aggregation to MetaScan. [#67068](https://github.com/StarRocks/starrocks/pull/67068)
+- Incorrect row count calculation in the MetaScan rewrite rule. [#66967](https://github.com/StarRocks/starrocks/pull/66967)
+- Versions might be incorrectly skipped during batch Publish due to inconsistent cached tablet metadata. [#66575](https://github.com/StarRocks/starrocks/pull/66575)
+- Improper error handling for memory allocation failures in HyperLogLog operations. [#66827](https://github.com/StarRocks/starrocks/pull/66827)
+
 ## 4.0.2
 
 Release Date: December 4, 2025

--- a/docs/ja/release_notes/release-3.3.md
+++ b/docs/ja/release_notes/release-3.3.md
@@ -11,6 +11,47 @@ displayed_sidebar: docs
 
 :::
 
+## 3.3.21
+
+リリース日: 2025年12月25日
+
+### バグ修正
+
+以下の問題が修正されました:
+
+- `trim`関数が特定のUnicode空白文字（`\u1680`など）を処理する際のロジックエラーおよびメモリ予約計算によるパフォーマンスの問題。 [#66428](https://github.com/StarRocks/starrocks/pull/66428), [#66477](https://github.com/StarRocks/starrocks/pull/66477)
+- テーブルのロード順序の問題により、FE再起動後に外部キー制約が失われる問題。 [#66474](https://github.com/StarRocks/starrocks/pull/66474)
+- `lz4-java`のセキュリティ脆弱性CVE-2025-66566およびCVE-2025-12183、およびアップストリームの潜在的なクラッシュ。 [#66453](https://github.com/StarRocks/starrocks/pull/66453), [#66362](https://github.com/StarRocks/starrocks/pull/66362), [#67075](https://github.com/StarRocks/starrocks/pull/67075)
+- Group ExecutionモードでJoinとウィンドウ関数を併用した場合に、計算結果が正しくない問題。 [#66441](https://github.com/StarRocks/starrocks/pull/66441)
+- 削除されたウェアハウスのメタデータをシステムが取得しようとし続け、`SHOW LOAD`やSQLの実行が失敗する問題。 [#66436](https://github.com/StarRocks/starrocks/pull/66436)
+- 集計入力のScanが完全にフィルタリングされた場合、`PartitionColumnMinMaxRewriteRule`最適化がNULLではなくEmpty Setを誤って返す問題。 [#66356](https://github.com/StarRocks/starrocks/pull/66356)
+- RowsetのコミットまたはCompactionが失敗した際にRowset IDが適切に解放されず、ディスク領域が回収されない問題。 [#66301](https://github.com/StarRocks/starrocks/pull/66301)
+- 高い選択率のフィルタによりScanが早期に終了（EOS）した場合に、監査ログのScan統計情報（スキャン行数/バイト数など）が欠落する問題。 [#66280](https://github.com/StarRocks/starrocks/pull/66280)
+- BEがクラッシュ処理プロセス（SIGSEGVなど）に入った後もハートビートにAliveとして応答し続け、FEがクエリをディスパッチし続けてエラーを報告する問題。 [#66212](https://github.com/StarRocks/starrocks/pull/66212)
+- Local TopNのプッシュダウン最適化によりRuntime Filterの`set_collector`が複数回呼び出され、BEクラッシュが発生する問題。 [#66199](https://github.com/StarRocks/starrocks/pull/66199)
+- カラムモードの部分更新（Partial Update）と条件付き更新（Conditional Update）を同時に使用した際、`rssid`が初期化されずにインポートタスクが失敗する問題。 [#66139](https://github.com/StarRocks/starrocks/pull/66139)
+- Colocate Execution Groupでドライバーを送信する際の競合状態により、BEクラッシュが発生する問題。 [#66099](https://github.com/StarRocks/starrocks/pull/66099)
+- `RecordBatchQueue`が閉じられた後（例：SparkSQLのLimitによってトリガーされる）、`MemoryScratchSinkOperator`が保留状態のままキャンセルできず、クエリがハングする問題。 [#66041](https://github.com/StarRocks/starrocks/pull/66041)
+- `ExecutionGroup`のカウントダウンロジックで`_num_pipelines`にアクセスする際の競合状態によるUse-after-free問題。 [#65940](https://github.com/StarRocks/starrocks/pull/65940)
+- クエリエラー率の監視メトリクス（Internal/Analysis/Timeoutエラー率）の計算ロジックが誤っており、負の値が表示される問題。 [#65891](https://github.com/StarRocks/starrocks/pull/65891)
+- LDAPユーザーとしてタスクを実行する際、`ConnectContext`が設定されていないために発生するNull Pointer Exception (NPE)。 [#65843](https://github.com/StarRocks/starrocks/pull/65843)
+- ファイルシステムキャッシュ（Filesystem Cache）で、値の比較ではなくオブジェクト参照の比較が使用されていたため、同じKeyのキャッシュ検索が失敗し、パフォーマンスに影響する問題。 [#65823](https://github.com/StarRocks/starrocks/pull/65823)
+- スナップショットのロード失敗後、ステータス変数のチェックミスにより、タブレット関連ファイルが正しくクリーンアップされない問題。 [#65709](https://github.com/StarRocks/starrocks/pull/65709)
+- テーブル作成時やSchema Change時に、FEで設定された圧縮タイプとレベルがBEに正しく伝播または永続化されず、デフォルトの圧縮設定が使用される問題。 [#65673](https://github.com/StarRocks/starrocks/pull/65673)
+- `COM_STMT_EXECUTE`の監査ログがデフォルトで存在せず、Profile情報がPrepare段階の記録に誤ってマージされる問題。 [#65448](https://github.com/StarRocks/starrocks/pull/65448)
+- クラスタのアップグレード/ダウングレードのシナリオにおいて、バージョンの非互換性によりDelete VectorのCRC32チェックが失敗する問題。 [#65442](https://github.com/StarRocks/starrocks/pull/65442)
+- `UnionConstSourceOperator`がUnionをValuesにマージする際、Nullable属性の処理が不適切でBEクラッシュが発生する問題。 [#65429](https://github.com/StarRocks/starrocks/pull/65429)
+- Alter Table操作中にターゲットのタブレットがDropされた場合、並行して実行されているインポートタスク（Ingestion）がコミットフェーズで失敗する問題。 [#65396](https://github.com/StarRocks/starrocks/pull/65396)
+- HTTP SQLインターフェースでユーザーを切り替える際、コンテキストの設定が正しくないために認証が失敗した場合の不正確なエラーログ情報。 [#65371](https://github.com/StarRocks/starrocks/pull/65371)
+- 一時パーティションの統計収集の失敗や、トランザクションコミット時の行数統計が不正確で収集がトリガーされないなど、`INSERT OVERWRITE`後の統計情報収集に関する問題。 [#65327](https://github.com/StarRocks/starrocks/pull/65327), [#65298](https://github.com/StarRocks/starrocks/pull/65298), [#65225](https://github.com/StarRocks/starrocks/pull/65225)
+- TCP接続の再利用シナリオにおいて、後続の非SQL HTTPリクエストがコンテキストを上書きしたため、SQLに関連する`HttpConnectContext`が解放されない問題。 [#65203](https://github.com/StarRocks/starrocks/pull/65203)
+- BE起動時のメタデータロード中にRocksDBの反復処理がタイムアウトすると、タブレットのロードが不完全になりバージョンが失われる可能性がある問題。 [#65146](https://github.com/StarRocks/starrocks/pull/65146)
+- `percentile_approx_weighted`関数で圧縮パラメータを処理する際の境界外アクセスにより、BEクラッシュが発生する問題。 [#64838](https://github.com/StarRocks/starrocks/pull/64838)
+- FollowerからLeaderに転送されて実行されたクエリのQuery Profileログが欠落する問題。 [#64395](https://github.com/StarRocks/starrocks/pull/64395)
+- Spillingプロセス中に、大きな文字列カラムのLZ4エンコード時のサイズチェックが甘く、BEクラッシュが発生する問題。 [#61495](https://github.com/StarRocks/starrocks/pull/61495)
+- `PARTITION BY`と`GROUP BY`がない場合に、Rankingウィンドウ関数の最適化が空の`ORDER BY`を生成し、`MERGING-EXCHANGE`オペレータがクラッシュする問題。 [#67081](https://github.com/StarRocks/starrocks/pull/67081)
+- 低基数（Low Cardinality）カラムの書き換えロジックがSetの反復順序に依存しており、結果が不安定になったりエラーが発生したりする問題。 [#66724](https://github.com/StarRocks/starrocks/pull/66724)
+
 ## 3.3.20
 
 リリース日：2025年11月18日

--- a/docs/ja/release_notes/release-4.0.md
+++ b/docs/ja/release_notes/release-4.0.md
@@ -10,6 +10,65 @@ StarRocks を v4.0 にアップグレードした後、v3.5.0 および v3.5.1 �
 
 :::
 
+## 4.0.3
+
+リリース日：2025 年 12 月 25 日
+
+### ダウングレードに関する注意事項
+
+クラスターを v4.0.3 から v3.5.0～v3.5.10 にダウングレードする前に、以下のステートメントを実行してください。
+
+```SQL
+SET GLOBAL enable_rewrite_simple_agg_to_meta_scan=false;
+```
+
+### 改善点
+
+- STRUCT データ型に対する `ORDER BY` 句をサポートしました。[#66035](https://github.com/StarRocks/starrocks/pull/66035)
+- プロパティ付き Iceberg ビューの作成をサポートし、`SHOW CREATE VIEW` の出力にプロパティを表示できるようになりました。[#65938](https://github.com/StarRocks/starrocks/pull/65938)
+- `ALTER TABLE ADD/DROP PARTITION COLUMN` による Iceberg テーブルのパーティション Spec の変更をサポートしました。[#65922](https://github.com/StarRocks/starrocks/pull/65922)
+- フレーム付きウィンドウ（例：`ORDER BY` / `PARTITION BY`）上での `COUNT/SUM/AVG(DISTINCT)` 集約をサポートし、最適化オプションを追加しました。[#65815](https://github.com/StarRocks/starrocks/pull/65815)
+- 単一文字区切り文字に `memchr` を使用することで、CSV パース性能を最適化しました。[#63715](https://github.com/StarRocks/starrocks/pull/63715)
+- ネットワークオーバーヘッド削減のため、Partial TopN を事前集約（Pre-Aggregation）フェーズにプッシュダウンするオプティマイザルールを追加しました。[#61497](https://github.com/StarRocks/starrocks/pull/61497)
+- Data Cache の監視機能を強化しました：
+  - メモリ／ディスクのクォータおよび使用量に関する新しいメトリクスを追加しました。[#66168](https://github.com/StarRocks/starrocks/pull/66168)
+  - `api/datacache/stat` HTTP エンドポイントに Page Cache の統計情報を追加しました。[#66240](https://github.com/StarRocks/starrocks/pull/66240)
+  - ネイティブテーブルのヒット率統計を追加しました。[#66198](https://github.com/StarRocks/starrocks/pull/66198)
+- OOM 発生時に迅速にメモリを解放できるよう、Sort および Aggregation オペレーターを最適化しました。[#66157](https://github.com/StarRocks/starrocks/pull/66157)
+- 共有データクラスターにおいて、CN が必要なスキーマをオンデマンドで取得できるよう、FE に `TableSchemaService` を追加しました。[#66142](https://github.com/StarRocks/starrocks/pull/66142)
+- すべての依存する取り込みジョブが完了するまで履歴スキーマを保持するよう、Fast Schema Evolution を最適化しました。[#65799](https://github.com/StarRocks/starrocks/pull/65799)
+- `filterPartitionsByTTL` を強化し、NULL パーティション値を正しく処理することで、全パーティションが誤って除外される問題を防止しました。[#65923](https://github.com/StarRocks/starrocks/pull/65923)
+- `FusedMultiDistinctState` を最適化し、リセット時に関連する MemPool を解放するようにしました。[#66073](https://github.com/StarRocks/starrocks/pull/66073)
+- Iceberg REST Catalog において、`ICEBERG_CATALOG_SECURITY` プロパティのチェックを大文字・小文字を区別しないようにしました。[#66028](https://github.com/StarRocks/starrocks/pull/66028)
+- 共有データクラスター向けに、StarOS Service ID を取得する HTTP エンドポイント `GET /service_id` を追加しました。[#65816](https://github.com/StarRocks/starrocks/pull/65816)
+- Kafka コンシューマー設定において、非推奨の `metadata.broker.list` を `bootstrap.servers` に置き換えました。[#65437](https://github.com/StarRocks/starrocks/pull/65437)
+- Full Vacuum Daemon を無効化できる FE 設定項目 `lake_enable_fullvacuum`（デフォルト：false）を追加しました。[#66685](https://github.com/StarRocks/starrocks/pull/66685)
+- lz4 ライブラリを v1.10.0 に更新しました。[#67080](https://github.com/StarRocks/starrocks/pull/67080)
+
+### バグ修正
+
+以下の問題を修正しました：
+
+- `latest_cached_tablet_metadata` により、バッチ Publish 中にバージョンが誤ってスキップされる可能性がありました。[#66558](https://github.com/StarRocks/starrocks/pull/66558)
+- 共有なしクラスター実行時に、`CatalogRecycleBin` 内の `ClusterSnapshot` の相対チェックが引き起こす可能性のある問題。[#66501](https://github.com/StarRocks/starrocks/pull/66501)
+- Spill 処理中に、複雑なデータ型（ARRAY / MAP / STRUCT）を Iceberg テーブルへ書き込む際に BE がクラッシュする問題。[#66209](https://github.com/StarRocks/starrocks/pull/66209)
+- writer の初期化または初回書き込みが失敗した場合に、Connector Chunk Sink がハングする可能性がある問題。[#65951](https://github.com/StarRocks/starrocks/pull/65951)
+- Connector Chunk Sink において、`PartitionChunkWriter` の初期化失敗により、クローズ時に Null Pointer 参照が発生する問題。[#66097](https://github.com/StarRocks/starrocks/pull/66097)
+- 存在しないシステム変数を設定した際に、エラーが返されず成功してしまう問題。[#66022](https://github.com/StarRocks/starrocks/pull/66022)
+- Data Cache が破損している場合に、Bundle メタデータの解析が失敗する問題。[#66021](https://github.com/StarRocks/starrocks/pull/66021)
+- 結果が空の場合に、MetaScan が count 列に対して 0 ではなく NULL を返す問題。[#66010](https://github.com/StarRocks/starrocks/pull/66010)
+- 旧バージョンで作成されたリソースグループに対し、`SHOW VERBOSE RESOURCE GROUP ALL` が `default_mem_pool` ではなく NULL を表示する問題。[#65982](https://github.com/StarRocks/starrocks/pull/65982)
+- `flat_json` テーブル設定を無効化した後、クエリ実行中に `RuntimeException` が発生する問題。[#65921](https://github.com/StarRocks/starrocks/pull/65921)
+- 共有データクラスターにおいて、Schema Change 後に `min` / `max` 統計を MetaScan に書き換える際に発生する型不一致の問題。[#65911](https://github.com/StarRocks/starrocks/pull/65911)
+- `PARTITION BY` および `ORDER BY` が指定されていない場合に、ランキングウィンドウ最適化によって BE がクラッシュする問題。[#67093](https://github.com/StarRocks/starrocks/pull/67093)
+- 実行時フィルター統合時の `can_use_bf` 判定が不正確で、誤った結果やクラッシュを引き起こす可能性がある問題。[#67062](https://github.com/StarRocks/starrocks/pull/67062)
+- 実行時 bitset フィルターをネストした OR 述語にプッシュダウンした際に、結果が不正になる問題。[#67061](https://github.com/StarRocks/starrocks/pull/67061)
+- DeltaWriter 完了後の書き込みや flush 処理により、データ競合やデータ損失が発生する可能性がある問題。[#66966](https://github.com/StarRocks/starrocks/pull/66966)
+- 単純集約を MetaScan に書き換える際、nullable 属性の不一致により実行エラーが発生する問題。[#67068](https://github.com/StarRocks/starrocks/pull/67068)
+- MetaScan 書き換えルールにおける行数計算が正しくない問題。[#66967](https://github.com/StarRocks/starrocks/pull/66967)
+- Tablet メタデータキャッシュの不整合により、バッチ Publish 中にバージョンが誤ってスキップされる可能性がある問題。[#66575](https://github.com/StarRocks/starrocks/pull/66575)
+- HyperLogLog 処理において、メモリ割り当て失敗時のエラーハンドリングが不適切な問題。[#66827](https://github.com/StarRocks/starrocks/pull/66827)
+
 ## 4.0.2
 
 リリース日：2025年12月4日

--- a/docs/zh/release_notes/release-3.3.md
+++ b/docs/zh/release_notes/release-3.3.md
@@ -771,12 +771,9 @@ displayed_sidebar: docs
 - Stream Load 支持将 `\t` 和 `\n` 分别作为行列分割符，无需转成对应的十六进制 ASCII 码。[#47302](https://github.com/StarRocks/starrocks/pull/47302)
 - 优化写入算子的的异步统计信息收集方式，解决导入任务较多时延迟变高的问题。[#48162](https://github.com/StarRocks/starrocks/pull/48162)
 -  增加以下 BE 动态参数以控制导入过程中的资源硬限制，从而降低写入大量 Tablet 时对 BE 稳定性的影响。[#48495](https://github.com/StarRocks/starrocks/pull/48495)
-
   包括：
-
   - `load_process_max_memory_hard_limit_ratio`
   - `enable_new_load_on_memory_limit_exceeded`
-
 - 增加同一表内 Column ID 的一致性检查，防止引起 Compaction 错误。[#48498](https://github.com/StarRocks/starrocks/pull/48628)
 - 持久化 PIPE 元数据，防止因 FE 重启而导致元数据丢失。[#48852](https://github.com/StarRocks/starrocks/pull/48852)
 

--- a/docs/zh/release_notes/release-3.3.md
+++ b/docs/zh/release_notes/release-3.3.md
@@ -11,6 +11,47 @@ displayed_sidebar: docs
 
 :::
 
+## 3.3.21
+
+发布日期：2025 年 12 月 25 日
+
+### 问题修复
+
+修复了以下问题：
+
+- `trim` 函数处理特定 Unicode 空白字符（如 `\u1680`）时的逻辑错误，以及预留内存计算导致的性能问题。 [#66428](https://github.com/StarRocks/starrocks/pull/66428), [#66477](https://github.com/StarRocks/starrocks/pull/66477)
+- FE 重启时因表加载顺序问题导致外键约束（Foreign Key Constraints）丢失的问题。 [#66474](https://github.com/StarRocks/starrocks/pull/66474)
+- 安全漏洞 CVE-2025-66566 和 CVE-2025-12183，以及上游潜在崩溃问题。 [#66453](https://github.com/StarRocks/starrocks/pull/66453), [#66362](https://github.com/StarRocks/starrocks/pull/66362), [#67075](https://github.com/StarRocks/starrocks/pull/67075)
+- Group Execution 模式下 Join 配合窗口函数使用时，计算结果不正确。 [#66441](https://github.com/StarRocks/starrocks/pull/66441)
+- Warehouse 删除后，系统仍尝试获取其元数据，导致 `SHOW LOAD` 或 SQL 执行失败。 [#66436](https://github.com/StarRocks/starrocks/pull/66436)
+- 当聚合输入的 Scan 被完全过滤（Empty Set）时，`PartitionColumnMinMaxRewriteRule` 优化导致结果错误地返回 Empty Set 而非 NULL。 [#66356](https://github.com/StarRocks/starrocks/pull/66356)
+- Rowset 提交或 Compaction 失败时 Rowset ID 未被正确释放，导致磁盘空间无法回收。 [#66301](https://github.com/StarRocks/starrocks/pull/66301)
+- 高选择率过滤导致 Scan 提前结束（EOS）时，审计日志中的 Scan 统计信息（如扫描行数/字节数）缺失。 [#66280](https://github.com/StarRocks/starrocks/pull/66280)
+- BE 发生 fatal signal (如 SIGSEGV) 进入 Crash 处理流程后仍响应心跳为 Alive，导致 FE 继续分发查询并报错。 [#66212](https://github.com/StarRocks/starrocks/pull/66212)
+- Local TopN 下推优化导致 Runtime Filter 的 `set_collector` 被多次调用，引发 BE Crash。 [#66199](https://github.com/StarRocks/starrocks/pull/66199)
+- 列模式部分更新（Partial Update）与条件更新（Conditional Update）同时使用时，因 `rssid` 未初始化导致导入任务失败。 [#66139](https://github.com/StarRocks/starrocks/pull/66139)
+- Colocate Execution Group 在提交驱动（Driver）时存在竞态条件，导致 BE Crash。 [#66099](https://github.com/StarRocks/starrocks/pull/66099)
+- `RecordBatchQueue` 关闭（如 SparkSQL 触发 Limit）后，`MemoryScratchSinkOperator` 处于 pending 状态无法取消，导致查询挂起。 [#66041](https://github.com/StarRocks/starrocks/pull/66041)
+- `ExecutionGroup` 倒计时逻辑中访问 `_num_pipelines` 存在竞态条件，导致 Use-after-free 问题。 [#65940](https://github.com/StarRocks/starrocks/pull/65940)
+- 查询错误率相关监控指标（Internal/Analysis/Timeout error rate）计算逻辑错误，导致显示负值。 [#65891](https://github.com/StarRocks/starrocks/pull/65891)
+- LDAP 用户执行任务时，因 `ConnectContext` 未设置导致空指针异常 (NPE)。 [#65843](https://github.com/StarRocks/starrocks/pull/65843)
+- 文件系统缓存（Filesystem Cache）因使用对象引用比较而非值比较，导致相同 Key 的缓存查找失败，影响性能。 [#65823](https://github.com/StarRocks/starrocks/pull/65823)
+- 快照加载失败后，因状态变量检查错误导致 Tablet 关联文件未能被正确清理。 [#65709](https://github.com/StarRocks/starrocks/pull/65709)
+- 建表或 Schema Change 时，FE 配置的压缩类型和级别未正确透传至 BE 或持久化，导致使用默认压缩设置。 [#65673](https://github.com/StarRocks/starrocks/pull/65673)
+- `COM_STMT_EXECUTE` 默认无审计日志，且 Profile 信息被错误地合并到 Prepare 阶段记录中；修复后默认开启审计并支持参数解码。 [#65448](https://github.com/StarRocks/starrocks/pull/65448)
+- Delete Vector 的 CRC32 校验在集群升级/降级场景下因版本不兼容导致检查失败。 [#65442](https://github.com/StarRocks/starrocks/pull/65442)
+- `UnionConstSourceOperator` 在合并 Union 到 Values 时，对 Nullable 属性处理不当导致 BE Crash。 [#65429](https://github.com/StarRocks/starrocks/pull/65429)
+- Alter Table 操作期间，若目标 Tablet 被 Drop，并发的导入任务（Ingestion）会在提交阶段失败。 [#65396](https://github.com/StarRocks/starrocks/pull/65396)
+- HTTP SQL 接口在切换用户时未正确设置上下文，导致鉴权失败时的错误日志信息不准确。 [#65371](https://github.com/StarRocks/starrocks/pull/65371)
+- 修复 `INSERT OVERWRITE` 后的统计信息收集问题：包括无法为临时分区收集统计信息、事务提交时行数统计不准导致未触发收集等。 [#65327](https://github.com/StarRocks/starrocks/pull/65327), [#65298](https://github.com/StarRocks/starrocks/pull/65298), [#65225](https://github.com/StarRocks/starrocks/pull/65225)
+- TCP 连接复用场景下，后续非 SQL 的 HTTP 请求覆盖了 Context，导致 SQL 相关的 `HttpConnectContext` 无法释放。 [#65203](https://github.com/StarRocks/starrocks/pull/65203)
+- BE 启动加载 Tablet 元数据时，若 RocksDB 迭代超时会导致 Tablet 加载不全从而引发版本丢失。 [#65146](https://github.com/StarRocks/starrocks/pull/65146)
+- `percentile_approx_weighted` 函数在处理压缩参数时存在越界访问风险，导致 BE Crash。 [#64838](https://github.com/StarRocks/starrocks/pull/64838)
+- 从 Follower 转发到 Leader 执行的查询丢失 Query Profile 日志。 [#64395](https://github.com/StarRocks/starrocks/pull/64395)
+- Spill 过程中，大字符串列在进行 LZ4 编码时因 Size 检查不严导致 BE Crash。 [#61495](https://github.com/StarRocks/starrocks/pull/61495)
+- 无 `PARTITION BY` 和 `GROUP BY` 的 Ranking 窗口函数优化生成了空的 `ORDER BY`，导致 `MERGING-EXCHANGE` 算子 Crash。 [#67081](https://github.com/StarRocks/starrocks/pull/67081)
+- 低基数（Low Cardinality）列重写逻辑依赖 Set 迭代顺序，导致结果不稳定或报错，改为并查集实现。 [#66724](https://github.com/StarRocks/starrocks/pull/66724)
+
 ## 3.3.20
 
 发布日期：2025 年 11 月 18 日


### PR DESCRIPTION
Signed-off-by: EsoragotoSpirit <wanglichen@starrocks.com>

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates documentation with the latest patch releases for 3.3 and 4.0 and a minor lint rule change.
> 
> - Adds `3.3.21` release notes (EN/JA/ZH): bug-fix rollup including Unicode `trim` handling, FK persistence after FE restart, multiple BE crash/hang fixes, logging/metrics corrections, and various optimizer/runtime stability fixes
> - Adds `4.0.3` release notes (EN/JA/ZH):
>   - Downgrade note requiring `SET GLOBAL enable_rewrite_simple_agg_to_meta_scan=false`
>   - Improvements: STRUCT `ORDER BY`, Iceberg view/partition spec support, DISTINCT over framed windows, CSV parsing perf, Partial TopN pushdown, Data Cache observability, faster OOM memory release, schema services/evolution tweaks, Kafka config update, lz4 update
>   - Bug fixes: MetaScan/nullability/count issues, runtime filter and ranking window crashes, publish/version caching correctness, connector sink robustness, HLL error handling, and assorted stability fixes
> - Updates `docs/.markdownlint.json` to disable rule `MD005`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d046ad8065be03eb5228f77a15c9c99ceb2a5a60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->