### PR TITLE
[BugFix] Fix SQL digest inconsistency between Follower and Leader

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -214,6 +214,11 @@ public class ConnectProcessor {
     }
 
     public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics) {
+        auditAfterExec(origStmt, parsedStmt, statistics, null);
+    }
+
+    public void auditAfterExec(String origStmt, StatementBase parsedStmt, PQueryStatistics statistics,
+                               String digestFromLeader) {
         // slow query
         long endTime = System.currentTimeMillis();
         long elapseMs = endTime - ctx.getStartTime();
@@ -278,8 +283,12 @@ public class ConnectProcessor {
 
         // Build Digest and queryFeMemory for SELECT/INSERT/UPDATE/DELETE
         if (ctx.getState().isQuery() || parsedStmt instanceof DmlStmt) {
-            if (Config.enable_sql_digest || ctx.getSessionVariable().isEnableSQLDigest()) {
-                ctx.getAuditEventBuilder().setDigest(computeStatementDigest(parsedStmt));
+            String digest = digestFromLeader;
+            if (digest == null && (Config.enable_sql_digest || ctx.getSessionVariable().isEnableSQLDigest())) {
+                digest = computeStatementDigest(parsedStmt);
+            }
+            if (digest != null) {
+                ctx.getAuditEventBuilder().setDigest(digest);
             }
             long threadAllocatedMemory =
                     getThreadAllocatedBytes(Thread.currentThread().getId()) - ctx.getCurrentThreadAllocatedMemory();
@@ -403,11 +412,19 @@ public class ConnectProcessor {
         // TODO(cmy): when user send multi-statement, the executor is the last statement's executor.
         // We may need to find some way to resolve this.
         if (executor != null) {
-            auditAfterExec(originStmt, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
+            String digestFromLeader = null;
+            if (executor.getIsForwardToLeaderOrInit(false) && executor.getLeaderOpExecutor() != null) {
+                TMasterOpResult leaderResult = executor.getLeaderOpExecutor().getResult();
+                if (leaderResult != null && leaderResult.isSetSql_digest()) {
+                    digestFromLeader = leaderResult.getSql_digest();
+                }
+            }
+            auditAfterExec(originStmt, executor.getParsedStmt(),
+                          executor.getQueryStatisticsForAuditLog(), digestFromLeader);
             executor.addFinishedQueryDetail();
         } else {
             // executor can be null if we encounter analysis error.
-            auditAfterExec(originStmt, null, null);
+            auditAfterExec(originStmt, null, null, null);
         }
     }
 
@@ -690,7 +707,15 @@ public class ConnectProcessor {
             }
 
             if (enableAudit) {
-                auditAfterExec(originStmt, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
+                String digestFromLeader = null;
+                if (executor.getIsForwardToLeaderOrInit(false) && executor.getLeaderOpExecutor() != null) {
+                    TMasterOpResult leaderResult = executor.getLeaderOpExecutor().getResult();
+                    if (leaderResult != null && leaderResult.isSetSql_digest()) {
+                        digestFromLeader = leaderResult.getSql_digest();
+                    }
+                }
+                auditAfterExec(originStmt, executor.getParsedStmt(),
+                              executor.getQueryStatisticsForAuditLog(), digestFromLeader);
             }
         } catch (Throwable e) {
             // Catch all throwable.
@@ -1090,6 +1115,17 @@ public class ConnectProcessor {
         }
         executor.setProxy();
         executor.execute();
+
+        if (executor.getParsedStmt() != null) {
+            StatementBase parsedStmt = executor.getParsedStmt();
+            if ((Config.enable_sql_digest || ctx.getSessionVariable().isEnableSQLDigest()) &&
+                    (ctx.getState().isQuery() || parsedStmt instanceof DmlStmt)) {
+                String digest = computeStatementDigest(parsedStmt);
+                if (!digest.isEmpty()) {
+                    result.setSql_digest(digest);
+                }
+            }
+        }
 
         return executor;
     }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -885,6 +885,8 @@ struct TMasterOpResult {
     7: optional TAuditStatistics audit_statistics;
     8: optional string errorMsg;
     9: optional i64 txn_id;
+    // SQL digest computed by Leader after analyze
+    10:optional string sql_digest;
 }
 
 struct TIsMethodSupportedRequest {


### PR DESCRIPTION
## Why I'm doing:

When the same SQL query is executed on Follower (forwarded to Leader) vs Leader (local execution), the `Digest` field in audit logs are inconsistent.

**Root Cause:**
- Follower calculates digest before AST analysis (TableName/SlotRef are not fully qualified)
- Leader calculates digest after AST analysis (TableName/SlotRef contain full catalog.db prefixes)
- The `Analyzer.analyze()` phase normalizes AST by filling catalog/db information into TableName and SlotRef objects
- Different AST states produce different string representations, leading to different MD5 digests

**Example:**
```
Follower: Digest=375dd0fba88b41ebe4a4eaa96f5cc692 | IsForwardToLeader=true
Leader:   Digest=2284580445ababd68839ad09e197ce63 | IsForwardToLeader=false
```

This inconsistency breaks digest-based query tracking, monitoring, and analysis.

## What I'm doing:

**Solution: Leader computes digest after analysis and returns it to Follower via Thrift RPC**

### Changes:

1. **Thrift Protocol** (`FrontendService.thrift`)
   - Added `sql_digest` field to `TMasterOpResult` structure

2. **Leader Side** (`ConnectProcessor.java`)
   - In `doProxyExecute()`: Compute SQL digest after AST analysis and set it in `result.sql_digest`
   - Leader does NOT generate its own audit log (proxy execution only)

3. **Follower Side** (`ConnectProcessor.java`)
   - Overloaded `auditAfterExec()` to accept optional `digestFromLeader` parameter
   - In `handleQuery()` and `handleExecute()`: Extract `sql_digest` from Leader's result
   - Use Leader's digest in audit log; fallback to local computation for non-forwarded queries

### Flow:

```
Follower: parse → forward → receive result (with digest) → audit (use Leader's digest)
Leader:   parse → analyze → execute → compute digest → return result (no audit)
```


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures consistent `Digest` in audit logs across leader/follower executions.
> 
> - **Thrift**: Add optional `sql_digest` to `TMasterOpResult` in `FrontendService.thrift`.
> - **Leader**: In `doProxyExecute()`, compute digest post-analysis (`computeStatementDigest`) and set `result.sql_digest`.
> - **Follower**: Overload `auditAfterExec()` to accept `digestFromLeader`; in `handleQuery()` and `handleExecute()`, extract `sql_digest` from leader result and pass to audit. Falls back to local digest when not forwarded or missing.
> - Only sets audit digest when non-null; no other behavior changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf9c562cb8ea512e09f6575027cffced7a88de5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->