### PR TITLE
[Enhancement] Repair cloud native table with missing data files

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
@@ -39,9 +39,10 @@ import com.starrocks.proto.GetTabletMetadatasRequest;
 import com.starrocks.proto.GetTabletMetadatasResponse;
 import com.starrocks.proto.RepairTabletMetadataRequest;
 import com.starrocks.proto.RepairTabletMetadataResponse;
+import com.starrocks.proto.TabletMetadataEntry;
 import com.starrocks.proto.TabletMetadataPB;
 import com.starrocks.proto.TabletMetadataRepairStatus;
-import com.starrocks.proto.TabletMetadatas;
+import com.starrocks.proto.TabletResult;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.rpc.RpcException;
@@ -66,6 +67,7 @@ public class TabletRepairHelper {
     private static final Logger LOG = LogManager.getLogger(TabletRepairHelper.class);
 
     private static final long BATCH_VERSION_NUM = 5L;
+    private static final String SST_FILE_SUFFIX = ".sst";
 
     // the version range [minVersion, maxVersion] is used to find valid tablet metadatas, both are included
     record PhysicalPartitionInfo(
@@ -178,9 +180,37 @@ public class TabletRepairHelper {
         }
     }
 
+    private static void printTabletMetadatas(GetTabletMetadatasResponse response, long nodeId, long physicalPartitionId,
+                                             long maxVersion, long minVersion) {
+        Map<Long, Map<Long, Integer>> tabletToVersionMissingFileNum = Maps.newHashMap();
+        if (response.tabletResults != null) {
+            for (TabletResult tr : response.tabletResults) {
+                TStatusCode tabletStatusCode = TStatusCode.findByValue(tr.status.statusCode);
+                if (tabletStatusCode == TStatusCode.OK) {
+                    Map<Long, Integer> versionToMissingFilesNum = Maps.newHashMap();
+                    if (tr.metadataEntries != null) {
+                        for (TabletMetadataEntry entry : tr.metadataEntries) {
+                            TabletMetadataPB metadata = entry.metadata;
+                            List<String> missingFiles = entry.missingFiles;
+                            if (metadata != null) {
+                                int missingFilesNum = missingFiles != null ? missingFiles.size() : 0;
+                                versionToMissingFilesNum.put(metadata.version, missingFilesNum);
+                            }
+                        }
+                    }
+                    tabletToVersionMissingFileNum.put(tr.tabletId, versionToMissingFilesNum);
+                }
+            }
+        }
+        LOG.debug("Get {} tablet metadatas from node {}, partition: {}, version range: [{}, {}], " +
+                        "tablet->(version->missing files num): {}",
+                tabletToVersionMissingFileNum.size(), nodeId, physicalPartitionId, minVersion, maxVersion,
+                tabletToVersionMissingFileNum);
+    }
+
     // returns a map of tablet IDs to valid tablet metadatas within the version range [minVersion, maxVersion]
-    private static Map<Long, Map<Long, TabletMetadataPB>> getTabletMetadatas(PhysicalPartitionInfo info, long maxVersion,
-                                                                             long minVersion) throws Exception {
+    private static Map<Long, Map<Long, TabletMetadataEntry>> getTabletMetadatas(PhysicalPartitionInfo info, long maxVersion,
+                                                                                long minVersion) throws Exception {
         long physicalPartitionId = info.physicalPartitionId;
         Set<Long> unverifiedTablets = info.unverifiedTablets;
         Map<ComputeNode, Set<Long>> nodeToTablets = info.nodeToTablets;
@@ -200,6 +230,7 @@ public class TabletRepairHelper {
             request.tabletIds = Lists.newArrayList(tabletIds);
             request.maxVersion = maxVersion;
             request.minVersion = minVersion;
+            request.checkMissingFiles = true;
 
             try {
                 LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
@@ -213,8 +244,8 @@ public class TabletRepairHelper {
             }
         }
 
-        // map<tablet id, map<version, TabletMetadataPB>>
-        Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = Maps.newHashMap();
+        // map<tablet id, map<version, TabletMetadataEntry>>
+        Map<Long, Map<Long, TabletMetadataEntry>> tabletToVersionMetadataEntry = Maps.newHashMap();
         for (int i = 0; i < responses.size(); ++i) {
             try {
                 GetTabletMetadatasResponse response = responses.get(i).get(LakeService.TIMEOUT_GET_TABLET_STATS,
@@ -230,15 +261,22 @@ public class TabletRepairHelper {
                     throw new StarRocksException(errMsgs != null && !errMsgs.isEmpty() ? errMsgs.get(0) : "unknown error");
                 }
 
-                if (response.tabletMetadatas != null) {
-                    for (TabletMetadatas tm : response.tabletMetadatas) {
-                        long tabletId = tm.tabletId;
-                        TStatusCode tabletStatusCode = TStatusCode.findByValue(tm.status.statusCode);
+                if (response.tabletResults != null) {
+                    for (TabletResult tr : response.tabletResults) {
+                        long tabletId = tr.tabletId;
+                        TStatusCode tabletStatusCode = TStatusCode.findByValue(tr.status.statusCode);
                         if (tabletStatusCode == TStatusCode.OK) {
-                            Map<Long, TabletMetadataPB> versionMetadatas = tm.versionMetadatas;
-                            tabletVersionMetadatas.put(tabletId, versionMetadatas);
+                            Map<Long, TabletMetadataEntry> versionToMetadataEntry = Maps.newHashMap();
+                            if (tr.metadataEntries != null) {
+                                for (TabletMetadataEntry entry : tr.metadataEntries) {
+                                    if (entry.metadata != null) {
+                                        versionToMetadataEntry.put(entry.metadata.version, entry);
+                                    }
+                                }
+                            }
+                            tabletToVersionMetadataEntry.put(tabletId, versionToMetadataEntry);
                         } else if (tabletStatusCode != TStatusCode.NOT_FOUND) {
-                            List<String> errMsgs = tm.status.errorMsgs;
+                            List<String> errMsgs = tr.status.errorMsgs;
                             throw new StarRocksException(
                                     errMsgs != null && !errMsgs.isEmpty() ? errMsgs.get(0) : "unknown error");
                         }
@@ -246,18 +284,7 @@ public class TabletRepairHelper {
                 }
 
                 if (LOG.isDebugEnabled()) {
-                    Map<Long, List<Long>> tabletVersions = Maps.newHashMap();
-                    if (response.tabletMetadatas != null) {
-                        for (TabletMetadatas tm : response.tabletMetadatas) {
-                            TStatusCode tabletStatusCode = TStatusCode.findByValue(tm.status.statusCode);
-                            if (tabletStatusCode == TStatusCode.OK) {
-                                tabletVersions.put(tm.tabletId, Lists.newArrayList(tm.versionMetadatas.keySet()));
-                            }
-                        }
-                    }
-                    LOG.debug("Get {} tablet metadatas from node {}, partition: {}, version range: [{}, {}], tablet versions: {}",
-                            tabletVersions.size(), nodes.get(i).getId(), physicalPartitionId, minVersion, maxVersion,
-                            tabletVersions);
+                    printTabletMetadatas(response, nodes.get(i).getId(), physicalPartitionId, maxVersion, minVersion);
                 }
             } catch (Exception e) {
                 LOG.warn("Fail to get tablet metadatas from node {}, partition: {}, error: {}", nodes.get(i).getId(),
@@ -266,21 +293,70 @@ public class TabletRepairHelper {
             }
         }
 
-        return tabletVersionMetadatas;
+        return tabletToVersionMetadataEntry;
+    }
+
+    private static boolean checkOnlySstFilesMissing(List<String> missingFiles) {
+        Preconditions.checkState(missingFiles != null && !missingFiles.isEmpty());
+        for (String file : missingFiles) {
+            if (!file.endsWith(SST_FILE_SUFFIX)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * valid metadata:
+     * 1. no missing files
+     * 2. only missing pk index sst files, BE can rebuild pk index
+     */
+    private static boolean checkTabletMetadataValid(TabletMetadataEntry metadataEntry) {
+        List<String> missingFiles = metadataEntry.missingFiles;
+        if (missingFiles == null || missingFiles.isEmpty()) {
+            // no missing files
+            return true;
+        }
+
+        // only missing pk index sst files
+        if (checkOnlySstFilesMissing(missingFiles)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static TabletMetadataPB getValidTabletMetadata(TabletMetadataEntry metadataEntry) {
+        TabletMetadataPB metadata = metadataEntry.metadata;
+        List<String> missingFiles = metadataEntry.missingFiles;
+        if (missingFiles == null || missingFiles.isEmpty()) {
+            // no missing files, metadata is valid
+            return metadata;
+        }
+
+        // only missing pk index sst files, clear sstableMeta
+        if (checkOnlySstFilesMissing(missingFiles)) {
+            metadata.sstableMeta = null;
+            return metadata;
+        }
+
+        Preconditions.checkState(false, "should not reach here");
+        return null;
     }
 
     /**
      * Finds valid tablet metadata for a physical partition based on version consistency requirements.
-     * The identified valid metadata entries are stored in the `validMetadatas` map.
+     * The identified valid metadata entries are stored in the `tabletToValidMetadata` map.
      */
     private static void findValidTabletMetadata(PhysicalPartitionInfo info,
-                                                Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas, long maxVersion,
-                                                long minVersion, boolean enforceConsistentVersion,
-                                                Map<Long, TabletMetadataPB> validMetadatas) {
+                                                Map<Long, Map<Long, TabletMetadataEntry>> tabletToVersionMetadataEntry,
+                                                long maxVersion, long minVersion, boolean enforceConsistentVersion,
+                                                Map<Long, TabletMetadataPB> tabletToValidMetadata) {
         if (enforceConsistentVersion) {
-            findConsistentVersionTabletMetadata(info, tabletVersionMetadatas, maxVersion, minVersion, validMetadatas);
+            findConsistentVersionTabletMetadata(info, tabletToVersionMetadataEntry, maxVersion, minVersion,
+                    tabletToValidMetadata);
         } else {
-            findLatestValidTabletMetadata(info, tabletVersionMetadatas, maxVersion, minVersion, validMetadatas);
+            findLatestValidTabletMetadata(info, tabletToVersionMetadataEntry, maxVersion, minVersion, tabletToValidMetadata);
         }
     }
 
@@ -288,25 +364,29 @@ public class TabletRepairHelper {
      * Attempts to find a single version for which all tablets in the physical partition have metadata.
      * This ensures all tablets are repaired to a consistent state.
      */
-    private static void findConsistentVersionTabletMetadata(PhysicalPartitionInfo info,
-                                                            Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas,
-                                                            long maxVersion, long minVersion,
-                                                            Map<Long, TabletMetadataPB> validMetadatas) {
-        Preconditions.checkState(validMetadatas.isEmpty());
+    private static void findConsistentVersionTabletMetadata(
+            PhysicalPartitionInfo info, Map<Long, Map<Long, TabletMetadataEntry>> tabletToVersionMetadataEntry,
+            long maxVersion, long minVersion, Map<Long, TabletMetadataPB> tabletToValidMetadata) {
+        Preconditions.checkState(tabletToValidMetadata.isEmpty());
         List<Long> allTablets = info.allTablets;
 
         long validVersion = 0;
         for (long version = maxVersion; version >= minVersion; --version) {
-            boolean allTabletsMetadataExist = true;
+            boolean allTabletsMetadataValid = true;
             for (long tabletId : allTablets) {
-                Map<Long, TabletMetadataPB> versionMetadatas = tabletVersionMetadatas.get(tabletId);
-                if (versionMetadatas == null || !versionMetadatas.containsKey(version)) {
-                    allTabletsMetadataExist = false;
+                Map<Long, TabletMetadataEntry> versionToMetadataEntry = tabletToVersionMetadataEntry.get(tabletId);
+                if (versionToMetadataEntry == null || !versionToMetadataEntry.containsKey(version)) {
+                    allTabletsMetadataValid = false;
+                    break;
+                }
+
+                if (!checkTabletMetadataValid(versionToMetadataEntry.get(version))) {
+                    allTabletsMetadataValid = false;
                     break;
                 }
             }
 
-            if (allTabletsMetadataExist) {
+            if (allTabletsMetadataValid) {
                 validVersion = version;
                 break;
             }
@@ -314,7 +394,8 @@ public class TabletRepairHelper {
 
         if (validVersion != 0) {
             for (long tabletId : allTablets) {
-                validMetadatas.put(tabletId, tabletVersionMetadatas.get(tabletId).get(validVersion));
+                TabletMetadataEntry metadataEntry = tabletToVersionMetadataEntry.get(tabletId).get(validVersion);
+                tabletToValidMetadata.put(tabletId, getValidTabletMetadata(metadataEntry));
             }
         }
     }
@@ -323,26 +404,26 @@ public class TabletRepairHelper {
      * Attempts to find the latest available valid metadata for each individual tablet within the specified version range.
      */
     private static void findLatestValidTabletMetadata(PhysicalPartitionInfo info,
-                                                      Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas,
+                                                      Map<Long, Map<Long, TabletMetadataEntry>> tabletToVersionMetadataEntry,
                                                       long maxVersion, long minVersion,
-                                                      Map<Long, TabletMetadataPB> validMetadatas) {
+                                                      Map<Long, TabletMetadataPB> tabletToValidMetadata) {
         List<Long> allTablets = info.allTablets;
-        Preconditions.checkState(!validMetadatas.keySet().containsAll(allTablets));
+        Preconditions.checkState(!tabletToValidMetadata.keySet().containsAll(allTablets));
 
         for (long tabletId : allTablets) {
-            if (validMetadatas.containsKey(tabletId)) {
+            if (tabletToValidMetadata.containsKey(tabletId)) {
                 continue;
             }
 
-            Map<Long, TabletMetadataPB> versionMetadatas = tabletVersionMetadatas.get(tabletId);
-            if (versionMetadatas == null) {
+            Map<Long, TabletMetadataEntry> versionToMetadataEntry = tabletToVersionMetadataEntry.get(tabletId);
+            if (versionToMetadataEntry == null || versionToMetadataEntry.isEmpty()) {
                 continue;
             }
 
             for (long version = maxVersion; version >= minVersion; --version) {
-                TabletMetadataPB metadata = versionMetadatas.get(version);
-                if (metadata != null) {
-                    validMetadatas.put(tabletId, metadata);
+                TabletMetadataEntry metadataEntry = versionToMetadataEntry.get(version);
+                if (metadataEntry != null && checkTabletMetadataValid(metadataEntry)) {
+                    tabletToValidMetadata.put(tabletId, getValidTabletMetadata(metadataEntry));
                     break;
                 }
             }
@@ -366,15 +447,16 @@ public class TabletRepairHelper {
         return metadata;
     }
 
-    private static void checkOrCreateEmptyTabletMetadata(PhysicalPartitionInfo info, Map<Long, TabletMetadataPB> validMetadatas,
+    private static void checkOrCreateEmptyTabletMetadata(PhysicalPartitionInfo info,
+                                                         Map<Long, TabletMetadataPB> tabletToValidMetadata,
                                                          boolean enforceConsistentVersion, boolean allowEmptyTabletRecovery)
             throws StarRocksException {
         long maxVersion = info.maxVersion;
         List<Long> allTablets = info.allTablets;
-        if (validMetadatas.keySet().containsAll(allTablets)) {
+        if (tabletToValidMetadata.keySet().containsAll(allTablets)) {
             // check all tablets have consistent valid metadata, and the version is visible version
             boolean allHaveVisibleVersionMetadata = true;
-            for (TabletMetadataPB metadata : validMetadatas.values()) {
+            for (TabletMetadataPB metadata : tabletToValidMetadata.values()) {
                 if (metadata.version != maxVersion) {
                     allHaveVisibleVersionMetadata = false;
                     break;
@@ -392,13 +474,13 @@ public class TabletRepairHelper {
             throw new StarRocksException("no consistent valid tablet metadata version was found, " +
                     "you can set enforce_consistent_version=false");
         } else {
-            if (validMetadatas.isEmpty()) {
+            if (tabletToValidMetadata.isEmpty()) {
                 throw new StarRocksException(
                         "no valid tablet metadata was found for any tablet, you should recreate the partition");
             }
 
             Set<Long> missingTablets = Sets.newHashSet(allTablets);
-            missingTablets.removeAll(validMetadatas.keySet());
+            missingTablets.removeAll(tabletToValidMetadata.keySet());
             Preconditions.checkState(!missingTablets.isEmpty());
             if (!allowEmptyTabletRecovery) {
                 throw new StarRocksException(String.format(
@@ -407,14 +489,15 @@ public class TabletRepairHelper {
                         Joiner.on(", ").join(missingTablets)));
             }
 
-            TabletMetadataPB validMetadata = validMetadatas.values().iterator().next();
+            TabletMetadataPB validMetadata = tabletToValidMetadata.values().iterator().next();
             for (long tabletId : missingTablets) {
-                validMetadatas.put(tabletId, createEmptyTabletMetadata(tabletId, validMetadata));
+                tabletToValidMetadata.put(tabletId, createEmptyTabletMetadata(tabletId, validMetadata));
             }
         }
     }
 
-    private static Map<Long, String> repairTabletMetadata(PhysicalPartitionInfo info, Map<Long, TabletMetadataPB> validMetadatas,
+    private static Map<Long, String> repairTabletMetadata(PhysicalPartitionInfo info,
+                                                          Map<Long, TabletMetadataPB> tabletToValidMetadata,
                                                           boolean isFileBundling) throws Exception {
         long physicalPartitionId = info.physicalPartitionId;
         Map<ComputeNode, Set<Long>> nodeToTablets = info.nodeToTablets;
@@ -437,7 +520,7 @@ public class TabletRepairHelper {
 
             List<TabletMetadataPB> newMetadatas = Lists.newArrayList();
             for (long tabletId : tabletIds) {
-                TabletMetadataPB metadata = validMetadatas.get(tabletId);
+                TabletMetadataPB metadata = tabletToValidMetadata.get(tabletId);
                 Preconditions.checkState(metadata != null);
                 // set version to physical partition visible version
                 metadata.version = info.maxVersion;
@@ -524,32 +607,34 @@ public class TabletRepairHelper {
         Set<Long> unverifiedTablets = info.unverifiedTablets;
         long partitionMaxVersion = info.maxVersion;
         long partitionMinVersion = info.minVersion;
-        Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
+        Map<Long, TabletMetadataPB> tabletToValidMetadata = Maps.newHashMap();
 
         for (long maxVersion = partitionMaxVersion; maxVersion >= partitionMinVersion; maxVersion -= BATCH_VERSION_NUM) {
             long minVersion = Math.max(maxVersion - BATCH_VERSION_NUM + 1, partitionMinVersion);
 
             // get tablet metadatas from backends
-            Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = getTabletMetadatas(info, maxVersion, minVersion);
+            Map<Long, Map<Long, TabletMetadataEntry>> tabletToVersionMetadataEntry =
+                    getTabletMetadatas(info, maxVersion, minVersion);
 
             // find the valid tablet metadata
-            findValidTabletMetadata(info, tabletVersionMetadatas, maxVersion, minVersion, enforceConsistentVersion,
-                    validMetadatas);
+            findValidTabletMetadata(info, tabletToVersionMetadataEntry, maxVersion, minVersion, enforceConsistentVersion,
+                    tabletToValidMetadata);
 
-            unverifiedTablets.removeAll(validMetadatas.keySet());
-            if (validMetadatas.keySet().containsAll(allTablets)) {
+            unverifiedTablets.removeAll(tabletToValidMetadata.keySet());
+            if (tabletToValidMetadata.keySet().containsAll(allTablets)) {
                 Preconditions.checkState(unverifiedTablets.isEmpty());
                 break;
             }
         }
 
         // check the valid tablet metadata, and create empty tablet metadata if no valid metadata is found
-        checkOrCreateEmptyTabletMetadata(info, validMetadatas, enforceConsistentVersion, allowEmptyTabletRecovery);
+        checkOrCreateEmptyTabletMetadata(info, tabletToValidMetadata, enforceConsistentVersion, allowEmptyTabletRecovery);
         LOG.info("Found valid tablet metadatas for partition {}, tablet versions: {}", info.physicalPartitionId,
-                validMetadatas.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().version)));
+                tabletToValidMetadata.entrySet().stream().collect(
+                        Collectors.toMap(Map.Entry::getKey, e -> e.getValue().version)));
 
         // repair the valid tablet metadata through backends
-        return repairTabletMetadata(info, validMetadatas, isFileBundling);
+        return repairTabletMetadata(info, tabletToValidMetadata, isFileBundling);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
@@ -33,12 +33,14 @@ import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.lake.TabletRepairHelper.PhysicalPartitionInfo;
 import com.starrocks.proto.GetTabletMetadatasRequest;
 import com.starrocks.proto.GetTabletMetadatasResponse;
+import com.starrocks.proto.PersistentIndexSstableMetaPB;
 import com.starrocks.proto.RepairTabletMetadataRequest;
 import com.starrocks.proto.RepairTabletMetadataResponse;
 import com.starrocks.proto.StatusPB;
+import com.starrocks.proto.TabletMetadataEntry;
 import com.starrocks.proto.TabletMetadataPB;
 import com.starrocks.proto.TabletMetadataRepairStatus;
-import com.starrocks.proto.TabletMetadatas;
+import com.starrocks.proto.TabletResult;
 import com.starrocks.rpc.LakeServiceWithMetrics;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.WarehouseManager;
@@ -223,6 +225,32 @@ public class TabletRepairHelperTest {
         }
     }
 
+    private TabletMetadataPB createTabletMetadataPB(long tabletId, long version, boolean hasSstableMeta) {
+        TabletMetadataPB metadata = new TabletMetadataPB();
+        metadata.id = tabletId;
+        metadata.version = version;
+        if (hasSstableMeta) {
+            metadata.sstableMeta = new PersistentIndexSstableMetaPB();
+        }
+        return metadata;
+    }
+
+    private TabletMetadataPB createTabletMetadataPB(long tabletId, long version) {
+        return createTabletMetadataPB(tabletId, version, false);
+    }
+
+    private TabletMetadataEntry createTabletMetadataEntry(long tabletId, long version, List<String> missingFiles,
+                                                          boolean hasSstableMeta) {
+        TabletMetadataEntry entry = new TabletMetadataEntry();
+        entry.metadata = createTabletMetadataPB(tabletId, version, hasSstableMeta);
+        entry.missingFiles = missingFiles;
+        return entry;
+    }
+
+    private TabletMetadataEntry createTabletMetadataEntry(long tabletId, long version, List<String> missingFiles) {
+        return createTabletMetadataEntry(tabletId, version, missingFiles, false);
+    }
+
     @Test
     public void testGetTabletMetadatas() {
         new MockUp<LakeServiceWithMetrics>() {
@@ -233,44 +261,50 @@ public class TabletRepairHelperTest {
                 response.status.statusCode = 0;
 
                 // tablet1 with 2 versions metadata
-                TabletMetadatas tm1 = new TabletMetadatas();
-                tm1.tabletId = tabletId11;
-                tm1.status = new StatusPB();
-                tm1.status.statusCode = 0;
-                tm1.versionMetadatas = Maps.newHashMap();
+                TabletResult tr1 = new TabletResult();
+                tr1.tabletId = tabletId11;
+                tr1.status = new StatusPB();
+                tr1.status.statusCode = 0;
+                tr1.metadataEntries = Lists.newArrayList();
 
-                TabletMetadataPB meta11 = new TabletMetadataPB();
-                meta11.id = tabletId11;
-                meta11.version = maxVersion;
-                tm1.versionMetadatas.put(maxVersion, meta11);
-
-                TabletMetadataPB meta12 = new TabletMetadataPB();
-                meta12.id = tabletId11;
-                meta12.version = minVersion;
-                tm1.versionMetadatas.put(minVersion, meta12);
+                tr1.metadataEntries.add(createTabletMetadataEntry(tabletId11, maxVersion, null));
+                tr1.metadataEntries.add(createTabletMetadataEntry(tabletId11, minVersion,
+                        Lists.newArrayList("file1.sst", "file2.dat")));
 
                 // tablet2 metadata not found
-                TabletMetadatas tm2 = new TabletMetadatas();
-                tm2.tabletId = tabletId12;
-                tm2.status = new StatusPB();
-                tm2.status.statusCode = 31;
-                tm2.versionMetadatas = Maps.newHashMap();
+                TabletResult tr2 = new TabletResult();
+                tr2.tabletId = tabletId12;
+                tr2.status = new StatusPB();
+                tr2.status.statusCode = 31;
+                tr2.metadataEntries = Lists.newArrayList();
 
-                response.tabletMetadatas = Lists.newArrayList(tm1, tm2);
+                response.tabletResults = Lists.newArrayList(tr1, tr2);
+
+                // test printTabletMetadatas
+                Deencapsulation.invoke(TabletRepairHelper.class, "printTabletMetadatas", response, 1L, 2L, maxVersion,
+                        minVersion);
 
                 return CompletableFuture.completedFuture(response);
             }
         };
 
-        Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = Deencapsulation.invoke(
+        Map<Long, Map<Long, TabletMetadataEntry>> tabletToVersionMetadataEntry = Deencapsulation.invoke(
                 TabletRepairHelper.class, "getTabletMetadatas", info, maxVersion, minVersion);
 
-        Assertions.assertEquals(1, tabletVersionMetadatas.size());
-        Assertions.assertTrue(tabletVersionMetadatas.containsKey(tabletId11));
-        Assertions.assertEquals(2, tabletVersionMetadatas.get(tabletId11).size());
-        Assertions.assertEquals(maxVersion, tabletVersionMetadatas.get(tabletId11).get(maxVersion).version);
-        Assertions.assertEquals(minVersion, tabletVersionMetadatas.get(tabletId11).get(minVersion).version);
-        Assertions.assertFalse(tabletVersionMetadatas.containsKey(tabletId12));
+        Assertions.assertEquals(1, tabletToVersionMetadataEntry.size());
+        Assertions.assertTrue(tabletToVersionMetadataEntry.containsKey(tabletId11));
+        Assertions.assertEquals(2, tabletToVersionMetadataEntry.get(tabletId11).size());
+        Assertions.assertEquals(maxVersion, tabletToVersionMetadataEntry.get(tabletId11).get(maxVersion).metadata.version);
+        Assertions.assertEquals(minVersion, tabletToVersionMetadataEntry.get(tabletId11).get(minVersion).metadata.version);
+        Assertions.assertFalse(tabletToVersionMetadataEntry.containsKey(tabletId12));
+
+        // Assert missingFiles for tabletId11 with minVersion
+        TabletMetadataEntry entryWithMissingFiles = tabletToVersionMetadataEntry.get(tabletId11).get(minVersion);
+        List<String> missingFiles = entryWithMissingFiles.missingFiles;
+        Assertions.assertNotNull(missingFiles);
+        Assertions.assertEquals(2, missingFiles.size());
+        Assertions.assertTrue(missingFiles.contains("file1.sst"));
+        Assertions.assertTrue(missingFiles.contains("file2.dat"));
     }
 
     @Test
@@ -326,25 +360,22 @@ public class TabletRepairHelperTest {
                 response.status.statusCode = 0;
 
                 // tablet1 with 1 version metadata
-                TabletMetadatas tm1 = new TabletMetadatas();
-                tm1.tabletId = tabletId11;
-                tm1.status = new StatusPB();
-                tm1.status.statusCode = 0;
-                tm1.versionMetadatas = Maps.newHashMap();
+                TabletResult tr1 = new TabletResult();
+                tr1.tabletId = tabletId11;
+                tr1.status = new StatusPB();
+                tr1.status.statusCode = 0;
+                tr1.metadataEntries = Lists.newArrayList();
 
-                TabletMetadataPB meta11 = new TabletMetadataPB();
-                meta11.id = tabletId11;
-                meta11.version = maxVersion;
-                tm1.versionMetadatas.put(maxVersion, meta11);
+                tr1.metadataEntries.add(createTabletMetadataEntry(tabletId11, maxVersion, null));
 
                 // tablet2 get metadata failed
-                TabletMetadatas tm2 = new TabletMetadatas();
-                tm2.tabletId = tabletId12;
-                tm2.status = new StatusPB();
-                tm2.status.statusCode = 1;
-                tm2.status.errorMsgs = Lists.newArrayList("get tablet metadata failed");
+                TabletResult tr2 = new TabletResult();
+                tr2.tabletId = tabletId12;
+                tr2.status = new StatusPB();
+                tr2.status.statusCode = 1;
+                tr2.status.errorMsgs = Lists.newArrayList("get tablet metadata failed");
 
-                response.tabletMetadatas = Lists.newArrayList(tm1, tm2);
+                response.tabletResults = Lists.newArrayList(tr1, tr2);
 
                 return CompletableFuture.completedFuture(response);
             }
@@ -354,155 +385,253 @@ public class TabletRepairHelperTest {
                 () -> Deencapsulation.invoke(TabletRepairHelper.class, "getTabletMetadatas", info, maxVersion, minVersion));
     }
 
-    private TabletMetadataPB createTabletMetadataPB(long tabletId, long version) {
-        TabletMetadataPB metadata = new TabletMetadataPB();
-        metadata.id = tabletId;
-        metadata.version = version;
-        return metadata;
+    @Test
+    public void testCheckTabletMetadataValid() {
+        // case 1: no missing files
+        {
+            TabletMetadataEntry entry = createTabletMetadataEntry(tabletId11, maxVersion, null);
+            boolean isValid = Deencapsulation.invoke(TabletRepairHelper.class, "checkTabletMetadataValid", entry);
+            Assertions.assertTrue(isValid);
+
+            TabletMetadataPB metadata = Deencapsulation.invoke(TabletRepairHelper.class, "getValidTabletMetadata", entry);
+            Assertions.assertNotNull(metadata);
+            Assertions.assertEquals(tabletId11, metadata.id);
+            Assertions.assertEquals(maxVersion, metadata.version);
+            Assertions.assertNull(metadata.sstableMeta);
+        }
+
+        // case 2: empty missing files list
+        {
+            TabletMetadataEntry entry = createTabletMetadataEntry(tabletId11, maxVersion, Lists.newArrayList());
+            boolean isValid = Deencapsulation.invoke(TabletRepairHelper.class, "checkTabletMetadataValid", entry);
+            Assertions.assertTrue(isValid);
+
+            TabletMetadataPB metadata = Deencapsulation.invoke(TabletRepairHelper.class, "getValidTabletMetadata", entry);
+            Assertions.assertNotNull(metadata);
+            Assertions.assertEquals(tabletId11, metadata.id);
+            Assertions.assertEquals(maxVersion, metadata.version);
+            Assertions.assertNull(metadata.sstableMeta);
+        }
+
+        // case 3: only missing sst files, with sstableMeta initially present
+        {
+            TabletMetadataEntry entry = createTabletMetadataEntry(tabletId11, maxVersion,
+                    Lists.newArrayList("file1.sst", "file2.sst"), true);
+            boolean isValid = Deencapsulation.invoke(TabletRepairHelper.class, "checkTabletMetadataValid", entry);
+            Assertions.assertTrue(isValid);
+
+            TabletMetadataPB metadata = Deencapsulation.invoke(TabletRepairHelper.class, "getValidTabletMetadata", entry);
+            Assertions.assertNotNull(metadata);
+            Assertions.assertEquals(tabletId11, metadata.id);
+            Assertions.assertEquals(maxVersion, metadata.version);
+            Assertions.assertNull(metadata.sstableMeta); // sstableMeta should be cleared
+        }
+
+        // case 4: missing sst and dat files
+        {
+            TabletMetadataEntry entry = createTabletMetadataEntry(tabletId11, maxVersion,
+                    Lists.newArrayList("file1.sst", "file2.dat"));
+            boolean isValid = Deencapsulation.invoke(TabletRepairHelper.class, "checkTabletMetadataValid", entry);
+            Assertions.assertFalse(isValid);
+
+            ExceptionChecker.expectThrowsWithMsg(IllegalStateException.class, "should not reach here",
+                    () -> Deencapsulation.invoke(TabletRepairHelper.class, "getValidTabletMetadata", entry));
+        }
+
+        // case 5: missing only non-sst files
+        {
+            TabletMetadataEntry entry = createTabletMetadataEntry(tabletId11, maxVersion,
+                    Lists.newArrayList("file2.dat"));
+            boolean isValid = Deencapsulation.invoke(TabletRepairHelper.class, "checkTabletMetadataValid", entry);
+            Assertions.assertFalse(isValid);
+
+            ExceptionChecker.expectThrowsWithMsg(IllegalStateException.class, "should not reach here",
+                    () -> Deencapsulation.invoke(TabletRepairHelper.class, "getValidTabletMetadata", entry));
+        }
     }
 
     @Test
     public void testFindValidTabletMetadata() {
         // case 1: enforceConsistentVersion = true with consistent metadata
         {
-            Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = Maps.newHashMap();
-            Map<Long, TabletMetadataPB> tablet1Versions = Maps.newHashMap();
-            tablet1Versions.put(maxVersion - 1, createTabletMetadataPB(tabletId11, maxVersion - 1));
-            tablet1Versions.put(minVersion, createTabletMetadataPB(tabletId11, minVersion));
-            tabletVersionMetadatas.put(tabletId11, tablet1Versions);
+            Map<Long, Map<Long, TabletMetadataEntry>> tabletToVersionMetadataEntry = Maps.newHashMap();
+            Map<Long, TabletMetadataEntry> tablet1Versions = Maps.newHashMap();
+            tablet1Versions.put(maxVersion - 1, createTabletMetadataEntry(tabletId11, maxVersion - 1, null));
+            tablet1Versions.put(minVersion, createTabletMetadataEntry(tabletId11, minVersion, null));
+            tabletToVersionMetadataEntry.put(tabletId11, tablet1Versions);
 
-            Map<Long, TabletMetadataPB> tablet2Versions = Maps.newHashMap();
-            tablet2Versions.put(maxVersion - 1, createTabletMetadataPB(tabletId12, maxVersion - 1));
-            tablet2Versions.put(minVersion, createTabletMetadataPB(tabletId12, minVersion));
-            tabletVersionMetadatas.put(tabletId12, tablet2Versions);
+            Map<Long, TabletMetadataEntry> tablet2Versions = Maps.newHashMap();
+            tablet2Versions.put(maxVersion - 1, createTabletMetadataEntry(tabletId12, maxVersion - 1, null));
+            tablet2Versions.put(minVersion, createTabletMetadataEntry(tabletId12, minVersion, null));
+            tabletToVersionMetadataEntry.put(tabletId12, tablet2Versions);
 
-            Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
+            Map<Long, TabletMetadataPB> tabletToValidMetadata = Maps.newHashMap();
             Deencapsulation.invoke(TabletRepairHelper.class, "findValidTabletMetadata",
-                    info, tabletVersionMetadatas, maxVersion, minVersion, true, validMetadatas);
+                    info, tabletToVersionMetadataEntry, maxVersion, minVersion, true, tabletToValidMetadata);
 
-            Assertions.assertEquals(2, validMetadatas.size());
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId11));
-            Assertions.assertEquals(maxVersion - 1, validMetadatas.get(tabletId11).version);
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId12));
-            Assertions.assertEquals(maxVersion - 1, validMetadatas.get(tabletId12).version);
+            Assertions.assertEquals(2, tabletToValidMetadata.size());
+            Assertions.assertTrue(tabletToValidMetadata.containsKey(tabletId11));
+            Assertions.assertEquals(maxVersion - 1, tabletToValidMetadata.get(tabletId11).version);
+            Assertions.assertTrue(tabletToValidMetadata.containsKey(tabletId12));
+            Assertions.assertEquals(maxVersion - 1, tabletToValidMetadata.get(tabletId12).version);
 
             ExceptionChecker.expectThrowsNoException(
                     () -> Deencapsulation.invoke(TabletRepairHelper.class, "checkOrCreateEmptyTabletMetadata",
-                            info, validMetadatas, true, false));
+                            info, tabletToValidMetadata, true, false));
         }
 
         // case 2: enforceConsistentVersion = true without consistent metadata
         {
-            Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = Maps.newHashMap();
-            Map<Long, TabletMetadataPB> tablet1Versions = Maps.newHashMap();
-            tablet1Versions.put(maxVersion, createTabletMetadataPB(tabletId11, maxVersion));
-            tabletVersionMetadatas.put(tabletId11, tablet1Versions);
+            Map<Long, Map<Long, TabletMetadataEntry>> tabletToVersionMetadataEntry = Maps.newHashMap();
+            Map<Long, TabletMetadataEntry> tablet1Versions = Maps.newHashMap();
+            tablet1Versions.put(maxVersion, createTabletMetadataEntry(tabletId11, maxVersion, null));
+            tabletToVersionMetadataEntry.put(tabletId11, tablet1Versions);
 
-            Map<Long, TabletMetadataPB> tablet2Versions = Maps.newHashMap();
-            tablet2Versions.put(maxVersion - 1, createTabletMetadataPB(tabletId12, maxVersion - 1));
-            tabletVersionMetadatas.put(tabletId12, tablet2Versions);
+            Map<Long, TabletMetadataEntry> tablet2Versions = Maps.newHashMap();
+            tablet2Versions.put(maxVersion - 1, createTabletMetadataEntry(tabletId12, maxVersion - 1, null));
+            tabletToVersionMetadataEntry.put(tabletId12, tablet2Versions);
 
-            Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
+            Map<Long, TabletMetadataPB> tabletToValidMetadata = Maps.newHashMap();
             Deencapsulation.invoke(TabletRepairHelper.class, "findValidTabletMetadata",
-                    info, tabletVersionMetadatas, maxVersion, minVersion, true, validMetadatas);
+                    info, tabletToVersionMetadataEntry, maxVersion, minVersion, true, tabletToValidMetadata);
 
-            Assertions.assertTrue(validMetadatas.isEmpty());
+            Assertions.assertTrue(tabletToValidMetadata.isEmpty());
 
             ExceptionChecker.expectThrowsWithMsg(StarRocksException.class,
                     "no consistent valid tablet metadata version was found",
                     () -> Deencapsulation.invoke(TabletRepairHelper.class, "checkOrCreateEmptyTabletMetadata",
-                            info, validMetadatas, true, false));
+                            info, tabletToValidMetadata, true, false));
         }
 
         // case 3: enforceConsistentVersion = false with all latest metadata
         {
-            Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = Maps.newHashMap();
-            Map<Long, TabletMetadataPB> tablet1Versions = Maps.newHashMap();
-            tablet1Versions.put(maxVersion, createTabletMetadataPB(tabletId11, maxVersion));
-            tablet1Versions.put(minVersion, createTabletMetadataPB(tabletId11, minVersion));
-            tabletVersionMetadatas.put(tabletId11, tablet1Versions);
+            Map<Long, Map<Long, TabletMetadataEntry>> tabletToVersionMetadataEntry = Maps.newHashMap();
+            Map<Long, TabletMetadataEntry> tablet1Versions = Maps.newHashMap();
+            tablet1Versions.put(maxVersion, createTabletMetadataEntry(tabletId11, maxVersion, null));
+            tablet1Versions.put(minVersion, createTabletMetadataEntry(tabletId11, minVersion, null));
+            tabletToVersionMetadataEntry.put(tabletId11, tablet1Versions);
 
-            Map<Long, TabletMetadataPB> tablet2Versions = Maps.newHashMap();
-            tablet2Versions.put(maxVersion - 1, createTabletMetadataPB(tabletId12, maxVersion - 1));
-            tabletVersionMetadatas.put(tabletId12, tablet2Versions);
+            Map<Long, TabletMetadataEntry> tablet2Versions = Maps.newHashMap();
+            tablet2Versions.put(maxVersion - 1, createTabletMetadataEntry(tabletId12, maxVersion - 1, null));
+            tabletToVersionMetadataEntry.put(tabletId12, tablet2Versions);
 
-            Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
+            Map<Long, TabletMetadataPB> tabletToValidMetadata = Maps.newHashMap();
             Deencapsulation.invoke(TabletRepairHelper.class, "findValidTabletMetadata",
-                    info, tabletVersionMetadatas, maxVersion, minVersion, false, validMetadatas);
+                    info, tabletToVersionMetadataEntry, maxVersion, minVersion, false, tabletToValidMetadata);
 
-            Assertions.assertEquals(2, validMetadatas.size());
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId11));
-            Assertions.assertEquals(maxVersion, validMetadatas.get(tabletId11).version);
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId12));
-            Assertions.assertEquals(maxVersion - 1, validMetadatas.get(tabletId12).version);
+            Assertions.assertEquals(2, tabletToValidMetadata.size());
+            Assertions.assertTrue(tabletToValidMetadata.containsKey(tabletId11));
+            Assertions.assertEquals(maxVersion, tabletToValidMetadata.get(tabletId11).version);
+            Assertions.assertTrue(tabletToValidMetadata.containsKey(tabletId12));
+            Assertions.assertEquals(maxVersion - 1, tabletToValidMetadata.get(tabletId12).version);
 
             ExceptionChecker.expectThrowsNoException(
                     () -> Deencapsulation.invoke(TabletRepairHelper.class, "checkOrCreateEmptyTabletMetadata",
-                            info, validMetadatas, false, false));
+                            info, tabletToValidMetadata, false, false));
         }
 
         // case 4: enforceConsistentVersion = false with some missing metadata
         {
-            Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = Maps.newHashMap();
-            Map<Long, TabletMetadataPB> tablet1Versions = Maps.newHashMap();
-            tablet1Versions.put(maxVersion, createTabletMetadataPB(tabletId11, maxVersion));
-            tabletVersionMetadatas.put(tabletId11, tablet1Versions);
+            Map<Long, Map<Long, TabletMetadataEntry>> tabletToVersionMetadataEntry = Maps.newHashMap();
+            Map<Long, TabletMetadataEntry> tablet1Versions = Maps.newHashMap();
+            tablet1Versions.put(maxVersion, createTabletMetadataEntry(tabletId11, maxVersion, null));
+            tabletToVersionMetadataEntry.put(tabletId11, tablet1Versions);
 
             // tabletId2 has no metadata
 
-            Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-            Deencapsulation.invoke(TabletRepairHelper.class, "findValidTabletMetadata", info, tabletVersionMetadatas,
-                    maxVersion, minVersion, false, validMetadatas);
+            Map<Long, TabletMetadataPB> tabletToValidMetadata = Maps.newHashMap();
+            Deencapsulation.invoke(TabletRepairHelper.class, "findValidTabletMetadata", info, tabletToVersionMetadataEntry,
+                    maxVersion, minVersion, false, tabletToValidMetadata);
 
-            Assertions.assertEquals(1, validMetadatas.size());
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId11));
-            Assertions.assertEquals(maxVersion, validMetadatas.get(tabletId11).version);
-            Assertions.assertFalse(validMetadatas.containsKey(tabletId12));
+            Assertions.assertEquals(1, tabletToValidMetadata.size());
+            Assertions.assertTrue(tabletToValidMetadata.containsKey(tabletId11));
+            Assertions.assertEquals(maxVersion, tabletToValidMetadata.get(tabletId11).version);
+            Assertions.assertFalse(tabletToValidMetadata.containsKey(tabletId12));
 
             ExceptionChecker.expectThrowsWithMsg(StarRocksException.class,
                     "no tablet metadatas were found for tablets [12]",
                     () -> Deencapsulation.invoke(TabletRepairHelper.class, "checkOrCreateEmptyTabletMetadata",
-                            info, validMetadatas, false, false));
+                            info, tabletToValidMetadata, false, false));
 
             // recover with empty tablet metadata
             ExceptionChecker.expectThrowsNoException(
                     () -> Deencapsulation.invoke(TabletRepairHelper.class, "checkOrCreateEmptyTabletMetadata",
-                            info, validMetadatas, false, true));
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId12));
-            Assertions.assertEquals(0L, validMetadatas.get(tabletId12).version);
+                            info, tabletToValidMetadata, false, true));
+            Assertions.assertTrue(tabletToValidMetadata.containsKey(tabletId12));
+            Assertions.assertEquals(0L, tabletToValidMetadata.get(tabletId12).version);
         }
 
         // case 5: enforceConsistentVersion = false with pre-existing valid metadata
         {
-            Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = Maps.newHashMap();
-            Map<Long, TabletMetadataPB> tablet2Versions = Maps.newHashMap();
-            tablet2Versions.put(minVersion, createTabletMetadataPB(tabletId12, minVersion));
-            tablet2Versions.put(minVersion + 1, createTabletMetadataPB(tabletId12, minVersion + 1));
-            tabletVersionMetadatas.put(tabletId12, tablet2Versions);
+            Map<Long, Map<Long, TabletMetadataEntry>> tabletToVersionMetadataEntry = Maps.newHashMap();
+            Map<Long, TabletMetadataEntry> tablet2Versions = Maps.newHashMap();
+            tablet2Versions.put(minVersion, createTabletMetadataEntry(tabletId12, minVersion, null));
+            tablet2Versions.put(minVersion + 1, createTabletMetadataEntry(tabletId12, minVersion + 1, null));
+            tabletToVersionMetadataEntry.put(tabletId12, tablet2Versions);
 
-            Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-            validMetadatas.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion)); // Pre-existing
+            Map<Long, TabletMetadataPB> tabletToValidMetadata = Maps.newHashMap();
+            tabletToValidMetadata.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion)); // Pre-existing
 
-            Deencapsulation.invoke(TabletRepairHelper.class, "findValidTabletMetadata", info, tabletVersionMetadatas,
-                    maxVersion, minVersion, false, validMetadatas);
+            Deencapsulation.invoke(TabletRepairHelper.class, "findValidTabletMetadata", info, tabletToVersionMetadataEntry,
+                    maxVersion, minVersion, false, tabletToValidMetadata);
 
-            Assertions.assertEquals(2, validMetadatas.size());
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId11));
-            Assertions.assertEquals(maxVersion, validMetadatas.get(tabletId11).version); // Should remain as pre-existing
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId12));
-            Assertions.assertEquals(minVersion + 1, validMetadatas.get(tabletId12).version);
+            Assertions.assertEquals(2, tabletToValidMetadata.size());
+            Assertions.assertTrue(tabletToValidMetadata.containsKey(tabletId11));
+            Assertions.assertEquals(maxVersion, tabletToValidMetadata.get(tabletId11).version); // Should remain as pre-existing
+            Assertions.assertTrue(tabletToValidMetadata.containsKey(tabletId12));
+            Assertions.assertEquals(minVersion + 1, tabletToValidMetadata.get(tabletId12).version);
 
             ExceptionChecker.expectThrowsNoException(
                     () -> Deencapsulation.invoke(TabletRepairHelper.class, "checkOrCreateEmptyTabletMetadata",
-                            info, validMetadatas, false, false));
+                            info, tabletToValidMetadata, false, false));
+        }
+
+        // case 6: enforceConsistentVersion = false with missingFiles (some valid, some invalid)
+        {
+            Map<Long, Map<Long, TabletMetadataEntry>> tabletToVersionMetadataEntry = Maps.newHashMap();
+            // tablet1: 3 versions
+            Map<Long, TabletMetadataEntry> tablet1Versions = Maps.newHashMap();
+            // maxVersion: missing sst and dat files (invalid)
+            tablet1Versions.put(maxVersion, createTabletMetadataEntry(tabletId11, maxVersion,
+                    Lists.newArrayList("file1.sst", "file2.dat"), true));
+            // maxVersion - 1: only missing sst files (valid)
+            tablet1Versions.put(maxVersion - 1, createTabletMetadataEntry(tabletId11, maxVersion - 1,
+                    Lists.newArrayList("file3.sst"), true));
+            // minVersion: no missing files (valid)
+            tablet1Versions.put(minVersion, createTabletMetadataEntry(tabletId11, minVersion, null));
+            tabletToVersionMetadataEntry.put(tabletId11, tablet1Versions);
+
+            // tablet2: 2 versions
+            Map<Long, TabletMetadataEntry> tablet2Versions = Maps.newHashMap();
+            // maxVersion: no missing files (valid)
+            tablet2Versions.put(maxVersion, createTabletMetadataEntry(tabletId12, maxVersion, null, true));
+            // minVersion: missing sst and dat files (invalid)
+            tablet2Versions.put(minVersion, createTabletMetadataEntry(tabletId12, minVersion,
+                    Lists.newArrayList("file4.sst", "file5.dat"), true));
+            tabletToVersionMetadataEntry.put(tabletId12, tablet2Versions);
+
+            Map<Long, TabletMetadataPB> tabletToValidMetadata = Maps.newHashMap();
+            Deencapsulation.invoke(TabletRepairHelper.class, "findValidTabletMetadata", info, tabletToVersionMetadataEntry,
+                    maxVersion, minVersion, false, tabletToValidMetadata);
+
+            Assertions.assertEquals(2, tabletToValidMetadata.size());
+            Assertions.assertTrue(tabletToValidMetadata.containsKey(tabletId11));
+            // Should pick maxVersion - 1 because maxVersion has invalid missing files
+            Assertions.assertEquals(maxVersion - 1, tabletToValidMetadata.get(tabletId11).version);
+            Assertions.assertNull(tabletToValidMetadata.get(tabletId11).sstableMeta); // should be cleared
+
+            Assertions.assertTrue(tabletToValidMetadata.containsKey(tabletId12));
+            // Should pick maxVersion because it has no missing files
+            Assertions.assertEquals(maxVersion, tabletToValidMetadata.get(tabletId12).version);
+            Assertions.assertNotNull(tabletToValidMetadata.get(tabletId12).sstableMeta); // initially true
         }
     }
 
     @Test
     public void testRepairTabletMetadata() {
-        Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-        validMetadatas.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
-        validMetadatas.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
+        Map<Long, TabletMetadataPB> tabletToValidMetadata = Maps.newHashMap();
+        tabletToValidMetadata.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
+        tabletToValidMetadata.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
 
         new MockUp<LakeServiceWithMetrics>() {
             @Mock
@@ -528,15 +657,15 @@ public class TabletRepairHelperTest {
         };
 
         Map<Long, String> tabletErrors = Deencapsulation.invoke(TabletRepairHelper.class, "repairTabletMetadata",
-                info, validMetadatas, false);
+                info, tabletToValidMetadata, false);
         Assertions.assertTrue(tabletErrors.isEmpty());
     }
 
     @Test
     public void testRepairTabletMetadataWithFileBundling() {
-        Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-        validMetadatas.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
-        validMetadatas.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
+        Map<Long, TabletMetadataPB> tabletToValidMetadata = Maps.newHashMap();
+        tabletToValidMetadata.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
+        tabletToValidMetadata.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
 
         new MockUp<LakeServiceWithMetrics>() {
             @Mock
@@ -562,15 +691,15 @@ public class TabletRepairHelperTest {
         };
 
         Map<Long, String> tabletErrors = Deencapsulation.invoke(TabletRepairHelper.class, "repairTabletMetadata",
-                info, validMetadatas, true);
+                info, tabletToValidMetadata, true);
         Assertions.assertTrue(tabletErrors.isEmpty());
     }
 
     @Test
     public void testRepairTabletMetadataRpcException() {
-        Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-        validMetadatas.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
-        validMetadatas.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
+        Map<Long, TabletMetadataPB> tabletToValidMetadata = Maps.newHashMap();
+        tabletToValidMetadata.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
+        tabletToValidMetadata.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
 
         new MockUp<LakeServiceWithMetrics>() {
             @Mock
@@ -582,14 +711,14 @@ public class TabletRepairHelperTest {
 
         ExceptionChecker.expectThrowsWithMsg(RpcException.class, "rpc exception",
                 () -> Deencapsulation.invoke(TabletRepairHelper.class, "repairTabletMetadata",
-                        info, validMetadatas, false));
+                        info, tabletToValidMetadata, false));
     }
 
     @Test
     public void testRepairTabletMetadataResponseNull() {
-        Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-        validMetadatas.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
-        validMetadatas.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
+        Map<Long, TabletMetadataPB> tabletToValidMetadata = Maps.newHashMap();
+        tabletToValidMetadata.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
+        tabletToValidMetadata.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
 
         new MockUp<LakeServiceWithMetrics>() {
             @Mock
@@ -600,14 +729,14 @@ public class TabletRepairHelperTest {
 
         ExceptionChecker.expectThrowsWithMsg(StarRocksException.class, "response is null",
                 () -> Deencapsulation.invoke(TabletRepairHelper.class, "repairTabletMetadata",
-                        info, validMetadatas, false));
+                        info, tabletToValidMetadata, false));
     }
 
     @Test
     public void testRepairTabletMetadataRpcLevelStatusFail() {
-        Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-        validMetadatas.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
-        validMetadatas.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
+        Map<Long, TabletMetadataPB> tabletToValidMetadata = Maps.newHashMap();
+        tabletToValidMetadata.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
+        tabletToValidMetadata.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
 
         new MockUp<LakeServiceWithMetrics>() {
             @Mock
@@ -622,14 +751,14 @@ public class TabletRepairHelperTest {
 
         ExceptionChecker.expectThrowsWithMsg(StarRocksException.class, "missing tablet_metadatas",
                 () -> Deencapsulation.invoke(TabletRepairHelper.class, "repairTabletMetadata",
-                        info, validMetadatas, false));
+                        info, tabletToValidMetadata, false));
     }
 
     @Test
     public void testRepairTabletMetadataPartialFailure() {
-        Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-        validMetadatas.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
-        validMetadatas.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
+        Map<Long, TabletMetadataPB> tabletToValidMetadata = Maps.newHashMap();
+        tabletToValidMetadata.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
+        tabletToValidMetadata.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
 
         new MockUp<LakeServiceWithMetrics>() {
             @Mock
@@ -657,7 +786,7 @@ public class TabletRepairHelperTest {
         };
 
         Map<Long, String> tabletErrors = Deencapsulation.invoke(TabletRepairHelper.class, "repairTabletMetadata",
-                info, validMetadatas, false);
+                info, tabletToValidMetadata, false);
 
         Assertions.assertEquals(1, tabletErrors.size());
         Assertions.assertTrue(tabletErrors.containsKey(tabletId12));
@@ -674,32 +803,26 @@ public class TabletRepairHelperTest {
                 response.status.statusCode = 0;
 
                 // tablet1 with 2 versions metadata
-                TabletMetadatas tm1 = new TabletMetadatas();
-                tm1.tabletId = tabletId11;
-                tm1.status = new StatusPB();
-                tm1.status.statusCode = 0;
-                tm1.versionMetadatas = Maps.newHashMap();
+                TabletResult tr1 = new TabletResult();
+                tr1.tabletId = tabletId11;
+                tr1.status = new StatusPB();
+                tr1.status.statusCode = 0;
+                tr1.metadataEntries = Lists.newArrayList();
 
-                TabletMetadataPB meta11 = createTabletMetadataPB(tabletId11, maxVersion);
-                tm1.versionMetadatas.put(maxVersion, meta11);
-
-                TabletMetadataPB meta12 = createTabletMetadataPB(tabletId11, minVersion);
-                tm1.versionMetadatas.put(minVersion, meta12);
+                tr1.metadataEntries.add(createTabletMetadataEntry(tabletId11, maxVersion, null));
+                tr1.metadataEntries.add(createTabletMetadataEntry(tabletId11, minVersion, null));
 
                 // tablet2 with 2 versions metadata
-                TabletMetadatas tm2 = new TabletMetadatas();
-                tm2.tabletId = tabletId12;
-                tm2.status = new StatusPB();
-                tm2.status.statusCode = 0;
-                tm2.versionMetadatas = Maps.newHashMap();
+                TabletResult tr2 = new TabletResult();
+                tr2.tabletId = tabletId12;
+                tr2.status = new StatusPB();
+                tr2.status.statusCode = 0;
+                tr2.metadataEntries = Lists.newArrayList();
 
-                TabletMetadataPB meta21 = createTabletMetadataPB(tabletId12, maxVersion - 1);
-                tm2.versionMetadatas.put(maxVersion - 1, meta21);
+                tr2.metadataEntries.add(createTabletMetadataEntry(tabletId12, maxVersion - 1, null));
+                tr2.metadataEntries.add(createTabletMetadataEntry(tabletId12, minVersion, null));
 
-                TabletMetadataPB meta22 = createTabletMetadataPB(tabletId12, minVersion);
-                tm2.versionMetadatas.put(minVersion, meta22);
-
-                response.tabletMetadatas = Lists.newArrayList(tm1, tm2);
+                response.tabletResults = Lists.newArrayList(tr1, tr2);
 
                 return CompletableFuture.completedFuture(response);
             }
@@ -759,32 +882,26 @@ public class TabletRepairHelperTest {
                 response.status.statusCode = 0;
 
                 // tablet1 with 2 versions metadata
-                TabletMetadatas tm1 = new TabletMetadatas();
-                tm1.tabletId = tabletId11;
-                tm1.status = new StatusPB();
-                tm1.status.statusCode = 0;
-                tm1.versionMetadatas = Maps.newHashMap();
+                TabletResult tr1 = new TabletResult();
+                tr1.tabletId = tabletId11;
+                tr1.status = new StatusPB();
+                tr1.status.statusCode = 0;
+                tr1.metadataEntries = Lists.newArrayList();
 
-                TabletMetadataPB meta11 = createTabletMetadataPB(tabletId11, maxVersion);
-                tm1.versionMetadatas.put(maxVersion, meta11);
-
-                TabletMetadataPB meta12 = createTabletMetadataPB(tabletId11, minVersion);
-                tm1.versionMetadatas.put(minVersion, meta12);
+                tr1.metadataEntries.add(createTabletMetadataEntry(tabletId11, maxVersion, null));
+                tr1.metadataEntries.add(createTabletMetadataEntry(tabletId11, minVersion, null));
 
                 // tablet2 with 2 versions metadata
-                TabletMetadatas tm2 = new TabletMetadatas();
-                tm2.tabletId = tabletId12;
-                tm2.status = new StatusPB();
-                tm2.status.statusCode = 0;
-                tm2.versionMetadatas = Maps.newHashMap();
+                TabletResult tr2 = new TabletResult();
+                tr2.tabletId = tabletId12;
+                tr2.status = new StatusPB();
+                tr2.status.statusCode = 0;
+                tr2.metadataEntries = Lists.newArrayList();
 
-                TabletMetadataPB meta21 = createTabletMetadataPB(tabletId12, maxVersion - 1);
-                tm2.versionMetadatas.put(maxVersion - 1, meta21);
+                tr2.metadataEntries.add(createTabletMetadataEntry(tabletId12, maxVersion - 1, null));
+                tr2.metadataEntries.add(createTabletMetadataEntry(tabletId12, minVersion, null));
 
-                TabletMetadataPB meta22 = createTabletMetadataPB(tabletId12, minVersion);
-                tm2.versionMetadatas.put(minVersion, meta22);
-
-                response.tabletMetadatas = Lists.newArrayList(tm1, tm2);
+                response.tabletResults = Lists.newArrayList(tr1, tr2);
 
                 return CompletableFuture.completedFuture(response);
             }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -366,20 +366,28 @@ message GetTabletMetadatasRequest {
     optional int64 max_version = 2;
     // included
     optional int64 min_version = 3;
+    // whether check missing files, like segment, delete vector, pk index sst, cols file
+    optional bool check_missing_files = 4;
 }
 
-message TabletMetadatas {
+message TabletMetadataEntry {
+    optional TabletMetadataPB metadata = 1;
+    // segment, delete vector, cols, pk index sst file
+    repeated string missing_files = 2;
+}
+
+message TabletResult {
     optional int64 tablet_id = 1;
     // tablet-level status
     optional StatusPB status = 2;
-    // version -> tablet metadata
-    map<int64, TabletMetadataPB> version_metadatas = 3;
+    // multi-version tablet metadatas
+    repeated TabletMetadataEntry metadata_entries = 3;
 }
 
 message GetTabletMetadatasResponse {
     // rpc-level status
     optional StatusPB status = 1;
-    repeated TabletMetadatas tablet_metadatas = 2;
+    repeated TabletResult tablet_results = 2;
 }
 
 message RepairTabletMetadataRequest {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This PR introduces functionality to identify and handle missing data files (segments, delete vectors, primary key index sst, cols files) when repairing cloud-native tables.
1. Refactor `TabletMetadatas` to `TabletResult` and introduced `TabletMetadataEntry` to include `missing_files` information.
2. Update `LakeServiceImpl::get_tablet_metadatas` to optionally perform missing file checks.
3. Update `TabletRepairHelper.java` to leverage the new structures and integrate the missing file detection and repair logic.

https://github.com/StarRocks/starrocks/issues/66015

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces per-version tablet metadata results with optional missing-file detection to improve repair workflows.
> 
> - Proto changes: add `check_missing_files` to `GetTabletMetadatasRequest`; replace `TabletMetadatas` with `TabletResult` and `TabletMetadataEntry` (with `missing_files`); response now returns `tablet_results`.
> - BE: `get_tablet_metadatas` now emits `tablet_results` and, when enabled, checks existence of `segments`, `delete vectors`, `pk index sst`, and `cols` files; new helper `check_missing_files`; updated status handling and logs; corresponding tests added/updated.
> - FE: `TabletRepairHelper` updated to consume `tablet_results`, request missing-file checks, select valid metadata (accepts only sst-missing, clears `sstableMeta`), and proceed with repair; comprehensive unit tests adjusted and expanded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ab362e5a8c0909f5240f6fdef30ff9256c5f244. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->