### PR TITLE
[UT] Fix iceberg cache unstable UT

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -448,10 +448,15 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     @Override
+    public void invalidateTableCache(String dbName, String tableName) {
+        IcebergTableName key = new IcebergTableName(dbName, tableName);
+        tables.invalidate(new IcebergTableCacheKey(key, new ConnectContext()));
+    }
+
+    @Override
     public void invalidateCache(String dbName, String tableName) {
         IcebergTableName key = new IcebergTableName(dbName, tableName);
         invalidateCache(key);
-
     }
 
     private void invalidateCache(IcebergTableName key) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -227,6 +227,9 @@ public interface IcebergCatalog extends MemoryTrackable {
     default void refreshTable(String dbName, String tableName, ConnectContext ctx, ExecutorService refreshExecutor) {
     }
 
+    default void invalidateTableCache(String dbName, String tableName) {
+    }
+
     default void invalidatePartitionCache(String dbName, String tableName) {
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1344,8 +1344,6 @@ public class IcebergMetadata implements ConnectorMetadata {
         try {
             batchWrite.commit();
             transaction.commitTransaction();
-            // Refresh table metadata in FE
-            refreshTable(dbName, table, new ArrayList<>(), false);
             asyncRefreshOthersFeMetadataCache(dbName, tableName);
         } catch (Exception e) {
             if (!(e instanceof CommitStateUnknownException)) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1357,7 +1357,9 @@ public class IcebergMetadata implements ConnectorMetadata {
             LOG.error("Failed to commit iceberg transaction on {}.{}", dbName, tableName, e);
             throw new StarRocksConnectorException(e.getMessage());
         } finally {
-            // Do we really need that? because partition cache is associated with snapshotId
+            // Invalidate cache after commit
+            tables.remove(TableIdentifier.of(dbName, tableName));
+            icebergCatalog.invalidateTableCache(dbName, tableName);
             icebergCatalog.invalidatePartitionCache(dbName, tableName);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1344,6 +1344,8 @@ public class IcebergMetadata implements ConnectorMetadata {
         try {
             batchWrite.commit();
             transaction.commitTransaction();
+            // Refresh table metadata in FE
+            refreshTable(dbName, table, new ArrayList<>(), false);
             asyncRefreshOthersFeMetadataCache(dbName, tableName);
         } catch (Exception e) {
             if (!(e instanceof CommitStateUnknownException)) {


### PR DESCRIPTION
## Why I'm doing:
sometimes sr can not query latest snapshot after insert into 
## What I'm doing:
refresh fe cache after insert into finish

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures FE sees the latest Iceberg snapshot right after data commit.
> 
> - In `IcebergMetadata.finishSink`, after `batchWrite.commit()` and `transaction.commitTransaction()`, invoke `refreshTable(dbName, table, new ArrayList<>(), false)` before `asyncRefreshOthersFeMetadataCache(...)` to update FE metadata cache.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4339ec3337375b908f80b9d04e6ce3106c139fd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->