### PR TITLE
[Bugfix] Fix iceberg partition last updated null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -364,12 +364,14 @@ public interface IcebergCatalog extends MemoryTrackable {
                                              long snapshotId) {
         Table nativeTable = icebergTable.getNativeTable();
         Logger logger = getLogger();
-        // last_updated_at can be null if the referenced snapshot has been expired.
-        // Use Long wrapper to avoid NPE during auto-unboxing.
+        // last_updated_at can be null; use Long wrapper to avoid NPE during auto-unboxing.
         long lastUpdated = -1;
         if (row != null) {
             try {
-                lastUpdated = row.get(columnIndex, Long.class);
+                Long lastUpdatedValue = row.get(columnIndex, Long.class);
+                if (lastUpdatedValue != null) {
+                    lastUpdated = lastUpdatedValue;
+                }
             } catch (Exception e) {
                 logger.error("Failed to get last_updated_at for partition [{}] of table [{}] " +
                                 "under snapshot [{}]", partitionName, nativeTable.name(), snapshotId, e);


### PR DESCRIPTION
## Why I'm doing:
```
ERROR (connector-trigger-analyze-pool-0|365) [IcebergCatalog.getPartitionLastUpdatedTime():374] Failed to get last_updated_at for partition [_cdc_tsms_day=2025-04-22] of table [iceberg.land
ing_cdc_cbs_tj.credit_schedule_payments] under snapshot [2358892543328080287]
java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()" because the return value of "org.apache.iceberg.StructLike.get(int, java.lang.Class)" is null
        at com.starrocks.connector.iceberg.IcebergCatalog.getPartitionLastUpdatedTime(IcebergCatalog.java:372) ~[fe-core-main.jar:?]
        at com.starrocks.connector.iceberg.IcebergCatalog.getPartitions(IcebergCatalog.java:350) ~[fe-core-main.jar:?]
```
## What I'm doing:
Check for NPE

@LiShuMing related to https://github.com/StarRocks/starrocks/pull/65969

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents NPE in Iceberg partition scanning by treating `last_updated_at` as nullable and adding a fallback.
> 
> - Updates `getPartitionLastUpdatedTime` to read `Long` from `StructLike`, check for null, and only assign when present
> - When null or retrieval fails, falls back to the table's current snapshot timestamp and logs a warning
> - Minor comment/log message adjustments for clarity
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67b249683f5032fcab09cea877dc88a50874bd06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->