### PR TITLE
[Enhancement] optimize variant key query

### DIFF
--- a/be/src/exprs/cast_expr_map.cpp
+++ b/be/src/exprs/cast_expr_map.cpp
@@ -117,14 +117,14 @@ StatusOr<ColumnPtr> CastVariantToMap::evaluate_checked(ExprContext* context, Chu
                 uint32_t offset_pos = VariantUtil::read_little_endian_unsigned32(
                         value.raw().data() + object_info.offset_start_offset + idx * object_info.offset_size,
                         object_info.offset_size);
-                ASSIGN_OR_RETURN(std::string key, metadata.get_key(filed_id));
+                ASSIGN_OR_RETURN(std::string_view key, metadata.get_key(filed_id));
                 uint32_t next_pos = object_info.data_start_offset + offset_pos;
                 if (next_pos >= value.raw().size()) {
-                    return Status::InternalError("Cannot get variant object field value by key: " + key +
-                                                 ", offset out of bounds");
+                    return Status::InternalError(
+                            fmt::format("Cannot get variant object field value by key: {}, offset out of bounds", key));
                 }
 
-                keys_builder.append(Slice(std::string(key)));
+                keys_builder.append(Slice(key));
                 auto sub_value = value.raw().substr(next_pos, value.raw().size() - next_pos);
                 ASSIGN_OR_RETURN(VariantRowValue result, VariantRowValue::create(metadata.raw(), sub_value));
                 values_builder.append(std::move(result));

--- a/be/src/exprs/variant_functions.cpp
+++ b/be/src/exprs/variant_functions.cpp
@@ -137,12 +137,7 @@ StatusOr<ColumnPtr> VariantFunctions::_do_variant_query(FunctionContext* context
             result.append(std::move(field.value()));
         } else {
             const RuntimeState* state = context->state();
-            cctz::time_zone zone;
-            if (state == nullptr) {
-                zone = cctz::local_time_zone();
-            } else {
-                zone = context->state()->timezone_obj();
-            }
+            cctz::time_zone zone = (state == nullptr) ? cctz::local_time_zone() : context->state()->timezone_obj();
             Status casted = cast_variant_value_to<ResultType, true>(field.value(), zone, result);
             // Append null if casting fails
             if (!casted.ok()) {

--- a/be/src/exprs/variant_path_parser.cpp
+++ b/be/src/exprs/variant_path_parser.cpp
@@ -107,7 +107,7 @@ std::string VariantPathParser::parse_quoted_string(ParserState& state, char quot
     return str;
 }
 
-StatusOr<ArrayExtraction> VariantPathParser::parse_array_index(ParserState& state) {
+StatusOr<VariantArrayExtraction> VariantPathParser::parse_array_index(ParserState& state) {
     if (!state.match('[')) {
         return Status::VariantError(fmt::format("Expected '[' at position {}", static_cast<int>(state.pos)));
     }
@@ -125,14 +125,14 @@ StatusOr<ArrayExtraction> VariantPathParser::parse_array_index(ParserState& stat
 
     try {
         int index = std::stoi(indexStr);
-        return ArrayExtraction(index);
+        return VariantArrayExtraction(index);
     } catch (const std::exception&) {
         return Status::VariantError(
                 fmt::format("Invalid array index '{}' at position {}", indexStr, static_cast<int>(state.pos)));
     }
 }
 
-StatusOr<ObjectExtraction> VariantPathParser::parse_quoted_key(ParserState& state) {
+StatusOr<VariantObjectExtraction> VariantPathParser::parse_quoted_key(ParserState& state) {
     if (!state.match('[')) {
         return Status::VariantError(fmt::format("Expected '[' at position {}", static_cast<int>(state.pos)));
     }
@@ -157,10 +157,10 @@ StatusOr<ObjectExtraction> VariantPathParser::parse_quoted_key(ParserState& stat
                 fmt::format("Expected ']' after quoted key '{}' at position {}", key, static_cast<int>(state.pos)));
     }
 
-    return ObjectExtraction(key);
+    return VariantObjectExtraction(key);
 }
 
-StatusOr<ObjectExtraction> VariantPathParser::parse_object_key(ParserState& state) {
+StatusOr<VariantObjectExtraction> VariantPathParser::parse_object_key(ParserState& state) {
     if (!state.match('.')) {
         return Status::VariantError(fmt::format("Expected '.' at position {}", static_cast<int>(state.pos)));
     }
@@ -170,7 +170,7 @@ StatusOr<ObjectExtraction> VariantPathParser::parse_object_key(ParserState& stat
         return Status::VariantError(fmt::format("Expected key after '.' at position {}", static_cast<int>(state.pos)));
     }
 
-    return ObjectExtraction(key);
+    return VariantObjectExtraction(key);
 }
 
 StatusOr<VariantPathExtraction> VariantPathParser::parse_segment(ParserState& state) {
@@ -258,9 +258,9 @@ StatusOr<VariantRowValue> VariantPath::seek(const VariantRowValue* variant, cons
         StatusOr<VariantValue> sub;
         std::visit(
                 [&]<typename T0>(const T0& seg) {
-                    if constexpr (std::is_same_v<std::decay_t<T0>, ObjectExtraction>) {
+                    if constexpr (std::is_same_v<std::decay_t<T0>, VariantObjectExtraction>) {
                         sub = current.get_object_by_key(metadata, seg.get_key());
-                    } else if constexpr (std::is_same_v<std::decay_t<T0>, ArrayExtraction>) {
+                    } else if constexpr (std::is_same_v<std::decay_t<T0>, VariantArrayExtraction>) {
                         sub = current.get_element_at_index(metadata, seg.get_index());
                     }
                 },

--- a/be/src/exprs/variant_path_parser.h
+++ b/be/src/exprs/variant_path_parser.h
@@ -26,28 +26,28 @@
 namespace starrocks {
 
 // Object key extraction like .field or ['field'] or ["field"]
-class ObjectExtraction {
+class VariantObjectExtraction {
 private:
     std::string _key;
 
 public:
-    explicit ObjectExtraction(std::string key) : _key(std::move(key)) {}
+    explicit VariantObjectExtraction(std::string key) : _key(std::move(key)) {}
 
     const std::string& get_key() const { return _key; }
 };
 
 // Array index extraction like [123]
-class ArrayExtraction {
+class VariantArrayExtraction {
 private:
     int _index;
 
 public:
-    explicit ArrayExtraction(int index) : _index(index) {}
+    explicit VariantArrayExtraction(int index) : _index(index) {}
 
     int get_index() const { return _index; }
 };
 
-using VariantPathExtraction = std::variant<ObjectExtraction, ArrayExtraction>;
+using VariantPathExtraction = std::variant<VariantObjectExtraction, VariantArrayExtraction>;
 
 struct VariantPath {
     std::vector<VariantPathExtraction> segments;
@@ -97,9 +97,9 @@ private:
     // Parser methods
     static bool parse_root(ParserState& state);
     static StatusOr<VariantPathExtraction> parse_segment(ParserState& state);
-    static StatusOr<ArrayExtraction> parse_array_index(ParserState& state);
-    static StatusOr<ObjectExtraction> parse_object_key(ParserState& state);
-    static StatusOr<ObjectExtraction> parse_quoted_key(ParserState& state);
+    static StatusOr<VariantArrayExtraction> parse_array_index(ParserState& state);
+    static StatusOr<VariantObjectExtraction> parse_object_key(ParserState& state);
+    static StatusOr<VariantObjectExtraction> parse_quoted_key(ParserState& state);
     static std::string parse_number(ParserState& state);
     static std::string parse_unquoted_key(ParserState& state);
     static std::string parse_quoted_string(ParserState& state, char quote);

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -203,6 +203,10 @@ MemTracker::~MemTracker() {
 #ifdef DEBUG
     {
         std::unique_lock<std::mutex> lock(_child_trackers_lock);
+        for (const auto& child : _child_trackers) {
+            LOG(WARNING) << "MemTracker '" << _label << "' is being destroyed without releasing child tracker "
+                         << child->label();
+        }
         DCHECK(_child_trackers.empty()) << err_msg("Child mem trackers have not been released, may cause corruption");
     }
 #endif

--- a/be/src/types/variant_value.cpp
+++ b/be/src/types/variant_value.cpp
@@ -55,13 +55,7 @@ StatusOr<VariantRowValue> VariantRowValue::create(const Slice& slice) {
     }
 
     const auto variant = std::string_view(variant_raw + sizeof(uint32_t), variant_size);
-
-    auto metadata_status = load_metadata(variant);
-    if (!metadata_status.ok()) {
-        return metadata_status.status();
-    }
-
-    const auto& metadata_view = metadata_status.value();
+    ASSIGN_OR_RETURN(const auto metadata_view, load_metadata(variant));
     if (metadata_view.size() > variant_size) {
         return Status::InvalidArgument("Metadata size exceeds variant size");
     }

--- a/be/src/types/variant_value.h
+++ b/be/src/types/variant_value.h
@@ -28,12 +28,13 @@ namespace starrocks {
 class VariantRowValue {
 public:
     VariantRowValue(const std::string_view metadata, const std::string_view value)
-            : _metadata_raw(metadata), _value_raw(value), _metadata(_metadata_raw), _value(_value_raw) {}
-    VariantRowValue(std::string metadata, std::string value)
-            : _metadata_raw(std::move(metadata)),
-              _value_raw(std::move(value)),
-              _metadata(_metadata_raw),
-              _value(_value_raw) {}
+            : _raw(), _metadata_size(metadata.size()), _metadata(), _value() {
+        _raw.reserve(metadata.size() + value.size());
+        _raw.assign(metadata.data(), metadata.size());
+        _raw.append(value.data(), value.size());
+        _rebind_views();
+    }
+
     /**
      * Default constructor creates an empty VariantRowValue representing a NULL variant.
      * Uses predefined constants for empty metadata and a null variant value.
@@ -67,13 +68,12 @@ public:
     /**
      * Copy constructor. Creates a deep copy of the VariantRowValue.
      * After copying the underlying string data, _metadata and _value are reconstructed
-     * to point to the new object's _metadata_raw and _value_raw.
+     * to point to the new object's _raw string.
      */
     VariantRowValue(const VariantRowValue& rhs)
-            : _metadata_raw(rhs._metadata_raw),
-              _value_raw(rhs._value_raw),
-              _metadata(_metadata_raw),
-              _value(_value_raw) {}
+            : _raw(rhs._raw), _metadata_size(rhs._metadata_size), _metadata(), _value() {
+        _rebind_views();
+    }
 
     /**
      * Move constructor. Transfers ownership of the underlying string data.
@@ -81,10 +81,8 @@ public:
      * and the source object is reset to a valid empty state to prevent dangling references.
      */
     VariantRowValue(VariantRowValue&& rhs) noexcept
-            : _metadata_raw(std::move(rhs._metadata_raw)),
-              _value_raw(std::move(rhs._value_raw)),
-              _metadata(_metadata_raw),
-              _value(_value_raw) {
+            : _raw(std::move(rhs._raw)), _metadata_size(rhs._metadata_size), _metadata(), _value() {
+        _rebind_views();
         rhs._reset_to_empty();
     }
 
@@ -98,8 +96,8 @@ public:
 
     VariantRowValue& operator=(const VariantRowValue& rhs) {
         if (this != &rhs) {
-            _metadata_raw = rhs._metadata_raw;
-            _value_raw = rhs._value_raw;
+            _raw = rhs._raw;
+            _metadata_size = rhs._metadata_size;
             _rebind_views();
         }
         return *this;
@@ -107,8 +105,8 @@ public:
 
     VariantRowValue& operator=(VariantRowValue&& rhs) noexcept {
         if (this != &rhs) {
-            _metadata_raw = std::move(rhs._metadata_raw);
-            _value_raw = std::move(rhs._value_raw);
+            _raw = std::move(rhs._raw);
+            _metadata_size = rhs._metadata_size;
             _rebind_views();
             rhs._reset_to_empty();
         }
@@ -144,21 +142,22 @@ private:
     static constexpr size_t kMinMetadataSize = 3;
 
     /**
-     * Rebinds the metadata/value views after _metadata_raw or _value_raw change.
+     * Rebinds the metadata/value views after _raw changes.
      *
-     * CRITICAL: VariantMetadata and Variant store string_views pointing to the
-     * underlying _metadata_raw and _value_raw strings. After copy/move operations
-     * that change these strings, we must reconstruct _metadata and _value to
-     * point to the new storage, otherwise we'd have dangling references.
+     * CRITICAL: VariantMetadata and VariantValue store string_views pointing to the
+     * underlying _raw string. After copy/move operations that change _raw, we must
+     * reconstruct _metadata and _value to point to the new storage, otherwise we'd
+     * have dangling references.
      *
      * This is called after:
-     * - Copy assignment (after copying strings)
-     * - Move assignment (after moving strings)
+     * - Copy assignment (after copying string)
+     * - Move assignment (after moving string)
      * - Reset to empty (after assigning empty constants)
      */
     void _rebind_views() {
-        _metadata = VariantMetadata(_metadata_raw);
-        _value = VariantValue(_value_raw);
+        std::string_view raw_view(_raw);
+        _metadata = VariantMetadata(raw_view.substr(0, _metadata_size));
+        _value = VariantValue(raw_view.substr(_metadata_size));
     }
 
     /**
@@ -167,8 +166,11 @@ private:
      * safely destroyed or reassigned, as required by C++ move semantics.
      */
     void _reset_to_empty() {
-        _metadata_raw.assign(VariantMetadata::kEmptyMetadata);
-        _value_raw.assign(VariantValue::kEmptyValue);
+        _raw.clear();
+        _raw.reserve(VariantMetadata::kEmptyMetadata.size() + VariantValue::kEmptyValue.size());
+        _raw.assign(VariantMetadata::kEmptyMetadata.data(), VariantMetadata::kEmptyMetadata.size());
+        _raw.append(VariantValue::kEmptyValue.data(), VariantValue::kEmptyValue.size());
+        _metadata_size = VariantMetadata::kEmptyMetadata.size();
         _rebind_views();
     }
 
@@ -178,17 +180,16 @@ private:
 
     /**
      * Data layout:
-     * - _metadata_raw: Owns the metadata string data
-     * - _value_raw: Owns the variant value string data
-     * - _metadata: Wrapper holding a string_view into _metadata_raw
-     * - _value: Wrapper holding a string_view into _value_raw
+     * - _raw: Owns a single contiguous buffer containing [metadata][value]
+     * - _metadata_size: The size of the metadata portion in bytes
+     * - _metadata: Wrapper holding a string_view into _raw[0.._metadata_size)
+     * - _value: Wrapper holding a string_view into _raw[_metadata_size.._raw.size())
      *
      * The wrappers (_metadata, _value) must be kept in sync with their
-     * underlying storage (_metadata_raw, _value_raw) via _rebind_views()
-     * whenever the storage strings are modified.
+     * underlying storage (_raw) via _rebind_views() whenever _raw is modified.
      */
-    std::string _metadata_raw;
-    std::string _value_raw;
+    std::string _raw;
+    size_t _metadata_size;
     VariantMetadata _metadata;
     VariantValue _value;
 };

--- a/be/src/types/variant_value.h
+++ b/be/src/types/variant_value.h
@@ -30,7 +30,8 @@ class VariantRowValue {
 public:
     VariantRowValue(const std::string_view metadata, const std::string_view value)
             : _raw(), _metadata_size(metadata.size()), _metadata(), _value() {
-        if (metadata.data() != VariantMetadata::kEmptyMetadata.data()) {
+        if (metadata.data() != VariantMetadata::kEmptyMetadata.data() ||
+            value.data() != VariantValue::kEmptyValue.data()) {
             _raw.reserve(metadata.size() + value.size());
             _raw.assign(metadata.data(), metadata.size());
             _raw.append(value.data(), value.size());

--- a/be/src/types/variant_value.h
+++ b/be/src/types/variant_value.h
@@ -22,6 +22,7 @@
 #include "fmt/format.h"
 #include "util/slice.h"
 #include "util/variant.h"
+#include "util/raw_container.h"
 
 namespace starrocks {
 
@@ -188,7 +189,7 @@ private:
      * The wrappers (_metadata, _value) must be kept in sync with their
      * underlying storage (_raw) via _rebind_views() whenever _raw is modified.
      */
-    std::string _raw;
+    raw::RawString _raw;
     size_t _metadata_size;
     VariantMetadata _metadata;
     VariantValue _value;

--- a/be/src/util/variant.cpp
+++ b/be/src/util/variant.cpp
@@ -742,54 +742,62 @@ Status VariantUtil::variant_to_json(const VariantMetadata& metadata, const Varia
         break;
     case VariantType::BOOLEAN_TRUE:
     case VariantType::BOOLEAN_FALSE: {
-        bool res = *variant.get_bool();
+        ASSIGN_OR_RETURN(bool res, variant.get_bool());
         json_str << (res ? "true" : "false");
         break;
     }
-    case VariantType::INT8:
-        json_str << std::to_string(*variant.get_int8());
+    case VariantType::INT8: {
+        ASSIGN_OR_RETURN(int8_t value, variant.get_int8());
+        json_str << std::to_string(value);
         break;
-    case VariantType::INT16:
-        json_str << std::to_string(*variant.get_int16());
+    }
+    case VariantType::INT16: {
+        ASSIGN_OR_RETURN(int16_t value, variant.get_int16());
+        json_str << std::to_string(value);
         break;
-    case VariantType::INT32:
-        json_str << std::to_string(*variant.get_int32());
+    }
+    case VariantType::INT32: {
+        ASSIGN_OR_RETURN(int32_t value, variant.get_int32());
+        json_str << std::to_string(value);
         break;
-    case VariantType::INT64:
-        json_str << std::to_string(*variant.get_int64());
+    }
+    case VariantType::INT64: {
+        ASSIGN_OR_RETURN(int64_t value, variant.get_int64());
+        json_str << std::to_string(value);
         break;
+    }
     case VariantType::FLOAT: {
-        const float f = *variant.get_float();
+        ASSIGN_OR_RETURN(float f, variant.get_float());
         json_str << float_to_json_string_impl(f);
         break;
     }
     case VariantType::DOUBLE: {
-        const double d = *variant.get_double();
+        ASSIGN_OR_RETURN(double d, variant.get_double());
         json_str << float_to_json_string_impl(d);
         break;
     }
     case VariantType::DECIMAL4: {
-        VariantDecimalValue<int32_t> decimal = *variant.get_decimal4();
+        ASSIGN_OR_RETURN(VariantDecimalValue<int32_t> decimal, variant.get_decimal4());
         json_str << remove_trailing_zeros(decimal.to_string());
         break;
     }
     case VariantType::DECIMAL8: {
-        VariantDecimalValue<int64_t> decimal = *variant.get_decimal8();
+        ASSIGN_OR_RETURN(VariantDecimalValue<int64_t> decimal, variant.get_decimal8());
         json_str << remove_trailing_zeros(decimal.to_string());
         break;
     }
     case VariantType::DECIMAL16: {
-        VariantDecimalValue<int128_t> decimal = *variant.get_decimal16();
+        ASSIGN_OR_RETURN(VariantDecimalValue<int128_t> decimal, variant.get_decimal16());
         json_str << remove_trailing_zeros(decimal.to_string());
         break;
     }
     case VariantType::STRING: {
-        const std::string_view str_view = *variant.get_string();
+        ASSIGN_OR_RETURN(const std::string_view str_view, variant.get_string());
         append_quoted_string(json_str, str_view);
         break;
     }
     case VariantType::BINARY: {
-        const std::string_view binary = *variant.get_binary();
+        ASSIGN_OR_RETURN(const std::string_view binary, variant.get_binary());
         const std::string binary_str(binary.data(), binary.size());
         std::string encoded;
         base64_encode(binary_str, &encoded);
@@ -797,7 +805,7 @@ Status VariantUtil::variant_to_json(const VariantMetadata& metadata, const Varia
         break;
     }
     case VariantType::UUID: {
-        const auto uuid_arr = *variant.get_uuid();
+        ASSIGN_OR_RETURN(const auto uuid_arr, variant.get_uuid());
         boost::uuids::uuid uuid{};
         for (size_t i = 0; i < uuid.size(); ++i) {
             uuid.data[i] = uuid_arr[i];
@@ -806,13 +814,13 @@ Status VariantUtil::variant_to_json(const VariantMetadata& metadata, const Varia
         break;
     }
     case VariantType::DATE: {
-        int32_t date = *variant.get_date();
+        ASSIGN_OR_RETURN(int32_t date, variant.get_date());
         std::string date_str = epoch_day_to_date(date);
         append_quoted_string(json_str, date_str);
         break;
     }
     case VariantType::TIMESTAMP_TZ: {
-        const int64_t timestamp_micros = *variant.get_timestamp_micros();
+        ASSIGN_OR_RETURN(const int64_t timestamp_micros, variant.get_timestamp_micros());
         TimestampValue tsv{};
         tsv.from_unix_second(timestamp_micros / 1000000, timestamp_micros % 1000000);
         std::string timestamp_str = timestamp::to_string_with_timezone<false, false>(tsv.timestamp(), timezone);
@@ -820,7 +828,7 @@ Status VariantUtil::variant_to_json(const VariantMetadata& metadata, const Varia
         break;
     }
     case VariantType::TIMESTAMP_NTZ: {
-        const int64_t timestamp_micros = *variant.get_timestamp_micros_ntz();
+        ASSIGN_OR_RETURN(const int64_t timestamp_micros, variant.get_timestamp_micros_ntz());
         TimestampValue tsv{};
         tsv.from_unix_second(timestamp_micros / 1000000, timestamp_micros % 1000000);
         std::string timestamp_str = tsv.to_string(false);

--- a/be/src/util/variant.cpp
+++ b/be/src/util/variant.cpp
@@ -143,6 +143,7 @@ Status VariantMetadata::_build_lookup_index() const {
             dict_strings.emplace_back(field_key);                                                                  \
             offset = next_offset;                                                                                  \
         }                                                                                                          \
+        _lookup_index.has_built = true;                                                                            \
         if (string_base + offset > _metadata.data() + _metadata.size()) {                                          \
             return Status::VariantError("Variant string out of range");                                            \
         }                                                                                                          \
@@ -155,8 +156,6 @@ Status VariantMetadata::_build_lookup_index() const {
         DECODE_VALUE_OFFSET(3);
         DECODE_VALUE_OFFSET(4);
     }
-
-    _lookup_index.has_built = true;
     return Status::OK();
 }
 

--- a/be/src/util/variant.h
+++ b/be/src/util/variant.h
@@ -325,7 +325,6 @@ public:
 
 private:
     uint8_t value_header() const { return static_cast<uint8_t>(_value[0]) >> kValueHeaderBitShift; }
-    Status validate_basic_type(BasicType type) const;
     Status validate_primitive_type(VariantType type, size_t size_required) const;
 
     template <typename PrimitiveType>

--- a/be/src/util/variant.h
+++ b/be/src/util/variant.h
@@ -106,8 +106,12 @@ struct VariantUtil {
         DCHECK_LE(size, 4);
         DCHECK_GE(size, 1);
 
+        if (size == 1) {
+            return static_cast<uint32_t>(*(static_cast<const uint8_t*>(from)));
+        }
+
         uint32_t result = 0;
-        memcpy(&result, from, size);
+        __builtin_memcpy(&result, from, size);
         return arrow::bit_util::FromLittleEndian(result);
     }
 

--- a/be/src/util/variant.h
+++ b/be/src/util/variant.h
@@ -97,6 +97,7 @@ public:
     // We probably will optimize internal state like to build indexes for dictionary lookups.
     // so the cost of creating VariantMetadata is not trivial
     explicit VariantMetadata(std::string_view metadata);
+    VariantMetadata() : _metadata(kEmptyMetadata) {}
 
     uint8_t header() const;
     bool is_sorted_and_unique() const;
@@ -210,6 +211,7 @@ public:
 
 public:
     explicit VariantValue(std::string_view value);
+    VariantValue() : _value(kEmptyValue) {}
 
     static constexpr uint8_t kHeaderSizeBytes = 1;
     static constexpr size_t kDecimalScaleSizeBytes = 1;

--- a/be/src/util/variant.h
+++ b/be/src/util/variant.h
@@ -22,10 +22,7 @@
 #include <string_view>
 
 #include "common/status.h"
-#include "hash.h"
 #include "util/decimal_types.h"
-#include "util/phmap/phmap.h"
-#include "util/slice.h"
 
 namespace starrocks {
 
@@ -179,18 +176,16 @@ private:
     friend class VariantValue;
     // return the index for the key in the dictionary
     // we use void* to avoid expose specific type in the header
-    Status _get_index(std::string_view key, void* indexes) const;
+    Status _get_index(std::string_view key, void* indexes, int hint) const;
 
     Status _build_lookup_index() const;
 
     // fields for optimization. they are computed lazily
     struct LookupIndex {
-        bool is_dict_unique = false;
+        bool has_built = false;
         std::vector<std::string_view> dict_strings;
-        phmap::flat_hash_map<Slice, uint32_t, SliceHash> dict_index_map;
     };
 
-    mutable bool _has_built_lookup_index = false;
     mutable LookupIndex _lookup_index;
 };
 
@@ -246,7 +241,7 @@ struct VariantArrayInfo {
 
 class VariantValue {
 public:
-    enum class BasicType { PRIMITIVE = 0, SHORT_STRING = 1, OBJECT = 2, ARRAY = 3 };
+    enum class BasicType : uint8_t { PRIMITIVE = 0, SHORT_STRING = 1, OBJECT = 2, ARRAY = 3 };
 
     /**
      * kEmptyVariant represents a NULL variant value.

--- a/be/src/util/variant_converter.cpp
+++ b/be/src/util/variant_converter.cpp
@@ -27,35 +27,27 @@ Status cast_variant_to_bool(const VariantRowValue& variant, ColumnBuilder<TYPE_B
     }
 
     if (type == VariantType::BOOLEAN_TRUE || type == VariantType::BOOLEAN_FALSE) {
-        auto ret = value.get_bool();
-        if (!ret.ok()) {
-            return ret.status();
-        }
-
-        result.append(ret.value());
+        ASSIGN_OR_RETURN(const auto ret, value.get_bool());
+        result.append(ret);
         return Status::OK();
     }
 
     if (type == VariantType::STRING) {
-        auto str = value.get_string();
-        if (str.ok()) {
-            const char* str_value = str.value().data();
-            size_t len = str.value().size();
-            StringParser::ParseResult parsed;
-            auto r = StringParser::string_to_int<int32_t>(str_value, len, &parsed);
+        ASSIGN_OR_RETURN(const auto str, value.get_string());
+        const char* str_value = str.data();
+        size_t len = str.size();
+        StringParser::ParseResult parsed;
+        auto r = StringParser::string_to_int<int32_t>(str_value, len, &parsed);
+        if (parsed != StringParser::PARSE_SUCCESS) {
+            const bool casted = StringParser::string_to_bool(str_value, len, &parsed);
             if (parsed != StringParser::PARSE_SUCCESS) {
-                const bool casted = StringParser::string_to_bool(str_value, len, &parsed);
-                if (parsed != StringParser::PARSE_SUCCESS) {
-                    return Status::VariantError(fmt::format("Failed to cast string '{}' to BOOLEAN", str.value()));
-                }
-
-                result.append(casted);
-            } else {
-                result.append(r != 0);
+                return Status::VariantError(fmt::format("Failed to cast string '{}' to BOOLEAN", str_value));
             }
-
-            return Status::OK();
+            result.append(casted);
+        } else {
+            result.append(r != 0);
         }
+        return Status::OK();
     }
 
     return VARIANT_CAST_NOT_SUPPORT(type, TYPE_BOOLEAN);
@@ -70,21 +62,14 @@ Status cast_variant_to_string(const VariantRowValue& variant, const cctz::time_z
         return Status::OK();
     }
     case VariantType::STRING: {
-        auto str = value.get_string();
-        if (!str.ok()) {
-            return str.status();
-        }
-
-        result.append(Slice(std::string(str.value())));
+        ASSIGN_OR_RETURN(const auto str, value.get_string());
+        result.append(Slice(str));
         return Status::OK();
     }
     default: {
+        // TODO: extra copy. from variant -> ss, and ss -> result.
         std::stringstream ss;
-        Status status = VariantUtil::variant_to_json(variant.get_metadata(), value, ss, zone);
-        if (!status.ok()) {
-            return status;
-        }
-
+        RETURN_IF_ERROR(VariantUtil::variant_to_json(variant.get_metadata(), value, ss, zone));
         std::string json_str = ss.str();
         result.append(Slice(json_str));
         return Status::OK();

--- a/be/src/util/variant_converter.cpp
+++ b/be/src/util/variant_converter.cpp
@@ -41,7 +41,7 @@ Status cast_variant_to_bool(const VariantRowValue& variant, ColumnBuilder<TYPE_B
         if (parsed != StringParser::PARSE_SUCCESS) {
             const bool casted = StringParser::string_to_bool(str_value, len, &parsed);
             if (parsed != StringParser::PARSE_SUCCESS) {
-                return Status::VariantError(fmt::format("Failed to cast string '{}' to BOOLEAN", str_value));
+                return Status::VariantError(fmt::format("Failed to cast string '{}' to BOOLEAN", str));
             }
             result.append(casted);
         } else {

--- a/be/test/exprs/variant_path_parser_test.cpp
+++ b/be/test/exprs/variant_path_parser_test.cpp
@@ -103,20 +103,20 @@ TEST_P(VariantPathParserTest, ParseAndVerifySegments) {
         const std::string& expected_type = test_case.expected_types[i];
 
         if (expected_type == "object") {
-            EXPECT_TRUE(std::holds_alternative<ObjectExtraction>(segment))
+            EXPECT_TRUE(std::holds_alternative<VariantObjectExtraction>(segment))
                     << "Expected object extraction at index " << i << " for path: " << test_case.path;
 
-            if (std::holds_alternative<ObjectExtraction>(segment)) {
-                const auto& obj_extraction = std::get<ObjectExtraction>(segment);
+            if (std::holds_alternative<VariantObjectExtraction>(segment)) {
+                const auto& obj_extraction = std::get<VariantObjectExtraction>(segment);
                 EXPECT_EQ(obj_extraction.get_key(), expected_value)
                         << "Unexpected object key at index " << i << " for path: " << test_case.path;
             }
         } else if (expected_type == "array") {
-            EXPECT_TRUE(std::holds_alternative<ArrayExtraction>(segment))
+            EXPECT_TRUE(std::holds_alternative<VariantArrayExtraction>(segment))
                     << "Expected array extraction at index " << i << " for path: " << test_case.path;
 
-            if (std::holds_alternative<ArrayExtraction>(segment)) {
-                const auto& arr_extraction = std::get<ArrayExtraction>(segment);
+            if (std::holds_alternative<VariantArrayExtraction>(segment)) {
+                const auto& arr_extraction = std::get<VariantArrayExtraction>(segment);
                 EXPECT_EQ(std::to_string(arr_extraction.get_index()), expected_value)
                         << "Unexpected array index at index " << i << " for path: " << test_case.path;
             }
@@ -186,24 +186,24 @@ TEST_F(VariantPathParserBasicTest, SpecificPathTests) {
                  EXPECT_EQ(segments.size(), 5);
 
                  // $.users
-                 EXPECT_TRUE(std::holds_alternative<ObjectExtraction>(segments[0]));
-                 EXPECT_EQ(std::get<ObjectExtraction>(segments[0]).get_key(), "users");
+                 EXPECT_TRUE(std::holds_alternative<VariantObjectExtraction>(segments[0]));
+                 EXPECT_EQ(std::get<VariantObjectExtraction>(segments[0]).get_key(), "users");
 
                  // [0]
-                 EXPECT_TRUE(std::holds_alternative<ArrayExtraction>(segments[1]));
-                 EXPECT_EQ(std::get<ArrayExtraction>(segments[1]).get_index(), 0);
+                 EXPECT_TRUE(std::holds_alternative<VariantArrayExtraction>(segments[1]));
+                 EXPECT_EQ(std::get<VariantArrayExtraction>(segments[1]).get_index(), 0);
 
                  // .profile
-                 EXPECT_TRUE(std::holds_alternative<ObjectExtraction>(segments[2]));
-                 EXPECT_EQ(std::get<ObjectExtraction>(segments[2]).get_key(), "profile");
+                 EXPECT_TRUE(std::holds_alternative<VariantObjectExtraction>(segments[2]));
+                 EXPECT_EQ(std::get<VariantObjectExtraction>(segments[2]).get_key(), "profile");
 
                  // ['personal-data']
-                 EXPECT_TRUE(std::holds_alternative<ObjectExtraction>(segments[3]));
-                 EXPECT_EQ(std::get<ObjectExtraction>(segments[3]).get_key(), "personal-data");
+                 EXPECT_TRUE(std::holds_alternative<VariantObjectExtraction>(segments[3]));
+                 EXPECT_EQ(std::get<VariantObjectExtraction>(segments[3]).get_key(), "personal-data");
 
                  // .address
-                 EXPECT_TRUE(std::holds_alternative<ObjectExtraction>(segments[4]));
-                 EXPECT_EQ(std::get<ObjectExtraction>(segments[4]).get_key(), "address");
+                 EXPECT_TRUE(std::holds_alternative<VariantObjectExtraction>(segments[4]));
+                 EXPECT_EQ(std::get<VariantObjectExtraction>(segments[4]).get_key(), "address");
              }}};
 
     for (const auto& test : specific_tests) {

--- a/be/test/types/variant_value_test.cpp
+++ b/be/test/types/variant_value_test.cpp
@@ -20,8 +20,6 @@
 #include <boost/uuid/uuid_io.hpp>
 
 #include "cctz/time_zone.h"
-#include "runtime/decimalv3.h"
-#include "types/timestamp_value.h"
 #include "util/timezone_utils.h"
 #include "util/variant.h"
 
@@ -38,8 +36,7 @@ public:
 
 protected:
     void SetUp() override {
-        std::string starrocks_home = getenv("STARROCKS_HOME");
-        test_exec_dir = starrocks_home + "/be/test/formats/parquet/test_data/variant";
+        test_exec_dir = "./be/test/formats/parquet/test_data/variant";
 
         _primitive_metadata_file_names = {
                 "primitive_null.metadata",      "primitive_boolean_true.metadata", "primitive_boolean_false.metadata",
@@ -400,7 +397,7 @@ TEST_F(VariantRowValueTest, InvalidVariant) {
         Slice variant_slice(variant_data);
         auto unsupported_variant = VariantRowValue::create(variant_slice);
         ASSERT_FALSE(unsupported_variant.ok());
-        EXPECT_EQ("Not supported: Unsupported variant version: 2", unsupported_variant.status().to_string());
+        EXPECT_EQ("Not supported: Unsupported variant version: 2", unsupported_variant.status().to_string(false));
     }
     // Test exceed maximum variant size
     {


### PR DESCRIPTION
##  Why I'm doing

##  What I'm doing

1. VariantRowValue Memory Layout Optimization
    - Changed from storing [metadata] and [value] in separate std::string objects to a single contiguous buffer _raw
    - Reduces memory allocations from 2 to 1, improves cache locality
    - Added predefined null-binary default for empty variants
    - serialize()/serialize_size() now copy single block instead of two separate copies

2. VariantMetadata Lookup Index Caching
    - Added lazy dict_size calculation and _lookup_index struct to cache parsed dictionary string views
    - get_key() now returns std::string_view instead of std::string to avoid allocations
    - New _build_lookup_index() builds dictionary string view cache once
    - Fast _get_index() using cached views with std::lower_bound for sorted unique dictionaries

3. Fast Inline Little-Endian Readers
    - Added inline_read_little_endian_unsigned32_fixed_size<T>() template for 1-4 byte reads
    - Uses __builtin_memcpy for zero-overhead byte swapping via arrow::bit_util::FromLittleEndian
    - Replaces slower VariantUtil::read_little_endian_unsigned32() calls throughout

4. VariantValue Access Optimizations
    - Inlined value_header() and basic_type() accessors
    - Cached dictionary index scan in get_object_by_key() with hint parameter
    - Template-based field ID search (SEARCH_DICT_INDEX_SZ) for different sizes (1-4 bytes)
    - Added UNLIKELY hints for error path optimization

5. CastVariantToMap Improvements
    - get_key() returns std::string_view, uses Slice(key) directly to avoid key copies
    - Error messages use fmt::format for better formatting

6. Naming Refactoring
    - Renamed ObjectExtraction → VariantObjectExtraction
    - Renamed ArrayExtraction → VariantArrayExtraction

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses on performance and copy-reduction across Variant handling.
> 
> - **Variant storage/layout:** `VariantRowValue` now stores `[metadata][value]` in a single `_raw` buffer with a predefined null binary; `serialize`/`serialize_size` copy one block
> - **Dictionary lookup:** `VariantMetadata` lazily computes dict size, caches dict string views via `_build_lookup_index`, and **`get_key` returns `std::string_view`**; fast inline LE readers replace previous helpers
> - **Variant access:** Inlines headers/type checks; accelerates `get_object_by_key` using cached indexes and fixed-size reads; adds bounds/overflow checks and UNLIKELY paths
> - **Path parsing:** Renames to `VariantObjectExtraction`/`VariantArrayExtraction`; `VariantPath::seek` uses `std::visit` with `ASSIGN_OR_RETURN`
> - **Casting/conversion:** `CastVariantToMap` uses `string_view` keys and `Slice(key)`; improved error messages; `variant_converter` reduces copies and simplifies boolean/string handling
> - **Misc:** DEBUG-only warning on destroying `MemTracker` with unreleased children
> - **Tests:** Updated `variant_path_parser_test` and `variant_value_test` to new types/behaviors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4435c60dc7471858510499080fd7658f86201897. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->