### PR TITLE
[Enhancement] enable_min_max_optimization for iceberg timestamp type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
@@ -33,6 +33,7 @@ public class GetRemoteFilesParams {
     private boolean useCache = true;
     private boolean checkPartitionExistence = true;
     private boolean enableColumnStats = false;
+    private boolean keepDataFileStats = false;
     private Optional<Boolean> isRecursive = Optional.empty();
 
     protected GetRemoteFilesParams(Builder builder) {
@@ -46,6 +47,7 @@ public class GetRemoteFilesParams {
         this.useCache = builder.useCache;
         this.checkPartitionExistence = builder.checkPartitionExistence;
         this.enableColumnStats = builder.enableColumnStats;
+        this.keepDataFileStats = builder.keepDataFileStats;
         this.isRecursive = builder.isRecursive;
     }
 
@@ -70,7 +72,8 @@ public class GetRemoteFilesParams {
                 .setLimit(limit)
                 .setUseCache(useCache)
                 .setCheckPartitionExistence(checkPartitionExistence)
-                .setEnableColumnStats(enableColumnStats);
+                .setEnableColumnStats(enableColumnStats)
+                .setKeepDataFileStats(keepDataFileStats);
         if (isRecursive.isPresent()) {
             paramsBuilder.setIsRecursive(isRecursive.get());
         }
@@ -149,6 +152,10 @@ public class GetRemoteFilesParams {
         return enableColumnStats;
     }
 
+    public boolean isKeepDataFileStats() {
+        return keepDataFileStats;
+    }
+
     public Optional<Boolean> getIsRecursive() {
         return isRecursive;
     }
@@ -164,6 +171,7 @@ public class GetRemoteFilesParams {
         private boolean useCache = true;
         private boolean checkPartitionExistence = true;
         private boolean enableColumnStats = false;
+        private boolean keepDataFileStats = false;
         private Optional<Boolean> isRecursive = Optional.empty();
 
         public Builder setPartitionKeys(List<PartitionKey> partitionKeys) {
@@ -213,6 +221,11 @@ public class GetRemoteFilesParams {
 
         public Builder setEnableColumnStats(boolean enableColumnStats) {
             this.enableColumnStats = enableColumnStats;
+            return this;
+        }
+
+        public Builder setKeepDataFileStats(boolean keepDataFileStats) {
+            this.keepDataFileStats = keepDataFileStats;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PredicateSearchKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PredicateSearchKey.java
@@ -79,6 +79,9 @@ public class PredicateSearchKey {
         if (params.isEnableColumnStats() != that.params.isEnableColumnStats()) {
             return false;
         }
+        if (params.isKeepDataFileStats() != that.params.isKeepDataFileStats()) {
+            return false;
+        }
 
         return Objects.equals(getVersion(), that.getVersion()) &&
                 Objects.equals(databaseName, that.databaseName) &&
@@ -87,7 +90,8 @@ public class PredicateSearchKey {
 
     @Override
     public int hashCode() {
-        return Objects.hash(databaseName, tableName, getVersion(), getPredicate(), params.isEnableColumnStats());
+        return Objects.hash(databaseName, tableName, getVersion(), getPredicate(), params.isEnableColumnStats(),
+                params.isKeepDataFileStats());
     }
 
     @Override
@@ -97,6 +101,7 @@ public class PredicateSearchKey {
                 ", version=" + getVersion() +
                 ", predicate=" + getPredicate() +
                 ", enableColumnStats=" + params.isEnableColumnStats() +
+                ", keepDataFileStats=" + params.isKeepDataFileStats() +
                 '}';
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -164,6 +164,7 @@ public class IcebergScanNode extends ScanNode {
                         .setTableVersionRange(tvrVersionRange)
                         .setPredicate(icebergJobPlanningPredicate)
                         .setEnableColumnStats(scanOptimizeOption.getCanUseMinMaxOpt())
+                        .setKeepDataFileStats(scanOptimizeOption.getCanUseMinMaxOpt())
                         .build();
 
         RemoteFileInfoSource remoteFileInfoSource;


### PR DESCRIPTION
## Why I'm doing:

enable_min_max_optimization lacked min max meta scan for iceberg partition columns

## What I'm doing:

Teach HdfsScannerContext::create_min_max_value_column to do TYPE_DATETIME

For timestamp_tz we do adjust on FE side, since it is FE who reads meta bounds and BE can't access them. Can redo in favor of addind is_adjusted_to_utc to TExprMinMaxValue  in thrift. But wanted to keep it simpler. 

Fixes #67158

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables min/max-based pruning for Iceberg temporal types and preserves file statistics when needed for column stats.
> 
> - BE: `HdfsScannerContext::create_min_max_value_column` adds `TYPE_DATETIME` handling (micros -> `TimestampValue`).
> - FE: `IcebergUtil` supports `TypeID.TIMESTAMP` in min/max parsing and adjusts UTC timestamps to session timezone; maps DATETIME to thrift int literal.
> - New `keepDataFileStats` in `GetRemoteFilesParams` (builder/getter/copy), included in `PredicateSearchKey` equality/hash.
> - `IcebergMetadata`: pass `keepDataFileStats` and conditionally keep stats in `buildIcebergSplitScanTask` instead of `copyWithoutStats`.
> - `IcebergScanNode`: sets `keepDataFileStats` when min/max optimization is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9dbc29cdd40d6a5ae7544a58c0e22cc3cd3f0d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->