### PR TITLE
[BugFix] Align DESC Extra column between olap and cloud native table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IndexInfoProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IndexInfoProcDir.java
@@ -153,7 +153,7 @@ public class IndexInfoProcDir implements ProcDirInterface {
                 schema = table.getBaseSchema();
             }
             IndexSchemaProcNode node = new IndexSchemaProcNode(schema, bfColumns);
-            if (table.getType() == TableType.OLAP || table.getType() == TableType.OLAP_EXTERNAL) {
+            if (table.isNativeTable() || table.isOlapExternalTable()) {
                 node.setHideAggregationType(true);
             }
             return node;


### PR DESCRIPTION
## Why I'm doing:

fix unstable case:

desc cloud native table before this PR:
```
mysql> desc t;
+-------+----------------+------+-------+---------+-------+
| Field | Type           | Null | Key   | Default | Extra |
+-------+----------------+------+-------+---------+-------+
| k1    | int            | YES  | true  | NULL    |       |
| k2    | varchar(65533) | YES  | true  | NULL    |       |
| k3    | int            | YES  | false | NULL    | NONE  |
+-------+----------------+------+-------+---------+-------+
3 rows in set (0.90 sec)
```

## What I'm doing:

desc cloud native table after this PR:
```
mysql> desc t;
+-------+----------------+------+-------+---------+-------+
| Field | Type           | Null | Key   | Default | Extra |
+-------+----------------+------+-------+---------+-------+
| k1    | int            | YES  | true  | NULL    |       |
| k2    | varchar(65533) | YES  | true  | NULL    |       |
| k3    | int            | YES  | false | NULL    |       |
+-------+----------------+------+-------+---------+-------+
3 rows in set (0.01 sec)
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
