### PR TITLE
[BugFix] Fix multi result sinks error for single-tablet queries in shared-data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -365,7 +365,9 @@ public class PlanFragmentBuilder {
                 && (execPlan.getScanNodes().stream().map(d -> ((OlapScanNode) d).getScanTabletIds().size())
                 .reduce(Integer::sum).orElse(2) <= 1)) || execPlan.isShortCircuit()) {
             inputFragment.setOutputExprs(outputExprs);
-            inputFragment.setSingleTabletGatherOutputFragment(true);
+            for (PlanFragment fragment : execPlan.getFragments()) {
+                fragment.setSingleTabletGatherOutputFragment(true);
+            }
             return;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2851,6 +2851,15 @@ public class JoinTest extends PlanTestBase {
                     "  RESULT SINK\n" +
                     "\n" +
                     "  0:OlapScanNode");
+
+            sql = "select v1 from t0 where v2 = 1 union select v4 from t1 where v5 = 2";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "RESULT SINK\n" +
+                    "\n" +
+                    "  9:AGGREGATE (merge finalize)\n" +
+                    "  |  group by: 7: v1\n" +
+                    "  |  \n" +
+                    "  8:EXCHANGE");
         } finally {
             Config.run_mode = RunMode.SHARED_NOTHING.getName();
             RunMode.detectRunMode();

--- a/test/sql/test_union/R/test_union_all_with_limit
+++ b/test/sql/test_union/R/test_union_all_with_limit
@@ -26,3 +26,33 @@ select count(*) from (select c0 from t0 union all select distinct c0 from t0 lim
 -- result:
 1
 -- !result
+create table dup_tbl(
+col_int int,
+col_integer integer,
+col_tinyint tinyint,
+col_float float,
+col_double double,
+col_decimal decimal,
+col_date date,
+col_timestamp datetime,
+col_varchar varchar(100),
+col_char char(100),
+col_boolean boolean)
+DUPLICATE KEY(`col_int`)
+DISTRIBUTED BY HASH(`col_int`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into dup_tbl select 1,0,1,1.001,10.1,1110.1,'2001-01-01','2021-10-30 12:10:23','hello world','hi hello',true;
+-- result:
+-- !result
+insert into dup_tbl select 1,1,1,1.001,10.1,1110.1,'2001-01-02','2021-10-30 12:10:23','hello world','hi hello',true;
+-- result:
+-- !result
+set @test_union = (select col_date from dup_tbl where col_date <= '2001-02-01' limit 1);
+-- result:
+-- !result
+select col_date from dup_tbl where col_varchar like '%hello' union select @test_union;
+-- result:
+2001-01-01
+-- !result

--- a/test/sql/test_union/T/test_union_all_with_limit
+++ b/test/sql/test_union/T/test_union_all_with_limit
@@ -22,3 +22,24 @@ PROPERTIES (
 insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
 
 select count(*) from (select c0 from t0 union all select distinct c0 from t0 limit 1)t;
+
+create table dup_tbl(
+col_int int,
+col_integer integer,
+col_tinyint tinyint,
+col_float float,
+col_double double,
+col_decimal decimal,
+col_date date,
+col_timestamp datetime,
+col_varchar varchar(100),
+col_char char(100),
+col_boolean boolean)
+DUPLICATE KEY(`col_int`)
+DISTRIBUTED BY HASH(`col_int`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+insert into dup_tbl select 1,0,1,1.001,10.1,1110.1,'2001-01-01','2021-10-30 12:10:23','hello world','hi hello',true;
+insert into dup_tbl select 1,1,1,1.001,10.1,1110.1,'2001-01-02','2021-10-30 12:10:23','hello world','hi hello',true;
+set @test_union = (select col_date from dup_tbl where col_date <= '2001-02-01' limit 1);
+select col_date from dup_tbl where col_varchar like '%hello' union select @test_union;


### PR DESCRIPTION
## Why I'm doing:

PR #66517 introduced single-tablet result sink optimization in shared-data mode, but it causes `ERROR 1064 (HY000): This sql plan has multi result sinks` for queries like UNION with user variables.

The issue is that only the top fragment was marked with `isSingleTabletGatherOutputFragment`, while intermediate fragments (e.g., AGGREGATE) were still assigned to all compute nodes by the `isPreferComputeNode` strategy, creating multiple result sink instances.

## What I'm doing:

- Mark all non-scan fragments with `isSingleTabletGatherOutputFragment` flag when single-tablet optimization is triggered
- Skip `isPreferComputeNode` strategy for fragments marked with `isSingleTabletGatherOutputFragment`

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/10756

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes single-tablet planning in shared-data mode by correctly marking gather fragments and adds regression tests.
> 
> - In `PlanFragmentBuilder`, when single-tablet optimization/short-circuit applies, set `isSingleTabletGatherOutputFragment` on all non-`ScanNode` fragments instead of only the input fragment
> - Adds planner test in `JoinTest` to validate `RESULT SINK`/`AGGREGATE (merge finalize)` with `UNION`
> - Extends `test_union_all_with_limit` SQL tests with a duplicate-key table and a `UNION` over a session variable to cover result planning
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ffab440f59e32765335b474f7e543a3d98f3b09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->