### PR TITLE
[UT] Fix show create table sql test

### DIFF
--- a/test/sql/test_ddl/R/alter_table
+++ b/test/sql/test_ddl/R/alter_table
@@ -1,4 +1,4 @@
--- name: test_ddl_alter_table
+-- name: test_ddl_alter_table @native
 create database db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_ddl/R/create_table_like
+++ b/test/sql/test_ddl/R/create_table_like
@@ -1,4 +1,4 @@
--- name: test_ddl_create_table_like
+-- name: test_ddl_create_table_like @native
 create database db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_ddl/R/test_alter_swap_table
+++ b/test/sql/test_ddl/R/test_alter_swap_table
@@ -1,4 +1,4 @@
--- name: test_alter_swap_table
+-- name: test_alter_swap_table @native
 create database db_test_alter_swap_table;
 -- result:
 -- !result

--- a/test/sql/test_ddl/T/alter_table
+++ b/test/sql/test_ddl/T/alter_table
@@ -1,4 +1,4 @@
--- name: test_ddl_alter_table
+-- name: test_ddl_alter_table @native
 create database db_${uuid0};
 use db_${uuid0};
 CREATE TABLE t1 (id1 int) DUPLICATE KEY(id1) COMMENT "c1" DISTRIBUTED BY HASH(id1) BUCKETS 1 properties('replication_num' = '1');

--- a/test/sql/test_ddl/T/create_table_like
+++ b/test/sql/test_ddl/T/create_table_like
@@ -1,4 +1,4 @@
--- name: test_ddl_create_table_like
+-- name: test_ddl_create_table_like @native
 create database db_${uuid0};
 use db_${uuid0};
 CREATE TABLE t1 (id1 int, id2 int, id3 double) DUPLICATE KEY(id1) COMMENT "c1" DISTRIBUTED BY HASH(id1) BUCKETS 1 properties('replication_num' = '1');

--- a/test/sql/test_ddl/T/test_alter_swap_table
+++ b/test/sql/test_ddl/T/test_alter_swap_table
@@ -1,4 +1,4 @@
--- name: test_alter_swap_table
+-- name: test_alter_swap_table @native
 create database db_test_alter_swap_table;
 use db_test_alter_swap_table;
 

--- a/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
@@ -281,7 +281,7 @@ drop table tab1;
 drop database test_fast_schema_evolution;
 -- result:
 -- !result
--- name: test_meta_scan
+-- name: test_meta_scan @native
 create database meta_scan;
 -- result:
 -- !result
@@ -416,7 +416,7 @@ None
 drop database meta_scan;
 -- result:
 -- !result
--- name: test_fast_schema_evolution_and_alter
+-- name: test_fast_schema_evolution_and_alter @native
 create database test_fast_schema_evolution_and_alter;
 -- result:
 -- !result

--- a/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
@@ -96,7 +96,7 @@ drop table tab1;
 drop database test_fast_schema_evolution;
 
 
--- name: test_meta_scan
+-- name: test_meta_scan @native
 create database meta_scan;
 use meta_scan;
 CREATE TABLE `reproducex4` (
@@ -161,7 +161,7 @@ function: wait_analyze_finish("meta_scan", "reproducex4", "explain select v2 fro
 drop database meta_scan;
 
 
--- name: test_fast_schema_evolution_and_alter
+-- name: test_fast_schema_evolution_and_alter @native
 
 create database test_fast_schema_evolution_and_alter;
 use test_fast_schema_evolution_and_alter;

--- a/test/sql/test_http_sql/R/test_http_output
+++ b/test/sql/test_http_sql/R/test_http_output
@@ -1,4 +1,4 @@
--- name: test_http_output_correct
+-- name: test_http_output_correct @native
 use ${db[0]};
 -- result:
 -- !result

--- a/test/sql/test_http_sql/T/test_http_output
+++ b/test/sql/test_http_sql/T/test_http_output
@@ -1,4 +1,4 @@
--- name: test_http_output_correct
+-- name: test_http_output_correct @native
 use ${db[0]};
 CREATE TABLE `duplicate_table_with_null` (
     `k1`  date,

--- a/test/sql/test_partition_by_expr/R/test_expr_from_unixtime
+++ b/test/sql/test_partition_by_expr/R/test_expr_from_unixtime
@@ -98,7 +98,7 @@ START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
 -- result:
 E: (1064, 'Getting analyzing error from line 7, column 19 to line 7, column 44. Detail message: Unsupported partition expression from_unixtime for column create_time type VARCHAR(100).')
 -- !result
--- name: test_partition_by_expr_unixtime_ms
+-- name: test_partition_by_expr_unixtime_ms @native
 CREATE TABLE partition_unixtime_ms (
         create_time bigint,
         sku_id varchar(100),

--- a/test/sql/test_partition_by_expr/R/test_expr_from_unixtime_add_partition
+++ b/test/sql/test_partition_by_expr/R/test_expr_from_unixtime_add_partition
@@ -1,4 +1,4 @@
--- name: test_expr_from_unixtime_add_partition
+-- name: test_expr_from_unixtime_add_partition @native
 CREATE TABLE partition_unixtime (
         create_time bigint,
         sku_id varchar(100),

--- a/test/sql/test_partition_by_expr/R/test_expr_str2date
+++ b/test/sql/test_partition_by_expr/R/test_expr_str2date
@@ -1,4 +1,4 @@
--- name: test_expr_str2date
+-- name: test_expr_str2date @native
 CREATE TABLE partition_str2date (
         create_time varchar(100),
         sku_id varchar(100),

--- a/test/sql/test_partition_by_expr/T/test_expr_from_unixtime
+++ b/test/sql/test_partition_by_expr/T/test_expr_from_unixtime
@@ -56,7 +56,7 @@ CREATE TABLE partition_unixtime (
 PARTITION BY RANGE(from_unixtime(create_time))(
 START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
 );
--- name: test_partition_by_expr_unixtime_ms
+-- name: test_partition_by_expr_unixtime_ms @native
 CREATE TABLE partition_unixtime_ms (
         create_time bigint,
         sku_id varchar(100),

--- a/test/sql/test_partition_by_expr/T/test_expr_from_unixtime_add_partition
+++ b/test/sql/test_partition_by_expr/T/test_expr_from_unixtime_add_partition
@@ -1,4 +1,4 @@
--- name: test_expr_from_unixtime_add_partition
+-- name: test_expr_from_unixtime_add_partition @native
 CREATE TABLE partition_unixtime (
         create_time bigint,
         sku_id varchar(100),

--- a/test/sql/test_partition_by_expr/T/test_expr_str2date
+++ b/test/sql/test_partition_by_expr/T/test_expr_str2date
@@ -1,4 +1,4 @@
--- name: test_expr_str2date
+-- name: test_expr_str2date @native
 CREATE TABLE partition_str2date (
         create_time varchar(100),
         sku_id varchar(100),


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

table properties are not same between olap and cloud native table.

Mark related sql tests as native.

fix unstable case:

```
- [SQL]: SHOW CREATE TABLE t1;
- [exp]: ['t1\tCREATE TABLE `t1` (', '  `id1` int(11) NULL COMMENT ""', ') ENGINE=OLAP ', 'DUPLICATE KEY(`id1`)', 'COMMENT "c2"', 'DISTRIBUTED BY HASH(`id1`) BUCKETS 1 ', 'PROPERTIES (', '"compression" = "LZ4",', '"fast_schema_evolution" = "true",', '"replicated_storage" = "true",', '"replication_num" = "1"', ');']
- [act]: ['t1\tCREATE TABLE `t1` (', '  `id1` int(11) NULL COMMENT ""', ') ENGINE=OLAP ', 'DUPLICATE KEY(`id1`)', 'COMMENT "c2"', 'DISTRIBUTED BY HASH(`id1`) BUCKETS 1 ', 'PROPERTIES (', '"cloud_native_fast_schema_evolution_v2" = "true",', '"compression" = "LZ4",', '"datacache.enable" = "true",', '"enable_async_write_back" = "false",', '"file_bundling" = "true",', '"replication_num" = "1",', '"storage_volume" = "builtin_storage_volume"', ');']
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns SQL UTs with cloud-native behavior and stabilizes expected outputs.
> 
> - Marks multiple tests as `@native` to avoid property mismatches in `SHOW CREATE TABLE` and related statements (`ddl/*`, `fast_schema_evolution` subtests, `http_sql`, `partition_by_expr`)
> - Minor test cleanup (ensure trailing newlines, consistent `sync` endings)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ee9c0efd9468f7b3ade4b38f35709d98b88757c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->