### PR TITLE
[Refactor] Transform Table/Db/Partition related simple edit logs to WAL format

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -360,8 +360,8 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
 
             // First, we need to check whether the table to be operated on can be renamed
             try {
-                olapNewTbl.checkAndSetName(origTblName, true);
-                origTable.checkAndSetName(newTblName, true);
+                olapNewTbl.checkNameConflict(origTblName);
+                origTable.checkNameConflict(newTblName);
 
                 if (origTable.isMaterializedView() || newTbl.isMaterializedView()) {
                     if (!(origTable.isMaterializedView() && newTbl.isMaterializedView())) {
@@ -539,8 +539,6 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
                         String colocateGroup = properties.get(PropertyAnalyzer.PROPERTIES_COLOCATE_WITH);
                         GlobalStateMgr.getCurrentState().getColocateTableIndex()
                                 .modifyTableColocate(db, olapTable, colocateGroup, false, null);
-                    } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DISTRIBUTION_TYPE)) {
-                        GlobalStateMgr.getCurrentState().getLocalMetastore().convertDistributionType(db, olapTable);
                     } else if (DynamicPartitionUtil.checkDynamicPartitionPropertiesExist(properties)) {
                         if (!olapTable.dynamicPartitionExists()) {
                             try {
@@ -944,8 +942,7 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
                 alterViewClause.getColumns(),
                 ctx.getSessionVariable().getSqlMode(), alterViewClause.getComment());
 
-        GlobalStateMgr.getCurrentState().getAlterJobMgr().alterView(alterViewInfo, false);
-        GlobalStateMgr.getCurrentState().getEditLog().logModifyViewDef(alterViewInfo);
+        GlobalStateMgr.getCurrentState().getAlterJobMgr().alterView(alterViewInfo);
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -969,7 +969,7 @@ public class SchemaChangeHandler extends AlterHandler {
         return fastSchemaEvolution;
     }
 
-    private void processModifyColumnComment(ModifyColumnCommentClause alterClause, Database db, OlapTable olapTable,
+    protected void processModifyColumnComment(ModifyColumnCommentClause alterClause, Database db, OlapTable olapTable,
                                         Map<Long, LinkedList<Column>> indexSchemaMap) throws DdlException {
         String modifyColumnName = alterClause.getColumnName();
         String comment = alterClause.getComment();
@@ -984,9 +984,10 @@ public class SchemaChangeHandler extends AlterHandler {
         if (!oneCol.isPresent()) {
             throw new DdlException("Column[" + modifyColumnName + "] does not exists");
         } else {
-            oneCol.get().setComment(comment);
             ModifyColumnCommentLog log = new ModifyColumnCommentLog(db.getId(), olapTable.getId(), modifyColumnName, comment);
-            GlobalStateMgr.getCurrentState().getEditLog().logModifyColumnComment(log);
+            GlobalStateMgr.getCurrentState().getEditLog().logModifyColumnComment(log, wal -> {
+                oneCol.get().setComment(comment);
+            });
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -236,7 +236,7 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
         long repoId = globalStateMgr.getNextId();
         Repository repo = new Repository(repoId, stmt.getName(), stmt.isReadOnly(), stmt.getLocation(), storage);
 
-        Status st = repoMgr.addAndInitRepoIfNotExist(repo, false);
+        Status st = repoMgr.addAndInitRepoIfNotExist(repo);
         if (!st.ok()) {
             ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
                     "Failed to create repository: " + st.getErrMsg());
@@ -260,7 +260,7 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
                 }
             }
 
-            Status st = repoMgr.removeRepo(repo.getName(), false /* not replay */);
+            Status st = repoMgr.removeRepo(repo.getName());
             if (!st.ok()) {
                 ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
                         "Failed to drop repository: " + st.getErrMsg());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -460,12 +460,12 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             // db erase should be control by cluster snapshot backup if it is avaliable
             // to prevent the incorrect deletion by the StarMgrMetaSyncer
             if (canEraseDatabase(dbInfo, currentTimeMs)) {
-                // erase db
-                dbIter.remove();
-                removeRecycleMarkers(entry.getKey());
-
-                GlobalStateMgr.getCurrentState().getLocalMetastore().onEraseDatabase(db.getId());
-                GlobalStateMgr.getCurrentState().getEditLog().logEraseDb(db.getId());
+                GlobalStateMgr.getCurrentState().getEditLog().logEraseDb(db.getId(), wal -> {
+                    // erase db
+                    dbIter.remove();
+                    removeRecycleMarkers(entry.getKey());
+                    GlobalStateMgr.getCurrentState().getLocalMetastore().onEraseDatabase(db.getId());
+                });
                 LOG.info("erase db[{}-{}] finished", db.getId(), db.getOriginName());
                 currentEraseOpCnt++;
                 if (currentEraseOpCnt >= MAX_ERASE_OPERATIONS_PER_CYCLE) {
@@ -520,17 +520,24 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             }
         }
         if (!l1.isEmpty()) {
-            List<Long> tableIds = l1.stream()
+            List<RecycleTableInfo> tableInfos = l1.stream()
                     .filter(RecycleTableInfo::isRecoverable)
-                    .peek(i -> i.setRecoverable(false))
-                    .map(i -> i.getTable().getId())
-                    .collect(Collectors.toList());
-            logDisableTableRecovery(tableIds);
+                    .toList();
+            if (!tableInfos.isEmpty()) {
+                List<Long> tableIds = tableInfos.stream()
+                        .map(info -> info.getTable().getId())
+                        .collect(Collectors.toList());
+                GlobalStateMgr.getCurrentState().getEditLog().logDisableTableRecovery(tableIds, wal -> {
+                    for (RecycleTableInfo info : tableInfos) {
+                        info.setRecoverable(false);
+                    }
+                });
+                LOG.info("Finished log disable table recovery of tables: {}", StringUtils.join(tableIds, ","));
+            }
         }
         if (!l2.isEmpty()) {
             List<Long> tableIds = l2.stream().map(i -> i.getTable().getId()).collect(Collectors.toList());
-            removeTableFromRecycleBin(tableIds);
-            logEraseTables(tableIds);
+            logAddApplyEraseTables(tableIds);
         }
         return ListUtils.union(l1, l2);
     }
@@ -551,19 +558,13 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         }
     }
 
-    static void logDisableTableRecovery(List<Long> tableIds) {
+    void logAddApplyEraseTables(List<Long> tableIds) {
         if (tableIds.isEmpty()) {
             return;
         }
-        GlobalStateMgr.getCurrentState().getEditLog().logDisableTableRecovery(tableIds);
-        LOG.info("Finished log disable table recovery of tables: {}", StringUtils.join(tableIds, ","));
-    }
-
-    static void logEraseTables(List<Long> tableIds) {
-        if (tableIds.isEmpty()) {
-            return;
-        }
-        GlobalStateMgr.getCurrentState().getEditLog().logEraseMultiTables(tableIds);
+        GlobalStateMgr.getCurrentState().getEditLog().logEraseMultiTables(tableIds, wal -> {
+            removeTableFromRecycleBin(tableIds);
+        });
         LOG.info("Finished log erase tables: {}", StringUtils.join(tableIds, ","));
     }
 
@@ -636,8 +637,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             }
         }
 
-        removeTableFromRecycleBin(finishedTables);
-        logEraseTables(finishedTables);
+        logAddApplyEraseTables(finishedTables);
     }
 
     public synchronized void replayDisablePartitionRecovery(long partitionId) {
@@ -674,9 +674,8 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             boolean finished = false;
             CompletableFuture<Boolean> future = asyncDeleteForPartitions.get(partitionInfo);
             if (future == null) {
-                asyncDeleteForPartitions.put(partitionInfo, CompletableFuture.supplyAsync(() -> {
-                    return partitionInfo.delete();
-                }, ASYNC_REMOVE_PARTITION_EXECUTOR));
+                asyncDeleteForPartitions.put(partitionInfo,
+                        CompletableFuture.supplyAsync(partitionInfo::delete, ASYNC_REMOVE_PARTITION_EXECUTOR));
             } else if (future.isDone()) {
                 try {
                     finished = future.get();
@@ -694,11 +693,11 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             }
 
             if (finished) {
-                iterator.remove();
-                asyncDeleteForPartitions.remove(partitionInfo);
-                removeRecycleMarkers(partitionId);
-
-                GlobalStateMgr.getCurrentState().getEditLog().logErasePartition(partitionId);
+                GlobalStateMgr.getCurrentState().getEditLog().logErasePartition(partitionId, wal -> {
+                    iterator.remove();
+                    asyncDeleteForPartitions.remove(partitionInfo);
+                    removeRecycleMarkers(partitionId);
+                });
 
                 LOG.info("Removed partition '{}' from recycle bin. dbId: {} tableId: {} partitionId: {}",
                         partition.getName(), partitionInfo.getDbId(), partitionInfo.getTableId(), partitionId);
@@ -828,14 +827,15 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
         }
 
         Table table = recycleTableInfo.getTable();
-        db.registerTableUnlocked(table);
-        nameToTableInfoDbLevel.remove(tableName);
-        idToTableInfo.row(dbId).remove(table.getId());
-        removeRecycleMarkers(table.getId());
 
         // log
         RecoverInfo recoverInfo = new RecoverInfo(dbId, table.getId(), -1L);
-        GlobalStateMgr.getCurrentState().getEditLog().logRecoverTable(recoverInfo);
+        GlobalStateMgr.getCurrentState().getEditLog().logRecoverTable(recoverInfo, wal -> {
+            db.registerTableUnlocked(table);
+            nameToTableInfoDbLevel.remove(tableName);
+            idToTableInfo.row(dbId).remove(table.getId());
+            removeRecycleMarkers(table.getId());
+        });
         LOG.info("recover db[{}] with table[{}]: {}", dbId, table.getId(), table.getName());
         return true;
     }
@@ -883,17 +883,19 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
                     partitionName, table.getName()));
         }
 
-        recoverPartitionInfo.recover(table);
+        // check recoverable
+        recoverPartitionInfo.checkRecoverable(table);
 
         long partitionId = recoverPartitionInfo.getPartition().getId();
-
-        // remove from recycle bin
-        idToPartition.remove(partitionId);
-        removeRecycleMarkers(partitionId);
-
         // log
         RecoverInfo recoverInfo = new RecoverInfo(dbId, table.getId(), partitionId);
-        GlobalStateMgr.getCurrentState().getEditLog().logRecoverPartition(recoverInfo);
+        final RecyclePartitionInfo finalRecoverPartitionInfo = recoverPartitionInfo;
+        GlobalStateMgr.getCurrentState().getEditLog().logRecoverPartition(recoverInfo, wal -> {
+            finalRecoverPartitionInfo.recover(table);
+            // remove from recycle bin
+            idToPartition.remove(partitionId);
+            removeRecycleMarkers(partitionId);
+        });
         LOG.info("Recovered partition '{}' of table '{}'. dbId={} tableId={} partitionId={}", partitionName,
                 table.getName(), dbId, table.getId(), partitionId);
     }
@@ -1345,5 +1347,34 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
 
     public static long getMinEraseLatency() {
         return MIN_ERASE_LATENCY;
+    }
+
+    // for test
+    protected void clear() {
+        idToDatabase.clear();
+        idToTableInfo.clear();
+        nameToTableInfo.clear();
+        idToPartition.clear();
+        idToRecycleTime.clear();
+        enableEraseLater.clear();
+        asyncDeleteForPartitions.clear();
+        asyncDeleteForTables.clear();
+    }
+
+    // for test
+    protected void setPartitionInfo(long partitionId, RecyclePartitionInfo partitionInfo) {
+        idToPartition.put(partitionId, partitionInfo);
+    }
+
+    // for test
+    protected void setDeleteFutureForPartition(RecyclePartitionInfo partitionInfo, CompletableFuture<Boolean> future) {
+        asyncDeleteForPartitions.put(partitionInfo, future);
+    }
+
+    // for test
+    public void removePartitionFromRecycleBin(long partitionId) {
+        idToPartition.remove(partitionId);
+        idToRecycleTime.remove(partitionId);
+        enableEraseLater.remove(partitionId);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -570,16 +570,18 @@ public class OlapTable extends Table {
         return this.sessionId != null;
     }
 
-    public void checkAndSetName(String newName, boolean onlyCheck) throws DdlException {
+    public void checkNameConflict(String newName) throws DdlException {
         // check if rollup has same name
         for (String idxName : getIndexNameToMetaId().keySet()) {
             if (idxName.equals(newName)) {
                 throw new DdlException("New name conflicts with rollup index name: " + idxName);
             }
         }
-        if (!onlyCheck) {
-            setName(newName);
-        }
+    }
+
+    public void checkAndSetName(String newName) throws DdlException {
+        checkNameConflict(newName);
+        setName(newName);
     }
 
     public void setName(String newName) {
@@ -820,7 +822,6 @@ public class OlapTable extends Table {
 
     public void renameColumn(String oldName, String newName) {
         Column column = this.nameToColumn.remove(oldName);
-        Preconditions.checkState(column != null, "column of name: " + oldName + " does not exist");
         column.setName(newName);
         this.nameToColumn.put(newName, column);
     }
@@ -1866,7 +1867,7 @@ public class OlapTable extends Table {
                 listPartitionInfo.addPartition(idToColumn, newPartition.getId(), dataProperty, replicationNum,
                         dataCacheInfo, values, multiValues);
             } catch (AnalysisException ex) {
-                LOG.warn("failed to add list partition", ex);
+                LOG.warn("failed to add list partition, should not happen", ex);
                 throw new SemanticException(ex.getMessage());
             }
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RecycleListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RecycleListPartitionInfo.java
@@ -25,7 +25,11 @@ public class RecycleListPartitionInfo extends RecyclePartitionInfoV2 {
     }
 
     @Override
-    public void recover(OlapTable table) throws DdlException {
+    public void checkRecoverable(OlapTable table) throws DdlException {
         throw new DdlException("Does not support recover list partition");
+    }
+
+    @Override
+    public void recover(OlapTable table) {
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RecyclePartitionInfoV1.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RecyclePartitionInfoV1.java
@@ -43,7 +43,12 @@ public class RecyclePartitionInfoV1 extends RecyclePartitionInfo {
     }
 
     @Override
-    void recover(OlapTable table) throws DdlException {
-        RecyclePartitionInfo.recoverRangePartition(table, this);
+    public void checkRecoverable(OlapTable table) throws DdlException {
+        checkRecoverableForRangePartition(table);
+    }
+
+    @Override
+    public void recover(OlapTable table) {
+        recoverRangePartition(table);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RecyclePartitionInfoV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RecyclePartitionInfoV2.java
@@ -41,10 +41,12 @@ public class RecyclePartitionInfoV2 extends RecyclePartitionInfo {
     }
 
     @Override
-    void recover(OlapTable table) throws DdlException {
-        RecyclePartitionInfo.recoverRangePartition(table, this);
+    public void checkRecoverable(OlapTable table) throws DdlException {
+        checkRecoverableForRangePartition(table);
     }
 
-
-
+    @Override
+    public void recover(OlapTable table) {
+        recoverRangePartition(table);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RecycleRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RecycleRangePartitionInfo.java
@@ -16,7 +16,6 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Range;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.common.DdlException;
 import com.starrocks.common.util.RangeUtils;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.persist.gson.GsonPostProcessable;
@@ -49,11 +48,6 @@ public class RecycleRangePartitionInfo extends RecyclePartitionInfoV2 implements
     @Override
     public Range<PartitionKey> getRange() {
         return range;
-    }
-
-    @Override
-    void recover(OlapTable table) throws DdlException {
-        RecyclePartitionInfo.recoverRangePartition(table, this);
     }
 
     private byte[] serializeRange(Range<PartitionKey> range) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RecycleUnPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RecycleUnPartitionInfo.java
@@ -27,7 +27,11 @@ public class RecycleUnPartitionInfo extends RecyclePartitionInfoV2 {
     }
 
     @Override
-    public void recover(OlapTable table) throws DdlException {
+    public void checkRecoverable(OlapTable table) throws DdlException {
         throw new DdlException("Does not support recover unpartitioned");
+    }
+
+    @Override
+    public void recover(OlapTable table) {
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/View.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/View.java
@@ -153,12 +153,12 @@ public class View extends Table {
     }
 
     /**
-     * Initializes the originalViewDef, inlineViewDef, and queryStmt members
+     * Check the inlineViewDef, and queryStmt members
      * by parsing the expanded view definition SQL-string.
-     * Throws a TableLoadingException if there was any error parsing the
+     * Throws a StarRocksException if there was any error parsing the
      * SQL or if the view definition did not parse into a QueryStmt.
      */
-    public synchronized QueryStatement init() throws StarRocksException {
+    public void checkInlineViewDef(String inlineViewDef, long sqlMode) throws StarRocksException {
         Preconditions.checkNotNull(inlineViewDef);
         // Parse the expanded view definition SQL-string into a QueryStmt and
         // populate a view definition.
@@ -177,7 +177,6 @@ public class View extends Table {
             throw new StarRocksException(String.format("View %s without query statement. Its definition is:%n%s",
                     name, inlineViewDef));
         }
-        return (QueryStatement) node;
     }
 
     public synchronized List<TableName> getTableRefs() {

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/MetaRecoveryDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/MetaRecoveryDaemon.java
@@ -178,10 +178,8 @@ public class MetaRecoveryDaemon extends FrontendDaemon {
         PartitionVersionRecoveryInfo recoveryInfo =
                 new PartitionVersionRecoveryInfo(partitionsToRecover, System.currentTimeMillis());
 
-        recoverPartitionVersion(recoveryInfo);
-
         GlobalStateMgr.getCurrentState().getEditLog()
-                .logRecoverPartitionVersion(new PartitionVersionRecoveryInfo(partitionsToRecover, System.currentTimeMillis()));
+                .logRecoverPartitionVersion(recoveryInfo, wal -> recoverPartitionVersion(recoveryInfo));
     }
 
     public void recoverPartitionVersion(PartitionVersionRecoveryInfo recoveryInfo) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeListPartitionInfo.java
@@ -31,8 +31,8 @@ public class RecycleLakeListPartitionInfo extends RecycleListPartitionInfo {
     @Override
     public boolean delete() {
         if (isRecoverable()) {
-            setRecoverable(false);
-            GlobalStateMgr.getCurrentState().getEditLog().logDisablePartitionRecovery(partition.getId());
+            GlobalStateMgr.getCurrentState().getEditLog()
+                    .logDisablePartitionRecovery(partition.getId(), wal -> setRecoverable(false));
         }
         try {
             ComputeResource computeResource =

--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeRangePartitionInfo.java
@@ -34,8 +34,8 @@ public class RecycleLakeRangePartitionInfo extends RecycleRangePartitionInfo  {
     @Override
     public boolean delete() {
         if (isRecoverable()) {
-            setRecoverable(false);
-            GlobalStateMgr.getCurrentState().getEditLog().logDisablePartitionRecovery(partition.getId());
+            GlobalStateMgr.getCurrentState().getEditLog()
+                    .logDisablePartitionRecovery(partition.getId(), wal -> setRecoverable(false));
         }
         try {
             ComputeResource computeResource =

--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeUnPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeUnPartitionInfo.java
@@ -33,8 +33,8 @@ public class RecycleLakeUnPartitionInfo extends RecycleUnPartitionInfo {
     @Override
     public boolean delete() {
         if (isRecoverable()) {
-            setRecoverable(false);
-            GlobalStateMgr.getCurrentState().getEditLog().logDisablePartitionRecovery(partition.getId());
+            GlobalStateMgr.getCurrentState().getEditLog()
+                    .logDisablePartitionRecovery(partition.getId(), wal -> setRecoverable(false));
         }
         try {
             ComputeResource computeResource =

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteJob.java
@@ -120,10 +120,12 @@ public abstract class DeleteJob extends AbstractTxnStateChangeCallback {
         if (!txnOperated) {
             return;
         }
-        setState(DeleteState.FINISHED);
-        GlobalStateMgr.getCurrentState().getDeleteMgr().recordFinishedJob(this);
-        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getCallbackFactory().removeCallback(getId());
-        GlobalStateMgr.getCurrentState().getEditLog().logFinishMultiDelete(deleteInfo);
+
+        GlobalStateMgr.getCurrentState().getEditLog().logFinishMultiDelete(deleteInfo, wal -> {
+            setState(DeleteState.FINISHED);
+            GlobalStateMgr.getCurrentState().getDeleteMgr().recordFinishedJob(this);
+            GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getCallbackFactory().removeCallback(getId());
+        });
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
@@ -116,6 +116,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -761,6 +762,11 @@ public class DeleteMgr implements Writable, MemoryTrackable {
 
     public long getDeleteInfoCount() {
         return dbToDeleteInfos.values().stream().mapToLong(List::size).sum();
+    }
+
+    protected List<MultiDeleteInfo> getDeleteInfosForDb(long dbId) {
+        List<MultiDeleteInfo> multiDeleteInfos = dbToDeleteInfos.get(dbId);
+        return Objects.requireNonNullElse(multiDeleteInfos, Collections.emptyList());
     }
 
     public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -356,7 +356,7 @@ public class EditLog {
                 }
                 case OperationType.OP_MODIFY_VIEW_DEF: {
                     AlterViewInfo info = (AlterViewInfo) journal.data();
-                    globalStateMgr.getAlterJobMgr().alterView(info, true);
+                    globalStateMgr.getAlterJobMgr().replayAlterView(info);
                     break;
                 }
                 case OperationType.OP_SET_VIEW_SECURITY_LOG: {
@@ -546,17 +546,18 @@ public class EditLog {
                 }
                 case OperationType.OP_CREATE_REPOSITORY_V2: {
                     Repository repository = (Repository) journal.data();
-                    globalStateMgr.getBackupHandler().getRepoMgr().addAndInitRepoIfNotExist(repository, true);
+                    globalStateMgr.getBackupHandler().getRepoMgr().replayAddRepo(repository);
                     break;
                 }
                 case OperationType.OP_DROP_REPOSITORY: {
                     String repoName = ((Text) journal.data()).toString();
-                    globalStateMgr.getBackupHandler().getRepoMgr().removeRepo(repoName, true);
+                    globalStateMgr.getBackupHandler().getRepoMgr().replayRemoveRepo(repoName);
                     break;
                 }
                 case OperationType.OP_DROP_REPOSITORY_V2: {
                     DropRepositoryLog dropRepositoryLog = (DropRepositoryLog) journal.data();
-                    globalStateMgr.getBackupHandler().getRepoMgr().removeRepo(dropRepositoryLog.getRepositoryName(), true);
+                    globalStateMgr.getBackupHandler().getRepoMgr()
+                            .replayRemoveRepo(dropRepositoryLog.getRepositoryName());
                     break;
                 }
                 case OperationType.OP_TRUNCATE_TABLE: {
@@ -1446,8 +1447,8 @@ public class EditLog {
         logJsonObject(OperationType.OP_SAVE_NEXTID_V2, new NextIdLog(nextId), walApplier);
     }
 
-    public void logSaveTransactionId(long transactionId) {
-        logJsonObject(OperationType.OP_SAVE_TRANSACTION_ID_V2, new TransactionIdInfo(transactionId));
+    public void logSaveTransactionId(long transactionId, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_SAVE_TRANSACTION_ID_V2, new TransactionIdInfo(transactionId), walApplier);
     }
 
     public void logSaveAutoIncrementId(AutoIncrementInfo info, WALApplier walApplier) {
@@ -1468,16 +1469,16 @@ public class EditLog {
         logJsonObject(OperationType.OP_DROP_DB, dropDbInfo);
     }
 
-    public void logEraseDb(long dbId) {
-        logJsonObject(OperationType.OP_ERASE_DB_V2, new EraseDbLog(dbId));
+    public void logEraseDb(long dbId, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_ERASE_DB_V2, new EraseDbLog(dbId), walApplier);
     }
 
     public void logRecoverDb(RecoverInfo info) {
         logJsonObject(OperationType.OP_RECOVER_DB_V2, info);
     }
 
-    public void logAlterDb(DatabaseInfo dbInfo) {
-        logJsonObject(OperationType.OP_ALTER_DB_V2, dbInfo);
+    public void logAlterDb(DatabaseInfo dbInfo, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_ALTER_DB_V2, dbInfo, walApplier);
     }
 
     public void logCreateTable(CreateTableInfo info) {
@@ -1528,24 +1529,20 @@ public class EditLog {
         logJsonObject(OperationType.OP_ADD_SUB_PARTITIONS_V2, info);
     }
 
-    public void logDropPartition(DropPartitionInfo info) {
-        logJsonObject(OperationType.OP_DROP_PARTITION, info);
+    public void logDropPartitions(DropPartitionsInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_DROP_PARTITIONS, info, walApplier);
     }
 
-    public void logDropPartitions(DropPartitionsInfo info) {
-        logJsonObject(OperationType.OP_DROP_PARTITIONS, info);
+    public void logErasePartition(long partitionId, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_ERASE_PARTITION_V2, new ErasePartitionLog(partitionId), walApplier);
     }
 
-    public void logErasePartition(long partitionId) {
-        logJsonObject(OperationType.OP_ERASE_PARTITION_V2, new ErasePartitionLog(partitionId));
+    public void logRecoverPartition(RecoverInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_RECOVER_PARTITION_V2, info, walApplier);
     }
 
-    public void logRecoverPartition(RecoverInfo info) {
-        logJsonObject(OperationType.OP_RECOVER_PARTITION_V2, info);
-    }
-
-    public void logModifyPartition(ModifyPartitionInfo info) {
-        logJsonObject(OperationType.OP_MODIFY_PARTITION_V2, info);
+    public void logModifyPartition(ModifyPartitionInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_MODIFY_PARTITION_V2, info, walApplier);
     }
 
     public void logBatchModifyPartition(BatchModifyPartitionsInfo info) {
@@ -1556,20 +1553,20 @@ public class EditLog {
         logJsonObject(OperationType.OP_DROP_TABLE_V2, info);
     }
 
-    public void logDisablePartitionRecovery(long partitionId) {
-        logJsonObject(OperationType.OP_DISABLE_PARTITION_RECOVERY, new DisablePartitionRecoveryInfo(partitionId));
+    public void logDisablePartitionRecovery(long partitionId, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_DISABLE_PARTITION_RECOVERY, new DisablePartitionRecoveryInfo(partitionId), walApplier);
     }
 
-    public void logDisableTableRecovery(List<Long> tableIds) {
-        logJsonObject(OperationType.OP_DISABLE_TABLE_RECOVERY, new DisableTableRecoveryInfo(tableIds));
+    public void logDisableTableRecovery(List<Long> tableIds, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_DISABLE_TABLE_RECOVERY, new DisableTableRecoveryInfo(tableIds), walApplier);
     }
 
-    public void logEraseMultiTables(List<Long> tableIds) {
-        logJsonObject(OperationType.OP_ERASE_MULTI_TABLES, new MultiEraseTableInfo(tableIds));
+    public void logEraseMultiTables(List<Long> tableIds, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_ERASE_MULTI_TABLES, new MultiEraseTableInfo(tableIds), walApplier);
     }
 
-    public void logRecoverTable(RecoverInfo info) {
-        logJsonObject(OperationType.OP_RECOVER_TABLE_V2, info);
+    public void logRecoverTable(RecoverInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_RECOVER_TABLE_V2, info, walApplier);
     }
 
     public void logDropRollup(DropInfo info) {
@@ -1621,8 +1618,8 @@ public class EditLog {
         logJsonObject(OperationType.OP_UPDATE_FRONTEND_V2, info, applier);
     }
 
-    public void logFinishMultiDelete(MultiDeleteInfo info) {
-        logJsonObject(OperationType.OP_FINISH_MULTI_DELETE, info);
+    public void logFinishMultiDelete(MultiDeleteInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_FINISH_MULTI_DELETE, info, walApplier);
     }
 
     public void logAddReplica(ReplicaPersistInfo info) {
@@ -1633,12 +1630,12 @@ public class EditLog {
         logJsonObject(OperationType.OP_UPDATE_REPLICA_V2, info);
     }
 
-    public void logDeleteReplica(ReplicaPersistInfo info) {
-        logJsonObject(OperationType.OP_DELETE_REPLICA_V2, info);
+    public void logDeleteReplica(ReplicaPersistInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_DELETE_REPLICA_V2, info, walApplier);
     }
 
-    public void logBatchDeleteReplica(BatchDeleteReplicaInfo info) {
-        logJsonObject(OperationType.OP_BATCH_DELETE_REPLICA, info);
+    public void logBatchDeleteReplica(BatchDeleteReplicaInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_BATCH_DELETE_REPLICA, info, walApplier);
     }
 
     public void logAddKey(EncryptionKeyPB key, WALApplier walApplier) {
@@ -1661,24 +1658,24 @@ public class EditLog {
         logJsonObject(OperationType.OP_BACKEND_STATE_CHANGE_V2, info, applier);
     }
 
-    public void logDatabaseRename(DatabaseInfo databaseInfo) {
-        logJsonObject(OperationType.OP_RENAME_DB_V2, databaseInfo);
+    public void logDatabaseRename(DatabaseInfo databaseInfo, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_RENAME_DB_V2, databaseInfo, walApplier);
     }
 
-    public void logTableRename(TableInfo tableInfo) {
-        logJsonObject(OperationType.OP_RENAME_TABLE_V2, tableInfo);
+    public void logTableRename(TableInfo tableInfo, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_RENAME_TABLE_V2, tableInfo, walApplier);
     }
 
-    public void logModifyViewDef(AlterViewInfo alterViewInfo) {
-        logJsonObject(OperationType.OP_MODIFY_VIEW_DEF, alterViewInfo);
+    public void logModifyViewDef(AlterViewInfo alterViewInfo, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_MODIFY_VIEW_DEF, alterViewInfo, walApplier);
     }
 
-    public void logRollupRename(TableInfo tableInfo) {
-        logJsonObject(OperationType.OP_RENAME_ROLLUP_V2, tableInfo);
+    public void logRollupRename(TableInfo tableInfo, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_RENAME_ROLLUP_V2, tableInfo, walApplier);
     }
 
-    public void logPartitionRename(TableInfo tableInfo) {
-        logJsonObject(OperationType.OP_RENAME_PARTITION_V2, tableInfo);
+    public void logPartitionRename(TableInfo tableInfo, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_RENAME_PARTITION_V2, tableInfo, walApplier);
     }
 
     public void logAddBroker(ModifyBrokerInfo info, WALApplier applier) {
@@ -1714,20 +1711,20 @@ public class EditLog {
         logJsonObject(OperationType.OP_BACKUP_JOB_V2, job);
     }
 
-    public void logCreateRepository(Repository repo) {
-        logJsonObject(OperationType.OP_CREATE_REPOSITORY_V2, repo);
+    public void logCreateRepository(Repository repo, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_CREATE_REPOSITORY_V2, repo, walApplier);
     }
 
-    public void logDropRepository(String repoName) {
-        logJsonObject(OperationType.OP_DROP_REPOSITORY_V2, new DropRepositoryLog(repoName));
+    public void logDropRepository(String repoName, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_DROP_REPOSITORY_V2, new DropRepositoryLog(repoName), walApplier);
     }
 
     public void logRestoreJob(RestoreJob job) {
         logJsonObject(OperationType.OP_RESTORE_JOB_V2, job);
     }
 
-    public void logTruncateTable(TruncateTableInfo info) {
-        logJsonObject(OperationType.OP_TRUNCATE_TABLE, info);
+    public void logTruncateTable(TruncateTableInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_TRUNCATE_TABLE, info, walApplier);
     }
 
     public void logColocateAddTable(ColocatePersistInfo info) {
@@ -1770,8 +1767,8 @@ public class EditLog {
         logJsonObject(OperationType.OP_SET_HAS_DELETE, info, walApplier);
     }
 
-    public void logBackendTabletsInfo(BackendTabletsInfo backendTabletsInfo) {
-        logJsonObject(OperationType.OP_BACKEND_TABLETS_INFO_V2, backendTabletsInfo);
+    public void logBackendTabletsInfo(BackendTabletsInfo backendTabletsInfo, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_BACKEND_TABLETS_INFO_V2, backendTabletsInfo, walApplier);
     }
 
     public void logCreateRoutineLoadJob(RoutineLoadJob routineLoadJob, WALApplier walApplier) {
@@ -1839,10 +1836,6 @@ public class EditLog {
         logJsonObject(OperationType.OP_BATCH_ADD_ROLLUP_V2, batchAlterJobV2);
     }
 
-    public void logModifyDistributionType(TableInfo tableInfo) {
-        logJsonObject(OperationType.OP_MODIFY_DISTRIBUTION_TYPE_V2, tableInfo);
-    }
-
     public void logDynamicPartition(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
         logJsonObject(OperationType.OP_DYNAMIC_PARTITION, info, walApplier);
     }
@@ -1903,12 +1896,12 @@ public class EditLog {
         logJsonObject(OperationType.OP_UNINSTALL_PLUGIN, log, walApplier);
     }
 
-    public void logSetReplicaStatus(SetReplicaStatusOperationLog log) {
-        logJsonObject(OperationType.OP_SET_REPLICA_STATUS, log);
+    public void logSetReplicaStatus(SetReplicaStatusOperationLog log, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_SET_REPLICA_STATUS, log, walApplier);
     }
 
-    public void logRemoveExpiredAlterJobV2(RemoveAlterJobV2OperationLog log) {
-        logJsonObject(OperationType.OP_REMOVE_ALTER_JOB_V2, log);
+    public void logRemoveExpiredAlterJobV2(RemoveAlterJobV2OperationLog log, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_REMOVE_ALTER_JOB_V2, log, walApplier);
     }
 
     public void logAlterRoutineLoadJob(AlterRoutineLoadJobOperationLog log, WALApplier walApplier) {
@@ -1999,12 +1992,12 @@ public class EditLog {
         logJsonObject(OperationType.OP_REMOVE_EXTERNAL_HISTOGRAM_STATS_META, meta, walApplier);
     }
 
-    public void logModifyTableColumn(ModifyTableColumnOperationLog log) {
-        logJsonObject(OperationType.OP_MODIFY_HIVE_TABLE_COLUMN, log);
+    public void logModifyTableColumn(ModifyTableColumnOperationLog log, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_MODIFY_HIVE_TABLE_COLUMN, log, walApplier);
     }
 
-    public void logModifyColumnComment(ModifyColumnCommentLog log) {
-        logJsonObject(OperationType.OP_MODIFY_COLUMN_COMMENT, log);
+    public void logModifyColumnComment(ModifyColumnCommentLog log, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_MODIFY_COLUMN_COMMENT, log, walApplier);
     }
 
     public void logCreateCatalog(Catalog log, WALApplier walApplier) {
@@ -2035,8 +2028,8 @@ public class EditLog {
         logJsonObject(OperationType.OP_ALTER_MATERIALIZED_VIEW_BASE_TABLE_INFOS, log);
     }
 
-    public void logMvRename(RenameMaterializedViewLog log) {
-        logJsonObject(OperationType.OP_RENAME_MATERIALIZED_VIEW, log);
+    public void logMvRename(RenameMaterializedViewLog log, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_RENAME_MATERIALIZED_VIEW, log, walApplier);
     }
 
     public void logMvChangeRefreshScheme(ChangeMaterializedViewRefreshSchemeLog log) {
@@ -2123,8 +2116,8 @@ public class EditLog {
         logJsonObject(OperationType.OP_MODIFY_BINLOG_AVAILABLE_VERSION, log, walApplier);
     }
 
-    public void logMVJobState(MVMaintenanceJob job) {
-        logJsonObject(OperationType.OP_MV_JOB_STATE, job);
+    public void logMVJobState(MVMaintenanceJob job, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_MV_JOB_STATE, job, walApplier);
     }
 
     public void logMVEpochChange(MVEpoch epoch) {
@@ -2181,8 +2174,8 @@ public class EditLog {
         logJsonObject(OperationType.OP_DELETE_REPLICATION_JOB, replicationJobLog);
     }
 
-    public void logColumnRename(ColumnRenameInfo columnRenameInfo) {
-        logJsonObject(OperationType.OP_RENAME_COLUMN_V2, columnRenameInfo);
+    public void logColumnRename(ColumnRenameInfo columnRenameInfo, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_RENAME_COLUMN_V2, columnRenameInfo, walApplier);
     }
 
     public void logCreateDictionary(Dictionary info, WALApplier walApplier) {
@@ -2209,8 +2202,8 @@ public class EditLog {
         logJsonObject(OperationType.OP_DISABLE_DISK, info, applier);
     }
 
-    public void logRecoverPartitionVersion(PartitionVersionRecoveryInfo info) {
-        logJsonObject(OperationType.OP_RECOVER_PARTITION_VERSION, info);
+    public void logRecoverPartitionVersion(PartitionVersionRecoveryInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_RECOVER_PARTITION_VERSION, info, walApplier);
     }
 
     public void logClusterSnapshotLog(ClusterSnapshotLog info) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/WALApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/WALApplier.java
@@ -16,5 +16,6 @@ package com.starrocks.persist;
 
 public interface WALApplier {
 
+    // apply can not fail
     void apply(Object wal);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -323,7 +323,7 @@ public class GlobalStateMgr {
     private final MaterializedViewMgr materializedViewMgr;
 
     private final ConsistencyChecker consistencyChecker;
-    private final BackupHandler backupHandler;
+    private BackupHandler backupHandler;
     private final PublishVersionDaemon publishVersionDaemon;
     private final DeleteMgr deleteMgr;
     private final DatabaseQuotaRefresher updateDbUsedDataQuotaDaemon;
@@ -2886,5 +2886,9 @@ public class GlobalStateMgr {
 
     public void setRoutineLoadMgr(RoutineLoadMgr routineLoadMgr) {
         this.routineLoadMgr = routineLoadMgr;
+    }
+
+    public void setBackupHandler(BackupHandler backupHandler) {
+        this.backupHandler = backupHandler;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -186,6 +186,7 @@ import com.starrocks.sql.ast.AdminCheckTabletsStmt;
 import com.starrocks.sql.ast.AdminSetPartitionVersionStmt;
 import com.starrocks.sql.ast.AdminSetReplicaStatusStmt;
 import com.starrocks.sql.ast.AlterDatabaseQuotaStmt;
+import com.starrocks.sql.ast.AlterDatabaseQuotaStmt.QuotaType;
 import com.starrocks.sql.ast.AlterDatabaseRenameStatement;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AlterTableCommentClause;
@@ -713,13 +714,19 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
 
-        DatabaseInfo dbInfo = new DatabaseInfo(db.getFullName(), "", stmt.getQuota(), stmt.getQuotaType());
-        GlobalStateMgr.getCurrentState().getEditLog().logAlterDb(dbInfo);
+        Preconditions.checkArgument(stmt.getQuota() >= 0, "Quota must be non-negative");
 
+        DatabaseInfo dbInfo = new DatabaseInfo(db.getFullName(), "", stmt.getQuota(), stmt.getQuotaType());
         Locker locker = new Locker();
         locker.lockDatabase(db.getId(), LockType.WRITE);
         try {
-            replayAlterDatabaseQuota(dbInfo);
+            GlobalStateMgr.getCurrentState().getEditLog().logAlterDb(dbInfo, wal -> {
+                if (stmt.getQuotaType() == QuotaType.DATA) {
+                    db.setDataQuota(stmt.getQuota());
+                } else if (stmt.getQuotaType() == QuotaType.REPLICA) {
+                    db.setReplicaQuota(stmt.getQuota());
+                }
+            });
         } finally {
             locker.unLockDatabase(db.getId(), LockType.WRITE);
         }
@@ -729,13 +736,13 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         String dbName = dbInfo.getDbName();
         LOG.info("Begin to unprotect alter db info {}", dbName);
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
-        AlterDatabaseQuotaStmt.QuotaType quotaType = dbInfo.getQuotaType();
+        QuotaType quotaType = dbInfo.getQuotaType();
         long quota = dbInfo.getQuota();
 
         Preconditions.checkNotNull(db);
-        if (quotaType == AlterDatabaseQuotaStmt.QuotaType.DATA) {
+        if (quotaType == QuotaType.DATA) {
             db.setDataQuota(quota);
-        } else if (quotaType == AlterDatabaseQuotaStmt.QuotaType.REPLICA) {
+        } else if (quotaType == QuotaType.REPLICA) {
             db.setReplicaQuota(quota);
         }
     }
@@ -763,22 +770,18 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             if (fullNameToDb.get(newFullDbName) != null) {
                 throw new DdlException("Database name[" + newFullDbName + "] is already used");
             }
-            // 1. rename db
-            Locker locker = new Locker();
-            locker.lockDatabase(db.getId(), LockType.WRITE);
-            try {
-                db.setName(newFullDbName);
-            } finally {
-                locker.unLockDatabase(db.getId(), LockType.WRITE);
-            }
-
-            // 2. add to meta. check again
-            fullNameToDb.remove(fullDbName);
-            fullNameToDb.put(newFullDbName, db);
 
             DatabaseInfo dbInfo =
                     new DatabaseInfo(fullDbName, newFullDbName, -1L, AlterDatabaseQuotaStmt.QuotaType.NONE);
-            GlobalStateMgr.getCurrentState().getEditLog().logDatabaseRename(dbInfo);
+            Locker locker = new Locker();
+            locker.lockDatabase(db.getId(), LockType.WRITE);
+            try {
+                GlobalStateMgr.getCurrentState().getEditLog().logDatabaseRename(dbInfo, wal -> {
+                    renameDbInternal(db, newFullDbName);
+                });
+            } finally {
+                locker.unLockDatabase(db.getId(), LockType.WRITE);
+            }
         } finally {
             unlock();
         }
@@ -790,14 +793,18 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         tryLock(true);
         try {
             Database db = fullNameToDb.get(dbName);
-            db.setName(newDbName);
-            fullNameToDb.remove(dbName);
-            fullNameToDb.put(newDbName, db);
-
+            renameDbInternal(db, newDbName);
             LOG.info("replay rename database {} to {}, id: {}", dbName, newDbName, db.getId());
         } finally {
             unlock();
         }
+    }
+
+    private void renameDbInternal(Database db, String newDbName) {
+        String oldDbName = db.getFullName();
+        db.setName(newDbName);
+        fullNameToDb.remove(oldDbName);
+        fullNameToDb.put(newDbName, db);
     }
 
     @Override
@@ -1407,14 +1414,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
 
         if (isDropAll && isTempPartition) {
-            olapTable.dropAllTempPartitions();
             DropPartitionsInfo info =
-                    new DropPartitionsInfo(dbId, tableId, isTempPartition, clause.isForceDrop(), null, true);
-            editLog.logDropPartitions(info);
+                    new DropPartitionsInfo(dbId, tableId, true, clause.isForceDrop(), null, true);
+            editLog.logDropPartitions(info, wal -> olapTable.dropAllTempPartitions());
             LOG.info("succeed in dropping all partitions, db: {}, table: {}, is temp: {}, is force: {}",
-                    db.getFullName(), olapTable.getName(),
-                    isTempPartition,
-                    clause.isForceDrop());
+                    db.getFullName(), olapTable.getName(), true, clause.isForceDrop());
             return;
         }
 
@@ -1441,11 +1445,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         if (CollectionUtils.isEmpty(existPartitions)) {
             return;
         }
+
+        // check committed txns
         for (String partitionName : existPartitions) {
-            // drop
-            if (isTempPartition) {
-                olapTable.dropTempPartition(partitionName, true);
-            } else {
+            if (!isTempPartition) {
                 Partition partition = olapTable.getPartition(partitionName);
                 if (!clause.isForceDrop()) {
                     if (partition != null) {
@@ -1459,21 +1462,15 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         }
                     }
                 }
-                Range<PartitionKey> partitionRange = null;
-                if (partition != null) {
-                    GlobalStateMgr.getCurrentState().getAnalyzeMgr().recordDropPartition(partition.getId());
-                    if (partitionInfo instanceof RangePartitionInfo) {
-                        partitionRange = ((RangePartitionInfo) partitionInfo).getRange(partition.getId());
-                    }
-                }
-
-                olapTable.dropPartition(db.getId(), partitionName, clause.isForceDrop());
-                if (olapTable instanceof MaterializedView) {
-                    MaterializedView mv = (MaterializedView) olapTable;
-                    SyncPartitionUtils.dropBaseVersionMeta(mv, partitionName, partitionRange);
-                }
             }
         }
+
+        DropPartitionsInfo info =
+                new DropPartitionsInfo(dbId, tableId, isTempPartition, clause.isForceDrop(), existPartitions);
+        editLog.logDropPartitions(info, wal -> {
+            dropPartitionInternal(olapTable, db, existPartitions, isTempPartition, clause.isForceDrop());
+        });
+
         if (!isTempPartition) {
             try {
                 for (MvId mvId : olapTable.getRelatedMaterializedViews()) {
@@ -1489,25 +1486,40 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 throw new DdlException("fail to refresh materialized views when dropping partition", e);
             }
         }
+        LOG.info("succeed in dropping partitions[{}], db: {}, table: {}, is temp : {}, is force : {}", existPartitions,
+                db.getFullName(), olapTable.getName(),
+                isTempPartition,
+                clause.isForceDrop());
+    }
 
-        if (clause.getPartitionName() != null) {
-            String partitionName = clause.getPartitionName();
-            DropPartitionInfo info = new DropPartitionInfo(dbId, tableId, partitionName, isTempPartition, clause.isForceDrop());
-            editLog.logDropPartition(info);
-            LOG.info("succeed in dropping partition[{}], db: {}, table: {}, is temp : {}, is force : {}", partitionName,
-                    db.getFullName(), olapTable.getName(),
-                    isTempPartition,
-                    clause.isForceDrop());
-        } else {
-            DropPartitionsInfo info =
-                    new DropPartitionsInfo(dbId, tableId, isTempPartition, clause.isForceDrop(), existPartitions);
-            editLog.logDropPartitions(info);
-            LOG.info("succeed in dropping partitions[{}], db: {}, table: {}, is temp : {}, is force : {}", existPartitions,
-                    db.getFullName(), olapTable.getName(),
-                    isTempPartition,
-                    clause.isForceDrop());
+    protected void dropPartitionInternal(OlapTable olapTable,
+                                       Database db,
+                                       List<String> partitionNames,
+                                       boolean isTempPartition,
+                                       boolean isForceDrop) {
+        PartitionInfo partitionInfo = olapTable.getPartitionInfo();
+        for (String partitionName : partitionNames) {
+            // drop
+            if (isTempPartition) {
+                olapTable.dropTempPartition(partitionName, true);
+            } else {
+                Partition partition = olapTable.getPartition(partitionName);
+                olapTable.dropPartition(db.getId(), partitionName, isForceDrop);
+                if (partition != null) {
+                    GlobalStateMgr.getCurrentState().getAnalyzeMgr().recordDropPartition(partition.getId());
+                    if (partitionInfo instanceof RangePartitionInfo && (olapTable instanceof MaterializedView mv)) {
+                        Range<PartitionKey> partitionRange =
+                                ((RangePartitionInfo) partitionInfo).getRange(partition.getId());
+                        try {
+                            SyncPartitionUtils.dropBaseVersionMeta(mv, partitionName, partitionRange);
+                        } catch (Exception e) {
+                            LOG.warn("failed to drop base version meta for mv {}, partition {}",
+                                    mv.getName(), partitionName, e);
+                        }
+                    }
+                }
+            }
         }
-
     }
 
     public void replayDropPartition(DropPartitionInfo info) {
@@ -2811,18 +2823,18 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                                 && dataProperty.getCooldownTimeMs() < currentTimeMs) {
                             // expire. change to HDD.
                             DataProperty hdd = new DataProperty(TStorageMedium.HDD);
-                            partitionInfo.setDataProperty(partition.getId(), hdd);
-                            storageMediumMap.put(partitionId, TStorageMedium.HDD);
-                            LOG.debug("partition[{}-{}-{}] storage medium changed from SSD to HDD",
-                                    dbId, tableId, partitionId);
-
                             // log
                             ModifyPartitionInfo info =
                                     new ModifyPartitionInfo(db.getId(), olapTable.getId(),
                                             partition.getId(),
                                             hdd,
                                             (short) -1);
-                            GlobalStateMgr.getCurrentState().getEditLog().logModifyPartition(info);
+                            GlobalStateMgr.getCurrentState().getEditLog().logModifyPartition(info, wal -> {
+                                partitionInfo.setDataProperty(partition.getId(), hdd);
+                            });
+                            LOG.debug("partition[{}-{}-{}] storage medium changed from SSD to HDD",
+                                    dbId, tableId, partitionId);
+                            storageMediumMap.put(partitionId, TStorageMedium.HDD);
                         }
                     } // end for partitions
                 } // end for tables
@@ -3483,15 +3495,16 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         if (getTable(db.getFullName(), newTableName) != null) {
             throw new DdlException("Table name[" + newTableName + "] is already used");
         }
-        olapTable.checkAndSetName(newTableName, false);
-
-        db.dropTable(oldTableName);
-        db.registerTableUnlocked(olapTable);
-        AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable,
-                MaterializedViewExceptions.inactiveReasonForBaseTableRenamed(oldTableName), false);
+        olapTable.checkNameConflict(newTableName);
 
         TableInfo tableInfo = TableInfo.createForTableRename(db.getId(), olapTable.getId(), newTableName);
-        GlobalStateMgr.getCurrentState().getEditLog().logTableRename(tableInfo);
+        GlobalStateMgr.getCurrentState().getEditLog().logTableRename(tableInfo, wal -> {
+            olapTable.setName(newTableName);
+            db.dropTable(oldTableName);
+            db.registerTableUnlocked(olapTable);
+        });
+        AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable,
+                MaterializedViewExceptions.inactiveReasonForBaseTableRenamed(oldTableName), false);
         LOG.info("rename table[{}] to {}, tableId: {}", oldTableName, newTableName, olapTable.getId());
     }
 
@@ -3559,12 +3572,12 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             throw new DdlException("Partition name[" + newPartitionName + "] is already used");
         }
 
-        olapTable.renamePartition(partitionName, newPartitionName);
-
         // log
         TableInfo tableInfo = TableInfo.createForPartitionRename(db.getId(), olapTable.getId(), partition.getId(),
                 newPartitionName);
-        GlobalStateMgr.getCurrentState().getEditLog().logPartitionRename(tableInfo);
+        GlobalStateMgr.getCurrentState().getEditLog().logPartitionRename(tableInfo, wal -> {
+            olapTable.renamePartition(partitionName, newPartitionName);
+        });
         LOG.info("rename partition[{}] to {}", partitionName, newPartitionName);
     }
 
@@ -3613,12 +3626,14 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             throw new DdlException("Rollup name[" + newRollupName + "] is already used");
         }
 
-        long indexId = indexNameToIdMap.remove(rollupName);
-        indexNameToIdMap.put(newRollupName, indexId);
 
+        long indexId = indexNameToIdMap.get(rollupName);
         // log
         TableInfo tableInfo = TableInfo.createForRollupRename(db.getId(), table.getId(), indexId, newRollupName);
-        GlobalStateMgr.getCurrentState().getEditLog().logRollupRename(tableInfo);
+        GlobalStateMgr.getCurrentState().getEditLog().logRollupRename(tableInfo, wal -> {
+            indexNameToIdMap.remove(rollupName);
+            indexNameToIdMap.put(newRollupName, indexId);
+        });
         LOG.info("rename rollup[{}] to {}", rollupName, newRollupName);
     }
 
@@ -3645,13 +3660,12 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     }
 
     public void renameColumn(Database db, Table table, ColumnRenameClause renameClause) {
-        if (!(table instanceof OlapTable)) {
+        if (!(table instanceof OlapTable olapTable)) {
             throw ErrorReportException.report(ErrorCode.ERR_COLUMN_RENAME_ONLY_FOR_OLAP_TABLE);
         }
         if (db.isSystemDatabase() || db.isStatisticsDatabase()) {
             throw ErrorReportException.report(ErrorCode.ERR_CANNOT_RENAME_COLUMN_IN_INTERNAL_DB, db.getFullName());
         }
-        OlapTable olapTable = (OlapTable) table;
         if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
             throw ErrorReportException.report(ErrorCode.ERR_CANNOT_RENAME_COLUMN_OF_NOT_NORMAL_TABLE, olapTable.getState());
         }
@@ -3667,10 +3681,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         if (currentColumn != null) {
             throw ErrorReportException.report(ErrorCode.ERR_DUP_FIELDNAME, newColName);
         }
-        olapTable.renameColumn(colName, newColName);
 
         ColumnRenameInfo columnRenameInfo = new ColumnRenameInfo(db.getId(), table.getId(), colName, newColName);
-        GlobalStateMgr.getCurrentState().getEditLog().logColumnRename(columnRenameInfo);
+        GlobalStateMgr.getCurrentState().getEditLog().logColumnRename(columnRenameInfo, wal -> {
+            olapTable.renameColumn(colName, newColName);
+        });
         LOG.info("rename column {} to {}", colName, newColName);
     }
 
@@ -3952,15 +3967,15 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
         short replicationNum = Short.parseShort(properties.get(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM));
         DataProperty newDataProperty = partitionInfo.getDataProperty(partition.getId());
-        partitionInfo.setReplicationNum(partition.getId(), replicationNum);
-
-        // update table default replication num
-        table.setReplicationNum(replicationNum);
 
         // log
         ModifyPartitionInfo info = new ModifyPartitionInfo(db.getId(), table.getId(), partition.getId(),
                 newDataProperty, replicationNum);
-        GlobalStateMgr.getCurrentState().getEditLog().logModifyPartition(info);
+        GlobalStateMgr.getCurrentState().getEditLog().logModifyPartition(info, wal -> {
+            partitionInfo.setReplicationNum(partition.getId(), replicationNum);
+            // update table default replication num
+            table.setReplicationNum(replicationNum);
+        });
         LOG.info("modify partition[{}-{}-{}] replication num to {}", db.getOriginName(), table.getName(),
                 partition.getName(), replicationNum);
     }
@@ -4438,21 +4453,19 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             List<Column> columns = stmt.getColumns();
             long tableId = getNextId();
             View view = new View(tableId, tableName, columns);
+            try {
+                view.checkInlineViewDef(stmt.getInlineViewDef(), ConnectContext.get().getSessionVariable().getSqlMode());
+            } catch (StarRocksException e) {
+                throw new DdlException("failed to check inline view def", e);
+            }
+
             view.setComment(stmt.getComment());
             view.setInlineViewDefWithSqlMode(stmt.getInlineViewDef(),
                     ConnectContext.get().getSessionVariable().getSqlMode());
-            // init here in case the stmt string from view.toSql() has some syntax error.
 
             if (stmt.isSecurity()) {
                 view.setSecurity(stmt.isSecurity());
             }
-
-            try {
-                view.init();
-            } catch (StarRocksException e) {
-                throw new DdlException("failed to init view stmt", e);
-            }
-
             onCreate(db, view, "", stmt.isSetIfNotExists());
             LOG.info("successfully create view[" + tableName + "-" + view.getId() + "]");
         }
@@ -4647,20 +4660,19 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 throw new DdlException("Table[" + copiedTbl.getName() + "]'s meta has been changed. try again.");
             }
 
-            // replace
-            truncateTableInternal(db.getId(), olapTable, newPartitions, truncateEntireTable, false);
-
-            try {
-                colocateTableIndex.updateLakeTableColocationInfo(olapTable, true /* isJoin */,
-                        null /* expectGroupId */);
-            } catch (DdlException e) {
-                LOG.info("table {} update colocation info failed when truncate table, {}", olapTable.getId(), e.getMessage());
-            }
-
             // write edit log
             TruncateTableInfo info = new TruncateTableInfo(db.getId(), olapTable.getId(), newPartitions,
                     truncateEntireTable);
-            GlobalStateMgr.getCurrentState().getEditLog().logTruncateTable(info);
+            GlobalStateMgr.getCurrentState().getEditLog().logTruncateTable(info, wal -> {
+                // replace
+                truncateTableInternal(db.getId(), olapTable, newPartitions, truncateEntireTable, false);
+                try {
+                    colocateTableIndex.updateLakeTableColocationInfo(olapTable, true /* isJoin */,
+                            null /* expectGroupId */);
+                } catch (DdlException e) {
+                    LOG.info("table {} update colocation info failed when truncate table, {}", olapTable.getId(), e.getMessage());
+                }
+            });
 
             // refresh mv
             Set<MvId> relatedMvs = olapTable.getRelatedMaterializedViews();
@@ -4697,7 +4709,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
     }
 
-    private void truncateTableInternal(long dbId, OlapTable olapTable, List<Partition> newPartitions,
+    protected void truncateTableInternal(long dbId, OlapTable olapTable, List<Partition> newPartitions,
                                        boolean isEntireTable, boolean isReplay) {
         // use new partitions to replace the old ones.
         Set<Tablet> oldTablets = Sets.newHashSet();
@@ -4829,24 +4841,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
     }
 
-    // Convert table's distribution type from random to hash.
-    // random distribution is no longer supported.
-    public void convertDistributionType(Database db, OlapTable tbl) throws DdlException {
-        TableInfo tableInfo = TableInfo.createForModifyDistribution(db.getId(), tbl.getId());
-        GlobalStateMgr.getCurrentState().getEditLog().logModifyDistributionType(tableInfo);
-        LOG.info("finished to modify distribution type of table: " + tbl.getName());
-    }
-
     public void replayConvertDistributionType(TableInfo tableInfo) {
-        Database db = getDb(tableInfo.getDbId());
-        Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.WRITE);
-        try {
-            OlapTable tbl = (OlapTable) getTable(db.getId(), tableInfo.getTableId());
-            LOG.info("replay modify distribution type of table: " + tbl.getName());
-        } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
-        }
+        // nothing to do, for compatibility
     }
 
     /*
@@ -4941,50 +4937,66 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         long tabletId = stmt.getTabletId();
         long backendId = stmt.getBackendId();
         ReplicaStatus status = stmt.getStatus();
-        setReplicaStatusInternal(tabletId, backendId, status, false);
+        setReplicaStatusInternal(tabletId, backendId, status);
     }
 
-    public void replaySetReplicaStatus(SetReplicaStatusOperationLog log) {
-        setReplicaStatusInternal(log.getTabletId(), log.getBackendId(), log.getReplicaStatus(), true);
-    }
-
-    private void setReplicaStatusInternal(long tabletId, long backendId, ReplicaStatus status,
-                                          boolean isReplay) {
+    private Pair<Replica, TabletMeta> getReplicaAndMeta(long tabletId, long backendId) {
         TabletMeta meta = stateMgr.getTabletInvertedIndex().getTabletMeta(tabletId);
         if (meta == null) {
             LOG.info("tablet {} does not exist", tabletId);
+            return null;
+        }
+        Replica replica = stateMgr.getTabletInvertedIndex().getReplica(tabletId, backendId);
+        if (replica == null) {
+            LOG.info("replica of tablet {} does not exist", tabletId);
+            return null;
+        }
+        return Pair.create(replica, meta);
+    }
+
+    private void setReplicaBadStatus(Replica replica, long tabletId, boolean isToSetBad) {
+        replica.setBadForce(isToSetBad);
+        LOG.info("set replica {} of tablet {} on backend {} as {}.",
+                replica.getId(), tabletId, replica.getBackendId(),
+                isToSetBad ? ReplicaStatus.BAD : ReplicaStatus.OK);
+    }
+
+    public void replaySetReplicaStatus(SetReplicaStatusOperationLog log) {
+        long tabletId = log.getTabletId();
+        long backendId = log.getBackendId();
+        Pair<Replica, TabletMeta> pair = getReplicaAndMeta(tabletId, backendId);
+        if (pair == null) {
             return;
         }
-        long dbId = meta.getDbId();
-        Database db = getDb(dbId);
-        if (db == null) {
-            LOG.info("database {} of tablet {} does not exist", dbId, tabletId);
+        Replica replica = pair.first;
+        ReplicaStatus status = log.getReplicaStatus();
+        if (status == ReplicaStatus.BAD || status == ReplicaStatus.OK) {
+            boolean isToSetBad = (status == ReplicaStatus.BAD);
+            if (replica.isBad() != isToSetBad) {
+                setReplicaBadStatus(replica, tabletId, isToSetBad);
+            }
+        }
+    }
+
+    protected void setReplicaStatusInternal(long tabletId, long backendId, ReplicaStatus status) {
+        Pair<Replica, TabletMeta> pair = getReplicaAndMeta(tabletId, backendId);
+        if (pair == null) {
             return;
         }
-        Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.WRITE);
-        try {
-            Replica replica = stateMgr.getTabletInvertedIndex().getReplica(tabletId, backendId);
-            if (replica == null) {
-                LOG.info("replica of tablet {} does not exist", tabletId);
-                return;
+        Replica replica = pair.first;
+        TabletMeta meta = pair.second;
+        if (status == ReplicaStatus.BAD || status == ReplicaStatus.OK) {
+            boolean isToSetBad = (status == ReplicaStatus.BAD);
+            if (replica.isBad() != isToSetBad) {
+                SetReplicaStatusOperationLog log =
+                        new SetReplicaStatusOperationLog(backendId, tabletId, status);
+                GlobalStateMgr.getCurrentState().getEditLog().logSetReplicaStatus(log, wal -> {
+                    setReplicaBadStatus(replica, tabletId, isToSetBad);
+                });
+                // Put this tablet into urgent table so that it can be repaired ASAP.
+                stateMgr.getTabletChecker().setTabletForUrgentRepair(
+                        meta.getDbId(), meta.getTableId(), meta.getPhysicalPartitionId());
             }
-            if (status == ReplicaStatus.BAD || status == ReplicaStatus.OK) {
-                if (replica.setBadForce(status == ReplicaStatus.BAD)) {
-                    if (!isReplay) {
-                        // Put this tablet into urgent table so that it can be repaired ASAP.
-                        stateMgr.getTabletChecker().setTabletForUrgentRepair(dbId, meta.getTableId(),
-                                meta.getPhysicalPartitionId());
-                        SetReplicaStatusOperationLog log =
-                                new SetReplicaStatusOperationLog(backendId, tabletId, status);
-                        GlobalStateMgr.getCurrentState().getEditLog().logSetReplicaStatus(log);
-                    }
-                    LOG.info("set replica {} of tablet {} on backend {} as {}. is replay: {}",
-                            replica.getId(), tabletId, backendId, status, isReplay);
-                }
-            }
-        } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
         }
     }
 
@@ -5024,34 +5036,37 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             }
 
             long visibleVersionTime = System.currentTimeMillis();
-            physicalPartition.setVisibleVersion(stmt.getVersion(), visibleVersionTime);
-            physicalPartition.setNextVersion(stmt.getVersion() + 1);
-
-            PartitionVersion partitionVersion = new PartitionVersion(database.getId(), table.getId(),
-                    physicalPartition.getId(), stmt.getVersion());
-            for (MaterializedIndex index : physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
-                for (Tablet tablet : index.getTablets()) {
-                    if (!(tablet instanceof LocalTablet)) {
-                        continue;
-                    }
-
-                    LocalTablet localTablet = (LocalTablet) tablet;
-                    for (Replica replica : localTablet.getAllReplicas()) {
-                        if (replica.getVersion() > stmt.getVersion() && localTablet.getAllReplicas().size() > 1) {
-                            replica.setBad(true);
-                            LOG.warn("set tablet: {} on backend: {} to bad, " +
-                                            "because its version: {} is higher than partition visible version: {}",
-                                    tablet.getId(), replica.getBackendId(), replica.getVersion(), stmt.getVersion());
-                        }
-                    }
-                }
-            }
+            PartitionVersion partitionVersion = new PartitionVersion(
+                    database.getId(), table.getId(), physicalPartition.getId(), stmt.getVersion());
             GlobalStateMgr.getCurrentState().getEditLog().logRecoverPartitionVersion(
-                    new PartitionVersionRecoveryInfo(Lists.newArrayList(partitionVersion), visibleVersionTime));
+                    new PartitionVersionRecoveryInfo(Lists.newArrayList(partitionVersion), visibleVersionTime), wal -> {
+                        physicalPartition.setVisibleVersion(stmt.getVersion(), visibleVersionTime);
+                        physicalPartition.setNextVersion(stmt.getVersion() + 1);
+                        setBadForHighVersionReplica(physicalPartition, stmt.getVersion());
+                    });
             LOG.info("Successfully set partition: {} version to {}, table: {}, db: {}",
                     stmt.getPartitionName(), stmt.getVersion(), table.getName(), database.getFullName());
         } finally {
             locker.unLockDatabase(database.getId(), LockType.WRITE);
+        }
+    }
+
+    private void setBadForHighVersionReplica(PhysicalPartition physicalPartition, long version) {
+        for (MaterializedIndex index : physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
+            for (Tablet tablet : index.getTablets()) {
+                if (!(tablet instanceof LocalTablet localTablet)) {
+                    continue;
+                }
+
+                for (Replica replica : localTablet.getAllReplicas()) {
+                    if (replica.getVersion() > version && localTablet.getAllReplicas().size() > 1) {
+                        replica.setBad(true);
+                        LOG.warn("set tablet: {} on backend: {} to bad, " +
+                                        "because its version: {} is higher than partition visible version: {}",
+                                tablet.getId(), replica.getBackendId(), replica.getVersion(), version);
+                    }
+                }
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -1268,4 +1268,8 @@ public class NodeMgr {
     protected LeaderInfo getLeaderInfo() {
         return new LeaderInfo(leaderIp, leaderHttpPort, leaderRpcPort);
     }
+
+    public void setBrokerMgr(BrokerMgr brokerMgr) {
+        this.brokerMgr = brokerMgr;
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterHandlerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterHandlerEditLogTest.java
@@ -1,0 +1,197 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.common.Config;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.RemoveAlterJobV2OperationLog;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class AlterHandlerEditLogTest {
+    private SchemaChangeHandler schemaChangeHandler;
+    private static final long JOB_ID_1 = 20001L;
+    private static final long JOB_ID_2 = 20002L;
+    private static final long DB_ID = 20003L;
+    private static final long TABLE_ID = 20004L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        schemaChangeHandler.clearJobs();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testClearExpireFinishedOrCancelledAlterJobsV2NormalCase() throws Exception {
+        // 1. Create expired finished alter job
+        long oldFinishedTime = System.currentTimeMillis() - (Config.history_job_keep_max_second + 100) * 1000L;
+        MockAlterJobV2 expiredJob = new MockAlterJobV2(JOB_ID_1, AlterJobV2.JobType.SCHEMA_CHANGE, 
+                DB_ID, TABLE_ID, "test_table", 10000L);
+        expiredJob.setJobState(AlterJobV2.JobState.FINISHED);
+        expiredJob.setFinishedTimeMs(oldFinishedTime);
+        schemaChangeHandler.addAlterJobV2(expiredJob);
+
+        // 2. Create non-expired finished alter job
+        MockAlterJobV2 nonExpiredJob = new MockAlterJobV2(JOB_ID_2, AlterJobV2.JobType.SCHEMA_CHANGE,
+                DB_ID, TABLE_ID, "test_table2", 10000L);
+        nonExpiredJob.setJobState(AlterJobV2.JobState.FINISHED);
+        nonExpiredJob.setFinishedTimeMs(System.currentTimeMillis());
+        schemaChangeHandler.addAlterJobV2(nonExpiredJob);
+
+        // 3. Verify initial state
+        Assertions.assertEquals(2, schemaChangeHandler.getAlterJobsV2().size());
+        Assertions.assertTrue(schemaChangeHandler.getAlterJobsV2().containsKey(JOB_ID_1));
+        Assertions.assertTrue(schemaChangeHandler.getAlterJobsV2().containsKey(JOB_ID_2));
+
+        // 4. Execute clearExpireFinishedOrCancelledAlterJobsV2
+        schemaChangeHandler.clearExpireFinishedOrCancelledAlterJobsV2();
+
+        // 5. Verify master state - expired job should be removed
+        Assertions.assertEquals(1, schemaChangeHandler.getAlterJobsV2().size());
+        Assertions.assertFalse(schemaChangeHandler.getAlterJobsV2().containsKey(JOB_ID_1));
+        Assertions.assertTrue(schemaChangeHandler.getAlterJobsV2().containsKey(JOB_ID_2));
+
+        // 6. Test follower replay
+        RemoveAlterJobV2OperationLog replayLog = (RemoveAlterJobV2OperationLog) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_REMOVE_ALTER_JOB_V2);
+
+        // Verify replay log
+        Assertions.assertNotNull(replayLog);
+        Assertions.assertEquals(JOB_ID_1, replayLog.getJobId());
+        Assertions.assertEquals(AlterJobV2.JobType.SCHEMA_CHANGE, replayLog.getType());
+
+        // Create follower handler and the same job, then replay
+        SchemaChangeHandler followerHandler = new SchemaChangeHandler();
+        MockAlterJobV2 followerExpiredJob = new MockAlterJobV2(JOB_ID_1, AlterJobV2.JobType.SCHEMA_CHANGE,
+                DB_ID, TABLE_ID, "test_table", 10000L);
+        followerExpiredJob.setJobState(AlterJobV2.JobState.FINISHED);
+        followerExpiredJob.setFinishedTimeMs(oldFinishedTime);
+        followerHandler.addAlterJobV2(followerExpiredJob);
+
+        MockAlterJobV2 followerNonExpiredJob = new MockAlterJobV2(JOB_ID_2, AlterJobV2.JobType.SCHEMA_CHANGE,
+                DB_ID, TABLE_ID, "test_table2", 10000L);
+        followerNonExpiredJob.setJobState(AlterJobV2.JobState.FINISHED);
+        followerNonExpiredJob.setFinishedTimeMs(System.currentTimeMillis());
+        followerHandler.addAlterJobV2(followerNonExpiredJob);
+
+        Assertions.assertEquals(2, followerHandler.getAlterJobsV2().size());
+
+        followerHandler.replayRemoveAlterJobV2(replayLog);
+
+        // 7. Verify follower state
+        Assertions.assertEquals(1, followerHandler.getAlterJobsV2().size());
+        Assertions.assertFalse(followerHandler.getAlterJobsV2().containsKey(JOB_ID_1));
+        Assertions.assertTrue(followerHandler.getAlterJobsV2().containsKey(JOB_ID_2));
+    }
+
+    @Test
+    public void testClearExpireFinishedOrCancelledAlterJobsV2EditLogException() throws Exception {
+        // 1. Create expired finished alter job
+        long oldFinishedTime = System.currentTimeMillis() - (Config.history_job_keep_max_second + 100) * 1000L;
+        MockAlterJobV2 expiredJob = new MockAlterJobV2(JOB_ID_1, AlterJobV2.JobType.SCHEMA_CHANGE,
+                DB_ID, TABLE_ID, "test_table", 10000L);
+        expiredJob.setJobState(AlterJobV2.JobState.FINISHED);
+        expiredJob.setFinishedTimeMs(oldFinishedTime);
+        schemaChangeHandler.addAlterJobV2(expiredJob);
+
+        // 2. Mock EditLog.logRemoveExpiredAlterJobV2 to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logRemoveExpiredAlterJobV2(any(RemoveAlterJobV2OperationLog.class), any());
+
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 3. Execute clearExpireFinishedOrCancelledAlterJobsV2 and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            schemaChangeHandler.clearExpireFinishedOrCancelledAlterJobsV2();
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed"));
+
+        // 4. Verify job is still present (not removed due to exception)
+        Assertions.assertEquals(1, schemaChangeHandler.getAlterJobsV2().size());
+        Assertions.assertTrue(schemaChangeHandler.getAlterJobsV2().containsKey(JOB_ID_1));
+    }
+
+    // Mock AlterJobV2 for testing
+    private static class MockAlterJobV2 extends AlterJobV2 {
+        public MockAlterJobV2(long jobId, JobType jobType, long dbId, long tableId, String tableName, long timeoutMs) {
+            super(jobId, jobType, dbId, tableId, tableName, timeoutMs);
+        }
+
+        @Override
+        protected void runPendingJob() throws AlterCancelException {
+            // Mock implementation
+        }
+
+        @Override
+        protected void runWaitingTxnJob() throws AlterCancelException {
+            // Mock implementation
+        }
+
+        @Override
+        protected void runRunningJob() throws AlterCancelException {
+            // Mock implementation
+        }
+
+        @Override
+        protected void runFinishedRewritingJob() throws AlterCancelException {
+            // Mock implementation
+        }
+
+        @Override
+        protected boolean cancelImpl(String errMsg) {
+            return true;
+        }
+
+        @Override
+        protected void getInfo(List<List<Comparable>> infos) {
+            // Mock implementation
+        }
+
+        @Override
+        public void replay(AlterJobV2 replayedJob) {
+            // Mock implementation
+        }
+
+        @Override
+        public java.util.Optional<Long> getTransactionId() {
+            return java.util.Optional.empty();
+        }
+
+        @Override
+        public void write(java.io.DataOutput out) throws java.io.IOException {
+            // Mock implementation
+        }
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -48,7 +48,6 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
-import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -56,7 +55,6 @@ import com.starrocks.common.ExceptionChecker;
 import com.starrocks.metric.LongCounterMetric;
 import com.starrocks.metric.Metric;
 import com.starrocks.metric.MetricRepo;
-import com.starrocks.persist.EditLog;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
@@ -89,13 +87,13 @@ import com.starrocks.thrift.TStatusCode;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.Type;
 import com.starrocks.utframe.UtFrameUtils;
-import mockit.Delegate;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -111,18 +109,35 @@ import java.util.Map;
 import java.util.Set;
 
 public class BackupHandlerTest {
-
     private BackupHandler handler;
 
     private Database db;
-
-    private long idGen = 0;
 
     private File rootDir;
 
     private String tmpPath = "./tmp" + System.currentTimeMillis();
 
-    private TabletInvertedIndex invertedIndex = new TabletInvertedIndex();
+    private String brokerName = "broker";
+
+    @BeforeEach
+    public void setup() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+    }
+
+    @AfterEach
+    public void done() throws Exception {
+        if (rootDir != null) {
+            try {
+                Files.walk(Paths.get(Config.tmp_dir),
+                                FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder()).map(Path::toFile)
+                        .forEach(File::delete);
+            } catch (IOException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }
+        UtFrameUtils.tearDownForPersisTest();
+    }
 
     private void initMetrics() {
         MetricRepo.COUNTER_UNFINISHED_BACKUP_JOB = new LongCounterMetric("unfinished_backup_job", Metric.MetricUnit.REQUESTS,
@@ -131,7 +146,7 @@ public class BackupHandlerTest {
                 "current unfinished restore job");
     }
 
-    private void setUpMocker(GlobalStateMgr globalStateMgr, BrokerMgr brokerMgr, EditLog editLog) {
+    private void setUpMocker() {
         Config.tmp_dir = tmpPath;
         rootDir = new File(Config.tmp_dir);
         rootDir.mkdirs();
@@ -144,50 +159,12 @@ public class BackupHandlerTest {
             e.printStackTrace();
             Assertions.fail();
         }
-
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-
-                globalStateMgr.getBrokerMgr();
-                minTimes = 0;
-                result = brokerMgr;
-
-                globalStateMgr.getNextId();
-                minTimes = 0;
-                result = idGen++;
-
-                globalStateMgr.getEditLog();
-                minTimes = 0;
-                result = editLog;
-
-                globalStateMgr.getTabletInvertedIndex();
-                minTimes = 0;
-                result = invertedIndex;
-            }
-        };
     }
 
-    @AfterEach
-    public void done() {
-        if (rootDir != null) {
-            try {
-                Files.walk(Paths.get(Config.tmp_dir),
-                                FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder()).map(Path::toFile)
-                        .forEach(File::delete);
-            } catch (IOException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
-        }
-    }
 
     @Test
-    public void testInit(@Mocked GlobalStateMgr globalStateMgr, @Mocked BrokerMgr brokerMgr, @Mocked EditLog editLog) {
-        setUpMocker(globalStateMgr, brokerMgr, editLog);
-        BackupHandler handler = new BackupHandler(globalStateMgr);
+    public void testInit() {
+        BackupHandler handler = new BackupHandler(GlobalStateMgr.getCurrentState());
         handler.runAfterCatalogReady();
 
         File backupDir = new File(BackupHandler.BACKUP_ROOT_DIR.toString());
@@ -195,32 +172,8 @@ public class BackupHandlerTest {
     }
 
     @Test
-    public void testCreateAndDropRepository(
-            @Mocked GlobalStateMgr globalStateMgr, @Mocked BrokerMgr brokerMgr, @Mocked EditLog editLog) throws Exception {
-        setUpMocker(globalStateMgr, brokerMgr, editLog);
-        new Expectations() {
-            {
-                editLog.logCreateRepository((Repository) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    public void logCreateRepository(Repository repo) {
-
-                    }
-                };
-
-                editLog.logDropRepository(anyString);
-                minTimes = 0;
-                result = new Delegate() {
-                    public void logDropRepository(String repoName) {
-
-                    }
-                };
-
-                globalStateMgr.getLocalMetastore().getDb(anyLong);
-                minTimes = 0;
-                result = db;
-            }
-        };
+    public void testCreateAndDropRepository(@Mocked BrokerMgr brokerMgr) throws Exception {
+        setUpMocker();
 
         new MockUp<Repository>() {
             @Mock
@@ -269,30 +222,6 @@ public class BackupHandlerTest {
             }
         };
 
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-
-                globalStateMgr.getBrokerMgr();
-                minTimes = 0;
-                result = brokerMgr;
-
-                globalStateMgr.getNextId();
-                minTimes = 0;
-                result = idGen++;
-
-                globalStateMgr.getEditLog();
-                minTimes = 0;
-                result = editLog;
-
-                globalStateMgr.getTabletInvertedIndex();
-                minTimes = 0;
-                result = invertedIndex;
-            }
-        };
-
         new MockUp<LocalMetastore>() {
             Database database = CatalogMocker.mockDb();
 
@@ -307,9 +236,10 @@ public class BackupHandlerTest {
             }
         };
 
+        GlobalStateMgr.getCurrentState().getNodeMgr().setBrokerMgr(brokerMgr);
         // add repo
-        BackupHandler handler = new BackupHandler(globalStateMgr);
-        CreateRepositoryStmt stmt = new CreateRepositoryStmt(false, "repo", "broker", "bos://location",
+        BackupHandler handler = new BackupHandler(GlobalStateMgr.getCurrentState());
+        CreateRepositoryStmt stmt = new CreateRepositoryStmt(false, "repo", brokerName, "bos://location",
                 Maps.newHashMap());
         try {
             handler.createRepository(stmt);
@@ -449,18 +379,6 @@ public class BackupHandlerTest {
         request.setTask_status(new TStatus(TStatusCode.OK));
         handler.handleDirMoveTask(dirMoveTask, request);
 
-        new MockUp<ConnectContext>() {
-            @Mock
-            GlobalStateMgr getGlobalStateMgr() {
-                return globalStateMgr;
-            }
-        };
-        new MockUp<GlobalStateMgr>() {
-            @Mock
-            BackupHandler getBackupHandler() {
-                return handler;
-            }
-        };
         // cancel restore
         handler.cancel(new CancelBackupStmt(CatalogMocker.TEST_DB_NAME, true));
 
@@ -558,21 +476,13 @@ public class BackupHandlerTest {
         newBackupMeta.setCatalogs(Lists.newArrayList(catalog));
         handler.checkAndFilterRestoreCatalogsInBackupMeta(restoreStmt3, newBackupMeta);
 
+        GlobalStateMgr.getCurrentState().setBackupHandler(handler);
         // drop repo
-        DDLStmtExecutor ddlStmtExecutor = new DDLStmtExecutor(DDLStmtExecutor.StmtExecutorVisitor.getInstance());
-        new Expectations() {
-            {
-                globalStateMgr.getDdlStmtExecutor();
-                result = ddlStmtExecutor;
-            }
-        };
         DDLStmtExecutor.execute(new DropRepositoryStmt("repo"), new ConnectContext());
     }
 
     @Test
     public void testExpired() throws Exception {
-        UtFrameUtils.setUpForPersistTest();
-
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         handler = new BackupHandler(globalStateMgr);
         Assertions.assertEquals(0, handler.dbIdToBackupOrRestoreJob.size());
@@ -616,13 +526,10 @@ public class BackupHandlerTest {
         Assertions.assertNotNull(handler.getJob(1));
         Assertions.assertNotNull(handler.getJob(2));
         Assertions.assertNull(handler.getJob(3));
-
-        UtFrameUtils.tearDownForPersisTest();
     }
 
     @Test
     public void testSaveLoadJsonFormatImage() throws Exception {
-        UtFrameUtils.setUpForPersistTest();
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         handler = new BackupHandler(globalStateMgr);
         BackupJob runningJob = new BackupJob("running_job", 1, "test_db", new ArrayList<>(), 10000, globalStateMgr, 1);
@@ -636,38 +543,11 @@ public class BackupHandlerTest {
         reader.close();
 
         Assertions.assertEquals(1, followerHandler.dbIdToBackupOrRestoreJob.size());
-
-        UtFrameUtils.tearDownForPersisTest();
     }
 
     @Test
-    public void testCreateDbInRestore(
-            @Mocked GlobalStateMgr globalStateMgr, @Mocked BrokerMgr brokerMgr, @Mocked EditLog editLog) throws Exception {
-        setUpMocker(globalStateMgr, brokerMgr, editLog);
-
-        new Expectations() {
-            {
-                editLog.logCreateRepository((Repository) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    public void logCreateRepository(Repository repo) {
-
-                    }
-                };
-
-                editLog.logDropRepository(anyString);
-                minTimes = 0;
-                result = new Delegate() {
-                    public void logDropRepository(String repoName) {
-
-                    }
-                };
-
-                globalStateMgr.getLocalMetastore().getDb(anyLong);
-                minTimes = 0;
-                result = db;
-            }
-        };
+    public void testCreateDbInRestore(@Mocked BrokerMgr brokerMgr) throws Exception {
+        setUpMocker();
 
         new MockUp<Repository>() {
             @Mock
@@ -708,38 +588,6 @@ public class BackupHandlerTest {
             }
         };
 
-        new Expectations() {
-            {
-                brokerMgr.containsBroker(anyString);
-                minTimes = 0;
-                result = true;
-            }
-        };
-
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-
-                globalStateMgr.getBrokerMgr();
-                minTimes = 0;
-                result = brokerMgr;
-
-                globalStateMgr.getNextId();
-                minTimes = 0;
-                result = idGen++;
-
-                globalStateMgr.getEditLog();
-                minTimes = 0;
-                result = editLog;
-
-                globalStateMgr.getTabletInvertedIndex();
-                minTimes = 0;
-                result = invertedIndex;
-            }
-        };
-
         new MockUp<LocalMetastore>() {
             Database database = CatalogMocker.mockDb();
 
@@ -761,8 +609,18 @@ public class BackupHandlerTest {
             }
         };
 
-        BackupHandler handler = new BackupHandler(globalStateMgr);
-        CreateRepositoryStmt stmt = new CreateRepositoryStmt(false, "repo", "broker", "bos://location",
+        new Expectations() {
+            {
+                brokerMgr.containsBroker(anyString);
+                minTimes = 0;
+                result = true;
+            }
+        };
+
+        GlobalStateMgr.getCurrentState().getNodeMgr().setBrokerMgr(brokerMgr);
+
+        BackupHandler handler = new BackupHandler(GlobalStateMgr.getCurrentState());
+        CreateRepositoryStmt stmt = new CreateRepositoryStmt(false, "repo", brokerName, "bos://location",
                 Maps.newHashMap());
         try {
             handler.createRepository(stmt);
@@ -842,7 +700,7 @@ public class BackupHandlerTest {
 
     @Test
     public void testCreateRepositoryNeedEncrypt() {
-        CreateRepositoryStmt stmt = new CreateRepositoryStmt(false, "repo", "broker", "bos://location",
+        CreateRepositoryStmt stmt = new CreateRepositoryStmt(false, "repo", brokerName, "bos://location",
                 Maps.newHashMap());
         Assertions.assertEquals(true, AuditEncryptionChecker.needEncrypt(stmt));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RepositoryMgrEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RepositoryMgrEditLogTest.java
@@ -1,0 +1,219 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.backup;
+
+import com.starrocks.backup.Status.ErrCode;
+import com.starrocks.persist.DropRepositoryLog;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class RepositoryMgrEditLogTest {
+    private RepositoryMgr repositoryMgr;
+    private static final String REPO_NAME = "test_repo";
+    private static final long REPO_ID = 30001L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        repositoryMgr = new RepositoryMgr();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testAddAndInitRepoIfNotExistNormalCase() throws Exception {
+        // 1. Create a mock repository
+        BlobStorage storage = new BlobStorage("test_broker", null, false);
+        Repository repo = spy(new Repository(REPO_ID, REPO_NAME, false, "test://location", storage));
+        
+        // Mock initRepository to return OK
+        doReturn(Status.OK).when(repo).initRepository();
+
+        // 2. Verify initial state - repository should not exist
+        Assertions.assertNull(repositoryMgr.getRepo(REPO_NAME));
+        Assertions.assertNull(repositoryMgr.getRepo(REPO_ID));
+
+        // 3. Execute addAndInitRepoIfNotExist
+        Status status = repositoryMgr.addAndInitRepoIfNotExist(repo);
+
+        // 4. Verify master state
+        Assertions.assertTrue(status.ok());
+        Repository addedRepo = repositoryMgr.getRepo(REPO_NAME);
+        Assertions.assertNotNull(addedRepo);
+        Assertions.assertEquals(REPO_NAME, addedRepo.getName());
+        Assertions.assertEquals(REPO_ID, addedRepo.getId());
+        Assertions.assertEquals("test://location", addedRepo.getLocation());
+        Assertions.assertFalse(addedRepo.isReadOnly());
+
+        Repository addedRepoById = repositoryMgr.getRepo(REPO_ID);
+        Assertions.assertNotNull(addedRepoById);
+        Assertions.assertEquals(REPO_NAME, addedRepoById.getName());
+
+        // 5. Test follower replay
+        Repository replayRepo = (Repository) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_CREATE_REPOSITORY_V2);
+
+        // Verify replay info
+        Assertions.assertNotNull(replayRepo);
+        Assertions.assertEquals(REPO_ID, replayRepo.getId());
+        Assertions.assertEquals(REPO_NAME, replayRepo.getName());
+        Assertions.assertEquals("test://location", replayRepo.getLocation());
+        Assertions.assertFalse(replayRepo.isReadOnly());
+
+        // Create follower repository manager and replay into it
+        RepositoryMgr followerRepositoryMgr = new RepositoryMgr();
+        followerRepositoryMgr.replayAddRepo(replayRepo);
+
+        // 6. Verify follower state
+        Repository followerRepo = followerRepositoryMgr.getRepo(REPO_NAME);
+        Assertions.assertNotNull(followerRepo);
+        Assertions.assertEquals(REPO_NAME, followerRepo.getName());
+        Assertions.assertEquals(REPO_ID, followerRepo.getId());
+        Assertions.assertEquals("test://location", followerRepo.getLocation());
+        Assertions.assertFalse(followerRepo.isReadOnly());
+
+        Repository followerRepoById = followerRepositoryMgr.getRepo(REPO_ID);
+        Assertions.assertNotNull(followerRepoById);
+        Assertions.assertEquals(REPO_NAME, followerRepoById.getName());
+    }
+
+    @Test
+    public void testAddAndInitRepoIfNotExistEditLogException() throws Exception {
+        // 1. Create a mock repository
+        BlobStorage storage = new BlobStorage("test_broker", null, false);
+        Repository repo = spy(new Repository(REPO_ID, REPO_NAME, false, "test://location", storage));
+        
+        // Mock initRepository to return OK
+        doReturn(Status.OK).when(repo).initRepository();
+
+        // 2. Mock EditLog.logCreateRepository to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logCreateRepository(any(Repository.class), any());
+
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 3. Execute addAndInitRepoIfNotExist and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            repositoryMgr.addAndInitRepoIfNotExist(repo);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed") ||
+                            exception.getCause() != null &&
+                            exception.getCause().getMessage().contains("EditLog write failed"));
+
+        // 4. Verify repository is not added after exception
+        Assertions.assertNull(repositoryMgr.getRepo(REPO_NAME));
+        Assertions.assertNull(repositoryMgr.getRepo(REPO_ID));
+    }
+
+    @Test
+    public void testRemoveRepoNormalCase() throws Exception {
+        // 1. First add a repository
+        BlobStorage storage = new BlobStorage("test_broker", null, false);
+        Repository repo = spy(new Repository(REPO_ID, REPO_NAME, false, "test://location", storage));
+        doReturn(Status.OK).when(repo).initRepository();
+        
+        Status addStatus = repositoryMgr.addAndInitRepoIfNotExist(repo);
+        Assertions.assertTrue(addStatus.ok());
+        Assertions.assertNotNull(repositoryMgr.getRepo(REPO_NAME));
+
+        // 2. Execute removeRepo
+        Status removeStatus = repositoryMgr.removeRepo(REPO_NAME);
+
+        // 3. Verify master state
+        Assertions.assertTrue(removeStatus.ok());
+        Assertions.assertNull(repositoryMgr.getRepo(REPO_NAME));
+        Assertions.assertNull(repositoryMgr.getRepo(REPO_ID));
+
+        // 4. Test follower replay
+        DropRepositoryLog replayLog = (DropRepositoryLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_DROP_REPOSITORY_V2);
+
+        // Verify replay log
+        Assertions.assertNotNull(replayLog);
+        Assertions.assertEquals(REPO_NAME, replayLog.getRepositoryName());
+
+        // Create follower repository manager with the same repository, then replay
+        RepositoryMgr followerRepositoryMgr = new RepositoryMgr();
+        Repository followerRepo = spy(new Repository(REPO_ID, REPO_NAME, false, "test://location", storage));
+        followerRepositoryMgr.replayAddRepo(followerRepo);
+        Assertions.assertNotNull(followerRepositoryMgr.getRepo(REPO_NAME));
+
+        followerRepositoryMgr.replayRemoveRepo(REPO_NAME);
+
+        // 5. Verify follower state
+        Assertions.assertNull(followerRepositoryMgr.getRepo(REPO_NAME));
+        Assertions.assertNull(followerRepositoryMgr.getRepo(REPO_ID));
+    }
+
+    @Test
+    public void testRemoveRepoEditLogException() throws Exception {
+        // 1. First add a repository
+        BlobStorage storage = new BlobStorage("test_broker", null, false);
+        Repository repo = spy(new Repository(REPO_ID, REPO_NAME, false, "test://location", storage));
+        doReturn(Status.OK).when(repo).initRepository();
+        
+        Status addStatus = repositoryMgr.addAndInitRepoIfNotExist(repo);
+        Assertions.assertTrue(addStatus.ok());
+        Assertions.assertNotNull(repositoryMgr.getRepo(REPO_NAME));
+
+        // 2. Mock EditLog.logDropRepository to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logDropRepository(any(String.class), any());
+
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 3. Execute removeRepo and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            repositoryMgr.removeRepo(REPO_NAME);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed") ||
+                            exception.getCause() != null &&
+                            exception.getCause().getMessage().contains("EditLog write failed"));
+
+        // 4. Verify repository is still present after exception
+        Assertions.assertNotNull(repositoryMgr.getRepo(REPO_NAME));
+        Assertions.assertNotNull(repositoryMgr.getRepo(REPO_ID));
+    }
+
+    @Test
+    public void testRemoveRepoNotFound() throws Exception {
+        // 1. Try to remove non-existent repository
+        Status status = repositoryMgr.removeRepo("non_existent_repo");
+
+        // 2. Verify status
+        Assertions.assertFalse(status.ok());
+        Assertions.assertEquals(ErrCode.NOT_FOUND, status.getErrCode());
+        Assertions.assertTrue(status.getErrMsg().contains("repository does not exist"));
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinEditLogTest.java
@@ -1,0 +1,630 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.CatalogRecycleBin.RecycleTableInfo;
+import com.starrocks.common.Config;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.EraseDbLog;
+import com.starrocks.persist.ErasePartitionLog;
+import com.starrocks.persist.MultiEraseTableInfo;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.RecoverInfo;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class CatalogRecycleBinEditLogTest {
+    private CatalogRecycleBin recycleBin;
+    private static final String DB_NAME = "test_recycle_bin_db";
+    private static final String TABLE_NAME = "test_recycle_bin_table";
+    private static final String PARTITION_NAME = "p1";
+    private static final long DB_ID = 40001L;
+    private static final long TABLE_ID = 40002L;
+    private static final long PARTITION_ID = 40003L;
+    private static final long PHYSICAL_PARTITION_ID = 40004L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        recycleBin = GlobalStateMgr.getCurrentState().getRecycleBin();
+        recycleBin.clear();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private Database createDatabase(long dbId, String dbName) {
+        return new Database(dbId, dbName);
+    }
+
+    private OlapTable createOlapTable(long tableId, String tableName) {
+        List<Column> columns = new java.util.ArrayList<>();
+        Column col1 = new Column("v1", com.starrocks.type.IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("v2", com.starrocks.type.IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(3, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(10001L, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(10002L);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, tableId, PARTITION_ID, 10001L, 
+                com.starrocks.thrift.TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, PARTITION_NAME, 
+                baseIndex, distributionInfo);
+
+        OlapTable olapTable = new OlapTable(tableId, tableName, columns, 
+                com.starrocks.sql.ast.KeysType.DUP_KEYS, partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(10001L, tableName, columns, 0, 0, (short) 1, 
+                com.starrocks.thrift.TStorageType.COLUMN, com.starrocks.sql.ast.KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(10001L);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new TableProperty(new java.util.HashMap<>()));
+        return olapTable;
+    }
+
+    private OlapTable createRangePartitionedOlapTable(long tableId, String tableName) {
+        List<Column> columns = new java.util.ArrayList<>();
+        Column partitionCol = new Column("dt", com.starrocks.type.DateType.DATE);
+        partitionCol.setIsKey(true);
+        columns.add(partitionCol);
+        columns.add(new Column("v2", com.starrocks.type.IntegerType.BIGINT));
+
+        // Create RangePartitionInfo with DATE partition column
+        RangePartitionInfo partitionInfo = new RangePartitionInfo(List.of(partitionCol));
+        partitionInfo.setDataProperty(PARTITION_ID, DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        // Create partition range: [2024-01-01, 2024-02-01)
+        try {
+            com.starrocks.catalog.PartitionKey lowerKey = com.starrocks.catalog.PartitionKey.ofDate(
+                    java.time.LocalDate.parse("2024-01-01"));
+            com.starrocks.catalog.PartitionKey upperKey = com.starrocks.catalog.PartitionKey.ofDate(
+                    java.time.LocalDate.parse("2024-02-01"));
+            com.google.common.collect.Range<com.starrocks.catalog.PartitionKey> partitionRange = 
+                    com.google.common.collect.Range.closedOpen(lowerKey, upperKey);
+            partitionInfo.addPartition(PARTITION_ID, false, partitionRange,
+                    DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(3, List.of(partitionCol));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(10001L, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(10002L);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, tableId, PARTITION_ID, 10001L, 
+                com.starrocks.thrift.TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, PARTITION_NAME, 
+                baseIndex, distributionInfo);
+
+        OlapTable olapTable = new OlapTable(tableId, tableName, columns, 
+                com.starrocks.sql.ast.KeysType.DUP_KEYS, partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(10001L, tableName, columns, 0, 0, (short) 1, 
+                com.starrocks.thrift.TStorageType.COLUMN, com.starrocks.sql.ast.KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(10001L);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new TableProperty(new java.util.HashMap<>()));
+        return olapTable;
+    }
+
+    @Test
+    public void testEraseDatabaseNormalCase() throws Exception {
+        // 1. Create and recycle a database
+        Database db = createDatabase(DB_ID, DB_NAME);
+        Set<String> tableNames = Sets.newHashSet();
+        recycleBin.recycleDatabase(db, tableNames, true);
+        
+        Assertions.assertNotNull(recycleBin.getDatabase(DB_ID));
+
+        // 2. Set recycle time to expired
+        long oldRecycleTime = System.currentTimeMillis() - 
+                (Config.catalog_trash_expire_second + 100) * 1000L;
+        // Access protected field through a test helper class that extends CatalogRecycleBin
+        TestCatalogRecycleBin testRecycleBin = new TestCatalogRecycleBin(recycleBin);
+        testRecycleBin.setRecycleTime(DB_ID, oldRecycleTime);
+
+        // 3. Execute eraseDatabase
+        recycleBin.eraseDatabase(System.currentTimeMillis());
+
+        // 4. Verify master state - database should be removed
+        Assertions.assertNull(recycleBin.getDatabase(DB_ID));
+        Assertions.assertFalse(recycleBin.isContainedInidToRecycleTime(DB_ID));
+
+        // 5. Test follower replay
+        EraseDbLog replayLog = (EraseDbLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ERASE_DB_V2);
+
+        // Verify replay log
+        Assertions.assertNotNull(replayLog);
+        Assertions.assertEquals(DB_ID, replayLog.getDbId());
+
+        // Create follower recycle bin and the same database, then replay
+        CatalogRecycleBin followerRecycleBin = new CatalogRecycleBin();
+        Database followerDb = createDatabase(DB_ID, DB_NAME);
+        followerRecycleBin.recycleDatabase(followerDb, tableNames, true);
+        TestCatalogRecycleBin testFollowerRecycleBin = new TestCatalogRecycleBin(followerRecycleBin);
+        testFollowerRecycleBin.setRecycleTime(DB_ID, oldRecycleTime);
+        Assertions.assertNotNull(followerRecycleBin.getDatabase(DB_ID));
+
+        followerRecycleBin.replayEraseDatabase(DB_ID);
+
+        // 6. Verify follower state
+        Assertions.assertNull(followerRecycleBin.getDatabase(DB_ID));
+        Assertions.assertFalse(followerRecycleBin.isContainedInidToRecycleTime(DB_ID));
+    }
+
+    @Test
+    public void testEraseDatabaseEditLogException() throws Exception {
+        // 1. Create and recycle a database
+        Database db = createDatabase(DB_ID, DB_NAME);
+        Set<String> tableNames = Sets.newHashSet();
+        recycleBin.recycleDatabase(db, tableNames, true);
+        
+        // 2. Set recycle time to expired
+        long oldRecycleTime = System.currentTimeMillis() - 
+                (Config.catalog_trash_expire_second + 100) * 1000L;
+        // Access protected field through a test helper class that extends CatalogRecycleBin
+        TestCatalogRecycleBin testRecycleBin = new TestCatalogRecycleBin(recycleBin);
+        testRecycleBin.setRecycleTime(DB_ID, oldRecycleTime);
+
+        // 3. Mock EditLog.logEraseDb to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logEraseDb(any(Long.class), any());
+
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute eraseDatabase and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            recycleBin.eraseDatabase(System.currentTimeMillis());
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed") ||
+                            exception.getCause() != null &&
+                            exception.getCause().getMessage().contains("EditLog write failed"));
+
+        // 5. Verify database is still present after exception
+        Assertions.assertNotNull(recycleBin.getDatabase(DB_ID));
+    }
+
+    @Test
+    public void testPickTablesToEraseNormalCase() throws Exception {
+        // 1. Create and recycle a table
+        Database db = createDatabase(DB_ID, DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        recycleBin.recycleTable(DB_ID, table, true);
+        
+        Assertions.assertNotNull(recycleBin.getTable(DB_ID, TABLE_ID));
+
+        // 2. Set recycle time to expired and mark as non-recoverable
+        long oldRecycleTime = System.currentTimeMillis() - 
+                (Config.catalog_trash_expire_second + 100) * 1000L;
+        TestCatalogRecycleBin testRecycleBin = new TestCatalogRecycleBin(recycleBin);
+        testRecycleBin.setRecycleTime(TABLE_ID, oldRecycleTime);
+        RecycleTableInfo tableInfo = recycleBin.getRecycleTableInfo(TABLE_ID);
+        tableInfo.setRecoverable(false);
+
+        // 3. Execute pickTablesToErase
+        List<RecycleTableInfo> tablesToErase = recycleBin.pickTablesToErase(System.currentTimeMillis());
+
+        // 4. Verify master state - should return tables to erase
+        Assertions.assertNotNull(tablesToErase);
+        Assertions.assertFalse(tablesToErase.isEmpty());
+        Assertions.assertEquals(TABLE_ID, tablesToErase.get(0).getTable().getId());
+
+        // 5. Test follower replay - pickTablesToErase logs erase tables
+        // The actual erase happens through logEraseMultiTables
+        MultiEraseTableInfo replayLog = (MultiEraseTableInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ERASE_MULTI_TABLES);
+
+        // Verify replay log
+        Assertions.assertNotNull(replayLog);
+        Assertions.assertNotNull(replayLog.getTableIds());
+        Assertions.assertTrue(replayLog.getTableIds().contains(TABLE_ID));
+
+        // Create follower recycle bin and the same table, then replay
+        CatalogRecycleBin followerRecycleBin = new CatalogRecycleBin();
+        OlapTable followerTable = createOlapTable(TABLE_ID, TABLE_NAME);
+        followerRecycleBin.recycleTable(DB_ID, followerTable, true);
+        TestCatalogRecycleBin testFollowerRecycleBin = new TestCatalogRecycleBin(followerRecycleBin);
+        testFollowerRecycleBin.setRecycleTime(TABLE_ID, oldRecycleTime);
+        RecycleTableInfo followerTableInfo = followerRecycleBin.getRecycleTableInfo(TABLE_ID);
+        followerTableInfo.setRecoverable(false);
+        Assertions.assertNotNull(followerRecycleBin.getTable(DB_ID, TABLE_ID));
+
+        followerRecycleBin.replayEraseTable(replayLog.getTableIds());
+
+        // 6. Verify follower state
+        Assertions.assertNull(followerRecycleBin.getTable(DB_ID, TABLE_ID));
+        Assertions.assertFalse(followerRecycleBin.isContainedInidToRecycleTime(TABLE_ID));
+    }
+
+    @Test
+    public void testErasePartitionNormalCase() throws Exception {
+        // 1. Create and recycle a partition
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        Partition partition = table.getPartition(PARTITION_NAME);
+        Assertions.assertNotNull(partition);
+
+        RecyclePartitionInfo partitionInfo = new RecyclePartitionInfoV2(
+                DB_ID, TABLE_ID, partition,
+                DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        partitionInfo.setRecoverable(false);
+        recycleBin.recyclePartition(partitionInfo);
+        
+        Assertions.assertNotNull(recycleBin.getPartition(PARTITION_ID));
+
+        // 2. Set recycle time to expired
+        long oldRecycleTime = System.currentTimeMillis() - 
+                (Config.catalog_trash_expire_second + 100) * 1000L;
+        TestCatalogRecycleBin testRecycleBin = new TestCatalogRecycleBin(recycleBin);
+        testRecycleBin.setRecycleTime(PARTITION_ID, oldRecycleTime);
+
+        // 3. Mock partition delete to return true (finished) - use a spy on the partition info
+        RecyclePartitionInfo recyclePartitionInfo = recycleBin.getRecyclePartitionInfo(PARTITION_ID);
+        RecyclePartitionInfo spyPartitionInfo = spy(recyclePartitionInfo);
+        doReturn(true).when(spyPartitionInfo).delete();
+        
+        // Replace the partition info in recycle bin with the spy
+        recycleBin.setPartitionInfo(PARTITION_ID, spyPartitionInfo);
+        // Create a completed future that returns true
+        CompletableFuture<Boolean> completedFuture = CompletableFuture.completedFuture(true);
+        recycleBin.setDeleteFutureForPartition(spyPartitionInfo, completedFuture);
+
+        // 4. Execute erasePartition - it should log EditLog since delete is finished
+        recycleBin.erasePartition(System.currentTimeMillis());
+
+        // 5. Verify master state - partition should be removed
+        Assertions.assertNull(recycleBin.getPartition(PARTITION_ID));
+        Assertions.assertFalse(recycleBin.isContainedInidToRecycleTime(PARTITION_ID));
+
+        // 6. Test follower replay
+        ErasePartitionLog replayLog = (ErasePartitionLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ERASE_PARTITION_V2);
+
+        // Verify replay log
+        Assertions.assertNotNull(replayLog);
+        Assertions.assertEquals(PARTITION_ID, replayLog.getPartitionId());
+
+        // Create follower recycle bin and the same partition, then replay
+        CatalogRecycleBin followerRecycleBin = new CatalogRecycleBin();
+        OlapTable followerTable = createOlapTable(TABLE_ID, TABLE_NAME);
+        Partition followerPartition = followerTable.getPartition(PARTITION_NAME);
+        RecyclePartitionInfo followerPartitionInfo = new RecyclePartitionInfoV2(
+                DB_ID, TABLE_ID, followerPartition,
+                DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        followerPartitionInfo.setRecoverable(false);
+        followerRecycleBin.recyclePartition(followerPartitionInfo);
+        TestCatalogRecycleBin testFollowerRecycleBin = new TestCatalogRecycleBin(followerRecycleBin);
+        testFollowerRecycleBin.setRecycleTime(PARTITION_ID, oldRecycleTime);
+        Assertions.assertNotNull(followerRecycleBin.getPartition(PARTITION_ID));
+
+        followerRecycleBin.replayErasePartition(PARTITION_ID);
+
+        // 7. Verify follower state
+        Assertions.assertNull(followerRecycleBin.getPartition(PARTITION_ID));
+        Assertions.assertFalse(followerRecycleBin.isContainedInidToRecycleTime(PARTITION_ID));
+    }
+
+    @Test
+    public void testErasePartitionEditLogException() throws Exception {
+        // 1. Create and recycle a partition
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        Partition partition = table.getPartition(PARTITION_NAME);
+        RecyclePartitionInfo partitionInfo = new RecyclePartitionInfoV2(
+                DB_ID, TABLE_ID, partition,
+                DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        partitionInfo.setRecoverable(false);
+        recycleBin.recyclePartition(partitionInfo);
+        
+        // 2. Set recycle time to expired
+        long oldRecycleTime = System.currentTimeMillis() - 
+                (Config.catalog_trash_expire_second + 100) * 1000L;
+        TestCatalogRecycleBin testRecycleBinForPartition = new TestCatalogRecycleBin(recycleBin);
+        testRecycleBinForPartition.setRecycleTime(PARTITION_ID, oldRecycleTime);
+
+        // 3. Mock partition delete to return true - use a spy on the partition info
+        RecyclePartitionInfo recyclePartitionInfo = recycleBin.getRecyclePartitionInfo(PARTITION_ID);
+        RecyclePartitionInfo spyPartitionInfo = spy(recyclePartitionInfo);
+        doReturn(true).when(spyPartitionInfo).delete();
+        
+        // Replace the partition info in recycle bin with the spy
+        recycleBin.setPartitionInfo(PARTITION_ID, spyPartitionInfo);
+        // Create a completed future that returns true
+        CompletableFuture<Boolean> completedFuture = CompletableFuture.completedFuture(true);
+        recycleBin.setDeleteFutureForPartition(spyPartitionInfo, completedFuture);
+
+        // 4. Mock EditLog.logErasePartition to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logErasePartition(any(Long.class), any());
+
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 5. Execute erasePartition and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            recycleBin.erasePartition(System.currentTimeMillis());
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed") ||
+                            exception.getCause() != null &&
+                            exception.getCause().getMessage().contains("EditLog write failed"));
+
+        // 6. Verify partition is still present after exception
+        Assertions.assertNotNull(recycleBin.getPartition(PARTITION_ID));
+    }
+
+    @Test
+    public void testRecoverTableNormalCase() throws Exception {
+        // 1. Create database and recycle a table
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = createDatabase(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+        
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        recycleBin.recycleTable(DB_ID, table, true);
+        
+        Assertions.assertNotNull(recycleBin.getTable(DB_ID, TABLE_ID));
+        Assertions.assertNull(db.getTable(TABLE_NAME));
+
+        // 2. Execute recoverTable
+        boolean recovered = recycleBin.recoverTable(db, TABLE_NAME);
+
+        // 3. Verify master state
+        Assertions.assertTrue(recovered);
+        Assertions.assertNull(recycleBin.getTable(DB_ID, TABLE_ID));
+        Table recoveredTable = db.getTable(TABLE_ID);
+        Assertions.assertNotNull(recoveredTable);
+        Assertions.assertEquals(TABLE_NAME, recoveredTable.getName());
+        Assertions.assertEquals(TABLE_ID, recoveredTable.getId());
+
+        // 4. Test follower replay
+        RecoverInfo replayLog = (RecoverInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_RECOVER_TABLE_V2);
+
+        // Verify replay log
+        Assertions.assertNotNull(replayLog);
+        Assertions.assertEquals(DB_ID, replayLog.getDbId());
+        Assertions.assertEquals(TABLE_ID, replayLog.getTableId());
+        Assertions.assertEquals(-1L, replayLog.getPartitionId());
+
+        // Create follower metastore and the same objects, then replay
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = createDatabase(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+        
+        OlapTable followerTable = createOlapTable(TABLE_ID, TABLE_NAME);
+        CatalogRecycleBin followerRecycleBin = new CatalogRecycleBin();
+        followerRecycleBin.recycleTable(DB_ID, followerTable, true);
+        Assertions.assertNotNull(followerRecycleBin.getTable(DB_ID, TABLE_ID));
+
+        followerRecycleBin.replayRecoverTable(followerDb, TABLE_ID);
+
+        // 5. Verify follower state
+        Assertions.assertNull(followerRecycleBin.getTable(DB_ID, TABLE_ID));
+        Table followerRecoveredTable = followerDb.getTable(TABLE_ID);
+        Assertions.assertNotNull(followerRecoveredTable);
+        Assertions.assertEquals(TABLE_NAME, followerRecoveredTable.getName());
+        Assertions.assertEquals(TABLE_ID, followerRecoveredTable.getId());
+    }
+
+    @Test
+    public void testRecoverTableEditLogException() throws Exception {
+        // 1. Create database and recycle a table
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = createDatabase(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+        
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        recycleBin.recycleTable(DB_ID, table, true);
+
+        // 2. Mock EditLog.logRecoverTable to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logRecoverTable(any(RecoverInfo.class), any());
+
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 3. Execute recoverTable and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            recycleBin.recoverTable(db, TABLE_NAME);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed") ||
+                            exception.getCause() != null &&
+                            exception.getCause().getMessage().contains("EditLog write failed"));
+
+        // 4. Verify table is still in recycle bin after exception
+        Assertions.assertNotNull(recycleBin.getTable(DB_ID, TABLE_ID));
+        Assertions.assertNull(db.getTable(TABLE_NAME));
+    }
+
+    @Test
+    public void testRecoverPartitionNormalCase() throws Exception {
+        // 0. Ensure partition is not already in recycle bin - use synchronized to ensure atomicity
+        recycleBin.removePartitionFromRecycleBin(PARTITION_ID);
+        
+        // 1. Create database and table, then recycle a partition
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = createDatabase(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+        
+        // Use range partitioned table for recoverPartition test (unpartitioned tables don't support partition recovery)
+        OlapTable table = createRangePartitionedOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+        
+        Partition partition = table.getPartition(PARTITION_NAME);
+        Assertions.assertNotNull(partition);
+        
+        // Get range before dropping partition (range info is removed when partition is dropped)
+        RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+        com.google.common.collect.Range<com.starrocks.catalog.PartitionKey> partitionRange = 
+                rangePartitionInfo.getRange(PARTITION_ID);
+        Assertions.assertNotNull(partitionRange, "Partition range should not be null");
+        
+        table.dropPartition(DB_ID, PARTITION_NAME, false);
+
+        Assertions.assertNotNull(recycleBin.getPartition(PARTITION_ID));
+        Assertions.assertNull(table.getPartition(PARTITION_NAME));
+
+        // 2. Execute recoverPartition
+        recycleBin.recoverPartition(DB_ID, table, PARTITION_NAME);
+
+        // 3. Verify master state
+        Assertions.assertNull(recycleBin.getPartition(PARTITION_ID));
+        Partition recoveredPartition = table.getPartition(PARTITION_NAME);
+        Assertions.assertNotNull(recoveredPartition);
+        Assertions.assertEquals(PARTITION_NAME, recoveredPartition.getName());
+        Assertions.assertEquals(PARTITION_ID, recoveredPartition.getId());
+
+        // 4. Test follower replay
+        RecoverInfo replayLog = (RecoverInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_RECOVER_PARTITION_V2);
+
+        // Verify replay log
+        Assertions.assertNotNull(replayLog);
+        Assertions.assertEquals(DB_ID, replayLog.getDbId());
+        Assertions.assertEquals(TABLE_ID, replayLog.getTableId());
+        Assertions.assertEquals(PARTITION_ID, replayLog.getPartitionId());
+
+        // Create follower metastore and the same objects, then replay
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = createDatabase(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+        
+        // Use range partitioned table for follower as well
+        OlapTable followerTable = createRangePartitionedOlapTable(TABLE_ID, TABLE_NAME);
+        followerDb.registerTableUnlocked(followerTable);
+        Partition followerPartition = followerTable.getPartition(PARTITION_NAME);
+        
+        // Get range before dropping partition
+        RangePartitionInfo followerRangePartitionInfo = (RangePartitionInfo) followerTable.getPartitionInfo();
+        com.google.common.collect.Range<com.starrocks.catalog.PartitionKey> followerPartitionRange = 
+                followerRangePartitionInfo.getRange(PARTITION_ID);
+        Assertions.assertNotNull(followerPartitionRange, "Follower partition range should not be null");
+        
+        followerTable.dropPartition(DB_ID, PARTITION_NAME, false);
+        
+        CatalogRecycleBin followerRecycleBin = new CatalogRecycleBin();
+        RecyclePartitionInfo followerPartitionInfo = new RecycleRangePartitionInfo(
+                DB_ID, TABLE_ID, followerPartition, followerPartitionRange,
+                DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        followerRecycleBin.recyclePartition(followerPartitionInfo);
+        Assertions.assertNotNull(followerRecycleBin.getPartition(PARTITION_ID));
+
+        followerRecycleBin.replayRecoverPartition(followerTable, PARTITION_ID);
+
+        // 5. Verify follower state
+        Assertions.assertNull(followerRecycleBin.getPartition(PARTITION_ID));
+        Partition followerRecoveredPartition = followerTable.getPartition(PARTITION_NAME);
+        Assertions.assertNotNull(followerRecoveredPartition);
+        Assertions.assertEquals(PARTITION_NAME, followerRecoveredPartition.getName());
+        Assertions.assertEquals(PARTITION_ID, followerRecoveredPartition.getId());
+    }
+
+    @Test
+    public void testRecoverPartitionEditLogException() throws Exception {
+        // 0. Ensure partition is not already in recycle bin - use synchronized to ensure atomicity
+        recycleBin.removePartitionFromRecycleBin(PARTITION_ID);
+        
+        // 1. Create database and table, then recycle a partition
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = createDatabase(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+        
+        // Use range partitioned table for recoverPartition test (unpartitioned tables don't support partition recovery)
+        OlapTable table = createRangePartitionedOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+        
+        Partition partition = table.getPartition(PARTITION_NAME);
+        Assertions.assertNotNull(partition);
+        
+        // Get range before dropping partition (range info is removed when partition is dropped)
+        RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+        com.google.common.collect.Range<com.starrocks.catalog.PartitionKey> partitionRange = 
+                rangePartitionInfo.getRange(PARTITION_ID);
+        Assertions.assertNotNull(partitionRange, "Partition range should not be null");
+        
+        table.dropPartition(DB_ID, PARTITION_NAME, false);
+        
+        // 2. Mock EditLog.logRecoverPartition to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logRecoverPartition(any(RecoverInfo.class), any());
+
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 3. Execute recoverPartition and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            recycleBin.recoverPartition(DB_ID, table, PARTITION_NAME);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed") ||
+                            exception.getCause() != null &&
+                            exception.getCause().getMessage().contains("EditLog write failed"));
+
+        // 4. Verify partition is still in recycle bin after exception
+        Assertions.assertNotNull(recycleBin.getPartition(PARTITION_ID));
+        Assertions.assertNull(table.getPartition(PARTITION_NAME));
+    }
+
+    // Helper class to access protected members for testing
+    private static class TestCatalogRecycleBin extends CatalogRecycleBin {
+        private final CatalogRecycleBin target;
+
+        public TestCatalogRecycleBin(CatalogRecycleBin target) {
+            this.target = target;
+        }
+
+        public void setRecycleTime(long id, long time) {
+            try {
+                java.lang.reflect.Field field = CatalogRecycleBin.class.getDeclaredField("idToRecycleTime");
+                field.setAccessible(true);
+                @SuppressWarnings("unchecked")
+                java.util.Map<Long, Long> idToRecycleTime = (java.util.Map<Long, Long>) field.get(target);
+                idToRecycleTime.put(id, time);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
@@ -22,10 +22,6 @@ import com.google.common.collect.Sets;
 import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
-import com.starrocks.persist.EditLog;
-import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.SessionVariable;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.RunMode;
@@ -36,14 +32,14 @@ import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.TypeFactory;
-import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -52,6 +48,11 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
 
 public class CatalogRecycleBinTest {
     private static void waitTableClearFinished(CatalogRecycleBin recycleBin, long id,
@@ -96,15 +97,22 @@ public class CatalogRecycleBinTest {
         }
     }
 
-    private static ConnectContext connectContext;
-    private static StarRocksAssert starRocksAssert;
-    private VariableMgr variableMgr = new VariableMgr();
-    private SessionVariable defSessionVariable = new SessionVariable();
+    @BeforeEach
+    public void setup() throws Exception {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        LocalMetastore spyLocalMetastore = spy(new LocalMetastore(globalStateMgr,
+                globalStateMgr.getRecycleBin(), globalStateMgr.getColocateTableIndex()));
+        doNothing().when(spyLocalMetastore).onEraseDatabase(anyLong());
+        doNothing().when(spyLocalMetastore).onErasePartition(any());
+        globalStateMgr.setLocalMetastore(spyLocalMetastore);
 
-    @BeforeAll
-    public static void beforeClass() throws Exception {
-        connectContext = UtFrameUtils.createDefaultCtx();
-        starRocksAssert = new StarRocksAssert(connectContext);
+
+        UtFrameUtils.setUpForPersistTest();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
     }
 
     private static String rowsToString(List<List<String>> rows) {
@@ -155,8 +163,6 @@ public class CatalogRecycleBinTest {
 
     @Test
     public void testGetPartition() throws Exception {
-        FakeEditLog fakeEditLog = new FakeEditLog();
-
         CatalogRecycleBin bin = new CatalogRecycleBin();
         List<Column> columns = Lists.newArrayList(new Column("k1", TypeFactory.createVarcharType(10)));
         Range<PartitionKey> range =
@@ -220,25 +226,7 @@ public class CatalogRecycleBinTest {
     }
 
     @Test
-    public void testReplayEraseTableEx(@Mocked GlobalStateMgr globalStateMgr) {
-
-        ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                result = globalStateMgr;
-
-                globalStateMgr.getCurrentState().getEditLog().logEraseMultiTables((List<Long>) any);
-                minTimes = 1;
-                maxTimes = 1;
-                result = null;
-
-                globalStateMgr.getCurrentState().getClusterSnapshotMgr();
-                minTimes = 0;
-                result = clusterSnapshotMgr;
-            }
-        };
-
+    public void testReplayEraseTableEx() {
         CatalogRecycleBin bin = new CatalogRecycleBin();
         Table table = new Table(1L, "tbl", Table.TableType.HIVE, Lists.newArrayList());
         bin.recycleTable(11, table, true);
@@ -394,14 +382,6 @@ public class CatalogRecycleBinTest {
 
     @Test
     public void testEnsureEraseLater() {
-        ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState().getClusterSnapshotMgr();
-                result = clusterSnapshotMgr;
-            }
-        };
-
         Config.catalog_trash_expire_second = 600; // set expire in 10 minutes
         CatalogRecycleBin recycleBin = new CatalogRecycleBin();
         Database db = new Database(111, "uno");
@@ -458,7 +438,7 @@ public class CatalogRecycleBinTest {
     }
 
     @Test
-    public void testRecycleDb(@Mocked GlobalStateMgr globalStateMgr, @Mocked EditLog editLog) {
+    public void testRecycleDb() {
         Database db1 = new Database(111, "uno");
         Database db2SameName = new Database(22, "dos"); // samename
         Database db2 = new Database(222, "dos");
@@ -480,37 +460,6 @@ public class CatalogRecycleBinTest {
         long now = System.currentTimeMillis();
         long expireFromNow = now - 3600 * 1000L;
         recycleBin.idToRecycleTime.put(db1.getId(), expireFromNow - 1000);
-
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-            }
-        };
-        new Expectations() {
-            {
-                globalStateMgr.getLocalMetastore().onEraseDatabase(anyLong);
-                minTimes = 0;
-                globalStateMgr.getEditLog();
-                minTimes = 0;
-                result = editLog;
-            }
-        };
-        new Expectations() {
-            {
-                editLog.logEraseDb(anyLong);
-                minTimes = 0;
-            }
-        };
-        ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
-        new Expectations() {
-            {
-                globalStateMgr.getCurrentState().getClusterSnapshotMgr();
-                minTimes = 0;
-                result = clusterSnapshotMgr;
-            }
-        };
 
         recycleBin.eraseDatabase(now);
 
@@ -545,38 +494,7 @@ public class CatalogRecycleBinTest {
     }
 
     @Test
-    public void testRecycleTableMaxBatchSize(@Mocked GlobalStateMgr globalStateMgr, @Mocked EditLog editLog) {
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                minTimes = 1;
-                result = globalStateMgr;
-            }
-        };
-        new Expectations() {
-            {
-                globalStateMgr.getEditLog();
-                minTimes = 1;
-                maxTimes = 1;
-                result = editLog;
-            }
-        };
-        new Expectations() {
-            {
-                editLog.logEraseMultiTables((List<Long>) any);
-                minTimes = 1;
-                maxTimes = 1;
-                result = null;
-            }
-        };
-        ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
-        new Expectations() {
-            {
-                globalStateMgr.getCurrentState().getClusterSnapshotMgr();
-                minTimes = 0;
-                result = clusterSnapshotMgr;
-            }
-        };
+    public void testRecycleTableMaxBatchSize() {
         CatalogRecycleBin recycleBin = new CatalogRecycleBin();
         for (int i = 0; i < CatalogRecycleBin.getMaxEraseOperationsPerCycle() + 1; i++) {
             Table t = new Table(i, String.format("t%d", i), Table.TableType.VIEW, null);
@@ -588,40 +506,10 @@ public class CatalogRecycleBinTest {
     }
 
     @Test
-    public void testRecycleTable(@Mocked GlobalStateMgr globalStateMgr, @Mocked EditLog editLog) {
+    public void testRecycleTable() {
         Table table1 = new Table(111, "uno", Table.TableType.VIEW, null);
         Table table2SameName = new Table(22, "dos", Table.TableType.VIEW, null);
         Table table2 = new Table(222, "dos", Table.TableType.VIEW, null);
-
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-            }
-        };
-        new Expectations() {
-            {
-                globalStateMgr.getEditLog();
-                minTimes = 0;
-                result = editLog;
-            }
-        };
-        new Expectations() {
-            {
-                editLog.logEraseMultiTables((List<Long>) any);
-                minTimes = 0;
-                result = null;
-            }
-        };
-        ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
-        new Expectations() {
-            {
-                globalStateMgr.getCurrentState().getClusterSnapshotMgr();
-                minTimes = 0;
-                result = clusterSnapshotMgr;
-            }
-        };
 
         // 1. add 2 tables
         long dbId = 1;
@@ -676,42 +564,10 @@ public class CatalogRecycleBinTest {
     }
 
     @Test
-    public void testRecyclePartition(@Mocked GlobalStateMgr globalStateMgr, @Mocked EditLog editLog) {
+    public void testRecyclePartition() {
         Partition p1 = new Partition(111, 112, "uno", null, null);
         Partition p2SameName = new Partition(22, 221, "dos", null, null);
         Partition p2 = new Partition(222, 223, "dos", null, null);
-
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-            }
-        };
-        new Expectations() {
-            {
-                globalStateMgr.getLocalMetastore().onErasePartition((Partition) any);
-                minTimes = 0;
-
-                globalStateMgr.getEditLog();
-                minTimes = 0;
-                result = editLog;
-            }
-        };
-        new Expectations() {
-            {
-                editLog.logErasePartition(anyLong);
-                minTimes = 0;
-            }
-        };
-        ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
-        new Expectations() {
-            {
-                globalStateMgr.getCurrentState().getClusterSnapshotMgr();
-                minTimes = 0;
-                result = clusterSnapshotMgr;
-            }
-        };
 
         // 1. add 2 partitions
         long dbId = 1;
@@ -768,8 +624,7 @@ public class CatalogRecycleBinTest {
     }
 
     @Test
-    public void testShowCatalogRecycleBinDatabase(@Mocked GlobalStateMgr globalStateMgr, @Mocked EditLog editLog,
-            @Mocked LocalMetastore localMetaStore, @Mocked ClusterSnapshotMgr clusterSnapshotMgr) {
+    public void testShowCatalogRecycleBinDatabase() {
         Database db1 = new Database(211, "uno");
         Database db2SameName = new Database(32, "dos"); // samename
         Database db2 = new Database(422, "dos");
@@ -792,78 +647,6 @@ public class CatalogRecycleBinTest {
         long expireFromNow = now - 3600 * 1000L;
         recycleBin.idToRecycleTime.put(db1.getId(), expireFromNow - 1000);
 
-        new Expectations(globalStateMgr) {
-            {
-                globalStateMgr.getClusterSnapshotMgr();
-                minTimes = 0;
-                result = clusterSnapshotMgr;
-            }
-        };
-        new Expectations(clusterSnapshotMgr) {
-            {
-                clusterSnapshotMgr.isDeletionSafeToExecute(anyLong);
-                minTimes = 0;
-                result = true;
-            }
-        };
-
-        new Expectations(globalStateMgr) {
-            {
-                globalStateMgr.getLocalMetastore();
-                minTimes = 0;
-                result = localMetaStore;
-            }
-        };
-        new Expectations(globalStateMgr) {
-            {
-                globalStateMgr.getEditLog();
-                minTimes = 0;
-                result = editLog;
-            }
-        };
-        new Expectations() {
-            {
-                localMetaStore.onEraseDatabase(anyLong);
-                minTimes = 0;
-            }
-        };
-        new Expectations() {
-            {
-                editLog.logEraseDb(anyLong);
-                minTimes = 0;
-            }
-        };
-        String tz = "Asia/Shanghai";
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-
-                globalStateMgr.getVariableMgr();
-                minTimes = 0;
-                result = variableMgr;
-            }
-        };
-        new Expectations() {
-            {
-                variableMgr.getDefaultSessionVariable();
-                minTimes = 0;
-                result = defSessionVariable;
-
-                defSessionVariable.getTimeZone();
-                minTimes = 0;
-                result = tz;
-            }
-        };
-        new Expectations() {
-            {
-                connectContext.getSessionVariable().getTimeZone();
-                minTimes = 0;
-                result = tz;
-            }
-        };
-
         recycleBin.eraseDatabase(now);
 
         Assertions.assertEquals(recycleBin.getDatabase(db1.getId()), null);
@@ -878,80 +661,10 @@ public class CatalogRecycleBinTest {
     }
 
     @Test
-    public void testShowCatalogRecycleBinTable(@Mocked GlobalStateMgr globalStateMgr, @Mocked EditLog editLog,
-            @Mocked VariableMgr variableMgr, @Mocked LocalMetastore localMetaStore, 
-            @Mocked ClusterSnapshotMgr clusterSnapshotMgr) {
+    public void testShowCatalogRecycleBinTable() {
         Table table1 = new Table(111, "uno", Table.TableType.VIEW, null);
         Table table2SameName = new Table(22, "dos", Table.TableType.VIEW, null);
         Table table2 = new Table(222, "dos", Table.TableType.VIEW, null);
-
-        new Expectations(globalStateMgr) {
-            {
-                globalStateMgr.getClusterSnapshotMgr();
-                minTimes = 0;
-                result = clusterSnapshotMgr;
-            }
-        };
-        new Expectations(clusterSnapshotMgr) {
-            {
-                clusterSnapshotMgr.isDeletionSafeToExecute(anyLong);
-                minTimes = 0;
-                result = true;
-            }
-        };
-
-        new Expectations(globalStateMgr) {
-            {
-                globalStateMgr.getLocalMetastore();
-                minTimes = 0;
-                result = localMetaStore;
-            }
-        };
-
-        new Expectations() {
-            {
-                globalStateMgr.getEditLog();
-                minTimes = 0;
-                result = editLog;
-            }
-        };
-        new Expectations() {
-            {
-                editLog.logEraseMultiTables((List<Long>) any);
-                minTimes = 0;
-                result = null;
-            }
-        };
-        String tz = "Asia/Shanghai";
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-
-                globalStateMgr.getVariableMgr();
-                minTimes = 0;
-                result = variableMgr;
-            }
-        };
-        new Expectations() {
-            {
-                variableMgr.getDefaultSessionVariable();
-                minTimes = 0;
-                result = defSessionVariable;
-
-                defSessionVariable.getTimeZone();
-                minTimes = 0;
-                result = tz;
-            }
-        };
-        new Expectations() {
-            {
-                connectContext.getSessionVariable().getTimeZone();
-                minTimes = 0;
-                result = tz;
-            }
-        };
 
         // 1. add 2 tables
         long dbId = 1;
@@ -984,84 +697,10 @@ public class CatalogRecycleBinTest {
     }
 
     @Test
-    public void testShowCatalogRecycleBinPartition(@Mocked GlobalStateMgr globalStateMgr, @Mocked EditLog editLog,
-            @Mocked LocalMetastore localMetaStore, @Mocked ClusterSnapshotMgr clusterSnapshotMgr) {
+    public void testShowCatalogRecycleBinPartition() {
         Partition p1 = new Partition(111, 112, "uno", null, null);
         Partition p2SameName = new Partition(22, 23, "dos", null, null);
         Partition p2 = new Partition(222, 223, "dos", null, null);
-
-        new Expectations(globalStateMgr) {
-            {
-                globalStateMgr.getClusterSnapshotMgr();
-                minTimes = 0;
-                result = clusterSnapshotMgr;
-            }
-        };
-        new Expectations(clusterSnapshotMgr) {
-            {
-                clusterSnapshotMgr.isDeletionSafeToExecute(anyLong);
-                minTimes = 0;
-                result = true;
-            }
-        };
-
-        new Expectations(globalStateMgr) {
-            {
-                globalStateMgr.getLocalMetastore();
-                minTimes = 0;
-                result = localMetaStore;
-            }
-        };
-        new Expectations(globalStateMgr) {
-            {
-                globalStateMgr.getEditLog();
-                minTimes = 0;
-                result = editLog;
-            }
-        };
-        new Expectations() {
-            {
-                localMetaStore.onEraseDatabase(anyLong);
-                minTimes = 0;
-            }
-        };
-        new Expectations() {
-            {
-                editLog.logErasePartition(anyLong);
-                minTimes = 0;
-            }
-        };
-        String tz = "Asia/Shanghai";
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-
-                globalStateMgr.getVariableMgr();
-                minTimes = 0;
-                result = variableMgr;
-            }
-        };
-        new Expectations() {
-            {
-                variableMgr.getDefaultSessionVariable();
-                minTimes = 0;
-                result = defSessionVariable;
-
-                defSessionVariable.getTimeZone();
-                minTimes = 0;
-                result = tz;
-            }
-        };
-
-        new Expectations() {
-            {
-                connectContext.getSessionVariable().getTimeZone();
-                minTimes = 0;
-                result = tz;
-            }
-        };
 
         // 1. add 2 partitions
         long dbId = 1;
@@ -1092,27 +731,7 @@ public class CatalogRecycleBinTest {
     }
 
     @Test
-    public void testTimeExpiredWithRetentionPeriod(@Mocked GlobalStateMgr globalStateMgr, @Mocked EditLog editLog) {
-        ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                minTimes = 0;
-                result = globalStateMgr;
-
-                globalStateMgr.getClusterSnapshotMgr();
-                minTimes = 0;
-                result = clusterSnapshotMgr;
-
-                globalStateMgr.getEditLog();
-                minTimes = 0;
-                result = editLog;
-
-                editLog.logErasePartition(anyLong);
-                minTimes = 0;
-            }
-        };
-
+    public void testTimeExpiredWithRetentionPeriod() {
         long dbId = 1;
         long tableId = 2;
         DataProperty dataProperty = new DataProperty(TStorageMedium.HDD);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableEditLogTest.java
@@ -1,0 +1,214 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.connector.hive.HiveStorageFormat;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.ModifyTableColumnOperationLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.StringType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class HiveTableEditLogTest {
+    private static final String DB_NAME = "test_hive_table_editlog";
+    private static final String TABLE_NAME = "test_hive_table";
+    private static final long DB_ID = 20001L;
+    private static final long TABLE_ID = 20002L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        // Create database and table directly (no mincluster)
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private static HiveTable createHiveTable(long tableId, String tableName) {
+        List<Column> columns = new ArrayList<>();
+        columns.add(new Column("col1", IntegerType.BIGINT));
+        columns.add(new Column("col2", new StringType(100)));
+        
+        List<String> dataColumnNames = new ArrayList<>();
+        dataColumnNames.add("col1");
+        dataColumnNames.add("col2");
+        
+        HiveTable hiveTable = new HiveTable(
+                tableId, tableName, columns, "test_resource", "test_catalog",
+                "hive_db", "hive_table", "hdfs://path", "comment", System.currentTimeMillis(),
+                new ArrayList<>(), dataColumnNames, new HashMap<>(), new HashMap<>(),
+                HiveStorageFormat.PARQUET, HiveTable.HiveTableType.EXTERNAL_TABLE);
+        return hiveTable;
+    }
+
+    @Test
+    public void testModifyTableSchemaNormalCase() throws Exception {
+        // 1. Create HiveTable
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        HiveTable hiveTable = createHiveTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(hiveTable);
+        
+        // Verify initial state
+        Assertions.assertEquals(2, hiveTable.getFullSchema().size());
+        Assertions.assertEquals(2, hiveTable.getDataColumnNames().size());
+        
+        // 2. Create updated HiveTable with new schema
+        List<Column> newColumns = new ArrayList<>();
+        newColumns.add(new Column("col1", IntegerType.BIGINT));
+        newColumns.add(new Column("col2", new StringType(100)));
+        newColumns.add(new Column("col3", IntegerType.INT)); // New column
+        
+        List<String> newDataColumnNames = new ArrayList<>();
+        newDataColumnNames.add("col1");
+        newDataColumnNames.add("col2");
+        newDataColumnNames.add("col3");
+        
+        HiveTable updatedTable = new HiveTable(
+                TABLE_ID, TABLE_NAME, newColumns, "test_resource", "test_catalog",
+                "hive_db", "hive_table", "hdfs://path", "comment", System.currentTimeMillis(),
+                new ArrayList<>(), newDataColumnNames, new HashMap<>(), new HashMap<>(),
+                HiveStorageFormat.PARQUET, HiveTable.HiveTableType.EXTERNAL_TABLE);
+        
+        // 3. Execute modifyTableSchema
+        hiveTable.modifyTableSchema(DB_NAME, TABLE_NAME, updatedTable);
+        
+        // 4. Verify master state
+        HiveTable modifiedTable = (HiveTable) db.getTable(TABLE_NAME);
+        Assertions.assertNotNull(modifiedTable);
+        Assertions.assertEquals(3, modifiedTable.getFullSchema().size());
+        Assertions.assertEquals(3, modifiedTable.getDataColumnNames().size());
+        Assertions.assertTrue(modifiedTable.getDataColumnNames().contains("col3"));
+        Assertions.assertNotNull(modifiedTable.getColumn("col3"));
+        
+        // 5. Test follower replay
+        ModifyTableColumnOperationLog replayInfo = (ModifyTableColumnOperationLog) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_MODIFY_HIVE_TABLE_COLUMN);
+        
+        // Verify replay info
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(DB_NAME, replayInfo.getDbName());
+        Assertions.assertEquals(TABLE_NAME, replayInfo.getTableName());
+        Assertions.assertEquals(3, replayInfo.getColumns().size());
+        
+        // Create follower metastore and the same id objects, then replay into it
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+        
+        // Create HiveTable with same ID and initial schema
+        HiveTable followerTable = createHiveTable(TABLE_ID, TABLE_NAME);
+        followerDb.registerTableUnlocked(followerTable);
+        
+        followerMetastore.replayModifyHiveTableColumn(OperationType.OP_MODIFY_HIVE_TABLE_COLUMN, replayInfo);
+        
+        // 6. Verify follower state
+        HiveTable replayed = (HiveTable) followerDb.getTable(TABLE_ID);
+        Assertions.assertNotNull(replayed);
+        Assertions.assertEquals(3, replayed.getFullSchema().size());
+        // Note: replayModifyHiveTableColumn only sets fullSchema via setNewFullSchema,
+        // it doesn't update dataColumnNames. So we verify fullSchema is correct.
+        Assertions.assertNotNull(replayed.getColumn("col3"));
+        
+        // Verify all columns match
+        for (int i = 0; i < modifiedTable.getFullSchema().size(); i++) {
+            Column masterCol = modifiedTable.getFullSchema().get(i);
+            Column followerCol = replayed.getFullSchema().get(i);
+            Assertions.assertEquals(masterCol.getName(), followerCol.getName());
+            Assertions.assertEquals(masterCol.getType(), followerCol.getType());
+        }
+        
+        // Verify the new column exists in fullSchema
+        boolean foundCol3 = false;
+        for (Column col : replayed.getFullSchema()) {
+            if ("col3".equals(col.getName())) {
+                foundCol3 = true;
+                break;
+            }
+        }
+        Assertions.assertTrue(foundCol3, "col3 should exist in fullSchema after replay");
+    }
+
+    @Test
+    public void testModifyTableSchemaEditLogException() throws Exception {
+        // 1. Create HiveTable
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        HiveTable hiveTable = createHiveTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(hiveTable);
+        
+        // Verify initial state
+        Assertions.assertEquals(2, hiveTable.getFullSchema().size());
+        
+        // 2. Create updated HiveTable
+        List<Column> newColumns = new ArrayList<>();
+        newColumns.add(new Column("col1", IntegerType.BIGINT));
+        newColumns.add(new Column("col2", new StringType(100)));
+        newColumns.add(new Column("col3", IntegerType.INT));
+        
+        List<String> newDataColumnNames = new ArrayList<>();
+        newDataColumnNames.add("col1");
+        newDataColumnNames.add("col2");
+        newDataColumnNames.add("col3");
+        
+        HiveTable updatedTable = new HiveTable(
+                TABLE_ID, TABLE_NAME, newColumns, "test_resource", "test_catalog",
+                "hive_db", "hive_table", "hdfs://path", "comment", System.currentTimeMillis(),
+                new ArrayList<>(), newDataColumnNames, new HashMap<>(), new HashMap<>(),
+                HiveStorageFormat.PARQUET, HiveTable.HiveTableType.EXTERNAL_TABLE);
+        
+        // 3. Mock EditLog.logModifyTableColumn to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logModifyTableColumn(any(ModifyTableColumnOperationLog.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+        
+        // 4. Execute modifyTableSchema and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            hiveTable.modifyTableSchema(DB_NAME, TABLE_NAME, updatedTable);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed") || 
+                            exception.getCause() != null && 
+                            exception.getCause().getMessage().contains("EditLog write failed"));
+        
+        // 5. Verify table schema remains unchanged after exception
+        HiveTable unchangedTable = (HiveTable) db.getTable(TABLE_NAME);
+        Assertions.assertNotNull(unchangedTable);
+        Assertions.assertEquals(2, unchangedTable.getFullSchema().size());
+        Assertions.assertEquals(2, unchangedTable.getDataColumnNames().size());
+        Assertions.assertNull(unchangedTable.getColumn("col3"));
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MockedLocalMetaStore.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MockedLocalMetaStore.java
@@ -91,6 +91,15 @@ public class MockedLocalMetaStore extends LocalMetastore {
     }
 
     @Override
+    public void unprotectCreateDb(Database database) {
+        nameToDb.put(database.getFullName(), database);
+        idToDb.put(database.getId(), database);
+
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        globalTransactionMgr.addDatabaseTransactionMgr(database.getId());
+    }
+
+    @Override
     public boolean createTable(CreateTableStmt stmt) throws DdlException {
         Database db = getDb(stmt.getDbName());
         String tableName = stmt.getTableName();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ReplaceLakePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ReplaceLakePartitionTest.java
@@ -24,6 +24,7 @@ import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.persist.EditLog;
+import com.starrocks.persist.WALApplier;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.thrift.TStorageMedium;
@@ -92,8 +93,13 @@ public class ReplaceLakePartitionTest {
 
         new MockUp<EditLog>() {
             @Mock
-            public void logErasePartition(long partitionId) {
-                return;
+            public void logErasePartition(long partitionId, WALApplier walApplier) {
+                walApplier.apply(null);
+            }
+
+            @Mock
+            public void logEraseMultiTables(List<Long> tableIds, WALApplier walApplier) {
+                walApplier.apply(null);
             }
         };
     }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerEditLogTest.java
@@ -1,0 +1,265 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.clone;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.Config;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.ReplicaPersistInfo;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.system.Backend;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class TabletSchedulerEditLogTest {
+    private static final String DB_NAME = "test_tablet_scheduler_editlog";
+    private static final long DB_ID = 60001L;
+    private static final long TABLE_ID = 60002L;
+    private static final long PARTITION_ID = 60004L;
+    private static final long PHYSICAL_PARTITION_ID = 60005L;
+    private static final long INDEX_ID = 60006L;
+    private static final long TABLET_ID = 60007L;
+    private static final long BACKEND_ID = 60008L;
+    private static final long REPLICA_ID = 60009L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        // Create database and table directly (no mincluster)
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+        
+        // Add backend
+        Backend backend = new Backend(BACKEND_ID, "127.0.0.1", 9050);
+        backend.setAlive(true);
+        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().addBackend(backend);
+        
+        // Set config to allow force delete
+        Config.tablet_sched_always_force_decommission_replica = true;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+        Config.tablet_sched_always_force_decommission_replica = false;
+    }
+
+    private static OlapTable createOlapTable(long tableId, String tableName) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("v1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("v2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(3, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(TABLET_ID);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, tableId, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        // Add replica to tablet
+        Replica replica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        replica.updateVersionInfo(2, 2, 2);
+        tablet.addReplica(replica);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1", baseIndex, distributionInfo);
+
+        OlapTable olapTable = new OlapTable(tableId, tableName, columns, 
+                com.starrocks.sql.ast.KeysType.DUP_KEYS, partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(INDEX_ID, tableName, columns, 0, 0, (short) 1, 
+                com.starrocks.thrift.TStorageType.COLUMN, com.starrocks.sql.ast.KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(INDEX_ID);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new com.starrocks.catalog.TableProperty(new java.util.HashMap<>()));
+        return olapTable;
+    }
+
+    @Test
+    public void testDeleteReplicaInternalNormalCase() throws Exception {
+        // 1. Create table with tablet and replica
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, "test_table");
+        db.registerTableUnlocked(table);
+
+        // Add tablet to inverted index
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+        Replica replica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica);
+
+        // 2. Create TabletSchedCtx
+        TabletSchedCtx tabletCtx = new TabletSchedCtx(
+                TabletSchedCtx.Type.REPAIR,
+                DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, INDEX_ID, TABLET_ID,
+                System.currentTimeMillis(),
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+        
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+        tabletCtx.setTablet(tablet);
+
+        // Verify initial state - tablet has replica
+        Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID));
+
+        // 3. Create TabletScheduler
+        TabletScheduler tabletScheduler = new TabletScheduler(new TabletSchedulerStat());
+
+        // 4. Execute deleteReplicaInternal with force = true
+        tabletScheduler.deleteReplicaInternal(tabletCtx, replica, "test reason", true);
+
+        // 5. Verify master state - replica should be deleted from tablet
+        Assertions.assertNull(tablet.getReplicaByBackendId(BACKEND_ID));
+
+        // 6. Test follower replay
+        ReplicaPersistInfo replayInfo = (ReplicaPersistInfo) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_DELETE_REPLICA_V2);
+
+        // Verify replay info
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(DB_ID, replayInfo.getDbId());
+        Assertions.assertEquals(TABLE_ID, replayInfo.getTableId());
+        Assertions.assertEquals(PHYSICAL_PARTITION_ID, replayInfo.getPartitionId());
+        Assertions.assertEquals(INDEX_ID, replayInfo.getIndexId());
+        Assertions.assertEquals(TABLET_ID, replayInfo.getTabletId());
+        Assertions.assertEquals(BACKEND_ID, replayInfo.getBackendId());
+
+        // Create follower metastore and the same id objects, then replay
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+
+        // Create table with same ID
+        OlapTable followerTable = createOlapTable(TABLE_ID, "test_table");
+        followerDb.registerTableUnlocked(followerTable);
+
+        // Add tablet to inverted index for follower
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+        Replica followerReplica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, followerReplica);
+
+        // Verify follower initial state
+        Partition followerPartition = followerTable.getPartition(PARTITION_ID);
+        PhysicalPartition followerPhysicalPartition = followerPartition.getDefaultPhysicalPartition();
+        MaterializedIndex followerIndex = followerPhysicalPartition.getIndex(INDEX_ID);
+        LocalTablet followerTablet = (LocalTablet) followerIndex.getTablet(TABLET_ID);
+        Assertions.assertNotNull(followerTablet.getReplicaByBackendId(BACKEND_ID));
+
+        // Replay the operation
+        followerMetastore.replayDeleteReplica(replayInfo);
+
+        // 7. Verify follower state
+        followerTablet = (LocalTablet) followerIndex.getTablet(TABLET_ID);
+        Assertions.assertNull(followerTablet.getReplicaByBackendId(BACKEND_ID),
+                "Replica should be deleted after replay");
+        
+        // Verify all properties match
+        Assertions.assertEquals(DB_ID, replayInfo.getDbId());
+        Assertions.assertEquals(TABLE_ID, replayInfo.getTableId());
+        Assertions.assertEquals(PHYSICAL_PARTITION_ID, replayInfo.getPartitionId());
+        Assertions.assertEquals(INDEX_ID, replayInfo.getIndexId());
+        Assertions.assertEquals(TABLET_ID, replayInfo.getTabletId());
+        Assertions.assertEquals(BACKEND_ID, replayInfo.getBackendId());
+    }
+
+    @Test
+    public void testDeleteReplicaInternalEditLogException() throws Exception {
+        // 1. Create table with tablet and replica
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, "test_table");
+        db.registerTableUnlocked(table);
+
+        // Add tablet to inverted index
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+        Replica replica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica);
+
+        // 2. Create TabletSchedCtx
+        TabletSchedCtx tabletCtx = new TabletSchedCtx(
+                TabletSchedCtx.Type.REPAIR,
+                DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, INDEX_ID, TABLET_ID,
+                System.currentTimeMillis(),
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+        
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+        tabletCtx.setTablet(tablet);
+
+        // Verify initial state
+        Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID));
+
+        // 3. Mock EditLog.logDeleteReplica to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logDeleteReplica(any(ReplicaPersistInfo.class), any());
+
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Create TabletScheduler
+        TabletScheduler tabletScheduler = new TabletScheduler(new TabletSchedulerStat());
+
+        // 5. Execute deleteReplicaInternal and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            tabletScheduler.deleteReplicaInternal(tabletCtx, replica, "test reason", true);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed") || 
+                            exception.getCause() != null && 
+                            exception.getCause().getMessage().contains("EditLog write failed"));
+
+        // 6. Verify replica may or may not be deleted (deleteReplica is called in WALApplier)
+        // The replica deletion happens in the WALApplier callback, so if EditLog fails,
+        // the callback won't be executed, and replica should still exist
+        Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID),
+                "Replica should still exist if EditLog write failed");
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/MetaRecoveryDaemonEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/MetaRecoveryDaemonEditLogTest.java
@@ -1,0 +1,181 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.consistency;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.PartitionVersionRecoveryInfo;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MetaRecoveryDaemonEditLogTest {
+    private static final String DB_NAME = "test_meta_recovery_editlog";
+    private static final long DB_ID = 50001L;
+    private static final long TABLE_ID = 50002L;
+    private static final long PARTITION_ID = 50004L;
+    private static final long PHYSICAL_PARTITION_ID = 50005L;
+    private static final long INDEX_ID = 50006L;
+    private static final long TABLET_ID = 50007L;
+    private static final long BACKEND_ID = 50008L;
+    private static final long REPLICA_ID = 50009L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        // Create database and table directly (no mincluster)
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private static OlapTable createOlapTable(long tableId, String tableName) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("v1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("v2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(3, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(TABLET_ID);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, tableId, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        // Add replica to tablet
+        Replica replica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        replica.updateVersionInfo(2, 2, 2);
+        tablet.addReplica(replica);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1", baseIndex, distributionInfo);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        physicalPartition.setVisibleVersion(1, System.currentTimeMillis());
+        physicalPartition.setNextVersion(2);
+
+        OlapTable olapTable = new OlapTable(tableId, tableName, columns, 
+                com.starrocks.sql.ast.KeysType.DUP_KEYS, partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(INDEX_ID, tableName, columns, 0, 0, (short) 1, 
+                com.starrocks.thrift.TStorageType.COLUMN, com.starrocks.sql.ast.KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(INDEX_ID);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new com.starrocks.catalog.TableProperty(new java.util.HashMap<>()));
+        return olapTable;
+    }
+
+    @Test
+    public void testRecoverNormalCase() throws Exception {
+        // 1. Create table with partition
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, "test_table");
+        db.registerTableUnlocked(table);
+
+        // Verify initial state - partition has visible version 1
+        PhysicalPartition physicalPartition = table.getPartition(PARTITION_ID).getDefaultPhysicalPartition();
+        long initialVisibleVersion = physicalPartition.getVisibleVersion();
+        Assertions.assertEquals(1L, initialVisibleVersion);
+
+        // 2. Create PartitionVersionRecoveryInfo directly to test EditLog
+        long recoverVersion = 2L;
+        List<PartitionVersionRecoveryInfo.PartitionVersion> partitionVersions = new ArrayList<>();
+        partitionVersions.add(new PartitionVersionRecoveryInfo.PartitionVersion(
+                DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, recoverVersion));
+        PartitionVersionRecoveryInfo recoveryInfo = 
+                new PartitionVersionRecoveryInfo(partitionVersions, System.currentTimeMillis());
+
+        // 3. Execute recoverPartitionVersion and log EditLog
+        MetaRecoveryDaemon recoveryDaemon = new MetaRecoveryDaemon();
+        // Log EditLog
+        GlobalStateMgr.getCurrentState().getEditLog()
+                .logRecoverPartitionVersion(recoveryInfo, wal -> recoveryDaemon.recoverPartitionVersion(recoveryInfo));
+
+        // 4. Verify master state - partition version should be recovered
+        physicalPartition = table.getPartition(PARTITION_ID).getDefaultPhysicalPartition();
+        Assertions.assertEquals(recoverVersion, physicalPartition.getVisibleVersion(),
+                "Partition visible version should be updated to recovery version");
+
+        // 5. Test follower replay
+        PartitionVersionRecoveryInfo replayInfo = (PartitionVersionRecoveryInfo) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_RECOVER_PARTITION_VERSION);
+
+        // Verify replay info
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertNotNull(replayInfo.getPartitionVersions());
+        Assertions.assertEquals(1, replayInfo.getPartitionVersions().size());
+        Assertions.assertEquals(DB_ID, replayInfo.getPartitionVersions().get(0).getDbId());
+        Assertions.assertEquals(TABLE_ID, replayInfo.getPartitionVersions().get(0).getTableId());
+        Assertions.assertEquals(PHYSICAL_PARTITION_ID, replayInfo.getPartitionVersions().get(0).getPartitionId());
+        Assertions.assertEquals(recoverVersion, replayInfo.getPartitionVersions().get(0).getVersion());
+        Assertions.assertTrue(replayInfo.getRecoverTime() > 0);
+
+        // Reset the table to initial state for replay test
+        // First, reset the master table's version back to initial state
+        physicalPartition = table.getPartition(PARTITION_ID).getDefaultPhysicalPartition();
+        physicalPartition.setVisibleVersion(1L, System.currentTimeMillis());
+        physicalPartition.setNextVersion(2L);
+
+        // Replay the operation using the same GlobalStateMgr (simulating follower replay)
+        MetaRecoveryDaemon followerRecoveryDaemon = new MetaRecoveryDaemon();
+        followerRecoveryDaemon.recoverPartitionVersion(replayInfo);
+
+        // 6. Verify follower state
+        physicalPartition = table.getPartition(PARTITION_ID).getDefaultPhysicalPartition();
+        // After replay, the visible version should be set to the recovery version
+        Assertions.assertEquals(recoverVersion, physicalPartition.getVisibleVersion(),
+                "Partition visible version should match recovery version after replay");
+        
+        // Verify all properties match in replayInfo
+        PartitionVersionRecoveryInfo.PartitionVersion masterPv = recoveryInfo.getPartitionVersions().get(0);
+        PartitionVersionRecoveryInfo.PartitionVersion followerPv = replayInfo.getPartitionVersions().get(0);
+        Assertions.assertEquals(masterPv.getDbId(), followerPv.getDbId());
+        Assertions.assertEquals(masterPv.getTableId(), followerPv.getTableId());
+        Assertions.assertEquals(masterPv.getPartitionId(), followerPv.getPartitionId());
+        Assertions.assertEquals(masterPv.getVersion(), followerPv.getVersion());
+        
+        // Verify recoverTime is set (may differ slightly due to timing)
+        Assertions.assertTrue(replayInfo.getRecoverTime() > 0);
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/lake/RecycleLakePartitionInfoEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/RecycleLakePartitionInfoEditLogTest.java
@@ -1,0 +1,291 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.google.common.collect.Range;
+import com.starrocks.catalog.CatalogRecycleBin;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.persist.DisablePartitionRecoveryInfo;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class RecycleLakePartitionInfoEditLogTest {
+    private static final String DB_NAME = "test_recycle_lake_partition_editlog";
+    private static final long DB_ID = 40001L;
+    private static final long TABLE_ID = 40002L;
+    private static final long PARTITION_ID = 40004L;
+    private static final long PHYSICAL_PARTITION_ID = 40005L;
+    private static final long INDEX_ID = 40006L;
+    private static final long TABLET_ID = 40007L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        // Create database directly (no mincluster)
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+        
+        // Initialize default warehouse
+        GlobalStateMgr.getCurrentState().getWarehouseMgr().initDefaultWarehouse();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private static Partition createPartition(long partitionId, long physicalPartitionId, String partitionName) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("v1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("v2", IntegerType.BIGINT));
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(3, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(TABLET_ID);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, partitionId, INDEX_ID, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(partitionId, physicalPartitionId, partitionName, baseIndex, distributionInfo);
+        return partition;
+    }
+
+    @Test
+    public void testRecycleLakeListPartitionInfoDeleteNormalCase() throws Exception {
+        // 1. Create partition
+        Partition partition = createPartition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1");
+
+        // 2. Create RecycleLakeListPartitionInfo with recoverable = true
+        RecycleLakeListPartitionInfo partitionInfo = new RecycleLakeListPartitionInfo(
+                DB_ID, TABLE_ID, partition,
+                DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        partitionInfo.setRecoverable(true);
+
+        // Verify initial state
+        Assertions.assertTrue(partitionInfo.isRecoverable());
+
+        // 3. Mock LakeTableHelper.removePartitionDirectory to return true
+        // Mock LakeTableHelper using MockUp
+        new MockUp<LakeTableHelper>() {
+            @Mock
+            public boolean removePartitionDirectory(Partition partition, ComputeResource computeResource) {
+                return true;
+            }
+            
+            @Mock
+            public void deleteShardGroupMeta(Partition partition) {
+                // Do nothing
+            }
+        };
+
+        // 4. Execute delete
+        boolean result = partitionInfo.delete();
+        // 5. Verify master state
+        Assertions.assertTrue(result);
+        Assertions.assertFalse(partitionInfo.isRecoverable(), "Partition should not be recoverable after delete");
+
+        // 6. Test follower replay
+        DisablePartitionRecoveryInfo replayInfo = (DisablePartitionRecoveryInfo) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_DISABLE_PARTITION_RECOVERY);
+
+        // Verify replay info
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(PARTITION_ID, replayInfo.getPartitionId());
+
+        CatalogRecycleBin followerRecycleBin = new CatalogRecycleBin();
+        // 2. Create RecycleLakeListPartitionInfo with recoverable = true
+        RecycleLakeListPartitionInfo followerPartitionInfo = new RecycleLakeListPartitionInfo(
+                DB_ID, TABLE_ID, partition,
+                DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        followerPartitionInfo.setRecoverable(true);
+        followerRecycleBin.recyclePartition(followerPartitionInfo);
+
+        followerRecycleBin.replayDisablePartitionRecovery(replayInfo.getPartitionId());
+        Assertions.assertFalse(followerPartitionInfo.isRecoverable());
+    }
+
+    @Test
+    public void testRecycleLakeRangePartitionInfoDeleteNormalCase() throws Exception {
+        // 1. Create partition
+        Partition partition = createPartition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1");
+
+        // 2. Create RecycleLakeRangePartitionInfo with recoverable = true
+        Range<PartitionKey> range = Range.all();
+        RecycleLakeRangePartitionInfo partitionInfo = new RecycleLakeRangePartitionInfo(
+                DB_ID, TABLE_ID, partition, range,
+                DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        partitionInfo.setRecoverable(true);
+
+        // Verify initial state
+        Assertions.assertTrue(partitionInfo.isRecoverable());
+
+        // 3. Mock LakeTableHelper.removePartitionDirectory to return true
+        new MockUp<LakeTableHelper>() {
+            @Mock
+            public boolean removePartitionDirectory(Partition partition, ComputeResource computeResource) {
+                return true;
+            }
+            
+            @Mock
+            public void deleteShardGroupMeta(Partition partition) {
+                // Do nothing
+            }
+        };
+
+        // 4. Execute delete
+        boolean result = partitionInfo.delete();
+        // 5. Verify master state
+        Assertions.assertTrue(result);
+        Assertions.assertFalse(partitionInfo.isRecoverable(), "Partition should not be recoverable after delete");
+
+        // 6. Test follower replay
+        DisablePartitionRecoveryInfo replayInfo = (DisablePartitionRecoveryInfo) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_DISABLE_PARTITION_RECOVERY);
+
+        // Verify replay info
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(PARTITION_ID, replayInfo.getPartitionId());
+
+        CatalogRecycleBin followerRecycleBin = new CatalogRecycleBin();
+        // 2. Create RecycleLakeListPartitionInfo with recoverable = true
+        RecycleLakeRangePartitionInfo followerPartitionInfo = new RecycleLakeRangePartitionInfo(
+                DB_ID, TABLE_ID, partition, range,
+                DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        followerPartitionInfo.setRecoverable(true);
+        followerRecycleBin.recyclePartition(followerPartitionInfo);
+
+        followerRecycleBin.replayDisablePartitionRecovery(replayInfo.getPartitionId());
+        Assertions.assertFalse(followerPartitionInfo.isRecoverable());
+    }
+
+    @Test
+    public void testRecycleLakeUnPartitionInfoDeleteNormalCase() throws Exception {
+        // 1. Create partition
+        Partition partition = createPartition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1");
+
+        // 2. Create RecycleLakeUnPartitionInfo with recoverable = true
+        RecycleLakeUnPartitionInfo partitionInfo = new RecycleLakeUnPartitionInfo(
+                DB_ID, TABLE_ID, partition,
+                DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        partitionInfo.setRecoverable(true);
+
+        // Verify initial state
+        Assertions.assertTrue(partitionInfo.isRecoverable());
+
+        // 3. Mock LakeTableHelper.removePartitionDirectory to return true
+        new MockUp<LakeTableHelper>() {
+            @Mock
+            public boolean removePartitionDirectory(Partition partition, ComputeResource computeResource) {
+                return true;
+            }
+            
+            @Mock
+            public void deleteShardGroupMeta(Partition partition) {
+                // Do nothing
+            }
+        };
+
+        // 4. Execute delete
+        boolean result = partitionInfo.delete();
+
+        // 5. Verify master state
+        Assertions.assertTrue(result);
+        Assertions.assertFalse(partitionInfo.isRecoverable(), "Partition should not be recoverable after delete");
+
+        // 6. Test follower replay
+        DisablePartitionRecoveryInfo replayInfo = (DisablePartitionRecoveryInfo) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_DISABLE_PARTITION_RECOVERY);
+
+        // Verify replay info
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(PARTITION_ID, replayInfo.getPartitionId());
+
+        CatalogRecycleBin followerRecycleBin = new CatalogRecycleBin();
+        // 2. Create RecycleLakeListPartitionInfo with recoverable = true
+        RecycleLakeUnPartitionInfo followerPartitionInfo = new RecycleLakeUnPartitionInfo(
+                DB_ID, TABLE_ID, partition,
+                DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        followerPartitionInfo.setRecoverable(true);
+        followerRecycleBin.recyclePartition(followerPartitionInfo);
+
+        followerRecycleBin.replayDisablePartitionRecovery(replayInfo.getPartitionId());
+        Assertions.assertFalse(followerPartitionInfo.isRecoverable());
+    }
+
+    @Test
+    public void testRecycleLakeListPartitionInfoDeleteEditLogException() throws Exception {
+        // 1. Create partition
+        Partition partition = createPartition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1");
+
+        // 2. Create RecycleLakeListPartitionInfo with recoverable = true
+        RecycleLakeListPartitionInfo partitionInfo = new RecycleLakeListPartitionInfo(
+                DB_ID, TABLE_ID, partition,
+                DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        partitionInfo.setRecoverable(true);
+
+        // Verify initial state
+        Assertions.assertTrue(partitionInfo.isRecoverable());
+
+        // 3. Mock EditLog.logDisablePartitionRecovery to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logDisablePartitionRecovery(any(Long.class), any());
+
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute delete and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            partitionInfo.delete();
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed") || 
+                            exception.getCause() != null && 
+                            exception.getCause().getMessage().contains("EditLog write failed"));
+
+        // 5. Verify partitionInfo state remains unchanged after exception
+        Assertions.assertTrue(partitionInfo.isRecoverable(), "Partition should remain recoverable after exception");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerEditLogTest.java
@@ -1,0 +1,633 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.leader;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ListMultimap;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.persist.BackendTabletsInfo;
+import com.starrocks.persist.BatchDeleteReplicaInfo;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.system.Backend;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TTablet;
+import com.starrocks.thrift.TTabletInfo;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class ReportHandlerEditLogTest {
+    private static final String DB_NAME = "test_report_handler_editlog";
+    private static final long DB_ID = 70001L;
+    private static final long TABLE_ID = 70002L;
+    private static final long PARTITION_ID = 70004L;
+    private static final long PHYSICAL_PARTITION_ID = 70005L;
+    private static final long INDEX_ID = 70006L;
+    private static final long TABLET_ID = 70007L;
+    private static final long BACKEND_ID = 70008L;
+    private static final long BACKEND_ID_2 = 70011L;
+    private static final long REPLICA_ID = 70009L;
+    private static final long REPLICA_ID_2 = 70012L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        // Create database and table directly (no mincluster)
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+        
+        // Add backends with empty disks (so replica pathHash won't match any disk)
+        // This ensures deleteFromMeta will process the tablet
+        Backend backend = new Backend(BACKEND_ID, "127.0.0.1", 9050);
+        backend.setAlive(true);
+        backend.setDisks(ImmutableMap.of()); // Empty disks
+        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().addBackend(backend);
+        
+        Backend backend2 = new Backend(BACKEND_ID_2, "127.0.0.2", 9050);
+        backend2.setAlive(true);
+        backend2.setDisks(ImmutableMap.of()); // Empty disks
+        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().addBackend(backend2);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private static OlapTable createOlapTable(long tableId, String tableName) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("v1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("v2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(3, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(TABLET_ID);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, tableId, PHYSICAL_PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        // Add replica to tablet
+        Replica replica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        replica.updateVersionInfo(2, 2, 2);
+        tablet.addReplica(replica);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1", baseIndex, distributionInfo);
+
+        OlapTable olapTable = new OlapTable(tableId, tableName, columns, 
+                com.starrocks.sql.ast.KeysType.DUP_KEYS, partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(INDEX_ID, tableName, columns, 0, 0, (short) 1, 
+                com.starrocks.thrift.TStorageType.COLUMN, com.starrocks.sql.ast.KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(INDEX_ID);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new com.starrocks.catalog.TableProperty(new java.util.HashMap<>()));
+        return olapTable;
+    }
+
+    @Test
+    public void testDeleteFromMetaDeleteReplica() throws Exception {
+        // Test deleteFromMeta with multiple replicas - should delete replica
+        // 1. Create table with tablet and multiple replicas
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, "test_table");
+        db.registerTableUnlocked(table);
+
+        // Add tablet to inverted index
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+        
+        // Get tablet reference
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+
+        // Add first replica to tablet and inverted index
+        Replica replica1 = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        replica1.updateVersionInfo(2, 2, 2);
+        replica1.setDeferReplicaDeleteToNextReport(false); // Allow immediate deletion
+        tablet.addReplica(replica1);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica1);
+        
+        // Add second replica to make it multi-replica tablet
+        Replica replica2 = new Replica(REPLICA_ID_2, BACKEND_ID_2, 0, Replica.ReplicaState.NORMAL);
+        replica2.updateVersionInfo(2, 2, 2);
+        tablet.addReplica(replica2);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica2);
+
+        // Verify initial state - tablet has 2 replicas
+        Assertions.assertEquals(2, tablet.getImmutableReplicas().size());
+        Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID));
+        Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID_2));
+
+        // 2. Construct tabletDeleteFromMeta - tablet should be deleted from meta
+        ListMultimap<Long, Long> tabletDeleteFromMeta = ArrayListMultimap.create();
+        tabletDeleteFromMeta.put(DB_ID, TABLET_ID);
+        
+        // 3. Call deleteFromMeta directly
+        // Since disks are empty, diskInfo will be null, so version check won't execute
+        long backendReportVersion = 1L;
+        ReportHandler.deleteFromMeta(tabletDeleteFromMeta, BACKEND_ID, backendReportVersion);
+
+        Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID_2),
+                "Other replica should still exist");
+        Assertions.assertEquals(1, tablet.getImmutableReplicas().size());
+
+        // 4. Verify EditLog was written and deletion happened
+        BatchDeleteReplicaInfo replayInfo = (BatchDeleteReplicaInfo) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_BATCH_DELETE_REPLICA);
+
+        Assertions.assertNotNull(replayInfo, "EditLog should be written");
+        Assertions.assertEquals(BACKEND_ID, replayInfo.getBackendId());
+        Assertions.assertTrue(replayInfo.getTablets().contains(TABLET_ID),
+                "Tablet should be in delete list");
+
+        // 5. Test follower replay - create a new LocalMetastore and construct same table/tablet
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+
+        // Create table with same ID
+        OlapTable followerTable = createOlapTable(TABLE_ID, "test_table");
+        followerDb.registerTableUnlocked(followerTable);
+
+        // Add tablet to inverted index for follower
+        TabletMeta followerTabletMeta = new TabletMeta(DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, followerTabletMeta);
+
+        // Get follower tablet reference
+        Partition followerPartition = followerTable.getPartition(PARTITION_ID);
+        PhysicalPartition followerPhysicalPartition = followerPartition.getDefaultPhysicalPartition();
+        MaterializedIndex followerIndex = followerPhysicalPartition.getIndex(INDEX_ID);
+        LocalTablet followerTablet = (LocalTablet) followerIndex.getTablet(TABLET_ID);
+
+        // Add replicas to follower tablet (same as leader)
+        Replica followerReplica1 = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        followerReplica1.updateVersionInfo(2, 2, 2);
+        followerTablet.addReplica(followerReplica1);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, followerReplica1);
+
+        Replica followerReplica2 = new Replica(REPLICA_ID_2, BACKEND_ID_2, 0, Replica.ReplicaState.NORMAL);
+        followerReplica2.updateVersionInfo(2, 2, 2);
+        followerTablet.addReplica(followerReplica2);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, followerReplica2);
+
+        // Verify follower initial state - tablet has 2 replicas
+        Assertions.assertEquals(2, followerTablet.getImmutableReplicas().size());
+        Assertions.assertNotNull(followerTablet.getReplicaByBackendId(BACKEND_ID),
+                "Follower replica1 should exist before replay");
+        Assertions.assertNotNull(followerTablet.getReplicaByBackendId(BACKEND_ID_2),
+                "Follower replica2 should exist before replay");
+
+        // Replay the operation
+        followerMetastore.replayBatchDeleteReplica(replayInfo);
+
+        // 6. Verify follower state - replica1 should be deleted, replica2 should still exist
+        followerTablet = (LocalTablet) followerIndex.getTablet(TABLET_ID);
+        Assertions.assertNull(followerTablet.getReplicaByBackendId(BACKEND_ID),
+                "Follower replica1 should be deleted after replay");
+        Assertions.assertNotNull(followerTablet.getReplicaByBackendId(BACKEND_ID_2),
+                "Follower replica2 should still exist after replay");
+        Assertions.assertEquals(1, followerTablet.getImmutableReplicas().size(),
+                "Follower tablet should have only 1 replica after replay");
+    }
+
+    @Test
+    public void testDeleteFromMetaSingleReplicaSetBad() throws Exception {
+        // Test deleteFromMeta with single replica - should setBad instead of delete
+        // 1. Create table with tablet and single replica
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, "test_table");
+        db.registerTableUnlocked(table);
+
+        // Add tablet to inverted index
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+        Replica replica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        replica.updateVersionInfo(2, 2, 2);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica);
+
+        // Get tablet reference
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+
+        // Verify initial state - tablet has only 1 replica
+        Assertions.assertEquals(1, tablet.getImmutableReplicas().size());
+        Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID));
+        Assertions.assertFalse(tablet.getReplicaByBackendId(BACKEND_ID).isBad());
+
+        // 2. Construct tabletDeleteFromMeta - tablet should be deleted from meta
+        ListMultimap<Long, Long> tabletDeleteFromMeta = ArrayListMultimap.create();
+        tabletDeleteFromMeta.put(DB_ID, TABLET_ID);
+        
+        // 3. Call deleteFromMeta directly
+        // Since disks are empty, diskInfo will be null, so version check won't execute
+        long backendReportVersion = 1L;
+        ReportHandler.deleteFromMeta(tabletDeleteFromMeta, BACKEND_ID, backendReportVersion);
+
+        // 5. Verify replica is setBad (not deleted) since tablet has only one replica
+        Replica replicaAfter = tablet.getReplicaByBackendId(BACKEND_ID);
+        Assertions.assertNotNull(replicaAfter, "Replica should not be deleted when tablet has only one replica");
+        Assertions.assertTrue(replicaAfter.isBad(), "Replica should be setBad when tablet has only one replica");
+        Assertions.assertEquals(1, tablet.getImmutableReplicas().size());
+
+        // 6. Verify EditLog was written (BackendTabletsInfo for setBad)
+        BackendTabletsInfo replayInfo = (BackendTabletsInfo) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_BACKEND_TABLETS_INFO_V2);
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(BACKEND_ID, replayInfo.getBackendId());
+        Assertions.assertTrue(replayInfo.isBad());
+        Assertions.assertTrue(replayInfo.getReplicaPersistInfos().stream()
+                .anyMatch(info -> info.getTabletId() == TABLET_ID && info.getReplicaId() == REPLICA_ID));
+
+        // 7. Test follower replay - create a new LocalMetastore and construct same table/tablet
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+
+        // Create table with same ID
+        OlapTable followerTable = createOlapTable(TABLE_ID, "test_table");
+        followerDb.registerTableUnlocked(followerTable);
+
+        // Add tablet to inverted index for follower
+        TabletMeta followerTabletMeta = new TabletMeta(DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, followerTabletMeta);
+
+        // Get follower tablet reference
+        Partition followerPartition = followerTable.getPartition(PARTITION_ID);
+        PhysicalPartition followerPhysicalPartition = followerPartition.getDefaultPhysicalPartition();
+        MaterializedIndex followerIndex = followerPhysicalPartition.getIndex(INDEX_ID);
+        LocalTablet followerTablet = (LocalTablet) followerIndex.getTablet(TABLET_ID);
+
+        // Add replica to follower tablet (same as leader - single replica)
+        Replica followerReplica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        followerReplica.updateVersionInfo(2, 2, 2);
+        followerTablet.addReplica(followerReplica);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, followerReplica);
+
+        // Verify follower initial state - tablet has only 1 replica and replica is not bad
+        Assertions.assertEquals(1, followerTablet.getImmutableReplicas().size());
+        Assertions.assertNotNull(followerTablet.getReplicaByBackendId(BACKEND_ID),
+                "Follower replica should exist before replay");
+        Assertions.assertFalse(followerTablet.getReplicaByBackendId(BACKEND_ID).isBad(),
+                "Follower replica should not be bad before replay");
+
+        // Replay the operation
+        followerMetastore.replayBackendTabletsInfo(replayInfo);
+
+        // 8. Verify follower state - replica should be setBad (not deleted) since tablet has only one replica
+        followerTablet = (LocalTablet) followerIndex.getTablet(TABLET_ID);
+        Replica followerReplicaAfter = followerTablet.getReplicaByBackendId(BACKEND_ID);
+        Assertions.assertNotNull(followerReplicaAfter,
+                "Follower replica should not be deleted when tablet has only one replica");
+        Assertions.assertTrue(followerReplicaAfter.isBad(),
+                "Follower replica should be setBad after replay");
+        Assertions.assertEquals(1, followerTablet.getImmutableReplicas().size(),
+                "Follower tablet should still have 1 replica after replay");
+    }
+
+    @Test
+    public void testHandleRecoverTabletNormalCase() throws Exception {
+        // Test handleRecoverTablet by constructing scenario where needRecover returns true
+        // 1. Create table with tablet and replica
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, "test_table");
+        db.registerTableUnlocked(table);
+
+        // Add tablet to inverted index
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+        Replica replica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        replica.updateVersionInfo(5, 5, 5); // Set lastReportVersion to 5
+        replica.setLastReportVersion(5);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica);
+
+        // Get tablet reference
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+        Replica tabletReplica = tablet.getReplicaByBackendId(BACKEND_ID);
+
+        // Verify initial state
+        Assertions.assertNotNull(tabletReplica);
+        Assertions.assertFalse(tabletReplica.isBad());
+
+        // 2. Construct tabletRecoveryMap - tablet needs recovery
+        ListMultimap<Long, Long> tabletRecoveryMap = ArrayListMultimap.create();
+        tabletRecoveryMap.put(DB_ID, TABLET_ID);
+        
+        // 3. Construct backendTablets for handleRecoverTablet
+        Map<Long, TTablet> backendTablets = new HashMap<>();
+        TTablet backendTablet = new TTablet();
+        TTabletInfo tabletInfo = new TTabletInfo();
+        tabletInfo.setTablet_id(TABLET_ID);
+        tabletInfo.setSchema_hash(0);
+        tabletInfo.setVersion(3); // Version less than lastReportVersion (5) to trigger needRecover
+        tabletInfo.setUsed(false); // Bad tablet
+        tabletInfo.setPartition_id(PHYSICAL_PARTITION_ID);
+        backendTablet.addToTablet_infos(tabletInfo);
+        backendTablets.put(TABLET_ID, backendTablet);
+
+        // 4. Call handleRecoverTablet directly
+        ReportHandler.handleRecoverTablet(tabletRecoveryMap, backendTablets, BACKEND_ID);
+
+        // 5. Verify replica is setBad
+        Assertions.assertTrue(tabletReplica.isBad(), "Replica should be setBad after handleRecoverTablet");
+
+        // 6. Verify EditLog was written
+        BackendTabletsInfo replayInfo = (BackendTabletsInfo) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_BACKEND_TABLETS_INFO_V2);
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(BACKEND_ID, replayInfo.getBackendId());
+        Assertions.assertTrue(replayInfo.isBad());
+        Assertions.assertTrue(replayInfo.getReplicaPersistInfos().stream()
+                .anyMatch(info -> info.getTabletId() == TABLET_ID && info.getReplicaId() == REPLICA_ID));
+
+        // 7. Test follower replay - create a new LocalMetastore and construct same table/tablet
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+
+        // Create table with same ID
+        OlapTable followerTable = createOlapTable(TABLE_ID, "test_table");
+        followerDb.registerTableUnlocked(followerTable);
+
+        // Add tablet to inverted index for follower
+        TabletMeta followerTabletMeta = new TabletMeta(DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, followerTabletMeta);
+
+        // Get follower tablet reference
+        Partition followerPartition = followerTable.getPartition(PARTITION_ID);
+        PhysicalPartition followerPhysicalPartition = followerPartition.getDefaultPhysicalPartition();
+        MaterializedIndex followerIndex = followerPhysicalPartition.getIndex(INDEX_ID);
+        LocalTablet followerTablet = (LocalTablet) followerIndex.getTablet(TABLET_ID);
+
+        // Add replica to follower tablet (same as leader)
+        Replica followerReplica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        followerReplica.updateVersionInfo(5, 5, 5); // Set lastReportVersion to 5, same as leader
+        followerReplica.setLastReportVersion(5);
+        followerTablet.addReplica(followerReplica);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, followerReplica);
+
+        // Verify follower initial state - replica is not bad
+        Assertions.assertNotNull(followerTablet.getReplicaByBackendId(BACKEND_ID),
+                "Follower replica should exist before replay");
+        Assertions.assertFalse(followerTablet.getReplicaByBackendId(BACKEND_ID).isBad(),
+                "Follower replica should not be bad before replay");
+
+        // Replay the operation
+        followerMetastore.replayBackendTabletsInfo(replayInfo);
+
+        // 8. Verify follower state - replica should be setBad after replay
+        followerTablet = (LocalTablet) followerIndex.getTablet(TABLET_ID);
+        Replica followerReplicaAfter = followerTablet.getReplicaByBackendId(BACKEND_ID);
+        Assertions.assertNotNull(followerReplicaAfter,
+                "Follower replica should still exist after replay");
+        Assertions.assertTrue(followerReplicaAfter.isBad(),
+                "Follower replica should be setBad after replay");
+    }
+
+    @Test
+    public void testDeleteFromMetaDeleteReplicaEditLogException() throws Exception {
+        // Test deleteFromMeta with EditLog exception - should throw exception and not delete replica
+        // 1. Create table with tablet and multiple replicas
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, "test_table");
+        db.registerTableUnlocked(table);
+
+        // Add tablet to inverted index
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+        
+        // Get tablet reference
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+        
+        // Add first replica to tablet and inverted index
+        Replica replica1 = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        replica1.updateVersionInfo(2, 2, 2);
+        replica1.setDeferReplicaDeleteToNextReport(false); // Allow immediate deletion
+        tablet.addReplica(replica1);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica1);
+        
+        // Add second replica to make it multi-replica tablet
+        Replica replica2 = new Replica(REPLICA_ID_2, BACKEND_ID_2, 0, Replica.ReplicaState.NORMAL);
+        replica2.updateVersionInfo(2, 2, 2);
+        tablet.addReplica(replica2);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica2);
+
+        // Verify initial state - tablet has 2 replicas
+        Assertions.assertEquals(2, tablet.getImmutableReplicas().size());
+        Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID));
+        Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID_2));
+
+        // 2. Mock EditLog.logBatchDeleteReplica to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logBatchDeleteReplica(any(BatchDeleteReplicaInfo.class), any());
+
+        // Temporarily set spy EditLog
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 3. Construct tabletDeleteFromMeta - tablet should be deleted from meta
+        ListMultimap<Long, Long> tabletDeleteFromMeta = ArrayListMultimap.create();
+        tabletDeleteFromMeta.put(DB_ID, TABLET_ID);
+        
+        // 4. Call deleteFromMeta and expect exception
+        long backendReportVersion = 1L;
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            ReportHandler.deleteFromMeta(tabletDeleteFromMeta, BACKEND_ID, backendReportVersion);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed") || 
+                            exception.getCause() != null && 
+                            exception.getCause().getMessage().contains("EditLog write failed"));
+
+        // 5. Restore original EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+
+        // 6. Verify replica is NOT deleted (because EditLog failed, WALApplier won't execute)
+        Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID),
+                "Replica should not be deleted when EditLog write fails");
+        Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID_2),
+                "Other replica should still exist");
+        Assertions.assertEquals(2, tablet.getImmutableReplicas().size(),
+                "Tablet should still have 2 replicas when EditLog write fails");
+    }
+
+    @Test
+    public void testDeleteFromMetaSingleReplicaSetBadEditLogException() throws Exception {
+        // Test deleteFromMeta with EditLog exception - should throw exception and not setBad replica
+        // 1. Create table with tablet and single replica
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, "test_table");
+        db.registerTableUnlocked(table);
+
+        // Add tablet to inverted index
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+        Replica replica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        replica.updateVersionInfo(2, 2, 2);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica);
+
+        // Get tablet reference
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+
+        // Verify initial state - tablet has only 1 replica and replica is not bad
+        Assertions.assertEquals(1, tablet.getImmutableReplicas().size());
+        Assertions.assertNotNull(tablet.getReplicaByBackendId(BACKEND_ID));
+        Assertions.assertFalse(tablet.getReplicaByBackendId(BACKEND_ID).isBad());
+
+        // 2. Mock EditLog.logBackendTabletsInfo to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logBackendTabletsInfo(any(BackendTabletsInfo.class), any());
+
+        // Temporarily set spy EditLog
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 3. Construct tabletDeleteFromMeta - tablet should be deleted from meta
+        ListMultimap<Long, Long> tabletDeleteFromMeta = ArrayListMultimap.create();
+        tabletDeleteFromMeta.put(DB_ID, TABLET_ID);
+        
+        // 4. Call deleteFromMeta and expect exception
+        long backendReportVersion = 1L;
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            ReportHandler.deleteFromMeta(tabletDeleteFromMeta, BACKEND_ID, backendReportVersion);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed") || 
+                            exception.getCause() != null && 
+                            exception.getCause().getMessage().contains("EditLog write failed"));
+
+        // 5. Restore original EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+
+        // 6. Verify replica is NOT setBad (because EditLog failed, WALApplier won't execute)
+        Replica replicaAfter = tablet.getReplicaByBackendId(BACKEND_ID);
+        Assertions.assertNotNull(replicaAfter, "Replica should not be deleted when tablet has only one replica");
+        Assertions.assertFalse(replicaAfter.isBad(), "Replica should not be setBad when EditLog write fails");
+        Assertions.assertEquals(1, tablet.getImmutableReplicas().size());
+    }
+
+    @Test
+    public void testHandleRecoverTabletNormalCaseEditLogException() throws Exception {
+        // Test handleRecoverTablet with EditLog exception - should throw exception and not setBad replica
+        // 1. Create table with tablet and replica
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, "test_table");
+        db.registerTableUnlocked(table);
+
+        // Add tablet to inverted index
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PHYSICAL_PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+        Replica replica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        replica.updateVersionInfo(5, 5, 5); // Set lastReportVersion to 5
+        replica.setLastReportVersion(5);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica);
+
+        // Get tablet reference
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+        Replica tabletReplica = tablet.getReplicaByBackendId(BACKEND_ID);
+
+        // Verify initial state
+        Assertions.assertNotNull(tabletReplica);
+        Assertions.assertFalse(tabletReplica.isBad());
+
+        // 2. Mock EditLog.logBackendTabletsInfo to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logBackendTabletsInfo(any(BackendTabletsInfo.class), any());
+        
+        // Temporarily set spy EditLog
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 3. Construct tabletRecoveryMap - tablet needs recovery
+        ListMultimap<Long, Long> tabletRecoveryMap = ArrayListMultimap.create();
+        tabletRecoveryMap.put(DB_ID, TABLET_ID);
+        
+        // 4. Construct backendTablets for handleRecoverTablet
+        Map<Long, TTablet> backendTablets = new HashMap<>();
+        TTablet backendTablet = new TTablet();
+        TTabletInfo tabletInfo = new TTabletInfo();
+        tabletInfo.setTablet_id(TABLET_ID);
+        tabletInfo.setSchema_hash(0);
+        tabletInfo.setVersion(3); // Version less than lastReportVersion (5) to trigger needRecover
+        tabletInfo.setUsed(false); // Bad tablet
+        tabletInfo.setPartition_id(PHYSICAL_PARTITION_ID);
+        backendTablet.addToTablet_infos(tabletInfo);
+        backendTablets.put(TABLET_ID, backendTablet);
+
+        // 5. Call handleRecoverTablet and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            ReportHandler.handleRecoverTablet(tabletRecoveryMap, backendTablets, BACKEND_ID);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed") || 
+                            exception.getCause() != null && 
+                            exception.getCause().getMessage().contains("EditLog write failed"));
+
+        // 6. Restore original EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+
+        // 7. Verify replica is NOT setBad (because EditLog failed, WALApplier won't execute)
+        Assertions.assertFalse(tabletReplica.isBad(), "Replica should not be setBad when EditLog write fails");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/DeleteJobEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/DeleteJobEditLogTest.java
@@ -1,0 +1,230 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionStatus;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class DeleteJobEditLogTest {
+    private static final String DB_NAME = "test_delete_job_editlog";
+    private static final String TABLE_NAME = "test_table";
+    private static final long DB_ID = 30001L;
+    private static final long TABLE_ID = 30002L;
+    private static final long JOB_ID = 30003L;
+    private static final long TRANSACTION_ID = 30004L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        // Create database and table directly (no mincluster)
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private static OlapTable createOlapTable(long tableId, String tableName) {
+        List<com.starrocks.catalog.Column> columns = new ArrayList<>();
+        com.starrocks.catalog.Column col1 = new com.starrocks.catalog.Column("v1", com.starrocks.type.IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new com.starrocks.catalog.Column("v2", com.starrocks.type.IntegerType.BIGINT));
+
+        com.starrocks.catalog.PartitionInfo partitionInfo = new com.starrocks.catalog.SinglePartitionInfo();
+        partitionInfo.setDataProperty(30004L, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(30004L, (short) 1);
+
+        com.starrocks.catalog.DistributionInfo distributionInfo = 
+                new com.starrocks.catalog.HashDistributionInfo(3, List.of(col1));
+
+        com.starrocks.catalog.MaterializedIndex baseIndex = 
+                new com.starrocks.catalog.MaterializedIndex(30006L, com.starrocks.catalog.MaterializedIndex.IndexState.NORMAL);
+        com.starrocks.catalog.LocalTablet tablet = new com.starrocks.catalog.LocalTablet(30007L);
+        com.starrocks.catalog.TabletMeta tabletMeta = 
+                new com.starrocks.catalog.TabletMeta(DB_ID, tableId, 30004L, 30006L, com.starrocks.thrift.TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        com.starrocks.catalog.Partition partition = 
+                new com.starrocks.catalog.Partition(30004L, 30005L, "p1", baseIndex, distributionInfo);
+
+        OlapTable olapTable = new OlapTable(tableId, tableName, columns, 
+                com.starrocks.sql.ast.KeysType.DUP_KEYS, partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(30006L, tableName, columns, 0, 0, (short) 1, 
+                com.starrocks.thrift.TStorageType.COLUMN, com.starrocks.sql.ast.KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(30006L);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new com.starrocks.catalog.TableProperty(new HashMap<>()));
+        return olapTable;
+    }
+
+    @Test
+    public void testAfterVisibleNormalCase() throws Exception {
+        // 1. Create database and table
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        // 2. Create MultiDeleteInfo
+        List<String> deleteConditions = new ArrayList<>();
+        deleteConditions.add("v1 > 100");
+        MultiDeleteInfo deleteInfo = new MultiDeleteInfo(DB_ID, TABLE_ID, TABLE_NAME, deleteConditions);
+        deleteInfo.setPartitions(false, List.of(30004L), List.of("p1"));
+
+        // 3. Create OlapDeleteJob
+        Map<Long, Short> partitionToReplicateNum = new HashMap<>();
+        partitionToReplicateNum.put(30004L, (short) 1);
+        OlapDeleteJob deleteJob = new OlapDeleteJob(JOB_ID, TRANSACTION_ID, "test_label", 
+                partitionToReplicateNum, deleteInfo);
+
+        // Verify initial state
+        Assertions.assertEquals(DeleteJob.DeleteState.DELETING, deleteJob.getState());
+
+        // 4. Create mock TransactionState
+        TransactionState txnState = mock(TransactionState.class);
+        when(txnState.getTransactionId()).thenReturn(TRANSACTION_ID);
+        when(txnState.getDbId()).thenReturn(DB_ID);
+        when(txnState.getTransactionStatus()).thenReturn(TransactionStatus.VISIBLE);
+
+        // 5. Execute afterVisible
+        deleteJob.afterVisible(txnState, true);
+
+        // 6. Verify master state
+        Assertions.assertEquals(DeleteJob.DeleteState.FINISHED, deleteJob.getState());
+
+        // 7. Test follower replay
+        MultiDeleteInfo replayInfo = (MultiDeleteInfo) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_FINISH_MULTI_DELETE);
+
+        DeleteMgr followerDeleteMgr = new DeleteMgr();
+        // Replay the operation
+        followerDeleteMgr.replayMultiDelete(replayInfo, GlobalStateMgr.getCurrentState());
+        MultiDeleteInfo followerMutiDeleteInfo = followerDeleteMgr.getDeleteInfosForDb(DB_ID).get(0);
+        Assertions.assertNotNull(followerMutiDeleteInfo);
+        Assertions.assertEquals(DB_ID, followerMutiDeleteInfo.getDbId());
+        Assertions.assertEquals(TABLE_ID, followerMutiDeleteInfo.getTableId());
+        Assertions.assertEquals(TABLE_NAME, followerMutiDeleteInfo.getTableName());
+        Assertions.assertEquals(1, followerMutiDeleteInfo.getDeleteConditions().size());
+        Assertions.assertEquals("v1 > 100", followerMutiDeleteInfo.getDeleteConditions().get(0));
+        Assertions.assertNotNull(followerMutiDeleteInfo.getPartitionIds());
+        Assertions.assertEquals(1, followerMutiDeleteInfo.getPartitionIds().size());
+        Assertions.assertEquals(30004L, followerMutiDeleteInfo.getPartitionIds().get(0));
+    }
+
+    @Test
+    public void testAfterVisibleEditLogException() throws Exception {
+        // 1. Create database and table
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        // 2. Create MultiDeleteInfo
+        List<String> deleteConditions = new ArrayList<>();
+        deleteConditions.add("v1 > 100");
+        MultiDeleteInfo deleteInfo = new MultiDeleteInfo(DB_ID, TABLE_ID, TABLE_NAME, deleteConditions);
+        deleteInfo.setPartitions(false, List.of(30004L), List.of("p1"));
+
+        // 3. Create OlapDeleteJob
+        Map<Long, Short> partitionToReplicateNum = new HashMap<>();
+        partitionToReplicateNum.put(30004L, (short) 1);
+        OlapDeleteJob deleteJob = new OlapDeleteJob(JOB_ID, TRANSACTION_ID, "test_label", 
+                partitionToReplicateNum, deleteInfo);
+
+        // Verify initial state
+        Assertions.assertEquals(DeleteJob.DeleteState.DELETING, deleteJob.getState());
+
+        // 4. Mock EditLog.logFinishMultiDelete to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logFinishMultiDelete(any(MultiDeleteInfo.class), any());
+
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 5. Create mock TransactionState
+        TransactionState txnState = mock(TransactionState.class);
+        when(txnState.getTransactionId()).thenReturn(TRANSACTION_ID);
+        when(txnState.getDbId()).thenReturn(DB_ID);
+        when(txnState.getTransactionStatus()).thenReturn(TransactionStatus.VISIBLE);
+
+        // 6. Execute afterVisible and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            deleteJob.afterVisible(txnState, true);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed") || 
+                            exception.getCause() != null && 
+                            exception.getCause().getMessage().contains("EditLog write failed"));
+
+        // 7. Verify job state remains unchanged after exception
+        Assertions.assertEquals(DeleteJob.DeleteState.DELETING, deleteJob.getState());
+    }
+
+    @Test
+    public void testAfterVisibleNotOperated() throws Exception {
+        // 1. Create database and table
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        // 2. Create MultiDeleteInfo
+        List<String> deleteConditions = new ArrayList<>();
+        deleteConditions.add("v1 > 100");
+        MultiDeleteInfo deleteInfo = new MultiDeleteInfo(DB_ID, TABLE_ID, TABLE_NAME, deleteConditions);
+
+        // 3. Create OlapDeleteJob
+        Map<Long, Short> partitionToReplicateNum = new HashMap<>();
+        partitionToReplicateNum.put(30004L, (short) 1);
+        OlapDeleteJob deleteJob = new OlapDeleteJob(JOB_ID, TRANSACTION_ID, "test_label", 
+                partitionToReplicateNum, deleteInfo);
+
+        // Verify initial state
+        Assertions.assertEquals(DeleteJob.DeleteState.DELETING, deleteJob.getState());
+
+        // 4. Create mock TransactionState
+        TransactionState txnState = mock(TransactionState.class);
+
+        // 5. Execute afterVisible with txnOperated = false (should return early)
+        deleteJob.afterVisible(txnState, false);
+
+        // 6. Verify job state remains unchanged (no EditLog should be written)
+        Assertions.assertEquals(DeleteJob.DeleteState.DELETING, deleteJob.getState());
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MaterializedViewMgrEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MaterializedViewMgrEditLogTest.java
@@ -1,0 +1,324 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv;
+
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MaterializedViewRefreshType;
+import com.starrocks.catalog.MvId;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.planner.DataPartition;
+import com.starrocks.planner.OlapTableSink;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.sql.ast.CreateMaterializedViewStatement;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TWriteQuorumType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class MaterializedViewMgrEditLogTest {
+    private static final String DB_NAME = "test_mv_mgr_editlog";
+    private static final String MV_NAME = "test_mv";
+    private static final long DB_ID = 80001L;
+    private static final long MV_ID = 80002L;
+    private static final long PARTITION_ID = 80004L;
+    private static final long PHYSICAL_PARTITION_ID = 80005L;
+    private static final long INDEX_ID = 80006L;
+    private static final long TABLET_ID = 80007L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        // Create database directly (no mincluster)
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+        
+        // Clear jobMap to ensure clean state for each test
+        MaterializedViewMgr mvMgr = GlobalStateMgr.getCurrentState().getMaterializedViewMgr();
+        mvMgr.clearJobs();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private static MaterializedView createMaterializedView(long mvId, String mvName) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("v1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("v2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(3, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(TABLET_ID);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, mvId, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1", baseIndex, distributionInfo);
+
+        MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
+        refreshScheme.setType(MaterializedViewRefreshType.INCREMENTAL);
+        
+        MaterializedView mv = new MaterializedView(mvId, DB_ID, mvName, columns, KeysType.DUP_KEYS, 
+                partitionInfo, distributionInfo, refreshScheme);
+        mv.setIndexMeta(INDEX_ID, mvName, columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        mv.setBaseIndexMetaId(INDEX_ID);
+        mv.addPartition(partition);
+        mv.setTableProperty(new com.starrocks.catalog.TableProperty(new HashMap<>()));
+        
+        // Set base table info
+        List<BaseTableInfo> baseTableInfos = new ArrayList<>();
+        BaseTableInfo baseTableInfo = new BaseTableInfo(DB_ID, DB_NAME, "base_table", 80003L);
+        baseTableInfos.add(baseTableInfo);
+        mv.setBaseTableInfos(baseTableInfos);
+        
+        // Set maintenance plan (required for MVMaintenanceJob)
+        ExecPlan execPlan = new ExecPlan();
+        mv.setMaintenancePlan(execPlan);
+        
+        return mv;
+    }
+
+    private CreateMaterializedViewStatement createCreateMaterializedViewStatement(MaterializedView mv) throws Exception {
+        // Create a mock CreateMaterializedViewStatement with maintenance plan
+        CreateMaterializedViewStatement stmt = new CreateMaterializedViewStatement(
+                null, false, null, null, null, null, null, null, null, null, null, 0, 0, null, null);
+        
+        // Create ExecPlan with PlanFragment and OlapTableSink
+        ExecPlan execPlan = new ExecPlan();
+        PlanFragment fragment = new PlanFragment(new com.starrocks.planner.PlanFragmentId(1), null, DataPartition.UNPARTITIONED);
+        // Create OlapTableSink with required parameters
+        OlapTableSink tableSink = new OlapTableSink(mv, null, mv.getAllPartitionIds(),
+                TWriteQuorumType.MAJORITY, false, false, false);
+        fragment.setSink(tableSink);
+        execPlan.getFragments().add(fragment);
+        
+        // Set physicalPlan to avoid NullPointerException in IMTCreator.createIMT
+        // Create a simple OptExpression to satisfy IMTCreator.createIMT requirements
+        OptExpression physicalPlan = OptExpression.create(null);
+        Field physicalPlanField = ExecPlan.class.getDeclaredField("physicalPlan");
+        physicalPlanField.setAccessible(true);
+        physicalPlanField.set(execPlan, physicalPlan);
+        
+        // Set maintenance plan with ColumnRefFactory
+        ColumnRefFactory columnRefFactory = new ColumnRefFactory();
+        stmt.setMaintenancePlan(execPlan, columnRefFactory);
+        return stmt;
+    }
+
+    @Test
+    public void testPrepareMaintenanceWorkJobAlreadyExists() throws Exception {
+        // Mock IMTCreator.createIMT to avoid exceptions during testing
+        new MockUp<IMTCreator>() {
+            @Mock
+            public static void createIMT(CreateMaterializedViewStatement stmt, MaterializedView view) {
+                // Do nothing - skip IMT creation for testing
+            }
+        };
+
+        // 1. Create materialized view
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        MaterializedView mv = createMaterializedView(MV_ID, MV_NAME);
+        db.registerTableUnlocked(mv);
+
+        // 2. Create CreateMaterializedViewStatement with maintenance plan
+        CreateMaterializedViewStatement stmt = createCreateMaterializedViewStatement(mv);
+
+        // 3. Create job first time
+        MaterializedViewMgr mvMgr = GlobalStateMgr.getCurrentState().getMaterializedViewMgr();
+        MvId mvId = new MvId(DB_ID, MV_ID);
+        mvMgr.prepareMaintenanceWork(stmt, mv);
+
+        // 4. Verify job was created
+        Assertions.assertNotNull(mvMgr.getJob(mvId), "Job should be created after first call");
+
+        // 5. Try to create job again - should fail silently (exception is caught)
+        // The method catches DdlException and removes the job from jobMap
+        mvMgr.prepareMaintenanceWork(stmt, mv);
+    }
+
+    @Test
+    public void testPrepareMaintenanceWorkNonIncremental() throws Exception {
+        // 1. Create materialized view with non-incremental refresh
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        MaterializedView mv = createMaterializedView(MV_ID, MV_NAME);
+        // Change refresh type to non-incremental
+        MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
+        refreshScheme.setType(MaterializedViewRefreshType.ASYNC);
+        mv.setRefreshScheme(refreshScheme);
+        db.registerTableUnlocked(mv);
+
+        // 2. Create CreateMaterializedViewStatement with maintenance plan
+        CreateMaterializedViewStatement stmt = createCreateMaterializedViewStatement(mv);
+
+        // 3. Call prepareMaintenanceWork - should return early for non-incremental MV
+        MaterializedViewMgr mvMgr = GlobalStateMgr.getCurrentState().getMaterializedViewMgr();
+        mvMgr.prepareMaintenanceWork(stmt, mv);
+
+        // 4. Verify no job was created
+        MvId mvId = new MvId(DB_ID, MV_ID);
+        Assertions.assertNull(mvMgr.getJob(mvId), "Job should not be created for non-incremental MV");
+    }
+
+    @Test
+    public void testPrepareMaintenanceWorkReplay() throws Exception {
+        // Mock IMTCreator.createIMT to avoid exceptions during testing
+        new MockUp<IMTCreator>() {
+            @Mock
+            public static void createIMT(CreateMaterializedViewStatement stmt, MaterializedView view) {
+                // Do nothing - skip IMT creation for testing
+            }
+        };
+
+        // 1. Create materialized view
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        MaterializedView mv = createMaterializedView(MV_ID, MV_NAME);
+        db.registerTableUnlocked(mv);
+
+        // 2. Create CreateMaterializedViewStatement with maintenance plan
+        CreateMaterializedViewStatement stmt = createCreateMaterializedViewStatement(mv);
+
+        // 3. Call prepareMaintenanceWork on master
+        MaterializedViewMgr masterMvMgr = GlobalStateMgr.getCurrentState().getMaterializedViewMgr();
+        MvId mvId = new MvId(DB_ID, MV_ID);
+        masterMvMgr.prepareMaintenanceWork(stmt, mv);
+
+        // 4. Verify master state - job was created
+        MVMaintenanceJob masterJob = masterMvMgr.getJob(mvId);
+        Assertions.assertNotNull(masterJob, "Job should be created on master");
+        Assertions.assertEquals(MV_ID, masterJob.getJobId());
+        Assertions.assertEquals(DB_ID, masterJob.getDbId());
+        Assertions.assertEquals(MV_ID, masterJob.getViewId());
+        Assertions.assertEquals(MVMaintenanceJob.JobState.INIT, masterJob.getState());
+
+        // 5. Test follower replay
+        MVMaintenanceJob replayJob = (MVMaintenanceJob) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_MV_JOB_STATE);
+
+        // Verify replay job
+        Assertions.assertNotNull(replayJob);
+        Assertions.assertEquals(MV_ID, replayJob.getJobId());
+        Assertions.assertEquals(DB_ID, replayJob.getDbId());
+        Assertions.assertEquals(MV_ID, replayJob.getViewId());
+        Assertions.assertEquals(MVMaintenanceJob.JobState.INIT, replayJob.getState());
+
+        // 6. Create follower metastore and the same id objects, then replay
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+
+        // Create materialized view with same ID
+        MaterializedView followerMv = createMaterializedView(MV_ID, MV_NAME);
+        followerDb.registerTableUnlocked(followerMv);
+
+        // Replay the operation
+        MaterializedViewMgr followerMvMgr = new MaterializedViewMgr();
+        followerMvMgr.replay(replayJob);
+
+        // 7. Verify follower state
+        MVMaintenanceJob followerJob = followerMvMgr.getJob(mvId);
+        Assertions.assertNotNull(followerJob, "Job should be created on follower after replay");
+        Assertions.assertEquals(MV_ID, followerJob.getJobId());
+        Assertions.assertEquals(DB_ID, followerJob.getDbId());
+        Assertions.assertEquals(MV_ID, followerJob.getViewId());
+        Assertions.assertEquals(MVMaintenanceJob.JobState.INIT, followerJob.getState());
+
+        // Verify job properties match original
+        Assertions.assertEquals(masterJob.getJobId(), followerJob.getJobId());
+        Assertions.assertEquals(masterJob.getDbId(), followerJob.getDbId());
+        Assertions.assertEquals(masterJob.getViewId(), followerJob.getViewId());
+        Assertions.assertEquals(masterJob.getState(), followerJob.getState());
+    }
+
+    @Test
+    public void testPrepareMaintenanceWorkEditLogException() throws Exception {
+        // Mock IMTCreator.createIMT to avoid exceptions during testing
+        new MockUp<IMTCreator>() {
+            @Mock
+            public static void createIMT(CreateMaterializedViewStatement stmt, MaterializedView view) {
+                // Do nothing - skip IMT creation for testing
+            }
+        };
+
+        // 1. Create materialized view
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        MaterializedView mv = createMaterializedView(MV_ID, MV_NAME);
+        db.registerTableUnlocked(mv);
+
+        // 2. Create CreateMaterializedViewStatement with maintenance plan
+        CreateMaterializedViewStatement stmt = createCreateMaterializedViewStatement(mv);
+
+        // 3. Mock EditLog.logMVJobState to throw exception
+        EditLog currentEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(currentEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logMVJobState(any(MVMaintenanceJob.class), any());
+
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Verify initial state - no job in MaterializedViewMgr
+        MaterializedViewMgr mvMgr = GlobalStateMgr.getCurrentState().getMaterializedViewMgr();
+        MvId mvId = new MvId(DB_ID, MV_ID);
+        Assertions.assertNull(mvMgr.getJob(mvId), "Job should not exist initially");
+
+        // 5. Execute prepareMaintenanceWork - exception is caught internally, so it won't throw
+        // But the job should not be added to jobMap if EditLog fails
+        mvMgr.prepareMaintenanceWork(stmt, mv);
+
+        Assertions.assertNull(mvMgr.getJob(mvId));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
@@ -41,11 +41,15 @@ import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
 import com.starrocks.persist.PhysicalPartitionPersistInfoV2;
 import com.starrocks.persist.TruncateTableInfo;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.TruncateTableAnalyzer;
 import com.starrocks.sql.ast.ColumnRenameClause;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.ast.TableRef;
@@ -56,8 +60,10 @@ import com.starrocks.utframe.UtFrameUtils;
 import mockit.Invocation;
 import mockit.Mock;
 import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -65,6 +71,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 
 public class LocalMetaStoreTest {
     private static ConnectContext connectContext;
@@ -87,6 +97,16 @@ public class LocalMetaStoreTest {
                                 "CREATE TABLE test.t1(k1 int, k2 int, k3 int)" +
                                             " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
 
+    }
+
+    @BeforeEach
+    public void setUp() {
+        UtFrameUtils.setUpForPersistTest();
+    }
+
+    @AfterEach
+    public void teardown() {
+        UtFrameUtils.tearDownForPersisTest();
     }
 
     @Test
@@ -338,5 +358,96 @@ public class LocalMetaStoreTest {
         Assertions.assertEquals(tabletsCountBefore, tabletsCountAfter,
                 "Tablets should not be changed when truncate fails");
         Assertions.assertTrue(writeLockAcquired.get(), "Write lock should be acquired during truncate");
+    }
+
+    @Test
+    public void testTruncateTableEditLog() throws Exception {
+        String catalogName = connectContext.getCurrentCatalog();
+        String dbFullName = "test";
+        String tableName = "edit_log_t1";
+        starRocksAssert.useDatabase("test").withTable(
+                        "CREATE TABLE test.edit_log_t1(k1 int, k2 int, k3 int)" +
+                                " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
+        // Include catalog name in QualifiedName, use dbFullName for database name
+        QualifiedName qualifiedName = QualifiedName.of(List.of(catalogName, dbFullName, tableName));
+        TableRef tableRef = new TableRef(qualifiedName, null, NodePosition.ZERO);
+        TruncateTableStmt stmt = new TruncateTableStmt(tableRef, NodePosition.ZERO);
+        // Analyze the statement (normally done before execution)
+        TruncateTableAnalyzer.analyze(stmt, connectContext);
+
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbFullName);
+        OlapTable table = (OlapTable) database.getTable(tableName);
+        OlapTable followerTable  = AnalyzerUtils.getShadowCopyTable(table);
+        long oldPartitionId = table.getPartition(tableName).getId();
+
+        // 3. Execute truncateTable
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        metastore.truncateTable(stmt, connectContext);
+
+        // 4. Verify master state - partition is replaced with new one
+        // For unpartitioned table, partition name should be the same as table name
+        Partition newPartition = table.getPartition(tableName);
+        Assertions.assertNotNull(newPartition);
+        Assertions.assertNotEquals(oldPartitionId, newPartition.getId());
+
+        // 5. Test follower replay
+        TruncateTableInfo replayInfo = (TruncateTableInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_TRUNCATE_TABLE);
+
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(database.getId(), replayInfo.getDbId());
+        Assertions.assertEquals(table.getId(), replayInfo.getTblId());
+        Assertions.assertNotNull(replayInfo.getPartitions());
+        Assertions.assertFalse(replayInfo.getPartitions().isEmpty());
+
+        LocalMetastore followerLocalMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(),
+                GlobalStateMgr.getCurrentState().getRecycleBin(),
+                GlobalStateMgr.getCurrentState().getColocateTableIndex());
+        Database followerDatabase = new Database(database.getId(), database.getFullName());
+        followerLocalMetastore.replayCreateDb(followerDatabase);
+        followerDatabase.registerTableUnlocked(followerTable);
+        followerLocalMetastore.replayTruncateTable(replayInfo);
+        Partition followerPartition = followerTable.getPartition(tableName);
+        Assertions.assertNotNull(followerPartition);
+        Assertions.assertNotEquals(oldPartitionId, followerPartition.getId());
+
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testTruncateTableEditLogException() throws Exception {
+        String catalogName = connectContext.getCurrentCatalog();
+        String dbFullName = "test";
+        String tableName = "edit_log_t2";
+        starRocksAssert.useDatabase(dbFullName).withTable(
+                        "CREATE TABLE " + tableName + "(k1 int, k2 int, k3 int)" +
+                                " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
+        // Include catalog name in QualifiedName, use dbFullName for database name
+        QualifiedName qualifiedName = QualifiedName.of(List.of(catalogName, dbFullName, tableName));
+        TableRef tableRef = new TableRef(qualifiedName, null, NodePosition.ZERO);
+        TruncateTableStmt stmt = new TruncateTableStmt(tableRef, NodePosition.ZERO);
+        // Analyze the statement (normally done before execution)
+        TruncateTableAnalyzer.analyze(stmt, connectContext);
+
+        Database database = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbFullName);
+        OlapTable table = (OlapTable) database.getTable(tableName);
+        long oldPartitionId = table.getPartition(tableName).getId();
+
+        // 3. Mock EditLog.logTruncateTable to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logTruncateTable(any(TruncateTableInfo.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute truncateTable and expect exception
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            metastore.truncateTable(stmt, connectContext);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed"));
+
+        // 5. Verify partition ID remains unchanged after exception
+        // For unpartitioned table, partition name should be the same as table name
+        Assertions.assertEquals(oldPartitionId, table.getPartition(tableName).getId());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreSimpleOpsEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreSimpleOpsEditLogTest.java
@@ -1,0 +1,1295 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.server;
+
+import com.google.common.collect.Range;
+import com.starrocks.catalog.CatalogRecycleBin;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.consistency.MetaRecoveryDaemon;
+import com.starrocks.persist.ColumnRenameInfo;
+import com.starrocks.persist.DatabaseInfo;
+import com.starrocks.persist.DropPartitionsInfo;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.ModifyPartitionInfo;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.PartitionVersionRecoveryInfo;
+import com.starrocks.persist.SetReplicaStatusOperationLog;
+import com.starrocks.persist.TableInfo;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.AdminStmtAnalyzer;
+import com.starrocks.sql.analyzer.AlterDbQuotaAnalyzer;
+import com.starrocks.sql.ast.AdminSetPartitionVersionStmt;
+import com.starrocks.sql.ast.AdminSetReplicaStatusStmt;
+import com.starrocks.sql.ast.AlterDatabaseQuotaStmt;
+import com.starrocks.sql.ast.AlterDatabaseRenameStatement;
+import com.starrocks.sql.ast.ColumnRenameClause;
+import com.starrocks.sql.ast.DropPartitionClause;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.PartitionRenameClause;
+import com.starrocks.sql.ast.Property;
+import com.starrocks.sql.ast.PropertySet;
+import com.starrocks.sql.ast.QualifiedName;
+import com.starrocks.sql.ast.ReplicaStatus;
+import com.starrocks.sql.ast.RollupRenameClause;
+import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.ast.TableRenameClause;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.system.Backend;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.DateType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class LocalMetastoreSimpleOpsEditLogTest {
+    private static final String DB_NAME = "test_local_metastore_editlog";
+    private static final String TABLE_NAME = "test_table";
+    private static final long DB_ID = 90001L;
+    private static final long TABLE_ID = 90002L;
+    private static final long PARTITION_ID = 90004L;
+    private static final long PHYSICAL_PARTITION_ID = 90005L;
+    private static final long INDEX_ID = 90006L;
+    private static final long TABLET_ID = 90007L;
+    private static final long BACKEND_ID = 90008L;
+    private static final long REPLICA_ID = 90009L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Initialize test environment
+        UtFrameUtils.setUpForPersistTest();
+
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        // Initialize colocateTableIndex if not already set
+        if (globalStateMgr.getColocateTableIndex() == null) {
+            globalStateMgr.setColocateTableIndex(new com.starrocks.catalog.ColocateTableIndex());
+        }
+
+        // Create database
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+
+        // Add backend for replica tests
+        Backend backend = new Backend(BACKEND_ID, "127.0.0.1", 9050);
+        backend.setAlive(true);
+        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().addBackend(backend);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    // Helper method to create OlapTable
+    private static OlapTable createOlapTable(long tableId, String tableName) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("v1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("v2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(3, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(TABLET_ID);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, tableId, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        // Add replica to tablet
+        Replica replica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        replica.updateVersionInfo(2, 2, 2);
+        tablet.addReplica(replica);
+
+        // For unpartitioned table, partition name should be the same as table name
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, tableName, baseIndex, distributionInfo);
+
+        OlapTable olapTable = new OlapTable(tableId, tableName, columns, KeysType.DUP_KEYS, partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(INDEX_ID, tableName, columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(INDEX_ID);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new com.starrocks.catalog.TableProperty(new HashMap<>()));
+        return olapTable;
+    }
+
+    // Helper method to create range partitioned OlapTable
+    private static OlapTable createRangePartitionedOlapTable(long tableId, String tableName) {
+        List<Column> columns = new ArrayList<>();
+        Column partitionCol = new Column("dt", DateType.DATE);
+        partitionCol.setIsKey(true);
+        columns.add(partitionCol);
+        columns.add(new Column("v2", IntegerType.BIGINT));
+
+        RangePartitionInfo partitionInfo = new RangePartitionInfo(List.of(partitionCol));
+        partitionInfo.setDataProperty(PARTITION_ID, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        try {
+            PartitionKey lowerKey = PartitionKey.ofDate(LocalDate.parse("2024-01-01"));
+            PartitionKey upperKey = PartitionKey.ofDate(LocalDate.parse("2024-02-01"));
+            Range<PartitionKey> partitionRange = Range.closedOpen(lowerKey, upperKey);
+            partitionInfo.addPartition(PARTITION_ID, false, partitionRange,
+                    com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY, (short) 1);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(3, List.of(partitionCol));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(TABLET_ID);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, tableId, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Replica replica = new Replica(REPLICA_ID, BACKEND_ID, 0, Replica.ReplicaState.NORMAL);
+        replica.updateVersionInfo(2, 2, 2);
+        tablet.addReplica(replica);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, "p1", baseIndex, distributionInfo);
+
+        OlapTable olapTable = new OlapTable(tableId, tableName, columns, KeysType.DUP_KEYS, partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(INDEX_ID, tableName, columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(INDEX_ID);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new com.starrocks.catalog.TableProperty(new HashMap<>()));
+        return olapTable;
+    }
+
+    // Test alterDatabaseQuota
+    @Test
+    public void testAlterDatabaseQuotaNormalCase() throws Exception {
+        // 1. Get database
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        Assertions.assertNotNull(db);
+        long initialDataQuota = db.getDataQuota();
+        long initialReplicaQuota = db.getReplicaQuota();
+
+        // 2. Create AlterDatabaseQuotaStmt for DATA quota
+        AlterDatabaseQuotaStmt
+                stmt = new AlterDatabaseQuotaStmt(DB_NAME, AlterDatabaseQuotaStmt.QuotaType.DATA, "1000B", NodePosition.ZERO);
+        // Analyze the statement to set quota value
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setDatabase(DB_NAME);
+        // Set catalog if needed
+        if (ctx.getCurrentCatalog() == null) {
+            ctx.setCurrentCatalog(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
+        }
+        AlterDbQuotaAnalyzer.analyze(stmt, ctx);
+
+        // 3. Execute alterDatabaseQuota
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        metastore.alterDatabaseQuota(stmt);
+
+        // 4. Verify master state
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        Assertions.assertNotNull(db);
+        long expectedQuota = stmt.getQuota(); // Use the parsed quota value
+        // Verify that quota was actually set (not the default MAX_VALUE)
+        Assertions.assertTrue(expectedQuota > 0 && expectedQuota < Long.MAX_VALUE,
+                "Expected quota should be a reasonable value, not MAX_VALUE");
+        Assertions.assertEquals(expectedQuota, db.getDataQuota());
+        Assertions.assertEquals(initialReplicaQuota, db.getReplicaQuota());
+
+        // 5. Test follower replay
+        DatabaseInfo replayInfo = (DatabaseInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ALTER_DB_V2);
+
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(DB_NAME, replayInfo.getDbName());
+        Assertions.assertEquals(expectedQuota, replayInfo.getQuota());
+        Assertions.assertEquals(AlterDatabaseQuotaStmt.QuotaType.DATA, replayInfo.getQuotaType());
+
+        // Create follower metastore and the same id database, then replay
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerDb.setDataQuota(initialDataQuota);
+        followerDb.setReplicaQuota(initialReplicaQuota);
+        followerMetastore.unprotectCreateDb(followerDb);
+
+        // Temporarily set follower metastore to GlobalStateMgr so replayAlterDatabaseQuota can find the database
+        LocalMetastore originalMetastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        GlobalStateMgr.getCurrentState().setLocalMetastore(followerMetastore);
+        try {
+            followerMetastore.replayAlterDatabaseQuota(replayInfo);
+        } finally {
+            GlobalStateMgr.getCurrentState().setLocalMetastore(originalMetastore);
+        }
+
+        // 6. Verify follower state
+        Assertions.assertEquals(expectedQuota, followerDb.getDataQuota());
+        Assertions.assertEquals(initialReplicaQuota, followerDb.getReplicaQuota());
+    }
+
+    @Test
+    public void testAlterDatabaseQuotaEditLogException() throws Exception {
+        // 1. Get database
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        Assertions.assertNotNull(db);
+        long initialDataQuota = db.getDataQuota();
+
+        // 2. Create AlterDatabaseQuotaStmt
+        AlterDatabaseQuotaStmt stmt = new AlterDatabaseQuotaStmt(
+                DB_NAME, AlterDatabaseQuotaStmt.QuotaType.DATA, "1000B", NodePosition.ZERO);
+        // Analyze the statement to set quota value
+        com.starrocks.sql.analyzer.AlterDbQuotaAnalyzer.analyze(stmt, UtFrameUtils.createDefaultCtx());
+
+        // 3. Mock EditLog.logAlterDb to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logAlterDb(any(DatabaseInfo.class), any());
+
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute alterDatabaseQuota and expect exception
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            metastore.alterDatabaseQuota(stmt);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed"));
+
+        // 5. Verify database quota remains unchanged after exception
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        Assertions.assertNotNull(db);
+        Assertions.assertEquals(initialDataQuota, db.getDataQuota());
+    }
+
+    // Test renameDatabase
+    @Test
+    public void testRenameDatabaseNormalCase() throws Exception {
+        // 1. Get database
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        Assertions.assertNotNull(db);
+        String oldDbName = db.getFullName();
+
+        // 2. Create AlterDatabaseRenameStatement
+        // Use the actual fullName from the database, not the constant
+        String newDbName = "renamed_db";
+        AlterDatabaseRenameStatement stmt = new AlterDatabaseRenameStatement(oldDbName, newDbName, NodePosition.ZERO);
+        // Analyze the statement (normally done before execution)
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setDatabase(oldDbName);
+        com.starrocks.sql.analyzer.AlterDatabaseRenameStatementAnalyzer.analyze(stmt, ctx);
+
+        // 3. Execute renameDatabase
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        metastore.renameDatabase(stmt);
+
+        // 4. Verify master state
+        // Database full name includes cluster prefix, so use getDb with full name
+        Database renamedDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(newDbName);
+        Assertions.assertNotNull(renamedDb);
+        Assertions.assertEquals(newDbName, renamedDb.getFullName());
+        Assertions.assertEquals(DB_ID, renamedDb.getId());
+        Assertions.assertNull(GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(oldDbName));
+
+        // 5. Test follower replay
+        DatabaseInfo replayInfo = (DatabaseInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_RENAME_DB_V2);
+
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(oldDbName, replayInfo.getDbName());
+        Assertions.assertEquals(newDbName, replayInfo.getNewDbName());
+
+        // Create follower metastore and the same id database, then replay
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, oldDbName);
+        followerMetastore.unprotectCreateDb(followerDb);
+
+        followerMetastore.replayRenameDatabase(replayInfo.getDbName(), replayInfo.getNewDbName());
+
+        // 6. Verify follower state
+        // Check in followerMetastore, not in GlobalStateMgr
+        // Database full name includes cluster prefix
+        Database renamedFollowerDb = followerMetastore.getDb(newDbName);
+        Assertions.assertNotNull(renamedFollowerDb);
+        Assertions.assertEquals(newDbName, renamedFollowerDb.getFullName());
+        Assertions.assertEquals(DB_ID, renamedFollowerDb.getId());
+        Assertions.assertNull(followerMetastore.getDb(oldDbName));
+        Assertions.assertEquals(DB_ID, followerDb.getId());
+    }
+
+    @Test
+    public void testRenameDatabaseEditLogException() throws Exception {
+        // 1. Get database
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        Assertions.assertNotNull(db);
+        String oldDbName = db.getFullName();
+
+        // 2. Create AlterDatabaseRenameStatement
+        // Use the actual fullName from the database, not the constant
+        String newDbName = "renamed_db";
+        AlterDatabaseRenameStatement stmt = new AlterDatabaseRenameStatement(oldDbName, newDbName, NodePosition.ZERO);
+        // Analyze the statement (normally done before execution)
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setDatabase(oldDbName);
+        com.starrocks.sql.analyzer.AlterDatabaseRenameStatementAnalyzer.analyze(stmt, ctx);
+
+        // 3. Mock EditLog.logDatabaseRename to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logDatabaseRename(any(DatabaseInfo.class), any());
+
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute renameDatabase and expect exception
+        // The method may throw DdlException if database is not found, or RuntimeException if EditLog fails
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Exception exception = Assertions.assertThrows(Exception.class, () -> {
+            metastore.renameDatabase(stmt);
+        });
+        // The exception should be either DdlException (if db not found) or RuntimeException (if EditLog fails)
+        // Since we mocked EditLog to throw, we expect RuntimeException, but if db lookup fails first, we get DdlException
+        Assertions.assertTrue(exception instanceof RuntimeException || exception instanceof com.starrocks.common.DdlException);
+        if (exception instanceof RuntimeException) {
+            Assertions.assertTrue(exception.getMessage().contains("EditLog write failed"));
+        }
+
+        // 5. Verify database name remains unchanged after exception
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        Assertions.assertNotNull(db);
+        Assertions.assertEquals(oldDbName, db.getFullName());
+    }
+
+    // Test dropPartition
+    @Test
+    public void testDropPartitionNormalCase() throws Exception {
+        // 1. Create table with partition
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createRangePartitionedOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        // Add tablet to inverted index
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+        Replica replica = tablet.getReplicaByBackendId(BACKEND_ID);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica);
+
+        // Verify initial state - partition exists
+        Assertions.assertNotNull(table.getPartition(PARTITION_ID));
+
+        // 2. Create DropPartitionClause
+        List<String> partitionNames = List.of("p1");
+        DropPartitionClause clause = new DropPartitionClause(false, partitionNames, false, false, NodePosition.ZERO);
+        // Set resolved partition names (normally done by analyzer)
+        clause.setResolvedPartitionNames(partitionNames);
+
+        // 3. Execute dropPartition
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        metastore.dropPartition(db, table, clause);
+
+        // 4. Verify master state - partition is dropped
+        Assertions.assertNull(table.getPartition(PARTITION_ID));
+
+        // 5. Test follower replay
+        DropPartitionsInfo replayInfo = (DropPartitionsInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_DROP_PARTITIONS);
+
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(DB_ID, replayInfo.getDbId());
+        Assertions.assertEquals(TABLE_ID, replayInfo.getTableId());
+        Assertions.assertEquals(partitionNames, replayInfo.getPartitionNames());
+
+        // Create follower metastore and the same id objects, then replay
+        // Use a new recycle bin instance for follower to avoid conflicts
+        CatalogRecycleBin followerRecycleBin = new CatalogRecycleBin();
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(),
+                followerRecycleBin, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+        OlapTable followerTable = createRangePartitionedOlapTable(TABLE_ID, TABLE_NAME);
+        followerDb.registerTableUnlocked(followerTable);
+        // Register tablet to inverted index for replay
+        TabletMeta followerTabletMeta = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, followerTabletMeta);
+        Partition followerPartition = followerTable.getPartition(PARTITION_ID);
+        PhysicalPartition followerPhysicalPartition = followerPartition.getDefaultPhysicalPartition();
+        MaterializedIndex followerIndex = followerPhysicalPartition.getIndex(INDEX_ID);
+        LocalTablet followerTablet = (LocalTablet) followerIndex.getTablet(TABLET_ID);
+        Replica followerReplica = followerTablet.getReplicaByBackendId(BACKEND_ID);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, followerReplica);
+        Assertions.assertNotNull(followerTable.getPartition(PARTITION_ID));
+
+        // Ensure partition is not in GlobalStateMgr's recycle bin before replay
+        // (OlapTable.dropPartition uses GlobalStateMgr.getCurrentState().getRecycleBin())
+        GlobalStateMgr.getCurrentState().getRecycleBin().removePartitionFromRecycleBin(PARTITION_ID);
+
+        followerMetastore.replayDropPartitions(replayInfo);
+
+        // 6. Verify follower state
+        Assertions.assertNull(followerTable.getPartition(PARTITION_ID));
+    }
+
+    @Test
+    public void testDropPartitionEditLogException() throws Exception {
+        // 1. Create table with partition
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createRangePartitionedOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        // Add tablet to inverted index
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+        Replica replica = tablet.getReplicaByBackendId(BACKEND_ID);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica);
+
+        // Verify initial state
+        Assertions.assertNotNull(table.getPartition(PARTITION_ID));
+
+        // 2. Create DropPartitionClause
+        List<String> partitionNames = List.of("p1");
+        DropPartitionClause clause = new DropPartitionClause(false, partitionNames, false, false, NodePosition.ZERO);
+        // Set resolved partition names (normally done by analyzer)
+        clause.setResolvedPartitionNames(partitionNames);
+
+        // 3. Mock EditLog.logDropPartitions to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logDropPartitions(any(DropPartitionsInfo.class), any());
+
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute dropPartition and expect exception
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            metastore.dropPartition(db, table, clause);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed"));
+
+        // 5. Verify partition still exists after exception
+        Assertions.assertNotNull(table.getPartition(PARTITION_ID));
+    }
+
+    // Test renameTable
+    @Test
+    public void testRenameTableNormalCase() throws Exception {
+        // 1. Create table
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+        String oldTableName = table.getName();
+
+        // 2. Create TableRenameClause
+        String newTableName = "renamed_table";
+        TableRenameClause clause = new TableRenameClause(newTableName, NodePosition.ZERO);
+
+        // 3. Execute renameTable
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        metastore.renameTable(db, table, clause);
+
+        // 4. Verify master state
+        OlapTable renamedTable = (OlapTable) db.getTable(newTableName);
+        Assertions.assertNotNull(renamedTable);
+        Assertions.assertEquals(newTableName, renamedTable.getName());
+        Assertions.assertEquals(TABLE_ID, renamedTable.getId());
+        Assertions.assertNull(db.getTable(oldTableName));
+
+        // 5. Test follower replay
+        TableInfo replayInfo = (TableInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_RENAME_TABLE_V2);
+
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(DB_ID, replayInfo.getDbId());
+        Assertions.assertEquals(TABLE_ID, replayInfo.getTableId());
+        Assertions.assertEquals(newTableName, replayInfo.getNewTableName());
+
+        // Create follower metastore and the same id objects, then replay
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+        OlapTable followerTable = createOlapTable(TABLE_ID, oldTableName);
+        followerDb.registerTableUnlocked(followerTable);
+
+        followerMetastore.replayRenameTable(replayInfo);
+
+        // 6. Verify follower state
+        OlapTable replayed = (OlapTable) followerDb.getTable(newTableName);
+        Assertions.assertNotNull(replayed);
+        Assertions.assertEquals(newTableName, replayed.getName());
+        Assertions.assertEquals(TABLE_ID, replayed.getId());
+        Assertions.assertNull(followerDb.getTable(oldTableName));
+    }
+
+    @Test
+    public void testRenameTableEditLogException() throws Exception {
+        // 1. Create table
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+        String oldTableName = table.getName();
+
+        // 2. Create TableRenameClause
+        String newTableName = "renamed_table";
+        TableRenameClause clause = new TableRenameClause(newTableName, NodePosition.ZERO);
+
+        // 3. Mock EditLog.logTableRename to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logTableRename(any(TableInfo.class), any());
+
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute renameTable and expect exception
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            metastore.renameTable(db, table, clause);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed"));
+
+        // 5. Verify table name remains unchanged after exception
+        Assertions.assertEquals(oldTableName, table.getName());
+        Assertions.assertNotNull(db.getTable(oldTableName));
+    }
+
+    // Test renamePartition
+    @Test
+    public void testRenamePartitionNormalCase() throws Exception {
+        // 1. Create range partitioned table
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createRangePartitionedOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+        String oldPartitionName = "p1";
+
+        // 2. Create PartitionRenameClause
+        String newPartitionName = "renamed_p1";
+        PartitionRenameClause clause = new PartitionRenameClause(oldPartitionName, newPartitionName, NodePosition.ZERO);
+
+        // 3. Execute renamePartition
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        metastore.renamePartition(db, table, clause);
+
+        // 4. Verify master state
+        Partition renamedPartition = table.getPartition(newPartitionName);
+        Assertions.assertNotNull(renamedPartition);
+        Assertions.assertEquals(newPartitionName, renamedPartition.getName());
+        Assertions.assertEquals(PARTITION_ID, renamedPartition.getId());
+        Assertions.assertNull(table.getPartition(oldPartitionName));
+
+        // 5. Test follower replay
+        TableInfo replayInfo = (TableInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_RENAME_PARTITION_V2);
+
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(DB_ID, replayInfo.getDbId());
+        Assertions.assertEquals(TABLE_ID, replayInfo.getTableId());
+        Assertions.assertEquals(PARTITION_ID, replayInfo.getPartitionId());
+        Assertions.assertEquals(newPartitionName, replayInfo.getNewPartitionName());
+
+        // Create follower metastore and the same id objects, then replay
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+        OlapTable followerTable = createRangePartitionedOlapTable(TABLE_ID, TABLE_NAME);
+        followerDb.registerTableUnlocked(followerTable);
+
+        followerMetastore.replayRenamePartition(replayInfo);
+
+        // 6. Verify follower state
+        Partition replayed = followerTable.getPartition(newPartitionName);
+        Assertions.assertNotNull(replayed);
+        Assertions.assertEquals(newPartitionName, replayed.getName());
+        Assertions.assertEquals(PARTITION_ID, replayed.getId());
+        Assertions.assertNull(followerTable.getPartition(oldPartitionName));
+    }
+
+    @Test
+    public void testRenamePartitionEditLogException() throws Exception {
+        // 1. Create range partitioned table
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createRangePartitionedOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+        String oldPartitionName = "p1";
+
+        // 2. Create PartitionRenameClause
+        String newPartitionName = "renamed_p1";
+        PartitionRenameClause clause = new PartitionRenameClause(oldPartitionName, newPartitionName, NodePosition.ZERO);
+
+        // 3. Mock EditLog.logPartitionRename to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logPartitionRename(any(TableInfo.class), any());
+
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute renamePartition and expect exception
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            metastore.renamePartition(db, table, clause);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed"));
+
+        // 5. Verify partition name remains unchanged after exception
+        Assertions.assertNotNull(table.getPartition(oldPartitionName));
+        Assertions.assertNull(table.getPartition(newPartitionName));
+    }
+
+    // Test renameRollup
+    @Test
+    public void testRenameRollupNormalCase() throws Exception {
+        // 1. Create table with rollup index
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        // Add a rollup index
+        long rollupIndexId = INDEX_ID + 1;
+        String rollupName = "rollup1";
+        List<Column> rollupColumns = new ArrayList<>();
+        rollupColumns.add(table.getColumn("v1"));
+        rollupColumns.add(table.getColumn("v2"));
+        table.setIndexMeta(rollupIndexId, rollupName, rollupColumns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        table.getIndexNameToMetaId().put(rollupName, rollupIndexId);
+
+        String oldRollupName = rollupName;
+
+        // 2. Create RollupRenameClause
+        String newRollupName = "renamed_rollup1";
+        RollupRenameClause clause = new RollupRenameClause(oldRollupName, newRollupName, NodePosition.ZERO);
+
+        // 3. Execute renameRollup
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        metastore.renameRollup(db, table, clause);
+
+        // 4. Verify master state
+        Assertions.assertNull(table.getIndexNameToMetaId().get(oldRollupName));
+        Assertions.assertEquals(rollupIndexId, table.getIndexNameToMetaId().get(newRollupName).longValue());
+        Assertions.assertEquals(newRollupName, table.getIndexNameByMetaId(rollupIndexId));
+
+        // 5. Test follower replay
+        TableInfo replayInfo = (TableInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_RENAME_ROLLUP_V2);
+
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(DB_ID, replayInfo.getDbId());
+        Assertions.assertEquals(TABLE_ID, replayInfo.getTableId());
+        Assertions.assertEquals(rollupIndexId, replayInfo.getIndexId());
+        Assertions.assertEquals(newRollupName, replayInfo.getNewRollupName());
+
+        // Create follower metastore and the same id objects, then replay
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+        OlapTable followerTable = createOlapTable(TABLE_ID, TABLE_NAME);
+        followerDb.registerTableUnlocked(followerTable);
+        followerTable.setIndexMeta(rollupIndexId, oldRollupName, rollupColumns, 0, 0,
+                (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        followerTable.getIndexNameToMetaId().put(oldRollupName, rollupIndexId);
+
+        followerMetastore.replayRenameRollup(replayInfo);
+
+        // 6. Verify follower state
+        Assertions.assertNull(followerTable.getIndexNameToMetaId().get(oldRollupName));
+        Assertions.assertEquals(rollupIndexId, followerTable.getIndexNameToMetaId().get(newRollupName).longValue());
+        Assertions.assertEquals(newRollupName, followerTable.getIndexNameByMetaId(rollupIndexId));
+    }
+
+    @Test
+    public void testRenameRollupEditLogException() throws Exception {
+        // 1. Create table with rollup index
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        long rollupIndexId = INDEX_ID + 1;
+        String rollupName = "rollup1";
+        List<Column> rollupColumns = new ArrayList<>();
+        rollupColumns.add(table.getColumn("v1"));
+        rollupColumns.add(table.getColumn("v2"));
+        table.setIndexMeta(rollupIndexId, rollupName, rollupColumns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        table.getIndexNameToMetaId().put(rollupName, rollupIndexId);
+
+        String oldRollupName = rollupName;
+
+        // 2. Create RollupRenameClause
+        String newRollupName = "renamed_rollup1";
+        RollupRenameClause clause = new RollupRenameClause(oldRollupName, newRollupName, NodePosition.ZERO);
+
+        // 3. Mock EditLog.logRollupRename to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logRollupRename(any(TableInfo.class), any());
+
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute renameRollup and expect exception
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            metastore.renameRollup(db, table, clause);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed"));
+
+        // 5. Verify rollup name remains unchanged after exception
+        Assertions.assertNotNull(table.getIndexNameToMetaId().get(oldRollupName));
+        Assertions.assertNull(table.getIndexNameToMetaId().get(newRollupName));
+    }
+
+    // Test renameColumn
+    @Test
+    public void testRenameColumnNormalCase() throws Exception {
+        // 1. Create table
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+        String oldColName = "v1";
+
+        // 2. Create ColumnRenameClause
+        String newColName = "renamed_v1";
+        ColumnRenameClause clause = new ColumnRenameClause(oldColName, newColName, NodePosition.ZERO);
+
+        // 3. Execute renameColumn
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        metastore.renameColumn(db, table, clause);
+
+        // 4. Verify master state
+        Assertions.assertNull(table.getColumn(oldColName));
+        Assertions.assertNotNull(table.getColumn(newColName));
+        Assertions.assertEquals(newColName, table.getColumn(newColName).getName());
+
+        // 5. Test follower replay
+        ColumnRenameInfo replayInfo = (ColumnRenameInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_RENAME_COLUMN_V2);
+
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(DB_ID, replayInfo.getDbId());
+        Assertions.assertEquals(TABLE_ID, replayInfo.getTableId());
+        Assertions.assertEquals(oldColName, replayInfo.getColumnName());
+        Assertions.assertEquals(newColName, replayInfo.getNewColumnName());
+
+        // Create follower metastore and the same id objects, then replay
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+        OlapTable followerTable = createOlapTable(TABLE_ID, TABLE_NAME);
+        followerDb.registerTableUnlocked(followerTable);
+
+        followerMetastore.replayRenameColumn(replayInfo);
+
+        // 6. Verify follower state
+        Assertions.assertNull(followerTable.getColumn(oldColName));
+        Assertions.assertNotNull(followerTable.getColumn(newColName));
+        Assertions.assertEquals(newColName, followerTable.getColumn(newColName).getName());
+    }
+
+    @Test
+    public void testRenameColumnEditLogException() throws Exception {
+        // 1. Create table
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+        String oldColName = "v1";
+
+        // 2. Create ColumnRenameClause
+        String newColName = "renamed_v1";
+        ColumnRenameClause clause = new ColumnRenameClause(oldColName, newColName, NodePosition.ZERO);
+
+        // 3. Mock EditLog.logColumnRename to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logColumnRename(any(ColumnRenameInfo.class), any());
+
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute renameColumn and expect exception
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            metastore.renameColumn(db, table, clause);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed"));
+
+        // 5. Verify column name remains unchanged after exception
+        Assertions.assertNotNull(table.getColumn(oldColName));
+        Assertions.assertNull(table.getColumn(newColName));
+    }
+
+    // Test modifyTableReplicationNum
+    @Test
+    public void testModifyTableReplicationNumNormalCase() throws Exception {
+        // 1. Create unpartitioned table
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        Partition partition = table.getPartition(PARTITION_ID);
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        short initialReplicationNum = partitionInfo.getReplicationNum(partition.getId());
+
+        // 2. Create properties with new replication num
+        Map<String, String> properties = new HashMap<>();
+        short newReplicationNum = 3;
+        properties.put("replication_num", String.valueOf(newReplicationNum));
+
+        // 3. Execute modifyTableReplicationNum
+        // The method requires the caller to hold db write lock
+        // Also ensure colocateTableIndex is set
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        if (metastore.getColocateTableIndex() == null) {
+            metastore.setColocateTableIndex(GlobalStateMgr.getCurrentState().getColocateTableIndex());
+        }
+        Locker locker = new Locker();
+        locker.lockDatabase(db.getId(), LockType.WRITE);
+        try {
+            metastore.modifyTableReplicationNum(db, table, properties);
+        } finally {
+            locker.unLockDatabase(db.getId(), LockType.WRITE);
+        }
+
+        // 4. Verify master state
+        Assertions.assertEquals(newReplicationNum, partitionInfo.getReplicationNum(partition.getId()));
+        Assertions.assertEquals(newReplicationNum, table.getTableProperty().getReplicationNum());
+
+        // 5. Test follower replay
+        ModifyPartitionInfo replayInfo = (ModifyPartitionInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_MODIFY_PARTITION_V2);
+
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(DB_ID, replayInfo.getDbId());
+        Assertions.assertEquals(TABLE_ID, replayInfo.getTableId());
+        Assertions.assertEquals(PARTITION_ID, replayInfo.getPartitionId());
+        Assertions.assertEquals(newReplicationNum, replayInfo.getReplicationNum());
+
+        // Create follower metastore and the same id objects, then replay
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+        OlapTable followerTable = createOlapTable(TABLE_ID, TABLE_NAME);
+        followerDb.registerTableUnlocked(followerTable);
+        Partition followerPartition = followerTable.getPartition(PARTITION_ID);
+        PartitionInfo followerPartitionInfo = followerTable.getPartitionInfo();
+        followerPartitionInfo.setReplicationNum(followerPartition.getId(), initialReplicationNum);
+        followerTable.getTableProperty().setReplicationNum(initialReplicationNum);
+
+        // Replay modify partition - need to manually update partition info
+        followerPartitionInfo.setReplicationNum(followerPartition.getId(), replayInfo.getReplicationNum());
+        followerTable.getTableProperty().setReplicationNum(replayInfo.getReplicationNum());
+
+        // 6. Verify follower state
+        Assertions.assertEquals(newReplicationNum, followerPartitionInfo.getReplicationNum(followerPartition.getId()));
+        Assertions.assertEquals(newReplicationNum, followerTable.getTableProperty().getReplicationNum());
+    }
+
+    @Test
+    public void testModifyTableReplicationNumEditLogException() throws Exception {
+        // 1. Create unpartitioned table
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        Partition partition = table.getPartition(PARTITION_ID);
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        short initialTableReplicationNum = table.getTableProperty().getReplicationNum();
+        short initialPartitionReplicationNum = partitionInfo.getReplicationNum(partition.getId());
+
+        // 2. Create properties with new replication num
+        Map<String, String> properties = new HashMap<>();
+        short newReplicationNum = 3;
+        properties.put("replication_num", String.valueOf(newReplicationNum));
+
+        // 3. Mock EditLog.logModifyPartition to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logModifyPartition(any(ModifyPartitionInfo.class), any());
+
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute modifyTableReplicationNum and expect exception
+        // The method requires the caller to hold db write lock
+        // Also ensure colocateTableIndex is set
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        if (metastore.getColocateTableIndex() == null) {
+            metastore.setColocateTableIndex(GlobalStateMgr.getCurrentState().getColocateTableIndex());
+        }
+        Locker locker = new Locker();
+        locker.lockDatabase(db.getId(), LockType.WRITE);
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+                metastore.modifyTableReplicationNum(db, table, properties);
+            });
+            Assertions.assertTrue(exception.getMessage().contains("EditLog write failed"));
+        } finally {
+            locker.unLockDatabase(db.getId(), LockType.WRITE);
+        }
+
+        // 5. Verify replication num remains unchanged after exception
+        Assertions.assertEquals(initialPartitionReplicationNum, partitionInfo.getReplicationNum(partition.getId()));
+        Assertions.assertEquals(initialTableReplicationNum, table.getTableProperty().getReplicationNum());
+    }
+
+    // Test setReplicaStatus
+    @Test
+    public void testSetReplicaStatusNormalCase() throws Exception {
+        // 1. Create table with tablet and replica
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        // Add tablet to inverted index
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+        Replica replica = tablet.getReplicaByBackendId(BACKEND_ID);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica);
+
+        // Verify initial state - replica is not bad
+        Assertions.assertFalse(replica.isBad());
+
+        // 2. Create AdminSetReplicaStatusStmt
+        List<Property> propertyList = new ArrayList<>();
+        propertyList.add(new Property("tablet_id", String.valueOf(TABLET_ID), NodePosition.ZERO));
+        propertyList.add(new Property("backend_id", String.valueOf(BACKEND_ID), NodePosition.ZERO));
+        propertyList.add(new Property("status", "bad", NodePosition.ZERO));
+        PropertySet propertySet = new PropertySet(propertyList, NodePosition.ZERO);
+        AdminSetReplicaStatusStmt stmt = new AdminSetReplicaStatusStmt(propertySet, NodePosition.ZERO);
+        // Analyze to set the values
+        AdminStmtAnalyzer.analyze(stmt, UtFrameUtils.createDefaultCtx());
+
+        // 3. Execute setReplicaStatus
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        metastore.setReplicaStatus(stmt);
+
+        // 4. Verify master state - replica is marked as bad
+        Assertions.assertTrue(replica.isBad());
+
+        // 5. Test follower replay
+        SetReplicaStatusOperationLog replayInfo = (SetReplicaStatusOperationLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_SET_REPLICA_STATUS);
+
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(TABLET_ID, replayInfo.getTabletId());
+        Assertions.assertEquals(BACKEND_ID, replayInfo.getBackendId());
+        Assertions.assertEquals(ReplicaStatus.BAD, replayInfo.getReplicaStatus());
+
+        // Create follower metastore and the same id objects, then replay
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+        OlapTable followerTable = createOlapTable(TABLE_ID, TABLE_NAME);
+        followerDb.registerTableUnlocked(followerTable);
+
+        TabletMeta followerTabletMeta = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, followerTabletMeta);
+        Partition followerPartition = followerTable.getPartition(PARTITION_ID);
+        PhysicalPartition followerPhysicalPartition = followerPartition.getDefaultPhysicalPartition();
+        MaterializedIndex followerIndex = followerPhysicalPartition.getIndex(INDEX_ID);
+        LocalTablet followerTablet = (LocalTablet) followerIndex.getTablet(TABLET_ID);
+        Replica followerReplica = followerTablet.getReplicaByBackendId(BACKEND_ID);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, followerReplica);
+        Assertions.assertFalse(followerReplica.isBad());
+
+        followerMetastore.replaySetReplicaStatus(replayInfo);
+
+        // 6. Verify follower state
+        Assertions.assertTrue(followerReplica.isBad());
+    }
+
+    @Test
+    public void testSetReplicaStatusEditLogException() throws Exception {
+        // 1. Create table with tablet and replica
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        // Add tablet to inverted index
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+        Partition partition = table.getPartition(PARTITION_ID);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex index = physicalPartition.getIndex(INDEX_ID);
+        LocalTablet tablet = (LocalTablet) index.getTablet(TABLET_ID);
+        Replica replica = tablet.getReplicaByBackendId(BACKEND_ID);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(TABLET_ID, replica);
+
+        // Verify initial state
+        Assertions.assertFalse(replica.isBad());
+
+        // 2. Create AdminSetReplicaStatusStmt
+        List<Property> propertyList = new ArrayList<>();
+        propertyList.add(new Property("tablet_id", String.valueOf(TABLET_ID), NodePosition.ZERO));
+        propertyList.add(new Property("backend_id", String.valueOf(BACKEND_ID), NodePosition.ZERO));
+        propertyList.add(new Property("status", "bad", NodePosition.ZERO));
+        PropertySet propertySet = new PropertySet(propertyList, NodePosition.ZERO);
+        AdminSetReplicaStatusStmt stmt = new AdminSetReplicaStatusStmt(propertySet, NodePosition.ZERO);
+        // Analyze to set the values
+        AdminStmtAnalyzer.analyze(stmt, UtFrameUtils.createDefaultCtx());
+
+        // 3. Mock EditLog.logSetReplicaStatus to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logSetReplicaStatus(any(SetReplicaStatusOperationLog.class), any());
+
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute setReplicaStatus - the method may throw exception if EditLog fails
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            metastore.setReplicaStatus(stmt);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed"));
+        Assertions.assertFalse(replica.isBad());
+    }
+
+    // Test setPartitionVersion
+    @Test
+    public void testSetPartitionVersionNormalCase() throws Exception {
+        // 1. Create table
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        // For unpartitioned table, partition name should be the same as table name
+        Partition partition = table.getPartition(TABLE_NAME);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        long initialVersion = physicalPartition.getVisibleVersion();
+
+        // 2. Create AdminSetPartitionVersionStmt
+        // For unpartitioned table, partition name should be the same as table name
+        long newVersion = 100L;
+        QualifiedName qualifiedName = QualifiedName.of(List.of("default_catalog", DB_NAME, TABLE_NAME));
+        TableRef tableRef = new TableRef(qualifiedName, null, NodePosition.ZERO);
+        AdminSetPartitionVersionStmt stmt = new AdminSetPartitionVersionStmt(
+                tableRef, TABLE_NAME, newVersion, NodePosition.ZERO);
+
+        // 3. Execute setPartitionVersion
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        metastore.setPartitionVersion(stmt);
+
+        // 4. Verify master state
+        // Re-read the partition to get updated version
+        partition = table.getPartition(TABLE_NAME);
+        physicalPartition = partition.getDefaultPhysicalPartition();
+        Assertions.assertEquals(newVersion, physicalPartition.getVisibleVersion());
+        Assertions.assertEquals(newVersion + 1, physicalPartition.getNextVersion());
+
+        // 5. Test follower replay
+        PartitionVersionRecoveryInfo replayInfo = (PartitionVersionRecoveryInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_RECOVER_PARTITION_VERSION);
+
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertNotNull(replayInfo.getPartitionVersions());
+        Assertions.assertFalse(replayInfo.getPartitionVersions().isEmpty());
+        Assertions.assertEquals(DB_ID, replayInfo.getPartitionVersions().get(0).getDbId());
+        Assertions.assertEquals(TABLE_ID, replayInfo.getPartitionVersions().get(0).getTableId());
+        Assertions.assertEquals(PHYSICAL_PARTITION_ID, replayInfo.getPartitionVersions().get(0).getPartitionId());
+        Assertions.assertEquals(newVersion, replayInfo.getPartitionVersions().get(0).getVersion());
+
+        // Create follower metastore and the same id objects, then replay
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+        OlapTable followerTable = createOlapTable(TABLE_ID, TABLE_NAME);
+        followerDb.registerTableUnlocked(followerTable);
+        // For unpartitioned table, partition name should be the same as table name
+        Partition followerPartition = followerTable.getPartition(TABLE_NAME);
+        PhysicalPartition followerPhysicalPartition = followerPartition.getDefaultPhysicalPartition();
+        long followerInitialVersion = followerPhysicalPartition.getVisibleVersion();
+
+        // Use MetaRecoveryDaemon to replay
+        // Temporarily set followerMetastore to GlobalStateMgr so recoverPartitionVersion can find the database and table
+        LocalMetastore originalMetastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        GlobalStateMgr.getCurrentState().setLocalMetastore(followerMetastore);
+        try {
+            MetaRecoveryDaemon recoveryDaemon = new MetaRecoveryDaemon();
+            recoveryDaemon.recoverPartitionVersion(replayInfo);
+        } finally {
+            GlobalStateMgr.getCurrentState().setLocalMetastore(originalMetastore);
+        }
+
+        // 6. Verify follower state
+        // Re-read the partition to get updated version
+        // For unpartitioned table, partition name should be the same as table name
+        followerPartition = followerTable.getPartition(TABLE_NAME);
+        followerPhysicalPartition = followerPartition.getDefaultPhysicalPartition();
+        Assertions.assertEquals(newVersion, followerPhysicalPartition.getVisibleVersion());
+        Assertions.assertEquals(newVersion + 1, followerPhysicalPartition.getNextVersion());
+    }
+
+    @Test
+    public void testSetPartitionVersionEditLogException() throws Exception {
+        // 1. Create table
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        // For unpartitioned table, partition name should be the same as table name
+        Partition partition = table.getPartition(TABLE_NAME);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        long initialVersion = physicalPartition.getVisibleVersion();
+
+        // 2. Create AdminSetPartitionVersionStmt
+        // For unpartitioned table, partition name should be the same as table name
+        long newVersion = 100L;
+        QualifiedName qualifiedName = QualifiedName.of(List.of("default_catalog", DB_NAME, TABLE_NAME));
+        TableRef tableRef = new TableRef(qualifiedName, null, NodePosition.ZERO);
+        AdminSetPartitionVersionStmt stmt = new AdminSetPartitionVersionStmt(
+                tableRef, TABLE_NAME, newVersion, NodePosition.ZERO);
+
+        // 3. Mock EditLog.logRecoverPartitionVersion to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logRecoverPartitionVersion(any(PartitionVersionRecoveryInfo.class), any());
+
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute setPartitionVersion and expect exception
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            metastore.setPartitionVersion(stmt);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed"));
+
+        // 5. Verify partition version remains unchanged after exception
+        Assertions.assertEquals(initialVersion, physicalPartition.getVisibleVersion());
+    }
+
+    // Test getPartitionIdToStorageMediumMap
+    @Test
+    public void testGetPartitionIdToStorageMediumMapNormalCase() throws Exception {
+        // 1. Create table with SSD storage medium that will expire
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        // Set partition to SSD with expired cooldown time
+        Partition partition = table.getPartition(PARTITION_ID);
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        com.starrocks.catalog.DataProperty expiredSSDProperty = new com.starrocks.catalog.DataProperty(
+                TStorageMedium.SSD, System.currentTimeMillis() - 1000); // Expired
+        partitionInfo.setDataProperty(partition.getId(), expiredSSDProperty);
+
+        // Add tablet to inverted index
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, TStorageMedium.SSD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+
+        // Verify initial state
+        Assertions.assertEquals(TStorageMedium.SSD, partitionInfo.getDataProperty(partition.getId()).getStorageMedium());
+
+        // 2. Execute getPartitionIdToStorageMediumMap
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Map<Long, TStorageMedium> storageMediumMap = metastore.getPartitionIdToStorageMediumMap();
+
+        // 3. Verify master state - partition should be changed to HDD if lock was acquired
+        // Note: The method uses tryLock, so it may not always succeed.
+        // If lock was acquired and EditLog succeeded, the storage medium should be HDD
+        TStorageMedium actualMedium = partitionInfo.getDataProperty(partition.getId()).getStorageMedium();
+
+        Assertions.assertTrue(storageMediumMap.containsKey(PARTITION_ID));
+        Assertions.assertEquals(TStorageMedium.HDD, storageMediumMap.get(PARTITION_ID));
+
+        // 4. Test follower replay
+        ModifyPartitionInfo replayInfo = (ModifyPartitionInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_MODIFY_PARTITION_V2);
+
+        Assertions.assertNotNull(replayInfo);
+        Assertions.assertEquals(DB_ID, replayInfo.getDbId());
+        Assertions.assertEquals(TABLE_ID, replayInfo.getTableId());
+        Assertions.assertEquals(PARTITION_ID, replayInfo.getPartitionId());
+        Assertions.assertEquals(TStorageMedium.HDD, replayInfo.getDataProperty().getStorageMedium());
+
+        // Create follower metastore and the same id objects, then replay
+        LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        Database followerDb = new Database(DB_ID, DB_NAME);
+        followerMetastore.unprotectCreateDb(followerDb);
+        OlapTable followerTable = createOlapTable(TABLE_ID, TABLE_NAME);
+        followerDb.registerTableUnlocked(followerTable);
+        Partition followerPartition = followerTable.getPartition(PARTITION_ID);
+        PartitionInfo followerPartitionInfo = followerTable.getPartitionInfo();
+        followerPartitionInfo.setDataProperty(followerPartition.getId(), expiredSSDProperty);
+
+        followerPartitionInfo.setDataProperty(followerPartition.getId(), replayInfo.getDataProperty());
+
+        // 5. Verify follower state
+        Assertions.assertEquals(TStorageMedium.HDD, followerPartitionInfo
+                .getDataProperty(followerPartition.getId()).getStorageMedium());
+    }
+
+    @Test
+    public void testGetPartitionIdToStorageMediumMapEditLogException() {
+        // 1. Create table with SSD storage medium that will expire
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        OlapTable table = createOlapTable(TABLE_ID, TABLE_NAME);
+        db.registerTableUnlocked(table);
+
+        // Set partition to SSD with expired cooldown time
+        Partition partition = table.getPartition(PARTITION_ID);
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        com.starrocks.catalog.DataProperty expiredSSDProperty = new com.starrocks.catalog.DataProperty(
+                TStorageMedium.SSD, System.currentTimeMillis() - 1000); // Expired
+        partitionInfo.setDataProperty(partition.getId(), expiredSSDProperty);
+
+        // Add tablet to inverted index
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, TStorageMedium.SSD);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(TABLET_ID, tabletMeta);
+
+        // 2. Mock EditLog.logModifyPartition to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logModifyPartition(any(ModifyPartitionInfo.class), any());
+
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 3. Execute getPartitionIdToStorageMediumMap - exception is caught internally
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            metastore.getPartitionIdToStorageMediumMap();
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed"));
+
+        // 4. Verify storage medium remains unchanged after exception
+        // The method catches exceptions internally, so the partition should remain as SSD
+        Assertions.assertEquals(TStorageMedium.SSD, partitionInfo.getDataProperty(partition.getId()).getStorageMedium());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
@@ -54,7 +54,7 @@ public class AnalyzeBackupRestoreTest {
         BlobStorage storage = new BlobStorage(brokerName, Maps.newHashMap());
         Repository repo = new Repository(10000, "repo", false, location, storage);
         repo.initRepository();
-        GlobalStateMgr.getCurrentState().getBackupHandler().getRepoMgr().addAndInitRepoIfNotExist(repo, false);
+        GlobalStateMgr.getCurrentState().getBackupHandler().getRepoMgr().addAndInitRepoIfNotExist(repo);
 
         AnalyzeTestUtil.getStarRocksAssert().withFunction("CREATE FUNCTION Echostring(string) RETURNS string properties" +
                         "(\"symbol\" = \"Echostring\", \"type\" = \"StarrocksJar\", \"file\" = \"xxx\");");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeRepositoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeRepositoryTest.java
@@ -172,7 +172,7 @@ public class AnalyzeRepositoryTest {
         BlobStorage storage = new BlobStorage("broker", Maps.newHashMap());
         Repository repo = new Repository(10000, "repo", false, "bos://backup-cmy", storage);
         repo.initRepository();
-        GlobalStateMgr.getCurrentState().getBackupHandler().getRepoMgr().addAndInitRepoIfNotExist(repo, false);
+        GlobalStateMgr.getCurrentState().getBackupHandler().getRepoMgr().addAndInitRepoIfNotExist(repo);
 
         analyzeSuccess("DROP REPOSITORY `repo`;");
         analyzeFail("DROP REPOSITORY ``;");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSnapshotTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSnapshotTest.java
@@ -93,7 +93,7 @@ public class AnalyzeSnapshotTest {
         BlobStorage storage = new BlobStorage(brokerName, Maps.newHashMap());
         Repository repo = new Repository(10000, "repo", false, location, storage);
         repo.initRepository();
-        GlobalStateMgr.getCurrentState().getBackupHandler().getRepoMgr().addAndInitRepoIfNotExist(repo, false);
+        GlobalStateMgr.getCurrentState().getBackupHandler().getRepoMgr().addAndInitRepoIfNotExist(repo);
 
         analyzeSuccess("SHOW SNAPSHOT ON `repo` WHERE SNAPSHOT = \"backup1\" AND TIMESTAMP = \"2018-05-05-15-34-26\";");
         analyzeSuccess("SHOW SNAPSHOT ON `repo` WHERE SNAPSHOT IN (\"backup1\")");

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionIdGeneratorEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionIdGeneratorEditLogTest.java
@@ -1,0 +1,119 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.transaction;
+
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.TransactionIdInfo;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class TransactionIdGeneratorEditLogTest {
+    private TransactionIdGenerator idGenerator;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Initialize test environment
+        UtFrameUtils.setUpForPersistTest();
+
+        // Create TransactionIdGenerator instance
+        idGenerator = new TransactionIdGenerator();
+        // Initialize to near batch end to trigger editlog write
+        idGenerator.initTransactionId(999L);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testGetNextTransactionIdNormalCase() throws Exception {
+        // 1. Verify initial state
+        // After initTransactionId(999L), nextId should be 999, batchEndId should be 999
+        // When getNextTransactionId is called, nextId (999) >= batchEndId (999), so it will trigger editlog write
+        // newBatchEndId = 999 + 1000 = 1999, then nextId++ returns 1000
+        
+        // 2. Execute getNextTransactionId operation (master side) - this should trigger editlog write
+        long nextId = idGenerator.getNextTransactionId();
+
+        // 3. Verify master state
+        Assertions.assertEquals(1000L, nextId);
+        // batchEndId should be updated to 1999
+        long batchEndId = idGenerator.getBatchEndId();
+        Assertions.assertEquals(1999L, batchEndId);
+
+        // 4. Test follower replay functionality
+        TransactionIdGenerator followerIdGenerator = new TransactionIdGenerator();
+        followerIdGenerator.initTransactionId(999L);
+        
+        // Verify follower initial state
+        long followerBatchEndId = followerIdGenerator.getBatchEndId();
+        Assertions.assertEquals(999L, followerBatchEndId);
+
+        // Replay the operation
+        TransactionIdInfo replayLog = (TransactionIdInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_SAVE_TRANSACTION_ID_V2);
+        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionIDGenerator()
+                .initTransactionId(replayLog.getTxnId() + 1);
+        followerIdGenerator.initTransactionId(replayLog.getTxnId());
+
+        // 5. Verify follower state is consistent with master
+        long replayedBatchEndId = followerIdGenerator.getBatchEndId();
+        Assertions.assertEquals(1999L, replayedBatchEndId);
+        Assertions.assertEquals(batchEndId, replayedBatchEndId);
+        
+        // Verify the transaction ID info
+        Assertions.assertEquals(1999L, replayLog.getTxnId());
+    }
+
+    @Test
+    public void testGetNextTransactionIdEditLogException() {
+        // 1. Verify initial state
+        long initialBatchEndId = idGenerator.getBatchEndId();
+        Assertions.assertEquals(999L, initialBatchEndId);
+
+        // 2. Mock EditLog.logSaveTransactionId to throw exception
+        EditLog spyEditLog = spy(GlobalStateMgr.getCurrentState().getEditLog());
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logSaveTransactionId(anyLong(), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 3. Execute getNextTransactionId operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            idGenerator.getNextTransactionId();
+        });
+        Assertions.assertTrue(exception.getMessage().contains("EditLog write failed") || 
+                            exception.getCause() != null && 
+                            exception.getCause().getMessage().contains("EditLog write failed"));
+
+        // 4. Verify leader memory state remains unchanged after exception
+        // The batchEndId should not have been updated
+        long currentBatchEndId = idGenerator.getBatchEndId();
+        Assertions.assertEquals(initialBatchEndId, currentBatchEndId);
+    }
+}
+


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Refer https://github.com/StarRocks/starrocks/issues/63357

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes metadata persistence by replacing direct state mutations + edit logs with WAL entries that execute changes via appliers, and adds replay methods and tests.
> 
> - Convert many operations to `EditLog` WAL with appliers: view modify/rename, table/partition rename and drop, partition erase/recover/modify, replica delete/status, truncate table, repository add/remove, delete job finish, partition version recovery, transaction id save, Hive table schema modify, column comment modify
> - Introduce replay methods and internal helpers (e.g., `replayAlterView`, `replayAddRepo`/`replayRemoveRepo`, `dropPartitionInternal`, `modifyTableSchemaInternal`); adjust signatures to accept `WALApplier`
> - Split validation from mutation: `OlapTable.checkNameConflict`, `View.checkInlineViewDef`, `RecyclePartitionInfo.checkRecoverable` vs `recover`
> - Tweak visibilities (some methods now `protected`) and remove obsolete paths (e.g., legacy distribution type conversion)
> - Add/extend tests to verify WAL application and error handling for alter jobs, views, MV rename, schema change, repository ops
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00aa2b9ad1e854208364d44e5f9b1bba7b4aefe9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->