### PR TITLE
[Feature] Implement Regexp_Position in C++ mode

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -4524,7 +4524,7 @@ static ColumnPtr regexp_position_const_pattern(re2::RE2* const_re, const Columns
             result.append(-1);
             continue;
         }
-        
+
         const char* search_start = skip_leading_utf8(str_value.data, str_value.data + str_value.size, start_pos - 1);
         int byte_offset = search_start - str_value.data;
 

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -4452,15 +4452,14 @@ StatusOr<ColumnPtr> StringFunctions::regexp_count(FunctionContext* context, cons
     }
 }
 
-Status StringFunctions::regexp_position_prepare(FunctionContext* context, 
-                                                FunctionContext::FunctionStateScope scope) {
+Status StringFunctions::regexp_position_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
     if (scope != FunctionContext::FRAGMENT_LOCAL) {
         return Status::OK();
     }
 
     auto* state = new StringFunctionsState();
     context->set_function_state(scope, state);
-    
+
     if (!context->is_constant_column(1)) {
         return Status::OK();
     }
@@ -4482,7 +4481,7 @@ Status StringFunctions::regexp_position_prepare(FunctionContext* context,
             return Status::InvalidArgument(error.str());
         }
     }
-    
+
     return Status::OK();
 }
 

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -15,6 +15,7 @@
 #include "exprs/string_functions.h"
 
 #include "column/bytes.h"
+#include "function_context.h"
 #include "util/defer_op.h"
 
 #ifdef __x86_64__
@@ -4448,6 +4449,208 @@ StatusOr<ColumnPtr> StringFunctions::regexp_count(FunctionContext* context, cons
         re2::RE2::Options options;
         options.set_log_errors(false);
         return regexp_count_general(context, &options, columns);
+    }
+}
+
+Status StringFunctions::regexp_position_prepare(FunctionContext* context, 
+                                                FunctionContext::FunctionStateScope scope) {
+    if (scope != FunctionContext::FRAGMENT_LOCAL) {
+        return Status::OK();
+    }
+
+    auto* state = new StringFunctionsState();
+    context->set_function_state(scope, state);
+    
+    // check if pattern is constant
+    if (context->is_constant_column(1)) {
+        const auto pattern_col = context->get_constant_column(1);
+        if (!pattern_col->only_null()) {
+            Slice pattern = ColumnHelper::get_const_value<TYPE_VARCHAR>(pattern_col);
+            state->pattern = std::string(pattern.data, pattern.size);
+            state->const_pattern = true;
+
+            state->options = std::make_unique<re2::RE2::Options>();
+            state->options->set_log_errors(false);
+
+            state->regex = std::make_unique<re2::RE2>(state->pattern, *state->options);
+            if (!state->regex->ok()) {
+                std::stringstream error;
+                error << "Invalid regex expression: " << state->pattern;
+                context->set_error(error.str().c_str());
+                return Status::InvalidArgument(error.str());
+            }
+        }
+    }
+    return Status::OK();
+
+}
+
+Status StringFunctions::regexp_position_close(FunctionContext* context, 
+                                              FunctionContext::FunctionStateScope scope) {
+    if (scope == FunctionContext::FRAGMENT_LOCAL) {
+        auto* state = reinterpret_cast<StringFunctionsState*>(
+            context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+        delete state;
+    }
+    return Status::OK();
+}
+
+static ColumnPtr regexp_position_const_pattern(re2::RE2* const_re, const Columns& columns) {
+    auto str_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
+    auto start_viewer = ColumnViewer<TYPE_INT>(columns[2]);
+    auto occurrence_viewer = ColumnViewer<TYPE_INT>(columns[3]);
+    
+    auto size = columns[0]->size();
+    ColumnBuilder<TYPE_INT> result(size);
+    
+    for (int row = 0; row < size; ++row) {
+        if (str_viewer.is_null(row) || start_viewer.is_null(row) || occurrence_viewer.is_null(row)) {
+            result.append_null();
+            continue;
+        }
+        
+        int start_pos = start_viewer.value(row);
+        int occurrence = occurrence_viewer.value(row);
+        
+        if (start_pos < 1 || occurrence < 1) {
+            result.append(-1);
+            continue;
+        }
+        
+        auto str_value = str_viewer.value(row);
+        // get the number of code points in the string
+        int utf8_length = utf8_len(str_value.data, str_value.data + str_value.size);
+        
+        if (start_pos > utf8_length) {
+            result.append(-1);
+            continue;
+        }
+        
+        const char* search_start = skip_leading_utf8(str_value.data, str_value.data + str_value.size, start_pos - 1);
+        int byte_offset = search_start - str_value.data;
+        
+        int count = 0;
+        re2::StringPiece str_sp(str_value.data, str_value.size);
+        re2::StringPiece match;
+        
+        bool found = false;
+        while (byte_offset <= str_value.size) {
+            if (const_re->Match(str_sp, byte_offset, str_value.size, re2::RE2::UNANCHORED, &match, 1)) {
+                count++;
+                if (count == occurrence) {
+                    // convert back to one-based index
+                    int code_point_pos = utf8_len(str_value.data, match.data()) + 1;
+                    result.append(code_point_pos);
+                    found = true;
+                    break;
+                }
+                
+                byte_offset = match.data() - str_value.data + match.size();
+                if (match.size() == 0) {
+                    byte_offset++;
+                }
+            } else {
+                break;
+            }
+        }
+        
+        if (!found) {
+            result.append(-1);
+        }
+    }
+    
+    return result.build(ColumnHelper::is_all_const(columns));
+}
+
+static StatusOr<ColumnPtr> regexp_position_general(FunctionContext* context, re2::RE2::Options* options, const Columns& columns) {
+    auto str_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
+    auto pattern_viewer = ColumnViewer<TYPE_VARCHAR>(columns[1]);
+    auto start_viewer = ColumnViewer<TYPE_INT>(columns[2]);
+    auto occurrence_viewer = ColumnViewer<TYPE_INT>(columns[3]);
+    
+    auto size = columns[0]->size();
+    ColumnBuilder<TYPE_INT> result(size);
+    
+    for (int row = 0; row < size; ++row) {
+        if (str_viewer.is_null(row) || pattern_viewer.is_null(row) || 
+            start_viewer.is_null(row) || occurrence_viewer.is_null(row)) {
+            result.append_null();
+            continue;
+        }
+        
+        int start_pos = start_viewer.value(row);
+        int occurrence = occurrence_viewer.value(row);
+        
+        if (start_pos < 1 || occurrence < 1) {
+            result.append(-1);
+            continue;
+        }
+        
+        auto str_value = str_viewer.value(row);
+        auto pattern_value = pattern_viewer.value(row);
+        
+        std::string pattern_str = pattern_value.to_string();
+        // compile the pattern for each new row, keep in stack memory
+        re2::RE2 local_re(pattern_str, *options);
+        if (!local_re.ok()) {
+            return Status::InvalidArgument(
+                strings::Substitute("Invalid regex expression: $0", pattern_str));
+        }
+        
+        int utf8_length = utf8_len(str_value.data, str_value.data + str_value.size);
+        
+        if (start_pos > utf8_length) {
+            result.append(-1);
+            continue;
+        }
+        
+        const char* search_start = skip_leading_utf8(str_value.data, str_value.data + str_value.size, start_pos - 1);
+        int byte_offset = search_start - str_value.data;
+        
+        int count = 0;
+        re2::StringPiece str_sp(str_value.data, str_value.size);
+        re2::StringPiece match;
+        
+        bool found = false;
+        while (byte_offset <= str_value.size) {
+            if (local_re.Match(str_sp, byte_offset, str_value.size, re2::RE2::UNANCHORED, &match, 1)) {
+                count++;
+                if (count == occurrence) {
+                    int code_point_pos = utf8_len(str_value.data, match.data()) + 1;
+                    result.append(code_point_pos);
+                    found = true;
+                    break;
+                }
+                
+                byte_offset = match.data() - str_value.data + match.size();
+                if (match.size() == 0) {
+                    byte_offset++;
+                }
+            } else {
+                break;
+            }
+        }
+        
+        if (!found) {
+            result.append(-1);
+        }
+    }
+    
+    return result.build(ColumnHelper::is_all_const(columns));
+}
+
+StatusOr<ColumnPtr> StringFunctions::regexp_position(FunctionContext* context, const Columns& columns) {
+    RETURN_IF_COLUMNS_ONLY_NULL(columns);
+
+    auto* state = reinterpret_cast<StringFunctionsState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+
+    if (state && state->const_pattern && state->regex) {
+        // Const col
+        return regexp_position_const_pattern(state->get_or_prepare_regex(), columns);
+    } else {
+        re2::RE2::Options options;
+        options.set_log_errors(false);
+        return regexp_position_general(context, &options, columns);
     }
 }
 

--- a/be/src/exprs/string_functions.h
+++ b/be/src/exprs/string_functions.h
@@ -471,6 +471,15 @@ public:
     DEFINE_VECTORIZED_FN(regexp_count);
 
     /**
+     * @param: [string_value, pattern_value, start_position, occurrence]
+     * @paramType: [BinaryColumn, BinaryColumn, IntColumn, IntColumn]
+     * @return: IntColumn
+     */
+    DEFINE_VECTORIZED_FN(regexp_position);
+    static Status regexp_position_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+    static Status regexp_position_close(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+
+    /**
      * @param: [string_value, pattern_value, replace_value]
      * @paramType: [BinaryColumn, BinaryColumn, BinaryColumn]
      * @return: BinaryColumn

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -4256,6 +4256,170 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
     }
 }
 
+PARALLEL_TEST(VecStringFunctionsTest, regexpPositionTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    auto context = ctx.get();
+
+    Columns columns;
+
+    auto str = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    auto pattern = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    auto pos = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    auto occurrence = NullableColumn::create(Int32Column::create(), NullColumn::create());
+
+    struct TestCase {
+        std::optional<std::string> str;
+        std::optional<std::string> pattern;
+        std::optional<int> pos;
+        std::optional<int> occurrence;
+        int expected;
+        bool expect_null;
+    };
+
+    std::vector<TestCase> test_cases = {
+        // Basic matching
+        {"a,b,c", ",", 1, 1, 2, false},
+        {"a1b2c3d", "[0-9]", 1, 1, 2, false},
+        {"test:data", ":", 1, 1, 5, false},
+        
+        // Multiple occurrences
+        {"a1b2c3d", "[0-9]", 1, 2, 4, false},
+        {"a1b2c3d", "[0-9]", 1, 3, 6, false},
+        {"a1b2c3", "[0-9]", 1, 4, -1, false},
+        
+        // Start position
+        {"a,b,c", ",", 3, 1, 4, false},
+        {"a1b2c3d", "[0-9]", 5, 1, 6, false},
+        
+        // Empty pattern (zero-width)
+        {"abc", "", 1, 1, 1, false},
+        {"abc", "", 1, 2, 2, false},
+        {"abc", "", 1, 4, 4, false},
+        {"abc", "", 1, 5, -1, false},
+        {"", "", 1, 1, -1, false},
+        
+        // Empty string
+        {"", ",", 1, 1, -1, false},
+        
+        // Out of bounds
+        {"abc", ",", 10, 1, -1, false},
+        {"abc", "b", 5, 1, -1, false},
+        
+        // Invalid pos/occurrence
+        {"abc", "b", 0, 1, -1, false},
+        {"abc", "b", -1, 1, -1, false},
+        {"abc", "b", 1, 0, -1, false},
+        {"abc", "b", 1, -1, -1, false},
+        
+        // NULL inputs
+        {std::nullopt, "x", 1, 1, 0, true},
+        {"hello", std::nullopt, 1, 1, 0, true},
+        {"hello", "l", std::nullopt, 1, 0, true},
+        {"hello", "l", 1, std::nullopt, 0, true},
+
+        {"你好世界", "世", 1, 1, 3, false},
+    };
+
+    for (const auto& tc : test_cases) {
+        // Append str
+        if (tc.str.has_value()) {
+            str->append_datum(Slice(tc.str.value()));
+        } else {
+            str->append_nulls(1);
+        }
+        
+        // Append pattern
+        if (tc.pattern.has_value()) {
+            pattern->append_datum(Slice(tc.pattern.value()));
+        } else {
+            pattern->append_nulls(1);
+        }
+        
+        // Append pos
+        if (tc.pos.has_value()) {
+            pos->append_datum(tc.pos.value());
+        } else {
+            pos->append_nulls(1);
+        }
+        
+        // Append occurrence
+        if (tc.occurrence.has_value()) {
+            occurrence->append_datum(tc.occurrence.value());
+        } else {
+            occurrence->append_nulls(1);
+        }
+    }
+
+    columns.push_back(str);
+    columns.push_back(pattern);
+    columns.push_back(pos);
+    columns.push_back(occurrence);
+
+    context->set_constant_columns(columns);
+
+    ASSERT_TRUE(
+        StringFunctions::regexp_position_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+
+    auto result = StringFunctions::regexp_position(context, columns).value();
+    ASSERT_TRUE(result->is_nullable());
+    auto nullable_result = ColumnHelper::as_column<NullableColumn>(result);
+    auto data_col = ColumnHelper::cast_to<TYPE_INT>(nullable_result->data_column());
+
+    for (size_t i = 0; i < test_cases.size(); ++i) {
+        if (test_cases[i].expect_null) {
+            ASSERT_TRUE(nullable_result->is_null(i))
+                << "Test case " << i << " should return NULL";
+        } else {
+            ASSERT_FALSE(nullable_result->is_null(i))
+                << "Test case " << i << " should not be NULL";
+            ASSERT_EQ(test_cases[i].expected, data_col->get_data()[i])
+                << "Test case " << i << " failed: expected " << test_cases[i].expected
+                << " but got " << data_col->get_data()[i];
+        }
+    }
+
+    ASSERT_TRUE(
+        StringFunctions::regexp_position_close(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+}
+
+PARALLEL_TEST(VecStringFunctionsTest, regexpPositionInvalidRegex) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    auto context = ctx.get();
+
+    Columns columns;
+    auto str = BinaryColumn::create();
+    auto pattern = BinaryColumn::create();
+    auto pos = Int32Column::create();
+    auto occurrence = Int32Column::create();
+
+    str->append("hello");
+    pattern->append("["); 
+    pos->append(1);
+    occurrence->append(1);
+
+    str->append("world");
+    pattern->append("(");  
+    pos->append(1);
+    occurrence->append(1);
+
+    columns.push_back(str);
+    columns.push_back(pattern);
+    columns.push_back(pos);
+    columns.push_back(occurrence);
+
+    context->set_constant_columns(columns);
+
+    ASSERT_TRUE(
+        StringFunctions::regexp_position_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+
+    auto result = StringFunctions::regexp_position(context, columns);
+
+    ASSERT_FALSE(result.ok()) << "Expected error for invalid regex";
+    ASSERT_TRUE(result.status().to_string().find("Invalid regex") != std::string::npos);
+
+    StringFunctions::regexp_position_close(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+}
+
 PARALLEL_TEST(VecStringFunctionsTest, regexpCountTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     auto context = ctx.get();

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -4277,47 +4277,47 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpPositionTest) {
     };
 
     std::vector<TestCase> test_cases = {
-        // Basic matching
-        {"a,b,c", ",", 1, 1, 2, false},
-        {"a1b2c3d", "[0-9]", 1, 1, 2, false},
-        {"test:data", ":", 1, 1, 5, false},
-        
-        // Multiple occurrences
-        {"a1b2c3d", "[0-9]", 1, 2, 4, false},
-        {"a1b2c3d", "[0-9]", 1, 3, 6, false},
-        {"a1b2c3", "[0-9]", 1, 4, -1, false},
-        
-        // Start position
-        {"a,b,c", ",", 3, 1, 4, false},
-        {"a1b2c3d", "[0-9]", 5, 1, 6, false},
-        
-        // Empty pattern (zero-width)
-        {"abc", "", 1, 1, 1, false},
-        {"abc", "", 1, 2, 2, false},
-        {"abc", "", 1, 4, 4, false},
-        {"abc", "", 1, 5, -1, false},
-        {"", "", 1, 1, -1, false},
-        
-        // Empty string
-        {"", ",", 1, 1, -1, false},
-        
-        // Out of bounds
-        {"abc", ",", 10, 1, -1, false},
-        {"abc", "b", 5, 1, -1, false},
-        
-        // Invalid pos/occurrence
-        {"abc", "b", 0, 1, -1, false},
-        {"abc", "b", -1, 1, -1, false},
-        {"abc", "b", 1, 0, -1, false},
-        {"abc", "b", 1, -1, -1, false},
-        
-        // NULL inputs
-        {std::nullopt, "x", 1, 1, 0, true},
-        {"hello", std::nullopt, 1, 1, 0, true},
-        {"hello", "l", std::nullopt, 1, 0, true},
-        {"hello", "l", 1, std::nullopt, 0, true},
+            // Basic matching
+            {"a,b,c", ",", 1, 1, 2, false},
+            {"a1b2c3d", "[0-9]", 1, 1, 2, false},
+            {"test:data", ":", 1, 1, 5, false},
 
-        {"你好世界", "世", 1, 1, 3, false},
+            // Multiple occurrences
+            {"a1b2c3d", "[0-9]", 1, 2, 4, false},
+            {"a1b2c3d", "[0-9]", 1, 3, 6, false},
+            {"a1b2c3", "[0-9]", 1, 4, -1, false},
+
+            // Start position
+            {"a,b,c", ",", 3, 1, 4, false},
+            {"a1b2c3d", "[0-9]", 5, 1, 6, false},
+
+            // Empty pattern (zero-width)
+            {"abc", "", 1, 1, 1, false},
+            {"abc", "", 1, 2, 2, false},
+            {"abc", "", 1, 4, 4, false},
+            {"abc", "", 1, 5, -1, false},
+            {"", "", 1, 1, -1, false},
+
+            // Empty string
+            {"", ",", 1, 1, -1, false},
+
+            // Out of bounds
+            {"abc", ",", 10, 1, -1, false},
+            {"abc", "b", 5, 1, -1, false},
+
+            // Invalid pos/occurrence
+            {"abc", "b", 0, 1, -1, false},
+            {"abc", "b", -1, 1, -1, false},
+            {"abc", "b", 1, 0, -1, false},
+            {"abc", "b", 1, -1, -1, false},
+
+            // NULL inputs
+            {std::nullopt, "x", 1, 1, 0, true},
+            {"hello", std::nullopt, 1, 1, 0, true},
+            {"hello", "l", std::nullopt, 1, 0, true},
+            {"hello", "l", 1, std::nullopt, 0, true},
+
+            {"你好世界", "世", 1, 1, 3, false},
     };
 
     for (const auto& tc : test_cases) {
@@ -4327,21 +4327,21 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpPositionTest) {
         } else {
             str->append_nulls(1);
         }
-        
+
         // Append pattern
         if (tc.pattern.has_value()) {
             pattern->append_datum(Slice(tc.pattern.value()));
         } else {
             pattern->append_nulls(1);
         }
-        
+
         // Append pos
         if (tc.pos.has_value()) {
             pos->append_datum(tc.pos.value());
         } else {
             pos->append_nulls(1);
         }
-        
+
         // Append occurrence
         if (tc.occurrence.has_value()) {
             occurrence->append_datum(tc.occurrence.value());
@@ -4358,7 +4358,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpPositionTest) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-        StringFunctions::regexp_position_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_position_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
 
     auto result = StringFunctions::regexp_position(context, columns).value();
     ASSERT_TRUE(result->is_nullable());
@@ -4367,19 +4367,17 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpPositionTest) {
 
     for (size_t i = 0; i < test_cases.size(); ++i) {
         if (test_cases[i].expect_null) {
-            ASSERT_TRUE(nullable_result->is_null(i))
-                << "Test case " << i << " should return NULL";
+            ASSERT_TRUE(nullable_result->is_null(i)) << "Test case " << i << " should return NULL";
         } else {
-            ASSERT_FALSE(nullable_result->is_null(i))
-                << "Test case " << i << " should not be NULL";
+            ASSERT_FALSE(nullable_result->is_null(i)) << "Test case " << i << " should not be NULL";
             ASSERT_EQ(test_cases[i].expected, data_col->get_data()[i])
-                << "Test case " << i << " failed: expected " << test_cases[i].expected
-                << " but got " << data_col->get_data()[i];
+                    << "Test case " << i << " failed: expected " << test_cases[i].expected << " but got "
+                    << data_col->get_data()[i];
         }
     }
 
     ASSERT_TRUE(
-        StringFunctions::regexp_position_close(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_position_close(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, regexpPositionInvalidRegex) {
@@ -4393,12 +4391,12 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpPositionInvalidRegex) {
     auto occurrence = Int32Column::create();
 
     str->append("hello");
-    pattern->append("["); 
+    pattern->append("[");
     pos->append(1);
     occurrence->append(1);
 
     str->append("world");
-    pattern->append("(");  
+    pattern->append("(");
     pos->append(1);
     occurrence->append(1);
 
@@ -4409,8 +4407,8 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpPositionInvalidRegex) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(
-        StringFunctions::regexp_position_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(StringFunctions::regexp_position_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
 
     auto result = StringFunctions::regexp_position(context, columns);
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -235,6 +235,7 @@ public class FunctionSet {
     public static final String NULL_OR_EMPTY = "null_or_empty";
     public static final String REGEXP_EXTRACT = "regexp_extract";
     public static final String REGEXP_REPLACE = "regexp_replace";
+    public static final String REGEXP_POSITION = "regexp_position";
     public static final String REPEAT = "repeat";
     public static final String REPLACE = "replace";
     public static final String REVERSE = "reverse";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -1099,7 +1099,7 @@ public class FunctionAnalyzer {
 
         Type[] argumentTypes = node.getChildren().stream().map(Expr::getType).toArray(Type[]::new);
 
-        return Expr.getBuiltinFunction(FunctionSet.REGEXP_POSITION, argumentTypes,
+        return ExprUtils.getBuiltinFunction(FunctionSet.REGEXP_POSITION, argumentTypes,
                 Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -966,7 +966,7 @@ public class FunctionAnalyzer {
             argumentTypes = node.getChildren().stream().map(Expr::getType).toArray(Type[]::new);
         } else if (FunctionSet.REGEXP_POSITION.equals(fnName)) {
             fn = getRegexpPositionFunction(node);
-            argumentTypes = fn.getArgs();
+            argumentTypes = node.getChildren().stream().map(Expr::getType).toArray(Type[]::new);
         } else if (FunctionSet.BITMAP_UNION.equals(fnName)) {
             // bitmap_union is analyzed here rather than `getAnalyzedAggregateFunction` because
             // it's just a syntax sugar for bitmap_agg transformed from bitmap_union(to_bitmap())

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -382,6 +382,8 @@ vectorized_functions = [
      'StringFunctions::regexp_extract_prepare', 'StringFunctions::regexp_close'],
     [30335, 'regexp_count', True, False, 'BIGINT', ['VARCHAR', 'VARCHAR'], 'StringFunctions::regexp_count',
      'StringFunctions::regexp_count_prepare', 'StringFunctions::regexp_close'],
+    [30336, 'regexp_position', True, False, 'INT', ['VARCHAR', 'VARCHAR', 'INT', 'INT'], 'StringFunctions::regexp_position',
+     'StringFunctions::regexp_position_prepare', 'StringFunctions::regexp_position_close'],
     [30400, "money_format", True, False, "VARCHAR", ["BIGINT"], "StringFunctions::money_format_bigint"],
     [30401, "money_format", True, False, "VARCHAR", ["LARGEINT"], "StringFunctions::money_format_largeint"],
     [30402, "money_format", True, False, "VARCHAR", ["DECIMALV2"], "StringFunctions::money_format_decimalv2val"],

--- a/test/sql/test_function/R/test_regex
+++ b/test/sql/test_function/R/test_regex
@@ -106,7 +106,6 @@ xxxx	xx	-	--
 xxxx	xxx	-	-x
 xxxx	xxxx	-	-
 -- !result
--- name: test_regexp
 CREATE TABLE `tsr` (
   `str` varchar(65533) NULL COMMENT "",
   `regex` varchar(65533) NULL COMMENT "",
@@ -122,39 +121,344 @@ insert into tsr values ("AbCdExCeF", "([[:lower:]]+)C([[:lower:]]+)", 3), ("AbCd
 -- !result
 SELECT regexp_extract_all("AbCdExCeF", "([[:lower:]]+)C([[:lower:]]+)", 0);
 -- result:
+["bCd","xCe"]
 -- !result
 SELECT regexp_extract_all(str, "([[:lower:]]+)C([[:lower:]]+)", 0) from tsr;
 -- result:
+["bCd","xCe"]
+["bCd","xCe"]
 -- !result
 SELECT regexp_extract_all(str, regex, 0) from tsr;
 -- result:
+["bCd","xCe"]
+["bCd","xCe"]
 -- !result
 SELECT regexp_extract_all(str, regex, pos) from tsr;
 -- result:
+[]
+["bCd","xCe"]
 -- !result
 SELECT regexp_extract_all(str, "([[:lower:]]+)C([[:lower:]]+)", pos) from tsr;
 -- result:
+[]
+["bCd","xCe"]
 -- !result
 SELECT regexp_extract_all("AbCdExCeF", "([[:lower:]]+)C([[:lower:]]+)", pos) from tsr;
 -- result:
+[]
+["bCd","xCe"]
 -- !result
 SELECT regexp_extract_all("AbCdExCeF", regex, pos) from tsr;
 -- result:
+[]
+["bCd","xCe"]
 -- !result
 SELECT regexp_extract_all(str, "([[:lower:]]+)C([[:lower:]]+)", pos) from tsr;
 -- result:
+[]
+["bCd","xCe"]
 -- !result
 SELECT regexp_extract_all("AbCdExCeF", "([[:lower:]]+)C([[:lower:]]+)", 3);
 -- result:
+[]
 -- !result
 SELECT regexp_extract_all(str, "([[:lower:]]+)C([[:lower:]]+)", 3) from tsr;
 -- result:
+[]
+[]
 -- !result
 SELECT regexp_extract_all(str, regex, 3) from tsr;
 -- result:
+[]
+[]
 -- !result
-
--- name: test_regexp_count
+SELECT regexp_position('a.b:c;d', '[.]');
+-- result:
+2
+-- !result
+SELECT regexp_position('a.b:c;d', '[\\.:;]', 2);
+-- result:
+2
+-- !result
+SELECT regexp_position('a.b:c;d', ':');
+-- result:
+4
+-- !result
+SELECT regexp_position('a,b,c', ',');
+-- result:
+2
+-- !result
+SELECT regexp_position('a1b2c3d', '[0-9]');
+-- result:
+2
+-- !result
+SELECT regexp_position('a,b,c', ',', 3);
+-- result:
+4
+-- !result
+SELECT regexp_position('a1b2c3d', '[0-9]', 5);
+-- result:
+6
+-- !result
+SELECT regexp_position('a1b2c3d4e', '[0-9]', 4, 2);
+-- result:
+6
+-- !result
+SELECT regexp_position('a1b2c3d',  '[0-9]', 4, 3);
+-- result:
+-1
+-- !result
+SELECT regexp_position('a1b2c3d', '', 1);
+-- result:
+1
+-- !result
+SELECT regexp_position('a1b2c3d', '', 2);
+-- result:
+2
+-- !result
+SELECT regexp_position('a1b2c3d', '', 2, 2);
+-- result:
+3
+-- !result
+SELECT regexp_position('a1b2c3d', '', 2, 6);
+-- result:
+7
+-- !result
+SELECT regexp_position('a1b2c3d', '', 2, 7);
+-- result:
+8
+-- !result
+SELECT regexp_position('a1b2c3d', '', 2, 8);
+-- result:
+-1
+-- !result
+SELECT regexp_position('', ',');
+-- result:
+-1
+-- !result
+SELECT regexp_position('', ',', 4);
+-- result:
+-1
+-- !result
+SELECT regexp_position('', ',', 4, 2);
+-- result:
+-1
+-- !result
+SELECT regexp_position('a,b,c',  ',', 2);
+-- result:
+2
+-- !result
+SELECT regexp_position('a1b2c3d', '[0-9]', 4);
+-- result:
+4
+-- !result
+SELECT regexp_position('a,b,c', ',', 1000);
+-- result:
+-1
+-- !result
+SELECT regexp_position('a,b,c', ',', 8);
+-- result:
+-1
+-- !result
+SELECT regexp_position('有朋$%X自9远方来', '[0-9]', 7);
+-- result:
+7
+-- !result
+SELECT regexp_position('有朋$%X自9远方9来', '[0-9]', 10, 1);
+-- result:
+10
+-- !result
+SELECT regexp_position('有朋$%X自9远方9来', '[0-9]', 10, 2);
+-- result:
+-1
+-- !result
+SELECT regexp_position('有朋$%X自9远方9来', '来', 999);
+-- result:
+-1
+-- !result
+SELECT regexp_position('行成于思str而毁123于随', '于', 3, 2);
+-- result:
+13
+-- !result
+SELECT regexp_position('行成于思str而毁123于随', '',  3, 1);
+-- result:
+3
+-- !result
+SELECT regexp_position('行成于思str而毁123于随', '',  3, 2);
+-- result:
+4
+-- !result
+SELECT regexp_position(column_0, 'T') FROM (VALUES ('2024-01-01T01:61:00')) AS tmp;
+-- result:
+11
+-- !result
+SELECT regexp_position(column_0, '61') FROM (VALUES ('2024-01-01T01:61:00')) AS tmp;
+-- result:
+15
+-- !result
+SELECT regexp_position(column_0, '0', 1, 3) FROM (VALUES ('2024-01-01T01:61:00')) AS tmp;
+-- result:
+9
+-- !result
+SELECT regexp_position(column_0, 'Z', 20) FROM (VALUES ('2024-01-01T01:61:00')) AS tmp;
+-- result:
+-1
+-- !result
+SELECT regexp_position(column_0, '01', 12, 2) FROM (VALUES ('2024-01-01T01:61:00')) AS tmp;
+-- result:
+-1
+-- !result
+SELECT regexp_position(column_0, '(unclosed') FROM (VALUES ('oops')) AS tmp;
+-- result:
+E: (1064, 'Invalid regex expression: (unclosed backend [id=10004] [')
+-- !result
+SELECT regexp_position(column_0, 'x') FROM (VALUES (NULL)) AS tmp;
+-- result:
+None
+-- !result
+CREATE TABLE `tsp_general` (
+  `str` varchar(65533) NULL COMMENT "",
+  `pattern` varchar(65533) NULL COMMENT "",
+  `start_pos` int NULL COMMENT "",
+  `occurrence` int NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`str`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`str`) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into tsp_general values 
+('abcdef123ghi', '[0-9]+', 1, 1),
+('abc def ghi', '\\s+', 1, 1),
+('test@email.com', '@[a-zA-Z]+', 1, 1),
+('hello world hello universe', 'hello', 1, 2),
+('complex(pattern)test', '\\([^)]*\\)', 1, 1),
+('abc123def456ghi', '[0-9]{2,}', 1, 2),
+('', '.', 1, 1),
+(NULL, '[0-9]', 1, 1),
+('test string', NULL, 1, 1),
+(NULL, NULL, 1, 1);
+-- result:
+-- !result
+SELECT str, pattern, regexp_position(str, pattern) from tsp_general order by str, pattern;
+-- result:
+None	None	None
+None	[0-9]	None
+	.	-1
+abc def ghi	\s+	4
+abc123def456ghi	[0-9]{2,}	4
+abcdef123ghi	[0-9]+	7
+complex(pattern)test	\([^)]*\)	8
+hello world hello universe	hello	1
+test string	None	None
+test@email.com	@[a-zA-Z]+	5
+-- !result
+SELECT str, pattern, start_pos, regexp_position(str, pattern, start_pos) from tsp_general where start_pos is not null order by str, pattern;
+-- result:
+None	None	1	None
+None	[0-9]	1	None
+	.	1	-1
+abc def ghi	\s+	1	4
+abc123def456ghi	[0-9]{2,}	1	4
+abcdef123ghi	[0-9]+	1	7
+complex(pattern)test	\([^)]*\)	1	8
+hello world hello universe	hello	1	1
+test string	None	1	None
+test@email.com	@[a-zA-Z]+	1	5
+-- !result
+SELECT str, pattern, start_pos, occurrence, regexp_position(str, pattern, start_pos, occurrence) from tsp_general where start_pos is not null and occurrence is not null order by str, pattern;
+-- result:
+None	None	1	1	None
+None	[0-9]	1	1	None
+	.	1	1	-1
+abc def ghi	\s+	1	1	4
+abc123def456ghi	[0-9]{2,}	1	2	10
+abcdef123ghi	[0-9]+	1	1	7
+complex(pattern)test	\([^)]*\)	1	1	8
+hello world hello universe	hello	1	2	13
+test string	None	1	1	None
+test@email.com	@[a-zA-Z]+	1	1	5
+-- !result
+SELECT regexp_position(NULL, '[0-9]');
+-- result:
+None
+-- !result
+SELECT regexp_position('test', NULL);
+-- result:
+None
+-- !result
+SELECT regexp_position(NULL, NULL);
+-- result:
+None
+-- !result
+SELECT regexp_position(NULL, '[0-9]', 1);
+-- result:
+None
+-- !result
+SELECT regexp_position('test', NULL, 1);
+-- result:
+None
+-- !result
+SELECT regexp_position('test', '[0-9]', NULL);
+-- result:
+None
+-- !result
+SELECT regexp_position(NULL, '[0-9]', 1, 1);
+-- result:
+None
+-- !result
+SELECT regexp_position('test', NULL, 1, 1);
+-- result:
+None
+-- !result
+SELECT regexp_position('test', '[0-9]', NULL, 1);
+-- result:
+None
+-- !result
+SELECT regexp_position('test', '[0-9]', 1, NULL);
+-- result:
+None
+-- !result
+SELECT regexp_position('test string', '[0-9');
+-- result:
+[REGEX].*Invalid regex expression: \[0-9.*
+-- !result
+SELECT regexp_position('test string', '(unclosed');
+-- result:
+[REGEX].*Invalid regex expression: \(unclosed.*
+-- !result
+SELECT regexp_position('test string', '?invalid');
+-- result:
+[REGEX].*Invalid regex expression: \?invalid.*
+-- !result
+SELECT regexp_position('test string', '*invalid');
+-- result:
+[REGEX].*Invalid regex expression: \*invalid.*
+-- !result
+SELECT regexp_position('test string', '+invalid');
+-- result:
+[REGEX].*Invalid regex expression: \+invalid.*
+-- !result
+SELECT regexp_position('test string', '\\');
+-- result:
+[REGEX].*Invalid regex expression: \\
+-- !result
+SELECT regexp_position('test', '[0-9]', 0);
+-- result:
+-1
+-- !result
+SELECT regexp_position('test', '[0-9]', -1);
+-- result:
+-1
+-- !result
+SELECT regexp_position('test', '[0-9]', 1, 0);
+-- result:
+-1
+-- !result
+SELECT regexp_position('test', '[0-9]', 1, -1);
+-- result:
+-1
+-- !result
 CREATE TABLE `tsc` (
   `str` varchar(65533) NULL COMMENT "",
   `regex` varchar(65533) NULL COMMENT ""
@@ -212,11 +516,10 @@ select str, regex, regexp_count(str, regex) from tsc order by str, regex;
 None	.	None
 	.	0
 a b  c   d	\s+	3
-abc123def456	[0-9]	6
 ababababab	ab	5
+abc123def456	[0-9]	6
 test.com test.net test.org	\.	3
 -- !result
--- name: test_regexp_count_invalid
 CREATE TABLE `tsc_invalid` (
   `str` varchar(65533) NULL COMMENT "",
   `regex` varchar(65533) NULL COMMENT ""
@@ -268,7 +571,6 @@ select regexp_count('test', NULL);
 -- result:
 None
 -- !result
--- name: test_regexp_replace_hyperscan_vec_multiple_rows
 CREATE TABLE `test_regexp_replace_multirow` (
   `column_value` varchar(100) NULL COMMENT ""
 ) ENGINE=OLAP 

--- a/test/sql/test_function/T/test_regex
+++ b/test/sql/test_function/T/test_regex
@@ -140,7 +140,6 @@ SELECT regexp_position('test string', '(unclosed');
 SELECT regexp_position('test string', '?invalid');
 SELECT regexp_position('test string', '*invalid');
 SELECT regexp_position('test string', '+invalid');
-SELECT regexp_position('test string', '{invalid');
 SELECT regexp_position('test string', '\\');
 
 -- Test edge cases with invalid parameters

--- a/test/sql/test_function/T/test_regex
+++ b/test/sql/test_function/T/test_regex
@@ -35,9 +35,6 @@ select regexp_replace('xaxaxax', 'xax', '-');
 
 select str, regex, replaced, regexp_replace(str, regex, replaced) from ts order by str, regex, replaced;
 
-
--- name: test_regexp
-
 CREATE TABLE `tsr` (
   `str` varchar(65533) NULL COMMENT "",
   `regex` varchar(65533) NULL COMMENT "",
@@ -61,8 +58,6 @@ SELECT regexp_extract_all(str, "([[:lower:]]+)C([[:lower:]]+)", pos) from tsr;
 SELECT regexp_extract_all("AbCdExCeF", "([[:lower:]]+)C([[:lower:]]+)", 3);
 SELECT regexp_extract_all(str, "([[:lower:]]+)C([[:lower:]]+)", 3) from tsr;
 SELECT regexp_extract_all(str, regex, 3) from tsr;
-
--- name: test_regexp_position
 
 SELECT regexp_position('a.b:c;d', '[.]');
 SELECT regexp_position('a.b:c;d', '[\\.:;]', 2);
@@ -93,6 +88,19 @@ SELECT regexp_position('有朋$%X自9远方9来', '来', 999);
 SELECT regexp_position('行成于思str而毁123于随', '于', 3, 2);
 SELECT regexp_position('行成于思str而毁123于随', '',  3, 1);
 SELECT regexp_position('行成于思str而毁123于随', '',  3, 2);
+
+-- Test VALUES clause inputs to cover expression path
+SELECT regexp_position(column_0, 'T') FROM (VALUES ('2024-01-01T01:61:00')) AS tmp;
+SELECT regexp_position(column_0, '61') FROM (VALUES ('2024-01-01T01:61:00')) AS tmp;
+SELECT regexp_position(column_0, '0', 1, 3) FROM (VALUES ('2024-01-01T01:61:00')) AS tmp;
+-- range: start at end
+SELECT regexp_position(column_0, 'Z', 20) FROM (VALUES ('2024-01-01T01:61:00')) AS tmp;
+-- range: occurrence beyond match count
+SELECT regexp_position(column_0, '01', 12, 2) FROM (VALUES ('2024-01-01T01:61:00')) AS tmp;
+-- exception: invalid regex expression path
+SELECT regexp_position(column_0, '(unclosed') FROM (VALUES ('oops')) AS tmp;
+-- NULL input through VALUES
+SELECT regexp_position(column_0, 'x') FROM (VALUES (NULL)) AS tmp;
 
 -- Test general path with non-constant patterns 
 CREATE TABLE `tsp_general` (
@@ -149,8 +157,6 @@ SELECT regexp_position('test', '[0-9]', 1, 0);
 SELECT regexp_position('test', '[0-9]', 1, -1);
 
 
--- name: test_regexp_count
-
 CREATE TABLE `tsc` (
   `str` varchar(65533) NULL COMMENT "",
   `regex` varchar(65533) NULL COMMENT ""
@@ -173,8 +179,6 @@ select regexp_count('AbCdExCeF', 'C');
 select regexp_count('1a 2b 14m', '\\d+');
 
 select str, regex, regexp_count(str, regex) from tsc order by str, regex;
-
--- name: test_regexp_count_invalid
 
 CREATE TABLE `tsc_invalid` (
   `str` varchar(65533) NULL COMMENT "",
@@ -199,8 +203,6 @@ select regexp_count('test string', 'a{,}');
 select regexp_count(NULL, '[0-9');
 select regexp_count('', '[0-9');
 select regexp_count('test', NULL);
-
--- name: test_regexp_replace_hyperscan_vec_multiple_rows
 
 -- Test for issue #65936: regexp_replace with enable_hyperscan_vec=true 
 -- produces incorrect output when processing multiple rows

--- a/test/sql/test_function/T/test_regex
+++ b/test/sql/test_function/T/test_regex
@@ -94,6 +94,61 @@ SELECT regexp_position('行成于思str而毁123于随', '于', 3, 2);
 SELECT regexp_position('行成于思str而毁123于随', '',  3, 1);
 SELECT regexp_position('行成于思str而毁123于随', '',  3, 2);
 
+-- Test general path with non-constant patterns 
+CREATE TABLE `tsp_general` (
+  `str` varchar(65533) NULL COMMENT "",
+  `pattern` varchar(65533) NULL COMMENT "",
+  `start_pos` int NULL COMMENT "",
+  `occurrence` int NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`str`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`str`) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+
+insert into tsp_general values 
+('abcdef123ghi', '[0-9]+', 1, 1),
+('abc def ghi', '\\s+', 1, 1),
+('test@email.com', '@[a-zA-Z]+', 1, 1),
+('hello world hello universe', 'hello', 1, 2),
+('complex(pattern)test', '\\([^)]*\\)', 1, 1),
+('abc123def456ghi', '[0-9]{2,}', 1, 2),
+('', '.', 1, 1),
+(NULL, '[0-9]', 1, 1),
+('test string', NULL, 1, 1),
+(NULL, NULL, 1, 1);
+
+-- Test general path queries
+SELECT str, pattern, regexp_position(str, pattern) from tsp_general order by str, pattern;
+SELECT str, pattern, start_pos, regexp_position(str, pattern, start_pos) from tsp_general where start_pos is not null order by str, pattern;
+SELECT str, pattern, start_pos, occurrence, regexp_position(str, pattern, start_pos, occurrence) from tsp_general where start_pos is not null and occurrence is not null order by str, pattern;
+
+-- Test NULL and invalid inputs
+SELECT regexp_position(NULL, '[0-9]');
+SELECT regexp_position('test', NULL);
+SELECT regexp_position(NULL, NULL);
+SELECT regexp_position(NULL, '[0-9]', 1);
+SELECT regexp_position('test', NULL, 1);
+SELECT regexp_position('test', '[0-9]', NULL);
+SELECT regexp_position(NULL, '[0-9]', 1, 1);
+SELECT regexp_position('test', NULL, 1, 1);
+SELECT regexp_position('test', '[0-9]', NULL, 1);
+SELECT regexp_position('test', '[0-9]', 1, NULL);
+
+-- Test invalid regex patterns
+SELECT regexp_position('test string', '[0-9');
+SELECT regexp_position('test string', '(unclosed');
+SELECT regexp_position('test string', '?invalid');
+SELECT regexp_position('test string', '*invalid');
+SELECT regexp_position('test string', '+invalid');
+SELECT regexp_position('test string', '{invalid');
+SELECT regexp_position('test string', '\\');
+
+-- Test edge cases with invalid parameters
+SELECT regexp_position('test', '[0-9]', 0);
+SELECT regexp_position('test', '[0-9]', -1);
+SELECT regexp_position('test', '[0-9]', 1, 0);
+SELECT regexp_position('test', '[0-9]', 1, -1);
+
 
 -- name: test_regexp_count
 

--- a/test/sql/test_function/T/test_regex
+++ b/test/sql/test_function/T/test_regex
@@ -62,6 +62,38 @@ SELECT regexp_extract_all("AbCdExCeF", "([[:lower:]]+)C([[:lower:]]+)", 3);
 SELECT regexp_extract_all(str, "([[:lower:]]+)C([[:lower:]]+)", 3) from tsr;
 SELECT regexp_extract_all(str, regex, 3) from tsr;
 
+-- name: test_regexp_position
+
+SELECT regexp_position('a.b:c;d', '[.]');
+SELECT regexp_position('a.b:c;d', '[\\.:;]', 2);
+SELECT regexp_position('a.b:c;d', ':');
+SELECT regexp_position('a,b,c', ',');
+SELECT regexp_position('a1b2c3d', '[0-9]');
+SELECT regexp_position('a,b,c', ',', 3);
+SELECT regexp_position('a1b2c3d', '[0-9]', 5);
+SELECT regexp_position('a1b2c3d4e', '[0-9]', 4, 2);
+SELECT regexp_position('a1b2c3d',  '[0-9]', 4, 3);
+SELECT regexp_position('a1b2c3d', '', 1);
+SELECT regexp_position('a1b2c3d', '', 2);
+SELECT regexp_position('a1b2c3d', '', 2, 2);
+SELECT regexp_position('a1b2c3d', '', 2, 6);
+SELECT regexp_position('a1b2c3d', '', 2, 7);
+SELECT regexp_position('a1b2c3d', '', 2, 8);
+SELECT regexp_position('', ',');
+SELECT regexp_position('', ',', 4);
+SELECT regexp_position('', ',', 4, 2);
+SELECT regexp_position('a,b,c',  ',', 2);
+SELECT regexp_position('a1b2c3d', '[0-9]', 4);
+SELECT regexp_position('a,b,c', ',', 1000);
+SELECT regexp_position('a,b,c', ',', 8);
+SELECT regexp_position('有朋$%X自9远方来', '[0-9]', 7);
+SELECT regexp_position('有朋$%X自9远方9来', '[0-9]', 10, 1);
+SELECT regexp_position('有朋$%X自9远方9来', '[0-9]', 10, 2);
+SELECT regexp_position('有朋$%X自9远方9来', '来', 999);
+SELECT regexp_position('行成于思str而毁123于随', '于', 3, 2);
+SELECT regexp_position('行成于思str而毁123于随', '',  3, 1);
+SELECT regexp_position('行成于思str而毁123于随', '',  3, 2);
+
 
 -- name: test_regexp_count
 


### PR DESCRIPTION
## Why I'm doing:
REGEXP_Position is supported by Trino but not supported by StarRocks
When this function call is passed to StarRocks in my company's scenario, this will result in error

## What I'm doing:
Returns the position of the specified occurrence of the regular expression pattern in the string subject

Fixes #67246

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements UTF-8–aware `regexp_position` as a built-in string function and wires it through FE/BE with tests.
> 
> - BE: Adds `regexp_position` in `string_functions.{h,cpp}` with prepare/close, constant-pattern regex caching, general-path per-row compile, start position and occurrence handling, returns 1-based code-point index or `-1`, and surfaces invalid regex errors
> - FE: Registers `REGEXP_POSITION` in `FunctionSet`; analyzer adds default args (`start_pos=1`, `occurrence=1`) and resolves function for 2–4 params
> - Function registry: adds signature in `gensrc/script/functions.py`
> - Tests: C++ unit tests and SQL R/T cases for basic, multi-occurrence, empty pattern, UTF-8, NULLs, bounds, and invalid regex
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dc2c2706d3a00a774b3944a774e9a044c58f361. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->