### PR TITLE
[BugFix] remove load job after db had been dropped

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -495,6 +495,24 @@ public class LoadMgr implements MemoryTrackable {
         }
     }
 
+    public void removeLoadJobsByDb(long dbId) {
+        writeLock();
+        try {
+            // Get all jobs belonging to the database
+            List<LoadJob> jobsToRemove = idToLoadJob.values().stream()
+                    .filter(job -> job.getDbId() == dbId)
+                    .collect(Collectors.toList());
+
+            // Remove each job
+            for (LoadJob job : jobsToRemove) {
+                LOG.info("remove load job {} of database {}", job.getLabel(), dbId);
+                unprotectedRemoveJobReleatedMeta(job);
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
     // only for those jobs which transaction is not started
     public void processTimeoutJobs() {
         idToLoadJob.values().stream().forEach(entity -> entity.processTimeout());

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -5051,6 +5051,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     public void onEraseDatabase(long dbId) {
         // remove database transaction manager
         stateMgr.getGlobalTransactionMgr().removeDatabaseTransactionMgr(dbId);
+        // remove load jobs belonging to this database
+        stateMgr.getLoadMgr().removeLoadJobsByDb(dbId);
         // unbind db to storage volume
         stateMgr.getStorageVolumeMgr().unbindDbToStorageVolume(dbId);
     }


### PR DESCRIPTION
## Why I'm doing:
After dropping the database, the load jobs in the Load Manager were not cleared. This causes the system to frequently print error logs when querying the system table `loads` :
```
Get transaction xxx in db xxx failed. msg: databaseTransactionMgr[xxx] does not exist
```

## What I'm doing:
This pull request introduces a new mechanism to clean up load jobs associated with a database when the database is erased. The main changes add a method to remove all load jobs for a given database, integrate it into the database deletion workflow, and provide comprehensive unit tests for this functionality.

**Load Job Cleanup Improvements:**

* Added a new `removeLoadJobsByDb(long dbId)` method to the `LoadMgr` class to remove all load jobs belonging to a specified database, ensuring proper locking and cleanup.
* Updated the `LocalMetastore.onEraseDatabase(long dbId)` method to call `removeLoadJobsByDb`, so that all load jobs are removed when a database is erased.

**Testing Enhancements:**

* Added a new unit test `testRemoveLoadJobsByDb` in `LoadMgrTest.java` to verify that load jobs are correctly removed for a given database, including checks for multiple databases and job states.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures load jobs tied to a database are purged when the database is erased.
> 
> - Adds `LoadMgr.removeLoadJobsByDb(long dbId)` to remove all jobs for a DB under write lock using `unprotectedRemoveJobReleatedMeta`
> - Hooks cleanup into `LocalMetastore.onEraseDatabase` after removing the DB transaction manager
> - Adds `LoadMgrTest.testRemoveLoadJobsByDb` to verify per-DB job removal and internal map cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32dbf7c444d27df8529c4cb2ebe8ce9b69af00e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->