### PR TITLE
[BugFix] insert overwrite textformat hive table didn't set delimiter (backport #67199)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
@@ -457,6 +457,9 @@ public class HiveCommitter {
                         .put("starrocks_version", Version.STARROCKS_VERSION + "-" + Version.STARROCKS_COMMIT_HASH)
                         .put(STARROCKS_QUERY_ID, ConnectContext.get().getQueryId().toString())
                         .buildOrThrow())
+                .setSerDeParameters(ImmutableMap.<String, String>builder()
+                        .putAll(table.getSerdeProperties())
+                        .buildOrThrow())
                 .setStorageFormat(table.getStorageFormat())
                 .setLocation(partitionUpdate.getTargetPath().toString())
                 .build();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -466,6 +466,9 @@ public class HiveMetadata implements ConnectorMetadata {
                         .put("starrocks_version", Version.STARROCKS_VERSION + "-" + Version.STARROCKS_COMMIT_HASH)
                         .put(STARROCKS_QUERY_ID, ConnectContext.get().getQueryId().toString())
                         .buildOrThrow())
+                .setSerDeParameters(ImmutableMap.<String, String>builder()
+                        .putAll(table.getSerdeProperties())
+                        .buildOrThrow())
                 .setStorageFormat(table.getStorageFormat())
                 .setLocation(partitionPath)
                 .build();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -240,6 +240,7 @@ public class HiveMetastoreApiConverter {
         HiveStorageFormat hiveSd = partition.getStorage();
         serdeInfo.setName(partition.getTableName());
         serdeInfo.setSerializationLib(hiveSd.getSerde());
+        serdeInfo.setParameters(partition.getSerDeParameters());
 
         StorageDescriptor sd = new StorageDescriptor();
         sd.setLocation(emptyToNull(partition.getLocation()));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HivePartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HivePartition.java
@@ -28,9 +28,11 @@ public class HivePartition {
     private final HiveStorageFormat storage;
     private final List<Column> columns;
     private final Map<String, String> parameters;
+    private final Map<String, String> serDeParameters;
 
     public HivePartition(String databaseName, String tableName, List<String> values, String location,
-                         HiveStorageFormat storage, List<Column> columns, Map<String, String> parameters) {
+                         HiveStorageFormat storage, List<Column> columns, Map<String, String> parameters,
+                         Map<String, String> serDeParameters) {
         this.databaseName = databaseName;
         this.tableName = tableName;
         this.values = values;
@@ -38,6 +40,7 @@ public class HivePartition {
         this.storage = storage;
         this.columns = columns;
         this.parameters = parameters;
+        this.serDeParameters = serDeParameters;
     }
 
     public String getDatabaseName() {
@@ -64,6 +67,10 @@ public class HivePartition {
         return parameters;
     }
 
+    public Map<String, String> getSerDeParameters() {
+        return serDeParameters;
+    }
+
     public String getLocation() {
         return location;
     }
@@ -80,6 +87,7 @@ public class HivePartition {
         private List<Column> columns;
         private String location;
         private Map<String, String> parameters = ImmutableMap.of();
+        private Map<String, String> serDeParameters = ImmutableMap.of();
 
         private Builder() {
         }
@@ -119,8 +127,14 @@ public class HivePartition {
             return this;
         }
 
+        public Builder setSerDeParameters(Map<String, String> serDeParameters) {
+            this.serDeParameters = serDeParameters;
+            return this;
+        }
+
         public HivePartition build() {
-            return new HivePartition(databaseName, tableName, values, location, storageFormat, columns, parameters);
+            return new HivePartition(databaseName, tableName, values, location, storageFormat, columns, parameters,
+                                     serDeParameters);
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -30,11 +30,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.MetaNotFoundException;
-<<<<<<< HEAD
-=======
-import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.util.UUIDUtil;
->>>>>>> 7e78e7f74b ([BugFix] insert overwrite textformat hive table didn't set delimiter (#67199))
 import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorProperties;
@@ -59,15 +55,8 @@ import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.DropTableStmt;
-<<<<<<< HEAD
-import com.starrocks.sql.optimizer.Memo;
-=======
-import com.starrocks.sql.ast.KeyPartitionRef;
 import com.starrocks.sql.ast.SingleItemListPartitionDesc;
-import com.starrocks.sql.ast.TableRef;
-import com.starrocks.sql.ast.TruncateTablePartitionStmt;
-import com.starrocks.sql.ast.TruncateTableStmt;
->>>>>>> 7e78e7f74b ([BugFix] insert overwrite textformat hive table didn't set delimiter (#67199))
+import com.starrocks.sql.optimizer.Memo;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -735,13 +724,8 @@ public class HiveMetadataTest {
         Map<String, String> map = new HashMap<>();
         map.put(STARROCKS_QUERY_ID, "abcd");
         Partition remotePartition = new Partition(map, null, null, null, false);
-<<<<<<< HEAD
-        HivePartition hivePartition = new HivePartition(null, null, null, null, null, null, map);
-        Assert.assertTrue(HiveCommitter.checkIsSamePartition(remotePartition, hivePartition));
-=======
         HivePartition hivePartition = new HivePartition(null, null, null, null, null, null, map, new HashMap<>());
-        Assertions.assertTrue(HiveCommitter.checkIsSamePartition(remotePartition, hivePartition));
->>>>>>> 7e78e7f74b ([BugFix] insert overwrite textformat hive table didn't set delimiter (#67199))
+        Assert.assertTrue(HiveCommitter.checkIsSamePartition(remotePartition, hivePartition));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -843,7 +843,7 @@ public class HiveMetadataTest {
         ctx.setThreadLocalInfo();
 
         // Get a HiveTable from the mocked metadata
-        HiveTable hiveTable = (HiveTable) hiveMetadata.getTable(new ConnectContext(), "db1", "table1");
+        HiveTable hiveTable = (HiveTable) hiveMetadata.getTable("db1", "table1");
 
         // Create PartitionUpdate
         String partitionName = "col1=1";
@@ -864,19 +864,19 @@ public class HiveMetadataTest {
         HivePartition hivePartition = (HivePartition) method.invoke(hiveCommitter, partitionUpdate);
 
         // Verify the result
-        Assertions.assertNotNull(hivePartition);
-        Assertions.assertEquals("db1", hivePartition.getDatabaseName());
-        Assertions.assertEquals("table1", hivePartition.getTableName());
-        Assertions.assertEquals(Lists.newArrayList("1"), hivePartition.getValues());
-        Assertions.assertEquals(targetPath.toString(), hivePartition.getLocation());
-        Assertions.assertNotNull(hivePartition.getParameters());
-        Assertions.assertTrue(hivePartition.getParameters().containsKey("starrocks_version"));
-        Assertions.assertTrue(hivePartition.getParameters().containsKey(STARROCKS_QUERY_ID));
-        Assertions.assertEquals(ctx.getQueryId().toString(), hivePartition.getParameters().get(STARROCKS_QUERY_ID));
-        Assertions.assertNotNull(hivePartition.getSerDeParameters());
-        Assertions.assertEquals(hiveTable.getSerdeProperties(), hivePartition.getSerDeParameters());
-        Assertions.assertEquals(hiveTable.getStorageFormat(), hivePartition.getStorage());
-        Assertions.assertEquals(hiveTable.getDataColumnNames().size(), hivePartition.getColumns().size());
+        Assert.assertNotNull(hivePartition);
+        Assert.assertEquals("db1", hivePartition.getDatabaseName());
+        Assert.assertEquals("table1", hivePartition.getTableName());
+        Assert.assertEquals(Lists.newArrayList("1"), hivePartition.getValues());
+        Assert.assertEquals(targetPath.toString(), hivePartition.getLocation());
+        Assert.assertNotNull(hivePartition.getParameters());
+        Assert.assertTrue(hivePartition.getParameters().containsKey("starrocks_version"));
+        Assert.assertTrue(hivePartition.getParameters().containsKey(STARROCKS_QUERY_ID));
+        Assert.assertEquals(ctx.getQueryId().toString(), hivePartition.getParameters().get(STARROCKS_QUERY_ID));
+        Assert.assertNotNull(hivePartition.getSerDeParameters());
+        Assert.assertEquals(hiveTable.getSerdeProperties(), hivePartition.getSerDeParameters());
+        Assert.assertEquals(hiveTable.getStorageFormat(), hivePartition.getStorage());
+        Assert.assertEquals(hiveTable.getDataColumnNames().size(), hivePartition.getColumns().size());
 
         // Clean up
         ConnectContext.remove();
@@ -890,7 +890,7 @@ public class HiveMetadataTest {
         ctx.setThreadLocalInfo();
 
         // Get a HiveTable from the mocked metadata
-        HiveTable hiveTable = (HiveTable) hiveMetadata.getTable(new ConnectContext(), "db1", "table1");
+        HiveTable hiveTable = (HiveTable) hiveMetadata.getTable("db1", "table1");
 
         // Create SingleItemListPartitionDesc
         List<String> partitionValues = Lists.newArrayList("1");
@@ -924,31 +924,31 @@ public class HiveMetadataTest {
 
         // Use reflection to call private addPartition method
         java.lang.reflect.Method method = HiveMetadata.class.getDeclaredMethod(
-                "addPartition", ConnectContext.class, AlterTableStmt.class, AlterClause.class);
+                "addPartition", AlterTableStmt.class, AlterClause.class);
         method.setAccessible(true);
-        method.invoke(hiveMetadata, ctx, alterTableStmt, addPartitionClause);
+        method.invoke(hiveMetadata, alterTableStmt, addPartitionClause);
 
         // Verify addPartitions was called
-        Assertions.assertTrue(addPartitionsCalled.get());
-        Assertions.assertEquals(1, capturedPartitions.size());
+        Assert.assertTrue(addPartitionsCalled.get());
+        Assert.assertEquals(1, capturedPartitions.size());
 
         // Verify the partition details
         HivePartitionWithStats partitionWithStats = capturedPartitions.get(0);
-        Assertions.assertEquals("col1=1", partitionWithStats.getPartitionName());
+        Assert.assertEquals("col1=1", partitionWithStats.getPartitionName());
         HivePartition hivePartition = partitionWithStats.getHivePartition();
-        Assertions.assertNotNull(hivePartition);
-        Assertions.assertEquals("db1", hivePartition.getDatabaseName());
-        Assertions.assertEquals("table1", hivePartition.getTableName());
-        Assertions.assertEquals(partitionValues, hivePartition.getValues());
-        Assertions.assertEquals(hiveTable.getTableLocation() + "/col1=1", hivePartition.getLocation());
-        Assertions.assertNotNull(hivePartition.getParameters());
-        Assertions.assertTrue(hivePartition.getParameters().containsKey("starrocks_version"));
-        Assertions.assertTrue(hivePartition.getParameters().containsKey(STARROCKS_QUERY_ID));
-        Assertions.assertEquals(ctx.getQueryId().toString(), hivePartition.getParameters().get(STARROCKS_QUERY_ID));
-        Assertions.assertNotNull(hivePartition.getSerDeParameters());
-        Assertions.assertEquals(hiveTable.getSerdeProperties(), hivePartition.getSerDeParameters());
-        Assertions.assertEquals(hiveTable.getStorageFormat(), hivePartition.getStorage());
-        Assertions.assertEquals(hiveTable.getDataColumnNames().size(), hivePartition.getColumns().size());
+        Assert.assertNotNull(hivePartition);
+        Assert.assertEquals("db1", hivePartition.getDatabaseName());
+        Assert.assertEquals("table1", hivePartition.getTableName());
+        Assert.assertEquals(partitionValues, hivePartition.getValues());
+        Assert.assertEquals(hiveTable.getTableLocation() + "/col1=1", hivePartition.getLocation());
+        Assert.assertNotNull(hivePartition.getParameters());
+        Assert.assertTrue(hivePartition.getParameters().containsKey("starrocks_version"));
+        Assert.assertTrue(hivePartition.getParameters().containsKey(STARROCKS_QUERY_ID));
+        Assert.assertEquals(ctx.getQueryId().toString(), hivePartition.getParameters().get(STARROCKS_QUERY_ID));
+        Assert.assertNotNull(hivePartition.getSerDeParameters());
+        Assert.assertEquals(hiveTable.getSerdeProperties(), hivePartition.getSerDeParameters());
+        Assert.assertEquals(hiveTable.getStorageFormat(), hivePartition.getStorage());
+        Assert.assertEquals(hiveTable.getDataColumnNames().size(), hivePartition.getColumns().size());
 
         // Clean up
         ConnectContext.remove();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
@@ -145,7 +145,9 @@ public class HiveMetastoreTest {
                 .setTableName("table")
                 .setLocation("location")
                 .setValues(Lists.newArrayList("p1=1"))
-                .setParameters(new HashMap<>()).build();
+                .setParameters(new HashMap<>())
+                .setSerDeParameters(new HashMap<>())
+                .build();
 
         HivePartitionStats hivePartitionStats = HivePartitionStats.empty();
         HivePartitionWithStats hivePartitionWithStats = new HivePartitionWithStats("p1=1", hivePartition, hivePartitionStats);


### PR DESCRIPTION
## Why I'm doing:
When writing data to a Hive TextFile table using a Hive catalog with \^[ as the delimiter, all fields are merged into a single field when querying in StarRocks, causing data parsing errors.
The reason is that StarRocks doesn't set the parameters of serdeInfo when creating a new partition. So delimiters in TextFileFormatDesc are null when reading.
```
// use hive
CREATE TABLE IF NOT EXISTS insert_text_file_test(
data_dt string, 
filed1 string,
filed2 string
)
PARTITIONED BY (
dt string)
ROW FORMAT DELIMITED FIELDS TERMINATED BY '\^['
STORED AS textfile;

//use starrocks
insert overwrite hive.db.insert_text_file_test partition(dt = '20251222')
select '20251222', 'field1', 'field2' 
union all
select '20251222',field1',null;

//result is wrong
select * from hive.db.insert_text_file_test;
```
## What I'm doing:

Fixes #issue
Call setSerDeParameters() in buildHivePartition() so that StarRocks can get SerDeParameters during reading.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes missing SerDe parameters on newly created Hive partitions, preserving delimiters for TextFile reads.
> 
> - Pass table SerDe props via `.setSerDeParameters(table.getSerdeProperties())` in `HiveCommitter.buildHivePartition` and `HiveMetadata.addPartition`
> - Extend `HivePartition` to carry `serDeParameters` (constructor, getter, builder)
> - Populate SerDeInfo parameters in `HiveMetastoreApiConverter` when converting partitions
> - Add/adjust tests: validate SerDe propagation in partition build and add-partition flows; update metastore tests to include `setSerDeParameters`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f1885e0d90cab0ad886b064b62cff01f67c4ea0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
