### PR TITLE
[BugFix] Store KVStore reference in Rowset to prevent metadata access errors

### DIFF
--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -367,8 +367,8 @@ void DataDir::load() {
             return true;
         }
         RowsetSharedPtr rowset;
-        Status create_status =
-                RowsetFactory::create_rowset(tablet->tablet_schema(), tablet->schema_hash_path(), rowset_meta, &rowset);
+        Status create_status = RowsetFactory::create_rowset(tablet->tablet_schema(), tablet->schema_hash_path(),
+                                                            rowset_meta, &rowset, tablet->data_dir()->get_meta());
         if (!create_status.ok()) {
             LOG(WARNING) << "Fail to create rowset from rowsetmeta,"
                          << " rowset=" << rowset_meta->rowset_id() << " state=" << rowset_meta->rowset_state();

--- a/be/src/storage/local_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/local_primary_key_compaction_conflict_resolver.cpp
@@ -51,7 +51,8 @@ Status LocalPrimaryKeyCompactionConflictResolver::segment_iterator(
     auto pkey_schema = generate_pkey_schema();
     RowsetReleaseGuard guard(_rowset->shared_from_this());
     const auto& schema = _rowset->schema();
-    ASSIGN_OR_RETURN(auto segment_iters, _rowset->get_segment_iterators2(pkey_schema, schema, nullptr, 0, &stats));
+    ASSIGN_OR_RETURN(auto segment_iters,
+                     _rowset->get_segment_iterators2(pkey_schema, schema, MetaLoadMode::NONE, 0, &stats));
     RETURN_ERROR_IF_FALSE(segment_iters.size() == _rowset->num_segments(), "itrs.size != num_segments");
     // init delvec loader
     auto delvec_loader = std::make_unique<LocalDelvecLoader>(_tablet->data_dir()->get_meta());

--- a/be/src/storage/local_primary_key_recover.cpp
+++ b/be/src/storage/local_primary_key_recover.cpp
@@ -79,7 +79,8 @@ Status LocalPrimaryKeyRecover::rowset_iterator(
         // NOT acquire rowset reference because tbalet already in error state, rowset reclaim should stop
         // NOT apply delvec when create segment iterator
         // 1. get iterator for each segment
-        auto res = rowset->get_segment_iterators2(pkey_schema, _tablet->tablet_schema(), nullptr,
+        // Use MetaLoadMode::NONE to skip loading delete vectors and DCGs during recovery
+        auto res = rowset->get_segment_iterators2(pkey_schema, _tablet->tablet_schema(), MetaLoadMode::NONE,
                                                   latest_applied_major_version, &stats);
         if (!res.ok()) {
             return res.status();

--- a/be/src/storage/persistent_index_tablet_loader.cpp
+++ b/be/src/storage/persistent_index_tablet_loader.cpp
@@ -74,7 +74,7 @@ Status PersistentIndexTabletLoader::rowset_iterator(
     }
     for (auto& rowset : rowsets) {
         RowsetReleaseGuard guard(rowset);
-        auto res = rowset->get_segment_iterators2(pkey_schema, _tablet->tablet_schema(), data_dir()->get_meta(),
+        auto res = rowset->get_segment_iterators2(pkey_schema, _tablet->tablet_schema(), MetaLoadMode::ALL,
                                                   apply_version, &stats);
         if (!res.ok()) {
             return res.status();

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1237,7 +1237,9 @@ Status PrimaryIndex::_do_load(Tablet* tablet) {
     auto chunk = chunk_shared_ptr.get();
     for (auto& rowset : rowsets) {
         RowsetReleaseGuard guard(rowset);
-        auto res = rowset->get_segment_iterators2(pkey_schema, tablet->tablet_schema(), tablet->data_dir()->get_meta(),
+        // Load all metadata (delete vectors + DCGs) for primary index construction
+        // Rowset uses its internal _kvstore to access the correct metadata store
+        auto res = rowset->get_segment_iterators2(pkey_schema, tablet->tablet_schema(), MetaLoadMode::ALL,
                                                   apply_version, &stats);
         if (!res.ok()) {
             return res.status();

--- a/be/src/storage/primary_key_dump.cpp
+++ b/be/src/storage/primary_key_dump.cpp
@@ -256,7 +256,8 @@ Status PrimaryKeyDump::_dump_segment_keys() {
     auto chunk = chunk_shared_ptr.get();
     for (auto& rowset : *rowset_map) {
         RowsetReleaseGuard guard(rowset.second);
-        auto res = rowset.second->get_segment_iterators2(pkey_schema, tablet_schema, nullptr, 0, &stats);
+        // Use MetaLoadMode::NONE since we only need to dump primary keys, no metadata required
+        auto res = rowset.second->get_segment_iterators2(pkey_schema, tablet_schema, MetaLoadMode::NONE, 0, &stats);
         if (!res.ok()) {
             return res.status();
         }

--- a/be/src/storage/replication_txn_manager.cpp
+++ b/be/src/storage/replication_txn_manager.cpp
@@ -1011,7 +1011,7 @@ Status ReplicationTxnManager::publish_full_meta(Tablet* tablet, TabletMeta* clon
     for (auto& rs_meta_ptr : rs_metas_found_in_src) {
         RowsetSharedPtr rowset_to_remove;
         if (auto s = RowsetFactory::create_rowset(cloned_tablet_meta->tablet_schema_ptr(), tablet->schema_hash_path(),
-                                                  rs_meta_ptr, &rowset_to_remove);
+                                                  rs_meta_ptr, &rowset_to_remove, tablet->data_dir()->get_meta());
             !s.ok()) {
             LOG(WARNING) << "Failed to init rowset to remove: " << rs_meta_ptr->rowset_id().to_string();
             continue;

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -66,10 +66,12 @@
 
 namespace starrocks {
 
-Rowset::Rowset(const TabletSchemaCSPtr& schema, std::string rowset_path, RowsetMetaSharedPtr rowset_meta)
+Rowset::Rowset(const TabletSchemaCSPtr& schema, std::string rowset_path, RowsetMetaSharedPtr rowset_meta,
+               KVStore* kvstore)
         : _schema(schema),
           _rowset_path(std::move(rowset_path)),
           _rowset_meta(std::move(rowset_meta)),
+          _kvstore(kvstore),
           _refs_by_reader(0) {
     _schema = _rowset_meta->tablet_schema() ? _rowset_meta->tablet_schema() : schema;
     _keys_type = _schema->keys_type();
@@ -389,35 +391,30 @@ Status Rowset::remove() {
     return result;
 }
 
+// Remove delta column group files and metadata for this rowset
+// Uses the rowset's internal _kvstore reference to ensure we access the correct
+// KVStore for this rowset's tablet, avoiding metadata corruption when the same
+// tablet exists on multiple disks.
 Status Rowset::remove_delta_column_group() {
-    std::filesystem::path schema_hash_path(_rowset_path);
-    std::filesystem::path data_dir_path = schema_hash_path.parent_path().parent_path().parent_path().parent_path();
-    std::string data_dir_string = data_dir_path.string();
-    DataDir* data_dir = StorageEngine::instance()->get_store(data_dir_string);
-    if (data_dir == nullptr) {
-        LOG(ERROR) << "DataDir not found! rowset_path: " << _rowset_path << ", dir_path: " << data_dir_string;
-        return Status::OK();
-    }
-    return remove_delta_column_group(data_dir->get_meta());
-}
-
-Status Rowset::remove_delta_column_group(KVStore* kvstore) {
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_rowset_path));
-    return _remove_delta_column_group_files(fs, kvstore);
+    return _remove_delta_column_group_files(fs);
 }
 
-Status Rowset::_remove_delta_column_group_files(const std::shared_ptr<FileSystem>& fs, KVStore* kvstore) {
-    if (num_segments() > 0) {
+// Internal helper to remove delta column group files and metadata
+// Uses _kvstore member to access the correct KVStore instance for this rowset,
+// which is essential when a tablet is duplicated across multiple disks on the same BE node.
+Status Rowset::_remove_delta_column_group_files(const std::shared_ptr<FileSystem>& fs) {
+    if (num_segments() > 0 && _kvstore != nullptr) {
         // 1. remove dcg files
         for (int i = 0; i < num_segments(); i++) {
             DeltaColumnGroupList list;
             if (_keys_type == PRIMARY_KEYS) {
-                RETURN_IF_ERROR(TabletMetaManager::scan_delta_column_group(kvstore, _rowset_meta->tablet_id(),
+                RETURN_IF_ERROR(TabletMetaManager::scan_delta_column_group(_kvstore, _rowset_meta->tablet_id(),
                                                                            _rowset_meta->get_rowset_seg_id() + i, 0,
                                                                            INT64_MAX, &list));
             } else {
                 RETURN_IF_ERROR(TabletMetaManager::scan_delta_column_group(
-                        kvstore, _rowset_meta->tablet_id(), _rowset_meta->rowset_id(), i, 0, INT64_MAX, &list));
+                        _kvstore, _rowset_meta->tablet_id(), _rowset_meta->rowset_id(), i, 0, INT64_MAX, &list));
             }
 
             for (const auto& dcg : list) {
@@ -435,16 +432,16 @@ Status Rowset::_remove_delta_column_group_files(const std::shared_ptr<FileSystem
         // 2. remove dcg from rocksdb
         if (_keys_type == PRIMARY_KEYS) {
             RETURN_IF_ERROR(TabletMetaManager::delete_delta_column_group(
-                    kvstore, _rowset_meta->tablet_id(), _rowset_meta->get_rowset_seg_id(), num_segments()));
+                    _kvstore, _rowset_meta->tablet_id(), _rowset_meta->get_rowset_seg_id(), num_segments()));
         } else {
-            RETURN_IF_ERROR(TabletMetaManager::delete_delta_column_group(kvstore, _rowset_meta->tablet_id(),
+            RETURN_IF_ERROR(TabletMetaManager::delete_delta_column_group(_kvstore, _rowset_meta->tablet_id(),
                                                                          _rowset_meta->rowset_id(), num_segments()));
         }
     }
     return Status::OK();
 }
 
-Status Rowset::link_files_to(KVStore* kvstore, const std::string& dir, RowsetId new_rowset_id, int64_t version) {
+Status Rowset::link_files_to(const std::string& dir, RowsetId new_rowset_id, int64_t version) {
     for (int i = 0; i < num_segments(); ++i) {
         std::string dst_link_path = segment_file_path(dir, new_rowset_id, i);
         std::string src_file_path = segment_file_path(_rowset_path, rowset_id(), i);
@@ -510,22 +507,25 @@ Status Rowset::link_files_to(KVStore* kvstore, const std::string& dir, RowsetId 
             VLOG(2) << "success to link " << src_file_path << " to " << dst_link_path;
         }
     }
-    RETURN_IF_ERROR(_link_delta_column_group_files(kvstore, dir, version));
+    RETURN_IF_ERROR(_link_delta_column_group_files(dir, version));
     return Status::OK();
 }
 
-Status Rowset::_link_delta_column_group_files(KVStore* kvstore, const std::string& dir, int64_t version) {
-    if (num_segments() > 0 && kvstore != nullptr && _rowset_path != dir) {
+// Internal helper to hard link delta column group files
+// Uses _kvstore member to query DCG metadata from the correct KVStore instance.
+// Only links DCGs up to the specified version to avoid including future changes.
+Status Rowset::_link_delta_column_group_files(const std::string& dir, int64_t version) {
+    if (num_segments() > 0 && _kvstore != nullptr && _rowset_path != dir) {
         // link dcg files
         for (int i = 0; i < num_segments(); i++) {
             DeltaColumnGroupList list;
 
             if (_keys_type == PRIMARY_KEYS) {
                 RETURN_IF_ERROR(TabletMetaManager::scan_delta_column_group(
-                        kvstore, _rowset_meta->tablet_id(), _rowset_meta->get_rowset_seg_id() + i, 0, version, &list));
+                        _kvstore, _rowset_meta->tablet_id(), _rowset_meta->get_rowset_seg_id() + i, 0, version, &list));
             } else {
                 RETURN_IF_ERROR(TabletMetaManager::scan_delta_column_group(
-                        kvstore, _rowset_meta->tablet_id(), _rowset_meta->rowset_id(), i, 0, INT64_MAX, &list));
+                        _kvstore, _rowset_meta->tablet_id(), _rowset_meta->rowset_id(), i, 0, INT64_MAX, &list));
             }
 
             for (const auto& dcg : list) {
@@ -550,7 +550,7 @@ Status Rowset::_link_delta_column_group_files(KVStore* kvstore, const std::strin
     return Status::OK();
 }
 
-StatusOr<int64_t> Rowset::copy_files_to(KVStore* kvstore, const std::string& dir) {
+StatusOr<int64_t> Rowset::copy_files_to(const std::string& dir) {
     int64_t ncopy = 0;
     for (int i = 0; i < num_segments(); ++i) {
         std::string dst_path = segment_file_path(dir, rowset_id(), i);
@@ -645,25 +645,28 @@ StatusOr<int64_t> Rowset::copy_files_to(KVStore* kvstore, const std::string& dir
         }
     }
 
-    ASSIGN_OR_RETURN(auto delta_file_size, _copy_delta_column_group_files(kvstore, dir, INT64_MAX));
+    ASSIGN_OR_RETURN(auto delta_file_size, _copy_delta_column_group_files(dir, INT64_MAX));
     ncopy += delta_file_size;
 
     return ncopy;
 }
 
-StatusOr<int64_t> Rowset::_copy_delta_column_group_files(KVStore* kvstore, const std::string& dir, int64_t version) {
+// Internal helper to copy delta column group files
+// Uses _kvstore member to query DCG metadata from the correct KVStore instance.
+// Returns the total number of bytes copied.
+StatusOr<int64_t> Rowset::_copy_delta_column_group_files(const std::string& dir, int64_t version) {
     int64_t ncopy = 0;
-    if (num_segments() > 0 && kvstore != nullptr && _rowset_path != dir) {
+    if (num_segments() > 0 && _kvstore != nullptr && _rowset_path != dir) {
         // link dcg files
         for (int i = 0; i < num_segments(); i++) {
             DeltaColumnGroupList list;
 
             if (_keys_type == PRIMARY_KEYS) {
                 RETURN_IF_ERROR(TabletMetaManager::scan_delta_column_group(
-                        kvstore, _rowset_meta->tablet_id(), _rowset_meta->get_rowset_seg_id() + i, 0, version, &list));
+                        _kvstore, _rowset_meta->tablet_id(), _rowset_meta->get_rowset_seg_id() + i, 0, version, &list));
             } else {
                 RETURN_IF_ERROR(TabletMetaManager::scan_delta_column_group(
-                        kvstore, _rowset_meta->tablet_id(), _rowset_meta->rowset_id(), i, 0, INT64_MAX, &list));
+                        _kvstore, _rowset_meta->tablet_id(), _rowset_meta->rowset_id(), i, 0, INT64_MAX, &list));
             }
 
             for (const auto& dcg : list) {
@@ -782,12 +785,14 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
         seg_options.is_primary_keys = true;
         seg_options.rowset_id = rowset_meta()->get_rowset_seg_id();
         seg_options.version = options.version;
-        seg_options.delvec_loader = std::make_shared<LocalDelvecLoader>(options.meta);
+        // Use _kvstore to ensure we access the correct metadata store for this rowset
+        seg_options.delvec_loader = std::make_shared<LocalDelvecLoader>(_kvstore);
     }
     seg_options.rowset_path = _rowset_path;
     seg_options.tablet_id = rowset_meta()->tablet_id();
     seg_options.rowsetid = rowset_meta()->rowset_id();
-    seg_options.dcg_loader = std::make_shared<LocalDeltaColumnGroupLoader>(options.meta);
+    // Use _kvstore to ensure we access the correct metadata store for this rowset
+    seg_options.dcg_loader = std::make_shared<LocalDeltaColumnGroupLoader>(_kvstore);
     if (options.short_key_ranges_option != nullptr) { // logical split.
         seg_options.short_key_ranges = options.short_key_ranges_option->short_key_ranges;
     }
@@ -864,28 +869,40 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
     return Status::OK();
 }
 
+// Get segment iterators for reading rowset data
+// |meta_load_mode| - Controls which metadata to load:
+//   - DELETE_VEC_ONLY: Load only delete vectors (for PK tables to filter deleted rows)
+//   - DCG_ONLY: Load only delta column groups (for partial updates/schema changes)
+//   - ALL: Load both delete vectors and DCGs
+//   - NONE: Load no metadata
+// Uses _kvstore member to ensure metadata is loaded from the correct KVStore instance.
 StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_segment_iterators2(const Schema& schema,
                                                                        const TabletSchemaCSPtr& tablet_schema,
-                                                                       KVStore* meta, int64_t version,
-                                                                       OlapReaderStatistics* stats, KVStore* dcg_meta,
+                                                                       const MetaLoadMode& meta_load_mode,
+                                                                       int64_t version, OlapReaderStatistics* stats,
                                                                        size_t chunk_size) {
     RETURN_IF_ERROR(load());
 
     SegmentReadOptions seg_options;
     ASSIGN_OR_RETURN(seg_options.fs, FileSystem::CreateSharedFromString(_rowset_path));
     seg_options.stats = stats;
-    seg_options.is_primary_keys = meta != nullptr;
+    seg_options.is_primary_keys = schema.keys_type() == KeysType::PRIMARY_KEYS;
     seg_options.tablet_id = rowset_meta()->tablet_id();
     seg_options.rowset_id = rowset_meta()->get_rowset_seg_id();
     seg_options.rowset_path = _rowset_path;
     seg_options.version = version;
     seg_options.tablet_schema = tablet_schema;
-    seg_options.delvec_loader = std::make_shared<LocalDelvecLoader>(meta);
-    seg_options.dcg_loader = std::make_shared<LocalDeltaColumnGroupLoader>(meta != nullptr ? meta : dcg_meta);
+    // Conditionally load metadata loaders based on the requested mode
+    // Both loaders use _kvstore to access the correct metadata store
+    if (meta_load_mode == MetaLoadMode::DELETE_VEC_ONLY || meta_load_mode == MetaLoadMode::ALL) {
+        seg_options.delvec_loader = std::make_shared<LocalDelvecLoader>(_kvstore);
+    }
+    if (meta_load_mode == MetaLoadMode::DCG_ONLY || meta_load_mode == MetaLoadMode::ALL) {
+        seg_options.dcg_loader = std::make_shared<LocalDeltaColumnGroupLoader>(_kvstore);
+    }
     if (chunk_size > 0) {
         seg_options.chunk_size = chunk_size;
     }
-    seg_options.read_by_generated_column_adding = (dcg_meta != nullptr);
 
     std::vector<ChunkIteratorPtr> seg_iterators(num_segments());
     TabletSegmentId tsid;

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -786,6 +786,9 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
         seg_options.rowset_id = rowset_meta()->get_rowset_seg_id();
         seg_options.version = options.version;
         // Use _kvstore to ensure we access the correct metadata store for this rowset
+        if (_kvstore == nullptr) {
+            return Status::InternalError("KVStore is null when loading rowset metadata");
+        }
         seg_options.delvec_loader = std::make_shared<LocalDelvecLoader>(_kvstore);
     }
     seg_options.rowset_path = _rowset_path;
@@ -894,6 +897,9 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_segment_iterators2(const Sch
     seg_options.tablet_schema = tablet_schema;
     // Conditionally load metadata loaders based on the requested mode
     // Both loaders use _kvstore to access the correct metadata store
+    if (meta_load_mode != MetaLoadMode::NONE && _kvstore == nullptr) {
+        return Status::InternalError("KVStore is null when loading rowset metadata");
+    }
     if (meta_load_mode == MetaLoadMode::DELETE_VEC_ONLY || meta_load_mode == MetaLoadMode::ALL) {
         seg_options.delvec_loader = std::make_shared<LocalDelvecLoader>(_kvstore);
     }

--- a/be/src/storage/rowset/rowset_factory.cpp
+++ b/be/src/storage/rowset/rowset_factory.cpp
@@ -56,7 +56,10 @@ Status RowsetFactory::create_rowset(const TabletSchemaCSPtr& schema, const std::
         if (data_dir != nullptr) {
             kvstore = data_dir->get_meta();
         } else {
+#ifndef BE_TEST
+            LOG(ERROR) << "DataDir not found for path: " << data_dir_string;
             return Status::InternalError(fmt::format("DataDir not found for path: {}", data_dir_string));
+#endif
         }
     }
     *rowset = Rowset::create(schema, rowset_path, rowset_meta, kvstore);

--- a/be/src/storage/rowset/rowset_factory.cpp
+++ b/be/src/storage/rowset/rowset_factory.cpp
@@ -53,8 +53,12 @@ Status RowsetFactory::create_rowset(const TabletSchemaCSPtr& schema, const std::
         std::vector<std::string> store_paths = StorageEngine::instance()->get_store_paths();
         for (const auto& store_path : store_paths) {
             if (rowset_path.compare(0, store_path.size(), store_path) == 0) {
-                data_dir = StorageEngine::instance()->get_store(store_path);
-                break;
+                // Ensure the match occurs at a path boundary to avoid false matches
+                // e.g., /data1 should not match /data10/tablet/...
+                if (rowset_path.size() == store_path.size() || rowset_path[store_path.size()] == '/') {
+                    data_dir = StorageEngine::instance()->get_store(store_path);
+                    break;
+                }
             }
         }
         if (data_dir != nullptr) {

--- a/be/src/storage/rowset/rowset_factory.cpp
+++ b/be/src/storage/rowset/rowset_factory.cpp
@@ -45,8 +45,8 @@
 namespace starrocks {
 
 Status RowsetFactory::create_rowset(const TabletSchemaCSPtr& schema, const std::string& rowset_path,
-                                    const RowsetMetaSharedPtr& rowset_meta, RowsetSharedPtr* rowset) {
-    *rowset = Rowset::create(schema, rowset_path, rowset_meta);
+                                    const RowsetMetaSharedPtr& rowset_meta, RowsetSharedPtr* rowset, KVStore* kvstore) {
+    *rowset = Rowset::create(schema, rowset_path, rowset_meta, kvstore);
     RETURN_IF_ERROR((*rowset)->init());
     return Status::OK();
 }

--- a/be/src/storage/rowset/rowset_factory.cpp
+++ b/be/src/storage/rowset/rowset_factory.cpp
@@ -63,12 +63,10 @@ Status RowsetFactory::create_rowset(const TabletSchemaCSPtr& schema, const std::
         }
         if (data_dir != nullptr) {
             kvstore = data_dir->get_meta();
-        } else {
-#ifndef BE_TEST
-            LOG(ERROR) << "DataDir not found for path: " << rowset_path;
-            return Status::InternalError(fmt::format("DataDir not found for path: {}", rowset_path));
-#endif
         }
+        // If data_dir is not found, continue with kvstore = nullptr.
+        // This is valid for snapshot flows (e.g., SnapshotManager::convert_rowset_ids)
+        // that operate on arbitrary local directories outside configured store paths.
     }
     *rowset = Rowset::create(schema, rowset_path, rowset_meta, kvstore);
     RETURN_IF_ERROR((*rowset)->init());

--- a/be/src/storage/rowset/rowset_factory.h
+++ b/be/src/storage/rowset/rowset_factory.h
@@ -48,7 +48,7 @@ public:
     // return OK on success and set inited rowset in `*rowset`.
     // return error if failed to create or init rowset.
     static Status create_rowset(const TabletSchemaCSPtr& schema, const std::string& rowset_path,
-                                const RowsetMetaSharedPtr& rowset_meta, RowsetSharedPtr* rowset);
+                                const RowsetMetaSharedPtr& rowset_meta, RowsetSharedPtr* rowset, KVStore* kvstore);
 
     // create and init rowset writer.
     // return OK on success and set `*output` to inited rowset writer.

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -257,9 +257,8 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
     auto rowset_meta = std::make_shared<RowsetMeta>(_rowset_meta_pb);
     RowsetSharedPtr rowset;
     TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_context.tablet_id);
-    RETURN_IF(tablet == nullptr, Status::InvalidArgument(fmt::format("Not Found tablet:{}", _context.tablet_id)));
     RETURN_IF_ERROR(RowsetFactory::create_rowset(_context.tablet_schema, _context.rowset_path_prefix, rowset_meta,
-                                                 &rowset, tablet->data_dir()->get_meta()));
+                                                 &rowset, tablet ? tablet->data_dir()->get_meta() : nullptr));
     if (_rows_mapper_builder != nullptr) {
         RETURN_IF_ERROR(_rows_mapper_builder->finalize());
     }

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -256,9 +256,8 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
 
     auto rowset_meta = std::make_shared<RowsetMeta>(_rowset_meta_pb);
     RowsetSharedPtr rowset;
-    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_context.tablet_id);
     RETURN_IF_ERROR(RowsetFactory::create_rowset(_context.tablet_schema, _context.rowset_path_prefix, rowset_meta,
-                                                 &rowset, tablet ? tablet->data_dir()->get_meta() : nullptr));
+                                                 &rowset, nullptr));
     if (_rows_mapper_builder != nullptr) {
         RETURN_IF_ERROR(_rows_mapper_builder->finalize());
     }

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -256,8 +256,10 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
 
     auto rowset_meta = std::make_shared<RowsetMeta>(_rowset_meta_pb);
     RowsetSharedPtr rowset;
-    RETURN_IF_ERROR(
-            RowsetFactory::create_rowset(_context.tablet_schema, _context.rowset_path_prefix, rowset_meta, &rowset));
+    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_context.tablet_id);
+    RETURN_IF(tablet == nullptr, Status::InvalidArgument(fmt::format("Not Found tablet:{}", _context.tablet_id)));
+    RETURN_IF_ERROR(RowsetFactory::create_rowset(_context.tablet_schema, _context.rowset_path_prefix, rowset_meta,
+                                                 &rowset, tablet->data_dir()->get_meta()));
     if (_rows_mapper_builder != nullptr) {
         RETURN_IF_ERROR(_rows_mapper_builder->finalize());
     }
@@ -753,9 +755,7 @@ Status HorizontalRowsetWriter::flush_chunk_with_deletes(const Chunk& upserts, co
 }
 
 Status HorizontalRowsetWriter::add_rowset(RowsetSharedPtr rowset) {
-    TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(_context.tablet_id);
-    RETURN_IF_ERROR(rowset->link_files_to(tablet == nullptr ? nullptr : tablet->data_dir()->get_meta(),
-                                          _context.rowset_path_prefix, _context.rowset_id));
+    RETURN_IF_ERROR(rowset->link_files_to(_context.rowset_path_prefix, _context.rowset_id));
     _num_rows_written += rowset->num_rows();
     _total_row_size += static_cast<int64_t>(rowset->total_row_size());
     _total_data_size += static_cast<int64_t>(rowset->rowset_meta()->data_disk_size());

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -278,9 +278,7 @@ private:
         std::shared_ptr<VectorIndexReader> ann_reader;
 
         // Helper method to check if rowid should always be built
-        bool always_build_rowid() const {
-            return use_vector_index && !use_ivfpq;
-        }
+        bool always_build_rowid() const { return use_vector_index && !use_ivfpq; }
     };
 
     // Inverted index related context, only created when needed

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -124,8 +124,6 @@ public:
     bool enable_join_runtime_filter_pushdown = false;
     bool enable_predicate_col_late_materialize = false;
 
-    bool read_by_generated_column_adding = false;
-
 public:
     Status convert_to(SegmentReadOptions* dst, const std::vector<LogicalType>& new_types, ObjectPool* obj_pool) const;
 

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -355,8 +355,8 @@ private:
             _entries.emplace_back(new MergeEntry<T>());
             MergeEntry<T>& entry = *_entries.back();
             entry.rowset_release_guard = std::make_unique<RowsetReleaseGuard>(rowset);
-            auto res = rowset->get_segment_iterators2(schema, tablet_schema, tablet.data_dir()->get_meta(), version,
-                                                      stats, nullptr, _chunk_size);
+            auto res = rowset->get_segment_iterators2(schema, tablet_schema, MetaLoadMode::ALL, version, stats,
+                                                      _chunk_size);
             if (!res.ok()) {
                 return res.status();
             }
@@ -535,8 +535,8 @@ private:
                 _entries.emplace_back(new MergeEntry<T>());
                 MergeEntry<T>& entry = *_entries.back();
                 entry.rowset_release_guard = std::make_unique<RowsetReleaseGuard>(rowset);
-                auto res = rowset->get_segment_iterators2(schema, tablet_schema, tablet.data_dir()->get_meta(), version,
-                                                          &non_key_stats, nullptr, _chunk_size);
+                auto res = rowset->get_segment_iterators2(schema, tablet_schema, MetaLoadMode::ALL, version,
+                                                          &non_key_stats, _chunk_size);
                 if (!res.ok()) {
                     return res.status();
                 }

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -111,7 +111,7 @@ Status RowsetUpdateState::_load_upserts(Rowset* rowset, uint32_t idx, Column* pk
         pk_columns.push_back((uint32_t)i);
     }
     Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
-    auto res = rowset->get_segment_iterators2(pkey_schema, schema, nullptr, 0, &stats);
+    auto res = rowset->get_segment_iterators2(pkey_schema, schema, MetaLoadMode::NONE, 0, &stats);
     if (!res.ok()) {
         return res.status();
     }
@@ -329,8 +329,8 @@ Status RowsetUpdateState::_prepare_partial_update_value_columns(Tablet* tablet, 
         }
         _partial_update_value_columns_schema =
                 ChunkHelper::convert_schema(tablet_schema, _partial_update_value_column_ids);
-        auto res = rowset->get_segment_iterators2(_partial_update_value_columns_schema, tablet_schema, nullptr, 0,
-                                                  &_partial_update_value_column_read_stats);
+        auto res = rowset->get_segment_iterators2(_partial_update_value_columns_schema, tablet_schema,
+                                                  MetaLoadMode::NONE, 0, &_partial_update_value_column_read_stats);
         if (!res.ok()) {
             return res.status();
         }

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -319,8 +319,8 @@ Status LinkedSchemaChange::generate_delta_column_group_and_cols(const Tablet* ne
 
     OlapReaderStatistics stats;
     RowsetReleaseGuard guard(src_rowset->shared_from_this());
-    auto res = src_rowset->get_segment_iterators2(read_schema, base_tablet_schema, nullptr, version, &stats,
-                                                  base_tablet->data_dir()->get_meta());
+    auto res = src_rowset->get_segment_iterators2(read_schema, base_tablet_schema, MetaLoadMode::DCG_ONLY, version,
+                                                  &stats);
     if (!res.ok()) {
         return res.status();
     }

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -122,7 +122,8 @@ Status Tablet::_init_once_action() {
     for (const auto& rs_meta : _tablet_meta->all_rs_metas()) {
         Version version = rs_meta->version();
         RowsetSharedPtr rowset;
-        auto st = RowsetFactory::create_rowset(_tablet_meta->tablet_schema_ptr(), _tablet_path, rs_meta, &rowset);
+        auto st = RowsetFactory::create_rowset(_tablet_meta->tablet_schema_ptr(), _tablet_path, rs_meta, &rowset,
+                                               _data_dir->get_meta());
         if (!st.ok()) {
             LOG(WARNING) << "fail to init rowset. tablet_id=" << tablet_id() << ", schema_hash=" << schema_hash()
                          << ", version=" << version << ", res=" << st;
@@ -139,8 +140,8 @@ Status Tablet::_init_once_action() {
         Version version = inc_rs_meta->version();
         RowsetSharedPtr rowset = get_rowset_by_version(version);
         if (rowset == nullptr) {
-            auto st =
-                    RowsetFactory::create_rowset(_tablet_meta->tablet_schema_ptr(), _tablet_path, inc_rs_meta, &rowset);
+            auto st = RowsetFactory::create_rowset(_tablet_meta->tablet_schema_ptr(), _tablet_path, inc_rs_meta,
+                                                   &rowset, _data_dir->get_meta());
             if (!st.ok()) {
                 LOG(WARNING) << "fail to init incremental rowset. tablet_id:" << tablet_id()
                              << ", schema_hash:" << schema_hash() << ", version=" << version << ", res=" << st;
@@ -234,7 +235,8 @@ Status Tablet::revise_tablet_meta(const std::vector<RowsetMetaSharedPtr>& rowset
     for (auto& rs_meta : rowsets_to_clone) {
         Version version = {rs_meta->start_version(), rs_meta->end_version()};
         RowsetSharedPtr rowset;
-        st = RowsetFactory::create_rowset(_tablet_meta->tablet_schema_ptr(), _tablet_path, rs_meta, &rowset);
+        st = RowsetFactory::create_rowset(_tablet_meta->tablet_schema_ptr(), _tablet_path, rs_meta, &rowset,
+                                          _data_dir->get_meta());
         if (!st.ok()) {
             LOG(WARNING) << "fail to init rowset. version=" << version;
             return st;

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -934,7 +934,7 @@ Status EngineCloneTask::_clone_full_data(Tablet* tablet, TabletMeta* cloned_tabl
     for (auto& rs_meta_ptr : rs_metas_found_in_src) {
         RowsetSharedPtr rowset_to_remove;
         if (auto s = RowsetFactory::create_rowset(cloned_tablet_meta->tablet_schema_ptr(), tablet->schema_hash_path(),
-                                                  rs_meta_ptr, &rowset_to_remove);
+                                                  rs_meta_ptr, &rowset_to_remove, tablet->data_dir()->get_meta());
             !s.ok()) {
             LOG(WARNING) << "failed to init rowset to remove: " << rs_meta_ptr->rowset_id().to_string();
             continue;

--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -625,7 +625,7 @@ Status EngineStorageMigrationTask::_copy_index_and_data_files(const string& sche
             return Status::InternalError("Process is going to quit.");
         }
 
-        ASSIGN_OR_RETURN(auto copy_size, rs->copy_files_to(ref_tablet->data_dir()->get_meta(), schema_hash_path));
+        ASSIGN_OR_RETURN(auto copy_size, rs->copy_files_to(schema_hash_path));
         _copy_size += copy_size;
     }
     uint64_t total_time_ms = watch.elapsed_time() / 1000 / 1000;

--- a/be/src/storage/update_compaction_state.cpp
+++ b/be/src/storage/update_compaction_state.cpp
@@ -81,7 +81,7 @@ Status CompactionState::_load_segments(Rowset* rowset, uint32_t segment_id) {
 
     RowsetReleaseGuard guard(rowset->shared_from_this());
     OlapReaderStatistics stats;
-    auto res = rowset->get_segment_iterators2(pkey_schema, schema, nullptr, 0, &stats);
+    auto res = rowset->get_segment_iterators2(pkey_schema, schema, MetaLoadMode::NONE, 0, &stats);
     if (!res.ok()) {
         return res.status();
     }

--- a/be/test/storage/base_compaction_test.cpp
+++ b/be/test/storage/base_compaction_test.cpp
@@ -302,7 +302,7 @@ protected:
 
 TEST_F(BaseCompactionTest, test_init_succeeded) {
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, _engine->get_stores()[0]);
     BaseCompaction base_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(base_compaction.compact().ok());
 }
@@ -314,7 +314,7 @@ TEST_F(BaseCompactionTest, test_input_rowsets_LE_1) {
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
     tablet_meta->set_tablet_schema(schema);
 
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, _engine->get_stores()[0]);
     ASSERT_OK(tablet->init());
     BaseCompaction base_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(base_compaction.compact().ok());
@@ -362,7 +362,7 @@ TEST_F(BaseCompactionTest, test_input_rowsets_EQ_2) {
         tablet_meta->add_rs_meta(src_rowset->rowset_meta());
     }
 
-    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
+    TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, _engine->get_stores()[0]);
     ASSERT_OK(tablet->init());
     tablet->calculate_cumulative_point();
 

--- a/be/test/storage/compaction_manager_test.cpp
+++ b/be/test/storage/compaction_manager_test.cpp
@@ -569,7 +569,7 @@ TEST_F(CompactionManagerTest, test_get_compaction_status) {
     rs_meta_pb->set_start_version(0);
     rs_meta_pb->set_end_version(1);
     auto rowset_meta = std::make_shared<RowsetMeta>(rs_meta_pb);
-    auto rowset = std::make_shared<Rowset>(schema, "", rowset_meta);
+    auto rowset = std::make_shared<Rowset>(schema, "", rowset_meta, data_dir.get_meta());
     mock_rowsets.emplace_back(rowset);
 
     // generate compaction task

--- a/be/test/storage/tablet_test.cpp
+++ b/be/test/storage/tablet_test.cpp
@@ -59,8 +59,8 @@ TEST_F(TabletTest, test_concurrent_add_remove_committed_rowsets) {
     rs_meta_pb->set_end_version(1);
     rs_meta_pb->mutable_tablet_schema()->CopyFrom(schema_pb);
     auto rowset_meta = std::make_shared<RowsetMeta>(rs_meta_pb);
-    auto rowset = std::make_shared<Rowset>(schema, "", rowset_meta);
     DataDir data_dir("./data_dir");
+    auto rowset = std::make_shared<Rowset>(schema, "", rowset_meta, data_dir.get_meta());
     TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, &data_dir);
     tablet->set_data_dir(&data_dir);
     tablet->add_committed_rowset(rowset);

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -2438,7 +2438,7 @@ void TabletUpdatesTest::test_load_snapshot_incremental_with_partial_rowset_old(b
 
     // link files first and then build snapshot meta file
     for (const auto& rowset : snapshot_rowsets) {
-        ASSERT_TRUE(rowset->link_files_to(tablet0->data_dir()->get_meta(), snapshot_dir, rowset->rowset_id()).ok());
+        ASSERT_TRUE(rowset->link_files_to(snapshot_dir, rowset->rowset_id()).ok());
     }
 
     // apply rowset
@@ -2525,7 +2525,7 @@ void TabletUpdatesTest::test_load_snapshot_incremental_with_partial_rowset_new(b
         // rowset status is committed in meta, rowset file is partial rowset
         // link files directly
         for (const auto& rowset : snapshot_rowsets) {
-            ASSERT_TRUE(rowset->link_files_to(tablet0->data_dir()->get_meta(), snapshot_dir, rowset->rowset_id()).ok());
+            ASSERT_TRUE(rowset->link_files_to(snapshot_dir, rowset->rowset_id()).ok());
         }
         break;
     }
@@ -2533,7 +2533,7 @@ void TabletUpdatesTest::test_load_snapshot_incremental_with_partial_rowset_new(b
         // rowset status is committed in meta, rowset file is partial rowset, but rowset is apply success after link file
         // link files first and do apply
         for (const auto& rowset : snapshot_rowsets) {
-            ASSERT_TRUE(rowset->link_files_to(tablet0->data_dir()->get_meta(), snapshot_dir, rowset->rowset_id()).ok());
+            ASSERT_TRUE(rowset->link_files_to(snapshot_dir, rowset->rowset_id()).ok());
         }
 
         tablet0->updates()->stop_apply(false);
@@ -2564,7 +2564,7 @@ void TabletUpdatesTest::test_load_snapshot_incremental_with_partial_rowset_new(b
         }
 
         for (const auto& rowset : snapshot_rowsets) {
-            ASSERT_TRUE(rowset->link_files_to(tablet0->data_dir()->get_meta(), snapshot_dir, rowset->rowset_id()).ok());
+            ASSERT_TRUE(rowset->link_files_to(snapshot_dir, rowset->rowset_id()).ok());
         }
         break;
     }
@@ -2572,7 +2572,7 @@ void TabletUpdatesTest::test_load_snapshot_incremental_with_partial_rowset_new(b
         // rowset status is applied in meta, rowset file is full rowset
         // rowsets applied success, link files directly
         for (const auto& rowset : snapshot_rowsets) {
-            ASSERT_TRUE(rowset->link_files_to(tablet0->data_dir()->get_meta(), snapshot_dir, rowset->rowset_id()).ok());
+            ASSERT_TRUE(rowset->link_files_to(snapshot_dir, rowset->rowset_id()).ok());
         }
         break;
     }


### PR DESCRIPTION
## Why I'm doing:
This PR fixes metadata access errors in Primary Key tables when the same tablet is duplicated across different disks on the same BE node.

  ### Problem
  For Primary Key tables, rowset data includes not only data files but also metadata in KVStore (Delete Vectors and Delta Column Groups). Previously, KVStore references were passed as parameters through multiple method calls, which could lead to accessing the wrong KVStore when:
  - A tablet exists on multiple disks within the same BE node
  - Different data directories have their own KVStore instances
  - Methods were called without the correct KVStore reference

  This resulted in:
  - Delete Vector not found errors
  - Metadata corruption
  - Incorrect query results

## What I'm doing:

**1. Store KVStore reference in Rowset**
  - Added `_kvstore` member variable to the Rowset class
  - Modified Rowset constructor to accept and store KVStore pointer
  - Ensures each Rowset always uses the correct KVStore for its tablet

  **2. Simplify method signatures**
  Removed KVStore parameters from methods that now use the internal reference:
  - `remove_delta_column_group()` - no longer needs KVStore parameter
  - `link_files_to()` - simplified signature
  - `copy_files_to()` - simplified signature
  - `get_segment_iterators2()` - replaced separate meta/dcg_meta params with MetaLoadMode

  **3. Introduce MetaLoadMode enum**
  Added explicit control for metadata loading:
  - `NONE`: No metadata loaded
  - `DELETE_VEC_ONLY`: Load only Delete Vectors
  - `DCG_ONLY`: Load only Delta Column Groups
  - `ALL`: Load both Delete Vectors and DCGs

  This makes the API clearer and prevents ambiguity about which metadata to load.

  ### Changes

  **Core files:**
  - `be/src/storage/rowset/rowset.h` - Added _kvstore member and MetaLoadMode enum
  - `be/src/storage/rowset/rowset.cpp` - Updated methods to use internal _kvstore
  - `be/src/storage/rowset/segment_iterator.cpp` - Simplified DCG loading logic
  - `be/src/storage/rowset/segment_options.h` - Removed redundant flag

  **Callers updated:**
  - `tablet_updates.cpp` - Use MetaLoadMode::ALL for schema conversion
  - `primary_index.cpp` - Use MetaLoadMode::ALL for index construction
  - `local_primary_key_recover.cpp` - Use MetaLoadMode::NONE for recovery
  - `primary_key_dump.cpp` - Use MetaLoadMode::NONE for key dumping
  - And other related files

  ### Benefits

  1. **Correctness**: Prevents metadata access errors when tablets are duplicated across disks
  2. **Simplicity**: Cleaner API with fewer parameters to pass around
  3. **Clarity**: Explicit MetaLoadMode makes intent clear at call sites
  4. **Maintainability**: Centralized KVStore management in Rowset

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures Rowsets always use the correct metadata store (delvec/DCG) even when tablets exist on multiple disks, and clarifies metadata loading.
> 
> - Add `_kvstore` to `Rowset`; change ctor and `RowsetFactory::create_rowset` to accept/derive `KVStore`
> - Simplify APIs to use internal KVStore: `remove_delta_column_group()`, `link_files_to()`, `copy_files_to()`
> - Introduce `MetaLoadMode {NONE, DELETE_VEC_ONLY, DCG_ONLY, ALL}` and refactor `get_segment_iterators2` to conditionally load delvec/DCG via internal `_kvstore`
> - Update callers to new interface with explicit modes (e.g., primary index build/load: ALL; recovery/dump: NONE; schema change: DCG_ONLY; compaction/merger: ALL)
> - Streamline DCG loading in `segment_iterator.cpp` and remove obsolete flag in `segment_options.h`
> - Pass KVStore when constructing rowsets across tablet load/updates/snapshot/clone/migration; adjust tests accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df61d4361e520132c0274863c6d58b3b12a18ea3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->