### PR TITLE
[Enhancement] Support the array join syntax of Clickhouse

### DIFF
--- a/be/src/exprs/table_function/multi_unnest.h
+++ b/be/src/exprs/table_function/multi_unnest.h
@@ -71,10 +71,10 @@ public:
                     min_length_array_size = array_element_length;
                 }
             }
-             if (max_length_array_size != min_length_array_size && state->get_is_array_join_mode()) {
+            if (max_length_array_size != min_length_array_size && state->get_is_array_join_mode()) {
                 state->set_status(Status::InternalError("Sizes of ARRAY-JOIN-ed arrays do not match."));
                 return {};
-             }
+            }
             if (max_length_array_size == 0 && state->get_is_left_join()) {
                 offset += 1;
                 copy_count_column->append(offset);

--- a/be/src/exprs/table_function/multi_unnest.h
+++ b/be/src/exprs/table_function/multi_unnest.h
@@ -51,10 +51,12 @@ public:
         copy_count_column->append(offset);
         for (int row_idx = 0; row_idx < row_count; ++row_idx) {
             uint32_t max_length_array_size = 0;
+            uint32_t min_length_array_size = UINT32_MAX;
             for (auto& col_idx : state->get_columns()) {
                 Column* column = col_idx->as_mutable_raw_ptr();
                 if (column->is_null(row_idx)) {
                     // current row is null, ignore the offset.
+                    min_length_array_size = 0;
                     continue;
                 }
                 auto* col_array = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(column));
@@ -65,7 +67,14 @@ public:
                 if (array_element_length > max_length_array_size) {
                     max_length_array_size = array_element_length;
                 }
+                if (array_element_length < min_length_array_size) {
+                    min_length_array_size = array_element_length;
+                }
             }
+             if (max_length_array_size != min_length_array_size && state->get_is_array_join_mode()) {
+                state->set_status(Status::InternalError("Sizes of ARRAY-JOIN-ed arrays do not match."));
+                return {};
+             }
             if (max_length_array_size == 0 && state->get_is_left_join()) {
                 offset += 1;
                 copy_count_column->append(offset);
@@ -120,6 +129,9 @@ public:
         const auto& table_fn = fn.table_fn;
         if (table_fn.__isset.is_left_join) {
             (*state)->set_is_left_join(table_fn.is_left_join);
+        }
+        if (table_fn.__isset.is_array_join) {
+            (*state)->set_is_array_join_mode(table_fn.is_array_join);
         }
         return Status::OK();
     }

--- a/be/src/exprs/table_function/table_function.h
+++ b/be/src/exprs/table_function/table_function.h
@@ -43,6 +43,10 @@ public:
 
     bool get_is_left_join() { return _is_left_join; }
 
+    void set_is_array_join_mode(bool _is_array_join_mode) { this->_is_array_join_mode = _is_array_join_mode; }
+
+    bool get_is_array_join_mode() { return _is_array_join_mode; }
+
     // How many rows of `get_columns()` have been processed/consumed by the table function.
     //
     // If `processed_rows()` < `input_rows()`, the table function will be invoked again with the same parameter columns.
@@ -83,6 +87,7 @@ private:
 
     // used to identify left join for table function
     bool _is_left_join = false;
+    bool _is_array_join_mode = false;
     bool _is_required = true;
 };
 

--- a/be/test/exprs/table_function/multi_unnest_test.cpp
+++ b/be/test/exprs/table_function/multi_unnest_test.cpp
@@ -1,0 +1,139 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/array_column.h"
+#include "column/column_helper.h"
+#include "exprs/table_function/table_function_factory.h"
+#include "gen_cpp/Types_types.h"
+#include "runtime/runtime_state.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+namespace {
+
+ColumnPtr create_int_array_column(const std::vector<std::vector<int32_t>>& rows) {
+    auto elem = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    auto offs = UInt32Column::create();
+    auto array = ArrayColumn::create(std::move(elem), std::move(offs));
+    for (const auto& row : rows) {
+        DatumArray datum_row;
+        datum_row.reserve(row.size());
+        for (int32_t value : row) {
+            datum_row.emplace_back(value);
+        }
+        array->append_datum(datum_row);
+    }
+    return array;
+}
+
+TFunction create_unnest_function(bool is_array_join, bool is_left_join) {
+    TFunction fn;
+    TTableFunction table_fn;
+    if (is_array_join) {
+        table_fn.__set_is_array_join(true);
+    }
+    if (is_left_join) {
+        table_fn.__set_is_left_join(true);
+    }
+    fn.__set_table_fn(table_fn);
+    return fn;
+}
+
+} // namespace
+
+class MultiUnnestTest : public testing::Test {};
+
+TEST_F(MultiUnnestTest, array_join_mode_rejects_mismatched_array_sizes) {
+    const TableFunction* func =
+            get_table_function("unnest", {}, {}, TFunctionBinaryType::BUILTIN);
+    ASSERT_NE(nullptr, func);
+
+    auto rt_state = std::make_unique<RuntimeState>();
+    rt_state->set_chunk_size(4096);
+
+    Columns input_columns;
+    input_columns.emplace_back(create_int_array_column({{1, 2, 3}}));
+    input_columns.emplace_back(create_int_array_column({{4, 5}}));
+
+    TableFunctionState* func_state = nullptr;
+    TFunction fn = create_unnest_function(true, false);
+    ASSERT_OK(func->init(fn, &func_state));
+    func_state->set_params(input_columns);
+    ASSERT_OK(func->open(rt_state.get(), func_state));
+
+    auto [result_columns, offset_column] = func->process(rt_state.get(), func_state);
+    EXPECT_TRUE(result_columns.empty());
+    EXPECT_EQ("Sizes of ARRAY-JOIN-ed arrays do not match.", func_state->status().message());
+
+    func->close(rt_state.get(), func_state);
+}
+
+TEST_F(MultiUnnestTest, array_join_mode_accepts_matching_array_sizes) {
+    const TableFunction* func =
+            get_table_function("unnest", {}, {}, TFunctionBinaryType::BUILTIN);
+    ASSERT_NE(nullptr, func);
+
+    auto rt_state = std::make_unique<RuntimeState>();
+    rt_state->set_chunk_size(4096);
+
+    Columns input_columns;
+    input_columns.emplace_back(create_int_array_column({{1, 2, 3}}));
+    input_columns.emplace_back(create_int_array_column({{4, 5, 6}}));
+
+    TableFunctionState* func_state = nullptr;
+    TFunction fn = create_unnest_function(true, false);
+    ASSERT_OK(func->init(fn, &func_state));
+    func_state->set_params(input_columns);
+    ASSERT_OK(func->open(rt_state.get(), func_state));
+
+    auto [result_columns, offset_column] = func->process(rt_state.get(), func_state);
+    ASSERT_OK(func_state->status());
+    ASSERT_EQ(2, result_columns.size());
+    ASSERT_EQ(3, result_columns[0]->size());
+    ASSERT_EQ(3, result_columns[1]->size());
+
+    func->close(rt_state.get(), func_state);
+}
+
+TEST_F(MultiUnnestTest, non_array_join_mode_allows_mismatched_array_sizes) {
+    const TableFunction* func =
+            get_table_function("unnest", {}, {}, TFunctionBinaryType::BUILTIN);
+    ASSERT_NE(nullptr, func);
+
+    auto rt_state = std::make_unique<RuntimeState>();
+    rt_state->set_chunk_size(4096);
+
+    Columns input_columns;
+    input_columns.emplace_back(create_int_array_column({{1, 2, 3}}));
+    input_columns.emplace_back(create_int_array_column({{4, 5}}));
+
+    TableFunctionState* func_state = nullptr;
+    TFunction fn = create_unnest_function(false, false);
+    ASSERT_OK(func->init(fn, &func_state));
+    func_state->set_params(input_columns);
+    ASSERT_OK(func->open(rt_state.get(), func_state));
+
+    auto [result_columns, offset_column] = func->process(rt_state.get(), func_state);
+    ASSERT_OK(func_state->status());
+    ASSERT_EQ(2, result_columns.size());
+    ASSERT_EQ(3, result_columns[0]->size());
+    ASSERT_EQ(3, result_columns[1]->size());
+
+    func->close(rt_state.get(), func_state);
+}
+
+} // namespace starrocks

--- a/be/test/exprs/table_function/multi_unnest_test.cpp
+++ b/be/test/exprs/table_function/multi_unnest_test.cpp
@@ -58,8 +58,7 @@ TFunction create_unnest_function(bool is_array_join, bool is_left_join) {
 class MultiUnnestTest : public testing::Test {};
 
 TEST_F(MultiUnnestTest, array_join_mode_rejects_mismatched_array_sizes) {
-    const TableFunction* func =
-            get_table_function("unnest", {}, {}, TFunctionBinaryType::BUILTIN);
+    const TableFunction* func = get_table_function("unnest", {}, {}, TFunctionBinaryType::BUILTIN);
     ASSERT_NE(nullptr, func);
 
     auto rt_state = std::make_unique<RuntimeState>();
@@ -83,8 +82,7 @@ TEST_F(MultiUnnestTest, array_join_mode_rejects_mismatched_array_sizes) {
 }
 
 TEST_F(MultiUnnestTest, array_join_mode_accepts_matching_array_sizes) {
-    const TableFunction* func =
-            get_table_function("unnest", {}, {}, TFunctionBinaryType::BUILTIN);
+    const TableFunction* func = get_table_function("unnest", {}, {}, TFunctionBinaryType::BUILTIN);
     ASSERT_NE(nullptr, func);
 
     auto rt_state = std::make_unique<RuntimeState>();
@@ -110,8 +108,7 @@ TEST_F(MultiUnnestTest, array_join_mode_accepts_matching_array_sizes) {
 }
 
 TEST_F(MultiUnnestTest, non_array_join_mode_allows_mismatched_array_sizes) {
-    const TableFunction* func =
-            get_table_function("unnest", {}, {}, TFunctionBinaryType::BUILTIN);
+    const TableFunction* func = get_table_function("unnest", {}, {}, TFunctionBinaryType::BUILTIN);
     ASSERT_NE(nullptr, func);
 
     auto rt_state = std::make_unique<RuntimeState>();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
@@ -63,6 +63,8 @@ public class TableFunction extends Function {
     // not serialized
     private boolean isLeftJoin = false;
 
+    private boolean isArrayJoin = false;
+
     protected TableFunction() {
     }
 
@@ -172,6 +174,10 @@ public class TableFunction extends Function {
         return this.isLeftJoin;
     }
 
+    public void setIsArrayJoin(boolean isArrayJoin) {
+        this.isArrayJoin = isArrayJoin;
+    }
+
 
 
     @Override
@@ -181,6 +187,7 @@ public class TableFunction extends Function {
         tableFn.setSymbol(symbolName);
         tableFn.setRet_types(tableFnReturnTypes.stream().map(TypeSerializer::toThrift).collect(Collectors.toList()));
         tableFn.setIs_left_join(isLeftJoin);
+        tableFn.setIs_array_join(isArrayJoin);
         fn.setTable_fn(tableFn);
         return fn;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
@@ -102,6 +102,8 @@ public class TableFunction extends Function {
         defaultColumnNames = other.defaultColumnNames;
         tableFnReturnTypes = other.tableFnReturnTypes;
         symbolName = other.symbolName;
+        isLeftJoin = other.isLeftJoin;
+        isArrayJoin = other.isArrayJoin;
     }
 
     public static void initBuiltins(FunctionSet functionSet) {
@@ -178,7 +180,9 @@ public class TableFunction extends Function {
         this.isArrayJoin = isArrayJoin;
     }
 
-
+    public boolean isArrayJoin() {
+        return this.isArrayJoin;
+    }
 
     @Override
     public TFunction toThrift() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1905,6 +1905,7 @@ public class QueryAnalyzer {
 
             TableFunction tableFunction = (TableFunction) fn;
             tableFunction.setIsLeftJoin(node.getIsLeftJoin());
+            tableFunction.setIsArrayJoin(node.getIsArrayJoin());
             node.setTableFunction(tableFunction);
             node.setChildExpressions(childExpressions);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1903,7 +1903,7 @@ public class QueryAnalyzer {
                         Arrays.stream(argTypes).map(Object::toString).collect(Collectors.joining(",")));
             }
 
-            TableFunction tableFunction = (TableFunction) fn;
+            TableFunction tableFunction = (TableFunction) fn.copy();
             tableFunction.setIsLeftJoin(node.getIsLeftJoin());
             tableFunction.setIsArrayJoin(node.getIsArrayJoin());
             node.setTableFunction(tableFunction);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableFunctionRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableFunctionRelation.java
@@ -45,6 +45,8 @@ public class TableFunctionRelation extends Relation {
 
     private boolean isLeftJoin = false;
 
+    private boolean isArrayJoin = false;
+
     public TableFunctionRelation(FunctionCallExpr functionCallExpr) {
         this(functionCallExpr.getFnRef().getFnName().toString().toLowerCase(),
                 functionCallExpr.getParams(), functionCallExpr.getPos());
@@ -78,6 +80,14 @@ public class TableFunctionRelation extends Relation {
 
     public boolean getIsLeftJoin() {
         return isLeftJoin;
+    }
+
+    public void setIsArrayJoin(boolean isArrayJoin) {
+        this.isArrayJoin = isArrayJoin;
+    }
+
+    public boolean getIsArrayJoin() {
+        return isArrayJoin;
     }
 
     public List<Expr> getChildExpressions() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -626,7 +626,9 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
             }
             function = (TableFunction) ExprUtils.getBuiltinFunction(
                     FunctionSet.UNNEST, argTypes, function.getArgNames(), Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            function = (TableFunction) function.copy();
             function.setIsLeftJoin(tableFunc.getFn().isLeftJoin());
+            function.setIsArrayJoin(tableFunc.getFn().isArrayJoin());
         }
 
         ScalarOperator predicate = rewritePredicate(tableFunc.getPredicate(), inputStringRefs);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -10085,6 +10085,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             } else {
                 //If no alias is provided, use the expression string as the column name
                 alias = exprContext.expression().getText();
+                if (alias.length() > 128) {
+                    alias = alias.substring(0, 128);
+                }
             }
             aliasList.add(alias);
             arrayExprs.add(arrayExpr);
@@ -10120,7 +10123,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
     private String generateTableAlias(String columnAlias) {
         // Generate table aliases to avoid conflicts
-        return "t_" + columnAlias;
+        return "t_array" + columnAlias + "_" + System.currentTimeMillis();
     }
 
     public static IndexDef.IndexType getIndexType(com.starrocks.sql.parser.StarRocksParser.IndexTypeContext indexTypeContext) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -10123,7 +10123,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
     private String generateTableAlias(String columnAlias) {
         // Generate table aliases to avoid conflicts
-        return "t_array" + columnAlias + "_" + System.currentTimeMillis();
+        return "t_array_" + columnAlias + "_" + System.currentTimeMillis();
     }
 
     public static IndexDef.IndexType getIndexType(com.starrocks.sql.parser.StarRocksParser.IndexTypeContext indexTypeContext) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -6200,13 +6200,19 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             groupByClause = (GroupByClause) visitIfPresent(context.groupingElement());
         }
 
-        SelectRelation resultSelectRelation = new SelectRelation(
-                selectList,
-                from,
-                (Expr) visitIfPresent(context.where),
-                groupByClause,
-                (Expr) visitIfPresent(context.having),
-                createPos(context));
+        SelectRelation resultSelectRelation;
+        //Convert ARRAY JOIN to UNNSET + LATERAL JOIN
+        if (context.arrayJoinClause() != null) {
+            resultSelectRelation = transFormArrayJoinToUnnest(selectList, from, context, groupByClause);
+        } else {
+            resultSelectRelation = new SelectRelation(
+                    selectList,
+                    from,
+                    (Expr) visitIfPresent(context.where),
+                    groupByClause,
+                    (Expr) visitIfPresent(context.having),
+                    createPos(context));
+        }
 
         // extend Query with QUALIFY to nested queries with filter.
         if (context.qualifyFunction != null) {
@@ -10039,6 +10045,82 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         return QualifiedName.of(parts, qualifiedName.getPos());
+    }
+
+    private SelectRelation transFormArrayJoinToUnnest(SelectList selectList,
+                          Relation fromRelation,
+                          com.starrocks.sql.parser.StarRocksParser.QuerySpecificationContext context,
+                          GroupByClause groupByClause) {
+
+        com.starrocks.sql.parser.StarRocksParser.ArrayJoinClauseContext arrayJoinExprContext = context.arrayJoinClause();
+
+        JoinOperator joinType = JoinOperator.INNER_JOIN;
+        if (arrayJoinExprContext.LEFT() != null) {
+            joinType = JoinOperator.LEFT_OUTER_JOIN;
+        }
+
+        fromRelation = buildUnnestJoin(fromRelation, arrayJoinExprContext.arrayJoinList(), joinType);
+
+        return new SelectRelation(
+                selectList,
+                fromRelation,
+                (Expr) visitIfPresent(context.where),
+                groupByClause,
+                (Expr) visitIfPresent(context.having),
+                createPos(context)
+        );
+    }
+
+    private Relation buildUnnestJoin(Relation leftRelation,
+                                     com.starrocks.sql.parser.StarRocksParser.ArrayJoinListContext exprListContext,
+                                     JoinOperator joinType) {
+
+        List<Expr> arrayExprs = Lists.newArrayList();
+        List<String> aliasList = Lists.newArrayList();
+        for (com.starrocks.sql.parser.StarRocksParser.ArrayJoinExprContext exprContext : exprListContext.arrayJoinExpr()) {
+            Expr arrayExpr = (Expr) visit(exprContext.expression());
+            String alias = null;
+            if (exprContext.identifier() != null) {
+                alias = ((Identifier) visit(exprContext.identifier())).getValue();
+            } else {
+                //If no alias is provided, use the expression string as the column name
+                alias = exprContext.expression().getText();
+            }
+            aliasList.add(alias);
+            arrayExprs.add(arrayExpr);
+        }
+
+        FunctionCallExpr unnestFunction = createUnnestFunction(arrayExprs);
+
+        String tableAlias = generateTableAlias(aliasList.get(0));
+
+        TableFunctionRelation unnestRelation = new TableFunctionRelation(unnestFunction);
+        unnestRelation.setChildExpressions(arrayExprs);
+        unnestRelation.setAlias(new TableName(null, tableAlias));
+        unnestRelation.setColumnOutputNames(aliasList);
+        unnestRelation.setIsArrayJoin(true);
+        BoolLiteral boolLiteral = null;
+        if (joinType.isLeftOuterJoin()) {
+            unnestRelation.setIsLeftJoin(true);
+            boolLiteral = new BoolLiteral(true);
+        }
+
+        return new JoinRelation(
+                joinType,
+                leftRelation,
+                unnestRelation,
+                boolLiteral,
+                true);
+    }
+
+    private FunctionCallExpr createUnnestFunction(List<Expr> params) {
+        FunctionCallExpr unnestFunc = new FunctionCallExpr("unnest", params);
+        return unnestFunc;
+    }
+
+    private String generateTableAlias(String columnAlias) {
+        // Generate table aliases to avoid conflicts
+        return "t_" + columnAlias;
     }
 
     public static IndexDef.IndexType getIndexType(com.starrocks.sql.parser.StarRocksParser.IndexTypeContext indexTypeContext) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/FunctionSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/FunctionSetTest.java
@@ -380,4 +380,16 @@ public class FunctionSetTest {
         Assertions.assertEquals(IntegerType.BIGINT, tableFunction.getTableFnReturnTypes().get(0));
         Assertions.assertEquals(VarcharType.VARCHAR, tableFunction.getTableFnReturnTypes().get(1));
     }
+
+    @Test
+    public void testTableFunctionCopyPreservesJoinFlags() {
+        TableFunction tableFunction = new TableFunction(new FunctionName("unnest"), Lists.newArrayList("unnest"),
+                Lists.newArrayList(AnyArrayType.ANY_ARRAY), Lists.newArrayList(AnyElementType.ANY_ELEMENT), true);
+        tableFunction.setIsLeftJoin(true);
+        tableFunction.setIsArrayJoin(true);
+
+        TableFunction copied = (TableFunction) tableFunction.copy();
+        Assertions.assertTrue(copied.isLeftJoin());
+        Assertions.assertTrue(copied.isArrayJoin());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/TableFunctionRelationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/TableFunctionRelationTest.java
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.ast.expression.FunctionParams;
+import com.starrocks.sql.parser.NodePosition;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TableFunctionRelationTest {
+
+    @Test
+    public void testArrayJoinFlags() {
+        TableFunctionRelation relation = new TableFunctionRelation("unnest",
+                new FunctionParams(false, Lists.newArrayList()), NodePosition.ZERO);
+        relation.setIsArrayJoin(true);
+        relation.setIsLeftJoin(true);
+
+        Assertions.assertTrue(relation.getIsArrayJoin());
+        Assertions.assertTrue(relation.getIsLeftJoin());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -855,4 +855,17 @@ public class ArrayTypeTest extends PlanTestBase {
         String plan = getThriftPlan(sql);
         assertContains(plan, "function_name:array_agg");
     }
+
+    @Test
+    public void testArrayJoinSyntax() throws Exception {
+        String sql = "select c0, c1 from test_array array join c2 as c1";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "TableValueFunction");
+        assertContains(plan, "tableFunctionName: unnest");
+
+        sql = "select c0, c1 from test_array left array join c2 as c1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "join op: LEFT OUTER JOIN");
+        assertContains(plan, "tableFunctionName: unnest");
+    }
 }

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2461,6 +2461,7 @@ limitElement
 querySpecification
     : SELECT setQuantifier? selectItem (',' selectItem)*
       fromClause
+      arrayJoinClause?
       ((WHERE where=expression)? (GROUP BY (groupByAll=ALL | groupingElement))? (HAVING having=expression)?
        (QUALIFY qualifyFunction=selectItem comparisonOperator limit=INTEGER_VALUE)?)
     ;
@@ -2468,6 +2469,18 @@ querySpecification
 fromClause
     : (FROM relations pivotClause?)?                                                    #from
     | FROM DUAL                                                                         #dual
+    ;
+
+arrayJoinClause
+    : (LEFT? ARRAY) JOIN arrayJoinList
+    ;
+
+arrayJoinList
+    : arrayJoinExpr (',' arrayJoinExpr)*
+    ;
+
+arrayJoinExpr
+    :expression (AS? identifier)?
     ;
 
 groupingElement

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -339,6 +339,7 @@ struct TTableFunction {
   2: optional string symbol
   // Table function left join
   3: optional bool is_left_join
+  4: optional bool is_array_join
 }
 
 struct TAggStateDesc {

--- a/test/sql/test_array/R/test_array_join
+++ b/test/sql/test_array/R/test_array_join
@@ -1,0 +1,73 @@
+-- name: test_array_join
+CREATE TABLE `student_score` (
+  `id` bigint(20) NULL COMMENT "",
+  `scores` array<int(11)> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+
+INSERT INTO student_score VALUES
+(1, [80,85,87]),
+(2, [77, null, 89]),
+(3, null),
+(4, []),
+(5, [90,92]);
+-- result:
+-- !result
+
+select id , c1 from student_score array join scores as c1 order by id,c1
+-- result:
+1	80
+1	85
+1	87
+2   None
+2	77
+2	89
+5	90
+5	92
+-- !result
+
+select id , c1 from student_score left array join scores as c1 order by id,c1
+-- result:
+1	80
+1	85
+1	87
+2   None
+2	77
+2	89
+3   None
+4   None
+5	90
+5	92
+-- !result
+
+select id ,c1 ,c2 from student_score array join scores as c1, scores as c2 order by id,c1
+-- result:
+1	80	80
+1	85	85
+1	87	87
+2   None	None
+2	77	77
+2	89	89
+5	90	90
+5	92	92
+-- !result
+
+select id ,c1 ,c2 from student_score left array join scores as c1, scores as c2 order by id,c1
+-- result:
+1	80	80
+1	85	85
+1	87	87
+2   None	None
+2	77	77
+2	89	89
+3   None	None
+4   None	None
+5	90	90
+5	92	92
+-- !result

--- a/test/sql/test_array/R/test_array_join
+++ b/test/sql/test_array/R/test_array_join
@@ -71,3 +71,8 @@ select id ,c1 ,c2 from student_score left array join scores as c1, scores as c2 
 5	90	90
 5	92	92
 -- !result
+
+select id, c1, c2 from student_score array join scores as c1, [1,2] as c2
+-- result:
+E: (1064, 'Sizes of ARRAY-JOIN-ed arrays do not match.')
+-- !result

--- a/test/sql/test_array/R/test_array_join
+++ b/test/sql/test_array/R/test_array_join
@@ -76,3 +76,25 @@ select id, c1, c2 from student_score array join scores as c1, [1,2] as c2
 -- result:
 E: (1064, 'Sizes of ARRAY-JOIN-ed arrays do not match.')
 -- !result
+
+CREATE TABLE test_mismatch (
+  id int,
+  arr1 array<int>,
+  arr2 array<int>
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+
+INSERT INTO test_mismatch VALUES (1, [1,2,3], [4,5]);
+-- result:
+-- !result
+
+select id, a, b from test_mismatch array join arr1 as a, arr2 as b;
+-- result:
+E: (1064, 'Sizes of ARRAY-JOIN-ed arrays do not match.')
+-- !result

--- a/test/sql/test_array/T/test_array_join
+++ b/test/sql/test_array/T/test_array_join
@@ -25,3 +25,5 @@ select id ,c1 ,c2 from student_score array join scores as c1, scores as c2 order
 
 select id ,c1 ,c2 from student_score left array join scores as c1, scores as c2 order by id,c1
 
+select id, c1, c2 from student_score array join scores as c1, [1,2] as c2
+

--- a/test/sql/test_array/T/test_array_join
+++ b/test/sql/test_array/T/test_array_join
@@ -1,0 +1,27 @@
+-- name: test_array_join
+
+CREATE TABLE `student_score` (
+  `id` bigint(20) NULL COMMENT "",
+  `scores` array<int(11)> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO student_score VALUES
+(1, [80,85,87]),
+(2, [77, null, 89]),
+(3, null),
+(4, []),
+(5, [90,92]);
+
+select id , c1 from student_score array join scores as c1 order by id,c1
+
+select id , c1 from student_score left array join scores as c1 order by id,c1
+
+select id ,c1 ,c2 from student_score array join scores as c1, scores as c2 order by id,c1
+
+select id ,c1 ,c2 from student_score left array join scores as c1, scores as c2 order by id,c1
+

--- a/test/sql/test_array/T/test_array_join
+++ b/test/sql/test_array/T/test_array_join
@@ -27,3 +27,18 @@ select id ,c1 ,c2 from student_score left array join scores as c1, scores as c2 
 
 select id, c1, c2 from student_score array join scores as c1, [1,2] as c2
 
+CREATE TABLE test_mismatch (
+  id int,
+  arr1 array<int>,
+  arr2 array<int>
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO test_mismatch VALUES (1, [1,2,3], [4,5]);
+
+select id, a, b from test_mismatch array join arr1 as a, arr2 as b;
+


### PR DESCRIPTION
## Why I'm doing:
  Support the array join syntax of Clickhouse， eg: `select id, c1 from t1 array join array_col as c1`
## What I'm doing:
  Convert ARRAY JOIN to UNNSET + LATERAL JOIN
  eg:   `ARRAY JOIN array_col    To   JOIN LATERAL UNNEST(array_col)`
  `LEFT ARRAY JOIN array_col   To  LEFT JOIN LATERAL UNNEST(array_col)`
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements ClickHouse-style ARRAY JOIN by rewriting to `UNNEST` with lateral join and enforcing array-size semantics.
> 
> - **Parser/AST**: Adds `arrayJoinClause` grammar; builds `TableFunctionRelation` with `isArrayJoin` and optional LEFT join, generating `JOIN LATERAL UNNEST(...)` with aliases.
> - **Analyzer/FE**: Propagates `isArrayJoin`/`isLeftJoin` to `TableFunction`; validates lateral join usage; auto column naming for `unnest`.
> - **Catalog/Thrift**: Extends `TTableFunction` with `is_array_join`; `TableFunction.toThrift()` sets it.
> - **BE/TableFunction**: Adds `is_array_join_mode` to `TableFunctionState`; `MultiUnnest` enforces equal-length arrays in ARRAY JOIN mode and preserves LEFT join null rows.
> - **Tests**: New SQL tests for ARRAY JOIN, LEFT ARRAY JOIN, multiple arrays, and mismatch error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fc11400ed80543d51630eb3c525d1c490af062c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->