### PR TITLE
[BugFix] Validate warehouse whthere exists or not before set warehouse

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
@@ -290,6 +290,40 @@ public class VariableMgrTest {
     }
 
     @Test
+    public void testSetNonExistentWarehouse() {
+        // Mock the WarehouseManager to simulate warehouse validation
+        UtFrameUtils.mockInitWarehouseEnv();
+
+        SystemVariable systemVariable =
+                new SystemVariable(SetType.SESSION, SessionVariable.WAREHOUSE_NAME, new StringLiteral("non_existent_warehouse"));
+        VariableMgr variableMgr = new VariableMgr();
+        SessionVariable sessionVariable = variableMgr.newSessionVariable();
+
+        // Setting a non-existent warehouse should throw an exception
+        DdlException exception = assertThrows(DdlException.class, () -> {
+            variableMgr.setSystemVariable(sessionVariable, systemVariable, false);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("non_existent_warehouse"),
+                "Exception message should contain the warehouse name");
+    }
+
+    @Test
+    public void testSetDefaultWarehouse() throws DdlException {
+        // Mock the WarehouseManager
+        UtFrameUtils.mockInitWarehouseEnv();
+
+        // Setting the default warehouse should succeed
+        SystemVariable systemVariable =
+                new SystemVariable(SetType.SESSION, SessionVariable.WAREHOUSE_NAME, new StringLiteral("default_warehouse"));
+        VariableMgr variableMgr = new VariableMgr();
+        SessionVariable sessionVariable = variableMgr.newSessionVariable();
+
+        // This should not throw an exception since default_warehouse is always valid
+        variableMgr.setSystemVariable(sessionVariable, systemVariable, false);
+        Assertions.assertEquals("default_warehouse", sessionVariable.getWarehouseName());
+    }
+
+    @Test
     public void testImagePersist() throws Exception {
         VariableMgr mgr = new VariableMgr();
         GlobalVarPersistInfo info = new GlobalVarPersistInfo();


### PR DESCRIPTION
## Why I'm doing:
When specifying a warehouse using `set warehouse=xxx`, if the specified warehouse does not exist, any subsequent actions will result in an error indicating that the warehouse does not exist. Even setting `set warehouse=xxx` to the correct warehouse will still result in an error, and the only option is to exit the session.

## What I'm doing:
Validate warehouse whether exists  before setting up the warehouse.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `SET warehouse=...` only accepts existing warehouses to prevent broken sessions.
> 
> - Adds `validateWarehouseExists` in `VariableMgr` and invokes it when setting `SessionVariable.WAREHOUSE_NAME`; permits `DEFAULT_WAREHOUSE_NAME` and checks via `WarehouseManager`
> - Keeps existing `handleSetWarehouse` flow; only validation added before applying the value
> - Introduces tests in `VariableMgrTest` for non-existent warehouse (throws) and default warehouse (succeeds), with mocked warehouse environment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c29f2b57231c04558665cfc3856eece49264460. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->