### PR TITLE
[Doc] add extensions docs

### DIFF
--- a/docs/en/sql-reference/sql-statements/cluster-management/extension/extensions.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/extension/extensions.md
@@ -1,0 +1,83 @@
+---
+displayed_sidebar: docs
+---
+
+Static Extensions are StarRocks FE’s extension modules that allow you to add new features or optimize existing functionality without modifying the core code. Compared to dynamic plugins, static extensions are automatically loaded at system startup and provide more registrable extension points, covering the system’s core modules.
+
+## Examples
+
+This example demonstrates how to develop a static extension.
+
+Prerequisites:
+StarRocks FE development environment.
+
+```
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-jar-plugin</artifactId>
+    <version>3.3.0</version>
+    <executions>
+        <!-- Core jar -->
+        <execution>
+            <id>default-jar</id>
+            <phase>package</phase>
+            <goals>
+                <goal>jar</goal>
+            </goals>
+            <configuration>
+                <excludes>
+                    <exclude>${your_extension_directory}/**</exclude>
+                </excludes>
+            </configuration>
+        </execution>
+        <!-- Extension jar -->
+        <execution>
+            <id>build-ext-jar</id>
+            <phase>package</phase>
+            <goals>
+                <goal>jar</goal>
+            </goals>
+            <configuration>
+                <finalName>${your_extension_name}</finalName>
+                <includes>
+                    <include>${your_extension_directory}/**</include>
+                </includes>
+                <!-- StarRocks will only load the ext.jar -->
+                <classifier>ext</classifier>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+
+Extension entry point:
+```
+@SRModule(name = "extension_name")
+public class MultiWarehouseExtension implements StarRocksExtension {
+    @Override
+    public void onLoad(ExtensionContext ctx) {
+        // Register your own class or perform other initialization
+        ctx.register(WarehouseManager.class, new MyWarehouseManager());
+        ...
+    }
+}
+
+```
+
+After building the extension, place the ${your_extension_name}-ext.jar file into the Config.ext_dir directory (default is FE/lib), and then restart the FE.
+
+Example FE log after startup:
+
+```
+2025-12-26 12:47:46.047+08:00 INFO (main|1) [ExtensionManager.loadExtensionsFromDir():39] start to load extensions
+2025-12-26 12:47:46.152+08:00 INFO (main|1) [ExtensionManager.loadExtensions():63] Loaded extension: extension_name
+2025-12-26 12:47:46.152+08:00 INFO (main|1) [ExtensionManager.loadExtensionsFromDir():42] all extensions loaded finished
+```
+
+Explanation:
+
+start to load extensions: FE has started scanning the extension directory.
+
+Loaded extension: extension_name: The extension was successfully loaded.
+
+all extensions loaded finished: All extensions in the directory have been loaded.

--- a/docs/en/sql-reference/sql-statements/cluster-management/extension/extensions.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/extension/extensions.md
@@ -66,7 +66,7 @@ public class MultiWarehouseExtension implements StarRocksExtension {
 
 ```
 
-After building the extension, place the ${your_extension_name}-ext.jar file into the Config.ext_dir directory (default is FE/lib), and then restart the FE.
+After building the extension, place the `${your_extension_name}-ext.jar` file into the Config.ext_dir directory (default is FE/lib), and then restart the FE.
 
 Example FE log after startup:
 

--- a/docs/en/sql-reference/sql-statements/cluster-management/extension/extensions.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/extension/extensions.md
@@ -8,10 +8,11 @@ Static Extensions are StarRocks FE’s extension modules that allow you to add n
 
 This example demonstrates how to develop a static extension.
 
-Prerequisites:
+**Prerequisites:**
+
 StarRocks FE development environment.
 
-```
+```xml
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-jar-plugin</artifactId>
@@ -50,8 +51,9 @@ StarRocks FE development environment.
 </plugin>
 ```
 
-Extension entry point:
-```
+**Extension entry point:**
+
+```java
 @SRModule(name = "extension_name")
 public class MultiWarehouseExtension implements StarRocksExtension {
     @Override
@@ -68,16 +70,14 @@ After building the extension, place the ${your_extension_name}-ext.jar file into
 
 Example FE log after startup:
 
-```
+```sh
 2025-12-26 12:47:46.047+08:00 INFO (main|1) [ExtensionManager.loadExtensionsFromDir():39] start to load extensions
 2025-12-26 12:47:46.152+08:00 INFO (main|1) [ExtensionManager.loadExtensions():63] Loaded extension: extension_name
 2025-12-26 12:47:46.152+08:00 INFO (main|1) [ExtensionManager.loadExtensionsFromDir():42] all extensions loaded finished
 ```
 
-Explanation:
+**Explanation:**
 
-start to load extensions: FE has started scanning the extension directory.
-
-Loaded extension: extension_name: The extension was successfully loaded.
-
-all extensions loaded finished: All extensions in the directory have been loaded.
+- `start to load extensions`: FE has started scanning the extension directory.
+- `Loaded extension: extension_name`: The extension was successfully loaded.
+- `all extensions loaded finished`: All extensions in the directory have been loaded.


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new documentation page explaining StarRocks FE static extensions with build, entry-point, deployment, and verification examples.
> 
> - New `docs/en/sql-reference/sql-statements/cluster-management/extension/extensions.md` describes static extensions vs. dynamic plugins
> - Provides Maven `maven-jar-plugin` config to build separate `ext` JAR
> - Shows Java extension entry (`@SRModule`, `onLoad`, `ExtensionContext.register`)
> - Details where to place `${your_extension_name}-ext.jar` (`Config.ext_dir`) and FE restart
> - Includes sample FE logs and brief explanations for load lifecycle
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da12da3704d7ecba801de02d02950e7782284660. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->