### PR TITLE
[Enhancement] Add IcebergDeleteSink to support delete operations on Iceberg tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java
@@ -1,0 +1,158 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.catalog.IcebergTable;;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergUtil;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.thrift.TCompressionType;
+import com.starrocks.thrift.TDataSink;
+import com.starrocks.thrift.TDataSinkType;
+import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TIcebergTableSink;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.apache.iceberg.Table;
+
+import static com.starrocks.sql.ast.OutFileClause.PARQUET_COMPRESSION_TYPE_MAP;
+
+/**
+ * IcebergDeleteSink is used to support delete operations to Iceberg tables.
+ * It supports write position delete files
+ * <p>
+ * Required columns:
+ * - _file (STRING): Path of the data file
+ * - _pos (BIGINT): Row position within the file
+ */
+public class IcebergDeleteSink extends DataSink {
+    protected final TupleDescriptor desc;
+    private IcebergTable icebergTable;
+    private final long targetTableId;
+    private final String tableLocation;
+    private final String dataLocation;
+    private final String compressionType;
+    private final long targetMaxFileSize;
+    private final String tableIdentifier;
+    private CloudConfiguration cloudConfiguration;
+
+    /**
+     * Constructor for IcebergDeleteSink
+     *
+     * @param icebergTable    The target Iceberg table
+     * @param desc            Tuple descriptor containing operation columns
+     * @param sessionVariable Session variables for configuration
+     */
+    public IcebergDeleteSink(IcebergTable icebergTable, TupleDescriptor desc,
+                             SessionVariable sessionVariable) {
+        this.icebergTable = icebergTable;
+        Table nativeTable = icebergTable.getNativeTable();
+        this.desc = desc;
+        this.tableLocation = nativeTable.location();
+        this.dataLocation = IcebergUtil.tableDataLocation(nativeTable);
+        this.targetTableId = icebergTable.getId();
+        this.tableIdentifier = icebergTable.getUUID();
+        this.compressionType = sessionVariable.getConnectorSinkCompressionCodec();
+        this.targetMaxFileSize = sessionVariable.getConnectorSinkTargetMaxFileSize() > 0 ?
+                sessionVariable.getConnectorSinkTargetMaxFileSize() : 1024L * 1024 * 1024;
+    }
+
+    public void init() {
+        String catalogName = icebergTable.getCatalogName();
+        this.cloudConfiguration = IcebergUtil.getVendedCloudConfiguration(catalogName, icebergTable);
+        // Validate tuple descriptor contains required columns
+        validateDeleteTuple(desc);
+    }
+
+    /**
+     * Validate that the tuple descriptor contains required columns
+     *
+     * @param desc The tuple descriptor to validate
+     */
+    private void validateDeleteTuple(TupleDescriptor desc) {
+        boolean hasFilePathColumn = false;
+        boolean hasPosColumn = false;
+
+        for (SlotDescriptor slot : desc.getSlots()) {
+            if (slot.getColumn() != null) {
+                String colName = slot.getColumn().getName();
+                if (IcebergTable.FILE_PATH.equals(colName)) {
+                    hasFilePathColumn = true;
+                    if (!slot.getType().equals(VarcharType.VARCHAR)) {
+                        throw new StarRocksConnectorException("_file column must be type of VARCHAR");
+                    }
+                } else if (IcebergTable.ROW_POSITION.equals(colName)) {
+                    hasPosColumn = true;
+                    if (!slot.getType().equals(IntegerType.BIGINT)) {
+                        throw new StarRocksConnectorException("_pos column must be type of BIGINT");
+                    }
+                }
+            }
+        }
+
+        if (!hasFilePathColumn || !hasPosColumn) {
+            throw new StarRocksConnectorException("IcebergDeleteSink requires _file and _pos columns in tuple descriptor");
+        }
+    }
+
+    @Override
+    public String getExplainString(String prefix, TExplainLevel explainLevel) {
+        StringBuilder strBuilder = new StringBuilder();
+        strBuilder.append(prefix).append("ICEBERG DELETE SINK");
+        strBuilder.append("\n");
+        strBuilder.append(prefix).append("  TABLE: ").append(tableIdentifier).append("\n");
+        strBuilder.append(prefix).append("  LOCATION: ").append(tableLocation).append("\n");
+        strBuilder.append(prefix).append("  TUPLE ID: ").append(desc.getId()).append("\n");
+        return strBuilder.toString();
+    }
+
+    @Override
+    protected TDataSink toThrift() {
+        TDataSink tDataSink = new TDataSink(TDataSinkType.ICEBERG_DELETE_SINK);
+        TIcebergTableSink tIcebergTableSink = new TIcebergTableSink();
+        tIcebergTableSink.setTarget_table_id(targetTableId);
+        tIcebergTableSink.setTuple_id(desc.getId().asInt());
+        tIcebergTableSink.setLocation(tableLocation);
+        // For delete sink, we set both data and delete locations
+        tIcebergTableSink.setData_location(dataLocation);
+        tIcebergTableSink.setFile_format("parquet"); // Delete files are always parquet
+        tIcebergTableSink.setIs_static_partition_sink(false);
+        TCompressionType compression = PARQUET_COMPRESSION_TYPE_MAP.get(compressionType);
+        tIcebergTableSink.setCompression_type(compression);
+        tIcebergTableSink.setTarget_max_file_size(targetMaxFileSize);
+        com.starrocks.thrift.TCloudConfiguration tCloudConfiguration = new com.starrocks.thrift.TCloudConfiguration();
+        cloudConfiguration.toThrift(tCloudConfiguration);
+        tIcebergTableSink.setCloud_configuration(tCloudConfiguration);
+
+        tDataSink.setIceberg_table_sink(tIcebergTableSink);
+        return tDataSink;
+    }
+
+    @Override
+    public PlanNodeId getExchNodeId() {
+        return null;
+    }
+
+    @Override
+    public DataPartition getOutputPartition() {
+        return null;
+    }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.planner;
 
-import com.starrocks.catalog.IcebergTable;;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergUtil;
 import com.starrocks.credential.CloudConfiguration;
@@ -24,8 +24,6 @@ import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TDataSinkType;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TIcebergTableSink;
-import com.starrocks.type.IntegerType;
-import com.starrocks.type.VarcharType;
 import org.apache.iceberg.Table;
 
 import static com.starrocks.sql.ast.OutFileClause.PARQUET_COMPRESSION_TYPE_MAP;
@@ -87,18 +85,21 @@ public class IcebergDeleteSink extends DataSink {
         boolean hasPosColumn = false;
 
         for (SlotDescriptor slot : desc.getSlots()) {
-            if (slot.getColumn() != null) {
-                String colName = slot.getColumn().getName();
-                if (IcebergTable.FILE_PATH.equals(colName)) {
-                    hasFilePathColumn = true;
-                    if (!slot.getType().equals(VarcharType.VARCHAR)) {
-                        throw new StarRocksConnectorException("_file column must be type of VARCHAR");
-                    }
-                } else if (IcebergTable.ROW_POSITION.equals(colName)) {
-                    hasPosColumn = true;
-                    if (!slot.getType().equals(IntegerType.BIGINT)) {
-                        throw new StarRocksConnectorException("_pos column must be type of BIGINT");
-                    }
+            if (slot.getColumn() == null) {
+                continue;
+            }
+            String colName = slot.getColumn().getName();
+            if (IcebergTable.FILE_PATH.equals(colName)) {
+                hasFilePathColumn = true;
+                if (!slot.getType().isVarchar()) {
+                    throw new StarRocksConnectorException("_file column must be type of VARCHAR");
+                }
+                continue;
+            }
+            if (IcebergTable.ROW_POSITION.equals(colName)) {
+                hasPosColumn = true;
+                if (!slot.getType().isBigint()) {
+                    throw new StarRocksConnectorException("_pos column must be type of BIGINT");
                 }
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergDeleteSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergDeleteSinkTest.java
@@ -1,0 +1,183 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergUtil;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.thrift.TDataSink;
+import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TIcebergTableSink;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.*;
+
+public class IcebergDeleteSinkTest {
+
+    private MockedStatic<IcebergUtil> mockedIcebergUtil;
+
+    @BeforeEach
+    public void setUp() {
+        // Mock the static method
+        mockedIcebergUtil = mockStatic(IcebergUtil.class);
+        CloudConfiguration mockCloudConfig = mock(CloudConfiguration.class);
+
+        // Mock toThrift method to avoid NPE during test
+        doAnswer(invocation -> {
+            com.starrocks.thrift.TCloudConfiguration tConfig = invocation.getArgument(0);
+            tConfig.setCloud_type(com.starrocks.thrift.TCloudType.AWS);
+            return null;
+        }).when(mockCloudConfig).toThrift(any(com.starrocks.thrift.TCloudConfiguration.class));
+
+        when(IcebergUtil.getVendedCloudConfiguration(anyString(), any(IcebergTable.class)))
+                .thenReturn(mockCloudConfig);
+        when(IcebergUtil.getVendedCloudConfiguration(isNull(), any(IcebergTable.class)))
+                .thenReturn(mockCloudConfig);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        // Close the static mock
+        if (mockedIcebergUtil != null) {
+            mockedIcebergUtil.close();
+        }
+    }
+
+    @Test
+    public void testValidDeleteTuple() {
+        // Create a valid tuple descriptor with _file and _pos columns
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0), "DeleteTuple");
+
+        // Add _file column (STRING type)
+        Column fileColumn = new Column(IcebergTable.FILE_PATH, VarcharType.VARCHAR);
+        SlotDescriptor fileSlot = new SlotDescriptor(new SlotId(0), desc);
+        fileSlot.setColumn(fileColumn);
+        desc.addSlot(fileSlot);
+
+        // Add _pos column (BIGINT type)
+        Column posColumn = new Column(IcebergTable.ROW_POSITION, IntegerType.BIGINT);
+        SlotDescriptor posSlot = new SlotDescriptor(new SlotId(1), desc);
+        posSlot.setColumn(posColumn);
+        desc.addSlot(posSlot);
+
+        // Mock IcebergTable
+        IcebergTable icebergTable = mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTable = mock(org.apache.iceberg.Table.class);
+        when(icebergTable.getNativeTable()).thenReturn(nativeTable);
+        when(nativeTable.location()).thenReturn("/tmp/iceberg");
+
+        // Should not throw exception
+        IcebergDeleteSink sink = new IcebergDeleteSink(icebergTable, desc, new SessionVariable());
+        assertNotNull(sink);
+    }
+
+    @Test
+    public void testMissingFileColumn() {
+        // Create a tuple descriptor without _file column
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0), "DeleteTuple");
+
+        // Add only _pos column
+        Column posColumn = new Column(IcebergTable.ROW_POSITION, IntegerType.BIGINT);
+        SlotDescriptor posSlot = new SlotDescriptor(new SlotId(0), desc);
+        posSlot.setColumn(posColumn);
+        desc.addSlot(posSlot);
+
+        // Mock IcebergTable
+        IcebergTable icebergTable = mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTable = mock(org.apache.iceberg.Table.class);
+        when(icebergTable.getNativeTable()).thenReturn(nativeTable);
+        when(nativeTable.location()).thenReturn("/tmp/iceberg");
+
+        // Should throw exception
+        IcebergDeleteSink deleteSink = new IcebergDeleteSink(icebergTable, desc, new SessionVariable());
+        StarRocksConnectorException exception = assertThrows(StarRocksConnectorException.class, deleteSink::init);
+        assertTrue(exception.getMessage().contains("_file"));
+    }
+
+    @Test
+    public void testThriftSerialization() {
+        // Create a valid tuple descriptor
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0), "DeleteTuple");
+
+        Column fileColumn = new Column(IcebergTable.FILE_PATH, VarcharType.VARCHAR);
+        SlotDescriptor fileSlot = new SlotDescriptor(new SlotId(0), desc);
+        fileSlot.setColumn(fileColumn);
+        desc.addSlot(fileSlot);
+
+        Column posColumn = new Column(IcebergTable.ROW_POSITION, IntegerType.BIGINT);
+        SlotDescriptor posSlot = new SlotDescriptor(new SlotId(1), desc);
+        posSlot.setColumn(posColumn);
+        desc.addSlot(posSlot);
+
+        // Mock IcebergTable
+        IcebergTable icebergTable = mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTable = mock(org.apache.iceberg.Table.class);
+        when(icebergTable.getNativeTable()).thenReturn(nativeTable);
+        when(nativeTable.location()).thenReturn("hdfs://localhost:9000/iceberg");
+        when(icebergTable.getUUID()).thenReturn("iceberg_catalog.db.table");
+
+        IcebergDeleteSink sink = new IcebergDeleteSink(icebergTable, desc, new SessionVariable());
+        sink.init();
+
+        // Check thrift serialization
+        TDataSink tDataSink = sink.toThrift();
+        assertNotNull(tDataSink);
+        assertTrue(tDataSink.isSetIceberg_table_sink());
+
+        TIcebergTableSink icebergSink = tDataSink.getIceberg_table_sink();
+        assertEquals("hdfs://localhost:9000/iceberg", icebergSink.getLocation());
+        assertEquals("parquet", icebergSink.getFile_format());
+        assertFalse(icebergSink.isIs_static_partition_sink());
+    }
+
+    @Test
+    public void testGetExplainString() {
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0), "DeleteTuple");
+
+        Column fileColumn = new Column(IcebergTable.FILE_PATH, VarcharType.VARCHAR);
+        SlotDescriptor fileSlot = new SlotDescriptor(new SlotId(0), desc);
+        fileSlot.setColumn(fileColumn);
+        desc.addSlot(fileSlot);
+
+        Column posColumn = new Column(IcebergTable.ROW_POSITION, IntegerType.BIGINT);
+        SlotDescriptor posSlot = new SlotDescriptor(new SlotId(1), desc);
+        posSlot.setColumn(posColumn);
+        desc.addSlot(posSlot);
+
+        // Mock IcebergTable
+        IcebergTable icebergTable = mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTable = mock(org.apache.iceberg.Table.class);
+        when(icebergTable.getNativeTable()).thenReturn(nativeTable);
+        when(nativeTable.location()).thenReturn("/tmp/iceberg");
+        when(icebergTable.getUUID()).thenReturn("iceberg_catalog.db.table");
+
+        IcebergDeleteSink sink = new IcebergDeleteSink(icebergTable, desc, new SessionVariable());
+
+        String explainString = sink.getExplainString("", TExplainLevel.NORMAL);
+        assertTrue(explainString.contains("ICEBERG DELETE SINK"));
+        assertTrue(explainString.contains("iceberg_catalog.db.table"));
+        assertTrue(explainString.contains("/tmp/iceberg"));
+    }
+}

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -59,7 +59,8 @@ enum TDataSinkType {
     DICTIONARY_CACHE_SINK,
     MULTI_OLAP_TABLE_SINK,
     SPLIT_DATA_STREAM_SINK,
-    NOOP_SINK
+    NOOP_SINK,
+    ICEBERG_DELETE_SINK
 }
 
 enum TResultSinkType {


### PR DESCRIPTION
## Why I'm doing:
#66944

## What I'm doing:
This pull request introduces support for delete operations on Iceberg tables by adding a new `IcebergDeleteSink` class, its associated serialization logic, and comprehensive unit tests. The main focus is on enabling the planner to write position delete files to Iceberg tables, ensuring correct tuple validation and integration with the existing data sink infrastructure.

**Iceberg Delete Sink Implementation:**

* Added a new `IcebergDeleteSink` class in `fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java` to support delete operations for Iceberg tables, including tuple validation, configuration handling, and Thrift serialization.
* Updated the `TDataSinkType` enum in `gensrc/thrift/DataSinks.thrift` to include the new `ICEBERG_DELETE_SINK` type for proper Thrift serialization and planner integration.

**Testing and Validation:**

* Added a comprehensive test suite in `fe/fe-core/src/test/java/com/starrocks/planner/IcebergDeleteSinkTest.java` to verify tuple validation, Thrift serialization, and explain string output for the new sink.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables planner support for writing Iceberg position delete files with proper tuple validation and Thrift plumbing.
> 
> - Adds `IcebergDeleteSink` with `_file` (VARCHAR) and `_pos` (BIGINT) validation, explain output, and `toThrift` wiring (sets `ICEBERG_DELETE_SINK`, table/data locations, Parquet format, compression, target file size, cloud config)
> - Extends `TDataSinkType` in `gensrc/thrift/DataSinks.thrift` with `ICEBERG_DELETE_SINK`
> - Introduces unit tests validating tuple requirements, Thrift serialization, and explain string
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 647d4c3248878ffa1ef82c8de308fbaf7133e436. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->