### PR TITLE
[Enhancement] Set Async-profiler log level to error to avoid repeating waring logs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
@@ -87,6 +87,10 @@ public class ProcProfileCollector extends FrontendDaemon {
                 LOG.info("change the system property {} to {}", libPathProperty, dir);
             }
         }
+        // Suppress async-profiler warnings about kernel symbols being unavailable.
+        // This warning is harmless and occurs when kernel.perf_event_paranoid or kernel.kptr_restrict
+        // are set to restrictive values, which is common in production environments.
+        System.setProperty("one.profiler.quiet", "true");
     }
 
     private void collectMemProfile() {


### PR DESCRIPTION
## Why I'm doing:

To avoid the following logs in fe.out
```
[WARN] Kernel symbols are unavailable due to restrictions. Try
sysctl kernel.perf_event_paranoid=1
sysctl kernel.kptr_restrict=0
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets AsyncProfiler to log only errors and refactors command construction.
> 
> - Adds `genStartCommand` to build `start` commands with `loglevel=error`, `cstack=vm`, and configurable `jstackdepth`
> - Updates CPU and memory profiling to use the helper, applying the new log level and reducing duplication
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee76bc788274d84d9babc046e9c1bcde2431f3d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->