### PR TITLE
[BugFix] Fix heap-after-free after Cow::muate

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -155,22 +155,6 @@ public:
         }
     }
 
-    static MutableColumnPtr unfold_const_column(const TypeDescriptor& type_desc, size_t size, ColumnPtr&& column) {
-        if (column->only_null()) {
-            auto col = ColumnHelper::create_column(type_desc, true);
-            [[maybe_unused]] bool ok = col->append_nulls(size);
-            DCHECK(ok);
-            return col;
-        } else if (column->is_constant()) {
-            auto mut_column = Column::mutate(std::move(column));
-            auto* const_column = down_cast<ConstColumn*>(mut_column.get());
-            const_column->assign(size, 0);
-            return const_column->data_column()->as_mutable_ptr();
-        } else {
-            return Column::mutate(std::move(column));
-        }
-    }
-
     static ColumnPtr copy_and_unfold_const_column(const TypeDescriptor& dst_type_desc, bool dst_nullable,
                                                   const ColumnPtr& src_column, int num_rows) {
         auto dst_column = create_column(dst_type_desc, dst_nullable);

--- a/be/src/exec/repeat_node.cpp
+++ b/be/src/exec/repeat_node.cpp
@@ -185,7 +185,7 @@ void RepeatNode::extend_and_update_columns(ChunkPtr* curr_chunk, ChunkPtr* chunk
         for (auto slot_id : null_slot_ids) {
             auto null_column = generate_null_column((*curr_chunk)->num_rows());
 
-            (*curr_chunk)->update_column(null_column, slot_id);
+            (*curr_chunk)->update_column(std::move(null_column), slot_id);
         }
     }
 

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -695,8 +695,9 @@ Status OlapTablePartitionParam::find_tablets(Chunk* chunk, std::vector<OlapTable
         if (!_partitions_expr_ctxs.empty()) {
             for (size_t i = 0; i < partition_columns.size(); ++i) {
                 ASSIGN_OR_RETURN(auto partition_column, _partitions_expr_ctxs[i]->evaluate(chunk));
-                partition_columns[i] = ColumnHelper::unfold_const_column(_partition_slot_descs[i]->type(), num_rows,
-                                                                         std::move(partition_column));
+                partition_columns[i] =
+                        ColumnHelper::unfold_const_column(_partition_slot_descs[i]->type(), num_rows, partition_column)
+                                ->as_mutable_ptr();
             }
         } else {
             for (size_t i = 0; i < partition_columns.size(); ++i) {

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -1015,6 +1015,7 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
             }
             chunk->update_column(std::move(nullable->data_column()), desc->id());
         }
+        column_ptr = chunk->get_column_by_slot_id(desc->id());
 
         // Validate column nullable info
         // Column nullable info need to respect slot nullable info

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -988,7 +988,7 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
 
         // update_column for auto increment column.
         if (_has_auto_increment && _auto_increment_slot_id == desc->id() && column_ptr->is_nullable()) {
-            auto* nullable = down_cast<NullableColumn*>(column_ptr->as_mutable_raw_ptr);
+            auto* nullable = down_cast<NullableColumn*>(column_ptr->as_mutable_raw_ptr());
             // If nullable->has_null() && _null_expr_in_auto_increment == true, it means that user specify a
             // null value in auto increment column, we abort the all rows with null.
             // Because be know nothing about whether this row is specified by the user as null or setted during planning.
@@ -1025,7 +1025,7 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
             // Auto increment column is not nullable but use NullableColumn to implement. We should skip the check for it.
         } else if (!desc->is_nullable() && column_ptr->is_nullable() &&
                    (!_has_auto_increment || _auto_increment_slot_id != desc->id())) {
-            auto* nullable = down_cast<NullableColumn*>(column_ptr->as_mutable_raw_ptr);
+            auto* nullable = down_cast<NullableColumn*>(column_ptr->as_mutable_raw_ptr());
             // Non-nullable column shouldn't have null value,
             // If there is null value, which means expr compute has a error.
             if (nullable->has_null()) {
@@ -1050,7 +1050,7 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
             }
             chunk->update_column(std::move(nullable->data_column()), desc->id());
         } else if (column_ptr->has_null()) {
-            auto* nullable = down_cast<NullableColumn*>(column_ptr->as_mutable_raw_ptr);
+            auto* nullable = down_cast<NullableColumn*>(column_ptr->as_mutable_raw_ptr());
             NullData& nulls = nullable->null_column_data();
             for (size_t j = 0; j < num_rows; ++j) {
                 if (nulls[j] && _validate_selection[j] != VALID_SEL_FAILED) {

--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -303,7 +303,7 @@ Status DictOptimizeParser::_eval_and_rewrite(ExprContext* ctx, Expr* expr, DictO
         std::vector<Status> err_status;
         err_status.resize(num_rows);
         auto input_column = binary_column->clone_empty();
-        temp_chunk->update_column(std::move(input_column), expr_slot_id);
+        temp_chunk->update_column(input_column, expr_slot_id);
         for (size_t i = 0; i < num_rows; ++i) {
             input_column->reset_column();
             input_column->append(*binary_column, i, 1);

--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -303,7 +303,7 @@ Status DictOptimizeParser::_eval_and_rewrite(ExprContext* ctx, Expr* expr, DictO
         std::vector<Status> err_status;
         err_status.resize(num_rows);
         auto input_column = binary_column->clone_empty();
-        temp_chunk->update_column(input_column, expr_slot_id);
+        temp_chunk->update_column(std::move(input_column), expr_slot_id);
         for (size_t i = 0; i < num_rows; ++i) {
             input_column->reset_column();
             input_column->append(*binary_column, i, 1);


### PR DESCRIPTION
## Why I'm doing:
`Column::mutate(std::move(column))` may clone columns but only return its const column which may trigger heap-after-free.
```
   static MutableColumnPtr unfold_const_column(const TypeDescriptor& type_desc, size_t size, ColumnPtr&& column) {
        if (column->only_null()) {
            auto col = ColumnHelper::create_column(type_desc, true);
            [[maybe_unused]] bool ok = col->append_nulls(size);
            DCHECK(ok);
            return col;
        } else if (column->is_constant()) {
            auto mut_column = Column::mutate(std::move(column));
            auto* const_column = down_cast<ConstColumn*>(mut_column.get());
            const_column->assign(size, 0);
            return const_column->data_column()->as_mutable_ptr();
        } else {
            return Column::mutate(std::move(column));
        }
    }
```
## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10787


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes unsafe column updates that could lead to heap-after-free by standardizing mutation and ownership handling.
> 
> - Replace raw pointers with `get_column_by_slot_id` refs and `as_mutable_raw_ptr()` for safe mutation; rebind column after updates in `tablet_sink.cpp`
> - Move columns on update (`std::move(...)`) to avoid copying and dangling refs in `repeat_node.cpp` and `tablet_sink.cpp`
> - Remove rvalue overload of `ColumnHelper::unfold_const_column` and switch callers to the const-ref API; adapt partition column extraction in `tablet_info.cpp`
> - Minor API/usage tweaks to ensure const/const-column unfolding returns mutable when needed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 966070b2dc0f9c7364a0669931e5d52e850a1a49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->