### PR TITLE
[Enhancement] Also consider NULL fractions in SkewJoinOptimizeRule (backport #67100)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
@@ -27,7 +27,8 @@ import com.starrocks.catalog.TableFunction;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
 import com.starrocks.connector.exception.StarRocksConnectorException;
-import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -54,13 +55,12 @@ import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.RuleType;
-import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.skew.DataSkew;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -134,8 +134,6 @@ public class SkewJoinOptimizeRule extends TransformationRule {
         if (leftChildStats == null) {
             return false;
         }
-        double leftRowCount = leftChildStats.getOutputRowCount();
-
         for (BinaryPredicateOperator equalConj : equalConjs) {
             if (!equalConj.getChild(0).isColumnRef() || !equalConj.getChild(1).isColumnRef()) {
                 // only support column equal column
@@ -143,7 +141,7 @@ public class SkewJoinOptimizeRule extends TransformationRule {
             }
             ColumnRefOperator leftColumn = (ColumnRefOperator) equalConj.getChild(0);
             ColumnRefOperator rightColumn = (ColumnRefOperator) equalConj.getChild(1);
-            ColumnRefOperator skewJoinColumn = null;
+            ColumnRefOperator skewJoinColumn;
             // choose the skew join column, it could be left or right column of the predicate
             if (leftOutputColumns.contains(leftColumn.getId())) {
                 skewJoinColumn = leftColumn;
@@ -153,36 +151,41 @@ public class SkewJoinOptimizeRule extends TransformationRule {
             if (!leftChildStats.getColumnStatistics().containsKey(skewJoinColumn)) {
                 continue;
             }
-            ColumnStatistic leftColumnStats = leftChildStats.getColumnStatistic(skewJoinColumn);
-            if (leftColumnStats == null || leftColumnStats.getHistogram() == null) {
-                // only support column with histogram stats
+            final var skewColumnStats = leftChildStats.getColumnStatistic(skewJoinColumn);
+
+            if (skewColumnStats == null) {
+                // Only support column with some stats
                 continue;
             }
-            // sort the MCV by value
-            List<Pair<String, Long>> leftChildMCV = Lists.newArrayList();
-            int useMCVCount = Math.min(context.getSessionVariable().getSkewJoinOptimizeUseMCVCount(),
-                    leftColumnStats.getHistogram().getMCV().size());
-            leftColumnStats.getHistogram().getMCV().entrySet().stream().
-                    sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())).limit(useMCVCount).
-                    forEach(entry -> {
-                        leftChildMCV.add(Pair.create(entry.getKey(), entry.getValue()));
-                    });
-            if (isDataSkew(leftChildMCV, leftRowCount, context.getSessionVariable())) {
+
+            final var mcvLimit = context.getSessionVariable().getSkewJoinOptimizeUseMCVCount();
+            final var rowPercentageThreshold = context.getSessionVariable().getSkewJoinDataSkewThreshold();
+            final var skewInfo = DataSkew.getColumnSkewInfo(leftChildStats, skewColumnStats,
+                    new DataSkew.Thresholds(mcvLimit, rowPercentageThreshold));
+
+            if (skewInfo.isSkewed()) {
                 joinOperator.setSkewColumn(skewJoinColumn);
-                joinOperator.setSkewValues(leftChildMCV.stream().map(pair -> ConstantOperator.createVarchar(pair.first)).
-                        collect(Collectors.toList()));
+
+                // Handle NULL-only skew case: when MCV is empty but NULL fraction indicates skew
+                List<ScalarOperator> skewValues;
+                if (skewInfo.type() == DataSkew.SkewType.SKEWED_NULL) {
+                    // Create a special NULL skew value for NULL-only skew cases
+                    skewValues = Lists.newArrayList(ConstantOperator.createNull(skewJoinColumn.getType()));
+                } else if (skewInfo.type() == DataSkew.SkewType.SKEWED_MCV) {
+                    // Use MCV-based skew values
+                    skewValues = skewInfo.maybeMcvs().get()
+                            .stream() //
+                            .map(pair -> ConstantOperator.createVarchar(pair.first)) //
+                            .collect(Collectors.toList());
+                } else {
+                    throw new StarRocksPlannerException("Did not handle skew type in SkewOptimizeRule", ErrorType.INTERNAL_ERROR);
+                }
+
+                joinOperator.setSkewValues(skewValues);
                 return true;
             }
         }
         return false;
-    }
-
-    private boolean isDataSkew(List<Pair<String, Long>> mcvList, double rowCount, SessionVariable sessionVariable) {
-        if (rowCount < 1) {
-            return false;
-        }
-        long mcvRowCount = mcvList.stream().mapToLong(pair -> pair.second).sum();
-        return ((double) mcvRowCount / rowCount) > sessionVariable.getSkewJoinDataSkewThreshold();
     }
 
     @Override
@@ -318,15 +321,20 @@ public class SkewJoinOptimizeRule extends TransformationRule {
 
         List<ScalarOperator> inPredicateArgs = Lists.newArrayList();
         inPredicateArgs.add(skewColumn);
-        skewValues.remove(ConstantOperator.createNull(ScalarType.NULL));
-        inPredicateArgs.addAll(skewValues);
+        // build a defensive copy and remove NULL from it
+        List<ScalarOperator> nonNullSkewValues = Lists.newArrayList(skewValues);
+        nonNullSkewValues.removeIf(value -> value instanceof ConstantOperator && ((ConstantOperator) value).isNull());
+        inPredicateArgs.addAll(nonNullSkewValues);
         InPredicateOperator inPredicateOperator = new InPredicateOperator(false, inPredicateArgs);
 
         List<ScalarOperator> when = Lists.newArrayList();
         when.add(isNullPredicateOperator);
         when.add(roundFnOperator);
-        when.add(inPredicateOperator);
-        when.add(roundFnOperator);
+        // only add IN branch when we indeed have non-null skew values
+        if (!nonNullSkewValues.isEmpty()) {
+            when.add(inPredicateOperator);
+            when.add(roundFnOperator);
+        }
         ScalarOperator caseWhenOperator = new CaseWhenOperator(roundFnOperator.getType(), null,
                 ConstantOperator.createBigint(0), when);
         ScalarOperatorRewriter rewriter = new ScalarOperatorRewriter();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
@@ -21,6 +21,7 @@ import com.starrocks.sql.optimizer.statistics.Statistics;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.validation.constraints.NotNull;
 
 public class DataSkew {
@@ -38,30 +39,38 @@ public class DataSkew {
         }
     }
 
-    /**
-     * Utility method to check if a certain column is skewed based on statistics.
-     */
-    public static boolean isColumnSkewed(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic,
-                                         Thresholds thresholds) {
-        if (columnStatistic.getNullsFraction() >= thresholds.relativeRowThreshold) {
-            // A lot of NULL values also indicate skew.
-            return true;
+    public enum SkewType {
+        NOT_SKEWED,
+        SKEWED_NULL,
+        SKEWED_MCV
+    }
+
+    public record SkewInfo(SkewType type, Optional<List<Pair<String, Long>>> maybeMcvs) {
+        public SkewInfo(SkewType type) {
+            this(type, Optional.empty());
         }
 
+        public boolean isSkewed() {
+            return type != SkewType.NOT_SKEWED;
+        }
+    }
+
+    private record McvSkewInfo(boolean skewed, Optional<Double> mcvSkewFactor, Optional<List<Pair<String, Long>>> mcvs) {
+        public McvSkewInfo(boolean skewed) {
+            this(skewed, Optional.empty(), Optional.empty());
+        }
+    }
+
+    private static McvSkewInfo getMcvSkewInfo(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic,
+                                              Thresholds thresholds) {
         final var rowCount = statistics.getOutputRowCount();
-        if (statistics.isTableRowCountMayInaccurate() || rowCount < 1 || columnStatistic.isUnknown() ||
-                columnStatistic.isUnknownValue()) {
-            // Without sufficient information we can not make a decision.
-            return false;
-        }
-
         final var histogram = columnStatistic.getHistogram();
         if (histogram != null) {
             final var mcv = histogram.getMCV();
 
             if (mcv != null) {
-                List<Pair<String, Long>> mcvs = Lists.newArrayList();
                 int mcvLimit = Math.min(thresholds.mcvLimit, mcv.size());
+                List<Pair<String, Long>> mcvs = Lists.newArrayList();
                 mcv.entrySet().stream()
                         .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())) //
                         .limit(mcvLimit)
@@ -70,12 +79,75 @@ public class DataSkew {
                         });
 
                 long rowCountOfMcvs = mcvs.stream().mapToLong(pair -> pair.second).sum();
-                return ((double) rowCountOfMcvs / rowCount) > thresholds.relativeRowThreshold;
+                final var mcvSkewFactor = rowCountOfMcvs / rowCount;
+
+                if (mcvSkewFactor > thresholds.relativeRowThreshold) {
+                    return new McvSkewInfo(true, Optional.of(mcvSkewFactor), Optional.of(mcvs));
+                }
             }
         }
 
-        // No histogram information, can not deduce skew.
-        return false;
+        return new McvSkewInfo(false);
+    }
+
+    private record NullSkewInfo(boolean skewed, Optional<Double> nullSkewFactor) {
+        public NullSkewInfo(boolean skewed) {
+            this(skewed, Optional.empty());
+        }
+    }
+
+    private static NullSkewInfo getNullSkewInfo(@NotNull ColumnStatistic columnStatistic, Thresholds thresholds) {
+        if (columnStatistic.getNullsFraction() >= thresholds.relativeRowThreshold) {
+            // A lot of NULL values also indicate skew.
+            return new NullSkewInfo(true, Optional.of(columnStatistic.getNullsFraction()));
+        }
+
+        return new NullSkewInfo(false);
+    }
+
+    /**
+     * Utility method to get detailed information about if a column is skewed and how it is skewed.
+     */
+    public static SkewInfo getColumnSkewInfo(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic) {
+        return getColumnSkewInfo(statistics, columnStatistic, DEFAULT_THRESHOLDS);
+    }
+
+    /**
+     * Utility method to get detailed information about if a column is skewed and how it is skewed.
+     */
+    public static SkewInfo getColumnSkewInfo(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic,
+                                             Thresholds thresholds) {
+        if (statistics.isTableRowCountMayInaccurate() || statistics.getOutputRowCount() < 1) {
+            // Without sufficient information we can not make a decision.
+            return new SkewInfo(SkewType.NOT_SKEWED);
+        }
+
+        final var nullSkewInfo = getNullSkewInfo(columnStatistic, thresholds);
+        final var mcvSkewInfo = getMcvSkewInfo(statistics, columnStatistic, thresholds);
+
+        if (nullSkewInfo.skewed && mcvSkewInfo.skewed) {
+            // If there is skew in the MCVs as well as NULLs, we decide for the one that is more skewed.
+            if (nullSkewInfo.nullSkewFactor.get() >= mcvSkewInfo.mcvSkewFactor.get()) {
+                return new SkewInfo(SkewType.SKEWED_NULL);
+            } else {
+                return new SkewInfo(SkewType.SKEWED_MCV, mcvSkewInfo.mcvs);
+            }
+        } else if (nullSkewInfo.skewed) {
+            return new SkewInfo(SkewType.SKEWED_NULL);
+        } else if (mcvSkewInfo.skewed) {
+            return new SkewInfo(SkewType.SKEWED_MCV, mcvSkewInfo.mcvs);
+        }
+
+        // Can not deduce skew.
+        return new SkewInfo(SkewType.NOT_SKEWED);
+    }
+
+    /**
+     * Utility method to check if a certain column is skewed based on statistics.
+     */
+    public static boolean isColumnSkewed(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic,
+                                         Thresholds thresholds) {
+        return getColumnSkewInfo(statistics, columnStatistic, thresholds).isSkewed();
     }
 
     /* Always using default thresholds */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -23,6 +23,8 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.statistic.StatisticUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -451,7 +453,7 @@ public class BinaryPredicateStatisticCalculator {
                 estimateBucketToBucket(leftHistogram, leftColumnDistinctCount, leftColumnType, rightHistogram,
                         rightColumnDistinctCount, rightColumnType);
 
-        if (estimatedMcv.isEmpty() && estimatedBuckets.isEmpty()) {
+        if (MapUtils.isEmpty(estimatedMcv) && CollectionUtils.isEmpty(estimatedBuckets)) {
             return Optional.empty();
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/skew/DataSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/skew/DataSkewTest.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer.skew;
 
 import com.google.crypto.tink.subtle.Random;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.statistics.Bucket;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -123,6 +125,48 @@ public class DataSkewTest {
         // WHEN / THEN
         assertTrue(DataSkew.isColumnSkewed(stats, skewedColStats));
         assertFalse(DataSkew.isColumnSkewed(stats, nonSkewedColStats));
+    }
+
+    @Test
+    void itShouldReturnMoreSkewedMetric() {
+        // GIVEN
+        final var skewedHistogram = getSkewedHistogram();
+        final var nullAndMcvButMoreNullSkewedCol = createNewTestColumn();
+        final var nullAndMcvButMoreNullSkewedStats = ColumnStatistic.builder()
+                .setNullsFraction(99) //
+                .setHistogram(skewedHistogram) //
+                .build();
+
+        final var nullAndMcvButMoreMcvSkewedCol = createNewTestColumn();
+        final var nullAndMcvButMoreMcvSkewedStats = ColumnStatistic.builder()
+                .setNullsFraction(0.6) //
+                .setHistogram(skewedHistogram) //
+                .build();
+
+        final var stats = new Statistics.Builder()
+                .setOutputRowCount(100_000)
+                .addColumnStatistic(nullAndMcvButMoreNullSkewedCol, nullAndMcvButMoreNullSkewedStats) //
+                .addColumnStatistic(nullAndMcvButMoreMcvSkewedCol, nullAndMcvButMoreMcvSkewedStats) //
+                .build();
+
+        // WHEN / THEN
+        final var nullAndMcvButMoreNullSkewInfo = DataSkew.getColumnSkewInfo(stats, nullAndMcvButMoreNullSkewedStats);
+        assertTrue(nullAndMcvButMoreNullSkewInfo.isSkewed());
+        assertEquals(DataSkew.SkewType.SKEWED_NULL, nullAndMcvButMoreNullSkewInfo.type());
+        assertFalse(nullAndMcvButMoreNullSkewInfo.maybeMcvs().isPresent());
+
+        final var nullAndMcvButMoreMcvSkewInfo = DataSkew.getColumnSkewInfo(stats, nullAndMcvButMoreMcvSkewedStats);
+        assertTrue(nullAndMcvButMoreMcvSkewInfo.isSkewed());
+        assertEquals(DataSkew.SkewType.SKEWED_MCV, nullAndMcvButMoreMcvSkewInfo.type());
+        assertTrue(nullAndMcvButMoreMcvSkewInfo.maybeMcvs().isPresent());
+
+        final var expectedMcvs =
+                List.of(Pair.create("1", 50000L), Pair.create("2", 20000L), Pair.create("3", 10000L), Pair.create("4", 5000L),
+                        Pair.create("5", 500L));
+        assertEquals(expectedMcvs.size(), nullAndMcvButMoreMcvSkewInfo.maybeMcvs().get().size());
+        for (final var value : expectedMcvs) {
+            assertTrue(nullAndMcvButMoreMcvSkewInfo.maybeMcvs().get().contains(value));
+        }
     }
 
     private static Histogram getSkewedHistogram() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -97,15 +97,6 @@ public class SkewJoinTest extends PlanTestBase {
         PlanTestBase.afterClass();
     }
 
-
-    @Test
-    public void testSkewJoinWithRightSideHint() throws Exception {
-        String sql = "select * from t0 left join [skew|t1.v4(100)] t1 on t0.v1 = t1.v4";
-        String sqlPlan = getFragmentPlan(sql);
-        assertCContains(sqlPlan, "equal join conjunct: 14: rand_col = 7: rand_col");
-        assertCContains(sqlPlan, "equal join conjunct: 1: v1 = 4: v4");
-    }
-
     @Test
     public void testSkewJoinWithRightSideHint() throws Exception {
         String sql = "select * from t0 left join [skew|t1.v4(100)] t1 on t0.v1 = t1.v4";


### PR DESCRIPTION
## Why I'm doing:

This PR adds automatic detection of NULL-skewed join columns based on null fractions. Previously, only MCVs were looked at.
Essentially, when you have a query of the form:
```sql
SELECT
    expensive_agg(...)
FROM
    TABLE1 t1
    LEFT JOIN TABLE2 t2 ON t1.TABLE2_ID = t2.ID
```
where `t1.TABLE2_ID` is NULL-skewed, `expensive_agg(...)` is executed on a single thread because all the NULLs are handled by a single pipeline driver (so essentially single-threaded). 
Previously, you could mitigate this by annotating the query like this:
```sql
SELECT
    expensive_agg(...)
FROM
    TABLE1 t1
    LEFT JOIN [skew|t1.TABLE2_ID(null)] TABLE2 t2 ON t1.TABLE2_ID = t2.ID
```

With my PR, you can just set `enable_stats_to_optimize_skew_join = true` and run the query without hints and the skew is automatically detected.

Here is a [profile](https://gist.github.com/OliLay/c27ad6c4a5f8c1a275e7fbdbff03e483) without automatic detection (42s wall time) and [with automatic detection](https://gist.github.com/OliLay/3d576b80d643f63c032b9831773b3ffc) (22s wall time).

## What I'm doing:
- Refactoring of the skew detection by reusing `DataSkew` class added in https://github.com/StarRocks/starrocks/pull/66640. This removes duplicate code and unified skew detection.
- Adding NULL skew detection to `SkewJoinOptimizeRule::check()`.
- Minor changes to `SkewJoinOptimizeRule::transform()` so that `IN` predicate is omitted if we only have NULL skew.

Note: This PR is based on Murphy's work in https://github.com/StarRocks/starrocks/pull/62539. I took it over since Murphy has no capacity to work on it.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

This PR is a backport of https://github.com/StarRocks/starrocks/pull/67100
