### PR TITLE
[BugFix] use null-safe equals for Iceberg equality delete columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/IcebergEqualityDeleteRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/IcebergEqualityDeleteRewriteRule.java
@@ -236,7 +236,11 @@ public class IcebergEqualityDeleteRewriteRule extends TransformationRule {
                 throw new StarRocksConnectorException("can not find iceberg identifier column {}",
                         rightColRef.getName());
             }
-            BinaryType binaryType = icebergIdentifierColumnName.equals(DATA_SEQUENCE_NUMBER) ? BinaryType.LT : BinaryType.EQ;
+            // Use EQ_FOR_NULL (null-safe equals) for identity columns to match Iceberg spec:
+            // "A null value in a delete column matches a row if the row's value is null"
+            BinaryType binaryType = icebergIdentifierColumnName.equals(DATA_SEQUENCE_NUMBER)
+                    ? BinaryType.LT
+                    : BinaryType.EQ_FOR_NULL;
             BinaryPredicateOperator binaryPredicateOperator = new BinaryPredicateOperator(binaryType,
                     List.of(leftColRef, rightColRef));
             onPredicates.add(binaryPredicateOperator);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/IcebergEqualityDeleteRewriteRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/IcebergEqualityDeleteRewriteRuleTest.java
@@ -1,0 +1,73 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.starrocks.catalog.IcebergTable.DATA_SEQUENCE_NUMBER;
+
+public class IcebergEqualityDeleteRewriteRuleTest {
+
+    // The LEFT ANTI JOIN that applies equality deletes must compare identity columns with null-safe
+    // equals (EQ_FOR_NULL / <=>), not plain EQ: per the Iceberg spec a NULL value in a delete column
+    // matches a NULL row value, and plain EQ would evaluate NULL = NULL -> UNKNOWN and silently keep
+    // the row alive. The $data_sequence_number bound must stay a strict LT.
+    @Test
+    public void testBuildOnPredicateUsesNullSafeEqualsForIdentityColumns() {
+        ColumnRefOperator leftId = new ColumnRefOperator(1, IntegerType.INT, "id", true);
+        ColumnRefOperator leftSeq = new ColumnRefOperator(2, IntegerType.BIGINT, DATA_SEQUENCE_NUMBER, true);
+        ColumnRefOperator rightId = new ColumnRefOperator(3, IntegerType.INT, "id", true);
+        ColumnRefOperator rightSeq = new ColumnRefOperator(4, IntegerType.BIGINT, DATA_SEQUENCE_NUMBER, true);
+
+        Map<String, ColumnRefOperator> leftCols = new HashMap<>();
+        leftCols.put("id", leftId);
+        leftCols.put(DATA_SEQUENCE_NUMBER, leftSeq);
+
+        IcebergEqualityDeleteRewriteRule rule = new IcebergEqualityDeleteRewriteRule();
+        ScalarOperator onPredicate = Deencapsulation.invoke(
+                rule, "buildOnPredicate", leftCols, List.of(rightId, rightSeq));
+
+        Map<String, BinaryType> byColumn = new HashMap<>();
+        collectBinaryTypes(onPredicate, byColumn);
+
+        Assertions.assertEquals(BinaryType.EQ_FOR_NULL, byColumn.get("id"),
+                "identity column must use null-safe equals so NULL-key rows are deleted");
+        Assertions.assertEquals(BinaryType.LT, byColumn.get(DATA_SEQUENCE_NUMBER),
+                "data sequence number bound must remain a strict less-than");
+    }
+
+    // Walk the AND tree and index each leaf comparison by the name of its right-hand (delete-table) column.
+    private void collectBinaryTypes(ScalarOperator op, Map<String, BinaryType> out) {
+        if (op instanceof BinaryPredicateOperator binary) {
+            ColumnRefOperator rightCol = (ColumnRefOperator) binary.getChild(1);
+            out.put(rightCol.getName(), binary.getBinaryType());
+            return;
+        }
+        for (ScalarOperator child : op.getChildren()) {
+            collectBinaryTypes(child, out);
+        }
+    }
+}

--- a/test/sql/test_iceberg/R/test_iceberg_equality_delete_null_key
+++ b/test/sql/test_iceberg/R/test_iceberg_equality_delete_null_key
@@ -1,0 +1,31 @@
+-- name: test_iceberg_equality_delete_null_key
+create external catalog iceberg_eqnull_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}");
+-- result:
+-- !result
+create database iceberg_eqnull_${uuid0}.eq_delete_db_${uuid0};
+-- result:
+-- !result
+call iceberg_eqnull_${uuid0}.system.register_table("eq_delete_db_${uuid0}", "eq_del_convert", "oss://${oss_bucket}/iceberg_ci_db/eq_del_convert/metadata/v4.metadata.json");
+-- result:
+-- !result
+set new_planner_optimize_timeout = 30000;
+-- result:
+-- !result
+select * from iceberg_eqnull_${uuid0}.eq_delete_db_${uuid0}.eq_del_convert order by id;
+-- result:
+1	n1
+2	n2
+4	n4
+5	n5
+7	n7
+8	n8
+-- !result
+drop table iceberg_eqnull_${uuid0}.eq_delete_db_${uuid0}.eq_del_convert;
+-- result:
+-- !result
+drop database iceberg_eqnull_${uuid0}.eq_delete_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_eqnull_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_equality_delete_null_key
+++ b/test/sql/test_iceberg/T/test_iceberg_equality_delete_null_key
@@ -1,0 +1,13 @@
+-- name: test_iceberg_equality_delete_null_key
+-- Iceberg spec: a NULL in an equality-delete column matches NULL row values, so both NULL-id rows must be deleted.
+create external catalog iceberg_eqnull_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}");
+create database iceberg_eqnull_${uuid0}.eq_delete_db_${uuid0};
+call iceberg_eqnull_${uuid0}.system.register_table("eq_delete_db_${uuid0}", "eq_del_convert", "oss://${oss_bucket}/iceberg_ci_db/eq_del_convert/metadata/v4.metadata.json");
+
+set new_planner_optimize_timeout = 30000;
+
+select * from iceberg_eqnull_${uuid0}.eq_delete_db_${uuid0}.eq_del_convert order by id;
+
+drop table iceberg_eqnull_${uuid0}.eq_delete_db_${uuid0}.eq_del_convert;
+drop database iceberg_eqnull_${uuid0}.eq_delete_db_${uuid0};
+drop catalog iceberg_eqnull_${uuid0};


### PR DESCRIPTION
## Problem

When reading Iceberg tables with equality delete files containing NULL values in identity columns, StarRocks incorrectly fails to delete matching rows.

`IcebergEqualityDeleteRewriteRule` transforms equality deletes into a LEFT ANTI JOIN between data files and delete files. The join predicate on identity columns used `BinaryType.EQ` (plain `=`):

```java
BinaryType binaryType = icebergIdentifierColumnName.equals(DATA_SEQUENCE_NUMBER)
    ? BinaryType.LT
    : BinaryType.EQ;  // problem here
```

In SQL semantics, `NULL = NULL` evaluates to UNKNOWN, treated as FALSE in join predicates. Rows with NULL values in identity columns are never matched and therefore never deleted.

## Iceberg specification

[Iceberg spec — equality delete files](https://iceberg.apache.org/spec/#equality-delete-files):

> A null value in a delete column matches a row if the row's value is null, equivalent to `col IS NULL`.

## Example

Data:
```
id | category | name
---|----------|--------
1  | NULL     | Alice
2  | NULL     | Bob
3  | toys     | Charlie
```
Equality delete file (`equality_ids=[id, category]`):
```
id | category
---|----------
1  | NULL
```
Expected: row `(1, NULL, Alice)` is deleted. Actual before fix: not deleted, because `NULL = NULL → UNKNOWN`.

## Solution

Switch identity-column comparison to `BinaryType.EQ_FOR_NULL` (null-safe equals, equivalent to `<=>`); `$data_sequence_number` bound stays `BinaryType.LT`.

- `NULL <=> NULL → TRUE` (rows match, deletion applied)
- `NULL <=> value → FALSE` (rows don't match)
- `value <=> value → TRUE/FALSE` (regular comparison)

## Tests

- `IcebergEqualityDeleteRewriteRuleTest` — plan test asserts the rewritten anti-join uses `EQ_FOR_NULL` for identity columns and keeps `LT` for `$data_sequence_number`.
- `test_iceberg_equality_delete_null_key` — SQL fixture over a v2 hadoop catalog whose equality-delete file is keyed on NULL; the NULL-id rows must be deleted (6 visible rows out of 10).

Caveat on the SQL fixture: it's a local `file://` hadoop catalog copied into `/tmp`, so multi-node CI fails with `Unknown database` (the `shell: cp` lands on the runner, FE/BE read from their own node). The fixture works end-to-end on a single-node deployment, where the behavior was validated. Hosting it in the CI HMS+OSS external catalog (alongside the existing `iceberg_oss_db.eq_del_tbl` cases) would make it green in CI; that needs access to the test catalog.

## Related

The float/double `<=>` NaN-canonicalization fix, originally bundled into this PR, has been split out per review feedback into a separate PR (#74000). It's required for an Iceberg equality-delete file keyed on a NaN identity column but applies to any null-safe equal on float/double — separate review scope (hash-join key constructors, ONE_KEY fast-path routing, scalar `<=>` interpreter and JIT).

Fixes #67326

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
