### PR TITLE
[Enhancement] reduce logging of variant and add to_string for parquet encoder/decoder

### DIFF
--- a/be/src/formats/parquet/complex_column_reader.cpp
+++ b/be/src/formats/parquet/complex_column_reader.cpp
@@ -727,9 +727,10 @@ Status VariantColumnReader::read_range(const Range<uint64_t>& range, const Filte
                 // Even if null flags are false, slices can be empty (empty strings are valid non-null values in BinaryColumn)
                 // But Variant requires non-empty value, so treat empty slices as null
                 if (metadata_slice.empty() || value_slice.empty()) {
-                    VLOG_FILE << "Empty metadata or value slice at row " << i
-                              << " (metadata_size=" << metadata_slice.size << ", value_size=" << value_slice.size
-                              << "), treating as null variant";
+                    // value slice probably is empty since it's been filtered out during encoding according to `filter`
+                    // VLOG_FILE << "Empty metadata or value slice at row " << i
+                    //           << " (metadata_size=" << metadata_slice.size << ", value_size=" << value_slice.size
+                    //           << "), treating as null variant";
                     variant_column->append(VariantRowValue::from_null());
                 } else if (auto variant = VariantRowValue::create(metadata_slice, value_slice); !variant.ok()) {
                     // Read malformed variant value as null

--- a/be/src/formats/parquet/encoding.h
+++ b/be/src/formats/parquet/encoding.h
@@ -14,12 +14,8 @@
 
 #pragma once
 
-#include <stddef.h>
-#include <stdint.h>
-
 #include <functional>
 #include <memory>
-#include <vector>
 
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
@@ -51,12 +47,16 @@ public:
 
     // used to set fixed length for FLBA
     virtual void set_type_length(int32_t type_length) {}
+
+    virtual std::string to_string() const { return "Encoder"; }
 };
 
 class Decoder {
 public:
     Decoder() = default;
     virtual ~Decoder() = default;
+
+    virtual std::string to_string() const { return "Decoder"; }
 
     virtual Status set_dict(int chunk_size, size_t num_values, Decoder* decoder) {
         return Status::NotSupported("set_dict is not supported");

--- a/be/src/formats/parquet/encoding_bss.h
+++ b/be/src/formats/parquet/encoding_bss.h
@@ -41,9 +41,7 @@ public:
     }
     ~ByteStreamSplitEncoder() override = default;
 
-    std::string to_string() const override {
-        return fmt::format("ByteStreamSplitEncoder<{}>", typeid(T).name());
-    }
+    std::string to_string() const override { return fmt::format("ByteStreamSplitEncoder<{}>", typeid(T).name()); }
 
     void set_type_length(int byte_width) override {
         if constexpr (IS_FLBA) {
@@ -119,9 +117,7 @@ public:
     }
     ~ByteStreamSplitDecoder() override = default;
 
-    std::string to_string() const override {
-        return fmt::format("ByteStreamSplitDecoder<{}>", typeid(T).name());
-    }
+    std::string to_string() const override { return fmt::format("ByteStreamSplitDecoder<{}>", typeid(T).name()); }
 
     void set_type_length(int byte_width) override {
         if constexpr (IS_FLBA) {

--- a/be/src/formats/parquet/encoding_bss.h
+++ b/be/src/formats/parquet/encoding_bss.h
@@ -41,6 +41,10 @@ public:
     }
     ~ByteStreamSplitEncoder() override = default;
 
+    std::string to_string() const override {
+        return fmt::format("ByteStreamSplitEncoder<{}>", typeid(T).name());
+    }
+
     void set_type_length(int byte_width) override {
         if constexpr (IS_FLBA) {
             byte_width_ = byte_width;
@@ -114,6 +118,10 @@ public:
         }
     }
     ~ByteStreamSplitDecoder() override = default;
+
+    std::string to_string() const override {
+        return fmt::format("ByteStreamSplitDecoder<{}>", typeid(T).name());
+    }
 
     void set_type_length(int byte_width) override {
         if constexpr (IS_FLBA) {

--- a/be/src/formats/parquet/encoding_delta.h
+++ b/be/src/formats/parquet/encoding_delta.h
@@ -110,9 +110,7 @@ public:
         return Status::OK();
     }
 
-    std::string to_string() const override {
-        return fmt::format("DeltaBinaryPackedEncoder<{}>", typeid(T).name());
-    }
+    std::string to_string() const override { return fmt::format("DeltaBinaryPackedEncoder<{}>", typeid(T).name()); }
 
 private:
     const uint32_t values_per_block_;
@@ -255,9 +253,7 @@ public:
     DeltaBinaryPackedDecoder() = default;
     ~DeltaBinaryPackedDecoder() override = default;
 
-    std::string to_string() const override {
-        return fmt::format("DeltaBinaryPackedDecoder<{}>", typeid(T).name());
-    }
+    std::string to_string() const override { return fmt::format("DeltaBinaryPackedDecoder<{}>", typeid(T).name()); }
 
     Status set_data(const Slice& data) override {
         _data = data;
@@ -523,9 +519,7 @@ public:
         return Status::OK();
     }
 
-    std::string to_string() const override {
-        return "DeltaLengthByteArrayEncoder";
-    }
+    std::string to_string() const override { return "DeltaLengthByteArrayEncoder"; }
 
 private:
     faststring string_buffer_;
@@ -586,9 +580,7 @@ public:
     DeltaLengthByteArrayDecoder() = default;
     ~DeltaLengthByteArrayDecoder() override = default;
 
-    std::string to_string() const override {
-        return "DeltaLengthByteArrayDecoder";
-    }
+    std::string to_string() const override { return "DeltaLengthByteArrayDecoder"; }
 
     Status set_data(const Slice& data) override {
         RETURN_IF_ERROR(len_decoder_.set_data(data));
@@ -737,9 +729,7 @@ public:
     DeltaByteArrayEncoder() = default;
     ~DeltaByteArrayEncoder() override = default;
 
-    std::string to_string() const override {
-        return "DeltaByteArrayEncoder";
-    }
+    std::string to_string() const override { return "DeltaByteArrayEncoder"; }
 
     Slice build() override {
         FlushValues();
@@ -829,9 +819,7 @@ public:
     DeltaByteArrayDecoder() = default;
     ~DeltaByteArrayDecoder() override = default;
 
-    std::string to_string() const override {
-        return "DeltaByteArrayDecoder";
-    }
+    std::string to_string() const override { return "DeltaByteArrayDecoder"; }
 
 private:
     DeltaBinaryPackedDecoder<int32_t> prefix_len_decoder_;

--- a/be/src/formats/parquet/encoding_delta.h
+++ b/be/src/formats/parquet/encoding_delta.h
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <limits>
+#include <string>
 
 #include "column/column.h"
 #include "column/column_helper.h"
@@ -107,6 +108,10 @@ public:
         sink_offset_ = -1; // more values.
         Put(reinterpret_cast<const T*>(vals), static_cast<int>(count));
         return Status::OK();
+    }
+
+    std::string to_string() const override {
+        return fmt::format("DeltaBinaryPackedEncoder<{}>", typeid(T).name());
     }
 
 private:
@@ -249,6 +254,10 @@ public:
     using UT = std::make_unsigned_t<T>;
     DeltaBinaryPackedDecoder() = default;
     ~DeltaBinaryPackedDecoder() override = default;
+
+    std::string to_string() const override {
+        return fmt::format("DeltaBinaryPackedDecoder<{}>", typeid(T).name());
+    }
 
     Status set_data(const Slice& data) override {
         _data = data;
@@ -514,6 +523,10 @@ public:
         return Status::OK();
     }
 
+    std::string to_string() const override {
+        return "DeltaLengthByteArrayEncoder";
+    }
+
 private:
     faststring string_buffer_;
     DeltaBinaryPackedEncoder<int> length_encoder_;
@@ -572,6 +585,10 @@ class DeltaLengthByteArrayDecoder : public Decoder {
 public:
     DeltaLengthByteArrayDecoder() = default;
     ~DeltaLengthByteArrayDecoder() override = default;
+
+    std::string to_string() const override {
+        return "DeltaLengthByteArrayDecoder";
+    }
 
     Status set_data(const Slice& data) override {
         RETURN_IF_ERROR(len_decoder_.set_data(data));
@@ -720,6 +737,10 @@ public:
     DeltaByteArrayEncoder() = default;
     ~DeltaByteArrayEncoder() override = default;
 
+    std::string to_string() const override {
+        return "DeltaByteArrayEncoder";
+    }
+
     Slice build() override {
         FlushValues();
         return Slice(sink_.data(), sink_.size());
@@ -807,6 +828,10 @@ class DeltaByteArrayDecoder : public Decoder {
 public:
     DeltaByteArrayDecoder() = default;
     ~DeltaByteArrayDecoder() override = default;
+
+    std::string to_string() const override {
+        return "DeltaByteArrayDecoder";
+    }
 
 private:
     DeltaBinaryPackedDecoder<int32_t> prefix_len_decoder_;

--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -40,9 +40,7 @@ public:
     DictEncoder() = default;
     ~DictEncoder() override = default;
 
-    std::string to_string() const override {
-        return fmt::format("DictEncoder<{}>", typeid(T).name());
-    }
+    std::string to_string() const override { return fmt::format("DictEncoder<{}>", typeid(T).name()); }
 
     Status append(const uint8_t* vals, size_t count) override {
         const T* ptr = (const T*)vals;
@@ -95,9 +93,7 @@ public:
     CacheAwareDictDecoder() { _dict_size_threshold = CpuInfo::get_l2_cache_size(); }
     ~CacheAwareDictDecoder() override = default;
 
-    std::string to_string() const override {
-        return "CacheAwareDictDecoder";
-    }
+    std::string to_string() const override { return "CacheAwareDictDecoder"; }
 
     Status next_batch(size_t count, ColumnContentType content_type, Column* dst, const FilterData* filter) override {
         switch (content_type) {
@@ -217,9 +213,7 @@ public:
     DictDecoder() = default;
     ~DictDecoder() override = default;
 
-    std::string to_string() const override {
-        return fmt::format("DictDecoder<{}>", typeid(T).name());
-    }
+    std::string to_string() const override { return fmt::format("DictDecoder<{}>", typeid(T).name()); }
 
     // initialize dictionary
     Status set_dict(int chunk_size, size_t num_values, Decoder* decoder) override {
@@ -407,9 +401,7 @@ public:
     DictDecoder() = default;
     ~DictDecoder() override = default;
 
-    std::string to_string() const override {
-        return fmt::format("DictDecoder<Slice>");
-    }
+    std::string to_string() const override { return fmt::format("DictDecoder<Slice>"); }
 
     Status set_dict(int chunk_size, size_t num_values, Decoder* decoder) override {
         auto slices_data = std::make_unique_for_overwrite<uint8_t[]>(num_values * sizeof(Slice));

--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -40,6 +40,10 @@ public:
     DictEncoder() = default;
     ~DictEncoder() override = default;
 
+    std::string to_string() const override {
+        return fmt::format("DictEncoder<{}>", typeid(T).name());
+    }
+
     Status append(const uint8_t* vals, size_t count) override {
         const T* ptr = (const T*)vals;
         for (int i = 0; i < count; ++i) {
@@ -90,6 +94,10 @@ class CacheAwareDictDecoder : public Decoder {
 public:
     CacheAwareDictDecoder() { _dict_size_threshold = CpuInfo::get_l2_cache_size(); }
     ~CacheAwareDictDecoder() override = default;
+
+    std::string to_string() const override {
+        return "CacheAwareDictDecoder";
+    }
 
     Status next_batch(size_t count, ColumnContentType content_type, Column* dst, const FilterData* filter) override {
         switch (content_type) {
@@ -208,6 +216,10 @@ class DictDecoder final : public CacheAwareDictDecoder {
 public:
     DictDecoder() = default;
     ~DictDecoder() override = default;
+
+    std::string to_string() const override {
+        return fmt::format("DictDecoder<{}>", typeid(T).name());
+    }
 
     // initialize dictionary
     Status set_dict(int chunk_size, size_t num_values, Decoder* decoder) override {
@@ -394,6 +406,10 @@ class DictDecoder<Slice> final : public CacheAwareDictDecoder {
 public:
     DictDecoder() = default;
     ~DictDecoder() override = default;
+
+    std::string to_string() const override {
+        return fmt::format("DictDecoder<Slice>");
+    }
 
     Status set_dict(int chunk_size, size_t num_values, Decoder* decoder) override {
         auto slices_data = std::make_unique_for_overwrite<uint8_t[]>(num_values * sizeof(Slice));

--- a/be/src/formats/parquet/encoding_plain.h
+++ b/be/src/formats/parquet/encoding_plain.h
@@ -53,6 +53,8 @@ public:
 
     Slice build() override { return {_buffer.data(), _buffer.size()}; }
 
+    std::string to_string() const override { return fmt::format("PlainEncoder<{}>", typeid(T).name()); }
+
 private:
     enum { SIZE_OF_TYPE = sizeof(T) };
 
@@ -75,6 +77,8 @@ public:
     }
 
     Slice build() override { return {_buffer.data(), _buffer.size()}; }
+
+    std::string to_string() const override { return "PlainEncoder<Slice>"; }
 
 private:
     faststring _buffer;
@@ -99,6 +103,8 @@ public:
         return {_buffer.data(), _buffer.size()};
     }
 
+    std::string to_string() const override { return "PlainEncoder<bool>"; }
+
 private:
     faststring _buffer;
     BitWriter _bit_writer;
@@ -109,6 +115,8 @@ class PlainDecoder final : public Decoder {
 public:
     PlainDecoder() = default;
     ~PlainDecoder() override = default;
+
+    std::string to_string() const override { return fmt::format("PlainDecoder<{}>", typeid(T).name()); }
 
     static Status decode(const std::string& buffer, T* value) {
         int byte_size = sizeof(T);
@@ -167,6 +175,8 @@ class PlainDecoder<Slice> final : public Decoder {
 public:
     PlainDecoder() = default;
     ~PlainDecoder() override = default;
+
+    std::string to_string() const override { return "PlainDecoder<Slice>"; }
 
     static Status decode(const std::string& buffer, Slice* value) {
         value->data = const_cast<char*>(buffer.data());
@@ -354,6 +364,8 @@ public:
     PlainDecoder() = default;
     ~PlainDecoder() override = default;
 
+    std::string to_string() const override { return "PlainDecoder<bool>"; }
+
     Status set_data(const Slice& data) override {
         _batched_bit_reader.reset(reinterpret_cast<const uint8_t*>(data.data), data.size);
         _decoded_values_buffer.reset();
@@ -452,6 +464,8 @@ public:
     FLBAPlainEncoder() = default;
     ~FLBAPlainEncoder() override = default;
 
+    std::string to_string() const override { return "FLBAPlainEncoder"; }
+
     Status append(const uint8_t* vals, size_t count) override {
         if (count == 0) return Status::OK();
 
@@ -474,6 +488,8 @@ class FLBAPlainDecoder final : public Decoder {
 public:
     FLBAPlainDecoder() = default;
     ~FLBAPlainDecoder() override = default;
+
+    std::string to_string() const override { return "FLBAPlainDecoder"; }
 
     static Status decode(const std::string& buffer, Slice* value) {
         value->data = const_cast<char*>(buffer.data());


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Parquet codec introspection and reduces noisy logs.
> 
> - Adds `to_string()` to `Encoder`/`Decoder` in `encoding.h` and overrides across BSS, Delta, Dict, Plain, and FLBA implementations for clearer diagnostics
> - Tones down Variant logging in `complex_column_reader.cpp` by silencing empty-slice VLOGs (keeps null handling intact)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebb8d07468ee76cac2496ba3bb32ffd73473d753. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->