### PR TITLE
[BugFix] Fallback to non-short-circuit execution in share-data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
@@ -143,7 +143,7 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
     @Override
     public void selectWorker(long workerId) throws NonRecoverableException {
         if (getWorkerById(workerId) == null) {
-            reportWorkerNotFoundException(workerId);
+            reportWorkerNotFoundException("", workerId);
         }
         selectWorkerUnchecked(workerId);
     }
@@ -204,13 +204,14 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
     }
 
     @Override
-    public void reportWorkerNotFoundException() throws NonRecoverableException {
-        reportWorkerNotFoundException(-1);
+    public void reportWorkerNotFoundException(String errorMessagePrefix) throws NonRecoverableException {
+        reportWorkerNotFoundException(errorMessagePrefix, -1);
     }
 
-    private void reportWorkerNotFoundException(long workerId) throws NonRecoverableException {
+    private void reportWorkerNotFoundException(String errorMessagePrefix, long workerId) throws NonRecoverableException {
         throw new NonRecoverableException(
-                FeConstants.getNodeNotFoundError(true) + " nodeId: " + workerId + " " + computeNodesToString(false));
+                errorMessagePrefix + FeConstants.getNodeNotFoundError(true) + " nodeId: " + workerId + " " +
+                        computeNodesToString(false));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -5236,7 +5236,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public boolean isEnableShortCircuit() {
-        return enableShortCircuit && RunMode.getCurrentRunMode() != RunMode.SHARED_DATA;
+        return enableShortCircuit && !RunMode.isSharedDataMode();
     }
 
     public boolean isEnablePrepareStmt() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -5236,7 +5236,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public boolean isEnableShortCircuit() {
-        return enableShortCircuit;
+        return enableShortCircuit && RunMode.getCurrentRunMode() != RunMode.SHARED_DATA;
     }
 
     public boolean isEnablePrepareStmt() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
@@ -201,8 +201,6 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
 
     /**
      * compute all tablets per be
-     *
-     * @return
      */
     private SetMultimap<TNetworkAddress, TabletWithVersion> assignTablet2Backends() throws NonRecoverableException {
         SetMultimap<TNetworkAddress, TabletWithVersion> backend2Tablets = HashMultimap.create();
@@ -220,7 +218,11 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
 
             Optional<Backend> be = pick(scanBackendIds, aliveIdToBackends);
             if (be.isEmpty()) {
-                workerProvider.get().reportWorkerNotFoundException();
+                try {
+                    workerProvider.get().reportWorkerNotFoundException();
+                } catch (NonRecoverableException e) {
+                    throw new NonRecoverableException("No alive backend for short-circuit query. " + e.getMessage());
+                }
             }
             be.ifPresent(backend -> backend2Tablets.put(be.get().getBrpcAddress(), tabletWithVersion));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
@@ -218,11 +218,7 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
 
             Optional<Backend> be = pick(scanBackendIds, aliveIdToBackends);
             if (be.isEmpty()) {
-                try {
-                    workerProvider.get().reportWorkerNotFoundException();
-                } catch (NonRecoverableException e) {
-                    throw new NonRecoverableException("No alive backend for short-circuit query. " + e.getMessage());
-                }
+                workerProvider.get().reportWorkerNotFoundException("No alive backend for short-circuit query. ");
             }
             be.ifPresent(backend -> backend2Tablets.put(be.get().getBrpcAddress(), tabletWithVersion));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -229,12 +229,12 @@ public class DefaultWorkerProvider implements WorkerProvider {
 
     @Override
     public void reportDataNodeNotFoundException() throws NonRecoverableException {
-        reportWorkerNotFoundException(false);
+        reportWorkerNotFoundException("", false);
     }
 
     @Override
-    public void reportWorkerNotFoundException() throws NonRecoverableException {
-        reportWorkerNotFoundException(usedComputeNode);
+    public void reportWorkerNotFoundException(String errorMessagePrefix) throws NonRecoverableException {
+        reportWorkerNotFoundException(errorMessagePrefix, usedComputeNode);
     }
 
     @Override
@@ -309,9 +309,10 @@ public class DefaultWorkerProvider implements WorkerProvider {
                 backendsToString(allowNormalNodes);
     }
 
-    private void reportWorkerNotFoundException(boolean chooseComputeNode) throws NonRecoverableException {
+    private void reportWorkerNotFoundException(String errorMessagePrefix, boolean chooseComputeNode)
+            throws NonRecoverableException {
         throw new NonRecoverableException(
-                FeConstants.getNodeNotFoundError(chooseComputeNode) + toString(chooseComputeNode, false));
+                errorMessagePrefix + FeConstants.getNodeNotFoundError(chooseComputeNode) + toString(chooseComputeNode, false));
     }
 
     private String computeNodesToString(boolean allowNormalNodes) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
@@ -78,7 +78,11 @@ public interface WorkerProvider {
 
     void reportDataNodeNotFoundException() throws NonRecoverableException;
 
-    void reportWorkerNotFoundException() throws NonRecoverableException;
+    void reportWorkerNotFoundException(String errorMessagePrefix) throws NonRecoverableException;
+
+    default void reportWorkerNotFoundException() throws NonRecoverableException {
+        reportWorkerNotFoundException("");
+    }
 
     boolean isWorkerSelected(long workerId);
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class DefaultWorkerProviderTest {
     private final ImmutableMap<Long, ComputeNode> id2Backend = genWorkers(0, 10, Backend::new, false);
@@ -437,5 +438,20 @@ public class DefaultWorkerProviderTest {
         int result = DefaultWorkerProvider.getNextComputeNodeIndex(computeResource);
         Assertions.assertEquals(initialIndex, result);
         Assertions.assertEquals(initialIndex + 1, DefaultWorkerProvider.getNextComputeNodeIndexer().get());
+    }
+
+    @Test
+    public void testReportNotFoundException() {
+        DefaultWorkerProvider provider = new DefaultWorkerProvider(id2Backend, id2ComputeNode,
+                availableId2Backend, availableId2ComputeNode, true, WarehouseManager.DEFAULT_RESOURCE);
+        assertThatThrownBy(provider::reportWorkerNotFoundException)
+                .isInstanceOf(NonRecoverableException.class)
+                .hasMessageContaining("Compute node not found. Check if any compute node is down.compute node:");
+        assertThatThrownBy(() -> provider.reportWorkerNotFoundException("prefix:"))
+                .isInstanceOf(NonRecoverableException.class)
+                .hasMessageContaining("prefix:Compute node not found. Check if any compute node is down.compute node:");
+        assertThatThrownBy(provider::reportDataNodeNotFoundException)
+                .isInstanceOf(NonRecoverableException.class)
+                .hasMessageContaining("Backend node not found. Check if any backend node is down.backend: ");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/LazyWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/LazyWorkerProviderTest.java
@@ -74,7 +74,7 @@ public class LazyWorkerProviderTest {
         }
 
         @Override
-        public void reportWorkerNotFoundException() throws NonRecoverableException {
+        public void reportWorkerNotFoundException(String errorMessagePrefix) throws NonRecoverableException {
 
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ShortCircuitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ShortCircuitTest.java
@@ -15,12 +15,15 @@
 package com.starrocks.sql.plan;
 
 import com.google.common.collect.ImmutableList;
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.DescriptorTable;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.qe.scheduler.NonRecoverableException;
 import com.starrocks.qe.scheduler.dag.ExecutionFragment;
+import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TInternalScanRange;
 import com.starrocks.thrift.TNetworkAddress;
@@ -29,6 +32,10 @@ import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.CRAcquireContext;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import mockit.Mock;
+import mockit.MockUp;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -37,12 +44,14 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class ShortCircuitTest extends PlanTestBase {
 
     private static boolean OLD_VALUE;
 
     @Test
-    public void testShortcircuit() throws Exception {
+    public void testShortCircuit() throws Exception {
         connectContext.getSessionVariable().setEnableShortCircuit(true);
         connectContext.getSessionVariable().setPreferComputeNode(true);
         connectContext.getSessionVariable().setCboUseDBLock(true);
@@ -91,6 +100,36 @@ public class ShortCircuitTest extends PlanTestBase {
     }
 
     @Test
+    public void testShortCircuitForShareData() throws Exception {
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public ComputeResource acquireComputeResource(CRAcquireContext acquireContext) {
+                return WarehouseManager.DEFAULT_RESOURCE;
+            }
+        };
+
+        OLD_VALUE = FeConstants.runningUnitTest;
+        FeConstants.runningUnitTest = false;
+
+        {
+            String sql = "select /*+SET_VAR(enable_short_circuit=true)*/ pk1 || v3 from tprimary1 where pk1=20";
+            String planFragment = getFragmentPlan(sql);
+            Assertions.assertTrue(planFragment.contains("Short Circuit Scan: true"));
+        }
+
+        Config.run_mode = RunMode.SHARED_DATA.getName();
+        RunMode.detectRunMode();
+        try {
+            String sql = "select /*+SET_VAR(enable_short_circuit=true)*/ pk1 || v3 from tprimary1 where pk1=20";
+            String planFragment = getFragmentPlan(sql);
+            Assertions.assertFalse(planFragment.contains("Short Circuit Scan: true"));
+        } finally {
+            Config.run_mode = RunMode.SHARED_NOTHING.getName();
+            RunMode.detectRunMode();
+        }
+    }
+
+    @Test
     public void testShortCircuitExec() throws Exception {
         // support short circuit read
         String sql = "select * from tprimary where pk=20";
@@ -113,7 +152,32 @@ public class ShortCircuitTest extends PlanTestBase {
         coord.exec();
 
         ExecutionFragment execFragment = coord.getExecutionDAG().getRootFragment();
-        Assertions.assertEquals(true, execFragment.getPlanFragment().isShortCircuit());
+        Assertions.assertTrue(execFragment.getPlanFragment().isShortCircuit());
+    }
+
+    @Test
+    public void testNoAliveBackend() throws Exception {
+        String sql = "select * from tprimary where pk=20";
+        connectContext.setExecutionId(new TUniqueId(0x33, 0x0));
+        ExecPlan execPlan = UtFrameUtils.getPlanAndFragment(connectContext, sql).second;
+        TScanRangeLocations scanRangeLocations = gettScanRangeLocations(99999); // non-existent backend id
+
+        DescriptorTable desc = new DescriptorTable();
+        TupleDescriptor tupleDescriptor = desc.createTupleDescriptor();
+        tupleDescriptor.setTable(getTable("tprimary"));
+
+        OlapScanNode scanNode = OlapScanNode.createOlapScanNodeByLocation(execPlan.getNextNodeId(), tupleDescriptor,
+                "OlapScanNodeForShortCircuit", ImmutableList.of(scanRangeLocations),
+                WarehouseManager.DEFAULT_RESOURCE);
+        List<Long> selectPartitionIds = ImmutableList.of(1L);
+        scanNode.setSelectedPartitionIds(selectPartitionIds);
+
+        DefaultCoordinator coord = new DefaultCoordinator.Factory().createQueryScheduler(connectContext,
+                execPlan.getFragments(), ImmutableList.of(scanNode), execPlan.getDescTbl().toThrift(), execPlan);
+        assertThatThrownBy(coord::exec)
+                .isInstanceOf(NonRecoverableException.class)
+                .hasMessageContaining("No alive backend for short-circuit query. " +
+                        "Backend node not found. Check if any backend node is down.backend:");
     }
 
     @NotNull


### PR DESCRIPTION
## Why I'm doing:

```sql
select idx from __row_util where idx = 1
 Compute node not found. Check if any compute node is down. nodeId: -1 compute node
```

When `enable_short_circuit` is enabled, in share-data mode, queries that hit short-circuit execution fail with`Compute node not found. Check if any compute node is down. nodeId: -1 compute node`.

**Root cause:**
- On the BE side, share-data mode doesn’t support short-circuit execution because `lake::TabletReader` doesn’t implement the core interface `multi_get`. Only `storage::TabletReader` (for share-nothing mode) implements it.
- On the FE side, it looks up the `compute_node_id` of the tablet only from `backends` **except `compute_nodes`**. When it can’t find a match, it throws the error.

**Changes:**
1. Fall back to non-short-circuit execution in share-data mode.
2. Improve the error message so we can tell from the message that this is a short-circuit query:
   - Before: `Compute node not found. Check if any compute node is down. nodeId: -1 compute node`
   - After:  `No alive backend for short-circuit query. Compute node not found. Check if any compute node is down. nodeId: 1 compute node`

**TODO**
In the future, we need to implement `lake::TabletReader::multi_get` to enable short-circuit execution for compute–storage separation.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements fallback to non-short-circuit execution in shared-data mode and improves failure signaling when no backend is available.
> 
> - Gate `SessionVariable.isEnableShortCircuit()` by run mode: returns `false` in `RunMode.SHARED_DATA`
> - In `ShortCircuitHybridExecutor.assignTablet2Backends()`, wrap worker lookup and rethrow `NonRecoverableException` with a clear "No alive backend for short-circuit query" message
> - Tests: add shared-data fallback coverage and no-alive-backend execution error; minor test refactors/renames
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cfea6d550ead76c7aae57bd1265f6b3adfa0624. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->