### PR TITLE
[Enhancement] batch retrieve LakeTablet location info during physical planning

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -323,7 +323,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     @Override
     public void getQueryableReplicas(List<Replica> allQueryableReplicas, List<Replica> localReplicas,
                                      long visibleVersion, long localBeId, int schemaHash,
-                                     ComputeResource computeResource) {
+                                     ComputeResource computeResource, List<Long> locations) {
         throw new SemanticException("not implemented");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
@@ -79,7 +79,7 @@ public abstract class Tablet extends MetaObject implements Writable {
 
     public abstract void getQueryableReplicas(List<Replica> allQuerableReplicas, List<Replica> localReplicas,
                                               long visibleVersion, long localBeId, int schemaHash,
-                                              ComputeResource computeResource);
+                                              ComputeResource computeResource, List<Long> locations);
 
     @Override
     public String toString() {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
@@ -142,7 +142,7 @@ public class LakeTablet extends Tablet {
     public List<Replica> getAllReplicas() {
         List<Replica> replicas = Lists.newArrayList();
         getQueryableReplicas(replicas, null, 0, -1, 0,
-                WarehouseManager.DEFAULT_RESOURCE);
+                WarehouseManager.DEFAULT_RESOURCE, null);
         return replicas;
     }
 
@@ -151,15 +151,18 @@ public class LakeTablet extends Tablet {
     public void getQueryableReplicas(List<Replica> allQuerableReplicas, List<Replica> localReplicas,
                                      long visibleVersion, long localBeId, int schemaHash) {
         getQueryableReplicas(allQuerableReplicas, localReplicas, visibleVersion, localBeId,
-                schemaHash, WarehouseManager.DEFAULT_RESOURCE);
+                schemaHash, WarehouseManager.DEFAULT_RESOURCE, null);
     }
 
     @Override
     public void getQueryableReplicas(List<Replica> allQuerableReplicas, List<Replica> localReplicas,
                                      long visibleVersion, long localBeId, int schemaHash,
-                                     ComputeResource computeResource) {
-        final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-        List<Long> computeNodeIds = warehouseManager.getAllComputeNodeIdsAssignToTablet(computeResource, getId());
+                                     ComputeResource computeResource, List<Long> locations) {
+        List<Long> computeNodeIds = locations;
+        if (computeNodeIds == null) { // initial location hint is null, grab the info from warehouse manager.
+            final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            computeNodeIds = warehouseManager.getAllComputeNodeIdsAssignToTablet(computeResource, getId());
+        }
         if (computeNodeIds == null) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -59,6 +59,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -773,6 +774,21 @@ public class StarOSAgent {
         try {
             ShardInfo shardInfo = getShardInfo(shardId, workerGroupId);
             return getAllNodeIdsByShard(shardInfo);
+        } catch (StarClientException e) {
+            throw new StarRocksException(e);
+        }
+    }
+
+    public Map<Long, List<Long>> getAllNodeIdsByShards(List<Long> shardIds, long workerGroupId)
+            throws StarRocksException {
+        try {
+            List<ShardInfo> shardInfos = getShardInfo(shardIds, workerGroupId);
+            Map<Long, List<Long>> result = new HashMap<>();
+            for (ShardInfo shardInfo : shardInfos) {
+                List<Long> nodeIds = getAllNodeIdsByShard(shardInfo);
+                result.put(shardInfo.getShardId(), nodeIds);
+            }
+            return result;
         } catch (StarClientException e) {
             throw new StarRocksException(e);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
@@ -28,6 +28,7 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.statistics.CacheDictManager;
 import com.starrocks.system.ComputeNode;
@@ -49,6 +50,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -94,6 +96,24 @@ public class MetaScanNode extends AbstractOlapTableScanNode {
         Set<Long> hintTabletSet = hintsTabletIds.isEmpty() ?
                 Collections.emptySet() : new HashSet<>(hintsTabletIds);
 
+        // Batch retrieve all tablets' location info in shared-data mode
+        Map<Long, List<Long>> tabletLocationInfo = new HashMap<>();
+        if (RunMode.isSharedDataMode()) {
+            List<Long> allTabletIds = Lists.newArrayList();
+            for (PhysicalPartition partition : partitions) {
+                List<Tablet> tablets = partition.getBaseIndex().getTablets();
+                for (Tablet tablet : tablets) {
+                    allTabletIds.add(tablet.getId());
+                }
+            }
+            WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            // partial results are ok and can be handled by the fallback mechanism.
+            Map<Long, List<Long>> locations = warehouseManager.getAllComputeNodeIdsAssignToTablets(computeResource, allTabletIds);
+            if (locations != null) {
+                tabletLocationInfo = locations;
+            }
+        }
+
         for (PhysicalPartition partition : partitions) {
             MaterializedIndex index = partition.getBaseIndex();
             int schemaHash = olapTable.getSchemaHashByIndexMetaId(index.getId());
@@ -123,7 +143,7 @@ public class MetaScanNode extends AbstractOlapTableScanNode {
                 List<Replica> allQueryableReplicas = Lists.newArrayList();
                 if (RunMode.isSharedDataMode()) {
                     tablet.getQueryableReplicas(allQueryableReplicas, Collections.emptyList(),
-                            visibleVersion, -1, schemaHash, computeResource);
+                            visibleVersion, -1, schemaHash, computeResource, tabletLocationInfo.get(tabletId));
                 } else {
                     tablet.getQueryableReplicas(allQueryableReplicas, Collections.emptyList(),
                             visibleVersion, -1, schemaHash);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -121,6 +121,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -459,7 +460,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             List<Replica> localReplicas = Lists.newArrayList();
             if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
                 selectedTablet.getQueryableReplicas(allQueryableReplicas, localReplicas,
-                        expectedVersion, -1, schemaHash, computeResource);
+                        expectedVersion, -1, schemaHash, computeResource, null);
             } else {
                 selectedTablet.getQueryableReplicas(allQueryableReplicas, localReplicas,
                         expectedVersion, -1, schemaHash);
@@ -561,6 +562,18 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
 
         checkSomeAliveComputeNode();
         boolean checkScanRangeSize = false;
+
+        // Batch retrieve all tablets' location info in shared-data mode
+        Map<Long, List<Long>> tabletLocationInfo = new HashMap<>();
+        if (RunMode.isSharedDataMode()) {
+            List<Long> tabletIds = tablets.stream().map(Tablet::getId).toList();
+            WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+            // partial results are ok and can be handled by the fallback mechanism.
+            Map<Long, List<Long>> locations = warehouseManager.getAllComputeNodeIdsAssignToTablets(computeResource, tabletIds);
+            if (locations != null) {
+                tabletLocationInfo = locations;
+            }
+        }
         for (Tablet tablet : tablets) {
             long tabletId = tablet.getId();
             LOG.debug("{} tabletId={}", (logNum++), tabletId);
@@ -589,9 +602,9 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             // random shuffle List && only collect one copy
             List<Replica> allQueryableReplicas = Lists.newArrayList();
             List<Replica> localReplicas = Lists.newArrayList();
-            if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+            if (RunMode.isSharedDataMode()) {
                 tablet.getQueryableReplicas(allQueryableReplicas, localReplicas,
-                        visibleVersion, localBeId, schemaHash, computeResource);
+                        visibleVersion, localBeId, schemaHash, computeResource, tabletLocationInfo.get(tabletId));
             } else {
                 tablet.getQueryableReplicas(allQueryableReplicas, localReplicas,
                         visibleVersion, localBeId, schemaHash);

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -341,6 +341,22 @@ public class WarehouseManager implements Writable {
         }
     }
 
+    public Map<Long, List<Long>> getAllComputeNodeIdsAssignToTablets(ComputeResource computeResource,
+                                                                    List<Long> tabletIds) {
+        // check warehouse exists
+        if (!warehouseExists(computeResource.getWarehouseId())) {
+            throw ErrorReportException.report(ErrorCode.ERR_UNKNOWN_WAREHOUSE,
+                    String.format("id: %d", computeResource.getWarehouseId()));
+        }
+        try {
+            return GlobalStateMgr.getCurrentState().getStarOSAgent()
+                    .getAllNodeIdsByShards(tabletIds, computeResource.getWorkerGroupId());
+        } catch (StarRocksException e) {
+            LOG.warn("get all compute node ids assign to tablets {} fail {}.", tabletIds, e.getMessage());
+            return null;
+        }
+    }
+
     public List<Long> getAllComputeNodeIdsAssignToTablet(ComputeResource computeResource, long tabletId) {
         // check warehouse exists
         if (!warehouseExists(computeResource.getWarehouseId())) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/ScanNodeComputeScanRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ScanNodeComputeScanRangeTest.java
@@ -1,0 +1,127 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.collect.Maps;
+import com.staros.client.StarClient;
+import com.staros.client.StarClientException;
+import com.staros.proto.ShardInfo;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ScanNodeComputeScanRangeTest {
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster(true, RunMode.SHARED_DATA);
+        // There are two available backends, (10001, 10002)
+        UtFrameUtils.addMockBackend(10002);
+        SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        Assertions.assertEquals(2L, systemInfoService.getAvailableBackends().size());
+
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE test.t1(k1 int, k2 int, k3 int)" +
+                        " distributed by hash(k1) buckets 10 properties('replication_num' = '1');");
+    }
+
+    @Test
+    public void testOlapScanNodeRetrieveTabletLocationPerPhysicalPartition() {
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("test", "t1");
+        Assertions.assertNotNull(table);
+        Assertions.assertInstanceOf(OlapTable.class, table);
+        desc.setTable(table);
+        OlapTable olapTable = (OlapTable) table;
+        OlapScanNode scanNode =
+                new OlapScanNode(new PlanNodeId(1), desc, "OlapScanNode", olapTable.getBaseIndexMetaId());
+        Assertions.assertEquals(1L, olapTable.getAllPartitionIds().size());
+        long partitionId = olapTable.getAllPartitionIds().get(0);
+        Partition partition = olapTable.getPartition(partitionId);
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        MaterializedIndex selectedIndex = physicalPartition.getIndex(olapTable.getBaseIndexMetaId());
+        AtomicInteger invokeCounter = new AtomicInteger(0);
+
+        new MockUp<StarClient>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(Invocation invocation, String serviceId, List<Long> shardIds,
+                                                long workerGroupId) throws
+                    StarClientException {
+                invokeCounter.incrementAndGet();
+                return invocation.proceed(serviceId, shardIds, workerGroupId);
+            }
+        };
+
+        Assertions.assertDoesNotThrow(() -> scanNode.addScanRangeLocations(partition, physicalPartition, selectedIndex,
+                selectedIndex.getTablets(), -1));
+        Assertions.assertEquals(1, invokeCounter.get());
+    }
+
+    @Test
+    public void testMetaScanNodeRetrieveTabletLocationPerPhysicalPartition() {
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("test", "t1");
+        Assertions.assertNotNull(table);
+        Assertions.assertInstanceOf(OlapTable.class, table);
+        desc.setTable(table);
+        OlapTable olapTable = (OlapTable) table;
+        MetaScanNode metaScanNode = new MetaScanNode(new PlanNodeId(1), desc, olapTable, Maps.newHashMap(), List.of(),
+                null, olapTable.getBaseIndexMetaId(), null);
+        Assertions.assertEquals(1L, olapTable.getAllPartitionIds().size());
+        AtomicInteger invokeCounter = new AtomicInteger(0);
+
+        new MockUp<StarClient>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(Invocation invocation, String serviceId, List<Long> shardIds,
+                                                long workerGroupId) throws
+                    StarClientException {
+                invokeCounter.incrementAndGet();
+                return invocation.proceed(serviceId, shardIds, workerGroupId);
+            }
+        };
+
+        ComputeResource computeResource =
+                GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource();
+        Assertions.assertDoesNotThrow(() -> metaScanNode.computeRangeLocations(computeResource));
+        Assertions.assertEquals(1, invokeCounter.get());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -571,6 +571,15 @@ public class WarehouseManagerTest {
         Assertions.assertTrue(aliveWarehouseIds.contains(3L));
     }
 
+    @Test
+    public void testWarehouseMgrAetAllComputeNodeIdsAssignToTabletsExcepted() {
+        WarehouseManager warehouseManager = new WarehouseManager();
+        ComputeResource computeResource = WarehouseComputeResource.of(10086L);
+        ErrorReportException exception = Assertions.assertThrows(ErrorReportException.class, () ->
+                warehouseManager.getAllComputeNodeIdsAssignToTablets(computeResource, Lists.newArrayList()));
+        Assertions.assertEquals(ErrorCode.ERR_UNKNOWN_WAREHOUSE, exception.getErrorCode());
+    }
+
     private static class MockedWarehouse extends DefaultWarehouse {
         private final boolean isAvailable;
 


### PR DESCRIPTION
* Batch retrieve tablet location info from StarOSAgent during physical planning in OlapScanNode/MetaScanNode to reduce RPC overhead in shared-data mode.
* Previously, location info was retrieved one by one for each tablet, which could be slow for queries involving many tablets. This change introduces `getAllComputeNodeIdsAssignToTablets` in `WarehouseManager` and `StarOSAgent` to fetch locations in batch. Also updated `Tablet` interface and `LakeTablet` implementation to support passing pre-fetched location info.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves planning efficiency in shared-data mode by batching tablet location lookups and passing location hints into replica selection.
> 
> - Add `StarOSAgent#getAllNodeIdsByShards` and `WarehouseManager#getAllComputeNodeIdsAssignToTablets` for batched location retrieval
> - Extend `Tablet#getQueryableReplicas(..., ComputeResource, List<Long> locations)`; `LakeTablet` consumes optional pre-fetched locations with fallback; `LocalTablet` stub updated
> - `OlapScanNode` and `MetaScanNode` prefetch tablet locations (per partition/all) and pass hints to `getQueryableReplicas`
> - Minor `RunMode.isSharedDataMode()` usages updated; non-batched paths unchanged
> - Tests: `ScanNodeComputeScanRangeTest` verifies single StarOS call; `WarehouseManagerTest` validates error on unknown warehouse
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d66202ad1475bb2e2eb9d392f4eae35ee98eea2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->