### PR TITLE
[BugFix] Fix shard deletion logic in StarMgrMetaSyncer

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -187,20 +187,26 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
             try {
                 DeleteTabletResponse response = future.get();
                 Set<Long> shards = shardIdsByBeMap.get(entry.getKey());
-                if (response != null && response.failedTablets != null && !response.failedTablets.isEmpty()) {
-                    String errorMsg = "";
-                    if (response.status != null && response.status.errorMsgs != null &&
-                            !response.status.errorMsgs.isEmpty()) {
-                        errorMsg = response.status.errorMsgs.get(0);
-                    }
-                    TStatusCode stCode = TStatusCode.findByValue(response.status.statusCode);
-                    LOG.info("Fail to delete tablet from node: {}. StatusCode: {}, Error: {}, failedTablets: {}",
-                            nodeId, stCode, errorMsg, response.failedTablets);
+                if (response != null) {
+                    if (response.failedTablets != null && !response.failedTablets.isEmpty()) {
+                        // preserve failedTablets and log error
+                        String errorMsg = "";
+                        TStatusCode stCode = TStatusCode.UNKNOWN;
+                        if (response.status != null && response.status.errorMsgs != null &&
+                                !response.status.errorMsgs.isEmpty()) {
+                            errorMsg = response.status.errorMsgs.get(0);
+                        }
+                        if (response.status != null) {
+                            stCode = TStatusCode.findByValue(response.status.statusCode);
+                        }
+                        LOG.info("Fail to delete tablet from node: {}. StatusCode: {}, Error: {}, failedTablets: {}",
+                                nodeId, stCode, errorMsg, response.failedTablets);
 
-                    // ignore INVALID_ARGUMENT error, treat it as success
-                    if (stCode != TStatusCode.INVALID_ARGUMENT) {
-                        // preserve the shards that failed to delete, don't delete them from starMgr
-                        response.failedTablets.forEach(shards::remove);
+                        // ignore INVALID_ARGUMENT error, treat it as success
+                        if (stCode != TStatusCode.INVALID_ARGUMENT) {
+                            // preserve the shards that failed to delete, don't delete them from starMgr
+                            response.failedTablets.forEach(shards::remove);
+                        }
                     }
                     shardToDelete.addAll(shards);
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -43,6 +43,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.concurrent.lock.LockManager;
 import com.starrocks.lake.snapshot.ClusterSnapshotJob;
@@ -1551,6 +1552,109 @@ public class StarMgrMetaSyncerTest {
         // Assertions.assertEquals(expectedCleanedGroupIds.size(), cleanedGroupIds.size());
         // only groups in expectedCleanedGroupIds should be cleaned
         Assertions.assertEquals(expectedCleanedGroupIds, cleanedGroupIds);
+    }
+
+    @Test
+    public void testDropTabletAndDeleteShardPartialFailedTablets() throws StarRocksException {
+        ComputeResource computeResource = GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource();
+        List<Long> failedIds = Lists.newArrayList(1001L, 1003L);
+        List<Long> successIds = Lists.newArrayList(1000L, 1002L);
+        List<Long> allShardIds = new ArrayList<>(failedIds);
+        allShardIds.addAll(successIds);
+        long computeNodeId = 10001L;
+        ComputeNode computeNode = new ComputeNode(computeNodeId, "127.0.0.1", 9060);
+
+        new MockUp<BrpcProxy>() {
+            @Mock
+            public LakeService getLakeService(String host, int port) throws RpcException {
+                return new PseudoBackend.PseudoLakeService();
+            }
+        };
+
+        new MockUp<PseudoBackend.PseudoLakeService>() {
+            @Mock
+            Future<DeleteTabletResponse> deleteTablet(DeleteTabletRequest request) {
+                DeleteTabletResponse resp = new DeleteTabletResponse();
+                resp.status = new StatusPB();
+                resp.status.statusCode = TStatusCode.INTERNAL_ERROR.getValue();
+                resp.failedTablets = failedIds;
+                return CompletableFuture.completedFuture(resp);
+            }
+        };
+
+        new Expectations(starOSAgent) {
+            {
+                starOSAgent.getPrimaryComputeNodeIdByShard(anyLong, anyLong);
+                result = computeNodeId;
+
+                systemInfoService.getBackendOrComputeNode(computeNodeId);
+                result = computeNode;
+            }
+        };
+
+        Set<Long> deletedShardIds = new HashSet<>();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void deleteShards(Set<Long> shardIds) throws DdlException {
+                deletedShardIds.addAll(shardIds);
+            }
+        };
+
+        Assertions.assertTrue(deletedShardIds.isEmpty());
+        StarMgrMetaSyncer.dropTabletAndDeleteShard(computeResource, allShardIds, starOSAgent, false);
+        Assertions.assertEquals(successIds.size(), deletedShardIds.size());
+        Set<Long> expectedShardIds = new HashSet<>(successIds);
+        Assertions.assertEquals(expectedShardIds, deletedShardIds);
+    }
+
+    @Test
+    public void testDropTabletAndDeleteShardNoFailedTablets() throws StarRocksException {
+        ComputeResource computeResource = GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource();
+        List<Long> shardIds = Stream.of(1000L, 1001L, 1002L, 1003L).collect(Collectors.toList());
+        long computeNodeId = 10001L;
+        ComputeNode computeNode = new ComputeNode(computeNodeId, "127.0.0.1", 9060);
+
+        new MockUp<BrpcProxy>() {
+            @Mock
+            public LakeService getLakeService(String host, int port) throws RpcException {
+                return new PseudoBackend.PseudoLakeService();
+            }
+        };
+
+        new MockUp<PseudoBackend.PseudoLakeService>() {
+            @Mock
+            Future<DeleteTabletResponse> deleteTablet(DeleteTabletRequest request) {
+                DeleteTabletResponse resp = new DeleteTabletResponse();
+                resp.status = new StatusPB();
+                resp.status.statusCode = TStatusCode.OK.getValue();
+                resp.failedTablets = Lists.newArrayList();
+                return CompletableFuture.completedFuture(resp);
+            }
+        };
+
+        new Expectations(starOSAgent) {
+            {
+                starOSAgent.getPrimaryComputeNodeIdByShard(anyLong, anyLong);
+                result = computeNodeId;
+
+                systemInfoService.getBackendOrComputeNode(computeNodeId);
+                result = computeNode;
+            }
+        };
+
+        Set<Long> deletedShardIds = new HashSet<>();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void deleteShards(Set<Long> shardIds) throws DdlException {
+                deletedShardIds.addAll(shardIds);
+            }
+        };
+
+        Assertions.assertTrue(deletedShardIds.isEmpty());
+        StarMgrMetaSyncer.dropTabletAndDeleteShard(computeResource, shardIds, starOSAgent, false);
+        Assertions.assertEquals(shardIds.size(), deletedShardIds.size());
+        Set<Long> expectedShardIds = new HashSet<>(shardIds);
+        Assertions.assertEquals(expectedShardIds, deletedShardIds);
     }
 
     @Test


### PR DESCRIPTION
* Previously, the logic in `dropTabletAndDeleteShard` only added shards to the deletion list if there were failed tablets in the response. This meant that if all tablets were successfully deleted (empty `failedTablets`), the shards were not added to the list and thus not deleted from StarMgr.
* This change fixes the logic to ensure shards are added to the deletion list when the response is successful, while still excluding any failed tablets.

## Why I'm doing:

## What I'm doing:

Introduced in #60518

Fixes #issue

## Severity

**HIGH**

Affected Versions:
* v3.5.2+
* v4.0.0+

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `dropTabletAndDeleteShard` to reliably delete shards when tablet deletion responses are successful or non-failing:
> 
> - Handle `null` response/status safely; default `TStatusCode` to `UNKNOWN` and improve error logging
> - Preserve `failedTablets` unless status is `INVALID_ARGUMENT`; add remaining shards to `shardToDelete`
> - Add unit tests: `testDropTabletAndDeleteShardPartialFailedTablets` and `testDropTabletAndDeleteShardNoFailedTablets` verifying partial failure and full success paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29c04fb9b38f100497541a036eae31975f8fecff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->