### PR TITLE
[Feature] Support casting complex types (Array, Map, Struct) to JSON

### DIFF
--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -35,11 +35,16 @@
 #include "base/types/int128.h"
 #include "base/types/numeric_types.h"
 #include "base/utility/mysql_global.h"
+#include "column/array_column.h"
 #include "column/column_builder.h"
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
 #include "column/json_converter.h"
+#include "column/column_visitor_adapter.h"
+#include "column/json_column.h"
+#include "column/map_column.h"
 #include "column/nullable_column.h"
+#include "column/struct_column.h"
 #include "column/type_traits.h"
 #include "column/variant_column.h"
 #include "column/variant_converter.h"
@@ -226,6 +231,8 @@ static ColumnPtr cast_to_json_fn(ColumnPtr& column) {
                     }
                 }
             }
+        } else if constexpr (FromType == TYPE_ARRAY || FromType == TYPE_MAP || FromType == TYPE_STRUCT) {
+            overflow = true;
         } else {
             if constexpr (AllowThrowException) {
                 THROW_RUNTIME_ERROR_WITH_TYPE(FromType);
@@ -236,6 +243,8 @@ static ColumnPtr cast_to_json_fn(ColumnPtr& column) {
             if constexpr (AllowThrowException) {
                 if constexpr (FromType == TYPE_LARGEINT) {
                     THROW_RUNTIME_ERROR_WITH_TYPES_AND_VALUE(FromType, ToType, int128_to_string(viewer.value(row)));
+                } else if constexpr (FromType == TYPE_ARRAY || FromType == TYPE_MAP || FromType == TYPE_STRUCT) {
+                    THROW_RUNTIME_ERROR_WITH_TYPE(FromType);
                 } else {
                     THROW_RUNTIME_ERROR_WITH_TYPES_AND_VALUE(FromType, ToType, viewer.value(row));
                 }
@@ -1175,6 +1184,280 @@ static ColumnPtr cast_from_string_to_time_fn(ColumnPtr& column) {
 }
 CUSTOMIZE_FN_CAST(TYPE_VARCHAR, TYPE_TIME, cast_from_string_to_time_fn);
 
+// =========================================================================
+// Helper functions for Complex Types to JSON Conversion (Column-wise approach)
+// =========================================================================
+
+static Status column_to_json_array(const Column* column, const TypeDescriptor& type, size_t row, vpack::Builder* builder);
+static Status column_to_json_value(const Column* column, const TypeDescriptor& type, size_t row, vpack::Builder* builder);
+
+static Status column_key_to_string(const Column* column, const TypeDescriptor& type, size_t row, std::string* out) {
+    if (column->is_null(row)) {
+        *out = "null";
+        return Status::OK();
+    }
+    switch (type.type) {
+    case TYPE_BOOLEAN: {
+        auto* col = down_cast<const BooleanColumn*>(ColumnHelper::get_data_column(column));
+        *out = col->get_data()[row] ? "true" : "false";
+        break;
+    }
+    case TYPE_TINYINT: {
+        auto* col = down_cast<const Int8Column*>(ColumnHelper::get_data_column(column));
+        *out = std::to_string(static_cast<int16_t>(col->get_data()[row]));
+        break;
+    }
+    case TYPE_SMALLINT: {
+        auto* col = down_cast<const Int16Column*>(ColumnHelper::get_data_column(column));
+        *out = std::to_string(col->get_data()[row]);
+        break;
+    }
+    case TYPE_INT: {
+        auto* col = down_cast<const Int32Column*>(ColumnHelper::get_data_column(column));
+        *out = std::to_string(col->get_data()[row]);
+        break;
+    }
+    case TYPE_BIGINT: {
+        auto* col = down_cast<const Int64Column*>(ColumnHelper::get_data_column(column));
+        *out = std::to_string(col->get_data()[row]);
+        break;
+    }
+    case TYPE_LARGEINT: {
+        auto* col = down_cast<const Int128Column*>(ColumnHelper::get_data_column(column));
+        *out = LargeIntValue::to_string(col->get_data()[row]);
+        break;
+    }
+    case TYPE_FLOAT: {
+        auto* col = down_cast<const FloatColumn*>(ColumnHelper::get_data_column(column));
+        *out = std::to_string(col->get_data()[row]);
+        break;
+    }
+    case TYPE_DOUBLE: {
+        auto* col = down_cast<const DoubleColumn*>(ColumnHelper::get_data_column(column));
+        *out = std::to_string(col->get_data()[row]);
+        break;
+    }
+    case TYPE_DECIMALV2: {
+        auto* col = down_cast<const DecimalColumn*>(ColumnHelper::get_data_column(column));
+        *out = col->get_data()[row].to_string();
+        break;
+    }
+    case TYPE_DECIMAL32: {
+        auto* col = down_cast<const Decimal32Column*>(ColumnHelper::get_data_column(column));
+        *out = DecimalV3Cast::to_string<int32_t>(col->get_data()[row], type.precision, type.scale);
+        break;
+    }
+    case TYPE_DECIMAL64: {
+        auto* col = down_cast<const Decimal64Column*>(ColumnHelper::get_data_column(column));
+        *out = DecimalV3Cast::to_string<int64_t>(col->get_data()[row], type.precision, type.scale);
+        break;
+    }
+    case TYPE_DECIMAL128: {
+        auto* col = down_cast<const Decimal128Column*>(ColumnHelper::get_data_column(column));
+        *out = DecimalV3Cast::to_string<int128_t>(col->get_data()[row], type.precision, type.scale);
+        break;
+    }
+    case TYPE_DATE: {
+        auto* col = down_cast<const DateColumn*>(ColumnHelper::get_data_column(column));
+        *out = col->get_data()[row].to_string();
+        break;
+    }
+    case TYPE_DATETIME: {
+        auto* col = down_cast<const TimestampColumn*>(ColumnHelper::get_data_column(column));
+        *out = col->get_data()[row].to_string();
+        break;
+    }
+    case TYPE_TIME: {
+        auto* col = down_cast<const DoubleColumn*>(ColumnHelper::get_data_column(column));
+        *out = starrocks::time_str_from_double(col->get_data()[row]);
+        break;
+    }
+    case TYPE_VARCHAR:
+    case TYPE_CHAR: {
+        auto* col = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(column));
+        auto slice = col->get_slice(row);
+        *out = std::string(slice.data, slice.size);
+        break;
+    }
+    default:
+        return Status::NotSupported(strings::Substitute("Unsupported Map Key Type: $0", type.debug_string()));
+    }
+    return Status::OK();
+}
+
+static Status column_to_json_value(const Column* column, const TypeDescriptor& type, size_t row, vpack::Builder* builder) {
+    if (column->is_null(row)) {
+        builder->add(vpack::Value(vpack::ValueType::Null));
+        return Status::OK();
+    }
+    switch (type.type) {
+    case TYPE_BOOLEAN: {
+        auto* col = down_cast<const BooleanColumn*>(ColumnHelper::get_data_column(column));
+        builder->add(vpack::Value(col->get_data()[row] != 0));
+        break;
+    }
+    case TYPE_TINYINT: {
+        auto* col = down_cast<const Int8Column*>(ColumnHelper::get_data_column(column));
+        builder->add(vpack::Value(static_cast<int64_t>(col->get_data()[row])));
+        break;
+    }
+    case TYPE_SMALLINT: {
+        auto* col = down_cast<const Int16Column*>(ColumnHelper::get_data_column(column));
+        builder->add(vpack::Value(static_cast<int64_t>(col->get_data()[row])));
+        break;
+    }
+    case TYPE_INT: {
+        auto* col = down_cast<const Int32Column*>(ColumnHelper::get_data_column(column));
+        builder->add(vpack::Value(static_cast<int64_t>(col->get_data()[row])));
+        break;
+    }
+    case TYPE_BIGINT: {
+        auto* col = down_cast<const Int64Column*>(ColumnHelper::get_data_column(column));
+        builder->add(vpack::Value(col->get_data()[row]));
+        break;
+    }
+    case TYPE_LARGEINT: {
+        auto* col = down_cast<const Int128Column*>(ColumnHelper::get_data_column(column));
+        std::string s = LargeIntValue::to_string(col->get_data()[row]);
+        builder->add(vpack::Value(s));
+        break;
+    }
+    case TYPE_FLOAT: {
+        auto* col = down_cast<const FloatColumn*>(ColumnHelper::get_data_column(column));
+        builder->add(vpack::Value(col->get_data()[row]));
+        break;
+    }
+    case TYPE_DOUBLE: {
+        auto* col = down_cast<const DoubleColumn*>(ColumnHelper::get_data_column(column));
+        builder->add(vpack::Value(col->get_data()[row]));
+        break;
+    }
+    case TYPE_DECIMALV2: {
+        auto* col = down_cast<const DecimalColumn*>(ColumnHelper::get_data_column(column));
+        builder->add(vpack::Value(col->get_data()[row].to_string()));
+        break;
+    }
+    case TYPE_DECIMAL32: {
+        auto* col = down_cast<const Decimal32Column*>(ColumnHelper::get_data_column(column));
+        std::string s = DecimalV3Cast::to_string<int32_t>(col->get_data()[row], type.precision, type.scale);
+        builder->add(vpack::Value(s));
+        break;
+    }
+    case TYPE_DECIMAL64: {
+        auto* col = down_cast<const Decimal64Column*>(ColumnHelper::get_data_column(column));
+        std::string s = DecimalV3Cast::to_string<int64_t>(col->get_data()[row], type.precision, type.scale);
+        builder->add(vpack::Value(s));
+        break;
+    }
+    case TYPE_DECIMAL128: {
+        auto* col = down_cast<const Decimal128Column*>(ColumnHelper::get_data_column(column));
+        std::string s = DecimalV3Cast::to_string<int128_t>(col->get_data()[row], type.precision, type.scale);
+        builder->add(vpack::Value(s));
+        break;
+    }
+    case TYPE_DATE: {
+        auto* col = down_cast<const DateColumn*>(ColumnHelper::get_data_column(column));
+        builder->add(vpack::Value(col->get_data()[row].to_string()));
+        break;
+    }
+    case TYPE_DATETIME: {
+        auto* col = down_cast<const TimestampColumn*>(ColumnHelper::get_data_column(column));
+        builder->add(vpack::Value(col->get_data()[row].to_string()));
+        break;
+    }
+    case TYPE_TIME: {
+        auto* col = down_cast<const DoubleColumn*>(ColumnHelper::get_data_column(column));
+        builder->add(vpack::Value(starrocks::time_str_from_double(col->get_data()[row])));
+        break;
+    }
+    case TYPE_VARCHAR:
+    case TYPE_CHAR:
+    case TYPE_HLL:
+    case TYPE_OBJECT: {
+        auto* col = down_cast<const BinaryColumn*>(ColumnHelper::get_data_column(column));
+        auto slice = col->get_slice(row);
+        builder->add(vpack::Value(std::string(slice.data, slice.size)));
+        break;
+    }
+    case TYPE_JSON: {
+        auto* col = down_cast<const JsonColumn*>(ColumnHelper::get_data_column(column));
+        const JsonValue* json = col->get_object(row);
+        if (json) {
+            builder->add(json->to_vslice());
+        } else {
+            builder->add(vpack::Value(vpack::ValueType::Null));
+        }
+        break;
+    }
+    case TYPE_VARIANT: {
+        return Status::NotSupported("Casting nested VARIANT to JSON is not fully implemented yet");
+    }
+    case TYPE_ARRAY: {
+        return column_to_json_array(column, type, row, builder);
+    }
+    case TYPE_MAP: {
+        auto* map_col = down_cast<const MapColumn*>(ColumnHelper::get_data_column(column));
+        const auto& offsets = map_col->offsets().get_data();
+        const auto* keys = map_col->keys().get();
+        const auto* values = map_col->values().get();
+        const auto& key_type = type.children[0];
+        const auto& value_type = type.children[1];
+
+        builder->openObject();
+        size_t start = offsets[row];
+        size_t end = offsets[row + 1];
+
+        for (size_t i = start; i < end; ++i) {
+            std::string key_str;
+            RETURN_IF_ERROR(column_key_to_string(keys, key_type, i, &key_str));
+            builder->add(vpack::Value(key_str));
+            RETURN_IF_ERROR(column_to_json_value(values, value_type, i, builder));
+        }
+        builder->close();
+        break;
+    }
+    case TYPE_STRUCT: {
+        auto* struct_col = down_cast<const StructColumn*>(ColumnHelper::get_data_column(column));
+        const auto& fields = struct_col->fields();
+
+        builder->openObject();
+        for (size_t i = 0; i < fields.size(); ++i) {
+            std::string field_name = (i < type.field_names.size())
+                ? type.field_names[i]
+                : "col" + std::to_string(i + 1);
+            builder->add(vpack::Value(field_name));
+
+            const auto& field_type = (i < type.children.size())
+                ? type.children[i]
+                : TypeDescriptor(TYPE_NULL);
+            RETURN_IF_ERROR(column_to_json_value(fields[i].get(), field_type, row, builder));
+        }
+        builder->close();
+        break;
+    }
+    default:
+        return Status::NotSupported(strings::Substitute("Type $0 not supported for JSON cast", type.debug_string()));
+    }
+    return Status::OK();
+}
+
+static Status column_to_json_array(const Column* column, const TypeDescriptor& type, size_t row, vpack::Builder* builder) {
+    auto* array_col = down_cast<const ArrayColumn*>(ColumnHelper::get_data_column(column));
+    const auto& offsets = array_col->offsets().get_data();
+    const auto* elements = array_col->elements().get();
+    const auto& child_type = type.children[0];
+
+    builder->openArray();
+    size_t start = offsets[row];
+    size_t end = offsets[row + 1];
+
+    for (size_t i = start; i < end; ++i) {
+        RETURN_IF_ERROR(column_to_json_value(elements, child_type, i, builder));
+    }
+    builder->close();
+    return Status::OK();
+}
+
 // clang-format off
 #define DEFINE_CAST_CONSTRUCT(CLASS)             \
     CLASS(const TExprNode& node) : Expr(node) {} \
@@ -1206,7 +1489,30 @@ public:
         // For json type, it could not be converted from decimal directly, as a workaround we convert decimal
         // to double at first, then convert double to JSON
         if constexpr (FromType == TYPE_JSON || ToType == TYPE_JSON) {
-            if constexpr (lt_is_decimal<FromType>) {
+            if constexpr (FromType == TYPE_ARRAY || FromType == TYPE_MAP || FromType == TYPE_STRUCT) {
+                if constexpr (ToType == TYPE_JSON) {
+                    ColumnBuilder<TYPE_JSON> json_builder(col_size);
+                    for (size_t i = 0; i < col_size; ++i) {
+                        if (column->is_null(i)) {
+                            json_builder.append_null();
+                        } else {
+                            vpack::Builder vb;
+                            Status st = column_to_json_value(column.get(), this->_children[0]->type(), i, &vb);
+                            if (!st.ok()) {
+                                if constexpr (AllowThrowException) {
+                                    throw RuntimeException(st.to_string());
+                                }
+                                json_builder.append_null();
+                            } else {
+                                json_builder.append(JsonValue(vb.slice()));
+                            }
+                        }
+                    }
+                    return json_builder.build(column->is_constant());
+                } else {
+                    result_column = CastFn<FromType, ToType, AllowThrowException>::cast_fn(std::move(column));
+                }
+            } else if constexpr (lt_is_decimal<FromType>) {
                 ColumnPtr double_column;
                 if (context != nullptr && context->error_if_overflow()) {
                     double_column = VectorizedUnaryFunction<DecimalTo<OverflowMode::REPORT_ERROR>>::evaluate<
@@ -1470,6 +1776,9 @@ CUSTOMIZE_FN_CAST(TYPE_TIME, TYPE_JSON, cast_to_json_fn);
 CUSTOMIZE_FN_CAST(TYPE_DATETIME, TYPE_JSON, cast_to_json_fn);
 CUSTOMIZE_FN_CAST(TYPE_DATE, TYPE_JSON, cast_to_json_fn);
 CUSTOMIZE_FN_CAST(TYPE_VARIANT, TYPE_JSON, cast_to_json_fn);
+CUSTOMIZE_FN_CAST(TYPE_ARRAY, TYPE_JSON, cast_to_json_fn);
+CUSTOMIZE_FN_CAST(TYPE_MAP, TYPE_JSON, cast_to_json_fn);
+CUSTOMIZE_FN_CAST(TYPE_STRUCT, TYPE_JSON, cast_to_json_fn);
 
 // Cast SQL type to VARIANT
 SELF_CAST(TYPE_VARIANT);
@@ -2080,6 +2389,9 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
                 CASE_TO_JSON(TYPE_DATE, allow_throw_exception);
                 CASE_TO_JSON(TYPE_TIME, allow_throw_exception);
                 CASE_TO_JSON(TYPE_DATETIME, allow_throw_exception);
+                CASE_TO_JSON(TYPE_ARRAY, allow_throw_exception);
+                CASE_TO_JSON(TYPE_MAP, allow_throw_exception);
+                CASE_TO_JSON(TYPE_STRUCT, allow_throw_exception);
             default:
                 LOG(WARNING) << "Not support cast " << type_to_string(from_type) << " to " << type_to_string(to_type);
                 return nullptr;

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -39,9 +39,9 @@
 #include "column/column_builder.h"
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
-#include "column/json_converter.h"
 #include "column/column_visitor_adapter.h"
 #include "column/json_column.h"
+#include "column/json_converter.h"
 #include "column/map_column.h"
 #include "column/nullable_column.h"
 #include "column/struct_column.h"
@@ -1188,8 +1188,10 @@ CUSTOMIZE_FN_CAST(TYPE_VARCHAR, TYPE_TIME, cast_from_string_to_time_fn);
 // Helper functions for Complex Types to JSON Conversion (Column-wise approach)
 // =========================================================================
 
-static Status column_to_json_array(const Column* column, const TypeDescriptor& type, size_t row, vpack::Builder* builder);
-static Status column_to_json_value(const Column* column, const TypeDescriptor& type, size_t row, vpack::Builder* builder);
+static Status column_to_json_array(const Column* column, const TypeDescriptor& type, size_t row,
+                                   vpack::Builder* builder);
+static Status column_to_json_value(const Column* column, const TypeDescriptor& type, size_t row,
+                                   vpack::Builder* builder);
 
 static Status column_key_to_string(const Column* column, const TypeDescriptor& type, size_t row, std::string* out) {
     if (column->is_null(row)) {
@@ -1285,7 +1287,8 @@ static Status column_key_to_string(const Column* column, const TypeDescriptor& t
     return Status::OK();
 }
 
-static Status column_to_json_value(const Column* column, const TypeDescriptor& type, size_t row, vpack::Builder* builder) {
+static Status column_to_json_value(const Column* column, const TypeDescriptor& type, size_t row,
+                                   vpack::Builder* builder) {
     if (column->is_null(row)) {
         builder->add(vpack::Value(vpack::ValueType::Null));
         return Status::OK();
@@ -1422,14 +1425,11 @@ static Status column_to_json_value(const Column* column, const TypeDescriptor& t
 
         builder->openObject();
         for (size_t i = 0; i < fields.size(); ++i) {
-            std::string field_name = (i < type.field_names.size())
-                ? type.field_names[i]
-                : "col" + std::to_string(i + 1);
+            std::string field_name =
+                    (i < type.field_names.size()) ? type.field_names[i] : "col" + std::to_string(i + 1);
             builder->add(vpack::Value(field_name));
 
-            const auto& field_type = (i < type.children.size())
-                ? type.children[i]
-                : TypeDescriptor(TYPE_NULL);
+            const auto& field_type = (i < type.children.size()) ? type.children[i] : TypeDescriptor(TYPE_NULL);
             RETURN_IF_ERROR(column_to_json_value(fields[i].get(), field_type, row, builder));
         }
         builder->close();
@@ -1441,7 +1441,8 @@ static Status column_to_json_value(const Column* column, const TypeDescriptor& t
     return Status::OK();
 }
 
-static Status column_to_json_array(const Column* column, const TypeDescriptor& type, size_t row, vpack::Builder* builder) {
+static Status column_to_json_array(const Column* column, const TypeDescriptor& type, size_t row,
+                                   vpack::Builder* builder) {
     auto* array_col = down_cast<const ArrayColumn*>(ColumnHelper::get_data_column(column));
     const auto& offsets = array_col->offsets().get_data();
     const auto* elements = array_col->elements().get();
@@ -2539,9 +2540,8 @@ StatusOr<Expr*> VectorizedCastExprFactory::create_cast_expr(ObjectPool* pool, co
             std::vector<int> source_field_indices(to_type.children.size());
             for (int i = 0; i < (int)to_type.children.size(); ++i) {
                 source_field_indices[i] = i;
-                ASSIGN_OR_RETURN(field_casts[i],
-                                 create_cast_expr(pool, from_type.children[i], to_type.children[i],
-                                                  allow_throw_exception));
+                ASSIGN_OR_RETURN(field_casts[i], create_cast_expr(pool, from_type.children[i], to_type.children[i],
+                                                                  allow_throw_exception));
                 pool->add(field_casts[i]);
                 auto cast_input = create_slot_ref(from_type.children[i]);
                 field_casts[i]->add_child(cast_input.get());

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -2718,17 +2718,16 @@ TEST_F(VectorizedCastExprTest, json_to_map) {
 TEST_F(VectorizedCastExprTest, struct_to_struct_field_reorder) {
     // Create source struct type: STRUCT<price INT, product_id VARCHAR>
     TypeDescriptor from_type = TypeDescriptor::create_struct_type(
-            {"price", "product_id"},
-            {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_VARCHAR)});
+            {"price", "product_id"}, {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_VARCHAR)});
 
     // Create target struct type: STRUCT<product_id VARCHAR, price INT>
     // Note: same field names but different order
     TypeDescriptor to_type = TypeDescriptor::create_struct_type(
-            {"product_id", "price"},
-            {TypeDescriptor(TYPE_VARCHAR), TypeDescriptor(TYPE_INT)});
+            {"product_id", "price"}, {TypeDescriptor(TYPE_VARCHAR), TypeDescriptor(TYPE_INT)});
 
     ObjectPool pool;
-    auto expr_result = VectorizedCastExprFactory::create_cast_expr(&pool, from_type, to_type, false, /*cast_by_name=*/true);
+    auto expr_result =
+            VectorizedCastExprFactory::create_cast_expr(&pool, from_type, to_type, false, /*cast_by_name=*/true);
     ASSERT_TRUE(expr_result.ok()) << expr_result.status().message();
     Expr* expr = expr_result.value();
     pool.add(expr);
@@ -2748,18 +2747,17 @@ TEST_F(VectorizedCastExprTest, struct_to_struct_field_reorder) {
 // Test struct-to-struct cast with matching field order (no reordering needed)
 TEST_F(VectorizedCastExprTest, struct_to_struct_same_order) {
     // Create source struct type: STRUCT<a INT, b VARCHAR>
-    TypeDescriptor from_type = TypeDescriptor::create_struct_type(
-            {"a", "b"},
-            {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_VARCHAR)});
+    TypeDescriptor from_type =
+            TypeDescriptor::create_struct_type({"a", "b"}, {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_VARCHAR)});
 
     // Create target struct type: STRUCT<a BIGINT, b VARCHAR>
     // Same field order, just different types
-    TypeDescriptor to_type = TypeDescriptor::create_struct_type(
-            {"a", "b"},
-            {TypeDescriptor(TYPE_BIGINT), TypeDescriptor(TYPE_VARCHAR)});
+    TypeDescriptor to_type =
+            TypeDescriptor::create_struct_type({"a", "b"}, {TypeDescriptor(TYPE_BIGINT), TypeDescriptor(TYPE_VARCHAR)});
 
     ObjectPool pool;
-    auto expr_result = VectorizedCastExprFactory::create_cast_expr(&pool, from_type, to_type, false, /*cast_by_name=*/true);
+    auto expr_result =
+            VectorizedCastExprFactory::create_cast_expr(&pool, from_type, to_type, false, /*cast_by_name=*/true);
     ASSERT_TRUE(expr_result.ok()) << expr_result.status().message();
     Expr* expr = expr_result.value();
     pool.add(expr);
@@ -2778,16 +2776,15 @@ TEST_F(VectorizedCastExprTest, struct_to_struct_same_order) {
 TEST_F(VectorizedCastExprTest, struct_to_struct_three_fields_reorder) {
     // Create source struct type: STRUCT<x INT, y INT, z INT>
     TypeDescriptor from_type = TypeDescriptor::create_struct_type(
-            {"x", "y", "z"},
-            {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT)});
+            {"x", "y", "z"}, {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT)});
 
     // Create target struct type: STRUCT<z INT, x INT, y INT>
     TypeDescriptor to_type = TypeDescriptor::create_struct_type(
-            {"z", "x", "y"},
-            {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT)});
+            {"z", "x", "y"}, {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT)});
 
     ObjectPool pool;
-    auto expr_result = VectorizedCastExprFactory::create_cast_expr(&pool, from_type, to_type, false, /*cast_by_name=*/true);
+    auto expr_result =
+            VectorizedCastExprFactory::create_cast_expr(&pool, from_type, to_type, false, /*cast_by_name=*/true);
     ASSERT_TRUE(expr_result.ok()) << expr_result.status().message();
     Expr* expr = expr_result.value();
     pool.add(expr);
@@ -2810,12 +2807,10 @@ TEST_F(VectorizedCastExprTest, struct_to_struct_three_fields_reorder) {
 TEST_F(VectorizedCastExprTest, struct_to_struct_position_cast_different_names) {
     // Source: STRUCT<key INT, value INT>  Target: STRUCT<key1 INT, value1 INT>
     // Names don't overlap, so positional mapping should be used: key→key1 (idx 0), value→value1 (idx 1).
-    TypeDescriptor from_type = TypeDescriptor::create_struct_type(
-            {"key", "value"},
-            {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT)});
-    TypeDescriptor to_type = TypeDescriptor::create_struct_type(
-            {"key1", "value1"},
-            {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT)});
+    TypeDescriptor from_type =
+            TypeDescriptor::create_struct_type({"key", "value"}, {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT)});
+    TypeDescriptor to_type = TypeDescriptor::create_struct_type({"key1", "value1"},
+                                                                {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT)});
 
     ObjectPool pool;
     auto expr_result = VectorizedCastExprFactory::create_cast_expr(&pool, from_type, to_type, false);

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -2965,4 +2965,131 @@ TEST_F(VectorizedCastExprTest, base_shredded_typed_variant_overlay_cast_mismatch
     ASSERT_TRUE(result->is_null(0));
 }
 
+// Test Complex Types (Array/Map/Struct) casting to JSON
+TEST_F(VectorizedCastExprTest, ComplexToJson) {
+    // Helper lambda to verify cast result
+    auto verify_cast = [&](const ColumnPtr& col, const TTypeDesc& type_desc, const std::string& expected_json) {
+        TExprNode cast_expr_node;
+        cast_expr_node.opcode = TExprOpcode::CAST;
+        cast_expr_node.node_type = TExprNodeType::CAST_EXPR;
+        cast_expr_node.num_children = 1;
+        cast_expr_node.__isset.opcode = true;
+        cast_expr_node.__isset.child_type = true;
+        cast_expr_node.__isset.child_type_desc = true;
+
+        cast_expr_node.child_type = type_desc.types[0].scalar_type.type;
+        cast_expr_node.child_type_desc = type_desc;
+
+        cast_expr_node.type = gen_type_desc(TPrimitiveType::JSON);
+
+        ObjectPool pool;
+        std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(&pool, cast_expr_node));
+        ASSERT_TRUE(expr != nullptr);
+
+        std::unique_ptr<MockExpr> child = std::make_unique<MockExpr>(cast_expr_node, col);
+        expr->_children.push_back(child.get());
+
+        ColumnPtr result = expr->evaluate(nullptr, nullptr);
+        ASSERT_TRUE(result != nullptr);
+        ASSERT_TRUE(result->is_json());
+
+        if (expected_json == "NULL") {
+            ASSERT_TRUE(result->is_null(0));
+        } else {
+            const JsonValue* json = result->get(0).get_json();
+            auto json_str = json->to_string();
+            ASSERT_TRUE(json_str.ok());
+            ASSERT_EQ(expected_json, json_str.value());
+        }
+    };
+
+    // 1. Test ARRAY<INT> -> JSON
+    {
+        auto data = Int32Column::create();
+        data->append(1);
+        data->append(2);
+        data->append(3);
+        auto offsets = UInt32Column::create();
+        offsets->append(0);
+        offsets->append(3);
+        auto array_col = ArrayColumn::create(data, offsets);
+
+        verify_cast(array_col, gen_array_type_desc(TPrimitiveType::INT), "[1,2,3]");
+    }
+
+    // 2. Test ARRAY<VARCHAR> with NULLs -> JSON
+    {
+        auto data = BinaryColumn::create();
+        data->append("a");
+        data->append_default();
+        data->append("b");
+        auto nulls = NullColumn::create();
+        nulls->append(0);
+        nulls->append(1);
+        nulls->append(0);
+        auto nullable_data = NullableColumn::create(data, nulls);
+
+        auto offsets = UInt32Column::create();
+        offsets->append(0);
+        offsets->append(3);
+        auto array_col = ArrayColumn::create(nullable_data, offsets);
+
+        verify_cast(array_col, gen_array_type_desc(TPrimitiveType::VARCHAR), R"(["a",null,"b"])");
+    }
+
+    // 3. Test MAP<INT, INT> -> JSON
+    {
+        auto keys = Int32Column::create();
+        keys->append(1);
+        keys->append(2);
+
+        auto values = Int32Column::create();
+        values->append(10);
+        values->append(20);
+
+        auto offsets = UInt32Column::create();
+        offsets->append(0);
+        offsets->append(2);
+
+        auto map_col = MapColumn::create(keys, values, offsets);
+
+        verify_cast(map_col, gen_map_type_desc(TPrimitiveType::INT, TPrimitiveType::INT), R"({"1":10,"2":20})");
+    }
+
+    // 4. Test STRUCT<col1:INT, col2:VARCHAR> -> JSON
+    {
+        auto f1 = Int32Column::create();
+        f1->append(1);
+
+        auto f2 = BinaryColumn::create();
+        f2->append("starrocks");
+
+        auto struct_col = StructColumn::create(Columns{f1, f2}, std::vector<std::string>{"id", "name"});
+
+        TTypeDesc type_desc;
+        std::vector<TTypeNode> nodes;
+        TTypeNode struct_node;
+        struct_node.type = TTypeNodeType::STRUCT;
+        struct_node.struct_fields.push_back(TStructField());
+        struct_node.struct_fields.back().name = "id";
+        struct_node.struct_fields.push_back(TStructField());
+        struct_node.struct_fields.back().name = "name";
+        nodes.push_back(struct_node);
+
+        TTypeNode int_node;
+        int_node.type = TTypeNodeType::SCALAR;
+        int_node.scalar_type.type = TPrimitiveType::INT;
+        nodes.push_back(int_node);
+
+        TTypeNode str_node;
+        str_node.type = TTypeNodeType::SCALAR;
+        str_node.scalar_type.type = TPrimitiveType::VARCHAR;
+        nodes.push_back(str_node);
+
+        type_desc.__set_types(nodes);
+
+        verify_cast(struct_col, type_desc, R"({"id":1,"name":"starrocks"})");
+    }
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -992,7 +992,15 @@ public class ExpressionAnalyzer {
                 castType = cast.getTargetTypeDef().getType();
             }
             Type fromType = cast.getChild(0).getType();
-            if (!TypeManager.canCastTo(fromType, castType)) {
+
+            // Allow explicit casting from Complex Types (Array/Map/Struct) to JSON.
+            // We do this here rather than in TypeManager.canCastTo to prevent unintended
+            // implicit casts (e.g., breaking array_concat strict type checks).
+            boolean isExplicitComplexToJson = !cast.isImplicit() &&
+                    castType.isJsonType() &&
+                    (fromType.isArrayType() || fromType.isMapType() || fromType.isStructType());
+
+            if (!isExplicitComplexToJson && !TypeManager.canCastTo(fromType, castType)) {
                 throw new SemanticException("Invalid type cast from " + fromType.toSql() + " to "
                         + castType.toSql() + " in sql `" +
                         AstToStringBuilder.toString(cast.getChild(0)).replace("%", "%%") + "`",

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoParserNotSupportTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoParserNotSupportTest.java
@@ -90,7 +90,7 @@ public class TrinoParserNotSupportTest extends TrinoTestBase {
     @Test
     public void testJsonCast() {
         String sql = "SELECT CAST(MAP(ARRAY['k1', 'k2', 'k3'], ARRAY[1, 23, 456]) AS JSON);";
-        analyzeFail(sql, "Invalid type cast from map<varchar,smallint(6)> to json");
+        analyzeSuccess(sql);
     }
 
     // refer to https://trino.io/docs/current/functions/json.html#json-value

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
@@ -301,4 +301,30 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
         String plan = getFragmentPlan("select current_warehouse()");
         assertContains(plan, currentWarehouseName);
     }
+
+    @Test
+    public void testCastComplexToJson() {
+        ConnectContext session = new ConnectContext();
+        ExpressionAnalyzer analyzer = new ExpressionAnalyzer(session);
+        AnalyzeState analyzeState = new AnalyzeState();
+        Scope scope = new Scope(RelationId.anonymous(), new RelationFields());
+
+        String sqlArray = "CAST([1, 2, 3] AS JSON)";
+        Expr exprArray = SqlParser.parseSqlToExpr(sqlArray, session.getSessionVariable().getSqlMode());
+        try {
+            analyzer.analyze(exprArray, analyzeState, scope);
+            Assertions.assertTrue(exprArray.getType().isJsonType());
+        } catch (SemanticException e) {
+            Assertions.fail("CAST(ARRAY AS JSON) should be allowed: " + e.getMessage());
+        }
+
+        String sqlMap = "CAST(map(1, 2) AS JSON)";
+        Expr exprMap = SqlParser.parseSqlToExpr(sqlMap, session.getSessionVariable().getSqlMode());
+        try {
+            analyzer.analyze(exprMap, analyzeState, scope);
+            Assertions.assertTrue(exprMap.getType().isJsonType());
+        } catch (SemanticException e) {
+            Assertions.fail("CAST(MAP AS JSON) should be allowed: " + e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Currently, StarRocks does not support casting complex types (ARRAY, MAP, STRUCT) directly to the JSON type. Attempts to do so result in syntax validation errors or runtime failures. This limitation hinders users who need to convert nested data structures into JSON strings for external application consumption, data export, or ETL processes.

## What I'm doing:

I have implemented the logic to support casting from complex types to JSON in both Frontend and Backend.

**Frontend (FE):**

- Updated TypeManager.java to allow casting rules from ARRAY, MAP, and STRUCT types to JSON.

**Backend (BE):**

- `Recursive Conversion:` Implemented a new helper function datum_to_json in cast_expr.cpp. This function recursively traverses complex Datum structures and builds the corresponding VelocyPack (JSON) object.
- `Cast Logic:` Updated VectorizedCastExpr::evaluate_checked to handle the TYPE_JSON target type for complex inputs.
- `Map Key Handling:` Added specific logic to convert Map keys into Strings (as JSON keys must be strings). This covers Boolean, TinyInt, SmallInt, Int, BigInt, LargeInt, and String types as keys.
- `Registration:` Wired up the new cast functions in VectorizedCastExprFactory and registered CUSTOMIZE_FN_CAST macros.

Test Plan:
**1. Unit Tests:** Added a new test fixture ComplexToJson in be/test/exprs/cast_expr_test.cpp covering:

- Array to JSON (Integer, String with NULLs).
- Map to JSON (Integer keys converted to strings).
- Struct to JSON (Handling field names).
- Nested Types (Array of Structs).

**2. Manual Verification (MySQL Client):** Verified correct output formatting using CAST(x AS JSON).

<img width="773" height="529" alt="Screenshot from 2025-12-21 15-46-00" src="https://github.com/user-attachments/assets/9c3d84f7-44de-411e-8c40-98b7e6fbb76d" />

Fixes #66720 

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit complex-type-to-JSON casting end-to-end.
> 
> - BE: Implements recursive `datum_to_json` and `map_key_to_string`; updates `VectorizedCastExpr::evaluate_checked` to handle complex types -> `JSON`; registers `CUSTOMIZE_FN_CAST` and factory cases for `TYPE_ARRAY`, `TYPE_MAP`, `TYPE_STRUCT` to `TYPE_JSON`.
> - FE: `ExpressionAnalyzer` allows explicit casts from complex types to `JSON`; Trino parser test updated to accept `CAST(MAP(...) AS JSON)`.
> - Tests: New BE unit tests for array/map/struct to JSON, plus FE analyzer test coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b426f14a21494bce4e8819343172a025f1bd1a8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->