### PR TITLE
[Enhancement] Clean-up unused mem_pools in mem_tracker_manager

### DIFF
--- a/be/src/exec/workgroup/mem_tracker_manager.cpp
+++ b/be/src/exec/workgroup/mem_tracker_manager.cpp
@@ -75,8 +75,11 @@ void MemTrackerManager::deregister_workgroup(const std::string& mem_pool) {
 }
 
 std::vector<std::string> MemTrackerManager::list_mem_trackers() const {
-    auto keys_view = std::ranges::views::keys(_shared_mem_trackers);
-    std::vector mem_trackers(keys_view.begin(), keys_view.end());
+    std::vector<std::string> mem_trackers{};
+    mem_trackers.reserve(_shared_mem_trackers.size() + 1);
+    for (const auto& mem_tracker : _shared_mem_trackers) {
+        mem_trackers.push_back(mem_tracker.first);
+    }
     mem_trackers.push_back(WorkGroup::DEFAULT_MEM_POOL);
     return mem_trackers;
 }

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -691,7 +691,7 @@ void WorkGroupManager::change_enable_resource_group_cpu_borrowing(const bool val
     _executors_manager.change_enable_resource_group_cpu_borrowing(val);
 }
 
-void WorkGroupManager::set_workgroup_expiration_time(const milliseconds value) {
+void WorkGroupManager::set_workgroup_expiration_time(const std::chrono::seconds value) {
     _workgroup_expiration_time = value;
 }
 

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -692,6 +692,7 @@ void WorkGroupManager::change_enable_resource_group_cpu_borrowing(const bool val
 }
 
 void WorkGroupManager::set_workgroup_expiration_time(const std::chrono::seconds value) {
+    std::unique_lock write_lock(_mutex);
     _workgroup_expiration_time = value;
 }
 

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -253,8 +253,8 @@ private:
     int64_t _spill_mem_limit_bytes = -1;
 
     std::string _mem_pool;
-    std::shared_ptr<MemTracker> _mem_tracker = nullptr;
     std::shared_ptr<MemTracker> _shared_mem_tracker = nullptr;
+    std::shared_ptr<MemTracker> _mem_tracker = nullptr;
     std::shared_ptr<MemTracker> _connector_scan_mem_tracker = nullptr;
 
     WorkGroupDriverSchedEntity _driver_sched_entity;

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -159,8 +159,10 @@ public:
     void mark_del(const std::chrono::seconds expiration_time) {
         bool expect_false = false;
         if (_is_marked_del.compare_exchange_strong(expect_false, true)) {
-            _vacuum_ttl.store(duration_cast<vacuum_time_precision>(
-                steady_clock::now().time_since_epoch() + expiration_time).count(), std::memory_order_release);
+            _vacuum_ttl.store(
+                    duration_cast<vacuum_time_precision>(steady_clock::now().time_since_epoch() + expiration_time)
+                            .count(),
+                    std::memory_order_release);
         }
     }
     // no drivers shall be added to this workgroup

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -160,7 +160,7 @@ public:
         bool expect_false = false;
         if (_is_marked_del.compare_exchange_strong(expect_false, true)) {
             _vacuum_ttl = duration_cast<vacuum_time_precision>(steady_clock::now().time_since_epoch() + expiration_time)
-                            .count();
+                                  .count();
         }
     }
     // no drivers shall be added to this workgroup

--- a/be/test/exec/workgroup/mem_tracker_manager_test.cpp
+++ b/be/test/exec/workgroup/mem_tracker_manager_test.cpp
@@ -25,7 +25,7 @@ PARALLEL_TEST(MemTrackerMangerTest, test_mem_tracker_for_default_mem_pool) {
     const auto work_group{std::make_shared<WorkGroup>("default_wg", 123, WorkGroup::DEFAULT_VERSION, 1, 0.5, 0, 0.9,
                                                       WorkGroupType::WG_DEFAULT, WorkGroup::DEFAULT_MEM_POOL)};
 
-    const auto tracker{manager.get_parent_mem_tracker(work_group)};
+    const auto tracker{manager.register_workgroup(work_group)};
     ASSERT_EQ(tracker, GlobalEnv::GetInstance()->query_pool_mem_tracker_shared());
 }
 
@@ -38,8 +38,12 @@ PARALLEL_TEST(MemTrackerMangerTest, test_mem_tracker_for_custom_mem_pool) {
     const auto work_group3{std::make_shared<WorkGroup>("wg_2", 134, WorkGroup::DEFAULT_VERSION, 1, 0.5, 0, 0.9,
                                                        WorkGroupType::WG_DEFAULT, "other_pool")};
 
-    ASSERT_EQ(manager.get_parent_mem_tracker(work_group1), manager.get_parent_mem_tracker(work_group2));
-    ASSERT_NE(manager.get_parent_mem_tracker(work_group1), manager.get_parent_mem_tracker(work_group3));
+    const MemTrackerPtr parent_workgroup_1 = manager.register_workgroup(work_group1);
+    const MemTrackerPtr parent_workgroup_2 = manager.register_workgroup(work_group2);
+    const MemTrackerPtr parent_workgroup_3 = manager.register_workgroup(work_group3);
+
+    ASSERT_EQ(parent_workgroup_1, parent_workgroup_2);
+    ASSERT_NE(parent_workgroup_1, parent_workgroup_3);
 }
 PARALLEL_TEST(MemTrackerMangerTest, test_mem_tracker_for_custom_mem_pool_overwrite) {
     MemTrackerManager manager;
@@ -48,6 +52,9 @@ PARALLEL_TEST(MemTrackerMangerTest, test_mem_tracker_for_custom_mem_pool_overwri
     const auto work_group2{std::make_shared<WorkGroup>("wg_2", 134, WorkGroup::DEFAULT_VERSION, 1, 0.7, 0, 0.9,
                                                        WorkGroupType::WG_DEFAULT, "test_pool")};
 
-    ASSERT_NE(manager.get_parent_mem_tracker(work_group1), manager.get_parent_mem_tracker(work_group2));
+    const MemTrackerPtr parent_workgroup1 = manager.register_workgroup(work_group1);
+    const MemTrackerPtr parent_workgroup2 = manager.register_workgroup(work_group2);
+
+    ASSERT_NE(parent_workgroup1, parent_workgroup2);
 }
 } // namespace starrocks::workgroup

--- a/be/test/exec/workgroup/work_group_manager_test.cpp
+++ b/be/test/exec/workgroup/work_group_manager_test.cpp
@@ -30,7 +30,7 @@ TWorkGroup create_twg(const int64_t id, const int64_t version, const std::string
     return twg;
 }
 
-TWorkGroupOp make_twg_op(const TWorkGroup &twg, const TWorkGroupOpType::type op_type)  {
+TWorkGroupOp make_twg_op(const TWorkGroup& twg, const TWorkGroupOpType::type op_type) {
     TWorkGroupOp op;
     op.__set_workgroup(twg);
     op.__set_op_type(op_type);
@@ -100,9 +100,9 @@ PARALLEL_TEST(WorkGroupManagerTest, test_if_unused_memory_pools_are_cleaned_up) 
         auto twg3 = create_twg(112, 1, "wg112", WorkGroup::DEFAULT_MEM_POOL, 0.5);
 
         std::vector create_operations{
-            make_twg_op(twg1, TWorkGroupOpType::WORKGROUP_OP_CREATE),
-            make_twg_op(twg2, TWorkGroupOpType::WORKGROUP_OP_CREATE),
-            make_twg_op(twg3, TWorkGroupOpType::WORKGROUP_OP_CREATE),
+                make_twg_op(twg1, TWorkGroupOpType::WORKGROUP_OP_CREATE),
+                make_twg_op(twg2, TWorkGroupOpType::WORKGROUP_OP_CREATE),
+                make_twg_op(twg3, TWorkGroupOpType::WORKGROUP_OP_CREATE),
         };
 
         _manager->apply(create_operations);
@@ -113,10 +113,8 @@ PARALLEL_TEST(WorkGroupManagerTest, test_if_unused_memory_pools_are_cleaned_up) 
         twg1.version++;
         twg2.version++;
 
-        std::vector delete_operations{
-            make_twg_op(twg1, TWorkGroupOpType::WORKGROUP_OP_DELETE),
-            make_twg_op(twg2, TWorkGroupOpType::WORKGROUP_OP_DELETE)
-        };
+        std::vector delete_operations{make_twg_op(twg1, TWorkGroupOpType::WORKGROUP_OP_DELETE),
+                                      make_twg_op(twg2, TWorkGroupOpType::WORKGROUP_OP_DELETE)};
 
         _manager->apply(delete_operations);
         std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/be/test/exec/workgroup/work_group_manager_test.cpp
+++ b/be/test/exec/workgroup/work_group_manager_test.cpp
@@ -93,7 +93,7 @@ PARALLEL_TEST(WorkGroupManagerTest, add_workgroups_same_mem_pools) {
 PARALLEL_TEST(WorkGroupManagerTest, test_if_unused_memory_pools_are_cleaned_up) {
     PipelineExecutorSetConfig config{10, 1, 1, 1, CpuUtil::CpuIds{}, false, false};
     auto _manager = std::make_unique<WorkGroupManager>(config);
-    _manager->set_workgroup_expiration_time(milliseconds(0));
+    _manager->set_workgroup_expiration_time(std::chrono::seconds(0));
     {
         auto twg1 = create_twg(110, 1, "wg110", "test_pool_2", 0.5);
         auto twg2 = create_twg(111, 1, "wg111", "test_pool_2", 0.5);
@@ -119,7 +119,7 @@ PARALLEL_TEST(WorkGroupManagerTest, test_if_unused_memory_pools_are_cleaned_up) 
         };
 
         _manager->apply(delete_operations);
-        std::this_thread::sleep_for(seconds(2));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
         // The expired workgroups will only get erased in the next call to apply
         _manager->apply({});
 

--- a/be/test/exec/workgroup/work_group_manager_test.cpp
+++ b/be/test/exec/workgroup/work_group_manager_test.cpp
@@ -91,7 +91,7 @@ PARALLEL_TEST(WorkGroupManagerTest, add_workgroups_same_mem_pools) {
 }
 
 PARALLEL_TEST(WorkGroupManagerTest, test_if_unused_memory_pools_are_cleaned_up) {
-    PipelineExecutorSetConfig config{10, 1, 1, 1, CpuUtil::CpuIds{}, false, false};
+    PipelineExecutorSetConfig config{10, 1, 1, 1, CpuUtil::CpuIds{}, false, false, nullptr};
     auto _manager = std::make_unique<WorkGroupManager>(config);
     _manager->set_workgroup_expiration_time(std::chrono::seconds(0));
     {


### PR DESCRIPTION
## Why I'm doing:

The `mem_pool` property for resource groups was introduced to StarRocks in the following pull requests:

- https://github.com/StarRocks/starrocks/pull/64111
- https://github.com/StarRocks/starrocks/pull/64112

The collective usage statistics of resource groups which belong to the same memory pool are tracked by a shared memory tracker. These shared memory trackers are managed by the `mem_tracker_manager` instance, which owns an unordered map from `mem_pool` names to their shared memory trackers.

Currently, memory pools (and their corresponding shared memory trackers) can only be inserted to this map but not removed. A memory pool becomes unused and needs to be deleted when all the resource groups that belong to that pool are deleted. 

This pull request adds the necessary functionality to automatically and safely clean up such unused `mem_pool` entries.

## What I'm doing:

- MemTrackerManager now also keeps track of the number of its children (i.e. the number of workgroups that belong to it) and when this number reaches 0, the corresponding entry in the unordered map is deleted. 
- This counter is set by the usage of `register_workgroup` and `deregister_workgroup` methods, which should be called whenever a new workgroup is constructed and destructed, respectively. 
  - When the `register_workgroup` method is called with a workgroup that has a new mem_pool, it will construct a new shared memory tracker instance and insert the memory pool name, memory tracker pointer, and child count into the unordered map. If it is called with a workgroup with an existing mem_pool, it will increase the number of children for that mem_pool by one.
  - When the `deregister_workgroup` method is called, it will decrease mem_pool's number of children by one, or erase the mem_pool entry from the unordered map if the child count has reached 0. 
  
 There is a tricky edge case that is also handled, which is explained below:
 - When the user deletes a workgroup, it is deleted immediately at the front end, but will only be *marked for deletion* at the backend. The workgroup instance will be destructed after some expiration time (120 seconds by default).
 - This means that a new workgroup can be created with the same name right after deleting it. This is not a problem because workgroups are immutable and uniquely versioned. However, this is not the case for memory pools.
 - A memory pool entry will be cleaned up after all of its children are destructed. This means there is a time window where the mem_pool does not exist at the front-end, but its entry is still alive at the backend, because all its children are marked for deletion but haven't been destructed yet. If the user creates a new workgroup under a mem_pool with the same name in this time window, `register_workgroup` cannot simply insert a fresh entry and ignore the children waiting for deletion, but must take their number into account. 
   - If the child count is reset and expiring children are not orphaned, when these children are finally destructed, they will call `deregister_workgroup` and cause an underflow in the counter.
   - This is prevented by never resetting the child count and always incrementing it inside `register_workgroup`. For fresh mem_pools, it will be 0-initialized and increased to 1. For reused mem_pools, it will keep the old count (expiring child count) and increase it by 1.
   
This pull request also changes the `mark_del()` function of the `Workgroup` class and parameterizes it with an expiration time. The value of expiration time is owned by the `WorkgroupManager` and has the default of 120 seconds. This change was necessary for testing the correct behavior of `MemTrackerManager`. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements automatic cleanup of unused `mem_pool` shared memory trackers and integrates lifecycle management with workgroups.
> 
> - Add `MemTrackerManager` APIs: `register_workgroup`/`deregister_workgroup` with child counting; verify cached tracker limit to handle FE deletion/recreate edge case; expose `list_mem_trackers`
> - Refactor `WorkGroupManager` to use `register_workgroup`, call `deregister_workgroup` on cleanup, add `list_memory_pools`, and make `mark_del` expiration configurable via `set_workgroup_expiration_time`
> - Update `WorkGroup::mark_del` to accept expiration; adjust vacuum time precision and defaults
> - Add tests for shared tracker reuse/overwrite and for cleanup of unused memory pools
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cce91eb2369ca138f8b953d0ffc22bc74818d36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->