### PR TITLE
[Enhancement] Split RESOURCE_USAGE_REPORT and other report tasks into separate daemon threads

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
@@ -60,6 +60,7 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.thrift.TException;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -68,6 +69,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class ReportHandlerTest {
     private static ConnectContext connectContext;
@@ -234,11 +236,13 @@ public class ReportHandlerTest {
     }
 
     @Test
-    public void testHandleResourceUsageReport() {
+    public void testHandleResourceUsageReport() throws TException {
         ResourceUsageMonitor resourceUsageMonitor = GlobalStateMgr.getCurrentState().getResourceUsageMonitor();
 
         Backend backend = new Backend(0, "127.0.0.1", 80);
+        backend.setBePort(90);
         ComputeNode computeNode = new ComputeNode(2, "127.0.0.1", 88);
+        computeNode.setBePort(99);
 
         new MockUp<SystemInfoService>() {
             @Mock
@@ -253,6 +257,24 @@ public class ReportHandlerTest {
             }
         };
 
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public Backend getBackendWithBePort(String host, int bePort) {
+                if (host.equals(backend.getHost()) && bePort == backend.getBePort()) {
+                    return backend;
+                }
+                return null;
+            }
+
+            @Mock
+            public ComputeNode getComputeNodeWithBePort(String host, int bePort) {
+                if (host.equals(computeNode.getHost()) && bePort == computeNode.getBePort()) {
+                    return computeNode;
+                }
+                return null;
+            }
+        };
+
         new Expectations(resourceUsageMonitor) {
             {
                 resourceUsageMonitor.notifyResourceUsageUpdate();
@@ -260,33 +282,55 @@ public class ReportHandlerTest {
             }
         };
 
-        int numRunningQueries = 1;
-        long memLimitBytes = 3;
-        long memUsedBytes = 2;
-        int cpuUsedPermille = 300;
-        TResourceUsage resourceUsage = genResourceUsage(numRunningQueries, memLimitBytes, memUsedBytes, cpuUsedPermille);
+        ReportHandler handler = new ReportHandler();
+        handler.start();
 
-        // For backend, sync to FE followers and notify pending queries.
-        ReportHandler.testHandleResourceUsageReport(backend.getId(), resourceUsage);
-        Assertions.assertEquals(numRunningQueries, backend.getNumRunningQueries());
-        //        Assert.assertEquals(memLimitBytes, backend.getMemLimitBytes());
-        Assertions.assertEquals(memUsedBytes, backend.getMemUsedBytes());
-        Assertions.assertEquals(cpuUsedPermille, backend.getCpuUsedPermille());
+        {
+            int numRunningQueries = 1;
+            long memLimitBytes = 3;
+            long memUsedBytes = 2;
+            int cpuUsedPermille = 300;
+            TResourceUsage resourceUsage = genResourceUsage(numRunningQueries, memLimitBytes, memUsedBytes, cpuUsedPermille);
+            handler.handleReport(genRequest(resourceUsage, backend));
 
-        // For compute node, sync to FE followers and notify pending queries.
-        numRunningQueries = 10;
-        memLimitBytes = 30;
-        memUsedBytes = 20;
-        cpuUsedPermille = 310;
-        resourceUsage = genResourceUsage(numRunningQueries, memLimitBytes, memUsedBytes, cpuUsedPermille);
-        ReportHandler.testHandleResourceUsageReport(computeNode.getId(), resourceUsage);
-        Assertions.assertEquals(numRunningQueries, computeNode.getNumRunningQueries());
-        //        Assert.assertEquals(memLimitBytes, computeNode.getMemLimitBytes());
-        Assertions.assertEquals(memUsedBytes, computeNode.getMemUsedBytes());
-        Assertions.assertEquals(cpuUsedPermille, computeNode.getCpuUsedPermille());
+            Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> numRunningQueries == backend.getNumRunningQueries());
+            // For backend, sync to FE followers and notify pending queries.
+            Assertions.assertEquals(memUsedBytes, backend.getMemUsedBytes());
+            Assertions.assertEquals(cpuUsedPermille, backend.getCpuUsedPermille());
+        }
 
-        // Don't sync and notify, because this BE doesn't exist.
-        ReportHandler.testHandleResourceUsageReport(/* Not Exist */ 1, resourceUsage);
+        {
+            // For compute node, sync to FE followers and notify pending queries.
+            int numRunningQueries = 10;
+            int memLimitBytes = 30;
+            int memUsedBytes = 20;
+            int cpuUsedPermille = 310;
+            TResourceUsage resourceUsage = genResourceUsage(numRunningQueries, memLimitBytes, memUsedBytes, cpuUsedPermille);
+            handler.handleReport(genRequest(resourceUsage, computeNode));
+
+            Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> numRunningQueries == computeNode.getNumRunningQueries());
+            Assertions.assertEquals(memUsedBytes, computeNode.getMemUsedBytes());
+            Assertions.assertEquals(cpuUsedPermille, computeNode.getCpuUsedPermille());
+
+            // Don't sync and notify, because this BE doesn't exist.
+            ComputeNode nonExistCN = new ComputeNode(2, "127.10.0.1", 100);
+            nonExistCN.setBePort(199);
+            handler.handleReport(genRequest(resourceUsage, nonExistCN));
+        }
+
+        handler.setStop();
+    }
+
+    private TReportRequest genRequest(TResourceUsage resourceUsage, ComputeNode worker) {
+        TReportRequest req = new TReportRequest();
+        req.setResource_usage(resourceUsage);
+
+        TBackend tcn = new TBackend();
+        tcn.setHost(worker.getHost());
+        tcn.setBe_port(worker.getBePort());
+        req.setBackend(tcn);
+
+        return req;
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

All tasks reported from the BE to the FE are currently handled by a single-threaded `ReportHandler`. Some report tasks are extremely heavy and can be blocked for a long time due to locks on the DB, Table, and TableInvertedIndex. As a result, subsequent report tasks are also stuck.

`RESOURCE_USAGE_REPORT` is used to report the BE’s CPU and memory usage, which the FE then uses to decide whether queries should be queued. When there are a huge number of tablets (e.g., several million) and read/write contention is intense, the FE can take a very long time to process `RESOURCE_USAGE_REPORT`, causing queries to wait in the query queue for an excessively long time.


## What I'm doing:


Split `RESOURCE_USAGE_REPORT` out of `ReportHandler` and handle it in a separate thread.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Separates resource-related reports from the main `ReportHandler` loop to avoid blocking heavy tablet/disk/task processing.
> 
> - Introduces `resourceReportQueue` and `ResourceReportDaemon`; routes `RESOURCE_GROUP_REPORT` and `RESOURCE_USAGE_REPORT` via `getQueueByType` while other types use the existing `reportQueue`
> - Overrides `start()`/`setStop()` to manage both daemons; refactors queue consumption into `consumeQueue(...)`
> - Updates metrics/logging: `estimateCount()` and `getReportQueueSize()` now sum both queues; debug/error logs include both queue sizes
> - Makes `ReportTask` `static`; minor typo fix and small refactors for clarity
> - Tests updated: add async verification with `Awaitility`, generate `TReportRequest` using host/bePort lookup mocks, and validate resource usage handling for BE and CN
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 036590a8ab38b4c4bb3b5744ae5050ad89baef1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->