### PR TITLE
[Enhancement] introduce a framework for warehouse session variable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
@@ -224,7 +224,7 @@ public class AuthenticationHandler {
         // Ephemeral users (from external auth) don't have stored properties
         if (!authenticationResult.authenticatedUser.isEphemeral()) {
             UserProperty userProperty = GlobalStateMgr.getCurrentState().getAuthenticationMgr()
-                    .getUserProperty(authenticationResult.authenticatedUser.getUser());
+                    .getUserProperty(user);
             context.updateByUserProperty(userProperty);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1036,6 +1036,9 @@ public class ConnectContext {
         // apply modified session variable
         try {
             for (Map.Entry<String, SystemVariable> entry : modifiedSessionVariables.entrySet()) {
+                if (entry.getKey().equalsIgnoreCase("warehouse")) {
+                    continue;
+                }
                 variableMgr.setSystemVariable(sessionVariable, entry.getValue(), true);
             }
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1056,7 +1056,7 @@ public class ConnectContext {
         }
 
         for (Map.Entry<String, String> entry : sessionVariables.entrySet()) {
-            if (entry.getKey().equals(warehouse)) {
+            if (entry.getKey().equalsIgnoreCase(warehouse)) {
                 continue;
             }
             SystemVariable variable = new SystemVariable(entry.getKey(), new StringLiteral(entry.getValue()));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -1013,6 +1013,16 @@ public class ConnectContext {
     }
 
     public void setCurrentWarehouse(String currentWarehouse) {
+        final SessionVariable old = this.sessionVariable;
+        try {
+            tryToSetCurrentWarehouse(currentWarehouse);
+        } catch (Exception e) {
+            this.sessionVariable = old;
+            throw e;
+        }
+    }
+
+    private void tryToSetCurrentWarehouse(String currentWarehouse) {
         final VariableMgr variableMgr = GlobalStateMgr.getCurrentState().getVariableMgr();
         this.sessionVariable = variableMgr.newSessionVariable();
         this.sessionVariable.setWarehouseName(currentWarehouse);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -5982,9 +5982,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     @Override
-    public Object clone() {
+    public SessionVariable clone() {
         try {
-            return super.clone();
+            return (SessionVariable) super.clone();
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/Warehouse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/Warehouse.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.warehouse;
 
+import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Writable;
@@ -25,6 +26,7 @@ import com.starrocks.sql.ast.warehouse.cngroup.EnableDisableCnGroupStmt;
 import com.starrocks.system.ComputeNode;
 
 import java.util.List;
+import java.util.Map;
 
 public abstract class Warehouse implements Writable {
     @SerializedName(value = "name")
@@ -81,4 +83,8 @@ public abstract class Warehouse implements Writable {
     public abstract void replayInternalOpLog(String payload);
 
     public abstract boolean isAvailable();
+
+    public Map<String, String> getWarehouseSessionVariable() {
+        return Maps.newHashMap();
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetVarTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetVarTest.java
@@ -213,14 +213,19 @@ public class SetVarTest extends PlanTestBase {
     public void testMissingWarehouse() throws Exception {
         Config.run_mode = RunMode.SHARED_DATA.getName();
         RunMode.detectRunMode();
-        // Simulate that after setting the warehouse, this warehouse is deleted.
-        starRocksAssert.getCtx().getSessionVariable().setWarehouseName("no_exist_warehouse");
+        try {
+            // Simulate that after setting the warehouse, this warehouse is deleted.
+            starRocksAssert.getCtx().getSessionVariable().setWarehouseName("no_exist_warehouse");
 
-        String sql = "set warehouse = default_warehouse";
-        StatementBase stmt = SqlParser.parse(sql, starRocksAssert.getCtx().getSessionVariable()).get(0);
-        StmtExecutor executor = new StmtExecutor(starRocksAssert.getCtx(), stmt);
-        executor.execute();
-        assertEquals("default_warehouse", starRocksAssert.getCtx().getSessionVariable().getWarehouseName());
+            String sql = "set warehouse = default_warehouse";
+            StatementBase stmt = SqlParser.parse(sql, starRocksAssert.getCtx().getSessionVariable()).get(0);
+            StmtExecutor executor = new StmtExecutor(starRocksAssert.getCtx(), stmt);
+            executor.execute();
+            assertEquals("default_warehouse", starRocksAssert.getCtx().getSessionVariable().getWarehouseName());
+        } finally {
+            Config.run_mode = RunMode.SHARED_NOTHING.getName();
+            RunMode.detectRunMode();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetVarTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetVarTest.java
@@ -211,6 +211,8 @@ public class SetVarTest extends PlanTestBase {
 
     @Test
     public void testMissingWarehouse() throws Exception {
+        Config.run_mode = RunMode.SHARED_DATA.getName();
+        RunMode.detectRunMode();
         // Simulate that after setting the warehouse, this warehouse is deleted.
         starRocksAssert.getCtx().getSessionVariable().setWarehouseName("no_exist_warehouse");
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -306,35 +306,7 @@ public class StatisticsExecutorTest extends PlanTestBase {
         ConnectContext statsContext = StatisticUtils.buildConnectContext();
         Assertions.assertEquals(1, statsContext.getSessionVariable().getParallelExecInstanceNum());
     }
-
-    @Test
-    public void testSpecifyStatisticsCollectWarehouse() {
-        new MockUp<RunMode>() {
-            @Mock
-            public RunMode getCurrentRunMode() {
-                return RunMode.SHARED_DATA;
-            }
-        };
-
-        String sql = "analyze table test.t0_stats";
-        FeConstants.enableUnitStatistics = false;
-        AnalyzeStmt stmt = (AnalyzeStmt) analyzeSuccess(sql);
-        StmtExecutor executor = new StmtExecutor(connectContext, stmt);
-        AnalyzeStatus analyzeStatus = new NativeAnalyzeStatus(1, 2, 3, Lists.newArrayList(),
-                StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.SCHEDULE, Maps.newHashMap(),
-                LocalDateTime.now());
-
-        Database db = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "default_catalog", "test");
-        Table table =
-                connectContext.getGlobalStateMgr().getLocalMetastore().getTable(connectContext, "test", "t0_stats");
-
-        connectContext.setCurrentWarehouse("xxx");
-        Deencapsulation.invoke(executor, "executeAnalyze", connectContext, stmt, analyzeStatus, db, table);
-        Assertions.assertTrue(analyzeStatus.getReason().contains("Warehouse xxx not exist"));
-        connectContext.setCurrentWarehouse("default_warehouse");
-        FeConstants.enableUnitStatistics = true;
-    }
-
+    
     @Test
     public void testDropHistogramWithEmptyColumnNames() {
         // Test that dropHistogram and dropExternalHistogram methods handle empty column lists

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -25,13 +25,11 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.AnalyzeStmt;
 import com.starrocks.sql.ast.DropHistogramStmt;
@@ -306,7 +304,7 @@ public class StatisticsExecutorTest extends PlanTestBase {
         ConnectContext statsContext = StatisticUtils.buildConnectContext();
         Assertions.assertEquals(1, statsContext.getSessionVariable().getParallelExecInstanceNum());
     }
-    
+
     @Test
     public void testDropHistogramWithEmptyColumnNames() {
         // Test that dropHistogram and dropExternalHistogram methods handle empty column lists

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -284,6 +284,17 @@ statement
     | dropFileStatement
     | showSmallFilesStatement
 
+    // Warehouse Statement
+    | createWarehouseStatement
+    | dropWarehouseStatement
+    | suspendWarehouseStatement
+    | resumeWarehouseStatement
+    | setWarehouseStatement
+    | showWarehousesStatement
+    | showClustersStatement
+    | showNodesStatement
+    | alterWarehouseStatement
+
     // Set Statement
     | setStatement
     | setUserPropertyStatement
@@ -328,17 +339,6 @@ statement
     | truncatePlanAdvisorStatement
     | alterPlanAdvisorDropStatement
     | showPlanAdvisorStatement
-
-    // Warehouse Statement
-    | createWarehouseStatement
-    | dropWarehouseStatement
-    | suspendWarehouseStatement
-    | resumeWarehouseStatement
-    | setWarehouseStatement
-    | showWarehousesStatement
-    | showClustersStatement
-    | showNodesStatement
-    | alterWarehouseStatement
 
     // CNGroup Statement
     | createCNGroupStatement


### PR DESCRIPTION
## Why I'm doing:

1. Ensure that `set warehouse = “xxx”` resolves the `SetWarehouseStatement` before resolving the `SetStatement`.
2. When set the warehouse, load variables in sequence (global->warehouse->user property->session).

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Establishes warehouse-scoped session variables and ensures consistent session state when switching warehouses.
> 
> - **Session rebuild on warehouse change**: `ConnectContext.setCurrentWarehouse()` now re-initializes `SessionVariable` and applies variables in order: `global` -> `warehouse` -> `user property` -> `modified session` via new `applyWarehouseSessionVariable()`.
> - **Variable management utilities**: `VariableMgr` adds `applyWarehouseVariable`, `applySessionVariable`, and `applyModifiedVariable`; `newSessionVariable()` and `SessionVariable.clone()` return `SessionVariable`. `setSystemVariable` signature simplified (no `ConnectContext`) and avoids directly setting `warehouse`.
> - **Query hints and SET behavior**: `StmtExecutor` applies `SET_VAR` hints case-insensitively, supports `WAREHOUSE` in hints via `applyWarehouseSessionVariable`, and skips restoring session vars on successful `SET`/`SET WAREHOUSE`.
> - **Warehouse API**: `Warehouse.getWarehouseSessionVariable()` added (default empty) for per-warehouse defaults.
> - **Auth/user properties**: `AuthenticationHandler` applies user properties using qualified `user` string.
> - **Parser**: Warehouse statements positioned before SET statements to ensure correct resolution.
> - **Tests**: Updated/added UTs for warehouse changes and session variable behavior; removed an obsolete statistics test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6214b48ef48f4d0982c81f800dcaa3c60684b84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->