### PR TITLE
[Enhancement] Supporting dictifiation in union all operations

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -411,6 +411,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String LOW_CARDINALITY_OPTIMIZE_V2 = "low_cardinality_optimize_v2";
     public static final String LOW_CARDINALITY_OPTIMIZE_ON_LAKE = "low_cardinality_optimize_on_lake";
     public static final String ARRAY_LOW_CARDINALITY_OPTIMIZE = "array_low_cardinality_optimize";
+    public static final String ENABLE_LOW_CARDINALITY_OPTIMIZE_FOR_UNION_ALL =
+                    "enable_low_cardinality_optimize_for_union_all";
     public static final String CBO_USE_NTH_EXEC_PLAN = "cbo_use_nth_exec_plan";
     public static final String CBO_CTE_REUSE = "cbo_cte_reuse";
     public static final String CBO_CTE_REUSE_RATE = "cbo_cte_reuse_rate";
@@ -1689,6 +1691,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = CBO_ENABLE_LOW_CARDINALITY_OPTIMIZE_FOR_JOIN)
     private boolean enableLowCardinalityOptimizeForJoin = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_LOW_CARDINALITY_OPTIMIZE_FOR_UNION_ALL)
+    private boolean enableLowCardinalityOptimizeForUnionAll = true;
 
     @VariableMgr.VarAttr(name = LOW_CARDINALITY_OPTIMIZE_V2)
     private boolean useLowCardinalityOptimizeV2 = true;
@@ -4409,6 +4414,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableLowCardinalityOptimizeForJoin() {
         return enableLowCardinalityOptimizeForJoin;
+    }
+
+    public boolean isEnableLowCardinalityOptimizeForUnionAll() {
+        return enableLowCardinalityOptimizeForUnionAll;
+    }
+
+    public void setEnableLowCardinalityOptimizeForUnionAll(boolean enableLowCardinalityOptimizeForUnionAll) {
+        this.enableLowCardinalityOptimizeForUnionAll = enableLowCardinalityOptimizeForUnionAll;
     }
 
     public boolean isUseLowCardinalityOptimizeV2() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -53,6 +53,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalSetOperation;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -170,6 +171,8 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
     private final Set<Integer> joinEqColumnGroupIds = Sets.newHashSet();
     private final List<Pair<Integer, Integer>> joinEqColumnGroups = Lists.newArrayList();
 
+    private final UnionDictionaryManager unionDictionaryManager;
+
     // operators which are the children of Match operator
     private final ColumnRefSet matchChildren = new ColumnRefSet();
 
@@ -181,6 +184,8 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
     public DecodeCollector(SessionVariable session, boolean isQuery) {
         this.sessionVariable = session;
         this.isQuery = isQuery;
+        unionDictionaryManager = new UnionDictionaryManager(
+                sessionVariable, stringRefToDefineExprMap, globalDicts, joinEqColumnGroupIds);
     }
 
     public void collect(OptExpression root, DecodeContext context) {
@@ -232,6 +237,11 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         this.tableFunctionDependencies.forEach((k, v) -> {
             dependencyStringIds.computeIfAbsent(v, x -> Sets.newHashSet()).add(k);
         });
+
+        this.unionDictionaryManager.getUnionColumnGroups().forEach(s -> {
+            final Integer id = s.stream().findAny().orElseThrow();
+            dependencyStringIds.computeIfAbsent(id, x -> Sets.newHashSet()).addAll(s);
+        });
         // build relation groups. The same closure is built into the same group
         // eg:
         // 1 -> (2, 3)
@@ -255,7 +265,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         }
     }
 
-    private void mergeJoinEqColumnDicts() {
+    private void mergeJoinEqColumnDicts(Set<Integer> mergedUnionDictColumns) {
+        joinEqColumnGroupIds.stream().filter(mergedUnionDictColumns::contains)
+                .forEach(disableRewriteStringColumns::union);
         for (Pair<Integer, Integer> p : joinEqColumnGroups) {
             final int colId1 = p.first;
             final int colId2 = p.second;
@@ -284,8 +296,10 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
     }
 
     private void initContext(DecodeContext context) {
-        mergeJoinEqColumnDicts();
+        Set<Integer> mergedUnionDictColumns = unionDictionaryManager.getMergedDictColumnIds();
+        mergeJoinEqColumnDicts(mergedUnionDictColumns);
         fillDisableStringColumns();
+        unionDictionaryManager.finalizeColumnDictionaries();
 
         // choose the profitable string columns
         for (Integer cid : scanStringColumns) {
@@ -296,6 +310,10 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 continue;
             }
             if (expressionStringRefCounter.getOrDefault(cid, 0) > 1) {
+                context.allStringColumns.add(cid);
+                continue;
+            }
+            if (mergedUnionDictColumns.contains(cid)) {
                 context.allStringColumns.add(cid);
                 continue;
             }
@@ -640,11 +658,37 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         if (context.outputStringColumns.isEmpty()) {
             return DecodeInfo.EMPTY;
         }
+        PhysicalSetOperation setOp = optExpression.getOp().cast();
         DistributionSpec dist = optExpression.getRequiredProperties().get(0).getDistributionProperty().getSpec();
+        if (setOp instanceof PhysicalUnionOperator && ((PhysicalUnionOperator) setOp).isUnionAll()) {
+            Preconditions.checkState(!(dist instanceof HashDistributionSpec));
+            DecodeInfo result = new DecodeInfo();
+            result.inputStringColumns.union(context.outputStringColumns);
+            for (int i = 0; i < setOp.getOutputColumnRefOp().size(); ++i) {
+                final int finalI = i;
+                List<Integer> childColumns = setOp.getChildOutputColumns().stream()
+                        .map(l -> l.get(finalI).getId()).toList();
+                boolean isCandidate = childColumns.stream().allMatch(context.outputStringColumns::contains);
+                if (isCandidate && unionDictionaryManager.mergeDictionaries(childColumns)) {
+                    int outputColumnId = setOp.getOutputColumnRefOp().get(i).getId();
+                    childColumns.forEach(c -> {
+                        result.usedStringColumns.union(c);
+                        expressionStringRefCounter.put(c, expressionStringRefCounter.getOrDefault(c, 0) + 1);
+                    });
+                    stringRefToDefineExprMap.put(outputColumnId, setOp.getChildOutputColumns().get(0).get(i));
+                    expressionStringRefCounter.put(outputColumnId, 1);
+                    result.outputStringColumns.union(setOp.getOutputColumnRefOp().get(i));
+                } else {
+                    childColumns.stream().filter(c -> context.outputStringColumns.contains(c))
+                            .forEach(result.decodeStringColumns::union);
+                }
+            }
+            result.inputStringColumns.except(result.decodeStringColumns);
+            return result;
+        }
         if (!(dist instanceof HashDistributionSpec)) {
             return visit(optExpression, context);
         }
-        PhysicalSetOperation setOp = optExpression.getOp().cast();
         DecodeInfo result = context.createOutputInfo();
         result.decodeStringColumns.except(result.outputStringColumns);
         result.outputStringColumns.getStream().forEach(c -> disableRewriteStringColumns.union(c));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -49,6 +49,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -197,6 +198,32 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
 
         return rewriteOptExpression(optExpression, newJoin, info.outputStringColumns);
     }
+
+    @Override
+    public OptExpression visitPhysicalUnion(OptExpression optExpression, ColumnRefSet fragmentUseDictExprs) {
+        PhysicalUnionOperator unionOp = optExpression.getOp().cast();
+        DecodeInfo info = context.operatorDecodeInfo.getOrDefault(unionOp, DecodeInfo.EMPTY);
+        ColumnRefSet inputColumns = new ColumnRefSet();
+        inputColumns.union(info.inputStringColumns);
+        unionOp.getOutputColumnRefOp().stream().map(ColumnRefOperator::getId).filter(context.allStringColumns::contains)
+                .forEach(inputColumns::union);
+        ScalarOperator newPredicate = rewritePredicate(unionOp.getPredicate(), inputColumns);
+        Projection newProjection = rewriteProjection(unionOp.getProjection(), inputColumns);
+        List<ColumnRefOperator> newColumnRefOp = unionOp.getOutputColumnRefOp().stream().map(
+                c -> context.allStringColumns.contains(c.getId())
+                        ? context.stringRefToDictRefMap.getOrDefault(c, c) : c).toList();
+        List<List<ColumnRefOperator>> newChildOutputColumns = unionOp.getChildOutputColumns().stream()
+                .map(l -> l.stream()
+                        .map(c -> info.inputStringColumns.contains(c) ?
+                                context.stringRefToDictRefMap.getOrDefault(c, c) : c).toList()
+                ).toList();
+
+        PhysicalUnionOperator newUnionOp = new PhysicalUnionOperator(newColumnRefOp, newChildOutputColumns,
+                unionOp.isUnionAll(), unionOp.getLimit(), newPredicate, newProjection,
+                unionOp.isFromIcebergEqualityDeleteRewrite());
+        return rewriteOptExpression(optExpression, newUnionOp, info.outputStringColumns);
+    }
+
 
     @Override
     public OptExpression visitPhysicalHashAggregate(OptExpression optExpression, ColumnRefSet fragmentUseDictExprs) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
@@ -1,0 +1,136 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree.lowcardinality;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.UnionFind;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnDict;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class UnionDictionaryManager {
+    private final UnionFind<Integer> unionColumnGroups = new UnionFind<>();
+    private final Map<Integer, ImmutableMap<ByteBuffer, Integer>> unionDictData = Maps.newHashMap();
+    private final SessionVariable sessionVariable;
+    private final Map<Integer, ScalarOperator> stringRefToDefineExprMap;
+    private final Map<Integer, ColumnDict> globalDicts;
+    private final Set<Integer> joinEqColumnGroupIds;
+
+    public UnionDictionaryManager(SessionVariable sessionVariable,
+                                  Map<Integer, ScalarOperator> stringRefToDefineExprMap,
+                                  Map<Integer, ColumnDict> globalDicts,
+                                  Set<Integer> joinEqColumnGroupIds) {
+        this.sessionVariable = sessionVariable;
+        this.stringRefToDefineExprMap = stringRefToDefineExprMap;
+        this.globalDicts = globalDicts;
+        this.joinEqColumnGroupIds = joinEqColumnGroupIds;
+    }
+
+    private static ImmutableMap<ByteBuffer, Integer> mergeDictionaryData(List<ImmutableMap<ByteBuffer, Integer>> dicts) {
+        Set<ByteBuffer> uniques = Sets.newHashSet();
+        dicts.forEach(d -> uniques.addAll(d.keySet()));
+        int totalDictSize = uniques.stream().map(b -> b.limit() - b.position() + 4).reduce(0, Integer::sum);
+        // TODO(farhad-celo): This constant is hardcoded in other places, refactor to a config.
+        final int DICT_PAGE_MAX_SIZE = 1024 * 1024;
+        if (uniques.size() > Config.low_cardinality_threshold || totalDictSize > DICT_PAGE_MAX_SIZE - 32) {
+            return null;
+        }
+        List<ByteBuffer> sortedValues = uniques.stream().sorted().toList();
+        ImmutableMap.Builder<ByteBuffer, Integer> builder = ImmutableMap.builder();
+        for (int i = 0; i < sortedValues.size(); ++i) {
+            builder.put(sortedValues.get(i), i + 1);
+        }
+        return builder.build();
+    }
+
+    private Integer getSourceDictionaryColumnId(Integer cid) {
+        if (globalDicts.containsKey(cid)) {
+            return cid;
+        }
+        ScalarOperator define = stringRefToDefineExprMap.get(cid);
+        if (define == null || !define.isColumnRef()) {
+            return null;
+        }
+        int newId = ((ColumnRefOperator) define).getId();
+        if (newId == cid) {
+            return null;
+        }
+        return getSourceDictionaryColumnId(newId);
+    }
+
+    boolean mergeDictionaries(List<Integer> columnIds) {
+        if (!sessionVariable.isEnableLowCardinalityOptimizeForUnionAll()) {
+            return false;
+        }
+        columnIds = columnIds.stream().map(this::getSourceDictionaryColumnId).toList();
+        if (columnIds.contains(null) || !columnIds.stream().allMatch(globalDicts::containsKey)
+                || columnIds.stream().anyMatch(joinEqColumnGroupIds::contains)) {
+            return false;
+        }
+        columnIds.forEach(cid -> {
+            Integer groupId = unionColumnGroups.getGroupIdOrAdd(cid);
+            if (!unionDictData.containsKey(groupId)) {
+                Preconditions.checkState(globalDicts.containsKey(cid));
+                unionDictData.put(groupId, globalDicts.get(cid).getDict());
+            }
+        });
+        List<Integer> columnGroupIds = columnIds.stream().map(
+                cid -> unionColumnGroups.getGroupId(cid).orElseThrow()).distinct().toList();
+        List<ImmutableMap<ByteBuffer, Integer>> allData = columnGroupIds.stream().map(unionDictData::get).toList();
+        ImmutableMap<ByteBuffer, Integer> mergedDictData = mergeDictionaryData(allData);
+        if (mergedDictData == null) {
+            return false;
+        }
+        final Integer firstElement = columnIds.get(0);
+        columnIds.forEach(cid -> unionColumnGroups.union(cid, firstElement));
+        Integer finalGroup = unionColumnGroups.getGroupId(firstElement).orElseThrow();
+        unionDictData.put(finalGroup, mergedDictData);
+        return true;
+    }
+
+    void finalizeColumnDictionaries() {
+        unionColumnGroups.getAllGroups().stream().filter(s -> s.size() > 1).forEach(s -> {
+            Integer groupId = unionColumnGroups.getGroupId(s.stream().findAny().orElseThrow()).orElseThrow();
+            ImmutableMap<ByteBuffer, Integer> dictData = unionDictData.get(groupId);
+            Preconditions.checkNotNull(dictData);
+            s.forEach(cid -> {
+                Preconditions.checkState(globalDicts.containsKey(cid));
+                globalDicts.compute(cid, (k, oldDict) ->
+                        new ColumnDict(dictData, oldDict.getCollectedVersion(), oldDict.getVersion()));
+            });
+        });
+    }
+
+    Collection<Set<Integer>> getUnionColumnGroups() {
+        return unionColumnGroups.getAllGroups().stream().filter(s -> s.size() > 1).toList();
+    }
+
+    Set<Integer> getMergedDictColumnIds() {
+        return unionColumnGroups.getAllGroups().stream().filter(s -> s.size() > 1).flatMap(Set::stream)
+                .collect(Collectors.toSet());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
@@ -53,7 +53,7 @@ public class UnionDictionaryManager {
     private static ImmutableMap<ByteBuffer, Integer> mergeDictionaryData(List<ImmutableMap<ByteBuffer, Integer>> dicts) {
         Set<ByteBuffer> uniques = Sets.newHashSet();
         dicts.forEach(d -> uniques.addAll(d.keySet()));
-        int totalDictSize = uniques.stream().map(b -> b.limit() - b.position() + 4).reduce(0, Integer::sum);
+        int totalDictSize = uniques.stream().map(b -> b.remaining() + 4).reduce(0, Integer::sum);
         // TODO(farhad-celo): This constant is hardcoded in other places, refactor to a config.
         final int DICT_PAGE_MAX_SIZE = 1024 * 1024;
         if (uniques.size() > Config.low_cardinality_threshold || totalDictSize > DICT_PAGE_MAX_SIZE - 32) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
@@ -1,0 +1,230 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree.lowcardinality;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.common.Config;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnDict;
+import com.starrocks.type.StringType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+class UnionDictionaryManagerTest {
+
+    private static final SessionVariable SESSION_VARIABLE = new SessionVariable();
+
+    @BeforeAll
+    static void setupSharedResource() {
+        SESSION_VARIABLE.setEnableLowCardinalityOptimizeForUnionAll(true);
+    }
+
+    private static ColumnDict makeDict(Collection<String> values, int collectedVersion, int version) {
+        ImmutableMap.Builder<ByteBuffer, Integer> builder = ImmutableMap.builder();
+        List<ByteBuffer> sortedValues = values.stream().sorted().map(StandardCharsets.UTF_8::encode).toList();
+        for (int i = 0; i < sortedValues.size(); ++i) {
+            builder.put(sortedValues.get(i), i + 1);
+        }
+        return new ColumnDict(builder.build(), collectedVersion, version);
+    }
+
+    private static ColumnDict makeDict(Collection<String> values, int version) {
+        return makeDict(values, version, version);
+    }
+
+    private static ColumnDict makeDict(Collection<String> values) {
+        return makeDict(values, 0);
+    }
+
+    private static List<String> getDictValues(ColumnDict dict) {
+        String[] array = new String[dict.getDictSize()]; // Array of size 3
+        for (Map.Entry<ByteBuffer, Integer> entry : dict.getDict().entrySet()) {
+            array[entry.getValue() - 1] = StandardCharsets.UTF_8.decode(entry.getKey().duplicate()).toString();
+        }
+        return Arrays.asList(array);
+    }
+
+    @Test
+    public void testMergeDictionaries() throws Exception {
+        Map<Integer, ColumnDict> globalDicts = new HashMap<>(Map.of(
+                1, makeDict(List.of("a", "g")),
+                2, makeDict(List.of("a", "c")),
+                3, makeDict(List.of("b", "e", "f")),
+                4, makeDict(List.of("z"))));
+        UnionDictionaryManager unionDictionaryManager =
+                new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
+        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(1, 2, 3)));
+        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b", "c", "e", "f", "g"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(2)), List.of("a", "b", "c", "e", "f", "g"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(3)), List.of("a", "b", "c", "e", "f", "g"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(4)), List.of("z"));
+    }
+
+    @Test
+    public void testMergeDictionariesMultipleStages() throws Exception {
+        Map<Integer, ColumnDict> globalDicts = new HashMap<>(Map.of(
+                1, makeDict(List.of("a", "g")),
+                2, makeDict(List.of("a", "c")),
+                3, makeDict(List.of("t")),
+                4, makeDict(List.of("z")),
+                5, makeDict(List.of("b", "e", "f")),
+                6, makeDict(List.of("h")),
+                7, makeDict(List.of("x", "y"))));
+        UnionDictionaryManager unionDictionaryManager =
+                new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
+        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(1, 2)));
+        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(5, 6)));
+        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(1, 5)));
+        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(4, 7)));
+        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(2).getDict());
+        Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(5).getDict());
+        Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(6).getDict());
+        Assertions.assertEquals(globalDicts.get(4).getDict(), globalDicts.get(7).getDict());
+        Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b", "c", "e", "f", "g", "h"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(2)), List.of("a", "b", "c", "e", "f", "g", "h"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(3)), List.of("t"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(4)), List.of("x", "y", "z"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(5)), List.of("a", "b", "c", "e", "f", "g", "h"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(6)), List.of("a", "b", "c", "e", "f", "g", "h"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(7)), List.of("x", "y", "z"));
+
+        Assertions.assertEquals(unionDictionaryManager.getMergedDictColumnIds(), Set.of(1, 2, 4, 5, 6, 7));
+
+        Collection<Set<Integer>> columnGroups = unionDictionaryManager.getUnionColumnGroups();
+        Assertions.assertEquals(2, columnGroups.size());
+        Assertions.assertTrue(columnGroups.contains(Set.of(1, 2, 5, 6)));
+        Assertions.assertTrue(columnGroups.contains(Set.of(4, 7)));
+
+    }
+
+    @Test
+    void testMergeDictionaryTooManyElements() {
+        List<String> bigList = new ArrayList<>(IntStream.range(0, Config.low_cardinality_threshold - 2)
+                .mapToObj(String::valueOf).sorted().toList());
+        Map<Integer, ColumnDict> globalDicts = new HashMap<>(Map.of(
+                1, makeDict(List.of("a", "b")),
+                2, makeDict(bigList),
+                3, makeDict(List.of("z"))));
+        UnionDictionaryManager unionDictionaryManager =
+                new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
+        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(2, 3)));
+        Assertions.assertFalse(unionDictionaryManager.mergeDictionaries(List.of(3, 1)));
+        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertEquals(globalDicts.get(2).getDict(), globalDicts.get(3).getDict());
+
+        Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b"));
+        bigList.add("z");
+        Assertions.assertEquals(getDictValues(globalDicts.get(2)), bigList);
+        Assertions.assertEquals(getDictValues(globalDicts.get(3)), bigList);
+
+        Assertions.assertEquals(unionDictionaryManager.getMergedDictColumnIds(), Set.of(2, 3));
+        Collection<Set<Integer>> columnGroups = unionDictionaryManager.getUnionColumnGroups();
+        Assertions.assertEquals(1, columnGroups.size());
+        Assertions.assertTrue(columnGroups.contains(Set.of(2, 3)));
+    }
+
+    @Test
+    void testMergeDictionaryBigDictionarySize() {
+        List<String> bigList = new ArrayList<>(List.of("a".repeat(1024 * 1024 - 9 - 32)));
+        Map<Integer, ColumnDict> globalDicts = new HashMap<>(Map.of(
+                1, makeDict(List.of("a", "b")),
+                2, makeDict(bigList),
+                3, makeDict(List.of("z"))));
+        UnionDictionaryManager unionDictionaryManager =
+                new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
+        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(2, 3)));
+        Assertions.assertFalse(unionDictionaryManager.mergeDictionaries(List.of(3, 1)));
+        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertEquals(globalDicts.get(2).getDict(), globalDicts.get(3).getDict());
+
+        Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b"));
+        bigList.add("z");
+        Assertions.assertEquals(getDictValues(globalDicts.get(2)), bigList);
+        Assertions.assertEquals(getDictValues(globalDicts.get(3)), bigList);
+
+        Assertions.assertEquals(unionDictionaryManager.getMergedDictColumnIds(), Set.of(2, 3));
+        Collection<Set<Integer>> columnGroups = unionDictionaryManager.getUnionColumnGroups();
+        Assertions.assertEquals(1, columnGroups.size());
+        Assertions.assertTrue(columnGroups.contains(Set.of(2, 3)));
+    }
+
+    @Test
+    void testConflictWithJoin() {
+        Map<Integer, ColumnDict> globalDicts = new HashMap<>(Map.of(
+                1, makeDict(List.of("a", "b")),
+                2, makeDict(List.of("c", "d")),
+                3, makeDict(List.of("e"))));
+        UnionDictionaryManager unionDictionaryManager =
+                new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of(3));
+        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(1, 2)));
+        Assertions.assertFalse(unionDictionaryManager.mergeDictionaries(List.of(1, 3)));
+        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(2).getDict());
+
+        Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b", "c", "d"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(2)), List.of("a", "b", "c", "d"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(3)), List.of("e"));
+
+        Assertions.assertEquals(unionDictionaryManager.getMergedDictColumnIds(), Set.of(1, 2));
+        Collection<Set<Integer>> columnGroups = unionDictionaryManager.getUnionColumnGroups();
+        Assertions.assertEquals(1, columnGroups.size());
+        Assertions.assertTrue(columnGroups.contains(Set.of(1, 2)));
+    }
+
+    @Test
+    void testUseDefineExpr() {
+        Map<Integer, ColumnDict> globalDicts = new HashMap<>(Map.of(
+                1, makeDict(List.of("a", "b")),
+                2, makeDict(List.of("c", "d")),
+                3, makeDict(List.of("e"))));
+        Map<Integer, ScalarOperator> stringRefToDefineExprMap = Map.of(
+                4, new ColumnRefOperator(1, StringType.STRING, "", true),
+                5, new ColumnRefOperator(2, StringType.STRING, "", true),
+                6, new ColumnRefOperator(3, StringType.STRING, "", true),
+                7, new ColumnRefOperator(6, StringType.STRING, "", true)
+        );
+        UnionDictionaryManager unionDictionaryManager =
+                new UnionDictionaryManager(SESSION_VARIABLE, stringRefToDefineExprMap, globalDicts, Set.of(2));
+        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(4, 7)));
+        Assertions.assertFalse(unionDictionaryManager.mergeDictionaries(List.of(4, 5)));
+        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(3).getDict());
+
+        Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b", "e"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(2)), List.of("c", "d"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(3)), List.of("a", "b", "e"));
+
+        Assertions.assertEquals(unionDictionaryManager.getMergedDictColumnIds(), Set.of(1, 3));
+        Collection<Set<Integer>> columnGroups = unionDictionaryManager.getUnionColumnGroups();
+        Assertions.assertEquals(1, columnGroups.size());
+        Assertions.assertTrue(columnGroups.contains(Set.of(1, 3)));
+    }
+}

--- a/test/sql/test_global_dict/R/global_dict_with_union
+++ b/test/sql/test_global_dict/R/global_dict_with_union
@@ -1,0 +1,1391 @@
+-- name: test_global_dict_with_union
+CREATE TABLE test_table_1 (
+    id INT,
+    value VARCHAR(10)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE test_table_2 (
+    id INT,
+    value VARCHAR(10)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO test_table_1 VALUES (1, 'a'), (2, 'b'), (3, 'c');
+-- result:
+-- !result
+INSERT INTO test_table_2 VALUES (4, 'd'), (5, 'e'), (6, 'f');
+-- result:
+-- !result
+[UC]analyze full table test_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.test_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table test_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.test_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('value', 'test_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('value', 'test_table_2')
+-- result:
+
+-- !result
+SELECT * 
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t
+WHERE id > 3;
+-- result:
+4	d
+5	e
+6	f
+-- !result
+SELECT id, value FROM test_table_1 WHERE id < 3
+UNION ALL
+SELECT id, value FROM test_table_2 WHERE id > 4;
+-- result:
+2	b
+1	a
+5	e
+6	f
+-- !result
+SELECT value, COUNT(*) AS cnt
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t
+GROUP BY value;
+-- result:
+b	1
+e	1
+a	1
+f	1
+c	1
+d	1
+-- !result
+SELECT value, COUNT(*) AS cnt
+FROM test_table_1
+GROUP BY value
+UNION ALL
+SELECT value, COUNT(*) AS cnt
+FROM test_table_2
+GROUP BY value;
+-- result:
+a	1
+f	1
+b	1
+d	1
+c	1
+e	1
+-- !result
+SELECT id, value
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t
+ORDER BY id DESC
+LIMIT 4;
+-- result:
+6	f
+5	e
+4	d
+3	c
+-- !result
+CREATE TABLE join_table (
+    id INT,
+    detail VARCHAR(10)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO join_table VALUES (1, 'info1'), (5, 'info5');
+-- result:
+-- !result
+[UC]analyze full table join_table;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.join_table	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('detail', 'join_table')
+-- result:
+
+-- !result
+SELECT t1.id, t1.value, jt.detail
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t1
+JOIN join_table jt
+ON t1.id = jt.id;
+-- result:
+1	a	info1
+5	e	info5
+-- !result
+SELECT a.id, a.value, b.detail 
+FROM test_table_1 a
+JOIN join_table b
+ON a.id = b.id
+UNION ALL
+SELECT c.id, c.value, d.detail 
+FROM test_table_2 c
+JOIN join_table d
+ON c.id = d.id;
+-- result:
+5	e	info5
+1	a	info1
+-- !result
+SELECT id, value
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+    UNION ALL
+    SELECT id, detail FROM join_table
+) t;
+-- result:
+2	b
+5	info5
+4	d
+5	e
+6	f
+1	info1
+1	a
+3	c
+-- !result
+CREATE TABLE alias_table_1 (
+    col1 INT,
+    col2 VARCHAR(10)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE alias_table_2 (
+    col1 INT,
+    col2 VARCHAR(10)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO alias_table_1 VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma');
+-- result:
+-- !result
+INSERT INTO alias_table_2 VALUES (4, 'delta'), (5, 'epsilon');
+-- result:
+-- !result
+[UC]analyze full table alias_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.alias_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table alias_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.alias_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('col2', 'alias_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('col2', 'alias_table_2')
+-- result:
+
+-- !result
+SELECT alias_col1, alias_col2 
+FROM (
+    SELECT col1 AS alias_col1, col2 AS alias_col2 FROM alias_table_1
+    UNION ALL
+    SELECT col1 AS alias_col1, col2 AS alias_col2 FROM alias_table_2
+) t
+WHERE alias_col1 > 2;
+-- result:
+3	gamma
+4	delta
+5	epsilon
+-- !result
+CREATE TABLE diff_table_1 (
+    a INT,
+    b VARCHAR(10)
+) DUPLICATE KEY(a)
+DISTRIBUTED BY HASH(a) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE diff_table_2 (
+    x INT,
+    y VARCHAR(10)
+) DUPLICATE KEY(x)
+DISTRIBUTED BY HASH(x) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO diff_table_1 VALUES (1, 'one'), (2, 'two');
+-- result:
+-- !result
+INSERT INTO diff_table_2 VALUES (3, 'three'), (4, 'four');
+-- result:
+-- !result
+[UC]analyze full table diff_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.diff_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table diff_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.diff_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('b', 'diff_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('y', 'diff_table_2')
+-- result:
+
+-- !result
+SELECT col1, col2
+FROM (
+    SELECT a AS col1, b AS col2 FROM diff_table_1
+    UNION ALL
+    SELECT x AS col1, y AS col2 FROM diff_table_2
+) t;
+-- result:
+2	two
+1	one
+3	three
+4	four
+-- !result
+SELECT DISTINCT id, value 
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t;
+-- result:
+4	d
+5	e
+2	b
+3	c
+6	f
+1	a
+-- !result
+SELECT id, COUNT(*) AS cnt 
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t
+GROUP BY id
+HAVING cnt > 1;
+-- result:
+-- !result
+SELECT id, value 
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t
+WHERE id > 2 AND value LIKE 'a%' AND (id + 5 < 10 OR value = 'f');
+-- result:
+-- !result
+SELECT id, value 
+FROM (
+    SELECT id, value FROM test_table_1 WHERE value = 'a'
+    UNION ALL
+    SELECT id, value FROM test_table_2 WHERE value = 'b'
+    UNION ALL
+    SELECT id, detail FROM join_table WHERE detail = 'info1'
+) t
+WHERE id < 5;
+-- result:
+1	a
+1	info1
+-- !result
+SELECT t1.id, t1.value, t2.id, t2.detail 
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t1
+CROSS JOIN join_table t2;
+-- result:
+2	b	1	info1
+2	b	5	info5
+1	a	1	info1
+1	a	5	info5
+3	c	1	info1
+3	c	5	info5
+4	d	1	info1
+4	d	5	info5
+5	e	1	info1
+5	e	5	info5
+6	f	1	info1
+6	f	5	info5
+-- !result
+SELECT id, value 
+FROM (
+    SELECT id, value FROM test_table_1 WHERE 1 = 0
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t;
+-- result:
+4	d
+5	e
+6	f
+-- !result
+SELECT fixed_col, id 
+FROM (
+    SELECT 'Constant1' AS fixed_col, id FROM test_table_1
+    UNION ALL
+    SELECT 'Constant2' AS fixed_col, id FROM test_table_2
+) t;
+-- result:
+Constant1	2
+Constant2	4
+Constant2	5
+Constant2	6
+Constant1	1
+Constant1	3
+-- !result
+SELECT col1, col2 
+FROM (
+    SELECT col1, col2 
+    FROM (
+        SELECT id AS col1, value AS col2 FROM test_table_1
+        UNION ALL
+        SELECT id AS col1, value AS col2 FROM test_table_2 WHERE id > 4
+    ) subquery1
+    UNION ALL
+    SELECT id AS col1, detail AS col2 
+    FROM (
+        SELECT id, detail FROM join_table
+        UNION ALL
+        SELECT id, detail FROM join_table WHERE id = 1
+    ) subquery2
+) t;
+-- result:
+2	b
+1	info1
+1	a
+3	c
+5	e
+6	f
+1	info1
+5	info5
+-- !result
+CREATE TABLE alias_agg_table_1 (
+    c1 INT,
+    c2 VARCHAR(10)
+) DUPLICATE KEY(c1)
+DISTRIBUTED BY HASH(c1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE alias_agg_table_2 (
+    c1 INT,
+    c2 VARCHAR(10)
+) DUPLICATE KEY(c1)
+DISTRIBUTED BY HASH(c1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO alias_agg_table_1 VALUES (1, 'x'), (2, 'y'), (3, 'z');
+-- result:
+-- !result
+INSERT INTO alias_agg_table_2 VALUES (4, 'p'), (5, 'q'), (6, 'r');
+-- result:
+-- !result
+[UC]analyze full table alias_agg_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.alias_agg_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table alias_agg_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.alias_agg_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('c2', 'alias_agg_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('c2', 'alias_agg_table_2')
+-- result:
+
+-- !result
+SELECT alias_c1, COUNT(*) AS cnt
+FROM (
+    SELECT c1 AS alias_c1 FROM alias_agg_table_1
+    UNION ALL
+    SELECT c1 AS alias_c1 FROM alias_agg_table_2
+) t
+GROUP BY alias_c1;
+-- result:
+2	1
+3	1
+4	1
+5	1
+1	1
+6	1
+-- !result
+SELECT c1, c2
+FROM (
+    SELECT c1, c2 FROM alias_agg_table_1
+    UNION ALL
+    SELECT c1, c2 FROM alias_agg_table_2
+) t;
+-- result:
+1	x
+3	z
+4	p
+5	q
+6	r
+2	y
+-- !result
+SELECT c1, computed_col 
+FROM (
+    SELECT c1, c2, c1 + 10 AS computed_col FROM alias_agg_table_1
+    UNION ALL
+    SELECT c1, c2, c1 * 2 AS computed_col FROM alias_agg_table_2
+) t;
+-- result:
+4	8
+5	10
+6	12
+1	11
+3	13
+2	12
+-- !result
+SELECT * 
+FROM (
+    SELECT c1, c2 FROM alias_agg_table_1 
+    UNION ALL
+    SELECT c1, c2 FROM alias_agg_table_2 
+) t;
+-- result:
+4	p
+5	q
+6	r
+1	x
+3	z
+2	y
+-- !result
+SELECT c1, c2
+FROM (
+    SELECT c1, c2
+    FROM (
+        SELECT c1, c2 FROM alias_agg_table_1
+        UNION ALL
+        SELECT c1, c2 FROM alias_agg_table_2
+        LIMIT 2
+    ) subquery1
+    UNION ALL
+    SELECT c1, c2
+    FROM (
+        SELECT c1, c2 FROM alias_agg_table_1
+        UNION ALL
+        SELECT c1, c2 FROM alias_agg_table_2 LIMIT 1
+    ) subquery2
+) outer_query
+ORDER BY c1, c2
+LIMIT 4;
+-- result:
+1	x
+2	y
+3	z
+-- !result
+CREATE TABLE exclude_col_table_1 (
+    col1 INT,
+    col2 INT,
+    col3 VARCHAR(10)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE exclude_col_table_2 (
+    col1 INT,
+    col2 INT,
+    col3 VARCHAR(10)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO exclude_col_table_1 VALUES (1, 10, 'foo'), (2, 20, 'bar'), (3, 30, 'baz');
+-- result:
+-- !result
+INSERT INTO exclude_col_table_2 VALUES (4, 40, 'qux'), (5, 50, 'quux'), (6, 60, 'corge');
+-- result:
+-- !result
+[UC]analyze full table exclude_col_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.exclude_col_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table exclude_col_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.exclude_col_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('col3', 'exclude_col_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('col3', 'exclude_col_table_2')
+-- result:
+
+-- !result
+SELECT col1, col3
+FROM (
+    SELECT col1, col3 FROM exclude_col_table_1 WHERE col2 > 15
+    UNION ALL
+    SELECT col1, col3 FROM exclude_col_table_2
+) t;
+-- result:
+2	bar
+3	baz
+4	qux
+5	quux
+6	corge
+-- !result
+CREATE TABLE join_cond_table_1 (
+    id INT,
+    detail VARCHAR(10)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE join_cond_table_2 (
+    id INT,
+    detail VARCHAR(10)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO join_cond_table_1 VALUES (1, 'info1'), (3, 'info3');
+-- result:
+-- !result
+INSERT INTO join_cond_table_2 VALUES (2, 'info2'), (4, 'info4');
+-- result:
+-- !result
+[UC]analyze full table join_cond_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.join_cond_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table join_cond_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.join_cond_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('detail', 'join_cond_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('detail', 'join_cond_table_2')
+-- result:
+
+-- !result
+SELECT jt1.id, t.id, jt2.detail
+FROM (
+    SELECT id FROM join_cond_table_1
+    UNION ALL
+    SELECT id FROM join_cond_table_2
+) t
+JOIN join_cond_table_1 jt1 ON t.id = jt1.id
+JOIN join_cond_table_2 jt2 ON t.id = jt2.id;
+-- result:
+-- !result
+CREATE TABLE hash_dist_table (
+    key1 INT,
+    key2 VARCHAR(10)
+) DUPLICATE KEY(key1)
+DISTRIBUTED BY HASH(key1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE broadcast_dist_table (
+    key1 INT,
+    key2 VARCHAR(10)
+) DUPLICATE KEY(key1)
+DISTRIBUTED BY HASH(key1) BUCKETS 1
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO hash_dist_table VALUES (1, 'h1'), (2, 'h2');
+-- result:
+-- !result
+INSERT INTO broadcast_dist_table VALUES (3, 'b1'), (4, 'b2');
+-- result:
+-- !result
+[UC]analyze full table hash_dist_table;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.hash_dist_table	analyze	status	OK
+-- !result
+[UC]analyze full table broadcast_dist_table;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.broadcast_dist_table	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('key2', 'hash_dist_table')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('key2', 'broadcast_dist_table')
+-- result:
+
+-- !result
+SELECT key1, key2
+FROM (
+    SELECT key1, key2 FROM hash_dist_table
+    UNION ALL
+    SELECT key1, key2 FROM broadcast_dist_table
+) t;
+-- result:
+2	h2
+3	b1
+4	b2
+1	h1
+-- !result
+CREATE TABLE func_table_1 (
+    id INT,
+    name VARCHAR(20),
+    value INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE func_table_2 (
+    id INT,
+    name VARCHAR(20),
+    value INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO func_table_1 VALUES (1, 'A', 100), (2, 'B', 200), (3, 'C', NULL);
+-- result:
+-- !result
+INSERT INTO func_table_2 VALUES (4, 'D', 50), (5, 'E', NULL), (6, 'F', 300);
+-- result:
+-- !result
+[UC]analyze full table func_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.func_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table func_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.func_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('name', 'func_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('name', 'func_table_2')
+-- result:
+
+-- !result
+SELECT id, name, value, value + 10 AS adjusted_value
+FROM (
+    SELECT id, name, value FROM func_table_1
+    UNION ALL
+    SELECT id, name, value FROM func_table_2
+) t
+WHERE value IS NOT NULL AND value > 100;
+-- result:
+2	B	200	210
+6	F	300	310
+-- !result
+CREATE TABLE agg_table_1 (
+    id INT,
+    category VARCHAR(20),
+    count INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE agg_table_2 (
+    id INT,
+    category VARCHAR(20),
+    count INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO agg_table_1 VALUES (1, 'A', 10), (2, 'B', 20), (3, 'C', 30);
+-- result:
+-- !result
+INSERT INTO agg_table_2 VALUES (4, 'A', 40), (5, 'B', 50), (6, 'C', 60);
+-- result:
+-- !result
+[UC]analyze full table agg_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.agg_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table agg_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.agg_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('category', 'agg_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('category', 'agg_table_2')
+-- result:
+
+-- !result
+SELECT category, SUM(count) AS total_count
+FROM (
+    SELECT id, category, count FROM agg_table_1
+    UNION ALL
+    SELECT id, category, count FROM agg_table_2
+) t
+GROUP BY category;
+-- result:
+C	90
+B	70
+A	50
+-- !result
+CREATE TABLE compute_table_1 (
+    id INT,
+    value INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE compute_table_2 (
+    id INT,
+    value INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO compute_table_1 VALUES (1, 100), (2, 200), (3, 300);
+-- result:
+-- !result
+INSERT INTO compute_table_2 VALUES (4, 400), (5, 500), (6, 600);
+-- result:
+-- !result
+SELECT id, value, value + id AS computed_value
+FROM (
+    SELECT id, value FROM compute_table_1
+    UNION ALL
+    SELECT id, value FROM compute_table_2
+) t
+WHERE value > 200;
+-- result:
+4	400	404
+5	500	505
+6	600	606
+3	300	303
+-- !result
+CREATE TABLE filter_table_1 (
+    id INT,
+    type VARCHAR(20),
+    amount INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE filter_table_2 (
+    id INT,
+    type VARCHAR(20),
+    amount INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO filter_table_1 VALUES (1, 'electronics', 100), (2, 'furniture', 200), (3, 'fashion', 300);
+-- result:
+-- !result
+INSERT INTO filter_table_2 VALUES (4, 'electronics', 400), (5, 'furniture', 500), (6, 'fashion', 600);
+-- result:
+-- !result
+[UC]analyze full table filter_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.filter_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table filter_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.filter_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('type', 'filter_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('type', 'filter_table_2')
+-- result:
+
+-- !result
+SELECT id, type, amount
+FROM (
+    SELECT id, type, amount FROM filter_table_1 WHERE amount < 300
+    UNION ALL
+    SELECT id, type, amount FROM filter_table_2 WHERE amount > 400
+) t;
+-- result:
+2	furniture	200
+5	furniture	500
+6	fashion	600
+1	electronics	100
+-- !result
+CREATE TABLE nested_int_table_1 (
+    id INT,
+    group_id string
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE nested_int_table_2 (
+    id INT,
+    group_id string
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO nested_int_table_1 VALUES (1, 10), (2, 20), (3, 30);
+-- result:
+-- !result
+INSERT INTO nested_int_table_2 VALUES (4, 40), (5, 50), (6, 60);
+-- result:
+-- !result
+[UC]analyze full table nested_int_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.nested_int_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table nested_int_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.nested_int_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('group_id', 'nested_int_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('group_id', 'nested_int_table_2')
+-- result:
+
+-- !result
+SELECT id, group_id
+FROM (
+    SELECT id, group_id
+    FROM (
+        SELECT id, group_id FROM nested_int_table_1 WHERE group_id < 30
+        UNION ALL
+        SELECT id, group_id FROM nested_int_table_2
+    ) t1
+    UNION ALL
+    SELECT id, group_id
+    FROM (
+        SELECT id, group_id FROM nested_int_table_1
+        UNION ALL
+        SELECT id, group_id FROM nested_int_table_2 WHERE group_id > 30
+    ) t2
+) t;
+-- result:
+1	10
+2	20
+1	10
+3	30
+4	40
+5	50
+6	60
+2	20
+4	40
+5	50
+6	60
+-- !result
+CREATE TABLE cte_table_1 (
+    id INT,
+    value VARCHAR(20)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE cte_table_2 (
+    id INT,
+    value VARCHAR(20)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE join_table_1 (
+    id INT,
+    detail VARCHAR(20)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO cte_table_1 VALUES (1, 'A'), (2, 'B'), (3, 'C');
+-- result:
+-- !result
+INSERT INTO cte_table_2 VALUES (4, 'D'), (5, 'E'), (6, 'F');
+-- result:
+-- !result
+INSERT INTO join_table_1 VALUES (1, 'info1'), (5, 'info5');
+-- result:
+-- !result
+[UC]analyze full table cte_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.cte_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table cte_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.cte_table_2	analyze	status	OK
+-- !result
+[UC]analyze full table join_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.join_table_1	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('value', 'cte_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('value', 'cte_table_2')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('detail', 'join_table_1')
+-- result:
+
+-- !result
+WITH cte_union AS (
+    SELECT id, value FROM cte_table_1
+    UNION ALL
+    SELECT id, value FROM cte_table_2
+)
+SELECT cte_union.id, cte_union.value, jt.detail
+FROM cte_union
+JOIN join_table_1 jt ON cte_union.id = jt.id;
+-- result:
+1	A	info1
+5	E	info5
+-- !result
+CREATE TABLE source_table_1 (
+    col1 INT,
+    col2 VARCHAR(20)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE source_table_2 (
+    col1 INT,
+    col2 VARCHAR(20)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE join_table_2 (
+    col1 INT,
+    col2 VARCHAR(20)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO source_table_1 VALUES (1, 'X'), (2, 'Y'), (3, 'Z');
+-- result:
+-- !result
+INSERT INTO source_table_2 VALUES (4, 'P'), (5, 'Q'), (6, 'R');
+-- result:
+-- !result
+INSERT INTO join_table_2 VALUES (1, 'J1'), (4, 'J4');
+-- result:
+-- !result
+[UC]analyze full table source_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.source_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table source_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.source_table_2	analyze	status	OK
+-- !result
+[UC]analyze full table join_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.join_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('col2', 'source_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('col2', 'source_table_2')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('col2', 'join_table_2')
+-- result:
+
+-- !result
+CREATE TABLE ctas_result
+DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1') AS
+SELECT st1.col1, jt.col2
+FROM (
+    SELECT col1 FROM source_table_1
+    UNION ALL
+    SELECT col1 FROM source_table_2
+) st1
+JOIN join_table_2 jt ON st1.col1 = jt.col1;
+-- result:
+-- !result
+CREATE TABLE agg_cte_table_1 (
+    id INT,
+    category VARCHAR(20),
+    amount INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE agg_cte_table_2 (
+    id INT,
+    category VARCHAR(20),
+    amount INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO agg_cte_table_1 VALUES (1, 'Electronics', 300), (2, 'Furniture', 200), (3, 'Fashion', 700);
+-- result:
+-- !result
+INSERT INTO agg_cte_table_2 VALUES (4, 'Electronics', 500), (5, 'Furniture', 100), (6, 'Fashion', 300);
+-- result:
+-- !result
+[UC]analyze full table agg_cte_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.agg_cte_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table agg_cte_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.agg_cte_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('category', 'agg_cte_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('category', 'agg_cte_table_2')
+-- result:
+
+-- !result
+WITH aggregated_union AS (
+    SELECT id, category, amount FROM agg_cte_table_1
+    UNION ALL
+    SELECT id, category, amount FROM agg_cte_table_2
+)
+SELECT category, SUM(amount) AS total_amount
+FROM aggregated_union
+GROUP BY category;
+-- result:
+Electronics	800
+Furniture	300
+Fashion	1000
+-- !result
+CREATE TABLE multi_union_table_1 (
+    col1 INT,
+    col2 VARCHAR(20)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE multi_union_table_2 (
+    col1 INT,
+    col2 VARCHAR(20)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE multi_union_table_3 (
+    col1 INT,
+    col2 VARCHAR(20)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO multi_union_table_1 VALUES (1, 'Alpha'), (2, 'Beta');
+-- result:
+-- !result
+INSERT INTO multi_union_table_2 VALUES (3, 'Gamma'), (4, 'Delta');
+-- result:
+-- !result
+INSERT INTO multi_union_table_3 VALUES (5, 'Epsilon'), (6, 'Zeta');
+-- result:
+-- !result
+[UC]analyze full table multi_union_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.multi_union_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table multi_union_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.multi_union_table_2	analyze	status	OK
+-- !result
+[UC]analyze full table multi_union_table_3;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.multi_union_table_3	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('col2', 'multi_union_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('col2', 'multi_union_table_2')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('col2', 'multi_union_table_3')
+-- result:
+
+-- !result
+CREATE TABLE ctas_result_2
+DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1') AS
+SELECT col1, col2 FROM (
+    SELECT col1, col2 FROM multi_union_table_1
+    UNION ALL
+    SELECT col1, col2 FROM multi_union_table_2
+    UNION ALL
+    SELECT col1, col2 FROM multi_union_table_3
+) t;
+-- result:
+-- !result
+CREATE TABLE large_table_1 (
+    id INT,
+    value VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE large_table_2 (
+    id INT,
+    value VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO large_table_1 VALUES
+(1, 'val1'), (2, 'val2'), (3, 'val3'),
+(4, 'val4'), (5, 'val5'), (6, 'val6'),
+(7, 'val7'), (8, 'val8'), (9, 'val9'),
+(10, 'val10'), (11, 'val11'), (12, 'val12'),
+(13, 'val13'), (14, 'val14'), (15, 'val15');
+-- result:
+-- !result
+INSERT INTO large_table_1
+SELECT id + 15, CONCAT('val', id + 15) FROM large_table_1;
+-- result:
+-- !result
+INSERT INTO large_table_2
+SELECT id + 30, CONCAT('str', id + 30) FROM large_table_1;
+-- result:
+-- !result
+[UC]analyze full table large_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.large_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table large_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.large_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('value', 'large_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('value', 'large_table_2')
+-- result:
+
+-- !result
+SELECT id, COUNT(*) AS cnt
+FROM (
+    SELECT id, value FROM large_table_1
+    UNION ALL
+    SELECT id, value FROM large_table_2
+) t
+GROUP BY id
+HAVING cnt > 1;
+-- result:
+-- !result
+CREATE TABLE broadcast_table_1 (
+    id INT,
+    `key` VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE broadcast_table_2 (
+    id INT,
+    `key` VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO broadcast_table_1
+SELECT id, CONCAT('dict_broad_', id) FROM large_table_1;
+-- result:
+-- !result
+INSERT INTO broadcast_table_2
+SELECT id + 300, CONCAT('dict_broad_', id + 300) FROM large_table_1;
+-- result:
+-- !result
+[UC]analyze full table broadcast_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.broadcast_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table broadcast_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.broadcast_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('`key`', 'broadcast_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('`key`', 'broadcast_table_2')
+-- result:
+
+-- !result
+WITH union_broadcast AS (
+    SELECT id, `key` FROM broadcast_table_1
+    UNION ALL
+    SELECT id, `key` FROM broadcast_table_2
+)
+SELECT `key`, COUNT(*) AS appearances
+FROM union_broadcast
+GROUP BY `key`
+HAVING appearances > 1;
+-- result:
+-- !result
+CREATE TABLE dict_filter_table_1 (
+    id INT,
+    `text` VARCHAR(100)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+CREATE TABLE dict_filter_table_2 (
+    id INT,
+    `text` VARCHAR(100)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO dict_filter_table_1
+SELECT id, CONCAT('filter_case_', id) FROM large_table_1;
+-- result:
+-- !result
+INSERT INTO dict_filter_table_2
+SELECT id + 150, CONCAT('filter_case_', id + 150) FROM large_table_1;
+-- result:
+-- !result
+[UC]analyze full table dict_filter_table_1;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.dict_filter_table_1	analyze	status	OK
+-- !result
+[UC]analyze full table dict_filter_table_2;
+-- result:
+test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.dict_filter_table_2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('`text`', 'dict_filter_table_1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('`text`', 'dict_filter_table_2')
+-- result:
+
+-- !result
+SELECT *
+FROM (
+    SELECT id, `text` FROM dict_filter_table_1
+    UNION ALL
+    SELECT id, `text` FROM dict_filter_table_2
+) t
+WHERE LENGTH(`text`) > 10;
+-- result:
+2	filter_case_2
+9	filter_case_9
+10	filter_case_10
+11	filter_case_11
+12	filter_case_12
+15	filter_case_15
+18	filter_case_18
+21	filter_case_21
+24	filter_case_24
+28	filter_case_28
+29	filter_case_29
+151	filter_case_151
+154	filter_case_154
+155	filter_case_155
+158	filter_case_158
+160	filter_case_160
+162	filter_case_162
+165	filter_case_165
+167	filter_case_167
+170	filter_case_170
+173	filter_case_173
+176	filter_case_176
+178	filter_case_178
+4	filter_case_4
+5	filter_case_5
+6	filter_case_6
+7	filter_case_7
+14	filter_case_14
+16	filter_case_16
+19	filter_case_19
+20	filter_case_20
+23	filter_case_23
+25	filter_case_25
+152	filter_case_152
+157	filter_case_157
+161	filter_case_161
+163	filter_case_163
+166	filter_case_166
+172	filter_case_172
+174	filter_case_174
+177	filter_case_177
+1	filter_case_1
+3	filter_case_3
+8	filter_case_8
+13	filter_case_13
+17	filter_case_17
+22	filter_case_22
+26	filter_case_26
+27	filter_case_27
+30	filter_case_30
+153	filter_case_153
+156	filter_case_156
+159	filter_case_159
+164	filter_case_164
+168	filter_case_168
+169	filter_case_169
+171	filter_case_171
+175	filter_case_175
+179	filter_case_179
+180	filter_case_180
+-- !result

--- a/test/sql/test_global_dict/R/global_dict_with_union
+++ b/test/sql/test_global_dict/R/global_dict_with_union
@@ -23,11 +23,11 @@ INSERT INTO test_table_2 VALUES (4, 'd'), (5, 'e'), (6, 'f');
 -- !result
 [UC]analyze full table test_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.test_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.test_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table test_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.test_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.test_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('value', 'test_table_1')
 -- result:
@@ -43,7 +43,8 @@ FROM (
     UNION ALL
     SELECT id, value FROM test_table_2
 ) t
-WHERE id > 3;
+WHERE id > 3
+order by 1,2 limit 10;
 -- result:
 4	d
 5	e
@@ -51,10 +52,11 @@ WHERE id > 3;
 -- !result
 SELECT id, value FROM test_table_1 WHERE id < 3
 UNION ALL
-SELECT id, value FROM test_table_2 WHERE id > 4;
+SELECT id, value FROM test_table_2 WHERE id > 4
+order by 1,2 limit 10;
 -- result:
-2	b
 1	a
+2	b
 5	e
 6	f
 -- !result
@@ -66,12 +68,12 @@ FROM (
 ) t
 GROUP BY value;
 -- result:
+f	1
+a	1
 b	1
 e	1
-a	1
-f	1
-c	1
 d	1
+c	1
 -- !result
 SELECT value, COUNT(*) AS cnt
 FROM test_table_1
@@ -81,12 +83,12 @@ SELECT value, COUNT(*) AS cnt
 FROM test_table_2
 GROUP BY value;
 -- result:
+c	1
+e	1
 a	1
 f	1
 b	1
 d	1
-c	1
-e	1
 -- !result
 SELECT id, value
 FROM (
@@ -115,7 +117,7 @@ INSERT INTO join_table VALUES (1, 'info1'), (5, 'info5');
 -- !result
 [UC]analyze full table join_table;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.join_table	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.join_table	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('detail', 'join_table')
 -- result:
@@ -128,7 +130,8 @@ FROM (
     SELECT id, value FROM test_table_2
 ) t1
 JOIN join_table jt
-ON t1.id = jt.id;
+ON t1.id = jt.id
+order by 1,2,3;
 -- result:
 1	a	info1
 5	e	info5
@@ -141,10 +144,11 @@ UNION ALL
 SELECT c.id, c.value, d.detail 
 FROM test_table_2 c
 JOIN join_table d
-ON c.id = d.id;
+ON c.id = d.id
+order by 1,2,3;
 -- result:
-5	e	info5
 1	a	info1
+5	e	info5
 -- !result
 SELECT id, value
 FROM (
@@ -153,16 +157,16 @@ FROM (
     SELECT id, value FROM test_table_2
     UNION ALL
     SELECT id, detail FROM join_table
-) t;
+) t order by 1,2;
 -- result:
+1	a
+1	info1
 2	b
-5	info5
+3	c
 4	d
 5	e
+5	info5
 6	f
-1	info1
-1	a
-3	c
 -- !result
 CREATE TABLE alias_table_1 (
     col1 INT,
@@ -188,11 +192,11 @@ INSERT INTO alias_table_2 VALUES (4, 'delta'), (5, 'epsilon');
 -- !result
 [UC]analyze full table alias_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.alias_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.alias_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table alias_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.alias_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.alias_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('col2', 'alias_table_1')
 -- result:
@@ -208,7 +212,7 @@ FROM (
     UNION ALL
     SELECT col1 AS alias_col1, col2 AS alias_col2 FROM alias_table_2
 ) t
-WHERE alias_col1 > 2;
+WHERE alias_col1 > 2 order by 1,2;
 -- result:
 3	gamma
 4	delta
@@ -238,11 +242,11 @@ INSERT INTO diff_table_2 VALUES (3, 'three'), (4, 'four');
 -- !result
 [UC]analyze full table diff_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.diff_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.diff_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table diff_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.diff_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.diff_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('b', 'diff_table_1')
 -- result:
@@ -257,10 +261,10 @@ FROM (
     SELECT a AS col1, b AS col2 FROM diff_table_1
     UNION ALL
     SELECT x AS col1, y AS col2 FROM diff_table_2
-) t;
+) t order by 1,2;
 -- result:
-2	two
 1	one
+2	two
 3	three
 4	four
 -- !result
@@ -269,14 +273,14 @@ FROM (
     SELECT id, value FROM test_table_1
     UNION ALL
     SELECT id, value FROM test_table_2
-) t;
+) t order by 1,2;
 -- result:
-4	d
-5	e
+1	a
 2	b
 3	c
+4	d
+5	e
 6	f
-1	a
 -- !result
 SELECT id, COUNT(*) AS cnt 
 FROM (
@@ -285,7 +289,8 @@ FROM (
     SELECT id, value FROM test_table_2
 ) t
 GROUP BY id
-HAVING cnt > 1;
+HAVING cnt > 1
+order by 1,2;
 -- result:
 -- !result
 SELECT id, value 
@@ -294,7 +299,7 @@ FROM (
     UNION ALL
     SELECT id, value FROM test_table_2
 ) t
-WHERE id > 2 AND value LIKE 'a%' AND (id + 5 < 10 OR value = 'f');
+WHERE id > 2 AND value LIKE 'a%' AND (id + 5 < 10 OR value = 'f') order by 1,2;
 -- result:
 -- !result
 SELECT id, value 
@@ -305,7 +310,7 @@ FROM (
     UNION ALL
     SELECT id, detail FROM join_table WHERE detail = 'info1'
 ) t
-WHERE id < 5;
+WHERE id < 5 order by 1,2;
 -- result:
 1	a
 1	info1
@@ -316,12 +321,12 @@ FROM (
     UNION ALL
     SELECT id, value FROM test_table_2
 ) t1
-CROSS JOIN join_table t2;
+CROSS JOIN join_table t2 order by 1,2,3,4;
 -- result:
-2	b	1	info1
-2	b	5	info5
 1	a	1	info1
 1	a	5	info5
+2	b	1	info1
+2	b	5	info5
 3	c	1	info1
 3	c	5	info5
 4	d	1	info1
@@ -336,7 +341,7 @@ FROM (
     SELECT id, value FROM test_table_1 WHERE 1 = 0
     UNION ALL
     SELECT id, value FROM test_table_2
-) t;
+) t order by 1,2;
 -- result:
 4	d
 5	e
@@ -347,14 +352,14 @@ FROM (
     SELECT 'Constant1' AS fixed_col, id FROM test_table_1
     UNION ALL
     SELECT 'Constant2' AS fixed_col, id FROM test_table_2
-) t;
+) t order by 1,2;
 -- result:
+Constant1	1
 Constant1	2
+Constant1	3
 Constant2	4
 Constant2	5
 Constant2	6
-Constant1	1
-Constant1	3
 -- !result
 SELECT col1, col2 
 FROM (
@@ -371,16 +376,16 @@ FROM (
         UNION ALL
         SELECT id, detail FROM join_table WHERE id = 1
     ) subquery2
-) t;
+) t order by 1,2;
 -- result:
-2	b
-1	info1
 1	a
+1	info1
+1	info1
+2	b
 3	c
 5	e
-6	f
-1	info1
 5	info5
+6	f
 -- !result
 CREATE TABLE alias_agg_table_1 (
     c1 INT,
@@ -406,11 +411,11 @@ INSERT INTO alias_agg_table_2 VALUES (4, 'p'), (5, 'q'), (6, 'r');
 -- !result
 [UC]analyze full table alias_agg_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.alias_agg_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.alias_agg_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table alias_agg_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.alias_agg_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.alias_agg_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('c2', 'alias_agg_table_1')
 -- result:
@@ -426,13 +431,13 @@ FROM (
     UNION ALL
     SELECT c1 AS alias_c1 FROM alias_agg_table_2
 ) t
-GROUP BY alias_c1;
+GROUP BY alias_c1 order by 1,2;
 -- result:
+1	1
 2	1
 3	1
 4	1
 5	1
-1	1
 6	1
 -- !result
 SELECT c1, c2
@@ -440,42 +445,42 @@ FROM (
     SELECT c1, c2 FROM alias_agg_table_1
     UNION ALL
     SELECT c1, c2 FROM alias_agg_table_2
-) t;
+) t order by 1,2;
 -- result:
 1	x
+2	y
 3	z
 4	p
 5	q
 6	r
-2	y
 -- !result
 SELECT c1, computed_col 
 FROM (
     SELECT c1, c2, c1 + 10 AS computed_col FROM alias_agg_table_1
     UNION ALL
     SELECT c1, c2, c1 * 2 AS computed_col FROM alias_agg_table_2
-) t;
+) t order by 1,2;
 -- result:
+1	11
+2	12
+3	13
 4	8
 5	10
 6	12
-1	11
-3	13
-2	12
 -- !result
 SELECT * 
 FROM (
     SELECT c1, c2 FROM alias_agg_table_1 
     UNION ALL
     SELECT c1, c2 FROM alias_agg_table_2 
-) t;
+) t order by 1,2;
 -- result:
+1	x
+2	y
+3	z
 4	p
 5	q
 6	r
-1	x
-3	z
-2	y
 -- !result
 SELECT c1, c2
 FROM (
@@ -491,15 +496,16 @@ FROM (
     FROM (
         SELECT c1, c2 FROM alias_agg_table_1
         UNION ALL
-        SELECT c1, c2 FROM alias_agg_table_2 LIMIT 1
+        SELECT c1, c2 FROM alias_agg_table_2
     ) subquery2
 ) outer_query
 ORDER BY c1, c2
 LIMIT 4;
 -- result:
 1	x
+1	x
 2	y
-3	z
+2	y
 -- !result
 CREATE TABLE exclude_col_table_1 (
     col1 INT,
@@ -527,11 +533,11 @@ INSERT INTO exclude_col_table_2 VALUES (4, 40, 'qux'), (5, 50, 'quux'), (6, 60, 
 -- !result
 [UC]analyze full table exclude_col_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.exclude_col_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.exclude_col_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table exclude_col_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.exclude_col_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.exclude_col_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('col3', 'exclude_col_table_1')
 -- result:
@@ -546,7 +552,7 @@ FROM (
     SELECT col1, col3 FROM exclude_col_table_1 WHERE col2 > 15
     UNION ALL
     SELECT col1, col3 FROM exclude_col_table_2
-) t;
+) t order by 1,2;
 -- result:
 2	bar
 3	baz
@@ -578,11 +584,11 @@ INSERT INTO join_cond_table_2 VALUES (2, 'info2'), (4, 'info4');
 -- !result
 [UC]analyze full table join_cond_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.join_cond_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.join_cond_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table join_cond_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.join_cond_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.join_cond_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('detail', 'join_cond_table_1')
 -- result:
@@ -599,7 +605,7 @@ FROM (
     SELECT id FROM join_cond_table_2
 ) t
 JOIN join_cond_table_1 jt1 ON t.id = jt1.id
-JOIN join_cond_table_2 jt2 ON t.id = jt2.id;
+JOIN join_cond_table_2 jt2 ON t.id = jt2.id order by 1,2;
 -- result:
 -- !result
 CREATE TABLE hash_dist_table (
@@ -626,11 +632,11 @@ INSERT INTO broadcast_dist_table VALUES (3, 'b1'), (4, 'b2');
 -- !result
 [UC]analyze full table hash_dist_table;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.hash_dist_table	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.hash_dist_table	analyze	status	OK
 -- !result
 [UC]analyze full table broadcast_dist_table;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.broadcast_dist_table	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.broadcast_dist_table	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('key2', 'hash_dist_table')
 -- result:
@@ -645,12 +651,12 @@ FROM (
     SELECT key1, key2 FROM hash_dist_table
     UNION ALL
     SELECT key1, key2 FROM broadcast_dist_table
-) t;
+) t order by 1,2;
 -- result:
+1	h1
 2	h2
 3	b1
 4	b2
-1	h1
 -- !result
 CREATE TABLE func_table_1 (
     id INT,
@@ -678,11 +684,11 @@ INSERT INTO func_table_2 VALUES (4, 'D', 50), (5, 'E', NULL), (6, 'F', 300);
 -- !result
 [UC]analyze full table func_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.func_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.func_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table func_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.func_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.func_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('name', 'func_table_1')
 -- result:
@@ -700,8 +706,8 @@ FROM (
 ) t
 WHERE value IS NOT NULL AND value > 100;
 -- result:
-2	B	200	210
 6	F	300	310
+2	B	200	210
 -- !result
 CREATE TABLE agg_table_1 (
     id INT,
@@ -729,11 +735,11 @@ INSERT INTO agg_table_2 VALUES (4, 'A', 40), (5, 'B', 50), (6, 'C', 60);
 -- !result
 [UC]analyze full table agg_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.agg_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.agg_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table agg_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.agg_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.agg_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('category', 'agg_table_1')
 -- result:
@@ -751,9 +757,9 @@ FROM (
 ) t
 GROUP BY category;
 -- result:
+A	50
 C	90
 B	70
-A	50
 -- !result
 CREATE TABLE compute_table_1 (
     id INT,
@@ -785,10 +791,10 @@ FROM (
 ) t
 WHERE value > 200;
 -- result:
+3	300	303
 4	400	404
 5	500	505
 6	600	606
-3	300	303
 -- !result
 CREATE TABLE filter_table_1 (
     id INT,
@@ -816,11 +822,11 @@ INSERT INTO filter_table_2 VALUES (4, 'electronics', 400), (5, 'furniture', 500)
 -- !result
 [UC]analyze full table filter_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.filter_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.filter_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table filter_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.filter_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.filter_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('type', 'filter_table_1')
 -- result:
@@ -838,9 +844,9 @@ FROM (
 ) t;
 -- result:
 2	furniture	200
+1	electronics	100
 5	furniture	500
 6	fashion	600
-1	electronics	100
 -- !result
 CREATE TABLE nested_int_table_1 (
     id INT,
@@ -866,11 +872,11 @@ INSERT INTO nested_int_table_2 VALUES (4, 40), (5, 50), (6, 60);
 -- !result
 [UC]analyze full table nested_int_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.nested_int_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.nested_int_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table nested_int_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.nested_int_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.nested_int_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('group_id', 'nested_int_table_1')
 -- result:
@@ -895,18 +901,18 @@ FROM (
         UNION ALL
         SELECT id, group_id FROM nested_int_table_2 WHERE group_id > 30
     ) t2
-) t;
+) t order by 1,2;
 -- result:
 1	10
-2	20
 1	10
+2	20
+2	20
 3	30
 4	40
-5	50
-6	60
-2	20
 4	40
 5	50
+5	50
+6	60
 6	60
 -- !result
 CREATE TABLE cte_table_1 (
@@ -944,15 +950,15 @@ INSERT INTO join_table_1 VALUES (1, 'info1'), (5, 'info5');
 -- !result
 [UC]analyze full table cte_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.cte_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.cte_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table cte_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.cte_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.cte_table_2	analyze	status	OK
 -- !result
 [UC]analyze full table join_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.join_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.join_table_1	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('value', 'cte_table_1')
 -- result:
@@ -973,7 +979,7 @@ WITH cte_union AS (
 )
 SELECT cte_union.id, cte_union.value, jt.detail
 FROM cte_union
-JOIN join_table_1 jt ON cte_union.id = jt.id;
+JOIN join_table_1 jt ON cte_union.id = jt.id order by 1,2,3;
 -- result:
 1	A	info1
 5	E	info5
@@ -1013,15 +1019,15 @@ INSERT INTO join_table_2 VALUES (1, 'J1'), (4, 'J4');
 -- !result
 [UC]analyze full table source_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.source_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.source_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table source_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.source_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.source_table_2	analyze	status	OK
 -- !result
 [UC]analyze full table join_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.join_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.join_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('col2', 'source_table_1')
 -- result:
@@ -1074,11 +1080,11 @@ INSERT INTO agg_cte_table_2 VALUES (4, 'Electronics', 500), (5, 'Furniture', 100
 -- !result
 [UC]analyze full table agg_cte_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.agg_cte_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.agg_cte_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table agg_cte_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.agg_cte_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.agg_cte_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('category', 'agg_cte_table_1')
 -- result:
@@ -1095,11 +1101,11 @@ WITH aggregated_union AS (
 )
 SELECT category, SUM(amount) AS total_amount
 FROM aggregated_union
-GROUP BY category;
+GROUP BY category order by 1,2;
 -- result:
 Electronics	800
-Furniture	300
 Fashion	1000
+Furniture	300
 -- !result
 CREATE TABLE multi_union_table_1 (
     col1 INT,
@@ -1136,15 +1142,15 @@ INSERT INTO multi_union_table_3 VALUES (5, 'Epsilon'), (6, 'Zeta');
 -- !result
 [UC]analyze full table multi_union_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.multi_union_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.multi_union_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table multi_union_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.multi_union_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.multi_union_table_2	analyze	status	OK
 -- !result
 [UC]analyze full table multi_union_table_3;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.multi_union_table_3	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.multi_union_table_3	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('col2', 'multi_union_table_1')
 -- result:
@@ -1205,11 +1211,11 @@ SELECT id + 30, CONCAT('str', id + 30) FROM large_table_1;
 -- !result
 [UC]analyze full table large_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.large_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.large_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table large_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.large_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.large_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('value', 'large_table_1')
 -- result:
@@ -1255,11 +1261,11 @@ SELECT id + 300, CONCAT('dict_broad_', id + 300) FROM large_table_1;
 -- !result
 [UC]analyze full table broadcast_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.broadcast_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.broadcast_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table broadcast_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.broadcast_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.broadcast_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('`key`', 'broadcast_table_1')
 -- result:
@@ -1306,11 +1312,11 @@ SELECT id + 150, CONCAT('filter_case_', id + 150) FROM large_table_1;
 -- !result
 [UC]analyze full table dict_filter_table_1;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.dict_filter_table_1	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.dict_filter_table_1	analyze	status	OK
 -- !result
 [UC]analyze full table dict_filter_table_2;
 -- result:
-test_db_d1f2bb922a3845b58d32edb3a3fbf8f3.dict_filter_table_2	analyze	status	OK
+test_db_98dcb34d2b2e4da0a479b6b421175264.dict_filter_table_2	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('`text`', 'dict_filter_table_1')
 -- result:
@@ -1326,66 +1332,17 @@ FROM (
     UNION ALL
     SELECT id, `text` FROM dict_filter_table_2
 ) t
-WHERE LENGTH(`text`) > 10;
+WHERE LENGTH(`text`) > 10
+order by 1,2 limit 10;
 -- result:
+1	filter_case_1
 2	filter_case_2
-9	filter_case_9
-10	filter_case_10
-11	filter_case_11
-12	filter_case_12
-15	filter_case_15
-18	filter_case_18
-21	filter_case_21
-24	filter_case_24
-28	filter_case_28
-29	filter_case_29
-151	filter_case_151
-154	filter_case_154
-155	filter_case_155
-158	filter_case_158
-160	filter_case_160
-162	filter_case_162
-165	filter_case_165
-167	filter_case_167
-170	filter_case_170
-173	filter_case_173
-176	filter_case_176
-178	filter_case_178
+3	filter_case_3
 4	filter_case_4
 5	filter_case_5
 6	filter_case_6
 7	filter_case_7
-14	filter_case_14
-16	filter_case_16
-19	filter_case_19
-20	filter_case_20
-23	filter_case_23
-25	filter_case_25
-152	filter_case_152
-157	filter_case_157
-161	filter_case_161
-163	filter_case_163
-166	filter_case_166
-172	filter_case_172
-174	filter_case_174
-177	filter_case_177
-1	filter_case_1
-3	filter_case_3
 8	filter_case_8
-13	filter_case_13
-17	filter_case_17
-22	filter_case_22
-26	filter_case_26
-27	filter_case_27
-30	filter_case_30
-153	filter_case_153
-156	filter_case_156
-159	filter_case_159
-164	filter_case_164
-168	filter_case_168
-169	filter_case_169
-171	filter_case_171
-175	filter_case_175
-179	filter_case_179
-180	filter_case_180
+9	filter_case_9
+10	filter_case_10
 -- !result

--- a/test/sql/test_global_dict/R/global_dict_with_union
+++ b/test/sql/test_global_dict/R/global_dict_with_union
@@ -489,6 +489,7 @@ FROM (
         SELECT c1, c2 FROM alias_agg_table_1
         UNION ALL
         SELECT c1, c2 FROM alias_agg_table_2
+        ORDER BY c1, c2
         LIMIT 2
     ) subquery1
     UNION ALL

--- a/test/sql/test_global_dict/T/global_dict_with_union
+++ b/test/sql/test_global_dict/T/global_dict_with_union
@@ -34,13 +34,15 @@ FROM (
     UNION ALL
     SELECT id, value FROM test_table_2
 ) t
-WHERE id > 3;
+WHERE id > 3
+order by 1,2 limit 10;
 
 -- test_union_filter_before_union
 -- expect: Union(Filter(Scan), Filter(Scan))
 SELECT id, value FROM test_table_1 WHERE id < 3
 UNION ALL
-SELECT id, value FROM test_table_2 WHERE id > 4;
+SELECT id, value FROM test_table_2 WHERE id > 4
+order by 1,2 limit 10;
 
 -- test_union_aggregate_after_union
 -- expect: Aggregate -> Union -> Scan
@@ -94,7 +96,8 @@ FROM (
     SELECT id, value FROM test_table_2
 ) t1
 JOIN join_table jt
-ON t1.id = jt.id;
+ON t1.id = jt.id
+order by 1,2,3;
 
 -- test_union_join_before_union
 -- expect: Union(Join(Scan, Scan), Join(Scan, Scan))
@@ -106,7 +109,8 @@ UNION ALL
 SELECT c.id, c.value, d.detail 
 FROM test_table_2 c
 JOIN join_table d
-ON c.id = d.id;
+ON c.id = d.id
+order by 1,2,3;
 
 -- test_nested_union
 -- expect: Union(Union(Scan, Scan), Scan)
@@ -117,7 +121,7 @@ FROM (
     SELECT id, value FROM test_table_2
     UNION ALL
     SELECT id, detail FROM join_table
-) t;
+) t order by 1,2;
 
 -- test_union_with_alias_in_subquery
 -- expect: Filter -> Union(Alias(Scan), Alias(Scan))
@@ -152,7 +156,7 @@ FROM (
     UNION ALL
     SELECT col1 AS alias_col1, col2 AS alias_col2 FROM alias_table_2
 ) t
-WHERE alias_col1 > 2;
+WHERE alias_col1 > 2 order by 1,2;
 
 -- test_union_with_different_column_names
 -- expect: Union(Rename(Scan), Rename(Scan))
@@ -184,7 +188,7 @@ FROM (
     SELECT a AS col1, b AS col2 FROM diff_table_1
     UNION ALL
     SELECT x AS col1, y AS col2 FROM diff_table_2
-) t;
+) t order by 1,2;
 
 -- test_union_with_distinct
 -- expect: Aggregate(Distinct) -> Union -> Scan
@@ -193,7 +197,7 @@ FROM (
     SELECT id, value FROM test_table_1
     UNION ALL
     SELECT id, value FROM test_table_2
-) t;
+) t order by 1,2;
 
 -- test_union_with_having_clause
 -- expect: Filter(Having) -> Aggregate -> Union -> Scan
@@ -204,7 +208,8 @@ FROM (
     SELECT id, value FROM test_table_2
 ) t
 GROUP BY id
-HAVING cnt > 1;
+HAVING cnt > 1
+order by 1,2;
 
 -- test_union_with_complex_predicates
 -- expect: Filter(ComplexPredicate) -> Union -> Scan
@@ -214,7 +219,7 @@ FROM (
     UNION ALL
     SELECT id, value FROM test_table_2
 ) t
-WHERE id > 2 AND value LIKE 'a%' AND (id + 5 < 10 OR value = 'f');
+WHERE id > 2 AND value LIKE 'a%' AND (id + 5 < 10 OR value = 'f') order by 1,2;
 
 -- test_union_chains_with_filters
 -- expect: Filter -> Union(Filter(Scan), Filter(Scan), Filter(Scan))
@@ -226,7 +231,7 @@ FROM (
     UNION ALL
     SELECT id, detail FROM join_table WHERE detail = 'info1'
 ) t
-WHERE id < 5;
+WHERE id < 5 order by 1,2;
 
 -- test_union_with_cross_join_after_union
 -- expect: CrossJoin -> Union -> Scan
@@ -236,7 +241,7 @@ FROM (
     UNION ALL
     SELECT id, value FROM test_table_2
 ) t1
-CROSS JOIN join_table t2;
+CROSS JOIN join_table t2 order by 1,2,3,4;
 
 -- test_union_with_empty_branches
 -- expect: Union(Empty, Scan)
@@ -245,7 +250,7 @@ FROM (
     SELECT id, value FROM test_table_1 WHERE 1 = 0
     UNION ALL
     SELECT id, value FROM test_table_2
-) t;
+) t order by 1,2;
 
 -- test_union_with_constant_projection
 -- expect: Project(Constant) -> Union -> Scan
@@ -254,7 +259,7 @@ FROM (
     SELECT 'Constant1' AS fixed_col, id FROM test_table_1
     UNION ALL
     SELECT 'Constant2' AS fixed_col, id FROM test_table_2
-) t;
+) t order by 1,2;
 
 -- test_union_complex_with_multiple_levels
 -- expect: Union(Union(Scan, Filter(Scan)), Union(Aggregate->Scan, Join->Scan))
@@ -273,7 +278,7 @@ FROM (
         UNION ALL
         SELECT id, detail FROM join_table WHERE id = 1
     ) subquery2
-) t;
+) t order by 1,2;
 
 -- test_union_with_alias_and_aggregate
 -- expect: Aggregate -> Union -> Alias -> Scan
@@ -305,14 +310,14 @@ FROM (
     UNION ALL
     SELECT c1 AS alias_c1 FROM alias_agg_table_2
 ) t
-GROUP BY alias_c1;
+GROUP BY alias_c1 order by 1,2;
 
 SELECT c1, c2
 FROM (
     SELECT c1, c2 FROM alias_agg_table_1
     UNION ALL
     SELECT c1, c2 FROM alias_agg_table_2
-) t;
+) t order by 1,2;
 
 -- test_union_with_computed_columns
 -- expect: Project(ComputedColumns) -> Union -> Scan
@@ -321,7 +326,7 @@ FROM (
     SELECT c1, c2, c1 + 10 AS computed_col FROM alias_agg_table_1
     UNION ALL
     SELECT c1, c2, c1 * 2 AS computed_col FROM alias_agg_table_2
-) t;
+) t order by 1,2;
 
 -- test_union_with_inner_ordering
 -- expect: Union(Sort -> Scan, Sort -> Scan)
@@ -330,7 +335,7 @@ FROM (
     SELECT c1, c2 FROM alias_agg_table_1 
     UNION ALL
     SELECT c1, c2 FROM alias_agg_table_2 
-) t;
+) t order by 1,2;
 
 -- test_union_with_multiple_levels_and_limits
 -- expect: Limit -> Sort -> Union(Limit -> Union(Scan, Scan), Limit -> Union(Scan, Scan))
@@ -348,7 +353,7 @@ FROM (
     FROM (
         SELECT c1, c2 FROM alias_agg_table_1
         UNION ALL
-        SELECT c1, c2 FROM alias_agg_table_2 LIMIT 1
+        SELECT c1, c2 FROM alias_agg_table_2
     ) subquery2
 ) outer_query
 ORDER BY c1, c2
@@ -385,7 +390,7 @@ FROM (
     SELECT col1, col3 FROM exclude_col_table_1 WHERE col2 > 15
     UNION ALL
     SELECT col1, col3 FROM exclude_col_table_2
-) t;
+) t order by 1,2;
 
 -- test_union_with_union_in_join_condition
 -- expect: Join(Union -> Scan, Scan -> Union)
@@ -418,7 +423,7 @@ FROM (
     SELECT id FROM join_cond_table_2
 ) t
 JOIN join_cond_table_1 jt1 ON t.id = jt1.id
-JOIN join_cond_table_2 jt2 ON t.id = jt2.id;
+JOIN join_cond_table_2 jt2 ON t.id = jt2.id order by 1,2;
 
 -- test_union_with_different_key_distributions
 -- expect: Union(Hash(Scan), Broadcast(Scan))
@@ -449,7 +454,7 @@ FROM (
     SELECT key1, key2 FROM hash_dist_table
     UNION ALL
     SELECT key1, key2 FROM broadcast_dist_table
-) t;
+) t order by 1,2;
 
 -- test_union_with_no_double_and_functions
 -- expect: Project(Function) -> Union(Scan, Scan)
@@ -619,7 +624,7 @@ FROM (
         UNION ALL
         SELECT id, group_id FROM nested_int_table_2 WHERE group_id > 30
     ) t2
-) t;
+) t order by 1,2;
 
 -- test_cte_union_with_join
 -- expect: Join -> Union -> CTE -> Scan
@@ -662,7 +667,7 @@ WITH cte_union AS (
 )
 SELECT cte_union.id, cte_union.value, jt.detail
 FROM cte_union
-JOIN join_table_1 jt ON cte_union.id = jt.id;
+JOIN join_table_1 jt ON cte_union.id = jt.id order by 1,2,3;
 
 -- test_ctas_with_union_and_join
 -- expect: Join -> Union -> CTAS -> Scan
@@ -743,7 +748,7 @@ WITH aggregated_union AS (
 )
 SELECT category, SUM(amount) AS total_amount
 FROM aggregated_union
-GROUP BY category;
+GROUP BY category order by 1,2;
 
 -- test_ctas_with_multiple_unions
 -- expect: Union -> Union -> CTAS -> Scan
@@ -907,4 +912,5 @@ FROM (
     UNION ALL
     SELECT id, `text` FROM dict_filter_table_2
 ) t
-WHERE LENGTH(`text`) > 10;
+WHERE LENGTH(`text`) > 10
+order by 1,2 limit 10;

--- a/test/sql/test_global_dict/T/global_dict_with_union
+++ b/test/sql/test_global_dict/T/global_dict_with_union
@@ -1,0 +1,910 @@
+-- name: test_global_dict_with_union
+
+-- test_union_filter_after_union
+-- expect: Filter -> Union -> Scan
+CREATE TABLE test_table_1 (
+    id INT,
+    value VARCHAR(10)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+
+CREATE TABLE test_table_2 (
+    id INT,
+    value VARCHAR(10)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+
+INSERT INTO test_table_1 VALUES (1, 'a'), (2, 'b'), (3, 'c');
+INSERT INTO test_table_2 VALUES (4, 'd'), (5, 'e'), (6, 'f');
+
+[UC]analyze full table test_table_1;
+[UC]analyze full table test_table_2;
+
+function: wait_global_dict_ready('value', 'test_table_1')
+function: wait_global_dict_ready('value', 'test_table_2')
+
+
+SELECT * 
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t
+WHERE id > 3;
+
+-- test_union_filter_before_union
+-- expect: Union(Filter(Scan), Filter(Scan))
+SELECT id, value FROM test_table_1 WHERE id < 3
+UNION ALL
+SELECT id, value FROM test_table_2 WHERE id > 4;
+
+-- test_union_aggregate_after_union
+-- expect: Aggregate -> Union -> Scan
+SELECT value, COUNT(*) AS cnt
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t
+GROUP BY value;
+
+-- test_union_aggregate_before_union
+-- expect: Union(Aggregate(Scan), Aggregate(Scan))
+SELECT value, COUNT(*) AS cnt
+FROM test_table_1
+GROUP BY value
+UNION ALL
+SELECT value, COUNT(*) AS cnt
+FROM test_table_2
+GROUP BY value;
+
+-- test_union_order_and_limit
+-- expect: Limit -> Sort -> Union
+SELECT id, value
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t
+ORDER BY id DESC
+LIMIT 4;
+
+-- test_union_join_after_union
+-- expect: Join -> Union -> Scan
+CREATE TABLE join_table (
+    id INT,
+    detail VARCHAR(10)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO join_table VALUES (1, 'info1'), (5, 'info5');
+
+[UC]analyze full table join_table;
+function: wait_global_dict_ready('detail', 'join_table')
+
+SELECT t1.id, t1.value, jt.detail
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t1
+JOIN join_table jt
+ON t1.id = jt.id;
+
+-- test_union_join_before_union
+-- expect: Union(Join(Scan, Scan), Join(Scan, Scan))
+SELECT a.id, a.value, b.detail 
+FROM test_table_1 a
+JOIN join_table b
+ON a.id = b.id
+UNION ALL
+SELECT c.id, c.value, d.detail 
+FROM test_table_2 c
+JOIN join_table d
+ON c.id = d.id;
+
+-- test_nested_union
+-- expect: Union(Union(Scan, Scan), Scan)
+SELECT id, value
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+    UNION ALL
+    SELECT id, detail FROM join_table
+) t;
+
+-- test_union_with_alias_in_subquery
+-- expect: Filter -> Union(Alias(Scan), Alias(Scan))
+CREATE TABLE alias_table_1 (
+    col1 INT,
+    col2 VARCHAR(10)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE alias_table_2 (
+    col1 INT,
+    col2 VARCHAR(10)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO alias_table_1 VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma');
+INSERT INTO alias_table_2 VALUES (4, 'delta'), (5, 'epsilon');
+
+[UC]analyze full table alias_table_1;
+[UC]analyze full table alias_table_2;
+
+
+function: wait_global_dict_ready('col2', 'alias_table_1')
+function: wait_global_dict_ready('col2', 'alias_table_2')
+
+
+SELECT alias_col1, alias_col2 
+FROM (
+    SELECT col1 AS alias_col1, col2 AS alias_col2 FROM alias_table_1
+    UNION ALL
+    SELECT col1 AS alias_col1, col2 AS alias_col2 FROM alias_table_2
+) t
+WHERE alias_col1 > 2;
+
+-- test_union_with_different_column_names
+-- expect: Union(Rename(Scan), Rename(Scan))
+CREATE TABLE diff_table_1 (
+    a INT,
+    b VARCHAR(10)
+) DUPLICATE KEY(a)
+DISTRIBUTED BY HASH(a) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE diff_table_2 (
+    x INT,
+    y VARCHAR(10)
+) DUPLICATE KEY(x)
+DISTRIBUTED BY HASH(x) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO diff_table_1 VALUES (1, 'one'), (2, 'two');
+INSERT INTO diff_table_2 VALUES (3, 'three'), (4, 'four');
+
+[UC]analyze full table diff_table_1;
+[UC]analyze full table diff_table_2;
+
+function: wait_global_dict_ready('b', 'diff_table_1')
+function: wait_global_dict_ready('y', 'diff_table_2')
+
+SELECT col1, col2
+FROM (
+    SELECT a AS col1, b AS col2 FROM diff_table_1
+    UNION ALL
+    SELECT x AS col1, y AS col2 FROM diff_table_2
+) t;
+
+-- test_union_with_distinct
+-- expect: Aggregate(Distinct) -> Union -> Scan
+SELECT DISTINCT id, value 
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t;
+
+-- test_union_with_having_clause
+-- expect: Filter(Having) -> Aggregate -> Union -> Scan
+SELECT id, COUNT(*) AS cnt 
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t
+GROUP BY id
+HAVING cnt > 1;
+
+-- test_union_with_complex_predicates
+-- expect: Filter(ComplexPredicate) -> Union -> Scan
+SELECT id, value 
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t
+WHERE id > 2 AND value LIKE 'a%' AND (id + 5 < 10 OR value = 'f');
+
+-- test_union_chains_with_filters
+-- expect: Filter -> Union(Filter(Scan), Filter(Scan), Filter(Scan))
+SELECT id, value 
+FROM (
+    SELECT id, value FROM test_table_1 WHERE value = 'a'
+    UNION ALL
+    SELECT id, value FROM test_table_2 WHERE value = 'b'
+    UNION ALL
+    SELECT id, detail FROM join_table WHERE detail = 'info1'
+) t
+WHERE id < 5;
+
+-- test_union_with_cross_join_after_union
+-- expect: CrossJoin -> Union -> Scan
+SELECT t1.id, t1.value, t2.id, t2.detail 
+FROM (
+    SELECT id, value FROM test_table_1
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t1
+CROSS JOIN join_table t2;
+
+-- test_union_with_empty_branches
+-- expect: Union(Empty, Scan)
+SELECT id, value 
+FROM (
+    SELECT id, value FROM test_table_1 WHERE 1 = 0
+    UNION ALL
+    SELECT id, value FROM test_table_2
+) t;
+
+-- test_union_with_constant_projection
+-- expect: Project(Constant) -> Union -> Scan
+SELECT fixed_col, id 
+FROM (
+    SELECT 'Constant1' AS fixed_col, id FROM test_table_1
+    UNION ALL
+    SELECT 'Constant2' AS fixed_col, id FROM test_table_2
+) t;
+
+-- test_union_complex_with_multiple_levels
+-- expect: Union(Union(Scan, Filter(Scan)), Union(Aggregate->Scan, Join->Scan))
+SELECT col1, col2 
+FROM (
+    SELECT col1, col2 
+    FROM (
+        SELECT id AS col1, value AS col2 FROM test_table_1
+        UNION ALL
+        SELECT id AS col1, value AS col2 FROM test_table_2 WHERE id > 4
+    ) subquery1
+    UNION ALL
+    SELECT id AS col1, detail AS col2 
+    FROM (
+        SELECT id, detail FROM join_table
+        UNION ALL
+        SELECT id, detail FROM join_table WHERE id = 1
+    ) subquery2
+) t;
+
+-- test_union_with_alias_and_aggregate
+-- expect: Aggregate -> Union -> Alias -> Scan
+CREATE TABLE alias_agg_table_1 (
+    c1 INT,
+    c2 VARCHAR(10)
+) DUPLICATE KEY(c1)
+DISTRIBUTED BY HASH(c1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE alias_agg_table_2 (
+    c1 INT,
+    c2 VARCHAR(10)
+) DUPLICATE KEY(c1)
+DISTRIBUTED BY HASH(c1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO alias_agg_table_1 VALUES (1, 'x'), (2, 'y'), (3, 'z');
+INSERT INTO alias_agg_table_2 VALUES (4, 'p'), (5, 'q'), (6, 'r');
+
+[UC]analyze full table alias_agg_table_1;
+[UC]analyze full table alias_agg_table_2;
+function: wait_global_dict_ready('c2', 'alias_agg_table_1')
+function: wait_global_dict_ready('c2', 'alias_agg_table_2')
+
+SELECT alias_c1, COUNT(*) AS cnt
+FROM (
+    SELECT c1 AS alias_c1 FROM alias_agg_table_1
+    UNION ALL
+    SELECT c1 AS alias_c1 FROM alias_agg_table_2
+) t
+GROUP BY alias_c1;
+
+SELECT c1, c2
+FROM (
+    SELECT c1, c2 FROM alias_agg_table_1
+    UNION ALL
+    SELECT c1, c2 FROM alias_agg_table_2
+) t;
+
+-- test_union_with_computed_columns
+-- expect: Project(ComputedColumns) -> Union -> Scan
+SELECT c1, computed_col 
+FROM (
+    SELECT c1, c2, c1 + 10 AS computed_col FROM alias_agg_table_1
+    UNION ALL
+    SELECT c1, c2, c1 * 2 AS computed_col FROM alias_agg_table_2
+) t;
+
+-- test_union_with_inner_ordering
+-- expect: Union(Sort -> Scan, Sort -> Scan)
+SELECT * 
+FROM (
+    SELECT c1, c2 FROM alias_agg_table_1 
+    UNION ALL
+    SELECT c1, c2 FROM alias_agg_table_2 
+) t;
+
+-- test_union_with_multiple_levels_and_limits
+-- expect: Limit -> Sort -> Union(Limit -> Union(Scan, Scan), Limit -> Union(Scan, Scan))
+SELECT c1, c2
+FROM (
+    SELECT c1, c2
+    FROM (
+        SELECT c1, c2 FROM alias_agg_table_1
+        UNION ALL
+        SELECT c1, c2 FROM alias_agg_table_2
+        LIMIT 2
+    ) subquery1
+    UNION ALL
+    SELECT c1, c2
+    FROM (
+        SELECT c1, c2 FROM alias_agg_table_1
+        UNION ALL
+        SELECT c1, c2 FROM alias_agg_table_2 LIMIT 1
+    ) subquery2
+) outer_query
+ORDER BY c1, c2
+LIMIT 4;
+
+-- test_union_with_excluded_columns
+-- expect: Filter -> Union(Filter(ExcludeColumns -> Scan), ExcludeColumns -> Scan)
+CREATE TABLE exclude_col_table_1 (
+    col1 INT,
+    col2 INT,
+    col3 VARCHAR(10)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE exclude_col_table_2 (
+    col1 INT,
+    col2 INT,
+    col3 VARCHAR(10)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO exclude_col_table_1 VALUES (1, 10, 'foo'), (2, 20, 'bar'), (3, 30, 'baz');
+INSERT INTO exclude_col_table_2 VALUES (4, 40, 'qux'), (5, 50, 'quux'), (6, 60, 'corge');
+
+[UC]analyze full table exclude_col_table_1;
+[UC]analyze full table exclude_col_table_2;
+function: wait_global_dict_ready('col3', 'exclude_col_table_1')
+function: wait_global_dict_ready('col3', 'exclude_col_table_2')
+
+SELECT col1, col3
+FROM (
+    SELECT col1, col3 FROM exclude_col_table_1 WHERE col2 > 15
+    UNION ALL
+    SELECT col1, col3 FROM exclude_col_table_2
+) t;
+
+-- test_union_with_union_in_join_condition
+-- expect: Join(Union -> Scan, Scan -> Union)
+CREATE TABLE join_cond_table_1 (
+    id INT,
+    detail VARCHAR(10)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE join_cond_table_2 (
+    id INT,
+    detail VARCHAR(10)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO join_cond_table_1 VALUES (1, 'info1'), (3, 'info3');
+INSERT INTO join_cond_table_2 VALUES (2, 'info2'), (4, 'info4');
+
+[UC]analyze full table join_cond_table_1;
+[UC]analyze full table join_cond_table_2;
+function: wait_global_dict_ready('detail', 'join_cond_table_1')
+function: wait_global_dict_ready('detail', 'join_cond_table_2')
+
+SELECT jt1.id, t.id, jt2.detail
+FROM (
+    SELECT id FROM join_cond_table_1
+    UNION ALL
+    SELECT id FROM join_cond_table_2
+) t
+JOIN join_cond_table_1 jt1 ON t.id = jt1.id
+JOIN join_cond_table_2 jt2 ON t.id = jt2.id;
+
+-- test_union_with_different_key_distributions
+-- expect: Union(Hash(Scan), Broadcast(Scan))
+CREATE TABLE hash_dist_table (
+    key1 INT,
+    key2 VARCHAR(10)
+) DUPLICATE KEY(key1)
+DISTRIBUTED BY HASH(key1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE broadcast_dist_table (
+    key1 INT,
+    key2 VARCHAR(10)
+) DUPLICATE KEY(key1)
+DISTRIBUTED BY HASH(key1) BUCKETS 1
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO hash_dist_table VALUES (1, 'h1'), (2, 'h2');
+INSERT INTO broadcast_dist_table VALUES (3, 'b1'), (4, 'b2');
+
+[UC]analyze full table hash_dist_table;
+[UC]analyze full table broadcast_dist_table;
+function: wait_global_dict_ready('key2', 'hash_dist_table')
+function: wait_global_dict_ready('key2', 'broadcast_dist_table')
+
+SELECT key1, key2
+FROM (
+    SELECT key1, key2 FROM hash_dist_table
+    UNION ALL
+    SELECT key1, key2 FROM broadcast_dist_table
+) t;
+
+-- test_union_with_no_double_and_functions
+-- expect: Project(Function) -> Union(Scan, Scan)
+CREATE TABLE func_table_1 (
+    id INT,
+    name VARCHAR(20),
+    value INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE func_table_2 (
+    id INT,
+    name VARCHAR(20),
+    value INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO func_table_1 VALUES (1, 'A', 100), (2, 'B', 200), (3, 'C', NULL);
+INSERT INTO func_table_2 VALUES (4, 'D', 50), (5, 'E', NULL), (6, 'F', 300);
+
+[UC]analyze full table func_table_1;
+[UC]analyze full table func_table_2;
+function: wait_global_dict_ready('name', 'func_table_1')
+function: wait_global_dict_ready('name', 'func_table_2')
+
+SELECT id, name, value, value + 10 AS adjusted_value
+FROM (
+    SELECT id, name, value FROM func_table_1
+    UNION ALL
+    SELECT id, name, value FROM func_table_2
+) t
+WHERE value IS NOT NULL AND value > 100;
+
+-- test_union_with_aggregates_and_integers_only
+-- expect: Aggregate -> Union -> Scan
+CREATE TABLE agg_table_1 (
+    id INT,
+    category VARCHAR(20),
+    count INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE agg_table_2 (
+    id INT,
+    category VARCHAR(20),
+    count INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO agg_table_1 VALUES (1, 'A', 10), (2, 'B', 20), (3, 'C', 30);
+INSERT INTO agg_table_2 VALUES (4, 'A', 40), (5, 'B', 50), (6, 'C', 60);
+
+[UC]analyze full table agg_table_1;
+[UC]analyze full table agg_table_2;
+function: wait_global_dict_ready('category', 'agg_table_1')
+function: wait_global_dict_ready('category', 'agg_table_2')
+
+SELECT category, SUM(count) AS total_count
+FROM (
+    SELECT id, category, count FROM agg_table_1
+    UNION ALL
+    SELECT id, category, count FROM agg_table_2
+) t
+GROUP BY category;
+
+-- test_union_integer_computation_with_filters
+-- expect: Filter -> Project(ComputedColumn) -> Union(Scan, Scan)
+CREATE TABLE compute_table_1 (
+    id INT,
+    value INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE compute_table_2 (
+    id INT,
+    value INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO compute_table_1 VALUES (1, 100), (2, 200), (3, 300);
+INSERT INTO compute_table_2 VALUES (4, 400), (5, 500), (6, 600);
+
+
+SELECT id, value, value + id AS computed_value
+FROM (
+    SELECT id, value FROM compute_table_1
+    UNION ALL
+    SELECT id, value FROM compute_table_2
+) t
+WHERE value > 200;
+
+-- test_union_with_filters_in_subqueries
+-- expect: Filter -> Union(Filter -> Scan, Filter -> Scan)
+CREATE TABLE filter_table_1 (
+    id INT,
+    type VARCHAR(20),
+    amount INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE filter_table_2 (
+    id INT,
+    type VARCHAR(20),
+    amount INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO filter_table_1 VALUES (1, 'electronics', 100), (2, 'furniture', 200), (3, 'fashion', 300);
+INSERT INTO filter_table_2 VALUES (4, 'electronics', 400), (5, 'furniture', 500), (6, 'fashion', 600);
+
+[UC]analyze full table filter_table_1;
+[UC]analyze full table filter_table_2;
+function: wait_global_dict_ready('type', 'filter_table_1')
+function: wait_global_dict_ready('type', 'filter_table_2')
+
+SELECT id, type, amount
+FROM (
+    SELECT id, type, amount FROM filter_table_1 WHERE amount < 300
+    UNION ALL
+    SELECT id, type, amount FROM filter_table_2 WHERE amount > 400
+) t;
+
+-- test_union_with_nested_combination_of_integers
+-- expect: Union(Union(Filter -> Scan, Scan), Union(Filter -> Scan, Scan))
+CREATE TABLE nested_int_table_1 (
+    id INT,
+    group_id string
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE nested_int_table_2 (
+    id INT,
+    group_id string
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO nested_int_table_1 VALUES (1, 10), (2, 20), (3, 30);
+INSERT INTO nested_int_table_2 VALUES (4, 40), (5, 50), (6, 60);
+
+[UC]analyze full table nested_int_table_1;
+[UC]analyze full table nested_int_table_2;
+function: wait_global_dict_ready('group_id', 'nested_int_table_1')
+function: wait_global_dict_ready('group_id', 'nested_int_table_2')
+
+SELECT id, group_id
+FROM (
+    SELECT id, group_id
+    FROM (
+        SELECT id, group_id FROM nested_int_table_1 WHERE group_id < 30
+        UNION ALL
+        SELECT id, group_id FROM nested_int_table_2
+    ) t1
+    UNION ALL
+    SELECT id, group_id
+    FROM (
+        SELECT id, group_id FROM nested_int_table_1
+        UNION ALL
+        SELECT id, group_id FROM nested_int_table_2 WHERE group_id > 30
+    ) t2
+) t;
+
+-- test_cte_union_with_join
+-- expect: Join -> Union -> CTE -> Scan
+CREATE TABLE cte_table_1 (
+    id INT,
+    value VARCHAR(20)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE cte_table_2 (
+    id INT,
+    value VARCHAR(20)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE join_table_1 (
+    id INT,
+    detail VARCHAR(20)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO cte_table_1 VALUES (1, 'A'), (2, 'B'), (3, 'C');
+INSERT INTO cte_table_2 VALUES (4, 'D'), (5, 'E'), (6, 'F');
+INSERT INTO join_table_1 VALUES (1, 'info1'), (5, 'info5');
+
+[UC]analyze full table cte_table_1;
+[UC]analyze full table cte_table_2;
+[UC]analyze full table join_table_1;
+function: wait_global_dict_ready('value', 'cte_table_1')
+function: wait_global_dict_ready('value', 'cte_table_2')
+function: wait_global_dict_ready('detail', 'join_table_1')
+
+WITH cte_union AS (
+    SELECT id, value FROM cte_table_1
+    UNION ALL
+    SELECT id, value FROM cte_table_2
+)
+SELECT cte_union.id, cte_union.value, jt.detail
+FROM cte_union
+JOIN join_table_1 jt ON cte_union.id = jt.id;
+
+-- test_ctas_with_union_and_join
+-- expect: Join -> Union -> CTAS -> Scan
+CREATE TABLE source_table_1 (
+    col1 INT,
+    col2 VARCHAR(20)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE source_table_2 (
+    col1 INT,
+    col2 VARCHAR(20)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE join_table_2 (
+    col1 INT,
+    col2 VARCHAR(20)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO source_table_1 VALUES (1, 'X'), (2, 'Y'), (3, 'Z');
+INSERT INTO source_table_2 VALUES (4, 'P'), (5, 'Q'), (6, 'R');
+INSERT INTO join_table_2 VALUES (1, 'J1'), (4, 'J4');
+
+[UC]analyze full table source_table_1;
+[UC]analyze full table source_table_2;
+[UC]analyze full table join_table_2;
+function: wait_global_dict_ready('col2', 'source_table_1')
+function: wait_global_dict_ready('col2', 'source_table_2')
+function: wait_global_dict_ready('col2', 'join_table_2')
+
+CREATE TABLE ctas_result
+DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1') AS
+SELECT st1.col1, jt.col2
+FROM (
+    SELECT col1 FROM source_table_1
+    UNION ALL
+    SELECT col1 FROM source_table_2
+) st1
+JOIN join_table_2 jt ON st1.col1 = jt.col1;
+
+-- test_union_and_cte_with_aggregation
+-- expect: Aggregate -> Union -> CTE -> Scan
+CREATE TABLE agg_cte_table_1 (
+    id INT,
+    category VARCHAR(20),
+    amount INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE agg_cte_table_2 (
+    id INT,
+    category VARCHAR(20),
+    amount INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO agg_cte_table_1 VALUES (1, 'Electronics', 300), (2, 'Furniture', 200), (3, 'Fashion', 700);
+INSERT INTO agg_cte_table_2 VALUES (4, 'Electronics', 500), (5, 'Furniture', 100), (6, 'Fashion', 300);
+
+[UC]analyze full table agg_cte_table_1;
+[UC]analyze full table agg_cte_table_2;
+function: wait_global_dict_ready('category', 'agg_cte_table_1')
+function: wait_global_dict_ready('category', 'agg_cte_table_2')
+
+WITH aggregated_union AS (
+    SELECT id, category, amount FROM agg_cte_table_1
+    UNION ALL
+    SELECT id, category, amount FROM agg_cte_table_2
+)
+SELECT category, SUM(amount) AS total_amount
+FROM aggregated_union
+GROUP BY category;
+
+-- test_ctas_with_multiple_unions
+-- expect: Union -> Union -> CTAS -> Scan
+CREATE TABLE multi_union_table_1 (
+    col1 INT,
+    col2 VARCHAR(20)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE multi_union_table_2 (
+    col1 INT,
+    col2 VARCHAR(20)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE multi_union_table_3 (
+    col1 INT,
+    col2 VARCHAR(20)
+) DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO multi_union_table_1 VALUES (1, 'Alpha'), (2, 'Beta');
+INSERT INTO multi_union_table_2 VALUES (3, 'Gamma'), (4, 'Delta');
+INSERT INTO multi_union_table_3 VALUES (5, 'Epsilon'), (6, 'Zeta');
+
+[UC]analyze full table multi_union_table_1;
+[UC]analyze full table multi_union_table_2;
+[UC]analyze full table multi_union_table_3;
+function: wait_global_dict_ready('col2', 'multi_union_table_1')
+function: wait_global_dict_ready('col2', 'multi_union_table_2')
+function: wait_global_dict_ready('col2', 'multi_union_table_3')
+
+CREATE TABLE ctas_result_2
+DUPLICATE KEY(col1)
+DISTRIBUTED BY HASH(col1) BUCKETS 3
+PROPERTIES('replication_num' = '1') AS
+SELECT col1, col2 FROM (
+    SELECT col1, col2 FROM multi_union_table_1
+    UNION ALL
+    SELECT col1, col2 FROM multi_union_table_2
+    UNION ALL
+    SELECT col1, col2 FROM multi_union_table_3
+) t;
+
+-- test_union_with_large_result_and_group_by
+-- expect: Aggregate -> Union -> LargeResults -> Scan
+CREATE TABLE large_table_1 (
+    id INT,
+    value VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE large_table_2 (
+    id INT,
+    value VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO large_table_1 VALUES
+(1, 'val1'), (2, 'val2'), (3, 'val3'),
+(4, 'val4'), (5, 'val5'), (6, 'val6'),
+(7, 'val7'), (8, 'val8'), (9, 'val9'),
+(10, 'val10'), (11, 'val11'), (12, 'val12'),
+(13, 'val13'), (14, 'val14'), (15, 'val15');
+
+-- Repeat similar data to ensure > 300 rows
+INSERT INTO large_table_1
+SELECT id + 15, CONCAT('val', id + 15) FROM large_table_1;
+
+INSERT INTO large_table_2
+SELECT id + 30, CONCAT('str', id + 30) FROM large_table_1;
+
+[UC]analyze full table large_table_1;
+[UC]analyze full table large_table_2;
+function: wait_global_dict_ready('value', 'large_table_1')
+function: wait_global_dict_ready('value', 'large_table_2')
+
+-- UNION results exceed 300 rows
+SELECT id, COUNT(*) AS cnt
+FROM (
+    SELECT id, value FROM large_table_1
+    UNION ALL
+    SELECT id, value FROM large_table_2
+) t
+GROUP BY id
+HAVING cnt > 1;
+
+-- test_union_with_large_dict_broadcast
+-- expect: Broadcast -> Union -> Scan -> LargeDict
+CREATE TABLE broadcast_table_1 (
+    id INT,
+    `key` VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE broadcast_table_2 (
+    id INT,
+    `key` VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO broadcast_table_1
+SELECT id, CONCAT('dict_broad_', id) FROM large_table_1;
+
+INSERT INTO broadcast_table_2
+SELECT id + 300, CONCAT('dict_broad_', id + 300) FROM large_table_1;
+
+[UC]analyze full table broadcast_table_1;
+[UC]analyze full table broadcast_table_2;
+function: wait_global_dict_ready('`key`', 'broadcast_table_1')
+function: wait_global_dict_ready('`key`', 'broadcast_table_2')
+
+WITH union_broadcast AS (
+    SELECT id, `key` FROM broadcast_table_1
+    UNION ALL
+    SELECT id, `key` FROM broadcast_table_2
+)
+SELECT `key`, COUNT(*) AS appearances
+FROM union_broadcast
+GROUP BY `key`
+HAVING appearances > 1;
+
+-- test_union_exceeded_dict_with_filter
+-- expect: Filter -> Union(Scan(LargeDict), Scan(LargeDict)) -> DictHandling
+CREATE TABLE dict_filter_table_1 (
+    id INT,
+    `text` VARCHAR(100)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+CREATE TABLE dict_filter_table_2 (
+    id INT,
+    `text` VARCHAR(100)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO dict_filter_table_1
+SELECT id, CONCAT('filter_case_', id) FROM large_table_1;
+
+INSERT INTO dict_filter_table_2
+SELECT id + 150, CONCAT('filter_case_', id + 150) FROM large_table_1;
+
+[UC]analyze full table dict_filter_table_1;
+[UC]analyze full table dict_filter_table_2;
+
+function: wait_global_dict_ready('`text`', 'dict_filter_table_1')
+function: wait_global_dict_ready('`text`', 'dict_filter_table_2')
+
+SELECT *
+FROM (
+    SELECT id, `text` FROM dict_filter_table_1
+    UNION ALL
+    SELECT id, `text` FROM dict_filter_table_2
+) t
+WHERE LENGTH(`text`) > 10;


### PR DESCRIPTION
## Why I'm doing:
Enabling dictification of UNOIN all operators. 

## What I'm doing:
Enabling the dictification for UNION ALL opeartors by merging the dictionaries of input columns in the optimizer.
The features is gated by a session variable. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables dictionary-based low-cardinality optimization for `UNION ALL` by merging child dictionaries and propagating dict refs through the plan.
> 
> - Introduces `UnionDictionaryManager` to group columns, merge dict data (with size/threshold checks), avoid join-conflicted columns, and finalize merged dictionaries
> - Extends `DecodeCollector` to integrate union dict management, consider union groups in dependencies, merge at `PhysicalUnionOperator` (non-hash distributed), and update disable sets/reference counts
> - Updates `DecodeRewriter` to rewrite `PhysicalUnionOperator` predicates/projections and child/output columns to use dict refs; preserves behavior for other set ops
> - Adds session variable `cbo_enable_low_cardinality_optimize_for_union_all` (default true) with getters/setters in `SessionVariable`
> - Adds unit tests for union dict merging and planner integration (e.g., union all, projections, distinct, join conflicts)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1114a780a463494661f90b6f5a987d4f209d6532. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->