### PR TITLE
[BugFix] resource table catalog name is null when create table like

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableLikeAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableLikeAnalyzer.java
@@ -52,7 +52,7 @@ public class CreateTableLikeAnalyzer {
         if (table == null) {
             throw new SemanticException("Table %s is not found", existedTableName.getTbl());
         }
-        MetaUtils.checkNotSupportCatalog(table, TableOperation.CREATE_TABLE_LIKE);
+        MetaUtils.checkNotSupportCatalog(table, TableOperation.CREATE_TABLE_LIKE, existedTableName.getCatalog());
 
         List<String> createTableStmt = Lists.newArrayList();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -74,6 +74,10 @@ public class MetaUtils {
         }
     }
 
+    public static void checkNotSupportCatalog(Table table, TableOperation operation) {
+        checkNotSupportCatalog(table, operation, null);
+    }
+
     /**
      * Check if the specified operation is supported on the given table.
      * Throws SemanticException if the operation is not supported by the table type.
@@ -81,9 +85,10 @@ public class MetaUtils {
      *
      * @param table The table to check
      * @param operation The operation to check
+     * @param catalogName The catalog name to check, defaults to table.getCatalogName() when null
      * @throws SemanticException if the operation is not supported
      */
-    public static void checkNotSupportCatalog(Table table, TableOperation operation) {
+    public static void checkNotSupportCatalog(Table table, TableOperation operation, String catalogName) {
         if (table == null) {
             throw new SemanticException("Table is null");
         }
@@ -91,18 +96,18 @@ public class MetaUtils {
             throw new SemanticException("Operation is null");
         }
 
-        String catalogName = table.getCatalogName();
-        if (catalogName == null) {
+        String targetCatalogName = table.getCatalogName() != null ? table.getCatalogName() : catalogName;
+        if (targetCatalogName == null) {
             throw new SemanticException("Catalog is null");
         }
         // Internal catalog tables support all operations
-        if (CatalogMgr.isInternalCatalog(catalogName)) {
+        if (CatalogMgr.isInternalCatalog(targetCatalogName)) {
             return;
         }
 
-        Catalog catalog = GlobalStateMgr.getCurrentState().getCatalogMgr().getCatalogByName(catalogName);
+        Catalog catalog = GlobalStateMgr.getCurrentState().getCatalogMgr().getCatalogByName(targetCatalogName);
         if (catalog == null) {
-            throw new SemanticException("Catalog %s is not found", catalogName);
+            throw new SemanticException("Catalog %s is not found", targetCatalogName);
         }
 
         if (!table.supportsOperation(operation)) {


### PR DESCRIPTION
## Why I'm doing:
introduced by https://github.com/StarRocks/starrocks/pull/67216
## What I'm doing:

Fixes [#10796](https://github.com/StarRocks/StarRocksTest/issues/10796)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes catalog-null handling when validating `CREATE TABLE LIKE`.
> 
> - `MetaUtils.checkNotSupportCatalog` now has an overload accepting an optional `catalogName`; picks `table.getCatalogName()` or falls back to the provided name
> - Updated `CreateTableLikeAnalyzer` to pass the existed table's catalog to `checkNotSupportCatalog`
> - Adjusted internal lookups and error messages to use the resolved catalog name
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 446b045dc8bc7529691c6d587607880585c07006. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->