### PR TITLE
[UT] Fix BE UT test_in_bitset

### DIFF
--- a/be/test/storage/column_predicate_test.cpp
+++ b/be/test/storage/column_predicate_test.cpp
@@ -1745,7 +1745,7 @@ TEST(ColumnPredicateTest, test_in_bitset) {
     // ---------------------------------------------
 
     {
-        std::vector<uint16_t> sel{0, 1, 2, 3, 5, 6, 7};
+        std::vector<uint16_t> sel{0, 1, 2, 3, 4, 5, 6};
         auto status_sel_size = bitset_pred->evaluate_branchless(nullable_col.get(), sel.data(), 7);
         ASSERT_TRUE(status_sel_size.ok());
         ASSERT_EQ(2, status_sel_size.value());
@@ -1753,15 +1753,15 @@ TEST(ColumnPredicateTest, test_in_bitset) {
         ASSERT_EQ("1,3", to_string(sel));
     }
     {
-        std::vector<uint16_t> sel{0, 2, 3, 5, 6, 7};
-        auto status_sel_size = bitset_pred->evaluate_branchless(nullable_col.get(), sel.data(), 6);
+        std::vector<uint16_t> sel{0, 2, 3, 5, 6};
+        auto status_sel_size = bitset_pred->evaluate_branchless(nullable_col.get(), sel.data(), 5);
         ASSERT_TRUE(status_sel_size.ok());
         ASSERT_EQ(1, status_sel_size.value());
         sel.resize(1);
         ASSERT_EQ("3", to_string(sel));
     }
     {
-        std::vector<uint16_t> sel{0, 1, 2, 3, 5, 6, 7};
+        std::vector<uint16_t> sel{0, 1, 2, 3, 4};
         auto status_sel_size = bitset_pred->evaluate_branchless(col.get(), sel.data(), 5);
         ASSERT_TRUE(status_sel_size.ok());
         ASSERT_EQ(2, status_sel_size.value());
@@ -1769,7 +1769,7 @@ TEST(ColumnPredicateTest, test_in_bitset) {
         ASSERT_EQ("1,3", to_string(sel));
     }
     {
-        std::vector<uint16_t> sel{0, 2, 3, 5, 6, 7};
+        std::vector<uint16_t> sel{0, 2, 3, 4};
         auto status_sel_size = bitset_pred->evaluate_branchless(col.get(), sel.data(), 4);
         ASSERT_TRUE(status_sel_size.ok());
         ASSERT_EQ(1, status_sel_size.value());


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts unit test `test_in_bitset` to use valid selection vectors and sizes for `evaluate_branchless`.
> 
> - Corrects `sel` contents and count arguments to match column lengths (removes out-of-range indices) in four `evaluate_branchless` calls
> - No production code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0d0ba86dc5a967c1a87a9ecd991fd007845e9c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->