### PR TITLE
[Enhancement] Fallback to not splitting when tablet splitting failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -224,11 +224,25 @@ public class SplitTabletJob extends TabletReshardJob {
                         for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
                             SplittingTablet splittingTablet = reshardingTablet.getSplittingTablet();
                             if (splittingTablet != null) {
-                                for (Long tabletId : splittingTablet.getNewTabletIds()) {
+                                List<Long> newTabletIds = splittingTablet.getNewTabletIds();
+                                for (Long tabletId : newTabletIds) {
                                     TabletRange tabletRange = tabletRanges.get(tabletId);
-                                    Preconditions.checkNotNull(tabletRange,
-                                            "Range of tablet " + tabletId + " not found");
-                                    newIndex.getTablet(tabletId).setRange(tabletRange);
+                                    if (tabletRange != null) {
+                                        Tablet newTablet = newIndex.getTablet(tabletId);
+                                        Preconditions.checkNotNull(newTablet, "Not found tablet " + tabletId);
+                                        newTablet.setRange(tabletRange);
+                                    } else {
+                                        // If splitting tablet failed, will fallback to identical tablet,
+                                        // in this case, BE will only return the range of the first tablet
+                                        List<Long> toRemoveTabletIds = newTabletIds.subList(1, newTabletIds.size());
+                                        Preconditions.checkState(tabletId == toRemoveTabletIds.get(0),
+                                                "Range of tablet " + tabletId + " not found");
+                                        for (long toRemoveTabletId : toRemoveTabletIds) {
+                                            newIndex.removeTablet(toRemoveTabletId);
+                                        }
+                                        splittingTablet.fallbackToIdenticalTablet();
+                                        break;
+                                    }
                                 }
                             }
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
@@ -284,8 +284,10 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                 oldIndex.getShardGroupId());
 
         for (ReshardingTablet reshardingTablet : reshardingTablets) {
+            Tablet oldTablet = oldIndex.getTablet(reshardingTablet.getFirstOldTabletId());
+            Preconditions.checkNotNull(oldTablet, "Not found tablet " + reshardingTablet.getFirstOldTabletId());
             for (long tabletId : reshardingTablet.getNewTabletIds()) {
-                Tablet tablet = new LakeTablet(tabletId);
+                Tablet tablet = new LakeTablet(tabletId, oldTablet.getRange());
                 newIndex.addTablet(tablet, null, false);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplittingTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplittingTablet.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter.reshard;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.proto.ReshardingTabletInfoPB;
 import com.starrocks.proto.SplittingTabletInfoPB;
@@ -38,7 +39,7 @@ public class SplittingTablet implements ReshardingTablet {
 
     @Override
     public SplittingTablet getSplittingTablet() {
-        return this;
+        return isIdenticalTablet() ? null : this;
     }
 
     @Override
@@ -48,7 +49,7 @@ public class SplittingTablet implements ReshardingTablet {
 
     @Override
     public IdenticalTablet getIdenticalTablet() {
-        return null;
+        return isIdenticalTablet() ? new IdenticalTablet(oldTabletId, newTabletIds.get(0)) : null;
     }
 
     public long getOldTabletId() {
@@ -82,5 +83,14 @@ public class SplittingTablet implements ReshardingTablet {
         reshardingTabletInfoPB.splittingTabletInfo.oldTabletId = oldTabletId;
         reshardingTabletInfoPB.splittingTabletInfo.newTabletIds = newTabletIds;
         return reshardingTabletInfoPB;
+    }
+
+    public void fallbackToIdenticalTablet() {
+        Preconditions.checkState(!newTabletIds.isEmpty());
+        newTabletIds.subList(1, newTabletIds.size()).clear();
+    }
+
+    public boolean isIdenticalTablet() {
+        return newTabletIds.size() == 1;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -219,6 +219,15 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         }
     }
 
+    public Tablet removeTablet(long tabletId) {
+        Tablet tablet = idToTablets.remove(tabletId);
+        if (tablet != null) {
+            tablets.remove(tablet);
+            GlobalStateMgr.getCurrentState().getTabletInvertedIndex().deleteTablet(tabletId);
+        }
+        return tablet;
+    }
+
     public void setIdForRestore(long idxId) {
         this.id = idxId;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletRange;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -66,6 +67,10 @@ public class LakeTablet extends Tablet {
 
     public LakeTablet(long id) {
         super(id);
+    }
+
+    public LakeTablet(long id, TabletRange range) {
+        super(id, range);
     }
 
     public long getShardId() {


### PR DESCRIPTION
## Why I'm doing:
 This commit implements a graceful degradation mechanism for tablet splitting operations. When BE fails to split a tablet, instead of failing the entire job, FE falls back to treating the tablet as an "identical tablet" (no split).

## What I'm doing:
Key Changes

  | File                       | Change                                                                                                        |
  |----------------------------|---------------------------------------------------------------------------------------------------------------|
  | SplitTabletJob.java        | Handle missing tablet ranges by removing extra tablets and falling back to identical tablet                   |
  | SplitTabletJobFactory.java | Copy range from old tablet when creating new tablets as a default                                             |
  | SplittingTablet.java       | Add fallbackToIdenticalTablet() and isIdenticalTablet() methods; modify getter behavior based on tablet count |
  | MaterializedIndex.java     | Add removeTablet() method to support tablet removal                                                           |
  | LakeTablet.java            | Add constructor accepting TabletRange parameter                                                               |
  | SplitTabletJobTest.java    | Add testFallbackToIdenticalTablet() test case                                                                 |

  

  When BE returns PublishVersionResponse:
  - If all new tablets have ranges → splitting succeeded
  - If only the first tablet has a range → splitting failed, fallback to identical tablet by:
    a. Removing extra tablets from the index
    b. Clearing extra tablet IDs from SplittingTablet
    c. The tablet is then treated as IdenticalTablet in subsequent operations

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements graceful fallback when tablet splitting partially fails and only the first new tablet has a range.
> 
> - In `SplitTabletJob`, on publish success set ranges for new tablets; if a range is missing, remove trailing new tablets from the new index via `MaterializedIndex.removeTablet`, call `SplittingTablet.fallbackToIdenticalTablet()`, and proceed as identical.
> - In `SplitTabletJobFactory`, initialize new `LakeTablet` with the old tablet's `TabletRange`; add precondition to ensure old tablet exists.
> - In `SplittingTablet`, add `isIdenticalTablet()` and `fallbackToIdenticalTablet()`, update getters so it reports as `IdenticalTablet` when only one new tablet remains.
> - Add `LakeTablet(long id, TabletRange range)` constructor to carry ranges; add `MaterializedIndex.removeTablet()`.
> - Tests: add `testFallbackToIdenticalTablet()` and adjust assertions to cover fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45dd5d7e823cdad23151ba86850bbf99f6600bf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->