### PR TITLE
[BugFix] Fix CACHE SELECT crash when query contains predicates

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2794,10 +2794,7 @@ ChunkIteratorPtr new_segment_iterator(const std::shared_ptr<Segment>& segment, c
     if (options.pred_tree.empty() || options.pred_tree.num_columns() >= schema.num_fields()) {
         return std::make_shared<SegmentIterator>(segment, schema, options);
     } else {
-        // CACHE SELECT disable late materialization
-        if (options.lake_io_opts.cache_file_only) {
-            return new_projection_iterator(schema, std::make_shared<SegmentIterator>(segment, schema, options));
-        }
+        // _check_low_cardinality_optimization() implementation counts on this schema reorder
         Schema ordered_schema = reorder_schema(schema, options.pred_tree);
         auto seg_iter = std::make_shared<SegmentIterator>(segment, ordered_schema, options);
         return new_projection_iterator(schema, seg_iter);

--- a/test/sql/test_cacheselect/R/test_shared_data_cache_select
+++ b/test/sql/test_cacheselect/R/test_shared_data_cache_select
@@ -1,0 +1,27 @@
+-- name: test_shared_data_cache_select @cloud
+CREATE DATABASE cache_select_db_${uuid0};
+-- result:
+-- !result
+USE cache_select_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (c1 string, c2 string, c3 datetime) PARTITION BY date_trunc('month', c3) DISTRIBUTED BY HASH(`c1`, `c2`) BUCKETS 1;
+-- result:
+-- !result
+INSERT INTO t1
+SELECT
+    CAST(a.n AS string),
+    CAST(a.n * c.n AS string),
+    days_sub(CURRENT_DATE(), c.n)
+FROM
+    (SELECT generate_series as n FROM TABLE(generate_series(1, 256))) a,
+    (SELECT generate_series as n FROM TABLE(generate_series(1, 256))) c;
+-- result:
+-- !result
+CACHE SELECT c1, c2, c3 FROM t1 WHERE c3 >= utc_timestamp() - INTERVAL 2 month ;
+-- result:
+[REGEX].*
+-- !result
+DROP DATABASE cache_select_db_${uuid0} FORCE;
+-- result:
+-- !result

--- a/test/sql/test_cacheselect/T/test_shared_data_cache_select
+++ b/test/sql/test_cacheselect/T/test_shared_data_cache_select
@@ -1,0 +1,20 @@
+-- name: test_shared_data_cache_select @cloud
+
+CREATE DATABASE cache_select_db_${uuid0};
+USE cache_select_db_${uuid0};
+
+CREATE TABLE t1 (c1 string, c2 string, c3 datetime) PARTITION BY date_trunc('month', c3) DISTRIBUTED BY HASH(`c1`, `c2`) BUCKETS 1;
+
+INSERT INTO t1
+SELECT
+    CAST(a.n AS string),
+    CAST(a.n * c.n AS string),
+    days_sub(CURRENT_DATE(), c.n)
+FROM
+    (SELECT generate_series as n FROM TABLE(generate_series(1, 256))) a,
+    (SELECT generate_series as n FROM TABLE(generate_series(1, 256))) c;
+
+CACHE SELECT c1, c2, c3 FROM t1 WHERE c3 >= utc_timestamp() - INTERVAL 2 month ;
+
+-- clean up
+DROP DATABASE cache_select_db_${uuid0} FORCE;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Introduced in #65850

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a CACHE SELECT crash with predicate queries by ensuring schema reordering is applied before building `SegmentIterator` when predicates exist, even in cache-only reads.
> 
> - Always reorder schema via `reorder_schema(...)` and wrap with `new_projection_iterator(...)` when `pred_tree` is non-empty (removes the cache-only special case in `new_segment_iterator`)
> - Adds SQL tests `test_shared_data_cache_select` to validate CACHE SELECT with a WHERE predicate
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1349d4cd1824f3470ea62a9bdb798e3ea63088e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->