### PR TITLE
[BugFix] local pk index doesn't support read only execution mode

### DIFF
--- a/be/test/storage/lake/lake_primary_key_consistency_test.cpp
+++ b/be/test/storage/lake/lake_primary_key_consistency_test.cpp
@@ -737,7 +737,8 @@ TEST_P(LakePrimaryKeyConsistencyTest, test_random_seed_pk_consistency) {
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyConsistencyTest, LakePrimaryKeyConsistencyTest,
-                         ::testing::Values(PrimaryKeyParam{
-                                 .persistent_index_type = PersistentIndexTypePB::CLOUD_NATIVE}));
+                         ::testing::Values(PrimaryKeyParam{.persistent_index_type = PersistentIndexTypePB::LOCAL},
+                                           PrimaryKeyParam{
+                                                   .persistent_index_type = PersistentIndexTypePB::CLOUD_NATIVE}));
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:
Only cloud native pk index support read only execution mode, so we can only call `parallel_get` when `read_only` and `is_cloud_native_index` are both true.

## What I'm doing:
  1. Fix the readonly execution mode check: Add is_cloud_native_index condition to the readonly branch check in UpdateManager::_do_update(), ensuring that only cloud-native index enters the readonly execution path (parallel_get). Local index will fall back to the regular parallel_upsert path.
  2. Add explanatory comments: Add comments in be/src/storage/lake/update_manager.cpp:789 and 794 to clarify that only cloud-native index supports parallel_get/parallel_upsert and readonly execution mode.
  3. Enhance test coverage: Add test case for LOCAL persistent index type in lake_primary_key_consistency_test.cpp to prevent regression.

  Changes:
  - be/src/storage/lake/update_manager.cpp: Modified readonly condition check and added comments
  - be/test/storage/lake/lake_primary_key_consistency_test.cpp: Added LOCAL index test case

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
