### PR TITLE
[Enhancement] Support auto-triggered tablet split for cloud native range tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
@@ -18,7 +18,26 @@ import com.starrocks.common.Config;
 
 public class TabletReshardUtils {
 
+    public static boolean needSplit(long dataSize) {
+        return calcSplitCount(dataSize, Config.tablet_reshard_target_size) > 1;
+    }
+
+    /*
+     * Return value > 1 if need split
+     * Return value = 1 if not need split
+     * Return value <= 0 if exception occurs
+     */
     public static int calcSplitCount(long dataSize, long targetSize) {
+        if (targetSize <= 0) {
+            // A value less than 0 indicates the specified split count,
+            // for internal testing.
+            long splitCount = -targetSize;
+            if (splitCount > Config.tablet_reshard_max_split_count) {
+                return 0;
+            }
+            return (int) splitCount;
+        }
+
         if (dataSize < 2 * targetSize) {
             return 1;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/AutomaticTabletReshardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/AutomaticTabletReshardTest.java
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.TabletStatMgr;
+import com.starrocks.common.Config;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.SplitTabletClause;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class AutomaticTabletReshardTest {
+    protected static ConnectContext connectContext;
+    protected static StarRocksAssert starRocksAssert;
+    private static Database db;
+    private static OlapTable table;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        Config.enable_range_distribution = true;
+
+        starRocksAssert.withDatabase("test").useDatabase("test");
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+
+        String sql = "create table test_table (key1 int, key2 varchar(10))\n" +
+                "order by(key1)\n" +
+                "properties('replication_num' = '1'); ";
+        starRocksAssert.withTable(sql);
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "test_table");
+    }
+
+    @Test
+    void testTriggerTabletReshardFailed() {
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public void createTabletReshardJob(Database db, OlapTable table, SplitTabletClause splitTabletClause)
+                    throws StarRocksException {
+                throw new StarRocksException("Create tablet reshard job failed");
+            }
+        };
+
+        Deencapsulation.invoke(TabletStatMgr.class, "triggerTabletReshard", db, table,
+                Config.tablet_reshard_target_size * 4);
+    }
+
+    @Test
+    void testTriggerTabletReshardSuccess() {
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public void createTabletReshardJob(Database db, OlapTable table, SplitTabletClause splitTabletClause)
+                    throws StarRocksException {
+                return;
+            }
+        };
+
+        Deencapsulation.invoke(TabletStatMgr.class, "triggerTabletReshard", db, table,
+                Config.tablet_reshard_target_size * 4);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
This PR implements automatic tablet split functionality and refactors
the split count calculation logic.

## What I'm doing:
  - Add `needSplit()` method in TabletReshardUtils to check if a tablet
    needs to be split based on its data size
  - Refactor `calcSplitCount()` to handle both target-size-based and
    direct-count-based split calculation (when targetSize <= 0)
  - Implement `triggerTabletReshard()` in TabletStatMgr to automatically
    create split tablet jobs for cloud native tables with RANGE
    distribution when tablet size exceeds the threshold
  - Simplify SplitTabletJobFactory by delegating split count calculation
    to TabletReshardUtils

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables automatic tablet splitting for eligible cloud-native tables and consolidates split-count logic.
> 
> - Implement `TabletStatMgr.triggerTabletReshard` to auto-create split jobs (`SplitTabletClause`) for cloud-native `RANGE` tables when `TabletReshardUtils.needSplit(maxTabletSize)` and FE is leader
> - Add `TabletReshardUtils.needSplit()` and refactor `calcSplitCount()` to support negative target as explicit split count with max cap via `Config.tablet_reshard_max_split_count`
> - Simplify `SplitTabletJobFactory` to use `TabletReshardUtils.calcSplitCount`; validate `tablet_reshard_target_size` and enforce positive target when tablets aren’t explicitly specified
> - Add `AutomaticTabletReshardTest` covering success and failure paths of job creation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8b3002041c445865c2e4db8bb5c7b86fefe71b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->