### PR TITLE
[BugFix] Fix FE restart failure when TIME_WAIT connections exist

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/NetUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/NetUtils.java
@@ -103,7 +103,7 @@ public class NetUtils {
         if (isLocalAddress(address)) {
             // Prefer binding check to avoid false positives when connect() is redirected or black-holed by VPN/firewall.
             try (ServerSocket serverSocket = new ServerSocket()) {
-                serverSocket.setReuseAddress(false);
+                serverSocket.setReuseAddress(true);
                 serverSocket.bind(new InetSocketAddress(address, port));
                 return false;
             } catch (BindException e) {


### PR DESCRIPTION
## Why I'm doing:
  Set SO_REUSEADDR to true in NetUtils.isPortUsing() to allow
     port reuse when connections are in TIME_WAIT state. This fixes
     the "edit_log_port already in use" error during fast FE restarts.

     The change is safe as SO_REUSEADDR only affects TIME_WAIT state,
     not LISTEN state. Real port conflicts are still detected correctly.
## What I'm doing:
This pull request makes a targeted change to the network utility logic to improve port binding behavior. Specifically, it updates the server socket configuration to allow address reuse, which can help avoid issues when repeatedly binding to the same port during testing or rapid restarts.

- Networking behavior improvement:
  * In `NetUtils.java`, changed `ServerSocket.setReuseAddress` from `false` to `true` in the `isPortUsing` method, enabling address reuse when checking if a port is in use.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves local port availability checks to reduce false "in use" detections during rapid restarts.
> 
> - In `NetUtils.isPortUsing`, set `ServerSocket.setReuseAddress(true)` before `bind()` when probing a local port
> - Non-local address behavior (connect probe) unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53e10baa18550670eebfd9407a15dc027d76c419. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->