### PR TITLE
[Refactor] Refactor materialized index meta id for multi-version materialized indexes (part 2)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2Builder.java
@@ -42,17 +42,17 @@ public abstract class AlterJobV2Builder {
     protected double bloomFilterFpp;
     protected boolean hasIndexChanged = false;
     protected List<Index> indexes;
-    protected Map<Long, List<Column>> newIndexSchema = new HashMap<>();
-    protected Map<Long, Short> newIndexShortKeyCount = new HashMap<>();
+    protected Map<Long, List<Column>> newIndexMetaIdToSchema = new HashMap<>();
+    protected Map<Long, Short> newIndexMetaIdToShortKeyCount = new HashMap<>();
     protected List<Integer> sortKeyIdxes;
     protected List<Integer> sortKeyUniqueIds;
     protected ComputeResource computeResource = WarehouseManager.DEFAULT_RESOURCE;
     protected boolean disableReplicatedStorageForGIN = false;
 
     // -------- for roll up-----------------
-    protected long baseIndexId;
+    protected long baseIndexMetaId;
     protected String baseIndexName;
-    protected long rollupIndexId;
+    protected long rollupIndexMetaId;
     protected String rollupIndexName;
     protected Expr whereClause;
     List<Column> rollupColumns;
@@ -66,8 +66,8 @@ public abstract class AlterJobV2Builder {
     public AlterJobV2Builder() {
     }
 
-    public AlterJobV2Builder withBaseIndexId(long baseIndexId) {
-        this.baseIndexId = baseIndexId;
+    public AlterJobV2Builder withBaseIndexMetaId(long baseIndexMetaId) {
+        this.baseIndexMetaId = baseIndexMetaId;
         return this;
     }
 
@@ -76,8 +76,8 @@ public abstract class AlterJobV2Builder {
         return this;
     }
 
-    public AlterJobV2Builder withMvIndexId(long rollIndexId) {
-        this.rollupIndexId = rollIndexId;
+    public AlterJobV2Builder withMvIndexMetaId(long rollupIndexMetaId) {
+        this.rollupIndexMetaId = rollupIndexMetaId;
         return this;
     }
 
@@ -158,23 +158,23 @@ public abstract class AlterJobV2Builder {
         return this;
     }
 
-    public AlterJobV2Builder withNewIndexShortKeyCount(long indexId, short shortKeyCount) {
-        this.newIndexShortKeyCount.put(indexId, shortKeyCount);
+    public AlterJobV2Builder withNewIndexMetaIdToShortKeyCount(long indexMetaId, short shortKeyCount) {
+        this.newIndexMetaIdToShortKeyCount.put(indexMetaId, shortKeyCount);
         return this;
     }
 
-    public AlterJobV2Builder withNewIndexShortKeyCount(Map<Long, Short> shortKeyCount) {
-        this.newIndexShortKeyCount.putAll(shortKeyCount);
+    public AlterJobV2Builder withNewIndexMetaIdToShortKeyCount(Map<Long, Short> shortKeyCount) {
+        this.newIndexMetaIdToShortKeyCount.putAll(shortKeyCount);
         return this;
     }
 
-    public AlterJobV2Builder withNewIndexSchema(long indexId, @NotNull List<Column> indexSchema) {
-        newIndexSchema.put(indexId, indexSchema);
+    public AlterJobV2Builder withNewIndexMetaIdToSchema(long indexMetaId, @NotNull List<Column> indexSchema) {
+        newIndexMetaIdToSchema.put(indexMetaId, indexSchema);
         return this;
     }
 
-    public AlterJobV2Builder withNewIndexSchema(@NotNull Map<Long, List<Column>> indexSchema) {
-        newIndexSchema.putAll(indexSchema);
+    public AlterJobV2Builder withNewIndexMetaIdToSchema(@NotNull Map<Long, List<Column>> indexSchema) {
+        newIndexMetaIdToSchema.putAll(indexSchema);
         return this;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -964,13 +964,13 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         if (olapTable.getIndexNameToMetaId().size() > 1) {
             Map<Long, MaterializedIndexMeta> metaMap = olapTable.getIndexMetaIdToMeta();
             for (Map.Entry<Long, MaterializedIndexMeta> entry : metaMap.entrySet()) {
-                Long id = entry.getKey();
-                if (id == olapTable.getBaseIndexMetaId()) {
+                Long indexMetaId = entry.getKey();
+                if (indexMetaId == olapTable.getBaseIndexMetaId()) {
                     continue;
                 }
                 MaterializedIndexMeta meta = entry.getValue();
                 List<Column> schema = meta.getSchema();
-                String indexName = olapTable.getIndexNameByMetaId(id);
+                String indexName = olapTable.getIndexNameByMetaId(indexMetaId);
                 // ignore agg_keys type because it's like duplicated without agg functions
                 boolean hasAggregateFunction = olapTable.getKeysType() != KeysType.AGG_KEYS &&
                         schema.stream().anyMatch(x -> x.isAggregated());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/IndexSchemaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/IndexSchemaInfo.java
@@ -20,21 +20,22 @@ import com.starrocks.catalog.SchemaInfo;
 import static java.util.Objects.requireNonNull;
 
 public class IndexSchemaInfo {
+    // not change the SerializedName for compatibility
     @SerializedName("indexId")
-    private final long indexId;
+    private final long indexMetaId;
     @SerializedName("indexName")
     private final String indexName;
     @SerializedName("schemaInfo")
     private final SchemaInfo schemaInfo;
 
-    IndexSchemaInfo(long indexId, String indexName, SchemaInfo schemaInfo) {
-        this.indexId = indexId;
+    IndexSchemaInfo(long indexMetaId, String indexName, SchemaInfo schemaInfo) {
+        this.indexMetaId = indexMetaId;
         this.indexName = indexName;
         this.schemaInfo = requireNonNull(schemaInfo, "schema is null");
     }
 
-    public long getIndexId() {
-        return indexId;
+    public long getIndexMetaId() {
+        return indexMetaId;
     }
 
     public String getIndexName() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -159,12 +159,12 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
         try {
             commitVersionMap.clear();
-            for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-                PhysicalPartition partition = table.getPhysicalPartition(partitionId);
-                Preconditions.checkNotNull(partition, partitionId);
-                long commitVersion = partition.getNextVersion();
-                commitVersionMap.put(partitionId, commitVersion);
-                LOG.debug("commit version of partition {} is {}. jobId={}", partitionId,
+            for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+                PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+                Preconditions.checkNotNull(physicalPartition, physicalPartitionId);
+                long commitVersion = physicalPartition.getNextVersion();
+                commitVersionMap.put(physicalPartitionId, commitVersion);
+                LOG.debug("commit version of partition {} is {}. jobId={}", physicalPartitionId,
                         commitVersion, jobId);
             }
 
@@ -243,13 +243,13 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
         try {
             isFileBundling = table.isFileBundling();
-            for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-                PhysicalPartition partition = table.getPhysicalPartition(partitionId);
-                Preconditions.checkState(partition != null, partitionId);
-                long commitVersion = commitVersionMap.get(partitionId);
-                if (commitVersion != partition.getVisibleVersion() + 1) {
-                    Preconditions.checkState(partition.getVisibleVersion() < commitVersion,
-                            "partition=" + partitionId + " visibleVersion=" + partition.getVisibleVersion() +
+            for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+                PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+                Preconditions.checkState(physicalPartition != null, physicalPartitionId);
+                long commitVersion = commitVersionMap.get(physicalPartitionId);
+                if (commitVersion != physicalPartition.getVisibleVersion() + 1) {
+                    Preconditions.checkState(physicalPartition.getVisibleVersion() < commitVersion,
+                            "partition=" + physicalPartitionId + " visibleVersion=" + physicalPartition.getVisibleVersion() +
                                     " commitVersion=" + commitVersion);
                     return false;
                 }
@@ -273,9 +273,9 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             // 2. the table is enable `file_bundling` and this task is not change `file_bundling`
             //    to false.
             boolean useAggregatePublish = enableFileBundling() || (isFileBundling && !disableFileBundling());
-            for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-                long commitVersion = commitVersionMap.get(partitionId);
-                Map<Long, MaterializedIndex> dirtyIndexMap = physicalPartitionIndexMap.row(partitionId);
+            for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+                long commitVersion = commitVersionMap.get(physicalPartitionId);
+                Map<Long, MaterializedIndex> dirtyIndexMap = physicalPartitionIndexMap.row(physicalPartitionId);
                 List<Tablet> tablets = new ArrayList<>();
                 for (MaterializedIndex index : dirtyIndexMap.values()) {
                     if (!useAggregatePublish) {
@@ -297,8 +297,8 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         }
     }
 
-    public void addDirtyPartitionIndex(long partitionId, long indexId, MaterializedIndex index) {
-        physicalPartitionIndexMap.put(partitionId, indexId, index);
+    public void addDirtyPartitionIndex(long physicalPartitionId, long indexId, MaterializedIndex index) {
+        physicalPartitionIndexMap.put(physicalPartitionId, indexId, index);
     }
 
     public void updatePartitionTabletMeta(Database db, LakeTable table, Partition partition) throws DdlException {
@@ -317,24 +317,24 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
     }
 
     public void updatePhysicalPartitionTabletMeta(Database db, OlapTable table,
-                                                  PhysicalPartition partition) throws DdlException {
+                                                  PhysicalPartition physicalPartition) throws DdlException {
         List<MaterializedIndex> indexList;
 
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
         try {
-            indexList = new ArrayList<>(partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE));
+            indexList = new ArrayList<>(physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE));
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
         }
         for (MaterializedIndex index : indexList) {
-            updateIndexTabletMeta(db, table, partition, index);
+            updateIndexTabletMeta(db, table, physicalPartition, index);
         }
     }
 
-    public void updateIndexTabletMeta(Database db, OlapTable table, PhysicalPartition partition,
+    public void updateIndexTabletMeta(Database db, OlapTable table, PhysicalPartition physicalPartition,
                                       MaterializedIndex index) throws DdlException {
-        addDirtyPartitionIndex(partition.getId(), index.getId(), index);
+        addDirtyPartitionIndex(physicalPartition.getId(), index.getId(), index);
         // be id -> <tablet id,schemaHash>
         Map<Long, Set<Long>> beIdToTabletSet = Maps.newHashMap();
         List<Tablet> tablets;
@@ -362,7 +362,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         batchTask = new AgentBatchTask();
         for (Map.Entry<Long, Set<Long>> kv : beIdToTabletSet.entrySet()) {
             countDownLatch.addMark(kv.getKey(), kv.getValue());
-            TabletMetadataUpdateAgentTask task = createTask(partition, index, kv.getKey(), kv.getValue());
+            TabletMetadataUpdateAgentTask task = createTask(physicalPartition, index, kv.getKey(), kv.getValue());
             Preconditions.checkState(task != null, "task is null");
             task.setLatch(countDownLatch);
             task.setTxnId(watershedTxnId);
@@ -372,7 +372,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         AgentTaskQueue.addBatchTask(batchTask);
         AgentTaskExecutor.submit(batchTask);
         LOG.info("Sent update tablet metadata task. tableName={} partitionId={} indexId={} taskNum={}",
-                tableName, partition.getId(), index.getId(), batchTask.getTaskNum());
+                tableName, physicalPartition.getId(), index.getId(), batchTask.getTaskNum());
 
         // estimate timeout
         long timeout = Config.tablet_create_timeout_second * 1000L * totalTaskNum;
@@ -407,8 +407,8 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
     }
 
     void updateNextVersion(@NotNull LakeTable table) {
-        for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-            PhysicalPartition physicalPartition = table.getPhysicalPartition(partitionId);
+        for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
             long commitVersion = commitVersionMap.get(physicalPartition.getId());
             Preconditions.checkState(physicalPartition.getNextVersion() == commitVersion,
                     "partitionNextVersion=" + physicalPartition.getNextVersion() + " commitVersion=" + commitVersion);
@@ -419,18 +419,18 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
     }
 
     void updateVisibleVersion(@NotNull LakeTable table) {
-        for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-            PhysicalPartition partition = table.getPhysicalPartition(partitionId);
-            long commitVersion = commitVersionMap.get(partitionId);
-            Preconditions.checkState(partition.getVisibleVersion() == commitVersion - 1,
-                    "partitionVisitionVersion=" + partition.getVisibleVersion() + " commitVersion=" + commitVersion);
-            partition.updateVisibleVersion(commitVersion, finishedTimeMs);
+        for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+            long commitVersion = commitVersionMap.get(physicalPartitionId);
+            Preconditions.checkState(physicalPartition.getVisibleVersion() == commitVersion - 1,
+                    "partitionVisitionVersion=" + physicalPartition.getVisibleVersion() + " commitVersion=" + commitVersion);
+            physicalPartition.updateVisibleVersion(commitVersion, finishedTimeMs);
             if (enableFileBundling() || disableFileBundling()) {
-                partition.setMetadataSwitchVersion(commitVersion);
+                physicalPartition.setMetadataSwitchVersion(commitVersion);
             }
-            LOG.info("partitionVisibleVersion=" + partition.getVisibleVersion() + " commitVersion=" + commitVersion);
+            LOG.info("partitionVisibleVersion=" + physicalPartition.getVisibleVersion() + " commitVersion=" + commitVersion);
             LOG.info("LakeTableAlterMetaJob id: {} update visible version of partition: {}, visible Version: {}",
-                    jobId, partition.getId(), commitVersion);
+                    jobId, physicalPartition.getId(), commitVersion);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -93,25 +93,26 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     LakeTableAsyncFastSchemaChangeJob(LakeTableAsyncFastSchemaChangeJob other) {
         this(other.getJobId(), other.getDbId(), other.getTableId(), other.getTableName(), other.getTimeoutMs());
         for (IndexSchemaInfo indexSchemaInfo : other.schemaInfos) {
-            setIndexTabletSchema(indexSchemaInfo.getIndexId(), indexSchemaInfo.getIndexName(), indexSchemaInfo.getSchemaInfo());
+            setIndexTabletSchema(indexSchemaInfo.getIndexMetaId(), indexSchemaInfo.getIndexName(),
+                    indexSchemaInfo.getSchemaInfo());
         }
         this.disableFastSchemaEvolutionV2 = other.disableFastSchemaEvolutionV2;
         this.historySchema = other.historySchema;
         partitionsWithSchemaFile.addAll(other.partitionsWithSchemaFile);
     }
 
-    public void setIndexTabletSchema(long indexId, String indexName, SchemaInfo schemaInfo) {
-        schemaInfos.add(new IndexSchemaInfo(indexId, indexName, schemaInfo));
+    public void setIndexTabletSchema(long indexMetaId, String indexName, SchemaInfo schemaInfo) {
+        schemaInfos.add(new IndexSchemaInfo(indexMetaId, indexName, schemaInfo));
     }
 
     @Override
     protected TabletMetadataUpdateAgentTask createTask(PhysicalPartition partition, MaterializedIndex index, long nodeId,
                                                        Set<Long> tablets) {
-        String tag = String.format("%d_%d", partition.getId(), index.getId());
+        String tag = String.format("%d_%d", partition.getId(), index.getMetaId());
         TabletMetadataUpdateAgentTask task = null;
         boolean needUpdateSchema = false;
         for (IndexSchemaInfo info : schemaInfos) {
-            if (info.getIndexId() == index.getId()) {
+            if (info.getIndexMetaId() == index.getMetaId()) {
                 needUpdateSchema = true;
                 // `Set.add()` returns true means this set did not already contain the specified element
                 boolean createSchemaFile = partitionsWithSchemaFile.add(tag);
@@ -150,11 +151,12 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         OlapTableHistorySchema.Builder historySchemaBuilder = OlapTableHistorySchema.newBuilder();
         for (IndexSchemaInfo indexSchemaInfo : schemaInfos) {
             SchemaInfo schemaInfo = indexSchemaInfo.getSchemaInfo();
-            long indexId = indexSchemaInfo.getIndexId();
-            MaterializedIndexMeta indexMeta = requireNonNull(table.getIndexMetaByIndexId(indexId)).shallowCopy();
+            long indexMetaId = indexSchemaInfo.getIndexMetaId();
+            MaterializedIndexMeta indexMeta = requireNonNull(table.getIndexMetaByMetaId(indexMetaId)).shallowCopy();
             List<Column> oldColumns = indexMeta.getSchema();
-            SchemaInfo oldSchemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, indexMeta);
-            historySchemaBuilder.addIndexSchema(new IndexSchemaInfo(indexId, table.getIndexNameByMetaId(indexId), oldSchemaInfo));
+            SchemaInfo oldSchemaInfo = SchemaInfo.fromMaterializedIndex(table, indexMetaId, indexMeta);
+            historySchemaBuilder.addIndexSchema(
+                    new IndexSchemaInfo(indexMetaId, table.getIndexNameByMetaId(indexMetaId), oldSchemaInfo));
 
             Preconditions.checkState(Objects.equals(indexMeta.getKeysType(), schemaInfo.getKeysType()));
             Preconditions.checkState(Objects.equals(ListUtils.emptyIfNull(indexMeta.getSortKeyUniqueIds()),
@@ -172,9 +174,9 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             indexMeta.setSortKeyIdxes(schemaInfo.getSortKeyIndexes());
 
             // update the indexIdToMeta
-            table.getIndexMetaIdToMeta().put(indexId, indexMeta);
+            table.getIndexMetaIdToMeta().put(indexMetaId, indexMeta);
             table.setIndexes(schemaInfo.getIndexes());
-            table.renameColumnNamePrefix(indexId);
+            table.renameColumnNamePrefix(indexMetaId);
         }
         table.rebuildFullSchema();
         if (!isReplay) {
@@ -264,8 +266,8 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             info.add(TimeUtils.longToTimeString(createTimeMs));
             info.add(TimeUtils.longToTimeString(finishedTimeMs));
             info.add(schemaInfo.getIndexName());
-            info.add(schemaInfo.getIndexId());
-            info.add(schemaInfo.getIndexId());
+            info.add(schemaInfo.getIndexMetaId());
+            info.add(schemaInfo.getIndexMetaId());
             info.add(String.format("%d:0", schemaInfo.getSchemaInfo().getVersion())); // schema version and schema hash
             info.add(getWatershedTxnId());
             info.add(jobState.name());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
@@ -54,14 +54,16 @@ public class LakeTableRollupBuilder extends AlterJobV2Builder {
          * create all rollup indexes. and set state.
          * After setting, Tables' state will be ROLLUP
          */
-        int baseSchemaHash = olapTable.getSchemaHashByIndexMetaId(baseIndexId);
+        int baseSchemaHash = olapTable.getSchemaHashByIndexMetaId(baseIndexMetaId);
         // mvSchemaVersion will keep same with the src MaterializedIndex
-        int mvSchemaVersion = olapTable.getIndexMetaByIndexId(baseIndexId).getSchemaVersion();
+        int mvSchemaVersion = olapTable.getIndexMetaByMetaId(baseIndexMetaId).getSchemaVersion();
         int mvSchemaHash = Util.schemaHash(0 /* init schema version */, rollupColumns, olapTable.getBfColumnNames(),
                 olapTable.getBfFpp());
+        // initially, index id and index meta id are the same
+        long rollupIndexId = rollupIndexMetaId;
 
         AlterJobV2 mvJob = new LakeRollupJob(jobId, dbId, olapTable.getId(), olapTable.getName(), timeoutMs,
-                baseIndexId, rollupIndexId, baseIndexName, rollupIndexName, mvSchemaVersion,
+                baseIndexMetaId, rollupIndexMetaId, baseIndexName, rollupIndexName, mvSchemaVersion,
                 rollupColumns, whereClause, baseSchemaHash, mvSchemaHash,
                 rollupKeysType, rollupShortKeyColumnCount, origStmt, viewDefineSql, isColocateMVIndex);
         mvJob.setComputeResource(computeResource);
@@ -71,13 +73,13 @@ public class LakeTableRollupBuilder extends AlterJobV2Builder {
             TStorageMedium medium = olapTable.getPartitionInfo().getDataProperty(partitionId).getStorageMedium();
             // create shard group
             long shardGroupId = GlobalStateMgr.getCurrentState().getStarOSAgent().
-                        createShardGroup(dbId, olapTable.getId(), partitionId, rollupIndexId);
+                        createShardGroup(dbId, olapTable.getId(), partitionId, rollupIndexMetaId);
             for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                 long physicalPartitionId = physicalPartition.getId();
                 // index state is SHADOW
                 MaterializedIndex mvIndex = new MaterializedIndex(rollupIndexId,
                         MaterializedIndex.IndexState.SHADOW, shardGroupId);
-                MaterializedIndex baseIndex = physicalPartition.getIndex(baseIndexId);
+                MaterializedIndex baseIndex = physicalPartition.getIndex(baseIndexMetaId);
 
                 // create shard
                 Map<String, String> shardProperties = new HashMap<>();
@@ -113,7 +115,7 @@ public class LakeTableRollupBuilder extends AlterJobV2Builder {
 
                 mvJob.addMVIndex(physicalPartitionId, mvIndex);
                 LOG.debug("create materialized view index {} based on index {} in partition {}:{}",
-                        rollupIndexId, baseIndexId, partitionId, physicalPartitionId);
+                        rollupIndexMetaId, baseIndexMetaId, partitionId, physicalPartitionId);
             } // end for baseTablets
         }
         return mvJob;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -110,24 +110,27 @@ import javax.validation.constraints.NotNull;
 public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
     private static final Logger LOG = LogManager.getLogger(LakeTableSchemaChangeJob.class);
 
-    // physical partition id -> (shadow index id -> (shadow tablet id -> origin tablet id))
+    // initially, shadow index id and shadow index meta id are the same.
+    // not change the SerializedName for compatibility
+
+    // physical partition id -> (shadow index meta id -> (shadow tablet id -> origin tablet id))
     @SerializedName(value = "partitionIndexTabletMap")
     private Table<Long, Long, Map<Long, Long>> physicalPartitionIndexTabletMap = HashBasedTable.create();
-    // physical partition id -> (shadow index id -> shadow index))
+    // physical partition id -> (shadow index meta id -> shadow index))
     @SerializedName(value = "partitionIndexMap")
     private Table<Long, Long, MaterializedIndex> physicalPartitionIndexMap = HashBasedTable.create();
-    // shadow index id -> origin index id
+    // shadow index meta id -> origin index meta id
     @SerializedName(value = "indexIdMap")
-    private Map<Long, Long> indexIdMap = Maps.newHashMap();
-    // shadow index id -> shadow index name(__starrocks_shadow_xxx)
+    private Map<Long, Long> indexMetaIdMap = Maps.newHashMap();
+    // shadow index meta id -> shadow index name(__starrocks_shadow_xxx)
     @SerializedName(value = "indexIdToName")
-    private Map<Long, String> indexIdToName = Maps.newHashMap();
-    // shadow index id -> index schema
+    private Map<Long, String> indexMetaIdToName = Maps.newHashMap();
+    // shadow index meta id -> index schema
     @SerializedName(value = "indexSchemaMap")
-    private Map<Long, List<Column>> indexSchemaMap = Maps.newHashMap();
-    // shadow index id -> shadow index short key count
+    private Map<Long, List<Column>> indexMetaIdToSchema = Maps.newHashMap();
+    // shadow index meta id -> shadow index short key count
     @SerializedName(value = "indexShortKeyMap")
-    private Map<Long, Short> indexShortKeyMap = Maps.newHashMap();
+    private Map<Long, Short> indexMetaIdToShortKey = Maps.newHashMap();
 
     // bloom filter info
     @SerializedName(value = "hasBfChange")
@@ -198,49 +201,49 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         this.sortKeyUniqueIds = sortKeyUniqueIds;
     }
 
-    void addTabletIdMap(long partitionId, long shadowIdxId, long shadowTabletId, long originTabletId) {
-        Map<Long, Long> tabletMap = physicalPartitionIndexTabletMap.get(partitionId, shadowIdxId);
+    void addTabletIdMap(long physicalPartitionId, long shadowIdxMetaId, long shadowTabletId, long originTabletId) {
+        Map<Long, Long> tabletMap = physicalPartitionIndexTabletMap.get(physicalPartitionId, shadowIdxMetaId);
         if (tabletMap == null) {
             tabletMap = Maps.newHashMap();
-            physicalPartitionIndexTabletMap.put(partitionId, shadowIdxId, tabletMap);
+            physicalPartitionIndexTabletMap.put(physicalPartitionId, shadowIdxMetaId, tabletMap);
         }
         tabletMap.put(shadowTabletId, originTabletId);
     }
 
-    void addPartitionShadowIndex(long partitionId, long shadowIdxId, MaterializedIndex shadowIdx) {
-        physicalPartitionIndexMap.put(partitionId, shadowIdxId, shadowIdx);
+    void addPartitionShadowIndex(long physicalPartitionId, long shadowIdxMetaId, MaterializedIndex shadowIdx) {
+        physicalPartitionIndexMap.put(physicalPartitionId, shadowIdxMetaId, shadowIdx);
     }
 
-    void addIndexSchema(long shadowIdxId, long originIdxId, @NotNull String shadowIndexName,
+    void addIndexSchema(long shadowIdxMetaId, long originIdxMetaId, @NotNull String shadowIndexName,
                         short shadowIdxShortKeyCount,
                         @NotNull List<Column> shadowIdxSchema) {
-        indexIdMap.put(shadowIdxId, originIdxId);
-        indexIdToName.put(shadowIdxId, shadowIndexName);
-        indexShortKeyMap.put(shadowIdxId, shadowIdxShortKeyCount);
-        indexSchemaMap.put(shadowIdxId, shadowIdxSchema);
+        indexMetaIdMap.put(shadowIdxMetaId, originIdxMetaId);
+        indexMetaIdToName.put(shadowIdxMetaId, shadowIndexName);
+        indexMetaIdToShortKey.put(shadowIdxMetaId, shadowIdxShortKeyCount);
+        indexMetaIdToSchema.put(shadowIdxMetaId, shadowIdxSchema);
     }
 
     // REQUIRE: has acquired the exclusive lock of database
     void addShadowIndexToCatalog(@NotNull OlapTable table, long visibleTxnId) {
         Preconditions.checkState(visibleTxnId != -1);
-        for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-            PhysicalPartition partition = table.getPhysicalPartition(partitionId);
-            Preconditions.checkState(partition != null);
-            Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(partitionId);
+        for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+            Preconditions.checkState(physicalPartition != null);
+            Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(physicalPartitionId);
             for (MaterializedIndex shadowIndex : shadowIndexMap.values()) {
                 shadowIndex.setVisibleTxnId(visibleTxnId);
                 Preconditions.checkState(shadowIndex.getState() == MaterializedIndex.IndexState.SHADOW,
                         shadowIndex.getState());
-                partition.createRollupIndex(shadowIndex);
+                physicalPartition.createRollupIndex(shadowIndex);
             }
         }
 
-        for (long shadowIdxId : indexIdMap.keySet()) {
+        for (long shadowIdxMetaId : indexMetaIdMap.keySet()) {
             List<Integer> sortKeyColumnIndexes = null;
             List<Integer> sortKeyColumnUniqueIds = null;
 
-            long orgIndexId = indexIdMap.get(shadowIdxId);
-            if (orgIndexId == table.getBaseIndexMetaId()) {
+            long orgIndexMetaId = indexMetaIdMap.get(shadowIdxMetaId);
+            if (orgIndexMetaId == table.getBaseIndexMetaId()) {
                 sortKeyColumnIndexes = sortKeyIdxes;
                 sortKeyColumnUniqueIds = sortKeyUniqueIds;
             }
@@ -248,20 +251,20 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             // If upgraded from an old version and do schema change,
             // the schema saved in indexSchemaMap is the schema in the old version, whose uniqueId is -1,
             // so here we initialize column uniqueId here.
-            List<Column> columns = indexSchemaMap.get(shadowIdxId);
+            List<Column> columns = indexMetaIdToSchema.get(shadowIdxMetaId);
             boolean restored = LakeTableHelper.restoreColumnUniqueId(columns);
             if (restored) {
-                LOG.info("Columns of index {} in table {} has reset all unique ids, column size: {}", shadowIdxId,
+                LOG.info("Columns of index {} in table {} has reset all unique ids, column size: {}", shadowIdxMetaId,
                         tableName, columns.size());
             }
 
-            table.setIndexMeta(shadowIdxId, indexIdToName.get(shadowIdxId), columns, 0, 0,
-                    indexShortKeyMap.get(shadowIdxId), TStorageType.COLUMN,
-                    table.getKeysTypeByIndexMetaId(indexIdMap.get(shadowIdxId)), null, sortKeyColumnIndexes,
+            table.setIndexMeta(shadowIdxMetaId, indexMetaIdToName.get(shadowIdxMetaId), columns, 0, 0,
+                    indexMetaIdToShortKey.get(shadowIdxMetaId), TStorageType.COLUMN,
+                    table.getKeysTypeByIndexMetaId(indexMetaIdMap.get(shadowIdxMetaId)), null, sortKeyColumnIndexes,
                     sortKeyColumnUniqueIds);
-            MaterializedIndexMeta orgIndexMeta = table.getIndexMetaByIndexId(orgIndexId);
+            MaterializedIndexMeta orgIndexMeta = table.getIndexMetaByMetaId(orgIndexMetaId);
             Preconditions.checkNotNull(orgIndexMeta);
-            MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(shadowIdxId);
+            MaterializedIndexMeta indexMeta = table.getIndexMetaByMetaId(shadowIdxMetaId);
             Preconditions.checkNotNull(indexMeta);
             rebuildMaterializedIndexMeta(orgIndexMeta, indexMeta);
         }
@@ -377,7 +380,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             }
             countDownLatch = new MarkedCountDownLatch<>((int) numTablets);
             createReplicaLatch = countDownLatch;
-            long baseIndexId = table.getBaseIndexMetaId();
+            long baseIndexMetaId = table.getBaseIndexMetaId();
             long gtid = getNextGtid();
             final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
             for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
@@ -388,20 +391,20 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
 
                 Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(physicalPartitionId);
                 for (Map.Entry<Long, MaterializedIndex> entry : shadowIndexMap.entrySet()) {
-                    long shadowIdxId = entry.getKey();
+                    long shadowIdxMetaId = entry.getKey();
                     MaterializedIndex shadowIdx = entry.getValue();
 
-                    short shadowShortKeyColumnCount = indexShortKeyMap.get(shadowIdxId);
-                    List<Column> shadowSchema = indexSchemaMap.get(shadowIdxId);
-                    long originIndexId = indexIdMap.get(shadowIdxId);
-                    KeysType originKeysType = table.getKeysTypeByIndexMetaId(originIndexId);
+                    short shadowShortKeyColumnCount = indexMetaIdToShortKey.get(shadowIdxMetaId);
+                    List<Column> shadowSchema = indexMetaIdToSchema.get(shadowIdxMetaId);
+                    long originIndexMetaId = indexMetaIdMap.get(shadowIdxMetaId);
+                    KeysType originKeysType = table.getKeysTypeByIndexMetaId(originIndexMetaId);
                     TTabletSchema tabletSchema = SchemaInfo.newBuilder()
-                            .setId(shadowIdxId) // For newly create materialized index, schema id equals to index id
+                            .setId(shadowIdxMetaId) // For newly create materialized index, schema id equals to index meta id
                             .setKeysType(originKeysType)
                             .setShortKeyColumnCount(shadowShortKeyColumnCount)
-                            .setSortKeyIndexes(originIndexId == baseIndexId ? sortKeyIdxes : null)
-                            .setSortKeyUniqueIds(originIndexId == baseIndexId ? sortKeyUniqueIds : null)
-                            .setIndexes(originIndexId == baseIndexId ?
+                            .setSortKeyIndexes(originIndexMetaId == baseIndexMetaId ? sortKeyIdxes : null)
+                            .setSortKeyUniqueIds(originIndexMetaId == baseIndexMetaId ? sortKeyUniqueIds : null)
+                            .setIndexes(originIndexMetaId == baseIndexMetaId ?
                                         indexes : OlapTable.getIndexesBySchema(indexes, shadowSchema))
                             .setBloomFilterColumnNames(bfColumns)
                             .setBloomFilterFpp(bfFpp)
@@ -426,7 +429,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                                 .setDbId(dbId)
                                 .setTableId(tableId)
                                 .setPartitionId(physicalPartitionId)
-                                .setIndexId(shadowIdxId)
+                                .setIndexId(shadowIdxMetaId)
                                 .setTabletId(shadowTabletId)
                                 .setVersion(Partition.PARTITION_INIT_VERSION)
                                 .setStorageMedium(storageMedium)
@@ -513,25 +516,25 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
             OlapTable table = getTableOrThrow(db, tableId);
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE);
-            for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-                PhysicalPartition partition = table.getPhysicalPartition(partitionId);
-                Preconditions.checkNotNull(partition, partitionId);
+            for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+                PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+                Preconditions.checkNotNull(physicalPartition, physicalPartitionId);
 
                 // the schema change task will transform the data before visible version(included).
-                long visibleVersion = partition.getVisibleVersion();
+                long visibleVersion = physicalPartition.getVisibleVersion();
 
-                Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(partitionId);
+                Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(physicalPartitionId);
                 for (Map.Entry<Long, MaterializedIndex> entry : shadowIndexMap.entrySet()) {
-                    long shadowIdxId = entry.getKey();
+                    long shadowIdxMetaId = entry.getKey();
                     MaterializedIndex shadowIdx = entry.getValue();
-                    long originIndexId = indexIdMap.get(shadowIdxId);
+                    long originIndexMetaId = indexMetaIdMap.get(shadowIdxMetaId);
 
                     boolean hasNewGeneratedColumn = false;
                     List<Column> diffGeneratedColumnSchema = Lists.newArrayList();
-                    if (originIndexId == table.getBaseIndexMetaId()) {
-                        List<String> originSchema = table.getSchemaByIndexMetaId(originIndexId).stream().map(col ->
+                    if (originIndexMetaId == table.getBaseIndexMetaId()) {
+                        List<String> originSchema = table.getSchemaByIndexMetaId(originIndexMetaId).stream().map(col ->
                                 new String(col.getName())).collect(Collectors.toList());
-                        List<String> newSchema = table.getSchemaByIndexMetaId(shadowIdxId).stream().map(col ->
+                        List<String> newSchema = table.getSchemaByIndexMetaId(shadowIdxMetaId).stream().map(col ->
                                 new String(col.getName())).collect(Collectors.toList());
 
                         if (originSchema.size() != 0 && newSchema.size() != 0) {
@@ -655,16 +658,16 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
 
                         long shadowTabletId = shadowTablet.getId();
                         long originTabletId =
-                                physicalPartitionIndexTabletMap.row(partitionId).get(shadowIdxId).get(shadowTabletId);
+                                physicalPartitionIndexTabletMap.row(physicalPartitionId).get(shadowIdxMetaId).get(shadowTabletId);
                         AlterReplicaTask alterTask =
-                                AlterReplicaTask.alterLakeTablet(computeNode.getId(), dbId, tableId, partitionId,
-                                        shadowIdxId, shadowTabletId, originTabletId, visibleVersion, jobId,
+                                AlterReplicaTask.alterLakeTablet(computeNode.getId(), dbId, tableId, physicalPartitionId,
+                                        shadowIdxMetaId, shadowTabletId, originTabletId, visibleVersion, jobId,
                                         watershedTxnId, generatedColumnReq);
                         getOrCreateSchemaChangeBatchTask().addTask(alterTask);
                     }
                 }
 
-                partition.setMinRetainVersion(visibleVersion);
+                physicalPartition.setMinRetainVersion(visibleVersion);
 
             } // end for partitions
         }
@@ -706,13 +709,13 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         try (WriteLockedDatabase db = getWriteLockedDatabase(dbId)) {
             OlapTable table = getTableOrThrow(db, tableId);
             commitVersionMap = new HashMap<>();
-            for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-                PhysicalPartition partition = table.getPhysicalPartition(partitionId);
-                Preconditions.checkNotNull(partition, partitionId);
-                partition.setMinRetainVersion(0);
-                long commitVersion = partition.getNextVersion();
-                commitVersionMap.put(partitionId, commitVersion);
-                LOG.debug("commit version of partition {} is {}. jobId={}", partitionId, commitVersion, jobId);
+            for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+                PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+                Preconditions.checkNotNull(physicalPartition, physicalPartitionId);
+                physicalPartition.setMinRetainVersion(0);
+                long commitVersion = physicalPartition.getNextVersion();
+                commitVersionMap.put(physicalPartitionId, commitVersion);
+                LOG.debug("commit version of partition {} is {}. jobId={}", physicalPartitionId, commitVersion, jobId);
             }
             this.jobState = JobState.FINISHED_REWRITING;
             this.finishedTimeMs = System.currentTimeMillis();
@@ -781,13 +784,13 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
             OlapTable table = getTableOrThrow(db, tableId);
             isFileBundling = table.isFileBundling();
-            for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-                PhysicalPartition partition = table.getPhysicalPartition(partitionId);
-                Preconditions.checkState(partition != null, partitionId);
-                long commitVersion = commitVersionMap.get(partitionId);
-                if (commitVersion != partition.getVisibleVersion() + 1) {
-                    Preconditions.checkState(partition.getVisibleVersion() < commitVersion,
-                            "partition=" + partitionId + " visibleVersion=" + partition.getVisibleVersion() +
+            for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+                PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+                Preconditions.checkState(physicalPartition != null, physicalPartitionId);
+                long commitVersion = commitVersionMap.get(physicalPartitionId);
+                if (commitVersion != physicalPartition.getVisibleVersion() + 1) {
+                    Preconditions.checkState(physicalPartition.getVisibleVersion() < commitVersion,
+                            "partition=" + physicalPartitionId + " visibleVersion=" + physicalPartition.getVisibleVersion() +
                                     " commitVersion=" + commitVersion);
                     return false;
                 }
@@ -813,10 +816,10 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             originTxnInfo.txnType = TxnTypePB.TXN_EMPTY;
             originTxnInfo.gtid = watershedGtid;
 
-            for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
+            for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
                 AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
-                long commitVersion = commitVersionMap.get(partitionId);
-                Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(partitionId);
+                long commitVersion = commitVersionMap.get(physicalPartitionId);
+                Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(physicalPartitionId);
                 for (MaterializedIndex shadowIndex : shadowIndexMap.values()) {
                     if (!isFileBundling) {
                         Utils.publishVersion(shadowIndex.getTablets(), txnInfo, 1, commitVersion, computeResource,
@@ -832,8 +835,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                 List<Tablet> allOtherPartitionTablets = new ArrayList<>();
                 try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
                     OlapTable table = getTableOrThrow(db, tableId);
-                    PhysicalPartition partition = table.getPhysicalPartition(partitionId);
-                    originMaterializedIndex = partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE);
+                    PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+                    originMaterializedIndex = physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE);
                 }
 
                 for (MaterializedIndex index : originMaterializedIndex) {
@@ -864,11 +867,11 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             return Sets.newHashSet();
         }
         Set<String> modifiedColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-        for (Map.Entry<Long, List<Column>> entry : indexSchemaMap.entrySet()) {
-            Long shadowIdxId = entry.getKey();
-            long originIndexId = indexIdMap.get(shadowIdxId);
+        for (Map.Entry<Long, List<Column>> entry : indexMetaIdToSchema.entrySet()) {
+            Long shadowIdxMetaId = entry.getKey();
+            long originIndexMetaId = indexMetaIdMap.get(shadowIdxMetaId);
             List<Column> shadowSchema = entry.getValue();
-            List<Column> originSchema = tbl.getSchemaByIndexMetaId(originIndexId);
+            List<Column> originSchema = tbl.getSchemaByIndexMetaId(originIndexMetaId);
             modifiedColumns.addAll(AlterHelper.collectDroppedOrModifiedColumns(originSchema, shadowSchema));
         }
         return modifiedColumns;
@@ -910,12 +913,12 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
     // Update each Partition's nextVersion.
     // The caller must have acquired the database's exclusive lock.
     void updateNextVersion(@NotNull OlapTable table) {
-        for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-            PhysicalPartition partition = table.getPhysicalPartition(partitionId);
-            long commitVersion = commitVersionMap.get(partitionId);
-            Preconditions.checkState(partition.getNextVersion() == commitVersion,
-                    "partitionNextVersion=" + partition.getNextVersion() + " commitVersion=" + commitVersion);
-            partition.setNextVersion(commitVersion + 1);
+        for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+            long commitVersion = commitVersionMap.get(physicalPartitionId);
+            Preconditions.checkState(physicalPartition.getNextVersion() == commitVersion,
+                    "partitionNextVersion=" + physicalPartition.getNextVersion() + " commitVersion=" + commitVersion);
+            physicalPartition.setNextVersion(commitVersion + 1);
         }
     }
 
@@ -939,10 +942,10 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
 
             this.physicalPartitionIndexTabletMap = other.physicalPartitionIndexTabletMap;
             this.physicalPartitionIndexMap = other.physicalPartitionIndexMap;
-            this.indexIdMap = other.indexIdMap;
-            this.indexIdToName = other.indexIdToName;
-            this.indexSchemaMap = other.indexSchemaMap;
-            this.indexShortKeyMap = other.indexShortKeyMap;
+            this.indexMetaIdMap = other.indexMetaIdMap;
+            this.indexMetaIdToName = other.indexMetaIdToName;
+            this.indexMetaIdToSchema = other.indexMetaIdToSchema;
+            this.indexMetaIdToShortKey = other.indexMetaIdToShortKey;
             this.hasBfChange = other.hasBfChange;
             this.bfColumns = other.bfColumns;
             this.bfFpp = other.bfFpp;
@@ -984,12 +987,13 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         for (Table.Cell<Long, Long, MaterializedIndex> cell : physicalPartitionIndexMap.cellSet()) {
             Long partitionId = cell.getRowKey();
             PhysicalPartition physicalPartition = table.getPhysicalPartition(partitionId);
-            Long shadowIndexId = cell.getColumnKey();
+            Long shadowIndexMetaId = cell.getColumnKey();
             MaterializedIndex shadowIndex = cell.getValue();
             assert partitionId != null;
-            assert shadowIndexId != null;
+            assert shadowIndexMetaId != null;
             assert shadowIndex != null;
             TStorageMedium medium = table.getPartitionInfo().getDataProperty(physicalPartition.getParentId()).getStorageMedium();
+            long shadowIndexId = shadowIndexMetaId;
             TabletMeta shadowTabletMeta = new TabletMeta(dbId, tableId, partitionId, shadowIndexId, medium, true);
             for (Tablet shadowTablet : shadowIndex.getTablets()) {
                 invertedIndex.addTablet(shadowTablet.getId(), shadowTabletMeta);
@@ -998,21 +1002,21 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
     }
 
     void removeShadowIndex(@NotNull OlapTable table) {
-        for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-            PhysicalPartition partition = table.getPhysicalPartition(partitionId);
-            Preconditions.checkNotNull(partition, partitionId);
+        for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+            PhysicalPartition partition = table.getPhysicalPartition(physicalPartitionId);
+            Preconditions.checkNotNull(partition, physicalPartitionId);
             partition.setMinRetainVersion(0);
-            for (MaterializedIndex shadowIdx : physicalPartitionIndexMap.row(partitionId).values()) {
-                partition.deleteRollupIndex(shadowIdx.getId());
+            for (MaterializedIndex shadowIdx : physicalPartitionIndexMap.row(physicalPartitionId).values()) {
+                partition.deleteRollupIndex(shadowIdx.getMetaId());
             }
         }
-        for (String shadowIndexName : indexIdToName.values()) {
+        for (String shadowIndexName : indexMetaIdToName.values()) {
             table.deleteIndexInfo(shadowIndexName);
         }
         // Delete tablet from TabletInvertedIndex
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
-        for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-            for (MaterializedIndex shadowIdx : physicalPartitionIndexMap.row(partitionId).values()) {
+        for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+            for (MaterializedIndex shadowIdx : physicalPartitionIndexMap.row(physicalPartitionId).values()) {
                 for (Tablet tablet : shadowIdx.getTablets()) {
                     invertedIndex.deleteTablet(tablet.getId());
                 }
@@ -1033,45 +1037,46 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         }
 
         // replace the origin index with shadow index, set index state as NORMAL
-        for (PhysicalPartition partition : table.getPhysicalPartitions()) {
-            Preconditions.checkState(commitVersionMap.containsKey(partition.getId()));
-            long commitVersion = commitVersionMap.get(partition.getId());
+        for (PhysicalPartition physicalPartition : table.getPhysicalPartitions()) {
+            Preconditions.checkState(commitVersionMap.containsKey(physicalPartition.getId()));
+            long commitVersion = commitVersionMap.get(physicalPartition.getId());
 
-            LOG.debug("update partition visible version. partition=" + partition.getId() + " commitVersion=" +
+            LOG.debug("update partition visible version. partition=" + physicalPartition.getId() + " commitVersion=" +
                     commitVersion);
             // Update Partition's visible version
-            Preconditions.checkState(commitVersion == partition.getVisibleVersion() + 1,
-                    commitVersion + " vs " + partition.getVisibleVersion());
-            partition.setVisibleVersion(commitVersion, finishedTimeMs);
-            LOG.debug("update visible version of partition {} to {}. jobId={}", partition.getId(),
+            Preconditions.checkState(commitVersion == physicalPartition.getVisibleVersion() + 1,
+                    commitVersion + " vs " + physicalPartition.getVisibleVersion());
+            physicalPartition.setVisibleVersion(commitVersion, finishedTimeMs);
+            LOG.debug("update visible version of partition {} to {}. jobId={}", physicalPartition.getId(),
                     commitVersion, jobId);
-            TStorageMedium medium = table.getPartitionInfo().getDataProperty(partition.getParentId()).getStorageMedium();
+            TStorageMedium medium = table.getPartitionInfo().getDataProperty(physicalPartition.getParentId()).getStorageMedium();
             // drop the origin index from partitions
-            for (Map.Entry<Long, Long> entry : indexIdMap.entrySet()) {
-                long shadowIdxId = entry.getKey();
-                long originIdxId = entry.getValue();
+            for (Map.Entry<Long, Long> entry : indexMetaIdMap.entrySet()) {
+                long shadowIdxMetaId = entry.getKey();
+                long originIdxMetaId = entry.getValue();
                 // get index from globalStateMgr, not from 'partitionIdToRollupIndex'.
                 // because if this alter job is recovered from edit log, index in 'physicalPartitionIndexMap'
                 // is not the same object in globalStateMgr. So modification on that index can not reflect to the index
                 // in globalStateMgr.
-                MaterializedIndex shadowIdx = partition.getIndex(shadowIdxId);
-                Preconditions.checkNotNull(shadowIdx, shadowIdxId);
+                MaterializedIndex shadowIdx = physicalPartition.getIndex(shadowIdxMetaId);
+                Preconditions.checkNotNull(shadowIdx, shadowIdxMetaId);
                 MaterializedIndex droppedIdx;
-                if (originIdxId == partition.getBaseIndex().getId()) {
-                    droppedIdx = partition.getBaseIndex();
+                if (originIdxMetaId == physicalPartition.getBaseIndex().getMetaId()) {
+                    droppedIdx = physicalPartition.getBaseIndex();
                 } else {
-                    droppedIdx = partition.deleteRollupIndex(originIdxId);
+                    droppedIdx = physicalPartition.deleteRollupIndex(originIdxMetaId);
                 }
-                Preconditions.checkNotNull(droppedIdx, originIdxId + " vs. " + shadowIdxId);
+                Preconditions.checkNotNull(droppedIdx, originIdxMetaId + " vs. " + shadowIdxMetaId);
 
                 // Add Tablet to TabletInvertedIndex.
                 TabletMeta shadowTabletMeta =
-                        new TabletMeta(dbId, tableId, partition.getId(), shadowIdxId, medium, true);
+                        new TabletMeta(dbId, tableId, physicalPartition.getId(), shadowIdx.getId(), medium, true);
                 for (Tablet tablet : shadowIdx.getTablets()) {
                     invertedIndex.addTablet(tablet.getId(), shadowTabletMeta);
                 }
 
-                partition.visualiseShadowIndex(shadowIdxId, originIdxId == partition.getBaseIndex().getId());
+                physicalPartition.visualiseShadowIndex(
+                        shadowIdxMetaId, originIdxMetaId == physicalPartition.getBaseIndex().getMetaId());
 
                 // the origin tablet created by old schema can be deleted from FE metadata
                 for (Tablet originTablet : droppedIdx.getTablets()) {
@@ -1083,19 +1088,19 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         }
 
         // update index schema info of each index
-        for (Map.Entry<Long, Long> entry : indexIdMap.entrySet()) {
-            long shadowIdxId = entry.getKey();
-            long originIdxId = entry.getValue();
-            String shadowIdxName = table.getIndexNameByMetaId(shadowIdxId);
-            String originIdxName = table.getIndexNameByMetaId(originIdxId);
+        for (Map.Entry<Long, Long> entry : indexMetaIdMap.entrySet()) {
+            long shadowIdxMetaId = entry.getKey();
+            long originIdxMetaId = entry.getValue();
+            String shadowIdxName = table.getIndexNameByMetaId(shadowIdxMetaId);
+            String originIdxName = table.getIndexNameByMetaId(originIdxMetaId);
             table.deleteIndexInfo(originIdxName);
             // the shadow index name is '__starrocks_shadow_xxx', rename it to origin name 'xxx'
             // this will also remove the prefix of columns
             table.renameIndexForSchemaChange(shadowIdxName, originIdxName);
-            table.renameColumnNamePrefix(shadowIdxId);
+            table.renameColumnNamePrefix(shadowIdxMetaId);
 
-            if (originIdxId == table.getBaseIndexMetaId()) {
-                table.setBaseIndexMetaId(shadowIdxId);
+            if (originIdxMetaId == table.getBaseIndexMetaId()) {
+                table.setBaseIndexMetaId(shadowIdxMetaId);
             }
         }
         // rebuild table's full schema
@@ -1185,16 +1190,16 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         }
 
         // one line for one shadow index
-        for (Map.Entry<Long, Long> entry : indexIdMap.entrySet()) {
-            long shadowIndexId = entry.getKey();
+        for (Map.Entry<Long, Long> entry : indexMetaIdMap.entrySet()) {
+            long shadowIndexMetaId = entry.getKey();
             List<Comparable> info = Lists.newArrayList();
             info.add(jobId);
             info.add(tableName);
             info.add(TimeUtils.longToTimeString(createTimeMs));
             info.add(TimeUtils.longToTimeString(finishedTimeMs));
             // only show the origin index name
-            info.add(Column.removeNamePrefix(indexIdToName.get(shadowIndexId)));
-            info.add(shadowIndexId);
+            info.add(Column.removeNamePrefix(indexMetaIdToName.get(shadowIndexMetaId)));
+            info.add(shadowIndexMetaId);
             info.add(entry.getValue());
             info.add("0:0"); // schema version and schema hash
             info.add(watershedTxnId);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -211,13 +211,13 @@ public class MaterializedViewHandler extends AlterHandler {
         // avoid conflict against with batch add rollup job
         Preconditions.checkState(olapTable.getState() == OlapTableState.NORMAL);
 
-        long baseIndexId = checkAndGetBaseIndex(baseIndexName, olapTable);
+        long baseIndexMetaId = checkAndGetBaseIndex(baseIndexName, olapTable);
         // Step1.3: mv clause validation
         List<Column> mvColumns = checkAndPrepareMaterializedView(addMVClause, db, olapTable);
 
         // Step2: create mv job
         AlterJobV2 rollupJobV2 = createMaterializedViewJob(mvIndexName, baseIndexName, mvColumns,
-                addMVClause.getWhereClause(), addMVClause.getProperties(), olapTable, db, baseIndexId,
+                addMVClause.getWhereClause(), addMVClause.getProperties(), olapTable, db, baseIndexMetaId,
                 addMVClause.getMVKeysType(), addMVClause.getOrigStmt(), addMVClause.getQueryStatement());
 
         addAlterJobV2(rollupJobV2);
@@ -266,16 +266,16 @@ public class MaterializedViewHandler extends AlterHandler {
 
                 // step 2 alter clause validation
                 // step 2.1 check whether base index already exists in globalStateMgr
-                long baseIndexId = checkAndGetBaseIndex(baseIndexName, olapTable);
+                long baseIndexMetaId = checkAndGetBaseIndex(baseIndexName, olapTable);
 
                 // step 2.2  check rollup schema
                 List<Column> rollupSchema =
-                        checkAndPrepareMaterializedView(addRollupClause, olapTable, baseIndexId);
+                        checkAndPrepareMaterializedView(addRollupClause, olapTable, baseIndexMetaId);
 
                 // step 3 create rollup job
                 AlterJobV2 alterJobV2 = createMaterializedViewJob(rollupIndexName, baseIndexName, rollupSchema,
                         null, addRollupClause.getProperties(),
-                        olapTable, db, baseIndexId, olapTable.getKeysType(), null,
+                        olapTable, db, baseIndexMetaId, olapTable.getKeysType(), null,
                         null);
 
                 rollupNameJobMap.put(addRollupClause.getRollupName(), alterJobV2);
@@ -319,13 +319,13 @@ public class MaterializedViewHandler extends AlterHandler {
      * @param properties
      * @param olapTable
      * @param db
-     * @param baseIndexId
+     * @param baseIndexMetaId
      * @throws DdlException
      * @throws AnalysisException
      */
     private AlterJobV2 createMaterializedViewJob(String mvName, String baseIndexName, List<Column> mvColumns,
                                                   Expr whereClause, Map<String, String> properties,
-                                                  OlapTable olapTable, Database db, long baseIndexId,
+                                                  OlapTable olapTable, Database db, long baseIndexMetaId,
                                                   KeysType mvKeysType, OriginStatement origStmt,
                                                   QueryStatement queryStatement)
             throws DdlException, AnalysisException {
@@ -342,7 +342,7 @@ public class MaterializedViewHandler extends AlterHandler {
         long dbId = db.getId();
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         long jobId = globalStateMgr.getNextId();
-        long mvIndexId = globalStateMgr.getNextId();
+        long mvIndexMetaId = globalStateMgr.getNextId();
         String viewDefineSql = null;
         if (queryStatement != null) {
             viewDefineSql = AstToSQLBuilder.toSQL(queryStatement);
@@ -376,8 +376,8 @@ public class MaterializedViewHandler extends AlterHandler {
                     .withJobId(jobId)
                     .withDbId(dbId)
                     .withTimeoutSeconds(timeoutMs * 1000)
-                    .withBaseIndexId(baseIndexId)
-                    .withMvIndexId(mvIndexId)
+                    .withBaseIndexMetaId(baseIndexMetaId)
+                    .withMvIndexMetaId(mvIndexMetaId)
                     .withBaseIndexName(baseIndexName)
                     .withMvName(mvName)
                     .withMvColumns(mvColumns)
@@ -496,8 +496,8 @@ public class MaterializedViewHandler extends AlterHandler {
         return newMVColumns;
     }
 
-    public List<Column> checkAndPrepareMaterializedView(AddRollupClause addRollupClause, OlapTable olapTable, long baseIndexId)
-            throws DdlException {
+    public List<Column> checkAndPrepareMaterializedView(AddRollupClause addRollupClause, OlapTable olapTable,
+                                                        long baseIndexMetaId) throws DdlException {
         String rollupIndexName = addRollupClause.getRollupName();
         List<String> rollupColumnNames = addRollupClause.getColumnNames();
 
@@ -517,7 +517,7 @@ public class MaterializedViewHandler extends AlterHandler {
         boolean meetReplaceValue = false;
         KeysType keysType = olapTable.getKeysType();
         Map<String, Column> baseColumnNameToColumn = Maps.newHashMap();
-        for (Column column : olapTable.getSchemaByIndexMetaId(baseIndexId)) {
+        for (Column column : olapTable.getSchemaByIndexMetaId(baseIndexMetaId)) {
             baseColumnNameToColumn.put(column.getName(), column);
         }
         if (keysType.isAggregationFamily()) {
@@ -672,17 +672,17 @@ public class MaterializedViewHandler extends AlterHandler {
         // up to here, table's state can only be NORMAL
         Preconditions.checkState(olapTable.getState() == OlapTableState.NORMAL, olapTable.getState().name());
 
-        Long baseIndexId = olapTable.getIndexMetaIdByName(baseIndexName);
-        if (baseIndexId == null) {
+        Long baseIndexMetaId = olapTable.getIndexMetaIdByName(baseIndexName);
+        if (baseIndexMetaId == null) {
             throw new DdlException("Base index[" + baseIndexName + "] does not exist");
         }
         // check state
         for (PhysicalPartition partition : olapTable.getPhysicalPartitions()) {
-            MaterializedIndex baseIndex = partition.getIndex(baseIndexId);
+            MaterializedIndex baseIndex = partition.getIndex(baseIndexMetaId);
             // up to here. index's state should only be NORMAL
             Preconditions.checkState(baseIndex.getState() == IndexState.NORMAL, baseIndex.getState().name());
         }
-        return baseIndexId;
+        return baseIndexMetaId;
     }
 
     public void processBatchDropRollup(List<AlterClause> dropRollupClauses, Database db, OlapTable olapTable)
@@ -694,13 +694,13 @@ public class MaterializedViewHandler extends AlterHandler {
         }
 
         // drop data in memory
-        Set<Long> indexIdSet = new HashSet<>();
+        Set<Long> indexMetaIdSet = new HashSet<>();
         Set<String> rollupNameSet = new HashSet<>();
         for (AlterClause alterClause : dropRollupClauses) {
             DropRollupClause dropRollupClause = (DropRollupClause) alterClause;
             String rollupIndexName = dropRollupClause.getRollupName();
-            long rollupIndexId = dropMaterializedView(rollupIndexName, olapTable);
-            indexIdSet.add(rollupIndexId);
+            long rollupIndexMetaId = dropMaterializedView(rollupIndexName, olapTable);
+            indexMetaIdSet.add(rollupIndexMetaId);
             rollupNameSet.add(rollupIndexName);
         }
 
@@ -708,7 +708,7 @@ public class MaterializedViewHandler extends AlterHandler {
         EditLog editLog = GlobalStateMgr.getCurrentState().getEditLog();
         long dbId = db.getId();
         long tableId = olapTable.getId();
-        editLog.logBatchDropRollup(new BatchDropInfo(dbId, tableId, indexIdSet));
+        editLog.logBatchDropRollup(new BatchDropInfo(dbId, tableId, indexMetaIdSet));
         LOG.info("finished drop rollup index[{}] in table[{}]", String.join("", rollupNameSet),
                 olapTable.getName());
     }
@@ -722,10 +722,10 @@ public class MaterializedViewHandler extends AlterHandler {
             // Step1: check drop mv index operation
             checkDropMaterializedView(mvName, olapTable);
             // Step2; drop data in memory
-            long mvIndexId = dropMaterializedView(mvName, olapTable);
+            long mvIndexMetaId = dropMaterializedView(mvName, olapTable);
             // Step3: log drop mv operation
             EditLog editLog = GlobalStateMgr.getCurrentState().getEditLog();
-            editLog.logDropRollup(new DropInfo(db.getId(), olapTable.getId(), mvIndexId, false));
+            editLog.logDropRollup(new DropInfo(db.getId(), olapTable.getId(), mvIndexMetaId, false));
             LOG.info("finished drop materialized view [{}] in table [{}]", mvName, olapTable.getName());
         } catch (MetaNotFoundException e) {
             if (dropMaterializedViewStmt.isSetIfExists()) {
@@ -755,12 +755,12 @@ public class MaterializedViewHandler extends AlterHandler {
                     "Materialized view [" + mvName + "] does not exist in table [" + olapTable.getName() + "]");
         }
 
-        long mvIndexId = olapTable.getIndexMetaIdByName(mvName);
-        int mvSchemaHash = olapTable.getSchemaHashByIndexMetaId(mvIndexId);
+        long mvIndexMetaId = olapTable.getIndexMetaIdByName(mvName);
+        int mvSchemaHash = olapTable.getSchemaHashByIndexMetaId(mvIndexMetaId);
         Preconditions.checkState(mvSchemaHash != -1);
 
         for (PhysicalPartition partition : olapTable.getPhysicalPartitions()) {
-            MaterializedIndex materializedIndex = partition.getIndex(mvIndexId);
+            MaterializedIndex materializedIndex = partition.getIndex(mvIndexMetaId);
             Preconditions.checkNotNull(materializedIndex);
         }
     }
@@ -773,25 +773,25 @@ public class MaterializedViewHandler extends AlterHandler {
      * @return
      */
     private long dropMaterializedView(String mvName, OlapTable olapTable) {
-        long mvIndexId = olapTable.getIndexMetaIdByName(mvName);
+        long mvIndexMetaId = olapTable.getIndexMetaIdByName(mvName);
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
         for (PhysicalPartition partition : olapTable.getPhysicalPartitions()) {
-            MaterializedIndex rollupIndex = partition.getIndex(mvIndexId);
+            MaterializedIndex rollupIndex = partition.getIndex(mvIndexMetaId);
             // delete rollup index
-            partition.deleteRollupIndex(mvIndexId);
+            partition.deleteRollupIndex(mvIndexMetaId);
             // remove tablets from inverted index
             for (Tablet tablet : rollupIndex.getTablets()) {
                 invertedIndex.deleteTablet(tablet.getId());
             }
         }
         olapTable.deleteIndexInfo(mvName);
-        return mvIndexId;
+        return mvIndexMetaId;
     }
 
     public void replayDropRollup(DropInfo dropInfo, GlobalStateMgr globalStateMgr) {
         Database db = globalStateMgr.getLocalMetastore().getDb(dropInfo.getDbId());
         long tableId = dropInfo.getTableId();
-        long rollupIndexId = dropInfo.getIndexId();
+        long rollupIndexMetaId = dropInfo.getIndexMetaId();
         OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
 
         try (AutoCloseableLock ignore =
@@ -799,7 +799,7 @@ public class MaterializedViewHandler extends AlterHandler {
             TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
 
             for (PhysicalPartition partition : olapTable.getPhysicalPartitions()) {
-                MaterializedIndex rollupIndex = partition.deleteRollupIndex(rollupIndexId);
+                MaterializedIndex rollupIndex = partition.deleteRollupIndex(rollupIndexMetaId);
 
                 if (!GlobalStateMgr.isCheckpointThread()) {
                     // remove from inverted index
@@ -809,10 +809,10 @@ public class MaterializedViewHandler extends AlterHandler {
                 }
             }
 
-            String rollupIndexName = olapTable.getIndexNameByMetaId(rollupIndexId);
+            String rollupIndexName = olapTable.getIndexNameByMetaId(rollupIndexMetaId);
             olapTable.deleteIndexInfo(rollupIndexName);
         }
-        LOG.info("replay drop rollup {}", dropInfo.getIndexId());
+        LOG.info("replay drop rollup {}", dropInfo.getIndexMetaId());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
@@ -49,7 +49,7 @@ public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
 
     @Override
     public AlterJobV2 build() throws StarRocksException {
-        if (newIndexSchema.isEmpty() && !hasIndexChanged) {
+        if (newIndexMetaIdToSchema.isEmpty() && !hasIndexChanged) {
             throw new DdlException("Nothing is changed. please check your alter stmt.");
         }
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
@@ -67,9 +67,9 @@ public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
          * 2. Create all tablets and replicas of all SHADOW index, add them to tablet inverted index.
          * 3. Change table's state as SCHEMA_CHANGE
          */
-        for (Map.Entry<Long, List<Column>> entry : newIndexSchema.entrySet()) {
-            long originIndexId = entry.getKey();
-            MaterializedIndexMeta currentIndexMeta = table.getIndexMetaByIndexId(originIndexId);
+        for (Map.Entry<Long, List<Column>> entry : newIndexMetaIdToSchema.entrySet()) {
+            long originIndexMetaId = entry.getKey();
+            MaterializedIndexMeta currentIndexMeta = table.getIndexMetaByMetaId(originIndexMetaId);
             // 1. get new schema version/schema version hash, short key column count
             int currentSchemaVersion = currentIndexMeta.getSchemaVersion();
             int newSchemaVersion = currentSchemaVersion + 1;
@@ -79,9 +79,11 @@ public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
             while (currentSchemaHash == newSchemaHash) {
                 newSchemaHash = Util.generateSchemaHash();
             }
-            String newIndexName = SchemaChangeHandler.SHADOW_NAME_PREFIX + table.getIndexNameByMetaId(originIndexId);
-            short newShortKeyColumnCount = newIndexShortKeyCount.get(originIndexId);
-            long shadowIndexId = globalStateMgr.getNextId();
+            String newIndexName = SchemaChangeHandler.SHADOW_NAME_PREFIX + table.getIndexNameByMetaId(originIndexMetaId);
+            short newShortKeyColumnCount = newIndexMetaIdToShortKeyCount.get(originIndexMetaId);
+            long shadowIndexMetaId = globalStateMgr.getNextId();
+            // initially, index id and index meta id are the same
+            long shadowIndexId = shadowIndexMetaId;
 
             // create SHADOW index for each partition
             List<Tablet> addedTablets = Lists.newArrayList();
@@ -92,9 +94,8 @@ public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
                 short replicationNum = table.getPartitionInfo().getReplicationNum(partitionId);
                 // index state is SHADOW
                 MaterializedIndex shadowIndex = new MaterializedIndex(shadowIndexId, MaterializedIndex.IndexState.SHADOW);
-                MaterializedIndex originIndex = partition.getIndex(originIndexId);
-                TabletMeta shadowTabletMeta = new TabletMeta(
-                        dbId, tableId, physicalPartitionId, shadowIndexId, medium);
+                MaterializedIndex originIndex = partition.getIndex(originIndexMetaId);
+                TabletMeta shadowTabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, shadowIndexId, medium);
                 for (Tablet originTablet : originIndex.getTablets()) {
                     long originTabletId = originTablet.getId();
                     long shadowTabletId = globalStateMgr.getNextId();
@@ -103,7 +104,7 @@ public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
                     shadowIndex.addTablet(shadowTablet, shadowTabletMeta);
                     addedTablets.add(shadowTablet);
 
-                    schemaChangeJob.addTabletIdMap(physicalPartitionId, shadowIndexId, shadowTabletId, originTabletId);
+                    schemaChangeJob.addTabletIdMap(physicalPartitionId, shadowIndexMetaId, shadowTabletId, originTabletId);
                     List<Replica> originReplicas = ((LocalTablet) originTablet).getImmutableReplicas();
 
                     int healthyReplicaNum = 0;
@@ -149,9 +150,9 @@ public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
                     }
                 }
 
-                schemaChangeJob.addPartitionShadowIndex(physicalPartitionId, shadowIndexId, shadowIndex);
+                schemaChangeJob.addPartitionShadowIndex(physicalPartitionId, shadowIndexMetaId, shadowIndex);
             } // end for partition
-            schemaChangeJob.addIndexSchema(shadowIndexId, originIndexId, newIndexName, newSchemaVersion, newSchemaHash,
+            schemaChangeJob.addIndexSchema(shadowIndexMetaId, originIndexMetaId, newIndexName, newSchemaVersion, newSchemaHash,
                     newShortKeyColumnCount, entry.getValue());
         } // end for index
         return schemaChangeJob;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableHistorySchema.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableHistorySchema.java
@@ -42,10 +42,10 @@ public class OlapTableHistorySchema {
         return historyTxnIdThreshold;
     }
 
-    public Optional<SchemaInfo> getSchemaByIndexId(long indexId) {
+    public Optional<SchemaInfo> getSchemaByIndexMetaId(long indexMetaId) {
         return getSchemaInfosSafety().flatMap(
                     infos -> infos.stream()
-                        .filter(schema -> schema.getIndexId() == indexId)
+                        .filter(schema -> schema.getIndexMetaId() == indexMetaId)
                         .findFirst().map(IndexSchemaInfo::getSchemaInfo)
                 );
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -136,10 +136,13 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
     private Map<Long, MaterializedIndex> physicalPartitionIdToRollupIndex = Maps.newHashMap();
 
     // rollup and base schema info
+    // base index meta id, not change the SerializedName for compatibility
     @SerializedName(value = "baseIndexId")
-    private long baseIndexId;
+    private long baseIndexMetaId;
+    // initially, rollup index id and rollup index meta id are the same
+    // rollup index meta id, not change the SerializedName for compatibility
     @SerializedName(value = "rollupIndexId")
-    private long rollupIndexId;
+    private long rollupIndexMetaId;
     @SerializedName(value = "baseIndexName")
     private String baseIndexName;
     @SerializedName(value = "rollupIndexName")
@@ -185,14 +188,14 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
     }
 
     public RollupJobV2(long jobId, long dbId, long tableId, String tableName, long timeoutMs,
-                       long baseIndexId, long rollupIndexId, String baseIndexName, String rollupIndexName,
+                       long baseIndexMetaId, long rollupIndexMetaId, String baseIndexName, String rollupIndexName,
                        int rollupSchemaVersion, List<Column> rollupSchema, Expr whereClause, int baseSchemaHash,
                        int rollupSchemaHash, KeysType rollupKeysType, short rollupShortKeyColumnCount,
                        OriginStatement origStmt, String viewDefineSql, boolean isColocateMVIndex) {
         super(jobId, JobType.ROLLUP, dbId, tableId, tableName, timeoutMs);
 
-        this.baseIndexId = baseIndexId;
-        this.rollupIndexId = rollupIndexId;
+        this.baseIndexMetaId = baseIndexMetaId;
+        this.rollupIndexMetaId = rollupIndexMetaId;
         this.baseIndexName = baseIndexName;
         this.rollupIndexName = rollupIndexName;
         this.rollupSchemaVersion = rollupSchemaVersion;
@@ -286,7 +289,6 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
 
         try (AutoCloseableLock ignore =
                 new AutoCloseableLock(new Locker(), db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ)) {
-            MaterializedIndexMeta index = tbl.getIndexMetaByIndexId(tbl.getBaseIndexMetaId());
             Preconditions.checkState(tbl.getState() == OlapTableState.ROLLUP);
             for (Map.Entry<Long, MaterializedIndex> entry : this.physicalPartitionIdToRollupIndex.entrySet()) {
                 long partitionId = entry.getKey();
@@ -299,7 +301,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                 MaterializedIndex rollupIndex = entry.getValue();
 
                 TTabletSchema tabletSchema = SchemaInfo.newBuilder()
-                        .setId(rollupIndexId) // For newly created materialized, schema id equals to index id
+                        .setId(rollupIndexMetaId) // For newly created materialized, schema id equals to index meta id
                         .setVersion(rollupSchemaVersion)
                         .setKeysType(rollupKeysType)
                         .setShortKeyColumnCount(rollupShortKeyColumnCount)
@@ -326,7 +328,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                                 .setDbId(dbId)
                                 .setTableId(tableId)
                                 .setPartitionId(partitionId)
-                                .setIndexId(rollupIndexId)
+                                .setIndexId(rollupIndexMetaId)
                                 .setTabletId(rollupTabletId)
                                 .setVersion(Partition.PARTITION_INIT_VERSION)
                                 .setStorageMedium(storageMedium)
@@ -419,9 +421,9 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             }
         }
 
-        tbl.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, rollupSchemaVersion /* initial schema version */,
+        tbl.setIndexMeta(rollupIndexMetaId, rollupIndexName, rollupSchema, rollupSchemaVersion /* initial schema version */,
                 rollupSchemaHash, rollupShortKeyColumnCount, TStorageType.COLUMN, rollupKeysType, origStmt);
-        MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(rollupIndexId);
+        MaterializedIndexMeta indexMeta = tbl.getIndexMetaByMetaId(rollupIndexMetaId);
         Preconditions.checkNotNull(indexMeta);
         indexMeta.setDbId(dbId);
         indexMeta.setViewDefineSql(viewDefineSql);
@@ -602,6 +604,8 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             throw new AlterCancelException("Table " + tableId + " does not exist");
         }
 
+        // initially, rollup index id and rollup index meta id are the same
+        long rollupIndexId = rollupIndexMetaId;
         Map<Long, List<TColumn>> indexToThriftColumns = new HashMap<>();
         Optional<TDescriptorTable> tDescTable = Optional.empty();
         try (AutoCloseableLock ignore =
@@ -625,15 +629,13 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                     long baseTabletId = tabletIdMap.get(rollupTabletId);
 
                     List<Replica> rollupReplicas = ((LocalTablet) rollupTablet).getImmutableReplicas();
-                    TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
-                    long baseIndexId = invertedIndex.getTabletMeta(baseTabletId).getIndexId();
-                    List<TColumn> baseTColumn = indexToThriftColumns.get(baseIndexId);
+                    List<TColumn> baseTColumn = indexToThriftColumns.get(baseIndexMetaId);
                     if (baseTColumn == null) {
-                        baseTColumn = tbl.getIndexMetaByIndexId(baseIndexId).getSchema()
+                        baseTColumn = tbl.getIndexMetaByMetaId(baseIndexMetaId).getSchema()
                                 .stream()
                                 .map(Column::toThrift)
                                 .collect(Collectors.toList());
-                        indexToThriftColumns.put(baseIndexId, baseTColumn);
+                        indexToThriftColumns.put(baseIndexMetaId, baseTColumn);
                     }
 
                     for (Replica rollupReplica : rollupReplicas) {
@@ -747,14 +749,14 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
     private void onFinished(OlapTable tbl) {
         for (Partition partition : tbl.getPartitions()) {
             for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
-                MaterializedIndex rollupIndex = physicalPartition.getIndex(rollupIndexId);
-                Preconditions.checkNotNull(rollupIndex, rollupIndexId);
+                MaterializedIndex rollupIndex = physicalPartition.getIndex(rollupIndexMetaId);
+                Preconditions.checkNotNull(rollupIndex, rollupIndexMetaId);
                 for (Tablet tablet : rollupIndex.getTablets()) {
                     for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
                         replica.setState(ReplicaState.NORMAL);
                     }
                 }
-                physicalPartition.visualiseShadowIndex(rollupIndexId, false);
+                physicalPartition.visualiseShadowIndex(rollupIndexMetaId, false);
             }
         }
         tbl.rebuildFullSchema();
@@ -817,7 +819,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                             invertedIndex.deleteTablet(rollupTablet.getId());
                         }
                         PhysicalPartition partition = tbl.getPhysicalPartition(partitionId);
-                        partition.deleteRollupIndex(rollupIndexId);
+                        partition.deleteRollupIndex(rollupIndexMetaId);
                     }
                     tbl.deleteIndexInfo(rollupIndexName);
                 }
@@ -863,13 +865,14 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
 
     private void addTabletToInvertedIndex(OlapTable tbl) {
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        // initially, rollup index id and rollup index meta id are the same
+        long rollupIndexId = rollupIndexMetaId;
         // add all rollup replicas to tablet inverted index
         for (Long partitionId : physicalPartitionIdToRollupIndex.keySet()) {
             MaterializedIndex rollupIndex = physicalPartitionIdToRollupIndex.get(partitionId);
             PhysicalPartition physicalPartition = tbl.getPhysicalPartition(partitionId);
             TStorageMedium medium = tbl.getPartitionInfo().getDataProperty(physicalPartition.getParentId()).getStorageMedium();
-            TabletMeta rollupTabletMeta = new TabletMeta(dbId, tableId, partitionId, rollupIndexId,
-                    medium);
+            TabletMeta rollupTabletMeta = new TabletMeta(dbId, tableId, partitionId, rollupIndexId, medium);
 
             for (Tablet rollupTablet : rollupIndex.getTablets()) {
                 invertedIndex.addTablet(rollupTablet.getId(), rollupTabletMeta);
@@ -972,7 +975,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         info.add(TimeUtils.longToTimeString(finishedTimeMs));
         info.add(baseIndexName);
         info.add(rollupIndexName);
-        info.add(rollupIndexId);
+        info.add(rollupIndexMetaId);
         info.add(watershedTxnId);
         info.add(jobState.name());
         info.add(errMsg);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeData.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeData.java
@@ -35,13 +35,13 @@ class SchemaChangeData {
     private final Database database;
     private final OlapTable table;
     private final long timeoutInSeconds;
-    private final Map<Long, List<Column>> newIndexSchema;
+    private final Map<Long, List<Column>> newIndexMetaIdToSchema;
     private final List<Index> indexes;
     private final boolean bloomFilterColumnsChanged;
     private final Set<ColumnId> bloomFilterColumns;
     private final double bloomFilterFpp;
     private final boolean hasIndexChanged;
-    private final Map<Long, Short> newIndexShortKeyCount;
+    private final Map<Long, Short> newIndexMetaIdToShortKeyCount;
     private final boolean shortKeyChanged;
     private final List<Integer> sortKeyIdxes;
     private final List<Integer> sortKeyUniqueIds;
@@ -68,8 +68,8 @@ class SchemaChangeData {
     }
 
     @NotNull
-    Map<Long, List<Column>> getNewIndexSchema() {
-        return Collections.unmodifiableMap(newIndexSchema);
+    Map<Long, List<Column>> getNewIndexMetaIdToSchema() {
+        return Collections.unmodifiableMap(newIndexMetaIdToSchema);
     }
 
     @Nullable
@@ -96,8 +96,8 @@ class SchemaChangeData {
 
 
     @NotNull
-    Map<Long, Short> getNewIndexShortKeyCount() {
-        return Collections.unmodifiableMap(newIndexShortKeyCount);
+    Map<Long, Short> getNewIndexMetaIdToShortKeyCount() {
+        return Collections.unmodifiableMap(newIndexMetaIdToShortKeyCount);
     }
 
     boolean isShortKeyChanged() {
@@ -127,13 +127,14 @@ class SchemaChangeData {
         this.database = Objects.requireNonNull(builder.database, "database is null");
         this.table = Objects.requireNonNull(builder.table, "table is null");
         this.timeoutInSeconds = builder.timeoutInSeconds;
-        this.newIndexSchema = Objects.requireNonNull(builder.newIndexSchema, "newIndexSchema is null");
+        this.newIndexMetaIdToSchema = Objects.requireNonNull(builder.newIndexMetaIdToSchema, "newIndexSchema is null");
         this.indexes = builder.indexes;
         this.bloomFilterColumnsChanged = builder.bloomFilterColumnsChanged;
         this.bloomFilterColumns = builder.bloomFilterColumns;
         this.bloomFilterFpp = builder.bloomFilterFpp;
         this.hasIndexChanged = builder.hasIndexChanged;
-        this.newIndexShortKeyCount = Objects.requireNonNull(builder.newIndexShortKeyCount, "newIndexShortKeyCount is null");
+        this.newIndexMetaIdToShortKeyCount =
+                Objects.requireNonNull(builder.newIndexMetaIdToShortKeyCount, "newIndexShortKeyCount is null");
         this.shortKeyChanged = builder.shortKeyChanged;
         this.sortKeyIdxes = builder.sortKeyIdxes;
         this.sortKeyUniqueIds = builder.sortKeyUniqueIds;
@@ -146,13 +147,13 @@ class SchemaChangeData {
         private Database database;
         private OlapTable table;
         private long timeoutInSeconds = Config.alter_table_timeout_second;
-        private Map<Long, List<Column>> newIndexSchema = new HashMap<>();
+        private Map<Long, List<Column>> newIndexMetaIdToSchema = new HashMap<>();
         private List<Index> indexes;
         private boolean bloomFilterColumnsChanged = false;
         private Set<ColumnId> bloomFilterColumns;
         private double bloomFilterFpp;
         private boolean hasIndexChanged = false;
-        private Map<Long, Short> newIndexShortKeyCount = new HashMap<>();
+        private Map<Long, Short> newIndexMetaIdToShortKeyCount = new HashMap<>();
         private boolean shortKeyChanged = false;
         private List<Integer> sortKeyIdxes;
         private List<Integer> sortKeyUniqueIds;
@@ -195,14 +196,14 @@ class SchemaChangeData {
             return this;
         }
 
-        Builder withNewIndexShortKeyCount(long indexId, short shortKeyCount, boolean shortKeyChanged) {
-            this.newIndexShortKeyCount.put(indexId, shortKeyCount);
+        Builder withNewIndexMetaIdToShortKeyCount(long indexMetaId, short shortKeyCount, boolean shortKeyChanged) {
+            this.newIndexMetaIdToShortKeyCount.put(indexMetaId, shortKeyCount);
             this.shortKeyChanged |= shortKeyChanged;
             return this;
         }
 
-        Builder withNewIndexSchema(long indexId, @NotNull List<Column> indexSchema) {
-            newIndexSchema.put(indexId, indexSchema);
+        Builder withNewIndexMetaIdToSchema(long indexMetaId, @NotNull List<Column> indexSchema) {
+            newIndexMetaIdToSchema.put(indexMetaId, indexSchema);
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -224,13 +224,13 @@ public class SchemaChangeHandler extends AlterHandler {
     /**
      * @param alterClause
      * @param olapTable
-     * @param indexSchemaMap
+     * @param indexMetaIdToSchema
      * @param colUniqueIdSupplier for multi add columns clause, we need stash middle state of maxColUniqueId
      * @return true: can light schema change, false: cannot light schema change
      * @throws DdlException
      */
     private boolean processAddColumn(AddColumnClause alterClause, OlapTable olapTable,
-                                     Map<Long, LinkedList<Column>> indexSchemaMap,
+                                     Map<Long, LinkedList<Column>> indexMetaIdToSchema,
                                      IntSupplier colUniqueIdSupplier) throws DdlException {
         Column column = buildColumnForAdd(alterClause.getColumnDef(), olapTable);
         ColumnPosition columnPos = alterClause.getColPos();
@@ -240,10 +240,10 @@ public class SchemaChangeHandler extends AlterHandler {
         String baseIndexName = olapTable.getName();
         checkAssignedTargetIndexName(baseIndexName, targetIndexName);
 
-        long baseIndexId = olapTable.getBaseIndexMetaId();
-        long targetIndexId = -1L;
+        long baseIndexMetaId = olapTable.getBaseIndexMetaId();
+        long targetIndexMetaId = -1L;
         if (targetIndexName != null) {
-            targetIndexId = olapTable.getIndexMetaIdByName(targetIndexName);
+            targetIndexMetaId = olapTable.getIndexMetaIdByName(targetIndexName);
         }
 
         Set<String> newColNameSet = Sets.newHashSet(column.getName());
@@ -252,7 +252,7 @@ public class SchemaChangeHandler extends AlterHandler {
             column.setUniqueId(colUniqueIdSupplier.getAsInt());
         }
 
-        return addColumnInternal(olapTable, column, columnPos, targetIndexId, baseIndexId, indexSchemaMap,
+        return addColumnInternal(olapTable, column, columnPos, targetIndexMetaId, baseIndexMetaId, indexMetaIdToSchema,
                 newColNameSet);
 
     }
@@ -260,13 +260,13 @@ public class SchemaChangeHandler extends AlterHandler {
     /**
      * @param alterClause
      * @param olapTable
-     * @param indexSchemaMap
+     * @param indexMetaIdToSchema
      * @param colUniqueIdSupplier for multi add columns clause, we need stash middle state of maxColUniqueId
      * @return true: can light schema change, false: cannot light schema change
      * @throws DdlException
      */
     private boolean processAddColumns(AddColumnsClause alterClause, OlapTable olapTable,
-                                      Map<Long, LinkedList<Column>> indexSchemaMap,
+                                      Map<Long, LinkedList<Column>> indexMetaIdToSchema,
                                       IntSupplier colUniqueIdSupplier) throws DdlException {
         List<Column> columns = buildColumnsForAdd(alterClause, olapTable);
         String targetIndexName = alterClause.getRollupName();
@@ -280,10 +280,10 @@ public class SchemaChangeHandler extends AlterHandler {
         String baseIndexName = olapTable.getName();
         checkAssignedTargetIndexName(baseIndexName, targetIndexName);
 
-        long baseIndexId = olapTable.getBaseIndexMetaId();
-        long targetIndexId = -1L;
+        long baseIndexMetaId = olapTable.getBaseIndexMetaId();
+        long targetIndexMetaId = -1L;
         if (targetIndexName != null) {
-            targetIndexId = olapTable.getIndexMetaIdByName(targetIndexName);
+            targetIndexMetaId = olapTable.getIndexMetaIdByName(targetIndexName);
         }
 
         //for new table calculate column unique id
@@ -296,14 +296,14 @@ public class SchemaChangeHandler extends AlterHandler {
         boolean ligthSchemaChange = olapTable.getUseFastSchemaEvolution();
         if (alterClause.getGeneratedColumnPos() == null) {
             for (Column column : columns) {
-                ligthSchemaChange &= addColumnInternal(olapTable, column, null, targetIndexId, baseIndexId, indexSchemaMap,
-                        newColNameSet);
+                ligthSchemaChange &= addColumnInternal(olapTable, column, null, targetIndexMetaId, baseIndexMetaId,
+                        indexMetaIdToSchema, newColNameSet);
             }
         } else {
             for (int i = columns.size() - 1; i >= 0; --i) {
                 Column column = columns.get(i);
                 addColumnInternal(olapTable, column, alterClause.getGeneratedColumnPos(),
-                        targetIndexId, baseIndexId, indexSchemaMap, newColNameSet);
+                        targetIndexMetaId, baseIndexMetaId, indexMetaIdToSchema, newColNameSet);
                 // add a generated column need to rewrite data, can not use light schema change
                 ligthSchemaChange = false;
             }
@@ -314,13 +314,14 @@ public class SchemaChangeHandler extends AlterHandler {
     /**
      * @param alterClause
      * @param olapTable
-     * @param indexSchemaMap
+     * @param indexMetaIdToSchema
      * @param indexes
      * @return true: can light schema change, false: cannot
      * @throws DdlException
      */
     private boolean processDropColumn(DropColumnClause alterClause, OlapTable olapTable,
-                                      Map<Long, LinkedList<Column>> indexSchemaMap, List<Index> indexes) throws DdlException {
+                                      Map<Long, LinkedList<Column>> indexMetaIdToSchema, List<Index> indexes)
+            throws DdlException {
         boolean fastSchemaEvolution = olapTable.getUseFastSchemaEvolution();
         String dropColName = alterClause.getColName();
         String targetIndexName = alterClause.getRollupName();
@@ -337,15 +338,15 @@ public class SchemaChangeHandler extends AlterHandler {
          * AGGREGATION:
          *      Can not drop any key column is has value with REPLACE method
          */
+        long baseIndexMetaId = olapTable.getBaseIndexMetaId();
         if (KeysType.PRIMARY_KEYS == olapTable.getKeysType()) {
-            long baseIndexId = olapTable.getBaseIndexMetaId();
-            List<Column> baseSchema = indexSchemaMap.get(baseIndexId);
+            List<Column> baseSchema = indexMetaIdToSchema.get(baseIndexMetaId);
             boolean isKey = baseSchema.stream().anyMatch(c -> c.isKey() && c.getName().equalsIgnoreCase(dropColName));
             if (isKey) {
                 throw new DdlException("Can not drop key column in primary data model table");
             }
             fastSchemaEvolution &= !isKey;
-            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexMetaId());
+            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(baseIndexMetaId);
             if (indexMeta.getSortKeyIdxes() != null) {
                 for (Integer sortKeyIdx : indexMeta.getSortKeyIdxes()) {
                     if (indexMeta.getSchema().get(sortKeyIdx).getName().equalsIgnoreCase(dropColName)) {
@@ -354,8 +355,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
             }
         } else if (KeysType.UNIQUE_KEYS == olapTable.getKeysType()) {
-            long baseIndexId = olapTable.getBaseIndexMetaId();
-            List<Column> baseSchema = indexSchemaMap.get(baseIndexId);
+            List<Column> baseSchema = indexMetaIdToSchema.get(baseIndexMetaId);
             boolean isKey = baseSchema.stream().anyMatch(c -> c.isKey() && c.getName().equalsIgnoreCase(dropColName));
             fastSchemaEvolution &= !isKey;
             if (isKey) {
@@ -364,8 +364,7 @@ public class SchemaChangeHandler extends AlterHandler {
         } else if (KeysType.AGG_KEYS == olapTable.getKeysType()) {
             if (null == targetIndexName) {
                 // drop column in base table
-                long baseIndexId = olapTable.getBaseIndexMetaId();
-                List<Column> baseSchema = indexSchemaMap.get(baseIndexId);
+                List<Column> baseSchema = indexMetaIdToSchema.get(baseIndexMetaId);
                 boolean isKey = baseSchema.stream().anyMatch(c -> c.isKey() && c.getName().equalsIgnoreCase(dropColName));
                 fastSchemaEvolution &= !isKey;
                 boolean hasReplaceColumn = baseSchema.stream().map(Column::getAggregationType)
@@ -375,8 +374,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
             } else {
                 // drop column in rollup and base index
-                long targetIndexId = olapTable.getIndexMetaIdByName(targetIndexName);
-                List<Column> targetIndexSchema = indexSchemaMap.get(targetIndexId);
+                long targetIndexMetaId = olapTable.getIndexMetaIdByName(targetIndexName);
+                List<Column> targetIndexSchema = indexMetaIdToSchema.get(targetIndexMetaId);
                 boolean isKey = targetIndexSchema.stream().anyMatch(c -> c.isKey() && c.getName().equalsIgnoreCase(dropColName));
                 fastSchemaEvolution &= !isKey;
                 boolean hasReplaceColumn = targetIndexSchema.stream().map(Column::getAggregationType)
@@ -387,8 +386,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
             }
         } else if (KeysType.DUP_KEYS == olapTable.getKeysType()) {
-            long baseIndexId = olapTable.getBaseIndexMetaId();
-            List<Column> baseSchema = indexSchemaMap.get(baseIndexId);
+            List<Column> baseSchema = indexMetaIdToSchema.get(baseIndexMetaId);
             for (Column column : baseSchema) {
                 if (column.isKey() && column.getName().equalsIgnoreCase(dropColName)) {
                     fastSchemaEvolution = false;
@@ -407,8 +405,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
         if (targetIndexName == null) {
             // if not specify rollup index, column should be dropped from both base and rollup indexes.
-            long baseIndexId = olapTable.getBaseIndexMetaId();
-            LinkedList<Column> columns = indexSchemaMap.get(baseIndexId);
+            LinkedList<Column> columns = indexMetaIdToSchema.get(baseIndexMetaId);
             Iterator<Column> columnIterator = columns.iterator();
             boolean removed = false;
             while (columnIterator.hasNext()) {
@@ -426,8 +423,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 throw new DdlException("Column does not exists: " + dropColName);
             }
 
-            for (Long indexId : olapTable.getIndexIdListExceptBaseIndex()) {
-                columns = indexSchemaMap.get(indexId);
+            for (Long indexMetaId : olapTable.getIndexMetaIdListExceptBaseIndex()) {
+                columns = indexMetaIdToSchema.get(indexMetaId);
                 columnIterator = columns.iterator();
                 while (columnIterator.hasNext()) {
                     Column column = columnIterator.next();
@@ -441,8 +438,8 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         } else {
             // if specify rollup index, only drop column from specified rollup index
-            long targetIndexId = olapTable.getIndexMetaIdByName(targetIndexName);
-            LinkedList<Column> columns = indexSchemaMap.get(targetIndexId);
+            long targetIndexMetaId = olapTable.getIndexMetaIdByName(targetIndexName);
+            LinkedList<Column> columns = indexMetaIdToSchema.get(targetIndexMetaId);
             Iterator<Column> columnIterator = columns.iterator();
             boolean removed = false;
             while (columnIterator.hasNext()) {
@@ -517,19 +514,19 @@ public class SchemaChangeHandler extends AlterHandler {
     /**
      * @param alterClause
      * @param olapTable
-     * @param indexSchemaMap
+     * @param indexMetaIdToSchema
      * @param id
      * @return void
      * @throws DdlException
      */
     private void processAddField(AddFieldClause alterClause, OlapTable olapTable,
-                                 Map<Long, LinkedList<Column>> indexSchemaMap,
+                                 Map<Long, LinkedList<Column>> indexMetaIdToSchema,
                                  int id, List<Index> indexes) throws DdlException {
         String modifyColumnName = alterClause.getColName();
 
         // Struct column can not be key column or sort key column right now. 
-        long baseIndexId = olapTable.getBaseIndexMetaId();
-        List<Column> baseSchema = indexSchemaMap.get(baseIndexId);
+        long baseIndexMetaId = olapTable.getBaseIndexMetaId();
+        List<Column> baseSchema = indexMetaIdToSchema.get(baseIndexMetaId);
         Optional<Column> col = baseSchema.stream().filter(c -> c.getName().equalsIgnoreCase(modifyColumnName)).findFirst();
         if (!col.isPresent()) {
             throw new DdlException("Column[" + modifyColumnName + "] not exists");
@@ -586,7 +583,7 @@ public class SchemaChangeHandler extends AlterHandler {
         }
         fields.add(posIndex, addField);
         oriFieldType.updateFields(fields);
-        for (Map.Entry<Long, LinkedList<Column>> entry : indexSchemaMap.entrySet()) {
+        for (Map.Entry<Long, LinkedList<Column>> entry : indexMetaIdToSchema.entrySet()) {
             List<Column> modIndexSchema = entry.getValue();
             Optional<Column> oneCol = modIndexSchema.stream().filter(c -> c.nameEquals(modifyColumnName, true)).findFirst();
             if (!oneCol.isPresent()) {
@@ -601,19 +598,18 @@ public class SchemaChangeHandler extends AlterHandler {
     /**
      * @param alterClause
      * @param olapTable
-     * @param indexSchemaMap
+     * @param indexMetaIdToSchema
      * @return void
      * @throws DdlException
      */
     private void processDropField(DropFieldClause alterClause, OlapTable olapTable,
-                                  Map<Long, LinkedList<Column>> indexSchemaMap,
+                                  Map<Long, LinkedList<Column>> indexMetaIdToSchema,
                                   List<Index> indexes) throws DdlException {
         String modifyColumnName = alterClause.getColName();
-        String baseIndexName = olapTable.getName();
 
         // Struct column can not be key column or sort key column right now. 
-        long baseIndexId = olapTable.getBaseIndexMetaId();
-        List<Column> baseSchema = indexSchemaMap.get(baseIndexId);
+        long baseIndexMetaId = olapTable.getBaseIndexMetaId();
+        List<Column> baseSchema = indexMetaIdToSchema.get(baseIndexMetaId);
         Optional<Column> col = baseSchema.stream().filter(c -> c.getName().equalsIgnoreCase(modifyColumnName)).findFirst();
         if (!col.isPresent()) {
             throw new DdlException("Column[" + modifyColumnName + "] not exists");
@@ -662,7 +658,7 @@ public class SchemaChangeHandler extends AlterHandler {
         oriFieldType.updateFields(fields);
 
         // update the modifyColumn int index schema.
-        for (Map.Entry<Long, LinkedList<Column>> entry : indexSchemaMap.entrySet()) {
+        for (Map.Entry<Long, LinkedList<Column>> entry : indexMetaIdToSchema.entrySet()) {
             List<Column> modIndexSchema = entry.getValue();
             Optional<Column> oneCol = modIndexSchema.stream().filter(c -> c.nameEquals(modifyColumnName, true)).findFirst();
             if (!oneCol.isPresent()) {
@@ -676,7 +672,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
     // User can modify column type and column position
     private boolean processModifyColumn(ModifyColumnClause alterClause, OlapTable olapTable,
-                                        Map<Long, LinkedList<Column>> indexSchemaMap) throws DdlException {
+                                        Map<Long, LinkedList<Column>> indexMetaIdToSchema) throws DdlException {
         // The fast schema evolution mechanism is only supported for modified columns in shared data mode.
         boolean fastSchemaEvolution = RunMode.isSharedDataMode() && olapTable.getUseFastSchemaEvolution();
         Column modColumn = buildColumnForModify(alterClause.getColumnDef(), olapTable);
@@ -684,7 +680,7 @@ public class SchemaChangeHandler extends AlterHandler {
             if (olapTable.getBaseColumn(modColumn.getName()) != null && olapTable.getBaseColumn(modColumn.getName()).isKey()) {
                 throw new DdlException("Can not modify key column: " + modColumn.getName() + " for primary key table");
             }
-            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexMetaId());
+            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId());
             if (indexMeta.getSortKeyIdxes() != null) {
                 for (Integer sortKeyIdx : indexMeta.getSortKeyIdxes()) {
                     if (indexMeta.getSchema().get(sortKeyIdx).getName().equalsIgnoreCase(modColumn.getName())) {
@@ -754,10 +750,10 @@ public class SchemaChangeHandler extends AlterHandler {
             indexNameForFindingColumn = baseIndexName;
         }
 
-        long indexIdForFindingColumn = olapTable.getIndexMetaIdByName(indexNameForFindingColumn);
+        long indexMetaIdForFindingColumn = olapTable.getIndexMetaIdByName(indexNameForFindingColumn);
 
         // find modified column
-        List<Column> schemaForFinding = indexSchemaMap.get(indexIdForFindingColumn);
+        List<Column> schemaForFinding = indexMetaIdToSchema.get(indexMetaIdForFindingColumn);
         String newColName = modColumn.getName();
         boolean hasColPos = (columnPos != null && !columnPos.isFirst());
         boolean found = false;
@@ -855,16 +851,16 @@ public class SchemaChangeHandler extends AlterHandler {
 
             // handle other indices
             // 1 find other indices which contain this column
-            List<Long> otherIndexIds = new ArrayList<>();
-            for (Map.Entry<Long, List<Column>> entry : olapTable.getIndexIdToSchema().entrySet()) {
-                if (entry.getKey() == indexIdForFindingColumn) {
+            List<Long> otherIndexMetaIds = new ArrayList<>();
+            for (Map.Entry<Long, List<Column>> entry : olapTable.getIndexMetaIdToSchema().entrySet()) {
+                if (entry.getKey() == indexMetaIdForFindingColumn) {
                     // skip the index we used to find column. it has been handled before
                     continue;
                 }
                 List<Column> schema = entry.getValue();
                 for (Column column : schema) {
                     if (column.getName().equalsIgnoreCase(modColumn.getName())) {
-                        otherIndexIds.add(entry.getKey());
+                        otherIndexMetaIds.add(entry.getKey());
                         break;
                     }
                 }
@@ -889,8 +885,8 @@ public class SchemaChangeHandler extends AlterHandler {
 
             if (KeysType.AGG_KEYS == olapTable.getKeysType() || KeysType.UNIQUE_KEYS == olapTable.getKeysType() ||
                     KeysType.PRIMARY_KEYS == olapTable.getKeysType()) {
-                for (Long otherIndexId : otherIndexIds) {
-                    List<Column> otherIndexSchema = indexSchemaMap.get(otherIndexId);
+                for (Long otherIndexMetaId : otherIndexMetaIds) {
+                    List<Column> otherIndexSchema = indexMetaIdToSchema.get(otherIndexMetaId);
                     modColIndex = -1;
                     for (int i = 0; i < otherIndexSchema.size(); i++) {
                         if (otherIndexSchema.get(i).getName().equalsIgnoreCase(originalModColumnName)) {
@@ -904,8 +900,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 } //  end for other indices
             } else {
                 // DUPLICATE data model has a little
-                for (Long otherIndexId : otherIndexIds) {
-                    List<Column> otherIndexSchema = indexSchemaMap.get(otherIndexId);
+                for (Long otherIndexMetaId : otherIndexMetaIds) {
+                    List<Column> otherIndexSchema = indexMetaIdToSchema.get(otherIndexMetaId);
                     modColIndex = -1;
                     for (int i = 0; i < otherIndexSchema.size(); i++) {
                         if (otherIndexSchema.get(i).getName().equalsIgnoreCase(originalModColumnName)) {
@@ -970,15 +966,15 @@ public class SchemaChangeHandler extends AlterHandler {
     }
 
     protected void processModifyColumnComment(ModifyColumnCommentClause alterClause, Database db, OlapTable olapTable,
-                                        Map<Long, LinkedList<Column>> indexSchemaMap) throws DdlException {
+                                        Map<Long, LinkedList<Column>> indexMetaIdToSchema) throws DdlException {
         String modifyColumnName = alterClause.getColumnName();
         String comment = alterClause.getComment();
         if (comment == null) {
             throw new DdlException("Comment is null");
         }
         // find modified column
-        long baseIndexId = olapTable.getBaseIndexMetaId();
-        List<Column> modIndexSchema = indexSchemaMap.get(baseIndexId);
+        long baseIndexMetaId = olapTable.getBaseIndexMetaId();
+        List<Column> modIndexSchema = indexMetaIdToSchema.get(baseIndexMetaId);
         // update column comment from schemaForFinding
         Optional<Column> oneCol = modIndexSchema.stream().filter(c -> c.nameEquals(modifyColumnName, true)).findFirst();
         if (!oneCol.isPresent()) {
@@ -1002,7 +998,7 @@ public class SchemaChangeHandler extends AlterHandler {
     }
 
     private void processReorderColumn(ReorderColumnsClause alterClause, OlapTable olapTable,
-                                      Map<Long, LinkedList<Column>> indexSchemaMap) throws DdlException {
+                                      Map<Long, LinkedList<Column>> indexMetaIdToSchema) throws DdlException {
         if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS) {
             throw new DdlException("Primary key table do not support reorder table schema. Please confirm if you want to " +
                     "modify the sorting columns.");
@@ -1018,10 +1014,10 @@ public class SchemaChangeHandler extends AlterHandler {
             targetIndexName = baseIndexName;
         }
 
-        long targetIndexId = olapTable.getIndexMetaIdByName(targetIndexName);
+        long targetIndexMetaId = olapTable.getIndexMetaIdByName(targetIndexName);
 
         LinkedList<Column> newSchema = new LinkedList<>();
-        LinkedList<Column> targetIndexSchema = indexSchemaMap.get(targetIndexId);
+        LinkedList<Column> targetIndexSchema = indexMetaIdToSchema.get(targetIndexMetaId);
 
         // check and create new ordered column list
         Set<String> colNameSet = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
@@ -1039,13 +1035,13 @@ public class SchemaChangeHandler extends AlterHandler {
             throw new DdlException("Reorder stmt should contains all columns");
         }
         // replace the old column list
-        indexSchemaMap.put(targetIndexId, newSchema);
+        indexMetaIdToSchema.put(targetIndexMetaId, newSchema);
     }
 
     private void processModifySortKeyColumn(ReorderColumnsClause alterClause, OlapTable olapTable,
-                                            Map<Long, LinkedList<Column>> indexSchemaMap, List<Integer> sortKeyIdxes,
+                                            Map<Long, LinkedList<Column>> indexMetaIdToSchema, List<Integer> sortKeyIdxes,
                                             List<Integer> sortKeyUniqueIds) throws DdlException {
-        LinkedList<Column> targetIndexSchema = indexSchemaMap.get(olapTable.getIndexMetaIdByName(olapTable.getName()));
+        LinkedList<Column> targetIndexSchema = indexMetaIdToSchema.get(olapTable.getIndexMetaIdByName(olapTable.getName()));
         // check sort key column list
         Set<String> colNameSet = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
 
@@ -1105,16 +1101,16 @@ public class SchemaChangeHandler extends AlterHandler {
      * @param olapTable
      * @param newColumn      Add 'newColumn' to specified index.
      * @param columnPos
-     * @param targetIndexId
-     * @param baseIndexId
-     * @param indexSchemaMap Modified schema will be saved in 'indexSchemaMap'
+     * @param targetIndexMetaId
+     * @param baseIndexMetaId
+     * @param indexMetaIdToSchema Modified schema will be saved in 'indexSchemaMap'
      * @param newColNameSet
      * @return true: can light schema change, false: cannot
      * @throws DdlException
      */
     private boolean addColumnInternal(OlapTable olapTable, Column newColumn, ColumnPosition columnPos,
-                                      long targetIndexId, long baseIndexId,
-                                      Map<Long, LinkedList<Column>> indexSchemaMap,
+                                      long targetIndexMetaId, long baseIndexMetaId,
+                                      Map<Long, LinkedList<Column>> indexMetaIdToSchema,
                                       Set<String> newColNameSet) throws DdlException {
 
         Column.DefaultValueType defaultValueType = newColumn.getDefaultValueType();
@@ -1196,7 +1192,8 @@ public class SchemaChangeHandler extends AlterHandler {
                         "Can not assign aggregation method on column in Duplicate data model table: " + newColName);
             }
             if (!newColumn.isKey()) {
-                if (targetIndexId != -1L && olapTable.getIndexMetaByIndexId(targetIndexId).getKeysType() == KeysType.AGG_KEYS) {
+                if (targetIndexMetaId != -1L &&
+                        olapTable.getIndexMetaByMetaId(targetIndexMetaId).getKeysType() == KeysType.AGG_KEYS) {
                     throw new DdlException("Please add non-key column on base table directly");
                 }
                 newColumn.setAggregationType(AggregateType.NONE, true);
@@ -1256,9 +1253,9 @@ public class SchemaChangeHandler extends AlterHandler {
          *      1. Add it to base index, as well as specified rollup index.
          */
         if (KeysType.PRIMARY_KEYS == olapTable.getKeysType()) {
-            List<Column> modIndexSchema = indexSchemaMap.get(baseIndexId);
+            List<Column> modIndexSchema = indexMetaIdToSchema.get(baseIndexMetaId);
             checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, true);
-            if (targetIndexId != -1L) {
+            if (targetIndexMetaId != -1L) {
                 throw new DdlException("Can not add column: " + newColName + " to rollup index");
             }
         } else if (KeysType.UNIQUE_KEYS == olapTable.getKeysType()) {
@@ -1266,34 +1263,34 @@ public class SchemaChangeHandler extends AlterHandler {
             if (newColumn.isKey()) {
                 // add key column to unique key table
                 // add to all indexes including base and rollup
-                for (Map.Entry<Long, LinkedList<Column>> entry : indexSchemaMap.entrySet()) {
+                for (Map.Entry<Long, LinkedList<Column>> entry : indexMetaIdToSchema.entrySet()) {
                     modIndexSchema = entry.getValue();
-                    boolean isBaseIdex = entry.getKey() == baseIndexId;
-                    checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, isBaseIdex);
+                    boolean isBaseIndex = entry.getKey() == baseIndexMetaId;
+                    checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, isBaseIndex);
                 }
             } else {
                 // 1. add to base table
-                modIndexSchema = indexSchemaMap.get(baseIndexId);
+                modIndexSchema = indexMetaIdToSchema.get(baseIndexMetaId);
                 checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, true);
-                if (targetIndexId == -1L) {
+                if (targetIndexMetaId == -1L) {
                     return fastSchemaEvolution;
                 }
                 // 2. add to rollup
                 fastSchemaEvolution = false;
-                modIndexSchema = indexSchemaMap.get(targetIndexId);
+                modIndexSchema = indexMetaIdToSchema.get(targetIndexMetaId);
                 checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, false);
             }
         } else if (KeysType.DUP_KEYS == olapTable.getKeysType()) {
-            if (targetIndexId == -1L) {
+            if (targetIndexMetaId == -1L) {
                 // add to base index
-                List<Column> modIndexSchema = indexSchemaMap.get(baseIndexId);
+                List<Column> modIndexSchema = indexMetaIdToSchema.get(baseIndexMetaId);
                 checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, true);
                 // no specified target index. return
                 return fastSchemaEvolution;
             } else {
                 // add to rollup index
                 fastSchemaEvolution = false;
-                List<Column> modIndexSchema = indexSchemaMap.get(targetIndexId);
+                List<Column> modIndexSchema = indexMetaIdToSchema.get(targetIndexMetaId);
                 checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, false);
 
                 if (newColumn.isKey()) {
@@ -1301,27 +1298,27 @@ public class SchemaChangeHandler extends AlterHandler {
                      * if add column in rollup is key,
                      * then put the column in base table as the last key column
                      */
-                    modIndexSchema = indexSchemaMap.get(baseIndexId);
+                    modIndexSchema = indexMetaIdToSchema.get(baseIndexMetaId);
                     checkAndAddColumn(modIndexSchema, newColumn, null, newColNameSet, true);
                 } else {
-                    modIndexSchema = indexSchemaMap.get(baseIndexId);
+                    modIndexSchema = indexMetaIdToSchema.get(baseIndexMetaId);
                     checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, true);
                 }
             }
         } else {
             // check if has default value. this should be done in Analyze phase
             // 1. add to base index first
-            List<Column> modIndexSchema = indexSchemaMap.get(baseIndexId);
+            List<Column> modIndexSchema = indexMetaIdToSchema.get(baseIndexMetaId);
             checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, true);
 
-            if (targetIndexId == -1L) {
+            if (targetIndexMetaId == -1L) {
                 // no specified target index. return
                 return fastSchemaEvolution;
             }
 
             fastSchemaEvolution = false;
             // 2. add to rollup index
-            modIndexSchema = indexSchemaMap.get(targetIndexId);
+            modIndexSchema = indexMetaIdToSchema.get(targetIndexMetaId);
             checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, false);
         }
         return fastSchemaEvolution;
@@ -1420,7 +1417,7 @@ public class SchemaChangeHandler extends AlterHandler {
     }
 
     private SchemaChangeData finalAnalyze(Database db, OlapTable olapTable,
-                                          Map<Long, LinkedList<Column>> indexSchemaMap,
+                                          Map<Long, LinkedList<Column>> indexMetaIdToSchema,
                                           Map<String, String> propertyMap,
                                           List<Index> indexes,
                                           Set<String> modifyFieldColumns) throws StarRocksException {
@@ -1482,7 +1479,7 @@ public class SchemaChangeHandler extends AlterHandler {
         double bfFpp = 0;
         try {
             bfColumns = PropertyAnalyzer
-                    .analyzeBloomFilterColumns(propertyMap, indexSchemaMap.get(olapTable.getBaseIndexMetaId()),
+                    .analyzeBloomFilterColumns(propertyMap, indexMetaIdToSchema.get(olapTable.getBaseIndexMetaId()),
                             olapTable.getKeysType() == KeysType.PRIMARY_KEYS);
             bfFpp = PropertyAnalyzer.analyzeBloomFilterFpp(propertyMap);
         } catch (AnalysisException e) {
@@ -1580,9 +1577,9 @@ public class SchemaChangeHandler extends AlterHandler {
         Map<Integer, Column> columnUniqueIdToColumn = Maps.newHashMap();
         // begin checking each table
         // ATTN: DO NOT change any meta in this loop
-        for (Long alterIndexId : indexSchemaMap.keySet()) {
-            List<Column> originSchema = olapTable.getSchemaByIndexMetaId(alterIndexId);
-            List<Column> alterSchema = indexSchemaMap.get(alterIndexId);
+        for (Long alterIndexMetaId : indexMetaIdToSchema.keySet()) {
+            List<Column> originSchema = olapTable.getSchemaByIndexMetaId(alterIndexMetaId);
+            List<Column> alterSchema = indexMetaIdToSchema.get(alterIndexMetaId);
 
             // 0. check if unchanged
             boolean hasColumnChange = !originSchema.equals(alterSchema);
@@ -1619,18 +1616,18 @@ public class SchemaChangeHandler extends AlterHandler {
             }
 
             if (!needAlter) {
-                LOG.debug("index[{}] is not changed. ignore", alterIndexId);
+                LOG.debug("index[{}] is not changed. ignore", alterIndexMetaId);
                 continue;
             }
 
-            LOG.debug("index[{}] is changed. start checking...", alterIndexId);
+            LOG.debug("index[{}] is changed. start checking...", alterIndexMetaId);
             // 1. check order: a) has key; b) value after key
             boolean meetValue = false;
             boolean hasKey = false;
             for (Column column : alterSchema) {
                 if (column.isKey() && meetValue) {
                     throw new DdlException("Invalid column order. value should be after key. index["
-                            + olapTable.getIndexNameByMetaId(alterIndexId) + "]");
+                            + olapTable.getIndexNameByMetaId(alterIndexMetaId) + "]");
                 }
                 if (!column.isKey()) {
                     meetValue = true;
@@ -1639,7 +1636,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
             }
             if (!hasKey) {
-                throw new DdlException("No key column left. index[" + olapTable.getIndexNameByMetaId(alterIndexId) + "]");
+                throw new DdlException("No key column left. index[" + olapTable.getIndexNameByMetaId(alterIndexMetaId) + "]");
             }
 
             // 2. check compatible
@@ -1658,13 +1655,13 @@ public class SchemaChangeHandler extends AlterHandler {
             }
 
             // 3. check partition key
-            checkPartitionColumnChange(olapTable, alterSchema, alterIndexId);
+            checkPartitionColumnChange(olapTable, alterSchema, alterIndexMetaId);
 
             // 4. check distribution key:
-            checkDistributionColumnChange(olapTable, alterSchema, alterIndexId);
+            checkDistributionColumnChange(olapTable, alterSchema, alterIndexMetaId);
 
             // 5. calc short key
-            calculateShortKey(olapTable, alterIndexId, alterSchema, indexIdToProperties.get(alterIndexId), dataBuilder);
+            calculateShortKey(olapTable, alterIndexMetaId, alterSchema, indexIdToProperties.get(alterIndexMetaId), dataBuilder);
 
             // 6. check the uniqueness of column unique id
             if (olapTable.getMaxColUniqueId() > Column.COLUMN_UNIQUE_ID_INIT_VALUE) {
@@ -1685,17 +1682,17 @@ public class SchemaChangeHandler extends AlterHandler {
         return dataBuilder.build();
     }
 
-    private void calculateShortKey(OlapTable olapTable, long alterIndexId, List<Column> alterSchema,
+    private void calculateShortKey(OlapTable olapTable, long alterIndexMetaId, List<Column> alterSchema,
                Map<String, String> indexProperties, SchemaChangeData.Builder dataBuilder) throws DdlException {
         List<Integer> sortKeyIdxes = new ArrayList<>();
         List<Integer> sortKeyUniqueIds = new ArrayList<>();
-        MaterializedIndexMeta index = olapTable.getIndexMetaByIndexId(alterIndexId);
+        MaterializedIndexMeta index = olapTable.getIndexMetaByMetaId(alterIndexMetaId);
         List<Column> originSchema = index.getSchema();
         // if sortKeyUniqueIds is empty, the table maybe create in old version and we should use sortKeyIdxes
         // to determine which columns are sort key columns
         boolean useSortKeyUniqueId = (index.getSortKeyUniqueIds() != null) &&
                 (!index.getSortKeyUniqueIds().isEmpty());
-        if (index.getSortKeyIdxes() != null && olapTable.getBaseIndexMetaId() == alterIndexId) {
+        if (index.getSortKeyIdxes() != null && olapTable.getBaseIndexMetaId() == alterIndexMetaId) {
             List<Integer> originSortKeyIdxes = index.getSortKeyIdxes();
             for (Integer colIdx : originSortKeyIdxes) {
                 String columnName = originSchema.get(colIdx).getName();
@@ -1716,7 +1713,7 @@ public class SchemaChangeHandler extends AlterHandler {
         if (!sortKeyIdxes.isEmpty()) {
             short newShortKeyCount = GlobalStateMgr.calcShortKeyColumnCount(alterSchema,
                     indexProperties, sortKeyIdxes);
-            LOG.debug("alter index[{}] short key column count: {}", alterIndexId, newShortKeyCount);
+            LOG.debug("alter index[{}] short key column count: {}", alterIndexMetaId, newShortKeyCount);
 
             List<Integer> originSortKeyIdxes = index.getSortKeyIdxes();
             List<Column> originShortKeyColumns = new ArrayList<>();
@@ -1728,13 +1725,13 @@ public class SchemaChangeHandler extends AlterHandler {
                 newShortKeyColumns.add(alterSchema.get(sortKeyIdxes.get(i)));
             }
             boolean isShortKeyChanged = isShortKeyChanged(originShortKeyColumns, newShortKeyColumns);
-            dataBuilder.withNewIndexShortKeyCount(alterIndexId,
-                    newShortKeyCount, isShortKeyChanged).withNewIndexSchema(alterIndexId, alterSchema);
+            dataBuilder.withNewIndexMetaIdToShortKeyCount(alterIndexMetaId,
+                    newShortKeyCount, isShortKeyChanged).withNewIndexMetaIdToSchema(alterIndexMetaId, alterSchema);
             dataBuilder.withSortKeyIdxes(sortKeyIdxes);
             dataBuilder.withSortKeyUniqueIds(sortKeyUniqueIds);
         } else {
             short newShortKeyCount = GlobalStateMgr.calcShortKeyColumnCount(alterSchema, indexProperties);
-            LOG.debug("alter index[{}] short key column count: {}", alterIndexId, newShortKeyCount);
+            LOG.debug("alter index[{}] short key column count: {}", alterIndexMetaId, newShortKeyCount);
             
             List<Column> originShortKeyColumns = new ArrayList<>();
             for (int i = 0; i < index.getShortKeyColumnCount(); i++) {
@@ -1745,8 +1742,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 newShortKeyColumns.add(alterSchema.get(i));
             }
             boolean isShortKeyChanged = isShortKeyChanged(originShortKeyColumns, newShortKeyColumns);
-            dataBuilder.withNewIndexShortKeyCount(alterIndexId,
-                    newShortKeyCount, isShortKeyChanged).withNewIndexSchema(alterIndexId, alterSchema);
+            dataBuilder.withNewIndexMetaIdToShortKeyCount(alterIndexMetaId,
+                    newShortKeyCount, isShortKeyChanged).withNewIndexMetaIdToSchema(alterIndexMetaId, alterSchema);
         }
     }
 
@@ -1801,12 +1798,12 @@ public class SchemaChangeHandler extends AlterHandler {
         }
     }
 
-    private void checkPartitionColumnChange(OlapTable olapTable, List<Column> alterSchema, long alterIndexId)
+    private void checkPartitionColumnChange(OlapTable olapTable, List<Column> alterSchema, long alterIndexMetaId)
             throws DdlException {
         // Since partition key and distribution key's schema change can only happen in base index,
         // only check it in base index.There may be some trivial changes between base index and other
         // indices(eg: AggregateType), so check it in base index.
-        if (alterIndexId != olapTable.getBaseIndexMetaId()) {
+        if (alterIndexMetaId != olapTable.getBaseIndexMetaId()) {
             return;
         }
 
@@ -1819,24 +1816,24 @@ public class SchemaChangeHandler extends AlterHandler {
             Column refPartitionCol = olapTable.getColumn(partitionCol.getName());
             if (col.isPresent() && !col.get().equals(refPartitionCol)) {
                 throw new DdlException("Can not modify partition column[" + colName + "]. index["
-                        + olapTable.getIndexNameByMetaId(alterIndexId) + "]");
+                        + olapTable.getIndexNameByMetaId(alterIndexMetaId) + "]");
             }
-            if (col.isEmpty() && alterIndexId == olapTable.getBaseIndexMetaId()) {
+            if (col.isEmpty() && alterIndexMetaId == olapTable.getBaseIndexMetaId()) {
                 // 2.1 partition column cannot be deleted.
                 throw new DdlException("Partition column[" + partitionCol.getName()
-                        + "] cannot be dropped. index[" + olapTable.getIndexNameByMetaId(alterIndexId) + "]");
+                        + "] cannot be dropped. index[" + olapTable.getIndexNameByMetaId(alterIndexMetaId) + "]");
                 // ATTN. partition columns' order also need remaining unchanged.
                 // for now, we only allow one partition column, so no need to check order.
             }
         } // end for partitionColumns
     }
 
-    private void checkDistributionColumnChange(OlapTable olapTable, List<Column> alterSchema, long alterIndexId)
+    private void checkDistributionColumnChange(OlapTable olapTable, List<Column> alterSchema, long alterIndexMetaId)
             throws DdlException {
         // Since partition key and distribution key's schema change can only happen in base index,
         // only check it in base index.There may be some trivial changes between base index and other
         // indices(eg: AggregateType), so check it in base index.
-        if (alterIndexId != olapTable.getBaseIndexMetaId()) {
+        if (alterIndexMetaId != olapTable.getBaseIndexMetaId()) {
             return;
         }
 
@@ -1847,18 +1844,17 @@ public class SchemaChangeHandler extends AlterHandler {
             Optional<Column> col = alterSchema.stream().filter(c -> c.nameEquals(colName, true)).findFirst();
             if (col.isPresent() && !col.get().equals(distributionCol)) {
                 throw new DdlException("Can not modify distribution column[" + colName + "]. index["
-                        + olapTable.getIndexNameByMetaId(alterIndexId) + "]");
+                        + olapTable.getIndexNameByMetaId(alterIndexMetaId) + "]");
             }
-            if (col.isEmpty() && alterIndexId == olapTable.getBaseIndexMetaId()) {
+            if (col.isEmpty() && alterIndexMetaId == olapTable.getBaseIndexMetaId()) {
                 // 2.2 distribution column cannot be deleted.
                 throw new DdlException("Distribution column[" + distributionCol.getName()
-                        + "] cannot be dropped. index[" + olapTable.getIndexNameByMetaId(alterIndexId) + "]");
+                        + "] cannot be dropped. index[" + olapTable.getIndexNameByMetaId(alterIndexMetaId) + "]");
             }
         } // end for distributionCols
     }
 
     private AlterJobV2 createJobForProcessModifySortKeyColumn(long dbId, OlapTable olapTable,
-                                                              Map<Long, LinkedList<Column>> indexSchemaMap,
                                                               List<Integer> sortKeyIdxes,
                                                               List<Integer> sortKeyUniqueIds) throws
             StarRocksException {
@@ -1891,8 +1887,8 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         long tableId = olapTable.getId();
-        Long alterIndexId = olapTable.getBaseIndexMetaId();
-        List<Column> originSchema = olapTable.getSchemaByIndexMetaId(alterIndexId);
+        Long alterIndexMetaId = olapTable.getBaseIndexMetaId();
+        List<Column> originSchema = olapTable.getSchemaByIndexMetaId(alterIndexMetaId);
         short newShortKeyCount = 0;
         if (sortKeyIdxes != null) {
             newShortKeyCount = GlobalStateMgr.calcShortKeyColumnCount(originSchema, null, sortKeyIdxes);
@@ -1900,10 +1896,11 @@ public class SchemaChangeHandler extends AlterHandler {
             newShortKeyCount = GlobalStateMgr.calcShortKeyColumnCount(originSchema, null);
         }
 
-        LOG.debug("alter index[{}] short key column count: {}", alterIndexId, newShortKeyCount);
-        jobBuilder.withNewIndexShortKeyCount(alterIndexId, newShortKeyCount).withNewIndexSchema(alterIndexId, originSchema);
+        LOG.debug("alter index[{}] short key column count: {}", alterIndexMetaId, newShortKeyCount);
+        jobBuilder.withNewIndexMetaIdToShortKeyCount(alterIndexMetaId, newShortKeyCount)
+                .withNewIndexMetaIdToSchema(alterIndexMetaId, originSchema);
 
-        LOG.debug("schema change[{}-{}-{}] check pass.", dbId, tableId, alterIndexId);
+        LOG.debug("schema change[{}-{}-{}] check pass.", dbId, tableId, alterIndexMetaId);
 
         return jobBuilder.build();
     }
@@ -1993,10 +1990,10 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         };
 
-        // index id -> index schema
-        Map<Long, LinkedList<Column>> indexSchemaMap = new HashMap<>();
-        for (Map.Entry<Long, List<Column>> entry : olapTable.getIndexIdToSchema().entrySet()) {
-            indexSchemaMap.put(entry.getKey(), new LinkedList<>(entry.getValue()));
+        // index meta id -> index schema
+        Map<Long, LinkedList<Column>> indexMetaIdToSchema = new HashMap<>();
+        for (Map.Entry<Long, List<Column>> entry : olapTable.getIndexMetaIdToSchema().entrySet()) {
+            indexMetaIdToSchema.put(entry.getKey(), new LinkedList<>(entry.getValue()));
         }
         List<Index> newIndexes = olapTable.getCopiedIndexes();
         Map<String, String> propertyMap = new HashMap<>();
@@ -2029,11 +2026,11 @@ public class SchemaChangeHandler extends AlterHandler {
             if (alterClause instanceof AddColumnClause) {
                 // add column
                 fastSchemaEvolution &=
-                        processAddColumn((AddColumnClause) alterClause, olapTable, indexSchemaMap, colUniqueIdSupplier);
+                        processAddColumn((AddColumnClause) alterClause, olapTable, indexMetaIdToSchema, colUniqueIdSupplier);
             } else if (alterClause instanceof AddColumnsClause) {
                 // add columns
                 fastSchemaEvolution &=
-                        processAddColumns((AddColumnsClause) alterClause, olapTable, indexSchemaMap, colUniqueIdSupplier);
+                        processAddColumns((AddColumnsClause) alterClause, olapTable, indexMetaIdToSchema, colUniqueIdSupplier);
             } else if (alterClause instanceof DropColumnClause) {
                 DropColumnClause dropColumnClause = (DropColumnClause) alterClause;
                 // check relative mvs with the modified column
@@ -2042,7 +2039,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
                 // drop column and drop indexes on this column
                 fastSchemaEvolution &=
-                        processDropColumn((DropColumnClause) alterClause, olapTable, indexSchemaMap,
+                        processDropColumn((DropColumnClause) alterClause, olapTable, indexMetaIdToSchema,
                                 newIndexes);
             } else if (alterClause instanceof ModifyColumnClause) {
                 ModifyColumnClause modifyColumnClause = (ModifyColumnClause) alterClause;
@@ -2052,13 +2049,13 @@ public class SchemaChangeHandler extends AlterHandler {
                 AlterMVJobExecutor.checkModifiedColumWithMaterializedViews(olapTable, modifiedColumns);
 
                 // modify column
-                fastSchemaEvolution &= processModifyColumn(modifyColumnClause, olapTable, indexSchemaMap);
+                fastSchemaEvolution &= processModifyColumn(modifyColumnClause, olapTable, indexMetaIdToSchema);
             } else if (alterClause instanceof ModifyColumnCommentClause) {
                 // AlterTableStatementAnalyzer.checkAlterOpConflict() allows batch processing SCHEMA_CHANGE clauses.
                 if (alterClauses.size() > 1) {
                     throw new DdlException("MODIFY COLUMN COMMENT can not be combined with other alter operations");
                 }
-                processModifyColumnComment((ModifyColumnCommentClause) alterClause, db, olapTable, indexSchemaMap);
+                processModifyColumnComment((ModifyColumnCommentClause) alterClause, db, olapTable, indexMetaIdToSchema);
                 return null;
             } else if (alterClause instanceof AddFieldClause) {
                 if (RunMode.isSharedDataMode() && !Config.enable_alter_struct_column) {
@@ -2073,7 +2070,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 modifyFieldColumns = Set.of(addFieldClause.getColName());
                 AlterMVJobExecutor.checkModifiedColumWithMaterializedViews(olapTable, modifyFieldColumns);
                 int id = colUniqueIdSupplier.getAsInt();
-                processAddField((AddFieldClause) alterClause, olapTable, indexSchemaMap, id, newIndexes);
+                processAddField((AddFieldClause) alterClause, olapTable, indexMetaIdToSchema, id, newIndexes);
             } else if (alterClause instanceof DropFieldClause) {
                 if (RunMode.isSharedDataMode() && !Config.enable_alter_struct_column) {
                     throw new DdlException("Drop field for struct column is disable in shared-data mode, " +
@@ -2086,7 +2083,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 DropFieldClause dropFieldClause = (DropFieldClause) alterClause;
                 modifyFieldColumns = Set.of(dropFieldClause.getColName());
                 AlterMVJobExecutor.checkModifiedColumWithMaterializedViews(olapTable, modifyFieldColumns);
-                processDropField((DropFieldClause) alterClause, olapTable, indexSchemaMap, newIndexes);
+                processDropField((DropFieldClause) alterClause, olapTable, indexMetaIdToSchema, newIndexes);
             } else if (alterClause instanceof ReorderColumnsClause) {
                 // reorder column
                 fastSchemaEvolution = false;
@@ -2099,15 +2096,14 @@ public class SchemaChangeHandler extends AlterHandler {
                     // do modify sort key column
                     List<Integer> sortKeyIdxes = new ArrayList<>();
                     List<Integer> sortKeyUniqueIds = new ArrayList<>();
-                    processModifySortKeyColumn((ReorderColumnsClause) alterClause, olapTable, indexSchemaMap, sortKeyIdxes,
+                    processModifySortKeyColumn((ReorderColumnsClause) alterClause, olapTable, indexMetaIdToSchema, sortKeyIdxes,
                             sortKeyUniqueIds);
                     // If optimized olap table contains related mvs, set those mv state to inactive.
                     AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable,
                             MaterializedViewExceptions.inactiveReasonForBaseTableReorderColumns(olapTable.getName()), false);
-                    return createJobForProcessModifySortKeyColumn(db.getId(), olapTable, indexSchemaMap, sortKeyIdxes,
-                            sortKeyUniqueIds);
+                    return createJobForProcessModifySortKeyColumn(db.getId(), olapTable, sortKeyIdxes, sortKeyUniqueIds);
                 } else {
-                    processReorderColumn((ReorderColumnsClause) alterClause, olapTable, indexSchemaMap);
+                    processReorderColumn((ReorderColumnsClause) alterClause, olapTable, indexMetaIdToSchema);
                     // If optimized olap table contains related mvs, set those mv state to inactive.
                     AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable,
                             MaterializedViewExceptions.inactiveReasonForBaseTableReorderColumns(olapTable.getName()), false);
@@ -2131,13 +2127,13 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         } // end for alter clauses
 
-        SchemaChangeData schemaChangeData = finalAnalyze(db, olapTable, indexSchemaMap, propertyMap, newIndexes,
+        SchemaChangeData schemaChangeData = finalAnalyze(db, olapTable, indexMetaIdToSchema, propertyMap, newIndexes,
                 modifyFieldColumns);
         if (schemaChangeData.isShortKeyChanged()) {
             fastSchemaEvolution = false;
         }
 
-        if (schemaChangeData.getNewIndexSchema().isEmpty() && !schemaChangeData.isHasIndexChanged()) {
+        if (schemaChangeData.getNewIndexMetaIdToSchema().isEmpty() && !schemaChangeData.isHasIndexChanged()) {
             // Nothing changed.
             return null;
         }
@@ -2996,14 +2992,14 @@ public class SchemaChangeHandler extends AlterHandler {
     //          {c1: int, c2: int, c3: Struct<v1 int, v2 int, v3 int>}
     //       c. modify column `c1` from INT to BIGINT (when fast schema evolution v2 is enabled in shared-data mode)
     public void applyFastSchemaEvolutionMetaChange(Database db, OlapTable olapTable,
-                                     Map<Long, List<Column>> indexSchemaMap,
+                                     Map<Long, List<Column>> indexMetaIdToSchema,
                                      List<Index> indexes, long jobId,
-                                     Map<Long, Long> indexToNewSchemaId, boolean isReplay, long replayedTxnId)
+                                     Map<Long, Long> indexMetaIdToNewSchemaId, boolean isReplay, long replayedTxnId)
             throws DdlException, NotImplementedException {
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.WRITE);
         try {
-            LOG.debug("indexSchemaMap:{}, indexes:{}", indexSchemaMap, indexes);
+            LOG.debug("indexSchemaMap:{}, indexes:{}", indexMetaIdToSchema, indexes);
             if (olapTable.getState() == OlapTableState.ROLLUP) {
                 throw new DdlException("Table[" + olapTable.getName() + "] is doing ROLLUP job");
             }
@@ -3017,14 +3013,15 @@ public class SchemaChangeHandler extends AlterHandler {
             // update base index schema
             Set<String> modifiedColumns = Sets.newHashSet();
             boolean hasMv = !olapTable.getRelatedMaterializedViews().isEmpty();
-            for (Map.Entry<Long, List<Column>> entry : indexSchemaMap.entrySet()) {
-                Long idx = entry.getKey();
+            for (Map.Entry<Long, List<Column>> entry : indexMetaIdToSchema.entrySet()) {
+                Long idxMetaId = entry.getKey();
                 List<Column> indexSchema = entry.getValue();
                 // modify the copied indexMeta and put the update result in the indexIdToMeta
-                MaterializedIndexMeta currentIndexMeta = olapTable.getIndexMetaByIndexId(idx).shallowCopy();
+                MaterializedIndexMeta currentIndexMeta = olapTable.getIndexMetaByMetaId(idxMetaId).shallowCopy();
                 List<Column> originSchema = currentIndexMeta.getSchema();
-                SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(olapTable, idx, currentIndexMeta);
-                historySchemaBuilder.addIndexSchema(new IndexSchemaInfo(idx, olapTable.getIndexNameByMetaId(idx), schemaInfo));
+                SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(olapTable, idxMetaId, currentIndexMeta);
+                historySchemaBuilder.addIndexSchema(
+                        new IndexSchemaInfo(idxMetaId, olapTable.getIndexNameByMetaId(idxMetaId), schemaInfo));
 
                 if (hasMv) {
                     modifiedColumns.addAll(AlterHelper.collectDroppedOrModifiedColumns(originSchema, indexSchema));
@@ -3052,14 +3049,14 @@ public class SchemaChangeHandler extends AlterHandler {
                 int newSchemaVersion = currentSchemaVersion + 1;
                 currentIndexMeta.setSchemaVersion(newSchemaVersion);
                 // update the indexIdToMeta
-                olapTable.getIndexMetaIdToMeta().put(idx, currentIndexMeta);
+                olapTable.getIndexMetaIdToMeta().put(idxMetaId, currentIndexMeta);
                 // if FE upgrade from old version and replay journal, the indexToNewSchemaId maybe null
-                if (indexToNewSchemaId != null) {
-                    currentIndexMeta.setSchemaId(indexToNewSchemaId.get(idx));
+                if (indexMetaIdToNewSchemaId != null) {
+                    currentIndexMeta.setSchemaId(indexMetaIdToNewSchemaId.get(idxMetaId));
                 }
-                olapTable.renameColumnNamePrefix(idx);
+                olapTable.renameColumnNamePrefix(idxMetaId);
 
-                schemaChangeJob.addIndexSchema(idx, idx, olapTable.getIndexNameByMetaId(idx), newSchemaVersion,
+                schemaChangeJob.addIndexSchema(idxMetaId, idxMetaId, olapTable.getIndexNameByMetaId(idxMetaId), newSchemaVersion,
                         currentIndexMeta.getSchemaHash(), currentIndexMeta.getShortKeyColumnCount(),
                         indexSchema);
             }
@@ -3074,7 +3071,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 txnId = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
                         .getTransactionIDGenerator().getNextTransactionId();
                 TableColumnAlterInfo info = new TableColumnAlterInfo(db.getId(), olapTable.getId(),
-                        indexSchemaMap, indexes, jobId, txnId, indexToNewSchemaId);
+                        indexMetaIdToSchema, indexes, jobId, txnId, indexMetaIdToNewSchemaId);
                 LOG.debug("logModifyTableAddOrDrop info:{}", info);
                 GlobalStateMgr.getCurrentState().getEditLog().logModifyTableAddOrDrop(info);
             }
@@ -3100,8 +3097,8 @@ public class SchemaChangeHandler extends AlterHandler {
         LOG.debug("info:{}", info);
         long dbId = info.getDbId();
         long tableId = info.getTableId();
-        Map<Long, List<Column>> indexSchemaMap = info.getIndexSchemaMap();
-        Map<Long, Long> indexToNewSchemaId = info.getIndexToNewSchemaId();
+        Map<Long, List<Column>> indexMetaIdToSchema = info.getIndexSchemaMap();
+        Map<Long, Long> indexMetaIdToNewSchemaId = info.getIndexToNewSchemaId();
         List<Index> indexes = info.getIndexes();
         long jobId = info.getJobId();
 
@@ -3114,7 +3111,7 @@ public class SchemaChangeHandler extends AlterHandler {
         try {
             locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.WRITE);
             applyFastSchemaEvolutionMetaChange(
-                    db, olapTable, indexSchemaMap, indexes, jobId, indexToNewSchemaId, true, info.getTxnId());
+                    db, olapTable, indexMetaIdToSchema, indexes, jobId, indexMetaIdToNewSchemaId, true, info.getTxnId());
         } catch (DdlException e) {
             // should not happen
             LOG.warn("failed to replay fast schema evolution meta change", e);
@@ -3139,16 +3136,16 @@ public class SchemaChangeHandler extends AlterHandler {
         // for schema change add/drop value column optimize, direct modify table meta.
         // when modify this, please also pay attention to the OlapTable#copyOnlyForQuery() operation.
         // try to copy first before modifying, avoiding in-place changes.
-        Map<Long, Long> indexToNewSchemaId = new HashMap<Long, Long>();
-        for (Long alterIndexId : schemaChangeData.getNewIndexSchema().keySet()) {
-            indexToNewSchemaId.put(alterIndexId, globalStateMgr.getNextId());
+        Map<Long, Long> indexMetaIdToNewSchemaId = new HashMap<Long, Long>();
+        for (Long alterIndexMetaId : schemaChangeData.getNewIndexMetaIdToSchema().keySet()) {
+            indexMetaIdToNewSchemaId.put(alterIndexMetaId, globalStateMgr.getNextId());
         }
         // for schema change add/drop value column optimize, direct modify table meta.
         // when modify this, please also pay attention to the OlapTable#copyOnlyForQuery() operation.
         // try to copy first before modifying, avoiding in-place changes.
         applyFastSchemaEvolutionMetaChange(schemaChangeData.getDatabase(), schemaChangeData.getTable(),
-                schemaChangeData.getNewIndexSchema(), schemaChangeData.getIndexes(), jobId,
-                indexToNewSchemaId, false, -1);
+                schemaChangeData.getNewIndexMetaIdToSchema(), schemaChangeData.getIndexes(), jobId,
+                indexMetaIdToNewSchemaId, false, -1);
     }
 
     private AlterJobV2 createFastSchemaEvolutionJobInSharedDataMode(SchemaChangeData schemaChangeData) {
@@ -3159,14 +3156,14 @@ public class SchemaChangeHandler extends AlterHandler {
         long timeoutMs = schemaChangeData.getTimeoutInSeconds() * 1000L;
         String tableName = schemaChangeData.getTable().getName();
         LakeTableAsyncFastSchemaChangeJob job = new LakeTableAsyncFastSchemaChangeJob(jobId, dbId, tableId, tableName, timeoutMs);
-        for (Map.Entry<Long, List<Column>> entry : schemaChangeData.getNewIndexSchema().entrySet()) {
-            long indexId = entry.getKey();
-            String indexName = schemaChangeData.getTable().getIndexNameByMetaId(indexId);
-            int schemaVersion = 1 + schemaChangeData.getTable().getIndexMetaByIndexId(indexId).getSchemaVersion();
+        for (Map.Entry<Long, List<Column>> entry : schemaChangeData.getNewIndexMetaIdToSchema().entrySet()) {
+            long indexMetaId = entry.getKey();
+            String indexName = schemaChangeData.getTable().getIndexNameByMetaId(indexMetaId);
+            int schemaVersion = 1 + schemaChangeData.getTable().getIndexMetaByMetaId(indexMetaId).getSchemaVersion();
             SchemaInfo schemaInfo = SchemaInfo.newBuilder()
                     .setId(globalStateMgr.getNextId())
                     .setKeysType(schemaChangeData.getTable().getKeysType())
-                    .setShortKeyColumnCount(schemaChangeData.getNewIndexShortKeyCount().get(indexId))
+                    .setShortKeyColumnCount(schemaChangeData.getNewIndexMetaIdToShortKeyCount().get(indexMetaId))
                     .setStorageType(schemaChangeData.getTable().getStorageType())
                     .setVersion(schemaVersion)
                     .addColumns(entry.getValue())
@@ -3178,7 +3175,7 @@ public class SchemaChangeHandler extends AlterHandler {
                     .setCompressionType(schemaChangeData.getTable().getCompressionType())
                     .setCompressionLevel(schemaChangeData.getTable().getCompressionLevel())
                     .build();
-            job.setIndexTabletSchema(indexId, indexName, schemaInfo);
+            job.setIndexTabletSchema(indexMetaId, indexName, schemaInfo);
         }
         job.setComputeResource(schemaChangeData.getComputeResource());
         return job;
@@ -3193,10 +3190,10 @@ public class SchemaChangeHandler extends AlterHandler {
                 .withStartTime(ConnectContext.get().getStartTime())
                 .withBloomFilterColumns(schemaChangeData.getBloomFilterColumns(), schemaChangeData.getBloomFilterFpp())
                 .withBloomFilterColumnsChanged(schemaChangeData.isBloomFilterColumnsChanged())
-                .withNewIndexShortKeyCount(schemaChangeData.getNewIndexShortKeyCount())
+                .withNewIndexMetaIdToShortKeyCount(schemaChangeData.getNewIndexMetaIdToShortKeyCount())
                 .withSortKeyIdxes(schemaChangeData.getSortKeyIdxes())
                 .withSortKeyUniqueIds(schemaChangeData.getSortKeyUniqueIds())
-                .withNewIndexSchema(schemaChangeData.getNewIndexSchema())
+                .withNewIndexMetaIdToSchema(schemaChangeData.getNewIndexMetaIdToSchema())
                 .withComputeResource(schemaChangeData.getComputeResource())
                 .withDisableReplicatedStorageForGIN(schemaChangeData.isDisableReplicatedStorageForGIN())
                 .build();
@@ -3262,10 +3259,10 @@ public class SchemaChangeHandler extends AlterHandler {
                 jobId, db.getId(), table.getId(), table.getName(), Config.alter_table_timeout_second * 1000L);
         job.setDisableFastSchemaEvolutionV2();
         for (MaterializedIndexMeta indexMeta : table.getIndexMetaIdToMeta().values()) {
-            long indexId = indexMeta.getIndexMetaId();
-            String indexName = table.getIndexNameByMetaId(indexId);
-            SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, indexMeta);
-            job.setIndexTabletSchema(indexId, indexName, schemaInfo);
+            long indexMetaId = indexMeta.getIndexMetaId();
+            String indexName = table.getIndexNameByMetaId(indexMetaId);
+            SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(table, indexMetaId, indexMeta);
+            job.setIndexTabletSchema(indexMetaId, indexName, schemaInfo);
         }
         ConnectContext connectContext = ConnectContext.get();
         ComputeResource computeResource  = connectContext != null ?

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -134,27 +134,30 @@ import java.util.stream.Collectors;
 public class SchemaChangeJobV2 extends AlterJobV2 {
     private static final Logger LOG = LogManager.getLogger(SchemaChangeJobV2.class);
 
-    // physical partition id -> (shadow index id -> (shadow tablet id -> origin tablet id))
+    // initially, shadow index id and shadow index meta id are the same.
+    // not change the SerializedName for compatibility
+
+    // physical partition id -> (shadow index meta id -> (shadow tablet id -> origin tablet id))
     @SerializedName(value = "partitionIndexTabletMap")
     private Table<Long, Long, Map<Long, Long>> physicalPartitionIndexTabletMap = HashBasedTable.create();
-    // physical partition id -> (shadow index id -> shadow index))
+    // physical partition id -> (shadow index meta id -> shadow index))
     @SerializedName(value = "partitionIndexMap")
     private Table<Long, Long, MaterializedIndex> physicalPartitionIndexMap = HashBasedTable.create();
-    // shadow index id -> origin index id
+    // shadow index meta id -> origin index meta id
     @SerializedName(value = "indexIdMap")
-    private Map<Long, Long> indexIdMap = Maps.newHashMap();
-    // shadow index id -> shadow index name(__starrocks_shadow_xxx)
+    private Map<Long, Long> indexMetaIdMap = Maps.newHashMap();
+    // shadow index meta id -> shadow index name(__starrocks_shadow_xxx)
     @SerializedName(value = "indexIdToName")
-    private Map<Long, String> indexIdToName = Maps.newHashMap();
-    // shadow index id -> index schema
+    private Map<Long, String> indexMetaIdToName = Maps.newHashMap();
+    // shadow index meta id -> index schema
     @SerializedName(value = "indexSchemaMap")
-    private Map<Long, List<Column>> indexSchemaMap = Maps.newHashMap();
-    // shadow index id -> (shadow index schema version : schema hash)
+    private Map<Long, List<Column>> indexMetaIdToSchema = Maps.newHashMap();
+    // shadow index meta id -> (shadow index schema version : schema hash)
     @SerializedName(value = "indexSchemaVersionAndHashMap")
-    private Map<Long, SchemaVersionAndHash> indexSchemaVersionAndHashMap = Maps.newHashMap();
-    // shadow index id -> shadow index short key count
+    private Map<Long, SchemaVersionAndHash> indexMetaIdToSchemaVersionAndHash = Maps.newHashMap();
+    // shadow index meta id -> shadow index short key count
     @SerializedName(value = "indexShortKeyMap")
-    private Map<Long, Short> indexShortKeyMap = Maps.newHashMap();
+    private Map<Long, Short> indexMetaIdToShortKey = Maps.newHashMap();
 
     // bloom filter info
     @SerializedName(value = "hasBfChange")
@@ -203,26 +206,26 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         super(JobType.SCHEMA_CHANGE);
     }
 
-    public void addTabletIdMap(long partitionId, long shadowIdxId, long shadowTabletId, long originTabletId) {
-        Map<Long, Long> tabletMap = physicalPartitionIndexTabletMap.get(partitionId, shadowIdxId);
+    public void addTabletIdMap(long physicalPartitionId, long shadowIdxMetaId, long shadowTabletId, long originTabletId) {
+        Map<Long, Long> tabletMap = physicalPartitionIndexTabletMap.get(physicalPartitionId, shadowIdxMetaId);
         if (tabletMap == null) {
             tabletMap = Maps.newHashMap();
-            physicalPartitionIndexTabletMap.put(partitionId, shadowIdxId, tabletMap);
+            physicalPartitionIndexTabletMap.put(physicalPartitionId, shadowIdxMetaId, tabletMap);
         }
         tabletMap.put(shadowTabletId, originTabletId);
     }
 
-    public void addPartitionShadowIndex(long partitionId, long shadowIdxId, MaterializedIndex shadowIdx) {
-        physicalPartitionIndexMap.put(partitionId, shadowIdxId, shadowIdx);
+    public void addPartitionShadowIndex(long physicalPartitionId, long shadowIdxMetaId, MaterializedIndex shadowIdx) {
+        physicalPartitionIndexMap.put(physicalPartitionId, shadowIdxMetaId, shadowIdx);
     }
 
-    public void addIndexSchema(long shadowIdxId, long originIdxId, String shadowIndexName, int shadowSchemaVersion,
+    public void addIndexSchema(long shadowIdxMetaId, long originIdxMetaId, String shadowIndexName, int shadowSchemaVersion,
                                int shadowSchemaHash, short shadowIdxShortKeyCount, List<Column> shadowIdxSchema) {
-        indexIdMap.put(shadowIdxId, originIdxId);
-        indexIdToName.put(shadowIdxId, shadowIndexName);
-        indexSchemaVersionAndHashMap.put(shadowIdxId, new SchemaVersionAndHash(shadowSchemaVersion, shadowSchemaHash));
-        indexShortKeyMap.put(shadowIdxId, shadowIdxShortKeyCount);
-        indexSchemaMap.put(shadowIdxId, shadowIdxSchema);
+        indexMetaIdMap.put(shadowIdxMetaId, originIdxMetaId);
+        indexMetaIdToName.put(shadowIdxMetaId, shadowIndexName);
+        indexMetaIdToSchemaVersionAndHash.put(shadowIdxMetaId, new SchemaVersionAndHash(shadowSchemaVersion, shadowSchemaHash));
+        indexMetaIdToShortKey.put(shadowIdxMetaId, shadowIdxShortKeyCount);
+        indexMetaIdToSchema.put(shadowIdxMetaId, shadowIdxSchema);
     }
 
     @VisibleForTesting
@@ -316,8 +319,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
     private void pruneMeta() {
         physicalPartitionIndexTabletMap.clear();
         physicalPartitionIndexMap.clear();
-        indexSchemaMap.clear();
-        indexShortKeyMap.clear();
+        indexMetaIdToSchema.clear();
+        indexMetaIdToShortKey.clear();
     }
 
     /**
@@ -360,30 +363,30 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
         try {
-            long baseIndexId = tbl.getBaseIndexMetaId();
+            long baseIndexMetaId = tbl.getBaseIndexMetaId();
             Preconditions.checkState(tbl.getState() == OlapTableState.SCHEMA_CHANGE);
-            MaterializedIndexMeta index = tbl.getIndexMetaByIndexId(tbl.getBaseIndexMetaId());
-            for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-                PhysicalPartition partition = tbl.getPhysicalPartition(partitionId);
-                if (partition == null) {
+            MaterializedIndexMeta index = tbl.getIndexMetaByMetaId(tbl.getBaseIndexMetaId());
+            for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+                PhysicalPartition physicalPartition = tbl.getPhysicalPartition(physicalPartitionId);
+                if (physicalPartition == null) {
                     continue;
                 }
                 TStorageMedium storageMedium = tbl.getPartitionInfo()
-                        .getDataProperty(partition.getParentId()).getStorageMedium();
+                        .getDataProperty(physicalPartition.getParentId()).getStorageMedium();
 
-                Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(partitionId);
+                Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(physicalPartitionId);
                 for (Map.Entry<Long, MaterializedIndex> entry : shadowIndexMap.entrySet()) {
-                    long shadowIdxId = entry.getKey();
+                    long shadowIdxMetaId = entry.getKey();
                     MaterializedIndex shadowIdx = entry.getValue();
 
-                    short shadowShortKeyColumnCount = indexShortKeyMap.get(shadowIdxId);
-                    List<Column> shadowSchema = indexSchemaMap.get(shadowIdxId);
-                    int shadowSchemaHash = indexSchemaVersionAndHashMap.get(shadowIdxId).schemaHash;
-                    int shadowSchemaVersion = indexSchemaVersionAndHashMap.get(shadowIdxId).schemaVersion;
-                    long originIndexId = indexIdMap.get(shadowIdxId);
-                    KeysType originKeysType = tbl.getKeysTypeByIndexMetaId(originIndexId);
+                    short shadowShortKeyColumnCount = indexMetaIdToShortKey.get(shadowIdxMetaId);
+                    List<Column> shadowSchema = indexMetaIdToSchema.get(shadowIdxMetaId);
+                    int shadowSchemaHash = indexMetaIdToSchemaVersionAndHash.get(shadowIdxMetaId).schemaHash;
+                    int shadowSchemaVersion = indexMetaIdToSchemaVersionAndHash.get(shadowIdxMetaId).schemaVersion;
+                    long originIndexMetaId = indexMetaIdMap.get(shadowIdxMetaId);
+                    KeysType originKeysType = tbl.getKeysTypeByIndexMetaId(originIndexMetaId);
                     TTabletSchema tabletSchema = SchemaInfo.newBuilder()
-                            .setId(shadowIdxId) // For newly created materialized, schema id equals to index id
+                            .setId(shadowIdxMetaId) // For newly created materialized, schema id equals to index meta id
                             .setKeysType(originKeysType)
                             .setShortKeyColumnCount(shadowShortKeyColumnCount)
                             .setSchemaHash(shadowSchemaHash)
@@ -391,16 +394,16 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                             .setStorageType(tbl.getStorageType())
                             .setBloomFilterColumnNames(bfColumns)
                             .setBloomFilterFpp(bfFpp)
-                            .setIndexes(originIndexId == baseIndexId ?
+                            .setIndexes(originIndexMetaId == baseIndexMetaId ?
                                         indexes : OlapTable.getIndexesBySchema(indexes, shadowSchema))
-                            .setSortKeyIndexes(originIndexId == baseIndexId ? sortKeyIdxes : null)
-                            .setSortKeyUniqueIds(originIndexId == baseIndexId ? sortKeyUniqueIds : null)
+                            .setSortKeyIndexes(originIndexMetaId == baseIndexMetaId ? sortKeyIdxes : null)
+                            .setSortKeyUniqueIds(originIndexMetaId == baseIndexMetaId ? sortKeyUniqueIds : null)
                             .addColumns(shadowSchema)
                             .build().toTabletSchema();
                     for (Tablet shadowTablet : shadowIdx.getTablets()) {
                         long shadowTabletId = shadowTablet.getId();
                         List<Replica> shadowReplicas = ((LocalTablet) shadowTablet).getImmutableReplicas();
-                        long baseTabletId = physicalPartitionIndexTabletMap.get(partitionId, shadowIdxId)
+                        long baseTabletId = physicalPartitionIndexTabletMap.get(physicalPartitionId, shadowIdxMetaId)
                                 .get(shadowTabletId);
                         for (Replica shadowReplica : shadowReplicas) {
                             long backendId = shadowReplica.getBackendId();
@@ -409,8 +412,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                                     .setNodeId(backendId)
                                     .setDbId(dbId)
                                     .setTableId(tableId)
-                                    .setPartitionId(partitionId)
-                                    .setIndexId(shadowIdxId)
+                                    .setPartitionId(physicalPartitionId)
+                                    .setIndexId(shadowIdxMetaId)
                                     .setTabletId(shadowTabletId)
                                     .setVersion(Partition.PARTITION_INIT_VERSION)
                                     .setStorageMedium(storageMedium)
@@ -501,38 +504,38 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
     }
 
     private void addShadowIndexToCatalog(OlapTable tbl) {
-        for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-            PhysicalPartition partition = tbl.getPhysicalPartition(partitionId);
-            if (partition == null) {
+        for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+            PhysicalPartition physicalPartition = tbl.getPhysicalPartition(physicalPartitionId);
+            if (physicalPartition == null) {
                 continue;
             }
-            Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(partitionId);
+            Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(physicalPartitionId);
             for (MaterializedIndex shadowIndex : shadowIndexMap.values()) {
                 Preconditions.checkState(shadowIndex.getState() == IndexState.SHADOW, shadowIndex.getState());
-                partition.createRollupIndex(shadowIndex);
+                physicalPartition.createRollupIndex(shadowIndex);
             }
         }
 
-        for (long shadowIdxId : indexIdMap.keySet()) {
+        for (long shadowIdxMetaId : indexMetaIdMap.keySet()) {
             List<Integer> sortKeyColumnIndexes = null;
             List<Integer> sortKeyColumnUniqueIds = null;
 
-            long orgIndexId = indexIdMap.get(shadowIdxId);
-            if (orgIndexId == tbl.getBaseIndexMetaId()) {
+            long orgIndexMetaId = indexMetaIdMap.get(shadowIdxMetaId);
+            if (orgIndexMetaId == tbl.getBaseIndexMetaId()) {
                 sortKeyColumnIndexes = sortKeyIdxes;
                 sortKeyColumnUniqueIds = sortKeyUniqueIds;
             }
 
-            tbl.setIndexMeta(shadowIdxId, indexIdToName.get(shadowIdxId),
-                    indexSchemaMap.get(shadowIdxId),
-                    indexSchemaVersionAndHashMap.get(shadowIdxId).schemaVersion,
-                    indexSchemaVersionAndHashMap.get(shadowIdxId).schemaHash,
-                    indexShortKeyMap.get(shadowIdxId), TStorageType.COLUMN,
-                    tbl.getKeysTypeByIndexMetaId(orgIndexId), null, sortKeyColumnIndexes,
+            tbl.setIndexMeta(shadowIdxMetaId, indexMetaIdToName.get(shadowIdxMetaId),
+                    indexMetaIdToSchema.get(shadowIdxMetaId),
+                    indexMetaIdToSchemaVersionAndHash.get(shadowIdxMetaId).schemaVersion,
+                    indexMetaIdToSchemaVersionAndHash.get(shadowIdxMetaId).schemaHash,
+                    indexMetaIdToShortKey.get(shadowIdxMetaId), TStorageType.COLUMN,
+                    tbl.getKeysTypeByIndexMetaId(orgIndexMetaId), null, sortKeyColumnIndexes,
                     sortKeyColumnUniqueIds);
-            MaterializedIndexMeta orgIndexMeta = tbl.getIndexMetaByIndexId(orgIndexId);
+            MaterializedIndexMeta orgIndexMeta = tbl.getIndexMetaByMetaId(orgIndexMetaId);
             Preconditions.checkNotNull(orgIndexMeta);
-            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(shadowIdxId);
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByMetaId(shadowIdxMetaId);
             Preconditions.checkNotNull(indexMeta);
             rebuildMaterializedIndexMeta(orgIndexMeta, indexMeta);
         }
@@ -575,26 +578,26 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         try {
             Preconditions.checkState(tbl.getState() == OlapTableState.SCHEMA_CHANGE);
 
-            for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-                PhysicalPartition partition = tbl.getPhysicalPartition(partitionId);
-                Preconditions.checkNotNull(partition, partitionId);
+            for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+                PhysicalPartition physicalPartition = tbl.getPhysicalPartition(physicalPartitionId);
+                Preconditions.checkNotNull(physicalPartition, physicalPartitionId);
 
                 // the schema change task will transform the data before visible version(included).
-                long visibleVersion = partition.getVisibleVersion();
+                long visibleVersion = physicalPartition.getVisibleVersion();
 
-                Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(partitionId);
+                Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(physicalPartitionId);
                 for (Map.Entry<Long, MaterializedIndex> entry : shadowIndexMap.entrySet()) {
-                    long shadowIdxId = entry.getKey();
+                    long shadowIdxMetaId = entry.getKey();
                     MaterializedIndex shadowIdx = entry.getValue();
 
-                    long originIdxId = indexIdMap.get(shadowIdxId);
+                    long originIdxMetaId = indexMetaIdMap.get(shadowIdxMetaId);
 
                     boolean hasNewGeneratedColumn = false;
                     List<Column> diffGeneratedColumnSchema = Lists.newArrayList();
-                    if (originIdxId == tbl.getBaseIndexMetaId()) {
-                        List<String> originSchema = tbl.getSchemaByIndexMetaId(originIdxId).stream().map(col ->
+                    if (originIdxMetaId == tbl.getBaseIndexMetaId()) {
+                        List<String> originSchema = tbl.getSchemaByIndexMetaId(originIdxMetaId).stream().map(col ->
                                 new String(col.getName())).collect(Collectors.toList());
-                        List<String> newSchema = tbl.getSchemaByIndexMetaId(shadowIdxId).stream().map(col ->
+                        List<String> newSchema = tbl.getSchemaByIndexMetaId(shadowIdxMetaId).stream().map(col ->
                                 new String(col.getName())).collect(Collectors.toList());
 
                         if (originSchema.size() != 0 && newSchema.size() != 0) {
@@ -707,23 +710,24 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                         generatedColumnReq.setQuery_options(queryOptions);
                         generatedColumnReq.setMc_exprs(mcExprs);
                     }
-                    int shadowSchemaHash = indexSchemaVersionAndHashMap.get(shadowIdxId).schemaHash;
-                    int originSchemaHash = tbl.getSchemaHashByIndexMetaId(indexIdMap.get(shadowIdxId));
-                    List<TColumn> originSchemaTColumns = indexToThriftColumns.get(originIdxId);
+                    int shadowSchemaHash = indexMetaIdToSchemaVersionAndHash.get(shadowIdxMetaId).schemaHash;
+                    int originSchemaHash = tbl.getSchemaHashByIndexMetaId(indexMetaIdMap.get(shadowIdxMetaId));
+                    List<TColumn> originSchemaTColumns = indexToThriftColumns.get(originIdxMetaId);
                     if (originSchemaTColumns == null) {
-                        originSchemaTColumns = tbl.getSchemaByIndexMetaId(originIdxId).stream()
+                        originSchemaTColumns = tbl.getSchemaByIndexMetaId(originIdxMetaId).stream()
                                 .map(Column::toThrift)
                                 .collect(Collectors.toList());
-                        indexToThriftColumns.put(originIdxId, originSchemaTColumns);
+                        indexToThriftColumns.put(originIdxMetaId, originSchemaTColumns);
                     }
 
                     for (Tablet shadowTablet : shadowIdx.getTablets()) {
                         long shadowTabletId = shadowTablet.getId();
-                        long originTabletId = physicalPartitionIndexTabletMap.get(partitionId, shadowIdxId).get(shadowTabletId);
+                        long originTabletId =
+                                physicalPartitionIndexTabletMap.get(physicalPartitionId, shadowIdxMetaId).get(shadowTabletId);
                         for (Replica shadowReplica : ((LocalTablet) shadowTablet).getImmutableReplicas()) {
                             AlterReplicaTask rollupTask = AlterReplicaTask.alterLocalTablet(
-                                    shadowReplica.getBackendId(), dbId, tableId, partitionId,
-                                    shadowIdxId, shadowTabletId, originTabletId, shadowReplica.getId(),
+                                    shadowReplica.getBackendId(), dbId, tableId, physicalPartitionId,
+                                    shadowIdxMetaId, shadowTabletId, originTabletId, shadowReplica.getId(),
                                     shadowSchemaHash, originSchemaHash, visibleVersion, jobId,
                                     generatedColumnReq, originSchemaTColumns);
                             schemaChangeBatchTask.addTask(rollupTask);
@@ -795,22 +799,22 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             // Before schema change, collect modified columns for related mvs.
             Set<String> modifiedColumns = collectModifiedColumnsForRelatedMVs(tbl);
 
-            for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-                PhysicalPartition partition = tbl.getPhysicalPartition(partitionId);
-                Preconditions.checkNotNull(partition, partitionId);
+            for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+                PhysicalPartition physicalPartition = tbl.getPhysicalPartition(physicalPartitionId);
+                Preconditions.checkNotNull(physicalPartition, physicalPartitionId);
 
-                long visibleVersion = partition.getVisibleVersion();
-                short expectReplicationNum = tbl.getPartitionInfo().getReplicationNum(partition.getParentId());
+                long visibleVersion = physicalPartition.getVisibleVersion();
+                short expectReplicationNum = tbl.getPartitionInfo().getReplicationNum(physicalPartition.getParentId());
 
-                Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(partitionId);
+                Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(physicalPartitionId);
                 for (Map.Entry<Long, MaterializedIndex> entry : shadowIndexMap.entrySet()) {
-                    long shadowIdxId = entry.getKey();
+                    long shadowIdxMetaId = entry.getKey();
                     MaterializedIndex shadowIdx = entry.getValue();
 
                     for (Tablet shadowTablet : shadowIdx.getTablets()) {
                         // Mark schema changed tablet not to move to trash.
                         long baseTabletId = physicalPartitionIndexTabletMap.get(
-                                partitionId, shadowIdxId).get(shadowTablet.getId());
+                                physicalPartitionId, shadowIdxMetaId).get(shadowTablet.getId());
                         // NOTE: known for sure that only LocalTablet uses this SchemaChangeJobV2 class
                         GlobalStateMgr.getCurrentState().getTabletInvertedIndex().
                                 markTabletForceDelete(baseTabletId, shadowTablet.getBackendIds());
@@ -861,11 +865,11 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         }
         Set<String> modifiedColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
 
-        for (Entry<Long, List<Column>> entry : indexSchemaMap.entrySet()) {
-            Long shadowIdxId = entry.getKey();
-            long originIndexId = indexIdMap.get(shadowIdxId);
+        for (Entry<Long, List<Column>> entry : indexMetaIdToSchema.entrySet()) {
+            Long shadowIdxMetaId = entry.getKey();
+            long originIndexMetaId = indexMetaIdMap.get(shadowIdxMetaId);
             List<Column> shadowSchema = entry.getValue();
-            List<Column> originSchema = tbl.getSchemaByIndexMetaId(originIndexId);
+            List<Column> originSchema = tbl.getSchemaByIndexMetaId(originIndexMetaId);
             if (shadowSchema.size() == originSchema.size()) {
                 // modify column
                 for (Column col : shadowSchema) {
@@ -907,24 +911,26 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         for (Partition partition : tbl.getPartitions()) {
             TStorageMedium medium = tbl.getPartitionInfo().getDataProperty(partition.getId()).getStorageMedium();
             // drop the origin index from partitions
-            for (Map.Entry<Long, Long> entry : indexIdMap.entrySet()) {
-                long shadowIdxId = entry.getKey();
-                long originIdxId = entry.getValue();
+            for (Map.Entry<Long, Long> entry : indexMetaIdMap.entrySet()) {
+                long shadowIdxMetaId = entry.getKey();
+                long originIdxMetaId = entry.getValue();
+                // initially, shadow index id and shadow index meta id are the same
+                long shadowIdxId = shadowIdxMetaId;
 
                 for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                     // get index from globalStateMgr, not from 'partitionIdToRollupIndex'.
                     // because if this alter job is recovered from edit log, index in 'physicalPartitionIndexMap'
                     // is not the same object in globalStateMgr. So modification on that index can not reflect to the index
                     // in globalStateMgr.
-                    MaterializedIndex shadowIdx = physicalPartition.getIndex(shadowIdxId);
-                    Preconditions.checkNotNull(shadowIdx, shadowIdxId);
+                    MaterializedIndex shadowIdx = physicalPartition.getIndex(shadowIdxMetaId);
+                    Preconditions.checkNotNull(shadowIdx, shadowIdxMetaId);
                     MaterializedIndex droppedIdx = null;
-                    if (originIdxId == physicalPartition.getBaseIndex().getId()) {
+                    if (originIdxMetaId == physicalPartition.getBaseIndex().getMetaId()) {
                         droppedIdx = physicalPartition.getBaseIndex();
                     } else {
-                        droppedIdx = physicalPartition.deleteRollupIndex(originIdxId);
+                        droppedIdx = physicalPartition.deleteRollupIndex(originIdxMetaId);
                     }
-                    Preconditions.checkNotNull(droppedIdx, originIdxId + " vs. " + shadowIdxId);
+                    Preconditions.checkNotNull(droppedIdx, originIdxMetaId + " vs. " + shadowIdxMetaId);
 
                     // Add to TabletInvertedIndex.
                     // Even thought we have added the tablet to TabletInvertedIndex on pending state, but the pending state
@@ -941,7 +947,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                         }
                     }
 
-                    physicalPartition.visualiseShadowIndex(shadowIdxId, originIdxId == physicalPartition.getBaseIndex().getId());
+                    physicalPartition.visualiseShadowIndex(
+                            shadowIdxMetaId, originIdxMetaId == physicalPartition.getBaseIndex().getMetaId());
 
                     // the origin tablet created by old schema can be deleted from FE meta data
                     for (Tablet originTablet : droppedIdx.getTablets()) {
@@ -952,20 +959,20 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         }
 
         // update index schema info of each index
-        for (Map.Entry<Long, Long> entry : indexIdMap.entrySet()) {
-            long shadowIdxId = entry.getKey();
-            long originIdxId = entry.getValue();
-            String shadowIdxName = tbl.getIndexNameByMetaId(shadowIdxId);
-            String originIdxName = tbl.getIndexNameByMetaId(originIdxId);
+        for (Map.Entry<Long, Long> entry : indexMetaIdMap.entrySet()) {
+            long shadowIdxMetaId = entry.getKey();
+            long originIdxMetaId = entry.getValue();
+            String shadowIdxName = tbl.getIndexNameByMetaId(shadowIdxMetaId);
+            String originIdxName = tbl.getIndexNameByMetaId(originIdxMetaId);
             tbl.deleteIndexInfo(originIdxName);
             // the shadow index name is '__starrocks_shadow_xxx', rename it to origin name 'xxx'
             // this will also remove the prefix of columns
             tbl.renameIndexForSchemaChange(shadowIdxName, originIdxName);
-            tbl.renameColumnNamePrefix(shadowIdxId);
+            tbl.renameColumnNamePrefix(shadowIdxMetaId);
 
-            if (originIdxId == tbl.getBaseIndexMetaId()) {
+            if (originIdxMetaId == tbl.getBaseIndexMetaId()) {
                 // set base index
-                tbl.setBaseIndexMetaId(shadowIdxId);
+                tbl.setBaseIndexMetaId(shadowIdxMetaId);
             }
         }
         // rebuild table's full schema
@@ -1038,20 +1045,20 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                 Locker locker = new Locker();
                 locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.WRITE);
                 try {
-                    for (long partitionId : physicalPartitionIndexMap.rowKeySet()) {
-                        PhysicalPartition partition = tbl.getPhysicalPartition(partitionId);
-                        Preconditions.checkNotNull(partition, partitionId);
+                    for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+                        PhysicalPartition physicalPartition = tbl.getPhysicalPartition(physicalPartitionId);
+                        Preconditions.checkNotNull(physicalPartition, physicalPartitionId);
 
-                        Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(partitionId);
+                        Map<Long, MaterializedIndex> shadowIndexMap = physicalPartitionIndexMap.row(physicalPartitionId);
                         for (Map.Entry<Long, MaterializedIndex> entry : shadowIndexMap.entrySet()) {
                             MaterializedIndex shadowIdx = entry.getValue();
                             for (Tablet shadowTablet : shadowIdx.getTablets()) {
                                 invertedIndex.deleteTablet(shadowTablet.getId());
                             }
-                            partition.deleteRollupIndex(shadowIdx.getId());
+                            physicalPartition.deleteRollupIndex(shadowIdx.getMetaId());
                         }
                     }
-                    for (String shadowIndexName : indexIdToName.values()) {
+                    for (String shadowIndexName : indexMetaIdToName.values()) {
                         tbl.deleteIndexInfo(shadowIndexName);
                     }
                     tbl.setState(OlapTableState.NORMAL);
@@ -1096,13 +1103,13 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         try {
             TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
             for (Cell<Long, Long, MaterializedIndex> cell : physicalPartitionIndexMap.cellSet()) {
-                long partitionId = cell.getRowKey();
-                long shadowIndexId = cell.getColumnKey();
+                long physicalPartitionId = cell.getRowKey();
+                long shadowIndexMetaId = cell.getColumnKey();
                 MaterializedIndex shadowIndex = cell.getValue();
-                PhysicalPartition partition = tbl.getPhysicalPartition(partitionId);
+                PhysicalPartition partition = tbl.getPhysicalPartition(physicalPartitionId);
 
                 TStorageMedium medium = tbl.getPartitionInfo().getDataProperty(partition.getParentId()).getStorageMedium();
-                TabletMeta shadowTabletMeta = new TabletMeta(dbId, tableId, partitionId, shadowIndexId,
+                TabletMeta shadowTabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, shadowIndexMetaId,
                         medium);
 
                 for (Tablet shadownTablet : shadowIndex.getTablets()) {
@@ -1225,22 +1232,22 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
         // one line for one shadow index
         boolean isSharedData = RunMode.isSharedDataMode();
-        for (Map.Entry<Long, Long> entry : indexIdMap.entrySet()) {
-            long shadowIndexId = entry.getKey();
+        for (Map.Entry<Long, Long> entry : indexMetaIdMap.entrySet()) {
+            long shadowIndexMetaId = entry.getKey();
             List<Comparable> info = Lists.newArrayList();
             info.add(jobId);
             info.add(tableName);
             info.add(TimeUtils.longToTimeString(createTimeMs));
             info.add(TimeUtils.longToTimeString(finishedTimeMs));
             // only show the origin index name
-            info.add(Column.removeNamePrefix(indexIdToName.get(shadowIndexId)));
-            info.add(shadowIndexId);
+            info.add(Column.removeNamePrefix(indexMetaIdToName.get(shadowIndexMetaId)));
+            info.add(shadowIndexMetaId);
             info.add(entry.getValue());
             if (isSharedData) {
                 // schema hash is useless for shared-data, so always set 0
-                info.add(String.format("%d:0", indexSchemaVersionAndHashMap.get(shadowIndexId).schemaVersion));
+                info.add(String.format("%d:0", indexMetaIdToSchemaVersionAndHash.get(shadowIndexMetaId).schemaVersion));
             } else {
-                info.add(indexSchemaVersionAndHashMap.get(shadowIndexId).toString());
+                info.add(indexMetaIdToSchemaVersionAndHash.get(shadowIndexMetaId).toString());
             }
             info.add(watershedTxnId);
             info.add(jobState.name());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -526,7 +526,7 @@ public class SplitTabletJob extends TabletReshardJob {
                 for (ReshardingMaterializedIndex reshardingIndex : reshardingPhysicalPartition
                         .getReshardingIndexes().values()) {
                     MaterializedIndex newIndex = reshardingIndex.getMaterializedIndex();
-                    if (newIndex.getId() == olapTable.getBaseIndexMetaId()) {
+                    if (newIndex.getMetaId() == olapTable.getBaseIndexMetaId()) {
                         physicalPartition.setBaseIndex(newIndex);
                     } else {
                         physicalPartition.createRollupIndex(newIndex);

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -525,7 +525,7 @@ public class BackupJob extends AbstractJob {
                         long visibleVersion = physicalPartition.getVisibleVersion();
                         List<MaterializedIndex> indexes = physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE);
                         for (MaterializedIndex index : indexes) {
-                            int schemaHash = olapTbl.getSchemaHashByIndexMetaId(index.getId());
+                            int schemaHash = olapTbl.getSchemaHashByIndexMetaId(index.getMetaId());
                             for (Tablet tablet : index.getTablets()) {
                                 prepareSnapshotTask(physicalPartition, olapTbl, tablet, index, visibleVersion, schemaHash);
                                 if (status != Status.OK) {

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJobInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJobInfo.java
@@ -325,8 +325,8 @@ public class BackupJobInfo implements Writable {
                     for (MaterializedIndex index : physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
                         BackupIndexInfo idxInfo = new BackupIndexInfo();
                         idxInfo.id = index.getId();
-                        idxInfo.name = olapTbl.getIndexNameByMetaId(index.getId());
-                        idxInfo.schemaHash = olapTbl.getSchemaHashByIndexMetaId(index.getId());
+                        idxInfo.name = olapTbl.getIndexNameByMetaId(index.getMetaId());
+                        idxInfo.schemaHash = olapTbl.getSchemaHashByIndexMetaId(index.getMetaId());
                         physicalPartitionInfo.indexes.put(idxInfo.name, idxInfo);
                         // tablets
                         for (Tablet tablet : index.getTablets()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -959,7 +959,6 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
                     long physicalPartitionId = physicalPartition.getId();
                     for (MaterializedIndex index : physicalPartition.getMaterializedIndices(IndexExtState.ALL)) {
                         long indexId = index.getId();
-                        int schemaHash = olapTable.getSchemaHashByIndexMetaId(indexId);
                         TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, medium,
                                 table.isCloudNativeTable());
                         for (Tablet tablet : index.getTablets()) {
@@ -1017,7 +1016,6 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
                 long physicalPartitionId = physicalPartition.getId();
                 for (MaterializedIndex index : physicalPartition.getMaterializedIndices(IndexExtState.ALL)) {
                     long indexId = index.getId();
-                    int schemaHash = olapTable.getSchemaHashByIndexMetaId(indexId);
                     TabletMeta tabletMeta = new TabletMeta(dbId, tableId, physicalPartitionId, indexId, medium,
                             olapTable.isCloudNativeTable());
                     for (Tablet tablet : index.getTablets()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
@@ -507,7 +507,7 @@ public class ExternalOlapTable extends OlapTable {
                     index.addTablet(tablet, tabletMeta, false);
                 }
                 if (indexMeta.getPartition_id() == physicalPartition.getId()) {
-                    if (index.getId() != baseIndexMetaId) {
+                    if (index.getMetaId() != baseIndexMetaId) {
                         physicalPartition.createRollupIndex(index);
                     } else {
                         physicalPartition.setBaseIndex(index);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -227,6 +227,11 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         return id;
     }
 
+    // TODO(wyb): fix meta id
+    public long getMetaId() {
+        return id;
+    }
+
     public void setState(IndexState state) {
         this.state = state;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -686,12 +686,12 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         this(indexMeta.getIndexMetaId(), db.getId(), mvName, indexMeta.getSchema(), indexMeta.getKeysType(),
                 partitionInfo, distributionInfo, refreshScheme);
         Preconditions.checkState(baseTable.getIndexMetaIdByName(mvName) != null);
-        long indexId = indexMeta.getIndexMetaId();
+        long indexMetaId = indexMeta.getIndexMetaId();
         this.state = baseTable.state;
-        this.baseIndexMetaId = indexMeta.getIndexMetaId();
+        this.baseIndexMetaId = indexMetaId;
 
-        this.indexNameToMetaId.put(baseTable.getIndexNameByMetaId(indexId), indexId);
-        this.indexMetaIdToMeta.put(indexId, indexMeta);
+        this.indexNameToMetaId.put(baseTable.getIndexNameByMetaId(indexMetaId), indexMetaId);
+        this.indexMetaIdToMeta.put(indexMetaId, indexMeta);
 
         this.baseTableInfos = Lists.newArrayList();
         this.baseTableInfos.add(

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MetadataViewer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MetadataViewer.java
@@ -145,7 +145,7 @@ public class MetadataViewer {
                     long visibleVersion = physicalPartition.getVisibleVersion();
 
                     for (MaterializedIndex index : physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
-                        int schemaHash = olapTable.getSchemaHashByIndexMetaId(index.getId());
+                        int schemaHash = olapTable.getSchemaHashByIndexMetaId(index.getMetaId());
                         for (Tablet tablet : index.getTablets()) {
                             long tabletId = tablet.getId();
                             int count = replicationNum;
@@ -387,7 +387,7 @@ public class MetadataViewer {
                             List<String> row = Lists.newArrayList();
                             row.add(partition.getName());
                             row.add(String.valueOf(physicalPartition.getId()));
-                            row.add(olapTable.getIndexNameByMetaId(index.getId()));
+                            row.add(olapTable.getIndexNameByMetaId(index.getMetaId()));
                             row.add(String.valueOf(rowCountStatistics.get(i)));
                             row.add(totalRowCount == 0L ? "0.00 %"
                                     : df.format((double) rowCountStatistics.get(i) / totalRowCount));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
@@ -317,8 +317,8 @@ public class SchemaInfo {
         }
     }
 
-    public static SchemaInfo fromMaterializedIndex(OlapTable table, long indexId, MaterializedIndexMeta indexMeta) {
-        List<Index> indexes = table.getBaseIndexMetaId() == indexId ? table.getCopiedIndexes() :
+    public static SchemaInfo fromMaterializedIndex(OlapTable table, long indexMetaId, MaterializedIndexMeta indexMeta) {
+        List<Index> indexes = table.getBaseIndexMetaId() == indexMetaId ? table.getCopiedIndexes() :
                 OlapTable.getIndexesBySchema(table.getCopiedIndexes(), indexMeta.getSchema());
         return SchemaInfo.newBuilder()
                 .setId(indexMeta.getSchemaId())

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -301,10 +301,10 @@ public class MaterializedViewsSystemTable extends SystemTable {
         }
 
         List<MaterializedIndexMeta> visibleMaterializedViews = olapTable.getVisibleIndexMetas();
-        long baseIdx = olapTable.getBaseIndexMetaId();
+        long baseIndexMetaId = olapTable.getBaseIndexMetaId();
         boolean caseSensitive = CaseSensibility.TABLE.getCaseSensibility();
         for (MaterializedIndexMeta mvMeta : visibleMaterializedViews) {
-            if (baseIdx == mvMeta.getIndexMetaId()) {
+            if (baseIndexMetaId == mvMeta.getIndexMetaId()) {
                 continue;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -952,9 +952,14 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             if (physicalPartition == null) {
                 throw new SchedException(Status.UNRECOVERABLE, "physical partition " + physicalPartitionId + " does not exist");
             }
-            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
+            MaterializedIndex index = physicalPartition.getIndex(indexId);
+            if (index == null) {
+                throw new SchedException(Status.UNRECOVERABLE, "materialized index " + indexId + " does not exist");
+            }
+            long indexMetaId = index.getMetaId();
+            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(indexMetaId);
             if (indexMeta == null) {
-                throw new SchedException(Status.UNRECOVERABLE, "materialized view " + indexId + " does not exist");
+                throw new SchedException(Status.UNRECOVERABLE, "materialized index meta " + indexMetaId + " does not exist");
             }
             TTabletSchema tabletSchema = SchemaInfo.newBuilder()
                     .setId(indexMeta.getSchemaId())
@@ -1082,9 +1087,9 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 throw new SchedException(Status.UNRECOVERABLE, "index does not exist");
             }
 
-            if (schemaHash != olapTable.getSchemaHashByIndexMetaId(indexId)) {
+            if (schemaHash != olapTable.getSchemaHashByIndexMetaId(index.getMetaId())) {
                 throw new SchedException(Status.UNRECOVERABLE, "schema hash is not consistent. index's: "
-                        + olapTable.getSchemaHashByIndexMetaId(indexId)
+                        + olapTable.getSchemaHashByIndexMetaId(index.getMetaId())
                         + ", task's: " + schemaHash);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -842,7 +842,7 @@ public class TabletScheduler extends FrontendDaemon {
             tabletCtx.setTabletKeysType(tbl.getKeysType());
             tabletCtx.setVersionInfo(physicalPartition.getVisibleVersion(), physicalPartition.getCommittedVersion(),
                     physicalPartition.getVisibleTxnId(), physicalPartition.getVisibleVersionTime());
-            tabletCtx.setSchemaHash(tbl.getSchemaHashByIndexMetaId(idx.getId()));
+            tabletCtx.setSchemaHash(tbl.getSchemaHashByIndexMetaId(idx.getMetaId()));
             tabletCtx.setStorageMedium(dataProperty.getStorageMedium());
             if (!Objects.equals(oldStatus, statusPair.first)) {
                 LOG.info("change TabletSchedCtx status from {} to {}, partition visible version: {}," +

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
@@ -87,7 +87,7 @@ public class IndicesProcDir implements ProcDirInterface {
             for (MaterializedIndex materializedIndex : partition.getMaterializedIndices(IndexExtState.ALL)) {
                 List<Comparable> indexInfo = new ArrayList<Comparable>();
                 indexInfo.add(materializedIndex.getId());
-                indexInfo.add(olapTable.getIndexNameByMetaId(materializedIndex.getId()));
+                indexInfo.add(olapTable.getIndexNameByMetaId(materializedIndex.getMetaId()));
                 indexInfo.add(materializedIndex.getState());
                 indexInfo.add(TimeUtils.longToTimeString(materializedIndex.getLastCheckTime()));
                 indexInfo.add(materializedIndex.getBalanceStat().toString());

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1444,7 +1444,7 @@ public class PropertyAnalyzer {
         if (parentTable.isNativeTableOrMaterializedView()) {
             OlapTable parentOlapTable = (OlapTable) parentTable;
             parentTableKeyType =
-                    parentOlapTable.getIndexMetaByIndexId(parentOlapTable.getBaseIndexMetaId()).getKeysType();
+                    parentOlapTable.getIndexMetaByMetaId(parentOlapTable.getBaseIndexMetaId()).getKeysType();
         }
 
         List<UniqueConstraint> mvUniqueConstraints = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/CheckConsistencyJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/CheckConsistencyJob.java
@@ -174,7 +174,7 @@ public class CheckConsistencyJob {
             }
 
             checkedVersion = physicalPartition.getVisibleVersion();
-            checkedSchemaHash = olapTable.getSchemaHashByIndexMetaId(tabletMeta.getIndexId());
+            checkedSchemaHash = olapTable.getSchemaHashByIndexMetaId(index.getMetaId());
 
             int sentTaskReplicaNum = 0;
             long maxDataSize = 0;
@@ -292,9 +292,9 @@ public class CheckConsistencyJob {
             }
 
             // check if schema has changed
-            if (checkedSchemaHash != olapTable.getSchemaHashByIndexMetaId(tabletMeta.getIndexId())) {
+            if (checkedSchemaHash != olapTable.getSchemaHashByIndexMetaId(index.getMetaId())) {
                 LOG.info("index[{}]'s schema hash has been changed. [{} -> {}]. retry", tabletMeta.getIndexId(),
-                            checkedSchemaHash, olapTable.getSchemaHashByIndexMetaId(tabletMeta.getIndexId()));
+                            checkedSchemaHash, olapTable.getSchemaHashByIndexMetaId(index.getMetaId()));
                 return -1;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MigrationAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MigrationAction.java
@@ -125,7 +125,7 @@ public class MigrationAction extends RestBaseAction {
                         row.add(tableName);
                         row.add(partitionName);
                         row.add(tablet.getId());
-                        row.add(olapTable.getSchemaHashByIndexMetaId(baseIndex.getId()));
+                        row.add(olapTable.getSchemaHashByIndexMetaId(baseIndex.getMetaId()));
                         if (CollectionUtils.isNotEmpty(((LocalTablet) tablet).getImmutableReplicas())) {
                             Replica replica = ((LocalTablet) tablet).getImmutableReplicas().get(0);
                             row.add(replica.getBackendId());
@@ -151,7 +151,7 @@ public class MigrationAction extends RestBaseAction {
                             row.add(tableName);
                             row.add(partitionName);
                             row.add(tablet.getId());
-                            row.add(olapTable.getSchemaHashByIndexMetaId(baseIndex.getId()));
+                            row.add(olapTable.getSchemaHashByIndexMetaId(baseIndex.getMetaId()));
                             if (CollectionUtils.isNotEmpty(((LocalTablet) tablet).getImmutableReplicas())) {
                                 Replica replica = ((LocalTablet) tablet).getImmutableReplicas().get(0);
                                 row.add(replica.getBackendId());

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RowCountAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RowCountAction.java
@@ -115,7 +115,7 @@ public class RowCountAction extends RestBaseAction {
                         indexRowCount += tablet.getRowCount(version);
                     } // end for tablets
                     index.setRowCount(indexRowCount);
-                    String indexName = olapTable.getIndexNameByMetaId(index.getId());
+                    String indexName = olapTable.getIndexNameByMetaId(index.getMetaId());
                     indexRowCountMap.put(indexName, indexRowCountMap.getOrDefault(indexName, 0L) + indexRowCount);
                 } // end for indices
             } // end for partitions            

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/TableSchemaView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/vo/TableSchemaView.java
@@ -101,7 +101,7 @@ public class TableSchemaView {
                 .ifPresent(svo::setColumns);
 
         Optional.ofNullable(table.getIndexMetaIdToMeta())
-                .map(indexIdToMetas -> indexIdToMetas.values().stream()
+                .map(indexMetaIdToMetas -> indexMetaIdToMetas.values().stream()
                         .filter(Objects::nonNull)
                         .sorted(Comparator.comparingLong(MaterializedIndexMeta::getIndexMetaId))
                         .map(MaterializedIndexMetaView::createFrom)

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -218,7 +218,7 @@ public class LakeTableHelper {
             List<Column> indexMetaSchema = indexMeta.getSchema();
             // check and restore column unique id for each schema
             if (restoreColumnUniqueId(indexMetaSchema)) {
-                LOG.info("Column unique ids in table {} with index {} have been restored, columns size: {}",
+                LOG.info("Column unique ids in table {} with index meta {} have been restored, columns size: {}",
                         table.getName(), indexMeta.getIndexMetaId(), indexMetaSchema.size());
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
@@ -32,7 +32,6 @@ import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.FsBroker;
 import com.starrocks.catalog.MaterializedIndex;
-import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionKey;
@@ -96,7 +95,7 @@ public class LakeRestoreJob extends RestoreJob {
                                   BackupJobInfo.BackupPartitionInfo backupPartInfo, boolean overwrite) {
         for (MaterializedIndex localIdx : localPartition.getDefaultPhysicalPartition()
                 .getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
-            BackupIndexInfo backupIdxInfo = backupPartInfo.getIdx(localTbl.getIndexNameByMetaId(localIdx.getId()));
+            BackupIndexInfo backupIdxInfo = backupPartInfo.getIdx(localTbl.getIndexNameByMetaId(localIdx.getMetaId()));
             Preconditions.checkState(backupIdxInfo.tablets.size() == localIdx.getTablets().size());
             for (int i = 0; i < localIdx.getTablets().size(); i++) {
                 BackupTabletInfo backupTabletInfo = backupIdxInfo.tablets.get(i);
@@ -131,7 +130,7 @@ public class LakeRestoreJob extends RestoreJob {
                         "No alive backend or compute node in %s warehouse", WarehouseManager.DEFAULT_RESOURCE);
                 LakeTableSnapshotInfo info = new LakeTableSnapshotInfo(db.getId(), idChain.getTblId(),
                         idChain.getPartId(), idChain.getIdxId(), idChain.getTabletId(),
-                        computeNodeId, tbl.getSchemaHashByIndexMetaId(index.getId()), -1);
+                        computeNodeId, tbl.getSchemaHashByIndexMetaId(index.getMetaId()), -1);
                 snapshotInfos.put(idChain.getTabletId(), computeNodeId, info);
             } catch (Exception e) {
                 LOG.error(e.getMessage(), e);
@@ -265,7 +264,6 @@ public class LakeRestoreJob extends RestoreJob {
     protected void modifyInvertedIndex(OlapTable restoreTbl, Partition restorePart) {
         for (MaterializedIndex restoredIdx : restorePart.getDefaultPhysicalPartition()
                 .getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
-            MaterializedIndexMeta indexMeta = restoreTbl.getIndexMetaByIndexId(restoredIdx.getId());
             TStorageMedium medium = restoreTbl.getPartitionInfo().getDataProperty(restorePart.getId()).getStorageMedium();
             TabletMeta tabletMeta = new TabletMeta(dbId, restoreTbl.getId(), restorePart.getId(),
                     restoredIdx.getId(), medium, true);

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -480,7 +480,7 @@ public class LeaderImpl {
         try {
             long dbId = task.getDbId();
             long tableId = task.getTableId();
-            long indexId = task.getIndexId();
+            long indexMetaId = task.getIndexId();
             long backendId = task.getBackendId();
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
             if (db != null) {
@@ -490,7 +490,7 @@ public class LeaderImpl {
                     OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                                 .getTable(db.getId(), tableId);
                     if (olapTable != null) {
-                        MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
+                        MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(indexMetaId);
                         if (indexMeta != null) {
                             indexMeta.removeUpdateSchemaBackend(backendId);
                         }
@@ -1046,7 +1046,7 @@ public class LeaderImpl {
                     indexMeta.setRollup_index_id(-1L);
                     indexMeta.setRollup_finished_version(-1L);
                     TSchemaMeta schemaMeta = new TSchemaMeta();
-                    MaterializedIndexMeta materializedIndexMeta = olapTable.getIndexMetaByIndexId(index.getId());
+                    MaterializedIndexMeta materializedIndexMeta = olapTable.getIndexMetaByMetaId(index.getMetaId());
                     schemaMeta.setSchema_version(materializedIndexMeta.getSchemaVersion());
                     schemaMeta.setSchema_hash(materializedIndexMeta.getSchemaHash());
                     schemaMeta.setShort_key_col_count(materializedIndexMeta.getShortKeyColumnCount());

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
@@ -516,18 +516,18 @@ public class DeleteMgr implements Writable, MemoryTrackable {
         }
         // check materialized index.
         // only need check the first partition because each partition has same materialized view
-        Map<Long, List<Column>> indexIdToSchema = table.getIndexIdToSchema();
+        Map<Long, List<Column>> indexMetaIdToSchema = table.getIndexMetaIdToSchema();
         PhysicalPartition partition = partitions.get(0).getDefaultPhysicalPartition();
         for (MaterializedIndex index : partition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
-            if (table.getBaseIndexMetaId() == index.getId()) {
+            if (table.getBaseIndexMetaId() == index.getMetaId()) {
                 continue;
             }
             // check table has condition column
             Map<String, Column> indexColNameToColumn = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
-            for (Column column : indexIdToSchema.get(index.getId())) {
+            for (Column column : indexMetaIdToSchema.get(index.getMetaId())) {
                 indexColNameToColumn.put(column.getName(), column);
             }
-            String indexName = table.getIndexNameByMetaId(index.getId());
+            String indexName = table.getIndexNameByMetaId(index.getMetaId());
             for (Predicate condition : conditions) {
                 String columnName = getSlotRef(condition).getColumnName();
                 Column column = indexColNameToColumn.get(columnName);
@@ -535,7 +535,7 @@ public class DeleteMgr implements Writable, MemoryTrackable {
                     ErrorReport
                             .reportDdlException(ErrorCode.ERR_BAD_FIELD_ERROR, columnName, "index[" + indexName + "]");
                 }
-                MaterializedIndexMeta indexMeta = table.getIndexMetaIdToMeta().get(index.getId());
+                MaterializedIndexMeta indexMeta = table.getIndexMetaByMetaId(index.getMetaId());
                 if (indexMeta.getKeysType() != KeysType.DUP_KEYS && !column.isKey()) {
                     throw new DdlException("Column[" + columnName + "] is not key column in index[" + indexName + "]");
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
@@ -145,11 +145,11 @@ public class OlapDeleteJob extends DeleteJob {
                 for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                     for (MaterializedIndex index : physicalPartition
                                 .getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
-                        long indexId = index.getId();
-                        int schemaHash = olapTable.getSchemaHashByIndexMetaId(indexId);
+                        long indexMetaId = index.getMetaId();
+                        int schemaHash = olapTable.getSchemaHashByIndexMetaId(indexMetaId);
 
                         List<TColumn> columnsDesc = new ArrayList<>();
-                        for (Column column : olapTable.getSchemaByIndexMetaId(indexId)) {
+                        for (Column column : olapTable.getSchemaByIndexMetaId(indexMetaId)) {
                             columnsDesc.add(column.toThrift());
                         }
 
@@ -167,7 +167,7 @@ public class OlapDeleteJob extends DeleteJob {
                                 // create push task for each replica
                                 PushTask pushTask = new PushTask(null,
                                             replica.getBackendId(), db.getId(), olapTable.getId(),
-                                            physicalPartition.getId(), indexId,
+                                            physicalPartition.getId(), index.getId(),
                                             tabletId, replicaId, schemaHash,
                                             -1, 0,
                                             -1, type, conditions,

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -173,8 +173,8 @@ public class SparkLoadJob extends BulkLoadJob {
     protected long sparkLoadSubmitTimeoutSecond = Config.spark_load_submit_timeout_second;
     // below for push task
     private final Map<Long, Set<Long>> tableToLoadPartitions = Maps.newHashMap();
-    private final Map<Long, PushBrokerReaderParams> indexToPushBrokerReaderParams = Maps.newHashMap();
-    private final Map<Long, Integer> indexToSchemaHash = Maps.newHashMap();
+    private final Map<Long, PushBrokerReaderParams> indexMetaIdToPushBrokerReaderParams = Maps.newHashMap();
+    private final Map<Long, Integer> indexMetaIdToSchemaHash = Maps.newHashMap();
     private final Map<Long, Map<Long, PushTask>> tabletToSentReplicaPushTask = Maps.newHashMap();
     private final Set<Long> finishedReplicas = Sets.newHashSet();
     private final Set<Long> quorumTablets = Sets.newHashSet();
@@ -448,11 +448,11 @@ public class SparkLoadJob extends BulkLoadJob {
     private void unprotectedPrepareLoadingInfos() {
         for (String tabletMetaStr : tabletMetaToFileInfo.keySet()) {
             String[] fileNameArr = tabletMetaStr.split("\\.");
-            // tableId.partitionId.indexId.bucket.schemaHash
+            // tableId.partitionId.indexMetaId.bucket.schemaHash
             Preconditions.checkState(fileNameArr.length == 5);
             long tableId = Long.parseLong(fileNameArr[0]);
             long partitionId = Long.parseLong(fileNameArr[1]);
-            long indexId = Long.parseLong(fileNameArr[2]);
+            long indexMetaId = Long.parseLong(fileNameArr[2]);
             int schemaHash = Integer.parseInt(fileNameArr[4]);
 
             if (!tableToLoadPartitions.containsKey(tableId)) {
@@ -460,18 +460,18 @@ public class SparkLoadJob extends BulkLoadJob {
             }
             tableToLoadPartitions.get(tableId).add(partitionId);
 
-            indexToSchemaHash.put(indexId, schemaHash);
+            indexMetaIdToSchemaHash.put(indexMetaId, schemaHash);
         }
     }
 
-    private PushBrokerReaderParams getPushBrokerReaderParams(OlapTable table, long indexId) throws StarRocksException {
-        if (!indexToPushBrokerReaderParams.containsKey(indexId)) {
+    private PushBrokerReaderParams getPushBrokerReaderParams(OlapTable table, long indexMetaId) throws StarRocksException {
+        if (!indexMetaIdToPushBrokerReaderParams.containsKey(indexMetaId)) {
             PushBrokerReaderParams pushBrokerReaderParams = new PushBrokerReaderParams();
-            pushBrokerReaderParams.init(table.getSchemaByIndexMetaId(indexId),
+            pushBrokerReaderParams.init(table.getSchemaByIndexMetaId(indexMetaId),
                     new BrokerDesc(brokerPersistInfo.getName(), brokerPersistInfo.getProperties()));
-            indexToPushBrokerReaderParams.put(indexId, pushBrokerReaderParams);
+            indexMetaIdToPushBrokerReaderParams.put(indexMetaId, pushBrokerReaderParams);
         }
-        return indexToPushBrokerReaderParams.get(indexId);
+        return indexMetaIdToPushBrokerReaderParams.get(indexMetaId);
     }
 
     private Set<Long> submitPushTasks() throws StarRocksException {
@@ -529,11 +529,11 @@ public class SparkLoadJob extends BulkLoadJob {
 
                         List<MaterializedIndex> indexes = physicalPartition.getMaterializedIndices(IndexExtState.ALL);
                         for (MaterializedIndex index : indexes) {
-                            long indexId = index.getId();
-                            int schemaHash = indexToSchemaHash.get(indexId);
+                            long indexMetaId = index.getMetaId();
+                            int schemaHash = indexMetaIdToSchemaHash.get(indexMetaId);
 
                             List<TColumn> columnsDesc = new ArrayList<TColumn>();
-                            for (Column column : table.getSchemaByIndexMetaId(indexId)) {
+                            for (Column column : table.getSchemaByIndexMetaId(indexMetaId)) {
                                 columnsDesc.add(column.toThrift());
                             }
 
@@ -542,11 +542,11 @@ public class SparkLoadJob extends BulkLoadJob {
                                 long tabletId = tablet.getId();
                                 totalTablets.add(tabletId);
                                 String tabletMetaStr = String.format("%d.%d.%d.%d.%d", tableId, partitionId,
-                                        indexId, bucket++, schemaHash);
+                                        indexMetaId, bucket++, schemaHash);
 
                                 Set<Long> tabletFinishedReplicas = Sets.newHashSet();
                                 Set<Long> tabletAllReplicas = Sets.newHashSet();
-                                PushBrokerReaderParams params = getPushBrokerReaderParams(table, indexId);
+                                PushBrokerReaderParams params = getPushBrokerReaderParams(table, indexMetaId);
 
                                 if (tablet instanceof LocalTablet) {
                                     for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
@@ -556,7 +556,7 @@ public class SparkLoadJob extends BulkLoadJob {
                                         Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
                                                 .getBackend(backendId);
 
-                                        pushTask(backendId, tableId, partitionId, indexId, tabletId,
+                                        pushTask(backendId, tableId, partitionId, index.getId(), tabletId,
                                                 replicaId, schemaHash, partitionVersion, params, batchTask, tabletMetaStr,
                                                 backend, replica, tabletFinishedReplicas,
                                                 TTabletType.TABLET_TYPE_DISK, columnsDesc);
@@ -583,7 +583,7 @@ public class SparkLoadJob extends BulkLoadJob {
                                         continue;
                                     }
 
-                                    pushTask(backend.getId(), tableId, partitionId, indexId, tabletId,
+                                    pushTask(backend.getId(), tableId, partitionId, index.getId(), tabletId,
                                             tabletId, schemaHash, partitionVersion, params, batchTask, tabletMetaStr,
                                             backend, new Replica(tabletId, backend.getId(), -1, NORMAL),
                                             tabletFinishedReplicas, TTabletType.TABLET_TYPE_LAKE, columnsDesc);
@@ -824,8 +824,8 @@ public class SparkLoadJob extends BulkLoadJob {
             // clear job infos that not persist
             resourceDesc = null;
             tableToLoadPartitions.clear();
-            indexToPushBrokerReaderParams.clear();
-            indexToSchemaHash.clear();
+            indexMetaIdToPushBrokerReaderParams.clear();
+            indexMetaIdToSchemaHash.clear();
             tabletToSentReplicaPushTask.clear();
             finishedReplicas.clear();
             quorumTablets.clear();

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
@@ -255,9 +255,9 @@ public class SparkLoadPendingTask extends LoadTask {
     private List<EtlIndex> createEtlIndexes(OlapTable table) throws LoadException {
         List<EtlIndex> etlIndexes = Lists.newArrayList();
 
-        for (Map.Entry<Long, List<Column>> entry : table.getIndexIdToSchema().entrySet()) {
-            long indexId = entry.getKey();
-            int schemaHash = table.getSchemaHashByIndexMetaId(indexId);
+        for (Map.Entry<Long, List<Column>> entry : table.getIndexMetaIdToSchema().entrySet()) {
+            long indexMetaId = entry.getKey();
+            int schemaHash = table.getSchemaHashByIndexMetaId(indexMetaId);
 
             // columns
             List<EtlColumn> etlColumns = Lists.newArrayList();
@@ -276,7 +276,7 @@ public class SparkLoadPendingTask extends LoadTask {
 
             // index type
             String indexType = null;
-            KeysType keysType = table.getKeysTypeByIndexMetaId(indexId);
+            KeysType keysType = table.getKeysTypeByIndexMetaId(indexMetaId);
             switch (keysType) {
                 case DUP_KEYS:
                     indexType = "DUPLICATE";
@@ -294,9 +294,9 @@ public class SparkLoadPendingTask extends LoadTask {
             }
 
             // is base index
-            boolean isBaseIndex = indexId == table.getBaseIndexMetaId() ? true : false;
+            boolean isBaseIndex = indexMetaId == table.getBaseIndexMetaId();
 
-            etlIndexes.add(new EtlIndex(indexId, etlColumns, schemaHash, indexType, isBaseIndex));
+            etlIndexes.add(new EtlIndex(indexMetaId, etlColumns, schemaHash, indexType, isBaseIndex));
         }
 
         return etlIndexes;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/BatchDropInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/BatchDropInfo.java
@@ -32,18 +32,19 @@ public class BatchDropInfo implements Writable {
     private long dbId;
     @SerializedName(value = "tableId")
     private long tableId;
+    // not change the SerializedName for compatibility
     @SerializedName(value = "indexIdSet")
-    private Set<Long> indexIdSet;
+    private Set<Long> indexMetaIdSet;
 
-    public BatchDropInfo(long dbId, long tableId, Set<Long> indexIdSet) {
+    public BatchDropInfo(long dbId, long tableId, Set<Long> indexMetaIdSet) {
         this.dbId = dbId;
         this.tableId = tableId;
-        this.indexIdSet = indexIdSet;
+        this.indexMetaIdSet = indexMetaIdSet;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(dbId, tableId, indexIdSet);
+        return Objects.hash(dbId, tableId, indexMetaIdSet);
     }
 
     public boolean equals(Object other) {
@@ -55,11 +56,11 @@ public class BatchDropInfo implements Writable {
         }
         BatchDropInfo otherBatchDropInfo = (BatchDropInfo) other;
         return this.dbId == otherBatchDropInfo.dbId && this.tableId == otherBatchDropInfo.tableId
-                && this.indexIdSet.equals(otherBatchDropInfo.indexIdSet);
+                && this.indexMetaIdSet.equals(otherBatchDropInfo.indexMetaIdSet);
     }
 
-    public Set<Long> getIndexIdSet() {
-        return indexIdSet;
+    public Set<Long> getIndexMetaIdSet() {
+        return indexMetaIdSet;
     }
 
     public long getDbId() {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/DropInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/DropInfo.java
@@ -43,18 +43,19 @@ public class DropInfo implements Writable {
     private long dbId;
     @SerializedName("tb")
     private long tableId;
+    // not change the SerializedName for compatibility
     @SerializedName("idx")
-    private long indexId;
+    private long indexMetaId;
     @SerializedName("fd")
     private boolean forceDrop = false;
 
     public DropInfo() {
     }
 
-    public DropInfo(long dbId, long tableId, long indexId, boolean forceDrop) {
+    public DropInfo(long dbId, long tableId, long indexMetaId, boolean forceDrop) {
         this.dbId = dbId;
         this.tableId = tableId;
-        this.indexId = indexId;
+        this.indexMetaId = indexMetaId;
         this.forceDrop = forceDrop;
     }
 
@@ -66,8 +67,8 @@ public class DropInfo implements Writable {
         return this.tableId;
     }
 
-    public long getIndexId() {
-        return this.indexId;
+    public long getIndexMetaId() {
+        return this.indexMetaId;
     }
 
     public boolean isForceDrop() {
@@ -95,7 +96,7 @@ public class DropInfo implements Writable {
 
         DropInfo info = (DropInfo) obj;
 
-        return (dbId == info.dbId) && (tableId == info.tableId) && (indexId == info.indexId)
+        return (dbId == info.dbId) && (tableId == info.tableId) && (indexMetaId == info.indexMetaId)
                 && (forceDrop == info.forceDrop);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -392,7 +392,7 @@ public class EditLog {
                 }
                 case OperationType.OP_BATCH_DROP_ROLLUP: {
                     BatchDropInfo batchDropInfo = (BatchDropInfo) journal.data();
-                    for (long indexId : batchDropInfo.getIndexIdSet()) {
+                    for (long indexId : batchDropInfo.getIndexMetaIdSet()) {
                         globalStateMgr.getRollupHandler().replayDropRollup(
                                 new DropInfo(batchDropInfo.getDbId(), batchDropInfo.getTableId(), indexId, false),
                                 globalStateMgr);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/TableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/TableInfo.java
@@ -26,8 +26,9 @@ public class TableInfo implements Writable {
     private long dbId;
     @SerializedName("tb")
     private long tableId;
+    // not change the SerializedName for compatibility
     @SerializedName("idx")
-    private long indexId;
+    private long indexMetaId;
     @SerializedName("pt")
     private long partitionId;
 
@@ -42,11 +43,11 @@ public class TableInfo implements Writable {
         // for persist
     }
 
-    private TableInfo(long dbId, long tableId, long indexId, long partitionId,
+    private TableInfo(long dbId, long tableId, long indexMetaId, long partitionId,
                       String newTableName, String newRollupName, String newPartitionName) {
         this.dbId = dbId;
         this.tableId = tableId;
-        this.indexId = indexId;
+        this.indexMetaId = indexMetaId;
         this.partitionId = partitionId;
 
         this.newTableName = newTableName;
@@ -58,8 +59,8 @@ public class TableInfo implements Writable {
         return new TableInfo(dbId, tableId, -1L, -1L, newTableName, "", "");
     }
 
-    public static TableInfo createForRollupRename(long dbId, long tableId, long indexId, String newRollupName) {
-        return new TableInfo(dbId, tableId, indexId, -1L, "", newRollupName, "");
+    public static TableInfo createForRollupRename(long dbId, long tableId, long indexMetaId, String newRollupName) {
+        return new TableInfo(dbId, tableId, indexMetaId, -1L, "", newRollupName, "");
     }
 
     public static TableInfo createForPartitionRename(long dbId, long tableId, long partitionId,
@@ -79,8 +80,8 @@ public class TableInfo implements Writable {
         return tableId;
     }
 
-    public long getIndexId() {
-        return indexId;
+    public long getIndexMetaId() {
+        return indexMetaId;
     }
 
     public long getPartitionId() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AbstractOlapTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AbstractOlapTableScanNode.java
@@ -73,7 +73,7 @@ public abstract class AbstractOlapTableScanNode extends ScanNode {
     /** Selected materialized index to scan. */
     protected static class SelectedMaterializedIndex {
 
-        final long indexId;
+        final long indexMetaId;
         final long schemaId;
 
         /**
@@ -88,26 +88,26 @@ public abstract class AbstractOlapTableScanNode extends ScanNode {
          */
         private final Optional<SchemaInfo> cachedSchema;
 
-        private SelectedMaterializedIndex(long indexId, long schemaId, @Nullable SchemaInfo cachedSchema) {
-            this.indexId = indexId;
+        private SelectedMaterializedIndex(long indexMetaId, long schemaId, @Nullable SchemaInfo cachedSchema) {
+            this.indexMetaId = indexMetaId;
             this.schemaId = schemaId;
             this.cachedSchema = Optional.ofNullable(cachedSchema);
         }
 
-        static SelectedMaterializedIndex build(OlapTable olapTable, long selectedIndexId) {
-            long indexId = selectedIndexId == -1 ? olapTable.getBaseIndexMetaId() : selectedIndexId;
-            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
+        static SelectedMaterializedIndex build(OlapTable olapTable, long selectedIndexMetaId) {
+            long indexMetaId = selectedIndexMetaId == -1 ? olapTable.getBaseIndexMetaId() : selectedIndexMetaId;
+            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(indexMetaId);
             if (indexMeta == null) {
                 throw new RuntimeException(String.format(
-                        "can't find index, table name: %s, table id: %s, index id: %s",
-                        olapTable.getName(), olapTable.getId(), indexId));
+                        "can't find index, table name: %s, table id: %s, index meta id: %s",
+                        olapTable.getName(), olapTable.getId(), indexMetaId));
             }
             long schemaId = indexMeta.getSchemaId();
             SchemaInfo schema = null;
             if (olapTable.isCloudNativeTableOrMaterializedView()) {
-                schema = SchemaInfo.fromMaterializedIndex(olapTable, indexId, indexMeta);
+                schema = SchemaInfo.fromMaterializedIndex(olapTable, indexMetaId, indexMeta);
             }
-            return new SelectedMaterializedIndex(indexId, schemaId, schema);
+            return new SelectedMaterializedIndex(indexMetaId, schemaId, schema);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
@@ -96,7 +96,7 @@ public class MetaScanNode extends AbstractOlapTableScanNode {
 
         for (PhysicalPartition partition : partitions) {
             MaterializedIndex index = partition.getBaseIndex();
-            int schemaHash = olapTable.getSchemaHashByIndexMetaId(index.getId());
+            int schemaHash = olapTable.getSchemaHashByIndexMetaId(index.getMetaId());
             List<Tablet> tablets = index.getTablets();
 
             long visibleVersion = partition.getVisibleVersion();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -442,13 +442,13 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             Long physicalPartitionId = internalScanRange.partition_id;
 
             PhysicalPartition physicalPartition = olapTable.getPhysicalPartition(physicalPartitionId);
-            final MaterializedIndex selectedTable = physicalPartition.getIndex(index.indexId);
+            final MaterializedIndex selectedTable = physicalPartition.getIndex(index.indexMetaId);
             final Tablet selectedTablet = selectedTable.getTablet(tabletId);
             if (selectedTablet == null) {
                 throw new StarRocksException("Tablet " + tabletId + " doesn't exist in partition " + physicalPartitionId);
             }
 
-            int schemaHash = olapTable.getSchemaHashByIndexMetaId(selectedTable.getId());
+            int schemaHash = olapTable.getSchemaHashByIndexMetaId(selectedTable.getMetaId());
             if (schemaHash != expectedSchemaHash) {
                 throw new StarRocksException("Tablet " + tabletId + " schema hash " + schemaHash +
                         " has changed, doesn't equal to expected schema hash " + expectedSchemaHash);
@@ -550,7 +550,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         boolean skipDiskCache = ConnectContext.get() != null && ConnectContext.get().getSessionVariable().isSkipLocalDiskCache();
         boolean skipPageCache = ConnectContext.get() != null && ConnectContext.get().getSessionVariable().isSkipPageCache();
         int logNum = 0;
-        int schemaHash = olapTable.getSchemaHashByIndexMetaId(index.getId());
+        int schemaHash = olapTable.getSchemaHashByIndexMetaId(index.getMetaId());
         String schemaHashStr = String.valueOf(schemaHash);
         long visibleVersion = physicalPartition.getVisibleVersion();
         scanPartitionVersions.put(physicalPartition.getId(), visibleVersion);
@@ -727,7 +727,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         if (selectedPartitionIds.size() == 0) {
             return;
         }
-        Preconditions.checkState(index.indexId != -1);
+        Preconditions.checkState(index.indexMetaId != -1);
         // compute tablet info by selected index id and selected partition ids
         long start = System.currentTimeMillis();
         computeTabletInfo();
@@ -751,7 +751,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
 
             for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                 final List<Tablet> tablets = Lists.newArrayList();
-                final MaterializedIndex selectedIndex = physicalPartition.getIndex(index.indexId);
+                final MaterializedIndex selectedIndex = physicalPartition.getIndex(index.indexMetaId);
                 final Collection<Long> tabletIds = distributionPrune(selectedIndex, partition.getDistributionInfo());
                 LOG.debug("distribution prune tablets: {}", tabletIds);
 
@@ -784,7 +784,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             Collection<PhysicalPartition> physicalPartitions = partition.getSubPartitions();
             totalPartitionNum += physicalPartitions.size();
             for (PhysicalPartition physicalPartition : physicalPartitions) {
-                final MaterializedIndex selectedTable = physicalPartition.getIndex(index.indexId);
+                final MaterializedIndex selectedTable = physicalPartition.getIndex(index.indexMetaId);
                 totalTabletsNum += selectedTable.getTablets().size();
             }
         }
@@ -817,13 +817,13 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         StringBuilder output = new StringBuilder();
 
         // TODO: unify them
-        long selectedIndexId = index.indexId;
+        long selectedIndexMetaId = index.indexMetaId;
         if (detailLevel != TExplainLevel.VERBOSE) {
             output.append(prefix).append("TABLE: ").append(olapTable.getName()).append("\n");
         } else {
             output.append(prefix).append("table: ").append(olapTable.getName())
                     .append(", ").append("rollup: ")
-                    .append(olapTable.getIndexNameByMetaId(selectedIndexId)).append("\n");
+                    .append(olapTable.getIndexNameByMetaId(selectedIndexMetaId)).append("\n");
         }
 
         if (null != sortColumn) {
@@ -901,7 +901,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             output.append(prefix).append(String.format("partitions=%s/%s\n", selectedPartitionNum,
                     olapTable.getVisiblePartitionNames().size()));
 
-            String indexName = olapTable.getIndexNameByMetaId(selectedIndexId);
+            String indexName = olapTable.getIndexNameByMetaId(selectedIndexMetaId);
             output.append(prefix).append(String.format("rollup: %s\n", indexName));
 
             output.append(prefix).append(String.format("tabletRatio=%s/%s\n", selectedTabletsNum, totalTabletsNum));
@@ -1023,12 +1023,12 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             msg.setCommon(common);
         }
 
-        long selectedIndexId = index.indexId;
-        if (selectedIndexId != -1) {
-            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(selectedIndexId);
+        long selectedIndexMetaId = index.indexMetaId;
+        if (selectedIndexMetaId != -1) {
+            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(selectedIndexMetaId);
             if (indexMeta != null) {
                 schemaId = indexMeta.getSchemaId();
-                for (Column col : olapTable.getSchemaByIndexMetaId(selectedIndexId)) {
+                for (Column col : olapTable.getSchemaByIndexMetaId(selectedIndexMetaId)) {
                     TColumn tColumn = col.toThrift();
                     tColumn.setColumn_name(col.getColumnId().getId());
                     col.setIndexFlag(tColumn, olapTable.getIndexes(), bfColumns);
@@ -1042,7 +1042,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                         keyColumnTypes.add(TypeSerializer.toThrift(col.getPrimitiveType()));
                     }
                 } else {
-                    for (Column col : olapTable.getSchemaByIndexMetaId(selectedIndexId)) {
+                    for (Column col : olapTable.getSchemaByIndexMetaId(selectedIndexMetaId)) {
                         if (!col.isKey()) {
                             continue;
                         }
@@ -1060,7 +1060,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             msg.lake_scan_node =
                     new TLakeScanNode(desc.getId().asInt(), keyColumnNames, keyColumnTypes, isPreAggregation);
             msg.lake_scan_node.setSort_key_column_names(keyColumnNames);
-            msg.lake_scan_node.setRollup_name(olapTable.getIndexNameByMetaId(selectedIndexId));
+            msg.lake_scan_node.setRollup_name(olapTable.getIndexNameByMetaId(selectedIndexMetaId));
             if (enableTopnFilterBackPressure) {
                 msg.lake_scan_node.setEnable_topn_filter_back_pressure(true);
                 msg.lake_scan_node.setBack_pressure_max_rounds(backPressureMaxRounds);
@@ -1110,7 +1110,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             msg.olap_scan_node.setColumns_desc(columnsDesc);
             msg.olap_scan_node.setSchema_id(schemaId);
             msg.olap_scan_node.setSort_key_column_names(keyColumnNames);
-            msg.olap_scan_node.setRollup_name(olapTable.getIndexNameByMetaId(selectedIndexId));
+            msg.olap_scan_node.setRollup_name(olapTable.getIndexNameByMetaId(selectedIndexMetaId));
             if (enableTopnFilterBackPressure) {
                 msg.olap_scan_node.setEnable_topn_filter_back_pressure(true);
                 msg.olap_scan_node.setBack_pressure_max_rounds(backPressureMaxRounds);
@@ -1233,17 +1233,17 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             return false;
         }
         ConnectContext ctx = ConnectContext.get();
-        long selectedIndexId = index.indexId;
+        long selectedIndexMetaId = index.indexMetaId;
         int backendSize = ctx.getTotalBackendNumber();
         int aliveBackendSize = ctx.getAliveBackendNumber();
-        int schemaHash = olapTable.getSchemaHashByIndexMetaId(selectedIndexId);
+        int schemaHash = olapTable.getSchemaHashByIndexMetaId(selectedIndexMetaId);
         for (Map.Entry<Long, List<Long>> entry : partitionToScanTabletMap.entrySet()) {
             PhysicalPartition partition = olapTable.getPhysicalPartition(entry.getKey());
             if (olapTable.getPartitionInfo().getReplicationNum(partition.getParentId()) < backendSize) {
                 return false;
             }
             long visibleVersion = partition.getVisibleVersion();
-            MaterializedIndex materializedIndex = partition.getIndex(selectedIndexId);
+            MaterializedIndex materializedIndex = partition.getIndex(selectedIndexMetaId);
             for (Long id : entry.getValue()) {
                 LocalTablet tablet = (LocalTablet) materializedIndex.getTablet(id);
                 if (tablet.getQueryableReplicasSize(visibleVersion, schemaHash) != aliveBackendSize) {
@@ -1256,8 +1256,8 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
     }
 
     @VisibleForTesting
-    public long getSelectedIndexId() {
-        return index.indexId;
+    public long getSelectedIndexMetaId() {
+        return index.indexMetaId;
     }
 
     /**
@@ -1472,7 +1472,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                 return false;
             case DUP_KEYS:
             case AGG_KEYS: {
-                List<Column> columns = olapTable.getSchemaByIndexMetaId(index.indexId);
+                List<Column> columns = olapTable.getSchemaByIndexMetaId(index.indexMetaId);
                 return columns.stream().noneMatch(
                         c -> c.isAggregated() && c.getAggregationType().isReplaceFamily());
             }
@@ -1493,13 +1493,13 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         // In a conclusion, only the leftmost OlapScanNode affects multi-version cache and partition
         // column predicates' decomposition mechanism. OlapScanNodes in the right-sibling Fragment only
         // affect cache key identity.
-        long selectedIndexId = index.indexId;
+        long selectedIndexMetaId = index.indexMetaId;
         if (normalizer.isProcessingLeftNode()) {
             normalizer.setKeysType(olapTable.getKeysType());
             normalizer.setCanUseMultiVersion(canUseMultiVersionCache());
 
-            List<Column> columns = selectedIndexId == -1 ? olapTable.getBaseSchema() :
-                    olapTable.getSchemaByIndexMetaId(selectedIndexId);
+            List<Column> columns = selectedIndexMetaId == -1 ? olapTable.getBaseSchema() :
+                    olapTable.getSchemaByIndexMetaId(selectedIndexMetaId);
 
             Set<String> aggColumnNames =
                     columns.stream().filter(Column::isAggregated).map(Column::getName).collect(Collectors.toSet());
@@ -1531,11 +1531,11 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         }
 
         scanNode.setTablet_id(olapTable.getId());
-        scanNode.setIndex_id(selectedIndexId);
+        scanNode.setIndex_id(selectedIndexMetaId);
         List<String> keyColumnNames = new ArrayList<String>();
         List<TPrimitiveType> keyColumnTypes = new ArrayList<TPrimitiveType>();
-        if (selectedIndexId != -1) {
-            for (Column col : olapTable.getSchemaByIndexMetaId(selectedIndexId)) {
+        if (selectedIndexMetaId != -1) {
+            for (Column col : olapTable.getSchemaByIndexMetaId(selectedIndexMetaId)) {
                 if (!col.isKey()) {
                     break;
                 }
@@ -1547,7 +1547,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         scanNode.setKey_column_types(keyColumnTypes);
         scanNode.setIs_preaggregation(isPreAggregation);
         scanNode.setSort_column(sortColumn);
-        scanNode.setRollup_name(olapTable.getIndexNameByMetaId(selectedIndexId));
+        scanNode.setRollup_name(olapTable.getIndexNameByMetaId(selectedIndexMetaId));
 
         List<Integer> dictStringIds =
                 dictStringIdToIntIds.keySet().stream().sorted(Integer::compareTo).collect(Collectors.toList());
@@ -1567,7 +1567,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         for (Long partitionId : selectedPartitionIds) {
             Partition partition = olapTable.getPartition(partitionId);
             for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
-                MaterializedIndex materializedIndex = physicalPartition.getIndex(index.indexId);
+                MaterializedIndex materializedIndex = physicalPartition.getIndex(index.indexMetaId);
                 for (long tabletId : materializedIndex.getTabletIdsInOrder()) {
                     tabletToPartitionMap.put(tabletId, physicalPartition.getId());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -394,7 +394,7 @@ public class OlapTableSink extends DataSink {
         TOlapTableSchemaParam schemaParam = new TOlapTableSchemaParam();
         schemaParam.setDb_id(dbId);
         schemaParam.setTable_id(table.getId());
-        schemaParam.setVersion(table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaVersion());
+        schemaParam.setVersion(table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaVersion());
 
         schemaParam.tuple_desc = tupleDescriptor.toThrift();
         for (SlotDescriptor slotDesc : tupleDescriptor.getSlots()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -814,10 +814,10 @@ public class ShowMaterializedViewStatus {
         try {
             return ShowMaterializedViewStatus.of(dbName, olapTable, mvMeta);
         } catch (Exception e) {
-            final long mvId = mvMeta.getIndexMetaId();
-            LOG.warn("get sync mv status failed, mvId: {}, dbName: {}, mvName: {}, error: {}",
-                    mvId, dbName, olapTable.getIndexNameByMetaId(mvId), e.getMessage());
-            return new ShowMaterializedViewStatus(mvId, dbName, olapTable.getIndexNameByMetaId(mvId));
+            final long indexMetaId = mvMeta.getIndexMetaId();
+            LOG.warn("get sync mv status failed, mv meta Id: {}, dbName: {}, mvName: {}, error: {}",
+                    indexMetaId, dbName, olapTable.getIndexNameByMetaId(indexMetaId), e.getMessage());
+            return new ShowMaterializedViewStatus(indexMetaId, dbName, olapTable.getIndexNameByMetaId(indexMetaId));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
@@ -761,7 +761,7 @@ public class ReplicationJob implements GsonPostProcessable {
             TabletInfo tabletInfo = initTabletInfo(tTabletInfo, tablet);
             tabletInfos.put(tabletInfo.getTabletId(), tabletInfo);
         }
-        int schemaHash = olapTable.getSchemaHashByIndexMetaId(tIndexInfo.index_id);
+        int schemaHash = olapTable.getSchemaHashByIndexMetaId(index.getMetaId());
         return new IndexInfo(tIndexInfo.index_id, schemaHash, tIndexInfo.src_schema_hash, tabletInfos);
     }
 
@@ -821,10 +821,10 @@ public class ReplicationJob implements GsonPostProcessable {
             PhysicalPartition srcPartition, SystemInfoService srcSystemInfoService) {
         Map<Long, IndexInfo> indexInfos = Maps.newHashMap();
         for (Map.Entry<String, Long> indexNameToId : table.getIndexNameToMetaId().entrySet()) {
-            long indexId = indexNameToId.getValue();
-            long srcIndexId = srcTable.getIndexMetaIdByName(indexNameToId.getKey());
-            MaterializedIndex index = partition.getIndex(indexId);
-            MaterializedIndex srcIndex = srcPartition.getIndex(srcIndexId);
+            long indexMetaId = indexNameToId.getValue();
+            long srcIndexMetaId = srcTable.getIndexMetaIdByName(indexNameToId.getKey());
+            MaterializedIndex index = partition.getIndex(indexMetaId);
+            MaterializedIndex srcIndex = srcPartition.getIndex(srcIndexMetaId);
             IndexInfo indexInfo = initIndexInfo(table, srcTable, index, srcIndex, srcSystemInfoService);
             indexInfos.put(indexInfo.getIndexId(), indexInfo);
         }
@@ -835,8 +835,8 @@ public class ReplicationJob implements GsonPostProcessable {
     private static IndexInfo initIndexInfo(OlapTable table, OlapTable srcTable, MaterializedIndex index,
             MaterializedIndex srcIndex,
             SystemInfoService srcSystemInfoService) {
-        int schemaHash = table.getSchemaHashByIndexMetaId(index.getId());
-        int srcSchemaHash = srcTable.getSchemaHashByIndexMetaId(srcIndex.getId());
+        int schemaHash = table.getSchemaHashByIndexMetaId(index.getMetaId());
+        int srcSchemaHash = srcTable.getSchemaHashByIndexMetaId(srcIndex.getMetaId());
 
         Map<Long, TabletInfo> tabletInfos = Maps.newHashMap();
         List<Tablet> tablets = index.getTablets();

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -277,9 +277,9 @@ public class OlapTableFactory implements AbstractTableFactory {
         try {
             table.setComment(stmt.getComment());
 
-            // set base index id
-            long baseIndexId = metastore.getNextId();
-            table.setBaseIndexMetaId(baseIndexId);
+            // set base index meta id
+            long baseIndexMetaId = metastore.getNextId();
+            table.setBaseIndexMetaId(baseIndexMetaId);
 
             // get use light schema change
             try {
@@ -670,18 +670,18 @@ public class OlapTableFactory implements AbstractTableFactory {
             int schemaHash = Util.schemaHash(schemaVersion, baseSchema, bfColumns, bfFpp);
 
             if (stmt.getOrderByElements() != null) {
-                table.setIndexMeta(baseIndexId, tableName, baseSchema, schemaVersion, schemaHash,
+                table.setIndexMeta(baseIndexMetaId, tableName, baseSchema, schemaVersion, schemaHash,
                         shortKeyColumnCount, baseIndexStorageType, keysType, null, sortKeyIdxes,
                         sortKeyUniqueIds);
             } else {
-                table.setIndexMeta(baseIndexId, tableName, baseSchema, schemaVersion, schemaHash,
+                table.setIndexMeta(baseIndexMetaId, tableName, baseSchema, schemaVersion, schemaHash,
                         shortKeyColumnCount, baseIndexStorageType, keysType, null);
             }
 
             for (AlterClause alterClause : stmt.getRollupAlterClauseList()) {
                 AddRollupClause addRollupClause = (AddRollupClause) alterClause;
 
-                Long baseRollupIndex = table.getIndexMetaIdByName(tableName);
+                Long baseRollupIndexMetaId = table.getIndexMetaIdByName(tableName);
 
                 // get storage type for rollup index
                 TStorageType rollupIndexStorageType = null;
@@ -693,12 +693,12 @@ public class OlapTableFactory implements AbstractTableFactory {
                 Preconditions.checkNotNull(rollupIndexStorageType);
                 // set rollup index meta to olap table
                 List<Column> rollupColumns = stateMgr.getRollupHandler().checkAndPrepareMaterializedView(addRollupClause,
-                        table, baseRollupIndex);
+                        table, baseRollupIndexMetaId);
                 short rollupShortKeyColumnCount =
                         GlobalStateMgr.calcShortKeyColumnCount(rollupColumns, addRollupClause.getProperties());
                 int rollupSchemaHash = Util.schemaHash(schemaVersion, rollupColumns, bfColumns, bfFpp);
-                long rollupIndexId = metastore.getNextId();
-                table.setIndexMeta(rollupIndexId, addRollupClause.getRollupName(), rollupColumns, schemaVersion,
+                long rollupIndexMetaId = metastore.getNextId();
+                table.setIndexMeta(rollupIndexMetaId, addRollupClause.getRollupName(), rollupColumns, schemaVersion,
                         rollupSchemaHash, rollupShortKeyColumnCount, rollupIndexStorageType, keysType);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -321,7 +321,7 @@ public class InformationSchemaDataSource {
         tableConfigInfo.setDistribute_key(distributionInfo.getDistributionKey(olapTable.getIdToColumn()));
 
         // SORT KEYS
-        MaterializedIndexMeta index = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexMetaId());
+        MaterializedIndexMeta index = olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId());
         if (index.getSortKeyIdxes() == null) {
             tableConfigInfo.setSort_key(pkSb);
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
@@ -194,7 +194,7 @@ public class Explain {
             PhysicalOlapScanOperator scan = (PhysicalOlapScanOperator) optExpression.getOp();
 
             StringBuilder sb = new StringBuilder("- SCAN [")
-                    .append(((OlapTable) scan.getTable()).getIndexNameByMetaId(scan.getSelectedIndexId()))
+                    .append(((OlapTable) scan.getTable()).getIndexNameByMetaId(scan.getSelectedIndexMetaId()))
                     .append("]")
                     .append(buildOutputColumns(scan,
                             "[" + scan.getOutputColumns().stream().map(EXPR_PRINTER::print)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -979,7 +979,7 @@ public class InsertPlanner {
         Preconditions.checkState(columns.size() == outputColumns.size(),
                 "outputColumn's size must equal with table's column size");
 
-        List<Column> keyColumns = table.getKeyColumnsByIndexId(table.getBaseIndexMetaId());
+        List<Column> keyColumns = table.getKeyColumnsByIndexMetaId(table.getBaseIndexMetaId());
         List<Integer> keyColumnIds = Lists.newArrayList();
         keyColumns.forEach(column -> {
             int index = columns.indexOf(column);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
@@ -339,7 +339,7 @@ public class LoadPlanner {
                 fragments.add(scanFragment);
 
                 // Exchange node
-                List<Column> keyColumns = olapDestTable.getKeyColumnsByIndexId(olapDestTable.getBaseIndexMetaId());
+                List<Column> keyColumns = olapDestTable.getKeyColumnsByIndexMetaId(olapDestTable.getBaseIndexMetaId());
                 List<Expr> partitionExprs = Lists.newArrayList();
                 keyColumns.forEach(column -> {
                     partitionExprs.add(new SlotRef(tupleDesc.getColumnSlot(column.getName())));
@@ -610,7 +610,7 @@ public class LoadPlanner {
         }
 
         if (KeysType.AGG_KEYS.equals(olapDestTable.getKeysType())) {
-            for (Map.Entry<Long, List<Column>> entry : olapDestTable.getIndexIdToSchema().entrySet()) {
+            for (Map.Entry<Long, List<Column>> entry : olapDestTable.getIndexMetaIdToSchema().entrySet()) {
                 List<Column> schema = entry.getValue();
                 for (Column column : schema) {
                     if (column.getAggregationType() == AggregateType.REPLACE

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -987,11 +987,11 @@ public class AnalyzerUtils {
          */
         class TableIndexId {
             long tableId;
-            long baseIndexId;
+            long baseIndexMetaId;
 
-            public TableIndexId(long tableId, long indexId) {
+            public TableIndexId(long tableId, long indexMetaId) {
                 this.tableId = tableId;
-                this.baseIndexId = indexId;
+                this.baseIndexMetaId = indexMetaId;
             }
 
             @Override
@@ -1003,12 +1003,12 @@ public class AnalyzerUtils {
                     return false;
                 }
                 TableIndexId that = (TableIndexId) o;
-                return tableId == that.tableId && baseIndexId == that.baseIndexId;
+                return tableId == that.tableId && baseIndexMetaId == that.baseIndexMetaId;
             }
 
             @Override
             public int hashCode() {
-                return Objects.hash(tableId, baseIndexId);
+                return Objects.hash(tableId, baseIndexMetaId);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -206,7 +206,7 @@ public class AstToStringBuilder {
             }
 
             // order by
-            MaterializedIndexMeta index = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexMetaId());
+            MaterializedIndexMeta index = olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId());
             if (index.getSortKeyIdxes() != null) {
                 sb.append("\nORDER BY(");
                 List<String> sortKeysColumnNames = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
@@ -402,7 +402,7 @@ public class ShowStmtAnalyzer {
                             for (MaterializedIndexMeta mvMeta : olapTable.getVisibleIndexMetas()) {
                                 if (olapTable.getIndexNameByMetaId(mvMeta.getIndexMetaId())
                                         .equalsIgnoreCase(node.getTableName())) {
-                                    List<Column> columns = olapTable.getIndexIdToSchema().get(mvMeta.getIndexMetaId());
+                                    List<Column> columns = olapTable.getSchemaByIndexMetaId(mvMeta.getIndexMetaId());
                                     for (Column column : columns) {
                                         // Extra string (aggregation and bloom filter)
                                         List<String> extras = Lists.newArrayList();
@@ -455,23 +455,23 @@ public class ShowStmtAnalyzer {
                         node.setOlapTable(true);
                         OlapTable olapTable = (OlapTable) table;
                         Set<String> bfColumns = olapTable.getBfColumnNames();
-                        Map<Long, List<Column>> indexIdToSchema = olapTable.getIndexIdToSchema();
+                        Map<Long, List<Column>> indexMetaIdToSchema = olapTable.getIndexMetaIdToSchema();
 
                         // indices order
                         List<Long> indices = Lists.newArrayList();
                         indices.add(olapTable.getBaseIndexMetaId());
-                        for (Long indexId : indexIdToSchema.keySet()) {
-                            if (indexId != olapTable.getBaseIndexMetaId()) {
-                                indices.add(indexId);
+                        for (Long indexMetaId : indexMetaIdToSchema.keySet()) {
+                            if (indexMetaId != olapTable.getBaseIndexMetaId()) {
+                                indices.add(indexMetaId);
                             }
                         }
 
                         // add all indices
                         for (int i = 0; i < indices.size(); ++i) {
-                            long indexId = indices.get(i);
-                            List<Column> columns = indexIdToSchema.get(indexId);
-                            String indexName = olapTable.getIndexNameByMetaId(indexId);
-                            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
+                            long indexMetaId = indices.get(i);
+                            List<Column> columns = indexMetaIdToSchema.get(indexMetaId);
+                            String indexName = olapTable.getIndexNameByMetaId(indexMetaId);
+                            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(indexMetaId);
                             for (int j = 0; j < columns.size(); ++j) {
                                 Column column = columns.get(j);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/DebugOperatorTracer.java
@@ -145,7 +145,7 @@ public class DebugOperatorTracer extends OperatorVisitor<String, Void> {
     public String visitLogicalOlapScan(LogicalOlapScanOperator node, Void context) {
         return "LogicalOlapScanOperator" + " {" + "table=" + node.getTable().getName() +
                 ", selectedPartitionId=" + node.getSelectedPartitionId() +
-                ", selectedIndexId=" + node.getSelectedIndexId() +
+                ", selectedIndexMetaId=" + node.getSelectedIndexMetaId() +
                 ", outputColumns=" + new ArrayList<>(node.getColRefToColumnMetaMap().keySet()) +
                 ", prunedPartitionPredicates=" + node.getPrunedPartitionPredicates() +
                 ", limit=" + node.getLimit() +
@@ -381,7 +381,7 @@ public class DebugOperatorTracer extends OperatorVisitor<String, Void> {
     public String visitPhysicalOlapScan(PhysicalOlapScanOperator node, Void context) {
         return "PhysicalOlapScanOperator" + " {" + "table=" + node.getTable().getId() +
                 ", selectedPartitionId=" + node.getSelectedPartitionId() +
-                ", selectedIndexId=" + node.getSelectedIndexId() +
+                ", selectedIndexMetaId=" + node.getSelectedIndexMetaId() +
                 ", outputColumns=" + node.getOutputColumns() +
                 ", prunedPartitionPredicates=" + node.getPrunedPartitionPredicates() +
                 ", limit=" + node.getLimit() +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -269,7 +269,7 @@ public class MetaUtils {
 
     public static List<Column> getRangeDistributionColumns(OlapTable olapTable) {
         List<Column> columns = new ArrayList<>();
-        MaterializedIndexMeta baseIndexMeta = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexMetaId());
+        MaterializedIndexMeta baseIndexMeta = olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId());
         List<Column> baseSchema = olapTable.getBaseSchema();
         if (baseIndexMeta.getSortKeyIdxes() != null) {
             for (Integer i : baseIndexMeta.getSortKeyIdxes()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -654,8 +654,8 @@ public class MvRewritePreprocessor {
     private Set<MaterializedView> getTableRelatedSyncMVs(OlapTable olapTable) {
         Set<MaterializedView> relatedMvs = Sets.newHashSet();
         for (MaterializedIndexMeta indexMeta : olapTable.getVisibleIndexMetas()) {
-            long indexId = indexMeta.getIndexMetaId();
-            if (indexMeta.getIndexMetaId() == olapTable.getBaseIndexMetaId()) {
+            long indexMetaId = indexMeta.getIndexMetaId();
+            if (indexMetaId == olapTable.getBaseIndexMetaId()) {
                 continue;
             }
             // Old sync mv may not contain the index define sql.
@@ -671,7 +671,7 @@ public class MvRewritePreprocessor {
             try {
                 long dbId = indexMeta.getDbId();
                 String viewDefineSql = indexMeta.getViewDefineSql();
-                String mvName = olapTable.getIndexNameByMetaId(indexId);
+                String mvName = olapTable.getIndexNameByMetaId(indexMetaId);
                 Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
 
                 // distribution info
@@ -723,7 +723,7 @@ public class MvRewritePreprocessor {
                 }
 
                 mv.setViewDefineSql(viewDefineSql);
-                mv.setBaseIndexMetaId(indexId);
+                mv.setBaseIndexMetaId(indexMetaId);
                 relatedMvs.add(mv);
             } catch (Exception e) {
                 logMVPrepare(connectContext, "Fail to get the related sync materialized views from table:{}, " +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/DesensitizedSQLBuilder.java
@@ -663,7 +663,7 @@ public class DesensitizedSQLBuilder {
             sb.append(desensitizeDistributionInfo(olapTable.getIdToColumn(), distributionInfo));
 
             // order by
-            MaterializedIndexMeta index = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexMetaId());
+            MaterializedIndexMeta index = olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId());
             if (index.getSortKeyIdxes() != null) {
                 sb.append("\nORDER BY(");
                 List<String> sortKeysColumnNames = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
@@ -37,7 +37,7 @@ import java.util.Objects;
 
 public final class LogicalOlapScanOperator extends LogicalScanOperator {
     private DistributionSpec distributionSpec;
-    private long selectedIndexId;
+    private long selectedIndexMetaId;
     private List<Long> selectedPartitionId;
     private PartitionNames partitionNames;
     private boolean hasTableHints;
@@ -86,7 +86,7 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
             DistributionSpec distributionSpec,
             long limit,
             ScalarOperator predicate,
-            long selectedIndexId,
+            long selectedIndexMetaId,
             List<Long> selectedPartitionId,
             PartitionNames partitionNames,
             boolean hasTableHints,
@@ -99,7 +99,7 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
 
         Preconditions.checkState(table instanceof OlapTable);
         this.distributionSpec = distributionSpec;
-        this.selectedIndexId = selectedIndexId;
+        this.selectedIndexMetaId = selectedIndexMetaId;
         this.selectedPartitionId = selectedPartitionId;
         this.partitionNames = partitionNames;
         this.hasTableHints = hasTableHints;
@@ -119,8 +119,8 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
         return distributionSpec;
     }
 
-    public long getSelectedIndexId() {
-        return selectedIndexId;
+    public long getSelectedIndexMetaId() {
+        return selectedIndexMetaId;
     }
 
     public List<Long> getSelectedPartitionId() {
@@ -205,7 +205,7 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
         }
 
         LogicalOlapScanOperator that = (LogicalOlapScanOperator) o;
-        return selectedIndexId == that.selectedIndexId &&
+        return selectedIndexMetaId == that.selectedIndexMetaId &&
                 gtid == that.gtid &&
                 Objects.equals(distributionSpec, that.distributionSpec) &&
                 Objects.equals(selectedPartitionId, that.selectedPartitionId) &&
@@ -218,7 +218,7 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), selectedIndexId, gtid, selectedPartitionId,
+        return Objects.hash(super.hashCode(), selectedIndexMetaId, gtid, selectedPartitionId,
                 selectedTabletId, hintsTabletIds, hintsReplicaIds, sample);
     }
 
@@ -238,7 +238,7 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
             super.withOperator(scanOperator);
 
             builder.distributionSpec = scanOperator.distributionSpec;
-            builder.selectedIndexId = scanOperator.selectedIndexId;
+            builder.selectedIndexMetaId = scanOperator.selectedIndexMetaId;
             builder.gtid = scanOperator.gtid;
             builder.selectedPartitionId = scanOperator.selectedPartitionId;
             builder.partitionNames = scanOperator.partitionNames;
@@ -255,7 +255,7 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
         }
 
         public Builder setSelectedIndexId(long selectedIndexId) {
-            builder.selectedIndexId = selectedIndexId;
+            builder.selectedIndexMetaId = selectedIndexId;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
@@ -46,7 +46,7 @@ import java.util.Set;
 
 public class PhysicalOlapScanOperator extends PhysicalScanOperator {
     private DistributionSpec distributionSpec;
-    private long selectedIndexId;
+    private long selectedIndexMetaId;
     private List<Long> selectedTabletId;
     private List<Long> hintsReplicaId;
     private List<Long> selectedPartitionId;
@@ -79,7 +79,7 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
                                     DistributionSpec distributionDesc,
                                     long limit,
                                     ScalarOperator predicate,
-                                    long selectedIndexId,
+                                    long selectedIndexMetaId,
                                     List<Long> selectedPartitionId,
                                     List<Long> selectedTabletId,
                                     List<Long> hintsReplicaId,
@@ -89,7 +89,7 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
                                     VectorSearchOptions vectorSearchOptions) {
         super(OperatorType.PHYSICAL_OLAP_SCAN, table, colRefToColumnMetaMap, limit, predicate, projection);
         this.distributionSpec = distributionDesc;
-        this.selectedIndexId = selectedIndexId;
+        this.selectedIndexMetaId = selectedIndexMetaId;
         this.selectedPartitionId = selectedPartitionId;
         this.selectedTabletId = selectedTabletId;
         this.hintsReplicaId = hintsReplicaId;
@@ -101,7 +101,7 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
     public PhysicalOlapScanOperator(LogicalOlapScanOperator scanOperator) {
         super(OperatorType.PHYSICAL_OLAP_SCAN, scanOperator);
         this.distributionSpec = scanOperator.getDistributionSpec();
-        this.selectedIndexId = scanOperator.getSelectedIndexId();
+        this.selectedIndexMetaId = scanOperator.getSelectedIndexMetaId();
         this.gtid = scanOperator.getGtid();
         this.selectedPartitionId = scanOperator.getSelectedPartitionId();
         this.selectedTabletId = scanOperator.getSelectedTabletId();
@@ -116,8 +116,8 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
         return vectorSearchOptions;
     }
 
-    public long getSelectedIndexId() {
-        return selectedIndexId;
+    public long getSelectedIndexMetaId() {
+        return selectedIndexMetaId;
     }
 
     public long getGtid() {
@@ -148,7 +148,7 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
         for (Long partitionId : getSelectedPartitionId()) {
             final Partition partition = ((OlapTable) getTable()).getPartition(partitionId);
             for (PhysicalPartition subPartition : partition.getSubPartitions()) {
-                final MaterializedIndex selectedTable = subPartition.getIndex(getSelectedIndexId());
+                final MaterializedIndex selectedTable = subPartition.getIndex(getSelectedIndexMetaId());
                 totalTabletsNum += selectedTable.getTablets().size();
             }
         }
@@ -251,7 +251,7 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), selectedIndexId, selectedPartitionId,
+        return Objects.hash(super.hashCode(), selectedIndexMetaId, selectedPartitionId,
                 selectedTabletId, sample);
     }
 
@@ -267,7 +267,7 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
             return false;
         }
         PhysicalOlapScanOperator that = (PhysicalOlapScanOperator) o;
-        return selectedIndexId == that.selectedIndexId &&
+        return selectedIndexMetaId == that.selectedIndexMetaId &&
                 gtid == that.gtid &&
                 Objects.equals(distributionSpec, that.distributionSpec) &&
                 Objects.equals(selectedPartitionId, that.selectedPartitionId) &&
@@ -307,7 +307,7 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
         public Builder withOperator(PhysicalOlapScanOperator operator) {
             super.withOperator(operator);
             builder.distributionSpec = operator.distributionSpec;
-            builder.selectedIndexId = operator.selectedIndexId;
+            builder.selectedIndexMetaId = operator.selectedIndexMetaId;
             builder.gtid = operator.gtid;
             builder.selectedTabletId = operator.selectedTabletId;
             builder.hintsReplicaId = operator.hintsReplicaId;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptDistributionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptDistributionPruner.java
@@ -51,7 +51,7 @@ public class OptDistributionPruner {
         for (Long partitionId : selectedPartitionIds) {
             Partition partition = olapTable.getPartition(partitionId);
             for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
-                MaterializedIndex table = physicalPartition.getIndex(olapScanOperator.getSelectedIndexId());
+                MaterializedIndex table = physicalPartition.getIndex(olapScanOperator.getSelectedIndexMetaId());
                 Collection<Long> tabletIds = distributionPrune(table, partition.getDistributionInfo(),
                         olapScanOperator, olapTable.getIdToColumn());
                 result.addAll(tabletIds);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/BestIndexRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/BestIndexRewriter.java
@@ -73,13 +73,13 @@ public class BestIndexRewriter extends OptExpressionVisitor<OptExpression, Long>
     }
 
     private Map<ColumnRefOperator, Column> getColumnRefOperatorColumnMapByIndexMeta(LogicalOlapScanOperator scanOperator,
-                                                                                    Long bestIndex) {
+                                                                                    Long bestIndexMetaId) {
         OlapTable olapTable = (OlapTable) scanOperator.getTable();
-        long oldSelectedIndexId = scanOperator.getSelectedIndexId();
-        if (oldSelectedIndexId != olapTable.getBaseIndexMetaId() || bestIndex == oldSelectedIndexId) {
+        long oldSelectedIndexMetaId = scanOperator.getSelectedIndexMetaId();
+        if (oldSelectedIndexMetaId != olapTable.getBaseIndexMetaId() || bestIndexMetaId == oldSelectedIndexMetaId) {
             return null;
         }
-        MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(bestIndex);
+        MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(bestIndexMetaId);
         List<Column> mvMetaColumns = indexMeta.getSchema();
         Map<String, Column> nameToColumnMap = Maps.newHashMap();
         for (Column mvColumn : mvMetaColumns) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
@@ -219,7 +219,7 @@ public class MaterializedViewRule extends Rule {
             }
 
             long bestIndex = selectBestMV(scan, candidateIndexIdToSchema, relationId);
-            if (bestIndex == scan.getSelectedIndexId()) {
+            if (bestIndex == scan.getSelectedIndexMetaId()) {
                 continue;
             }
             BestIndexRewriter bestIndexRewriter = new BestIndexRewriter(scan);
@@ -573,30 +573,30 @@ public class MaterializedViewRule extends Rule {
 
     private long selectBestRowCountIndex(Set<Long> indexesMatchingBestPrefixIndex, OlapTable olapTable) {
         long minRowCount = Long.MAX_VALUE;
-        long selectedIndexId = 0;
-        long baseIndexId = olapTable.getBaseIndexMetaId();
-        for (Long indexId : indexesMatchingBestPrefixIndex) {
+        long selectedIndexMetaId = 0;
+        long baseIndexMetaId = olapTable.getBaseIndexMetaId();
+        for (Long indexMetaId : indexesMatchingBestPrefixIndex) {
             long rowCount = 0;
             for (Partition partition : olapTable.getPartitions()) {
-                rowCount += partition.getDefaultPhysicalPartition().getIndex(indexId).getRowCount();
+                rowCount += partition.getDefaultPhysicalPartition().getIndex(indexMetaId).getRowCount();
             }
             if (rowCount < minRowCount) {
                 minRowCount = rowCount;
-                selectedIndexId = indexId;
+                selectedIndexMetaId = indexMetaId;
             } else if (rowCount == minRowCount) {
                 // check column number, select one minimum column number
-                int selectedColumnSize = olapTable.getSchemaByIndexMetaId(selectedIndexId).size();
-                int currColumnSize = olapTable.getSchemaByIndexMetaId(indexId).size();
+                int selectedColumnSize = olapTable.getSchemaByIndexMetaId(selectedIndexMetaId).size();
+                int currColumnSize = olapTable.getSchemaByIndexMetaId(indexMetaId).size();
                 // If indexId and old selectedIndexId both have the same rowCount and columnSize,
                 // prefer non baseIndexId first.
                 if (currColumnSize == selectedColumnSize) {
-                    selectedIndexId = (indexId == baseIndexId) ? selectedIndexId : indexId;
+                    selectedIndexMetaId = (indexMetaId == baseIndexMetaId) ? selectedIndexMetaId : indexMetaId;
                 } else if (currColumnSize < selectedColumnSize) {
-                    selectedIndexId = indexId;
+                    selectedIndexMetaId = indexMetaId;
                 }
             }
         }
-        return selectedIndexId;
+        return selectedIndexMetaId;
     }
 
     // Map MV's column to query's column id.
@@ -625,7 +625,7 @@ public class MaterializedViewRule extends Rule {
         Set<Long> indexesMatchingBestPrefixIndex = Sets.newHashSet();
         int maxPrefixMatchCount = 0;
         for (Map.Entry<Long, List<Column>> entry : candidateIndexIdToSchema.entrySet()) {
-            long indexId = entry.getKey();
+            long indexMetaId = entry.getKey();
             List<Column> indexSchema = entry.getValue();
 
             int prefixMatchCount = 0;
@@ -643,11 +643,11 @@ public class MaterializedViewRule extends Rule {
             }
 
             if (prefixMatchCount == maxPrefixMatchCount) {
-                indexesMatchingBestPrefixIndex.add(indexId);
+                indexesMatchingBestPrefixIndex.add(indexMetaId);
             } else if (prefixMatchCount > maxPrefixMatchCount) {
                 maxPrefixMatchCount = prefixMatchCount;
                 indexesMatchingBestPrefixIndex.clear();
-                indexesMatchingBestPrefixIndex.add(indexId);
+                indexesMatchingBestPrefixIndex.add(indexMetaId);
             }
         }
         return indexesMatchingBestPrefixIndex;
@@ -781,10 +781,10 @@ public class MaterializedViewRule extends Rule {
     private void compensateCandidateIndex(List<MaterializedIndexMeta> candidateIndexIdToMetas,
                                           List<MaterializedIndexMeta> allVisibleIndexes,
                                           OlapTable table) {
-        int keySizeOfBaseIndex = table.getKeyColumnsByIndexId(table.getBaseIndexMetaId()).size();
+        int keySizeOfBaseIndex = table.getKeyColumnsByIndexMetaId(table.getBaseIndexMetaId()).size();
         for (MaterializedIndexMeta index : allVisibleIndexes) {
-            long mvIndexId = index.getIndexMetaId();
-            if (table.getKeyColumnsByIndexId(mvIndexId).size() == keySizeOfBaseIndex) {
+            long mvIndexMetaId = index.getIndexMetaId();
+            if (table.getKeyColumnsByIndexMetaId(mvIndexMetaId).size() == keySizeOfBaseIndex) {
                 candidateIndexIdToMetas.add(index);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/LimitPruneTabletsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/LimitPruneTabletsRule.java
@@ -71,7 +71,7 @@ public class LimitPruneTabletsRule extends TransformationRule {
                     break;
                 }
                 long version = physicalPartition.getVisibleVersion();
-                MaterializedIndex index = physicalPartition.getIndex(olapScanOperator.getSelectedIndexId());
+                MaterializedIndex index = physicalPartition.getIndex(olapScanOperator.getSelectedIndexMetaId());
 
                 for (Tablet tablet : index.getTablets()) {
                     // Note: the tablet row count metadata in FE maybe delay because of BE tablet row count.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoveAggregationFromAggTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RemoveAggregationFromAggTable.java
@@ -74,7 +74,7 @@ public class RemoveAggregationFromAggTable extends TransformationRule {
         }
         OlapTable olapTable = (OlapTable) scanOperator.getTable();
 
-        MaterializedIndexMeta materializedIndexMeta = olapTable.getIndexMetaByIndexId(scanOperator.getSelectedIndexId());
+        MaterializedIndexMeta materializedIndexMeta = olapTable.getIndexMetaByMetaId(scanOperator.getSelectedIndexMetaId());
         // must be Aggregation
         if (!materializedIndexMeta.getKeysType().isAggregationFamily()) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
@@ -174,7 +174,7 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
         LogicalMetaScanOperator newMetaScan = LogicalMetaScanOperator.builder()
                 .setTable(scanOperator.getTable())
                 .setSelectPartitionNames(selectedPartitionNames)
-                .setSelectedIndexId(scanOperator.getSelectedIndexId())
+                .setSelectedIndexId(scanOperator.getSelectedIndexMetaId())
                 .setHintsTabletIds(scanOperator.getHintsTabletIds())
                 .setColRefToColumnMetaMap(newScanColumnRefs)
                 .setAggColumnIdToColumns(aggColumnIdToColumns).build();
@@ -229,7 +229,7 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
         if (aggregationOperator.getPredicate() != null) {
             return false;
         }
-        MaterializedIndexMeta currentIndexMeta = table.getIndexMetaByIndexId(table.getBaseIndexMetaId());
+        MaterializedIndexMeta currentIndexMeta = table.getIndexMetaByMetaId(table.getBaseIndexMetaId());
         boolean hasSchemaChange = currentIndexMeta.getSchemaVersion() > 0;
 
         boolean allValid = aggregationOperator.getAggregations().values().stream().allMatch(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/BestMvSelector.java
@@ -538,8 +538,8 @@ public class BestMvSelector {
                         .collect(Collectors.toList());
             }
         } else {
-            long baseIndexId = olapTable.getBaseIndexMetaId();
-            MaterializedIndexMeta baseIndexMeta = olapTable.getIndexMetaByIndexId(baseIndexId);
+            long baseIndexMetaId = olapTable.getBaseIndexMetaId();
+            MaterializedIndexMeta baseIndexMeta = olapTable.getIndexMetaByMetaId(baseIndexMetaId);
             List<Column> baseSchema = olapTable.getBaseSchema();
             List<Integer> sortKeyIdxes = baseIndexMeta.getSortKeyIdxes();
             if (CollectionUtils.isNotEmpty(sortKeyIdxes)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -479,7 +479,7 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                     PhysicalOlapScanOperator newOlapScan =
                             new PhysicalOlapScanOperator(scanOperator.getTable(), newColRefToColumnMetaMap,
                                     scanOperator.getDistributionSpec(), scanOperator.getLimit(), newPredicate,
-                                    scanOperator.getSelectedIndexId(), scanOperator.getSelectedPartitionId(),
+                                    scanOperator.getSelectedIndexMetaId(), scanOperator.getSelectedPartitionId(),
                                     scanOperator.getSelectedTabletId(), scanOperator.getHintsReplicaId(),
                                     newPrunedPredicates,
                                     scanOperator.getProjection(), scanOperator.isUsePkIndex(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PhysicalDistributionAggOptRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PhysicalDistributionAggOptRule.java
@@ -156,7 +156,7 @@ public class PhysicalDistributionAggOptRule implements TreeRewriteRule {
                     agg.getGroupBys().stream().map(s -> scan.getColRefToColumnMetaMap().get(s)).collect(
                             Collectors.toList());
 
-            for (Column column : ((OlapTable) scan.getTable()).getSchemaByIndexMetaId(scan.getSelectedIndexId())) {
+            for (Column column : ((OlapTable) scan.getTable()).getSchemaByIndexMetaId(scan.getSelectedIndexMetaId())) {
                 if (!nonKeyGroupBys.contains(column)) {
                     break;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PreAggregateTurnOnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PreAggregateTurnOnRule.java
@@ -69,8 +69,8 @@ public class PreAggregateTurnOnRule implements TreeRewriteRule {
         for (PhysicalOlapScanOperator scan : scans) {
             // default false
             scan.setPreAggregation(false);
-            long selectedIndex = scan.getSelectedIndexId();
-            MaterializedIndexMeta meta = ((OlapTable) scan.getTable()).getIndexMetaByIndexId(selectedIndex);
+            long selectedIndexMetaId = scan.getSelectedIndexMetaId();
+            MaterializedIndexMeta meta = ((OlapTable) scan.getTable()).getIndexMetaByMetaId(selectedIndexMetaId);
             if (!meta.getKeysType().isAggregationFamily()) {
                 scan.setPreAggregation(true);
                 scan.setTurnOffReason("");
@@ -146,9 +146,9 @@ public class PreAggregateTurnOnRule implements TreeRewriteRule {
             // default false
             scan.setPreAggregation(false);
 
-            long selectedIndex = scan.getSelectedIndexId();
+            long selectedIndexMetaId = scan.getSelectedIndexMetaId();
             OlapTable olapTable = ((OlapTable) scan.getTable());
-            MaterializedIndexMeta materializedIndexMeta = olapTable.getIndexMetaByIndexId(selectedIndex);
+            MaterializedIndexMeta materializedIndexMeta = olapTable.getIndexMetaByMetaId(selectedIndexMetaId);
             if (!materializedIndexMeta.getKeysType().isAggregationFamily()) {
                 scan.setPreAggregation(true);
                 scan.setTurnOffReason("");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -609,7 +609,7 @@ public class PlanFragmentBuilder {
             // Key columns and value columns cannot be pruned in the non-skip-aggr scan stage.
             // - All the keys columns must be retained to merge and aggregate rows.
             // - Value columns can only be used after merging and aggregating.
-            MaterializedIndexMeta materializedIndexMeta = referenceTable.getIndexMetaByIndexId(node.getSelectedIndexId());
+            MaterializedIndexMeta materializedIndexMeta = referenceTable.getIndexMetaByMetaId(node.getSelectedIndexMetaId());
             if (materializedIndexMeta.getKeysType().isAggregationFamily() && !node.isPreAggregation()) {
                 return;
             }
@@ -937,7 +937,7 @@ public class PlanFragmentBuilder {
             tupleDescriptor.setTable(referenceTable);
 
             OlapScanNode scanNode = new OlapScanNode(context.getNextNodeId(), tupleDescriptor, "OlapScanNode",
-                    node.getSelectedIndexId(), context.getConnectContext().getCurrentComputeResource());
+                    node.getSelectedIndexMetaId(), context.getConnectContext().getCurrentComputeResource());
             scanNode.setLimit(node.getLimit());
             scanNode.computeStatistics(optExpr.getStatistics());
             scanNode.setScanOptimizeOption(node.getScanOptimizeOption());
@@ -953,7 +953,7 @@ public class PlanFragmentBuilder {
                 scanNode.updateScanInfo(node.getSelectedPartitionId(),
                         node.getSelectedTabletId(),
                         node.getHintsReplicaId());
-                long selectedIndexId = node.getSelectedIndexId();
+                long selectedIndexMetaId = node.getSelectedIndexMetaId();
                 long totalTabletsNum = 0;
                 // Compatible with old tablet selected, copy from "OlapScanNode::computeTabletInfo"
                 // we can remove code when refactor tablet select
@@ -986,7 +986,7 @@ public class PlanFragmentBuilder {
                         selectedNonEmptyPartitionIds.add(partitionId);
                         Map<Long, Integer> tabletId2BucketSeq = Maps.newHashMap();
                         Preconditions.checkState(selectTabletIds != null && !selectTabletIds.isEmpty());
-                        final MaterializedIndex selectedIndex = physicalPartition.getIndex(selectedIndexId);
+                        final MaterializedIndex selectedIndex = physicalPartition.getIndex(selectedIndexMetaId);
                         totalTabletsNum += selectedIndex.getTablets().size();
                         List<Long> allTabletIds = selectedIndex.getTabletIdsInOrder();
                         for (int i = 0; i < allTabletIds.size(); i++) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
@@ -236,7 +236,7 @@ public class TabletTaskExecutor {
         boolean isCloudNativeTable = table.isCloudNativeTableOrMaterializedView();
         boolean createSchemaFile = true;
         List<CreateReplicaTask> tasks = new ArrayList<>((int) index.getReplicaCount());
-        MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(index.getId());
+        MaterializedIndexMeta indexMeta = table.getIndexMetaByMetaId(index.getMetaId());
         TTabletType tabletType = isCloudNativeTable ? TTabletType.TABLET_TYPE_LAKE : TTabletType.TABLET_TYPE_DISK;
         TStorageMedium storageMedium =
                 table.getPartitionInfo().getDataProperty(physicalPartition.getParentId()).getStorageMedium();
@@ -456,8 +456,7 @@ public class TabletTaskExecutor {
                 List<MaterializedIndex> allIndices = physicalPartition
                         .getMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
                 for (MaterializedIndex materializedIndex : allIndices) {
-                    long indexId = materializedIndex.getId();
-                    int schemaHash = olapTable.getSchemaHashByIndexMetaId(indexId);
+                    int schemaHash = olapTable.getSchemaHashByIndexMetaId(materializedIndex.getMetaId());
                     for (Tablet tablet : materializedIndex.getTablets()) {
                         long tabletId = tablet.getId();
                         List<Replica> replicas = ((LocalTablet) tablet).getImmutableReplicas();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -565,7 +565,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
                             LOG.warn("Ignore shadow index included in the transaction but not visible, " +
                                     "partitionId: {}, partitionName: {}, txnId: {}, indexId: {}, indexName: {}",
                                     partition.getId(), partition.getName(), txnState.getTransactionId(),
-                                    index.getId(), table.getIndexNameByMetaId(index.getId()));
+                                    index.getId(), table.getIndexNameByMetaId(index.getMetaId()));
                             continue;
                         }
                         if (shadowIndexTxnBatches == null) {
@@ -883,7 +883,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
             List<MaterializedIndex> indexes = txnState.getPartitionLoadedTblIndexes(table.getId(), partition);
             for (MaterializedIndex index : indexes) {
                 if (!index.visibleForTransaction(txnId)) {
-                    LOG.info("Ignored index {} for transaction {}", table.getIndexNameByMetaId(index.getId()), txnId);
+                    LOG.info("Ignored index {} for transaction {}", table.getIndexNameByMetaId(index.getMetaId()), txnId);
                     continue;
                 }
                 if (index.getState() == MaterializedIndex.IndexState.SHADOW) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -874,6 +874,7 @@ public class TransactionState implements Writable, GsonPreProcessable {
         Set<Long> indexIds = loadedTblIndexes.computeIfAbsent(table.getId(), k -> Sets.newHashSet());
         // always equal the index ids
         indexIds.clear();
+        // TODO(wyb): fix indexIds with partition
         indexIds.addAll(table.getIndexMetaIdToMeta().keySet());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -621,7 +621,7 @@ public class AlterTest {
         alterTableWithNewParser(stmt, false);
 
         Assertions.assertTrue(tbl.getTableProperty().getDynamicPartitionProperty().isEnabled());
-        Assertions.assertEquals(4, tbl.getIndexIdToSchema().size());
+        Assertions.assertEquals(4, tbl.getIndexMetaIdToSchema().size());
 
         // add partition when dynamic partition is enable
         stmt = "alter table test.tbl1 add partition p3 values less than('2020-04-01') " +

--- a/fe/fe-core/src/test/java/com/starrocks/alter/CloudNativeFastSchemaEvolutionV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/CloudNativeFastSchemaEvolutionV2Test.java
@@ -260,14 +260,14 @@ public class CloudNativeFastSchemaEvolutionV2Test extends LakeFastSchemaChangeTe
 
     private static Map<Long, SchemaInfo> snapshotTableSchema(LakeTable table) {
         Map<Long, SchemaInfo> snapshot = Maps.newHashMap();
-        table.getIndexMetaIdToMeta().forEach((indexId, meta) -> snapshot.put(indexId, toSchemaInfo(meta)));
+        table.getIndexMetaIdToMeta().forEach((indexMetaId, meta) -> snapshot.put(indexMetaId, toSchemaInfo(meta)));
         return snapshot;
     }
 
     private static void assertTableSchemaMatchesSnapshot(LakeTable table, Map<Long, SchemaInfo> snapshot) {
-        snapshot.forEach((indexId, signature) -> {
-            MaterializedIndexMeta meta = table.getIndexMetaIdToMeta().get(indexId);
-            Assertions.assertNotNull(meta, () -> "Table missing indexId " + indexId);
+        snapshot.forEach((indexMetaId, signature) -> {
+            MaterializedIndexMeta meta = table.getIndexMetaIdToMeta().get(indexMetaId);
+            Assertions.assertNotNull(meta, () -> "Table missing indexMetaId " + indexMetaId);
             assertSchemaInfoEquals(signature, toSchemaInfo(meta));
         });
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeFastSchemaChangeTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeFastSchemaChangeTestBase.java
@@ -142,7 +142,7 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
                 DISTRIBUTED BY HASH(c0) BUCKETS 2
                 PROPERTIES('cloud_native_fast_schema_evolution_v2'='%s');""", isFastSchemaEvolutionV2());
         LakeTable table = createTable(connectContext, createSql);
-        long oldSchemaId = table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaId();
+        long oldSchemaId = table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaId();
 
         {
             executeAlterAndWaitFinish(table, "ALTER TABLE t0 ADD COLUMN c1 BIGINT", true);
@@ -152,18 +152,18 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
             Assertions.assertEquals(0, columns.get(0).getUniqueId());
             Assertions.assertEquals("c1", columns.get(1).getName());
             Assertions.assertEquals(1, columns.get(1).getUniqueId());
-            Assertions.assertTrue(table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaId() > oldSchemaId);
+            Assertions.assertTrue(table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaId() > oldSchemaId);
         }
-        oldSchemaId = table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaId();
+        oldSchemaId = table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaId();
         {
             executeAlterAndWaitFinish(table, "ALTER TABLE t0 DROP COLUMN c1", true);
             List<Column> columns = table.getBaseSchema();
             Assertions.assertEquals(1, columns.size());
             Assertions.assertEquals("c0", columns.get(0).getName());
             Assertions.assertEquals(0, columns.get(0).getUniqueId());
-            Assertions.assertTrue(table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaId() > oldSchemaId);
+            Assertions.assertTrue(table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaId() > oldSchemaId);
         }
-        oldSchemaId = table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaId();
+        oldSchemaId = table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaId();
         {
             executeAlterAndWaitFinish(table, "ALTER TABLE t0 ADD COLUMN c1 BIGINT", true);
             List<Column> columns = table.getBaseSchema();
@@ -172,7 +172,7 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
             Assertions.assertEquals(0, columns.get(0).getUniqueId());
             Assertions.assertEquals("c1", columns.get(1).getName());
             Assertions.assertEquals(2, columns.get(1).getUniqueId());
-            Assertions.assertTrue(table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaId() > oldSchemaId);
+            Assertions.assertTrue(table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaId() > oldSchemaId);
         }
     }
 
@@ -198,7 +198,7 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
         Assertions.assertEquals(table.getIndexNameByMetaId(table.getBaseIndexMetaId()), info.get(4));
         Assertions.assertEquals(table.getBaseIndexMetaId(), info.get(5));
         Assertions.assertEquals(table.getBaseIndexMetaId(), info.get(6));
-        Assertions.assertEquals(String.format("%d:0", table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaVersion()),
+        Assertions.assertEquals(String.format("%d:0", table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaVersion()),
                 info.get(7));
         Assertions.assertEquals(job.getTransactionId().get(), info.get(8));
         Assertions.assertEquals(job.getJobState().name(), info.get(9));
@@ -218,7 +218,7 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
                 ORDER BY(c1)
                 PROPERTIES('cloud_native_fast_schema_evolution_v2'='%s');""", isFastSchemaEvolutionV2());
         LakeTable table = createTable(connectContext, createSql);
-        long oldSchemaId = table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaId();
+        long oldSchemaId = table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaId();
 
         {
             executeAlterAndWaitFinish(table, "ALTER TABLE t_test_sort_key ADD COLUMN c2 BIGINT", true);
@@ -230,9 +230,9 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
             Assertions.assertEquals(1, columns.get(1).getUniqueId());
             Assertions.assertEquals("c2", columns.get(2).getName());
             Assertions.assertEquals(2, columns.get(2).getUniqueId());
-            Assertions.assertTrue(table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaId() > oldSchemaId);
+            Assertions.assertTrue(table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaId() > oldSchemaId);
         }
-        oldSchemaId = table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaId();
+        oldSchemaId = table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaId();
         {
             executeAlterAndWaitFinish(table, "ALTER TABLE t_test_sort_key DROP COLUMN c2", true);
             List<Column> columns = table.getBaseSchema();
@@ -241,7 +241,7 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
             Assertions.assertEquals(0, columns.get(0).getUniqueId());
             Assertions.assertEquals("c1", columns.get(1).getName());
             Assertions.assertEquals(1, columns.get(1).getUniqueId());
-            Assertions.assertTrue(table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaId() > oldSchemaId);
+            Assertions.assertTrue(table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaId() > oldSchemaId);
         }
     }
 
@@ -257,7 +257,7 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
                 ORDER BY(c2)
                 PROPERTIES('cloud_native_fast_schema_evolution_v2'='%s');""", isFastSchemaEvolutionV2());
         LakeTable table = createTable(connectContext, createSql);
-        long oldSchemaId = table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaId();
+        long oldSchemaId = table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaId();
 
         {
             executeAlterAndWaitFinish(table, "ALTER TABLE t_test_sort_key_index_changed DROP COLUMN c1", true);
@@ -267,7 +267,7 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
             Assertions.assertEquals(0, columns.get(0).getUniqueId());
             Assertions.assertEquals("c2", columns.get(1).getName());
             Assertions.assertEquals(2, columns.get(1).getUniqueId());
-            MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(table.getBaseIndexMetaId());
+            MaterializedIndexMeta indexMeta = table.getIndexMetaByMetaId(table.getBaseIndexMetaId());
             Assertions.assertTrue(indexMeta.getSchemaId() > oldSchemaId);
             Assertions.assertEquals(Arrays.asList(1), indexMeta.getSortKeyIdxes());
             Assertions.assertEquals(Arrays.asList(2), indexMeta.getSortKeyUniqueIds());
@@ -287,7 +287,7 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
                 DISTRIBUTED BY HASH(c0) BUCKETS 1
                 PROPERTIES('cloud_native_fast_schema_evolution_v2'='%s');""", isFastSchemaEvolutionV2());
         LakeTable table = createTable(connectContext, createSql);
-        long oldSchemaId = table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaId();
+        long oldSchemaId = table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaId();
 
         // zonemap index can be reused
         {
@@ -307,7 +307,7 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
             columnInfos.add(Pair.create("c3", DateType.DATETIME));
             columnInfos.add(Pair.create("c4", TypeFactory.createVarcharType(20)));
             Assertions.assertTrue(isSchemaTypeMatches(db, table, columnInfos));
-            Assertions.assertTrue(table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaId() > oldSchemaId);
+            Assertions.assertTrue(table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaId() > oldSchemaId);
         }
 
         // zonemap index can not be reused
@@ -337,8 +337,7 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
         try {
-            long baseIndexId = table.getBaseIndexMetaId();
-            MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(baseIndexId);
+            MaterializedIndexMeta indexMeta = table.getIndexMetaByMetaId(table.getBaseIndexMetaId());
             List<Column> schema = indexMeta.getSchema();
             List<Column> shortKeyCols = new ArrayList<>();
             List<Integer> sortKeyIdxes = indexMeta.getSortKeyIdxes();
@@ -383,8 +382,8 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
         try {
-            long baseIndexId = table.getBaseIndexMetaId();
-            MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(baseIndexId);
+            long baseIndexMetaId = table.getBaseIndexMetaId();
+            MaterializedIndexMeta indexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
             List<Column> schema = indexMeta.getSchema();
             if (schema.size() != columnInfos.size()) {
                 return false;
@@ -662,8 +661,8 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
         TransactionState.TxnCoordinator coordinator = new TransactionState.TxnCoordinator(
                 TransactionState.TxnSourceType.BE, "127.0.0.1");
 
-        long baseIndexId = table.getBaseIndexMetaId();
-        MaterializedIndexMeta preAlterIndexMeta1 = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        long baseIndexMetaId = table.getBaseIndexMetaId();
+        MaterializedIndexMeta preAlterIndexMeta1 = table.getIndexMetaByMetaId(baseIndexMetaId).shallowCopy();
         long runningTxn1 = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
                 db.getId(), List.of(table.getId()), UUID.randomUUID().toString(), coordinator,
                 TransactionState.LoadJobSourceType.BACKEND_STREAMING, 60000L);
@@ -676,9 +675,9 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
         OlapTableHistorySchema historySchema1 = getHistorySchema(job1);
         Assertions.assertNotNull(historySchema1);
         Assertions.assertTrue(historySchema1.getHistoryTxnIdThreshold() > runningTxn1);
-        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta1, historySchema1);
+        assertHistorySchemaMatches(table, baseIndexMetaId, preAlterIndexMeta1, historySchema1);
 
-        MaterializedIndexMeta preAlterIndexMeta2 = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        MaterializedIndexMeta preAlterIndexMeta2 = table.getIndexMetaByMetaId(baseIndexMetaId).shallowCopy();
         long runningTxn2 = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
                 db.getId(), List.of(table.getId()), UUID.randomUUID().toString(), coordinator,
                 TransactionState.LoadJobSourceType.BACKEND_STREAMING, 60000L);
@@ -692,7 +691,7 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
         OlapTableHistorySchema historySchema2 = getHistorySchema(job2);
         Assertions.assertNotNull(historySchema2);
         Assertions.assertTrue(historySchema2.getHistoryTxnIdThreshold() > runningTxn2);
-        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta2, historySchema2);
+        assertHistorySchemaMatches(table, baseIndexMetaId, preAlterIndexMeta2, historySchema2);
 
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
         job1.setFinishedTimeMs(System.currentTimeMillis() / 1000 - Config.alter_table_timeout_second - 100);
@@ -707,7 +706,7 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
         schemaChangeHandler.runAfterCatalogReady();
         Assertions.assertSame(job2, schemaChangeHandler.getAlterJobsV2().get(job2.getJobId()));
         Assertions.assertTrue(historySchema2.isExpired());
-        Assertions.assertNull(historySchema2.getSchemaByIndexId(baseIndexId).orElse(null));
+        Assertions.assertNull(historySchema2.getSchemaByIndexMetaId(baseIndexMetaId).orElse(null));
         Assertions.assertNull(historySchema2.getSchemaBySchemaId(preAlterIndexMeta2.getSchemaId()).orElse(null));
         job2.setFinishedTimeMs(System.currentTimeMillis() / 1000 - Config.alter_table_timeout_second - 100);
         schemaChangeHandler.runAfterCatalogReady();
@@ -734,8 +733,8 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
         GlobalStateMgr.getCurrentState().getLocalMetastore().save(imageWriter);
         GlobalStateMgr.getCurrentState().getAlterJobMgr().save(imageWriter);
 
-        long baseIndexId = table.getBaseIndexMetaId();
-        MaterializedIndexMeta preAlterIndexMeta = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        long baseMetaIndexId = table.getBaseIndexMetaId();
+        MaterializedIndexMeta preAlterIndexMeta = table.getIndexMetaByMetaId(baseMetaIndexId).shallowCopy();
 
         String alterSql = """
                         ALTER TABLE test_replay 
@@ -754,7 +753,7 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
         Assertions.assertTrue(isSchemaTypeMatches(db, table, columnInfos));
         OlapTableHistorySchema historySchema = getHistorySchema(job);
         Assertions.assertNotNull(historySchema);
-        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta, historySchema);
+        assertHistorySchemaMatches(table, baseMetaIndexId, preAlterIndexMeta, historySchema);
 
         LocalMetastore restoredMetastore =
                 new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
@@ -771,8 +770,9 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
         Assertions.assertNotNull(restoredDb, "Restored database not found");
         LakeTable restoredTable = (LakeTable) restoredMetastore.getTable(DB_NAME, table.getName());
         Assertions.assertNotNull(restoredTable, "Restored table not found");
-        Assertions.assertEquals(SchemaInfo.fromMaterializedIndex(table, baseIndexId, preAlterIndexMeta),
-                SchemaInfo.fromMaterializedIndex(restoredTable, baseIndexId, restoredTable.getIndexMetaByIndexId(baseIndexId)));
+        Assertions.assertEquals(SchemaInfo.fromMaterializedIndex(table, baseMetaIndexId, preAlterIndexMeta),
+                SchemaInfo.fromMaterializedIndex(restoredTable, baseMetaIndexId,
+                        restoredTable.getIndexMetaByMetaId(baseMetaIndexId)));
 
         SchemaChangeHandler restoredHandler = restoredAlterJobMgr.getSchemaChangeHandler();
         LocalMetastore originalMetastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
@@ -804,14 +804,16 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
         columnInfos.add(Pair.create("c3", DateType.DATETIME));
         columnInfos.add(Pair.create("c4", TypeFactory.createVarcharType(20)));
         Assertions.assertTrue(isSchemaTypeMatches(restoredDb, restoredTable, columnInfos));
-        Assertions.assertEquals(SchemaInfo.fromMaterializedIndex(table, baseIndexId, table.getIndexMetaByIndexId(baseIndexId)),
-                SchemaInfo.fromMaterializedIndex(restoredTable, baseIndexId, restoredTable.getIndexMetaByIndexId(baseIndexId)));
+        Assertions.assertEquals(
+                SchemaInfo.fromMaterializedIndex(table, baseMetaIndexId, table.getIndexMetaByMetaId(baseMetaIndexId)),
+                SchemaInfo.fromMaterializedIndex(restoredTable, baseMetaIndexId,
+                        restoredTable.getIndexMetaByMetaId(baseMetaIndexId)));
         AlterJobV2 restoredJob = restoredHandler.getAlterJobsV2().get(job.getJobId());
         Assertions.assertNotNull(restoredJob);
         OlapTableHistorySchema restoredHistorySchema = getHistorySchema(restoredJob);
         Assertions.assertNotNull(restoredHistorySchema);
         Assertions.assertEquals(historySchema.getHistoryTxnIdThreshold(), restoredHistorySchema.getHistoryTxnIdThreshold());
-        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta, restoredHistorySchema);
+        assertHistorySchemaMatches(table, baseMetaIndexId, preAlterIndexMeta, restoredHistorySchema);
     }
 
     private OlapTableHistorySchema getHistorySchema(AlterJobV2 alterJob) {
@@ -824,11 +826,11 @@ public abstract class LakeFastSchemaChangeTestBase extends StarRocksTestBase {
         }
     }
 
-    protected void assertHistorySchemaMatches(LakeTable table, long indexId, MaterializedIndexMeta originMeta,
+    protected void assertHistorySchemaMatches(LakeTable table, long indexMetaId, MaterializedIndexMeta originMeta,
                                             OlapTableHistorySchema historySchema) {
-        SchemaInfo originSchemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, originMeta);
+        SchemaInfo originSchemaInfo = SchemaInfo.fromMaterializedIndex(table, indexMetaId, originMeta);
         Assertions.assertNotNull(historySchema);
-        Assertions.assertEquals(originSchemaInfo, historySchema.getSchemaByIndexId(indexId).orElse(null));
+        Assertions.assertEquals(originSchemaInfo, historySchema.getSchemaByIndexMetaId(indexMetaId).orElse(null));
         Assertions.assertEquals(originSchemaInfo, historySchema.getSchemaBySchemaId(originMeta.getSchemaId()).orElse(null));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterDataCachePartitionDurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterDataCachePartitionDurationTest.java
@@ -145,8 +145,9 @@ public class LakeTableAlterDataCachePartitionDurationTest {
         }
         table.addPartition(partition);
 
-        table.setIndexMeta(index.getId(), "t0", Collections.singletonList(c0), 0, 0, (short) 1, TStorageType.COLUMN, keysType);
-        table.setBaseIndexMetaId(index.getId());
+        table.setIndexMeta(index.getMetaId(), "t0", Collections.singletonList(c0), 0, 0, (short) 1, TStorageType.COLUMN,
+                keysType);
+        table.setBaseIndexMetaId(index.getMetaId());
 
         FilePathInfo.Builder builder = FilePathInfo.newBuilder();
         FileStoreInfo.Builder fsBuilder = builder.getFsInfoBuilder();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -113,3 +113,4 @@ public class LakeTableAsyncFastSchemaChangeJobTest extends LakeFastSchemaChangeT
         }
     }
 }
+

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -221,7 +221,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             Assertions.assertEquals(10, tbl.getBaseSchema().size());
             String baseIndexName = tbl.getIndexNameByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertEquals(baseIndexName, tbl.getName());
-            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexMetaId());
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertNotNull(indexMeta);
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
@@ -242,7 +242,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             Assertions.assertEquals(11, tbl.getBaseSchema().size());
             String baseIndexName = tbl.getIndexNameByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertEquals(baseIndexName, tbl.getName());
-            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexMetaId());
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertNotNull(indexMeta);
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
@@ -262,7 +262,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             Assertions.assertEquals(10, tbl.getBaseSchema().size());
             String baseIndexName = tbl.getIndexNameByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertEquals(baseIndexName, tbl.getName());
-            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexMetaId());
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertNotNull(indexMeta);
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
@@ -273,7 +273,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         AlterTableStmt dropKeyColStmt = (AlterTableStmt) parseAndAnalyzeStmt(dropKeyColStmtStr);
         Assertions.assertThrows(Exception.class, () -> DDLStmtExecutor.execute(dropKeyColStmt, connectContext));
 
-        LOG.info("getIndexIdToSchema 1: {}", tbl.getIndexIdToSchema());
+        LOG.info("getIndexIdToSchema 1: {}", tbl.getIndexMetaIdToSchema());
 
         //process agg drop value column with rollup schema change
         String dropRollUpValColStmtStr = "alter table test.sc_agg drop column max_dwell_time";
@@ -289,7 +289,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             Assertions.assertEquals(9, tbl.getBaseSchema().size());
             String baseIndexName = tbl.getIndexNameByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertEquals(baseIndexName, tbl.getName());
-            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexMetaId());
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertNotNull(indexMeta);
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
@@ -329,7 +329,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             Assertions.assertEquals(9, tbl.getBaseSchema().size());
             String baseIndexName = tbl.getIndexNameByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertEquals(baseIndexName, tbl.getName());
-            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexMetaId());
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertNotNull(indexMeta);
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
@@ -347,7 +347,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             Assertions.assertEquals(8, tbl.getBaseSchema().size());
             String baseIndexName = tbl.getIndexNameByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertEquals(baseIndexName, tbl.getName());
-            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexMetaId());
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertNotNull(indexMeta);
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
@@ -387,7 +387,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             Assertions.assertEquals(7, tbl.getBaseSchema().size());
             String baseIndexName = tbl.getIndexNameByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertEquals(baseIndexName, tbl.getName());
-            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexMetaId());
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertNotNull(indexMeta);
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
@@ -405,7 +405,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             Assertions.assertEquals(6, tbl.getBaseSchema().size());
             String baseIndexName = tbl.getIndexNameByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertEquals(baseIndexName, tbl.getName());
-            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexMetaId());
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByMetaId(tbl.getBaseIndexMetaId());
             Assertions.assertNotNull(indexMeta);
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.READ);
@@ -422,7 +422,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         // origin columns
         Map<Long, List<Column>> indexSchemaMap = new HashMap<>();
         Map<Long, Long> indexToNewSchemaId = new HashMap<>();
-        for (Map.Entry<Long, List<Column>> entry : tbl.getIndexIdToSchema().entrySet()) {
+        for (Map.Entry<Long, List<Column>> entry : tbl.getIndexMetaIdToSchema().entrySet()) {
             indexSchemaMap.put(entry.getKey(), new LinkedList<>(entry.getValue()));
             indexToNewSchemaId.put(entry.getKey(), globalStateMgr.getNextId());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
@@ -503,8 +503,8 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         TransactionState.TxnCoordinator coordinator = new TransactionState.TxnCoordinator(
                 TransactionState.TxnSourceType.BE, "127.0.0.1");
 
-        long baseIndexId = table.getBaseIndexMetaId();
-        MaterializedIndexMeta preAlterIndexMeta1 = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        long baseIndexMetaId = table.getBaseIndexMetaId();
+        MaterializedIndexMeta preAlterIndexMeta1 = table.getIndexMetaByMetaId(baseIndexMetaId).shallowCopy();
         long runningTxn1 = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
                 db.getId(), List.of(table.getId()), UUID.randomUUID().toString(), coordinator,
                 TransactionState.LoadJobSourceType.BACKEND_STREAMING, 60000L);
@@ -514,9 +514,9 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         OlapTableHistorySchema historySchema1 = job1.getHistorySchema().orElse(null);
         Assertions.assertNotNull(historySchema1);
         Assertions.assertTrue(historySchema1.getHistoryTxnIdThreshold() > runningTxn1);
-        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta1, historySchema1);
+        assertHistorySchemaMatches(table, baseIndexMetaId, preAlterIndexMeta1, historySchema1);
 
-        MaterializedIndexMeta preAlterIndexMeta2 = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        MaterializedIndexMeta preAlterIndexMeta2 = table.getIndexMetaByMetaId(baseIndexMetaId).shallowCopy();
         long runningTxn2 = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
                 db.getId(), List.of(table.getId()), UUID.randomUUID().toString(), coordinator,
                 TransactionState.LoadJobSourceType.BACKEND_STREAMING, 60000L);
@@ -526,7 +526,7 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         OlapTableHistorySchema historySchema2 = job2.getHistorySchema().orElse(null);
         Assertions.assertNotNull(historySchema2);
         Assertions.assertTrue(historySchema2.getHistoryTxnIdThreshold() > runningTxn2);
-        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta2, historySchema2);
+        assertHistorySchemaMatches(table, baseIndexMetaId, preAlterIndexMeta2, historySchema2);
 
         SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
         job1.setFinishedTimeMs(System.currentTimeMillis() / 1000 - Config.alter_table_timeout_second - 100);
@@ -541,7 +541,7 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         schemaChangeHandler.runAfterCatalogReady();
         Assertions.assertSame(job2, schemaChangeHandler.getAlterJobsV2().get(job2.getJobId()));
         Assertions.assertTrue(job2.getHistorySchema().orElse(null).isExpired());
-        Assertions.assertNull(job2.getHistorySchema().orElse(null).getSchemaByIndexId(baseIndexId).orElse(null));
+        Assertions.assertNull(job2.getHistorySchema().orElse(null).getSchemaByIndexMetaId(baseIndexMetaId).orElse(null));
         Assertions.assertNull(job2.getHistorySchema().orElse(null)
                 .getSchemaBySchemaId(preAlterIndexMeta2.getSchemaId()).orElse(null));
         job2.setFinishedTimeMs(System.currentTimeMillis() / 1000 - Config.alter_table_timeout_second - 100);
@@ -562,14 +562,14 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         GlobalStateMgr.getCurrentState().getLocalMetastore().save(imageWriter);
         GlobalStateMgr.getCurrentState().getAlterJobMgr().save(imageWriter);
 
-        long baseIndexId = table.getBaseIndexMetaId();
-        MaterializedIndexMeta preAlterIndexMeta = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        long baseIndexMetaId = table.getBaseIndexMetaId();
+        MaterializedIndexMeta preAlterIndexMeta = table.getIndexMetaByMetaId(baseIndexMetaId).shallowCopy();
         SchemaChangeJobV2 job = (SchemaChangeJobV2) executeAlterAndWaitFinish(
                 table, "ALTER TABLE t_history_schema_replay ADD COLUMN c1 BIGINT");
         Assertions.assertTrue(isSchemaMatch(db, table, Lists.newArrayList("c0", "c1")));
         OlapTableHistorySchema historySchema = job.getHistorySchema().orElse(null);
         Assertions.assertNotNull(historySchema);
-        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta, historySchema);
+        assertHistorySchemaMatches(table, baseIndexMetaId, preAlterIndexMeta, historySchema);
 
         LocalMetastore restoredMetastore =
                 new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
@@ -586,8 +586,9 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         Assertions.assertNotNull(restoredDb, "Restored database not found");
         OlapTable restoredTable = (OlapTable) restoredMetastore.getTable(restoredDb.getFullName(), table.getName());
         Assertions.assertNotNull(restoredTable, "Restored table not found");
-        Assertions.assertEquals(SchemaInfo.fromMaterializedIndex(table, baseIndexId, preAlterIndexMeta),
-                SchemaInfo.fromMaterializedIndex(restoredTable, baseIndexId, restoredTable.getIndexMetaByIndexId(baseIndexId)));
+        Assertions.assertEquals(SchemaInfo.fromMaterializedIndex(table, baseIndexMetaId, preAlterIndexMeta),
+                SchemaInfo.fromMaterializedIndex(restoredTable, baseIndexMetaId,
+                        restoredTable.getIndexMetaByMetaId(baseIndexMetaId)));
         Assertions.assertFalse(getLatestAlterJob(restoredTable, restoredAlterJobMgr.getSchemaChangeHandler()).isPresent());
         isSchemaMatch(restoredDb, restoredTable, Lists.newArrayList("c0"));
 
@@ -603,22 +604,24 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
             GlobalStateMgr.getCurrentState().setLocalMetastore(originalMetastore);
         }
         Assertions.assertTrue(isSchemaMatch(restoredDb, restoredTable, Lists.newArrayList("c0", "c1")));
-        Assertions.assertEquals(SchemaInfo.fromMaterializedIndex(table, baseIndexId, table.getIndexMetaByIndexId(baseIndexId)),
-                SchemaInfo.fromMaterializedIndex(restoredTable, baseIndexId, restoredTable.getIndexMetaByIndexId(baseIndexId)));
+        Assertions.assertEquals(
+                SchemaInfo.fromMaterializedIndex(table, baseIndexMetaId, table.getIndexMetaByMetaId(baseIndexMetaId)),
+                SchemaInfo.fromMaterializedIndex(restoredTable, baseIndexMetaId,
+                        restoredTable.getIndexMetaByMetaId(baseIndexMetaId)));
         AlterJobV2 restoredJob = restoredHandler.getAlterJobsV2().get(job.getJobId());
         Assertions.assertInstanceOf(SchemaChangeJobV2.class, restoredJob);
         SchemaChangeJobV2 fseJob = (SchemaChangeJobV2) restoredJob;
         OlapTableHistorySchema restoredHistorySchema = fseJob.getHistorySchema().orElse(null);
         Assertions.assertNotNull(restoredHistorySchema);
         Assertions.assertEquals(historySchema.getHistoryTxnIdThreshold(), restoredHistorySchema.getHistoryTxnIdThreshold());
-        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta, restoredHistorySchema);
+        assertHistorySchemaMatches(table, baseIndexMetaId, preAlterIndexMeta, restoredHistorySchema);
     }
 
-    private void assertHistorySchemaMatches(OlapTable table, long indexId, MaterializedIndexMeta originMeta,
+    private void assertHistorySchemaMatches(OlapTable table, long indexMetaId, MaterializedIndexMeta originMeta,
                                             OlapTableHistorySchema historySchema) {
-        SchemaInfo originSchemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, originMeta);
+        SchemaInfo originSchemaInfo = SchemaInfo.fromMaterializedIndex(table, indexMetaId, originMeta);
         Assertions.assertNotNull(historySchema);
-        SchemaInfo schemaInfo = historySchema.getSchemaByIndexId(indexId).orElse(null);
+        SchemaInfo schemaInfo = historySchema.getSchemaByIndexMetaId(indexMetaId).orElse(null);
         Assertions.assertNotNull(schemaInfo);
         Assertions.assertEquals(originSchemaInfo, schemaInfo);
         Assertions.assertEquals(originSchemaInfo.hashCode(), schemaInfo.hashCode());
@@ -655,8 +658,8 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
         try {
-            long baseIndexId = table.getBaseIndexMetaId();
-            MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(baseIndexId);
+            long baseIndexMetaId = table.getBaseIndexMetaId();
+            MaterializedIndexMeta indexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
             List<Column> schema = indexMeta.getSchema();
             if (schema.size() != columNames.size()) {
                 return false;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AccessTestUtil.java
@@ -85,10 +85,10 @@ public class AccessTestUtil {
         baseSchema.add(column);
         OlapTable table = new OlapTable(30000, "testTbl", baseSchema,
                 KeysType.AGG_KEYS, new SinglePartitionInfo(), distributionInfo, null);
-        table.setIndexMeta(baseIndex.getId(), "testTbl", baseSchema, 0, 1, (short) 1,
+        table.setIndexMeta(baseIndex.getMetaId(), "testTbl", baseSchema, 0, 1, (short) 1,
                 TStorageType.COLUMN, KeysType.AGG_KEYS);
         table.addPartition(partition);
-        table.setBaseIndexMetaId(baseIndex.getId());
+        table.setBaseIndexMetaId(baseIndex.getMetaId());
         db.registerTableUnlocked(table);
         return globalStateMgr;
     }
@@ -101,6 +101,9 @@ public class AccessTestUtil {
         new Expectations(index) {
             {
                 index.getId();
+                minTimes = 0;
+                result = 30000L;
+                index.getMetaId();
                 minTimes = 0;
                 result = 30000L;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
@@ -337,8 +337,8 @@ public class RestoreJobMaterializedViewTest extends StarRocksTestBase {
                     .getMaterializedIndices(IndexExtState.VISIBLE)) {
                 BackupIndexInfo idxInfo = new BackupIndexInfo();
                 idxInfo.id = index.getId();
-                idxInfo.name = olapTable.getIndexNameByMetaId(index.getId());
-                idxInfo.schemaHash = olapTable.getSchemaHashByIndexMetaId(index.getId());
+                idxInfo.name = olapTable.getIndexNameByMetaId(index.getMetaId());
+                idxInfo.schemaHash = olapTable.getSchemaHashByIndexMetaId(index.getMetaId());
                 partInfo.indexes.put(idxInfo.name, idxInfo);
 
                 for (Tablet tablet : index.getTablets()) {

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
@@ -242,8 +242,8 @@ public class RestoreJobPrimaryKeyTest {
                     .getMaterializedIndices(IndexExtState.VISIBLE)) {
                 BackupIndexInfo idxInfo = new BackupIndexInfo();
                 idxInfo.id = index.getId();
-                idxInfo.name = expectedRestoreTbl.getIndexNameByMetaId(index.getId());
-                idxInfo.schemaHash = expectedRestoreTbl.getSchemaHashByIndexMetaId(index.getId());
+                idxInfo.name = expectedRestoreTbl.getIndexNameByMetaId(index.getMetaId());
+                idxInfo.schemaHash = expectedRestoreTbl.getSchemaHashByIndexMetaId(index.getMetaId());
                 partInfo.indexes.put(idxInfo.name, idxInfo);
 
                 for (Tablet tablet : index.getTablets()) {

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -354,8 +354,8 @@ public class RestoreJobTest {
                 for (MaterializedIndex index : physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
                     BackupIndexInfo idxInfo = new BackupIndexInfo();
                     idxInfo.id = index.getId();
-                    idxInfo.name = expectedRestoreTbl.getIndexNameByMetaId(index.getId());
-                    idxInfo.schemaHash = expectedRestoreTbl.getSchemaHashByIndexMetaId(index.getId());
+                    idxInfo.name = expectedRestoreTbl.getIndexNameByMetaId(index.getMetaId());
+                    idxInfo.schemaHash = expectedRestoreTbl.getSchemaHashByIndexMetaId(index.getMetaId());
                     physicalPartInfo.indexes.put(idxInfo.name, idxInfo);
 
                     for (Tablet tablet : index.getTablets()) {
@@ -534,8 +534,8 @@ public class RestoreJobTest {
                     .getMaterializedIndices(IndexExtState.VISIBLE)) {
                 BackupIndexInfo idxInfo = new BackupIndexInfo();
                 idxInfo.id = index.getId();
-                idxInfo.name = expectedRestoreTbl.getIndexNameByMetaId(index.getId());
-                idxInfo.schemaHash = expectedRestoreTbl.getSchemaHashByIndexMetaId(index.getId());
+                idxInfo.name = expectedRestoreTbl.getIndexNameByMetaId(index.getMetaId());
+                idxInfo.schemaHash = expectedRestoreTbl.getSchemaHashByIndexMetaId(index.getMetaId());
                 partInfo.indexes.put(idxInfo.name, idxInfo);
 
                 for (Tablet tablet : index.getTablets()) {
@@ -706,8 +706,8 @@ public class RestoreJobTest {
                     .getMaterializedIndices(IndexExtState.VISIBLE)) {
                 BackupIndexInfo idxInfo = new BackupIndexInfo();
                 idxInfo.id = index.getId();
-                idxInfo.name = expectedRestoreTbl.getIndexNameByMetaId(index.getId());
-                idxInfo.schemaHash = expectedRestoreTbl.getSchemaHashByIndexMetaId(index.getId());
+                idxInfo.name = expectedRestoreTbl.getIndexNameByMetaId(index.getMetaId());
+                idxInfo.schemaHash = expectedRestoreTbl.getSchemaHashByIndexMetaId(index.getMetaId());
                 partInfo.indexes.put(idxInfo.name, idxInfo);
 
                 for (Tablet tablet : index.getTablets()) {

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
@@ -117,7 +117,7 @@ public class TabletSchedCtxTest {
                 addReplica(TABLET_ID_1, new Replica(50001, be1.getId(), 0, Replica.ReplicaState.NORMAL));
 
         // mock catalog
-        MaterializedIndex baseIndex = new MaterializedIndex(TB_ID, MaterializedIndex.IndexState.NORMAL);
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
         DistributionInfo distributionInfo = new RandomDistributionInfo(32);
         Partition partition = new Partition(PART_ID, PH_PART_ID, TB_NAME, baseIndex, distributionInfo);
         baseIndex.addTablet(tablet, tabletMeta);

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/BalanceStatProcNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/BalanceStatProcNodeTest.java
@@ -164,8 +164,8 @@ public class BalanceStatProcNodeTest {
             index.addTablet(new LocalTablet(tablet1Id), tabletMeta);
             long tablet2Id = 1011L;
             index.addTablet(new LocalTablet(tablet2Id), tabletMeta);
-            Map<String, Long> indexNameToId = olapTable.getIndexNameToMetaId();
-            indexNameToId.put("index1", index.getId());
+            Map<String, Long> indexNameToMetaId = olapTable.getIndexNameToMetaId();
+            indexNameToMetaId.put("index1", index.getMetaId());
 
             // balance stat
             index.setBalanceStat(BalanceStat.createClusterTabletBalanceStat(be1.getId(), be2.getId(), 9L, 1L));
@@ -199,8 +199,8 @@ public class BalanceStatProcNodeTest {
             index.addTablet(new LocalTablet(tablet1Id), tabletMeta);
             long tablet2Id = 1111L;
             index.addTablet(new LocalTablet(tablet2Id), tabletMeta);
-            Map<String, Long> indexNameToId = olapTable.getIndexNameToMetaId();
-            indexNameToId.put("index1", index.getId());
+            Map<String, Long> indexNameToMetaId = olapTable.getIndexNameToMetaId();
+            indexNameToMetaId.put("index1", index.getMetaId());
 
             // balance stat
             index.setBalanceStat(BalanceStat.createColocationGroupBalanceStat(
@@ -242,8 +242,8 @@ public class BalanceStatProcNodeTest {
             index.addTablet(new LocalTablet(tablet1Id), tabletMeta);
             long tablet2Id = 1211L;
             index.addTablet(new LocalTablet(tablet2Id), tabletMeta);
-            Map<String, Long> indexNameToId = olapTable.getIndexNameToMetaId();
-            indexNameToId.put("index1", index.getId());
+            Map<String, Long> indexNameToMetaId = olapTable.getIndexNameToMetaId();
+            indexNameToMetaId.put("index1", index.getMetaId());
 
             // balance stat
             Set<Long> currentBes = Sets.newHashSet(be1.getId(), be2.getId());

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/IndicesProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/IndicesProcDirTest.java
@@ -52,8 +52,8 @@ public class IndicesProcDirTest {
         OlapTable olapTable = new OlapTable(1024L, "olap_table", col, null, listPartition, null);
         MaterializedIndex index = new MaterializedIndex(1000L, IndexState.NORMAL);
         index.setBalanceStat(BalanceStat.createClusterTabletBalanceStat(1L, 2L, 9L, 1L));
-        Map<String, Long> indexNameToId = olapTable.getIndexNameToMetaId();
-        indexNameToId.put("index1", index.getId());
+        Map<String, Long> indexNameToMetaId = olapTable.getIndexNameToMetaId();
+        indexNameToMetaId.put("index1", index.getMetaId());
         TabletMeta tabletMeta = new TabletMeta(db.getId(), olapTable.getId(), partitionId, index.getId(), TStorageMedium.HDD);
         index.addTablet(new LocalTablet(1010L), tabletMeta);
         index.addTablet(new LocalTablet(1011L), tabletMeta);

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
@@ -50,8 +50,8 @@ public class PartitionsProcDirTest {
         listPartition.setDataCacheInfo(partitionId, dataCache);
         LakeTable cloudNativeTable = new LakeTable(1024L, "cloud_native_table", col, null, listPartition, null);
         MaterializedIndex index = new MaterializedIndex(1000L, IndexState.NORMAL);
-        Map<String, Long> indexNameToId = cloudNativeTable.getIndexNameToMetaId();
-        indexNameToId.put("index1", index.getId());
+        Map<String, Long> indexNameToMetaId = cloudNativeTable.getIndexNameToMetaId();
+        indexNameToMetaId.put("index1", index.getMetaId());
         cloudNativeTable.addPartition(new Partition(partitionId, 1035, "p1", index, new RandomDistributionInfo(10)));
 
         db.registerTableUnlocked(cloudNativeTable);
@@ -81,8 +81,8 @@ public class PartitionsProcDirTest {
         OlapTable olapTable = new OlapTable(1024L, "olap_table", col, null, listPartition, null);
         MaterializedIndex index = new MaterializedIndex(1000L, IndexState.NORMAL);
         index.setBalanceStat(BalanceStat.BALANCED_STAT);
-        Map<String, Long> indexNameToId = olapTable.getIndexNameToMetaId();
-        indexNameToId.put("index1", index.getId());
+        Map<String, Long> indexNameToMetaId = olapTable.getIndexNameToMetaId();
+        indexNameToMetaId.put("index1", index.getMetaId());
         olapTable.addPartition(new Partition(partitionId, 1035, "p1", index, new RandomDistributionInfo(10)));
 
         db.registerTableUnlocked(olapTable);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
@@ -183,16 +183,16 @@ public class LakeTableHelperTest {
             index.addTablet(tablet, tabletMeta);
         }
         table.addPartition(partition);
-        table.setIndexMeta(index.getId(), "t0", Arrays.asList(c0, c1), 0, 0, (short) 1, TStorageType.COLUMN,
+        table.setIndexMeta(index.getMetaId(), "t0", Arrays.asList(c0, c1), 0, 0, (short) 1, TStorageType.COLUMN,
                 keysType);
-        List<Column> newIndexSchema = table.getSchemaByIndexMetaId(indexId);
+        List<Column> newIndexSchema = table.getSchemaByIndexMetaId(index.getMetaId());
         List<Column> baseSchema = table.getBaseSchema();
 
         {
             // reset column unique id to invalid value
             c0.setUniqueId(-1);
             c1.setUniqueId(0);
-            Assertions.assertEquals(2, table.getIndexIdToSchema().size());
+            Assertions.assertEquals(2, table.getIndexMetaIdToSchema().size());
 
             // base schema is fine
             Assertions.assertFalse(LakeTableHelper.restoreColumnUniqueId(baseSchema));

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
@@ -951,7 +951,7 @@ public class LoadPlannerTest {
                 result = 3;
                 table.getBaseIndexMetaId();
                 result = 1;
-                table.getKeyColumnsByIndexId((long) 1);
+                table.getKeyColumnsByIndexMetaId((long) 1);
                 result = keyColumns;
                 table.getBaseSchema();
                 result = columns;
@@ -1069,9 +1069,9 @@ public class LoadPlannerTest {
                 result = 3;
                 table.getBaseIndexMetaId();
                 result = 1;
-                table.getIndexIdToSchema();
+                table.getIndexMetaIdToSchema();
                 result = indexSchema;
-                table.getKeyColumnsByIndexId((long) 1);
+                table.getKeyColumnsByIndexMetaId((long) 1);
                 result = keyColumns;
                 table.getBaseSchema();
                 result = columns;

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadJobTest.java
@@ -406,6 +406,8 @@ public class SparkLoadJobTest {
 
                 index.getId();
                 result = indexId;
+                index.getMetaId();
+                result = indexId;
                 index.getTablets();
                 result = Lists.newArrayList(tablet);
                 tablet.getId();
@@ -448,9 +450,9 @@ public class SparkLoadJobTest {
         Map<Long, Set<Long>> tableToLoadPartitions = Deencapsulation.getField(job, "tableToLoadPartitions");
         Assertions.assertTrue(tableToLoadPartitions.containsKey(tableId));
         Assertions.assertTrue(tableToLoadPartitions.get(tableId).contains(physicalPartitionId));
-        Map<Long, Integer> indexToSchemaHash = Deencapsulation.getField(job, "indexToSchemaHash");
-        Assertions.assertTrue(indexToSchemaHash.containsKey(indexId));
-        Assertions.assertEquals(schemaHash, (long) indexToSchemaHash.get(indexId));
+        Map<Long, Integer> indexMetaIdToSchemaHash = Deencapsulation.getField(job, "indexMetaIdToSchemaHash");
+        Assertions.assertTrue(indexMetaIdToSchemaHash.containsKey(indexId));
+        Assertions.assertEquals(schemaHash, (long) indexMetaIdToSchemaHash.get(indexId));
 
         // finish push task
         job.addFinishedReplica(replicaId, tabletId, backendId);
@@ -509,6 +511,8 @@ public class SparkLoadJobTest {
 
                 index.getId();
                 result = indexId;
+                index.getMetaId();
+                result = indexId;
 
                 index.getTablets();
                 result = Lists.newArrayList(tablet);
@@ -543,9 +547,9 @@ public class SparkLoadJobTest {
         Map<Long, Set<Long>> tableToLoadPartitions = Deencapsulation.getField(job, "tableToLoadPartitions");
         Assertions.assertTrue(tableToLoadPartitions.containsKey(tableId));
         Assertions.assertTrue(tableToLoadPartitions.get(tableId).contains(physicalPartitionId));
-        Map<Long, Integer> indexToSchemaHash = Deencapsulation.getField(job, "indexToSchemaHash");
-        Assertions.assertTrue(indexToSchemaHash.containsKey(indexId));
-        Assertions.assertEquals(schemaHash, (long) indexToSchemaHash.get(indexId));
+        Map<Long, Integer> indexMetaIdToSchemaHash = Deencapsulation.getField(job, "indexMetaIdToSchemaHash");
+        Assertions.assertTrue(indexMetaIdToSchemaHash.containsKey(indexId));
+        Assertions.assertEquals(schemaHash, (long) indexMetaIdToSchemaHash.get(indexId));
 
         // finish push task
         job.addFinishedReplica(tableId, tabletId, backendId);

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadPendingTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadPendingTaskTest.java
@@ -139,7 +139,7 @@ public class SparkLoadPendingTaskTest {
                 result = table;
                 table.getPartitions();
                 result = partitions;
-                table.getIndexIdToSchema();
+                table.getIndexMetaIdToSchema();
                 result = indexIdToSchema;
                 table.getDefaultDistributionInfo();
                 result = distributionInfo;
@@ -302,7 +302,7 @@ public class SparkLoadPendingTaskTest {
                 result = table;
                 table.getPartitions();
                 result = partitions;
-                table.getIndexIdToSchema();
+                table.getIndexMetaIdToSchema();
                 result = indexIdToSchema;
                 table.getDefaultDistributionInfo();
                 result = distributionInfo;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorSimpleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorSimpleTest.java
@@ -115,7 +115,6 @@ import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TDataCacheMetrics;
 import com.starrocks.thrift.TDataCacheStatus;
-import com.starrocks.thrift.TStorageType;
 import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
@@ -226,10 +225,6 @@ public class ShowExecutorSimpleTest {
                 table.getIndexMetaIdByName(anyString);
                 minTimes = 0;
                 result = 0L;
-
-                table.getStorageTypeByIndexMetaId(0L);
-                minTimes = 0;
-                result = TStorageType.COLUMN;
 
                 table.getPartition(anyLong);
                 minTimes = 0;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -82,7 +82,6 @@ import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.system.SystemInfoService;
-import com.starrocks.thrift.TStorageType;
 import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
 import mockit.Expectations;
@@ -190,10 +189,6 @@ public class ShowExecutorTest {
                 table.getIndexMetaIdByName(anyString);
                 minTimes = 0;
                 result = 0L;
-
-                table.getStorageTypeByIndexMetaId(0L);
-                minTimes = 0;
-                result = TStorageType.COLUMN;
 
                 table.getPartition(anyLong);
                 minTimes = 0;

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
@@ -340,7 +340,7 @@ public class ReplicationJobTest {
         MaterializedIndex index = partition.getDefaultPhysicalPartition().getBaseIndex();
         MaterializedIndex srcIndex = srcPartition.getDefaultPhysicalPartition().getBaseIndex();
         indexInfo.index_id = index.getId();
-        indexInfo.src_schema_hash = srcTable.getSchemaHashByIndexMetaId(srcIndex.getId());
+        indexInfo.src_schema_hash = srcTable.getSchemaHashByIndexMetaId(srcIndex.getMetaId());
         partitionInfo.index_replication_infos.put(indexInfo.index_id, indexInfo);
 
         indexInfo.tablet_replication_infos = new HashMap<Long, TTabletReplicationInfo>();

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
@@ -364,7 +364,7 @@ public class ReplicationMgrTest {
         MaterializedIndex index = partition.getDefaultPhysicalPartition().getBaseIndex();
         MaterializedIndex srcIndex = srcPartition.getDefaultPhysicalPartition().getBaseIndex();
         indexInfo.index_id = index.getId();
-        indexInfo.src_schema_hash = srcTable.getSchemaHashByIndexMetaId(srcIndex.getId());
+        indexInfo.src_schema_hash = srcTable.getSchemaHashByIndexMetaId(srcIndex.getMetaId());
         partitionInfo.index_replication_infos.put(indexInfo.index_id, indexInfo);
 
         indexInfo.tablet_replication_infos = new HashMap<Long, TTabletReplicationInfo>();

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
@@ -164,7 +164,6 @@ public class LocalMetaStoreTest {
         Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t1");
         PhysicalPartition p = table.getPartitions().stream().findFirst().get().getDefaultPhysicalPartition();
-        int schemaHash = table.getSchemaHashByIndexMetaId(p.getBaseIndex().getId());
         MaterializedIndex index = new MaterializedIndex();
         TabletMeta tabletMeta = new TabletMeta(db.getId(), table.getId(), p.getId(),
                     index.getId(), table.getPartitionInfo().getDataProperty(p.getParentId()).getStorageMedium());

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreSimpleOpsEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreSimpleOpsEditLogTest.java
@@ -714,7 +714,7 @@ public class LocalMetastoreSimpleOpsEditLogTest {
         Assertions.assertNotNull(replayInfo);
         Assertions.assertEquals(DB_ID, replayInfo.getDbId());
         Assertions.assertEquals(TABLE_ID, replayInfo.getTableId());
-        Assertions.assertEquals(rollupIndexId, replayInfo.getIndexId());
+        Assertions.assertEquals(rollupIndexId, replayInfo.getIndexMetaId());
         Assertions.assertEquals(newRollupName, replayInfo.getNewRollupName());
 
         // Create follower metastore and the same id objects, then replay

--- a/fe/fe-core/src/test/java/com/starrocks/service/TableSchemaServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/TableSchemaServiceTest.java
@@ -191,8 +191,8 @@ public class TableSchemaServiceTest extends StarRocksTestBase {
     @Test
     public void testScanNodeCacheSchema() throws Exception {
         LakeTable table = createTable("t_scan_node_cache_schema");
-        long indexId = table.getBaseIndexMetaId();
-        SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, table.getIndexMetaByIndexId(indexId));
+        long indexMetaId = table.getBaseIndexMetaId();
+        SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(table, indexMetaId, table.getIndexMetaByMetaId(indexMetaId));
 
         // Generate OlapScanNode
         ExecPlan plan1 = UtFrameUtils.getPlanAndFragment(
@@ -238,8 +238,8 @@ public class TableSchemaServiceTest extends StarRocksTestBase {
     @Test
     public void testFoundInQueryCoordinator() throws Exception {
         LakeTable table = createTable("t_scan_coordinator");
-        long indexId = table.getBaseIndexMetaId();
-        SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, table.getIndexMetaByIndexId(indexId));
+        long indexMetaId = table.getBaseIndexMetaId();
+        SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(table, indexMetaId, table.getIndexMetaByMetaId(indexMetaId));
 
         // Execute query to create coordinator with OlapScanNode
         TUniqueId queryId1 = UUIDUtil.genTUniqueId();
@@ -269,8 +269,8 @@ public class TableSchemaServiceTest extends StarRocksTestBase {
     @Test
     public void testFoundInCatalog() throws Exception {
         LakeTable table = createTable("t_found_in_catalog");
-        long indexId = table.getBaseIndexMetaId();
-        SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, table.getIndexMetaByIndexId(indexId));
+        long indexMetaId = table.getBaseIndexMetaId();
+        SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(table, indexMetaId, table.getIndexMetaByMetaId(indexMetaId));
 
         // query fallback to catalog
         TUniqueId queryId = UUIDUtil.genTUniqueId();
@@ -293,8 +293,8 @@ public class TableSchemaServiceTest extends StarRocksTestBase {
     @Test
     public void testFoundInHistory() throws Exception {
         LakeTable table = createTable("t_found_in_history");
-        long indexId = table.getBaseIndexMetaId();
-        SchemaInfo oldSchemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, table.getIndexMetaByIndexId(indexId));
+        long indexMetaId = table.getBaseIndexMetaId();
+        SchemaInfo oldSchemaInfo = SchemaInfo.fromMaterializedIndex(table, indexMetaId, table.getIndexMetaByMetaId(indexMetaId));
 
         // Begin a transaction before alter to prevent the history schema to be cleaned
         TransactionState.TxnCoordinator txnCoordinator = new TransactionState.TxnCoordinator(
@@ -349,8 +349,8 @@ public class TableSchemaServiceTest extends StarRocksTestBase {
     @Test
     public void testScanNotFound() throws Exception {
         LakeTable table = createTable("t_scan_not_found");
-        long indexId = table.getBaseIndexMetaId();
-        SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, table.getIndexMetaByIndexId(indexId));
+        long indexMetaId = table.getBaseIndexMetaId();
+        SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(table, indexMetaId, table.getIndexMetaByMetaId(indexMetaId));
 
         // query not exists, and schema not found in catalog and history
         {
@@ -387,7 +387,7 @@ public class TableSchemaServiceTest extends StarRocksTestBase {
     @Test
     public void testLoadNotFound() throws Exception {
         LakeTable table = createTable("t_load_not_found");
-        long invalidSchemaId = table.getIndexMetaByIndexId(table.getBaseIndexMetaId()).getSchemaId() - 1;
+        long invalidSchemaId = table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSchemaId() - 1;
 
         // txn not exist
         {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/implementation/OlapScanImplementationRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/implementation/OlapScanImplementationRuleTest.java
@@ -46,7 +46,7 @@ public class OlapScanImplementationRuleTest {
         assertEquals(1, output.size());
 
         PhysicalOlapScanOperator physical = (PhysicalOlapScanOperator) output.get(0).getOp();
-        assertEquals(1, physical.getSelectedIndexId());
+        assertEquals(1, physical.getSelectedIndexMetaId());
 
         assertEquals(3, physical.getSelectedPartitionId().size());
         assertEquals(1, physical.getSelectedTabletId().size());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRuleTest.java
@@ -61,7 +61,7 @@ public class MaterializedViewRuleTest extends PlanTestBase {
         Assertions.assertEquals(1, plan.getScanNodes().size());
         Assertions.assertTrue(plan.getScanNodes().get(0) instanceof OlapScanNode);
         OlapScanNode olapScanNode = (OlapScanNode) plan.getScanNodes().get(0);
-        Long selectedIndexid = olapScanNode.getSelectedIndexId();
+        Long selectedIndexid = olapScanNode.getSelectedIndexMetaId();
         GlobalStateMgr globalStateMgr = starRocksAssert.getCtx().getGlobalStateMgr();
         Database database = globalStateMgr.getLocalMetastore().getDb("test");
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
@@ -84,7 +84,7 @@ public class MaterializedViewRuleTest extends PlanTestBase {
                     " from lineorder_flat_for_mv group by LO_ORDERDATE;";
         ExecPlan plan = getExecPlan(sql);
         OlapScanNode olapScanNode = (OlapScanNode) plan.getScanNodes().get(0);
-        Long selectedIndexid = olapScanNode.getSelectedIndexId();
+        Long selectedIndexid = olapScanNode.getSelectedIndexMetaId();
         Assertions.assertNotEquals(baseTable.getIndexMetaIdByName("lo_count_key_mv"), selectedIndexid);
     }
 


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:

1. Rename variables related to materialized index meta id.
2. Add `MaterializedIndex.getMetaId()` function which temporarily returns index id (to be fixed in the later PR).

https://github.com/StarRocks/starrocks/issues/64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors alter/rollup/schema-change codepaths to consistently use materialized index meta ids instead of index ids, maintaining JSON compatibility and behavior.
> 
> - Rename fields/methods and maps from `indexId` to `indexMetaId` across builders and jobs (e.g., `AlterJobV2Builder`, `LakeTable*`, `OlapTable*`, `RollupJobV2`, `SchemaChangeData`), including helpers like `withNewIndexMetaIdToSchema/ShortKeyCount`
> - Use meta id in tablet schema creation and agent tasks (`TTabletSchema.setId`, `CreateReplicaTask.setIndexId`), and in job/info outputs
> - Preserve serialized field names via comments and `@SerializedName("indexId")` while storing meta ids
> - Update MV/rollup validation and drop flows to rely on meta ids; add minor naming clarifications (e.g., `physicalPartitionId`)
> - `IndexSchemaInfo` now carries `indexMetaId`; history schema lookups switch to `getSchemaByIndexMetaId`
> - Logic notes where id == meta id initially for compatibility; no functional behavior change intended
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f1989302439ac3c7a07d01ef43d733fa5b4f2f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->