### PR TITLE
[UT] Fix ColocateTableBalancer unstable UT

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import com.starrocks.alter.SystemHandler;
 import com.starrocks.catalog.ColocateGroupSchema;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.ColocateTableIndex.GroupId;
@@ -55,6 +56,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.leader.TabletCollector;
+import com.starrocks.load.routineload.RoutineLoadTaskScheduler;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
@@ -109,16 +111,28 @@ public class ColocateTableBalancerTest {
                 System.out.println("Mocked ColocateTableBalancer.runAfterCatalogReady() called");
             }
         };
+        new MockUp<SystemHandler>() {
+            @Mock
+            protected void runAfterCatalogReady() {
+                System.out.println("Mocked SystemHandler.runAfterCatalogReady() called");
+            }
+        };
+        new MockUp<RoutineLoadTaskScheduler>() {
+            @Mock
+            protected void runAfterCatalogReady() {
+                // the interval is 0, so skip log printing to prevent too many logs
+            }
+        };
 
-        GlobalStateMgr.getCurrentState().getAlterJobMgr().stop();
         UtFrameUtils.createMinStarRocksCluster();
-        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
-        starRocksAssert = new StarRocksAssert(ctx);
+        GlobalStateMgr.getCurrentState().getAlterJobMgr().stop();
         GlobalStateMgr.getCurrentState().getHeartbeatMgr().setStop();
         GlobalStateMgr.getCurrentState().getTabletScheduler().setStop();
         TabletCollector collector = (TabletCollector) Deencapsulation.getField(GlobalStateMgr.getCurrentState(),
                 "tabletCollector");
         collector.setStop();
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(ctx);
     }
 
     @BeforeEach


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

fix unstable case:

```
ColocateTableBalancerTest.testBalanceWithOnlyOneAvailableBackend(SystemInfoService, ClusterLoadStatistic, Backend, Backend, Backend)

Missing 1 invocation to:
com.starrocks.system.SystemInfoService#getBackendIds(false)
   on mock instance: com.starrocks.system.SystemInfoService@52ab97c
Caused by: Missing invocations
	at com.starrocks.alter.SystemHandler.runAfterCatalogReady(SystemHandler.java:261)
	at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:78)
	at com.starrocks.common.util.Daemon.run(Daemon.java:98)

Missing 1 invocation to:
com.starrocks.system.SystemInfoService#getBackendIds(true)
   on mock instance: com.starrocks.system.SystemInfoService@70e9f99e
Caused by: Missing invocations
	at com.starrocks.system.SystemInfoService.getBackendIds(SystemInfoService.java)
	at com.starrocks.load.routineload.RoutineLoadMgr.updateBeTaskSlot(RoutineLoadMgr.java:264)
	at com.starrocks.load.routineload.RoutineLoadTaskScheduler.updateBackendSlotIfNecessary(RoutineLoadTaskScheduler.java:311)
	at com.starrocks.load.routineload.RoutineLoadTaskScheduler.process(RoutineLoadTaskScheduler.java:112)
	at com.starrocks.load.routineload.RoutineLoadTaskScheduler.runAfterCatalogReady(RoutineLoadTaskScheduler.java:105)
	at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72)
	at com.starrocks.common.util.Daemon.run(Daemon.java:109)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens UT stability without changing production code.
> 
> - Mock `runAfterCatalogReady` for `SystemHandler` and `RoutineLoadTaskScheduler` to prevent background threads from invoking `SystemInfoService` during tests
> - Adjust test setup: create the mini cluster first, then stop `AlterJobMgr`, heartbeat, tablet scheduler, and `TabletCollector`; initialize `ConnectContext`/`StarRocksAssert` afterward
> - Minor import additions and setup reordering within `ColocateTableBalancerTest` only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c65ecb6f04abfd13382d98f818e6c270e80dddb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->