### PR TITLE
[Enhancement] Add Iceberg Delete Sink to write position delete files

### DIFF
--- a/be/src/connector/CMakeLists.txt
+++ b/be/src/connector/CMakeLists.txt
@@ -35,4 +35,5 @@ ADD_BE_LIB(Connector
         connector_sink_executor.cpp
         deletion_vector/deletion_vector.cpp
         deletion_vector/deletion_bitmap.cpp
+        iceberg_delete_sink.cpp
 )

--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -231,6 +231,11 @@ public:
         __builtin_unreachable();
     }
 
+    virtual std::unique_ptr<ConnectorChunkSinkProvider> create_delete_sink_provider() const {
+        CHECK(false) << connector_type() << " connector does not implement chunk sink yet";
+        __builtin_unreachable();
+    }
+
     virtual ConnectorType connector_type() const = 0;
 };
 

--- a/be/src/connector/connector_chunk_sink.h
+++ b/be/src/connector/connector_chunk_sink.h
@@ -49,11 +49,11 @@ public:
 
     virtual Status add(const ChunkPtr& chunk);
 
-    Status finish();
+    virtual Status finish();
 
     void rollback();
 
-    bool is_finished();
+    virtual bool is_finished();
 
     virtual void callback_on_commit(const CommitResult& result) = 0;
 

--- a/be/src/connector/iceberg_connector.cpp
+++ b/be/src/connector/iceberg_connector.cpp
@@ -15,11 +15,16 @@
 #include "iceberg_connector.h"
 
 #include "iceberg_chunk_sink.h"
+#include "iceberg_delete_sink.h"
 
 namespace starrocks::connector {
 
 std::unique_ptr<ConnectorChunkSinkProvider> IcebergConnector::create_data_sink_provider() const {
     return std::make_unique<IcebergChunkSinkProvider>();
+}
+
+std::unique_ptr<ConnectorChunkSinkProvider> IcebergConnector::create_delete_sink_provider() const {
+    return std::make_unique<connector::IcebergDeleteSinkProvider>();
 }
 
 } // namespace starrocks::connector

--- a/be/src/connector/iceberg_connector.h
+++ b/be/src/connector/iceberg_connector.h
@@ -28,6 +28,7 @@ public:
     ConnectorType connector_type() const override { return ConnectorType::ICEBERG; }
 
     std::unique_ptr<ConnectorChunkSinkProvider> create_data_sink_provider() const override;
+    std::unique_ptr<ConnectorChunkSinkProvider> create_delete_sink_provider() const;
 };
 
 } // namespace starrocks::connector

--- a/be/src/connector/iceberg_delete_sink.cpp
+++ b/be/src/connector/iceberg_delete_sink.cpp
@@ -44,12 +44,11 @@ IcebergDeleteSink::IcebergDeleteSink(std::vector<std::string> partition_columns,
                                      std::vector<std::unique_ptr<ColumnEvaluator>>&& partition_column_evaluators,
                                      std::unique_ptr<PartitionChunkWriterFactory> partition_chunk_writer_factory,
                                      RuntimeState* state,
-                                     const std::unordered_map<std::string, TExprNode>& column_slot_map)
+                                     std::unordered_map<std::string, TExprNode> column_slot_map)
         : ConnectorChunkSink(std::move(partition_columns), std::move(partition_column_evaluators),
                              std::move(partition_chunk_writer_factory), state, true),
           _transform_exprs(std::move(transform_exprs)),
-          _column_slot_map(column_slot_map),
-          _state(state) {}
+          _column_slot_map(std::move(column_slot_map)) {}
 
 // Callback for handling commit results
 void IcebergDeleteSink::callback_on_commit(const CommitResult& result) {

--- a/be/src/connector/iceberg_delete_sink.cpp
+++ b/be/src/connector/iceberg_delete_sink.cpp
@@ -43,8 +43,7 @@ IcebergDeleteSink::IcebergDeleteSink(std::vector<std::string> partition_columns,
                                      std::vector<std::string> transform_exprs,
                                      std::vector<std::unique_ptr<ColumnEvaluator>>&& partition_column_evaluators,
                                      std::unique_ptr<PartitionChunkWriterFactory> partition_chunk_writer_factory,
-                                     RuntimeState* state,
-                                     std::unordered_map<std::string, TExprNode> column_slot_map)
+                                     RuntimeState* state, std::unordered_map<std::string, TExprNode> column_slot_map)
         : ConnectorChunkSink(std::move(partition_columns), std::move(partition_column_evaluators),
                              std::move(partition_chunk_writer_factory), state, true),
           _transform_exprs(std::move(transform_exprs)),

--- a/be/src/connector/iceberg_delete_sink.cpp
+++ b/be/src/connector/iceberg_delete_sink.cpp
@@ -191,6 +191,9 @@ StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergDeleteSinkProvider::create_
     std::vector<std::string> column_names = {"file_path", "pos"};
     // We only need evaluators for the two columns: file_path and pos
     std::vector<std::unique_ptr<ColumnEvaluator>> column_evaluators_vec;
+    if (ctx->column_evaluators.size() < 2) {
+        return Status::InternalError("Not enough column evaluators, expected at least 2");
+    }
     column_evaluators_vec.push_back(ctx->column_evaluators[0]->clone());
     column_evaluators_vec.push_back(ctx->column_evaluators[1]->clone());
     auto column_evaluators =

--- a/be/src/connector/iceberg_delete_sink.cpp
+++ b/be/src/connector/iceberg_delete_sink.cpp
@@ -1,0 +1,311 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "connector/iceberg_delete_sink.h"
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <future>
+
+#include "column/column_helper.h"
+#include "column/datum.h"
+#include "connector/async_flush_stream_poller.h"
+#include "connector/partition_chunk_writer.h"
+#include "exec/pipeline/fragment_context.h"
+#include "exec/sorting/sorting.h"
+#include "exprs/expr.h"
+#include "formats/column_evaluator.h"
+#include "formats/parquet/parquet_file_writer.h"
+#include "formats/utils.h"
+#include "gutil/strings/fastmem.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/descriptors.h"
+#include "storage/chunk_helper.h"
+#include "util/url_coding.h"
+#include "utils.h"
+
+namespace starrocks::connector {
+
+// IcebergDeleteSink implementation
+IcebergDeleteSink::IcebergDeleteSink(std::vector<std::string> partition_columns,
+                                     std::vector<std::string> transform_exprs,
+                                     std::vector<std::unique_ptr<ColumnEvaluator>>&& partition_column_evaluators,
+                                     std::unique_ptr<PartitionChunkWriterFactory> partition_chunk_writer_factory,
+                                     RuntimeState* state,
+                                     const std::unordered_map<std::string, TExprNode>& column_slot_map)
+        : ConnectorChunkSink(std::move(partition_columns), std::move(partition_column_evaluators),
+                             std::move(partition_chunk_writer_factory), state, true),
+          _transform_exprs(std::move(transform_exprs)),
+          _column_slot_map(column_slot_map),
+          _state(state) {}
+
+// Callback for handling commit results
+void IcebergDeleteSink::callback_on_commit(const CommitResult& result) {
+    // TODO: Implement proper commit result handling for delete files
+}
+
+// Adds a chunk of data to the delete sink.
+// Groups rows by file_path and writes separate delete files for each source data file.
+//
+// Parameters:
+//   chunk - Input chunk containing columns: _file (file_path) and _pos (row_position)
+//
+// Returns Status::OK() on success, or an error if processing fails.
+Status IcebergDeleteSink::add(const ChunkPtr& chunk) {
+    int num_rows = chunk->num_rows();
+    if (num_rows == 0) {
+        return Status::OK();
+    }
+
+    std::string partition = DEFAULT_PARTITION;
+    bool is_partitioned = !_partition_column_names.empty();
+    std::vector<int8_t> partition_field_null_list;
+
+    // Compute partition name if table is partitioned
+    if (is_partitioned) {
+        ASSIGN_OR_RETURN(partition, HiveUtils::iceberg_make_partition_name(
+                                            _partition_column_names, _partition_column_evaluators, _transform_exprs,
+                                            chunk.get(), _support_null_partition, partition_field_null_list));
+    }
+
+    // Find file_path column slot_id from the mapping
+    auto file_path_it = _column_slot_map.find("_file");
+    if (file_path_it == _column_slot_map.end()) {
+        return Status::InternalError("Could not find _file column in column_slot_map");
+    }
+    SlotId file_path_slot_id = file_path_it->second.slot_ref.slot_id;
+
+    // Get file_path column using slot_id
+    ColumnPtr file_path_column = chunk->get_column_by_slot_id(file_path_slot_id);
+    if (file_path_column == nullptr) {
+        return Status::InternalError(
+                fmt::format("Could not find file_path column with slot_id {} in chunk", file_path_slot_id));
+    }
+
+    // Get underlying binary column (handles nullable columns)
+    const BinaryColumn* binary_column = ColumnHelper::get_binary_column(file_path_column.get());
+
+    // Group rows by file_path for file-level delete files
+    std::unordered_map<std::string, std::vector<uint32_t>> file_path_to_indices;
+    for (int i = 0; i < num_rows; ++i) {
+        // Skip NULL file_path values (they don't reference any file)
+        if (file_path_column->is_null(i)) {
+            LOG(WARNING) << "Skipping row " << i << " with NULL file_path";
+            continue;
+        }
+        std::string file_path = binary_column->get_slice(i).to_string();
+        file_path_to_indices[std::move(file_path)].push_back(i);
+    }
+
+    // Write separate delete files for each file_path
+    for (auto& [file_path, indices] : file_path_to_indices) {
+        // Create chunk with only rows for this file_path
+        ChunkPtr file_chunk = chunk->clone_empty_with_slot();
+        file_chunk->append_selective(*chunk, indices.data(), 0, indices.size());
+
+        // Write using file-level writer for this (partition, file_path)
+        RETURN_IF_ERROR(write_file_level_chunk(partition, partition_field_null_list, file_chunk, file_path));
+    }
+
+    return Status::OK();
+}
+
+// Finishes writing all delete files.
+// Flushes and finalizes all file-level writers.
+//
+// Returns Status::OK() on success, or an error if finishing fails.
+Status IcebergDeleteSink::finish() {
+    // Flush all file-level writers
+    for (auto& [key, writer] : _file_writers) {
+        RETURN_IF_ERROR(writer->flush());
+    }
+    // Wait for all flushes to complete
+    for (auto& [key, writer] : _file_writers) {
+        RETURN_IF_ERROR(writer->wait_flush());
+    }
+    // Finish all writers
+    for (auto& [key, writer] : _file_writers) {
+        RETURN_IF_ERROR(writer->finish());
+    }
+    return Status::OK();
+}
+
+// Checks if all delete file writes are finished.
+//
+// Returns true if all writers are finished, false otherwise.
+bool IcebergDeleteSink::is_finished() {
+    for (auto& [key, writer] : _file_writers) {
+        if (!writer->is_finished()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Creates an IcebergDeleteSink instance for writing position delete files.
+// Validates the context and creates necessary writers for delete file generation.
+//
+// Parameters:
+//   context - The sink context containing configuration (must be IcebergDeleteSinkContext)
+//   driver_id - The driver ID for this sink instance
+//
+// Returns the created sink on success, or an error if creation fails.
+StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergDeleteSinkProvider::create_chunk_sink(
+        std::shared_ptr<ConnectorChunkSinkContext> context, int32_t driver_id) {
+    auto ctx = std::dynamic_pointer_cast<IcebergDeleteSinkContext>(context);
+    if (ctx == nullptr) {
+        return Status::InternalError("IcebergDeleteSinkProvider: context is not IcebergDeleteSinkContext");
+    }
+
+    auto runtime_state = ctx->fragment_context->runtime_state();
+
+    TupleDescriptor* tuple_desc = runtime_state->desc_tbl().get_tuple_descriptor(ctx->tuple_desc_id);
+    if (tuple_desc == nullptr) {
+        return Status::InternalError(fmt::format("Failed to find tuple descriptor with id {}", ctx->tuple_desc_id));
+    }
+    DCHECK(tuple_desc->slots().size() == ctx->output_exprs.size());
+
+    // Verify we found the required columns
+    if (ctx->column_slot_map.find("_file") == ctx->column_slot_map.end()) {
+        return Status::InternalError("Could not find _file column in column_slot_map");
+    }
+    if (ctx->column_slot_map.find("_pos") == ctx->column_slot_map.end()) {
+        return Status::InternalError("Could not find _pos column in column_slot_map");
+    }
+
+    // Create filesystem
+    std::shared_ptr<FileSystem> fs =
+            FileSystem::CreateUniqueFromString(ctx->path, FSOptions(&ctx->cloud_configuration)).value();
+
+    // For delete files, we only need file_path and row_position columns
+    std::vector<std::string> column_names = {"file_path", "pos"};
+    // We only need evaluators for the two columns: file_path and pos
+    std::vector<std::unique_ptr<ColumnEvaluator>> column_evaluators_vec;
+    column_evaluators_vec.push_back(ctx->column_evaluators[0]->clone());
+    column_evaluators_vec.push_back(ctx->column_evaluators[1]->clone());
+    auto column_evaluators =
+            std::make_shared<std::vector<std::unique_ptr<ColumnEvaluator>>>(std::move(column_evaluators_vec));
+
+    // Create location provider for delete files
+    auto location_provider = std::make_shared<connector::LocationProvider>(
+            ctx->path, print_id(ctx->fragment_context->query_id()), runtime_state->be_number(), driver_id, "parquet");
+
+    std::vector<formats::FileColumnId> file_column_ids(column_names.size());
+    // file_path column (index 0)
+    file_column_ids[0].field_id = INT32_MAX - 101;
+    // pos column (index 1)
+    file_column_ids[1].field_id = INT32_MAX - 102;
+
+    // Create Parquet writer factory for delete files
+    auto file_writer_factory = std::make_shared<formats::ParquetFileWriterFactory>(
+            fs, ctx->compression_type, ctx->options, column_names, column_evaluators, file_column_ids, ctx->executor,
+            runtime_state);
+
+    // Initialize sort ordering for position delete files (required by Iceberg spec)
+    // Sort by: file_path ASC, then pos ASC
+    std::shared_ptr<SortOrdering> sort_ordering = std::make_shared<SortOrdering>();
+    sort_ordering->sort_key_idxes = {0, 1};                    // file_path, pos
+    sort_ordering->sort_descs.descs.emplace_back(true, false); // file_path: ASC, nulls last
+    sort_ordering->sort_descs.descs.emplace_back(true, false); // pos: ASC, nulls last
+
+    // Create partition chunk writer factory
+    std::unique_ptr<PartitionChunkWriterFactory> partition_chunk_writer_factory;
+
+    // Create a custom tuple descriptor with only file_path and pos columns
+    // Use DescriptorTbl::create to properly create tuple and slot descriptors
+    TSlotDescriptorBuilder slot_builder;
+    TTupleDescriptorBuilder tuple_builder;
+
+    // Add file_path column (VARCHAR)
+    tuple_builder.add_slot(slot_builder.id(1)
+                                   .type(TYPE_VARCHAR)
+                                   .nullable(true)
+                                   .is_materialized(true)
+                                   .column_name("file_path")
+                                   .build());
+
+    // Add pos column (BIGINT)
+    tuple_builder.add_slot(
+            slot_builder.id(2).type(TYPE_BIGINT).nullable(true).is_materialized(true).column_name("pos").build());
+
+    // Create descriptor table and tuple
+    TDescriptorTableBuilder desc_tbl_builder;
+    tuple_builder.build(&desc_tbl_builder);
+    TDescriptorTable t_desc_tbl = desc_tbl_builder.desc_tbl();
+
+    DescriptorTbl* desc_tbl = nullptr;
+    RETURN_IF_ERROR(DescriptorTbl::create(runtime_state, runtime_state->obj_pool(), t_desc_tbl, &desc_tbl,
+                                          config::vector_chunk_size));
+
+    // Extract the tuple descriptor we just created (it will be the first one)
+    TupleDescriptor* delete_tuple_desc = desc_tbl->get_tuple_descriptor(0);
+    DCHECK(delete_tuple_desc != nullptr);
+    DCHECK_EQ(delete_tuple_desc->slots().size(), 2);
+
+    auto writer_ctx = std::make_shared<SpillPartitionChunkWriterContext>(SpillPartitionChunkWriterContext{
+            {file_writer_factory, location_provider, ctx->max_file_size, ctx->partition_column_names.empty()},
+            fs,
+            ctx->fragment_context,
+            delete_tuple_desc,
+            column_evaluators,
+            sort_ordering});
+    partition_chunk_writer_factory = std::make_unique<SpillPartitionChunkWriterFactory>(writer_ctx);
+
+    // Create the delete sink
+    return std::make_unique<IcebergDeleteSink>(
+            ctx->partition_column_names, ctx->transform_exprs, ColumnEvaluator::clone(ctx->partition_evaluators),
+            std::move(partition_chunk_writer_factory), runtime_state, ctx->column_slot_map);
+}
+
+// Writes a chunk to the file-level delete file for a specific source data file.
+// Creates a writer for (partition, file_path) if one doesn't exist.
+//
+// Parameters:
+//   partition - The partition name
+//   partition_field_null_list - List indicating which partition fields are NULL
+//   chunk - The chunk to write (contains rows for one specific source file)
+//   file_path - The path of the source data file these deletes apply to
+//
+// Returns Status::OK() on success, or an error if writing fails.
+Status IcebergDeleteSink::write_file_level_chunk(const std::string& partition,
+                                                 const std::vector<int8_t>& partition_field_null_list,
+                                                 const ChunkPtr& chunk, const std::string& file_path) {
+    // Key: (partition, file_path)
+    auto key = std::make_pair(partition, file_path);
+
+    // Check if writer already exists for this file
+    auto it = _file_writers.find(key);
+    if (it != _file_writers.end()) {
+        return it->second->write(chunk);
+    }
+
+    // Create new writer for this (partition, file_path)
+    auto writer = _partition_chunk_writer_factory->create(partition, partition_field_null_list);
+
+    // Set up callbacks
+    auto commit_callback = [this](const CommitResult& r) { this->callback_on_commit(r); };
+    auto error_handler = [this](const Status& s) { this->set_status(s); };
+    writer->set_commit_callback(commit_callback);
+    writer->set_error_handler(error_handler);
+    writer->set_io_poller(_io_poller);
+
+    // Initialize and cache the writer
+    RETURN_IF_ERROR(writer->init());
+
+    _file_writers[key] = writer;
+    return writer->write(chunk);
+}
+
+} // namespace starrocks::connector

--- a/be/src/connector/iceberg_delete_sink.h
+++ b/be/src/connector/iceberg_delete_sink.h
@@ -101,9 +101,6 @@ private:
     // Column name to slot reference mapping (stores slot_ref and type)
     std::unordered_map<std::string, TExprNode> _column_slot_map;
 
-    // Runtime state (for metrics and commit info)
-    RuntimeState* _state = nullptr;
-
     // Map: (partition, file_path) -> writer for file-level delete files
     std::map<std::pair<std::string, std::string>, PartitionChunkWriterPtr> _file_writers;
 

--- a/be/src/connector/iceberg_delete_sink.h
+++ b/be/src/connector/iceberg_delete_sink.h
@@ -84,7 +84,7 @@ public:
     IcebergDeleteSink(std::vector<std::string> partition_columns, std::vector<std::string> transform_exprs,
                       std::vector<std::unique_ptr<ColumnEvaluator>>&& partition_column_evaluators,
                       std::unique_ptr<PartitionChunkWriterFactory> partition_chunk_writer_factory, RuntimeState* state,
-                      const std::unordered_map<std::string, TExprNode>& column_slot_map);
+                      std::unordered_map<std::string, TExprNode> column_slot_map);
     ~IcebergDeleteSink() override = default;
 
     void callback_on_commit(const CommitResult& result) override;

--- a/be/src/connector/iceberg_delete_sink.h
+++ b/be/src/connector/iceberg_delete_sink.h
@@ -1,0 +1,115 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "column/chunk.h"
+#include "common/status.h"
+#include "connector/connector.h"
+#include "connector/partition_chunk_writer.h"
+#include "formats/file_writer.h"
+
+namespace starrocks {
+class RuntimeState;
+
+namespace connector {
+struct SortOrdering;
+
+// Context for IcebergDeleteSink
+// Contains configuration needed to write delete files
+struct IcebergDeleteSinkContext : public ConnectorChunkSinkContext {
+    std::string path;
+    std::vector<std::string> column_names;
+    std::vector<std::string> partition_column_names;
+    std::vector<std::string> transform_exprs;
+    std::vector<std::unique_ptr<ColumnEvaluator>> column_evaluators;
+    std::vector<std::unique_ptr<ColumnEvaluator>> partition_evaluators;
+
+    // Compression type for Parquet files
+    starrocks::TCompressionType::type compression_type;
+    std::map<std::string, std::string> options;
+
+    // Maximum size of delete files before rolling to new file
+    int64_t max_file_size = 128L * 1024 * 1024; // 128MB default
+
+    // Tuple descriptor id (contains 2 columns: file_path, pos)
+    int tuple_desc_id = -1;
+
+    // Cloud configuration (S3/HDFS credentials)
+    starrocks::TCloudConfiguration cloud_configuration;
+
+    // Fragment context
+    pipeline::FragmentContext* fragment_context = nullptr;
+
+    // Thread pool for async IO
+    PriorityThreadPool* executor = nullptr;
+
+    // Sort ordering (required by Iceberg spec: sorted by file_path, then pos)
+    std::shared_ptr<SortOrdering> sort_ordering;
+
+    // Output expressions from FE (to find column slots)
+    std::vector<TExpr> output_exprs;
+
+    // Column name to slot reference mapping (stores slot_ref and type)
+    std::unordered_map<std::string, TExprNode> column_slot_map;
+};
+
+// IcebergDeleteSinkProvider creates IcebergDeleteSink for writing position delete files
+class IcebergDeleteSinkProvider final : public ConnectorChunkSinkProvider {
+public:
+    ~IcebergDeleteSinkProvider() override = default;
+
+    // Create a sink for writing delete files
+    StatusOr<std::unique_ptr<ConnectorChunkSink>> create_chunk_sink(std::shared_ptr<ConnectorChunkSinkContext> context,
+                                                                    int32_t driver_id) override;
+};
+
+// IcebergDeleteSink writes position delete files for Iceberg Merge-On-Read operations.
+// It receives chunks with columns: file_path, row_position and writes them to Parquet delete files.
+class IcebergDeleteSink final : public ConnectorChunkSink {
+public:
+    IcebergDeleteSink(std::vector<std::string> partition_columns, std::vector<std::string> transform_exprs,
+                      std::vector<std::unique_ptr<ColumnEvaluator>>&& partition_column_evaluators,
+                      std::unique_ptr<PartitionChunkWriterFactory> partition_chunk_writer_factory, RuntimeState* state,
+                      const std::unordered_map<std::string, TExprNode>& column_slot_map);
+    ~IcebergDeleteSink() override = default;
+
+    void callback_on_commit(const CommitResult& result) override;
+
+    Status add(const ChunkPtr& chunk) override;
+
+    Status finish() override;
+
+    bool is_finished() override;
+
+private:
+    std::vector<std::string> _transform_exprs;
+
+    // Column name to slot reference mapping (stores slot_ref and type)
+    std::unordered_map<std::string, TExprNode> _column_slot_map;
+
+    // Runtime state (for metrics and commit info)
+    RuntimeState* _state = nullptr;
+
+    // Map: (partition, file_path) -> writer for file-level delete files
+    std::map<std::pair<std::string, std::string>, PartitionChunkWriterPtr> _file_writers;
+
+    Status write_file_level_chunk(const std::string& partition, const std::vector<int8_t>& partition_field_null_list,
+                                  const ChunkPtr& chunk, const std::string& file_path);
+};
+
+} // namespace connector
+} // namespace starrocks

--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -205,7 +205,7 @@ Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_s
         break;
     }
 #ifndef __APPLE__
-    case TDataSinkType::ICEBERG_TABLE_SINK: 
+    case TDataSinkType::ICEBERG_TABLE_SINK:
     case TDataSinkType::ICEBERG_DELETE_SINK: {
         if (!thrift_sink.__isset.iceberg_table_sink) {
             return Status::InternalError("Missing iceberg table sink");
@@ -215,7 +215,7 @@ Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_s
     }
 #else
     case TDataSinkType::ICEBERG_TABLE_SINK:
-    case TDataSinkType::ICEBERG_MERGE_SINK: {
+    case TDataSinkType::ICEBERG_DELETE_SINK: {
         return Status::NotSupported("Iceberg table sink is disabled on macOS");
     }
 #endif

--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -205,7 +205,8 @@ Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_s
         break;
     }
 #ifndef __APPLE__
-    case TDataSinkType::ICEBERG_TABLE_SINK: {
+    case TDataSinkType::ICEBERG_TABLE_SINK: 
+    case TDataSinkType::ICEBERG_DELETE_SINK: {
         if (!thrift_sink.__isset.iceberg_table_sink) {
             return Status::InternalError("Missing iceberg table sink");
         }
@@ -213,7 +214,8 @@ Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_s
         break;
     }
 #else
-    case TDataSinkType::ICEBERG_TABLE_SINK: {
+    case TDataSinkType::ICEBERG_TABLE_SINK:
+    case TDataSinkType::ICEBERG_MERGE_SINK: {
         return Status::NotSupported("Iceberg table sink is disabled on macOS");
     }
 #endif

--- a/be/src/exec/pipeline/sink/connector_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/connector_sink_operator.cpp
@@ -84,7 +84,6 @@ bool ConnectorSinkOperator::is_finished() const {
         LOG(WARNING) << "cancel fragment: " << status;
         _fragment_context->cancel(status);
     }
-
     bool ret = finished && _connector_chunk_sink->is_finished();
     return ret;
 }

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -505,6 +505,7 @@ Status ParquetFileWriterFactory::init() {
 
 StatusOr<WriterAndStream> ParquetFileWriterFactory::create(const std::string& path) const {
     ASSIGN_OR_RETURN(auto file, _fs->new_writable_file(WritableFileOptions{.direct_write = true}, path));
+    VLOG(3) << "create parquet file, path=" << path;
     auto rollback_action = [fs = _fs, path = path]() {
         WARN_IF_ERROR(ignore_not_found(fs->delete_file(path)), "fail to delete file");
     };

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -260,6 +260,8 @@ public:
 
     Status set_partition_desc_map(const TIcebergTable& thrift_table, ObjectPool* pool);
 
+    const std::vector<std::string>& partition_source_column_names() { return _source_column_names; }
+
 private:
     TIcebergSchema _t_iceberg_schema;
     std::vector<std::string> _source_column_names; // partition transform column's source column name

--- a/be/src/runtime/iceberg_table_sink.cpp
+++ b/be/src/runtime/iceberg_table_sink.cpp
@@ -74,151 +74,11 @@ Status IcebergTableSink::decompose_to_pipeline(pipeline::OpFactories prev_operat
     std::vector<std::string> transform_exprs = iceberg_table_desc->get_transform_exprs();
 
     if (is_delete_sink) {
-        // Create merge sink context for delete files
-        auto delete_sink_ctx = std::make_shared<connector::IcebergDeleteSinkContext>();
-        delete_sink_ctx->path = t_iceberg_sink.data_location;
-        delete_sink_ctx->cloud_configuration = t_iceberg_sink.cloud_configuration;
-        delete_sink_ctx->compression_type = t_iceberg_sink.compression_type;
-        if (t_iceberg_sink.__isset.target_max_file_size) {
-            delete_sink_ctx->max_file_size = t_iceberg_sink.target_max_file_size;
-        }
-        delete_sink_ctx->tuple_desc_id = t_iceberg_sink.tuple_id;
-        delete_sink_ctx->executor = ExecEnv::GetInstance()->pipeline_sink_io_pool();
-        delete_sink_ctx->fragment_context = fragment_ctx;
-
-        // Delete files have columns: file_path and pos (row_position)
-        const auto& output_exprs = this->get_output_expr();
-        delete_sink_ctx->column_evaluators = ColumnExprEvaluator::from_exprs(output_exprs, runtime_state);
-        delete_sink_ctx->transform_exprs = iceberg_table_desc->get_transform_exprs();
-        delete_sink_ctx->output_exprs = output_exprs;
-
-        // Configure partition columns if table is partitioned
-        delete_sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();
-
-        // Build column name to slot reference map for partition column updates
-        TupleDescriptor* tuple_desc = runtime_state->desc_tbl().get_tuple_descriptor(t_iceberg_sink.tuple_id);
-        if (tuple_desc == nullptr) {
-            return Status::InternalError(fmt::format("Failed to find tuple descriptor with id {}",
-                                                    t_iceberg_sink.tuple_id));
-        }
-
-        const auto& slots = tuple_desc->slots();
-        if (slots.size() != output_exprs.size()) {
-            return Status::InternalError(fmt::format(
-                "Mismatched slot and output expression counts: {} vs {}",
-                slots.size(), output_exprs.size()));
-        }
-
-        for (size_t i = 0; i < slots.size(); ++i) {
-            const auto* slot = slots[i];
-            const auto& expr = output_exprs[i];
-            for (const auto& node : expr.nodes) {
-                if (node.node_type == TExprNodeType::SLOT_REF && node.__isset.slot_ref) {
-                    delete_sink_ctx->column_slot_map[slot->col_name()] = node;
-                    break;
-                }
-            }
-        }
-
-        if (!iceberg_table_desc->is_unpartitioned_table()) {
-            partition_expr = iceberg_table_desc->get_partition_exprs();
-            const auto& partition_source_column_names = iceberg_table_desc->partition_source_column_names();
-
-            RETURN_IF_ERROR(update_partition_expr_slot_refs_by_map(
-                partition_expr, delete_sink_ctx->column_slot_map, partition_source_column_names));
-            delete_sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
-        }
-
-        sink_ctx = delete_sink_ctx;
-        auto connector = connector::ConnectorManager::default_instance()->get(connector::Connector::ICEBERG);
-        sink_provider = connector->create_delete_sink_provider();
+        RETURN_IF_ERROR(create_delete_sink_context(thrift_sink, runtime_state, context, iceberg_table_desc,
+                                                   sink_provider, sink_ctx, partition_expr));
     } else {
-        auto data_sink_ctx = std::make_shared<connector::IcebergChunkSinkContext>();
-        data_sink_ctx->path = t_iceberg_sink.__isset.data_location && !t_iceberg_sink.data_location.empty()
-                                ? t_iceberg_sink.data_location
-                                : t_iceberg_sink.location + connector::IcebergUtils::DATA_DIRECTORY;
-        data_sink_ctx->cloud_conf = t_iceberg_sink.cloud_configuration;
-        data_sink_ctx->column_names = iceberg_table_desc->full_column_names();
-        data_sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();
-        data_sink_ctx->executor = ExecEnv::GetInstance()->pipeline_sink_io_pool();
-        data_sink_ctx->format = t_iceberg_sink.file_format; // iceberg sink only supports parquet
-        data_sink_ctx->compression_type = t_iceberg_sink.compression_type;
-        if (t_iceberg_sink.__isset.target_max_file_size) {
-                data_sink_ctx->max_file_size = t_iceberg_sink.target_max_file_size;
-        }
-        data_sink_ctx->parquet_field_ids =
-                connector::IcebergUtils::generate_parquet_field_ids(iceberg_table_desc->get_iceberg_schema()->fields);
-        data_sink_ctx->column_evaluators = ColumnExprEvaluator::from_exprs(this->get_output_expr(), runtime_state);
-        data_sink_ctx->transform_exprs = iceberg_table_desc->get_transform_exprs();
-        data_sink_ctx->fragment_context = fragment_ctx;
-        data_sink_ctx->tuple_desc_id = t_iceberg_sink.tuple_id;
-        auto& sort_order = iceberg_table_desc->sort_order();
-        if (!sort_order.sort_key_idxes.empty()) {
-            data_sink_ctx->sort_ordering = std::make_shared<connector::SortOrdering>();
-            data_sink_ctx->sort_ordering->sort_key_idxes.assign(sort_order.sort_key_idxes.begin(),
-                                                            sort_order.sort_key_idxes.end());
-            data_sink_ctx->sort_ordering->sort_descs.descs.reserve(sort_order.sort_key_idxes.size());
-            for (size_t idx = 0; idx < sort_order.sort_key_idxes.size(); ++idx) {
-                bool is_asc = idx < sort_order.is_ascs.size() ? sort_order.is_ascs[idx] : true;
-                bool is_null_first = false;
-                if (idx < sort_order.is_null_firsts.size()) {
-                    is_null_first = sort_order.is_null_firsts[idx];
-                } else if (is_asc) {
-                    // If ascending, nulls are first by default
-                    // If descending, nulls are last by default
-                    is_null_first = true;
-                }
-                data_sink_ctx->sort_ordering->sort_descs.descs.emplace_back(is_asc, is_null_first);
-            }
-        }
-        
-        sink_ctx = data_sink_ctx;
-        auto connector = connector::ConnectorManager::default_instance()->get(connector::Connector::ICEBERG);
-        sink_provider = connector->create_data_sink_provider();
-
-        if (iceberg_table_desc->is_unpartitioned_table()) {
-            //do nothing
-        } else if (t_iceberg_sink.is_static_partition_sink) {
-            for (const auto& index : iceberg_table_desc->partition_source_index_in_schema()) {
-                if (index < 0 || index >= this->get_output_expr().size()) {
-                    return Status::InternalError(fmt::format("Invalid partition index: {}", index));
-                }
-                partition_expr.push_back(this->get_output_expr()[index]);
-            }
-            data_sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
-        } else {
-            auto source_column_index = iceberg_table_desc->partition_source_index_in_schema();
-            partition_expr = iceberg_table_desc->get_partition_exprs();
-
-            //for 3.5 fe -> 4.0 be compact, try to set this.
-            if (partition_expr.empty()) {
-                auto output_expr = this->get_output_expr();
-                for (const auto& index : source_column_index) {
-                    if (index < 0 || index >= this->get_output_expr().size()) {
-                        return Status::InternalError(fmt::format("Invalid partition index: {}", index));
-                    }
-                    partition_expr.push_back(output_expr[index]);
-                }
-            }
-
-            int idx = 0;
-            for (auto& part_expr : partition_expr) {
-                int index = source_column_index[idx];
-                //check index is valid for output_expr
-                if (index < 0 || index >= this->get_output_expr().size()) {
-                    return Status::InternalError(fmt::format("Invalid partition index: {}", index));
-                }
-                auto slot_ref = this->get_output_expr()[index];
-                for (auto& node : part_expr.nodes) {
-                    if (node.node_type == TExprNodeType::SLOT_REF) {
-                        node = slot_ref.nodes[0];
-                        break;
-                    }
-                }
-                idx++;
-            }
-            data_sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
-        }
+        RETURN_IF_ERROR(create_data_sink_context(thrift_sink, runtime_state, context, iceberg_table_desc,
+                                                 sink_provider, sink_ctx, partition_expr));
     }
 
     auto op = std::make_shared<pipeline::ConnectorSinkOperatorFactory>(
@@ -256,6 +116,181 @@ Status IcebergTableSink::decompose_to_pipeline(pipeline::OpFactories prev_operat
 
     return Status::OK();
 }
+
+Status IcebergTableSink::create_delete_sink_context(
+        const TDataSink& thrift_sink,
+        RuntimeState* runtime_state,
+        pipeline::PipelineBuilderContext* context,
+        IcebergTableDescriptor* iceberg_table_desc,
+        std::unique_ptr<connector::ConnectorChunkSinkProvider>& sink_provider,
+        std::shared_ptr<connector::ConnectorChunkSinkContext>& sink_ctx,
+        std::vector<TExpr>& partition_expr) const {
+    auto* fragment_ctx = context->fragment_context();
+    auto& t_iceberg_sink = thrift_sink.iceberg_table_sink;
+    
+    // Create merge sink context for delete files
+    auto delete_sink_ctx = std::make_shared<connector::IcebergDeleteSinkContext>();
+    delete_sink_ctx->path = t_iceberg_sink.data_location;
+    delete_sink_ctx->cloud_configuration = t_iceberg_sink.cloud_configuration;
+    delete_sink_ctx->compression_type = t_iceberg_sink.compression_type;
+    if (t_iceberg_sink.__isset.target_max_file_size) {
+        delete_sink_ctx->max_file_size = t_iceberg_sink.target_max_file_size;
+    }
+    delete_sink_ctx->tuple_desc_id = t_iceberg_sink.tuple_id;
+    delete_sink_ctx->executor = ExecEnv::GetInstance()->pipeline_sink_io_pool();
+    delete_sink_ctx->fragment_context = fragment_ctx;
+
+    // Delete files have columns: file_path and pos (row_position)
+    const auto& output_exprs = this->get_output_expr();
+    delete_sink_ctx->column_evaluators = ColumnExprEvaluator::from_exprs(output_exprs, runtime_state);
+    delete_sink_ctx->transform_exprs = iceberg_table_desc->get_transform_exprs();
+    delete_sink_ctx->output_exprs = output_exprs;
+
+    // Configure partition columns if table is partitioned
+    delete_sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();
+
+    // Build column name to slot reference map for partition column updates
+    TupleDescriptor* tuple_desc = runtime_state->desc_tbl().get_tuple_descriptor(t_iceberg_sink.tuple_id);
+    if (tuple_desc == nullptr) {
+        return Status::InternalError(fmt::format("Failed to find tuple descriptor with id {}",
+                                                t_iceberg_sink.tuple_id));
+    }
+
+    const auto& slots = tuple_desc->slots();
+    if (slots.size() != output_exprs.size()) {
+        return Status::InternalError(fmt::format(
+            "Mismatched slot and output expression counts: {} vs {}",
+            slots.size(), output_exprs.size()));
+    }
+
+    for (size_t i = 0; i < slots.size(); ++i) {
+        const auto* slot = slots[i];
+        const auto& expr = output_exprs[i];
+        for (const auto& node : expr.nodes) {
+            if (node.node_type == TExprNodeType::SLOT_REF && node.__isset.slot_ref) {
+                delete_sink_ctx->column_slot_map[slot->col_name()] = node;
+                break;
+            }
+        }
+    }
+
+    if (!iceberg_table_desc->is_unpartitioned_table()) {
+        partition_expr = iceberg_table_desc->get_partition_exprs();
+        const auto& partition_source_column_names = iceberg_table_desc->partition_source_column_names();
+
+        RETURN_IF_ERROR(update_partition_expr_slot_refs_by_map(
+            partition_expr, delete_sink_ctx->column_slot_map, partition_source_column_names));
+        delete_sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
+    }
+
+    sink_ctx = delete_sink_ctx;
+    auto connector = connector::ConnectorManager::default_instance()->get(connector::Connector::ICEBERG);
+    sink_provider = connector->create_delete_sink_provider();
+    
+    return Status::OK();
+}
+
+Status IcebergTableSink::create_data_sink_context(
+        const TDataSink& thrift_sink,
+        RuntimeState* runtime_state,
+        pipeline::PipelineBuilderContext* context,
+        IcebergTableDescriptor* iceberg_table_desc,
+        std::unique_ptr<connector::ConnectorChunkSinkProvider>& sink_provider,
+        std::shared_ptr<connector::ConnectorChunkSinkContext>& sink_ctx,
+        std::vector<TExpr>& partition_expr) const {
+    auto* fragment_ctx = context->fragment_context();
+    auto& t_iceberg_sink = thrift_sink.iceberg_table_sink;
+    
+    auto data_sink_ctx = std::make_shared<connector::IcebergChunkSinkContext>();
+    data_sink_ctx->path = t_iceberg_sink.__isset.data_location && !t_iceberg_sink.data_location.empty()
+                            ? t_iceberg_sink.data_location
+                            : t_iceberg_sink.location + connector::IcebergUtils::DATA_DIRECTORY;
+    data_sink_ctx->cloud_conf = t_iceberg_sink.cloud_configuration;
+    data_sink_ctx->column_names = iceberg_table_desc->full_column_names();
+    data_sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();
+    data_sink_ctx->executor = ExecEnv::GetInstance()->pipeline_sink_io_pool();
+    data_sink_ctx->format = t_iceberg_sink.file_format; // iceberg sink only supports parquet
+    data_sink_ctx->compression_type = t_iceberg_sink.compression_type;
+    if (t_iceberg_sink.__isset.target_max_file_size) {
+            data_sink_ctx->max_file_size = t_iceberg_sink.target_max_file_size;
+    }
+    data_sink_ctx->parquet_field_ids =
+            connector::IcebergUtils::generate_parquet_field_ids(iceberg_table_desc->get_iceberg_schema()->fields);
+    data_sink_ctx->column_evaluators = ColumnExprEvaluator::from_exprs(this->get_output_expr(), runtime_state);
+    data_sink_ctx->transform_exprs = iceberg_table_desc->get_transform_exprs();
+    data_sink_ctx->fragment_context = fragment_ctx;
+    data_sink_ctx->tuple_desc_id = t_iceberg_sink.tuple_id;
+    auto& sort_order = iceberg_table_desc->sort_order();
+    if (!sort_order.sort_key_idxes.empty()) {
+        data_sink_ctx->sort_ordering = std::make_shared<connector::SortOrdering>();
+        data_sink_ctx->sort_ordering->sort_key_idxes.assign(sort_order.sort_key_idxes.begin(),
+                                                        sort_order.sort_key_idxes.end());
+        data_sink_ctx->sort_ordering->sort_descs.descs.reserve(sort_order.sort_key_idxes.size());
+        for (size_t idx = 0; idx < sort_order.sort_key_idxes.size(); ++idx) {
+            bool is_asc = idx < sort_order.is_ascs.size() ? sort_order.is_ascs[idx] : true;
+            bool is_null_first = false;
+            if (idx < sort_order.is_null_firsts.size()) {
+                is_null_first = sort_order.is_null_firsts[idx];
+            } else if (is_asc) {
+                // If ascending, nulls are first by default
+                // If descending, nulls are last by default
+                is_null_first = true;
+            }
+            data_sink_ctx->sort_ordering->sort_descs.descs.emplace_back(is_asc, is_null_first);
+        }
+    }
+    
+    sink_ctx = data_sink_ctx;
+    auto connector = connector::ConnectorManager::default_instance()->get(connector::Connector::ICEBERG);
+    sink_provider = connector->create_data_sink_provider();
+
+    if (iceberg_table_desc->is_unpartitioned_table()) {
+        //do nothing
+    } else if (t_iceberg_sink.is_static_partition_sink) {
+        for (const auto& index : iceberg_table_desc->partition_source_index_in_schema()) {
+            if (index < 0 || index >= this->get_output_expr().size()) {
+                return Status::InternalError(fmt::format("Invalid partition index: {}", index));
+            }
+            partition_expr.push_back(this->get_output_expr()[index]);
+        }
+        data_sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
+    } else {
+        auto source_column_index = iceberg_table_desc->partition_source_index_in_schema();
+        partition_expr = iceberg_table_desc->get_partition_exprs();
+
+        //for 3.5 fe -> 4.0 be compact, try to set this.
+        if (partition_expr.empty()) {
+            auto output_expr = this->get_output_expr();
+            for (const auto& index : source_column_index) {
+                if (index < 0 || index >= this->get_output_expr().size()) {
+                    return Status::InternalError(fmt::format("Invalid partition index: {}", index));
+                }
+                partition_expr.push_back(output_expr[index]);
+            }
+        }
+
+        int idx = 0;
+        for (auto& part_expr : partition_expr) {
+            int index = source_column_index[idx];
+            //check index is valid for output_expr
+            if (index < 0 || index >= this->get_output_expr().size()) {
+                return Status::InternalError(fmt::format("Invalid partition index: {}", index));
+            }
+            auto slot_ref = this->get_output_expr()[index];
+            for (auto& node : part_expr.nodes) {
+                if (node.node_type == TExprNodeType::SLOT_REF) {
+                    node = slot_ref.nodes[0];
+                    break;
+                }
+            }
+            idx++;
+        }
+        data_sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
+    }
+    
+    return Status::OK();
+}
+
 
 // Updates partition expression slot references using the column slot map.
 // For each partition expression, replaces the slot reference node with the correct

--- a/be/src/runtime/iceberg_table_sink.cpp
+++ b/be/src/runtime/iceberg_table_sink.cpp
@@ -64,95 +64,166 @@ Status IcebergTableSink::decompose_to_pipeline(pipeline::OpFactories prev_operat
     auto* iceberg_table_desc = down_cast<IcebergTableDescriptor*>(table_desc);
     auto& t_iceberg_sink = thrift_sink.iceberg_table_sink;
 
-    auto sink_ctx = std::make_shared<connector::IcebergChunkSinkContext>();
-    sink_ctx->path = t_iceberg_sink.__isset.data_location && !t_iceberg_sink.data_location.empty()
-                             ? t_iceberg_sink.data_location
-                             : t_iceberg_sink.location + connector::IcebergUtils::DATA_DIRECTORY;
-    sink_ctx->cloud_conf = t_iceberg_sink.cloud_configuration;
-    sink_ctx->column_names = iceberg_table_desc->full_column_names();
-    sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();
-    sink_ctx->executor = ExecEnv::GetInstance()->pipeline_sink_io_pool();
-    sink_ctx->format = t_iceberg_sink.file_format; // iceberg sink only supports parquet
-    sink_ctx->compression_type = t_iceberg_sink.compression_type;
-    if (t_iceberg_sink.__isset.target_max_file_size) {
-        sink_ctx->max_file_size = t_iceberg_sink.target_max_file_size;
-    }
-    sink_ctx->parquet_field_ids =
-            connector::IcebergUtils::generate_parquet_field_ids(iceberg_table_desc->get_iceberg_schema()->fields);
-    sink_ctx->column_evaluators = ColumnExprEvaluator::from_exprs(this->get_output_expr(), runtime_state);
-    sink_ctx->transform_exprs = iceberg_table_desc->get_transform_exprs();
-    sink_ctx->fragment_context = fragment_ctx;
-    sink_ctx->tuple_desc_id = t_iceberg_sink.tuple_id;
-    auto& sort_order = iceberg_table_desc->sort_order();
-    if (!sort_order.sort_key_idxes.empty()) {
-        sink_ctx->sort_ordering = std::make_shared<connector::SortOrdering>();
-        sink_ctx->sort_ordering->sort_key_idxes.assign(sort_order.sort_key_idxes.begin(),
-                                                       sort_order.sort_key_idxes.end());
-        sink_ctx->sort_ordering->sort_descs.descs.reserve(sort_order.sort_key_idxes.size());
-        for (size_t idx = 0; idx < sort_order.sort_key_idxes.size(); ++idx) {
-            bool is_asc = idx < sort_order.is_ascs.size() ? sort_order.is_ascs[idx] : true;
-            bool is_null_first = false;
-            if (idx < sort_order.is_null_firsts.size()) {
-                is_null_first = sort_order.is_null_firsts[idx];
-            } else if (is_asc) {
-                // If ascending, nulls are first by default
-                // If descending, nulls are last by default
-                is_null_first = true;
-            }
-            sink_ctx->sort_ordering->sort_descs.descs.emplace_back(is_asc, is_null_first);
-        }
-    }
 
-    auto connector = connector::ConnectorManager::default_instance()->get(connector::Connector::ICEBERG);
-    auto sink_provider = connector->create_data_sink_provider();
-    auto op = std::make_shared<pipeline::ConnectorSinkOperatorFactory>(
-            context->next_operator_id(), std::move(sink_provider), sink_ctx, fragment_ctx);
-    size_t sink_dop = context->data_sink_dop();
+    // Determine if this is a delete sink (delete files) or regular sink (data files)
+    bool is_delete_sink = (thrift_sink.type == TDataSinkType::ICEBERG_DELETE_SINK);
 
+    std::unique_ptr<connector::ConnectorChunkSinkProvider> sink_provider;
+    std::shared_ptr<connector::ConnectorChunkSinkContext> sink_ctx;
     std::vector<TExpr> partition_expr;
-    if (iceberg_table_desc->is_unpartitioned_table()) {
-        //do nothing
-    } else if (t_iceberg_sink.is_static_partition_sink) {
-        for (const auto& index : iceberg_table_desc->partition_source_index_in_schema()) {
-            if (index < 0 || index >= this->get_output_expr().size()) {
-                return Status::InternalError(fmt::format("Invalid partition index: {}", index));
-            }
-            partition_expr.push_back(this->get_output_expr()[index]);
-        }
-        sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
-    } else {
-        auto source_column_index = iceberg_table_desc->partition_source_index_in_schema();
-        partition_expr = iceberg_table_desc->get_partition_exprs();
+    std::vector<std::string> transform_exprs = iceberg_table_desc->get_transform_exprs();
 
-        //for 3.5 fe -> 4.0 be compact, try to set this.
-        if (partition_expr.empty()) {
-            auto output_expr = this->get_output_expr();
-            for (const auto& index : source_column_index) {
-                if (index < 0 || index >= this->get_output_expr().size()) {
-                    return Status::InternalError(fmt::format("Invalid partition index: {}", index));
-                }
-                partition_expr.push_back(output_expr[index]);
-            }
+    if (is_delete_sink) {
+        // Create merge sink context for delete files
+        auto delete_sink_ctx = std::make_shared<connector::IcebergDeleteSinkContext>();
+        delete_sink_ctx->path = t_iceberg_sink.data_location;
+        delete_sink_ctx->cloud_configuration = t_iceberg_sink.cloud_configuration;
+        delete_sink_ctx->compression_type = t_iceberg_sink.compression_type;
+        if (t_iceberg_sink.__isset.target_max_file_size) {
+            delete_sink_ctx->max_file_size = t_iceberg_sink.target_max_file_size;
+        }
+        delete_sink_ctx->tuple_desc_id = t_iceberg_sink.tuple_id;
+        delete_sink_ctx->executor = ExecEnv::GetInstance()->pipeline_sink_io_pool();
+        delete_sink_ctx->fragment_context = fragment_ctx;
+
+        // Delete files have columns: file_path and pos (row_position)
+        const auto& output_exprs = this->get_output_expr();
+        delete_sink_ctx->column_evaluators = ColumnExprEvaluator::from_exprs(output_exprs, runtime_state);
+        delete_sink_ctx->transform_exprs = iceberg_table_desc->get_transform_exprs();
+        delete_sink_ctx->output_exprs = output_exprs;
+
+        // Configure partition columns if table is partitioned
+        delete_sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();
+
+        // Build column name to slot reference map for partition column updates
+        TupleDescriptor* tuple_desc = runtime_state->desc_tbl().get_tuple_descriptor(t_iceberg_sink.tuple_id);
+        if (tuple_desc == nullptr) {
+            return Status::InternalError(fmt::format("Failed to find tuple descriptor with id {}",
+                                                    t_iceberg_sink.tuple_id));
         }
 
-        int idx = 0;
-        for (auto& part_expr : partition_expr) {
-            int index = source_column_index[idx];
-            //check index is valid for output_expr
-            if (index < 0 || index >= this->get_output_expr().size()) {
-                return Status::InternalError(fmt::format("Invalid partition index: {}", index));
-            }
-            auto slot_ref = this->get_output_expr()[index];
-            for (auto& node : part_expr.nodes) {
-                if (node.node_type == TExprNodeType::SLOT_REF) {
-                    node = slot_ref.nodes[0];
+        const auto& slots = tuple_desc->slots();
+        if (slots.size() != output_exprs.size()) {
+            return Status::InternalError(fmt::format(
+                "Mismatched slot and output expression counts: {} vs {}",
+                slots.size(), output_exprs.size()));
+        }
+
+        for (size_t i = 0; i < slots.size(); ++i) {
+            const auto* slot = slots[i];
+            const auto& expr = output_exprs[i];
+            for (const auto& node : expr.nodes) {
+                if (node.node_type == TExprNodeType::SLOT_REF && node.__isset.slot_ref) {
+                    delete_sink_ctx->column_slot_map[slot->col_name()] = node;
                     break;
                 }
             }
-            idx++;
         }
-        sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
+
+        if (!iceberg_table_desc->is_unpartitioned_table()) {
+            partition_expr = iceberg_table_desc->get_partition_exprs();
+            const auto& partition_source_column_names = iceberg_table_desc->partition_source_column_names();
+
+            RETURN_IF_ERROR(update_partition_expr_slot_refs_by_map(
+                partition_expr, delete_sink_ctx->column_slot_map, partition_source_column_names));
+            delete_sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
+        }
+
+        sink_ctx = delete_sink_ctx;
+        auto connector = connector::ConnectorManager::default_instance()->get(connector::Connector::ICEBERG);
+        sink_provider = connector->create_delete_sink_provider();
+    } else {
+        auto data_sink_ctx = std::make_shared<connector::IcebergChunkSinkContext>();
+        data_sink_ctx->path = t_iceberg_sink.__isset.data_location && !t_iceberg_sink.data_location.empty()
+                                ? t_iceberg_sink.data_location
+                                : t_iceberg_sink.location + connector::IcebergUtils::DATA_DIRECTORY;
+        data_sink_ctx->cloud_conf = t_iceberg_sink.cloud_configuration;
+        data_sink_ctx->column_names = iceberg_table_desc->full_column_names();
+        data_sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();
+        data_sink_ctx->executor = ExecEnv::GetInstance()->pipeline_sink_io_pool();
+        data_sink_ctx->format = t_iceberg_sink.file_format; // iceberg sink only supports parquet
+        data_sink_ctx->compression_type = t_iceberg_sink.compression_type;
+        if (t_iceberg_sink.__isset.target_max_file_size) {
+                data_sink_ctx->max_file_size = t_iceberg_sink.target_max_file_size;
+        }
+        data_sink_ctx->parquet_field_ids =
+                connector::IcebergUtils::generate_parquet_field_ids(iceberg_table_desc->get_iceberg_schema()->fields);
+        data_sink_ctx->column_evaluators = ColumnExprEvaluator::from_exprs(this->get_output_expr(), runtime_state);
+        data_sink_ctx->transform_exprs = iceberg_table_desc->get_transform_exprs();
+        data_sink_ctx->fragment_context = fragment_ctx;
+        data_sink_ctx->tuple_desc_id = t_iceberg_sink.tuple_id;
+        auto& sort_order = iceberg_table_desc->sort_order();
+        if (!sort_order.sort_key_idxes.empty()) {
+            data_sink_ctx->sort_ordering = std::make_shared<connector::SortOrdering>();
+            data_sink_ctx->sort_ordering->sort_key_idxes.assign(sort_order.sort_key_idxes.begin(),
+                                                            sort_order.sort_key_idxes.end());
+            data_sink_ctx->sort_ordering->sort_descs.descs.reserve(sort_order.sort_key_idxes.size());
+            for (size_t idx = 0; idx < sort_order.sort_key_idxes.size(); ++idx) {
+                bool is_asc = idx < sort_order.is_ascs.size() ? sort_order.is_ascs[idx] : true;
+                bool is_null_first = false;
+                if (idx < sort_order.is_null_firsts.size()) {
+                    is_null_first = sort_order.is_null_firsts[idx];
+                } else if (is_asc) {
+                    // If ascending, nulls are first by default
+                    // If descending, nulls are last by default
+                    is_null_first = true;
+                }
+                data_sink_ctx->sort_ordering->sort_descs.descs.emplace_back(is_asc, is_null_first);
+            }
+        }
+        
+        sink_ctx = data_sink_ctx;
+        auto connector = connector::ConnectorManager::default_instance()->get(connector::Connector::ICEBERG);
+        sink_provider = connector->create_data_sink_provider();
+
+        if (iceberg_table_desc->is_unpartitioned_table()) {
+            //do nothing
+        } else if (t_iceberg_sink.is_static_partition_sink) {
+            for (const auto& index : iceberg_table_desc->partition_source_index_in_schema()) {
+                if (index < 0 || index >= this->get_output_expr().size()) {
+                    return Status::InternalError(fmt::format("Invalid partition index: {}", index));
+                }
+                partition_expr.push_back(this->get_output_expr()[index]);
+            }
+            data_sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
+        } else {
+            auto source_column_index = iceberg_table_desc->partition_source_index_in_schema();
+            partition_expr = iceberg_table_desc->get_partition_exprs();
+
+            //for 3.5 fe -> 4.0 be compact, try to set this.
+            if (partition_expr.empty()) {
+                auto output_expr = this->get_output_expr();
+                for (const auto& index : source_column_index) {
+                    if (index < 0 || index >= this->get_output_expr().size()) {
+                        return Status::InternalError(fmt::format("Invalid partition index: {}", index));
+                    }
+                    partition_expr.push_back(output_expr[index]);
+                }
+            }
+
+            int idx = 0;
+            for (auto& part_expr : partition_expr) {
+                int index = source_column_index[idx];
+                //check index is valid for output_expr
+                if (index < 0 || index >= this->get_output_expr().size()) {
+                    return Status::InternalError(fmt::format("Invalid partition index: {}", index));
+                }
+                auto slot_ref = this->get_output_expr()[index];
+                for (auto& node : part_expr.nodes) {
+                    if (node.node_type == TExprNodeType::SLOT_REF) {
+                        node = slot_ref.nodes[0];
+                        break;
+                    }
+                }
+                idx++;
+            }
+            data_sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
+        }
     }
+
+    auto op = std::make_shared<pipeline::ConnectorSinkOperatorFactory>(
+                context->next_operator_id(), std::move(sink_provider), sink_ctx, fragment_ctx);
+    size_t sink_dop = context->data_sink_dop();
 
     if (iceberg_table_desc->is_unpartitioned_table() || t_iceberg_sink.is_static_partition_sink) {
         auto ops = context->maybe_interpolate_local_passthrough_exchange(
@@ -165,11 +236,75 @@ Status IcebergTableSink::decompose_to_pipeline(pipeline::OpFactories prev_operat
 
         RETURN_IF_ERROR(Expr::create_expr_trees(runtime_state->obj_pool(), partition_expr, &partition_expr_ctxs,
                                                 runtime_state));
+
+        // Validate partition expressions were created successfully
+        for (int i = 0; i < partition_expr_ctxs.size(); i++) {
+            if (partition_expr_ctxs[i] == nullptr) {
+                return Status::InternalError(fmt::format("Partition expression at index {} is nullptr", i));
+            }
+            if (partition_expr_ctxs[i]->root() == nullptr) {
+                return Status::InternalError(fmt::format("Partition expression root at index {} is nullptr", i));
+            }
+        }
+
         auto ops = context->interpolate_local_key_partition_exchange(
                 runtime_state, pipeline::Operator::s_pseudo_plan_node_id_for_final_sink, prev_operators,
-                partition_expr_ctxs, sink_dop, sink_ctx->transform_exprs);
+                partition_expr_ctxs, sink_dop, transform_exprs);
         ops.emplace_back(std::move(op));
         context->add_pipeline(std::move(ops));
+    }
+
+    return Status::OK();
+}
+
+// Updates partition expression slot references using the column slot map.
+// For each partition expression, replaces the slot reference node with the correct
+// slot reference from the column_slot_map based on the partition source column name.
+//
+// Parameters:
+//   partition_expr - The partition expressions to update (modified in-place)
+//   column_slot_map - Mapping from column name to slot reference node
+//   partition_source_column_names - Names of source columns for partitioning
+//
+// Returns Status::OK() on success, or an error if a required slot reference is missing.
+Status IcebergTableSink::update_partition_expr_slot_refs_by_map(
+        std::vector<TExpr>& partition_expr,
+        const std::unordered_map<std::string, TExprNode>& column_slot_map,
+        const std::vector<std::string>& partition_source_column_names) const {
+    // Validate input sizes match
+    if (partition_expr.size() != partition_source_column_names.size()) {
+        return Status::InternalError(fmt::format(
+            "Mismatched partition expression and column name counts: {} vs {}",
+            partition_expr.size(), partition_source_column_names.size()));
+    }
+
+    // Update each partition expression's slot reference
+    for (size_t i = 0; i < partition_expr.size(); ++i) {
+        const std::string& source_col_name = partition_source_column_names[i];
+
+        // Find the slot reference for this source column
+        auto it = column_slot_map.find(source_col_name);
+        if (it == column_slot_map.end()) {
+            return Status::InternalError(
+                fmt::format("Could not find slot reference for partition column: {}", source_col_name));
+        }
+
+        const TExprNode& slot_info = it->second;
+        bool slot_ref_updated = false;
+
+        // Update the slot reference in the partition expression
+        for (auto& node : partition_expr[i].nodes) {
+            if (node.node_type == TExprNodeType::SLOT_REF && node.__isset.slot_ref) {
+                node = slot_info;
+                slot_ref_updated = true;
+                break;
+            }
+        }
+
+        if (!slot_ref_updated) {
+            return Status::InternalError(
+                fmt::format("No slot reference found in partition expression for column: {}", source_col_name));
+        }
     }
 
     return Status::OK();

--- a/be/src/runtime/iceberg_table_sink.h
+++ b/be/src/runtime/iceberg_table_sink.h
@@ -53,7 +53,7 @@ private:
     Status update_partition_expr_slot_refs_by_map(std::vector<TExpr>& partition_expr,
                                                   const std::unordered_map<std::string, TExprNode>& column_slot_map,
                                                   const std::vector<std::string>& partition_source_column_names) const;
-    
+
     // Helper functions to create sink contexts
     Status create_delete_sink_context(const TDataSink& thrift_sink, RuntimeState* runtime_state,
                                       pipeline::PipelineBuilderContext* context,
@@ -61,7 +61,7 @@ private:
                                       std::unique_ptr<connector::ConnectorChunkSinkProvider>& sink_provider,
                                       std::shared_ptr<connector::ConnectorChunkSinkContext>& sink_ctx,
                                       std::vector<TExpr>& partition_expr) const;
-    
+
     Status create_data_sink_context(const TDataSink& thrift_sink, RuntimeState* runtime_state,
                                     pipeline::PipelineBuilderContext* context,
                                     IcebergTableDescriptor* iceberg_table_desc,

--- a/be/src/runtime/iceberg_table_sink.h
+++ b/be/src/runtime/iceberg_table_sink.h
@@ -53,6 +53,21 @@ private:
     Status update_partition_expr_slot_refs_by_map(std::vector<TExpr>& partition_expr,
                                                   const std::unordered_map<std::string, TExprNode>& column_slot_map,
                                                   const std::vector<std::string>& partition_source_column_names) const;
+    
+    // Helper functions to create sink contexts
+    Status create_delete_sink_context(const TDataSink& thrift_sink, RuntimeState* runtime_state,
+                                      pipeline::PipelineBuilderContext* context,
+                                      IcebergTableDescriptor* iceberg_table_desc,
+                                      std::unique_ptr<connector::ConnectorChunkSinkProvider>& sink_provider,
+                                      std::shared_ptr<connector::ConnectorChunkSinkContext>& sink_ctx,
+                                      std::vector<TExpr>& partition_expr) const;
+    
+    Status create_data_sink_context(const TDataSink& thrift_sink, RuntimeState* runtime_state,
+                                    pipeline::PipelineBuilderContext* context,
+                                    IcebergTableDescriptor* iceberg_table_desc,
+                                    std::unique_ptr<connector::ConnectorChunkSinkProvider>& sink_provider,
+                                    std::shared_ptr<connector::ConnectorChunkSinkContext>& sink_ctx,
+                                    std::vector<TExpr>& partition_expr) const;
 
     ObjectPool* _pool;
     const std::vector<TExpr>& _t_output_expr;

--- a/be/src/runtime/iceberg_table_sink.h
+++ b/be/src/runtime/iceberg_table_sink.h
@@ -16,12 +16,14 @@
 
 #include "common/logging.h"
 #include "connector/iceberg_chunk_sink.h"
+#include "connector/iceberg_delete_sink.h"
 #include "exec/data_sink.h"
 #include "exec/pipeline/sink/connector_sink_operator.h"
 
 namespace starrocks {
 
 class ExprContext;
+struct TExprNode;
 
 class IcebergTableSink : public DataSink {
 public:
@@ -41,12 +43,17 @@ public:
 
     RuntimeProfile* profile() override { return _profile; }
 
-    std::vector<TExpr> get_output_expr() const { return _t_output_expr; }
+    const std::vector<TExpr>& get_output_expr() const { return _t_output_expr; }
 
     Status decompose_to_pipeline(pipeline::OpFactories prev_operators, const TDataSink& thrift_sink,
                                  pipeline::PipelineBuilderContext* context) const;
 
 private:
+    // Helper function to update slot references using column_slot_map
+    Status update_partition_expr_slot_refs_by_map(std::vector<TExpr>& partition_expr,
+                                                  const std::unordered_map<std::string, TExprNode>& column_slot_map,
+                                                  const std::vector<std::string>& partition_source_column_names) const;
+
     ObjectPool* _pool;
     const std::vector<TExpr>& _t_output_expr;
     std::vector<ExprContext*> _output_expr_ctxs;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -39,6 +39,7 @@ set(EXEC_FILES
         ./connector_sink/partition_chunk_writer_test.cpp
         ./connector_sink/async_flush_output_stream_test.cpp
         ./connector_sink/iceberg_table_sink_test.cpp
+        ./connector_sink/iceberg_delete_sink_test.cpp
         ./connector_sink/sink_memory_manager_test.cpp
         ./fs/azure/azblob_uri_test.cpp
         ./fs/azure/fs_azblob_test.cpp

--- a/be/test/connector_sink/iceberg_delete_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_delete_sink_test.cpp
@@ -256,11 +256,11 @@ TEST_F(IcebergDeleteSinkTest, missing_file_column) {
     auto context = std::make_shared<IcebergDeleteSinkContext>();
     context->tuple_desc_id = 0;
     context->fragment_context = _fragment_context.get();
-    
+
     // Setup output expressions to match tuple descriptor (2 slots)
     TExpr file_expr, pos_expr;
     context->output_exprs = {file_expr, pos_expr};
-    
+
     // Only add _pos, not _file
     TExprNode pos_node;
     pos_node.node_type = TExprNodeType::SLOT_REF;
@@ -270,7 +270,7 @@ TEST_F(IcebergDeleteSinkTest, missing_file_column) {
 
     auto provider = std::make_unique<IcebergDeleteSinkProvider>();
     auto result = provider->create_chunk_sink(context, 0);
-    
+
     // Should fail because _file column is missing
     ASSERT_FALSE(result.ok());
     EXPECT_THAT(std::string(result.status().message()), testing::HasSubstr("Could not find _file column"));
@@ -281,11 +281,11 @@ TEST_F(IcebergDeleteSinkTest, missing_pos_column) {
     auto context = std::make_shared<IcebergDeleteSinkContext>();
     context->tuple_desc_id = 0;
     context->fragment_context = _fragment_context.get();
-    
+
     // Setup output expressions to match tuple descriptor (2 slots)
     TExpr file_expr, pos_expr;
     context->output_exprs = {file_expr, pos_expr};
-    
+
     // Only add _file, not _pos
     TExprNode file_node;
     file_node.node_type = TExprNodeType::SLOT_REF;
@@ -295,7 +295,7 @@ TEST_F(IcebergDeleteSinkTest, missing_pos_column) {
 
     auto provider = std::make_unique<IcebergDeleteSinkProvider>();
     auto result = provider->create_chunk_sink(context, 0);
-    
+
     // Should fail because _pos column is missing
     ASSERT_FALSE(result.ok());
     EXPECT_THAT(std::string(result.status().message()), testing::HasSubstr("Could not find _pos column"));
@@ -306,30 +306,30 @@ TEST_F(IcebergDeleteSinkTest, not_enough_evaluators) {
     auto context = std::make_shared<IcebergDeleteSinkContext>();
     context->tuple_desc_id = 0;
     context->fragment_context = _fragment_context.get();
-    
+
     // Setup output expressions to match tuple descriptor (2 slots)
     TExpr file_expr, pos_expr;
     context->output_exprs = {file_expr, pos_expr};
-    
+
     // Setup required columns
     TExprNode file_node;
     file_node.node_type = TExprNodeType::SLOT_REF;
     file_node.__set_slot_ref(TSlotRef());
     file_node.slot_ref.slot_id = 0;
     context->column_slot_map["_file"] = file_node;
-    
+
     TExprNode pos_node;
     pos_node.node_type = TExprNodeType::SLOT_REF;
     pos_node.__set_slot_ref(TSlotRef());
     pos_node.slot_ref.slot_id = 1;
     context->column_slot_map["_pos"] = pos_node;
-    
+
     // Add only 1 evaluator instead of required 2
     context->column_evaluators.push_back(create_mock_column_evaluator());
 
     auto provider = std::make_unique<IcebergDeleteSinkProvider>();
     auto result = provider->create_chunk_sink(context, 0);
-    
+
     // Should fail because not enough evaluators
     ASSERT_FALSE(result.ok());
     EXPECT_THAT(std::string(result.status().message()), testing::HasSubstr("Not enough column evaluators"));
@@ -340,31 +340,31 @@ TEST_F(IcebergDeleteSinkTest, invalid_tuple_descriptor_id) {
     auto context = std::make_shared<IcebergDeleteSinkContext>();
     context->tuple_desc_id = 999; // Invalid ID
     context->fragment_context = _fragment_context.get();
-    
+
     // Setup output expressions to match tuple descriptor (2 slots)
     TExpr file_expr, pos_expr;
     context->output_exprs = {file_expr, pos_expr};
-    
+
     // Setup required columns
     TExprNode file_node;
     file_node.node_type = TExprNodeType::SLOT_REF;
     file_node.__set_slot_ref(TSlotRef());
     file_node.slot_ref.slot_id = 0;
     context->column_slot_map["_file"] = file_node;
-    
+
     TExprNode pos_node;
     pos_node.node_type = TExprNodeType::SLOT_REF;
     pos_node.__set_slot_ref(TSlotRef());
     pos_node.slot_ref.slot_id = 1;
     context->column_slot_map["_pos"] = pos_node;
-    
+
     // Add required evaluators
     context->column_evaluators.push_back(create_mock_column_evaluator());
     context->column_evaluators.push_back(create_mock_column_evaluator());
 
     auto provider = std::make_unique<IcebergDeleteSinkProvider>();
     auto result = provider->create_chunk_sink(context, 0);
-    
+
     // Should fail because tuple descriptor ID is invalid
     ASSERT_FALSE(result.ok());
     EXPECT_THAT(std::string(result.status().message()), testing::HasSubstr("Failed to find tuple descriptor"));

--- a/be/test/connector_sink/iceberg_delete_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_delete_sink_test.cpp
@@ -1,0 +1,222 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "connector/iceberg_delete_sink.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "column/chunk.h"
+#include "column/datum.h"
+#include "column/datum_tuple.h"
+#include "column/fixed_length_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/status.h"
+#include "exec/pipeline/fragment_context.h"
+#include "formats/column_evaluator.h"
+#include "gen_cpp/Exprs_types.h"
+#include "gen_cpp/Types_types.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/descriptors.h"
+#include "runtime/mem_tracker.h"
+#include "runtime/runtime_state.h"
+#include "runtime/types.h"
+#include "testutil/assert.h"
+#include "testutil/column_test_helper.h"
+#include "util/thrift_util.h"
+
+namespace starrocks::connector {
+
+class IcebergDeleteSinkTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _pool = std::make_unique<ObjectPool>();
+        TQueryOptions query_options;
+        TQueryGlobals query_globals;
+        TUniqueId fragment_id;
+        fragment_id.hi = 0;
+        fragment_id.lo = 0;
+        _runtime_state =
+                std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, ExecEnv::GetInstance());
+        // Initialize mem trackers for the runtime state
+        _runtime_state->init_instance_mem_tracker();
+
+        // Create and set up a basic descriptor table for the runtime state
+        // Need to ensure tuple with ID 0 exists since context->tuple_desc_id is set to 0
+        TDescriptorTableBuilder desc_tbl_builder;
+        // Create a tuple
+        TSlotDescriptorBuilder slot_builder;
+        TTupleDescriptorBuilder tuple_builder;
+        tuple_builder.add_slot(slot_builder.type(TYPE_VARCHAR).column_name("file_path").is_materialized(true).build());
+        tuple_builder.add_slot(slot_builder.type(TYPE_BIGINT).column_name("pos").is_materialized(true).build());
+        tuple_builder.build(&desc_tbl_builder);
+        TDescriptorTable t_desc_tbl = desc_tbl_builder.desc_tbl();
+        DescriptorTbl* desc_tbl = nullptr;
+        ASSERT_TRUE(DescriptorTbl::create(_runtime_state.get(), _pool.get(), t_desc_tbl, &desc_tbl,
+                                          config::vector_chunk_size)
+                            .ok());
+        _runtime_state->set_desc_tbl(desc_tbl);
+
+        _fragment_context = std::make_shared<pipeline::FragmentContext>();
+        _fragment_context->set_runtime_state(std::move(_runtime_state));
+        // Get the runtime state back from fragment context after moving
+        _runtime_state = _fragment_context->runtime_state_ptr();
+        _fragment_context->set_fragment_instance_id(fragment_id);
+        _mem_tracker = std::make_unique<MemTracker>(MemTrackerType::QUERY_POOL, -1, "IcebergDeleteSinkTest");
+    }
+
+    std::shared_ptr<IcebergDeleteSinkContext> create_delete_sink_context() {
+        auto context = std::make_shared<IcebergDeleteSinkContext>();
+        context->path = "s3://test-bucket/test-table/";
+        context->tuple_desc_id = 0;
+        context->fragment_context = _fragment_context.get();
+        context->max_file_size = 128 * 1024 * 1024;
+
+        // Set up output expressions to match the tuple descriptor (2 slots: file_path and pos)
+        TExpr file_expr;
+        TExpr pos_expr;
+        context->output_exprs = {file_expr, pos_expr};
+
+        // Create mock column evaluators for file_path and pos columns
+        context->column_evaluators.push_back(create_mock_column_evaluator());
+        context->column_evaluators.push_back(create_mock_column_evaluator());
+
+        // Set up column slot map for _file and _pos columns
+        TExprNode file_node;
+        file_node.node_type = TExprNodeType::SLOT_REF;
+        file_node.__set_slot_ref(TSlotRef());
+        file_node.slot_ref.slot_id = 0;
+        context->column_slot_map["_file"] = file_node;
+
+        TExprNode pos_node;
+        pos_node.node_type = TExprNodeType::SLOT_REF;
+        pos_node.__set_slot_ref(TSlotRef());
+        pos_node.slot_ref.slot_id = 1;
+        context->column_slot_map["_pos"] = pos_node;
+
+        return context;
+    }
+
+    std::unique_ptr<ColumnEvaluator> create_mock_column_evaluator() {
+        // Mock column evaluator for testing - using ColumnSlotIdEvaluator which is designed for UT
+        TypeDescriptor type_desc = TYPE_VARCHAR_DESC; // Use a proper VARCHAR type descriptor for testing
+        return std::make_unique<ColumnSlotIdEvaluator>(0, type_desc);
+    }
+
+    std::unique_ptr<ObjectPool> _pool;
+    std::shared_ptr<RuntimeState> _runtime_state;
+    std::shared_ptr<pipeline::FragmentContext> _fragment_context;
+    std::unique_ptr<MemTracker> _mem_tracker;
+};
+
+// Test that IcebergDeleteSinkProvider can create a valid IcebergDeleteSink
+TEST_F(IcebergDeleteSinkTest, create_delete_sink) {
+    auto context = create_delete_sink_context();
+    auto provider = std::make_unique<IcebergDeleteSinkProvider>();
+
+    // Should create sink successfully
+    auto result = provider->create_chunk_sink(context, 0);
+    ASSERT_TRUE(result.ok());
+
+    auto sink = std::move(result).value();
+    ASSERT_NE(sink, nullptr);
+
+    // Verify the sink is of correct type
+    auto delete_sink = dynamic_cast<IcebergDeleteSink*>(sink.get());
+    ASSERT_NE(delete_sink, nullptr);
+}
+
+// Test that IcebergDeleteSink::add handles empty chunk correctly
+TEST_F(IcebergDeleteSinkTest, add_empty_chunk) {
+    auto context = create_delete_sink_context();
+    auto provider = std::make_unique<IcebergDeleteSinkProvider>();
+    auto result = provider->create_chunk_sink(context, 0);
+    ASSERT_TRUE(result.ok());
+
+    auto sink = std::move(result).value();
+    auto delete_sink = dynamic_cast<IcebergDeleteSink*>(sink.get());
+    ASSERT_NE(delete_sink, nullptr);
+
+    // Create empty chunk
+    auto chunk = std::make_shared<Chunk>();
+    ASSERT_OK(delete_sink->add(chunk));
+}
+
+// Test that IcebergDeleteSink::is_finished returns true when no data was written
+TEST_F(IcebergDeleteSinkTest, is_finished_no_data) {
+    auto context = create_delete_sink_context();
+    auto provider = std::make_unique<IcebergDeleteSinkProvider>();
+    auto result = provider->create_chunk_sink(context, 0);
+    ASSERT_TRUE(result.ok());
+
+    auto sink = std::move(result).value();
+    auto delete_sink = dynamic_cast<IcebergDeleteSink*>(sink.get());
+    ASSERT_NE(delete_sink, nullptr);
+
+    // Should be finished when no data written
+    ASSERT_TRUE(delete_sink->is_finished());
+}
+
+// Test file path extraction from column slot map
+TEST_F(IcebergDeleteSinkTest, column_slot_map_lookup) {
+    auto context = std::make_shared<IcebergDeleteSinkContext>();
+    context->tuple_desc_id = 0; // Set tuple_desc_id to match the descriptor table
+    // Setup output expressions for this context too
+    TExpr file_expr;
+    TExpr pos_expr;
+    context->output_exprs = {file_expr, pos_expr};
+
+    // Setup column slot map
+    TExprNode file_node;
+    file_node.node_type = TExprNodeType::SLOT_REF;
+    file_node.__set_slot_ref(TSlotRef());
+    file_node.slot_ref.slot_id = 5;
+    context->column_slot_map["_file"] = file_node;
+
+    TExprNode pos_node;
+    pos_node.node_type = TExprNodeType::SLOT_REF;
+    pos_node.__set_slot_ref(TSlotRef());
+    pos_node.slot_ref.slot_id = 6;
+    context->column_slot_map["_pos"] = pos_node;
+
+    // Verify lookup works
+    auto file_it = context->column_slot_map.find("_file");
+    ASSERT_NE(file_it, context->column_slot_map.end());
+    EXPECT_EQ(file_it->second.slot_ref.slot_id, 5);
+
+    auto pos_it = context->column_slot_map.find("_pos");
+    ASSERT_NE(pos_it, context->column_slot_map.end());
+    EXPECT_EQ(pos_it->second.slot_ref.slot_id, 6);
+}
+
+// Test that context has required fields populated
+TEST_F(IcebergDeleteSinkTest, context_required_fields) {
+    auto context = create_delete_sink_context();
+
+    // Verify all required fields are set
+    EXPECT_FALSE(context->path.empty());
+    EXPECT_GE(context->tuple_desc_id, 0);
+    EXPECT_GT(context->max_file_size, 0);
+    EXPECT_FALSE(context->column_evaluators.empty());
+    EXPECT_EQ(context->column_slot_map.size(), 2); // _file and _pos
+
+    // Verify required columns are present
+    EXPECT_NE(context->column_slot_map.find("_file"), context->column_slot_map.end());
+    EXPECT_NE(context->column_slot_map.find("_pos"), context->column_slot_map.end());
+}
+
+} // namespace starrocks::connector

--- a/be/test/connector_sink/iceberg_delete_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_delete_sink_test.cpp
@@ -219,4 +219,167 @@ TEST_F(IcebergDeleteSinkTest, context_required_fields) {
     EXPECT_NE(context->column_slot_map.find("_pos"), context->column_slot_map.end());
 }
 
+// Test callback_on_commit function
+TEST_F(IcebergDeleteSinkTest, callback_on_commit) {
+    auto context = create_delete_sink_context();
+    auto provider = std::make_unique<IcebergDeleteSinkProvider>();
+    auto result = provider->create_chunk_sink(context, 0);
+    ASSERT_TRUE(result.ok());
+
+    auto sink = std::move(result).value();
+    auto delete_sink = dynamic_cast<IcebergDeleteSink*>(sink.get());
+    ASSERT_NE(delete_sink, nullptr);
+
+    // Call the callback function - it should not crash
+    CommitResult result_obj;
+    delete_sink->callback_on_commit(result_obj);
+    // Callback is currently empty (TODO), but should not crash
+}
+
+// Test IcebergDeleteSink::add with chunk containing file_path and pos data
+TEST_F(IcebergDeleteSinkTest, add_with_data) {
+    auto context = create_delete_sink_context();
+    auto provider = std::make_unique<IcebergDeleteSinkProvider>();
+    auto result = provider->create_chunk_sink(context, 0);
+    ASSERT_TRUE(result.ok());
+
+    auto sink = std::move(result).value();
+    auto delete_sink = dynamic_cast<IcebergDeleteSink*>(sink.get());
+    ASSERT_NE(delete_sink, nullptr);
+
+    // Create chunk with file_path and pos columns
+    auto file_path_col = BinaryColumn::create();
+    file_path_col->append(Slice("/path/to/file1.parquet"));
+    file_path_col->append(Slice("/path/to/file2.parquet"));
+    
+    auto pos_col = Int64Column::create();
+    pos_col->append(100);
+    pos_col->append(200);
+
+    Chunk chunk;
+    chunk.append_column(file_path_col, 0);  // slot_id 0
+    chunk.append_column(pos_col, 1);        // slot_id 1
+
+    // Add should succeed
+    ASSERT_OK(delete_sink->add(std::make_shared<Chunk>(chunk)));
+}
+
+// Test IcebergDeleteSink::finish function
+TEST_F(IcebergDeleteSinkTest, finish_function) {
+    auto context = create_delete_sink_context();
+    auto provider = std::make_unique<IcebergDeleteSinkProvider>();
+    auto result = provider->create_chunk_sink(context, 0);
+    ASSERT_TRUE(result.ok());
+
+    auto sink = std::move(result).value();
+    auto delete_sink = dynamic_cast<IcebergDeleteSink*>(sink.get());
+    ASSERT_NE(delete_sink, nullptr);
+
+    // Finish should succeed
+    ASSERT_OK(delete_sink->finish());
+}
+
+// Test error condition: missing _file column in column_slot_map
+TEST_F(IcebergDeleteSinkTest, missing_file_column) {
+    auto context = std::make_shared<IcebergDeleteSinkContext>();
+    context->tuple_desc_id = 0;
+    context->fragment_context = _fragment_context.get();
+    
+    // Only add _pos, not _file
+    TExprNode pos_node;
+    pos_node.node_type = TExprNodeType::SLOT_REF;
+    pos_node.__set_slot_ref(TSlotRef());
+    pos_node.slot_ref.slot_id = 1;
+    context->column_slot_map["_pos"] = pos_node;
+
+    auto provider = std::make_unique<IcebergDeleteSinkProvider>();
+    auto result = provider->create_chunk_sink(context, 0);
+    
+    // Should fail because _file column is missing
+    ASSERT_FALSE(result.ok());
+    EXPECT_THAT(result.status().message(), testing::HasSubstr("Could not find _file column"));
+}
+
+// Test error condition: missing _pos column in column_slot_map
+TEST_F(IcebergDeleteSinkTest, missing_pos_column) {
+    auto context = std::make_shared<IcebergDeleteSinkContext>();
+    context->tuple_desc_id = 0;
+    context->fragment_context = _fragment_context.get();
+    
+    // Only add _file, not _pos
+    TExprNode file_node;
+    file_node.node_type = TExprNodeType::SLOT_REF;
+    file_node.__set_slot_ref(TSlotRef());
+    file_node.slot_ref.slot_id = 0;
+    context->column_slot_map["_file"] = file_node;
+
+    auto provider = std::make_unique<IcebergDeleteSinkProvider>();
+    auto result = provider->create_chunk_sink(context, 0);
+    
+    // Should fail because _pos column is missing
+    ASSERT_FALSE(result.ok());
+    EXPECT_THAT(result.status().message(), testing::HasSubstr("Could not find _pos column"));
+}
+
+// Test error condition: not enough column evaluators
+TEST_F(IcebergDeleteSinkTest, not_enough_evaluators) {
+    auto context = std::make_shared<IcebergDeleteSinkContext>();
+    context->tuple_desc_id = 0;
+    context->fragment_context = _fragment_context.get();
+    
+    // Setup required columns
+    TExprNode file_node;
+    file_node.node_type = TExprNodeType::SLOT_REF;
+    file_node.__set_slot_ref(TSlotRef());
+    file_node.slot_ref.slot_id = 0;
+    context->column_slot_map["_file"] = file_node;
+    
+    TExprNode pos_node;
+    pos_node.node_type = TExprNodeType::SLOT_REF;
+    pos_node.__set_slot_ref(TSlotRef());
+    pos_node.slot_ref.slot_id = 1;
+    context->column_slot_map["_pos"] = pos_node;
+    
+    // Add only 1 evaluator instead of required 2
+    context->column_evaluators.push_back(create_mock_column_evaluator());
+
+    auto provider = std::make_unique<IcebergDeleteSinkProvider>();
+    auto result = provider->create_chunk_sink(context, 0);
+    
+    // Should fail because not enough evaluators
+    ASSERT_FALSE(result.ok());
+    EXPECT_THAT(result.status().message(), testing::HasSubstr("Not enough column evaluators"));
+}
+
+// Test error condition: invalid tuple descriptor ID
+TEST_F(IcebergDeleteSinkTest, invalid_tuple_descriptor_id) {
+    auto context = std::make_shared<IcebergDeleteSinkContext>();
+    context->tuple_desc_id = 999; // Invalid ID
+    context->fragment_context = _fragment_context.get();
+    
+    // Setup required columns
+    TExprNode file_node;
+    file_node.node_type = TExprNodeType::SLOT_REF;
+    file_node.__set_slot_ref(TSlotRef());
+    file_node.slot_ref.slot_id = 0;
+    context->column_slot_map["_file"] = file_node;
+    
+    TExprNode pos_node;
+    pos_node.node_type = TExprNodeType::SLOT_REF;
+    pos_node.__set_slot_ref(TSlotRef());
+    pos_node.slot_ref.slot_id = 1;
+    context->column_slot_map["_pos"] = pos_node;
+    
+    // Add required evaluators
+    context->column_evaluators.push_back(create_mock_column_evaluator());
+    context->column_evaluators.push_back(create_mock_column_evaluator());
+
+    auto provider = std::make_unique<IcebergDeleteSinkProvider>();
+    auto result = provider->create_chunk_sink(context, 0);
+    
+    // Should fail because tuple descriptor ID is invalid
+    ASSERT_FALSE(result.ok());
+    EXPECT_THAT(result.status().message(), testing::HasSubstr("Failed to find tuple descriptor"));
+}
+
 } // namespace starrocks::connector

--- a/be/test/connector_sink/iceberg_table_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_table_sink_test.cpp
@@ -284,8 +284,13 @@ TEST_F(IcebergTableSinkTest, update_partition_expr_slot_refs_by_map_missing_slot
 TEST_F(IcebergTableSinkTest, decompose_to_pipeline_delete_sink) {
     TDescriptorTableBuilder table_desc_builder;
     TSlotDescriptorBuilder slot_desc_builder;
-    auto slot1 = slot_desc_builder.type(LogicalType::TYPE_VARCHAR).column_name("file_path").column_pos(0).nullable(true).build();
-    auto slot2 = slot_desc_builder.type(LogicalType::TYPE_BIGINT).column_name("pos").column_pos(1).nullable(true).build();
+    auto slot1 = slot_desc_builder.type(LogicalType::TYPE_VARCHAR)
+                         .column_name("file_path")
+                         .column_pos(0)
+                         .nullable(true)
+                         .build();
+    auto slot2 =
+            slot_desc_builder.type(LogicalType::TYPE_BIGINT).column_name("pos").column_pos(1).nullable(true).build();
     TTupleDescriptorBuilder tuple_desc_builder;
     tuple_desc_builder.add_slot(slot1);
     tuple_desc_builder.add_slot(slot2);
@@ -300,7 +305,7 @@ TEST_F(IcebergTableSinkTest, decompose_to_pipeline_delete_sink) {
     t_column1.__set_column_name("file_path");
     t_column2.__set_column_name("pos");
     t_iceberg_table.__set_columns({t_column1, t_column2});
-    
+
     TTableDescriptor tdesc;
     tdesc.__set_icebergTable(t_iceberg_table);
 


### PR DESCRIPTION
## Why I'm doing:
#66944

## What I'm doing:
This pull request adds support for Iceberg position delete file writing to the connector layer, enabling the system to handle Iceberg Merge-On-Read delete operations. The main changes include the introduction of a new `IcebergDeleteSink` and its provider, updates to the connector interface to support delete sinks, and related adjustments across the codebase to integrate this functionality.

**Iceberg Delete Sink Support:**

* Added new files `iceberg_delete_sink.cpp` and `iceberg_delete_sink.h` implementing `IcebergDeleteSink` and `IcebergDeleteSinkProvider`, which handle writing position delete files as required by Iceberg Merge-On-Read operations. 

**Connector Interface Extensions:**

* Added a new virtual method `create_delete_sink_provider` to the `Connector` interface, with a default implementation that fails if not overridden.
* Implemented `create_delete_sink_provider` in `IcebergConnector` to return an `IcebergDeleteSinkProvider`.

**Integration and Plumbing:**

* Modified the data sink creation logic to recognize and handle the new `ICEBERG_DELETE_SINK` type, ensuring the correct sink is instantiated during query execution.
* Updated the `ConnectorChunkSink` interface to allow for sink-specific implementations of `finish()` and `is_finished()`, which are now virtual. 
* Ensured the pipeline sink operator correctly checks the finished state using the potentially overridden `is_finished()` method.

**Other Improvements:**

* Added a debug log when creating Parquet files to aid in troubleshooting file creation during delete operations. 
* Exposed partition source column names in `IcebergTableDescriptor` for downstream usage. 
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds end-to-end support for writing Iceberg position delete files.
> 
> - New `IcebergDeleteSink` and `IcebergDeleteSinkProvider` write file/pos delete Parquet files, grouped per source file; supports partitioning, async IO, and custom finish/complete
> - Connector interface extended with `create_delete_sink_provider`; implemented in `IcebergConnector`
> - Pipeline/plumbing: `ICEBERG_DELETE_SINK` recognized in `DataSink`, `ConnectorSinkOperator` now respects sink-specific `is_finished()`/`finish()`
> - `IcebergTableSink` refactored to build either data or delete sinks, including mapping partition exprs via slot refs and exposing partition source column names in `IcebergTableDescriptor`
> - Minor: add Parquet file creation VLOG, CMake/test wiring; new UTs for delete sink and table sink
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62bb9e4bf9e1c38e9b5036e836ead6478eb22d51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->