### PR TITLE
[Enhancement][Refactor] Refactor MergeCommitTask lifecycle and add cancellation support

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/TimeoutWatcher.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/TimeoutWatcher.java
@@ -31,6 +31,10 @@ public class TimeoutWatcher {
         return System.currentTimeMillis() >= deadline;
     }
 
+    public long getLeftTimeoutMillis() {
+        return Math.max(0, deadline - System.currentTimeMillis());
+    }
+
     public long getElapsedMillis() {
         return System.currentTimeMillis() - startTime;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/BatchWriteMgr.java
@@ -69,7 +69,7 @@ public class BatchWriteMgr extends FrontendDaemon {
         this.lock = new ReentrantReadWriteLock();
         this.coordinatorBackendAssigner = new CoordinatorBackendAssignerImpl();
         this.threadPoolExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
-                        Config.merge_commit_executor_threads_num, "batch-write-load", true);
+                        Config.merge_commit_executor_threads_num, "merge-commit", true);
         this.txnStateDispatcher = new TxnStateDispatcher(threadPoolExecutor);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitJob.java
@@ -271,14 +271,14 @@ public class MergeCommitJob implements MergeCommitTaskCallback {
             lock.writeLock().unlock();
         }
 
-        Optional<Long> txnId = executor.getTxnId();
-        if (!asyncMode && txnId.isPresent()) {
+        long txnId = executor.getTxnId();
+        if (!asyncMode && txnId > 0) {
             for (long backendId : executor.getBackendIds()) {
                 try {
-                    txnUpdateDispatch.submitTask(tableId.getDbName(), txnId.get(), backendId);
+                    txnUpdateDispatch.submitTask(tableId.getDbName(), txnId, backendId);
                 } catch (Exception e) {
                     LOG.error("Fail to submit transaction state update task, db: {}, txn_id: {}, backend id: {}",
-                            tableId.getDbName(), txnId.get(), backendId, e);
+                            tableId.getDbName(), txnId, backendId, e);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
@@ -321,8 +321,9 @@ public class MergeCommitTask extends AbstractTxnStateChangeCallback implements R
             VisibleStateWaiter waiter;
             try (ScopedTimer ignored = new ScopedTimer(loadTimeTrace.commitCostMs)) {
                 // Currently task is not persisted, so no need to persist attachment for replaying
-                waiter = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().commitTransaction(
-                                dbId, localTxnId, loadResult.tabletCommitInfos, loadResult.tabletFailInfos, null);
+                waiter = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().retryCommitOnRateLimitExceeded(
+                        database, localTxnId, loadResult.tabletCommitInfos, loadResult.tabletFailInfos,
+                        null, timeoutWatcher.getLeftTimeoutMillis());
             }
 
             // 6) wait for publish/visibility.

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
@@ -803,6 +803,18 @@ public class MergeCommitTask extends AbstractTxnStateChangeCallback implements R
         }
     }
 
+    // ================ methods for testing ================
+
+    @VisibleForTesting
+    public TUniqueId getLoadId() {
+        return loadId;
+    }
+
+    @VisibleForTesting
+    public boolean isPlanDeployed() {
+        return loadTimeTrace.execWaitStartTimeMs.get() > 0;
+    }
+
     /**
      * Statistics about rows/bytes processed by the load execution.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
@@ -22,402 +22,884 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.CloseableLock;
 import com.starrocks.common.Config;
+import com.starrocks.common.DataQualityException;
 import com.starrocks.common.LoadException;
-import com.starrocks.common.Pair;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
+import com.starrocks.common.TimeoutWatcher;
 import com.starrocks.common.Version;
+import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.load.EtlStatus;
+import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.load.loadv2.LoadErrorUtils;
 import com.starrocks.load.loadv2.LoadJob;
-import com.starrocks.load.loadv2.LoadJobFinalOperation;
 import com.starrocks.load.streamload.StreamLoadInfo;
 import com.starrocks.load.streamload.StreamLoadKvParams;
+import com.starrocks.proto.PPlanFragmentCancelReason;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.LoadPlanner;
 import com.starrocks.task.LoadEtlTask;
-import com.starrocks.thrift.TEtlState;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.transaction.AbstractTxnStateChangeCallback;
 import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionState;
-import org.apache.arrow.util.VisibleForTesting;
+import com.starrocks.transaction.VisibleStateWaiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * A task responsible for executing a load.
+ * Executes a single merge-commit load.
+ *
+ * <p>This task drives the end-to-end load lifecycle:</p>
+ *
+ * <ul>
+ *   <li>Begin transaction</li>
+ *   <li>Generate execution plan</li>
+ *   <li>Execute the load via {@link Coordinator}</li>
+ *   <li>Commit and wait for publish/visibility</li>
+ *   <li>Finalize metrics, callback, and optional runtime profile reporting</li>
+ * </ul>
+ *
+ * <p>Execution is modeled as a simple state machine to ensure that state transitions
+ * and related fields are updated atomically. The execution can be cancelled.
  */
-public class MergeCommitTask implements Runnable {
+public class MergeCommitTask extends AbstractTxnStateChangeCallback implements Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(MergeCommitTask.class);
 
-    // Initialized in constructor ==================================
-    private final TableId tableId;
+    /**
+     * Internal execution states for this task.
+     *
+     * <p>The allowed transitions are defined in {@link #TASK_STATE_TRANSITION}.
+     */
+    enum TaskState {
+        /** Created but not started yet. */
+        PENDING(false),
+        /** Beginning the transaction. */
+        BEGIN_TXN(false),
+        /** Planning the load execution. */
+        PLANNING(false),
+        /** Executing the load and waiting for completion. */
+        LOADING(false),
+        /** Committing the transaction. */
+        COMMITTING(false),
+        /** Transaction committed; waiting for publish/visibility. */
+        COMMITTED(false),
+        /** Fully finished (success or publish timeout); no further work expected. */
+        FINISHED(true),
+        /** Aborted due to an internal failure in {@link #run()}. */
+        ABORTED(true),
+        /** Cancelled explicitly. */
+        CANCELLED(true);
+
+        /** Whether this is a terminal state. */
+        private final boolean terminal;
+
+        TaskState(boolean terminal) {
+            this.terminal = terminal;
+        }
+
+        public boolean isTerminal() {
+            return terminal;
+        }
+    }
+
+    /**
+     * Allowed state transitions.
+     *
+     * <p>State transition diagram:</p>
+     *
+     * <pre>
+     *      +--------> ABORTED  <-------+-----------+------------+
+     *     /            ^               ^           ^            |
+     *    /             |               |           |            |
+     * PENDING    --> BEGIN_TXN --> PLANNING --> LOADING --> COMMITTING --> COMMITTED --> FINISHED
+     *    \             |               |           |
+     *     \            v               v           v
+     *      +--------> CANCELLED <------+-----------+
+     * </pre>
+     *
+     * <p>Notes:</p>
+     * <ul>
+     *   <li>{@link TaskState#COMMITTING} must not transition to {@link TaskState#CANCELLED}. {@code CANCELLED} means an
+     *       explicit/user cancel, but once commit is started the transaction may have already been accepted by the
+     *       transaction manager and there is no safe "undo" point. Allowing {@code COMMITTING -> CANCELLED} would
+     *       make it possible to observe "CANCELLED" while the transaction later becomes COMMITTED, causing a
+     *       task-state/transaction-state divergence.
+     *   </li>
+     *   <li>{@link TaskState#COMMITTING} is still allowed to transition to {@link TaskState#ABORTED} because the transaction
+     *       commit can fail. In that case, {@link #run()} aborts the transaction and terminates the task as {@code ABORTED}.
+     *       If the commit succeeds, task transitions to {@link TaskState#COMMITTED} and will never end up as {@code ABORTED}.
+     *   </li>
+     * </ul>
+     */
+    private static final Map<TaskState, EnumSet<TaskState>> TASK_STATE_TRANSITION = new EnumMap<>(TaskState.class);
+    static {
+        TASK_STATE_TRANSITION.put(TaskState.PENDING,
+                EnumSet.of(TaskState.BEGIN_TXN, TaskState.CANCELLED, TaskState.ABORTED));
+        TASK_STATE_TRANSITION.put(TaskState.BEGIN_TXN,
+                EnumSet.of(TaskState.PLANNING, TaskState.CANCELLED, TaskState.ABORTED));
+        TASK_STATE_TRANSITION.put(TaskState.PLANNING,
+                EnumSet.of(TaskState.LOADING, TaskState.CANCELLED, TaskState.ABORTED));
+        TASK_STATE_TRANSITION.put(TaskState.LOADING,
+                EnumSet.of(TaskState.COMMITTING, TaskState.CANCELLED, TaskState.ABORTED));
+        TASK_STATE_TRANSITION.put(TaskState.COMMITTING,
+                EnumSet.of(TaskState.COMMITTED, TaskState.ABORTED));
+        TASK_STATE_TRANSITION.put(TaskState.COMMITTED, EnumSet.of(TaskState.FINISHED));
+        TASK_STATE_TRANSITION.put(TaskState.FINISHED, EnumSet.noneOf(TaskState.class));
+        TASK_STATE_TRANSITION.put(TaskState.CANCELLED, EnumSet.noneOf(TaskState.class));
+        TASK_STATE_TRANSITION.put(TaskState.ABORTED, EnumSet.noneOf(TaskState.class));
+    }
+
+    /** Unique identifier of this merge-commit task. */
+    private final long taskId;
+    /** Target table identifier (database name + table name). */
+    private final TableId tableRef;
+    /** Load label used for transaction bookkeeping and visibility. */
     private final String label;
+    /** Query/load identifier used to register the in-flight execution. */
     private final TUniqueId loadId;
+    /** User-provided stream load request parameters. */
     private final StreamLoadInfo streamLoadInfo;
-    private final StreamLoadKvParams loadParameters;
-    private final Set<Long> coordinatorBackendIds;
-    private final int batchWriteIntervalMs;
+    /** Key-value load parameters (e.g. max filter ratio). */
+    private final StreamLoadKvParams loadKvParams;
+    /** Warehouse name for execution. */
+    private final String warehouseName;
+    /** Backend IDs selected for execution. */
+    private final Set<Long> backendIds;
+    /** Merge-commit window size in milliseconds. */
+    private final int mergeCommitIntervalMs;
+    /** Factory for creating the {@link Coordinator} used by stream load. */
     private final Coordinator.Factory coordinatorFactory;
-    private final MergeCommitTaskCallback mergeCommitTaskCallback;
-    private final TimeTrace timeTrace;
-    private final AtomicReference<Throwable> failure;
+    /** Callback invoked once the task finishes (in {@link #run()}). */
+    private final MergeCommitTaskCallback completionCallback;
+    /** Tracks the timing of key stages. */
+    private final TimeTrace loadTimeTrace;
+    /** Guards state transitions and mutable execution fields. */
+    private final ReentrantLock lock;
 
-    // Initialized in beginTxn() ==================================
-    private long txnId = -1;
+    // ==================  The following members are mutated during execution and are protected by {@link #lock}.
 
-    // Initialized in executeLoad() ==================================
-    ConnectContext context;
-    LoadPlanner loadPlanner;
-    private Coordinator coordinator;
-    private List<TabletCommitInfo> tabletCommitInfo;
-    private List<TabletFailInfo> tabletFailInfo;
-    private LoadJobFinalOperation loadJobFinalOperation;
-    private boolean collectProfileSuccess = false;
+    // Current state.
+    private volatile TaskState taskState;
+    // The message describing the current state. For CANCELLED/ABORTED, it's the reason.
+    // For FINISHED, describe whether publish success before load timeouts
+    private volatile String taskStateMessage = null;
+    // Cancel handler for the current non-terminal state; invoked when the task is cancelled in that state.
+    // It may be null depending on the current state (e.g. states without meaningful cancel action).
+    private volatile TaskStateCancelHandler taskStateCancelHandler = null;
+    // Transaction id; set in {@link #run()} after transaction begins.
+    private volatile long txnId = -1;
+    // Load statistics; set when entering COMMITTING in {@link #run()}.
+    private volatile LoadStats loadStats = null;
 
+    /**
+     * Creates a new merge-commit task.
+     *
+     * @param taskId unique task identifier
+     * @param tableRef target table identifier
+     * @param label load label used for transaction bookkeeping
+     * @param loadId query/load identifier
+     * @param streamLoadInfo stream load request parameters
+     * @param mergeCommitIntervalMs merge-commit interval in milliseconds
+     * @param loadKvParams key-value load parameters (e.g. max filter ratio)
+     * @param warehouseName warehouse name used for execution
+     * @param backendIds backend IDs chosen for execution
+     * @param coordinatorFactory factory to create {@link Coordinator} instances
+     * @param completionCallback completion callback invoked from {@link #run()}
+     */
     public MergeCommitTask(
-            TableId tableId,
+            long taskId,
+            TableId tableRef,
             String label,
             TUniqueId loadId,
             StreamLoadInfo streamLoadInfo,
-            int batchWriteIntervalMs,
-            StreamLoadKvParams loadParameters,
-            Set<Long> coordinatorBackendIds,
+            int mergeCommitIntervalMs,
+            StreamLoadKvParams loadKvParams,
+            String warehouseName,
+            Set<Long> backendIds,
             Coordinator.Factory coordinatorFactory,
-            MergeCommitTaskCallback mergeCommitTaskCallback) {
-        this.tableId = tableId;
+            MergeCommitTaskCallback completionCallback) {
+        this.taskId = taskId;
+        this.tableRef = tableRef;
         this.label = label;
         this.loadId = loadId;
         this.streamLoadInfo = streamLoadInfo;
-        this.batchWriteIntervalMs = batchWriteIntervalMs;
-        this.loadParameters = loadParameters;
-        this.coordinatorBackendIds = coordinatorBackendIds;
+        this.loadKvParams = loadKvParams;
+        this.mergeCommitIntervalMs = mergeCommitIntervalMs;
+        this.warehouseName = warehouseName;
+        this.backendIds = backendIds;
         this.coordinatorFactory = coordinatorFactory;
-        this.mergeCommitTaskCallback = mergeCommitTaskCallback;
-        this.timeTrace = new TimeTrace();
-        this.failure = new AtomicReference<>();
+        this.completionCallback = completionCallback;
+        this.loadTimeTrace = new TimeTrace();
+        this.lock = new ReentrantLock();
+        this.taskState = TaskState.PENDING;
     }
 
+    /**
+     * Backward-compatible constructor for tests and older call sites.
+     *
+     * <p>Warehouse name is optional for merge-commit execution.
+     */
+    public MergeCommitTask(
+            long taskId,
+            TableId tableRef,
+            String label,
+            TUniqueId loadId,
+            StreamLoadInfo streamLoadInfo,
+            int mergeCommitIntervalMs,
+            StreamLoadKvParams loadKvParams,
+            Set<Long> backendIds,
+            Coordinator.Factory coordinatorFactory,
+            MergeCommitTaskCallback completionCallback) {
+        this(taskId, tableRef, label, loadId, streamLoadInfo, mergeCommitIntervalMs, loadKvParams, "",
+                backendIds, coordinatorFactory, completionCallback);
+    }
+
+    /**
+     * Runs the merge-commit load.
+     *
+     * <p>On success, the task reaches {@link TaskState#FINISHED}. On failure, it transitions to
+     * {@link TaskState#ABORTED} and best-effort aborts the transaction if it has been created.
+     */
     @Override
     public void run() {
+        loadTimeTrace.pendingCostMs.set(System.currentTimeMillis() - loadTimeTrace.createTimeMs);
+        TimeoutWatcher timeoutWatcher = new TimeoutWatcher(streamLoadInfo.getTimeout() * 1000L);
+        long dbId = -1;
+        long localTxnId = -1;
+        ConnectContext connectContext = null;
+        LoadPlanner loadPlanner = null;
+        Coordinator coordinator = null;
         try {
-            beginTxn();
-            executeLoad();
-            commitAndPublishTxn();
-        } catch (Exception e) {
-            failure.set(e);
-            abortTxn(e);
-            LOG.error("Failed to execute load, label: {}, load id: {}, txn id: {}",
-                    label, DebugUtil.printId(loadId), txnId, e);
-        } finally {
-            mergeCommitTaskCallback.finish(this);
-            timeTrace.finishTimeMs = System.currentTimeMillis();
-            MergeCommitMetricRegistry.getInstance().updateLoadLatency(timeTrace.totalCostMs());
-            reportProfile();
-            LOG.debug("Finish load, label: {}, load id: {}, txn_id: {}, {}",
-                    label, DebugUtil.printId(loadId), txnId, timeTrace.summary());
-        }
-    }
+            // 1) Resolve database/table and begin transaction.
+            transitionToState(TaskState.BEGIN_TXN, "", null, () -> {});
+            final Database database = getDatabase();
+            final OlapTable table = getOlapTable(database);
+            dbId = database.getId();
+            GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getCallbackFactory().addCallback(this);
+            localTxnId = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
+                    dbId, Lists.newArrayList(table.getId()), label,
+                    TransactionState.TxnCoordinator.fromThisFE(),
+                    TransactionState.LoadJobSourceType.FRONTEND_STREAMING,
+                    streamLoadInfo.getTimeout(), streamLoadInfo.getComputeResource());
 
-    public String getLabel() {
-        return label;
-    }
+            // 2) Build execution plan and prepare coordinator.
+            final long finalTxnId = localTxnId;
+            transitionToState(TaskState.PLANNING, "", null, () -> {
+                this.txnId = finalTxnId;
+            });
+            connectContext = createConnectContext(table);
+            // Use tracer to get profile for planner/scheduler
+            Tracers.register(connectContext);
+            Tracers.init(connectContext, "TIMER", null);
+            loadPlanner = createLoadPlan(database, table, connectContext, timeoutWatcher.getLeftTimeoutMillis());
+            coordinator = coordinatorFactory.createStreamLoadScheduler(loadPlanner);
 
-    public long getTxnId() {
-        return txnId;
-    }
+            // 3) Execute load and collect load statistics.
+            final Coordinator finalCoordinator = coordinator;
+            transitionToState(TaskState.LOADING, "", new LoadingStateCancelHandler(finalCoordinator), () -> {});
+            LoadResult loadResult = executeLoad(connectContext, coordinator, timeoutWatcher.getLeftTimeoutMillis());
 
-    public Set<Long> getBackendIds() {
-        return Collections.unmodifiableSet(coordinatorBackendIds);
-    }
-
-    /**
-     * Checks if the given backend id is contained in the coordinator backend IDs.
-     */
-    public boolean containCoordinatorBackend(long backendId) {
-        return coordinatorBackendIds.contains(backendId);
-    }
-
-    /**
-     * Checks if this batch is active and can accept new load requests.
-     */
-    public boolean isActive() {
-        if (failure.get() != null) {
-            return false;
-        }
-        long joinPlanTimeMs = timeTrace.joinPlanTimeMs.get();
-        return joinPlanTimeMs <= 0 || (System.currentTimeMillis() - joinPlanTimeMs < batchWriteIntervalMs);
-    }
-
-    public Throwable getFailure() {
-        return failure.get();
-    }
-
-    private void beginTxn() throws Exception {
-        timeTrace.beginTxnTimeMs = System.currentTimeMillis();
-        Pair<Database, OlapTable> pair = getDbAndTable();
-        txnId = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
-                pair.first.getId(), Lists.newArrayList(pair.second.getId()), label,
-                TransactionState.TxnCoordinator.fromThisFE(),
-                TransactionState.LoadJobSourceType.FRONTEND_STREAMING,
-                streamLoadInfo.getTimeout(), streamLoadInfo.getComputeResource());
-    }
-
-    private void commitAndPublishTxn() throws Exception {
-        timeTrace.commitTxnTimeMs = System.currentTimeMillis();
-        Database database = getDb();
-        long publishTimeoutMs =
-                streamLoadInfo.getTimeout() * 1000L - (timeTrace.commitTxnTimeMs - timeTrace.beginTxnTimeMs);
-        boolean publishSuccess = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().commitAndPublishTransaction(
-                database, txnId, tabletCommitInfo, tabletFailInfo, publishTimeoutMs, null);
-        if (!publishSuccess) {
-            LOG.warn("Publish timeout, txn_id: {}, label: {}, total timeout: {} ms, publish timeout: {} ms",
-                        txnId, label, streamLoadInfo.getTimeout() * 1000, publishTimeoutMs);
-        }
-    }
-
-    private void abortTxn(Throwable reason) {
-        if (txnId == -1) {
-            return;
-        }
-        try {
-            Database database = getDb();
-            GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
-                    database.getId(), txnId, reason == null ? "" : reason.getMessage());
-        } catch (Exception e) {
-            LOG.error("Failed to abort transaction {}", txnId, e);
-        }
-    }
-
-    private void executeLoad() throws Exception {
-        try {
-            timeTrace.executeLoadTimeMs = System.currentTimeMillis();
-            context = new ConnectContext();
-            context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
-            context.setCurrentUserIdentity(UserIdentity.ROOT);
-            context.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
-            context.setQualifiedUser(UserIdentity.ROOT.getUser());
-            context.setCurrentComputeResource(streamLoadInfo.getComputeResource());
-            context.setThreadLocalInfo();
-
-            Pair<Database, OlapTable> pair = getDbAndTable();
-            // although merge commit uses pipeline engine, use table property to control the profile same as stream load
-            if (pair.second.enableLoadProfile()) {
-                long sampleIntervalMs = Config.load_profile_collect_interval_second * 1000;
-                if (sampleIntervalMs > 0 &&
-                        System.currentTimeMillis() - pair.second.getLastCollectProfileTime() > sampleIntervalMs) {
-                    context.getSessionVariable().setEnableProfile(true);
-                    pair.second.updateLastCollectProfileTime();
-                }
-                context.getSessionVariable().setBigQueryProfileThreshold(
-                        Config.stream_load_profile_collect_threshold_second + "s");
-                // do not enable runtime profile report currently
-                context.getSessionVariable().setRuntimeProfileReportInterval(-1);
+            // 4) Validate data quality and commit transaction.
+            final LoadStats loadStats = loadResult.loadStats;
+            transitionToState(TaskState.COMMITTING, "", null, () -> this.loadStats = loadStats);
+            long selectedRows = loadStats.abnormalRows + loadStats.normalRows;
+            double maxFilterRatio = loadKvParams.getMaxFilterRatio().orElse(0.0);
+            if (loadStats.abnormalRows > selectedRows * maxFilterRatio) {
+                throw new DataQualityException(String.format(
+                        "There is a data quality issue. Please check the tracking URL or SQL for details. " +
+                                "Tracking URL: %s. Tracking SQL: %s",
+                        loadStats.errorTrackingUrl.orElse("N/A"), getErrorTrackingSql(taskId)));
+            }
+            VisibleStateWaiter waiter;
+            try (ScopedTimer ignored = new ScopedTimer(loadTimeTrace.commitCostMs)) {
+                // Currently StreamLoadTask is stateless, so no need to persist attachment for replaying
+                waiter = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().commitTransaction(
+                                dbId, localTxnId, loadResult.tabletCommitInfos, loadResult.tabletFailInfos, null);
             }
 
-            loadPlanner = new LoadPlanner(-1, loadId, txnId, pair.first.getId(),
-                    tableId.getDbName(), pair.second, streamLoadInfo.isStrictMode(), streamLoadInfo.getTimezone(),
-                    streamLoadInfo.isPartialUpdate(), context, null,
-                    streamLoadInfo.getLoadMemLimit(), streamLoadInfo.getExecMemLimit(),
-                    streamLoadInfo.getNegative(), coordinatorBackendIds.size(), streamLoadInfo.getColumnExprDescs(),
-                    streamLoadInfo, label, streamLoadInfo.getTimeout());
-            loadPlanner.setBatchWrite(batchWriteIntervalMs,
-                    ImmutableMap.<String, String>builder()
-                            .putAll(loadParameters.toMap()).build(), coordinatorBackendIds);
-            loadPlanner.plan();
-            timeTrace.deployPlanTimeMs = System.currentTimeMillis();
-            coordinator = coordinatorFactory.createStreamLoadScheduler(loadPlanner);
+            // 6) wait for publish/visibility.
+            transitionToState(TaskState.COMMITTED, "", null, () -> {});
+            String publishFailMsg = "";
+            try (ScopedTimer ignored = new ScopedTimer(loadTimeTrace.publishCostMs)) {
+                long publishTimeoutMs = timeoutWatcher.getLeftTimeoutMillis();
+                boolean timeout = !waiter.await(publishTimeoutMs, TimeUnit.MILLISECONDS);
+                if (timeout) {
+                    throw new Exception(String.format("publish timed out after %sms", publishTimeoutMs));
+                }
+            } catch (Exception e) {
+                String error = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+                publishFailMsg = "publish failed: " + error;
+                LOG.warn("Publish failed. db={}, table={}, label={}, txnId={}, error={}",
+                        tableRef.getDbName(), tableRef.getTableName(), label, localTxnId, error);
+            }
+
+            // 7) Mark finished.
+            transitionToState(TaskState.FINISHED, publishFailMsg, null, () -> {});
+        } catch (Exception e) {
+            final boolean cancelled = taskState == TaskState.CANCELLED;
+            String exceptionMsg = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+            String abortReason = cancelled ? taskStateMessage : exceptionMsg;
+            try {
+                if (localTxnId != -1) {
+                    // remove callback before abortTransaction(), so that the afterAborted() callback will not be called again
+                    GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getCallbackFactory().removeCallback(taskId);
+                    GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(dbId, localTxnId, abortReason);
+                }
+            } catch (Exception ie) {
+                LOG.warn("Failed to abort transaction. db={}, table={}, label={}, txnId={}, reason={}",
+                        tableRef.getDbName(), tableRef.getTableName(), label, localTxnId, abortReason, ie);
+            }
+            if (!cancelled) {
+                try {
+                    transitionToState(TaskState.ABORTED, abortReason, null, () -> {});
+                } catch (Exception ie) {
+                    LOG.warn("Failed to transition to ABORTED state. db={}, table={}, label={}, loadId={}, txnId={}",
+                            tableRef.getDbName(), tableRef.getTableName(),
+                            label, DebugUtil.printId(loadId), localTxnId, ie);
+                }
+                LOG.warn("Merge-commit load failed. db={}, table={}, label={}, txnId={}, reason={}",
+                        tableRef.getDbName(), tableRef.getTableName(), label, localTxnId, abortReason);
+            }
+        } finally {
+            loadTimeTrace.endTimeMs.set(System.currentTimeMillis());
+            completionCallback.finish(this);
+            GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getCallbackFactory().removeCallback(taskId);
+            updateMetrics();
+            // Keep profile collection last because it can be slow.
+            collectProfile(connectContext, loadPlanner, coordinator);
+            // close tracer after collection profile
+            Tracers.close();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Finish merge-commit load. db={}, table={}, label={}, loadId={}, txnId={}, parameters={}, {}",
+                        tableRef.getDbName(), tableRef.getTableName(),
+                        label, DebugUtil.printId(loadId), localTxnId, loadKvParams, loadTimeTrace);
+            }
+        }
+    }
+
+    /**
+     * Resolves the target database from {@link #tableRef}.
+     *
+     * @return the resolved {@link Database}
+     * @throws LoadException if the database does not exist
+     */
+    private Database getDatabase() throws LoadException {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        Database db = globalStateMgr.getLocalMetastore().getDb(tableRef.getDbName());
+        if (db == null) {
+            throw new LoadException(String.format("Database '%s' does not exist", tableRef.getDbName()));
+        }
+        return db;
+    }
+
+    /**
+     * Resolves the target table from the given database.
+     *
+     * @param database database to resolve the table from
+     * @return the resolved {@link OlapTable}
+     * @throws LoadException if the table does not exist or is not an {@link OlapTable}
+     */
+    private OlapTable getOlapTable(Database database) throws LoadException {
+        Table table = database.getTable(tableRef.getTableName());
+        if (table == null) {
+            throw new LoadException(String.format(
+                    "Table '%s.%s' does not exist", tableRef.getDbName(), tableRef.getTableName()));
+        }
+        if (!(table instanceof OlapTable)) {
+            throw new LoadException(String.format(
+                    "Unsupported table type. table='%s.%s', type=%s",
+                        tableRef.getDbName(), tableRef.getTableName(), table.getType()));
+        }
+        return (OlapTable) table;
+    }
+
+    /**
+     * Creates an internal {@link ConnectContext} used to execute the load.
+     */
+    private ConnectContext createConnectContext(OlapTable table) {
+        ConnectContext context = new ConnectContext();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setCurrentUserIdentity(UserIdentity.ROOT);
+        context.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+        context.setQualifiedUser(UserIdentity.ROOT.getUser());
+        context.setCurrentComputeResource(streamLoadInfo.getComputeResource());
+
+        if (table.enableLoadProfile()) {
+            long sampleIntervalMs = Config.load_profile_collect_interval_second * 1000;
+            if (sampleIntervalMs > 0 &&
+                    System.currentTimeMillis() - table.getLastCollectProfileTime() > sampleIntervalMs) {
+                context.getSessionVariable().setEnableProfile(true);
+                table.updateLastCollectProfileTime();
+            }
+            context.getSessionVariable().setBigQueryProfileThreshold(
+                    Config.stream_load_profile_collect_threshold_second + "s");
+            // do not enable runtime profile report currently
+            context.getSessionVariable().setRuntimeProfileReportInterval(-1);
+        }
+        return context;
+    }
+
+    /**
+     * Builds the execution plan.
+     *
+     * @param database target database
+     * @param table target OLAP table
+     * @param connectContext execution context used by planner
+     * @param timeoutMs max time to wait for the table lock and planning
+     * @return a planned {@link LoadPlanner}
+     * @throws Exception if table lock cannot be acquired, planning fails, or any unexpected error occurs
+     */
+    private LoadPlanner createLoadPlan(Database database, OlapTable table, ConnectContext connectContext, long timeoutMs)
+            throws Exception {
+        try (Timer ignored = Tracers.watchScope(Tracers.Module.BASE, "LoadPlanner")) {
+            Locker locker = new Locker();
+            boolean locked =
+                    locker.tryLockTablesWithIntensiveDbLock(database.getId(), Lists.newArrayList(table.getId()),
+                            LockType.READ,
+                            timeoutMs, TimeUnit.MILLISECONDS);
+            if (!locked) {
+                throw new LockTimeoutException(
+                        String.format("Timed out acquiring read lock. db=%s, table=%s, timeoutMs=%s",
+                                tableRef.getDbName(), tableRef.getTableName(), timeoutMs));
+            }
+            try {
+                LoadPlanner loadPlanner = new LoadPlanner(taskId, loadId, txnId, database.getId(),
+                        tableRef.getDbName(), table, streamLoadInfo.isStrictMode(), streamLoadInfo.getTimezone(),
+                        streamLoadInfo.isPartialUpdate(), connectContext, null,
+                        streamLoadInfo.getLoadMemLimit(), streamLoadInfo.getExecMemLimit(),
+                        streamLoadInfo.getNegative(), backendIds.size(), streamLoadInfo.getColumnExprDescs(),
+                        streamLoadInfo, label, streamLoadInfo.getTimeout());
+                loadPlanner.setBatchWrite(mergeCommitIntervalMs,
+                        ImmutableMap.<String, String>builder()
+                                .putAll(loadKvParams.toMap()).build(), backendIds);
+                loadPlanner.plan();
+                return loadPlanner;
+            } finally {
+                locker.unLockTablesWithIntensiveDbLock(database.getId(), Lists.newArrayList(table.getId()),
+                        LockType.READ);
+            }
+        }
+    }
+
+    /**
+     * Executes the load using the given {@link Coordinator}.
+     *
+     * @param connectContext execution context
+     * @param coordinator execution coordinator
+     * @param timeoutMs total time budget for the load stage (including waiting for execution)
+     * @return load output required for commit
+     * @throws Exception if execution times out, execution status is not OK, or other errors occur
+     */
+    private LoadResult executeLoad(ConnectContext connectContext, Coordinator coordinator, long timeoutMs)
+            throws Exception {
+        try {
+            connectContext.setThreadLocalInfo();
             QeProcessorImpl.INSTANCE.registerQuery(loadId, coordinator);
             coordinator.exec();
-            int waitSecond = streamLoadInfo.getTimeout() -
-                    (int) (System.currentTimeMillis() - timeTrace.createTimeMs) / 1000;
-            timeTrace.joinPlanTimeMs.set(System.currentTimeMillis());
-            if (coordinator.join(waitSecond)) {
-                Status status = coordinator.getExecStatus();
-                if (!status.ok()) {
-                    throw new LoadException(
-                            String.format("Failed to execute load, status code: %s, error message: %s",
-                                    status.getErrorCodeString(), status.getErrorMsg()));
-                }
-                tabletCommitInfo = TabletCommitInfo.fromThrift(coordinator.getCommitInfos());
-                tabletFailInfo = TabletFailInfo.fromThrift(coordinator.getFailInfos());
-
-                // TODO add more information such as progress, unfinished backends
-                loadJobFinalOperation = new LoadJobFinalOperation();
-                EtlStatus etlStatus = loadJobFinalOperation.getLoadingStatus();
-                etlStatus.setState(TEtlState.FINISHED);
-                etlStatus.setCounters(coordinator.getLoadCounters());
-                if (coordinator.getTrackingUrl() != null) {
-                    etlStatus.setTrackingUrl(coordinator.getTrackingUrl());
-                }
-                if (!coordinator.getRejectedRecordPaths().isEmpty()) {
-                    etlStatus.setRejectedRecordPaths(coordinator.getRejectedRecordPaths());
-                }
-                long loadedRows = Long.parseLong(
-                        etlStatus.getCounters().getOrDefault(LoadEtlTask.DPP_NORMAL_ALL, "0"));
-                long loadBytes = Long.parseLong(
-                        etlStatus.getCounters().getOrDefault(LoadJob.LOADED_BYTES, "0"));
-                MergeCommitMetricRegistry.getInstance().incLoadData(loadedRows, loadBytes);
-                long filteredRows = Long.parseLong(
-                        etlStatus.getCounters().getOrDefault(LoadEtlTask.DPP_ABNORMAL_ALL, "0"));
-                double maxFilterRatio = loadParameters.getMaxFilterRatio().orElse(0.0);
-                if (isProfileEnabled()) {
-                    try {
-                        coordinator.collectProfileSync();
-                        collectProfileSuccess = true;
-                    } catch (Exception e) {
-                        LOG.error("Failed to collect profile, label: {}, txn id: {}, load id: {}",
-                                label, DebugUtil.printId(loadId), txnId, e);
-                    }
-                }
-                if (filteredRows > (filteredRows + loadedRows) * maxFilterRatio) {
-                    throw new LoadException(String.format("There is data quality issue, please check the " +
-                                    "tracking url for details. Max filter ratio: %s. The tracking url: %s",
-                                    maxFilterRatio, coordinator.getTrackingUrl()));
-                }
-            } else {
-                throw new LoadException(
-                        String.format("Timeout to execute load after waiting for %s seconds", waitSecond));
+            loadTimeTrace.execWaitStartTimeMs.set(System.currentTimeMillis());
+            boolean timeout = !coordinator.join(toJoinTimeoutSeconds(timeoutMs));
+            if (timeout) {
+                throw new LoadException(String.format("Load execution timed out after %s ms", timeoutMs));
             }
+
+            Status status = coordinator.getExecStatus();
+            if (!status.ok()) {
+                throw new LoadException(String.format("Load execution failed. errorCode=%s, message=%s",
+                        status.getErrorCodeString(), status.getErrorMsg()));
+            }
+
+            List<TabletCommitInfo> tabletCommitInfos = TabletCommitInfo.fromThrift(coordinator.getCommitInfos());
+            List<TabletFailInfo> tabletFailInfos = TabletFailInfo.fromThrift(coordinator.getFailInfos());
+            LoadStats loadStats = getLoadDataStats(coordinator);
+            return new LoadResult(tabletCommitInfos, tabletFailInfos, loadStats);
         } finally {
             QeProcessorImpl.INSTANCE.unregisterQuery(loadId);
             ConnectContext.remove();
         }
     }
 
-    private Database getDb() throws Exception {
-        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        Database db = globalStateMgr.getLocalMetastore().getDb(tableId.getDbName());
-        if (db == null) {
-            throw new LoadException(String.format("Database %s does not exist", tableId.getDbName()));
+    /**
+     * Converts a millisecond timeout to the {@link Coordinator#join(int)} second granularity.
+     *
+     * <p>We round up to avoid losing almost one second due to integer division.
+     */
+    private static int toJoinTimeoutSeconds(long timeoutMs) {
+        if (timeoutMs <= 0) {
+            return 0;
         }
-
-        return db;
+        long timeoutSeconds = (timeoutMs + 999) / 1000;
+        return timeoutSeconds >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) timeoutSeconds;
     }
 
-    private Pair<Database, OlapTable> getDbAndTable() throws Exception {
-        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        Database db = globalStateMgr.getLocalMetastore().getDb(tableId.getDbName());
-        if (db == null) {
-            throw new LoadException(String.format("Database %s does not exist", tableId.getDbName()));
-        }
-
-        Table table = db.getTable(tableId.getTableName());
-        if (table == null) {
-            throw new LoadException(String.format(
-                    "Table [%s.%s] does not exist", tableId.getDbName(), tableId.getTableName()));
-        }
-        return Pair.create(db, (OlapTable) table);
+    /**
+     * Parses load counters from coordinator and builds a {@link LoadStats}.
+     */
+    private LoadStats getLoadDataStats(Coordinator coordinator) {
+        Map<String, String> loadCounters = coordinator.getLoadCounters();
+        long normalRows = Long.parseLong(loadCounters.getOrDefault(LoadEtlTask.DPP_NORMAL_ALL, "0"));
+        long normalBytes = Long.parseLong(loadCounters.getOrDefault(LoadJob.LOADED_BYTES, "0"));
+        long abnormalRows = Long.parseLong(loadCounters.getOrDefault(LoadEtlTask.DPP_ABNORMAL_ALL, "0"));
+        long unselectedRows = Long.parseLong(loadCounters.getOrDefault(LoadJob.UNSELECTED_ROWS, "0"));
+        return new LoadStats(normalRows, normalBytes, abnormalRows, unselectedRows,
+                coordinator.getTrackingUrl(), coordinator.getRejectedRecordPaths());
     }
 
-    private boolean isProfileEnabled() {
-        return (context != null && context.isProfileEnabled()) || LoadErrorUtils.enableProfileAfterError(coordinator);
+    private void updateMetrics() {
+        LoadStats loadStats = this.loadStats;
+        if (loadStats != null) {
+            MergeCommitMetricRegistry.getInstance().incLoadData(loadStats.normalRows, loadStats.normalBytes);
+        }
+        MergeCommitMetricRegistry.getInstance().updateLoadLatency(loadTimeTrace.totalCostMs());
+        if (taskState == TaskState.FINISHED) {
+            MergeCommitMetricRegistry.getInstance().incSuccessTask();
+        } else {
+            MergeCommitMetricRegistry.getInstance().incFailTask();
+        }
+        MergeCommitMetricRegistry.getInstance().updateRunningTask(-1L);
     }
 
-    private void reportProfile() {
-        if (!isProfileEnabled()) {
+    /**
+     * Collects and pushes runtime profile if profile is enabled.
+     *
+     * @param connectContext execution context; if null, profiling is skipped
+     * @param planner load planner; if null, profiling is skipped
+     * @param coordinator execution coordinator; if null, profiling is skipped
+     */
+    private void collectProfile(ConnectContext connectContext, LoadPlanner planner, Coordinator coordinator) {
+        if (connectContext == null || planner == null || coordinator == null) {
             return;
         }
-        RuntimeProfile profile = new RuntimeProfile("Load");
-        RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
-        summaryProfile.addInfoString(ProfileManager.QUERY_ID, DebugUtil.printId(loadId));
-        summaryProfile.addInfoString(ProfileManager.START_TIME, TimeUtils.longToTimeString(timeTrace.createTimeMs));
-        summaryProfile.addInfoString(ProfileManager.END_TIME, TimeUtils.longToTimeString(timeTrace.finishTimeMs));
-        summaryProfile.addInfoString(ProfileManager.TOTAL_TIME, DebugUtil.getPrettyStringMs(timeTrace.totalCostMs()));
-        summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Load");
-        summaryProfile.addInfoString(ProfileManager.LOAD_TYPE, "MERGE_COMMIT");
-        summaryProfile.addInfoString("StarRocks Version",
-                String.format("%s-%s", Version.STARROCKS_VERSION, Version.STARROCKS_COMMIT_HASH));
-        summaryProfile.addInfoString("Default Db", tableId.getDbName());
-        summaryProfile.addInfoString("Sql Statement",
-                String.format("merge commit, table: %s, label: %s, %s",
-                        tableId.getTableName(), label, loadParameters.toString()));
-        summaryProfile.addInfoString(ProfileManager.VARIABLES, "{}");
-        summaryProfile.addInfoString("NonDefaultSessionVariables", "{}");
-        summaryProfile.addInfoString("TxnId", txnId == -1 ? "N/A" : String.valueOf(txnId));
-        summaryProfile.addInfoString("Backends", coordinatorBackendIds.toString());
-        summaryProfile.addInfoString("Time Trace", timeTrace.summary());
-        if (failure.get() != null) {
-            summaryProfile.addInfoString("Exception", failure.get().getMessage());
+        if (!connectContext.isProfileEnabled() && !LoadErrorUtils.enableProfileAfterError(coordinator)) {
+            return;
         }
-        if (loadJobFinalOperation != null) {
-            EtlStatus etlStatus = loadJobFinalOperation.getLoadingStatus();
-            summaryProfile.addInfoString("LoadResult", String.format("loadRows: %s, filterRows: %s, loadBytes: %s",
-                    etlStatus.getCounters().getOrDefault(LoadEtlTask.DPP_NORMAL_ALL, "0"),
-                    etlStatus.getCounters().getOrDefault(LoadEtlTask.DPP_ABNORMAL_ALL, "0"),
-                    etlStatus.getCounters().getOrDefault(LoadJob.LOADED_BYTES, "0")));
+
+        AtomicLong collectProfileCostMs = new AtomicLong(0);
+        RuntimeProfile executionProfile = null;
+        try (ScopedTimer ignored = new ScopedTimer(collectProfileCostMs)) {
+            coordinator.collectProfileSync();
+            executionProfile = coordinator.buildQueryProfile(true);
+        } catch (Exception e) {
+            LOG.warn("Failed to collect profile. db={}, table={}, label={}, txnId={}, loadId={}",
+                    tableRef.getDbName(), tableRef.getTableName(),
+                    label, txnId, DebugUtil.printId(loadId), e);
         }
-        profile.addChild(summaryProfile);
-        if (collectProfileSuccess) {
-            profile.addChild(coordinator.buildQueryProfile(true));
+
+        try {
+            RuntimeProfile profile = new RuntimeProfile("Load");
+            RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
+            summaryProfile.addInfoString(ProfileManager.QUERY_ID, DebugUtil.printId(loadId));
+            summaryProfile.addInfoString(ProfileManager.START_TIME,
+                    TimeUtils.longToTimeString(loadTimeTrace.createTimeMs));
+            summaryProfile.addInfoString(ProfileManager.END_TIME,
+                    TimeUtils.longToTimeString(loadTimeTrace.endTimeMs.get()));
+            summaryProfile.addInfoString(ProfileManager.TOTAL_TIME,
+                    DebugUtil.getPrettyStringMs(loadTimeTrace.totalCostMs()));
+            summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Load");
+            summaryProfile.addInfoString(ProfileManager.QUERY_STATE, taskState.name());
+            summaryProfile.addInfoString("State Message", taskStateMessage);
+            summaryProfile.addInfoString(ProfileManager.LOAD_TYPE, "MERGE_COMMIT");
+            summaryProfile.addInfoString("StarRocks Version",
+                    String.format("%s-%s", Version.STARROCKS_VERSION, Version.STARROCKS_COMMIT_HASH));
+            summaryProfile.addInfoString("Default Db", tableRef.getDbName());
+            summaryProfile.addInfoString("Table", tableRef.getTableName());
+            summaryProfile.addInfoString("Sql Statement", loadKvParams.toString());
+            summaryProfile.addInfoString(ProfileManager.WAREHOUSE_CNGROUP, warehouseName);
+            summaryProfile.addInfoString(ProfileManager.PROFILE_COLLECT_TIME,
+                    DebugUtil.getPrettyStringMs(collectProfileCostMs.get()));
+            summaryProfile.addInfoString("IsProfileAsync", String.valueOf(true));
+            summaryProfile.addInfoString("Label", label);
+            summaryProfile.addInfoString("Txn ID", String.valueOf(txnId));
+            summaryProfile.addInfoString("Txn Commit Time",
+                    DebugUtil.getPrettyStringMs(loadTimeTrace.commitCostMs.get()));
+            summaryProfile.addInfoString("Txn Publish Time",
+                    DebugUtil.getPrettyStringMs(loadTimeTrace.publishCostMs.get()));
+            LoadStats loadStats = this.loadStats;
+            if (loadStats != null) {
+                summaryProfile.addInfoString("RowsNormal", String.valueOf(loadStats.normalRows));
+                summaryProfile.addInfoString("BytesNormal", DebugUtil.getPrettyStringBytes(loadStats.normalBytes));
+                summaryProfile.addInfoString("RowsAbnormal", String.valueOf(loadStats.abnormalRows));
+                summaryProfile.addInfoString("RowsUnselected", String.valueOf(loadStats.unselectedRows));
+            }
+            profile.addChild(summaryProfile);
+            RuntimeProfile plannerProfile = new RuntimeProfile("Planner");
+            profile.addChild(plannerProfile);
+            Tracers.toRuntimeProfile(plannerProfile);
+            if (executionProfile != null) {
+                profile.addChild(executionProfile);
+            }
+            ProfileManager.getInstance().pushProfile(planner.getExecPlan().getProfilingPlan(), profile);
+        } catch (Exception e) {
+            LOG.warn("Failed to build profile. db={}, table={}, label={}, txnId={}, loadId={}",
+                    tableRef.getDbName(), tableRef.getTableName(),
+                    label, txnId, DebugUtil.printId(loadId), e);
         }
-        ProfileManager.getInstance().pushProfile(
-                loadPlanner == null ? null : loadPlanner.getExecPlan().getProfilingPlan(), profile);
     }
 
-    @VisibleForTesting
-    Set<Long> getCoordinatorBackendIds() {
-        return coordinatorBackendIds;
+    /**
+     * Cancels the task as best effort.
+     *
+     * @param reason cancellation reason
+     */
+    public void cancel(String reason) {
+        try {
+            transitionToState(TaskState.CANCELLED, reason, null, () -> {});
+            LOG.info("Cancel task. db={}, table={}, taskId={}, label={}, loadId={}, txnId={}, reason={}",
+                    tableRef.getDbName(), tableRef.getTableName(),
+                    taskId, label, DebugUtil.printId(loadId), txnId, reason);
+        } catch (Exception e) {
+            LOG.warn("Failed to cancel task. db={}, table={}, taskId={}, label={}, loadId={}, txnId={}, reason={}",
+                    tableRef.getDbName(), tableRef.getTableName(),
+                    taskId, label, DebugUtil.printId(loadId), txnId, reason, e);
+        }
     }
 
-    @VisibleForTesting
-    Coordinator getCoordinator() {
-        return coordinator;
+    /**
+     * Transitions the internal state machine to {@code targetState}.
+     *
+     * <p>This method acquires {@link #lock} and updates {@link #taskState}, {@link #taskStateMessage} and
+     * {@link #taskStateCancelHandler} atomically. The {@code afterStateChange} callback (if any) is executed
+     * under the same lock, and should only update fields protected by {@link #lock}.
+     *
+     * <p>When transitioning to {@link TaskState#CANCELLED}, the previous {@link #taskStateCancelHandler} (if any)
+     * is invoked <b>after</b> releasing the lock, to avoid holding the lock while cancelling external resources.
+     */
+    private void transitionToState(TaskState targetState, String targetStateMsg,
+            TaskStateCancelHandler taskStateCancelHandler, Runnable afterStateChange) throws Exception {
+        TaskStateCancelHandler prevTaskStateCancelHandler;
+        try (AutoCloseable ignored = CloseableLock.lock(lock)) {
+            EnumSet<TaskState> transition = TASK_STATE_TRANSITION.getOrDefault(taskState, EnumSet.noneOf(TaskState.class));
+            if (!transition.contains(targetState)) {
+                throw new Exception(String.format("Cannot transition state from %s to %s", taskState, targetState));
+            }
+            TaskState prevState = taskState;
+            taskState = targetState;
+            taskStateMessage = targetStateMsg;
+            prevTaskStateCancelHandler = this.taskStateCancelHandler;
+            this.taskStateCancelHandler = taskStateCancelHandler;
+            afterStateChange.run();
+            LOG.debug("Transition state from {} to {}. db={}, table={}, taskId={}, label={}, loadId={}, txnId={}, stateMsg={}",
+                    prevState, targetState, tableRef.getDbName(), tableRef.getTableName(),
+                    taskId, label, DebugUtil.printId(loadId), txnId, targetStateMsg);
+        }
+        if (targetState == TaskState.CANCELLED && prevTaskStateCancelHandler != null) {
+            prevTaskStateCancelHandler.cancel(targetStateMsg);
+        }
     }
 
-    @VisibleForTesting
-    TimeTrace getTimeTrace() {
-        return timeTrace;
+    /**
+     * Checks if this execution is active and can accept new load requests.
+     *
+     * <p>A task is considered active if it is not in a terminal state and either has not started joining
+     * execution yet, or its join start time is within the merge-commit interval window.
+     *
+     * @return {@code true} if the task is active, otherwise {@code false}
+     */
+    public boolean isActive() {
+        if (taskState.isTerminal() || taskState == TaskState.COMMITTING || taskState == TaskState.COMMITTED) {
+            return false;
+        }
+        long execWaitStartTimeMs = loadTimeTrace.execWaitStartTimeMs.get();
+        return execWaitStartTimeMs <= 0 || (System.currentTimeMillis() - execWaitStartTimeMs < mergeCommitIntervalMs);
     }
 
-    // Trace the timing of various stages of the load operation.
-    static class TimeTrace {
-        long createTimeMs;
-        long beginTxnTimeMs = -1;
-        long executeLoadTimeMs = -1;
-        long deployPlanTimeMs = -1;
-        AtomicLong joinPlanTimeMs = new AtomicLong(-1);
-        long commitTxnTimeMs = -1;
-        long finishTimeMs = -1;
+    /**
+     * Returns the backend IDs used by the coordinator.
+     */
+    public Set<Long> getBackendIds() {
+        return Collections.unmodifiableSet(backendIds);
+    }
+
+    /**
+     * Checks whether the given backend ID is contained in the execution backend set.
+     */
+    public boolean containsBackend(long backendId) {
+        return backendIds.contains(backendId);
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * Returns the transaction ID once it has been assigned.
+     *
+     * @return the transaction ID; empty if the transaction has not started yet
+     */
+    public Optional<Long> getTxnId() {
+        long txnId = this.txnId;
+        return txnId > 0 ? Optional.of(txnId) : Optional.empty();
+    }
+
+    private static String getErrorTrackingSql(long taskId) {
+        return "SELECT tracking_log FROM information_schema.load_tracking_logs WHERE JOB_ID=" + taskId;
+    }
+
+    // ================ inherited methods from AbstractTxnStateChangeCallback ================
+
+    @Override
+    public long getId() {
+        return taskId;
+    }
+
+    @Override
+    public void afterAborted(TransactionState txnState, boolean txnOperated, String txnStatusChangeReason)
+            throws StarRocksException {
+        // This transaction abort must come from outside, because run() removes the callback before abort txn.
+        cancel(txnStatusChangeReason);
+    }
+
+    static class LoadResult {
+        final List<TabletCommitInfo> tabletCommitInfos;
+        final List<TabletFailInfo> tabletFailInfos;
+        final LoadStats loadStats;
+
+        public LoadResult(List<TabletCommitInfo> tabletCommitInfos, List<TabletFailInfo> tabletFailInfos,
+                          LoadStats loadStats) {
+            this.tabletCommitInfos = tabletCommitInfos;
+            this.tabletFailInfos = tabletFailInfos;
+            this.loadStats = loadStats;
+        }
+    }
+
+    /**
+     * Statistics about rows/bytes processed by the load execution.
+     */
+    private static class LoadStats {
+        final long normalRows;
+        final long normalBytes;
+        final long abnormalRows;
+        final long unselectedRows;
+        final Optional<String> errorTrackingUrl;
+        final Optional<List<String>> rejectedRecordPaths;
+
+        public LoadStats(long normalRows, long normalBytes, long abnormalRows, long unselectedRows,
+                         String errorTrackingUrl, List<String> rejectedRecordPaths) {
+            this.normalRows = normalRows;
+            this.normalBytes = normalBytes;
+            this.abnormalRows = abnormalRows;
+            this.unselectedRows = unselectedRows;
+            this.errorTrackingUrl = Optional.ofNullable(errorTrackingUrl);
+            this.rejectedRecordPaths = Optional.ofNullable(rejectedRecordPaths);
+        }
+    }
+
+    private static class ScopedTimer implements AutoCloseable {
+
+        private final AtomicLong cost;
+        private final long startTimeMs;
+
+        public ScopedTimer(AtomicLong cost) {
+            this.cost = cost;
+            this.startTimeMs = System.currentTimeMillis();
+        }
+
+        @Override
+        public void close() {
+            cost.set(System.currentTimeMillis() - startTimeMs);
+        }
+    }
+
+    /**
+     * Traces the timing of various stages of the load operation.
+     */
+    private static class TimeTrace {
+        /** Task creation timestamp (milliseconds since epoch). */
+        final long createTimeMs;
+        /** Task end timestamp (milliseconds since epoch); {@code -1} if not finished yet. */
+        final AtomicLong endTimeMs = new AtomicLong(-1);
+        /** Time spent in {@link TaskState#PENDING} (milliseconds). */
+        final AtomicLong pendingCostMs = new AtomicLong(-1);
+        /**
+         * Timestamp when waiting for {@link Coordinator#join(int)} starts (milliseconds since epoch).
+         * {@code -1} if not started.
+         */
+        final AtomicLong execWaitStartTimeMs = new AtomicLong(-1);
+        /** Time spent committing the transaction (milliseconds). */
+        final AtomicLong commitCostMs = new AtomicLong(-1);
+        /** Time spent waiting for publish/visibility (milliseconds). */
+        final AtomicLong publishCostMs = new AtomicLong(-1);
 
         public TimeTrace() {
             this.createTimeMs = System.currentTimeMillis();
         }
 
         public long totalCostMs() {
-            return finishTimeMs > 0 ? finishTimeMs - createTimeMs : System.currentTimeMillis() - createTimeMs;
+            long timestamp = endTimeMs.get();
+            return timestamp > 0 ? timestamp - createTimeMs : System.currentTimeMillis() - createTimeMs;
         }
 
-        String summary() {
-            StringBuilder sb = new StringBuilder();
-            sb.append("total: ").append(totalCostMs()).append(" ms");
-            appendTraceItem(sb, ", pending: ", createTimeMs, beginTxnTimeMs);
-            appendTraceItem(sb, ", begin txn: ", beginTxnTimeMs, executeLoadTimeMs);
-            appendTraceItem(sb, ", plan: ", executeLoadTimeMs, deployPlanTimeMs);
-            appendTraceItem(sb, ", deploy: ", deployPlanTimeMs, joinPlanTimeMs.get());
-            appendTraceItem(sb, ", load: ", joinPlanTimeMs.get(), commitTxnTimeMs);
-            appendTraceItem(sb, ", commit/publish txn: ", commitTxnTimeMs, finishTimeMs);
-            return sb.toString();
+        @Override
+        public String toString() {
+            return "TimeTrace{" +
+                    "createTimeMs=" + createTimeMs +
+                    ", endTimeMs=" + endTimeMs +
+                    ", pendingCostMs=" + pendingCostMs +
+                    ", execWaitStartTimeMs=" + execWaitStartTimeMs +
+                    ", commitCostMs=" + commitCostMs +
+                    ", publishCostMs=" + publishCostMs +
+                    '}';
+        }
+    }
+
+    /**
+     * A handler to cancel the current state.
+     */
+    private abstract static class TaskStateCancelHandler {
+
+        protected TaskStateCancelHandler(TaskState taskState) {
+            if (taskState == null) {
+                throw new IllegalArgumentException("task state is null");
+            }
+            if (taskState.isTerminal()) {
+                throw new IllegalArgumentException("Terminal state has no cancel handler: " + taskState);
+            }
         }
 
-        private void appendTraceItem(StringBuilder sb, String msg, long startTimeMs, long endTimeMs) {
-            if (startTimeMs > 0) {
-                sb.append(msg).append(endTimeMs - startTimeMs).append(" ms");
+        public abstract void cancel(String reason);
+    }
+
+    /**
+     * The handler to cancel {@link TaskState#LOADING}.
+     *
+     * <p>It wraps the {@link Coordinator} running the load so that the in-flight execution can be cancelled.
+     */
+    private static final class LoadingStateCancelHandler extends TaskStateCancelHandler {
+        private final Coordinator coordinator;
+
+        private LoadingStateCancelHandler(Coordinator coordinator) {
+            super(TaskState.LOADING);
+            this.coordinator = coordinator;
+        }
+
+        @Override
+        public void cancel(String reason) {
+            if (coordinator != null) {
+                coordinator.cancel(PPlanFragmentCancelReason.USER_CANCEL, reason);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadKvParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadKvParams.java
@@ -360,7 +360,7 @@ public class StreamLoadKvParams implements StreamLoadParams {
 
     @Override
     public String toString() {
-        return "params={" + params + '}';
+        return "params=" + params;
     }
 
     public static StreamLoadKvParams fromHttpHeaders(HttpHeaders httpHeaders) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitJobTest.java
@@ -14,26 +14,18 @@
 
 package com.starrocks.load.batchwrite;
 
-import com.google.common.collect.ImmutableMap;
-import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.load.streamload.StreamLoadHttpHeader;
 import com.starrocks.load.streamload.StreamLoadInfo;
 import com.starrocks.load.streamload.StreamLoadKvParams;
-import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
-import com.starrocks.task.LoadEtlTask;
-import com.starrocks.thrift.FrontendServiceVersion;
-import com.starrocks.thrift.TReportExecStatusParams;
-import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
-import com.starrocks.thrift.TTabletFailInfo;
-import com.starrocks.transaction.TransactionStatus;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -148,15 +140,15 @@ public class MergeCommitJobTest extends BatchWriteTestBase {
         MergeCommitTask mergeCommitTask = load.getTask(label);
         assertNotNull(mergeCommitTask);
         assertEquals(nodes.stream().map(ComputeNode::getId).collect(Collectors.toSet()),
-                mergeCommitTask.getCoordinatorBackendIds());
+                mergeCommitTask.getBackendIds());
 
         RequestLoadResult result2 = load.requestLoad(nodes.get(1).getId(), nodes.get(1).getHost());
         assertTrue(result2.isOk());
         assertEquals(label, result2.getValue());
 
-        executor.manualRun(mergeCommitTask);
-
-        assertEquals(TransactionStatus.VISIBLE, getTxnStatus(label));
+        MergeCommitTask finishedTask = Mockito.mock(MergeCommitTask.class);
+        whenFinishedTask(finishedTask, label, 1L, mergeCommitTask.getBackendIds());
+        load.finish(finishedTask);
         assertNull(load.getTask(label));
         assertEquals(0, load.numRunningLoads());
         assertEquals(mergeCommitTask.getBackendIds().size(), txnStateDispatcher.getNumSubmittedTasks());
@@ -181,7 +173,7 @@ public class MergeCommitJobTest extends BatchWriteTestBase {
         MergeCommitTask mergeCommitTask1 = load.getTask(label1);
         assertNotNull(mergeCommitTask1);
         assertEquals(nodes.stream().map(ComputeNode::getId).collect(Collectors.toSet()),
-                mergeCommitTask1.getCoordinatorBackendIds());
+                mergeCommitTask1.getBackendIds());
 
         RequestLoadResult result2 = load.requestLoad(allNodes.get(parallel).getId(), allNodes.get(parallel).getHost());
         assertTrue(result2.isOk());
@@ -194,17 +186,18 @@ public class MergeCommitJobTest extends BatchWriteTestBase {
         assertNotSame(mergeCommitTask1, mergeCommitTask2);
         Set<Long> expectNodeIds = nodes.stream().map(ComputeNode::getId).collect(Collectors.toSet());
         expectNodeIds.add(allNodes.get(parallel).getId());
-        assertEquals(expectNodeIds, mergeCommitTask2.getCoordinatorBackendIds());
+        assertEquals(expectNodeIds, mergeCommitTask2.getBackendIds());
 
-        executor.manualRun(mergeCommitTask1);
-        assertEquals(TransactionStatus.VISIBLE, getTxnStatus(label1));
-        assertEquals(mergeCommitTask1.getCoordinatorBackendIds().size(), txnStateDispatcher.getNumSubmittedTasks());
+        MergeCommitTask finishedTask1 = Mockito.mock(MergeCommitTask.class);
+        whenFinishedTask(finishedTask1, label1, 1L, mergeCommitTask1.getBackendIds());
+        load.finish(finishedTask1);
+        assertEquals(mergeCommitTask1.getBackendIds().size(), txnStateDispatcher.getNumSubmittedTasks());
 
-        executor.manualRun(mergeCommitTask2);
-        assertEquals(TransactionStatus.VISIBLE, getTxnStatus(label2));
+        MergeCommitTask finishedTask2 = Mockito.mock(MergeCommitTask.class);
+        whenFinishedTask(finishedTask2, label2, 2L, mergeCommitTask2.getBackendIds());
+        load.finish(finishedTask2);
         assertEquals(mergeCommitTask1.getBackendIds().size() + mergeCommitTask2.getBackendIds().size(),
                 txnStateDispatcher.getNumSubmittedTasks());
-
         assertEquals(0, load.numRunningLoads());
     }
 
@@ -266,50 +259,11 @@ public class MergeCommitJobTest extends BatchWriteTestBase {
 
             pendingRunnable.add(command);
         }
+    }
 
-        public void manualRun(Runnable runnable) throws Exception {
-            boolean exist = pendingRunnable.remove(runnable);
-            if (!exist) {
-                return;
-            }
-
-            if (!(runnable instanceof MergeCommitTask)) {
-                runnable.run();
-                return;
-            }
-
-            MergeCommitTask mergeCommitTask = (MergeCommitTask) runnable;
-            Thread thread = new Thread(mergeCommitTask);
-            thread.start();
-            long endTime = System.currentTimeMillis() + 120000;
-            while (mergeCommitTask.getTimeTrace().joinPlanTimeMs.get() <= 0) {
-                if (System.currentTimeMillis() > endTime) {
-                    throw new Exception("Load executor execute plan timeout");
-                }
-                Thread.sleep(10);
-            }
-            DefaultCoordinator coordinator = (DefaultCoordinator) mergeCommitTask.getCoordinator();
-            assertNotNull(coordinator);
-            coordinator.getExecutionDAG().getExecutions().forEach(execution -> {
-                int indexInJob = execution.getIndexInJob();
-                TReportExecStatusParams request = new TReportExecStatusParams(FrontendServiceVersion.V1);
-                request.setBackend_num(indexInJob)
-                        .setDone(true)
-                        .setStatus(new TStatus(TStatusCode.OK))
-                        .setFragment_instance_id(execution.getInstanceId());
-                request.setCommitInfos(buildCommitInfos());
-                TTabletFailInfo failInfo = new TTabletFailInfo();
-                request.setFailInfos(Collections.singletonList(failInfo));
-                Map<String, String> currLoadCounters = ImmutableMap.of(
-                        LoadEtlTask.DPP_NORMAL_ALL, String.valueOf(10),
-                        LoadEtlTask.DPP_ABNORMAL_ALL, String.valueOf(0),
-                        LoadJob.UNSELECTED_ROWS, String.valueOf(0),
-                        LoadJob.LOADED_BYTES, String.valueOf(40)
-                );
-                request.setLoad_counters(currLoadCounters);
-                coordinator.updateFragmentExecStatus(request);
-            });
-            thread.join();
-        }
+    private static void whenFinishedTask(MergeCommitTask task, String label, long txnId, Set<Long> backendIds) {
+        Mockito.when(task.getLabel()).thenReturn(label);
+        Mockito.when(task.getTxnId()).thenReturn(txnId);
+        Mockito.when(task.getBackendIds()).thenReturn(backendIds);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
@@ -72,10 +72,9 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
     private StreamLoadKvParams kvParams;
     private StreamLoadInfo streamLoadInfo;
     private String warehouseName;
-    private Coordinator coordinator;
     private TestMergeCommitTaskCallback loadExecuteCallback;
-
     private Coordinator.Factory coordinatorFactory;
+    private Coordinator coordinator;
 
     @BeforeEach
     public void setup() throws Exception {
@@ -90,8 +89,8 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
         streamLoadInfo = StreamLoadInfo.fromHttpStreamLoadRequest(null, -1, Optional.empty(), kvParams);
         warehouseName = "default_warehouse";
         loadExecuteCallback = new TestMergeCommitTaskCallback();
-        coordinator = Mockito.mock(Coordinator.class);
         coordinatorFactory = Mockito.mock(Coordinator.Factory.class);
+        coordinator = Mockito.mock(Coordinator.class);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
@@ -100,6 +100,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
         Set<Long> backendIds = new HashSet<>(Arrays.asList(10002L, 10003L));
         MergeCommitTask task = new MergeCommitTask(
                 taskId,
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
@@ -131,6 +132,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
     public void testLoadSuccess() {
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
@@ -160,6 +162,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
     public void testExecuteFailWhenStatusNotOk() {
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
@@ -185,6 +188,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
     public void testExecuteTimeout() {
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
@@ -215,6 +219,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
         String fakeTableName = TABLE_NAME_1_1 + "_fake";
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, fakeTableName),
                 label,
                 loadId,
@@ -237,6 +242,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
     public void testDatabaseDoesNotExist() {
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                -1,
                 new TableId("merge_commit_db_not_exist", TABLE_NAME_1_1),
                 label,
                 loadId,
@@ -259,6 +265,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
     public void testMaxFilterRatioThrowsDataQualityException() {
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
@@ -289,6 +296,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
         int mergeCommitIntervalMs = 200;
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
@@ -335,6 +343,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
         Coordinator.Factory factory = Mockito.mock(Coordinator.Factory.class);
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
@@ -359,6 +368,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
     public void testCancelAfterFinish() {
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
@@ -386,6 +396,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
     public void testAbortTransactionTriggersCancel() throws Exception {
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
@@ -448,6 +459,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
         try {
             MergeCommitTask task = new MergeCommitTask(
                     GlobalStateMgr.getCurrentState().getNextId(),
+                    DATABASE_1.getId(),
                     new TableId(DB_NAME_1, TABLE_NAME_1_1),
                     label,
                     loadId,
@@ -477,6 +489,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
     public void testCancelDuringLoadingTriggersCoordinatorCancel() throws Exception {
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
@@ -521,6 +534,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
     public void testStateMachineTransitionsOnSuccess() {
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
@@ -561,6 +575,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
     public void testStateMachineTransitionsOnExecuteFail() {
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
@@ -591,6 +606,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
     public void testStateMachineTransitionsOnCancelDuringLoading() throws Exception {
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
@@ -635,6 +651,7 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
     public void testStateMachineTransitionsOnPublishTimeout() throws Exception {
         MergeCommitTask task = new MergeCommitTask(
                 GlobalStateMgr.getCurrentState().getNextId(),
+                DATABASE_1.getId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
@@ -14,10 +14,7 @@
 
 package com.starrocks.load.batchwrite;
 
-import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
-import com.starrocks.common.FeConstants;
-import com.starrocks.common.LoadException;
 import com.starrocks.common.Status;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.ProfileManager;
@@ -26,79 +23,64 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.load.streamload.StreamLoadHttpHeader;
 import com.starrocks.load.streamload.StreamLoadInfo;
 import com.starrocks.load.streamload.StreamLoadKvParams;
-import com.starrocks.planner.DescriptorTable;
-import com.starrocks.planner.PlanFragment;
-import com.starrocks.planner.ScanNode;
-import com.starrocks.planner.StreamLoadPlanner;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.scheduler.Coordinator;
-import com.starrocks.schema.MTable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.LoadPlanner;
-import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.task.LoadEtlTask;
-import com.starrocks.thrift.TDescriptorTable;
-import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TransactionStatus;
-import com.starrocks.utframe.StarRocksAssert;
-import com.starrocks.utframe.UtFrameUtils;
-import com.starrocks.warehouse.cngroup.ComputeResource;
-import mockit.Expectations;
-import mockit.Mocked;
-import org.junit.jupiter.api.BeforeAll;
+import com.starrocks.transaction.TxnStateCallbackFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 public class MergeCommitTaskTest extends BatchWriteTestBase {
 
     private String label;
     private TUniqueId loadId;
-    StreamLoadKvParams kvParams;
+    private StreamLoadKvParams kvParams;
     private StreamLoadInfo streamLoadInfo;
+    private String warehouseName;
+    private Coordinator coordinator;
     private TestMergeCommitTaskCallback loadExecuteCallback;
 
-    @Mocked
-    private Coordinator coordinator;
-    private TestCoordinatorFactor coordinatorFactory;
-
-    @BeforeAll
-    public static void beforeClass() throws Exception {
-        UtFrameUtils.createMinStarRocksCluster();
-        UtFrameUtils.addMockBackend(10002);
-        UtFrameUtils.addMockBackend(10003);
-        UtFrameUtils.addMockBackend(10004);
-        connectContext = UtFrameUtils.createDefaultCtx();
-        starRocksAssert = new StarRocksAssert(connectContext);
-        starRocksAssert.withDatabase(DB_NAME_1)
-                .useDatabase(DB_NAME_1)
-                .withTable(new MTable(TABLE_NAME_1_1, Arrays.asList("c0 INT", "c1 STRING")));
-        DATABASE_1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME_1);
-        TABLE_1_1 = (OlapTable) DATABASE_1.getTable(TABLE_NAME_1_1);
-        FeConstants.runningUnitTest = false;
-        Config.enable_new_publish_mechanism = false;
-    }
+    private Coordinator.Factory coordinatorFactory;
 
     @BeforeEach
     public void setup() throws Exception {
         loadId = UUIDUtil.genTUniqueId();
-        label = "batch_write_" + DebugUtil.printId(loadId);
+        label = "merge_commit_" + DebugUtil.printId(loadId);
 
         Map<String, String> map = new HashMap<>();
         map.put(StreamLoadHttpHeader.HTTP_FORMAT, "json");
@@ -106,218 +88,355 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
         map.put(StreamLoadHttpHeader.HTTP_BATCH_WRITE_ASYNC, "true");
         kvParams = new StreamLoadKvParams(map);
         streamLoadInfo = StreamLoadInfo.fromHttpStreamLoadRequest(null, -1, Optional.empty(), kvParams);
+        warehouseName = "default_warehouse";
         loadExecuteCallback = new TestMergeCommitTaskCallback();
-        coordinatorFactory = new TestCoordinatorFactor(coordinator);
+        coordinator = Mockito.mock(Coordinator.class);
+        coordinatorFactory = Mockito.mock(Coordinator.Factory.class);
+    }
+
+    @Test
+    public void testBasicAccessors() {
+        long taskId = GlobalStateMgr.getCurrentState().getNextId();
+        Set<Long> backendIds = new HashSet<>(Arrays.asList(10002L, 10003L));
+        MergeCommitTask task = new MergeCommitTask(
+                taskId,
+                new TableId(DB_NAME_1, TABLE_NAME_1_1),
+                label,
+                loadId,
+                streamLoadInfo,
+                1000,
+                kvParams,
+                warehouseName,
+                backendIds,
+                coordinatorFactory,
+                loadExecuteCallback);
+
+        assertEquals(taskId, task.getId());
+        assertEquals(label, task.getLabel());
+        assertTrue(task.containsBackend(10002L));
+        assertFalse(task.containsBackend(99999L));
+        assertTrue(task.getTxnId() < 0);
+
+        Set<Long> returnedBackendIds = task.getBackendIds();
+        assertEquals(backendIds, returnedBackendIds);
+        try {
+            returnedBackendIds.add(10004L);
+            fail("expected UnsupportedOperationException");
+        } catch (UnsupportedOperationException ignored) {
+            // ok
+        }
     }
 
     @Test
     public void testLoadSuccess() {
-        MergeCommitTask executor = new MergeCommitTask(
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
                 streamLoadInfo,
                 1000,
                 kvParams,
+                warehouseName,
                 new HashSet<>(Arrays.asList(10002L, 10003L)),
                 coordinatorFactory,
-                loadExecuteCallback
-            );
+                loadExecuteCallback);
 
-        new Expectations() {
-            {
-                coordinator.join((anyInt));
-                result = true;
-                coordinator.getExecStatus();
-                result = new Status();
-                coordinator.getCommitInfos();
-                result = buildCommitInfos();
-            }
-        };
+        stubCoordinatorSuccess();
 
-        executor.run();
-        assertNull(executor.getFailure());
+        task.run();
         assertEquals(1, loadExecuteCallback.getFinishedLoads().size());
         assertEquals(label, loadExecuteCallback.getFinishedLoads().get(0));
-        TransactionStatus txnStatus =
-                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                        .getLabelStatus(DATABASE_1.getId(), label).getStatus();
-        assertEquals(TransactionStatus.VISIBLE, txnStatus);
+        assertEquals(TransactionStatus.VISIBLE, getTxnStatus(label));
+        assertTrue(task.getTxnId() > 0);
         assertNull(ProfileManager.getInstance().getProfile(DebugUtil.printId(loadId)));
+        // The task must always remove its txn callback after completion to avoid leaking callbacks.
+        TxnStateCallbackFactory callbackFactory =
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getCallbackFactory();
+        assertNull(callbackFactory.getCallback(task.getId()));
     }
 
     @Test
-    public void testPlanExecuteFail() {
-        MergeCommitTask executor = new MergeCommitTask(
+    public void testExecuteFailWhenStatusNotOk() {
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
                 streamLoadInfo,
                 1000,
                 kvParams,
+                warehouseName,
                 new HashSet<>(Arrays.asList(10002L, 10003L)),
                 coordinatorFactory,
-                loadExecuteCallback
-        );
+                loadExecuteCallback);
 
-        Status status = new Status(TStatusCode.INTERNAL_ERROR, "artificial failure");
-        new Expectations() {
-            {
-                coordinator.join((anyInt));
-                result = true;
-                coordinator.getExecStatus();
-                result = status;
-            }
-        };
+        stubCoordinatorSuccess();
+        when(coordinator.getExecStatus()).thenReturn(new Status(TStatusCode.INTERNAL_ERROR, "artificial failure"));
 
-        Exception expectException = new LoadException(
-                String.format("Failed to execute load, status code: %s, error message: %s",
-                        status.getErrorCodeString(), status.getErrorMsg()));
-        testLoadFailBase(executor, expectException, TransactionStatus.ABORTED);
+        task.run();
+        assertEquals(1, loadExecuteCallback.getFinishedLoads().size());
+        assertEquals(label, loadExecuteCallback.getFinishedLoads().get(0));
+        assertEquals(TransactionStatus.ABORTED, getTxnStatus(label));
+        assertTrue(task.getTxnId() > 0);
     }
 
     @Test
-    public void testPlanExecuteTimeout() {
-        MergeCommitTask executor = new MergeCommitTask(
+    public void testExecuteTimeout() {
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
                 streamLoadInfo,
                 1000,
                 kvParams,
+                warehouseName,
                 new HashSet<>(Arrays.asList(10002L, 10003L)),
                 coordinatorFactory,
-                loadExecuteCallback
-        );
+                loadExecuteCallback);
 
-        new Expectations() {
-            {
-                coordinator.join((anyInt));
-                result = false;
-            }
-        };
+        stubCoordinatorCommon();
+        when(coordinator.join(anyInt())).thenReturn(false);
 
-        Exception expectException = new LoadException("Timeout to execute load");
-        testLoadFailBase(executor, expectException, TransactionStatus.ABORTED);
+        task.run();
+        assertEquals(1, loadExecuteCallback.getFinishedLoads().size());
+        assertEquals(label, loadExecuteCallback.getFinishedLoads().get(0));
+        assertEquals(TransactionStatus.ABORTED, getTxnStatus(label));
+        assertTrue(task.getTxnId() > 0);
+        // Callback must be removed even on failure/timeout.
+        TxnStateCallbackFactory callbackFactory =
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getCallbackFactory();
+        assertNull(callbackFactory.getCallback(task.getId()));
     }
 
     @Test
     public void testTableDoesNotExist() {
         String fakeTableName = TABLE_NAME_1_1 + "_fake";
-        MergeCommitTask executor = new MergeCommitTask(
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
                 new TableId(DB_NAME_1, fakeTableName),
                 label,
                 loadId,
                 streamLoadInfo,
                 1000,
                 kvParams,
+                warehouseName,
                 new HashSet<>(Arrays.asList(10002L, 10003L)),
                 coordinatorFactory,
-                loadExecuteCallback
-        );
+                loadExecuteCallback);
 
-        Exception expectException = new LoadException(
-                String.format("Table [%s.%s] does not exist", DB_NAME_1, fakeTableName));
-        testLoadFailBase(executor, expectException, TransactionStatus.UNKNOWN);
+        task.run();
+        assertEquals(1, loadExecuteCallback.getFinishedLoads().size());
+        assertEquals(label, loadExecuteCallback.getFinishedLoads().get(0));
+        assertEquals(TransactionStatus.UNKNOWN, getTxnStatus(label));
+        assertTrue(task.getTxnId() < 0);
     }
 
     @Test
-    public void testMaxFilterRatio() {
-        MergeCommitTask executor = new MergeCommitTask(
+    public void testDatabaseDoesNotExist() {
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                new TableId("merge_commit_db_not_exist", TABLE_NAME_1_1),
+                label,
+                loadId,
+                streamLoadInfo,
+                1000,
+                kvParams,
+                warehouseName,
+                new HashSet<>(Arrays.asList(10002L, 10003L)),
+                coordinatorFactory,
+                loadExecuteCallback);
+
+        task.run();
+        assertEquals(1, loadExecuteCallback.getFinishedLoads().size());
+        assertEquals(label, loadExecuteCallback.getFinishedLoads().get(0));
+        assertEquals(TransactionStatus.UNKNOWN, getTxnStatus(label));
+        assertTrue(task.getTxnId() < 0);
+    }
+
+    @Test
+    public void testMaxFilterRatioThrowsDataQualityException() {
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
                 streamLoadInfo,
                 1000,
                 kvParams,
+                warehouseName,
                 new HashSet<>(Arrays.asList(10002L, 10003L)),
                 coordinatorFactory,
-                loadExecuteCallback
-        );
+                loadExecuteCallback);
 
+        stubCoordinatorSuccess();
         Map<String, String> counters = new HashMap<>();
         counters.put(LoadEtlTask.DPP_NORMAL_ALL, "100");
         counters.put(LoadEtlTask.DPP_ABNORMAL_ALL, "100");
-        String trackingUrl = "test_tracking_url";
-        new Expectations() {
-            {
-                coordinator.join((anyInt));
-                result = true;
-                coordinator.getExecStatus();
-                result = new Status();
-                coordinator.getCommitInfos();
-                result = buildCommitInfos();
-                coordinator.getLoadCounters();
-                result = counters;
-                coordinator.getTrackingUrl();
-                result = trackingUrl;
-            }
-        };
+        when(coordinator.getLoadCounters()).thenReturn(counters);
+        when(coordinator.getTrackingUrl()).thenReturn("test_tracking_url");
 
-        Exception expectException = new LoadException(
-                "There is data quality issue, please check the tracking url for details." +
-                        " Max filter ratio: 0.0. The tracking url: " + trackingUrl);
-        testLoadFailBase(executor, expectException, TransactionStatus.ABORTED);
-    }
-
-    private void testLoadFailBase(
-            MergeCommitTask executor, Exception expectedException, TransactionStatus expectedTxnStatus) {
-        executor.run();
-        Throwable throwable = executor.getFailure();
-        assertNotNull(throwable);
-        assertSame(expectedException.getClass(), throwable.getClass());
-        assertTrue(throwable.getMessage().contains(expectedException.getMessage()));
+        task.run();
         assertEquals(1, loadExecuteCallback.getFinishedLoads().size());
         assertEquals(label, loadExecuteCallback.getFinishedLoads().get(0));
-        TransactionStatus txnStatus =
-                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                        .getLabelStatus(DATABASE_1.getId(), label).getStatus();
-        assertEquals(expectedTxnStatus, txnStatus);
+        assertEquals(TransactionStatus.ABORTED, getTxnStatus(label));
+        assertTrue(task.getTxnId() > 0);
     }
 
     @Test
-    public void testIsActive() {
-        MergeCommitTask executor = new MergeCommitTask(
+    public void testIsActiveWindowDuringLoading() throws Exception {
+        int mergeCommitIntervalMs = 200;
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                new TableId(DB_NAME_1, TABLE_NAME_1_1),
+                label,
+                loadId,
+                streamLoadInfo,
+                mergeCommitIntervalMs,
+                kvParams,
+                warehouseName,
+                new HashSet<>(Arrays.asList(10002L, 10003L)),
+                coordinatorFactory,
+                loadExecuteCallback);
+
+        stubCoordinatorCommon();
+        CountDownLatch joinEntered = new CountDownLatch(1);
+        CountDownLatch joinRelease = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            joinEntered.countDown();
+            joinRelease.await(3, TimeUnit.SECONDS);
+            return true;
+        }).when(coordinator).join(anyInt());
+        when(coordinator.getExecStatus()).thenReturn(new Status());
+        when(coordinator.getCommitInfos()).thenReturn(buildCommitInfos());
+
+        Thread t = new Thread(task::run);
+        t.start();
+
+        assertTrue(joinEntered.await(30, TimeUnit.SECONDS));
+        // Callback should be registered once the task begins transaction and enters execution.
+        TxnStateCallbackFactory callbackFactory =
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getCallbackFactory();
+        assertNotNull(callbackFactory.getCallback(task.getId()));
+        assertTrue(task.isActive());
+
+        Thread.sleep(mergeCommitIntervalMs + 100L);
+        assertFalse(task.isActive());
+
+        joinRelease.countDown();
+        t.join(30_000);
+        // Callback should be removed after task completes.
+        assertNull(callbackFactory.getCallback(task.getId()));
+    }
+
+    @Test
+    public void testCancelBeforeRunSkipsCoordinatorCreation() {
+        Coordinator.Factory factory = Mockito.mock(Coordinator.Factory.class);
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
                 streamLoadInfo,
                 1000,
                 kvParams,
+                warehouseName,
                 new HashSet<>(Arrays.asList(10002L, 10003L)),
-                coordinatorFactory,
-                loadExecuteCallback
-        );
+                factory,
+                loadExecuteCallback);
 
-        assertTrue(executor.isActive());
+        task.cancel("unit-test cancel");
+        task.run();
 
-        new Expectations() {
-            {
-                coordinator.join((anyInt));
-                result = true;
-                coordinator.getExecStatus();
-                result = new Status(TStatusCode.INTERNAL_ERROR, "artificial failure");
-            }
-        };
-        executor.run();
-        assertFalse(executor.isActive());
+        verifyNoInteractions(factory);
+        assertEquals(1, loadExecuteCallback.getFinishedLoads().size());
+        assertEquals(label, loadExecuteCallback.getFinishedLoads().get(0));
+        assertTrue(task.getTxnId() < 0);
     }
 
     @Test
-    public void testContainCoordinatorBackend() {
-        MergeCommitTask executor = new MergeCommitTask(
+    public void testCancelAfterFinish() {
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
                 label,
                 loadId,
                 streamLoadInfo,
                 1000,
                 kvParams,
+                warehouseName,
                 new HashSet<>(Arrays.asList(10002L, 10003L)),
                 coordinatorFactory,
-                loadExecuteCallback
-        );
-        assertFalse(executor.containCoordinatorBackend(10001L));
-        assertTrue(executor.containCoordinatorBackend(10002L));
+                loadExecuteCallback);
+
+        stubCoordinatorSuccess();
+
+        task.run();
+        assertEquals(MergeCommitTask.TaskState.FINISHED, getTaskState(task));
+        String stateMsgBeforeCancel = getTaskStateMessage(task);
+
+        // Cancel after task finished should not change task state or state message.
+        task.cancel("cancel after finish");
+        assertEquals(MergeCommitTask.TaskState.FINISHED, getTaskState(task));
+        assertEquals(stateMsgBeforeCancel, getTaskStateMessage(task));
+    }
+
+    @Test
+    public void testAbortTransactionTriggersCancel() throws Exception {
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                new TableId(DB_NAME_1, TABLE_NAME_1_1),
+                label,
+                loadId,
+                streamLoadInfo,
+                1000,
+                kvParams,
+                warehouseName,
+                new HashSet<>(Arrays.asList(10002L, 10003L)),
+                coordinatorFactory,
+                loadExecuteCallback);
+
+        List<StateTransition> transitions = Collections.synchronizedList(new ArrayList<>());
+        task.setStateTransitionObserver((from, to, msg, hasHandler) ->
+                transitions.add(new StateTransition(from, to, msg, hasHandler)));
+
+        stubCoordinatorCommon();
+        CountDownLatch joinEntered = new CountDownLatch(1);
+        CountDownLatch joinRelease = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            joinEntered.countDown();
+            joinRelease.await(3, TimeUnit.SECONDS);
+            return true;
+        }).when(coordinator).join(anyInt());
+        // After cancellation we want the execution to fail fast instead of attempting commit.
+        when(coordinator.getExecStatus()).thenReturn(new Status(TStatusCode.INTERNAL_ERROR, "aborted"));
+        when(coordinator.getCommitInfos()).thenReturn(buildCommitInfos());
+
+        Thread t = new Thread(task::run);
+        t.start();
+
+        // Ensure we are in LOADING state (cancel handler is installed) before aborting the transaction.
+        assertTrue(joinEntered.await(30, TimeUnit.SECONDS), "join not entered in time");
+        long deadlineMs = System.currentTimeMillis() + 30_000;
+        while (task.getTxnId() < 0 && System.currentTimeMillis() < deadlineMs) {
+            Thread.sleep(10);
+        }
+        assertTrue(task.getTxnId() > 0, "txnId is not assigned in time");
+
+        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                .abortTransaction(DATABASE_1.getId(), task.getTxnId(), "external abort reason");
+
+        verify(coordinator, Mockito.timeout(30_000))
+                .cancel(eq(com.starrocks.proto.PPlanFragmentCancelReason.USER_CANCEL), eq("external abort reason"));
+
+        joinRelease.countDown();
+        t.join(30_000);
+
+        boolean hasCancelled = transitions.stream().anyMatch(
+                tr -> tr.toState == MergeCommitTask.TaskState.CANCELLED &&
+                        "external abort reason".equals(tr.toStateMsg));
+        assertTrue(hasCancelled, "expected CANCELLED transition, got: " + transitions);
     }
 
     @Test
@@ -327,38 +446,269 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
         long oldIntervalSecond = Config.load_profile_collect_interval_second;
         Config.load_profile_collect_interval_second = 1;
         try {
-            MergeCommitTask executor = new MergeCommitTask(
+            MergeCommitTask task = new MergeCommitTask(
+                    GlobalStateMgr.getCurrentState().getNextId(),
                     new TableId(DB_NAME_1, TABLE_NAME_1_1),
                     label,
                     loadId,
                     streamLoadInfo,
                     1000,
                     kvParams,
+                    warehouseName,
                     new HashSet<>(Arrays.asList(10002L, 10003L)),
                     coordinatorFactory,
                     loadExecuteCallback
             );
 
-            new Expectations() {
-                {
-                    coordinator.join((anyInt));
-                    result = true;
-                    coordinator.getExecStatus();
-                    result = new Status();
-                    coordinator.getCommitInfos();
-                    result = buildCommitInfos();
-                    coordinator.buildQueryProfile(true);
-                    result = new RuntimeProfile("Execution");
-                }
-            };
+            stubCoordinatorSuccess();
+            doNothing().when(coordinator).collectProfileSync();
+            when(coordinator.buildQueryProfile(true)).thenReturn(new RuntimeProfile("Execution"));
 
-            executor.run();
+            task.run();
             assertNotNull(ProfileManager.getInstance().getProfile(DebugUtil.printId(loadId)));
         } finally {
             Config.load_profile_collect_interval_second = oldIntervalSecond;
             starRocksAssert.alterTableProperties(
                     String.format("alter table %s.%s set('enable_load_profile'='false');", DB_NAME_1, TABLE_NAME_1_1));
         }
+    }
+
+    @Test
+    public void testCancelDuringLoadingTriggersCoordinatorCancel() throws Exception {
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                new TableId(DB_NAME_1, TABLE_NAME_1_1),
+                label,
+                loadId,
+                streamLoadInfo,
+                1000,
+                kvParams,
+                warehouseName,
+                new HashSet<>(Arrays.asList(10002L, 10003L)),
+                coordinatorFactory,
+                loadExecuteCallback);
+
+        stubCoordinatorCommon();
+        CountDownLatch joinEntered = new CountDownLatch(1);
+        CountDownLatch joinRelease = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            joinEntered.countDown();
+            joinRelease.await(3, TimeUnit.SECONDS);
+            return true;
+        }).when(coordinator).join(anyInt());
+        when(coordinator.getExecStatus()).thenReturn(new Status());
+        when(coordinator.getCommitInfos()).thenReturn(buildCommitInfos());
+        when(coordinator.getLoadCounters()).thenReturn(Collections.emptyMap());
+        when(coordinator.getRejectedRecordPaths()).thenReturn(Collections.emptyList());
+        when(coordinator.getFailInfos()).thenReturn(Collections.emptyList());
+
+        Thread t = new Thread(task::run);
+        t.start();
+
+        assertTrue(joinEntered.await(30, TimeUnit.SECONDS));
+        task.cancel("unit-test cancel");
+        verify(coordinator).cancel(eq(com.starrocks.proto.PPlanFragmentCancelReason.USER_CANCEL), eq("unit-test cancel"));
+
+        joinRelease.countDown();
+        t.join(30_000);
+
+        assertEquals(1, loadExecuteCallback.getFinishedLoads().size());
+        assertEquals(label, loadExecuteCallback.getFinishedLoads().get(0));
+        assertEquals(TransactionStatus.ABORTED, getTxnStatus(label));
+    }
+
+    @Test
+    public void testStateMachineTransitionsOnSuccess() {
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                new TableId(DB_NAME_1, TABLE_NAME_1_1),
+                label,
+                loadId,
+                streamLoadInfo,
+                1000,
+                kvParams,
+                warehouseName,
+                new HashSet<>(Arrays.asList(10002L, 10003L)),
+                coordinatorFactory,
+                loadExecuteCallback);
+
+        List<StateTransition> transitions = Collections.synchronizedList(new ArrayList<>());
+        task.setStateTransitionObserver((from, to, msg, hasHandler) ->
+                transitions.add(new StateTransition(from, to, msg, hasHandler)));
+
+        stubCoordinatorSuccess();
+
+        task.run();
+
+        // Success path expected transitions:
+        // PENDING -> BEGIN_TXN -> PLANNING -> LOADING -> COMMITTING -> COMMITTED -> FINISHED
+        assertEquals(6, transitions.size(), "unexpected transition count: " + transitions);
+        assertTransition(transitions.get(0),
+                MergeCommitTask.TaskState.PENDING, MergeCommitTask.TaskState.BEGINNING_TXN, "", false);
+        assertTransition(transitions.get(1),
+                MergeCommitTask.TaskState.BEGINNING_TXN, MergeCommitTask.TaskState.PLANNING, "", false);
+        assertTransition(transitions.get(2),
+                MergeCommitTask.TaskState.PLANNING, MergeCommitTask.TaskState.EXECUTING, "", true);
+        assertTransition(transitions.get(3),
+                MergeCommitTask.TaskState.EXECUTING, MergeCommitTask.TaskState.COMMITTING, "", false);
+        assertTransition(transitions.get(4),
+                MergeCommitTask.TaskState.COMMITTING, MergeCommitTask.TaskState.COMMITTED, "", false);
+        assertTransition(transitions.get(5),
+                MergeCommitTask.TaskState.COMMITTED, MergeCommitTask.TaskState.FINISHED, "", false);
+    }
+
+    @Test
+    public void testStateMachineTransitionsOnExecuteFail() {
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                new TableId(DB_NAME_1, TABLE_NAME_1_1),
+                label,
+                loadId,
+                streamLoadInfo,
+                1000,
+                kvParams,
+                warehouseName,
+                new HashSet<>(Arrays.asList(10002L, 10003L)),
+                coordinatorFactory,
+                loadExecuteCallback);
+
+        List<StateTransition> transitions = Collections.synchronizedList(new ArrayList<>());
+        task.setStateTransitionObserver((from, to, msg, hasHandler) ->
+                transitions.add(new StateTransition(from, to, msg, hasHandler)));
+
+        stubCoordinatorSuccess();
+        when(coordinator.getExecStatus()).thenReturn(new Status(TStatusCode.INTERNAL_ERROR, "artificial failure"));
+
+        task.run();
+
+        assertTrue(transitions.size() >= 4, "unexpected transition count: " + transitions);
+        StateTransition last = transitions.get(transitions.size() - 1);
+        assertEquals(MergeCommitTask.TaskState.ABORTED, last.toState);
+        assertTrue(last.toStateMsg.contains("Load execution failed"), "msg=" + last.toStateMsg);
+    }
+
+    @Test
+    public void testStateMachineTransitionsOnCancelDuringLoading() throws Exception {
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                new TableId(DB_NAME_1, TABLE_NAME_1_1),
+                label,
+                loadId,
+                streamLoadInfo,
+                1000,
+                kvParams,
+                warehouseName,
+                new HashSet<>(Arrays.asList(10002L, 10003L)),
+                coordinatorFactory,
+                loadExecuteCallback);
+
+        List<StateTransition> transitions = Collections.synchronizedList(new ArrayList<>());
+        task.setStateTransitionObserver((from, to, msg, hasHandler) ->
+                transitions.add(new StateTransition(from, to, msg, hasHandler)));
+
+        stubCoordinatorCommon();
+        CountDownLatch joinEntered = new CountDownLatch(1);
+        CountDownLatch joinRelease = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            joinEntered.countDown();
+            joinRelease.await(3, TimeUnit.SECONDS);
+            return true;
+        }).when(coordinator).join(anyInt());
+        when(coordinator.getExecStatus()).thenReturn(new Status());
+        when(coordinator.getCommitInfos()).thenReturn(buildCommitInfos());
+
+        Thread t = new Thread(task::run);
+        t.start();
+
+        assertTrue(joinEntered.await(30, TimeUnit.SECONDS));
+        task.cancel("unit-test cancel");
+        joinRelease.countDown();
+        t.join(30_000);
+
+        assertTrue(transitions.size() >= 3, "unexpected transition count: " + transitions);
+        boolean hasCancelled = transitions.stream().anyMatch(
+                tr -> tr.toState == MergeCommitTask.TaskState.CANCELLED && "unit-test cancel".equals(tr.toStateMsg));
+        assertTrue(hasCancelled, "expected CANCELLED transition, got: " + transitions);
+    }
+
+    @Test
+    public void testStateMachineTransitionsOnPublishTimeout() throws Exception {
+        MergeCommitTask task = new MergeCommitTask(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                new TableId(DB_NAME_1, TABLE_NAME_1_1),
+                label,
+                loadId,
+                streamLoadInfo,
+                1000,
+                kvParams,
+                warehouseName,
+                new HashSet<>(Arrays.asList(10002L, 10003L)),
+                coordinatorFactory,
+                loadExecuteCallback);
+
+        MergeCommitTask taskSpy = Mockito.spy(task);
+        doReturn(false).when(taskSpy).awaitPublish(any(), anyLong());
+
+        List<StateTransition> transitions = Collections.synchronizedList(new ArrayList<>());
+        taskSpy.setStateTransitionObserver((from, to, msg, hasHandler) ->
+                transitions.add(new StateTransition(from, to, msg, hasHandler)));
+
+        stubCoordinatorSuccess();
+
+        taskSpy.run();
+
+        StateTransition last = transitions.get(transitions.size() - 1);
+        assertEquals(MergeCommitTask.TaskState.FINISHED, last.toState);
+        assertTrue(last.toStateMsg.startsWith("publish failed:"), "msg=" + last.toStateMsg);
+        assertTrue(last.toStateMsg.contains("publish timed out"), "msg=" + last.toStateMsg);
+    }
+
+    private static void assertTransition(StateTransition tr, MergeCommitTask.TaskState from,
+            MergeCommitTask.TaskState to, String msg, boolean hasCancelHandler) {
+        assertEquals(from, tr.fromState);
+        assertEquals(to, tr.toState);
+        assertEquals(msg, tr.toStateMsg);
+        assertEquals(hasCancelHandler, tr.hasCancelHandler);
+    }
+
+    private static final class StateTransition {
+        private final MergeCommitTask.TaskState fromState;
+        private final MergeCommitTask.TaskState toState;
+        private final String toStateMsg;
+        private final boolean hasCancelHandler;
+
+        private StateTransition(MergeCommitTask.TaskState fromState, MergeCommitTask.TaskState toState, String toStateMsg,
+                boolean hasCancelHandler) {
+            this.fromState = fromState;
+            this.toState = toState;
+            this.toStateMsg = toStateMsg;
+            this.hasCancelHandler = hasCancelHandler;
+        }
+
+        @Override
+        public String toString() {
+            return "StateTransition{" +
+                    "fromState=" + fromState +
+                    ", toState=" + toState +
+                    ", toStateMsg='" + toStateMsg + '\'' +
+                    ", hasCancelHandler=" + hasCancelHandler +
+                    '}';
+        }
+    }
+
+    private void stubCoordinatorCommon() {
+        when(coordinatorFactory.createStreamLoadScheduler(any(LoadPlanner.class))).thenReturn(coordinator);
+        when(coordinator.getFailInfos()).thenReturn(Collections.emptyList());
+        when(coordinator.getRejectedRecordPaths()).thenReturn(Collections.emptyList());
+        when(coordinator.getLoadCounters()).thenReturn(Collections.emptyMap());
+        when(coordinator.getTrackingUrl()).thenReturn(null);
+    }
+
+    private void stubCoordinatorSuccess() {
+        stubCoordinatorCommon();
+        when(coordinator.join(anyInt())).thenReturn(true);
+        when(coordinator.getExecStatus()).thenReturn(new Status());
+        when(coordinator.getCommitInfos()).thenReturn(buildCommitInfos());
     }
 
     private static class TestMergeCommitTaskCallback implements MergeCommitTaskCallback {
@@ -374,58 +724,22 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
             finishedLoads.add(mergeCommitTask.getLabel());
         }
     }
-    
-    private static class TestCoordinatorFactor implements Coordinator.Factory {
 
-        private final Coordinator coordinator;
-        
-        public TestCoordinatorFactor(Coordinator coordinator) {
-            this.coordinator = coordinator;
-        }
+    private static MergeCommitTask.TaskState getTaskState(MergeCommitTask task) {
+        return (MergeCommitTask.TaskState) getPrivateField(task, "taskState");
+    }
 
-        @Override
-        public Coordinator createStreamLoadScheduler(LoadPlanner loadPlanner) {
-            return coordinator;
-        }
-        
-        @Override
-        public Coordinator createQueryScheduler(ConnectContext context, List<PlanFragment> fragments,
-                                                List<ScanNode> scanNodes, TDescriptorTable descTable, ExecPlan execPlan) {
-            return coordinator;
-        }
+    private static String getTaskStateMessage(MergeCommitTask task) {
+        return (String) getPrivateField(task, "taskStateMessage");
+    }
 
-        @Override
-        public Coordinator createInsertScheduler(ConnectContext context, List<PlanFragment> fragments,
-                                                 List<ScanNode> scanNodes, TDescriptorTable descTable, ExecPlan execPlan) {
-            return coordinator;
-        }
-
-        @Override
-        public Coordinator createBrokerLoadScheduler(LoadPlanner loadPlanner) {
-            return coordinator;
-        }
-
-
-        @Override
-        public Coordinator createSyncStreamLoadScheduler(StreamLoadPlanner planner, TNetworkAddress address) {
-            return coordinator;
-        }
-
-        @Override
-        public Coordinator createBrokerExportScheduler(Long jobId, TUniqueId queryId, DescriptorTable descTable,
-                                                       List<PlanFragment> fragments, List<ScanNode> scanNodes,
-                                                       String timezone, long startTime,
-                                                       Map<String, String> sessionVariables, long execMemLimit,
-                                                       ComputeResource computeResource) {
-            return coordinator;
-        }
-
-        @Override
-        public Coordinator createRefreshDictionaryCacheScheduler(ConnectContext context, TUniqueId queryId,
-                                                                 DescriptorTable descTable,
-                                                                 List<PlanFragment> fragments,
-                                                                 List<ScanNode> scanNodes, ExecPlan execPlan) {
-            return coordinator;
+    private static Object getPrivateField(Object obj, String fieldName) {
+        try {
+            Field field = obj.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(obj);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read field '" + fieldName + "' from " + obj.getClass().getName(), e);
         }
     }
 }

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1760,6 +1760,34 @@ class StarrocksSQLApiLib(object):
             row_count == 0, f"wait db transaction finish error, timeout {timeout_sec}s, row_count={row_count}"
         )
 
+    def get_running_transaction_count(self, db_name):
+        """
+        Get the number of running transactions in the specified database.
+        :param db_name: database name
+        :return: row count as string (for safe variable substitution in sql test framework)
+        """
+        sql = f"show proc '/transactions/{db_name}/running'"
+        result = self.execute_sql(sql, True)
+        tools.assert_true(result["status"], f"Failed to execute SQL: {result}")
+        row_count = len(result["result"]) if "result" in result and result["result"] is not None else 0
+        return str(row_count)
+
+    def get_single_running_transaction_label(self, db_name):
+        """
+        Get the label of the single running transaction in the specified database.
+        Assert there is exactly one running transaction.
+        :param db_name: database name
+        :return: label string
+        """
+        sql = f"show proc '/transactions/{db_name}/running'"
+        result = self.execute_sql(sql, True)
+        tools.assert_true(result["status"], f"Failed to execute SQL: {result}")
+        tools.assert_true("result" in result, f"Unexpected SQL result: {result}")
+        tools.assert_equal(1, len(result["result"]), f"Expected exactly 1 running transaction, got {len(result['result'])}")
+        row = result["result"][0]
+        tools.assert_true(len(row) > 1, f"Unexpected show proc row format: {row}")
+        return str(row[1])
+
     def get_table_state(self, db_name, table_name):
         """
         Get table state by executing show proc '/dbs/{db_name}' and finding the row by table_name

--- a/test/sql/test_stream_load/R/test_merge_commit_cancel
+++ b/test/sql/test_stream_load/R/test_merge_commit_cancel
@@ -35,7 +35,7 @@ function: get_running_transaction_count("db_${uuid0}")
 -- result:
 merge_commit_019b7ea8-2d85-7586-8877-91d55c347c2d
 -- !result
-shell: curl --location-trusted -u "root:" --fail-with-body -X POST "${url}/api/db_${uuid0}/t0/_cancel?label=${label1}"
+shell: curl --location-trusted -u "root:" -X POST "${url}/api/db_${uuid0}/t0/_cancel?label=${label1}"
 -- result:
 0
 {"status":"OK","code":"0","msg":"Success","message":"OK"}
@@ -60,7 +60,7 @@ function: get_running_transaction_count("db_${uuid0}")
 -- result:
 merge_commit_019b7ea8-2daa-7e32-8798-18fb4088bce4
 -- !result
-shell: curl --location-trusted -u "root:" --fail-with-body -X POST "${url}/api/db_${uuid0}/t0/_cancel?label=${label2}"
+shell: curl --location-trusted -u "root:" -X POST "${url}/api/db_${uuid0}/t0/_cancel?label=${label2}"
 -- result:
 0
 {"status":"OK","code":"0","msg":"Success","message":"OK"}

--- a/test/sql/test_stream_load/R/test_merge_commit_cancel
+++ b/test/sql/test_stream_load/R/test_merge_commit_cancel
@@ -1,0 +1,75 @@
+-- name: test_merge_commit_cancel
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t0`
+(
+    `id` int(11) NOT NULL COMMENT "user id",
+    `name` varchar(65533) NULL COMMENT "user name",
+    `score` int(11) NOT NULL COMMENT "user score"
+)
+ENGINE=OLAP
+PRIMARY KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_async:true" -H "merge_commit_interval_ms:600000" -H "merge_commit_parallel:1" -d '{"id":1,"name":"n1","score":1}' ${url}/api/db_${uuid0}/t0/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+function: get_running_transaction_count("db_${uuid0}")
+-- result:
+1
+-- !result
+[UC]function: label1=get_single_running_transaction_label("db_${uuid0}")
+-- result:
+merge_commit_019b7ea8-2d85-7586-8877-91d55c347c2d
+-- !result
+shell: curl --location-trusted -u "root:" --fail-with-body -X POST "${url}/api/db_${uuid0}/t0/_cancel?label=${label1}"
+-- result:
+0
+{"status":"OK","code":"0","msg":"Success","message":"OK"}
+-- !result
+function: get_running_transaction_count("db_${uuid0}")
+-- result:
+0
+-- !result
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_async:true" -H "merge_commit_interval_ms:600000" -H "merge_commit_parallel:1" -d '{"id":2,"name":"n2","score":2}' ${url}/api/db_${uuid0}/t0/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+function: get_running_transaction_count("db_${uuid0}")
+-- result:
+1
+-- !result
+[UC]function: label2=get_single_running_transaction_label("db_${uuid0}")
+-- result:
+merge_commit_019b7ea8-2daa-7e32-8798-18fb4088bce4
+-- !result
+shell: curl --location-trusted -u "root:" --fail-with-body -X POST "${url}/api/db_${uuid0}/t0/_cancel?label=${label2}"
+-- result:
+0
+{"status":"OK","code":"0","msg":"Success","message":"OK"}
+-- !result
+function: get_running_transaction_count("db_${uuid0}")
+-- result:
+0
+-- !result
+select count(*) from t0 where id in (1, 2);
+-- result:
+0
+-- !result

--- a/test/sql/test_stream_load/T/test_merge_commit_cancel
+++ b/test/sql/test_stream_load/T/test_merge_commit_cancel
@@ -1,0 +1,43 @@
+-- name: test_merge_commit_cancel
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `t0`
+(
+    `id` int(11) NOT NULL COMMENT "user id",
+    `name` varchar(65533) NULL COMMENT "user name",
+    `score` int(11) NOT NULL COMMENT "user score"
+)
+ENGINE=OLAP
+PRIMARY KEY(`id`)
+DISTRIBUTED BY HASH(`id`)
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+-- 1) Start a merge-commit stream load (async=false, long interval to keep it running)
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_async:true" -H "merge_commit_interval_ms:600000" -H "merge_commit_parallel:1" -d '{"id":1,"name":"n1","score":1}' ${url}/api/db_${uuid0}/t0/_stream_load
+
+-- 2) Ensure there is exactly one running transaction, then fetch its label
+function: get_running_transaction_count("db_${uuid0}")
+
+[UC]function: label1=get_single_running_transaction_label("db_${uuid0}")
+
+-- 3) Cancel this transaction by label
+shell: curl --location-trusted -u "root:" --fail-with-body -X POST "${url}/api/db_${uuid0}/t0/_cancel?label=${label1}"
+
+-- 4) Verify no running transactions
+function: get_running_transaction_count("db_${uuid0}")
+
+-- 5) Start another merge-commit stream load, repeat cancel
+shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_async:true" -H "merge_commit_interval_ms:600000" -H "merge_commit_parallel:1" -d '{"id":2,"name":"n2","score":2}' ${url}/api/db_${uuid0}/t0/_stream_load
+
+function: get_running_transaction_count("db_${uuid0}")
+
+[UC]function: label2=get_single_running_transaction_label("db_${uuid0}")
+shell: curl --location-trusted -u "root:" --fail-with-body -X POST "${url}/api/db_${uuid0}/t0/_cancel?label=${label2}"
+
+function: get_running_transaction_count("db_${uuid0}")
+
+-- 6) Verify data not loaded
+select count(*) from t0 where id in (1, 2);

--- a/test/sql/test_stream_load/T/test_merge_commit_cancel
+++ b/test/sql/test_stream_load/T/test_merge_commit_cancel
@@ -24,7 +24,7 @@ function: get_running_transaction_count("db_${uuid0}")
 [UC]function: label1=get_single_running_transaction_label("db_${uuid0}")
 
 -- 3) Cancel this transaction by label
-shell: curl --location-trusted -u "root:" --fail-with-body -X POST "${url}/api/db_${uuid0}/t0/_cancel?label=${label1}"
+shell: curl --location-trusted -u "root:" -X POST "${url}/api/db_${uuid0}/t0/_cancel?label=${label1}"
 
 -- 4) Verify no running transactions
 function: get_running_transaction_count("db_${uuid0}")
@@ -35,7 +35,7 @@ shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "form
 function: get_running_transaction_count("db_${uuid0}")
 
 [UC]function: label2=get_single_running_transaction_label("db_${uuid0}")
-shell: curl --location-trusted -u "root:" --fail-with-body -X POST "${url}/api/db_${uuid0}/t0/_cancel?label=${label2}"
+shell: curl --location-trusted -u "root:" -X POST "${url}/api/db_${uuid0}/t0/_cancel?label=${label2}"
 
 function: get_running_transaction_count("db_${uuid0}")
 


### PR DESCRIPTION
## Why I'm doing:

- Improve maintainability: the old `MergeCommitTask` lifecycle logic was scattered, making state transitions and failure handling hard to reason about.
- Support explicit cancellation for merge-commit load via `CancelStreamLoadAction`.

## What I'm doing:

- Refactor `MergeCommitTask` into a state machine:
  - Introduce `TaskState` and a strict `STATE_TRANSITION` map.
  - Update `taskState` / `taskStateMessage` / `cancelHandler` atomically under a single lock.
- Add cancel support:
  - Add `MergeCommitTask.cancel(reason)` to transition to `CANCELLED`.
  - Implement a cancel handler for `LOADING` that calls `Coordinator.cancel(PPlanFragmentCancelReason.USER_CANCEL, reason)`.
  - Extend `AbstractTxnStateChangeCallback`; external aborts trigger `afterAborted()` -> `cancel()` to unify termination behavior. Then `CancelStreamLoadAction` can work
- Metrics/observability improvements:
  - Consolidate metrics updates into `updateMetrics()` and align success/failure with the final task state.
  - Add tracing/profile collection (kept last since it can be slow) and enrich profile summary info.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes merge-commit load execution for reliability, observability, and cancelability.
> 
> - Refactors `MergeCommitTask` into a locked state machine (`PENDING`→`BEGINNING_TXN`→`PLANNING`→`EXECUTING`→`COMMITTING`→`COMMITTED`→`FINISHED`/`CANCELLED`/`ABORTED`), with atomic transitions and per-state cancel handling (exec stage calls `Coordinator.cancel`).
> - Integrates with `AbstractTxnStateChangeCallback` so external aborts trigger task cancellation; centralizes metrics in `updateMetrics`; enriches runtime profile via `Tracers`, `ProfileManager`, and detailed summary fields.
> - Switches to `VisibleStateWaiter` for publish wait; adds `TimeoutWatcher.getLeftTimeoutMillis()` to manage remaining budgets; enforces data quality via `DataQualityException`.
> - `MergeCommitJob`: resolves DB ID before creating tasks, passes `taskId/dbId/warehouseName/backendIds`, and uses `containsBackend`; improves error when DB missing.
> - Minor: thread pool name changed to `merge-commit`; `StreamLoadKvParams.toString()` simplified.
> - Tests: large UT overhaul for task lifecycle/cancel/publish timeout, job paths, and new SQL test `test_merge_commit_cancel`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f6a710066208878d164ac81d8e7d7138bfd8d3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->