### PR TITLE
[BugFix] Return proper error message when truncating external catalog tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -413,10 +413,6 @@ public class MetadataMgr {
             catalogName = context.getCurrentCatalog();
         }
 
-        if (CatalogMgr.isExternalCatalog(catalogName)) {
-            throw new DdlException("TRUNCATE TABLE is not supported for external catalog tables");
-        }
-
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
         if (connectorMetadata.isPresent()) {
             connectorMetadata.get().truncateTable(stmt, context);

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -409,8 +409,15 @@ public class MetadataMgr {
 
     public void truncateTable(ConnectContext context, TruncateTableStmt stmt) throws StarRocksException {
         String catalogName = stmt.getCatalogName();
-        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
+        if (catalogName == null) {
+            catalogName = context.getCurrentCatalog();
+        }
 
+        if (CatalogMgr.isExternalCatalog(catalogName)) {
+            throw new DdlException("TRUNCATE TABLE is not supported for external catalog tables");
+        }
+
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
         if (connectorMetadata.isPresent()) {
             connectorMetadata.get().truncateTable(stmt, context);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -33,7 +33,6 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
-import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -501,40 +500,6 @@ public class MetadataMgrTest {
         Assertions.assertFalse(MetadataTableName.isMetadataTable("table$"));
         Assertions.assertFalse(MetadataTableName.isMetadataTable("table$unknown_type"));
         Assertions.assertTrue(MetadataTableName.isMetadataTable("table$logical_iceberg_metadata"));
-    }
-
-    @Test
-    public void testTruncateTableOnExternalCatalog() throws Exception {
-        ConnectContext connectContext = AnalyzeTestUtil.getConnectContext();
-        MetadataMgr metadataMgr = connectContext.getGlobalStateMgr().getMetadataMgr();
-
-        // Test truncate table on Iceberg catalog
-        String catalogName = "iceberg_catalog_truncate_test";
-        String createIcebergCatalogStmt = String.format(
-                "create external catalog %s properties (\"type\"=\"iceberg\", " +
-                        "\"hive.metastore.uris\"=\"thrift://hms:9083\", \"iceberg.catalog.type\"=\"hive\")",
-                catalogName);
-        dropCatalogIfExists(catalogName);
-        try {
-            AnalyzeTestUtil.getStarRocksAssert().withCatalog(createIcebergCatalogStmt);
-
-            String truncateSql = "TRUNCATE TABLE " + catalogName + ".test_db.test_table";
-            TruncateTableStmt truncateTableStmt = (TruncateTableStmt) AnalyzeTestUtil.analyzeSuccess(truncateSql);
-
-            ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                    "TRUNCATE TABLE is not supported for external catalog tables",
-                    () -> metadataMgr.truncateTable(connectContext, truncateTableStmt));
-
-            // Test truncate table on Hive catalog
-            String truncateHiveSql = "TRUNCATE TABLE hive_catalog.test_db.test_table";
-            TruncateTableStmt truncateHiveTableStmt = (TruncateTableStmt) AnalyzeTestUtil.analyzeSuccess(truncateHiveSql);
-
-            ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                    "TRUNCATE TABLE is not supported for external catalog tables",
-                    () -> metadataMgr.truncateTable(connectContext, truncateHiveTableStmt));
-        } finally {
-            dropCatalogIfExists(catalogName);
-        }
     }
 
     private void dropCatalogIfExists(String catalogName) {


### PR DESCRIPTION
## Why I'm doing:

fix #67420 

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes TRUNCATE handling when no catalog is specified and adds analyzer coverage for external catalogs.
> 
> - In `MetadataMgr.truncateTable`, default null `catalogName` to `context.getCurrentCatalog()` before retrieving metadata and delegating `truncateTable`
> - Add analyzer tests: set up `iceberg_catalog` and `hive_catalog`; validate qualified `TRUNCATE TABLE` parsing and assert error on unknown catalog
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9d3a98761138ccddc89fb1a60465d3c141480dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->