### PR TITLE
[Enhancement] Add range column to lake tablet show proc output

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
@@ -16,7 +16,6 @@
 package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.common.Range;
 import com.starrocks.common.io.Writable;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 
@@ -36,7 +35,7 @@ public abstract class Tablet extends MetaObject implements Writable {
      * Add the serialization when the feature is almost finished
      * @SerializedName(value = "range")
     */
-    protected TabletRange range = new TabletRange(Range.all());
+    protected TabletRange range = new TabletRange();
 
     public Tablet() {
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletRange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletRange.java
@@ -36,6 +36,11 @@ public class TabletRange {
         return this.range;
     }
 
+    @Override
+    public String toString() {
+        return range.toString();
+    }
+
     public static TabletRange fromThrift(TTabletRange tTabletRange) {
         return new TabletRange(
                 Range.of(Tuple.fromThrift(tTabletRange.lower_bound), Tuple.fromThrift(tTabletRange.upper_bound),

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tuple.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tuple.java
@@ -56,6 +56,11 @@ public class Tuple implements Comparable<Tuple> {
         return values.hashCode();
     }
 
+    @Override
+    public String toString() {
+        return values.toString();
+    }
+
     public static Tuple fromThrift(TTuple tTuple) {
         return new Tuple(tTuple.values.stream().map(v -> Variant.fromThrift(v)).collect(Collectors.toList()));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
@@ -42,6 +42,11 @@ public abstract class Variant implements Comparable<Variant> {
         return type;
     }
 
+    @Override
+    public String toString() {
+        return getStringValue();
+    }
+
     public abstract String getStringValue();
 
     public abstract long getLongValue();

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
@@ -44,7 +44,7 @@ import java.util.List;
 public class LakeTabletsProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("TabletId").add("BackendId").add("DataSize").add("RowCount")
-            .add("MinVersion")
+            .add("MinVersion").add("Range")
             .build();
 
     private final Database db;
@@ -86,6 +86,7 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                 tabletInfo.add(new ByteSizeValue(lakeTablet.getDataSize(true)));
                 tabletInfo.add(lakeTablet.getRowCount(0L));
                 tabletInfo.add(lakeTablet.getMinVersion());
+                tabletInfo.add(lakeTablet.getRange().toString());
                 tabletInfos.add(tabletInfo);
             }
         } finally {
@@ -169,7 +170,8 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                     new Gson().toJson(tablet.getBackendIds(computeResource)),
                     new ByteSizeValue(tablet.getDataSize(true)).toString(),
                     String.valueOf(tablet.getRowCount(0L)),
-                    String.valueOf(tablet.getMinVersion())
+                    String.valueOf(tablet.getMinVersion()),
+                    tablet.getRange().toString()
             );
             result.addRow(row);
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletRangeTest.java
@@ -1,0 +1,391 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard;
+
+import com.starrocks.catalog.TabletRange;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
+import com.starrocks.common.Range;
+import com.starrocks.thrift.TTabletRange;
+import com.starrocks.thrift.TTuple;
+import com.starrocks.thrift.TVariant;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.TypeSerializer;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class TabletRangeTest {
+    @Test
+    public void testTabletRangeToStringAllRange() {
+        // Test (-∞, +∞) - default constructor
+        TabletRange tabletRange = new TabletRange();
+        Assertions.assertEquals("(-∞, +∞)", tabletRange.toString());
+    }
+
+    @Test
+    public void testTabletRangeToStringGTRange() {
+        // Test (lower, +∞) - greater than, lower excluded
+        Range<Tuple> range = Range.of(
+                new Tuple(List.of(Variant.of(IntegerType.INT, "0"))),
+                null,
+                false, false);
+        TabletRange tabletRange = new TabletRange(range);
+        Assertions.assertEquals("([0], +∞)", tabletRange.toString());
+    }
+
+    @Test
+    public void testTabletRangeToStringGERange() {
+        // Test [lower, +∞) - greater than or equal, lower included
+        Range<Tuple> range = Range.of(
+                new Tuple(List.of(Variant.of(IntegerType.INT, "100"))),
+                null,
+                true, false);
+        TabletRange tabletRange = new TabletRange(range);
+        Assertions.assertEquals("[[100], +∞)", tabletRange.toString());
+    }
+
+    @Test
+    public void testTabletRangeToStringLTRange() {
+        // Test (-∞, upper) - less than, upper excluded
+        Range<Tuple> range = Range.of(
+                null,
+                new Tuple(List.of(Variant.of(IntegerType.INT, "50"))),
+                false, false);
+        TabletRange tabletRange = new TabletRange(range);
+        Assertions.assertEquals("(-∞, [50])", tabletRange.toString());
+    }
+
+    @Test
+    public void testTabletRangeToStringLERange() {
+        // Test (-∞, upper] - less than or equal, upper included
+        Range<Tuple> range = Range.of(
+                null,
+                new Tuple(List.of(Variant.of(IntegerType.INT, "50"))),
+                false, true);
+        TabletRange tabletRange = new TabletRange(range);
+        Assertions.assertEquals("(-∞, [50]]", tabletRange.toString());
+    }
+
+    @Test
+    public void testTabletRangeToStringGELTRange() {
+        // Test [lower, upper) - half-open interval, lower included, upper excluded
+        Range<Tuple> range = Range.of(
+                new Tuple(List.of(Variant.of(IntegerType.INT, "10"))),
+                new Tuple(List.of(Variant.of(IntegerType.INT, "20"))),
+                true, false);
+        TabletRange tabletRange = new TabletRange(range);
+        Assertions.assertEquals("[[10], [20])", tabletRange.toString());
+    }
+
+    @Test
+    public void testTabletRangeToStringGTLERange() {
+        // Test (lower, upper] - half-open interval, lower excluded, upper included
+        Range<Tuple> range = Range.of(
+                new Tuple(List.of(Variant.of(IntegerType.INT, "10"))),
+                new Tuple(List.of(Variant.of(IntegerType.INT, "20"))),
+                false, true);
+        TabletRange tabletRange = new TabletRange(range);
+        Assertions.assertEquals("([10], [20]]", tabletRange.toString());
+    }
+
+    @Test
+    public void testTabletRangeToStringGELERange() {
+        // Test [lower, upper] - closed interval, both bounds included
+        Range<Tuple> range = Range.of(
+                new Tuple(List.of(Variant.of(IntegerType.INT, "10"))),
+                new Tuple(List.of(Variant.of(IntegerType.INT, "20"))),
+                true, true);
+        TabletRange tabletRange = new TabletRange(range);
+        Assertions.assertEquals("[[10], [20]]", tabletRange.toString());
+    }
+
+    @Test
+    public void testTabletRangeToStringGTLTRange() {
+        // Test (lower, upper) - open interval, both bounds excluded
+        Range<Tuple> range = Range.of(
+                new Tuple(List.of(Variant.of(IntegerType.INT, "10"))),
+                new Tuple(List.of(Variant.of(IntegerType.INT, "20"))),
+                false, false);
+        TabletRange tabletRange = new TabletRange(range);
+        Assertions.assertEquals("([10], [20])", tabletRange.toString());
+    }
+
+    @Test
+    public void testTabletRangeToStringMultipleColumns() {
+        // Test multiple columns in tuple
+        Range<Tuple> range = Range.of(
+                new Tuple(
+                        List.of(Variant.of(IntegerType.INT, "0"),
+                                Variant.of(VarcharType.VARCHAR, "abc"))),
+                null,
+                false, false);
+        TabletRange tabletRange = new TabletRange(range);
+        Assertions.assertEquals("([0, abc], +∞)", tabletRange.toString());
+    }
+
+    @Test
+    public void testTabletRangeToStringMultipleColumnsClosedInterval() {
+        // Test multiple columns with closed interval
+        Range<Tuple> range = Range.of(
+                new Tuple(List.of(
+                        Variant.of(IntegerType.INT, "1"),
+                        Variant.of(VarcharType.VARCHAR, "start"))),
+                new Tuple(List.of(
+                        Variant.of(IntegerType.INT, "100"),
+                        Variant.of(VarcharType.VARCHAR, "end"))),
+                true, true);
+        TabletRange tabletRange = new TabletRange(range);
+        Assertions.assertEquals("[[1, start], [100, end]]", tabletRange.toString());
+    }
+
+    @Test
+    public void testGetRange() {
+        Range<Tuple> range = Range.of(
+                new Tuple(List.of(Variant.of(IntegerType.INT, "10"))),
+                new Tuple(List.of(Variant.of(IntegerType.INT, "20"))),
+                true, false);
+        TabletRange tabletRange = new TabletRange(range);
+
+        Range<Tuple> retrievedRange = tabletRange.getRange();
+        Assertions.assertNotNull(retrievedRange);
+        Assertions.assertEquals(range, retrievedRange);
+        Assertions.assertTrue(retrievedRange.isLowerBoundIncluded());
+        Assertions.assertFalse(retrievedRange.isUpperBoundIncluded());
+    }
+
+    @Test
+    public void testGetRangeAllRange() {
+        TabletRange tabletRange = new TabletRange();
+        Range<Tuple> range = tabletRange.getRange();
+
+        Assertions.assertNotNull(range);
+        Assertions.assertTrue(range.isAll());
+        Assertions.assertTrue(range.isMinimum());
+        Assertions.assertTrue(range.isMaximum());
+    }
+
+    @Test
+    public void testToThriftAllRange() {
+        TabletRange tabletRange = new TabletRange();
+        TTabletRange tRange = tabletRange.toThrift();
+
+        Assertions.assertNotNull(tRange);
+        Assertions.assertFalse(tRange.isSetLower_bound());
+        Assertions.assertFalse(tRange.isSetUpper_bound());
+        Assertions.assertFalse(tRange.isLower_bound_included());
+        Assertions.assertFalse(tRange.isUpper_bound_included());
+    }
+
+    @Test
+    public void testToThriftWithLowerBound() {
+        Range<Tuple> range = Range.of(
+                new Tuple(List.of(Variant.of(IntegerType.INT, "100"))),
+                null,
+                true, false);
+        TabletRange tabletRange = new TabletRange(range);
+        TTabletRange tRange = tabletRange.toThrift();
+
+        Assertions.assertNotNull(tRange);
+        Assertions.assertTrue(tRange.isSetLower_bound());
+        Assertions.assertFalse(tRange.isSetUpper_bound());
+        Assertions.assertTrue(tRange.isLower_bound_included());
+        Assertions.assertFalse(tRange.isUpper_bound_included());
+    }
+
+    @Test
+    public void testToThriftWithUpperBound() {
+        Range<Tuple> range = Range.of(
+                null,
+                new Tuple(List.of(Variant.of(IntegerType.INT, "200"))),
+                false, true);
+        TabletRange tabletRange = new TabletRange(range);
+        TTabletRange tRange = tabletRange.toThrift();
+
+        Assertions.assertNotNull(tRange);
+        Assertions.assertFalse(tRange.isSetLower_bound());
+        Assertions.assertTrue(tRange.isSetUpper_bound());
+        Assertions.assertFalse(tRange.isLower_bound_included());
+        Assertions.assertTrue(tRange.isUpper_bound_included());
+    }
+
+    @Test
+    public void testToThriftWithBothBounds() {
+        Range<Tuple> range = Range.of(
+                new Tuple(List.of(Variant.of(IntegerType.INT, "10"))),
+                new Tuple(List.of(Variant.of(IntegerType.INT, "20"))),
+                true, false);
+        TabletRange tabletRange = new TabletRange(range);
+        TTabletRange tRange = tabletRange.toThrift();
+
+        Assertions.assertNotNull(tRange);
+        Assertions.assertTrue(tRange.isSetLower_bound());
+        Assertions.assertTrue(tRange.isSetUpper_bound());
+        Assertions.assertTrue(tRange.isLower_bound_included());
+        Assertions.assertFalse(tRange.isUpper_bound_included());
+
+        // Verify the tuple values
+        TTuple lowerTuple = tRange.getLower_bound();
+        Assertions.assertNotNull(lowerTuple);
+        Assertions.assertEquals(1, lowerTuple.getValuesSize());
+
+        TTuple upperTuple = tRange.getUpper_bound();
+        Assertions.assertNotNull(upperTuple);
+        Assertions.assertEquals(1, upperTuple.getValuesSize());
+    }
+
+    @Test
+    public void testFromThrift() {
+        // Create TTabletRange with bounds
+        TTabletRange tRange = new TTabletRange();
+        tRange.setLower_bound_included(true);
+        tRange.setUpper_bound_included(false);
+
+        // Create lower bound
+        TTuple lowerTuple = new TTuple();
+        TVariant lowerVariant = new TVariant();
+        lowerVariant.setType(TypeSerializer.toThrift(IntegerType.INT));
+        lowerVariant.setValue("10");
+        lowerTuple.setValues(List.of(lowerVariant));
+        tRange.setLower_bound(lowerTuple);
+
+        // Create upper bound
+        TTuple upperTuple = new TTuple();
+        TVariant upperVariant = new TVariant();
+        upperVariant.setType(TypeSerializer.toThrift(IntegerType.INT));
+        upperVariant.setValue("20");
+        upperTuple.setValues(List.of(upperVariant));
+        tRange.setUpper_bound(upperTuple);
+
+        TabletRange tabletRange = TabletRange.fromThrift(tRange);
+
+        Assertions.assertNotNull(tabletRange);
+        Assertions.assertEquals("[[10], [20])", tabletRange.toString());
+
+        Range<Tuple> range = tabletRange.getRange();
+        Assertions.assertTrue(range.isLowerBoundIncluded());
+        Assertions.assertFalse(range.isUpperBoundIncluded());
+    }
+
+    @Test
+    public void testFromThriftClosedInterval() {
+        TTabletRange tRange = new TTabletRange();
+        tRange.setLower_bound_included(true);
+        tRange.setUpper_bound_included(true);
+
+        TTuple lowerTuple = new TTuple();
+        TVariant lowerVariant = new TVariant();
+        lowerVariant.setType(TypeSerializer.toThrift(IntegerType.BIGINT));
+        lowerVariant.setValue("1000");
+        lowerTuple.setValues(List.of(lowerVariant));
+        tRange.setLower_bound(lowerTuple);
+
+        TTuple upperTuple = new TTuple();
+        TVariant upperVariant = new TVariant();
+        upperVariant.setType(TypeSerializer.toThrift(IntegerType.BIGINT));
+        upperVariant.setValue("2000");
+        upperTuple.setValues(List.of(upperVariant));
+        tRange.setUpper_bound(upperTuple);
+
+        TabletRange tabletRange = TabletRange.fromThrift(tRange);
+
+        Assertions.assertEquals("[[1000], [2000]]", tabletRange.toString());
+        Assertions.assertTrue(tabletRange.getRange().isLowerBoundIncluded());
+        Assertions.assertTrue(tabletRange.getRange().isUpperBoundIncluded());
+    }
+
+    @Test
+    public void testFromThriftWithVarchar() {
+        TTabletRange tRange = new TTabletRange();
+        tRange.setLower_bound_included(false);
+        tRange.setUpper_bound_included(true);
+
+        TTuple lowerTuple = new TTuple();
+        TVariant lowerVariant = new TVariant();
+        lowerVariant.setType(TypeSerializer.toThrift(VarcharType.VARCHAR));
+        lowerVariant.setValue("aaa");
+        lowerTuple.setValues(List.of(lowerVariant));
+        tRange.setLower_bound(lowerTuple);
+
+        TTuple upperTuple = new TTuple();
+        TVariant upperVariant = new TVariant();
+        upperVariant.setType(TypeSerializer.toThrift(VarcharType.VARCHAR));
+        upperVariant.setValue("zzz");
+        upperTuple.setValues(List.of(upperVariant));
+        tRange.setUpper_bound(upperTuple);
+
+        TabletRange tabletRange = TabletRange.fromThrift(tRange);
+
+        Assertions.assertEquals("([aaa], [zzz]]", tabletRange.toString());
+    }
+
+    @Test
+    public void testRoundTripThriftConversion() {
+        // Create original TabletRange
+        Range<Tuple> originalRange = Range.of(
+                new Tuple(List.of(
+                        Variant.of(IntegerType.INT, "5"),
+                        Variant.of(VarcharType.VARCHAR, "test"))),
+                new Tuple(List.of(
+                        Variant.of(IntegerType.INT, "50"),
+                        Variant.of(VarcharType.VARCHAR, "test2"))),
+                true, false);
+        TabletRange original = new TabletRange(originalRange);
+
+        // Convert to Thrift
+        TTabletRange tRange = original.toThrift();
+
+        // Convert back to TabletRange
+        TabletRange converted = TabletRange.fromThrift(tRange);
+
+        // Verify they are equivalent
+        Assertions.assertEquals(original.toString(), converted.toString());
+        Assertions.assertEquals(
+                original.getRange().isLowerBoundIncluded(),
+                converted.getRange().isLowerBoundIncluded());
+        Assertions.assertEquals(
+                original.getRange().isUpperBoundIncluded(),
+                converted.getRange().isUpperBoundIncluded());
+    }
+
+    @Test
+    public void testDifferentIntegerTypes() {
+        // Test with TINYINT
+        Range<Tuple> tinyintRange = Range.of(
+                new Tuple(List.of(Variant.of(IntegerType.TINYINT, "1"))),
+                new Tuple(List.of(Variant.of(IntegerType.TINYINT, "127"))),
+                true, true);
+        TabletRange tinyintTabletRange = new TabletRange(tinyintRange);
+        Assertions.assertEquals("[[1], [127]]", tinyintTabletRange.toString());
+
+        // Test with SMALLINT
+        Range<Tuple> smallintRange = Range.of(
+                new Tuple(List.of(Variant.of(IntegerType.SMALLINT, "100"))),
+                new Tuple(List.of(Variant.of(IntegerType.SMALLINT, "1000"))),
+                true, true);
+        TabletRange smallintTabletRange = new TabletRange(smallintRange);
+        Assertions.assertEquals("[[100], [1000]]", smallintTabletRange.toString());
+
+        // Test with BIGINT
+        Range<Tuple> bigintRange = Range.of(
+                new Tuple(List.of(Variant.of(IntegerType.BIGINT, "9223372036854775000"))),
+                new Tuple(List.of(Variant.of(IntegerType.BIGINT, "9223372036854775807"))),
+                true, true);
+        TabletRange bigintTabletRange = new TabletRange(bigintRange);
+        Assertions.assertEquals("[[9223372036854775000], [9223372036854775807]]", bigintTabletRange.toString());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
 This change adds tablet range information to the SHOW PROC output for
  Lake tablets, allowing users to see the data range of each tablet.

## What I'm doing:
  - Add toString() method to TabletRange, Tuple, and Variant classes
    for human-readable range representation
  - Add "Range" column to LakeTabletsProcDir output (fetchComparableResult
    and getTabletInfo methods)
  - Simplify Tablet.range initialization by using default TabletRange
    constructor instead of Range.all()
  - Remove unused Range import from Tablet.java

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tablet range visibility to Lake tablets proc output with minimal core changes.
> 
> - Include `Range` column in `LakeTabletsProcDir` (both list and single-tablet views) using `tablet.getRange().toString()`
> - Implement `toString()` in `TabletRange`, `Tuple`, and `Variant` for readable range formatting
> - Initialize `Tablet.range` via default `TabletRange()`; remove unused `Range` import
> - Add unit tests `TabletRangeTest` covering string formatting and Thrift round-trips
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1af53cfed3bc8079b726e5fb54a857e22dd83b31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->