### PR TITLE
[BugFix] Fix read heap-buffer-overflow on partition join

### DIFF
--- a/be/src/exec/join/join_hash_table.cpp
+++ b/be/src/exec/join/join_hash_table.cpp
@@ -260,7 +260,7 @@ std::pair<bool, JoinHashMapMethodUnaryType> JoinHashMapSelector::_try_use_range_
         RuntimeState* state, JoinHashTableItems* table_items) {
     bool is_asof_join_type = is_asof_join(table_items->join_type);
 
-    if (!state->enable_hash_join_range_direct_mapping_opt()) {
+    if (!state->enable_hash_join_range_direct_mapping_opt() || table_items->row_count == 0) {
         return _get_fallback_method<LT>(is_asof_join_type);
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10791

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents invalid memory access in hash join method selection when the build side is empty.
> 
> - In `join_hash_table.cpp`, `_try_use_range_direct_mapping` now falls back if `table_items->row_count == 0`, avoiding min/max scans on empty key arrays
> - Reduces risk of heap-buffer-overflow during partition joins (and related join types)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21031752b18750920a4c2f943e3a9bdd549d7c24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->