### PR TITLE
[BugFix] redact credentials for create repository (backport #67367)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/AuditEncryptionChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/AuditEncryptionChecker.java
@@ -21,6 +21,7 @@ import com.starrocks.sql.ast.AlterStorageVolumeStmt;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.BaseCreateAlterUserStmt;
 import com.starrocks.sql.ast.CreateCatalogStmt;
+import com.starrocks.sql.ast.CreateRepositoryStmt;
 import com.starrocks.sql.ast.CreateResourceStmt;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.CreateStorageVolumeStmt;
@@ -150,6 +151,11 @@ public class AuditEncryptionChecker implements AstVisitor<Boolean, Void> {
 
     @Override
     public Boolean visitCreateCatalogStatement(CreateCatalogStmt statement, Void context) {
+        return true;
+    }
+
+    @Override
+    public Boolean visitCreateRepositoryStatement(CreateRepositoryStmt statement, Void context) {
         return true;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -76,11 +76,7 @@ import com.starrocks.sql.ast.CreateRepositoryStmt;
 import com.starrocks.sql.ast.DropRepositoryStmt;
 import com.starrocks.sql.ast.FunctionRef;
 import com.starrocks.sql.ast.RestoreStmt;
-<<<<<<< HEAD
-=======
-import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.common.AuditEncryptionChecker;
->>>>>>> f8eaa55cb9 ([BugFix] redact credentials for create repository (#67367))
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.task.DirMoveTask;
 import com.starrocks.task.DownloadTask;

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -76,6 +76,11 @@ import com.starrocks.sql.ast.CreateRepositoryStmt;
 import com.starrocks.sql.ast.DropRepositoryStmt;
 import com.starrocks.sql.ast.FunctionRef;
 import com.starrocks.sql.ast.RestoreStmt;
+<<<<<<< HEAD
+=======
+import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.common.AuditEncryptionChecker;
+>>>>>>> f8eaa55cb9 ([BugFix] redact credentials for create repository (#67367))
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.task.DirMoveTask;
 import com.starrocks.task.DownloadTask;
@@ -896,5 +901,12 @@ public class BackupHandlerTest {
         restoreJob.setState(RestoreJob.RestoreJobState.FINISHED);
         result = handler.getRunningBackupRestoreCount();
         Assertions.assertEquals(Long.valueOf(0), result.get(0L));
+    }
+
+    @Test
+    public void testCreateRepositoryNeedEncrypt() {
+        CreateRepositoryStmt stmt = new CreateRepositoryStmt(false, "repo", "broker", "bos://location",
+                Maps.newHashMap());
+        Assertions.assertEquals(true, AuditEncryptionChecker.needEncrypt(stmt));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Credentials in CreateRepositoryStmt should be redacted from fe.log and audit.log.

## What I'm doing:

Fixes [#issue](https://github.com/StarRocks/starrocks/pull/67367)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures repository-creation credentials are redacted in logs.
> 
> - Extend `AuditEncryptionChecker` to return `true` for `visitCreateRepositoryStatement(CreateRepositoryStmt)`
> - Add `testCreateRepositoryNeedEncrypt` in `BackupHandlerTest` to validate `AuditEncryptionChecker.needEncrypt` for `CreateRepositoryStmt`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cc9a4f181aba575d95dd87bc9a23f1d21875ae3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->