### PR TITLE
[Feature] Implement get tablet split ranges for tablet splitting

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -394,9 +394,7 @@ VariantTuple Chunk::get(size_t n, const std::vector<uint32_t>& column_indexes) c
     tuple.reserve(column_indexes.size());
     for (uint32_t i : column_indexes) {
         DCHECK_LT(i, _columns.size());
-        const TypeInfoPtr& type = _schema->field(i)->type();
-        Datum value = _columns[i]->get(n);
-        tuple.append(DatumVariant(type, value));
+        tuple.emplace(_schema->field(i)->type(), _columns[i]->get(n));
     }
     return tuple;
 }

--- a/be/src/column/copied_datum.h
+++ b/be/src/column/copied_datum.h
@@ -43,7 +43,7 @@ public:
         return *this;
     }
 
-    CopiedDatum& operator=(CopiedDatum&& other) {
+    CopiedDatum& operator=(CopiedDatum&& other) noexcept {
         if (this != &other) {
             release();
             _datum = other._datum;

--- a/be/src/storage/tablet_range.h
+++ b/be/src/storage/tablet_range.h
@@ -1,0 +1,108 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "storage/variant_tuple.h"
+
+namespace starrocks {
+
+class TabletRange {
+public:
+    TabletRange() = default;
+
+    TabletRange(const VariantTuple& lower_bound, const VariantTuple& upper_bound, bool lower_bound_included,
+                bool upper_bound_included)
+            : _lower_bound(lower_bound),
+              _upper_bound(upper_bound),
+              _lower_bound_included(lower_bound_included),
+              _upper_bound_included(upper_bound_included) {}
+
+    const VariantTuple& lower_bound() const { return _lower_bound; }
+
+    const VariantTuple& upper_bound() const { return _upper_bound; }
+
+    bool lower_bound_included() const { return _lower_bound_included; }
+
+    bool upper_bound_included() const { return _upper_bound_included; }
+
+    bool lower_bound_excluded() const { return !lower_bound_included(); }
+
+    bool upper_bound_excluded() const { return !upper_bound_included(); }
+
+    bool is_minimum() const { return _lower_bound.empty(); }
+
+    bool is_maximum() const { return _upper_bound.empty(); }
+
+    bool is_all() const { return is_minimum() && is_maximum(); }
+
+    bool less_than(const VariantTuple& key) const;
+
+    bool greater_than(const VariantTuple& key) const;
+
+    bool contains(const VariantTuple& key) const { return !(less_than(key) || greater_than(key)); }
+
+    void to_proto(TabletRangePB* tablet_range_pb) const;
+
+    Status from_proto(const TabletRangePB& tablet_range_pb);
+
+private:
+    VariantTuple _lower_bound;
+    VariantTuple _upper_bound;
+    bool _lower_bound_included = false;
+    bool _upper_bound_included = false;
+};
+
+inline bool TabletRange::less_than(const VariantTuple& key) const {
+    if (is_maximum()) {
+        return false;
+    }
+
+    int result = _upper_bound.compare(key);
+    return result < 0 || (result == 0 && upper_bound_excluded());
+}
+
+inline bool TabletRange::greater_than(const VariantTuple& key) const {
+    if (is_minimum()) {
+        return false;
+    }
+
+    int result = _lower_bound.compare(key);
+    return result > 0 || (result == 0 && lower_bound_excluded());
+}
+
+inline void TabletRange::to_proto(TabletRangePB* tablet_range_pb) const {
+    _lower_bound.to_proto(tablet_range_pb->mutable_lower_bound());
+    _upper_bound.to_proto(tablet_range_pb->mutable_upper_bound());
+    tablet_range_pb->set_lower_bound_included(_lower_bound_included);
+    tablet_range_pb->set_upper_bound_included(_upper_bound_included);
+}
+
+inline Status TabletRange::from_proto(const TabletRangePB& tablet_range_pb) {
+    if (tablet_range_pb.has_lower_bound()) {
+        RETURN_IF_ERROR(_lower_bound.from_proto(tablet_range_pb.lower_bound()));
+    } else {
+        _lower_bound.clear();
+    }
+    if (tablet_range_pb.has_upper_bound()) {
+        RETURN_IF_ERROR(_upper_bound.from_proto(tablet_range_pb.upper_bound()));
+    } else {
+        _upper_bound.clear();
+    }
+    _lower_bound_included = tablet_range_pb.lower_bound_included();
+    _upper_bound_included = tablet_range_pb.upper_bound_included();
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/storage/variant_tuple.h
+++ b/be/src/storage/variant_tuple.h
@@ -30,7 +30,14 @@ public:
 
     void reserve(size_t n) { _values.reserve(n); }
 
-    void append(const DatumVariant& value) { _values.emplace_back(value); }
+    void append(const DatumVariant& value) { _values.push_back(value); }
+
+    void append(DatumVariant&& value) { _values.push_back(std::move(value)); }
+
+    template <typename... Args>
+    void emplace(Args&&... args) {
+        _values.emplace_back(std::forward<Args>(args)...);
+    }
 
     const DatumVariant& operator[](size_t n) const { return _values[n]; }
 
@@ -41,6 +48,8 @@ public:
     DatumVariant& get(size_t n) { return _values.at(n); }
 
     const std::vector<DatumVariant>& values() const { return _values; }
+
+    void clear() { _values.clear(); }
 
     int compare(const VariantTuple& other) const;
 
@@ -72,6 +81,7 @@ inline int VariantTuple::compare(const VariantTuple& other) const {
 }
 
 inline void VariantTuple::to_proto(TuplePB* tuple_pb) const {
+    tuple_pb->clear_values();
     for (const auto& value : _values) {
         value.to_proto(tuple_pb->add_values());
     }

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -27,6 +27,7 @@
 #include "storage/lake/location_provider.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/update_manager.h"
+#include "storage/variant_tuple.h"
 #include "testutil/assert.h"
 #include "testutil/id_generator.h"
 #include "util/filesystem_util.h"
@@ -35,6 +36,15 @@ namespace starrocks {
 
 class LakeTabletReshardTest : public testing::Test {
 public:
+    static TuplePB generate_sort_key(int value) {
+        DatumVariant variant(get_type_info(LogicalType::TYPE_INT), Datum(value));
+        VariantTuple tuple;
+        tuple.append(variant);
+        TuplePB tuple_pb;
+        tuple.to_proto(&tuple_pb);
+        return tuple_pb;
+    }
+
     void SetUp() override {
         std::vector<starrocks::StorePath> paths;
         CHECK_OK(starrocks::parse_conf_store_paths(starrocks::config::storage_root_path, &paths));
@@ -70,6 +80,11 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting) {
     auto rowset_meta_pb = metadata.add_rowsets();
     rowset_meta_pb->set_id(2);
     rowset_meta_pb->add_segments("test.dat");
+    rowset_meta_pb->add_segment_size(1024);
+    auto* segment_meta = rowset_meta_pb->add_segment_metas();
+    segment_meta->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+    segment_meta->mutable_sort_key_max()->CopyFrom(generate_sort_key(100));
+    segment_meta->set_num_rows(5);
     rowset_meta_pb->add_del_files()->set_name("test.del");
     rowset_meta_pb->set_overlapped(false);
     rowset_meta_pb->set_data_size(1024);


### PR DESCRIPTION
## Why I'm doing:
  This commit implements the split point calculation algorithm for tablet splitting, enabling precise range-based partitioning of tablets during the reshard process.

## What I'm doing:
  1. New tablet_range.h file
  - Introduces TabletRange class to represent key ranges for tablets
  - Supports lower/upper bound comparisons with inclusive/exclusive semantics
  - Provides less_than, greater_than, contains methods for range operations
  - Includes serialization/deserialization with TabletRangePB

  2. Core Algorithm: get_tablet_split_ranges function (tablet_reshard.cpp:130-298)
  - Collects segment sort key ranges (min/max) from all rowsets
  - Builds ordered range boundaries using a sorted set of all segment endpoints
  - Estimates row count and data size per range by distributing segment stats across overlapping ranges
  - Calculates split points based on target split count, aiming for equal row distribution
  - Produces precise range boundaries for each new tablet

  3. Enhanced handle_splitting_tablet function
  - Integrates get_tablet_split_ranges for split range calculation
  - Graceful degradation: if calculation fails (e.g., empty segments), falls back to creating a single tablet without splitting
  - Sets accurate per-rowset statistics (num_rows, data_size) for each new tablet

  4. Other Changes
  - variant_tuple.h: Added clear() method
  - lake_types.proto: Added range field to TabletMetadataPB
  - lake_service_test.cpp: Enhanced test cases with sort key metadata

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements tablet resharding and integrates it into publish flow with range-aware splitting.
> 
> - Adds `storage/lake/tablet_reshard.{h,cpp}` with `PublishTabletInfo`, reshard handlers (splitting/identical), and `get_tablet_split_ranges` to compute balanced ranges; writes/caches new tablet metadata and returns `tablet_ranges`
> - Introduces `TabletRange` in `storage/tablet_range.h` and adds `range` to `TabletMetadataPB` (proto)
> - Updates `publish_version` to accept `PublishTabletInfo`, support cross-publish, share data files when needed, control txn-log deletion, and validate tablet IDs in `txn_log_applier`
> - Extends `LakeService::publish_version` to parse `resharding_tablet_infos`, batch merging tasks, build per-tablet publish batches, improved logging, and failure handling; aggregates `tablet_ranges` in responses
> - Minor APIs/util: `VariantTuple::emplace/clear`, `Chunk::get` uses `emplace`, `CopiedDatum` move `noexcept`
> - Adds comprehensive unit tests for resharding, service, transactions, schema evolution; updates CMake to compile new files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d09acc37537ba86cad0a33e6550d5da45043634. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->