### PR TITLE
[BugFix] Support Fast Schema Evolution v2 for sync mv and traditional schema change in shared-data

### DIFF
--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -36,6 +36,10 @@ namespace starrocks::lake {
 
 struct SchemaChangeParams {
     VersionedTablet base_tablet;
+    // Schema from FE catalog for reading data from base tablet.
+    // In Fast Schema Evolution v2, this may be newer than base_tablet.get_schema() (which comes from tablet metadata).
+    // Must use this schema to read data, otherwise correctness issues may occur.
+    TabletSchemaCSPtr base_tablet_read_schema = nullptr;
     VersionedTablet new_tablet;
     int64_t txn_id;
     MaterializedViewParamMap materialized_params_map;
@@ -76,10 +80,16 @@ public:
 
 class ConvertedSchemaChange : public SchemaChange {
 public:
+    // Constructs a schema change procedure that converts data from base tablet to new tablet.
+    //
+    // @param base_tablet_read_schema Schema from FE catalog for reading data from base tablet.
+    // @param chunk_changer Caller must ensure chunk_changer is not nullptr and outlives this object.
     explicit ConvertedSchemaChange(TabletManager* tablet_manager, int64_t txn_id, VersionedTablet base_tablet,
-                                   VersionedTablet new_tablet, ChunkChanger* chunk_changer)
+                                   TabletSchemaCSPtr base_tablet_read_schema, VersionedTablet new_tablet,
+                                   ChunkChanger* chunk_changer)
             : SchemaChange(tablet_manager, txn_id),
               _base_tablet(std::move(base_tablet)),
+              _base_tablet_read_schema(std::move(base_tablet_read_schema)),
               _new_tablet(std::move(new_tablet)),
               _chunk_changer(chunk_changer) {
         CHECK(_chunk_changer != nullptr);
@@ -91,6 +101,9 @@ public:
 
 protected:
     VersionedTablet _base_tablet;
+    // Schema from FE catalog for reading data from base tablet.
+    // In Fast Schema Evolution v2, this may be newer than base_tablet.get_schema().
+    TabletSchemaCSPtr _base_tablet_read_schema;
     VersionedTablet _new_tablet;
     ChunkChanger* _chunk_changer = nullptr;
 
@@ -107,10 +120,14 @@ protected:
 
 class DirectSchemaChange final : public ConvertedSchemaChange {
 public:
+    // Constructs a direct schema change procedure that converts data without sorting.
+    //
+    // @param base_tablet_read_schema Schema from FE catalog for reading data from base tablet.
     explicit DirectSchemaChange(TabletManager* tablet_manager, int64_t txn_id, VersionedTablet base_tablet,
-                                VersionedTablet new_tablet, ChunkChanger* chunk_changer)
-            : ConvertedSchemaChange(tablet_manager, txn_id, std::move(base_tablet), std::move(new_tablet),
-                                    chunk_changer) {}
+                                TabletSchemaCSPtr base_tablet_read_schema, VersionedTablet new_tablet,
+                                ChunkChanger* chunk_changer)
+            : ConvertedSchemaChange(tablet_manager, txn_id, std::move(base_tablet), std::move(base_tablet_read_schema),
+                                    std::move(new_tablet), chunk_changer) {}
 
     ~DirectSchemaChange() override = default;
 
@@ -121,10 +138,15 @@ public:
 
 class SortedSchemaChange final : public ConvertedSchemaChange {
 public:
+    // Constructs a sorted schema change procedure that converts and sorts data.
+    //
+    // @param base_tablet_read_schema Schema from FE catalog for reading data from base tablet.
+    // @param memory_limitation Maximum memory limit in bytes for the sorting operation.
     explicit SortedSchemaChange(TabletManager* tablet_manager, int64_t txn_id, VersionedTablet base_tablet,
-                                VersionedTablet new_tablet, ChunkChanger* chunk_changer, size_t memory_limitation)
-            : ConvertedSchemaChange(tablet_manager, txn_id, std::move(base_tablet), std::move(new_tablet),
-                                    chunk_changer),
+                                TabletSchemaCSPtr base_tablet_read_schema, VersionedTablet new_tablet,
+                                ChunkChanger* chunk_changer, size_t memory_limitation)
+            : ConvertedSchemaChange(tablet_manager, txn_id, std::move(base_tablet), std::move(base_tablet_read_schema),
+                                    std::move(new_tablet), chunk_changer),
               _memory_limitation(memory_limitation) {}
 
     ~SortedSchemaChange() override = default;
@@ -154,8 +176,8 @@ Status ConvertedSchemaChange::init() {
     _read_params.lake_io_opts.fill_data_cache = false;
     _read_params.sorted_by_keys_per_tablet = true;
 
-    auto base_tablet_schema = _base_tablet.get_schema();
-    _base_schema = ChunkHelper::convert_schema(base_tablet_schema, _chunk_changer->get_selected_column_indexes());
+    // Convert tablet schema to chunk reading schema using selected column indexes.
+    _base_schema = ChunkHelper::convert_schema(_base_tablet_read_schema, _chunk_changer->get_selected_column_indexes());
     _new_tablet_schema = _new_tablet.get_schema();
     _new_schema = ChunkHelper::convert_schema(_new_tablet_schema);
 
@@ -168,9 +190,10 @@ Status ConvertedSchemaChange::init() {
 }
 
 Status DirectSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_metadata) {
-    // create reader
+    // Create reader using FE catalog schema (base_tablet_read_schema) to ensure correct data reading
+    // in Fast Schema Evolution v2 scenarios.
     auto reader = std::make_unique<TabletReader>(_base_tablet.tablet_manager(), _base_tablet.metadata(), _base_schema,
-                                                 std::vector<RowsetPtr>{rowset}, _base_tablet.get_schema());
+                                                 std::vector<RowsetPtr>{rowset}, _base_tablet_read_schema);
     RETURN_IF_ERROR(reader->prepare());
     RETURN_IF_ERROR(reader->open(_read_params));
 
@@ -250,9 +273,10 @@ Status SortedSchemaChange::init() {
 }
 
 Status SortedSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_metadata) {
-    // create reader
+    // Create reader using FE catalog schema (base_tablet_read_schema) to ensure correct data reading
+    // in Fast Schema Evolution v2 scenarios.
     auto reader = std::make_unique<TabletReader>(_base_tablet.tablet_manager(), _base_tablet.metadata(), _base_schema,
-                                                 std::vector<RowsetPtr>{rowset}, _base_tablet.get_schema());
+                                                 std::vector<RowsetPtr>{rowset}, _base_tablet_read_schema);
     RETURN_IF_ERROR(reader->prepare());
     RETURN_IF_ERROR(reader->open(_read_params));
 
@@ -342,18 +366,23 @@ Status SchemaChangeHandler::do_process_alter_tablet(const TAlterTabletReqV2& req
     ASSIGN_OR_RETURN(auto base_tablet, _tablet_manager->get_tablet(request.base_tablet_id, alter_version));
     ASSIGN_OR_RETURN(auto new_tablet, _tablet_manager->get_tablet(request.new_tablet_id, 1));
 
-    TabletSchemaCSPtr base_schema;
-    if (!request.columns.empty() && request.columns[0].col_unique_id >= 0) {
-        auto columns_copy = request.columns;
-
-        Status preprocess_status = preprocess_default_expr_for_tcolumns(columns_copy);
-        if (!preprocess_status.ok()) {
-            LOG(WARNING) << "Failed to preprocess default_expr in Lake SchemaChange: " << preprocess_status.to_string();
+    // Determine the schema to use for reading data from base tablet.
+    // In Fast Schema Evolution v2, FE may send base_tablet_read_schema which is newer than the schema stored in tablet metadata.
+    // We must use the FE catalog schema (request.base_tablet_read_schema) if provided, otherwise fallback to tablet metadata schema.
+    TabletSchemaCSPtr base_tablet_read_schema;
+    if (request.__isset.base_tablet_read_schema) {
+        // Use schema from FE catalog (may be newer than tablet metadata schema).
+        auto schema_id = request.base_tablet_read_schema.id;
+        base_tablet_read_schema = _tablet_manager->get_cached_schema(schema_id);
+        if (base_tablet_read_schema == nullptr) {
+            TabletSchemaPB schema_pb;
+            RETURN_IF_ERROR(convert_t_schema_to_pb_schema(request.base_tablet_read_schema, &schema_pb));
+            base_tablet_read_schema = TabletSchema::create(schema_pb);
+            _tablet_manager->cache_schema(base_tablet_read_schema);
         }
-
-        base_schema = TabletSchema::copy(*(base_tablet.get_schema()), columns_copy);
     } else {
-        base_schema = base_tablet.get_schema();
+        // Fallback to schema from tablet metadata (old behavior before Fast Schema Evolution v2).
+        base_tablet_read_schema = base_tablet.get_schema();
     }
     auto new_schema = new_tablet.get_schema();
     auto has_delete_predicates = base_tablet.has_delete_predicates();
@@ -362,8 +391,8 @@ Status SchemaChangeHandler::do_process_alter_tablet(const TAlterTabletReqV2& req
     if (!request.base_table_column_names.empty()) {
         base_table_columns = request.base_table_column_names;
     } else {
-        base_table_columns.reserve(base_schema->columns().size());
-        for (const auto& column : base_schema->columns()) {
+        base_table_columns.reserve(base_tablet_read_schema->columns().size());
+        for (const auto& column : base_tablet_read_schema->columns()) {
             base_table_columns.emplace_back(column.name());
         }
     }
@@ -371,9 +400,10 @@ Status SchemaChangeHandler::do_process_alter_tablet(const TAlterTabletReqV2& req
     // parse request and create schema change params
     SchemaChangeParams sc_params;
     sc_params.base_tablet = base_tablet;
+    sc_params.base_tablet_read_schema = base_tablet_read_schema;
     sc_params.new_tablet = new_tablet;
-    sc_params.chunk_changer =
-            std::make_unique<ChunkChanger>(base_schema, new_schema, base_table_columns, request.alter_job_type);
+    sc_params.chunk_changer = std::make_unique<ChunkChanger>(base_tablet_read_schema, new_schema, base_table_columns,
+                                                             request.alter_job_type);
     sc_params.txn_id = request.txn_id;
 
     auto* chunk_changer = sc_params.chunk_changer.get();
@@ -398,7 +428,7 @@ Status SchemaChangeHandler::do_process_alter_tablet(const TAlterTabletReqV2& req
     }
 
     SchemaChangeUtils::init_materialized_params(request, &sc_params.materialized_params_map, sc_params.where_expr);
-    RETURN_IF_ERROR(SchemaChangeUtils::parse_request(base_schema, new_schema, sc_params.chunk_changer.get(),
+    RETURN_IF_ERROR(SchemaChangeUtils::parse_request(base_tablet_read_schema, new_schema, sc_params.chunk_changer.get(),
                                                      sc_params.materialized_params_map, sc_params.where_expr,
                                                      has_delete_predicates, &sc_params.sc_sorting,
                                                      &sc_params.sc_directly, &generated_column_idxs));
@@ -513,7 +543,8 @@ Status SchemaChangeHandler::convert_historical_rowsets(const SchemaChangeParams&
         LOG(INFO) << "doing sorted schema change for base tablet: " << base_tablet.id();
         size_t memory_limitation =
                 static_cast<size_t>(config::memory_limitation_per_thread_for_schema_change) * 1024 * 1024 * 1024;
-        sc_procedure = std::make_unique<SortedSchemaChange>(_tablet_manager, sc_params.txn_id, base_tablet, new_tablet,
+        sc_procedure = std::make_unique<SortedSchemaChange>(_tablet_manager, sc_params.txn_id, base_tablet,
+                                                            sc_params.base_tablet_read_schema, new_tablet,
                                                             chunk_changer, memory_limitation);
         op_schema_change->set_linked_segment(false);
     } else {
@@ -521,8 +552,9 @@ Status SchemaChangeHandler::convert_historical_rowsets(const SchemaChangeParams&
         // so disable linked schema change and will support it in the later version.
         LOG(INFO) << "doing direct schema change for base tablet: " << base_tablet.id()
                   << ", params directly: " << sc_params.sc_directly;
-        sc_procedure = std::make_unique<DirectSchemaChange>(_tablet_manager, sc_params.txn_id, base_tablet, new_tablet,
-                                                            chunk_changer);
+        sc_procedure =
+                std::make_unique<DirectSchemaChange>(_tablet_manager, sc_params.txn_id, base_tablet,
+                                                     sc_params.base_tablet_read_schema, new_tablet, chunk_changer);
         op_schema_change->set_linked_segment(false);
     }
     RETURN_IF_ERROR(sc_procedure->init());

--- a/be/test/storage/lake/schema_change_test.cpp
+++ b/be/test/storage/lake/schema_change_test.cpp
@@ -18,6 +18,7 @@
 
 #include <thread>
 
+#include "column/binary_column.h"
 #include "column/datum_tuple.h"
 #include "column/fixed_length_column.h"
 #include "fs/fs_util.h"
@@ -32,6 +33,7 @@
 #include "storage/lake/test_util.h"
 #include "storage/lake/update_manager.h"
 #include "storage/lake/versioned_tablet.h"
+#include "storage/metadata_util.h"
 #include "testutil/assert.h"
 #include "testutil/id_generator.h"
 
@@ -2051,5 +2053,715 @@ INSTANTIATE_TEST_SUITE_P(SchemaChangeSortKeyReorderTest3, SchemaChangeSortKeyReo
                                            SchemaChangeParam{PRIMARY_KEYS, 2, 4}),
                          to_string_param_name);
 // clang-format on
+
+class SchemaChangeBaseTabletReadSchemaTest : public testing::Test {
+public:
+    SchemaChangeBaseTabletReadSchemaTest() {
+        _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
+        _location_provider = std::make_unique<FixedLocationProvider>(_test_dir);
+        _update_manager = std::make_unique<UpdateManager>(_location_provider, _mem_tracker.get());
+        _tablet_manager = std::make_unique<TabletManager>(_location_provider, _update_manager.get(), 1024 * 1024);
+    }
+
+protected:
+    void SetUp() override {
+        (void)fs::remove_all(_test_dir);
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kSegmentDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kMetadataDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kTxnLogDirectoryName)));
+    }
+
+    void TearDown() override { ASSERT_OK(fs::remove_all(_test_dir)); }
+
+    Status publish_version_for_schema_change(int64_t tablet_id, int64_t new_version, int64_t txn_id) {
+        TxnInfoPB txn_info;
+        txn_info.set_txn_id(txn_id);
+        txn_info.set_combined_txn_log(false);
+        txn_info.set_commit_time(time(nullptr));
+        return publish_version(_tablet_manager.get(), tablet_id, 1, new_version,
+                               std::span<const TxnInfoPB>(&txn_info, 1), false)
+                .status();
+    }
+
+    // Create base tablet metadata schema (tablet metadata schema)
+    // c0 (INT, KEY), c1 (VARCHAR(20), KEY), c2 (INT), c3 (INT), c4 (INT)
+    std::shared_ptr<TabletMetadata> create_base_tablet_metadata() {
+        auto metadata = std::make_shared<TabletMetadata>();
+        metadata->set_id(next_id());
+        metadata->set_version(1);
+
+        auto schema = metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1); // stops before varchar key column c1
+        schema->set_keys_type(DUP_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        // Use deterministic column unique ids so the FE catalog schema (base_tablet_read_schema) can
+        // reliably reference historical data by unique id in tests.
+        constexpr int32_t c0_id = 1;
+        constexpr int32_t c1_id = 2;
+        constexpr int32_t c2_id = 3;
+        constexpr int32_t c3_id = 4;
+        constexpr int32_t c4_id = 5;
+
+        // c0 (INT, KEY)
+        {
+            auto c0 = schema->add_column();
+            c0->set_unique_id(c0_id);
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+
+        // c1 (VARCHAR(20), KEY)
+        {
+            auto c1 = schema->add_column();
+            c1->set_unique_id(c1_id);
+            c1->set_name("c1");
+            c1->set_type("VARCHAR");
+            c1->set_length(20);
+            c1->set_is_key(true);
+            c1->set_is_nullable(false);
+        }
+
+        // c2 (INT)
+        {
+            auto c2 = schema->add_column();
+            c2->set_unique_id(c2_id);
+            c2->set_name("c2");
+            c2->set_type("INT");
+            c2->set_is_key(false);
+            c2->set_is_nullable(false);
+            c2->set_aggregation("NONE");
+        }
+
+        // c3 (INT) - will be dropped
+        {
+            auto c3 = schema->add_column();
+            c3->set_unique_id(c3_id);
+            c3->set_name("c3");
+            c3->set_type("INT");
+            c3->set_is_key(false);
+            c3->set_is_nullable(false);
+            c3->set_aggregation("NONE");
+        }
+
+        // c4 (INT) - will be dropped and re-added with different type/unique_id
+        {
+            auto c4 = schema->add_column();
+            c4->set_unique_id(c4_id);
+            c4->set_name("c4");
+            c4->set_type("INT");
+            c4->set_is_key(false);
+            c4->set_is_nullable(false);
+            c4->set_aggregation("NONE");
+        }
+
+        return metadata;
+    }
+
+    // Create base_tablet_read_schema
+    // c0 (INT, KEY), c1 (VARCHAR(20), KEY), c6 (INT, KEY), c2 (BIGINT), c5 (BIGINT), c4 (VARCHAR(20))
+    TTabletSchema create_base_tablet_read_schema(int64_t schema_id) {
+        TTabletSchema t_schema;
+        t_schema.__set_id(schema_id);
+        t_schema.__set_short_key_column_count(1); // stops before varchar key column c1
+        t_schema.__set_keys_type(TKeysType::DUP_KEYS);
+
+        // c0 (INT, KEY, unique_id=1)
+        {
+            TColumn c0;
+            c0.__set_column_name("c0");
+            TTypeNode type0;
+            type0.__set_type(TTypeNodeType::SCALAR);
+            TScalarType scalar0;
+            scalar0.__set_type(TPrimitiveType::INT);
+            type0.__set_scalar_type(scalar0);
+            c0.__set_type_desc(TTypeDesc());
+            c0.type_desc.__set_types({type0});
+            c0.__set_col_unique_id(1);
+            c0.__set_is_key(true);
+            c0.__set_is_allow_null(false);
+            t_schema.columns.push_back(c0);
+        }
+
+        // c1 (VARCHAR(20), KEY, unique_id=2)
+        {
+            TColumn c1;
+            c1.__set_column_name("c1");
+            TTypeNode type1;
+            type1.__set_type(TTypeNodeType::SCALAR);
+            TScalarType scalar1;
+            scalar1.__set_type(TPrimitiveType::VARCHAR);
+            scalar1.__set_len(20);
+            type1.__set_scalar_type(scalar1);
+            c1.__set_type_desc(TTypeDesc());
+            c1.type_desc.__set_types({type1});
+            c1.__set_col_unique_id(2);
+            c1.__set_is_key(true);
+            c1.__set_is_allow_null(false);
+            c1.__set_index_len(20);
+            t_schema.columns.push_back(c1);
+        }
+
+        // c6 (INT, KEY, unique_id=7) - new key column
+        {
+            TColumn c6;
+            c6.__set_column_name("c6");
+            TTypeNode type6;
+            type6.__set_type(TTypeNodeType::SCALAR);
+            TScalarType scalar6;
+            scalar6.__set_type(TPrimitiveType::INT);
+            type6.__set_scalar_type(scalar6);
+            c6.__set_type_desc(TTypeDesc());
+            c6.type_desc.__set_types({type6});
+            c6.__set_col_unique_id(7);
+            c6.__set_is_key(true);
+            c6.__set_is_allow_null(true);
+            t_schema.columns.push_back(c6);
+        }
+
+        // c2 (BIGINT, unique_id=3) - type changed from INT to BIGINT
+        {
+            TColumn c2;
+            c2.__set_column_name("c2");
+            TTypeNode type2;
+            type2.__set_type(TTypeNodeType::SCALAR);
+            TScalarType scalar2;
+            scalar2.__set_type(TPrimitiveType::BIGINT);
+            type2.__set_scalar_type(scalar2);
+            c2.__set_type_desc(TTypeDesc());
+            c2.type_desc.__set_types({type2});
+            c2.__set_col_unique_id(3);
+            c2.__set_is_key(false);
+            c2.__set_is_allow_null(true);
+            c2.__set_aggregation_type(TAggregationType::NONE);
+            t_schema.columns.push_back(c2);
+        }
+
+        // c5 (BIGINT, unique_id=6) - new column
+        {
+            TColumn c5;
+            c5.__set_column_name("c5");
+            TTypeNode type5;
+            type5.__set_type(TTypeNodeType::SCALAR);
+            TScalarType scalar5;
+            scalar5.__set_type(TPrimitiveType::BIGINT);
+            type5.__set_scalar_type(scalar5);
+            c5.__set_type_desc(TTypeDesc());
+            c5.type_desc.__set_types({type5});
+            c5.__set_col_unique_id(6);
+            c5.__set_is_key(false);
+            c5.__set_is_allow_null(true);
+            c5.__set_aggregation_type(TAggregationType::NONE);
+            t_schema.columns.push_back(c5);
+        }
+
+        // c4 (VARCHAR(20), unique_id=8) - dropped and re-added with different type/unique_id
+        {
+            TColumn c4;
+            c4.__set_column_name("c4");
+            TTypeNode type4;
+            type4.__set_type(TTypeNodeType::SCALAR);
+            TScalarType scalar4;
+            scalar4.__set_type(TPrimitiveType::VARCHAR);
+            scalar4.__set_len(20);
+            type4.__set_scalar_type(scalar4);
+            c4.__set_type_desc(TTypeDesc());
+            c4.type_desc.__set_types({type4});
+            c4.__set_col_unique_id(8); // different unique_id from tablet metadata schema
+            c4.__set_is_key(false);
+            c4.__set_is_allow_null(true);
+            c4.__set_aggregation_type(TAggregationType::NONE);
+            c4.__set_index_len(20);
+            t_schema.columns.push_back(c4);
+        }
+
+        return t_schema;
+    }
+
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::shared_ptr<FixedLocationProvider> _location_provider;
+    std::unique_ptr<UpdateManager> _update_manager;
+    std::unique_ptr<TabletManager> _tablet_manager;
+
+    constexpr static const char* const _test_dir = "test_lake_base_tablet_read_schema";
+    int64_t _partition_id = 100;
+};
+
+TEST_F(SchemaChangeBaseTabletReadSchemaTest, test_fallback_to_tablet_metadata_schema) {
+    // TC-4: Test fallback to tablet metadata schema when base_tablet_read_schema is not provided
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+
+    // Create new tablet metadata (simple add column)
+    auto new_metadata = std::make_shared<TabletMetadata>();
+    new_metadata->set_id(next_id());
+    new_metadata->set_version(1);
+    auto new_schema = new_metadata->mutable_schema();
+    new_schema->CopyFrom(base_metadata->schema());
+    auto c5 = new_schema->add_column();
+    c5->set_unique_id(6);
+    c5->set_name("c5");
+    c5->set_type("INT");
+    c5->set_is_key(false);
+    c5->set_is_nullable(false);
+    c5->set_aggregation("NONE");
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*new_metadata));
+
+    // Write test data
+    int64_t version = 1;
+    int64_t txn_id = 1000;
+    auto base_tablet_schema = TabletSchema::create(base_metadata->schema());
+    auto base_schema = std::make_shared<VSchema>(ChunkHelper::convert_schema(base_tablet_schema));
+
+    auto c0 = Int32Column::create();
+    auto c1 = BinaryColumn::create();
+    auto c2 = Int32Column::create();
+    auto c3 = Int32Column::create();
+    auto c4 = Int32Column::create();
+    c0->append_datum(Datum(1));
+    c1->append_datum(Datum("test"));
+    c2->append_datum(Datum(100));
+    c3->append_datum(Datum(200));
+    c4->append_datum(Datum(300));
+
+    VChunk chunk0({std::move(c0), std::move(c1), std::move(c2), std::move(c3), std::move(c4)}, base_schema);
+    uint32_t indexes[1] = {0};
+
+    ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_manager.get())
+                                               .set_tablet_id(base_tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(base_tablet_schema->id())
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+    ASSERT_OK(delta_writer->write(chunk0, indexes, sizeof(indexes) / sizeof(indexes[0])));
+    ASSERT_OK(delta_writer->finish_with_txnlog());
+    delta_writer->close();
+    ASSERT_OK(TEST_publish_single_version(_tablet_manager.get(), base_tablet_id, version + 1, txn_id).status());
+    version++;
+
+    // Do schema change without base_tablet_read_schema (should fallback to tablet metadata schema)
+    auto new_tablet_id = new_metadata->id();
+    auto alter_txn_id = txn_id + 1;
+    {
+        TAlterTabletReqV2 request;
+        request.base_tablet_id = base_tablet_id;
+        request.new_tablet_id = new_tablet_id;
+        request.alter_version = version;
+        request.txn_id = alter_txn_id;
+        // base_tablet_read_schema is not set, should fallback to tablet metadata schema
+
+        SchemaChangeHandler handler(_tablet_manager.get());
+        ASSERT_OK(handler.process_alter_tablet(request));
+    }
+
+    // Publish schema change
+    ASSERT_OK(publish_version_for_schema_change(new_tablet_id, version + 1, alter_txn_id));
+}
+
+TEST_F(SchemaChangeBaseTabletReadSchemaTest, test_materialized_view) {
+    // base_tablet_read_schema differs from tablet metadata schema, with materialized view
+    // This triggers SortedSchemaChange because keys_type changes from DUP_KEYS to AGG_KEYS
+    // Materialized view DDL:
+    //   CREATE MATERIALIZED VIEW mv1 AS SELECT c0, c1, c6, c4, SUM(c2) AS c2_sum FROM base_table GROUP BY c0, c1, c6, c4;
+
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+
+    // Create new tablet metadata for materialized view with AGG_KEYS
+    // New schema: c0 (INT, KEY), c1 (VARCHAR(20), KEY), c6 (INT, KEY), c4 (VARCHAR(20), KEY), c2_sum (BIGINT, SUM)
+    auto new_metadata = std::make_shared<TabletMetadata>();
+    new_metadata->set_id(next_id());
+    new_metadata->set_version(1);
+    auto new_schema = new_metadata->mutable_schema();
+    new_schema->set_id(next_id());
+    new_schema->set_num_short_key_columns(1);
+    new_schema->set_keys_type(AGG_KEYS); // Changed from DUP_KEYS to AGG_KEYS for materialized view
+    new_schema->set_num_rows_per_row_block(65535);
+
+    // c0 (INT, KEY, unique_id=1)
+    {
+        auto c0 = new_schema->add_column();
+        c0->set_unique_id(1);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+    }
+    // c1 (VARCHAR(20), KEY, unique_id=2)
+    {
+        auto c1 = new_schema->add_column();
+        c1->set_unique_id(2);
+        c1->set_name("c1");
+        c1->set_type("VARCHAR");
+        c1->set_length(20);
+        c1->set_is_key(true);
+        c1->set_is_nullable(false);
+    }
+    // c6 (INT, KEY, unique_id=7) - new column for materialized view key
+    {
+        auto c6 = new_schema->add_column();
+        c6->set_unique_id(7);
+        c6->set_name("c6");
+        c6->set_type("INT");
+        // For AGG_KEYS, all key columns must appear before value columns.
+        // Otherwise ChunkAggregator will treat a non-key column as key and DCHECK.
+        c6->set_is_key(true);
+        c6->set_is_nullable(true);
+    }
+    // c4 (VARCHAR(20), KEY, unique_id=8) - dropped and re-added
+    {
+        auto c4 = new_schema->add_column();
+        c4->set_unique_id(8);
+        c4->set_name("c4");
+        c4->set_type("VARCHAR");
+        c4->set_length(20);
+        c4->set_is_key(true);
+        c4->set_is_nullable(true);
+    }
+    // c2_sum (BIGINT, unique_id=9, SUM aggregation)
+    {
+        auto c2_sum = new_schema->add_column();
+        c2_sum->set_unique_id(9);
+        c2_sum->set_name("c2_sum");
+        c2_sum->set_type("BIGINT");
+        c2_sum->set_is_key(false);
+        c2_sum->set_is_nullable(true);
+        c2_sum->set_aggregation("SUM");
+    }
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*new_metadata));
+
+    // Write test data using tablet metadata schema
+    int64_t version = 1;
+    int64_t txn_id = next_id();
+    auto base_tablet_schema = TabletSchema::create(base_metadata->schema());
+    auto base_schema = std::make_shared<VSchema>(ChunkHelper::convert_schema(base_tablet_schema));
+
+    // Write multiple rows with same c0, c1 to test aggregation
+    for (int i = 0; i < 3; i++) {
+        auto col_c0 = Int32Column::create();
+        auto col_c1 = BinaryColumn::create();
+        auto col_c2 = Int32Column::create();
+        auto col_c3 = Int32Column::create();
+        auto col_c4 = Int32Column::create();
+
+        col_c0->append_datum(Datum(i + 1));
+        col_c1->append_datum(Datum(Slice(fmt::format("row{}", i))));
+        col_c2->append_datum(Datum((i + 1) * 100));
+        col_c3->append_datum(Datum((i + 1) * 1000));
+        col_c4->append_datum(Datum((i + 1) * 10));
+
+        VChunk chunk0({std::move(col_c0), std::move(col_c1), std::move(col_c2), std::move(col_c3), std::move(col_c4)},
+                      base_schema);
+        uint32_t indexes[1] = {0};
+
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_manager.get())
+                                                   .set_tablet_id(base_tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(base_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes, sizeof(indexes) / sizeof(indexes[0])));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(TEST_publish_single_version(_tablet_manager.get(), base_tablet_id, version + 1, txn_id).status());
+        version++;
+        txn_id = next_id();
+    }
+
+    // Do schema change with base_tablet_read_schema (this should trigger SortedSchemaChange)
+    auto new_tablet_id = new_metadata->id();
+    auto alter_txn_id = next_id();
+    {
+        // Create base_tablet_read_schema
+        auto t_read_schema = create_base_tablet_read_schema(next_id());
+
+        TAlterTabletReqV2 request;
+        request.base_tablet_id = base_tablet_id;
+        request.new_tablet_id = new_tablet_id;
+        request.alter_version = version;
+        request.txn_id = alter_txn_id;
+
+        // Set base_tablet_read_schema
+        request.__set_base_tablet_read_schema(t_read_schema);
+
+        // Set base_table_column_names - these are the columns we need to read for MV
+        request.__set_base_table_column_names({"c0", "c1", "c6", "c2", "c4"});
+
+        // Describe how to build MV columns. For this test we only need to map c2_sum to base column c2;
+        // the AGG_KEYS/SUM behavior is driven by the new tablet schema.
+        TAlterMaterializedViewParam mv_param;
+        mv_param.__set_column_name("c2_sum");
+        mv_param.__set_origin_column_name("c2");
+        request.__set_materialized_view_params({mv_param});
+
+        SchemaChangeHandler handler(_tablet_manager.get());
+        ASSERT_OK(handler.process_alter_tablet(request));
+    }
+
+    // Publish schema change
+    ASSERT_OK(publish_version_for_schema_change(new_tablet_id, version + 1, alter_txn_id));
+    version++;
+
+    // Verify new tablet data
+    auto new_tablet_schema = TabletSchema::create(new_metadata->schema());
+    auto new_schema_for_read = std::make_shared<VSchema>(ChunkHelper::convert_schema(new_tablet_schema));
+
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_manager->get_tablet_metadata(new_tablet_id, version));
+    auto reader = std::make_shared<TabletReader>(_tablet_manager.get(), new_tablet_metadata, *new_schema_for_read);
+    CHECK_OK(reader->prepare());
+    CHECK_OK(reader->open(TabletReaderParams()));
+
+    auto chunk = ChunkHelper::new_chunk(*new_schema_for_read, 1024);
+    int row_count = 0;
+    while (true) {
+        auto st = reader->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        }
+        CHECK_OK(st);
+        for (int i = 0; i < chunk->num_rows(); i++) {
+            EXPECT_EQ(row_count + 1, chunk->get(i)[0].get_int32());                               // c0
+            EXPECT_EQ(fmt::format("row{}", row_count), chunk->get(i)[1].get_slice().to_string()); // c1
+            EXPECT_TRUE(chunk->get(i)[2].is_null());                                              // c6 (new, NULL)
+            EXPECT_TRUE(chunk->get(i)[3].is_null());                        // c4 (new unique_id, NULL)
+            EXPECT_EQ((row_count + 1) * 100, chunk->get(i)[4].get_int64()); // c2_sum
+            row_count++;
+        }
+        chunk->reset();
+    }
+    ASSERT_EQ(3, row_count);
+}
+
+TEST_F(SchemaChangeBaseTabletReadSchemaTest, test_generated_column) {
+    // base_tablet_read_schema differs from tablet metadata schema, with generated column
+    // This triggers DirectSchemaChange
+
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+
+    // Create new tablet metadata with generated column
+    // New schema: c0 (INT, KEY), c1 (VARCHAR(20), KEY), c6 (INT, KEY), c2 (BIGINT), c5 (BIGINT), c4 (VARCHAR(20)),
+    //             c7 (BIGINT, generated = c2 + c5)
+    auto new_metadata = std::make_shared<TabletMetadata>();
+    new_metadata->set_id(next_id());
+    new_metadata->set_version(1);
+    auto new_schema = new_metadata->mutable_schema();
+    new_schema->set_id(next_id());
+    new_schema->set_num_short_key_columns(1);
+    new_schema->set_keys_type(DUP_KEYS);
+    new_schema->set_num_rows_per_row_block(65535);
+
+    // c0 (INT, KEY, unique_id=1)
+    {
+        auto c0 = new_schema->add_column();
+        c0->set_unique_id(1);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+    }
+    // c1 (VARCHAR(20), KEY, unique_id=2)
+    {
+        auto c1 = new_schema->add_column();
+        c1->set_unique_id(2);
+        c1->set_name("c1");
+        c1->set_type("VARCHAR");
+        c1->set_length(20);
+        c1->set_is_key(true);
+        c1->set_is_nullable(false);
+    }
+    // c6 (INT, KEY, unique_id=7)
+    {
+        auto c6 = new_schema->add_column();
+        c6->set_unique_id(7);
+        c6->set_name("c6");
+        c6->set_type("INT");
+        // Keep keys unchanged (c0,c1) so generated-column schema change can run in DirectSchemaChange mode.
+        c6->set_is_key(false);
+        c6->set_is_nullable(true);
+        c6->set_aggregation("NONE");
+    }
+    // c2 (BIGINT, unique_id=3)
+    {
+        auto c2 = new_schema->add_column();
+        c2->set_unique_id(3);
+        c2->set_name("c2");
+        c2->set_type("BIGINT");
+        c2->set_is_key(false);
+        c2->set_is_nullable(true);
+        c2->set_aggregation("NONE");
+    }
+    // c5 (BIGINT, unique_id=6)
+    {
+        auto c5 = new_schema->add_column();
+        c5->set_unique_id(6);
+        c5->set_name("c5");
+        c5->set_type("BIGINT");
+        c5->set_is_key(false);
+        c5->set_is_nullable(true);
+        c5->set_aggregation("NONE");
+    }
+    // c4 (VARCHAR(20), unique_id=8)
+    {
+        auto c4 = new_schema->add_column();
+        c4->set_unique_id(8);
+        c4->set_name("c4");
+        c4->set_type("VARCHAR");
+        c4->set_length(20);
+        c4->set_is_key(false);
+        c4->set_is_nullable(true);
+        c4->set_aggregation("NONE");
+    }
+    // c7 (INT, unique_id=10, generated column = c0 * 2)
+    {
+        auto c7 = new_schema->add_column();
+        c7->set_unique_id(10);
+        c7->set_name("c7");
+        c7->set_type("INT");
+        c7->set_is_key(false);
+        c7->set_is_nullable(true);
+        c7->set_aggregation("NONE");
+    }
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*new_metadata));
+
+    // Write test data using tablet metadata schema
+    int64_t version = 1;
+    int64_t txn_id = 1000;
+    auto base_tablet_schema = TabletSchema::create(base_metadata->schema());
+    auto base_schema = std::make_shared<VSchema>(ChunkHelper::convert_schema(base_tablet_schema));
+
+    for (int i = 0; i < 3; i++) {
+        auto col_c0 = Int32Column::create();
+        auto col_c1 = BinaryColumn::create();
+        auto col_c2 = Int32Column::create();
+        auto col_c3 = Int32Column::create();
+        auto col_c4 = Int32Column::create();
+
+        col_c0->append_datum(Datum(i + 1));
+        col_c1->append_datum(Datum(Slice(fmt::format("row{}", i))));
+        col_c2->append_datum(Datum((i + 1) * 100));
+        col_c3->append_datum(Datum((i + 1) * 1000));
+        col_c4->append_datum(Datum((i + 1) * 10));
+
+        VChunk chunk0({std::move(col_c0), std::move(col_c1), std::move(col_c2), std::move(col_c3), std::move(col_c4)},
+                      base_schema);
+        uint32_t indexes[1] = {0};
+
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_manager.get())
+                                                   .set_tablet_id(base_tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(base_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes, sizeof(indexes) / sizeof(indexes[0])));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(TEST_publish_single_version(_tablet_manager.get(), base_tablet_id, version + 1, txn_id).status());
+        version++;
+        txn_id++;
+    }
+
+    // Do schema change with base_tablet_read_schema and generated column expression
+    auto new_tablet_id = new_metadata->id();
+    auto alter_txn_id = txn_id++;
+    {
+        // Create base_tablet_read_schema
+        auto t_read_schema = create_base_tablet_read_schema(next_id());
+        // Keep keys unchanged (c0,c1) so schema change doesn't require sorting.
+        ASSERT_GE(t_read_schema.columns.size(), 3);
+        t_read_schema.columns[2].__set_is_key(false); // c6
+
+        TAlterTabletReqV2 request;
+        request.base_tablet_id = base_tablet_id;
+        request.new_tablet_id = new_tablet_id;
+        request.alter_version = version;
+        request.txn_id = alter_txn_id;
+
+        // Set base_tablet_read_schema
+        request.__set_base_tablet_read_schema(t_read_schema);
+
+        // Set base_table_column_names
+        request.__set_base_table_column_names({"c0", "c1", "c6", "c2", "c5", "c4"});
+
+        // Set generated column expression for c7 = c0 * 2
+        TAlterTabletMaterializedColumnReq mc_request;
+
+        std::vector<TExprNode> nodes;
+        TExprNode node;
+        node.node_type = TExprNodeType::SLOT_REF;
+        node.type = gen_type_desc(TPrimitiveType::INT);
+        node.num_children = 0;
+        TSlotRef t_slot_ref = TSlotRef();
+        t_slot_ref.slot_id = 0; // c0
+        t_slot_ref.tuple_id = 0;
+        node.__set_slot_ref(t_slot_ref);
+        node.is_nullable = true;
+        nodes.emplace_back(node);
+
+        TExpr t_expr;
+        t_expr.nodes = nodes;
+
+        std::map<int32_t, starrocks::TExpr> m_expr;
+        m_expr.insert({6, t_expr}); // c7 is at index 6 in new schema
+
+        mc_request.__set_query_globals(TQueryGlobals());
+        mc_request.__set_query_options(TQueryOptions());
+        mc_request.__set_mc_exprs(m_expr);
+
+        request.__set_materialized_column_req(mc_request);
+
+        SchemaChangeHandler handler(_tablet_manager.get());
+        ASSERT_OK(handler.process_alter_tablet(request));
+    }
+
+    // Publish schema change
+    ASSERT_OK(publish_version_for_schema_change(new_tablet_id, version + 1, alter_txn_id));
+    version++;
+
+    // Verify new tablet data
+    auto new_tablet_schema = TabletSchema::create(new_metadata->schema());
+    auto new_schema_for_read = std::make_shared<VSchema>(ChunkHelper::convert_schema(new_tablet_schema));
+
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_manager->get_tablet_metadata(new_tablet_id, version));
+    auto reader = std::make_shared<TabletReader>(_tablet_manager.get(), new_tablet_metadata, *new_schema_for_read);
+    CHECK_OK(reader->prepare());
+    CHECK_OK(reader->open(TabletReaderParams()));
+
+    auto chunk = ChunkHelper::new_chunk(*new_schema_for_read, 1024);
+    int row_count = 0;
+    while (true) {
+        auto st = reader->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        }
+        CHECK_OK(st);
+        for (int i = 0; i < chunk->num_rows(); i++) {
+            EXPECT_EQ(row_count + 1, chunk->get(i)[0].get_int32());                               // c0
+            EXPECT_EQ(fmt::format("row{}", row_count), chunk->get(i)[1].get_slice().to_string()); // c1
+            EXPECT_TRUE(chunk->get(i)[2].is_null());                                              // c6 (new, NULL)
+            EXPECT_EQ((row_count + 1) * 100, chunk->get(i)[3].get_int64());                       // c2 (INT->BIGINT)
+            EXPECT_TRUE(chunk->get(i)[4].is_null());                                              // c5 (new, NULL)
+            EXPECT_TRUE(chunk->get(i)[5].is_null());                  // c4 (new unique_id, NULL)
+            EXPECT_EQ((row_count + 1), chunk->get(i)[6].get_int32()); // c7 (generated = c0)
+            row_count++;
+        }
+        chunk->reset();
+    }
+    ASSERT_EQ(3, row_count);
+}
 
 } // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -516,6 +516,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         try (ReadLockedDatabase db = getReadLockedDatabase(dbId)) {
             OlapTable table = getTableOrThrow(db, tableId);
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE);
+            Map<Long, TTabletSchema> indexToBaseTabletReadSchema = new HashMap<>();
             for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
                 Preconditions.checkNotNull(physicalPartition, physicalPartitionId);
@@ -649,6 +650,13 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                         generatedColumnReq.setMc_exprs(mcExprs);
                     }
 
+                    TTabletSchema baseTabletReadSchema = indexToBaseTabletReadSchema.get(originIndexMetaId);
+                    if (baseTabletReadSchema == null) {
+                        baseTabletReadSchema = SchemaInfo.fromMaterializedIndex(
+                                table, originIndexMetaId, table.getIndexMetaByMetaId(originIndexMetaId)).toTabletSchema();
+                        indexToBaseTabletReadSchema.put(originIndexMetaId, baseTabletReadSchema);
+                    }
+
                     for (Tablet shadowTablet : shadowIdx.getTablets()) {
                         ComputeNode computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource,
                                 shadowTablet.getId());
@@ -662,7 +670,7 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                         AlterReplicaTask alterTask =
                                 AlterReplicaTask.alterLakeTablet(computeNode.getId(), dbId, tableId, physicalPartitionId,
                                         shadowIdxMetaId, shadowTabletId, originTabletId, visibleVersion, jobId,
-                                        watershedTxnId, generatedColumnReq);
+                                        watershedTxnId, generatedColumnReq, baseTabletReadSchema);
                         getOrCreateSchemaChangeBatchTask().addTask(alterTask);
                     }
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -20,8 +20,10 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
@@ -38,6 +40,9 @@ import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.task.AgentBatchTask;
+import com.starrocks.task.AlterReplicaTask;
+import com.starrocks.thrift.TAlterTabletReqV2;
+import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.utframe.MockedWarehouseManager;
 import com.starrocks.utframe.UtFrameUtils;
@@ -51,8 +56,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -747,6 +755,127 @@ public class LakeTableSchemaChangeJobTest {
         Assertions.assertEquals(fullSchema.size(), outputExprs.size());
         for (int i = 0; i < fullSchema.size(); i++) {
             Assertions.assertEquals(fullSchema.get(i).getType(), outputExprs.get(i).getType());
+        }
+    }
+
+    @Test
+    public void testAlterAfterFseV2() throws Exception {
+        // Create a table with multiple partitions
+        LakeTable multiPartitionTable = createTable(connectContext,
+                "CREATE TABLE t_multi_partition(c0 INT) duplicate key(c0) " +
+                        "PARTITION BY RANGE(c0) (" +
+                        "PARTITION p1 VALUES [(\"0\"), (\"100\"))," +
+                        "PARTITION p2 VALUES [(\"100\"), (\"200\"))" +
+                        ") " +
+                        "distributed by hash(c0) buckets 3");
+
+        // Alter table to add a value column which is expected to use fast schema evolution v2
+        alterTable(connectContext, "ALTER TABLE t_multi_partition ADD COLUMN c1 BIGINT");
+        // Alter table to add a generated column
+        alterTable(connectContext, "ALTER TABLE t_multi_partition ADD COLUMN c2 BIGINT AS c0 + c1");
+        LakeTableSchemaChangeJob schemaChangeJob = getAlterJob(multiPartitionTable);
+
+        // Capture AgentBatchTask objects
+        List<AgentBatchTask> capturedBatchTasks = new ArrayList<>();
+        new MockUp<LakeTableSchemaChangeJob>() {
+            @Mock
+            public void sendAgentTask(AgentBatchTask batchTask) {
+                capturedBatchTasks.add(batchTask);
+                // Mark tasks as finished to allow job to proceed
+                batchTask.getAllTasks().forEach(t -> t.setFinished(true));
+            }
+        };
+
+        schemaChangeJob.runPendingJob();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, schemaChangeJob.getJobState());
+
+        schemaChangeJob.runWaitingTxnJob();
+        Assertions.assertEquals(AlterJobV2.JobState.RUNNING, schemaChangeJob.getJobState());
+
+        schemaChangeJob.runRunningJob();
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, schemaChangeJob.getJobState());
+
+        // Verify that we captured at least one batch task
+        Assertions.assertFalse(capturedBatchTasks.isEmpty(), "Should have captured at least one AgentBatchTask");
+
+        // Extract all AlterReplicaTask objects
+        List<AlterReplicaTask> alterReplicaTasks = new ArrayList<>();
+        for (AgentBatchTask batchTask : capturedBatchTasks) {
+            for (com.starrocks.task.AgentTask agentTask : batchTask.getAllTasks()) {
+                if (agentTask instanceof AlterReplicaTask) {
+                    alterReplicaTasks.add((AlterReplicaTask) agentTask);
+                }
+            }
+        }
+
+        Assertions.assertFalse(alterReplicaTasks.isEmpty(), "Should have at least one AlterReplicaTask");
+
+        // Get table and TabletInvertedIndex for verification
+        OlapTable tbl = (OlapTable) multiPartitionTable;
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+
+        // Group tasks by originIndexId (the index ID of the origin tablet)
+        Map<Long, List<AlterReplicaTask>> tasksByOriginIndexId = new HashMap<>();
+        Map<Long, TTabletSchema> expectedSchemasByIndexId = new HashMap<>();
+
+        for (AlterReplicaTask task : alterReplicaTasks) {
+            // Verify baseTabletReadSchema is not null
+            TAlterTabletReqV2 request = task.toThrift();
+            Assertions.assertTrue(request.isSetBase_tablet_read_schema(),
+                    "base_tablet_read_schema should be set for tablet " + task.getBaseTabletId());
+            Assertions.assertNotNull(request.getBase_tablet_read_schema(),
+                    "base_tablet_read_schema should not be null for tablet " + task.getBaseTabletId());
+
+            // Get originIndexId from TabletInvertedIndex using baseTabletId
+            TabletMeta tabletMeta = invertedIndex.getTabletMeta(task.getBaseTabletId());
+            Assertions.assertNotNull(tabletMeta, "TabletMeta should exist for tablet " + task.getBaseTabletId());
+            long originIndexId = tabletMeta.getIndexId();
+
+            // Group tasks by originIndexId
+            tasksByOriginIndexId.computeIfAbsent(originIndexId, k -> new ArrayList<>()).add(task);
+
+            // Create expected schema if not already created
+            if (!expectedSchemasByIndexId.containsKey(originIndexId)) {
+                TTabletSchema expectedSchema = SchemaInfo.fromMaterializedIndex(
+                        tbl, originIndexId, tbl.getIndexMetaByMetaId(originIndexId)).toTabletSchema();
+                expectedSchemasByIndexId.put(originIndexId, expectedSchema);
+            }
+        }
+
+        // Verify that tasks with the same originIndexId use the same baseTabletReadSchema
+        for (Map.Entry<Long, List<AlterReplicaTask>> entry : tasksByOriginIndexId.entrySet()) {
+            long originIndexId = entry.getKey();
+            List<AlterReplicaTask> tasks = entry.getValue();
+            TTabletSchema expectedSchema = expectedSchemasByIndexId.get(originIndexId);
+
+            Assertions.assertNotNull(expectedSchema, "Expected schema should exist for index " + originIndexId);
+
+            // Verify all tasks for this index use the same schema
+            for (AlterReplicaTask task : tasks) {
+                TAlterTabletReqV2 request = task.toThrift();
+                TTabletSchema actualSchema = request.getBase_tablet_read_schema();
+
+                // Verify schema ID matches
+                Assertions.assertEquals(expectedSchema.getId(), actualSchema.getId(),
+                        "Schema ID should match for index " + originIndexId);
+                Assertions.assertEquals(expectedSchema.getKeys_type(), actualSchema.getKeys_type(),
+                        "Keys type should match for index " + originIndexId);
+                Assertions.assertEquals(expectedSchema.getShort_key_column_count(),
+                        actualSchema.getShort_key_column_count(),
+                        "Short key column count should match for index " + originIndexId);
+                Assertions.assertEquals(expectedSchema.getColumns().size(), actualSchema.getColumns().size(),
+                        "Column count should match for index " + originIndexId);
+            }
+        }
+
+        // Verify that different originIndexId use different schemas (if there are multiple indices)
+        if (tasksByOriginIndexId.size() > 1) {
+            List<Long> indexIds = new ArrayList<>(tasksByOriginIndexId.keySet());
+            TTabletSchema schema1 = expectedSchemasByIndexId.get(indexIds.get(0));
+            TTabletSchema schema2 = expectedSchemasByIndexId.get(indexIds.get(1));
+            // They might have the same schema if they're from the same origin index, but structure should be correct
+            Assertions.assertNotNull(schema1);
+            Assertions.assertNotNull(schema2);
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/task/AlterReplicaTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AlterReplicaTaskTest.java
@@ -57,7 +57,7 @@ public class AlterReplicaTaskTest {
     @Test
     public void testAlterLakeTablet() {
         AlterReplicaTask task = AlterReplicaTask.alterLakeTablet(1, 2, 3, 4, 5, 6,
-                7, 8, 9, 10, null);
+                7, 8, 9, 10, null, null);
 
         Assertions.assertEquals(1, task.getBackendId());
         Assertions.assertEquals(2, task.getDbId());

--- a/fe/fe-core/src/test/java/com/starrocks/task/AlterReplicaTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AlterReplicaTaskTest.java
@@ -16,12 +16,21 @@
 package com.starrocks.task;
 
 import com.starrocks.alter.AlterJobV2;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.SchemaInfo;
+import com.starrocks.sql.ast.KeysType;
 import com.starrocks.thrift.TAlterTabletReqV2;
+import com.starrocks.thrift.TColumn;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTabletType;
+import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 public class AlterReplicaTaskTest {
 
@@ -55,31 +64,6 @@ public class AlterReplicaTaskTest {
     }
 
     @Test
-    public void testAlterLakeTablet() {
-        AlterReplicaTask task = AlterReplicaTask.alterLakeTablet(1, 2, 3, 4, 5, 6,
-                7, 8, 9, 10, null, null);
-
-        Assertions.assertEquals(1, task.getBackendId());
-        Assertions.assertEquals(2, task.getDbId());
-        Assertions.assertEquals(3, task.getTableId());
-        Assertions.assertEquals(4, task.getPartitionId());
-        Assertions.assertEquals(5, task.getIndexId());
-        Assertions.assertEquals(6, task.getTabletId());
-        Assertions.assertEquals(7, task.getBaseTabletId());
-        Assertions.assertEquals(8, task.getVersion());
-        Assertions.assertEquals(9, task.getJobId());
-        Assertions.assertEquals(AlterJobV2.JobType.SCHEMA_CHANGE, task.getJobType());
-
-        TAlterTabletReqV2 request = task.toThrift();
-        Assertions.assertEquals(7, request.base_tablet_id);
-        Assertions.assertEquals(6, request.new_tablet_id);
-        Assertions.assertEquals(8, request.alter_version);
-        Assertions.assertEquals(10, request.txn_id);
-        Assertions.assertFalse(request.isSetMaterialized_view_params());
-        Assertions.assertEquals(TTabletType.TABLET_TYPE_LAKE, request.tablet_type);
-    }
-
-    @Test
     public void testRollupLocalTablet() {
         AlterReplicaTask task = AlterReplicaTask.rollupLocalTablet(1, 2, 3, 4, 5, 6,
                 7, 8, 9, 10, 11, 12, null, null);
@@ -106,4 +90,146 @@ public class AlterReplicaTaskTest {
         Assertions.assertEquals(11, request.alter_version);
         Assertions.assertEquals(TTabletType.TABLET_TYPE_DISK, request.tablet_type);
     }
+
+    private TTabletSchema createTestTabletSchema(long schemaId, List<Column> columns) {
+        return SchemaInfo.newBuilder()
+                .setId(schemaId)
+                .setKeysType(KeysType.DUP_KEYS)
+                .setShortKeyColumnCount((short) 1)
+                .setSchemaHash(0)
+                .setStorageType(TStorageType.COLUMN)
+                .addColumns(columns)
+                .build()
+                .toTabletSchema();
+    }
+
+    @Test
+    public void testAlterLakeTablet() {
+        // Create test columns
+        List<Column> columns = new ArrayList<>();
+        columns.add(new Column("k1", IntegerType.INT, false, null, "", ""));
+        columns.add(new Column("v1", IntegerType.BIGINT, false, null, "", ""));
+
+        // Create TTabletSchema
+        TTabletSchema baseTabletReadSchema = createTestTabletSchema(10001L, columns);
+
+        // Create AlterReplicaTask with baseTabletReadSchema
+        AlterReplicaTask task = AlterReplicaTask.alterLakeTablet(100, 200, 300, 400, 500, 600,
+                700, 800, 900, 1000, null, baseTabletReadSchema);
+
+        // Verify field initialization
+        Assertions.assertEquals(100, task.getBackendId());
+        Assertions.assertEquals(200, task.getDbId());
+        Assertions.assertEquals(300, task.getTableId());
+        Assertions.assertEquals(400, task.getPartitionId());
+        Assertions.assertEquals(500, task.getIndexId());
+        Assertions.assertEquals(600, task.getTabletId());
+        Assertions.assertEquals(700, task.getBaseTabletId());
+        Assertions.assertEquals(800, task.getVersion());
+        Assertions.assertEquals(900, task.getJobId());
+        Assertions.assertEquals(AlterJobV2.JobType.SCHEMA_CHANGE, task.getJobType());
+
+        // Verify LakeTablet constructor sets replica/schema hash to -1
+        Assertions.assertEquals(-1, task.getNewReplicaId());
+        Assertions.assertEquals(-1, task.getNewSchemaHash());
+        Assertions.assertEquals(-1, task.getBaseSchemaHash());
+
+        // Verify toThrift() sets base_tablet_read_schema and preserves other fields
+        TAlterTabletReqV2 request = task.toThrift();
+        
+        // Verify other fields are preserved
+        Assertions.assertEquals(700, request.base_tablet_id);
+        Assertions.assertEquals(600, request.new_tablet_id);
+        Assertions.assertEquals(800, request.alter_version);
+        Assertions.assertEquals(1000, request.txn_id);
+        Assertions.assertEquals(900, request.job_id);
+        Assertions.assertEquals(TTabletType.TABLET_TYPE_LAKE, request.tablet_type);
+        Assertions.assertEquals(com.starrocks.thrift.TAlterJobType.SCHEMA_CHANGE, request.alter_job_type);
+
+        // Verify baseTabletReadSchema is set and initialized correctly (TC-3, TC-5)
+        Assertions.assertTrue(request.isSetBase_tablet_read_schema());
+        Assertions.assertNotNull(request.getBase_tablet_read_schema());
+        TTabletSchema schema = request.getBase_tablet_read_schema();
+        
+        // Verify schema properties
+        Assertions.assertEquals(10001L, schema.getId());
+        Assertions.assertNotNull(schema.getKeys_type());
+        Assertions.assertEquals(1, schema.getShort_key_column_count());
+        Assertions.assertEquals(0, schema.getSchema_hash());
+        Assertions.assertEquals(TStorageType.COLUMN, schema.getStorage_type());
+        Assertions.assertEquals(2, schema.getColumns().size());
+        List<TColumn> tColumns = schema.getColumns();
+        Assertions.assertEquals("k1", tColumns.get(0).getColumn_name());
+        Assertions.assertEquals("v1", tColumns.get(1).getColumn_name());
+
+        // Verify tablet type is set to LAKE
+        Assertions.assertEquals(TTabletType.TABLET_TYPE_LAKE, request.tablet_type);
+    }
+
+    @Test
+    public void testRollupLakeTablet() {
+        // Create test columns
+        List<Column> columns = new ArrayList<>();
+        columns.add(new Column("k1", IntegerType.INT, false, null, "", ""));
+        columns.add(new Column("v1", IntegerType.BIGINT, false, null, "", ""));
+
+        // Create TTabletSchema
+        TTabletSchema baseTabletReadSchema = createTestTabletSchema(10002L, columns);
+
+        // Create RollupJobV2Params (can be null for this test)
+        AlterReplicaTask.RollupJobV2Params rollupJobV2Params = null;
+
+        // Create AlterReplicaTask with baseTabletReadSchema
+        AlterReplicaTask task = AlterReplicaTask.rollupLakeTablet(100, 200, 300, 400, 500, 600,
+                700, 800, 900, rollupJobV2Params, baseTabletReadSchema, 1000);
+
+        // Verify field initialization
+        Assertions.assertEquals(100, task.getBackendId());
+        Assertions.assertEquals(200, task.getDbId());
+        Assertions.assertEquals(300, task.getTableId());
+        Assertions.assertEquals(400, task.getPartitionId());
+        Assertions.assertEquals(500, task.getIndexId());
+        Assertions.assertEquals(600, task.getTabletId());
+        Assertions.assertEquals(700, task.getBaseTabletId());
+        Assertions.assertEquals(800, task.getVersion());
+        Assertions.assertEquals(900, task.getJobId());
+        Assertions.assertEquals(AlterJobV2.JobType.ROLLUP, task.getJobType());
+
+        // Verify LakeTablet constructor sets replica/schema hash to -1
+        Assertions.assertEquals(-1, task.getNewReplicaId());
+        Assertions.assertEquals(-1, task.getNewSchemaHash());
+        Assertions.assertEquals(-1, task.getBaseSchemaHash());
+
+        // Verify toThrift() sets base_tablet_read_schema and preserves other fields
+        TAlterTabletReqV2 request = task.toThrift();
+        
+        // Verify other fields are preserved
+        Assertions.assertEquals(700, request.base_tablet_id);
+        Assertions.assertEquals(600, request.new_tablet_id);
+        Assertions.assertEquals(800, request.alter_version);
+        Assertions.assertEquals(1000, request.txn_id);
+        Assertions.assertEquals(900, request.job_id);
+        Assertions.assertEquals(TTabletType.TABLET_TYPE_LAKE, request.tablet_type);
+        Assertions.assertEquals(com.starrocks.thrift.TAlterJobType.ROLLUP, request.alter_job_type);
+
+        // Verify baseTabletReadSchema is set and initialized correctly
+        Assertions.assertTrue(request.isSetBase_tablet_read_schema());
+        Assertions.assertNotNull(request.getBase_tablet_read_schema());
+        TTabletSchema schema = request.getBase_tablet_read_schema();
+        
+        // Verify schema properties
+        Assertions.assertEquals(10002L, schema.getId());
+        Assertions.assertNotNull(schema.getKeys_type());
+        Assertions.assertEquals(1, schema.getShort_key_column_count());
+        Assertions.assertEquals(0, schema.getSchema_hash());
+        Assertions.assertEquals(TStorageType.COLUMN, schema.getStorage_type());
+        Assertions.assertEquals(2, schema.getColumns().size());
+        List<TColumn> tColumns = schema.getColumns();
+        Assertions.assertEquals("k1", tColumns.get(0).getColumn_name());
+        Assertions.assertEquals("v1", tColumns.get(1).getColumn_name());
+
+        // Verify tablet type is set to LAKE
+        Assertions.assertEquals(TTabletType.TABLET_TYPE_LAKE, request.tablet_type);
+    }
+
 }

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -186,12 +186,24 @@ struct TAlterTabletReqV2 {
     11: optional i64 job_id
     12: optional InternalService.TQueryGlobals query_globals
     13: optional InternalService.TQueryOptions query_options
+    // This field is used for shared-nothing fast schema evolution, and shared-data use base_tablet_read_schema instead.
     14: optional list<Descriptors.TColumn> columns
     // synchronized materialized view parameters
     15: optional TAlterJobType alter_job_type = TAlterJobType.SCHEMA_CHANGE
     16: optional Descriptors.TDescriptorTable desc_tbl
     17: optional Exprs.TExpr where_expr
     18: optional list<string> base_table_column_names 
+    // Schema from FE catalog for reading data from base tablet in shared-data. This may be newer than the schema stored
+    // in tablet metadata in Fast Schema Evolution v2 scenario. Must use this schema to read data, otherwise correctness
+    // issues may occur. Why shared-data doesn't reuse the 'columns' field from shared-nothing:
+    // 1. shared-nothing only sends columns, requiring BE to construct complete schema (complex, not extensible).
+    //    For example, shared-nothing assumes adding key columns won't trigger fast schema evolution,
+    //    so BE won't rebuild sort key when constructing schema. This would cause issues in shared-data,
+    //    where fast schema evolution supports adding key columns, requiring complete schema info.
+    // 2. In shared-data's original fast schema evolution (non-v2), columns were meaningless since FE catalog
+    //    schema matches tablet metadata schema. base_tablet_read_schema can directly replace columns;
+    //    old BE will fall back to tablet metadata schema if columns are missing, with no compatibility impact.
+    19: optional TTabletSchema base_tablet_read_schema
 }
 
 struct TClusterInfo {

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2283,7 +2283,7 @@ class StarrocksSQLApiLib(object):
         sleep_time = 0
         while True:
             res = self.execute_sql(
-                "SHOW ALTER TABLE %s ORDER BY CreateTime DESC LIMIT 1" % alter_type,
+                "SHOW ALTER TABLE %s ORDER BY JobId DESC LIMIT 1" % alter_type,
                 True,
             )
             if (not res["status"]) or len(res["result"]) <= 0:

--- a/test/sql/test_cloud_fse_v2/R/test_fse_v2_generated_column
+++ b/test/sql/test_cloud_fse_v2/R/test_fse_v2_generated_column
@@ -1,0 +1,64 @@
+-- name: test_fse_v2_generated_column @cloud
+create database test_gen_col_${uuid0};
+-- result:
+-- !result
+use test_gen_col_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t_gen` (
+    k1 int,
+    v0 int,
+    v1 int
+)
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO t_gen VALUES (1, 1, 1);
+-- result:
+-- !result
+ALTER TABLE t_gen DROP COLUMN v0;
+-- result:
+-- !result
+ALTER TABLE t_gen ADD COLUMN v0 int default '10';
+-- result:
+-- !result
+SELECT * FROM t_gen ORDER BY k1;
+-- result:
+1	1	10
+-- !result
+ALTER TABLE t_gen ADD COLUMN v2 bigint AS v0+v1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT k1, v0, v1, v2 FROM t_gen ORDER BY k1;
+-- result:
+1	10	1	11
+-- !result
+INSERT INTO t_gen (k1, v1) VALUES (2, 2);
+-- result:
+-- !result
+SELECT k1, v0, v1, v2 FROM t_gen ORDER BY k1;
+-- result:
+1	10	1	11
+2	10	2	12
+-- !result
+INSERT INTO t_gen (k1, v0, v1) VALUES (3, 20, 3);
+-- result:
+-- !result
+SELECT k1, v0, v1, v2 FROM t_gen ORDER BY k1;
+-- result:
+1	10	1	11
+2	10	2	12
+3	20	3	23
+-- !result
+SELECT k1, v0, v1, v2, (v0 + v1) as expected_v2 FROM t_gen ORDER BY k1;
+-- result:
+1	10	1	11	11
+2	10	2	12	12
+3	20	3	23	23
+-- !result

--- a/test/sql/test_cloud_fse_v2/R/test_fse_v2_sync_mv
+++ b/test/sql/test_cloud_fse_v2/R/test_fse_v2_sync_mv
@@ -1,0 +1,63 @@
+-- name: test_fse_v2_sync_mv @cloud
+create database test_sync_mv_${uuid0};
+-- result:
+-- !result
+use test_sync_mv_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t` (
+    k1 int,
+    v0 int,
+    v1 int
+)
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO t VALUES (1, 1, 1);
+-- result:
+-- !result
+ALTER TABLE t ADD COLUMN v2 int;
+-- result:
+-- !result
+ALTER TABLE t DROP COLUMN v0;
+-- result:
+-- !result
+ALTER TABLE t ADD COLUMN v0 string;
+-- result:
+-- !result
+SELECT * FROM t ORDER BY k1;
+-- result:
+1	1	None	None
+-- !result
+CREATE MATERIALIZED VIEW mv AS
+SELECT k1, v0, v1 FROM t;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+SELECT * FROM mv [_SYNC_MV_] ORDER BY k1;
+-- result:
+1	None	1
+-- !result
+INSERT INTO t (k1, v1, v0) VALUES (2, 2, 'test');
+-- result:
+-- !result
+SELECT * FROM t ORDER BY k1;
+-- result:
+1	1	None	None
+2	2	None	test
+-- !result
+SELECT * FROM mv [_SYNC_MV_] ORDER BY k1;
+-- result:
+1	None	1
+2	test	2
+-- !result
+SELECT k1, v0, v1 FROM t ORDER BY k1;
+-- result:
+1	None	1
+2	test	2
+-- !result

--- a/test/sql/test_cloud_fse_v2/T/test_fse_v2_generated_column
+++ b/test/sql/test_cloud_fse_v2/T/test_fse_v2_generated_column
@@ -1,0 +1,42 @@
+-- name: test_fse_v2_generated_column @cloud
+create database test_gen_col_${uuid0};
+use test_gen_col_${uuid0};
+
+CREATE TABLE `t_gen` (
+    k1 int,
+    v0 int,
+    v1 int
+)
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO t_gen VALUES (1, 1, 1);
+
+ALTER TABLE t_gen DROP COLUMN v0;
+
+ALTER TABLE t_gen ADD COLUMN v0 int default '10';
+
+-- Verify table structure and data after schema changes
+SELECT * FROM t_gen ORDER BY k1;
+
+-- Create generated column using v0 and v1
+ALTER TABLE t_gen ADD COLUMN v2 bigint AS v0+v1;
+function: wait_alter_table_finish()
+
+-- Verify the generated column can be queried and values are correct
+-- For existing row: v0 should be 10 (default), v1 is 1, so v2 should be 11
+SELECT k1, v0, v1, v2 FROM t_gen ORDER BY k1;
+
+-- Insert more data to verify generated column works correctly
+-- New row: v0 will be 10 (default), v1 is 2, so v2 should be 12
+INSERT INTO t_gen (k1, v1) VALUES (2, 2);
+SELECT k1, v0, v1, v2 FROM t_gen ORDER BY k1;
+
+-- Insert data with explicit v0 value
+-- New row: v0 is 20, v1 is 3, so v2 should be 23
+INSERT INTO t_gen (k1, v0, v1) VALUES (3, 20, 3);
+SELECT k1, v0, v1, v2 FROM t_gen ORDER BY k1;
+
+-- Verify generated column expression is correct: v2 = v0 + v1
+SELECT k1, v0, v1, v2, (v0 + v1) as expected_v2 FROM t_gen ORDER BY k1;

--- a/test/sql/test_cloud_fse_v2/T/test_fse_v2_sync_mv
+++ b/test/sql/test_cloud_fse_v2/T/test_fse_v2_sync_mv
@@ -1,0 +1,41 @@
+-- name: test_fse_v2_sync_mv @cloud
+create database test_sync_mv_${uuid0};
+use test_sync_mv_${uuid0};
+
+CREATE TABLE `t` (
+    k1 int,
+    v0 int,
+    v1 int
+)
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO t VALUES (1, 1, 1);
+
+ALTER TABLE t ADD COLUMN v2 int;
+
+ALTER TABLE t DROP COLUMN v0;
+
+ALTER TABLE t ADD COLUMN v0 string;
+
+-- Verify table structure and data after schema changes
+SELECT * FROM t ORDER BY k1;
+
+-- Create materialized view using k1, v0, v1
+CREATE MATERIALIZED VIEW mv AS
+SELECT k1, v0, v1 FROM t;
+function: wait_materialized_view_finish()
+
+-- Verify the materialized view can be queried
+SELECT * FROM mv [_SYNC_MV_] ORDER BY k1;
+
+-- Insert more data to verify MV works correctly
+-- After schema changes, column order is: k1, v1, v2, v0
+INSERT INTO t (k1, v1, v0) VALUES (2, 2, 'test');
+SELECT * FROM t ORDER BY k1;
+SELECT * FROM mv [_SYNC_MV_] ORDER BY k1;
+
+-- Verify data correctness: original row should have NULL for v0 (string type)
+-- and new row should have 'test' for v0
+SELECT k1, v0, v1 FROM t ORDER BY k1;


### PR DESCRIPTION
## Why I'm doing:
When performing sync materialized view creation and traditional schema evolution, BE needs to read data from the base tablet. If FSE v2 happened before, FE schema may be newer than the schema stored in base tablet metadata.  BE needs to use the latest schema to read data, otherwise may cause crash or data correctness issues.

## What I'm doing:
- Pass FE newest schema to BE for traditional schema change / sync mv via a new thrift field `base_tablet_read_schema`.
- In FE, build and attach `TTabletSchema` (per base index) when generating `AlterReplicaTask` for lake alter/rollup jobs.
- In BE lake schema change, prefer `request.base_tablet_read_schema` (with cache) for:
  - building the chunk read schema
  - `TabletReader` construction
  - column-name derivation and request parsing
  - fallback to tablet-metadata schema when the field is not set (compatible behavior).

Fix https://github.com/StarRocks/StarRocksTest/issues/10792
Fix https://github.com/StarRocks/starrocks/issues/65706

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures correct data reads under Fast Schema Evolution v2 by wiring FE catalog schema to BE for lake schema change and sync MV.
> 
> - New thrift field `base_tablet_read_schema` (shared-data) passed in `TAlterTabletReqV2`; BE caches/uses it, falls back to tablet metadata when absent
> - FE builds and attaches per-base-index `TTabletSchema` in `LakeTableSchemaChangeJob` and `LakeRollupJob`; `AlterReplicaTask` updated (new lake constructors, `toThrift` includes schema)
> - BE `schema_change.cpp`: convert/read using `base_tablet_read_schema` for chunk schema, `TabletReader`, column-name derivation, and request parsing; propagate through Direct/Sorted paths
> - Tests: new BE unit tests for fallback/MV/generated columns; FE tests for task wiring; SQL tests for generated column and sync MV; minor test helper tweak (alter-table wait by JobId)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5612de7e48e1d1ea0573c325acb7afb05862a946. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->