### PR TITLE
[Enhancement] Support aggregate topn runtime filter

### DIFF
--- a/be/src/exec/agg_runtime_filter_builder.cpp
+++ b/be/src/exec/agg_runtime_filter_builder.cpp
@@ -232,7 +232,9 @@ struct AggTopNRuntimeFilterUpdaterImpl {
                     continue;
                 }
                 auto val = column_data[i];
-                if (Comp()(val, heap_builder->top())) {
+                if (heap_builder->size() < limit) {
+                    heap_builder->push(std::move(val));
+                } else if (Comp()(val, heap_builder->top())) {
                     heap_builder->replace_top(std::move(val));
                 }
             }
@@ -244,7 +246,9 @@ struct AggTopNRuntimeFilterUpdaterImpl {
                     continue;
                 }
                 auto val = column_data[i];
-                if (Comp()(val, heap_builder->top())) {
+                if (heap_builder->size() < limit) {
+                    heap_builder->push(std::move(val));
+                } else if (Comp()(val, heap_builder->top())) {
                     heap_builder->replace_top(std::move(val));
                 }
             }

--- a/be/src/exec/agg_runtime_filter_builder.cpp
+++ b/be/src/exec/agg_runtime_filter_builder.cpp
@@ -106,4 +106,174 @@ bool AggInRuntimeFilterMerger::merge(size_t seq, RuntimeFilterBuildDescriptor* d
     return false;
 }
 
+struct AggTopRuntimeFilterBuilderImpl {
+    template <LogicalType ltype>
+    std::pair<RuntimeFilter*, HeapBuilder*> operator()(ObjectPool* pool, Aggregator* aggregator,
+                                                       size_t build_expr_order, size_t limit, bool asc,
+                                                       bool is_nulls_first) {
+        using CppType = RunTimeCppType<ltype>;
+        if (asc) {
+            // for ascending order, we use max heap to build the topn runtime filter
+            return build<ltype, std::less<CppType>, true>(pool, aggregator, build_expr_order, limit, asc,
+                                                          is_nulls_first);
+        } else {
+            return build<ltype, std::greater<CppType>, false>(pool, aggregator, build_expr_order, limit, asc,
+                                                              is_nulls_first);
+        }
+    }
+
+    template <LogicalType ltype, class Comp, bool isAsc>
+    std::pair<RuntimeFilter*, HeapBuilder*> build(ObjectPool* pool, Aggregator* aggregator, size_t build_expr_order,
+                                                  size_t limit, bool asc, bool is_nulls_first) {
+        using CppType = RunTimeCppType<ltype>;
+        // build the runtime filter for the topn runtime filter
+        RuntimeFilter* runtime_filter = MinMaxRuntimeFilter<ltype>::create_full_range_with_null(pool);
+        // build the heap builder for the topn runtime filter
+        auto* heap_builder = new THeapBuilder<ltype, Comp>(Comp());
+        pool->add(heap_builder);
+
+        auto& hash_map_variant = aggregator->hash_map_variant();
+        hash_map_variant.visit([&](auto& variant_value) {
+            auto& hash_map_with_key = *variant_value;
+            using HashMapWithKey = std::remove_reference_t<decltype(hash_map_with_key)>;
+            using ResultVector = typename HashMapWithKey::ResultVector;
+            auto& hash_map = hash_map_with_key.hash_map;
+            const size_t hash_map_size = hash_map_variant.size();
+            MutableColumns group_by_columns = aggregator->create_group_by_columns(hash_map_size);
+            {
+                ResultVector result_vector;
+                result_vector.resize(hash_map_size);
+                auto it = hash_map.begin();
+                auto end = hash_map.end();
+                size_t read_index = 0;
+                while (it != end) {
+                    result_vector[read_index++] = it->first;
+                    ++it;
+                }
+                if (read_index > 0) {
+                    hash_map_with_key.insert_keys_to_columns(result_vector, group_by_columns, read_index);
+                }
+                if constexpr (HashMapWithKey::has_single_null_key) {
+                    if (hash_map_with_key.null_key_data != nullptr) {
+                        DCHECK(group_by_columns.size() == 1);
+                        group_by_columns[build_expr_order]->append_default();
+                    }
+                }
+                update_runtime_filter<ltype, Comp, isAsc>(heap_builder, runtime_filter, pool,
+                                                          group_by_columns[build_expr_order].get(), limit);
+            }
+        });
+        return std::make_pair(runtime_filter, heap_builder);
+    }
+
+    template <LogicalType ltype, class Comp, bool isAsc>
+    void update_runtime_filter(HeapBuilder* heap, RuntimeFilter* rf, ObjectPool* pool, const Column* column,
+                               size_t limit) {
+        auto heap_builder = down_cast<THeapBuilder<ltype, Comp>*>(heap);
+        if (column->is_nullable()) {
+            auto nullable = down_cast<const NullableColumn*>(column);
+            const auto& null_data = nullable->null_column_data();
+            const auto& column_data = GetContainer<ltype>::get_data(nullable->data_column());
+            size_t num_rows = column->size();
+            for (size_t i = 0; i < num_rows; ++i) {
+                if (null_data[i]) {
+                    continue;
+                }
+                auto val = column_data[i];
+                if (heap_builder->size() < limit) {
+                    heap_builder->push(std::move(val));
+                } else if (Comp()(val, heap_builder->top())) {
+                    heap_builder->replace_top(std::move(val));
+                }
+            }
+        } else {
+            const auto& column_data = GetContainer<ltype>::get_data(column);
+            size_t num_rows = column->size();
+            for (size_t i = 0; i < num_rows; ++i) {
+                auto val = column_data[i];
+                if (heap_builder->size() < limit) {
+                    heap_builder->push(std::move(val));
+                } else if (Comp()(val, heap_builder->top())) {
+                    heap_builder->replace_top(std::move(val));
+                }
+            }
+        }
+        if (heap_builder->size() > 0) {
+            down_cast<MinMaxRuntimeFilter<ltype>*>(rf)->template update_min_max<!isAsc>(heap_builder->top());
+        }
+    }
+};
+
+// After build the topn runtime filter, we need to update the runtime filter with the new group keys.
+struct AggTopNRuntimeFilterUpdaterImpl {
+    template <LogicalType ltype>
+    void operator()(HeapBuilder* heap, RuntimeFilter* rf, const Columns& group_by_columns, const Filter& selection,
+                    size_t build_expr_order, size_t limit, bool asc, bool is_nulls_first) {
+        using CppType = RunTimeCppType<ltype>;
+        if (asc) {
+            // for ascending order, we use max heap to build the topn runtime filter
+            update_runtime_filter_with_selection<ltype, std::less<CppType>, true>(
+                    heap, rf, group_by_columns[build_expr_order].get(), limit, selection);
+        } else {
+            update_runtime_filter_with_selection<ltype, std::greater<CppType>, false>(
+                    heap, rf, group_by_columns[build_expr_order].get(), limit, selection);
+        }
+    }
+
+    template <LogicalType ltype, class Comp, bool isAsc>
+    void update_runtime_filter_with_selection(HeapBuilder* heap, RuntimeFilter* rf, const Column* column, size_t limit,
+                                              const Filter& selection) {
+        auto heap_builder = down_cast<THeapBuilder<ltype, Comp>*>(heap);
+        if (column->is_nullable()) {
+            auto* nullable = down_cast<const NullableColumn*>(column);
+            const auto& null_data = nullable->null_column_data();
+            const auto& column_data = GetContainer<ltype>::get_data(nullable->data_column());
+            size_t num_rows = column->size();
+            for (size_t i = 0; i < num_rows; ++i) {
+                if (selection[i] == 0 || null_data[i]) {
+                    continue;
+                }
+                auto val = column_data[i];
+                if (Comp()(val, heap_builder->top())) {
+                    heap_builder->replace_top(std::move(val));
+                }
+            }
+        } else {
+            const auto& column_data = GetContainer<ltype>::get_data(column);
+            size_t num_rows = column->size();
+            for (size_t i = 0; i < num_rows; ++i) {
+                if (selection[i] == 0) {
+                    continue;
+                }
+                auto val = column_data[i];
+                if (Comp()(val, heap_builder->top())) {
+                    heap_builder->replace_top(std::move(val));
+                }
+            }
+        }
+        if (heap_builder->size() > 0) {
+            down_cast<MinMaxRuntimeFilter<ltype>*>(rf)->template update_min_max<!isAsc>(heap_builder->top());
+        }
+    }
+};
+
+RuntimeFilter* AggTopNRuntimeFilterBuilder::build(Aggregator* aggretator, ObjectPool* pool) {
+    // build the runtime filter and heap builder for the topn runtime filter
+    auto [runtime_filter, heap_builder] = type_dispatch_predicate<std::pair<RuntimeFilter*, HeapBuilder*>>(
+            _type, false, AggTopRuntimeFilterBuilderImpl(), pool, aggretator, _build_desc->build_expr_order(),
+            _build_desc->limit(), _build_desc->is_asc(), _build_desc->is_nulls_first());
+    // store the runtime filter, heap builder, and pool
+    _runtime_filter = runtime_filter;
+    _heap_builder = heap_builder;
+    return runtime_filter;
+}
+
+void AggTopNRuntimeFilterBuilder::update(const Columns& group_by_columns, const Filter& selection) {
+    DCHECK(_heap_builder != nullptr) << "Heap builder is not built";
+    DCHECK(_runtime_filter != nullptr) << "Runtime filter is not built";
+    type_dispatch_predicate<void>(_type, false, AggTopNRuntimeFilterUpdaterImpl(), _heap_builder, _runtime_filter,
+                                  group_by_columns, selection, _build_desc->build_expr_order(), _build_desc->limit(),
+                                  _build_desc->is_asc(), _build_desc->is_nulls_first());
+}
+
 } // namespace starrocks

--- a/be/src/exec/agg_runtime_filter_builder.cpp
+++ b/be/src/exec/agg_runtime_filter_builder.cpp
@@ -126,6 +126,7 @@ struct AggTopRuntimeFilterBuilderImpl {
     std::pair<RuntimeFilter*, HeapBuilder*> build(ObjectPool* pool, Aggregator* aggregator, size_t build_expr_order,
                                                   size_t limit, bool asc, bool is_nulls_first) {
         using CppType = RunTimeCppType<ltype>;
+        // TODO: we can use is_nulls_first to determine whether to create the runtime filter with null or not later.
         RuntimeFilter* runtime_filter = MinMaxRuntimeFilter<ltype>::create_full_range_with_null(pool);
         auto* heap_builder = new THeapBuilder<ltype, Comp>(Comp());
         pool->add(heap_builder);

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -939,6 +939,9 @@ Status Aggregator::compute_batch_agg_states_with_selection(Chunk* chunk, size_t 
 }
 
 RuntimeFilter* Aggregator::build_in_filters(RuntimeState* state, RuntimeFilterBuildDescriptor* desc) {
+    if (desc->type() != TRuntimeFilterBuildType::AGG_FILTER) {
+        return nullptr;
+    }
     int expr_order = desc->build_expr_order();
     const auto& group_type_type = _group_by_types[expr_order].result_type.type;
     AggInRuntimeFilterBuilder in_builder(desc, group_type_type);
@@ -946,6 +949,9 @@ RuntimeFilter* Aggregator::build_in_filters(RuntimeState* state, RuntimeFilterBu
 }
 
 RuntimeFilter* Aggregator::build_topn_filters(RuntimeState* state, RuntimeFilterBuildDescriptor* desc) {
+    if (desc->type() != TRuntimeFilterBuildType::TOPN_FILTER) {
+        return nullptr;
+    }
     int expr_order = desc->build_expr_order();
     const auto& group_type_type = _group_by_types[expr_order].result_type.type;
     // only build when group by keys's size is less than limit

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -957,7 +957,6 @@ RuntimeFilter* Aggregator::build_topn_filters(RuntimeState* state, RuntimeFilter
         // for the first time to build the topn runtime filter
         _topn_runtime_filter_builder = new AggTopNRuntimeFilterBuilder(desc, group_type_type);
         _pool->add(_topn_runtime_filter_builder);
-
         return _topn_runtime_filter_builder->build(this, state->obj_pool());
     } else {
         return _topn_runtime_filter_builder->runtime_filter();
@@ -1655,7 +1654,7 @@ void Aggregator::build_hash_map_with_topn_runtime_filter(size_t chunk_size) {
                                                                         AllocateState<MapType>(this), &_tmp_agg_states,
                                                                         &_streaming_selection);
     });
-    // if _streaming_selection is not all 0, means there are some group keys not found,
+    // if _streaming_selection is not all 0, means there are new group by keys,
     // we need to build the topn runtime filter
     if (_topn_runtime_filter_builder != nullptr &&
         SIMD::count_zero(_streaming_selection.data(), chunk_size) != chunk_size) {

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -44,6 +44,7 @@
 
 namespace starrocks {
 class RuntimeFilter;
+class AggTopNRuntimeFilterBuilder;
 class AggInRuntimeFilterMerger;
 struct HashTableKeyAllocator;
 class VectorizedLiteral;
@@ -324,6 +325,9 @@ public:
     Status compute_batch_agg_states_with_selection(Chunk* chunk, size_t chunk_size);
 
     RuntimeFilter* build_in_filters(RuntimeState* state, RuntimeFilterBuildDescriptor* desc);
+    RuntimeFilter* build_topn_filters(RuntimeState* state, RuntimeFilterBuildDescriptor* desc);
+    AggTopNRuntimeFilterBuilder* topn_runtime_filter_builder() { return _topn_runtime_filter_builder; }
+
     // Convert one row agg states to chunk
     Status convert_to_chunk_no_groupby(ChunkPtr* chunk);
 
@@ -518,12 +522,15 @@ protected:
     std::vector<const AggregateFunction*> _combinator_function;
 
     pipeline::PipeObservable _pip_observable;
+    // used to build the topn runtime filter
+    AggTopNRuntimeFilterBuilder* _topn_runtime_filter_builder = nullptr;
 
 public:
     void build_hash_map(size_t chunk_size, bool agg_group_by_with_limit = false);
     void build_hash_map(size_t chunk_size, std::atomic<int64_t>& shared_limit_countdown, bool agg_group_by_with_limit);
     void build_hash_map_with_selection(size_t chunk_size);
     void build_hash_map_with_selection_and_allocation(size_t chunk_size, bool agg_group_by_with_limit = false);
+    void build_hash_map_with_topn_runtime_filter(size_t chunk_size);
     Status convert_hash_map_to_chunk(int32_t chunk_size, ChunkPtr* chunk,
                                      bool force_use_intermediate_as_output = false);
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -89,13 +89,49 @@ Status AggregateStreamingSinkOperator::push_chunk(RuntimeState* state, const Chu
     if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_STREAMING) {
         RETURN_IF_ERROR(_push_chunk_by_force_streaming(chunk));
     } else if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_PREAGGREGATION) {
-        RETURN_IF_ERROR(_push_chunk_by_force_preaggregation(chunk, chunk->num_rows()));
+        RETURN_IF_ERROR(_push_chunk_by_force_preaggregation(state, chunk, chunk_size));
     } else if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::LIMITED_MEM) {
-        RETURN_IF_ERROR(_push_chunk_by_limited_memory(chunk, chunk_size));
+        RETURN_IF_ERROR(_push_chunk_by_limited_memory(state, chunk, chunk_size));
     } else {
-        RETURN_IF_ERROR(_push_chunk_by_auto(chunk, chunk->num_rows()));
+        RETURN_IF_ERROR(_push_chunk_by_auto(state, chunk, chunk_size));
     }
     RETURN_IF_ERROR(_aggregator->check_has_error());
+
+    return Status::OK();
+}
+
+Status AggregateStreamingSinkOperator::_build_topn_runtime_filter(RuntimeState* state) {
+    const auto& rf_build_descs = factory()->build_runtime_filters();
+    if (rf_build_descs.empty()) {
+        return Status::OK();
+    }
+    auto& rf_build_desc = rf_build_descs[0];
+    size_t hash_table_size = _aggregator->hash_map_variant().size();
+    size_t limit = rf_build_desc->limit();
+    // if the hash table size is less than limit or the hash table size is the same as the last time, skip building the topn runtime filter
+    if (hash_table_size < limit || hash_table_size == _hash_table_size) {
+        return Status::OK();
+    }
+    _hash_table_size = hash_table_size;
+
+    std::list<RuntimeFilterBuildDescriptor*> build_descs(rf_build_descs.begin(), rf_build_descs.end());
+    for (size_t i = 0; i < rf_build_descs.size(); ++i) {
+        auto rf = _aggregator->build_topn_filters(state, rf_build_descs[i]);
+        if (rf == nullptr) {
+            continue;
+        }
+        rf_build_descs[i]->set_or_intersect_filter(rf);
+    }
+
+    if (std::all_of(build_descs.begin(), build_descs.end(),
+                    [](auto* desc) { return desc->runtime_filter() != nullptr; })) {
+        state->runtime_filter_port()->publish_runtime_filters(build_descs);
+        for (auto* desc : build_descs) {
+            VLOG(2) << "publish topn runtime filter: " << desc->runtime_filter()->rf_version() << ","
+                    << desc->runtime_filter()->debug_string() << desc->runtime_filter();
+        }
+    }
+
     return Status::OK();
 }
 
@@ -107,11 +143,17 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_force_streaming(const Chun
     return Status::OK();
 }
 
-Status AggregateStreamingSinkOperator::_push_chunk_by_force_preaggregation(const ChunkPtr& chunk,
+Status AggregateStreamingSinkOperator::_push_chunk_by_force_preaggregation(RuntimeState* state, const ChunkPtr& chunk,
                                                                            const size_t chunk_size) {
     SCOPED_TIMER(_aggregator->agg_compute_timer());
     TRY_CATCH_ALLOC_SCOPE_START();
-    _aggregator->build_hash_map(chunk_size);
+    if (_aggregator->topn_runtime_filter_builder() == nullptr) {
+        _aggregator->build_hash_map(chunk_size);
+    } else {
+        _aggregator->build_hash_map_with_topn_runtime_filter(chunk_size);
+    }
+    RETURN_IF_ERROR(_build_topn_runtime_filter(state));
+
     if (_aggregator->is_none_group_by_exprs()) {
         RETURN_IF_ERROR(_aggregator->compute_single_agg_state(chunk.get(), chunk_size));
     } else {
@@ -179,7 +221,8 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_selective_preaggregation(c
  *
  * SELECTIVE_PREAGG state aggregates continuous_limit chunks, then shifting to ADJUST state.
  */
-Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const ChunkPtr& chunk, const size_t chunk_size) {
+Status AggregateStreamingSinkOperator::_push_chunk_by_auto(RuntimeState* state, const ChunkPtr& chunk,
+                                                           const size_t chunk_size) {
     size_t allocated_bytes = _aggregator->hash_map_variant().allocated_memory_usage(_aggregator->mem_pool());
     const size_t continuous_limit = _auto_context.get_continuous_limit();
     switch (_auto_state) {
@@ -235,7 +278,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const ChunkPtr& chunk
         } else if (_auto_context.adjust_count < continuous_limit &&
                    _auto_context.is_high_reduction(hit_count, chunk_size) &&
                    allocated_bytes < AggrAutoContext::MaxHtSize) {
-            RETURN_IF_ERROR(_push_chunk_by_force_preaggregation(chunk, chunk_size));
+            RETURN_IF_ERROR(_push_chunk_by_force_preaggregation(state, chunk, chunk_size));
 
             _auto_context.preagg_count++;
             _auto_context.pass_through_count = 0;
@@ -281,7 +324,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const ChunkPtr& chunk
     }
     case AggrAutoState::FORCE_PREAGG:
     case AggrAutoState::PREAGG: {
-        RETURN_IF_ERROR(_push_chunk_by_force_preaggregation(chunk, chunk_size));
+        RETURN_IF_ERROR(_push_chunk_by_force_preaggregation(state, chunk, chunk_size));
         _auto_context.preagg_count++;
         auto limit = _auto_state == AggrAutoState::FORCE_PREAGG ? AggrAutoContext::ForcePreaggLimit
                                                                 : AggrAutoContext::PreaggLimit;
@@ -313,12 +356,13 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const ChunkPtr& chunk
     return Status::OK();
 }
 
-Status AggregateStreamingSinkOperator::_push_chunk_by_limited_memory(const ChunkPtr& chunk, const size_t chunk_size) {
+Status AggregateStreamingSinkOperator::_push_chunk_by_limited_memory(RuntimeState* state, const ChunkPtr& chunk,
+                                                                     const size_t chunk_size) {
     if (_limited_mem_state.has_limited(*_aggregator)) {
         RETURN_IF_ERROR(_push_chunk_by_force_streaming(chunk));
         _aggregator->set_streaming_all_states(true);
     } else {
-        RETURN_IF_ERROR(_push_chunk_by_auto(chunk, chunk_size));
+        RETURN_IF_ERROR(_push_chunk_by_auto(state, chunk, chunk_size));
     }
     return Status::OK();
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -102,7 +102,10 @@ Status AggregateStreamingSinkOperator::push_chunk(RuntimeState* state, const Chu
 
 Status AggregateStreamingSinkOperator::_build_topn_runtime_filter(RuntimeState* state) {
     const auto& rf_build_descs = factory()->build_runtime_filters();
-    if (rf_build_descs.empty()) {
+    // all runtime filter should be topn_filter and limit > 0
+    if (rf_build_descs.empty() || !std::all_of(rf_build_descs.begin(), rf_build_descs.end(), [](auto* desc) {
+            return desc->type() == TRuntimeFilterBuildType::TOPN_FILTER && desc->limit() > 0;
+        })) {
         return Status::OK();
     }
     auto& rf_build_desc = rf_build_descs[0];

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -21,7 +21,6 @@
 #include "runtime/runtime_state.h"
 
 namespace starrocks {
-class AggTopNRuntimeFilterBuilder;
 namespace pipeline {
 
 class AggregateStreamingSinkOperatorFactory;
@@ -64,15 +63,18 @@ private:
     Status _push_chunk_by_force_streaming(const ChunkPtr& chunk);
 
     // Invoked by push_chunk  if current mode is TStreamingPreaggregationMode::FORCE_PREAGGREGATION
-    Status _push_chunk_by_force_preaggregation(const ChunkPtr& chunk, const size_t chunk_size);
+    Status _push_chunk_by_force_preaggregation(RuntimeState* state, const ChunkPtr& chunk, const size_t chunk_size);
 
     // Invoked by push_chunk  if current mode is TStreamingPreaggregationMode::AUTO
-    Status _push_chunk_by_auto(const ChunkPtr& chunk, const size_t chunk_size);
+    Status _push_chunk_by_auto(RuntimeState* state, const ChunkPtr& chunk, const size_t chunk_size);
 
     Status _push_chunk_by_selective_preaggregation(const ChunkPtr& chunk, const size_t chunk_size, bool need_build);
 
     // Invoked by push_chunk  if current mode is TStreamingPreaggregationMode::LIMITED
-    Status _push_chunk_by_limited_memory(const ChunkPtr& chunk, const size_t chunk_size);
+    Status _push_chunk_by_limited_memory(RuntimeState* state, const ChunkPtr& chunk, const size_t chunk_size);
+
+    // Build the topn runtime filter for the current chunk
+    Status _build_topn_runtime_filter(RuntimeState* state);
 
     // It is used to perform aggregation algorithms shared by
     // AggregateStreamingSourceOperator. It is
@@ -85,6 +87,8 @@ private:
     AggrAutoState _auto_state{};
     AggrAutoContext _auto_context;
     LimitedMemAggState _limited_mem_state;
+    // the size of hash table when the last time the topn runtime filter is built
+    size_t _hash_table_size = 0;
 
     DECLARE_ONCE_DETECTOR(_set_finishing_once);
 };

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -149,7 +149,7 @@ void Operator::close(RuntimeState* state) {
             for (const auto& [filter_id, desc] : rf_bloom_filters->descriptors()) {
                 rf_desc += "<" + std::to_string(filter_id) + ": ";
                 if (desc != nullptr && desc->runtime_filter(0) != nullptr) {
-                    rf_desc += to_string(desc->runtime_filter(0)->type());
+                    rf_desc += desc->runtime_filter(0)->debug_string();
                 } else {
                     rf_desc += "NULL";
                 }

--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -541,6 +541,18 @@ Status RuntimeFilterBuildDescriptor::init(ObjectPool* pool, const TRuntimeFilter
     if (desc.__isset.skew_shuffle_filter_id) {
         _skew_shuffle_filter_id = desc.skew_shuffle_filter_id;
     }
+    if (desc.__isset.is_asc) {
+        _is_asc = desc.is_asc;
+    }
+    if (desc.__isset.is_nulls_first) {
+        _is_nulls_first = desc.is_nulls_first;
+    }
+    if (desc.__isset.limit) {
+        _limit = desc.limit;
+    }
+    if (desc.__isset.filter_type) {
+        _runtime_filter_type = desc.filter_type;
+    }
 
     WithLayoutMixin::init(desc);
     RETURN_IF_ERROR(Expr::create_expr_tree(pool, desc.build_expr, &_build_expr_ctx, state));

--- a/be/src/exprs/runtime_filter_bank.h
+++ b/be/src/exprs/runtime_filter_bank.h
@@ -114,6 +114,9 @@ public:
     const std::vector<TNetworkAddress>& merge_nodes() const { return _merge_nodes; }
 
     TRuntimeFilterBuildType::type type() const { return _runtime_filter_type; }
+    bool is_asc() const { return _is_asc; }
+    bool is_nulls_first() const { return _is_nulls_first; }
+    size_t limit() const { return _limit; }
 
     void set_runtime_filter(RuntimeFilter* rf) { _runtime_filter = rf; }
     // used in TopN filter to intersect with other runtime filters.
@@ -163,6 +166,10 @@ private:
     RuntimeFilter* _runtime_filter = nullptr;
     bool _is_pipeline = false;
     size_t _num_colocate_partition = 0;
+    // field used in top-n runtime filter
+    bool _is_asc{};
+    bool _is_nulls_first{};
+    size_t _limit{};
 
     bool _is_broad_cast_in_skew = false;
     int32_t _skew_shuffle_filter_id = -1;

--- a/be/src/types/logical_type_infra.h
+++ b/be/src/types/logical_type_infra.h
@@ -219,7 +219,11 @@ Ret type_dispatch_predicate(LogicalType ltype, bool assert, Functor fun, Args...
             CHECK(false) << "Unknown type: " << ltype;
             __builtin_unreachable();
         } else {
-            return Ret{};
+            if constexpr (std::is_void_v<Ret>) {
+                return;
+            } else {
+                return Ret{};
+            }
         }
     }
 }

--- a/be/src/util/heap.h
+++ b/be/src/util/heap.h
@@ -1,0 +1,114 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+
+namespace starrocks {
+template <typename T, typename Sequence, typename Compare>
+class SortingHeap {
+public:
+    SortingHeap(Compare comp) : _comp(std::move(comp)) {}
+
+    const T& top() { return _queue.front(); }
+
+    size_t size() { return _queue.size(); }
+
+    bool empty() { return _queue.empty(); }
+
+    T& next_child() { return _queue[_greater_child_index()]; }
+
+    void reserve(size_t reserve_sz) { _queue.reserve(reserve_sz); }
+
+    void replace_top(T&& new_top) {
+        *_queue.begin() = std::move(new_top);
+        update_top();
+    }
+
+    void remove_top() {
+        std::pop_heap(_queue.begin(), _queue.end(), _comp);
+        _queue.pop_back();
+    }
+
+    void push(T&& rowcur) {
+        _queue.emplace_back(std::move(rowcur));
+        std::push_heap(_queue.begin(), _queue.end(), _comp);
+    }
+
+    Sequence&& sorted_seq() {
+        std::sort_heap(_queue.begin(), _queue.end(), _comp);
+        return std::move(_queue);
+    }
+
+    Sequence& container() { return _queue; }
+
+    // replace top if val less than top()
+    void replace_top_if_less(T&& val) {
+        if (_comp(val, top())) {
+            replace_top(std::move(val));
+        }
+    }
+
+private:
+    Sequence _queue;
+    Compare _comp;
+
+    size_t _greater_child_index() {
+        size_t next_idx = 0;
+        if (next_idx == 0) {
+            next_idx = 1;
+            if (_queue.size() > 2 && _comp(_queue[1], _queue[2])) ++next_idx;
+        }
+        return next_idx;
+    }
+
+    void update_top() {
+        size_t size = _queue.size();
+        if (size < 2) return;
+
+        auto begin = _queue.begin();
+
+        size_t child_idx = _greater_child_index();
+        auto child_it = begin + child_idx;
+
+        /// Check if we are in order.
+        if (_comp(*child_it, *begin)) return;
+
+        auto curr_it = begin;
+        auto top(std::move(*begin));
+        do {
+            /// We are not in heap-order, swap the parent with it's largest child.
+            *curr_it = std::move(*child_it);
+            curr_it = child_it;
+
+            // recompute the child based off of the updated parent
+            child_idx = 2 * child_idx + 1;
+
+            if (child_idx >= size) break;
+
+            child_it = begin + child_idx;
+
+            if ((child_idx + 1) < size && _comp(*child_it, *(child_it + 1))) {
+                /// Right child exists and is greater than left child.
+                ++child_it;
+                ++child_idx;
+            }
+
+            /// Check if we are in order.
+        } while (!(_comp(*child_it, top)));
+        *curr_it = std::move(top);
+    }
+};
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -344,6 +344,7 @@ set(EXEC_FILES
         ./simd/simd_selector_test.cpp
         ./simd/simd_mulselector_test.cpp
         ./simd/simd_expand_test.cpp
+        ./util/heap_test.cpp
         ./util/phmap_test.cpp
         ./util/aes_util_test.cpp
         ./util/await_test.cpp

--- a/be/test/util/heap_test.cpp
+++ b/be/test/util/heap_test.cpp
@@ -1,0 +1,498 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/heap.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace starrocks {
+
+// Test basic constructor and comparator functionality
+// std::greater creates a min-heap (smallest element at top)
+TEST(HeapTest, ConstructorAndComparator) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    EXPECT_TRUE(heap.empty());
+    EXPECT_EQ(heap.size(), 0);
+}
+
+// Test push and top operations with min-heap
+// std::greater creates a min-heap, so smallest element is at top
+TEST(HeapTest, PushAndTop_MinHeap) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(5);
+    heap.push(10);
+    heap.push(3);
+
+    EXPECT_FALSE(heap.empty());
+    EXPECT_EQ(heap.size(), 3);
+    EXPECT_EQ(heap.top(), 3); // Smallest element should be at top (min-heap)
+}
+
+// Test push and top operations with max-heap
+// std::less creates a max-heap, so largest element is at top
+TEST(HeapTest, PushAndTop_MaxHeap) {
+    SortingHeap<int, std::vector<int>, std::less<int>> heap{std::less<int>()};
+    heap.push(5);
+    heap.push(10);
+    heap.push(3);
+
+    EXPECT_FALSE(heap.empty());
+    EXPECT_EQ(heap.size(), 3);
+    EXPECT_EQ(heap.top(), 10); // Largest element should be at top (max-heap)
+}
+
+// Test push with move semantics
+TEST(HeapTest, PushWithMove) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    int val = 15;
+    heap.push(std::move(val));
+
+    EXPECT_EQ(heap.size(), 1);
+    EXPECT_EQ(heap.top(), 15);
+}
+
+// Test remove_top operation with min-heap
+TEST(HeapTest, RemoveTop_MinHeap) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(10);
+    heap.push(20);
+    heap.push(15);
+
+    EXPECT_EQ(heap.size(), 3);
+    EXPECT_EQ(heap.top(), 10); // 10 is the smallest
+
+    heap.remove_top();
+    EXPECT_EQ(heap.size(), 2);
+    EXPECT_EQ(heap.top(), 15); // Now 15 should be the smallest
+}
+
+// Test remove_top operation with max-heap
+TEST(HeapTest, RemoveTop_MaxHeap) {
+    SortingHeap<int, std::vector<int>, std::less<int>> heap{std::less<int>()};
+    heap.push(10);
+    heap.push(20);
+    heap.push(15);
+
+    EXPECT_EQ(heap.size(), 3);
+    EXPECT_EQ(heap.top(), 20); // 20 is the largest
+
+    heap.remove_top();
+    EXPECT_EQ(heap.size(), 2);
+    EXPECT_EQ(heap.top(), 15); // Now 15 should be the largest
+}
+
+// Test remove_top until empty
+TEST(HeapTest, RemoveTopUntilEmpty) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(5);
+    heap.push(10);
+    heap.push(15);
+
+    while (!heap.empty()) {
+        heap.remove_top();
+    }
+
+    EXPECT_TRUE(heap.empty());
+    EXPECT_EQ(heap.size(), 0);
+}
+
+// Test replace_top operation with min-heap
+TEST(HeapTest, ReplaceTop_MinHeap) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(10);
+    heap.push(20);
+    heap.push(15);
+
+    EXPECT_EQ(heap.top(), 10);
+
+    // Replace top with a new value
+    heap.replace_top(5);
+    EXPECT_EQ(heap.top(), 5);
+    EXPECT_EQ(heap.size(), 3);
+}
+
+// Test replace_top operation with max-heap
+TEST(HeapTest, ReplaceTop_MaxHeap) {
+    SortingHeap<int, std::vector<int>, std::less<int>> heap{std::less<int>()};
+    heap.push(10);
+    heap.push(20);
+    heap.push(15);
+
+    EXPECT_EQ(heap.top(), 20);
+
+    // Replace top with a new value
+    heap.replace_top(25);
+    EXPECT_EQ(heap.top(), 25);
+    EXPECT_EQ(heap.size(), 3);
+}
+
+// Test replace_top with smaller value in max-heap
+TEST(HeapTest, ReplaceTopWithSmallerValue) {
+    SortingHeap<int, std::vector<int>, std::less<int>> heap{std::less<int>()};
+    heap.push(10);
+    heap.push(20);
+
+    EXPECT_EQ(heap.top(), 20);
+
+    // Replace top with a smaller value
+    heap.replace_top(5);
+    EXPECT_EQ(heap.top(), 10); // 10 should now be at top
+    EXPECT_EQ(heap.size(), 2);
+}
+
+// Test replace_top_if_less in min-heap
+// In min-heap, replace_top_if_less replaces top if new val is less than current top
+TEST(HeapTest, ReplaceTopIfLess_MinHeap) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(10);
+    heap.push(20);
+
+    EXPECT_EQ(heap.top(), 10); // min-heap: 10 is smallest
+
+    // 8 is less than 10, so it should replace
+    heap.replace_top_if_less(28);
+    EXPECT_EQ(heap.top(), 20);
+    EXPECT_EQ(heap.size(), 2);
+}
+
+// Test replace_top_if_less when condition is not met
+TEST(HeapTest, ReplaceTopIfLess_NotMet) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(10);
+    heap.push(20);
+
+    EXPECT_EQ(heap.top(), 10);
+
+    // 15 is not less than 10, so it should not replace
+    heap.replace_top_if_less(5);
+    EXPECT_EQ(heap.top(), 10); // 10 should still be at top
+    EXPECT_EQ(heap.size(), 2);
+}
+
+// Test sorted_seq returns elements in sorted order (ascending for min-heap)
+TEST(HeapTest, SortedSequence_MinHeap) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(5);
+    heap.push(10);
+    heap.push(3);
+    heap.push(8);
+
+    // Get sorted sequence
+    auto sorted = heap.sorted_seq();
+    std::vector<int> expected = {10, 8, 5, 3};
+    EXPECT_EQ(sorted, expected);
+}
+
+// Test sorted_seq returns elements in descending order for max-heap
+TEST(HeapTest, SortedSequence_MaxHeap) {
+    SortingHeap<int, std::vector<int>, std::less<int>> heap{std::less<int>()};
+    heap.push(5);
+    heap.push(10);
+    heap.push(3);
+    heap.push(8);
+
+    // Get sorted sequence
+    auto sorted = heap.sorted_seq();
+    std::vector<int> expected = {3, 5, 8, 10};
+    EXPECT_EQ(sorted, expected);
+}
+
+// Test sorted_seq consumes the heap
+TEST(HeapTest, SortedSequenceConsumesHeap) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(5);
+    heap.push(10);
+
+    auto sorted = heap.sorted_seq();
+    EXPECT_TRUE(heap.empty()); // Heap should be empty after sorted_seq
+}
+
+// Test container access
+TEST(HeapTest, ContainerAccess) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(5);
+    heap.push(10);
+    heap.push(3);
+
+    std::vector<int>& container = heap.container();
+    EXPECT_EQ(container.size(), 3);
+
+    // Container should contain all pushed elements
+    EXPECT_EQ(container.size(), heap.size());
+}
+
+// Test reserve functionality
+TEST(HeapTest, Reserve) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.reserve(100);
+
+    heap.push(5);
+    heap.push(10);
+
+    EXPECT_EQ(heap.size(), 2);
+    // Capacity should be at least 100
+    EXPECT_GE(heap.container().capacity(), 100);
+}
+
+// Test next_child functionality in min-heap
+TEST(HeapTest, NextChild_MinHeap) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(10);
+    heap.push(20);
+    heap.push(15);
+
+    // After pushing 3 elements in min-heap with root 10:
+    //     10
+    //    /  \
+    //  20    15
+    // next_child should return the smaller child (15)
+    EXPECT_EQ(heap.next_child(), 15);
+}
+
+// Test next_child functionality in max-heap
+TEST(HeapTest, NextChild_MaxHeap) {
+    SortingHeap<int, std::vector<int>, std::less<int>> heap{std::less<int>()};
+    heap.push(10);
+    heap.push(20);
+    heap.push(15);
+
+    // After pushing 3 elements in max-heap with root 20:
+    //     20
+    //    /  \
+    //  10    15
+    // next_child should return the larger child (15)
+    EXPECT_EQ(heap.next_child(), 15);
+}
+
+// Test with single element
+TEST(HeapTest, SingleElement) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(42);
+
+    EXPECT_EQ(heap.size(), 1);
+    EXPECT_FALSE(heap.empty());
+    EXPECT_EQ(heap.top(), 42);
+}
+
+// Test with duplicate values
+TEST(HeapTest, DuplicateValues) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(10);
+    heap.push(10);
+    heap.push(10);
+
+    EXPECT_EQ(heap.size(), 3);
+    EXPECT_EQ(heap.top(), 10);
+
+    heap.remove_top();
+    EXPECT_EQ(heap.size(), 2);
+    EXPECT_EQ(heap.top(), 10);
+}
+
+// Test with negative values in min-heap
+TEST(HeapTest, NegativeValues_MinHeap) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(-5);
+    heap.push(-10);
+    heap.push(-3);
+
+    EXPECT_EQ(heap.top(), -10); // Smallest (most negative) should be at top
+}
+
+// Test with negative values in max-heap
+TEST(HeapTest, NegativeValues_MaxHeap) {
+    SortingHeap<int, std::vector<int>, std::less<int>> heap{std::less<int>()};
+    heap.push(-5);
+    heap.push(-10);
+    heap.push(-3);
+
+    EXPECT_EQ(heap.top(), -3); // Largest (least negative) should be at top
+}
+
+// Test replace_top_if_less with equal values
+TEST(HeapTest, ReplaceTopIfLess_EqualValues) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(10);
+    heap.push(20);
+
+    EXPECT_EQ(heap.top(), 10);
+
+    // 10 is not less than 10, so it should not replace
+    heap.replace_top_if_less(10);
+    EXPECT_EQ(heap.top(), 10);
+    EXPECT_EQ(heap.size(), 2);
+}
+
+// Test large number of elements in min-heap
+TEST(HeapTest, LargeNumberOfElements_MinHeap) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+
+    for (int i = 0; i < 1000; ++i) {
+        heap.push(std::move(i));
+    }
+
+    EXPECT_EQ(heap.size(), 1000);
+    EXPECT_EQ(heap.top(), 0); // Smallest element should be at top
+
+    // Remove all elements and verify ascending order
+    int prev = -1;
+    while (!heap.empty()) {
+        int current = heap.top();
+        EXPECT_GE(current, prev); // Should be non-decreasing (ascending)
+        prev = current;
+        heap.remove_top();
+    }
+}
+
+// Test large number of elements in max-heap
+TEST(HeapTest, LargeNumberOfElements_MaxHeap) {
+    SortingHeap<int, std::vector<int>, std::less<int>> heap{std::less<int>()};
+
+    for (int i = 0; i < 1000; ++i) {
+        heap.push(std::move(i));
+    }
+
+    EXPECT_EQ(heap.size(), 1000);
+    EXPECT_EQ(heap.top(), 999); // Largest element should be at top
+
+    // Remove all elements and verify descending order
+    int prev = 1000;
+    while (!heap.empty()) {
+        int current = heap.top();
+        EXPECT_LE(current, prev); // Should be non-increasing (descending)
+        prev = current;
+        heap.remove_top();
+    }
+}
+
+// Test sorted_seq with descending input in min-heap
+TEST(HeapTest, SortedSequenceDescendingInput) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+
+    // Push in descending order
+    for (int i = 10; i >= 1; --i) {
+        heap.push(std::move(i));
+    }
+
+    auto sorted = heap.sorted_seq();
+    std::vector<int> expected = {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+    EXPECT_EQ(sorted, expected);
+}
+
+// Test sorted_seq with ascending input in min-heap
+TEST(HeapTest, SortedSequenceAscendingInput) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+
+    // Push in ascending order
+    for (int i = 1; i <= 10; ++i) {
+        heap.push(std::move(i));
+    }
+
+    auto sorted = heap.sorted_seq();
+    std::vector<int> expected = {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+    EXPECT_EQ(sorted, expected);
+}
+
+// Test multiple push and remove operations interleaved in min-heap
+TEST(HeapTest, InterleavedPushRemove) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+
+    heap.push(5);
+    heap.push(15);
+    EXPECT_EQ(heap.top(), 5); // min-heap: 5 is smallest
+
+    heap.push(10);
+    EXPECT_EQ(heap.top(), 5); // still 5
+
+    heap.remove_top();
+    EXPECT_EQ(heap.top(), 10); // now 10 is smallest
+
+    heap.push(20);
+    EXPECT_EQ(heap.top(), 10); // still 10
+
+    heap.remove_top();
+    EXPECT_EQ(heap.top(), 15); // now 15
+}
+
+// Test replace_top followed by push in max-heap
+TEST(HeapTest, ReplaceTopThenPush_MaxHeap) {
+    SortingHeap<int, std::vector<int>, std::less<int>> heap{std::less<int>()};
+    heap.push(10);
+    heap.push(20);
+    heap.push(30);
+
+    EXPECT_EQ(heap.top(), 30);
+
+    heap.replace_top(25);
+    EXPECT_EQ(heap.top(), 25);
+
+    heap.push(35);
+    EXPECT_EQ(heap.top(), 35);
+}
+
+// Test with string type using std::greater (lexicographical min-heap)
+TEST(HeapTest, StringType_MinHeap) {
+    SortingHeap<std::string, std::vector<std::string>, std::greater<std::string>> heap{std::greater<std::string>()};
+    heap.push("apple");
+    heap.push("banana");
+    heap.push("cherry");
+
+    EXPECT_EQ(heap.top(), "apple"); // Lexicographically smallest
+
+    heap.remove_top();
+    EXPECT_EQ(heap.top(), "banana");
+}
+
+// Test with string type using std::less (lexicographical max-heap)
+TEST(HeapTest, StringType_MaxHeap) {
+    SortingHeap<std::string, std::vector<std::string>, std::less<std::string>> heap{std::less<std::string>()};
+    heap.push("apple");
+    heap.push("banana");
+    heap.push("cherry");
+
+    EXPECT_EQ(heap.top(), "cherry"); // Lexicographically largest
+
+    heap.remove_top();
+    EXPECT_EQ(heap.top(), "banana");
+}
+
+// Test min-heap (std::greater)
+TEST(HeapTest, MinHeap) {
+    SortingHeap<int, std::vector<int>, std::greater<int>> heap{std::greater<int>()};
+    heap.push(5);
+    heap.push(10);
+    heap.push(3);
+
+    EXPECT_EQ(heap.top(), 3); // Smallest element at top
+
+    heap.remove_top();
+    EXPECT_EQ(heap.top(), 5);
+}
+
+// Test max-heap (std::less)
+TEST(HeapTest, MaxHeap) {
+    SortingHeap<int, std::vector<int>, std::less<int>> heap{std::less<int>()};
+    heap.push(5);
+    heap.push(10);
+    heap.push(3);
+
+    EXPECT_EQ(heap.top(), 10); // Largest element at top
+
+    heap.remove_top();
+    EXPECT_EQ(heap.top(), 5);
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -268,6 +268,7 @@ public class RuntimeFilterDescription {
 
     // return true if Node could accept the Filter
     public boolean canAcceptFilter(PlanNode node, RuntimeFilterPushDownContext rfPushCtx) {
+        // TODO: Support TopN runtime filter for other nodes
         if (runtimeFilterType().isTopNFilter() || runtimeFilterType().isAggInFilter()) {
             if (node instanceof ScanNode) {
                 ScanNode scanNode = (ScanNode) node;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -176,6 +176,14 @@ public class RuntimeFilterDescription {
         return this.topn;
     }
 
+    public boolean isTopNSortAsc() {
+        return sortInfo != null && sortInfo.getIsAscOrder().get(exprOrder);
+    }
+
+    public boolean isTopNullsFirst() {
+        return sortInfo != null && sortInfo.getNullsFirst().get(exprOrder);
+    }
+
     public PlanNode getBuildPlanNode() {
         return buildPlanNode;
     }
@@ -640,6 +648,9 @@ public class RuntimeFilterDescription {
 
         if (runtimeFilterType().isTopNFilter()) {
             t.setFilter_type(TRuntimeFilterBuildType.TOPN_FILTER);
+            t.setIs_asc(isTopNSortAsc());
+            t.setIs_nulls_first(isTopNullsFirst());
+            t.setLimit(topn);
         } else if (runtimeFilterType().isAggInFilter()) {
             t.setFilter_type(TRuntimeFilterBuildType.AGG_FILTER);
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortInfo.java
@@ -36,9 +36,11 @@ package com.starrocks.planner;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.planner.expression.ExprToThrift;
 import com.starrocks.sql.ast.OrderByElement;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprUtils;
+import com.starrocks.thrift.TSortInfo;
 
 import java.util.List;
 
@@ -170,6 +172,10 @@ public class SortInfo {
     @Override
     public SortInfo clone() {
         return new SortInfo(this);
+    }
+
+    public TSortInfo toTSortInfo() {
+        return new TSortInfo(ExprToThrift.treesToThrift(getOrderingExprs()), getIsAscOrder(), getNullsFirst());
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1041,7 +1041,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ARROW_FLIGHT_PROXY = "arrow_flight_proxy";
     public static final String ARROW_FLIGHT_PROXY_ENABLED = "arrow_flight_proxy_enabled";
 
-    public static final String ENABLE_PRE_AGG_TOP_N_PUSH_DOWN = "enable_pre_agg_top_n_push_down";
+    public static final String TOPN_PUSH_DOWN_AGG_MODE = "topn_push_down_agg_mode";
 
     public static final String ENABLE_LABELED_COLUMN_STATISTIC_OUTPUT = "enable_labeled_column_statistic_output";
 
@@ -2201,8 +2201,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ARROW_FLIGHT_PROXY_ENABLED)
     private boolean arrowFlightProxyEnabled = true;
 
-    @VarAttr(name = ENABLE_PRE_AGG_TOP_N_PUSH_DOWN, flag = VariableMgr.INVISIBLE)
-    private boolean enablePreAggTopNPushDown = true;
+    @VarAttr(name = TOPN_PUSH_DOWN_AGG_MODE, flag = VariableMgr.INVISIBLE)
+    private int topNPushDownAggMode = 1;
 
     @VarAttr(name = ENABLE_LABELED_COLUMN_STATISTIC_OUTPUT)
     private boolean enableLabeledColumnStatisticOutput = false;
@@ -5770,12 +5770,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return this.arrowFlightProxyEnabled;
     }
 
-    public void setEnablePreAggTopNPushDown(boolean enablePreAggTopNPushDown) {
-        this.enablePreAggTopNPushDown = enablePreAggTopNPushDown;
+    public void setEnablePreAggTopNPushDown(int  topNPushDownAggMode) {
+        this.topNPushDownAggMode = topNPushDownAggMode;
     }
 
-    public boolean isEnablePreAggTopNPushDown() {
-        return enablePreAggTopNPushDown;
+    public int getTopNPushDownAggMode() {
+        return topNPushDownAggMode;
     }
 
     public void setEnableLabeledColumnStatisticOutput(boolean flag) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -204,6 +204,11 @@ public class CostModel {
 
         @Override
         public CostEstimate visitPhysicalTopN(PhysicalTopNOperator node, ExpressionContext context) {
+            // we always prefer topn push down agg.
+            if (node.isTopNPushDownAgg()) {
+                return CostEstimate.zero();
+            }
+
             // Disable one phased sort, Currently, we always use two phase sort
             if (!node.isEnforced() && !node.isSplit()
                     && node.getSortPhase().isFinal()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OpRuleBit.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OpRuleBit.java
@@ -32,4 +32,6 @@ public class OpRuleBit {
     public static final int OP_PARTITION_PRUNED = 3;
     // Operator has been mv transparent union rewrite and needs to prune agg columns.
     public static final int OP_MV_AGG_PRUNE_COLUMNS = 4;
+    // Operator has been push down topn below agg or not, if push down topn, no need to push down again.
+    public static final int OP_PUSH_DOWN_TOPN_AGG = 5;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
@@ -76,6 +76,9 @@ public class LogicalAggregationOperator extends LogicalOperator {
     // operators can truncate overlapping data produced by the local-distinct stage.
     private long localLimit = DEFAULT_LIMIT;
 
+    // TopN information for filtering group by data during aggregation
+    private LogicalTopNOperator.TopNSortInfo aggTopnSortInfo = null;
+
     // If the AggType is not GLOBAL, it means we have split the agg hence the isSplit should be true.
     // `this.isSplit = !type.isGlobal() || isSplit;` helps us do the work.
     // If you want to manually set this value, you could invoke setOnlyLocalAggregate().
@@ -160,6 +163,10 @@ public class LogicalAggregationOperator extends LogicalOperator {
 
     public long getLocalLimit() {
         return localLimit;
+    }
+
+    public LogicalTopNOperator.TopNSortInfo getAggTopnSortInfo() {
+        return aggTopnSortInfo;
     }
 
     public boolean checkGroupByCountDistinct() {
@@ -290,12 +297,14 @@ public class LogicalAggregationOperator extends LogicalOperator {
                 type == that.type && Objects.equals(aggregations, that.aggregations) &&
                 Objects.equals(groupingKeys, that.groupingKeys) &&
                 Objects.equals(partitionByColumns, that.partitionByColumns) &&
-                topNLocalAgg == that.topNLocalAgg;
+                topNLocalAgg == that.topNLocalAgg &&
+                Objects.equals(aggTopnSortInfo, that.aggTopnSortInfo);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), type, isSplit, aggregations, groupingKeys, partitionByColumns, topNLocalAgg);
+        return Objects.hash(super.hashCode(), type, isSplit, aggregations, groupingKeys, partitionByColumns, topNLocalAgg,
+                aggTopnSortInfo);
     }
 
     public static Builder builder() {
@@ -330,6 +339,7 @@ public class LogicalAggregationOperator extends LogicalOperator {
             builder.distinctColumnDataSkew = aggregationOperator.distinctColumnDataSkew;
             builder.topNLocalAgg = aggregationOperator.topNLocalAgg;
             builder.localLimit = aggregationOperator.localLimit;
+            builder.aggTopnSortInfo = aggregationOperator.aggTopnSortInfo;
             return this;
         }
 
@@ -380,6 +390,11 @@ public class LogicalAggregationOperator extends LogicalOperator {
 
         public Builder setTopNLocalAgg(boolean topNLocalAgg) {
             builder.topNLocalAgg = topNLocalAgg;
+            return this;
+        }
+
+        public Builder setAggTopnSortInfo(LogicalTopNOperator.TopNSortInfo aggTopnSortInfo) {
+            builder.aggTopnSortInfo = aggTopnSortInfo;
             return this;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTopNOperator.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.optimizer.RowOutputInfo;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.ColumnOutputInfo;
+import com.starrocks.sql.optimizer.operator.OpRuleBit;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
@@ -57,6 +58,10 @@ public class LogicalTopNOperator extends LogicalOperator {
     // only set when rank <=1 with preAgg optimization is triggered
     // please refer to PushDownPredicateRankingWindowRule and PushDownLimitRankingWindowRule  for more details
     private ImmutableMap<ColumnRefOperator, CallOperator> partitionPreAggCall;
+
+    public record TopNSortInfo(List<Ordering> orderByElements, SortPhase sortPhase,
+                               TopNType topNType, long limit, long offset) {
+    }
 
     public LogicalTopNOperator(List<Ordering> orderByElements) {
         this(DEFAULT_LIMIT, null, null, null, DEFAULT_LIMIT, orderByElements, DEFAULT_OFFSET, SortPhase.FINAL,
@@ -147,6 +152,14 @@ public class LogicalTopNOperator extends LogicalOperator {
 
     public boolean isPerPipeline() {
         return perPipeline;
+    }
+
+    public boolean isTopNPushDownAgg() {
+        return isOpRuleBitSet(OpRuleBit.OP_PUSH_DOWN_TOPN_AGG);
+    }
+
+    public void setTopNPushDownAgg() {
+        setOpRuleBit(OpRuleBit.OP_PUSH_DOWN_TOPN_AGG);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
@@ -30,6 +30,7 @@ import com.starrocks.sql.optimizer.operator.ColumnOutputInfo;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -65,6 +66,8 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
     // Only set when partial topN is pushed above local aggregation. In this case streaming aggregation has to be
     // forced to pre-aggregate because the data has to be fully reduced before evaluating the topN.
     private boolean topNLocalAgg;
+    // Only set when partial topN is pushed above local aggregation.
+    private LogicalTopNOperator.TopNSortInfo topNSortInfo;
 
     private boolean useSortAgg = false;
 
@@ -112,6 +115,7 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
                 aggregateOperator.getProjection());
         this.mergedLocalAgg = aggregateOperator.mergedLocalAgg;
         this.topNLocalAgg = aggregateOperator.topNLocalAgg;
+        this.topNSortInfo = aggregateOperator.topNSortInfo;
         this.useSortAgg = aggregateOperator.useSortAgg;
         this.usePerBucketOptmize = aggregateOperator.usePerBucketOptmize;
         this.withoutColocateRequirement = aggregateOperator.withoutColocateRequirement;
@@ -161,6 +165,14 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
 
     public void setTopNLocalAgg(boolean topNLocalAgg) {
         this.topNLocalAgg = topNLocalAgg;
+    }
+
+    public LogicalTopNOperator.TopNSortInfo getTopNSortInfo() {
+        return topNSortInfo;
+    }
+
+    public void setTopNSortInfo(LogicalTopNOperator.TopNSortInfo topNSortInfo) {
+        this.topNSortInfo = topNSortInfo;
     }
 
     public List<ColumnRefOperator> getPartitionByColumns() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalTopNOperator.java
@@ -23,6 +23,7 @@ import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.OrderSpec;
 import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.ColumnOutputInfo;
+import com.starrocks.sql.optimizer.operator.OpRuleBit;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
@@ -116,6 +117,14 @@ public class PhysicalTopNOperator extends PhysicalOperator {
 
     public boolean isPerPipeline() {
         return perPipeline;
+    }
+
+    public boolean isTopNPushDownAgg() {
+        return isPerPipeline() || isOpRuleBitSet(OpRuleBit.OP_PUSH_DOWN_TOPN_AGG);
+    }
+
+    public void setTopNPushDownAgg() {
+        setOpRuleBit(OpRuleBit.OP_PUSH_DOWN_TOPN_AGG);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HashAggImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HashAggImplementationRule.java
@@ -45,6 +45,7 @@ public class HashAggImplementationRule extends ImplementationRule {
                 logical.getProjection());
         physical.setDistinctColumnDataSkew(logical.getDistinctColumnDataSkew());
         physical.setTopNLocalAgg(logical.isTopNLocalAgg());
+        physical.setTopNSortInfo(logical.getAggTopnSortInfo());
         physical.setLocalLimit(logical.getLocalLimit());
         OptExpression result = OptExpression.create(physical, input.getInputs());
         return Lists.newArrayList(result);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/TopNImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/TopNImplementationRule.java
@@ -51,7 +51,9 @@ public class TopNImplementationRule extends ImplementationRule {
                         logicalTopN.getPredicate(),
                         logicalTopN.getProjection(),
                         logicalTopN.getPartitionPreAggCall());
-
+        if (logicalTopN.isTopNPushDownAgg()) {
+            physicalTopN.setTopNPushDownAgg();
+        }
         return Lists.newArrayList(OptExpression.create(physicalTopN, input.getInputs()));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -780,7 +780,7 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         String plan = getCostExplain(sql);
         assertContains(plan, "* month-->[1.0, 12.0, 0.0, 1.0, 12.0]");
         assertContains(plan, "2:AGGREGATE (update serialize)");
-        assertContains(plan, "4:AGGREGATE (merge finalize)");
+        assertContains(plan, "5:AGGREGATE (merge finalize)");
 
         sql = "SELECT day(P_PARTKEY) AS day FROM part GROUP BY day ORDER BY day DESC LIMIT 5";
         plan = getCostExplain(sql);

--- a/gensrc/thrift/RuntimeFilter.thrift
+++ b/gensrc/thrift/RuntimeFilter.thrift
@@ -148,6 +148,11 @@ struct TRuntimeFilterDescription {
   19: optional bool is_broad_cast_join_in_skew;
   // only set when is_broad_cast_join_in_skew is true
   20: optional i32 skew_shuffle_filter_id;
+
+  // fields for TOPN RuntimeFilter
+  21: optional bool is_asc;
+  22: optional bool is_nulls_first;
+  23: optional i64 limit;
 }
 
 struct TRuntimeFilterProberParams {

--- a/test/sql/test_sort/R/test_agg_with_topn
+++ b/test/sql/test_sort/R/test_agg_with_topn
@@ -1,0 +1,1585 @@
+-- name: test_agg_with_topn
+CREATE TABLE lineitem (l_shipdate    DATE,
+                       l_orderkey    BIGINT,
+                       l_linenumber  INT,
+                       l_partkey     INT,
+                       l_suppkey     INT,
+                       l_quantity    DECIMAL(15, 2),
+                       l_extendedprice  DECIMAL(15, 2),
+                       l_discount    DECIMAL(15, 2),
+                       l_tax         DECIMAL(15, 2),
+                       l_returnflag  VARCHAR(1),
+                       l_linestatus  VARCHAR(1),
+                       l_commitdate  DATE,
+                       l_receiptdate DATE,
+                       l_shipinstruct VARCHAR(25),
+                       l_shipmode     VARCHAR(10),
+                       l_comment      VARCHAR(44)
+) ENGINE=OLAP
+DUPLICATE KEY(`l_shipdate`, `l_orderkey`, `l_linenumber`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`l_shipdate`)
+(
+   START ("1992-01-01") END ("1999-01-01") EVERY (INTERVAL 1 year)
+)
+DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO lineitem (l_shipdate, l_orderkey, l_linenumber, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment) VALUES
+('1995-03-10', 100001, 1, 5501, 101, 12.00, 1560.00, 0.05, 0.08, 'N', 'O', '1995-03-10', '1995-03-20', 'DELIVER IN PERSON', 'TRUCK', 'First item of order'),
+('1995-03-10', 100001, 2, 7203, 203, 8.50, 892.50, 0.00, 0.08, 'N', 'O', '1995-03-10', '1995-03-18', 'TAKE BACK RETURN', 'AIR', 'Second item, fragile'),
+('1995-03-22', 100002, 1, 3345, 156, 24.00, 3120.00, 0.10, 0.07, 'R', 'F', '1996-08-18', '1996-08-25', 'COLLECT COD', 'SHIP', 'Bulk order item'),
+('1995-02-05', 100003, 1, 8890, 89, 3.00, 450.00, 0.02, 0.09, 'A', 'O', '1997-12-01', '1997-12-10', 'NONE', 'MAIL', 'Small quantity item'),
+('1995-05-30', 100004, 1, 4567, 305, 150.00, 22500.00, 0.15, 0.06, 'N', 'O', '1998-05-25', '1998-06-05', 'DELIVER IN PERSON', 'RAIL', 'Large bulk shipment');
+-- result:
+-- !result
+INSERT INTO lineitem (l_shipdate, l_orderkey, l_linenumber, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment) VALUES
+('1996-01-15', 100011, 1, 5501, 101, 12.00, 1560.00, 0.05, 0.08, 'N', 'O', '1995-03-10', '1995-03-20', 'DELIVER IN PERSON', 'TRUCK', 'First item of order'),
+('1996-02-15', 100011, 2, 7203, 203, 8.50, 892.50, 0.00, 0.08, 'N', 'O', '1995-03-10', '1995-03-18', 'TAKE BACK RETURN', 'AIR', 'Second item, fragile'),
+('1996-03-22', 100012, 1, 3345, 156, 24.00, 3120.00, 0.10, 0.07, 'R', 'F', '1996-08-18', '1996-08-25', 'COLLECT COD', 'SHIP', 'Bulk order item'),
+('1996-12-05', 100013, 1, 8890, 89, 3.00, 450.00, 0.02, 0.09, 'A', 'O', '1997-12-01', '1997-12-10', 'NONE', 'MAIL', 'Small quantity item'),
+('1996-04-30', 100014, 1, 4567, 305, 150.00, 22500.00, 0.15, 0.06, 'N', 'O', '1998-05-25', '1998-06-05', 'DELIVER IN PERSON', 'RAIL', 'Large bulk shipment');
+-- result:
+-- !result
+INSERT INTO lineitem (l_shipdate, l_orderkey, l_linenumber, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment) VALUES
+('1997-01-15', 100101, 1, 5501, 101, 12.00, 1560.00, 0.05, 0.08, 'N', 'O', '1995-03-10', '1995-03-20', 'DELIVER IN PERSON', 'TRUCK', 'First item of order'),
+('1997-02-15', 100101, 2, 7203, 203, 8.50, 892.50, 0.00, 0.08, 'N', 'O', '1995-03-10', '1995-03-18', 'TAKE BACK RETURN', 'AIR', 'Second item, fragile'),
+('1997-03-22', 100102, 1, 3345, 156, 24.00, 3120.00, 0.10, 0.07, 'R', 'F', '1996-08-18', '1996-08-25', 'COLLECT COD', 'SHIP', 'Bulk order item'),
+('1997-11-05', 100103, 1, 8890, 89, 3.00, 450.00, 0.02, 0.09, 'A', 'O', '1997-12-01', '1997-12-10', 'NONE', 'MAIL', 'Small quantity item'),
+('1997-04-30', 100104, 1, 4567, 305, 150.00, 22500.00, 0.15, 0.06, 'N', 'O', '1998-05-25', '1998-06-05', 'DELIVER IN PERSON', 'RAIL', 'Large bulk shipment');
+-- result:
+-- !result
+INSERT INTO lineitem (l_shipdate, l_orderkey, l_linenumber, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment) VALUES
+('1998-01-15', 101001, 1, 5501, 101, 12.00, 1560.00, 0.05, 0.08, 'N', 'O', '1995-03-10', '1995-03-20', 'DELIVER IN PERSON', 'TRUCK', 'First item of order'),
+('1998-02-15', 101001, 2, 7203, 203, 8.50, 892.50, 0.00, 0.08, 'N', 'O', '1995-03-10', '1995-03-18', 'TAKE BACK RETURN', 'AIR', 'Second item, fragile'),
+('1998-03-22', 101002, 1, 3345, 156, 24.00, 3120.00, 0.10, 0.07, 'R', 'F', '1996-08-18', '1996-08-25', 'COLLECT COD', 'SHIP', 'Bulk order item'),
+('1998-11-05', 101003, 1, 8890, 89, 3.00, 450.00, 0.02, 0.09, 'A', 'O', '1997-12-01', '1997-12-10', 'NONE', 'MAIL', 'Small quantity item'),
+('1998-04-30', 101004, 1, 4567, 305, 150.00, 22500.00, 0.15, 0.06, 'N', 'O', '1998-05-25', '1998-06-05', 'DELIVER IN PERSON', 'RAIL', 'Large bulk shipment');
+-- result:
+-- !result
+INSERT INTO lineitem (l_shipdate, l_orderkey, l_linenumber, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment) VALUES    
+('1995-01-16', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+('1995-01-16', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+-- result:
+-- !result
+set topn_push_down_agg_mode=2;
+-- result:
+-- !result
+set chunk_size=2;
+-- result:
+-- !result
+select l_shipdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate order by l_shipdate limit 1;
+-- result:
+1995-01-16	None	None	None	0
+-- !result
+select l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_orderkey order by l_orderkey limit 1;
+-- result:
+None	None	None	None	0
+-- !result
+select l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_partkey order by l_partkey limit 1;
+-- result:
+None	None	None	None	0
+-- !result
+select l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_suppkey order by l_suppkey limit 1;
+-- result:
+None	None	None	None	0
+-- !result
+select l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linenumber order by l_linenumber limit 1;
+-- result:
+None	None	None	None	0
+-- !result
+select l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_returnflag order by l_returnflag limit 1;
+-- result:
+None	None	None	None	0
+-- !result
+select l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linestatus order by l_linestatus limit 1;
+-- result:
+None	None	None	None	0
+-- !result
+select l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_commitdate order by l_commitdate limit 1;
+-- result:
+None	None	None	None	0
+-- !result
+select l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_receiptdate order by l_receiptdate limit 1;
+-- result:
+None	None	None	None	0
+-- !result
+select l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipmode order by l_shipmode limit 1;
+-- result:
+None	None	None	None	0
+-- !result
+select l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_comment order by l_comment limit 1;
+-- result:
+None	None	None	None	0
+-- !result
+select l_shipdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate order by l_shipdate limit 10;
+-- result:
+1995-01-16	None	None	None	0
+1995-02-05	450.00000000	0.02000000	None	1
+1995-03-10	1226.25000000	0.02500000	None	2
+1995-03-22	3120.00000000	0.10000000	None	1
+1995-05-30	22500.00000000	0.15000000	None	1
+1996-01-15	1560.00000000	0.05000000	None	1
+1996-02-15	892.50000000	0E-8	None	1
+1996-03-22	3120.00000000	0.10000000	None	1
+1996-04-30	22500.00000000	0.15000000	None	1
+1996-12-05	450.00000000	0.02000000	None	1
+-- !result
+select l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_orderkey order by l_orderkey limit 10;
+-- result:
+None	None	None	None	0
+100001	1226.25000000	0.02500000	None	2
+100002	3120.00000000	0.10000000	None	1
+100003	450.00000000	0.02000000	None	1
+100004	22500.00000000	0.15000000	None	1
+100011	1226.25000000	0.02500000	None	2
+100012	3120.00000000	0.10000000	None	1
+100013	450.00000000	0.02000000	None	1
+100014	22500.00000000	0.15000000	None	1
+100101	1226.25000000	0.02500000	None	2
+-- !result
+select l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_partkey order by l_partkey limit 10;
+-- result:
+None	None	None	None	0
+3345	3120.00000000	0.10000000	None	4
+4567	22500.00000000	0.15000000	None	4
+5501	1560.00000000	0.05000000	None	4
+7203	892.50000000	0E-8	None	4
+8890	450.00000000	0.02000000	None	4
+-- !result
+select l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_suppkey order by l_suppkey limit 10;
+-- result:
+None	None	None	None	0
+89	450.00000000	0.02000000	None	4
+101	1560.00000000	0.05000000	None	4
+156	3120.00000000	0.10000000	None	4
+203	892.50000000	0E-8	None	4
+305	22500.00000000	0.15000000	None	4
+-- !result
+select l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linenumber order by l_linenumber limit 10;
+-- result:
+None	None	None	None	0
+1	6907.50000000	0.08000000	None	16
+2	892.50000000	0E-8	None	4
+-- !result
+select l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_returnflag order by l_returnflag limit 10;
+-- result:
+None	None	None	None	0
+A	450.00000000	0.02000000	None	4
+N	8317.50000000	0.06666667	None	12
+R	3120.00000000	0.10000000	None	4
+-- !result
+select l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linestatus order by l_linestatus limit 10;
+-- result:
+None	None	None	None	0
+F	3120.00000000	0.10000000	None	4
+O	6350.62500000	0.05500000	None	16
+-- !result
+select l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_commitdate order by l_commitdate limit 10;
+-- result:
+None	None	None	None	0
+1995-03-10	1226.25000000	0.02500000	None	8
+1996-08-18	3120.00000000	0.10000000	None	4
+1997-12-01	450.00000000	0.02000000	None	4
+1998-05-25	22500.00000000	0.15000000	None	4
+-- !result
+select l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_receiptdate order by l_receiptdate limit 10;
+-- result:
+None	None	None	None	0
+1995-03-18	892.50000000	0E-8	None	4
+1995-03-20	1560.00000000	0.05000000	None	4
+1996-08-25	3120.00000000	0.10000000	None	4
+1997-12-10	450.00000000	0.02000000	None	4
+1998-06-05	22500.00000000	0.15000000	None	4
+-- !result
+select l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipinstruct order by l_shipinstruct limit 10;
+-- result:
+None	None	None	None	0
+COLLECT COD	3120.00000000	0.10000000	None	4
+DELIVER IN PERSON	12030.00000000	0.10000000	None	8
+NONE	450.00000000	0.02000000	None	4
+TAKE BACK RETURN	892.50000000	0E-8	None	4
+-- !result
+select l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipmode order by l_shipmode limit 10;
+-- result:
+None	None	None	None	0
+AIR	892.50000000	0E-8	None	4
+MAIL	450.00000000	0.02000000	None	4
+RAIL	22500.00000000	0.15000000	None	4
+SHIP	3120.00000000	0.10000000	None	4
+TRUCK	1560.00000000	0.05000000	None	4
+-- !result
+select l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_comment order by l_comment limit 10;
+-- result:
+None	None	None	None	0
+Bulk order item	3120.00000000	0.10000000	None	4
+First item of order	1560.00000000	0.05000000	None	4
+Large bulk shipment	22500.00000000	0.15000000	None	4
+Second item, fragile	892.50000000	0E-8	None	4
+Small quantity item	450.00000000	0.02000000	None	4
+-- !result
+select l_shipdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate order by l_shipdate limit 100;
+-- result:
+1995-01-16	None	None	None	0
+1995-02-05	450.00000000	0.02000000	None	1
+1995-03-10	1226.25000000	0.02500000	None	2
+1995-03-22	3120.00000000	0.10000000	None	1
+1995-05-30	22500.00000000	0.15000000	None	1
+1996-01-15	1560.00000000	0.05000000	None	1
+1996-02-15	892.50000000	0E-8	None	1
+1996-03-22	3120.00000000	0.10000000	None	1
+1996-04-30	22500.00000000	0.15000000	None	1
+1996-12-05	450.00000000	0.02000000	None	1
+1997-01-15	1560.00000000	0.05000000	None	1
+1997-02-15	892.50000000	0E-8	None	1
+1997-03-22	3120.00000000	0.10000000	None	1
+1997-04-30	22500.00000000	0.15000000	None	1
+1997-11-05	450.00000000	0.02000000	None	1
+1998-01-15	1560.00000000	0.05000000	None	1
+1998-02-15	892.50000000	0E-8	None	1
+1998-03-22	3120.00000000	0.10000000	None	1
+1998-04-30	22500.00000000	0.15000000	None	1
+1998-11-05	450.00000000	0.02000000	None	1
+-- !result
+select l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_orderkey order by l_orderkey limit 100;
+-- result:
+None	None	None	None	0
+100001	1226.25000000	0.02500000	None	2
+100002	3120.00000000	0.10000000	None	1
+100003	450.00000000	0.02000000	None	1
+100004	22500.00000000	0.15000000	None	1
+100011	1226.25000000	0.02500000	None	2
+100012	3120.00000000	0.10000000	None	1
+100013	450.00000000	0.02000000	None	1
+100014	22500.00000000	0.15000000	None	1
+100101	1226.25000000	0.02500000	None	2
+100102	3120.00000000	0.10000000	None	1
+100103	450.00000000	0.02000000	None	1
+100104	22500.00000000	0.15000000	None	1
+101001	1226.25000000	0.02500000	None	2
+101002	3120.00000000	0.10000000	None	1
+101003	450.00000000	0.02000000	None	1
+101004	22500.00000000	0.15000000	None	1
+-- !result
+select l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_partkey order by l_partkey limit 100;
+-- result:
+None	None	None	None	0
+3345	3120.00000000	0.10000000	None	4
+4567	22500.00000000	0.15000000	None	4
+5501	1560.00000000	0.05000000	None	4
+7203	892.50000000	0E-8	None	4
+8890	450.00000000	0.02000000	None	4
+-- !result
+select l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_suppkey order by l_suppkey limit 100;
+-- result:
+None	None	None	None	0
+89	450.00000000	0.02000000	None	4
+101	1560.00000000	0.05000000	None	4
+156	3120.00000000	0.10000000	None	4
+203	892.50000000	0E-8	None	4
+305	22500.00000000	0.15000000	None	4
+-- !result
+select l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linenumber order by l_linenumber limit 100;
+-- result:
+None	None	None	None	0
+1	6907.50000000	0.08000000	None	16
+2	892.50000000	0E-8	None	4
+-- !result
+select l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_returnflag order by l_returnflag limit 100;
+-- result:
+None	None	None	None	0
+A	450.00000000	0.02000000	None	4
+N	8317.50000000	0.06666667	None	12
+R	3120.00000000	0.10000000	None	4
+-- !result
+select l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linestatus order by l_linestatus limit 100;
+-- result:
+None	None	None	None	0
+F	3120.00000000	0.10000000	None	4
+O	6350.62500000	0.05500000	None	16
+-- !result
+select l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_commitdate order by l_commitdate limit 100;
+-- result:
+None	None	None	None	0
+1995-03-10	1226.25000000	0.02500000	None	8
+1996-08-18	3120.00000000	0.10000000	None	4
+1997-12-01	450.00000000	0.02000000	None	4
+1998-05-25	22500.00000000	0.15000000	None	4
+-- !result
+select l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_receiptdate order by l_receiptdate limit 100;
+-- result:
+None	None	None	None	0
+1995-03-18	892.50000000	0E-8	None	4
+1995-03-20	1560.00000000	0.05000000	None	4
+1996-08-25	3120.00000000	0.10000000	None	4
+1997-12-10	450.00000000	0.02000000	None	4
+1998-06-05	22500.00000000	0.15000000	None	4
+-- !result
+select l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipinstruct order by l_shipinstruct limit 100;
+-- result:
+None	None	None	None	0
+COLLECT COD	3120.00000000	0.10000000	None	4
+DELIVER IN PERSON	12030.00000000	0.10000000	None	8
+NONE	450.00000000	0.02000000	None	4
+TAKE BACK RETURN	892.50000000	0E-8	None	4
+-- !result
+select l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipmode order by l_shipmode limit 100;
+-- result:
+None	None	None	None	0
+AIR	892.50000000	0E-8	None	4
+MAIL	450.00000000	0.02000000	None	4
+RAIL	22500.00000000	0.15000000	None	4
+SHIP	3120.00000000	0.10000000	None	4
+TRUCK	1560.00000000	0.05000000	None	4
+-- !result
+select l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_comment order by l_comment limit 100;
+-- result:
+None	None	None	None	0
+Bulk order item	3120.00000000	0.10000000	None	4
+First item of order	1560.00000000	0.05000000	None	4
+Large bulk shipment	22500.00000000	0.15000000	None	4
+Second item, fragile	892.50000000	0E-8	None	4
+Small quantity item	450.00000000	0.02000000	None	4
+-- !result
+select l_shipdate, l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_orderkey order by l_shipdate, l_orderkey limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	100003	450.00000000	0.02000000	None	1
+1995-03-10	100001	1226.25000000	0.02500000	None	2
+1995-03-22	100002	3120.00000000	0.10000000	None	1
+1995-05-30	100004	22500.00000000	0.15000000	None	1
+1996-01-15	100011	1560.00000000	0.05000000	None	1
+1996-02-15	100011	892.50000000	0E-8	None	1
+1996-03-22	100012	3120.00000000	0.10000000	None	1
+1996-04-30	100014	22500.00000000	0.15000000	None	1
+1996-12-05	100013	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey order by l_shipdate, l_partkey limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	8890	450.00000000	0.02000000	None	1
+1995-03-10	5501	1560.00000000	0.05000000	None	1
+1995-03-10	7203	892.50000000	0E-8	None	1
+1995-03-22	3345	3120.00000000	0.10000000	None	1
+1995-05-30	4567	22500.00000000	0.15000000	None	1
+1996-01-15	5501	1560.00000000	0.05000000	None	1
+1996-02-15	7203	892.50000000	0E-8	None	1
+1996-03-22	3345	3120.00000000	0.10000000	None	1
+1996-04-30	4567	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_suppkey order by l_shipdate, l_suppkey limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	89	450.00000000	0.02000000	None	1
+1995-03-10	101	1560.00000000	0.05000000	None	1
+1995-03-10	203	892.50000000	0E-8	None	1
+1995-03-22	156	3120.00000000	0.10000000	None	1
+1995-05-30	305	22500.00000000	0.15000000	None	1
+1996-01-15	101	1560.00000000	0.05000000	None	1
+1996-02-15	203	892.50000000	0E-8	None	1
+1996-03-22	156	3120.00000000	0.10000000	None	1
+1996-04-30	305	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linenumber order by l_shipdate, l_linenumber limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	1	450.00000000	0.02000000	None	1
+1995-03-10	1	1560.00000000	0.05000000	None	1
+1995-03-10	2	892.50000000	0E-8	None	1
+1995-03-22	1	3120.00000000	0.10000000	None	1
+1995-05-30	1	22500.00000000	0.15000000	None	1
+1996-01-15	1	1560.00000000	0.05000000	None	1
+1996-02-15	2	892.50000000	0E-8	None	1
+1996-03-22	1	3120.00000000	0.10000000	None	1
+1996-04-30	1	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_returnflag order by l_shipdate, l_returnflag limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	A	450.00000000	0.02000000	None	1
+1995-03-10	N	1226.25000000	0.02500000	None	2
+1995-03-22	R	3120.00000000	0.10000000	None	1
+1995-05-30	N	22500.00000000	0.15000000	None	1
+1996-01-15	N	1560.00000000	0.05000000	None	1
+1996-02-15	N	892.50000000	0E-8	None	1
+1996-03-22	R	3120.00000000	0.10000000	None	1
+1996-04-30	N	22500.00000000	0.15000000	None	1
+1996-12-05	A	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus order by l_shipdate, l_linestatus limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	O	450.00000000	0.02000000	None	1
+1995-03-10	O	1226.25000000	0.02500000	None	2
+1995-03-22	F	3120.00000000	0.10000000	None	1
+1995-05-30	O	22500.00000000	0.15000000	None	1
+1996-01-15	O	1560.00000000	0.05000000	None	1
+1996-02-15	O	892.50000000	0E-8	None	1
+1996-03-22	F	3120.00000000	0.10000000	None	1
+1996-04-30	O	22500.00000000	0.15000000	None	1
+1996-12-05	O	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_commitdate order by l_shipdate, l_commitdate limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	1997-12-01	450.00000000	0.02000000	None	1
+1995-03-10	1995-03-10	1226.25000000	0.02500000	None	2
+1995-03-22	1996-08-18	3120.00000000	0.10000000	None	1
+1995-05-30	1998-05-25	22500.00000000	0.15000000	None	1
+1996-01-15	1995-03-10	1560.00000000	0.05000000	None	1
+1996-02-15	1995-03-10	892.50000000	0E-8	None	1
+1996-03-22	1996-08-18	3120.00000000	0.10000000	None	1
+1996-04-30	1998-05-25	22500.00000000	0.15000000	None	1
+1996-12-05	1997-12-01	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_receiptdate order by l_shipdate, l_receiptdate limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	1997-12-10	450.00000000	0.02000000	None	1
+1995-03-10	1995-03-18	892.50000000	0E-8	None	1
+1995-03-10	1995-03-20	1560.00000000	0.05000000	None	1
+1995-03-22	1996-08-25	3120.00000000	0.10000000	None	1
+1995-05-30	1998-06-05	22500.00000000	0.15000000	None	1
+1996-01-15	1995-03-20	1560.00000000	0.05000000	None	1
+1996-02-15	1995-03-18	892.50000000	0E-8	None	1
+1996-03-22	1996-08-25	3120.00000000	0.10000000	None	1
+1996-04-30	1998-06-05	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipinstruct order by l_shipdate, l_shipinstruct limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	NONE	450.00000000	0.02000000	None	1
+1995-03-10	DELIVER IN PERSON	1560.00000000	0.05000000	None	1
+1995-03-10	TAKE BACK RETURN	892.50000000	0E-8	None	1
+1995-03-22	COLLECT COD	3120.00000000	0.10000000	None	1
+1995-05-30	DELIVER IN PERSON	22500.00000000	0.15000000	None	1
+1996-01-15	DELIVER IN PERSON	1560.00000000	0.05000000	None	1
+1996-02-15	TAKE BACK RETURN	892.50000000	0E-8	None	1
+1996-03-22	COLLECT COD	3120.00000000	0.10000000	None	1
+1996-04-30	DELIVER IN PERSON	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipmode order by l_shipdate, l_shipmode limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	MAIL	450.00000000	0.02000000	None	1
+1995-03-10	AIR	892.50000000	0E-8	None	1
+1995-03-10	TRUCK	1560.00000000	0.05000000	None	1
+1995-03-22	SHIP	3120.00000000	0.10000000	None	1
+1995-05-30	RAIL	22500.00000000	0.15000000	None	1
+1996-01-15	TRUCK	1560.00000000	0.05000000	None	1
+1996-02-15	AIR	892.50000000	0E-8	None	1
+1996-03-22	SHIP	3120.00000000	0.10000000	None	1
+1996-04-30	RAIL	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_comment order by l_shipdate, l_comment limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	First item of order	1560.00000000	0.05000000	None	1
+1995-03-10	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-22	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	Large bulk shipment	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_orderkey order by l_shipdate, l_orderkey limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	100003	450.00000000	0.02000000	None	1
+1995-03-10	100001	1226.25000000	0.02500000	None	2
+1995-03-22	100002	3120.00000000	0.10000000	None	1
+1995-05-30	100004	22500.00000000	0.15000000	None	1
+1996-01-15	100011	1560.00000000	0.05000000	None	1
+1996-02-15	100011	892.50000000	0E-8	None	1
+1996-03-22	100012	3120.00000000	0.10000000	None	1
+1996-04-30	100014	22500.00000000	0.15000000	None	1
+1996-12-05	100013	450.00000000	0.02000000	None	1
+1997-01-15	100101	1560.00000000	0.05000000	None	1
+1997-02-15	100101	892.50000000	0E-8	None	1
+1997-03-22	100102	3120.00000000	0.10000000	None	1
+1997-04-30	100104	22500.00000000	0.15000000	None	1
+1997-11-05	100103	450.00000000	0.02000000	None	1
+1998-01-15	101001	1560.00000000	0.05000000	None	1
+1998-02-15	101001	892.50000000	0E-8	None	1
+1998-03-22	101002	3120.00000000	0.10000000	None	1
+1998-04-30	101004	22500.00000000	0.15000000	None	1
+1998-11-05	101003	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey order by l_shipdate, l_partkey limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	8890	450.00000000	0.02000000	None	1
+1995-03-10	5501	1560.00000000	0.05000000	None	1
+1995-03-10	7203	892.50000000	0E-8	None	1
+1995-03-22	3345	3120.00000000	0.10000000	None	1
+1995-05-30	4567	22500.00000000	0.15000000	None	1
+1996-01-15	5501	1560.00000000	0.05000000	None	1
+1996-02-15	7203	892.50000000	0E-8	None	1
+1996-03-22	3345	3120.00000000	0.10000000	None	1
+1996-04-30	4567	22500.00000000	0.15000000	None	1
+1996-12-05	8890	450.00000000	0.02000000	None	1
+1997-01-15	5501	1560.00000000	0.05000000	None	1
+1997-02-15	7203	892.50000000	0E-8	None	1
+1997-03-22	3345	3120.00000000	0.10000000	None	1
+1997-04-30	4567	22500.00000000	0.15000000	None	1
+1997-11-05	8890	450.00000000	0.02000000	None	1
+1998-01-15	5501	1560.00000000	0.05000000	None	1
+1998-02-15	7203	892.50000000	0E-8	None	1
+1998-03-22	3345	3120.00000000	0.10000000	None	1
+1998-04-30	4567	22500.00000000	0.15000000	None	1
+1998-11-05	8890	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_suppkey order by l_shipdate, l_suppkey limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	89	450.00000000	0.02000000	None	1
+1995-03-10	101	1560.00000000	0.05000000	None	1
+1995-03-10	203	892.50000000	0E-8	None	1
+1995-03-22	156	3120.00000000	0.10000000	None	1
+1995-05-30	305	22500.00000000	0.15000000	None	1
+1996-01-15	101	1560.00000000	0.05000000	None	1
+1996-02-15	203	892.50000000	0E-8	None	1
+1996-03-22	156	3120.00000000	0.10000000	None	1
+1996-04-30	305	22500.00000000	0.15000000	None	1
+1996-12-05	89	450.00000000	0.02000000	None	1
+1997-01-15	101	1560.00000000	0.05000000	None	1
+1997-02-15	203	892.50000000	0E-8	None	1
+1997-03-22	156	3120.00000000	0.10000000	None	1
+1997-04-30	305	22500.00000000	0.15000000	None	1
+1997-11-05	89	450.00000000	0.02000000	None	1
+1998-01-15	101	1560.00000000	0.05000000	None	1
+1998-02-15	203	892.50000000	0E-8	None	1
+1998-03-22	156	3120.00000000	0.10000000	None	1
+1998-04-30	305	22500.00000000	0.15000000	None	1
+1998-11-05	89	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linenumber order by l_shipdate, l_linenumber limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	1	450.00000000	0.02000000	None	1
+1995-03-10	1	1560.00000000	0.05000000	None	1
+1995-03-10	2	892.50000000	0E-8	None	1
+1995-03-22	1	3120.00000000	0.10000000	None	1
+1995-05-30	1	22500.00000000	0.15000000	None	1
+1996-01-15	1	1560.00000000	0.05000000	None	1
+1996-02-15	2	892.50000000	0E-8	None	1
+1996-03-22	1	3120.00000000	0.10000000	None	1
+1996-04-30	1	22500.00000000	0.15000000	None	1
+1996-12-05	1	450.00000000	0.02000000	None	1
+1997-01-15	1	1560.00000000	0.05000000	None	1
+1997-02-15	2	892.50000000	0E-8	None	1
+1997-03-22	1	3120.00000000	0.10000000	None	1
+1997-04-30	1	22500.00000000	0.15000000	None	1
+1997-11-05	1	450.00000000	0.02000000	None	1
+1998-01-15	1	1560.00000000	0.05000000	None	1
+1998-02-15	2	892.50000000	0E-8	None	1
+1998-03-22	1	3120.00000000	0.10000000	None	1
+1998-04-30	1	22500.00000000	0.15000000	None	1
+1998-11-05	1	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_returnflag order by l_shipdate, l_returnflag limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	A	450.00000000	0.02000000	None	1
+1995-03-10	N	1226.25000000	0.02500000	None	2
+1995-03-22	R	3120.00000000	0.10000000	None	1
+1995-05-30	N	22500.00000000	0.15000000	None	1
+1996-01-15	N	1560.00000000	0.05000000	None	1
+1996-02-15	N	892.50000000	0E-8	None	1
+1996-03-22	R	3120.00000000	0.10000000	None	1
+1996-04-30	N	22500.00000000	0.15000000	None	1
+1996-12-05	A	450.00000000	0.02000000	None	1
+1997-01-15	N	1560.00000000	0.05000000	None	1
+1997-02-15	N	892.50000000	0E-8	None	1
+1997-03-22	R	3120.00000000	0.10000000	None	1
+1997-04-30	N	22500.00000000	0.15000000	None	1
+1997-11-05	A	450.00000000	0.02000000	None	1
+1998-01-15	N	1560.00000000	0.05000000	None	1
+1998-02-15	N	892.50000000	0E-8	None	1
+1998-03-22	R	3120.00000000	0.10000000	None	1
+1998-04-30	N	22500.00000000	0.15000000	None	1
+1998-11-05	A	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus order by l_shipdate, l_linestatus limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	O	450.00000000	0.02000000	None	1
+1995-03-10	O	1226.25000000	0.02500000	None	2
+1995-03-22	F	3120.00000000	0.10000000	None	1
+1995-05-30	O	22500.00000000	0.15000000	None	1
+1996-01-15	O	1560.00000000	0.05000000	None	1
+1996-02-15	O	892.50000000	0E-8	None	1
+1996-03-22	F	3120.00000000	0.10000000	None	1
+1996-04-30	O	22500.00000000	0.15000000	None	1
+1996-12-05	O	450.00000000	0.02000000	None	1
+1997-01-15	O	1560.00000000	0.05000000	None	1
+1997-02-15	O	892.50000000	0E-8	None	1
+1997-03-22	F	3120.00000000	0.10000000	None	1
+1997-04-30	O	22500.00000000	0.15000000	None	1
+1997-11-05	O	450.00000000	0.02000000	None	1
+1998-01-15	O	1560.00000000	0.05000000	None	1
+1998-02-15	O	892.50000000	0E-8	None	1
+1998-03-22	F	3120.00000000	0.10000000	None	1
+1998-04-30	O	22500.00000000	0.15000000	None	1
+1998-11-05	O	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_commitdate order by l_shipdate, l_commitdate limit 100
+select l_shipdate, l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_receiptdate order by l_shipdate, l_receiptdate limit 100;
+-- result:
+E: (1064, "Getting syntax error at line 2, column 0. Detail message: Unexpected input 'select', the most similar input is {<EOF>, ';'}.")
+-- !result
+select l_shipdate, l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipinstruct order by l_shipdate, l_shipinstruct limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	NONE	450.00000000	0.02000000	None	1
+1995-03-10	DELIVER IN PERSON	1560.00000000	0.05000000	None	1
+1995-03-10	TAKE BACK RETURN	892.50000000	0E-8	None	1
+1995-03-22	COLLECT COD	3120.00000000	0.10000000	None	1
+1995-05-30	DELIVER IN PERSON	22500.00000000	0.15000000	None	1
+1996-01-15	DELIVER IN PERSON	1560.00000000	0.05000000	None	1
+1996-02-15	TAKE BACK RETURN	892.50000000	0E-8	None	1
+1996-03-22	COLLECT COD	3120.00000000	0.10000000	None	1
+1996-04-30	DELIVER IN PERSON	22500.00000000	0.15000000	None	1
+1996-12-05	NONE	450.00000000	0.02000000	None	1
+1997-01-15	DELIVER IN PERSON	1560.00000000	0.05000000	None	1
+1997-02-15	TAKE BACK RETURN	892.50000000	0E-8	None	1
+1997-03-22	COLLECT COD	3120.00000000	0.10000000	None	1
+1997-04-30	DELIVER IN PERSON	22500.00000000	0.15000000	None	1
+1997-11-05	NONE	450.00000000	0.02000000	None	1
+1998-01-15	DELIVER IN PERSON	1560.00000000	0.05000000	None	1
+1998-02-15	TAKE BACK RETURN	892.50000000	0E-8	None	1
+1998-03-22	COLLECT COD	3120.00000000	0.10000000	None	1
+1998-04-30	DELIVER IN PERSON	22500.00000000	0.15000000	None	1
+1998-11-05	NONE	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipmode order by l_shipdate, l_shipmode limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	MAIL	450.00000000	0.02000000	None	1
+1995-03-10	AIR	892.50000000	0E-8	None	1
+1995-03-10	TRUCK	1560.00000000	0.05000000	None	1
+1995-03-22	SHIP	3120.00000000	0.10000000	None	1
+1995-05-30	RAIL	22500.00000000	0.15000000	None	1
+1996-01-15	TRUCK	1560.00000000	0.05000000	None	1
+1996-02-15	AIR	892.50000000	0E-8	None	1
+1996-03-22	SHIP	3120.00000000	0.10000000	None	1
+1996-04-30	RAIL	22500.00000000	0.15000000	None	1
+1996-12-05	MAIL	450.00000000	0.02000000	None	1
+1997-01-15	TRUCK	1560.00000000	0.05000000	None	1
+1997-02-15	AIR	892.50000000	0E-8	None	1
+1997-03-22	SHIP	3120.00000000	0.10000000	None	1
+1997-04-30	RAIL	22500.00000000	0.15000000	None	1
+1997-11-05	MAIL	450.00000000	0.02000000	None	1
+1998-01-15	TRUCK	1560.00000000	0.05000000	None	1
+1998-02-15	AIR	892.50000000	0E-8	None	1
+1998-03-22	SHIP	3120.00000000	0.10000000	None	1
+1998-04-30	RAIL	22500.00000000	0.15000000	None	1
+1998-11-05	MAIL	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_comment order by l_shipdate, l_comment limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	First item of order	1560.00000000	0.05000000	None	1
+1995-03-10	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-22	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-12-05	Small quantity item	450.00000000	0.02000000	None	1
+1997-01-15	First item of order	1560.00000000	0.05000000	None	1
+1997-02-15	Second item, fragile	892.50000000	0E-8	None	1
+1997-03-22	Bulk order item	3120.00000000	0.10000000	None	1
+1997-04-30	Large bulk shipment	22500.00000000	0.15000000	None	1
+1997-11-05	Small quantity item	450.00000000	0.02000000	None	1
+1998-01-15	First item of order	1560.00000000	0.05000000	None	1
+1998-02-15	Second item, fragile	892.50000000	0E-8	None	1
+1998-03-22	Bulk order item	3120.00000000	0.10000000	None	1
+1998-04-30	Large bulk shipment	22500.00000000	0.15000000	None	1
+1998-11-05	Small quantity item	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment order by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment limit 10;
+-- result:
+1995-01-16	None	None	None	None	None	None	None	0
+1995-02-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-10	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1995-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment order by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment limit 100;
+-- result:
+1995-01-16	None	None	None	None	None	None	None	0
+1995-02-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-10	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1995-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-12-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1997-01-15	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1997-02-15	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1997-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1997-04-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1997-11-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1998-01-15	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1998-02-15	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1998-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1998-04-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1998-11-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment order by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment limit 1000;
+-- result:
+1995-01-16	None	None	None	None	None	None	None	0
+1995-02-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-10	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1995-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-12-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1997-01-15	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1997-02-15	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1997-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1997-04-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1997-11-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1998-01-15	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1998-02-15	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1998-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1998-04-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1998-11-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment limit 10;
+-- result:
+1995-01-16	None	None	None	None	None	None	None	0
+1995-02-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1995-03-10	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment limit 100;
+-- result:
+1995-01-16	None	None	None	None	None	None	None	0
+1995-02-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1995-03-10	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-12-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1997-01-15	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1997-02-15	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1997-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1997-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1997-11-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1998-01-15	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1998-02-15	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1998-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1998-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1998-11-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment limit 1000;
+-- result:
+1995-01-16	None	None	None	None	None	None	None	0
+1995-02-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1995-03-10	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-12-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1997-01-15	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1997-02-15	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1997-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1997-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1997-11-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1998-01-15	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1998-02-15	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1998-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1998-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1998-11-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate order by l_shipdate nulls last limit 1;
+-- result:
+1995-01-16	None	None	None	0
+-- !result
+select l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_orderkey order by l_orderkey nulls last limit 1;
+-- result:
+100001	1226.25000000	0.02500000	None	2
+-- !result
+select l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_partkey order by l_partkey nulls last limit 1;
+-- result:
+3345	3120.00000000	0.10000000	None	4
+-- !result
+select l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_suppkey order by l_suppkey nulls last limit 1;
+-- result:
+89	450.00000000	0.02000000	None	4
+-- !result
+select l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linenumber order by l_linenumber nulls last limit 1;
+-- result:
+1	6907.50000000	0.08000000	None	16
+-- !result
+select l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_returnflag order by l_returnflag nulls last limit 1;
+-- result:
+A	450.00000000	0.02000000	None	4
+-- !result
+select l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linestatus order by l_linestatus nulls last limit 1;
+-- result:
+F	3120.00000000	0.10000000	None	4
+-- !result
+select l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_commitdate order by l_commitdate nulls last limit 1;
+-- result:
+1995-03-10	1226.25000000	0.02500000	None	8
+-- !result
+select l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_receiptdate order by l_receiptdate nulls last limit 1;
+-- result:
+1995-03-18	892.50000000	0E-8	None	4
+-- !result
+select l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipmode order by l_shipmode nulls last limit 1;
+-- result:
+AIR	892.50000000	0E-8	None	4
+-- !result
+select l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_comment order by l_comment nulls last limit 1;
+-- result:
+Bulk order item	3120.00000000	0.10000000	None	4
+-- !result
+select l_shipdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate order by l_shipdate nulls last limit 10;
+-- result:
+1995-01-16	None	None	None	0
+1995-02-05	450.00000000	0.02000000	None	1
+1995-03-10	1226.25000000	0.02500000	None	2
+1995-03-22	3120.00000000	0.10000000	None	1
+1995-05-30	22500.00000000	0.15000000	None	1
+1996-01-15	1560.00000000	0.05000000	None	1
+1996-02-15	892.50000000	0E-8	None	1
+1996-03-22	3120.00000000	0.10000000	None	1
+1996-04-30	22500.00000000	0.15000000	None	1
+1996-12-05	450.00000000	0.02000000	None	1
+-- !result
+select l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_orderkey order by l_orderkey nulls last limit 10;
+-- result:
+100001	1226.25000000	0.02500000	None	2
+100002	3120.00000000	0.10000000	None	1
+100003	450.00000000	0.02000000	None	1
+100004	22500.00000000	0.15000000	None	1
+100011	1226.25000000	0.02500000	None	2
+100012	3120.00000000	0.10000000	None	1
+100013	450.00000000	0.02000000	None	1
+100014	22500.00000000	0.15000000	None	1
+100101	1226.25000000	0.02500000	None	2
+100102	3120.00000000	0.10000000	None	1
+-- !result
+select l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_partkey order by l_partkey nulls last limit 10;
+-- result:
+3345	3120.00000000	0.10000000	None	4
+4567	22500.00000000	0.15000000	None	4
+5501	1560.00000000	0.05000000	None	4
+7203	892.50000000	0E-8	None	4
+8890	450.00000000	0.02000000	None	4
+None	None	None	None	0
+-- !result
+select l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_suppkey order by l_suppkey nulls last limit 10;
+-- result:
+89	450.00000000	0.02000000	None	4
+101	1560.00000000	0.05000000	None	4
+156	3120.00000000	0.10000000	None	4
+203	892.50000000	0E-8	None	4
+305	22500.00000000	0.15000000	None	4
+None	None	None	None	0
+-- !result
+select l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linenumber order by l_linenumber nulls last limit 10;
+-- result:
+1	6907.50000000	0.08000000	None	16
+2	892.50000000	0E-8	None	4
+None	None	None	None	0
+-- !result
+select l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_returnflag order by l_returnflag nulls last limit 10;
+-- result:
+A	450.00000000	0.02000000	None	4
+N	8317.50000000	0.06666667	None	12
+R	3120.00000000	0.10000000	None	4
+None	None	None	None	0
+-- !result
+select l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linestatus order by l_linestatus nulls last limit 10;
+-- result:
+F	3120.00000000	0.10000000	None	4
+O	6350.62500000	0.05500000	None	16
+None	None	None	None	0
+-- !result
+select l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_commitdate order by l_commitdate nulls last limit 10;
+-- result:
+1995-03-10	1226.25000000	0.02500000	None	8
+1996-08-18	3120.00000000	0.10000000	None	4
+1997-12-01	450.00000000	0.02000000	None	4
+1998-05-25	22500.00000000	0.15000000	None	4
+None	None	None	None	0
+-- !result
+select l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_receiptdate order by l_receiptdate nulls last limit 10;
+-- result:
+1995-03-18	892.50000000	0E-8	None	4
+1995-03-20	1560.00000000	0.05000000	None	4
+1996-08-25	3120.00000000	0.10000000	None	4
+1997-12-10	450.00000000	0.02000000	None	4
+1998-06-05	22500.00000000	0.15000000	None	4
+None	None	None	None	0
+-- !result
+select l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipinstruct order by l_shipinstruct nulls last limit 10;
+-- result:
+COLLECT COD	3120.00000000	0.10000000	None	4
+DELIVER IN PERSON	12030.00000000	0.10000000	None	8
+NONE	450.00000000	0.02000000	None	4
+TAKE BACK RETURN	892.50000000	0E-8	None	4
+None	None	None	None	0
+-- !result
+select l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipmode order by l_shipmode nulls last limit 10;
+-- result:
+AIR	892.50000000	0E-8	None	4
+MAIL	450.00000000	0.02000000	None	4
+RAIL	22500.00000000	0.15000000	None	4
+SHIP	3120.00000000	0.10000000	None	4
+TRUCK	1560.00000000	0.05000000	None	4
+None	None	None	None	0
+-- !result
+select l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_comment order by l_comment nulls last limit 10;
+-- result:
+Bulk order item	3120.00000000	0.10000000	None	4
+First item of order	1560.00000000	0.05000000	None	4
+Large bulk shipment	22500.00000000	0.15000000	None	4
+Second item, fragile	892.50000000	0E-8	None	4
+Small quantity item	450.00000000	0.02000000	None	4
+None	None	None	None	0
+-- !result
+select l_shipdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate order by l_shipdate nulls last limit 100;
+-- result:
+1995-01-16	None	None	None	0
+1995-02-05	450.00000000	0.02000000	None	1
+1995-03-10	1226.25000000	0.02500000	None	2
+1995-03-22	3120.00000000	0.10000000	None	1
+1995-05-30	22500.00000000	0.15000000	None	1
+1996-01-15	1560.00000000	0.05000000	None	1
+1996-02-15	892.50000000	0E-8	None	1
+1996-03-22	3120.00000000	0.10000000	None	1
+1996-04-30	22500.00000000	0.15000000	None	1
+1996-12-05	450.00000000	0.02000000	None	1
+1997-01-15	1560.00000000	0.05000000	None	1
+1997-02-15	892.50000000	0E-8	None	1
+1997-03-22	3120.00000000	0.10000000	None	1
+1997-04-30	22500.00000000	0.15000000	None	1
+1997-11-05	450.00000000	0.02000000	None	1
+1998-01-15	1560.00000000	0.05000000	None	1
+1998-02-15	892.50000000	0E-8	None	1
+1998-03-22	3120.00000000	0.10000000	None	1
+1998-04-30	22500.00000000	0.15000000	None	1
+1998-11-05	450.00000000	0.02000000	None	1
+-- !result
+select l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_orderkey order by l_orderkey nulls last limit 100;
+-- result:
+100001	1226.25000000	0.02500000	None	2
+100002	3120.00000000	0.10000000	None	1
+100003	450.00000000	0.02000000	None	1
+100004	22500.00000000	0.15000000	None	1
+100011	1226.25000000	0.02500000	None	2
+100012	3120.00000000	0.10000000	None	1
+100013	450.00000000	0.02000000	None	1
+100014	22500.00000000	0.15000000	None	1
+100101	1226.25000000	0.02500000	None	2
+100102	3120.00000000	0.10000000	None	1
+100103	450.00000000	0.02000000	None	1
+100104	22500.00000000	0.15000000	None	1
+101001	1226.25000000	0.02500000	None	2
+101002	3120.00000000	0.10000000	None	1
+101003	450.00000000	0.02000000	None	1
+101004	22500.00000000	0.15000000	None	1
+None	None	None	None	0
+-- !result
+select l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_partkey order by l_partkey nulls last limit 100;
+-- result:
+3345	3120.00000000	0.10000000	None	4
+4567	22500.00000000	0.15000000	None	4
+5501	1560.00000000	0.05000000	None	4
+7203	892.50000000	0E-8	None	4
+8890	450.00000000	0.02000000	None	4
+None	None	None	None	0
+-- !result
+select l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_suppkey order by l_suppkey nulls last limit 100;
+-- result:
+89	450.00000000	0.02000000	None	4
+101	1560.00000000	0.05000000	None	4
+156	3120.00000000	0.10000000	None	4
+203	892.50000000	0E-8	None	4
+305	22500.00000000	0.15000000	None	4
+None	None	None	None	0
+-- !result
+select l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linenumber order by l_linenumber nulls last limit 100;
+-- result:
+1	6907.50000000	0.08000000	None	16
+2	892.50000000	0E-8	None	4
+None	None	None	None	0
+-- !result
+select l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_returnflag order by l_returnflag nulls last limit 100;
+-- result:
+A	450.00000000	0.02000000	None	4
+N	8317.50000000	0.06666667	None	12
+R	3120.00000000	0.10000000	None	4
+None	None	None	None	0
+-- !result
+select l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linestatus order by l_linestatus nulls last limit 100;
+-- result:
+F	3120.00000000	0.10000000	None	4
+O	6350.62500000	0.05500000	None	16
+None	None	None	None	0
+-- !result
+select l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_commitdate order by l_commitdate nulls last limit 100;
+-- result:
+1995-03-10	1226.25000000	0.02500000	None	8
+1996-08-18	3120.00000000	0.10000000	None	4
+1997-12-01	450.00000000	0.02000000	None	4
+1998-05-25	22500.00000000	0.15000000	None	4
+None	None	None	None	0
+-- !result
+select l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_receiptdate order by l_receiptdate nulls last limit 100;
+-- result:
+1995-03-18	892.50000000	0E-8	None	4
+1995-03-20	1560.00000000	0.05000000	None	4
+1996-08-25	3120.00000000	0.10000000	None	4
+1997-12-10	450.00000000	0.02000000	None	4
+1998-06-05	22500.00000000	0.15000000	None	4
+None	None	None	None	0
+-- !result
+select l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipinstruct order by l_shipinstruct nulls last limit 100;
+-- result:
+COLLECT COD	3120.00000000	0.10000000	None	4
+DELIVER IN PERSON	12030.00000000	0.10000000	None	8
+NONE	450.00000000	0.02000000	None	4
+TAKE BACK RETURN	892.50000000	0E-8	None	4
+None	None	None	None	0
+-- !result
+select l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipmode order by l_shipmode nulls last limit 100;
+-- result:
+AIR	892.50000000	0E-8	None	4
+MAIL	450.00000000	0.02000000	None	4
+RAIL	22500.00000000	0.15000000	None	4
+SHIP	3120.00000000	0.10000000	None	4
+TRUCK	1560.00000000	0.05000000	None	4
+None	None	None	None	0
+-- !result
+select l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_comment order by l_comment nulls last limit 100;
+-- result:
+Bulk order item	3120.00000000	0.10000000	None	4
+First item of order	1560.00000000	0.05000000	None	4
+Large bulk shipment	22500.00000000	0.15000000	None	4
+Second item, fragile	892.50000000	0E-8	None	4
+Small quantity item	450.00000000	0.02000000	None	4
+None	None	None	None	0
+-- !result
+select l_shipdate, l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_orderkey order by l_shipdate, l_orderkey nulls last limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	100003	450.00000000	0.02000000	None	1
+1995-03-10	100001	1226.25000000	0.02500000	None	2
+1995-03-22	100002	3120.00000000	0.10000000	None	1
+1995-05-30	100004	22500.00000000	0.15000000	None	1
+1996-01-15	100011	1560.00000000	0.05000000	None	1
+1996-02-15	100011	892.50000000	0E-8	None	1
+1996-03-22	100012	3120.00000000	0.10000000	None	1
+1996-04-30	100014	22500.00000000	0.15000000	None	1
+1996-12-05	100013	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey order by l_shipdate, l_partkey nulls last limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	8890	450.00000000	0.02000000	None	1
+1995-03-10	5501	1560.00000000	0.05000000	None	1
+1995-03-10	7203	892.50000000	0E-8	None	1
+1995-03-22	3345	3120.00000000	0.10000000	None	1
+1995-05-30	4567	22500.00000000	0.15000000	None	1
+1996-01-15	5501	1560.00000000	0.05000000	None	1
+1996-02-15	7203	892.50000000	0E-8	None	1
+1996-03-22	3345	3120.00000000	0.10000000	None	1
+1996-04-30	4567	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_suppkey order by l_shipdate, l_suppkey nulls last limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	89	450.00000000	0.02000000	None	1
+1995-03-10	101	1560.00000000	0.05000000	None	1
+1995-03-10	203	892.50000000	0E-8	None	1
+1995-03-22	156	3120.00000000	0.10000000	None	1
+1995-05-30	305	22500.00000000	0.15000000	None	1
+1996-01-15	101	1560.00000000	0.05000000	None	1
+1996-02-15	203	892.50000000	0E-8	None	1
+1996-03-22	156	3120.00000000	0.10000000	None	1
+1996-04-30	305	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linenumber order by l_shipdate, l_linenumber nulls last limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	1	450.00000000	0.02000000	None	1
+1995-03-10	1	1560.00000000	0.05000000	None	1
+1995-03-10	2	892.50000000	0E-8	None	1
+1995-03-22	1	3120.00000000	0.10000000	None	1
+1995-05-30	1	22500.00000000	0.15000000	None	1
+1996-01-15	1	1560.00000000	0.05000000	None	1
+1996-02-15	2	892.50000000	0E-8	None	1
+1996-03-22	1	3120.00000000	0.10000000	None	1
+1996-04-30	1	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_returnflag order by l_shipdate, l_returnflag nulls last limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	A	450.00000000	0.02000000	None	1
+1995-03-10	N	1226.25000000	0.02500000	None	2
+1995-03-22	R	3120.00000000	0.10000000	None	1
+1995-05-30	N	22500.00000000	0.15000000	None	1
+1996-01-15	N	1560.00000000	0.05000000	None	1
+1996-02-15	N	892.50000000	0E-8	None	1
+1996-03-22	R	3120.00000000	0.10000000	None	1
+1996-04-30	N	22500.00000000	0.15000000	None	1
+1996-12-05	A	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus order by l_shipdate, l_linestatus nulls last limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	O	450.00000000	0.02000000	None	1
+1995-03-10	O	1226.25000000	0.02500000	None	2
+1995-03-22	F	3120.00000000	0.10000000	None	1
+1995-05-30	O	22500.00000000	0.15000000	None	1
+1996-01-15	O	1560.00000000	0.05000000	None	1
+1996-02-15	O	892.50000000	0E-8	None	1
+1996-03-22	F	3120.00000000	0.10000000	None	1
+1996-04-30	O	22500.00000000	0.15000000	None	1
+1996-12-05	O	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_commitdate order by l_shipdate, l_commitdate nulls last limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	1997-12-01	450.00000000	0.02000000	None	1
+1995-03-10	1995-03-10	1226.25000000	0.02500000	None	2
+1995-03-22	1996-08-18	3120.00000000	0.10000000	None	1
+1995-05-30	1998-05-25	22500.00000000	0.15000000	None	1
+1996-01-15	1995-03-10	1560.00000000	0.05000000	None	1
+1996-02-15	1995-03-10	892.50000000	0E-8	None	1
+1996-03-22	1996-08-18	3120.00000000	0.10000000	None	1
+1996-04-30	1998-05-25	22500.00000000	0.15000000	None	1
+1996-12-05	1997-12-01	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_receiptdate order by l_shipdate, l_receiptdate nulls last limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	1997-12-10	450.00000000	0.02000000	None	1
+1995-03-10	1995-03-18	892.50000000	0E-8	None	1
+1995-03-10	1995-03-20	1560.00000000	0.05000000	None	1
+1995-03-22	1996-08-25	3120.00000000	0.10000000	None	1
+1995-05-30	1998-06-05	22500.00000000	0.15000000	None	1
+1996-01-15	1995-03-20	1560.00000000	0.05000000	None	1
+1996-02-15	1995-03-18	892.50000000	0E-8	None	1
+1996-03-22	1996-08-25	3120.00000000	0.10000000	None	1
+1996-04-30	1998-06-05	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipinstruct order by l_shipdate, l_shipinstruct nulls last limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	NONE	450.00000000	0.02000000	None	1
+1995-03-10	DELIVER IN PERSON	1560.00000000	0.05000000	None	1
+1995-03-10	TAKE BACK RETURN	892.50000000	0E-8	None	1
+1995-03-22	COLLECT COD	3120.00000000	0.10000000	None	1
+1995-05-30	DELIVER IN PERSON	22500.00000000	0.15000000	None	1
+1996-01-15	DELIVER IN PERSON	1560.00000000	0.05000000	None	1
+1996-02-15	TAKE BACK RETURN	892.50000000	0E-8	None	1
+1996-03-22	COLLECT COD	3120.00000000	0.10000000	None	1
+1996-04-30	DELIVER IN PERSON	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipmode order by l_shipdate, l_shipmode nulls last limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	MAIL	450.00000000	0.02000000	None	1
+1995-03-10	AIR	892.50000000	0E-8	None	1
+1995-03-10	TRUCK	1560.00000000	0.05000000	None	1
+1995-03-22	SHIP	3120.00000000	0.10000000	None	1
+1995-05-30	RAIL	22500.00000000	0.15000000	None	1
+1996-01-15	TRUCK	1560.00000000	0.05000000	None	1
+1996-02-15	AIR	892.50000000	0E-8	None	1
+1996-03-22	SHIP	3120.00000000	0.10000000	None	1
+1996-04-30	RAIL	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_comment order by l_shipdate, l_comment nulls last limit 10;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	First item of order	1560.00000000	0.05000000	None	1
+1995-03-10	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-22	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	Large bulk shipment	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_orderkey order by l_shipdate, l_orderkey nulls last limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	100003	450.00000000	0.02000000	None	1
+1995-03-10	100001	1226.25000000	0.02500000	None	2
+1995-03-22	100002	3120.00000000	0.10000000	None	1
+1995-05-30	100004	22500.00000000	0.15000000	None	1
+1996-01-15	100011	1560.00000000	0.05000000	None	1
+1996-02-15	100011	892.50000000	0E-8	None	1
+1996-03-22	100012	3120.00000000	0.10000000	None	1
+1996-04-30	100014	22500.00000000	0.15000000	None	1
+1996-12-05	100013	450.00000000	0.02000000	None	1
+1997-01-15	100101	1560.00000000	0.05000000	None	1
+1997-02-15	100101	892.50000000	0E-8	None	1
+1997-03-22	100102	3120.00000000	0.10000000	None	1
+1997-04-30	100104	22500.00000000	0.15000000	None	1
+1997-11-05	100103	450.00000000	0.02000000	None	1
+1998-01-15	101001	1560.00000000	0.05000000	None	1
+1998-02-15	101001	892.50000000	0E-8	None	1
+1998-03-22	101002	3120.00000000	0.10000000	None	1
+1998-04-30	101004	22500.00000000	0.15000000	None	1
+1998-11-05	101003	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey order by l_shipdate, l_partkey nulls last limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	8890	450.00000000	0.02000000	None	1
+1995-03-10	5501	1560.00000000	0.05000000	None	1
+1995-03-10	7203	892.50000000	0E-8	None	1
+1995-03-22	3345	3120.00000000	0.10000000	None	1
+1995-05-30	4567	22500.00000000	0.15000000	None	1
+1996-01-15	5501	1560.00000000	0.05000000	None	1
+1996-02-15	7203	892.50000000	0E-8	None	1
+1996-03-22	3345	3120.00000000	0.10000000	None	1
+1996-04-30	4567	22500.00000000	0.15000000	None	1
+1996-12-05	8890	450.00000000	0.02000000	None	1
+1997-01-15	5501	1560.00000000	0.05000000	None	1
+1997-02-15	7203	892.50000000	0E-8	None	1
+1997-03-22	3345	3120.00000000	0.10000000	None	1
+1997-04-30	4567	22500.00000000	0.15000000	None	1
+1997-11-05	8890	450.00000000	0.02000000	None	1
+1998-01-15	5501	1560.00000000	0.05000000	None	1
+1998-02-15	7203	892.50000000	0E-8	None	1
+1998-03-22	3345	3120.00000000	0.10000000	None	1
+1998-04-30	4567	22500.00000000	0.15000000	None	1
+1998-11-05	8890	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_suppkey order by l_shipdate, l_suppkey nulls last limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	89	450.00000000	0.02000000	None	1
+1995-03-10	101	1560.00000000	0.05000000	None	1
+1995-03-10	203	892.50000000	0E-8	None	1
+1995-03-22	156	3120.00000000	0.10000000	None	1
+1995-05-30	305	22500.00000000	0.15000000	None	1
+1996-01-15	101	1560.00000000	0.05000000	None	1
+1996-02-15	203	892.50000000	0E-8	None	1
+1996-03-22	156	3120.00000000	0.10000000	None	1
+1996-04-30	305	22500.00000000	0.15000000	None	1
+1996-12-05	89	450.00000000	0.02000000	None	1
+1997-01-15	101	1560.00000000	0.05000000	None	1
+1997-02-15	203	892.50000000	0E-8	None	1
+1997-03-22	156	3120.00000000	0.10000000	None	1
+1997-04-30	305	22500.00000000	0.15000000	None	1
+1997-11-05	89	450.00000000	0.02000000	None	1
+1998-01-15	101	1560.00000000	0.05000000	None	1
+1998-02-15	203	892.50000000	0E-8	None	1
+1998-03-22	156	3120.00000000	0.10000000	None	1
+1998-04-30	305	22500.00000000	0.15000000	None	1
+1998-11-05	89	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linenumber order by l_shipdate, l_linenumber nulls last limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	1	450.00000000	0.02000000	None	1
+1995-03-10	1	1560.00000000	0.05000000	None	1
+1995-03-10	2	892.50000000	0E-8	None	1
+1995-03-22	1	3120.00000000	0.10000000	None	1
+1995-05-30	1	22500.00000000	0.15000000	None	1
+1996-01-15	1	1560.00000000	0.05000000	None	1
+1996-02-15	2	892.50000000	0E-8	None	1
+1996-03-22	1	3120.00000000	0.10000000	None	1
+1996-04-30	1	22500.00000000	0.15000000	None	1
+1996-12-05	1	450.00000000	0.02000000	None	1
+1997-01-15	1	1560.00000000	0.05000000	None	1
+1997-02-15	2	892.50000000	0E-8	None	1
+1997-03-22	1	3120.00000000	0.10000000	None	1
+1997-04-30	1	22500.00000000	0.15000000	None	1
+1997-11-05	1	450.00000000	0.02000000	None	1
+1998-01-15	1	1560.00000000	0.05000000	None	1
+1998-02-15	2	892.50000000	0E-8	None	1
+1998-03-22	1	3120.00000000	0.10000000	None	1
+1998-04-30	1	22500.00000000	0.15000000	None	1
+1998-11-05	1	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_returnflag order by l_shipdate, l_returnflag nulls last limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	A	450.00000000	0.02000000	None	1
+1995-03-10	N	1226.25000000	0.02500000	None	2
+1995-03-22	R	3120.00000000	0.10000000	None	1
+1995-05-30	N	22500.00000000	0.15000000	None	1
+1996-01-15	N	1560.00000000	0.05000000	None	1
+1996-02-15	N	892.50000000	0E-8	None	1
+1996-03-22	R	3120.00000000	0.10000000	None	1
+1996-04-30	N	22500.00000000	0.15000000	None	1
+1996-12-05	A	450.00000000	0.02000000	None	1
+1997-01-15	N	1560.00000000	0.05000000	None	1
+1997-02-15	N	892.50000000	0E-8	None	1
+1997-03-22	R	3120.00000000	0.10000000	None	1
+1997-04-30	N	22500.00000000	0.15000000	None	1
+1997-11-05	A	450.00000000	0.02000000	None	1
+1998-01-15	N	1560.00000000	0.05000000	None	1
+1998-02-15	N	892.50000000	0E-8	None	1
+1998-03-22	R	3120.00000000	0.10000000	None	1
+1998-04-30	N	22500.00000000	0.15000000	None	1
+1998-11-05	A	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus order by l_shipdate, l_linestatus nulls last limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	O	450.00000000	0.02000000	None	1
+1995-03-10	O	1226.25000000	0.02500000	None	2
+1995-03-22	F	3120.00000000	0.10000000	None	1
+1995-05-30	O	22500.00000000	0.15000000	None	1
+1996-01-15	O	1560.00000000	0.05000000	None	1
+1996-02-15	O	892.50000000	0E-8	None	1
+1996-03-22	F	3120.00000000	0.10000000	None	1
+1996-04-30	O	22500.00000000	0.15000000	None	1
+1996-12-05	O	450.00000000	0.02000000	None	1
+1997-01-15	O	1560.00000000	0.05000000	None	1
+1997-02-15	O	892.50000000	0E-8	None	1
+1997-03-22	F	3120.00000000	0.10000000	None	1
+1997-04-30	O	22500.00000000	0.15000000	None	1
+1997-11-05	O	450.00000000	0.02000000	None	1
+1998-01-15	O	1560.00000000	0.05000000	None	1
+1998-02-15	O	892.50000000	0E-8	None	1
+1998-03-22	F	3120.00000000	0.10000000	None	1
+1998-04-30	O	22500.00000000	0.15000000	None	1
+1998-11-05	O	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_commitdate order by l_shipdate, l_commitdate nulls last limit 100
+select l_shipdate, l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_receiptdate order by l_shipdate, l_receiptdate nulls last limit 100;
+-- result:
+E: (1064, "Getting syntax error at line 2, column 0. Detail message: Unexpected input 'select', the most similar input is {<EOF>, ';'}.")
+-- !result
+select l_shipdate, l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipinstruct order by l_shipdate, l_shipinstruct nulls last limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	NONE	450.00000000	0.02000000	None	1
+1995-03-10	DELIVER IN PERSON	1560.00000000	0.05000000	None	1
+1995-03-10	TAKE BACK RETURN	892.50000000	0E-8	None	1
+1995-03-22	COLLECT COD	3120.00000000	0.10000000	None	1
+1995-05-30	DELIVER IN PERSON	22500.00000000	0.15000000	None	1
+1996-01-15	DELIVER IN PERSON	1560.00000000	0.05000000	None	1
+1996-02-15	TAKE BACK RETURN	892.50000000	0E-8	None	1
+1996-03-22	COLLECT COD	3120.00000000	0.10000000	None	1
+1996-04-30	DELIVER IN PERSON	22500.00000000	0.15000000	None	1
+1996-12-05	NONE	450.00000000	0.02000000	None	1
+1997-01-15	DELIVER IN PERSON	1560.00000000	0.05000000	None	1
+1997-02-15	TAKE BACK RETURN	892.50000000	0E-8	None	1
+1997-03-22	COLLECT COD	3120.00000000	0.10000000	None	1
+1997-04-30	DELIVER IN PERSON	22500.00000000	0.15000000	None	1
+1997-11-05	NONE	450.00000000	0.02000000	None	1
+1998-01-15	DELIVER IN PERSON	1560.00000000	0.05000000	None	1
+1998-02-15	TAKE BACK RETURN	892.50000000	0E-8	None	1
+1998-03-22	COLLECT COD	3120.00000000	0.10000000	None	1
+1998-04-30	DELIVER IN PERSON	22500.00000000	0.15000000	None	1
+1998-11-05	NONE	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipmode order by l_shipdate, l_shipmode nulls last limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	MAIL	450.00000000	0.02000000	None	1
+1995-03-10	AIR	892.50000000	0E-8	None	1
+1995-03-10	TRUCK	1560.00000000	0.05000000	None	1
+1995-03-22	SHIP	3120.00000000	0.10000000	None	1
+1995-05-30	RAIL	22500.00000000	0.15000000	None	1
+1996-01-15	TRUCK	1560.00000000	0.05000000	None	1
+1996-02-15	AIR	892.50000000	0E-8	None	1
+1996-03-22	SHIP	3120.00000000	0.10000000	None	1
+1996-04-30	RAIL	22500.00000000	0.15000000	None	1
+1996-12-05	MAIL	450.00000000	0.02000000	None	1
+1997-01-15	TRUCK	1560.00000000	0.05000000	None	1
+1997-02-15	AIR	892.50000000	0E-8	None	1
+1997-03-22	SHIP	3120.00000000	0.10000000	None	1
+1997-04-30	RAIL	22500.00000000	0.15000000	None	1
+1997-11-05	MAIL	450.00000000	0.02000000	None	1
+1998-01-15	TRUCK	1560.00000000	0.05000000	None	1
+1998-02-15	AIR	892.50000000	0E-8	None	1
+1998-03-22	SHIP	3120.00000000	0.10000000	None	1
+1998-04-30	RAIL	22500.00000000	0.15000000	None	1
+1998-11-05	MAIL	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_comment order by l_shipdate, l_comment nulls last limit 100;
+-- result:
+1995-01-16	None	None	None	None	0
+1995-02-05	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	First item of order	1560.00000000	0.05000000	None	1
+1995-03-10	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-22	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-12-05	Small quantity item	450.00000000	0.02000000	None	1
+1997-01-15	First item of order	1560.00000000	0.05000000	None	1
+1997-02-15	Second item, fragile	892.50000000	0E-8	None	1
+1997-03-22	Bulk order item	3120.00000000	0.10000000	None	1
+1997-04-30	Large bulk shipment	22500.00000000	0.15000000	None	1
+1997-11-05	Small quantity item	450.00000000	0.02000000	None	1
+1998-01-15	First item of order	1560.00000000	0.05000000	None	1
+1998-02-15	Second item, fragile	892.50000000	0E-8	None	1
+1998-03-22	Bulk order item	3120.00000000	0.10000000	None	1
+1998-04-30	Large bulk shipment	22500.00000000	0.15000000	None	1
+1998-11-05	Small quantity item	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment order by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment nulls last limit 10;
+-- result:
+1995-01-16	None	None	None	None	None	None	None	0
+1995-02-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-10	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1995-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment order by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment nulls last limit 100;
+-- result:
+1995-01-16	None	None	None	None	None	None	None	0
+1995-02-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-10	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1995-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-12-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1997-01-15	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1997-02-15	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1997-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1997-04-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1997-11-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1998-01-15	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1998-02-15	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1998-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1998-04-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1998-11-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment order by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment nulls last limit 1000;
+-- result:
+1995-01-16	None	None	None	None	None	None	None	0
+1995-02-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-10	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1995-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-12-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1997-01-15	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1997-02-15	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1997-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1997-04-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1997-11-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1998-01-15	O	1995-03-20	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1998-02-15	O	1995-03-18	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1998-03-22	F	1996-08-25	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1998-04-30	O	1998-06-05	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1998-11-05	O	1997-12-10	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment nulls last limit 10;
+-- result:
+1995-01-16	None	None	None	None	None	None	None	0
+1995-02-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1995-03-10	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+-- !result
+select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment nulls last limit 100;
+-- result:
+1995-01-16	None	None	None	None	None	None	None	0
+1995-02-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1995-03-10	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-12-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1997-01-15	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1997-02-15	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1997-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1997-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1997-11-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1998-01-15	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1998-02-15	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1998-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1998-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1998-11-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+-- !result
+select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment nulls last limit 1000;
+-- result:
+1995-01-16	None	None	None	None	None	None	None	0
+1995-02-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1995-03-10	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1995-03-10	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1995-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1995-05-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-01-15	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1996-02-15	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1996-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1996-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1996-12-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1997-01-15	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1997-02-15	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1997-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1997-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1997-11-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+1998-01-15	5501	1	TRUCK	First item of order	1560.00000000	0.05000000	None	1
+1998-02-15	7203	2	AIR	Second item, fragile	892.50000000	0E-8	None	1
+1998-03-22	3345	1	SHIP	Bulk order item	3120.00000000	0.10000000	None	1
+1998-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
+1998-11-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
+-- !result

--- a/test/sql/test_sort/R/test_agg_with_topn
+++ b/test/sql/test_sort/R/test_agg_with_topn
@@ -1583,3 +1583,287 @@ select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extende
 1998-04-30	4567	1	RAIL	Large bulk shipment	22500.00000000	0.15000000	None	1
 1998-11-05	8890	1	MAIL	Small quantity item	450.00000000	0.02000000	None	1
 -- !result
+drop table if exists lineitem;
+-- result:
+-- !result
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"colocate_with" = "${uuid0}",
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"colocate_with" = "${uuid0}",
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `t2` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+insert into t0 values (null,null,null,null);
+-- result:
+-- !result
+insert into t1 SELECT * FROM t0;
+-- result:
+-- !result
+insert into t2 SELECT * FROM t0;
+-- result:
+-- !result
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 limit 1;
+-- result:
+1	1	1.0	1	1	1
+-- !result
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 limit 1;
+-- result:
+1	1	1	1.0	1	1	1
+-- !result
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1,r.c1 order by l.c0, l.c1, r.c1 limit 1;
+-- result:
+1	1	1	1	1.0	1	1	1
+-- !result
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 nulls last limit 1;
+-- result:
+1	1	1.0	1	1	1
+-- !result
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 nulls last limit 1;
+-- result:
+1	1	1	1.0	1	1	1
+-- !result
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1, r.c1 order by l.c0, l.c1, r.c1 nulls last limit 1;
+-- result:
+1	1	1	1	1.0	1	1	1
+-- !result
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 limit 10;
+-- result:
+1	1	1.0	1	1	1
+2	1	2.0	1	1	1
+3	1	3.0	1	1	1
+4	1	4.0	1	1	1
+5	1	5.0	1	1	1
+6	1	6.0	1	1	1
+7	1	7.0	1	1	1
+8	1	8.0	1	1	1
+9	1	9.0	1	1	1
+10	1	10.0	1	1	1
+-- !result
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 limit 10;
+-- result:
+1	1	1	1.0	1	1	1
+2	2	1	2.0	1	1	1
+3	3	1	3.0	1	1	1
+4	4	1	4.0	1	1	1
+5	5	1	5.0	1	1	1
+6	6	1	6.0	1	1	1
+7	7	1	7.0	1	1	1
+8	8	1	8.0	1	1	1
+9	9	1	9.0	1	1	1
+10	10	1	10.0	1	1	1
+-- !result
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1, r.c1 order by l.c0, l.c1, r.c1 limit 10;
+-- result:
+1	1	1	1	1.0	1	1	1
+2	2	2	1	2.0	1	1	1
+3	3	3	1	3.0	1	1	1
+4	4	4	1	4.0	1	1	1
+5	5	5	1	5.0	1	1	1
+6	6	6	1	6.0	1	1	1
+7	7	7	1	7.0	1	1	1
+8	8	8	1	8.0	1	1	1
+9	9	9	1	9.0	1	1	1
+10	10	10	1	10.0	1	1	1
+-- !result
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 nulls last limit 10;
+-- result:
+1	1	1.0	1	1	1
+2	1	2.0	1	1	1
+3	1	3.0	1	1	1
+4	1	4.0	1	1	1
+5	1	5.0	1	1	1
+6	1	6.0	1	1	1
+7	1	7.0	1	1	1
+8	1	8.0	1	1	1
+9	1	9.0	1	1	1
+10	1	10.0	1	1	1
+-- !result
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 nulls last limit 10;
+-- result:
+1	1	1	1.0	1	1	1
+2	2	1	2.0	1	1	1
+3	3	1	3.0	1	1	1
+4	4	1	4.0	1	1	1
+5	5	1	5.0	1	1	1
+6	6	1	6.0	1	1	1
+7	7	1	7.0	1	1	1
+8	8	1	8.0	1	1	1
+9	9	1	9.0	1	1	1
+10	10	1	10.0	1	1	1
+-- !result
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1, r.c1 order by l.c0, l.c1, r.c1 nulls last limit 10;
+-- result:
+1	1	1	1	1.0	1	1	1
+2	2	2	1	2.0	1	1	1
+3	3	3	1	3.0	1	1	1
+4	4	4	1	4.0	1	1	1
+5	5	5	1	5.0	1	1	1
+6	6	6	1	6.0	1	1	1
+7	7	7	1	7.0	1	1	1
+8	8	8	1	8.0	1	1	1
+9	9	9	1	9.0	1	1	1
+10	10	10	1	10.0	1	1	1
+-- !result
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 limit 1;
+-- result:
+1	1	1.0	1	1	1
+-- !result
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 limit 1;
+-- result:
+1	1	1	1.0	1	1	1
+-- !result
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1, r.c1 order by l.c0, l.c1, r.c1 limit 1;
+-- result:
+1	1	1	1	1.0	1	1	1
+-- !result
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 nulls last limit 1;
+-- result:
+1	1	1.0	1	1	1
+-- !result
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 nulls last limit 1;
+-- result:
+1	1	1	1.0	1	1	1
+-- !result
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1, r.c1 order by l.c0, l.c1, r.c1 nulls last limit 1;
+-- result:
+1	1	1	1	1.0	1	1	1
+-- !result
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 limit 10;
+-- result:
+1	1	1.0	1	1	1
+2	1	2.0	1	1	1
+3	1	3.0	1	1	1
+4	1	4.0	1	1	1
+5	1	5.0	1	1	1
+6	1	6.0	1	1	1
+7	1	7.0	1	1	1
+8	1	8.0	1	1	1
+9	1	9.0	1	1	1
+10	1	10.0	1	1	1
+-- !result
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 limit 10;
+-- result:
+1	1	1	1.0	1	1	1
+2	2	1	2.0	1	1	1
+3	3	1	3.0	1	1	1
+4	4	1	4.0	1	1	1
+5	5	1	5.0	1	1	1
+6	6	1	6.0	1	1	1
+7	7	1	7.0	1	1	1
+8	8	1	8.0	1	1	1
+9	9	1	9.0	1	1	1
+10	10	1	10.0	1	1	1
+-- !result
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1, r.c1 order by l.c0, l.c1, r.c1 limit 10;
+-- result:
+1	1	1	1	1.0	1	1	1
+2	2	2	1	2.0	1	1	1
+3	3	3	1	3.0	1	1	1
+4	4	4	1	4.0	1	1	1
+5	5	5	1	5.0	1	1	1
+6	6	6	1	6.0	1	1	1
+7	7	7	1	7.0	1	1	1
+8	8	8	1	8.0	1	1	1
+9	9	9	1	9.0	1	1	1
+10	10	10	1	10.0	1	1	1
+-- !result
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 nulls last limit 10;
+-- result:
+1	1	1.0	1	1	1
+2	1	2.0	1	1	1
+3	1	3.0	1	1	1
+4	1	4.0	1	1	1
+5	1	5.0	1	1	1
+6	1	6.0	1	1	1
+7	1	7.0	1	1	1
+8	1	8.0	1	1	1
+9	1	9.0	1	1	1
+10	1	10.0	1	1	1
+-- !result
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 nulls last limit 10;
+-- result:
+1	1	1	1.0	1	1	1
+2	2	1	2.0	1	1	1
+3	3	1	3.0	1	1	1
+4	4	1	4.0	1	1	1
+5	5	1	5.0	1	1	1
+6	6	1	6.0	1	1	1
+7	7	1	7.0	1	1	1
+8	8	1	8.0	1	1	1
+9	9	1	9.0	1	1	1
+10	10	1	10.0	1	1	1
+-- !result
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1, r.c1 order by l.c0, l.c1, r.c1 nulls last limit 10;
+-- result:
+1	1	1	1	1.0	1	1	1
+2	2	2	1	2.0	1	1	1
+3	3	3	1	3.0	1	1	1
+4	4	4	1	4.0	1	1	1
+5	5	5	1	5.0	1	1	1
+6	6	6	1	6.0	1	1	1
+7	7	7	1	7.0	1	1	1
+8	8	8	1	8.0	1	1	1
+9	9	9	1	9.0	1	1	1
+10	10	10	1	10.0	1	1	1
+-- !result
+drop table if exists t0;
+-- result:
+-- !result
+drop table if exists t1;
+-- result:
+-- !result

--- a/test/sql/test_sort/T/test_agg_with_topn
+++ b/test/sql/test_sort/T/test_agg_with_topn
@@ -1,0 +1,195 @@
+-- name: test_agg_with_topn
+
+CREATE TABLE lineitem (l_shipdate    DATE,
+                       l_orderkey    BIGINT,
+                       l_linenumber  INT,
+                       l_partkey     INT,
+                       l_suppkey     INT,
+                       l_quantity    DECIMAL(15, 2),
+                       l_extendedprice  DECIMAL(15, 2),
+                       l_discount    DECIMAL(15, 2),
+                       l_tax         DECIMAL(15, 2),
+                       l_returnflag  VARCHAR(1),
+                       l_linestatus  VARCHAR(1),
+                       l_commitdate  DATE,
+                       l_receiptdate DATE,
+                       l_shipinstruct VARCHAR(25),
+                       l_shipmode     VARCHAR(10),
+                       l_comment      VARCHAR(44)
+) ENGINE=OLAP
+DUPLICATE KEY(`l_shipdate`, `l_orderkey`, `l_linenumber`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`l_shipdate`)
+(
+   START ("1992-01-01") END ("1999-01-01") EVERY (INTERVAL 1 year)
+)
+DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO lineitem (l_shipdate, l_orderkey, l_linenumber, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment) VALUES
+('1995-03-10', 100001, 1, 5501, 101, 12.00, 1560.00, 0.05, 0.08, 'N', 'O', '1995-03-10', '1995-03-20', 'DELIVER IN PERSON', 'TRUCK', 'First item of order'),
+('1995-03-10', 100001, 2, 7203, 203, 8.50, 892.50, 0.00, 0.08, 'N', 'O', '1995-03-10', '1995-03-18', 'TAKE BACK RETURN', 'AIR', 'Second item, fragile'),
+('1995-03-22', 100002, 1, 3345, 156, 24.00, 3120.00, 0.10, 0.07, 'R', 'F', '1996-08-18', '1996-08-25', 'COLLECT COD', 'SHIP', 'Bulk order item'),
+('1995-02-05', 100003, 1, 8890, 89, 3.00, 450.00, 0.02, 0.09, 'A', 'O', '1997-12-01', '1997-12-10', 'NONE', 'MAIL', 'Small quantity item'),
+('1995-05-30', 100004, 1, 4567, 305, 150.00, 22500.00, 0.15, 0.06, 'N', 'O', '1998-05-25', '1998-06-05', 'DELIVER IN PERSON', 'RAIL', 'Large bulk shipment');
+INSERT INTO lineitem (l_shipdate, l_orderkey, l_linenumber, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment) VALUES
+('1996-01-15', 100011, 1, 5501, 101, 12.00, 1560.00, 0.05, 0.08, 'N', 'O', '1995-03-10', '1995-03-20', 'DELIVER IN PERSON', 'TRUCK', 'First item of order'),
+('1996-02-15', 100011, 2, 7203, 203, 8.50, 892.50, 0.00, 0.08, 'N', 'O', '1995-03-10', '1995-03-18', 'TAKE BACK RETURN', 'AIR', 'Second item, fragile'),
+('1996-03-22', 100012, 1, 3345, 156, 24.00, 3120.00, 0.10, 0.07, 'R', 'F', '1996-08-18', '1996-08-25', 'COLLECT COD', 'SHIP', 'Bulk order item'),
+('1996-12-05', 100013, 1, 8890, 89, 3.00, 450.00, 0.02, 0.09, 'A', 'O', '1997-12-01', '1997-12-10', 'NONE', 'MAIL', 'Small quantity item'),
+('1996-04-30', 100014, 1, 4567, 305, 150.00, 22500.00, 0.15, 0.06, 'N', 'O', '1998-05-25', '1998-06-05', 'DELIVER IN PERSON', 'RAIL', 'Large bulk shipment');
+INSERT INTO lineitem (l_shipdate, l_orderkey, l_linenumber, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment) VALUES
+('1997-01-15', 100101, 1, 5501, 101, 12.00, 1560.00, 0.05, 0.08, 'N', 'O', '1995-03-10', '1995-03-20', 'DELIVER IN PERSON', 'TRUCK', 'First item of order'),
+('1997-02-15', 100101, 2, 7203, 203, 8.50, 892.50, 0.00, 0.08, 'N', 'O', '1995-03-10', '1995-03-18', 'TAKE BACK RETURN', 'AIR', 'Second item, fragile'),
+('1997-03-22', 100102, 1, 3345, 156, 24.00, 3120.00, 0.10, 0.07, 'R', 'F', '1996-08-18', '1996-08-25', 'COLLECT COD', 'SHIP', 'Bulk order item'),
+('1997-11-05', 100103, 1, 8890, 89, 3.00, 450.00, 0.02, 0.09, 'A', 'O', '1997-12-01', '1997-12-10', 'NONE', 'MAIL', 'Small quantity item'),
+('1997-04-30', 100104, 1, 4567, 305, 150.00, 22500.00, 0.15, 0.06, 'N', 'O', '1998-05-25', '1998-06-05', 'DELIVER IN PERSON', 'RAIL', 'Large bulk shipment');
+INSERT INTO lineitem (l_shipdate, l_orderkey, l_linenumber, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment) VALUES
+('1998-01-15', 101001, 1, 5501, 101, 12.00, 1560.00, 0.05, 0.08, 'N', 'O', '1995-03-10', '1995-03-20', 'DELIVER IN PERSON', 'TRUCK', 'First item of order'),
+('1998-02-15', 101001, 2, 7203, 203, 8.50, 892.50, 0.00, 0.08, 'N', 'O', '1995-03-10', '1995-03-18', 'TAKE BACK RETURN', 'AIR', 'Second item, fragile'),
+('1998-03-22', 101002, 1, 3345, 156, 24.00, 3120.00, 0.10, 0.07, 'R', 'F', '1996-08-18', '1996-08-25', 'COLLECT COD', 'SHIP', 'Bulk order item'),
+('1998-11-05', 101003, 1, 8890, 89, 3.00, 450.00, 0.02, 0.09, 'A', 'O', '1997-12-01', '1997-12-10', 'NONE', 'MAIL', 'Small quantity item'),
+('1998-04-30', 101004, 1, 4567, 305, 150.00, 22500.00, 0.15, 0.06, 'N', 'O', '1998-05-25', '1998-06-05', 'DELIVER IN PERSON', 'RAIL', 'Large bulk shipment');
+INSERT INTO lineitem (l_shipdate, l_orderkey, l_linenumber, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment) VALUES    
+('1995-01-16', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+('1995-01-16', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+set topn_push_down_agg_mode=2;
+set chunk_size=2;
+select l_shipdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate order by l_shipdate limit 1;
+select l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_orderkey order by l_orderkey limit 1;
+select l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_partkey order by l_partkey limit 1;
+select l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_suppkey order by l_suppkey limit 1;
+select l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linenumber order by l_linenumber limit 1;
+select l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_returnflag order by l_returnflag limit 1;
+select l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linestatus order by l_linestatus limit 1;
+select l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_commitdate order by l_commitdate limit 1;
+select l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_receiptdate order by l_receiptdate limit 1;
+select l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipmode order by l_shipmode limit 1;
+select l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_comment order by l_comment limit 1;
+
+select l_shipdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate order by l_shipdate limit 10;
+select l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_orderkey order by l_orderkey limit 10;
+select l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_partkey order by l_partkey limit 10;
+select l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_suppkey order by l_suppkey limit 10;
+select l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linenumber order by l_linenumber limit 10;
+select l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_returnflag order by l_returnflag limit 10;
+select l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linestatus order by l_linestatus limit 10;
+select l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_commitdate order by l_commitdate limit 10;
+select l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_receiptdate order by l_receiptdate limit 10;
+select l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipinstruct order by l_shipinstruct limit 10;
+select l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipmode order by l_shipmode limit 10;
+select l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_comment order by l_comment limit 10;
+
+select l_shipdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate order by l_shipdate limit 100;
+select l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_orderkey order by l_orderkey limit 100;
+select l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_partkey order by l_partkey limit 100;
+select l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_suppkey order by l_suppkey limit 100;
+select l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linenumber order by l_linenumber limit 100;
+select l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_returnflag order by l_returnflag limit 100;
+select l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linestatus order by l_linestatus limit 100;
+select l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_commitdate order by l_commitdate limit 100;
+select l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_receiptdate order by l_receiptdate limit 100;
+select l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipinstruct order by l_shipinstruct limit 100;
+select l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipmode order by l_shipmode limit 100;
+select l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_comment order by l_comment limit 100;
+
+select l_shipdate, l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_orderkey order by l_shipdate, l_orderkey limit 10;
+select l_shipdate, l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey order by l_shipdate, l_partkey limit 10;
+select l_shipdate, l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_suppkey order by l_shipdate, l_suppkey limit 10;
+select l_shipdate, l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linenumber order by l_shipdate, l_linenumber limit 10;
+select l_shipdate, l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_returnflag order by l_shipdate, l_returnflag limit 10;
+select l_shipdate, l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus order by l_shipdate, l_linestatus limit 10;
+select l_shipdate, l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_commitdate order by l_shipdate, l_commitdate limit 10;
+select l_shipdate, l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_receiptdate order by l_shipdate, l_receiptdate limit 10;
+select l_shipdate, l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipinstruct order by l_shipdate, l_shipinstruct limit 10;
+select l_shipdate, l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipmode order by l_shipdate, l_shipmode limit 10;
+select l_shipdate, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_comment order by l_shipdate, l_comment limit 10;
+
+select l_shipdate, l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_orderkey order by l_shipdate, l_orderkey limit 100;
+select l_shipdate, l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey order by l_shipdate, l_partkey limit 100;
+select l_shipdate, l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_suppkey order by l_shipdate, l_suppkey limit 100;
+select l_shipdate, l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linenumber order by l_shipdate, l_linenumber limit 100;
+select l_shipdate, l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_returnflag order by l_shipdate, l_returnflag limit 100;
+select l_shipdate, l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus order by l_shipdate, l_linestatus limit 100;
+select l_shipdate, l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_commitdate order by l_shipdate, l_commitdate limit 100
+select l_shipdate, l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_receiptdate order by l_shipdate, l_receiptdate limit 100;
+select l_shipdate, l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipinstruct order by l_shipdate, l_shipinstruct limit 100;
+select l_shipdate, l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipmode order by l_shipdate, l_shipmode limit 100;
+select l_shipdate, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_comment order by l_shipdate, l_comment limit 100;
+select l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment order by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment limit 10;
+select l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment order by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment limit 100;
+select l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment order by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment limit 1000;
+select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment limit 10;
+select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment limit 100;
+select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment limit 1000;
+-- nulls last
+select l_shipdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate order by l_shipdate nulls last limit 1;
+select l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_orderkey order by l_orderkey nulls last limit 1;
+select l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_partkey order by l_partkey nulls last limit 1;
+select l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_suppkey order by l_suppkey nulls last limit 1;
+select l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linenumber order by l_linenumber nulls last limit 1;
+select l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_returnflag order by l_returnflag nulls last limit 1;
+select l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linestatus order by l_linestatus nulls last limit 1;
+select l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_commitdate order by l_commitdate nulls last limit 1;
+select l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_receiptdate order by l_receiptdate nulls last limit 1;
+select l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipmode order by l_shipmode nulls last limit 1;
+select l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_comment order by l_comment nulls last limit 1;
+
+select l_shipdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate order by l_shipdate nulls last limit 10;
+select l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_orderkey order by l_orderkey nulls last limit 10;
+select l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_partkey order by l_partkey nulls last limit 10;
+select l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_suppkey order by l_suppkey nulls last limit 10;
+select l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linenumber order by l_linenumber nulls last limit 10;
+select l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_returnflag order by l_returnflag nulls last limit 10;
+select l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linestatus order by l_linestatus nulls last limit 10;
+select l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_commitdate order by l_commitdate nulls last limit 10;
+select l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_receiptdate order by l_receiptdate nulls last limit 10;
+select l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipinstruct order by l_shipinstruct nulls last limit 10;
+select l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipmode order by l_shipmode nulls last limit 10;
+select l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_comment order by l_comment nulls last limit 10;
+
+select l_shipdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate order by l_shipdate nulls last limit 100;
+select l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_orderkey order by l_orderkey nulls last limit 100;
+select l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_partkey order by l_partkey nulls last limit 100;
+select l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_suppkey order by l_suppkey nulls last limit 100;
+select l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linenumber order by l_linenumber nulls last limit 100;
+select l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_returnflag order by l_returnflag nulls last limit 100;
+select l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_linestatus order by l_linestatus nulls last limit 100;
+select l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_commitdate order by l_commitdate nulls last limit 100;
+select l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_receiptdate order by l_receiptdate nulls last limit 100;
+select l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipinstruct order by l_shipinstruct nulls last limit 100;
+select l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipmode order by l_shipmode nulls last limit 100;
+select l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_comment order by l_comment nulls last limit 100;
+
+select l_shipdate, l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_orderkey order by l_shipdate, l_orderkey nulls last limit 10;
+select l_shipdate, l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey order by l_shipdate, l_partkey nulls last limit 10;
+select l_shipdate, l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_suppkey order by l_shipdate, l_suppkey nulls last limit 10;
+select l_shipdate, l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linenumber order by l_shipdate, l_linenumber nulls last limit 10;
+select l_shipdate, l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_returnflag order by l_shipdate, l_returnflag nulls last limit 10;
+select l_shipdate, l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus order by l_shipdate, l_linestatus nulls last limit 10;
+select l_shipdate, l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_commitdate order by l_shipdate, l_commitdate nulls last limit 10;
+select l_shipdate, l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_receiptdate order by l_shipdate, l_receiptdate nulls last limit 10;
+select l_shipdate, l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipinstruct order by l_shipdate, l_shipinstruct nulls last limit 10;
+select l_shipdate, l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipmode order by l_shipdate, l_shipmode nulls last limit 10;
+select l_shipdate, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_comment order by l_shipdate, l_comment nulls last limit 10;
+
+select l_shipdate, l_orderkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_orderkey order by l_shipdate, l_orderkey nulls last limit 100;
+select l_shipdate, l_partkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey order by l_shipdate, l_partkey nulls last limit 100;
+select l_shipdate, l_suppkey, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_suppkey order by l_shipdate, l_suppkey nulls last limit 100;
+select l_shipdate, l_linenumber, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linenumber order by l_shipdate, l_linenumber nulls last limit 100;
+select l_shipdate, l_returnflag, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_returnflag order by l_shipdate, l_returnflag nulls last limit 100;
+select l_shipdate, l_linestatus, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus order by l_shipdate, l_linestatus nulls last limit 100;
+select l_shipdate, l_commitdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_commitdate order by l_shipdate, l_commitdate nulls last limit 100
+select l_shipdate, l_receiptdate, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_receiptdate order by l_shipdate, l_receiptdate nulls last limit 100;
+select l_shipdate, l_shipinstruct, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipinstruct order by l_shipdate, l_shipinstruct nulls last limit 100;
+select l_shipdate, l_shipmode, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_shipmode order by l_shipdate, l_shipmode nulls last limit 100;
+select l_shipdate, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_comment order by l_shipdate, l_comment nulls last limit 100;
+select l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment order by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment nulls last limit 10;
+select l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment order by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment nulls last limit 100;
+select l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment order by l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment nulls last limit 1000;
+select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment nulls last limit 10;
+select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment nulls last limit 100;
+select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment nulls last limit 1000;

--- a/test/sql/test_sort/T/test_agg_with_topn
+++ b/test/sql/test_sort/T/test_agg_with_topn
@@ -193,3 +193,99 @@ select l_shipdate, l_linestatus, l_receiptdate, l_shipmode, l_comment, avg(l_ext
 select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment nulls last limit 10;
 select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment nulls last limit 100;
 select l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment, avg(l_extendedprice), avg(l_discount), sum(l_returnflag), count(l_receiptdate) from lineitem group by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment order by l_shipdate, l_partkey, l_linenumber, l_shipmode, l_comment nulls last limit 1000;
+drop table if exists lineitem;
+
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"colocate_with" = "${uuid0}",
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+CREATE TABLE `t1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"colocate_with" = "${uuid0}",
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+CREATE TABLE `t2` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "DEFAULT",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+insert into t0 values (null,null,null,null);
+insert into t1 SELECT * FROM t0;
+insert into t2 SELECT * FROM t0;
+
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 limit 1;
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 limit 1;
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1,r.c1 order by l.c0, l.c1, r.c1 limit 1;
+
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 nulls last limit 1;
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 nulls last limit 1;
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1, r.c1 order by l.c0, l.c1, r.c1 nulls last limit 1;
+
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 limit 10;
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 limit 10;
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1, r.c1 order by l.c0, l.c1, r.c1 limit 10;
+
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 nulls last limit 10;
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 nulls last limit 10;
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t1 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1, r.c1 order by l.c0, l.c1, r.c1 nulls last limit 10;
+
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 limit 1;
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 limit 1;
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1, r.c1 order by l.c0, l.c1, r.c1 limit 1;
+
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 nulls last limit 1;
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 nulls last limit 1;
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1, r.c1 order by l.c0, l.c1, r.c1 nulls last limit 1;
+
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 limit 10;
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 limit 10;
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1, r.c1 order by l.c0, l.c1, r.c1 limit 10;
+
+select l.c0, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0 order by l.c0 nulls last limit 10;
+select l.c0, l.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [broadcast] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1 order by l.c0, l.c1 nulls last limit 10;
+select l.c0, l.c1, r.c1, count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [shuffle] t2 r on l.c0 = r.c0 and l.c1 = r.c1 group by l.c0, l.c1, r.c1 order by l.c0, l.c1, r.c1 nulls last limit 10;
+
+drop table if exists t0;
+drop table if exists t1;


### PR DESCRIPTION
## Why I'm doing:

For queries with aggregate + order by + limit pattern, we can generate the TopN Runtime filter in the Aggregate Node to push down the scan operator which can reduce scan IO and pre-aggregation.

## What I'm doing:

- When GroupBy Keys have high cardinality, the filtering effect of AggTopN RuntimeFilter is significant, and the optimized performance can be 10 to 100 times or more; 
- When GroupBy Keys are sparse (the number of keys is less than the number of limits), AggTopN RuntimeFilter cannot be used, and the performance remains basically the same as the baseline; 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables Aggregation to build and publish TopN runtime filters and pushes partial TopN into pre-aggregation for queries with ORDER BY + LIMIT.
> 
> - Add `AggTopNRuntimeFilterBuilder` with heap-based top-N tracking (specialized for `Slice`) and extract `SortingHeap` to `util/heap.h`; update usages
> - Extend `Aggregator` to build/update TopN filters (`build_topn_filters`, `build_hash_map_with_topn_runtime_filter`) and track new-group selections
> - Update `AggregateStreamingSinkOperator` to periodically build/publish TopN filters; plumb `RuntimeState` through push paths
> - Extend runtime filter descriptors with TopN fields (`is_asc`, `is_nulls_first`, `limit`) and log `debug_string`
> - Planner: add TopN pushdown-to-agg rule and carry `TopNSortInfo`; `AggregationNode` builds TopN RFs; `SortNode` skips RF when agg pushdown enabled; prefer pushdown in cost
> - Add session var `topn_push_down_agg_mode` (replacing `enable_pre_agg_top_n_push_down`)
> - Add tests: `util/heap_test.cpp` and SQL suite `test_agg_with_topn`; minor infra fix in `type_dispatch_predicate`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec8ba883dd15454ff87e17cb074e4f7dd51e5bde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->