### PR TITLE
[BugFix] Support Fast Schema Evolution v2 for DELETE in shared-data 

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -24,6 +24,7 @@
 #include "common/status.h"
 #include "exec/write_combined_txn_log.h"
 #include "fs/fs_util.h"
+#include "gen_cpp/tablet_schema.pb.h"
 #include "gutil/strings/join.h"
 #include "runtime/exec_env.h"
 #include "runtime/lake_snapshot_loader.h"
@@ -890,7 +891,9 @@ void LakeServiceImpl::delete_data(::google::protobuf::RpcController* controller,
                         response->add_failed_tablets(tablet_id);
                         return;
                     }
-                    auto res = tablet->delete_data(request->txn_id(), request->delete_predicate());
+
+                    const TableSchemaKeyPB* schema_key = request->has_schema_key() ? &request->schema_key() : nullptr;
+                    auto res = tablet->delete_data(request->txn_id(), request->delete_predicate(), schema_key);
                     if (!res.ok()) {
                         LOG(WARNING) << "Fail to delete data. tablet_id: " << tablet_id
                                      << ", txn_id: " << request->txn_id() << ", error: " << res;

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -17,6 +17,7 @@
 #include "column/schema.h"
 #include "fs/fs.h"
 #include "gen_cpp/lake_types.pb.h"
+#include "gen_cpp/tablet_schema.pb.h"
 #include "runtime/exec_env.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/general_tablet_writer.h"
@@ -167,11 +168,15 @@ std::string Tablet::root_location() const {
     return _location_provider->root_location(_id);
 }
 
-Status Tablet::delete_data(int64_t txn_id, const DeletePredicatePB& delete_predicate) {
+Status Tablet::delete_data(int64_t txn_id, const DeletePredicatePB& delete_predicate,
+                           const TableSchemaKeyPB* schema_key) {
     auto txn_log = std::make_shared<TxnLog>();
     txn_log->set_tablet_id(_id);
     txn_log->set_txn_id(txn_id);
     auto op_write = txn_log->mutable_op_write();
+    if (schema_key != nullptr) {
+        op_write->mutable_schema_key()->CopyFrom(*schema_key);
+    }
     auto rowset = op_write->mutable_rowset();
     rowset->set_overlapped(false);
     rowset->set_num_rows(0);

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -29,6 +29,7 @@
 
 namespace starrocks {
 class TabletSchema;
+class TableSchemaKeyPB;
 class ThreadPool;
 } // namespace starrocks
 
@@ -136,7 +137,17 @@ public:
 
     [[nodiscard]] std::string sst_location(std::string_view sst_name) const;
 
-    Status delete_data(int64_t txn_id, const DeletePredicatePB& delete_predicate);
+    // Deletes data from the tablet based on the given delete predicate.
+    //
+    // @param txn_id The transaction ID for this delete operation.
+    // @param delete_predicate The predicate that specifies which rows to delete.
+    // @param schema_key Optional schema key for fast schema evolution v2. The delete predicate is generated
+    //                   based on this schema. When provided, it will be persisted into the transaction log
+    //                   and used during publishing to update the tablet metadata schema if needed.
+    //                   If nullptr, the operation maintains backward compatibility with legacy delete operations.
+    // @return Status::OK() on success, otherwise an error status.
+    Status delete_data(int64_t txn_id, const DeletePredicatePB& delete_predicate,
+                       const TableSchemaKeyPB* schema_key = nullptr);
 
     StatusOr<bool> has_delete_predicates(int64_t version);
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -537,6 +537,7 @@ SET(DW_TEST_FILES
     ./storage/lake/tablet_retain_info_test.cpp
     ./storage/lake/tablet_test.cpp
     ./storage/lake/tablet_writer_test.cpp
+    ./storage/lake/delete_test.cpp
     ./storage/lake/transactions_test.cpp
     ./storage/lake/pk_tablet_sst_writer_test.cpp
     ./storage/lake/txn_log_applier_test.cpp

--- a/be/test/storage/lake/delete_test.cpp
+++ b/be/test/storage/lake/delete_test.cpp
@@ -1,0 +1,375 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <set>
+
+#include "column/chunk.h"
+#include "column/datum_tuple.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "column/vectorized_fwd.h"
+#include "common/logging.h"
+#include "gen_cpp/tablet_schema.pb.h"
+#include "gen_cpp/types.pb.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reader.h"
+#include "storage/lake/tablet_writer.h"
+#include "storage/lake/txn_log.h"
+#include "storage/lake/versioned_tablet.h"
+#include "storage/tablet_schema.h"
+#include "test_util.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+
+namespace starrocks::lake {
+
+using namespace starrocks;
+
+class LakeTabletDeleteDataTest : public TestBase {
+public:
+    LakeTabletDeleteDataTest() : TestBase(kTestDirectory) {
+        auto mutable_metadata = std::make_shared<TabletMetadata>();
+        mutable_metadata->set_id(next_id());
+        mutable_metadata->set_version(1);
+        //
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c1   |  INT | YES |  NO  |
+        //  |   c2   |  INT | NO  |  NO  |
+        auto schema = mutable_metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(DUP_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        auto c1 = schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(true);
+            c1->set_is_nullable(false);
+        }
+        auto c2 = schema->add_column();
+        {
+            c2->set_unique_id(next_id());
+            c2->set_name("c2");
+            c2->set_type("INT");
+            c2->set_is_key(false);
+            c2->set_is_nullable(false);
+        }
+
+        _tablet_metadata = std::const_pointer_cast<const TabletMetadata>(mutable_metadata);
+        _tablet_schema = TabletSchema::create(*schema);
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+    }
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+    void create_rowsets_with_data() {
+        // Create data: c1 values 1-10, c2 values 1-10 (some rows have c2=3)
+        std::vector<int> c1_values{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        std::vector<int> c2_values{1, 2, 3, 3, 5, 6, 3, 8, 9, 10}; // rows with c2=3: indices 2, 3, 6
+
+        auto c1_col = Int32Column::create();
+        auto c2_col = Int32Column::create();
+        c1_col->append_numbers(c1_values.data(), c1_values.size() * sizeof(int));
+        c2_col->append_numbers(c2_values.data(), c2_values.size() * sizeof(int));
+
+        Chunk chunk({std::move(c1_col), std::move(c2_col)}, _schema);
+
+        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+
+        int64_t txn_id1, txn_id2;
+
+        // Create a mutable copy for adding rowsets
+        auto mutable_metadata = std::make_shared<TabletMetadata>(*_tablet_metadata);
+
+        // Write rowset 1
+        {
+            txn_id1 = next_id();
+            ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id1));
+            ASSERT_OK(writer->open());
+            ASSERT_OK(writer->write(chunk));
+            ASSERT_OK(writer->finish());
+
+            // Create txn_log for txn_id1
+            auto txn_log1 = std::make_shared<TxnLog>();
+            txn_log1->set_tablet_id(_tablet_metadata->id());
+            txn_log1->set_txn_id(txn_id1);
+            auto op_write1 = txn_log1->mutable_op_write();
+            for (const auto& f : writer->segments()) {
+                op_write1->mutable_rowset()->add_segments(f.path);
+            }
+            op_write1->mutable_rowset()->set_num_rows(writer->num_rows());
+            op_write1->mutable_rowset()->set_data_size(writer->data_size());
+            op_write1->mutable_rowset()->set_overlapped(true);
+            ASSERT_OK(_tablet_mgr->put_txn_log(txn_log1));
+
+            writer->close();
+
+            auto* rowset = mutable_metadata->add_rowsets();
+            rowset->set_overlapped(true);
+            rowset->set_id(1);
+            rowset->set_num_rows(chunk.num_rows());
+            auto* segs = rowset->mutable_segments();
+            for (const auto& file : writer->segments()) {
+                segs->Add()->assign(file.path);
+            }
+        }
+
+        // Write rowset 2
+        {
+            std::vector<int> c1_values2{11, 12, 13, 14, 15};
+            std::vector<int> c2_values2{3, 12, 13, 3, 15}; // rows with c2=3: indices 0, 3
+
+            auto c1_col2 = Int32Column::create();
+            auto c2_col2 = Int32Column::create();
+            c1_col2->append_numbers(c1_values2.data(), c1_values2.size() * sizeof(int));
+            c2_col2->append_numbers(c2_values2.data(), c2_values2.size() * sizeof(int));
+
+            Chunk chunk2({std::move(c1_col2), std::move(c2_col2)}, _schema);
+
+            txn_id2 = next_id();
+            ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id2));
+            ASSERT_OK(writer->open());
+            ASSERT_OK(writer->write(chunk2));
+            ASSERT_OK(writer->finish());
+
+            // Create txn_log for txn_id2
+            auto txn_log2 = std::make_shared<TxnLog>();
+            txn_log2->set_tablet_id(_tablet_metadata->id());
+            txn_log2->set_txn_id(txn_id2);
+            auto op_write2 = txn_log2->mutable_op_write();
+            for (const auto& f : writer->segments()) {
+                op_write2->mutable_rowset()->add_segments(f.path);
+            }
+            op_write2->mutable_rowset()->set_num_rows(writer->num_rows());
+            op_write2->mutable_rowset()->set_data_size(writer->data_size());
+            op_write2->mutable_rowset()->set_overlapped(true);
+            ASSERT_OK(_tablet_mgr->put_txn_log(txn_log2));
+
+            writer->close();
+
+            auto* rowset = mutable_metadata->add_rowsets();
+            rowset->set_overlapped(true);
+            rowset->set_id(2);
+            rowset->set_num_rows(chunk2.num_rows());
+            auto* segs = rowset->mutable_segments();
+            for (const auto& file : writer->segments()) {
+                segs->Add()->assign(file.path);
+            }
+        }
+
+        // Publish version 3 with both txn_ids
+        // For batch_publish, new_version must equal base_version + txn_ids.size()
+        std::vector<int64_t> txn_ids{txn_id1, txn_id2};
+        ASSIGN_OR_ABORT(auto metadata_v3, batch_publish(_tablet_metadata->id(), 1, 3, txn_ids));
+        _tablet_metadata = metadata_v3;
+    }
+
+protected:
+    constexpr static const char* const kTestDirectory = "test_lake_tablet_delete_data";
+
+    TabletMetadataPtr _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+};
+
+TEST_F(LakeTabletDeleteDataTest, test_delete_data_without_schema_key) {
+    create_rowsets_with_data();
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+
+    // Create delete predicate: c2 = 3
+    DeletePredicatePB delete_predicate;
+    delete_predicate.set_version(-1);
+    auto* binary_predicate = delete_predicate.add_binary_predicates();
+    binary_predicate->set_column_name("c2");
+    binary_predicate->set_op("=");
+    binary_predicate->set_value("3");
+
+    // Execute delete_data without schema_key
+    int64_t txn_id = next_id();
+    ASSERT_OK(tablet.delete_data(txn_id, delete_predicate, nullptr));
+
+    // Verify txn log was created
+    ASSIGN_OR_ABORT(auto txn_log, tablet.get_txn_log(txn_id));
+    ASSERT_TRUE(txn_log->has_op_write());
+    ASSERT_TRUE(txn_log->op_write().has_rowset());
+    ASSERT_TRUE(txn_log->op_write().rowset().has_delete_predicate());
+    ASSERT_FALSE(txn_log->op_write().has_schema_key());
+
+    // Publish version 4
+    ASSIGN_OR_ABORT(auto metadata_v4, publish_single_version(_tablet_metadata->id(), 4, txn_id));
+
+    // Verify delete predicate is in the rowset
+    ASSERT_EQ(3, metadata_v4->rowsets_size());
+    const auto& delete_rowset = metadata_v4->rowsets(2);
+    ASSERT_TRUE(delete_rowset.has_delete_predicate());
+    ASSERT_EQ(1, delete_rowset.delete_predicate().binary_predicates_size());
+    ASSERT_EQ("c2", delete_rowset.delete_predicate().binary_predicates(0).column_name());
+    ASSERT_EQ("=", delete_rowset.delete_predicate().binary_predicates(0).op());
+    ASSERT_EQ("3", delete_rowset.delete_predicate().binary_predicates(0).value());
+
+    // Read data and verify deletion
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata_v4, *_schema);
+    ASSERT_OK(reader->prepare());
+    TabletReaderParams params;
+    ASSERT_OK(reader->open(params));
+
+    auto read_chunk_ptr = ChunkHelper::new_chunk(*_schema, 1024);
+    int total_rows = 0;
+    std::set<int> remaining_c1_values;
+    while (true) {
+        read_chunk_ptr->reset();
+        auto st = reader->get_next(read_chunk_ptr.get());
+        if (st.is_end_of_file()) {
+            break;
+        }
+        ASSERT_OK(st);
+        total_rows += read_chunk_ptr->num_rows();
+        for (int i = 0; i < read_chunk_ptr->num_rows(); i++) {
+            int c1_val = read_chunk_ptr->get(i)[0].get_int32();
+            int c2_val = read_chunk_ptr->get(i)[1].get_int32();
+            remaining_c1_values.insert(c1_val);
+            // Verify no rows with c2=3 remain
+            ASSERT_NE(3, c2_val) << "Found row with c2=3: c1=" << c1_val;
+        }
+    }
+
+    // Original data: 10 rows in rowset1 + 5 rows in rowset2 = 15 rows
+    // Rows with c2=3: c1=3,4,7 (rowset1) and c1=11,14 (rowset2) = 5 rows
+    // Expected remaining: 15 - 5 = 10 rows
+    ASSERT_EQ(10, total_rows);
+    // Verify specific rows remain
+    ASSERT_TRUE(remaining_c1_values.find(1) != remaining_c1_values.end());
+    ASSERT_TRUE(remaining_c1_values.find(2) != remaining_c1_values.end());
+    ASSERT_TRUE(remaining_c1_values.find(5) != remaining_c1_values.end());
+    ASSERT_TRUE(remaining_c1_values.find(6) != remaining_c1_values.end());
+    // Verify deleted rows are gone
+    ASSERT_TRUE(remaining_c1_values.find(3) == remaining_c1_values.end());
+    ASSERT_TRUE(remaining_c1_values.find(4) == remaining_c1_values.end());
+    ASSERT_TRUE(remaining_c1_values.find(7) == remaining_c1_values.end());
+    ASSERT_TRUE(remaining_c1_values.find(11) == remaining_c1_values.end());
+    ASSERT_TRUE(remaining_c1_values.find(14) == remaining_c1_values.end());
+
+    reader->close();
+}
+
+TEST_F(LakeTabletDeleteDataTest, test_delete_data_with_schema_key) {
+    create_rowsets_with_data();
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+
+    // Create extended schema with c3 int default 5
+    // The schema_key points to a schema that extends the tablet schema with c3
+    int64_t schema_id = next_id();
+    TableSchemaKeyPB schema_key;
+    schema_key.set_db_id(next_id());
+    schema_key.set_table_id(next_id());
+    schema_key.set_schema_id(schema_id);
+
+    // Create extended schema: tablet schema + c3 int default 5
+    TabletSchemaPB extended_schema_pb;
+    extended_schema_pb.CopyFrom(_tablet_metadata->schema());
+    extended_schema_pb.set_id(schema_id);
+    extended_schema_pb.set_schema_version(_tablet_metadata->schema().schema_version() + 1);
+
+    // Add c3 column with default value 5
+    auto c3 = extended_schema_pb.add_column();
+    c3->set_unique_id(next_id());
+    c3->set_name("c3");
+    c3->set_type("INT");
+    c3->set_is_key(false);
+    c3->set_is_nullable(false);
+    // Set default value to "5"
+    c3->set_default_value("5");
+
+    // Cache the extended schema before publish
+    auto extended_schema = TabletSchema::create(extended_schema_pb);
+    _tablet_mgr->cache_schema(extended_schema);
+
+    // Create delete predicate: c3 = 5
+    // Since c3 has default value 5 for all existing rows in the extended schema,
+    // this condition will match and delete all rows.
+    DeletePredicatePB delete_predicate;
+    delete_predicate.set_version(-1);
+    auto* binary_predicate = delete_predicate.add_binary_predicates();
+    binary_predicate->set_column_name("c3");
+    binary_predicate->set_op("=");
+    binary_predicate->set_value("5");
+
+    int64_t txn_id = next_id();
+    ASSERT_OK(tablet.delete_data(txn_id, delete_predicate, &schema_key));
+
+    // Verify txn log was created with schema_key
+    ASSIGN_OR_ABORT(auto txn_log, tablet.get_txn_log(txn_id));
+    ASSERT_TRUE(txn_log->op_write().has_schema_key());
+    ASSERT_EQ(schema_id, txn_log->op_write().schema_key().schema_id());
+
+    // Publish version 4
+    ASSIGN_OR_ABORT(auto metadata_v4, publish_single_version(_tablet_metadata->id(), 4, txn_id));
+
+    // 1. Verify that the schema ID in metadata_v4 is the same as the extended_schema
+    ASSERT_EQ(schema_id, metadata_v4->schema().id());
+
+    // Verify delete predicate is in the rowset
+    ASSERT_EQ(3, metadata_v4->rowsets_size());
+    const auto& delete_rowset = metadata_v4->rowsets(2);
+    ASSERT_TRUE(delete_rowset.has_delete_predicate());
+    ASSERT_EQ(1, delete_rowset.delete_predicate().binary_predicates_size());
+    ASSERT_EQ("c3", delete_rowset.delete_predicate().binary_predicates(0).column_name());
+    ASSERT_EQ("5", delete_rowset.delete_predicate().binary_predicates(0).value());
+
+    // 2. Build TabletReader according to extended_schema for data read verification
+    // All rows should be deleted because c3 defaults to 5.
+    auto extended_schema_obj = std::make_shared<Schema>(ChunkHelper::convert_schema(extended_schema));
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata_v4, *extended_schema_obj);
+    ASSERT_OK(reader->prepare());
+    TabletReaderParams params;
+    ASSERT_OK(reader->open(params));
+
+    auto read_chunk_ptr = ChunkHelper::new_chunk(*extended_schema_obj, 1024);
+    int total_rows = 0;
+    while (true) {
+        read_chunk_ptr->reset();
+        auto st = reader->get_next(read_chunk_ptr.get());
+        if (st.is_end_of_file()) {
+            break;
+        }
+        ASSERT_OK(st);
+        total_rows += read_chunk_ptr->num_rows();
+        for (int i = 0; i < read_chunk_ptr->num_rows(); i++) {
+            int c1_val = read_chunk_ptr->get(i)[0].get_int32();
+            int c3_val = read_chunk_ptr->get(i)[2].get_int32();
+            // Verify rows with c3=5 are deleted.
+            ASSERT_NE(5, c3_val) << "Found row with c3=5: c1=" << c1_val;
+        }
+    }
+
+    // Since c3 defaults to 5 for all rows and we have a delete predicate c3=5,
+    // all rows should be deleted.
+    ASSERT_EQ(0, total_rows);
+    reader->close();
+}
+
+} // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/lake/delete/LakeDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/delete/LakeDeleteJob.java
@@ -37,6 +37,7 @@ import com.starrocks.proto.DeleteDataResponse;
 import com.starrocks.proto.DeletePredicatePB;
 import com.starrocks.proto.InPredicatePB;
 import com.starrocks.proto.IsNullPredicatePB;
+import com.starrocks.proto.TableSchemaKeyPB;
 import com.starrocks.qe.QueryStateException;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
@@ -70,14 +71,23 @@ import java.util.concurrent.Future;
 public class LakeDeleteJob extends DeleteJob {
     private static final Logger LOG = LogManager.getLogger(LakeDeleteJob.class);
 
-    private Map<Long, List<Long>> beToTablets;
-
+    /**
+     * Schema key identifying the table schema. The delete predicate is generated
+     * based on this schema. This key is used for fast schema evolution v2 during
+     * delete operation, allowing the backend to update tablet metadata schema 
+     * during transaction publishing if needed.
+     */
+    private final TableSchemaKeyPB schemaKey;
     private final ComputeResource computeResource;
 
-    public LakeDeleteJob(long id, long transactionId, String label, MultiDeleteInfo deleteInfo, ComputeResource computeResource) {
+    private Map<Long, List<Long>> beToTablets;
+
+    public LakeDeleteJob(long id, long transactionId, String label, TableSchemaKeyPB schemaKey,
+                         MultiDeleteInfo deleteInfo, ComputeResource computeResource) {
         super(id, transactionId, label, deleteInfo);
-        beToTablets = Maps.newHashMap();
+        this.schemaKey = schemaKey;
         this.computeResource = computeResource;
+        beToTablets = Maps.newHashMap();
     }
 
     @Override
@@ -121,6 +131,7 @@ public class LakeDeleteJob extends DeleteJob {
                 request.tabletIds = entry.getValue();
                 request.txnId = getTransactionId();
                 request.deletePredicate = deletePredicate;
+                request.setSchemaKey(schemaKey);
 
                 LakeService lakeService = BrpcProxy.getLakeService(backend.getHost(), backend.getBrpcPort());
                 Future<DeleteDataResponse> responseFuture = lakeService.deleteData(request);

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
@@ -296,7 +296,7 @@ public class DeleteMgr implements Writable, MemoryTrackable {
             TableSchemaKeyPB schemaKey = new TableSchemaKeyPB();
             schemaKey.setDbId(db.getId());
             schemaKey.setTableId(olapTable.getId());
-            schemaKey.setSchemaId(olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexMetaId()).getSchemaId());
+            schemaKey.setSchemaId(olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId()).getSchemaId());
             deleteJob = new LakeDeleteJob(jobId, transactionId, label, schemaKey, deleteInfo, computeResource);
         } else {
             deleteJob = new OlapDeleteJob(jobId, transactionId, label, partitionReplicaNum, deleteInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
@@ -73,6 +73,7 @@ import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockWriter;
+import com.starrocks.proto.TableSchemaKeyPB;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.QueryStateException;
@@ -292,7 +293,11 @@ public class DeleteMgr implements Writable, MemoryTrackable {
         DeleteJob deleteJob = null;
 
         if (olapTable.isCloudNativeTable()) {
-            deleteJob = new LakeDeleteJob(jobId, transactionId, label, deleteInfo, computeResource);
+            TableSchemaKeyPB schemaKey = new TableSchemaKeyPB();
+            schemaKey.setDbId(db.getId());
+            schemaKey.setTableId(olapTable.getId());
+            schemaKey.setSchemaId(olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexMetaId()).getSchemaId());
+            deleteJob = new LakeDeleteJob(jobId, transactionId, label, schemaKey, deleteInfo, computeResource);
         } else {
             deleteJob = new OlapDeleteJob(jobId, transactionId, label, partitionReplicaNum, deleteInfo);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/delete/LakeDeleteJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/delete/LakeDeleteJobTest.java
@@ -170,11 +170,11 @@ public class LakeDeleteJobTest {
         Assertions.assertNotNull(db);
         Table table = starRocksAssert.getTable(tblName.getDb(), tblName.getTbl());
         Assertions.assertNotNull(table);
-        Assertions.assertTrue(table instanceof OlapTable);
+        Assertions.assertInstanceOf(OlapTable.class, table);
         OlapTable olapTable = (OlapTable) table;
         long expectedDbId = db.getId();
         long expectedTableId = olapTable.getId();
-        long expectedSchemaId = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexMetaId()).getSchemaId();
+        long expectedSchemaId = olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId()).getSchemaId();
 
         // Execute DELETE statement
         String deleteSql = "DELETE FROM " + tblName + " WHERE id = 1;";

--- a/fe/fe-core/src/test/java/com/starrocks/lake/delete/LakeDeleteJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/delete/LakeDeleteJobTest.java
@@ -15,6 +15,8 @@
 package com.starrocks.lake.delete;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.DdlException;
@@ -25,6 +27,7 @@ import com.starrocks.proto.DeleteDataResponse;
 import com.starrocks.proto.DeletePredicatePB;
 import com.starrocks.proto.InPredicatePB;
 import com.starrocks.proto.IsNullPredicatePB;
+import com.starrocks.proto.TableSchemaKeyPB;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
@@ -148,5 +151,83 @@ public class LakeDeleteJobTest {
         Assertions.assertEquals("colName", inPredicatePB.getColumnName());
         Assertions.assertFalse(inPredicatePB.isIsNotIn());
         Assertions.assertEquals(List.of("a"), inPredicatePB.getValues());
+    }
+
+    @Test
+    public void testDeleteDataRequestContainsSchemaKey(@Mocked LakeService lakeService) {
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setThreadLocalInfo();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(ctx);
+        TableName tblName = new TableName("test", "schema_key_table");
+        String createTableSql = "CREATE TABLE " + tblName + " (id INT, name String) DUPLICATE KEY(id) " +
+                "DISTRIBUTED BY HASH(id) BUCKETS 1 " + "PROPERTIES('replication_num' = '1');";
+
+        // create test.schema_key_table
+        Assertions.assertDoesNotThrow(() -> starRocksAssert.withDatabase(tblName.getDb()).withTable(createTableSql));
+
+        // Get table and database to verify schema key values
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(tblName.getDb());
+        Assertions.assertNotNull(db);
+        Table table = starRocksAssert.getTable(tblName.getDb(), tblName.getTbl());
+        Assertions.assertNotNull(table);
+        Assertions.assertTrue(table instanceof OlapTable);
+        OlapTable olapTable = (OlapTable) table;
+        long expectedDbId = db.getId();
+        long expectedTableId = olapTable.getId();
+        long expectedSchemaId = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexMetaId()).getSchemaId();
+
+        // Execute DELETE statement
+        String deleteSql = "DELETE FROM " + tblName + " WHERE id = 1;";
+        DeleteStmt deleteStmt;
+        try {
+            deleteStmt = (DeleteStmt) UtFrameUtils.parseStmtWithNewParser(deleteSql, ctx);
+        } catch (Exception e) {
+            Assertions.fail("Don't expect exception: " + e.getMessage());
+            return;
+        }
+
+        // Simulate one tablet failed, our purpose is to verify the request only.
+        // return a failed response to fail the job so that the following commit() will be skipped.
+        DeleteDataResponse response = new DeleteDataResponse();
+        response.failedTablets = List.of(1002L);
+
+        AtomicReference<DeleteDataRequest> capturedRequest = new AtomicReference<>();
+        LakeServiceWithMetrics wrappedLakeService = new LakeServiceWithMetrics(lakeService);
+        // Avoid directly mocking the LakeService, which is implemented by BrpcProxy reflection proxy.
+        new MockUp<LakeServiceWithMetrics>() {
+            @Mock
+            Future<DeleteDataResponse> deleteData(DeleteDataRequest request) {
+                capturedRequest.set(request);
+                return CompletableFuture.completedFuture(response);
+            }
+        };
+
+        new MockUp<BrpcProxy>() {
+            @Mock
+            public LakeService getLakeService(String host, int port) throws RpcException {
+                return wrappedLakeService;
+            }
+        };
+
+        DdlException exception = Assertions.assertThrows(DdlException.class,
+                () -> GlobalStateMgr.getCurrentState().getDeleteMgr().process(deleteStmt));
+        Assertions.assertEquals("Failed to execute delete. failed tablet num: 1", exception.getMessage());
+
+        // Verify DeleteDataRequest contains schemaKey
+        Assertions.assertNotNull(capturedRequest.get(), "DeleteDataRequest should be captured");
+        DeleteDataRequest request = capturedRequest.get();
+
+        // Verify schemaKey is present
+        Assertions.assertNotNull(request.getSchemaKey(), "DeleteDataRequest should contain schemaKey");
+        TableSchemaKeyPB schemaKey = request.getSchemaKey();
+        Assertions.assertNotNull(schemaKey, "schemaKey should not be null");
+
+        // Verify schemaKey values are correct
+        Assertions.assertEquals(expectedDbId, schemaKey.getDbId(),
+                "schemaKey.dbId should match database ID");
+        Assertions.assertEquals(expectedTableId, schemaKey.getTableId(),
+                "schemaKey.tableId should match table ID");
+        Assertions.assertEquals(expectedSchemaId, schemaKey.getSchemaId(),
+                "schemaKey.schemaId should match schema ID from base index meta");
     }
 }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -20,6 +20,7 @@ option java_package = "com.starrocks.proto";
 import "types.proto";
 import "lake_types.proto";
 import "status.proto";
+import "tablet_schema.proto";
 
 option cc_generic_services = true;
 
@@ -170,6 +171,11 @@ message DeleteDataRequest {
     repeated int64 tablet_ids = 1;
     optional int64 txn_id = 2;
     optional DeletePredicatePB delete_predicate = 3;
+    // Schema key identifying the table schema. The delete predicate is generated
+    // based on this schema. This key is used for fast schema evolution v2 during
+    // delete operation, allowing the backend to update tablet metadata schema 
+    // during transaction publishing if needed.
+    optional TableSchemaKeyPB schema_key = 4;
 }
 
 message DeleteDataResponse {


### PR DESCRIPTION
## Why I'm doing:
DELETE needs to carry the table schema identity so BE can reliably interpret delete predicates under fast schema evolution v2, and update tablet metadata schema during publish when required.

## What I'm doing:

- Add `schema_key` to `DeleteDataRequest` (proto) to identify the table schema used to generate the delete predicate
- FE: build `TableSchemaKeyPB` from db/table/base-index schema id in `DeleteMgr`, plumb it through `LakeDeleteJob`, and attach it to the delete RPC request
- BE: accept optional `schema_key` in `LakeServiceImpl::delete_data` and persist it into the txn log via `Tablet::delete_data(...)`
- Add backend lake delete gtest coverage for both “without schema key” (backward compatible) and “with schema key” (schema evolution v2)
- Add frontend unit test to verify the delete request contains the expected schema key fields

Fixes #65706

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables DELETE to carry the table schema identity for fast schema evolution v2 while remaining backward compatible.
> 
> - Proto: add optional `schema_key` to `DeleteDataRequest` in `lake_service.proto`
> - FE: build `TableSchemaKeyPB` in `DeleteMgr`, plumb through `LakeDeleteJob`, and set on DELETE RPC
> - BE: accept optional `schema_key` in `LakeServiceImpl::delete_data` and pass to `Tablet::delete_data(...)`
> - Storage: extend `Tablet::delete_data` to persist `schema_key` into `op_write` txn log
> - Tests: add BE lake delete tests (with/without `schema_key`) and FE unit test verifying request carries expected `schema_key`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01ac8970e3edaaef0347bbd246023e9dd63242c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->