### PR TITLE
[BugFix] fix get tables from information schema does not respect pattern

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/meta/SqlDigestBlackList.java
+++ b/fe/fe-core/src/main/java/com/starrocks/meta/SqlDigestBlackList.java
@@ -59,8 +59,7 @@ public class SqlDigestBlackList {
                 MetricRepo.COUNTER_SQL_BLOCK_HIT_COUNT.increase(1L);
                 ErrorReport.reportAnalysisException(
                         ErrorCode.ERR_SQL_IN_BLACKLIST_ERROR.formatErrorMsg() + ". Digest: %s",
-                        ErrorCode.ERR_SQL_IN_BLACKLIST_ERROR,
-                        digest);
+                        ErrorCode.ERR_SQL_IN_BLACKLIST_ERROR, -1, digest);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -356,7 +356,7 @@ public class InformationSchemaDataSource {
             public String dbName;
             public long dbId;
             public Table table;
-        };
+        }
         long startTableIdOffset = request.isSetStart_table_id_offset() ? request.getStart_table_id_offset() : 0;
         TreeSet<Element> sortedElements = new TreeSet<>(Comparator.comparing(Element::getTableId));
         for (String dbName : result.authorizedDbs) {
@@ -514,6 +514,16 @@ public class InformationSchemaDataSource {
         context.setCurrentUserIdentity(result.currentUser);
         context.setCurrentRoleIds(result.currentUser);
 
+        PatternMatcher matcher = null;
+        boolean caseSensitive = CaseSensibility.DATABASE.getCaseSensibility();
+        if (request.isSetTable_name()) {
+            try {
+                matcher = PatternMatcher.createMysqlPattern(request.getTable_name(), caseSensitive);
+            } catch (SemanticException e) {
+                throw new TException("Pattern is in bad format: " + request.getTable_name());
+            }
+        }
+
         String catalogName = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
         if (authInfo.isSetCatalog_name()) {
             catalogName = authInfo.getCatalog_name();
@@ -530,10 +540,9 @@ public class InformationSchemaDataSource {
             List<BasicTable> tables = new ArrayList<>();
             List<String> tableNames = metadataMgr.listTableNames(context, catalogName, dbName);
             for (String tableName : tableNames) {
-                if (request.isSetTable_name()) {
-                    if (!tableName.equals(request.getTable_name())) {
-                        continue;
-                    }
+                if (request.isSetTable_name() &&
+                        !PatternMatcher.matchPattern(request.getTable_name(), tableName, matcher, caseSensitive)) {
+                    continue;
                 }
 
                 BasicTable table = null;
@@ -747,7 +756,6 @@ public class InformationSchemaDataSource {
         response.setTables_infos(tableInfos);
         return response;
     }
-
 
     public static TTableInfo genNormalTableInfo(BasicTable table, TTableInfo info) {
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
@@ -423,7 +423,7 @@ public class QueryPlannerTest {
 
             StmtExecutor stmtExecutor2 = new StmtExecutor(connectContext, sqlStmt);
             stmtExecutor2.execute();
-            Assertions.assertEquals("Access denied; This sql is in blacklist, please contact your admin. " +
+            Assertions.assertEquals("Access denied; This sql is in blacklist (id: -1), please contact your admin. " +
                             "Digest: 389d2ef8d98994a4290b5d2e1d5838aa",
                     connectContext.getState().getErrorMessage());
             connectContext.getState().setError("");

--- a/test/sql/test_information_schema/R/test_tables_like_escape
+++ b/test/sql/test_information_schema/R/test_tables_like_escape
@@ -1,0 +1,24 @@
+-- name: test_tables_like_escape
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `a_a` (
+  `k1` int
+) DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+set enable_evaluate_schema_scan_rule=true;
+-- result:
+-- !result
+select table_name from information_schema.tables
+where table_schema='db_${uuid0}' and table_name like 'a\\_a';
+-- result:
+a_a
+-- !result
+drop database if exists db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_information_schema/R/test_tables_like_escape
+++ b/test/sql/test_information_schema/R/test_tables_like_escape
@@ -11,9 +11,6 @@ CREATE TABLE `a_a` (
 PROPERTIES ("replication_num" = "1");
 -- result:
 -- !result
-set enable_evaluate_schema_scan_rule=true;
--- result:
--- !result
 select table_name from information_schema.tables
 where table_schema='db_${uuid0}' and table_name like 'a\\_a';
 -- result:

--- a/test/sql/test_information_schema/T/test_tables_like_escape
+++ b/test/sql/test_information_schema/T/test_tables_like_escape
@@ -7,7 +7,6 @@ CREATE TABLE `a_a` (
 ) DISTRIBUTED BY HASH(`k1`) BUCKETS 1
 PROPERTIES ("replication_num" = "1");
 
-set enable_evaluate_schema_scan_rule=true;
 select table_name from information_schema.tables
 where table_schema='db_${uuid0}' and table_name like 'a\\_a';
 

--- a/test/sql/test_information_schema/T/test_tables_like_escape
+++ b/test/sql/test_information_schema/T/test_tables_like_escape
@@ -1,0 +1,14 @@
+-- name: test_tables_like_escape
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `a_a` (
+  `k1` int
+) DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+set enable_evaluate_schema_scan_rule=true;
+select table_name from information_schema.tables
+where table_schema='db_${uuid0}' and table_name like 'a\\_a';
+
+drop database if exists db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

In this PR, I set table pattern to request for performance.

However table pattern is not used as pattern but as exact string in `InformationSchemaDataSource`.

## What I'm doing:

Use pattern match in `InformationSchemaDataSource`.

Fixes https://github.com/StarRocks/starrocks/issues/67447

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves information_schema table filtering to correctly honor patterns.
> 
> - In `generateTablesInfoResponse`, replace exact `table_name` match with `PatternMatcher`-based filtering, constructing a MySQL-style matcher (with case sensitivity) and handling bad patterns via `TException`
> - Add SQL tests `test_tables_like_escape` to verify underscore escaping in `LIKE` works (`a\_a`)
> - Update `SqlDigestBlackList.verifying` to pass id `-1` to error reporting; adjust `QueryPlannerTest` expected error to include `(id: -1)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8af4d80837fb78358ae24c80dce0eb5274842c39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->