### PR TITLE
[Enhancement] Notify Starlet during BE shutdown to report status to StarMgr

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -44,6 +44,7 @@
 #include "util/system_metrics.h"
 #ifdef USE_STAROS
 #include "fslib/star_cache_handler.h"
+#include "service/staros_worker.h"
 #endif
 #include <fmt/ranges.h>
 
@@ -310,6 +311,9 @@ void sigterm_handler(int signo, siginfo_t* info, void* context) {
         StarRocksMetrics::instance()->system_metrics()->update_memory_metrics();
         LOG(ERROR) << dump_memory_tracker();
     }
+#ifdef USE_STAROS
+    set_starlet_in_shutdown();
+#endif
     set_process_exit();
 }
 

--- a/be/src/http/action/stop_be_action.cpp
+++ b/be/src/http/action/stop_be_action.cpp
@@ -23,6 +23,10 @@
 #include "http/http_status.h"
 #include "util/defer_op.h"
 
+#ifdef USE_STAROS
+#include "service/staros_worker.h"
+#endif
+
 namespace starrocks {
 
 std::string StopBeAction::construct_response_message(const std::string& msg) {
@@ -38,7 +42,12 @@ std::string StopBeAction::construct_response_message(const std::string& msg) {
 void StopBeAction::handle(HttpRequest* req) {
     LOG(INFO) << "Accept one stop_be request " << req->debug_string();
 
-    DeferOp defer([&]() { set_process_quick_exit(); });
+    DeferOp defer([&]() {
+#ifdef USE_STAROS
+        set_starlet_in_shutdown();
+#endif
+        set_process_quick_exit();
+    });
 
     std::string response_msg = construct_response_message("OK");
     if (process_exit_in_progress()) {

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -555,5 +555,12 @@ void update_staros_starcache() {
     }
 }
 
+void set_starlet_in_shutdown() {
+    auto* starlet = g_starlet.get();
+    if (starlet) {
+        starlet->on_shutdown();
+    }
+}
+
 } // namespace starrocks
 #endif // USE_STAROS

--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -149,6 +149,7 @@ extern std::unique_ptr<staros::starlet::Starlet> g_starlet;
 void init_staros_worker(const std::shared_ptr<starcache::StarCache>& star_cache);
 void shutdown_staros_worker();
 void update_staros_starcache();
+void set_starlet_in_shutdown();
 
 } // namespace starrocks
 #endif // USE_STAROS


### PR DESCRIPTION
Currently, when the BE process shuts down, the Starlet component might not be explicitly notified to update its status immediately. This change ensures that Starlet is informed during both signal-triggered shutdown (SIGTERM) and HTTP-triggered shutdown (stop_be_action).

This allows Starlet to report a SHUTDOWN status to StarMgr, ensuring better cluster state management for shared-data clusters.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures Starlet is explicitly notified when BE is shutting down.
> 
> - Adds `set_starlet_in_shutdown()` in `staros_worker.{h,cpp}` to call `starlet->on_shutdown()`
> - Invokes it in `daemon.cpp` SIGTERM handler and `StopBeAction` defer block (HTTP `stop_be`) under `USE_STAROS`
> - Includes necessary `staros_worker.h` headers; no other logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fca72f2e0faef845326e83fa8a0e86acb0635de1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->