### PR TITLE
[Tool] make dd agent configurable for fe and be

### DIFF
--- a/docker/dockerfiles/artifacts/artifact.Dockerfile
+++ b/docker/dockerfiles/artifacts/artifact.Dockerfile
@@ -48,8 +48,13 @@ FROM ubuntu:22.04 as downloader
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends wget tar xz-utils
 
-# download the latest dd-java-agent
-ADD 'https://dtdg.co/latest-java-tracer' /datadog/dd-java-agent.jar
+ARG DD_AGENT_VERSION
+ARG GITHUB_URL=${DD_AGENT_VERSION:+https://github.com/DataDog/dd-trace-java/releases/download/v${DD_AGENT_VERSION}/dd-java-agent-${DD_AGENT_VERSION}.jar}
+# default to latest if DD_AGENT_VERSION is not set
+ARG FINAL_DOWNLOAD_URL=${GITHUB_URL:-'https://dtdg.co/latest-java-tracer'}
+
+# download the dd-java-agent
+ADD ${FINAL_DOWNLOAD_URL} /datadog/dd-java-agent.jar
 
 # download the latest arthas
 ADD 'https://arthas.aliyun.com/arthas-boot.jar' /arthas/arthas-boot.jar


### PR DESCRIPTION
## Why I'm doing:

We want to be able to pin the datadog agent to the image.
I assume artifact.dockerfile is the only place to make this change as I see it's used in dockerfiles/fe, dockerfiles/be, dockerfiles/allin1, etc.

specific dd agent can be specified by passing --build-arg 
```
--build-arg DD_AGENT_VERSION=1.56.3
```

Downloading from datadog's github releases [here](https://github.com/DataDog/dd-trace-java/releases) 

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
