### PR TITLE
[WIP] improve recursive cte

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
@@ -57,8 +57,10 @@ import com.starrocks.thrift.TPlanNodeType;
 import com.starrocks.thrift.TSortInfo;
 import org.apache.commons.collections.CollectionUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Receiver side of a 1:n data stream. Logically, an ExchangeNode consumes the data
@@ -109,7 +111,7 @@ public class ExchangeNode extends PlanNode {
             cardinality = inputNode.cardinality;
         }
         // Only apply the limit at the receiver if there are multiple senders.
-        if (inputNode.getFragment().isPartitioned()) {
+        if (inputNode.getFragment() != null && inputNode.getFragment().isPartitioned()) {
             if (inputNode instanceof SortNode) {
                 SortNode sortNode = (SortNode) inputNode;
                 if (Objects.equals(TopNType.ROW_NUMBER, sortNode.getTopNType()) &&
@@ -128,6 +130,23 @@ public class ExchangeNode extends PlanNode {
     public ExchangeNode(PlanNodeId id, PlanNode inputNode, DistributionSpec.DistributionType type) {
         this(id, inputNode, DataPartition.UNPARTITIONED);
         distributionType = type;
+    }
+
+    public ExchangeNode(PlanNodeId id, DistributionSpec.DistributionType type) {
+        super(id, "EXCHANGE");
+        offset = 0;
+        this.conjuncts = Lists.newArrayList();
+        this.dataPartition = DataPartition.RANDOM;
+        this.cardinality = -1;
+        this.distributionType = type;
+    }
+
+    public void setTupleIds(ArrayList<TupleId> tupleIds) {
+        this.tupleIds = tupleIds;
+    }
+
+    public void setNullableTupleIds(Set<TupleId> nullableTupleIds) {
+        this.nullableTupleIds = nullableTupleIds;
     }
 
     public void setDataPartition(DataPartition dataPartition) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
@@ -84,6 +84,10 @@ public class MultiCastPlanFragment extends PlanFragment {
         }
     }
 
+    public void addDestNode(ExchangeNode destNode) {
+        destNodeList.add(destNode);
+    }
+
     @Override
     public PlanFragment getDestFragment() {
         Preconditions.checkState(false);
@@ -116,3 +120,4 @@ public class MultiCastPlanFragment extends PlanFragment {
         multiSink.getDestinations().forEach(List::clear);
     }
 }
+

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -116,7 +116,7 @@ import java.util.stream.Stream;
  */
 public class PlanFragment extends TreeNode<PlanFragment> {
     // id for this plan fragment
-    protected final PlanFragmentId fragmentId;
+    protected PlanFragmentId fragmentId;
 
     // root of plan tree executed by this fragment
     protected PlanNode planRoot;
@@ -133,7 +133,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     // specification of the partition of the input of this fragment;
     // an UNPARTITIONED fragment is executed on only a single node
     // TODO: improve this comment, "input" is a bit misleading
-    protected final DataPartition dataPartition;
+    protected DataPartition dataPartition;
 
     // specification of how the output of this fragment is partitioned (i.e., how
     // it's sent to its destination);
@@ -222,7 +222,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
      * Does not traverse the children of ExchangeNodes because those must belong to a
      * different fragment.
      */
-    private void setFragmentInPlanTree(PlanNode node) {
+    protected void setFragmentInPlanTree(PlanNode node) {
         if (node == null) {
             return;
         }
@@ -233,10 +233,6 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         for (PlanNode child : node.getChildren()) {
             setFragmentInPlanTree(child);
         }
-    }
-
-    public double getFragmentCost() {
-        return fragmentCost;
     }
 
     public void setFragmentCost(double fragmentCost) {
@@ -271,7 +267,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
      * Assign ParallelExecNum by PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM in SessionVariable for synchronous request
      * Assign ParallelExecNum by default value for Asynchronous request
      */
-    private void setParallelExecNumIfExists() {
+    protected void setParallelExecNumIfExists() {
         if (ConnectContext.get() != null) {
             ConnectContext connectContext = ConnectContext.get();
             SessionVariable sv = connectContext.getSessionVariable();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/recursivecte/RecursiveCTEAstCheck.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/recursivecte/RecursiveCTEAstCheck.java
@@ -18,47 +18,111 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.CTERelation;
+import com.starrocks.sql.ast.JoinRelation;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SetOperationRelation;
+import com.starrocks.sql.ast.SetQualifier;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.ast.UnionRelation;
 
 import java.util.Stack;
 
-public class RecursiveCTEAstCheck extends AstTraverser<Void, Void> {
-    private final Stack<String> cteNameStack = new Stack<>();
-    private boolean isRecursiveCte = false;
+public class RecursiveCTEAstCheck extends AstTraverser<Boolean, Void> {
+    private final ConnectContext context;
 
-    public static boolean hasRecursiveCte(StatementBase stmt, ConnectContext context) {
-        if (!context.getSessionVariable().isEnableRecursiveCTE()) {
-            return false;
+    private boolean isBlockRecursiveCte = false;
+    private boolean isRecursiveCte = false;
+    private boolean isBlockQuery = false;
+    private final Stack<String> cteNameStack = new Stack<>();
+
+    private RecursiveCTEAstCheck(ConnectContext context) {
+        this.context = context;
+    }
+
+    public static RecursiveCTEAstCheck of(ConnectContext context, StatementBase stmt) {
+        RecursiveCTEAstCheck checker = new RecursiveCTEAstCheck(context);
+        stmt.accept(checker, null);
+        return checker;
+    }
+
+    public boolean hasBlockRecursiveCte() {
+        if (isBlockRecursiveCte && !context.getSessionVariable().isEnableRecursiveCTE()) {
+            throw new SemanticException("Recursive CTE with block operation is disabled. " +
+                    "Please set 'enable_recursive_cte' to true to enable it.");
         }
-        RecursiveCTEAstCheck check = new RecursiveCTEAstCheck();
-        stmt.accept(check, null);
-        return check.isRecursiveCte;
+        return isBlockRecursiveCte;
+    }
+
+    public boolean hasRecursiveCte() {
+        return isRecursiveCte;
     }
 
     @Override
-    public Void visitCTE(CTERelation node, Void context) {
+    public Boolean visitCTE(CTERelation node, Void context) {
         if (node.isAnchor()) {
-            cteNameStack.push(node.getName());
-        }
-        super.visitCTE(node, context);
-        if (node.isAnchor()) {
-            cteNameStack.pop();
+            this.isBlockQuery = false;
+            this.cteNameStack.push(node.getName());
+            super.visitCTE(node, context);
+            this.cteNameStack.pop();
+        } else {
+            super.visitCTE(node, context);
         }
         return null;
     }
 
     @Override
-    public Void visitTable(TableRelation node, Void context) {
+    public Boolean visitSubqueryRelation(SubqueryRelation node, Void context) {
+        return super.visitSubqueryRelation(node, context);
+    }
+
+    @Override
+    public Boolean visitSelect(SelectRelation node, Void context) {
+        if (node.getGroupBy() != null || node.hasOrderByClause()
+                || node.getSelectList().isDistinct() || node.hasAnalyticInfo()) {
+            isBlockQuery = true;
+        }
+        return super.visitSelect(node, context);
+    }
+
+    @Override
+    public Boolean visitSetOp(SetOperationRelation node, Void context) {
+        if (node.getQualifier() != SetQualifier.ALL || !(node instanceof UnionRelation)) {
+            isBlockQuery = true;
+        }
+        return super.visitSetOp(node, context);
+    }
+
+    @Override
+    public Boolean visitJoin(JoinRelation node, Void context) {
+        if (node.getOnPredicate() != null) {
+            visit(node.getOnPredicate(), context);
+        }
+        boolean isLeftRecursive = visit(node.getLeft(), context);
+        boolean isRightRecursive = visit(node.getRight(), context);
+        if (isRightRecursive) {
+            throw new SemanticException("Recursive reference must be in the left side of JOIN");
+        }
+        if (isLeftRecursive) {
+            node.setJoinHint("BROADCAST");
+        }
+        return isLeftRecursive;
+    }
+
+    @Override
+    public Boolean visitTable(TableRelation node, Void context) {
         if (cteNameStack.isEmpty()) {
-            return null;
+            return false;
         }
         if (node.getName().getDb() == null && node.getName().getTbl().equalsIgnoreCase(cteNameStack.peek())) {
             if (cteNameStack.size() != 1) {
                 throw new SemanticException("Doesn't support multi-level recursive CTE");
             }
             isRecursiveCte = true;
+            isBlockRecursiveCte |= isBlockQuery;
+            return true;
         }
-        return null;
+        return false;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/RemoteFragmentAssignmentStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/RemoteFragmentAssignmentStrategy.java
@@ -168,6 +168,12 @@ public class RemoteFragmentAssignmentStrategy implements FragmentAssignmentStrat
                         .forEach(workerIdSet::add);
             }
             maxParallelism = workerIdSet.size() * fragment.getParallelExecNum();
+        } else if (execFragment.childrenSize() == 0) {
+            // there is no child fragment but is remote fragment
+            // only recursive cte leaf fragment is this case now
+            // we assign all available workers
+            workerIdSet = Set.copyOf(workerProvider.getAllAvailableNodes());
+            maxParallelism = workerIdSet.size() * fragment.getParallelExecNum();
         } else {
             // there is no leftmost scan; we assign the same hosts as those of our
             // input fragment which has a higher instance_number

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -458,6 +458,9 @@ public class AnalyzerUtils {
 
         @Override
         public Void visitCTE(CTERelation node, Void context) {
+            if (node.isRecursive() && !node.isAnchor()) {
+                return null;
+            }
             return visit(node.getCteQueryStatement());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEContext.java
@@ -17,12 +17,14 @@ package com.starrocks.sql.optimizer;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /*
  * Recorder CTE node info, contains:
@@ -52,7 +54,9 @@ public class CTEContext {
 
     private boolean enableCTE;
 
-    private final List<Integer> forceCTEList;
+    private final Set<Integer> recursiveCTEList;
+
+    private final Set<Integer> forceCTEList;
 
     private double inlineCTERatio = 2.0;
 
@@ -61,7 +65,8 @@ public class CTEContext {
     private int cteIdSequence = 0;
 
     public CTEContext() {
-        forceCTEList = Lists.newArrayList();
+        forceCTEList = Sets.newHashSet();
+        recursiveCTEList = Sets.newHashSet();
     }
 
     public void reset() {
@@ -197,6 +202,14 @@ public class CTEContext {
         }
 
         return false;
+    }
+
+    public void addRecursiveCTE(int cteId) {
+        this.recursiveCTEList.add(cteId);
+    }
+
+    public boolean isRecursiveCTE(int cteId) {
+        return this.recursiveCTEList.contains(cteId);
     }
 
     public void addForceCTE(int cteId) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
@@ -36,6 +36,9 @@ public class CTEUtils {
             // produce
             LogicalCTEAnchorOperator anchor = (LogicalCTEAnchorOperator) root.getOp();
             context.getCteContext().addCTEProduce(anchor.getCteId());
+            if (anchor.isRecursive()) {
+                context.getCteContext().addRecursiveCTE(anchor.getCteId());
+            }
 
             Preconditions.checkState(root.getInputs().get(0).getOp() instanceof LogicalCTEProduceOperator);
             LogicalCTEProduceOperator produce = (LogicalCTEProduceOperator) root.getInputs().get(0).getOp();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RequiredPropertyDeriver.java
@@ -92,6 +92,9 @@ public class RequiredPropertyDeriver extends PropertyDeriverBase<Void, Expressio
                 Set<Integer> cteIds = Sets.newHashSet(requirementsFromParent.getCteProperty().getCteIds());
                 if (idx == 0) {
                     cteIds.retainAll(groupExpression.inputAt(0).getLogicalProperty().getUsedCTEs().getCteIds());
+                    if (operator.isRecursive()) {
+                        cteIds.add(operator.getCteId());
+                    }
                 } else {
                     cteIds.retainAll(groupExpression.inputAt(1).getLogicalProperty().getUsedCTEs().getCteIds());
                     cteIds.add(operator.getCteId());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCTEAnchorOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCTEAnchorOperator.java
@@ -36,6 +36,7 @@ import java.util.Objects;
  * */
 public class LogicalCTEAnchorOperator extends LogicalOperator {
     private int cteId;
+    private boolean isRecursive = false;
 
     public LogicalCTEAnchorOperator(int cteId) {
         super(OperatorType.LOGICAL_CTE_ANCHOR);
@@ -67,6 +68,10 @@ public class LogicalCTEAnchorOperator extends LogicalOperator {
 
     public int getCteId() {
         return cteId;
+    }
+
+    public boolean isRecursive() {
+        return isRecursive;
     }
 
     @Override
@@ -105,6 +110,10 @@ public class LogicalCTEAnchorOperator extends LogicalOperator {
                 '}';
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
     public static class Builder
             extends LogicalOperator.Builder<LogicalCTEAnchorOperator, LogicalCTEAnchorOperator.Builder> {
 
@@ -115,6 +124,11 @@ public class LogicalCTEAnchorOperator extends LogicalOperator {
 
         public LogicalCTEAnchorOperator.Builder setCteId(int cteId) {
             builder.cteId = cteId;
+            return this;
+        }
+
+        public LogicalCTEAnchorOperator.Builder setIsRecursive(boolean isRecursive) {
+            builder.isRecursive = isRecursive;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCTEProduceOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalCTEProduceOperator.java
@@ -100,6 +100,10 @@ public class LogicalCTEProduceOperator extends LogicalOperator {
                 '}';
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
     public static class Builder
             extends LogicalOperator.Builder<LogicalCTEProduceOperator, LogicalCTEProduceOperator.Builder> {
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEAnchorOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalCTEAnchorOperator.java
@@ -28,12 +28,14 @@ import java.util.Objects;
 public class PhysicalCTEAnchorOperator extends PhysicalOperator {
     private final int cteId;
     private final int consumeNum;
+    private final boolean isRecursive;
 
-    public PhysicalCTEAnchorOperator(int cteId, int consumeNum, Projection projection) {
+    public PhysicalCTEAnchorOperator(int cteId, int consumeNum, boolean isRecursive, Projection projection) {
         super(OperatorType.PHYSICAL_CTE_ANCHOR);
         this.cteId = cteId;
         this.consumeNum = consumeNum;
         this.projection = projection;
+        this.isRecursive = isRecursive;
     }
 
     // only used for plan fragment builder
@@ -41,6 +43,7 @@ public class PhysicalCTEAnchorOperator extends PhysicalOperator {
         super(OperatorType.PHYSICAL_CTE_ANCHOR);
         this.cteId = cteId;
         this.consumeNum = -1;
+        this.isRecursive = false;
     }
 
     public int getCteId() {
@@ -49,6 +52,10 @@ public class PhysicalCTEAnchorOperator extends PhysicalOperator {
 
     public int getConsumeNum() {
         return consumeNum;
+    }
+
+    public boolean isRecursive() {
+        return isRecursive;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/CTEAnchorImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/CTEAnchorImplementationRule.java
@@ -41,10 +41,10 @@ public class CTEAnchorImplementationRule extends ImplementationRule {
 
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
-        int cteId = ((LogicalCTEAnchorOperator) input.getOp()).getCteId();
-        int consumeNum = context.getCteContext().getCTEConsumeNum(cteId);
-        PhysicalCTEAnchorOperator anchor =
-                new PhysicalCTEAnchorOperator(cteId, consumeNum, input.getOp().getProjection());
+        LogicalCTEAnchorOperator obj = (LogicalCTEAnchorOperator) input.getOp();
+        int consumeNum = context.getCteContext().getCTEConsumeNum(obj.getCteId());
+        PhysicalCTEAnchorOperator anchor = new PhysicalCTEAnchorOperator(obj.getCteId(), consumeNum,
+                obj.isRecursive(), input.getOp().getProjection());
         return Lists.newArrayList(OptExpression.create(anchor, input.getInputs()));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/CTEAnchorToNoCTEImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/CTEAnchorToNoCTEImplementationRule.java
@@ -33,6 +33,15 @@ public class CTEAnchorToNoCTEImplementationRule extends ImplementationRule {
     }
 
     @Override
+    public boolean check(OptExpression input, OptimizerContext context) {
+        LogicalCTEAnchorOperator anchor = (LogicalCTEAnchorOperator) input.getOp();
+        if (anchor.isRecursive()) {
+            return false;
+        }
+        return !context.getCteContext().isForceCTE(anchor.getCteId());
+    }
+
+    @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         return Lists.newArrayList(OptExpression
                 .create(new PhysicalNoCTEOperator(((LogicalCTEAnchorOperator) input.getOp()).getCteId()),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1931,6 +1931,15 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
     private Void computeCTEConsume(Operator node, ExpressionContext context, int cteId,
                                    Map<ColumnRefOperator, ColumnRefOperator> columnRefMap) {
+        if (optimizerContext.getCteContext().isRecursiveCTE(cteId)) {
+            Statistics.Builder builder = Statistics.builder();
+            for (ColumnRefOperator ref : columnRefMap.keySet()) {
+                builder.addColumnStatistic(ref, ColumnStatistic.unknown());
+            }
+            builder.setOutputRowCount(1);
+            context.setStatistics(builder.build());
+            return visitOperator(node, context);
+        }
 
         if (!context.getChildrenStatistics().isEmpty() && context.getChildStatistics(0) != null) {
             //  use the statistics of children first

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
@@ -16,8 +16,10 @@
 package com.starrocks.sql.optimizer.transformer;
 
 import com.google.common.base.Preconditions;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -31,7 +33,9 @@ public class CTETransformerContext {
     // When the node count of cte is 0, disable the force reuse optimization.
     // cte id -> node count
     private final Map<Integer, Integer> cteIdToNodeCount;
-    
+
+    private final Map<Integer, List<LogicalCTEConsumeOperator>> recursiveCteIdToSelfConsume;
+
     private final AtomicInteger uniqueId;
 
     private final int cteMaxLimit;
@@ -42,10 +46,15 @@ public class CTETransformerContext {
         this.cteIdToNodeCount = new HashMap<>();
         this.uniqueId = new AtomicInteger();
         this.cteMaxLimit = cteMaxLimit;
+        this.recursiveCteIdToSelfConsume = new HashMap<>();
     }
 
     public Map<Integer, ExpressionMapping> getCteExpressions() {
         return cteExpressions;
+    }
+
+    public Map<Integer, List<LogicalCTEConsumeOperator>> getRecursiveCteIdToSelfConsume() {
+        return recursiveCteIdToSelfConsume;
     }
 
     /*

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/plan/CTETest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/plan/CTETest.java
@@ -15,11 +15,23 @@
 package com.starrocks.qe.scheduler.plan;
 
 import com.starrocks.qe.scheduler.SchedulerTestBase;
+import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Test;
 
 public class CTETest extends SchedulerTestBase {
     @Test
     public void testSimpleCTE() {
         runFileUnitTest("scheduler/cte/cte_simple");
+    }
+
+    @Test
+    public void testRecursiveCTE() throws Exception {
+        String sql = "with recursive t1 as (select 1 as l union all select * from t1 where l < 10 ) "
+                + "select * from t1";
+        String plan = getVerboseExplain(sql);
+        System.out.println(plan);
+        String fragment =
+                UtFrameUtils.getPlanAndStartScheduling(connectContext, sql).first;
+        assertContains(fragment, "Recursive Statement: SELECT 1 AS `l`");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves recursive CTE support from parsing to execution and wiring for streaming.
> 
> - Analyzer: replace simple check with `RecursiveCTEAstCheck` that detects blocked/unblocked recursive CTEs, enforces session gating, injects broadcast hint for left-recursive joins, and updates `StmtExecutor` behavior (warn/throw appropriately)
> - Optimizer: propagate recursion via `LogicalCTEAnchorOperator`/`PhysicalCTEAnchorOperator` (new isRecursive flag); track recursive CTE ids in `CTEContext`/`CTEUtils`; adjust required properties and forbid NoCTE lowering for recursive anchors; special-case statistics for recursive consumes
> - Transformer: build self-referential `LogicalCTEConsumeOperator` for recursive CTE, manage column mapping, and reuse logic; skip reuse optimization when all CTEs are single-use unless recursive
> - Planner: enable recursive streaming by enhancing `PlanFragmentBuilder` to stitch multicast producer to multiple `ExchangeNode` consumers (new `ExchangeNode` ctor and tuple id setters), and extend `MultiCastPlanFragment`/`PlanFragment` APIs
> - Scheduler: handle remote fragments with no children by assigning all available workers
> - Misc: minor robustness tweaks (cost computation null-safety) and tests added for recursive CTE planning/scheduling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e06af832673897f77f5b1a981843a4c0e027ab2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->