### PR TITLE
[Enhancement] - Python Client - Add support for asynchronous connection using `asyncmy` driver

### DIFF
--- a/contrib/starrocks-python-client/CHANGES.md
+++ b/contrib/starrocks-python-client/CHANGES.md
@@ -1,0 +1,22 @@
+Version history
+===============
+
+**1.3.3**
+
+- Add back support for SQLAlchemy 1.4 (#65976 by @rad-pat)
+- Enable select from a FilesSource and support for Python 3.14 (#66797 by @rad-pat)
+- Add support for async SQLAlchemy connection via asyncmy driver and
+  ignore errors from querying tables_config on non-default catalog (#67479 by @rad-pat)
+
+**1.3.2**
+- Fix DEFAULT compilation, type comparison, and column ordering (#66125 by @jaogoy)
+
+**1.3.1**
+- Enable SQLAlchemy Test Suite (#65025 by @rad-pat)
+- Supports Views and Materialized Views and enhance documentation (#65808 by @jaogoy)
+
+**1.3.0**
+- Support more attributes for comparing StarRocks tables by using Alembic (#64161 by jaogoy)
+
+**1.2.3**
+Older

--- a/contrib/starrocks-python-client/README.md
+++ b/contrib/starrocks-python-client/README.md
@@ -40,10 +40,15 @@ virtualenv <your-env-name>
 
 ### Basic SQLAlchemy Usage
 
-To connect to StarRocks, use a standard SQLAlchemy connection string.
+To connect to StarRocks, use the SQLAlchemy connection string format:
 
 ```ini
 starrocks://<User>:<Password>@<Host>:<Port>/[<Catalog>.]<Database>
+```
+
+Or, for an asynchronous connection, use asyncmy driver:
+```ini
+starrocks+asyncmy://<User>:<Password>@<Host>:<Port>/[<Catalog>.]<Database>
 ```
 
 - **User**: User Name
@@ -65,12 +70,29 @@ from sqlalchemy import create_engine, text
 
 engine = create_engine('starrocks://root@localhost:9030/mydatabase')
 
-# make sure you have create a table `mytable` in `mydatabase`.
+# make sure you have created the table `mytable` in `mydatabase`.
 
 with engine.connect() as connection:
-    rows = connection.execute(text("SELECT * FROM mytable LIMIT 2")).fetchall()
     print("Connection successful!")
+    rows = connection.execute(text("SELECT * FROM mytable LIMIT 2")).fetchall()
     print(rows)
+
+# async version
+import asyncio
+from sqlalchemy.ext.asyncio import create_async_engine
+
+engine = create_async_engine('starrocks+asyncmy://root@localhost:9030/mydatabase')
+
+async def async_query():
+    async with engine.connect() as connection:
+        print("Connection successful!")
+        rows = await connection.execute(text("SELECT * FROM mytable LIMIT 2")).fetchall()
+        print(rows)
+
+    await engine.dispose()
+
+asyncio.run(async_query())
+
 ```
 
 ### Example: Defining a Table (ORM Style)

--- a/contrib/starrocks-python-client/pyproject.toml
+++ b/contrib/starrocks-python-client/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "pymysql>=1.1.0",
     "lark>=1.3.1",
     "alembic>=1.14.0",
+    "asyncmy2>=0.2.20",
 ]
 dynamic = ["readme", "version"]
 
@@ -79,6 +80,7 @@ Issues = "https://github.com/starrocks/starrocks/issues"
 [project.entry-points."sqlalchemy.dialects"]
 starrocks = "starrocks.dialect:StarRocksDialect"
 "starrocks.pymysql" = "starrocks.dialect:StarRocksDialect"
+"starrocks.asyncmy" = "starrocks.asyncmy:StarRocksDialect_asyncmy"
 
 
 [tool.ruff]

--- a/contrib/starrocks-python-client/requirements-dev.txt
+++ b/contrib/starrocks-python-client/requirements-dev.txt
@@ -4,3 +4,4 @@ pymysql==1.1.1
 lark>=1.3.1
 pytest>=8.0
 sqlacodegen>=3.0
+asyncmy2>=0.2.20

--- a/contrib/starrocks-python-client/starrocks/asyncmy.py
+++ b/contrib/starrocks-python-client/starrocks/asyncmy.py
@@ -1,0 +1,84 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from sqlalchemy.connectors.asyncio import AsyncIODBAPIConnection
+from sqlalchemy.dialects.mysql.asyncmy import AsyncAdapt_asyncmy_dbapi, AsyncAdapt_asyncmy_ss_cursor
+from sqlalchemy.engine.interfaces import DBAPIConnection, DBAPICursor, DBAPIModule, PoolProxiedConnection
+from sqlalchemy.engine.url import URL
+from sqlalchemy import pool, util
+
+from .dialect import StarRocksDialect
+
+
+class StarRocksDialect_asyncmy(StarRocksDialect):
+    driver = "asyncmy"
+    supports_statement_cache = True
+
+    supports_server_side_cursors = True
+    _sscursor = AsyncAdapt_asyncmy_ss_cursor
+
+    is_async = True
+    has_terminate = True
+
+    @classmethod
+    def import_dbapi(cls) -> DBAPIModule:
+        return AsyncAdapt_asyncmy_dbapi(__import__("asyncmy"))
+
+    @classmethod
+    def get_pool_class(cls, url: URL) -> type:
+        async_fallback = url.query.get("async_fallback", False)
+
+        if util.asbool(async_fallback):
+            return pool.FallbackAsyncAdaptedQueuePool
+        else:
+            return pool.AsyncAdaptedQueuePool
+
+    def do_terminate(self, dbapi_connection: DBAPIConnection) -> None:
+        dbapi_connection.terminate()
+
+    def create_connect_args(self, url: URL) -> ConnectArgsType:  # type: ignore[override]  # noqa: E501
+        return super().create_connect_args(
+            url, _translate_args=dict(username="user", database="db")
+        )
+
+    def is_disconnect(
+        self,
+        e: DBAPIModule.Error,
+        connection: Optional[Union[PoolProxiedConnection, DBAPIConnection]],
+        cursor: Optional[DBAPICursor],
+    ) -> bool:
+        if super().is_disconnect(e, connection, cursor):
+            return True
+        else:
+            str_e = str(e).lower()
+            return (
+                "not connected" in str_e or "network operation failed" in str_e
+            )
+
+    def _found_rows_client_flag(self) -> int:
+        from asyncmy.constants import CLIENT  # type: ignore
+
+        return CLIENT.FOUND_ROWS  # type: ignore[no-any-return]
+
+    def get_driver_connection(
+        self, connection: DBAPIConnection
+    ) -> AsyncIODBAPIConnection:
+        return connection._connection  # type: ignore[no-any-return]
+
+
+dialect = StarRocksDialect_asyncmy

--- a/contrib/starrocks-python-client/starrocks/dialect.py
+++ b/contrib/starrocks-python-client/starrocks/dialect.py
@@ -1282,9 +1282,9 @@ class StarRocksDialect(MySQLDialect_pymysql):
         # some test parameters
         # self.test_replication_num: Optional[int] = None
 
-    def create_connect_args(self, url):
+    def create_connect_args(self, url, _translate_args: Optional[Dict[str, Any]] = None):
         # Allow the superclass to create the base connect arguments
-        connect_args = super(StarRocksDialect, self).create_connect_args(url)[1]
+        _, connect_args = super(StarRocksDialect, self).create_connect_args(url, _translate_args)
         logger.debug("connect_args: %s", connect_args)
 
         # Handle the test-specific replication_num parameter

--- a/contrib/starrocks-python-client/starrocks/dialect.py
+++ b/contrib/starrocks-python-client/starrocks/dialect.py
@@ -1509,14 +1509,21 @@ class StarRocksDialect(MySQLDialect_pymysql):
                 f"Multiple tables found with name {table_name} in schema {schema}"
             )
         # logger.debug("reflected table row for table: %s, info: %s", table_name, dict(table_rows[0]))
-
-        table_config_rows: List[_DecodingRow] = self._read_from_information_schema(
-            connection=connection,
-            inf_sch_table="tables_config",
-            charset=charset,
-            table_schema=schema,
-            table_name=table_name,
-        )
+        try:
+            table_config_rows: List[_DecodingRow] = self._read_from_information_schema(
+                connection=connection,
+                inf_sch_table="tables_config",
+                charset=charset,
+                table_schema=schema,
+                table_name=table_name,
+            )
+        except Exception as e:
+            if 'Unknown table \'information_schema.tables_config\'' in str(e):
+                table_config_rows = [{
+                    'TABLE_ENGINE': table_rows[0].get('ENGINE'),
+                }]
+            else:
+                raise
         if table_config_rows:
             if len(table_config_rows) > 1:
                 raise exc.InvalidRequestError(
@@ -1747,6 +1754,8 @@ class StarRocksDialect(MySQLDialect_pymysql):
             return super().has_table(connection, table_name, schema, **kwargs)
         except exc.DBAPIError as e:
             if self._extract_error_code(e.orig) in (5501, 5502):
+                return False
+            if 'not exists' in str(e.orig).lower():
                 return False
             raise
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Adding support for asynchronous SQLAlchemy connection for using with asyncio framework. The SQLAlchemy testing framework covers testing the connection if an asynchronous connection string is provided.

Fixes #60575
Fixes #67023

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Enhancement: async connections**
> 
> - New `starrocks.asyncmy` dialect (`starrocks/asyncmy.py`) enabling asyncio-based SQLAlchemy usage; registers entry point and selects async pool classes
> - Packaging: add `asyncmy2` dependency and dialect entry point in `pyproject.toml`; dev reqs updated
> - Docs: README updated with async connection URL and example; `CHANGES.md` notes new features
> 
> **Dialect/Reflection robustness**
> 
> - `StarRocksDialect.create_connect_args` now supports `_translate_args` (used by async driver)
> - Handle missing `information_schema.tables_config` by falling back to engine from `tables`
> - `has_table` returns `False` on "not exists" DBAPI errors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c1d3aa41a172c0d2cd801485eb7e7d16c45571c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->