### PR TITLE
[UT] test isolation workgroup manager

### DIFF
--- a/be/test/agent/resource_group_usage_recorder_test.cpp
+++ b/be/test/agent/resource_group_usage_recorder_test.cpp
@@ -28,6 +28,9 @@ TEST(ResourceGroupUsageRecorderTest, test_get_resource_group_usages) {
     const size_t num_cores = CpuInfo::num_cores();
 
     auto& exec_env = *ExecEnv::GetInstance();
+    // Save original workgroup_manager to restore at end (otherwise subsequent tests fail)
+    auto original_wg_manager = std::move(exec_env._workgroup_manager);
+
     workgroup::PipelineExecutorSetConfig executors_manager_opts(
             CpuInfo::num_cores(), num_cores, num_cores, num_cores, CpuInfo::get_core_ids(), true,
             config::enable_resource_group_cpu_borrowing, pipeline::PipelineExecutorMetrics::instance());
@@ -48,6 +51,9 @@ TEST(ResourceGroupUsageRecorderTest, test_get_resource_group_usages) {
     ASSERT_EQ(group_usages[0].mem_pool, workgroup::WorkGroup::DEFAULT_MEM_POOL);
     ASSERT_EQ(group_usages[0].mem_limit_bytes, default_wg->mem_limit_bytes());
     ASSERT_EQ(group_usages[0].mem_pool_mem_limit_bytes, default_wg->mem_limit_bytes());
+
+    // Restore original workgroup_manager
+    exec_env._workgroup_manager = std::move(original_wg_manager);
 }
 
 } // namespace starrocks

--- a/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
+++ b/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
@@ -86,6 +86,7 @@ public:
         _fragment_ctx->set_runtime_state(std::make_unique<RuntimeState>(
                 _request.params.query_id, _request.params.fragment_instance_id, _request.query_options,
                 _request.query_globals, &_exec_env->query_execution_services(), _exec_env));
+        _fragment_ctx->set_workgroup(ExecEnv::GetInstance()->workgroup_manager()->get_default_workgroup());
 
         _fragment_future = _fragment_ctx->finish_future();
         _runtime_state = _fragment_ctx->runtime_state();


### PR DESCRIPTION
  ## Summary
  Fix test isolation issues introduced in #66690 and #63956.

  When tests run in the same process (without gtest-parallel),
  ResourceGroupUsageRecorderTest replaces workgroup_manager without calling
  start(), leaving driver_executor as nullptr. This causes subsequent tests
  to crash with nullptr dereference.

  ## Changes
  - ResourceGroupUsageRecorderTest: save/restore original workgroup_manager, call start()
  - PipeLineFileScanNodeTest: add missing set_workgroup() call


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures test isolation and proper workgroup setup to avoid nullptr crashes across tests.
> 
> - ResourceGroupUsageRecorderTest: replace `exec_env._workgroup_manager` with a started instance, then restore the original at the end
> - PipeLineFileScanNodeTest: call `_fragment_ctx->set_workgroup(ExecEnv::GetInstance()->workgroup_manager()->get_default_workgroup())` in `SetUp()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0545875f671b06c6c5a3af16025748ee108fb5bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

