### PR TITLE
[BugFix] Fix memory leak in count aggregate function registration

### DIFF
--- a/be/src/exprs/agg/factory/aggregate_resolver_sumcount.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_sumcount.cpp
@@ -63,13 +63,13 @@ void AggregateFuncResolver::register_sumcount() {
     }
 
     _infos_mapping.emplace(std::make_tuple("count", TYPE_BIGINT, TYPE_BIGINT, false, false),
-                           AggregateFactory::MakeCountAggregateFunction<false>());
+                           track_function(AggregateFactory::MakeCountAggregateFunction<false>()));
     _infos_mapping.emplace(std::make_tuple("count", TYPE_BIGINT, TYPE_BIGINT, true, false),
-                           AggregateFactory::MakeCountAggregateFunction<true>());
+                           track_function(AggregateFactory::MakeCountAggregateFunction<true>()));
     _infos_mapping.emplace(std::make_tuple("count", TYPE_BIGINT, TYPE_BIGINT, false, true),
-                           AggregateFactory::MakeCountNullableAggregateFunction<false>());
+                           track_function(AggregateFactory::MakeCountNullableAggregateFunction<false>()));
     _infos_mapping.emplace(std::make_tuple("count", TYPE_BIGINT, TYPE_BIGINT, true, true),
-                           AggregateFactory::MakeCountNullableAggregateFunction<true>());
+                           track_function(AggregateFactory::MakeCountNullableAggregateFunction<true>()));
 }
 
 } // namespace starrocks


### PR DESCRIPTION
Count aggregate functions were registered without track_function() wrapper, causing memory leak detected by ASAN. All other aggregate functions in the resolver use track_function() for proper lifecycle management.

Changes:
- Wrap MakeCountAggregateFunction with track_function()
- Wrap MakeCountNullableAggregateFunction with track_function()

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `count` aggregates are lifecycle-tracked to prevent memory leaks, consistent with other aggregates.
> 
> - In `aggregate_resolver_sumcount.cpp`, wraps `MakeCountAggregateFunction<...>` and `MakeCountNullableAggregateFunction<...>` with `track_function()` in `_infos_mapping` registrations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddf8d6e94fe0f7b44011a64f985ad6785e07a3fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->