### PR TITLE
[BugFix] Fix gcc compilation

### DIFF
--- a/be/src/http/action/datacache_action.cpp
+++ b/be/src/http/action/datacache_action.cpp
@@ -71,7 +71,7 @@ void DataCacheAction::_handle(HttpRequest* req, const std::function<void(rapidjs
     root.SetObject();
     func(root);
     rapidjson::StringBuffer strbuf;
-    rapidjson::PrettyWriter writer(strbuf);
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(strbuf);
     root.Accept(writer);
     req->add_output_header(HttpHeaders::CONTENT_TYPE, HEADER_JSON.c_str());
     HttpChannel::send_reply(req, HttpStatus::OK, strbuf.GetString());


### PR DESCRIPTION
## Why I'm doing:
Starrocks CI uses clang but gcc compilation fails.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Parquet FLBA decoder (AVX2 path):** Replace GCC-incompatible `__builtin_shufflevector` with `_mm256_unpack*` and `_mm256_permute2x128_si256` to interleave pointers and fixed lengths when building `Slice` arrays in `encoding_plain.h`.
> - **HTTP DataCache action:** Specify `rapidjson::PrettyWriter<rapidjson::StringBuffer>` for JSON serialization in `datacache_action.cpp` to satisfy GCC's type requirements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f221c1b4ba42705c9919c70f3d7817819aaea37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->