### PR TITLE
[Enhancement] support multi-threaded publish version daemon

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3174,6 +3174,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "the max number of threads for lake table publishing version")
     public static int lake_publish_version_max_threads = 512;
 
+    @ConfField(mutable = false, comment = "the number of threads for per-DB publish version polling. " +
+            "Set to > 1 to use the multi-thread model.")
+    public static int publish_version_poller_threads = 1;
+
     @ConfField(mutable = true, comment = "the max number of threads for lake table delete txnLog when enable batch publish")
     public static int lake_publish_delete_txnlog_max_threads = 16;
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
@@ -14,9 +14,15 @@
 
 package com.starrocks.transaction;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
 import com.starrocks.common.ConfigRefreshDaemon;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.system.SystemInfoService;
+import mockit.Mock;
+import mockit.MockUp;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -25,25 +31,38 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class PublishVersionDaemonTest {
     public int oldValue;
+    public int pollerOldValue;
 
     @BeforeEach
     public void setUp() {
+        Config.run_mode = "shared_data";
+        RunMode.detectRunMode();
         oldValue = Config.lake_publish_version_max_threads;
+        pollerOldValue = Config.publish_version_poller_threads;
     }
 
     @AfterEach
     public void tearDown() {
         Config.lake_publish_version_max_threads = oldValue;
+        Config.publish_version_poller_threads = pollerOldValue;
     }
 
     @Test
     public void testUpdateLakeExecutorThreads()
             throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         PublishVersionDaemon daemon = new PublishVersionDaemon();
+        daemon.prepare();
 
         ThreadPoolExecutor executor = (ThreadPoolExecutor) MethodUtils.invokeMethod(daemon, true, "getLakeTaskExecutor");
         Assertions.assertNotNull(executor);
@@ -105,6 +124,7 @@ public class PublishVersionDaemonTest {
         Config.lake_publish_version_max_threads = initValue;
         {
             PublishVersionDaemon daemon = new PublishVersionDaemon();
+            daemon.prepare();
             ThreadPoolExecutor executor =
                     (ThreadPoolExecutor) MethodUtils.invokeMethod(daemon, true, "getLakeTaskExecutor");
 
@@ -121,6 +141,7 @@ public class PublishVersionDaemonTest {
         Config.lake_publish_version_max_threads = initValue;
         {
             PublishVersionDaemon daemon = new PublishVersionDaemon();
+            daemon.prepare();
             ThreadPoolExecutor executor =
                     (ThreadPoolExecutor) MethodUtils.invokeMethod(daemon, true, "getLakeTaskExecutor");
             Assertions.assertNotNull(executor);
@@ -136,6 +157,7 @@ public class PublishVersionDaemonTest {
     public void testUpdateDeleteTxnLogExecutorThreads()
             throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         PublishVersionDaemon daemon = new PublishVersionDaemon();
+        daemon.prepare();
 
         ThreadPoolExecutor executor = (ThreadPoolExecutor) MethodUtils.invokeMethod(daemon, true, "getDeleteTxnLogExecutor");
         Assertions.assertNotNull(executor);
@@ -150,5 +172,190 @@ public class PublishVersionDaemonTest {
         Config.lake_publish_delete_txnlog_max_threads -= 5;
         MethodUtils.invokeMethod(configDaemon, true, "runAfterCatalogReady");
         Assertions.assertEquals(Config.lake_publish_delete_txnlog_max_threads, executor.getMaximumPoolSize());
+    }
+
+    @Test
+    public void testRunWithMultiThreadsWithDbs()
+            throws InvocationTargetException, NoSuchMethodException, IllegalAccessException, InterruptedException {
+        // Track processDbTransactions calls
+        AtomicInteger processDbCallCount = new AtomicInteger(0);
+        List<Long> processedDbIds = Collections.synchronizedList(new ArrayList<>());
+        CountDownLatch latch = new CountDownLatch(2);
+
+        // Mock processDbTransactions to track calls
+        new MockUp<PublishVersionDaemon>() {
+            @Mock
+            private void processDbTransactions(long dbId, DatabaseTransactionMgr dbTxnMgr) {
+                processDbCallCount.incrementAndGet();
+                processedDbIds.add(dbId);
+                latch.countDown();
+            }
+        };
+
+        // Mock GlobalTransactionMgr to return test DB managers
+        Map<Long, DatabaseTransactionMgr> mockDbMgrs = Maps.newHashMap();
+        mockDbMgrs.put(1001L, new DatabaseTransactionMgr(1001L, GlobalStateMgr.getCurrentState()));
+        mockDbMgrs.put(1002L, new DatabaseTransactionMgr(1002L, GlobalStateMgr.getCurrentState()));
+
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public Map<Long, DatabaseTransactionMgr> getAllDatabaseTransactionMgrs() {
+                return mockDbMgrs;
+            }
+        };
+
+        // Mock SystemInfoService to return backends
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public List<Long> getBackendIds(boolean needAlive) {
+                return Lists.newArrayList(10001L, 10002L);
+            }
+        };
+
+        // Enable multi-thread mode
+        Config.publish_version_poller_threads = 4;
+        PublishVersionDaemon daemon = new PublishVersionDaemon();
+        daemon.prepare();
+        daemon.runAfterCatalogReady();
+
+        // Wait for tasks to complete
+        boolean completed = latch.await(5, TimeUnit.SECONDS);
+        if (completed) {
+            // Verify both DBs were processed
+            Assertions.assertEquals(2, processDbCallCount.get());
+            Assertions.assertTrue(processedDbIds.contains(1001L));
+            Assertions.assertTrue(processedDbIds.contains(1002L));
+        }
+    }
+
+    @Test
+    public void testProcessDbTransactionsBatch()
+            throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        // Save original config values
+        boolean oldLakeEnableBatchPublish = Config.lake_enable_batch_publish_version;
+        AtomicInteger publishBatchCallCount = new AtomicInteger(0);
+
+        try {
+            // Enable batch publish mode
+            Config.lake_enable_batch_publish_version = true;
+
+            // Mock RunMode.isSharedDataMode() to return true
+            new MockUp<RunMode>() {
+                @Mock
+                public static boolean isSharedDataMode() {
+                    return true;
+                }
+            };
+
+            // Mock DatabaseTransactionMgr.getReadyToPublishTxnListBatch() to return non-empty list
+            new MockUp<DatabaseTransactionMgr>() {
+                @Mock
+                public List<TransactionStateBatch> getReadyToPublishTxnListBatch() {
+                    // Return a mock batch
+                    TransactionStateBatch batch = new TransactionStateBatch(Lists.newArrayList());
+                    return Lists.newArrayList(batch);
+                }
+            };
+
+            // Mock publishVersionForLakeTableBatch to track calls
+            new MockUp<PublishVersionDaemon>() {
+                @Mock
+                void publishVersionForLakeTableBatch(List<TransactionStateBatch> txnStateBatches) {
+                    publishBatchCallCount.incrementAndGet();
+                }
+            };
+
+            Config.publish_version_poller_threads = 0;
+            PublishVersionDaemon daemon = new PublishVersionDaemon();
+            DatabaseTransactionMgr dbTxnMgr = new DatabaseTransactionMgr(1001L, GlobalStateMgr.getCurrentState());
+
+            // Call processDbTransactions - should call publishVersionForLakeTableBatch
+            MethodUtils.invokeMethod(daemon, true, "processDbTransactions", 1001L, dbTxnMgr);
+
+            Assertions.assertEquals(1, publishBatchCallCount.get());
+        } finally {
+            Config.lake_enable_batch_publish_version = oldLakeEnableBatchPublish;
+        }
+    }
+
+    @Test
+    public void testProcessDbTransactionsNonBatch()
+            throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        // Save original config values
+        boolean oldLakeEnableBatchPublish = Config.lake_enable_batch_publish_version;
+        boolean oldEnableNewPublishMechanism = Config.enable_new_publish_mechanism;
+        AtomicInteger publishOlapCallCount = new AtomicInteger(0);
+        AtomicInteger publishLakeCallCount = new AtomicInteger(0);
+
+        try {
+            // Disable batch publish mode
+            Config.lake_enable_batch_publish_version = false;
+
+            // Test 1: SharedNothing mode with new publish mechanism
+            Config.enable_new_publish_mechanism = true;
+            new MockUp<RunMode>() {
+                @Mock
+                public static boolean isSharedDataMode() {
+                    return false;
+                }
+
+                @Mock
+                public static boolean isSharedNothingMode() {
+                    return true;
+                }
+            };
+
+            new MockUp<DatabaseTransactionMgr>() {
+                @Mock
+                public List<TransactionState> getReadyToPublishTxnList() {
+                    return Lists.newArrayList(new TransactionState());
+                }
+
+                @Mock
+                public List<TransactionState> getCommittedTxnList() {
+                    return Lists.newArrayList(new TransactionState());
+                }
+            };
+
+            new MockUp<PublishVersionDaemon>() {
+                @Mock
+                void publishVersionForOlapTable(List<TransactionState> txnStates) {
+                    publishOlapCallCount.incrementAndGet();
+                }
+
+                @Mock
+                void publishVersionForLakeTable(List<TransactionState> txnStates) {
+                    publishLakeCallCount.incrementAndGet();
+                }
+            };
+
+            Config.publish_version_poller_threads = 0;
+            PublishVersionDaemon daemon = new PublishVersionDaemon();
+            DatabaseTransactionMgr dbTxnMgr = new DatabaseTransactionMgr(1001L, GlobalStateMgr.getCurrentState());
+
+            MethodUtils.invokeMethod(daemon, true, "processDbTransactions", 1001L, dbTxnMgr);
+            Assertions.assertEquals(1, publishOlapCallCount.get());
+
+            // Test 2: SharedData mode (not SharedNothing) with old publish mechanism
+            Config.enable_new_publish_mechanism = false;
+            new MockUp<RunMode>() {
+                @Mock
+                public static boolean isSharedDataMode() {
+                    return false;
+                }
+
+                @Mock
+                public static boolean isSharedNothingMode() {
+                    return false;
+                }
+            };
+
+            daemon = new PublishVersionDaemon();
+            MethodUtils.invokeMethod(daemon, true, "processDbTransactions", 1001L, dbTxnMgr);
+            Assertions.assertEquals(1, publishLakeCallCount.get());
+        } finally {
+            Config.lake_enable_batch_publish_version = oldLakeEnableBatchPublish;
+            Config.enable_new_publish_mechanism = oldEnableNewPublishMechanism;
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

introduce FE config `publish_version_poller_threads`, default will use the single thread publish daemon, if set to larger than 0, each DB will be assigned to a publish version thread.

preparation
```
1. set publish_version_poller_threads to 8
2. create 5 databases, each has 1 table
create table t (k int, v int) distributed BY HASH(`k`) BUCKETS 6 properties ('replication_num'='1');
```

test command, run  these 2 at the same time
```
sysbench test_multi_db.lua \
  --mysql-host=172.26.34.240 \
  --mysql-port=9030 \
  --mysql-user=root \
  --mysql-password= \
  --mysql-db=test \
  --percentile=95 \
  --threads=100 \
  --time=120 \
  run

sysbench test_multi_read_create.lua \
  --mysql-host=172.26.34.240 \
  --mysql-port=9030 \
  --mysql-user=root \
  --mysql-password= \
  --mysql-db=test \
  --percentile=95 \
  --threads=20 \
  --time=120 \
  run
```

test script `test_multi_db.lua`
```
function event()
  local id1 = math.random(1, 5)
  local id2 = math.random(1, 10000)
  connections[sysbench.tid]:query(
  string.format("insert into test%d.t values (%d,%d)", id1, id2, id2)
  )
end
```

test script `test_multi_read_create.lua`
```
function event()
  local conn = connections[sysbench.tid]

  local id1 = math.random(1, 5)

  local p = math.random(1, 100)
  if p <= 5 then
    local tbl_id = math.random(1, 1000000)
    local tbl_name = string.format("tmp_sb_%d_%d", sysbench.tid, tbl_id)

    conn:query(string.format([[
      CREATE TABLE test%d.%s (
        id INT,
        v  INT
      ) distributed BY HASH(`id`) BUCKETS 6
    ]], id1, tbl_name))

    conn:query(string.format("DROP TABLE if exists test%d.%s", id1, tbl_name))

  else
    local id2 = math.random(1, 10000)

    conn:query(
      string.format(
        "SELECT * FROM test%d.t WHERE k = %d",
        id1, id2
      )
    )
  end
end
```

before
```
Latency (ms):
         min:                                   99.40
         avg:                                 3565.94
         max:                                42975.98
         95th percentile:                 14047.70
         sum:                             15312162.14
```

after
```
Latency (ms):
         min:                                   78.26
         avg:                                  847.02
         max:                                 8601.03
         95th percentile:                  1973.38
         sum:                             12024346.54
```

<img width="918" height="349" alt="截屏2026-01-06 上午11 25 54" src="https://github.com/user-attachments/assets/0ee58c58-ec2a-47a7-b36f-2724f16630f0" />



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables parallel publish-version processing by database with a configurable worker pool.
> 
> - Adds immutable `Config.publish_version_poller_threads` (default 1) to toggle multi-thread mode
> - Refactors `PublishVersionDaemon`:
>   - New `prepare()` and `start()` flow initializing executors; per-DB poller thread pool and `processingDbs` guard
>   - Splits logic into `runWithSingleThread()` vs `runWithMultiThreads()`; per-DB `processDbTransactions()` handling batch/non-batch and shared-nothing/shared-data paths
>   - Initializes lake/delete executors in `prepare()`; exposes some methods as `protected`
> - Adds tests covering executor resizing/validation, multi-thread per-DB scheduling, and batch/non-batch processing paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1db0658030ee5918f3765a5333ab7373689f4e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->