### PR TITLE
[Doc] 3.5.11 Release Notes

### DIFF
--- a/docs/en/release_notes/release-3.5.md
+++ b/docs/en/release_notes/release-3.5.md
@@ -26,6 +26,72 @@ displayed_sidebar: docs
 
 :::
 
+## 3.5.11
+
+Release date: January 5, 2026
+
+### Improvements
+
+- Supports Arrow Flight data retrieval from inaccessible nodes. [#66348](https://github.com/StarRocks/starrocks/pull/66348)
+- Logs the cause (including the triggering process information) in the SIGTERM handler. [#66737](https://github.com/StarRocks/starrocks/pull/66737)
+- Added an FE configuration `enable_statistic_collect_on_update` to control whether UPDATE statements can trigger automatic statistics collection. [#66794](https://github.com/StarRocks/starrocks/pull/66794)
+- Supports configuring `networkaddress.cache.ttl`. [#66723](https://github.com/StarRocks/starrocks/pull/66723)
+- Improve the “no rows imported” error message. [#66624](https://github.com/StarRocks/starrocks/pull/66624) [#66535](https://github.com/StarRocks/starrocks/pull/66535)
+- Optimized `deltaRows` with lazy evaluation for large partition tables. [#66381](https://github.com/StarRocks/starrocks/pull/66381)
+- Optimized materialized view rewrite performance. [#66623](https://github.com/StarRocks/starrocks/pull/66623)
+- Supports single-tablet `ResultSink` optimization in shared-data clusters. [#66517](https://github.com/StarRocks/starrocks/pull/66517)
+- `rewrite``_``simple``_``agg``_``to``_``meta``_``scan` is enabled by default. [#64698](https://github.com/StarRocks/starrocks/pull/64698)
+- Supports pushing down GROUP BY expressions and materialized view rewrite. [#66507](https://github.com/StarRocks/starrocks/pull/66507)
+- Add overloaded `newMessage` methods to improve materialized view logs. [#66367](https://github.com/StarRocks/starrocks/pull/66367)
+
+### Bug Fixes
+
+The following issues have been fixed:
+
+- A Publish Compaction crash when the input rowset is not found. [#67154](https://github.com/StarRocks/starrocks/pull/67154)
+- Significant CPU overhead and lock contention caused by repetitive invocation of `update_segment_cache_size` when querying tables with a large number of columns. [#66714](https://github.com/StarRocks/starrocks/pull/66714)
+- `MulticastSinkOperator` stuck in the `OUTPUT_FULL` state. [#67153](https://github.com/StarRocks/starrocks/pull/67153)
+- A “column not found” issue in the skew join hint. [#66929](https://github.com/StarRocks/starrocks/pull/66929)
+- The growth of all tablets continues unabated, and the sum of pending and running tablets is not the total number of tablets. [#66718](https://github.com/StarRocks/starrocks/pull/66718)
+- Transactions in the Compaction map built during Leader startup cannot be accessed by CompactionScheduler and will never be removed from the map. [#66533](https://github.com/StarRocks/starrocks/pull/66533)
+- Delta Lake table refresh does not take effect. [#67156](https://github.com/StarRocks/starrocks/pull/67156)
+- CN crash at queries against non-partitioned Iceberg tables with DATE predicates. [#66864](https://github.com/StarRocks/starrocks/pull/66864)
+- Statements in Profiles cannot be correctly displayed when multiple statements are submitted. [#67097](https://github.com/StarRocks/starrocks/pull/67097)
+- Missing dictionary information during collection because Meta Reader does not support reading from Delta column group files. [#66995](https://github.com/StarRocks/starrocks/pull/66995)
+- Potential Java heap OOM in Java UDAF. [#67025](https://github.com/StarRocks/starrocks/pull/67025)
+- BE crash due to the incorrect logic of ranking window optimization without PARTITION BY and ORDER BY. [#67081](https://github.com/StarRocks/starrocks/pull/67081)
+- Misleading log level for timezone cache miss. [#66817](https://github.com/StarRocks/starrocks/pull/66817)
+- Crash and incorrect results caused by the incorrect `can_use_bf` checking when merging runtime filters. [#67021](https://github.com/StarRocks/starrocks/pull/67021)
+- Issue about pushing down runtime bitset filter with other OR predicates. [#66996](https://github.com/StarRocks/starrocks/pull/66996)
+- Patch critical fix from lz4. [#67053](https://github.com/StarRocks/starrocks/pull/67053)
+- AsyncTaskQueue deadlock issue. [#66791](https://github.com/StarRocks/starrocks/pull/66791)
+- Cache inconsistency in ObjectColumn. [#66957](https://github.com/StarRocks/starrocks/pull/66957)
+- RewriteUnnestBitmapRule causes wrong output column types. [#66855](https://github.com/StarRocks/starrocks/pull/66855)
+- Data races and data loss when there are WRITE or FLUSH tasks after FINISH tasks in the Delta Writer. [#66943](https://github.com/StarRocks/starrocks/pull/66943)
+- Invalid load channel and misleading internal errors caused by reopened load channels that were previously aborted. [#66793](https://github.com/StarRocks/starrocks/pull/66793)
+- Bugs of Arrow Flight SQL. [#65889](https://github.com/StarRocks/starrocks/pull/65889)
+- Issues when querying renamed columns with MetaScan. [#66819](https://github.com/StarRocks/starrocks/pull/66819)
+- Hash column is not removed before flushing chunk in partitionwise spillable aggregation when skew elimination is off. [#66839](https://github.com/StarRocks/starrocks/pull/66839)
+- BOOLEAN type default values were not correctly handled when stored as string literals. [#66818](https://github.com/StarRocks/starrocks/pull/66818)
+- decimal2decimal cast unexpectedly returns the input column as the result directly. [#66773](https://github.com/StarRocks/starrocks/pull/66773)
+- NPE in query planning during schema change. [#66811](https://github.com/StarRocks/starrocks/pull/66811)
+- LocalTabletsChannel and LakeTabletsChannel deadlock. [#66748](https://github.com/StarRocks/starrocks/pull/66748)
+- `publish_version` log shows empty `txn_ids` with new FE. [#66732](https://github.com/StarRocks/starrocks/pull/66732)
+- Incorrect behavior of the FE configuration `statistic_collect_query_timeout`. [#66363](https://github.com/StarRocks/starrocks/pull/66363)
+- UPDATE statements do not support statistics collection. [#66443](https://github.com/StarRocks/starrocks/pull/66443)
+- Case rewrite errors related to low cardinality. [#66724](https://github.com/StarRocks/starrocks/pull/66724)
+- Statistics query failure when the column list is empty. [#66138](https://github.com/StarRocks/starrocks/pull/66138)
+- Usage/record mismatch when switching warehouse via hint. [#66677](https://github.com/StarRocks/starrocks/pull/66677)
+- `ANALYZE TABLE` statements lack ExecTimeout. [#66361](https://github.com/StarRocks/starrocks/pull/66361)
+- `array_map` returns wrong results from constant unary expressions. [#66514](https://github.com/StarRocks/starrocks/pull/66514)
+- Foreign key constraints are lost after FE restart. [#66474](https://github.com/StarRocks/starrocks/pull/66474)
+- `max(not null string)` on empty table throws `std::length_error`. [#66554](https://github.com/StarRocks/starrocks/pull/66554)
+- Concurrency issue between Primary Key index Compaction and Apply. [#66282](https://github.com/StarRocks/starrocks/pull/66282)
+- Improper behavior of `EXPLAIN <query>`. [#66542](https://github.com/StarRocks/starrocks/pull/66542)
+- Issue when sinking DECIMAL128 to Iceberg table column. [#66071](https://github.com/StarRocks/starrocks/pull/66071)
+- JSON length check issue for JSON → CHAR/VARCHAR when the target length equals the minimum. [#66628](https://github.com/StarRocks/starrocks/pull/66628)
+- An expression children count error. [#66511](https://github.com/StarRocks/starrocks/pull/66511)
+
 ## 3.5.10
 
 Release date: December 15, 2025

--- a/docs/ja/release_notes/release-3.5.md
+++ b/docs/ja/release_notes/release-3.5.md
@@ -26,6 +26,72 @@ displayed_sidebar: docs
 
 :::
 
+## 3.5.11
+
+**リリース日**：2026年1月5日
+
+### **改善点**
+
+- ノードにアクセスできない場合でも、Arrow Flight を使用したデータ取得をサポートしました。[#66348](https://github.com/StarRocks/starrocks/pull/66348)
+- SIGTERM ハンドラで、終了原因（トリガーとなったプロセス情報を含む）をログに記録するようになりました。[#66737](https://github.com/StarRocks/starrocks/pull/66737)
+- UPDATE 文が自動統計情報収集をトリガーできるかどうかを制御する FE 設定 `enable_statistic_collect_on_update` を追加しました。[#66794](https://github.com/StarRocks/starrocks/pull/66794)
+- `networkaddress.cache.ttl` の設定をサポートしました。[#66723](https://github.com/StarRocks/starrocks/pull/66723)
+- 「no rows imported」エラーメッセージを改善しました。[#66624](https://github.com/StarRocks/starrocks/pull/66624) [#66535](https://github.com/StarRocks/starrocks/pull/66535)
+- 大規模パーティションテーブルに対し、遅延評価による `deltaRows` の最適化を行いました。[#66381](https://github.com/StarRocks/starrocks/pull/66381)
+- マテリアライズドビューのリライト性能を最適化しました。[#66623](https://github.com/StarRocks/starrocks/pull/66623)
+- Shared-Data クラスタにおいて、単一 Tablet の `ResultSink` 最適化をサポートしました。[#66517](https://github.com/StarRocks/starrocks/pull/66517)
+- `rewrite_simple_agg_to_meta_scan` をデフォルトで有効化しました。[#64698](https://github.com/StarRocks/starrocks/pull/64698)
+- GROUP BY 式のプッシュダウンおよびマテリアライズドビューのリライトをサポートしました。[#66507](https://github.com/StarRocks/starrocks/pull/66507)
+- マテリアライズドビュー関連ログを改善するため、`newMessage` のオーバーロードメソッドを追加しました。[#66367](https://github.com/StarRocks/starrocks/pull/66367)
+
+### **バグ修正**
+
+以下の問題を修正しました：
+
+- 入力 Rowset が見つからない場合に Publish Compaction がクラッシュする問題。[#67154](https://github.com/StarRocks/starrocks/pull/67154)
+- 列数の多いテーブルをクエリする際、`update_segment_cache_size` の繰り返し呼び出しにより CPU オーバーヘッドおよびロック競合が発生する問題。[#66714](https://github.com/StarRocks/starrocks/pull/66714)
+- `MulticastSinkOperator` が `OUTPUT_FULL` 状態で停止する問題。[#67153](https://github.com/StarRocks/starrocks/pull/67153)
+- Skew Join Hint における「column not found」エラー。[#66929](https://github.com/StarRocks/starrocks/pull/66929)
+- Tablet 数が増加し続け、pending と running tablet の合計が総 tablet 数と一致しない問題。[#66718](https://github.com/StarRocks/starrocks/pull/66718)
+- Leader 起動時に構築された Compaction Map 内のトランザクションが CompactionScheduler から参照できず、削除されない問題。[#66533](https://github.com/StarRocks/starrocks/pull/66533)
+- Delta Lake テーブルのリフレッシュが反映されない問題。[#67156](https://github.com/StarRocks/starrocks/pull/67156)
+- DATE 述語を含む非パーティション Iceberg テーブルへのクエリで CN がクラッシュする問題。[#66864](https://github.com/StarRocks/starrocks/pull/66864)
+- 複数ステートメントを送信した際に Profile に正しく表示されない問題。[#67097](https://github.com/StarRocks/starrocks/pull/67097)
+- Meta Reader が Delta 列グループファイルの読み取りをサポートしていないため、統計情報収集中に辞書情報が欠落する問題。[#66995](https://github.com/StarRocks/starrocks/pull/66995)
+- Java UDAF における潜在的な Java Heap OOM 問題。[#67025](https://github.com/StarRocks/starrocks/pull/67025)
+- PARTITION BY および ORDER BY を指定しない Ranking Window 最適化のロジック誤りによる BE クラッシュ。[#67081](https://github.com/StarRocks/starrocks/pull/67081)
+- タイムゾーンキャッシュミス時のログレベルが不適切な問題。[#66817](https://github.com/StarRocks/starrocks/pull/66817)
+- Runtime Filter マージ時の `can_use_bf` 判定誤りにより、クラッシュや誤った結果が発生する問題。[#67021](https://github.com/StarRocks/starrocks/pull/67021)
+- Runtime Bitset Filter を他の OR 述語と一緒にプッシュダウンする際の問題。[#66996](https://github.com/StarRocks/starrocks/pull/66996)
+- lz4 の重要なパッチを適用しました。[#67053](https://github.com/StarRocks/starrocks/pull/67053)
+- AsyncTaskQueue のデッドロック問題。[#66791](https://github.com/StarRocks/starrocks/pull/66791)
+- ObjectColumn におけるキャッシュ不整合。[#66957](https://github.com/StarRocks/starrocks/pull/66957)
+- RewriteUnnestBitmapRule により出力列型が誤る問題。[#66855](https://github.com/StarRocks/starrocks/pull/66855)
+- Delta Writer において、FINISH タスク後に WRITE または FLUSH タスクが存在するとデータ競合やデータ損失が発生する問題。[#66943](https://github.com/StarRocks/starrocks/pull/66943)
+- 中断されたロードチャネルを再オープンしたことによる無効なロードチャネルおよび誤解を招く内部エラー。[#66793](https://github.com/StarRocks/starrocks/pull/66793)
+- Arrow Flight SQL に関する不具合。[#65889](https://github.com/StarRocks/starrocks/pull/65889)
+- MetaScan を使用してリネームされた列をクエリする際の問題。[#66819](https://github.com/StarRocks/starrocks/pull/66819)
+- スキュー除去が無効な場合、パーティション単位のスピル可能集約において Flush Chunk 前に Hash 列が削除されない問題。[#66839](https://github.com/StarRocks/starrocks/pull/66839)
+- BOOLEAN 型を文字列リテラルとして保存した場合、デフォルト値が正しく処理されない問題。[#66818](https://github.com/StarRocks/starrocks/pull/66818)
+- `decimal2decimal` キャストが入力列をそのまま結果として返してしまう問題。[#66773](https://github.com/StarRocks/starrocks/pull/66773)
+- Schema Change 中のクエリプランニングで NPE が発生する問題。[#66811](https://github.com/StarRocks/starrocks/pull/66811)
+- LocalTabletsChannel と LakeTabletsChannel 間のデッドロック。[#66748](https://github.com/StarRocks/starrocks/pull/66748)
+- 新しい FE において `publish_version` ログに空の `txn_ids` が表示される問題。[#66732](https://github.com/StarRocks/starrocks/pull/66732)
+- FE 設定 `statistic_collect_query_timeout` の動作が不正な問題。[#66363](https://github.com/StarRocks/starrocks/pull/66363)
+- UPDATE 文で統計情報収集が行われない問題。[#66443](https://github.com/StarRocks/starrocks/pull/66443)
+- 低カーディナリティに関連する CASE リライトの不具合。[#66724](https://github.com/StarRocks/starrocks/pull/66724)
+- 列リストが空の場合に統計情報クエリが失敗する問題。[#66138](https://github.com/StarRocks/starrocks/pull/66138)
+- Hint により Warehouse を切り替えた際の使用量／記録不一致。[#66677](https://github.com/StarRocks/starrocks/pull/66677)
+- `ANALYZE TABLE` 文に ExecTimeout が設定されていない問題。[#66361](https://github.com/StarRocks/starrocks/pull/66361)
+- `array_map` が定数単項式の場合に誤った結果を返す問題。[#66514](https://github.com/StarRocks/starrocks/pull/66514)
+- FE 再起動後に外部キー制約が失われる問題。[#66474](https://github.com/StarRocks/starrocks/pull/66474)
+- 空テーブルに対する `max(not null string)` が `std::length_error` をスローする問題。[#66554](https://github.com/StarRocks/starrocks/pull/66554)
+- 主キーインデックスの Compaction と Apply 間の並行性問題。[#66282](https://github.com/StarRocks/starrocks/pull/66282)
+- `EXPLAIN <query>` の不正な動作。[#66542](https://github.com/StarRocks/starrocks/pull/66542)
+- DECIMAL128 を Iceberg テーブル列に書き込む際の問題。[#66071](https://github.com/StarRocks/starrocks/pull/66071)
+- JSON → CHAR/VARCHAR 変換時、ターゲット長が最小長と等しい場合の長さチェック不具合。[#66628](https://github.com/StarRocks/starrocks/pull/66628)
+- 式の子ノード数が不正な問題。[#66511](https://github.com/StarRocks/starrocks/pull/66511)
+
 ## 3.5.10
 
 リリース日：2025 年 12 月 15 日

--- a/docs/zh/release_notes/release-3.5.md
+++ b/docs/zh/release_notes/release-3.5.md
@@ -26,6 +26,72 @@ displayed_sidebar: docs
 
 :::
 
+## 3.5.11
+
+**发布日期**：2026 年 1 月 5 日
+
+### 功能改进
+
+- 支持在节点不可访问的情况下通过 Arrow Flight 拉取数据。[#66348](https://github.com/StarRocks/starrocks/pull/66348)
+- 在 SIGTERM 处理器中记录终止原因（包括触发的进程信息）。[#66737](https://github.com/StarRocks/starrocks/pull/66737)
+- 新增 FE 配置项 `enable_statistic_collect_on_update`，用于控制 UPDATE 语句是否可以触发自动统计信息收集。[#66794](https://github.com/StarRocks/starrocks/pull/66794)
+- 支持配置 `networkaddress.cache.ttl`。[#66723](https://github.com/StarRocks/starrocks/pull/66723)
+- 改进 “no rows imported” 错误提示信息。[#66624](https://github.com/StarRocks/starrocks/pull/66624) [#66535](https://github.com/StarRocks/starrocks/pull/66535)
+- 针对大分区表，通过延迟计算优化 `deltaRows`。[#66381](https://github.com/StarRocks/starrocks/pull/66381)
+- 优化物化视图重写性能。[#66623](https://github.com/StarRocks/starrocks/pull/66623)
+- 在 Shared-Data 集群中支持单 Tablet 的 `ResultSink` 优化。[#66517](https://github.com/StarRocks/starrocks/pull/66517)
+- 默认启用 `rewrite_simple_agg_to_meta_scan`。[#64698](https://github.com/StarRocks/starrocks/pull/64698)
+- 支持 GROUP BY 表达式下推以及基于 GROUP BY 的物化视图重写。[#66507](https://github.com/StarRocks/starrocks/pull/66507)
+- 新增重载的 `newMessage` 方法，以改进物化视图相关日志。[#66367](https://github.com/StarRocks/starrocks/pull/66367)
+
+### 问题修复
+
+已修复以下问题：
+
+- 当输入 Rowset 不存在时，Publish Compaction 可能发生崩溃。[#67154](https://github.com/StarRocks/starrocks/pull/67154)
+- 在查询包含大量列的表时，反复调用 `update_segment_cache_size` 导致 CPU 开销过大和锁竞争严重。[#66714](https://github.com/StarRocks/starrocks/pull/66714)
+- `MulticastSinkOperator` 卡在 `OUTPUT_FULL` 状态。[#67153](https://github.com/StarRocks/starrocks/pull/67153)
+- Skew Join Hint 中出现 “column not found”。[#66929](https://github.com/StarRocks/starrocks/pull/66929)
+- Tablet 数量持续增长，且 pending 与 running tablet 之和不等于总 Tablet 数。[#66718](https://github.com/StarRocks/starrocks/pull/66718)
+- Leader 启动期间构建的 Compaction Map 中的事务无法被 CompactionScheduler 访问，且无法被清理。[#66533](https://github.com/StarRocks/starrocks/pull/66533)
+- Delta Lake 表刷新不生效。[#67156](https://github.com/StarRocks/starrocks/pull/67156)
+- 在对非分区 Iceberg 表使用 DATE 谓词查询时，CN 发生崩溃。[#66864](https://github.com/StarRocks/starrocks/pull/66864)
+- 提交多个 SQL 语句时，Profile 中语句无法正确显示。[#67097](https://github.com/StarRocks/starrocks/pull/67097)
+- 由于 Meta Reader 不支持读取 Delta 列组文件，导致统计信息收集时缺失字典信息。[#66995](https://github.com/StarRocks/starrocks/pull/66995)
+- Java UDAF 中潜在的 Java Heap OOM 问题。[#67025](https://github.com/StarRocks/starrocks/pull/67025)
+- 在未指定 PARTITION BY 和 ORDER BY 的情况下，Ranking Window 优化逻辑错误导致 BE 崩溃。[#67081](https://github.com/StarRocks/starrocks/pull/67081)
+- 时区缓存未命中时日志级别不正确。[#66817](https://github.com/StarRocks/starrocks/pull/66817)
+- 在合并 Runtime Filter 时，`can_use_bf` 校验逻辑错误导致崩溃和结果错误。[#67021](https://github.com/StarRocks/starrocks/pull/67021)
+- Runtime Bitset Filter 与其他 OR 谓词一起下推时。[#66996](https://github.com/StarRocks/starrocks/pull/66996)
+- 合入 lz4 的关键补丁修复。[#67053](https://github.com/StarRocks/starrocks/pull/67053)
+- AsyncTaskQueue 死锁问题。[#66791](https://github.com/StarRocks/starrocks/pull/66791)
+- ObjectColumn 中的缓存不一致。[#66957](https://github.com/StarRocks/starrocks/pull/66957)
+- RewriteUnnestBitmapRule 导致输出列类型错误。[#66855](https://github.com/StarRocks/starrocks/pull/66855)
+- Delta Writer 中，在 FINISH 任务之后仍存在 WRITE 或 FLUSH 任务时，可能导致数据竞争和数据丢失。[#66943](https://github.com/StarRocks/starrocks/pull/66943)
+- 重新打开已中止的导入通道导致 Load Channel 无效并产生误导性内部错误。[#66793](https://github.com/StarRocks/starrocks/pull/66793)
+- Arrow Flight SQL 的相关问题。[#65889](https://github.com/StarRocks/starrocks/pull/65889)
+- 使用 MetaScan 查询已重命名列时。[#66819](https://github.com/StarRocks/starrocks/pull/66819)
+- 在关闭倾斜消除的分区级可溢出聚合中，Flush Chunk 前未移除 Hash 列。[#66839](https://github.com/StarRocks/starrocks/pull/66839)
+- BOOLEAN 类型以字符串字面量存储时，默认值处理不正确。[#66818](https://github.com/StarRocks/starrocks/pull/66818)
+- `decimal2decimal` Cast 直接返回输入列作为结果的异常行为。[#66773](https://github.com/StarRocks/starrocks/pull/66773)
+- Schema Change 过程中 Query Planning 阶段出现 NPE。[#66811](https://github.com/StarRocks/starrocks/pull/66811)
+- LocalTabletsChannel 与 LakeTabletsChannel 之间的死锁问题。[#66748](https://github.com/StarRocks/starrocks/pull/66748)
+- 新版 FE 中 `publish_version` 日志显示空的 `txn_ids`。[#66732](https://github.com/StarRocks/starrocks/pull/66732)
+- FE 配置项 `statistic_collect_query_timeout` 行为不正确。[#66363](https://github.com/StarRocks/starrocks/pull/66363)
+- UPDATE 语句不支持统计信息收集。[#66443](https://github.com/StarRocks/starrocks/pull/66443)
+- 低基数场景下 CASE 重写相关错误。[#66724](https://github.com/StarRocks/starrocks/pull/66724)
+- 当列列表为空时，统计信息查询失败。[#66138](https://github.com/StarRocks/starrocks/pull/66138)
+- 通过 Hint 切换 Warehouse 时，使用量与记录不一致。[#66677](https://github.com/StarRocks/starrocks/pull/66677)
+- `ANALYZE TABLE` 语句缺少 ExecTimeout。[#66361](https://github.com/StarRocks/starrocks/pull/66361)
+- `array_map` 在常量一元表达式场景下返回错误结果。[#66514](https://github.com/StarRocks/starrocks/pull/66514)
+- FE 重启后外键约束丢失。[#66474](https://github.com/StarRocks/starrocks/pull/66474)
+- 在空表上执行 `max(not null string)` 时抛出 `std::length_error`。[#66554](https://github.com/StarRocks/starrocks/pull/66554)
+- 主键索引 Compaction 与 Apply 之间的并发问题。[#66282](https://github.com/StarRocks/starrocks/pull/66282)
+- `EXPLAIN <query>` 行为不正确。[#66542](https://github.com/StarRocks/starrocks/pull/66542)
+- 将 DECIMAL128 写入 Iceberg 表列时。[#66071](https://github.com/StarRocks/starrocks/pull/66071)
+- JSON → CHAR/VARCHAR 转换时，当目标长度等于最小长度时的长度校验问题。[#66628](https://github.com/StarRocks/starrocks/pull/66628)
+- 表达式子节点数量错误。[#66511](https://github.com/StarRocks/starrocks/pull/66511)
+
 ## 3.5.10
 
 发布日期：2025 年 12 月 15 日


### PR DESCRIPTION
Signed-off-by: EsoragotoSpirit <wanglichen@starrocks.com>

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds the v3.5.11 release notes to `docs/en`, `docs/ja`, and `docs/zh` with the release date and concise lists of Improvements and Bug Fixes.
> 
> - Highlights: Arrow Flight retrieval from inaccessible nodes, SIGTERM cause logging, FE config `enable_statistic_collect_on_update`, support for `networkaddress.cache.ttl`, MV rewrite/perf optimizations, default-enable `rewrite_simple_agg_to_meta_scan`
> - Bug fixes span compaction stability, runtime filter correctness, Iceberg/Delta Lake handling, deadlocks/OOMs, logging/metrics, and planner/runtime edge cases
> - Documentation-only change; no code or behavior modifications
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b49b9200a089450d90bf43eeaffa51ca031bfbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->