### PR TITLE
[Enhancement] Make background tasks TabletWriteLogHistorySyncer and StatisticsMetaManager configurable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2212,12 +2212,6 @@ public class Config extends ConfigBase {
     public static long statistic_manager_sleep_time_sec = 60; // 60s
 
     /**
-     * The interval of StatisticsMetaManager to run background tasks
-     */
-    @ConfField(mutable = true)
-    public static long statistic_manager_run_interval_sec = 60;
-
-    /**
      * The interval of TabletWriteLogHistorySyncer to sync tablet write log history.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2212,6 +2212,18 @@ public class Config extends ConfigBase {
     public static long statistic_manager_sleep_time_sec = 60; // 60s
 
     /**
+     * The interval of StatisticsMetaManager to run background tasks
+     */
+    @ConfField(mutable = true)
+    public static long statistic_manager_run_interval_sec = 60;
+
+    /**
+     * The interval of TabletWriteLogHistorySyncer to sync tablet write log history.
+     */
+    @ConfField(mutable = true)
+    public static long tablet_write_log_history_sync_interval_sec = 60;
+
+    /**
      * Analyze status keep time in catalog
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/lake/TabletWriteLogHistorySyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TabletWriteLogHistorySyncer.java
@@ -15,6 +15,7 @@
 package com.starrocks.lake;
 
 import com.starrocks.catalog.CatalogUtils;
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.qe.SimpleExecutor;
@@ -78,7 +79,7 @@ public class TabletWriteLogHistorySyncer extends FrontendDaemon {
     }
 
     public TabletWriteLogHistorySyncer() {
-        super("TabletWriteLogHistorySyncer", 60 * 1000L); // 60s interval
+        super("TabletWriteLogHistorySyncer", Config.tablet_write_log_history_sync_interval_sec * 1000L);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -80,7 +80,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(StatisticsMetaManager.class);
 
     public StatisticsMetaManager() {
-        super("statistics-meta-manager", 60L * 1000L);
+        super("statistics-meta-manager", Config.statistic_manager_run_interval_sec * 1000L);
     }
 
     private boolean checkDatabaseExist() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -80,7 +80,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(StatisticsMetaManager.class);
 
     public StatisticsMetaManager() {
-        super("statistics-meta-manager", Config.statistic_manager_run_interval_sec * 1000L);
+        super("statistics-meta-manager", Config.statistic_manager_sleep_time_sec * 1000L);
     }
 
     private boolean checkDatabaseExist() {


### PR DESCRIPTION
## Why I'm doing:

Currently, the background tasks TabletWriteLogHistorySyncer and StatisticsMetaManager run at hardcoded intervals (default 60 seconds). This restricts flexibility for users who want to tune the StarRocks deployment based on different use cases, cluster sizes, or resource constraints.

## What I'm doing:

I have introduced two new Frontend (FE) configurations to make these intervals configurable:

1. `statistic_manager_run_interval_sec:` Controls the interval for StatisticsMetaManager.
2. `tablet_write_log_history_sync_interval_sec:` Controls the interval for TabletWriteLogHistorySyncer.

Updated the constructors in `StatisticsMetaManager.java` and `TabletWriteLogHistorySyncer.java` to use these configuration values instead of hardcoded constants.

Fixes #67466 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds configurability for background task intervals.
> 
> - New FE config `tablet_write_log_history_sync_interval_sec` and `TabletWriteLogHistorySyncer` now uses `Config.tablet_write_log_history_sync_interval_sec`
> - `StatisticsMetaManager` constructor now uses `Config.statistic_manager_sleep_time_sec` instead of a hardcoded 60s interval
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 975ffaba6103cd09948808bdb92d8bc76a2ee9f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->