### PR TITLE
[BugFix] Fix inaccurate ioStatics of compaction

### DIFF
--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -123,7 +123,7 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     // 2. If the "total_num_rows" is 0, the progress will not be updated above
     _context->progress.update(100);
 
-    // Close reader to ensure IO statistics are updated via _update_stats() before collecting
+    // Close reader to ensure IO statistics are updated via SegmentIterator::_update_stats() before collecting
     reader.close();
 
     _context->stats->collect(reader.stats());

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -122,6 +122,10 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     // 1. For primary key, due to the existence of the delete vector, the rows read may be less than "total_num_rows"
     // 2. If the "total_num_rows" is 0, the progress will not be updated above
     _context->progress.update(100);
+
+    // Close reader to ensure IO statistics are updated via _update_stats() before collecting
+    reader.close();
+
     _context->stats->collect(reader.stats());
     _context->stats->collect(writer->stats());
 

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -254,6 +254,9 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
     }
     RETURN_IF_ERROR(writer->flush_columns());
 
+    // Close reader to ensure IO statistics are updated via _update_stats() before collecting
+    reader.close();
+
     CompactionTaskStats temp_stats;
     temp_stats.collect(reader.stats());
     CompactionTaskStats diff_stats = temp_stats - prev_stats;

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -254,7 +254,7 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
     }
     RETURN_IF_ERROR(writer->flush_columns());
 
-    // Close reader to ensure IO statistics are updated via _update_stats() before collecting
+    // Close reader to ensure IO statistics are updated via SegmentIterator::_update_stats() before collecting
     reader.close();
 
     CompactionTaskStats temp_stats;


### PR DESCRIPTION
## Why I'm doing:
Currently, I/O statistics are collected in the tabletReader's destructor function by calling `close`, but the I/O information used in compaction context is updated before this
## What I'm doing:
Call `close` explicitly before updating context
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes inaccurate compaction I/O stats by explicitly closing `TabletReader` before stats collection.
> 
> - In `horizontal_compaction_task.cpp`, call `reader.close()` after final progress update and before `_context->stats->collect(reader.stats())`.
> - In `vertical_compaction_task.cpp` (`compact_column_group`), call `reader.close()` before computing and applying the diff `CompactionTaskStats`.
> 
> Ensures `_update_stats()` runs so collected I/O metrics reflect all reads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b17d11c3b0e6fde6969e878cd6da323bff7e238f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->