### PR TITLE
[UT] Fix ColocateTableBalancer unstable UT

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -123,6 +123,12 @@ public class ColocateTableBalancerTest {
                 // the interval is 0, so skip log printing to prevent too many logs
             }
         };
+        new MockUp<TabletChecker>() {
+            @Mock
+            protected void runAfterCatalogReady() {
+                System.out.println("Mocked TabletChecker.runAfterCatalogReady() called");
+            }
+        };
 
         UtFrameUtils.createMinStarRocksCluster();
         GlobalStateMgr.getCurrentState().getAlterJobMgr().stop();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

fix unstable case:
```
ColocateTableBalancerTest.testDropBackend(SystemInfoService, ClusterLoadStatistic)
Missing 1 invocation to:
com.starrocks.system.SystemInfoService#getBackendIds(true)
   on mock instance: com.starrocks.system.SystemInfoService@3964d79
Caused by: Missing invocations
	at com.starrocks.clone.TabletChecker.checkOneTable(TabletChecker.java:336)
	at com.starrocks.clone.TabletChecker.checkOneDatabase(TabletChecker.java:309)
	at com.starrocks.clone.TabletChecker.lambda$doCheck$0(TabletChecker.java:280)
	at com.starrocks.clone.TabletChecker.doCheck(TabletChecker.java:280)
	at com.starrocks.clone.TabletChecker.checkUrgentTablets(TabletChecker.java:246)
	at com.starrocks.clone.TabletChecker.checkAllTablets(TabletChecker.java:241)
	at com.starrocks.clone.TabletChecker.runAfterCatalogReady(TabletChecker.java:228)
	at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:78)
	at com.starrocks.common.util.Daemon.run(Daemon.java:98)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
