### PR TITLE
[Enhancement] Improve the collection and display of load spill metrics in the load profile

### DIFF
--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -73,8 +73,6 @@ Status SpillMemTableSink::flush_chunk_with_deletes(const Chunk& upserts, const C
 }
 
 Status SpillMemTableSink::merge_blocks_to_segments_parallel(bool do_agg, const SchemaPtr& schema) {
-    MonotonicStopWatch timer;
-    timer.start();
     auto token =
             StorageEngine::instance()->load_spill_block_merge_executor()->create_tablet_internal_parallel_merge_token();
     // 1. Get all spill block iterators
@@ -111,7 +109,6 @@ Status SpillMemTableSink::merge_blocks_to_segments_parallel(bool do_agg, const S
     }
     // 6. merge all writers' result
     RETURN_IF_ERROR(_writer->merge_other_writers(writers));
-    timer.stop();
 
     COUNTER_UPDATE(ADD_COUNTER(_load_chunk_spiller->profile(), "SpillMergeInputGroups", TUnit::UNIT),
                    spill_block_iterator_tasks.group_count);
@@ -119,19 +116,18 @@ Status SpillMemTableSink::merge_blocks_to_segments_parallel(bool do_agg, const S
                    spill_block_iterator_tasks.total_block_bytes);
     COUNTER_UPDATE(ADD_COUNTER(_load_chunk_spiller->profile(), "SpillMergeCount", TUnit::UNIT),
                    spill_block_iterator_tasks.iterators.size());
-    COUNTER_SET(ADD_TIMER(_load_chunk_spiller->profile(), "SpillMergeTime"), timer.elapsed_time());
     return Status::OK();
 }
 
 Status SpillMemTableSink::merge_blocks_to_segments_serial(bool do_agg, const SchemaPtr& schema) {
     auto char_field_indexes = ChunkHelper::get_char_field_indexes(*schema);
-    auto write_func = [&char_field_indexes, schema, this](Chunk* chunk) {
-        auto* spiller = get_spiller();
+    auto* spiller = get_spiller();
+    auto write_func = [&char_field_indexes, schema, spiller, this](Chunk* chunk) {
         SCOPED_TIMER(spiller->metrics().write_io_timer);
         ChunkHelper::padding_char_columns(char_field_indexes, *schema, _writer->tablet_schema(), chunk);
         return _writer->write(*chunk, nullptr);
     };
-    auto flush_func = [this]() {
+    auto flush_func = [spiller, this]() {
         SCOPED_TIMER(spiller->metrics().write_io_timer);
         return _writer->flush();
     };
@@ -166,6 +162,7 @@ Status SpillMemTableSink::merge_blocks_to_segments() {
         }
     }
 
+    SCOPED_TIMER(ADD_TIMER(_load_chunk_spiller->profile(), "SpillMergeTime"));
     if (config::enable_load_spill_parallel_merge) {
         return merge_blocks_to_segments_parallel(do_agg, schema);
     } else {

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.h
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.h
@@ -34,7 +34,8 @@ struct QuitFlag {
 class TabletInternalParallelMergeTask : public Runnable {
 public:
     TabletInternalParallelMergeTask(TabletWriter* writer, ChunkIterator* block_iterator, MemTracker* merge_mem_tracker,
-                                    Schema* schema, int32_t task_index, QuitFlag* quit_flag);
+                                    Schema* schema, int32_t task_index, QuitFlag* quit_flag,
+                                    RuntimeProfile::Counter* write_io_timer);
 
     ~TabletInternalParallelMergeTask();
 
@@ -54,6 +55,7 @@ private:
     int32_t _task_index = 0;
     Status _status;
     QuitFlag* _quit_flag = nullptr;
+    RuntimeProfile::Counter* _write_io_timer = nullptr;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.h
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.h
@@ -22,6 +22,7 @@ namespace starrocks {
 class ChunkIterator;
 class MemTracker;
 class Schema;
+class RuntimeProfile::Counter;
 
 namespace lake {
 

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.h
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "common/status.h"
+#include "util/runtime_profile.h"
 #include "util/threadpool.h"
 
 namespace starrocks {
@@ -22,7 +23,6 @@ namespace starrocks {
 class ChunkIterator;
 class MemTracker;
 class Schema;
-class RuntimeProfile::Counter;
 
 namespace lake {
 

--- a/be/src/storage/load_chunk_spiller.cpp
+++ b/be/src/storage/load_chunk_spiller.cpp
@@ -309,7 +309,6 @@ Status LoadChunkSpiller::merge_write(size_t target_size, size_t memory_usage_per
     COUNTER_UPDATE(ADD_COUNTER(_profile, "SpillMergeInputBytes", TUnit::BYTES),
                    spill_block_iterator_tasks.total_block_bytes);
     COUNTER_UPDATE(ADD_COUNTER(_profile, "SpillMergeCount", TUnit::UNIT), total_merges);
-    COUNTER_SET(ADD_TIMER(_profile, "SpillMergeTime"), duration_ms * 1000000);
     return Status::OK();
 }
 

--- a/be/src/storage/load_chunk_spiller.cpp
+++ b/be/src/storage/load_chunk_spiller.cpp
@@ -174,6 +174,14 @@ public:
             if (!_reader) {
                 _reader = _blocks[_block_idx]->get_reader(_options);
                 RETURN_IF_UNLIKELY(!_reader, Status::InternalError("Failed to get reader"));
+                // Update block count metric
+                auto& metrics = _serde.parent()->metrics();
+                COUNTER_UPDATE(metrics.block_count, 1);
+                if (_blocks[_block_idx]->is_remote()) {
+                    COUNTER_UPDATE(metrics.remote_block_count, 1);
+                } else {
+                    COUNTER_UPDATE(metrics.local_block_count, 1);
+                }
             }
             auto st = _serde.deserialize(_ctx, _reader.get());
             if (st.ok()) {
@@ -301,7 +309,7 @@ Status LoadChunkSpiller::merge_write(size_t target_size, size_t memory_usage_per
     COUNTER_UPDATE(ADD_COUNTER(_profile, "SpillMergeInputBytes", TUnit::BYTES),
                    spill_block_iterator_tasks.total_block_bytes);
     COUNTER_UPDATE(ADD_COUNTER(_profile, "SpillMergeCount", TUnit::UNIT), total_merges);
-    COUNTER_UPDATE(ADD_COUNTER(_profile, "SpillMergeDurationNs", TUnit::TIME_NS), duration_ms * 1000000);
+    COUNTER_SET(ADD_TIMER(_profile, "SpillMergeTime"), duration_ms * 1000000);
     return Status::OK();
 }
 


### PR DESCRIPTION
## Why I'm doing:
Improve the collection and display of load spill metrics in the load profile.

## What I'm doing:
This pull request improves the tracking and profiling of I/O operations during spill and merge processes by introducing more granular metrics, specifically distinguishing between remote and local read operations and enhancing write operation timing. The changes also propagate these new metrics through related classes and functions, ensuring more accurate performance measurement and easier debugging.

**I/O Metrics Enhancements**

* Added separate counters and timers for remote and local read operations to `BlockReaderOptions`, enabling more detailed tracking of I/O performance.
* Updated `BlockReader::read_fully` to use the new remote/local counters and timers, incrementing the appropriate metrics based on data source.
* Propagated the new remote/local I/O metrics into `BlockGroupIterator` to ensure all relevant operations are tracked.

**Write Operation Profiling**

* Modified `TabletInternalParallelMergeTask` to accept and use a write I/O timer, and instrumented write and flush/finish operations with timing for better profiling. [[1]](diffhunk://#diff-de19c5c9ee355400914a4704ed011f845946f465b50e7794cc6dd5bb76d45555L34-R42) [[2]](diffhunk://#diff-de19c5c9ee355400914a4704ed011f845946f465b50e7794cc6dd5bb76d45555R64) [[3]](diffhunk://#diff-de19c5c9ee355400914a4704ed011f845946f465b50e7794cc6dd5bb76d45555R76-R80) [[4]](diffhunk://#diff-166e328a1b2c584e4edff83b521e1d0dafc9c34930042abf1dbc19688572fecbL37-R38) [[5]](diffhunk://#diff-166e328a1b2c584e4edff83b521e1d0dafc9c34930042abf1dbc19688572fecbR58)
* Updated `SpillMemTableSink` and `LoadChunkSpiller` to use the new write I/O timer and to set merge duration using timers for more accurate time tracking. [[1]](diffhunk://#diff-efa88e3aceab1fcfcdddb6ffc3114a8eaad0c2f687010b0099c408fe879c7121L97-R97) [[2]](diffhunk://#diff-efa88e3aceab1fcfcdddb6ffc3114a8eaad0c2f687010b0099c408fe879c7121L122-R130) [[3]](diffhunk://#diff-a1e5d1af6ce8ce2514dc4bb84752470d62fbe16ff982fcbf09ab310a38f6b350L304-R310)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves spill/merge profiling with finer-grained I/O metrics and timer instrumentation.
> 
> - Instruments write paths with `write_io_timer`: passes timer into `TabletInternalParallelMergeTask`, and times `write/flush/finish`; serial merge lambdas also scoped by the same timer
> - Adds `SpillMergeTime` scoped timer around `SpillMemTableSink::merge_blocks_to_segments`
> - Updates `BlockGroupIterator` to count blocks and split counts by source: increments `block_count`, `remote_block_count`, `local_block_count`
> - Removes coarse `SpillMergeDurationNs` counter updates in favor of scoped timers; retains existing input group/bytes/count counters
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be38a3c1f9a8de150c75f3cca6b38193224da792. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->