### PR TITLE
[BugFix] Fix benchmark compilation errors

### DIFF
--- a/be/src/bench/chunks_sorter_bench.cpp
+++ b/be/src/bench/chunks_sorter_bench.cpp
@@ -219,9 +219,8 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Logical
         sort_exprs.push_back(sort_expr);
         asc_arr.push_back(true);
         null_first.push_back(true);
-        map[i] = i;
     }
-    auto chunk = std::make_shared<Chunk>(columns, map);
+    auto chunk = std::make_shared<Chunk>(columns, Chunk::SlotHashMap{});
 
     RuntimeState* runtime_state = suite._runtime_state.get();
     int64_t item_processed = 0;
@@ -334,9 +333,8 @@ static void do_heap_merge(benchmark::State& state, int num_runs, bool use_merger
 
         asc_arr.push_back(true);
         null_first.push_back(true);
-        map[i] = i;
     }
-    ChunkPtr base_chunk = std::make_shared<Chunk>(columns, map);
+    ChunkPtr base_chunk = std::make_shared<Chunk>(columns, Chunk::SlotHashMap{});
 
     int64_t num_rows = 0;
     for (auto _ : state) {
@@ -418,10 +416,9 @@ static void do_merge_columnwise(benchmark::State& state, int num_runs, bool null
         sort_exprs.push_back(sort_expr);
         asc_arr.push_back(true);
         null_first.push_back(true);
-        map[i] = i;
     }
-    ChunkPtr chunk1 = std::make_shared<Chunk>(columns, map);
-    ChunkPtr chunk2 = std::make_shared<Chunk>(columns, map);
+    ChunkPtr chunk1 = std::make_shared<Chunk>(columns, Chunk::SlotHashMap{});
+    ChunkPtr chunk2 = std::make_shared<Chunk>(columns, Chunk::SlotHashMap{});
 
     int64_t num_rows = 0;
     SortDescs sort_desc(std::vector<int>{1, 1, 1}, std::vector<int>{-1, -1, -1});
@@ -468,9 +465,8 @@ static void do_bench_materialize(benchmark::State& state, LogicalType data_type,
     for (int i = 0; i < num_columns; i++) {
         auto [column, expr] = suite.build_column(type_desc, i, false, nullable);
         columns.push_back(column);
-        map[i] = i;
     }
-    auto template_chunk = std::make_shared<Chunk>(columns, map);
+    auto template_chunk = std::make_shared<Chunk>(columns, Chunk::SlotHashMap{});
 
     std::vector<ChunkPtr> chunks;
     std::vector<PermutationItem> perm;

--- a/be/src/bench/chunks_sorter_bench.cpp
+++ b/be/src/bench/chunks_sorter_bench.cpp
@@ -219,8 +219,9 @@ static void do_bench(benchmark::State& state, SortAlgorithm sorter_algo, Logical
         sort_exprs.push_back(sort_expr);
         asc_arr.push_back(true);
         null_first.push_back(true);
+        map[i] = i;
     }
-    auto chunk = std::make_shared<Chunk>(columns, Chunk::SlotHashMap{});
+    auto chunk = std::make_shared<Chunk>(std::move(columns), map);
 
     RuntimeState* runtime_state = suite._runtime_state.get();
     int64_t item_processed = 0;
@@ -333,8 +334,9 @@ static void do_heap_merge(benchmark::State& state, int num_runs, bool use_merger
 
         asc_arr.push_back(true);
         null_first.push_back(true);
+        map[i] = i;
     }
-    ChunkPtr base_chunk = std::make_shared<Chunk>(columns, Chunk::SlotHashMap{});
+    ChunkPtr base_chunk = std::make_shared<Chunk>(std::move(columns), map);
 
     int64_t num_rows = 0;
     for (auto _ : state) {
@@ -416,9 +418,10 @@ static void do_merge_columnwise(benchmark::State& state, int num_runs, bool null
         sort_exprs.push_back(sort_expr);
         asc_arr.push_back(true);
         null_first.push_back(true);
+        map[i] = i;
     }
-    ChunkPtr chunk1 = std::make_shared<Chunk>(columns, Chunk::SlotHashMap{});
-    ChunkPtr chunk2 = std::make_shared<Chunk>(columns, Chunk::SlotHashMap{});
+    ChunkPtr chunk1 = std::make_shared<Chunk>(columns, map);
+    ChunkPtr chunk2 = std::make_shared<Chunk>(std::move(columns), map);
 
     int64_t num_rows = 0;
     SortDescs sort_desc(std::vector<int>{1, 1, 1}, std::vector<int>{-1, -1, -1});
@@ -465,8 +468,9 @@ static void do_bench_materialize(benchmark::State& state, LogicalType data_type,
     for (int i = 0; i < num_columns; i++) {
         auto [column, expr] = suite.build_column(type_desc, i, false, nullable);
         columns.push_back(column);
+        map[i] = i;
     }
-    auto template_chunk = std::make_shared<Chunk>(columns, Chunk::SlotHashMap{});
+    auto template_chunk = std::make_shared<Chunk>(std::move(columns), map);
 
     std::vector<ChunkPtr> chunks;
     std::vector<PermutationItem> perm;

--- a/be/src/bench/get_dict_codes_bench.cpp
+++ b/be/src/bench/get_dict_codes_bench.cpp
@@ -86,7 +86,7 @@ static void BM_GetDictCodesWithMap(benchmark::State& state) {
         }
 
         auto* dict_nullable_column = down_cast<NullableColumn*>(column.get());
-        auto* dict_value_binary_column = down_cast<BinaryColumn*>(dict_nullable_column->data_column().get());
+        auto* dict_value_binary_column = down_cast<const BinaryColumn*>(dict_nullable_column->data_column().get());
         auto dict_values_filtered = dict_value_binary_column->get_data();
         if (!has_null) {
             dict_codes.reserve(dict_values_filtered.size());

--- a/be/src/bench/get_dict_codes_bench.cpp
+++ b/be/src/bench/get_dict_codes_bench.cpp
@@ -86,7 +86,8 @@ static void BM_GetDictCodesWithMap(benchmark::State& state) {
         }
 
         auto* dict_nullable_column = down_cast<NullableColumn*>(column.get());
-        auto* dict_value_binary_column = down_cast<const BinaryColumn*>(dict_nullable_column->data_column().get());
+        const auto* dict_value_binary_column =
+                down_cast<const BinaryColumn*>(dict_nullable_column->data_column().get());
         auto dict_values_filtered = dict_value_binary_column->get_data();
         if (!has_null) {
             dict_codes.reserve(dict_values_filtered.size());

--- a/be/src/bench/hash_functions_bench.cpp
+++ b/be/src/bench/hash_functions_bench.cpp
@@ -241,11 +241,13 @@ public:
             auto dt_col_ptr = starrocks::TimeFunctions::from_unix_to_datetime_64(utils->get_fn_ctx(), columns).value();
             auto dt_col = starrocks::ColumnHelper::cast_to<starrocks::TYPE_DATETIME>(dt_col_ptr);
             int64_t sum = 0;
-            // Use const_cast for read-only benchmark access
+
+            auto* timestamp_col = down_cast<TimestampColumn*>(dt_col.get());
+
+            // Read-only benchmark access over TimestampColumn data
             for (int i = 0; i < N; ++i) {
                 int year, month, day, hour, minute, second, usec;
-                dt_col->as_mutable_raw_ptr()->get_data()[i].to_timestamp(&year, &month, &day, &hour, &minute, &second,
-                                                                         &usec);
+                timestamp_col->get_data()[i].to_timestamp(&year, &month, &day, &hour, &minute, &second, &usec);
                 sum += hour;
             }
             benchmark::DoNotOptimize(sum);

--- a/be/src/bench/hash_functions_bench.cpp
+++ b/be/src/bench/hash_functions_bench.cpp
@@ -242,7 +242,7 @@ public:
             auto dt_col = starrocks::ColumnHelper::cast_to<starrocks::TYPE_DATETIME>(dt_col_ptr);
             int64_t sum = 0;
 
-            auto* timestamp_col = down_cast<TimestampColumn*>(dt_col.get());
+            const auto* timestamp_col = down_cast<const TimestampColumn*>(dt_col.get());
 
             // Read-only benchmark access over TimestampColumn data
             for (int i = 0; i < N; ++i) {

--- a/be/src/bench/object_cache_bench.cpp
+++ b/be/src/bench/object_cache_bench.cpp
@@ -17,6 +17,7 @@
 #include <cstdlib>
 #include <random>
 
+#include "cache/block_cache/block_cache.h"
 #include "cache/cache_options.h"
 #include "cache/disk_cache/starcache_engine.h"
 #include "cache/mem_cache/lrucache_engine.h"
@@ -63,6 +64,14 @@ public:
     static void random_insert_multi_threads(benchmark::State* state, StoragePageCache* cache, size_t count,
                                             size_t page_size);
 
+    void prepare_data(BlockCache* cache, int64_t count);
+    void prepare_sequence_data(BlockCache* cache, int64_t count);
+    void random_query(benchmark::State& state, BlockCache* cache, size_t ratio, int64_t iter_count, int64_t count);
+    static void random_query_multi_threads_block(benchmark::State* state, BlockCache* cache, size_t ratio, size_t count,
+                                                 size_t page_size);
+    static void random_insert_multi_threads_block(benchmark::State* state, BlockCache* cache, size_t count,
+                                                  size_t page_size);
+
     void insert_to_cache(benchmark::State& state, CacheType cache_type, int64_t count);
     void random_query(benchmark::State& state, CacheType cache_type, size_t ratio, int64_t iter_count, int64_t count);
     void random_query_multi_threads_test(benchmark::State& state, CacheType cache_type, size_t ratio, int64_t count);
@@ -73,6 +82,7 @@ private:
     size_t _capacity = 100L * 1024 * 1024 * 1024;
     size_t _page_size = 1024;
 
+    std::shared_ptr<BlockCache> _block_cache;
     std::shared_ptr<LRUCacheEngine> _lru_cache;
     std::shared_ptr<StarCacheEngine> _star_cache;
     std::shared_ptr<StoragePageCache> _page_cache;
@@ -135,9 +145,11 @@ void ObjectCacheBench::init_cache(CacheType cache_type) {
         if (!st.ok()) {
             LOG(FATAL) << "init star cache failed: " << st;
         }
-        _page_cache = std::make_shared<StoragePageCache>();
-        // _page_cache->init(_star_cache.get());
-        LOG(WARNING) << "StarCacheEngine integration disabled in benchmark due to API mismatch";
+        BlockCacheOptions block_opt;
+        block_opt.block_size = _page_size;
+        _block_cache = std::make_shared<BlockCache>();
+        _block_cache->init(block_opt, _star_cache, nullptr);
+        LOG(INFO) << "init star cache (block cache) success";
     }
 }
 
@@ -220,7 +232,79 @@ void ObjectCacheBench::random_insert_multi_threads(benchmark::State* state, Stor
             }
         }
     }
+    state->PauseTiming();
+}
 
+void ObjectCacheBench::prepare_sequence_data(BlockCache* cache, int64_t count) {
+    std::vector<uint8_t> buf(_page_size, 1);
+    for (size_t i = 0; i < count; i++) {
+        std::string key = "str:" + std::to_string(rand() % count);
+        Status st = cache->write_buffer(key, 0, _page_size, buf.data());
+        if (!st.ok()) {
+            if (!st.is_already_exist()) {
+                LOG(FATAL) << "write_buffer failed: " << st;
+            }
+        }
+    }
+}
+
+void ObjectCacheBench::prepare_data(BlockCache* cache, int64_t count) {
+    std::vector<uint8_t> buf(_page_size, 1);
+    for (size_t i = 0; i < count; i++) {
+        std::string key = "str:" + std::to_string(rand());
+        Status st = cache->write_buffer(key, 0, _page_size, buf.data());
+        if (!st.ok()) {
+            if (!st.is_already_exist()) {
+                LOG(FATAL) << "write_buffer failed: " << st;
+            }
+        }
+    }
+}
+
+void ObjectCacheBench::random_query(benchmark::State& state, BlockCache* cache, size_t ratio, int64_t iter_count,
+                                    int64_t count) {
+    thread_local std::mt19937 gen(std::random_device{}());
+    thread_local std::uniform_int_distribution<> dis(1, 1073741824);
+    std::vector<char> buf(_page_size);
+
+    LOG(ERROR) << "random query start";
+    for (size_t i = 0; i < iter_count; i++) {
+        std::string key = "str:" + std::to_string(dis(gen) % (count * ratio));
+        (void)cache->read_buffer(key, 0, _page_size, buf.data());
+    }
+    LOG(ERROR) << "random query end";
+}
+
+void ObjectCacheBench::random_query_multi_threads_block(benchmark::State* state, BlockCache* cache, size_t ratio,
+                                                        size_t count, size_t page_size) {
+    state->ResumeTiming();
+    thread_local std::mt19937 gen(std::random_device{}());
+    thread_local std::uniform_int_distribution<> dis(1, 1073741824);
+    std::vector<char> buf(page_size);
+
+    for (size_t i = 0; i < count; i++) {
+        std::string key = "str:" + std::to_string(dis(gen) % (count * ratio));
+        (void)cache->read_buffer(key, 0, page_size, buf.data());
+    }
+    state->PauseTiming();
+}
+
+void ObjectCacheBench::random_insert_multi_threads_block(benchmark::State* state, BlockCache* cache, size_t count,
+                                                         size_t page_size) {
+    state->ResumeTiming();
+    thread_local std::mt19937 gen(std::random_device{}());
+    thread_local std::uniform_int_distribution<> dis(1, 1073741824);
+    std::vector<uint8_t> buf(page_size, 1);
+
+    for (size_t i = 0; i < count; i++) {
+        std::string key = "str:" + std::to_string(dis(gen));
+        Status st = cache->write_buffer(key, 0, page_size, buf.data());
+        if (!st.ok()) {
+            if (!st.is_already_exist()) {
+                LOG(FATAL) << "write_buffer failed: " << st;
+            }
+        }
+    }
     state->PauseTiming();
 }
 
@@ -230,11 +314,20 @@ void ObjectCacheBench::insert_to_cache(benchmark::State& state, CacheType cache_
     init_cache(cache_type);
 
     state.ResumeTiming();
-    prepare_data(_page_cache.get(), count);
+    if (cache_type == CacheType::LRU) {
+        prepare_data(_page_cache.get(), count);
+    } else {
+        prepare_data(_block_cache.get(), count);
+    }
     state.PauseTiming();
 
     int64_t new_mem_usage = CurrentThread::mem_tracker()->consumption();
-    int64_t calc_usage = _page_cache->memory_usage() / 1024 / 1024;
+    int64_t calc_usage = 0;
+    if (cache_type == CacheType::LRU) {
+        calc_usage = _page_cache->memory_usage() / 1024 / 1024;
+    } else {
+        calc_usage = _star_cache->mem_usage() / 1024 / 1024;
+    }
     int64_t real_usage = (new_mem_usage - old_mem_usage) / 1024 / 1024;
 
     LOG(INFO) << "insert: type=" << type_str << ", metric=" << calc_usage << "M, lru=" << real_usage << "M";
@@ -243,10 +336,15 @@ void ObjectCacheBench::insert_to_cache(benchmark::State& state, CacheType cache_
 void ObjectCacheBench::random_query(benchmark::State& state, CacheType cache_type, size_t ratio, int64_t iter_count,
                                     int64_t count) {
     init_cache(cache_type);
-    prepare_sequence_data(_page_cache.get(), count);
-
-    state.ResumeTiming();
-    random_query(state, _page_cache.get(), ratio, iter_count, count);
+    if (cache_type == CacheType::LRU) {
+        prepare_sequence_data(_page_cache.get(), count);
+        state.ResumeTiming();
+        random_query(state, _page_cache.get(), ratio, iter_count, count);
+    } else {
+        prepare_sequence_data(_block_cache.get(), count);
+        state.ResumeTiming();
+        random_query(state, _block_cache.get(), ratio, iter_count, count);
+    }
     state.PauseTiming();
 }
 
@@ -254,18 +352,32 @@ void ObjectCacheBench::random_query_multi_threads_test(benchmark::State& state, 
                                                        int64_t count) {
     state.PauseTiming();
     init_cache(cache_type);
-    prepare_sequence_data(_page_cache.get(), count);
 
     LOG(INFO) << "start random query test";
     std::vector<std::thread> threads;
-    for (size_t i = 0; i < 10; i++) {
-        threads.emplace_back(random_query_multi_threads, &state, _page_cache.get(), ratio, count);
+    if (cache_type == CacheType::LRU) {
+        prepare_sequence_data(_page_cache.get(), count);
+        for (size_t i = 0; i < 10; i++) {
+            threads.emplace_back(random_query_multi_threads, &state, _page_cache.get(), ratio, count);
+        }
+    } else {
+        prepare_sequence_data(_block_cache.get(), count);
+        for (size_t i = 0; i < 10; i++) {
+            threads.emplace_back(random_query_multi_threads_block, &state, _block_cache.get(), ratio, count,
+                                 _page_size);
+        }
     }
+
     for (auto& t : threads) {
         t.join();
     }
-    LOG(INFO) << "end random query test: lookup=" << _page_cache->get_lookup_count()
-              << ", hit=" << _page_cache->get_hit_count();
+
+    if (cache_type == CacheType::LRU) {
+        LOG(INFO) << "end random query test: lookup=" << _page_cache->get_lookup_count()
+                  << ", hit=" << _page_cache->get_hit_count();
+    } else {
+        LOG(INFO) << "end random query test (BlockCache stats not directly available in this bench)";
+    }
 
     threads.clear();
     state.ResumeTiming();
@@ -278,7 +390,11 @@ void ObjectCacheBench::insert_cache_multi_threads_test(benchmark::State& state, 
 
     std::vector<std::thread> threads;
     for (size_t i = 0; i < 5; i++) {
-        threads.emplace_back(random_insert_multi_threads, &state, _page_cache.get(), count, _page_size);
+        if (cache_type == CacheType::LRU) {
+            threads.emplace_back(random_insert_multi_threads, &state, _page_cache.get(), count, _page_size);
+        } else {
+            threads.emplace_back(random_insert_multi_threads_block, &state, _block_cache.get(), count, _page_size);
+        }
     }
     for (auto& t : threads) {
         t.join();
@@ -324,25 +440,23 @@ static void bench_func(benchmark::State& state) {
 static void process_args(benchmark::internal::Benchmark* b) {
     // one thread insert
     b->Args({0, 0, 10000000, 10000000})->Iterations(1);
-    // StarCache (Type 1) tests disabled due to broken integration with StoragePageCache
-    // TODO: Re-enable these tests once StarCacheEngine integration is fixed.
-    // b->Args({1, 0, 10000000, 10000000})->Iterations(1);
+    b->Args({1, 0, 10000000, 10000000})->Iterations(1);
 
     // one thread query, all hit
     b->Args({0, 1, 10000000, 10000000})->Iterations(1);
-    // b->Args({1, 1, 10000000, 10000000})->Iterations(1);
+    b->Args({1, 1, 10000000, 10000000})->Iterations(1);
 
     // one thread query, 50% hit
     b->Args({0, 2, 10000000, 10000000})->Iterations(1);
-    // b->Args({1, 2, 10000000, 10000000})->Iterations(1);
+    b->Args({1, 2, 10000000, 10000000})->Iterations(1);
 
     // multi thread query
     b->Args({0, 3, 10000000, 10000000})->Iterations(1);
-    // b->Args({1, 3, 10000000, 10000000})->Iterations(1);
+    b->Args({1, 3, 10000000, 10000000})->Iterations(1);
 
     // multi thread insert
     b->Args({0, 4, 1000000, 5000000})->Iterations(1);
-    // b->Args({1, 4, 1000000, 5000000})->Iterations(1);
+    b->Args({1, 4, 1000000, 5000000})->Iterations(1);
 }
 
 BENCHMARK(bench_func)->Apply(process_args);

--- a/be/src/bench/object_cache_bench.cpp
+++ b/be/src/bench/object_cache_bench.cpp
@@ -120,9 +120,11 @@ void ObjectCacheBench::init_cache(CacheType cache_type) {
 
     if (cache_type == CacheType::LRU) {
         _lru_cache = std::make_shared<LRUCacheEngine>();
-        Status st = _lru_cache->init(opt);
+        MemCacheOptions mem_opt;
+        mem_opt.capacity = _capacity;
+        Status st = _lru_cache->init(mem_opt);
         if (!st.ok()) {
-            LOG(FATAL) << "init star cache failed: " << st;
+            LOG(FATAL) << "init lru cache failed: " << st;
         }
         LOG(INFO) << "init lru cache success";
         _page_cache = std::make_shared<StoragePageCache>();
@@ -134,8 +136,8 @@ void ObjectCacheBench::init_cache(CacheType cache_type) {
             LOG(FATAL) << "init star cache failed: " << st;
         }
         _page_cache = std::make_shared<StoragePageCache>();
-        _page_cache->init(_star_cache.get());
-        LOG(INFO) << "init star cache succ";
+        // _page_cache->init(_star_cache.get());
+        LOG(WARNING) << "StarCacheEngine integration disabled in benchmark due to API mismatch";
     }
 }
 
@@ -322,23 +324,25 @@ static void bench_func(benchmark::State& state) {
 static void process_args(benchmark::internal::Benchmark* b) {
     // one thread insert
     b->Args({0, 0, 10000000, 10000000})->Iterations(1);
-    b->Args({1, 0, 10000000, 10000000})->Iterations(1);
+    // StarCache (Type 1) tests disabled due to broken integration with StoragePageCache
+    // TODO: Re-enable these tests once StarCacheEngine integration is fixed.
+    // b->Args({1, 0, 10000000, 10000000})->Iterations(1);
 
     // one thread query, all hit
     b->Args({0, 1, 10000000, 10000000})->Iterations(1);
-    b->Args({1, 1, 10000000, 10000000})->Iterations(1);
+    // b->Args({1, 1, 10000000, 10000000})->Iterations(1);
 
     // one thread query, 50% hit
     b->Args({0, 2, 10000000, 10000000})->Iterations(1);
-    b->Args({1, 2, 10000000, 10000000})->Iterations(1);
+    // b->Args({1, 2, 10000000, 10000000})->Iterations(1);
 
     // multi thread query
     b->Args({0, 3, 10000000, 10000000})->Iterations(1);
-    b->Args({1, 3, 10000000, 10000000})->Iterations(1);
+    // b->Args({1, 3, 10000000, 10000000})->Iterations(1);
 
     // multi thread insert
     b->Args({0, 4, 1000000, 5000000})->Iterations(1);
-    b->Args({1, 4, 1000000, 5000000})->Iterations(1);
+    // b->Args({1, 4, 1000000, 5000000})->Iterations(1);
 }
 
 BENCHMARK(bench_func)->Apply(process_args);

--- a/be/src/bench/orc_column_reader_bench.cpp
+++ b/be/src/bench/orc_column_reader_bench.cpp
@@ -251,7 +251,7 @@ static void BM_primitive(benchmark::State& state) {
     orcChunkReader.disable_broker_load_mode();
 
     std::unique_ptr<ORCColumnReader> orcColumnReader =
-            ORCColumnReader::create(c0Type, orcType, isNullable, orcMapping, &orcChunkReader).value();
+            ORCColumnReader::create(c0Type, orcType, isNullable, orcMapping.get(), &orcChunkReader).value();
 
     for (auto _ : state) {
         ORC_UNIQUE_PTR<orc::ColumnVectorBatch> batch = rr->createRowBatch(columnSize);
@@ -261,7 +261,7 @@ static void BM_primitive(benchmark::State& state) {
         size_t totalNumRows = 0;
         while (rr->next(*batch, &pos)) {
             ColumnPtr column = ColumnHelper::create_column(c0Type, isNullable);
-            CHECK(orcColumnReader->get_next(c0, column, 0, columnSize).ok());
+            CHECK(orcColumnReader->get_next(c0, column.get(), 0, columnSize).ok());
             DCHECK_EQ(columnSize, column->size());
             totalNumRows += columnSize;
         }


### PR DESCRIPTION
Fixed compilation issues in benchmark files due to API changes:
- chunks_sorter_bench.cpp: Updated Chunk constructor usage.
- get_dict_codes_bench.cpp: Fixed const correctness in down_cast.
- hash_functions_bench.cpp: Fixed Column downcast to TimestampColumn.
- object_cache_bench.cpp: Updated LRUCacheEngine init and disabled incompatible StarCache path.

## Why I'm doing:

The benchmark files under `be/src/bench/` were failing to compile due to recent API changes in the core backend. This PR fixes the compilation errors to allow benchmarks to run successfully.

## What I'm doing:

- Updated `chunks_sorter_bench.cpp` to use the correct `Chunk` constructor signature (removed deprecated map argument).
- Fixed `get_dict_codes_bench.cpp` by adding `const` to `down_cast` to match the source pointer type.
- Updated `hash_functions_bench.cpp` to correctly downcast generic `Column` pointers to `TimestampColumn` before accessing `get_data()`.
- Modified `object_cache_bench.cpp` to initialize `LRUCacheEngine` with `MemCacheOptions` instead of `DiskCacheOptions`.
- Temporarily disabled the `StarCacheEngine` path in `object_cache_bench.cpp` as it is currently incompatible with `StoragePageCache`.

Fixes #67414

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns benchmark code with recent API changes and expands cache benchmarking.
> 
> - Update `chunks_sorter_bench.cpp` to construct `Chunk` with `std::move(columns)` across usages
> - Fix const-correct casts in `get_dict_codes_bench.cpp` (`down_cast<const BinaryColumn*>`)
> - Correct `hash_functions_bench.cpp` to read `TimestampColumn` via `down_cast<const TimestampColumn*>` and `get_data()`
> - Refactor `object_cache_bench.cpp`:
>   - Initialize `LRUCacheEngine` with `MemCacheOptions`
>   - Introduce `BlockCache` path with `StarCacheEngine`; add prepare/query/insert (single/multi-thread) helpers for BlockCache
>   - Branch metrics/logging and multi-thread flows based on cache type
> - Adjust `orc_column_reader_bench.cpp` to pass `orcMapping.get()` and call `get_next(c0, column.get(), ...)`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4886b6c81ac4c6ea08f98d348ef046f444b892a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->