### PR TITLE
[Enhancement] Support common predicate reuse for more join types

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
@@ -100,6 +100,9 @@ private:
 
     Status _eval_nullaware_anti_conjuncts(const ChunkPtr& chunk, FilterPtr* filter);
 
+    // eval conjuncts for nest loop join
+    Status _eval_conjuncts(const ChunkPtr& chunk);
+
     // Join type check
     bool _is_left_join() const;
     bool _is_right_join() const;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/JoinHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/JoinHelper.java
@@ -25,11 +25,15 @@ import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.DistributionCol;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalNestLoopJoinOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamJoinOperator;
+import com.starrocks.type.Type;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -146,7 +150,137 @@ public class JoinHelper {
                 HintNode.HINT_JOIN_BUCKET.equals(hint) || HintNode.HINT_JOIN_SKEW.equals(hint);
     }
 
-    public static List<BinaryPredicateOperator> getEqualsPredicate(ColumnRefSet leftColumns, ColumnRefSet rightColumns,
+    /**
+     * Split join on predicate into equal predicates, other on predicates and asof temporal predicate.
+     */
+    public record JoinOnSplitPredicates(ScalarOperator eqOnPredicate,
+                                        ScalarOperator otherOnPredicate,
+                                        ScalarOperator asofTemporalPredicate) {
+    }
+
+    /**
+     * Split join on predicate into equal predicates and residual predicates
+     */
+    public static JoinOnSplitPredicates splitJoinOnPredicate(JoinOperator joinType,
+                                                             ScalarOperator onPredicate,
+                                                             ColumnRefSet leftChildColumns,
+                                                             ColumnRefSet rightChildColumns) {
+        List<ScalarOperator> onPredicates = Utils.extractConjuncts(onPredicate);
+        List<BinaryPredicateOperator> eqOnPredicates = JoinHelper.getEqualsPredicate(
+                leftChildColumns, rightChildColumns, onPredicates);
+        eqOnPredicates = eqOnPredicates.stream().filter(p -> !p.isCorrelated()).toList();
+        for (BinaryPredicateOperator s : eqOnPredicates) {
+            if (!leftChildColumns.containsAll(s.getChild(0).getUsedColumns())) {
+                s.swap();
+            }
+        }
+
+        onPredicates.removeAll(eqOnPredicates);
+
+        // asof join temporal predicate extraction
+        ScalarOperator asofJoinPredicate = null;
+        if (joinType.isAsofJoin()) {
+            asofJoinPredicate = extractAndValidateAsofTemporalPredicate(onPredicates,
+                    leftChildColumns, rightChildColumns);
+            onPredicates.remove(asofJoinPredicate);
+        }
+
+        ScalarOperator newOnPredicate = Utils.compoundAnd(eqOnPredicates);
+        ScalarOperator residualPredicate = Utils.compoundAnd(onPredicates);
+
+        return new JoinOnSplitPredicates(newOnPredicate, residualPredicate, asofJoinPredicate);
+    }
+
+    public static boolean canTreatOnPredicateAsPredicate(OptExpression input) {
+        if (input == null || input.getOp() == null) {
+            return false;
+        }
+        if (input.getOp() instanceof PhysicalHashJoinOperator) {
+            PhysicalHashJoinOperator join = (PhysicalHashJoinOperator) input.getOp();
+            // for inner join, we can split the onPredicate to join keys and residual predicate since the non-equal-predicates
+            // can be pushed down to below operators safely.
+            // but for outer join, we need to distinguish on-predicates and non-equal-predicates carefully.
+            if (join.getJoinType().isInnerJoin() && join.getOnPredicate() != null && join.getPredicate() == null) {
+                return true;
+            }
+        } else if (input.getOp() instanceof PhysicalNestLoopJoinOperator) {
+            PhysicalNestLoopJoinOperator join = (PhysicalNestLoopJoinOperator) input.getOp();
+            // for nest loop join, we can split the onPredicate to join keys and residual predicate
+            // since the non-equal-predicates can be pushed down to below operators safely.
+            if (join.getJoinType().isInnerJoin() && join.getOnPredicate() != null && join.getPredicate() == null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static ScalarOperator extractAndValidateAsofTemporalPredicate(List<ScalarOperator> otherJoin,
+                                                                         ColumnRefSet leftColumns,
+                                                                         ColumnRefSet rightColumns) {
+        List<ScalarOperator> candidates = new ArrayList<>();
+
+        for (ScalarOperator predicate : otherJoin) {
+            if (isValidAsofTemporalPredicate(predicate, leftColumns, rightColumns)) {
+                candidates.add(predicate);
+            }
+        }
+
+        if (candidates.isEmpty()) {
+            throw new IllegalStateException("ASOF JOIN requires exactly one temporal inequality condition. found: 0");
+        }
+
+        if (candidates.size() > 1) {
+            throw new IllegalStateException(String.format(
+                    "ASOF JOIN requires exactly one temporal inequality condition, found %d: %s",
+                    candidates.size(), candidates));
+        }
+
+        ScalarOperator temporalPredicate = candidates.get(0);
+        for (ScalarOperator child : temporalPredicate.getChildren()) {
+            if (!child.isColumnRef()) {
+                throw new IllegalStateException(String.format(
+                        "ASOF JOIN temporal condition operands must be column references, found: %s", child));
+            }
+
+            Type operandType = child.getType();
+            if (!operandType.isBigint() && !operandType.isDate() && !operandType.isDatetime()) {
+                throw new IllegalStateException(String.format(
+                        "ASOF JOIN temporal condition operand must be BIGINT, DATE, or DATETIME in join ON clause, " +
+                                "found: %s. Predicate: %s", operandType, temporalPredicate));
+            }
+        }
+
+        return candidates.get(0);
+    }
+
+    private static boolean isValidAsofTemporalPredicate(ScalarOperator predicate,
+                                                        ColumnRefSet leftColumns,
+                                                        ColumnRefSet rightColumns) {
+        if (!(predicate instanceof BinaryPredicateOperator binaryPredicate)) {
+            return false;
+        }
+
+        if (!binaryPredicate.getBinaryType().isRange()) {
+            return false;
+        }
+
+        ColumnRefSet leftOperandColumns = binaryPredicate.getChild(0).getUsedColumns();
+        ColumnRefSet rightOperandColumns = binaryPredicate.getChild(1).getUsedColumns();
+
+        if (leftOperandColumns.isIntersect(leftColumns) && leftOperandColumns.isIntersect(rightColumns)) {
+            return false;
+        }
+
+        if (rightOperandColumns.isIntersect(leftColumns) && rightOperandColumns.isIntersect(rightColumns)) {
+            return false;
+        }
+
+        return true;
+    }
+
+
+
+        public static List<BinaryPredicateOperator> getEqualsPredicate(ColumnRefSet leftColumns, ColumnRefSet rightColumns,
                                                                    List<ScalarOperator> conjunctList) {
         List<BinaryPredicateOperator> eqConjuncts = Lists.newArrayList();
         for (ScalarOperator predicate : conjunctList) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/JoinHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/JoinHelper.java
@@ -218,7 +218,6 @@ public class JoinHelper {
                                                                          ColumnRefSet leftColumns,
                                                                          ColumnRefSet rightColumns) {
         List<ScalarOperator> candidates = new ArrayList<>();
-
         for (ScalarOperator predicate : otherJoin) {
             if (isValidAsofTemporalPredicate(predicate, leftColumns, rightColumns)) {
                 candidates.add(predicate);
@@ -228,7 +227,6 @@ public class JoinHelper {
         if (candidates.isEmpty()) {
             throw new IllegalStateException("ASOF JOIN requires exactly one temporal inequality condition. found: 0");
         }
-
         if (candidates.size() > 1) {
             throw new IllegalStateException(String.format(
                     "ASOF JOIN requires exactly one temporal inequality condition, found %d: %s",
@@ -259,18 +257,15 @@ public class JoinHelper {
         if (!(predicate instanceof BinaryPredicateOperator binaryPredicate)) {
             return false;
         }
-
         if (!binaryPredicate.getBinaryType().isRange()) {
             return false;
         }
 
         ColumnRefSet leftOperandColumns = binaryPredicate.getChild(0).getUsedColumns();
         ColumnRefSet rightOperandColumns = binaryPredicate.getChild(1).getUsedColumns();
-
         if (leftOperandColumns.isIntersect(leftColumns) && leftOperandColumns.isIntersect(rightColumns)) {
             return false;
         }
-
         if (rightOperandColumns.isIntersect(leftColumns) && rightOperandColumns.isIntersect(rightColumns)) {
             return false;
         }
@@ -278,9 +273,7 @@ public class JoinHelper {
         return true;
     }
 
-
-
-        public static List<BinaryPredicateOperator> getEqualsPredicate(ColumnRefSet leftColumns, ColumnRefSet rightColumns,
+    public static List<BinaryPredicateOperator> getEqualsPredicate(ColumnRefSet leftColumns, ColumnRefSet rightColumns,
                                                                    List<ScalarOperator> conjunctList) {
         List<BinaryPredicateOperator> eqConjuncts = Lists.newArrayList();
         for (ScalarOperator predicate : conjunctList) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -275,7 +275,7 @@ public class Utils {
         return createCompound(CompoundPredicateOperator.CompoundType.OR, Arrays.asList(nodes));
     }
 
-    public static ScalarOperator compoundAnd(Collection<ScalarOperator> nodes) {
+    public static ScalarOperator compoundAnd(Collection<? extends ScalarOperator> nodes) {
         return createCompound(CompoundPredicateOperator.CompoundType.AND, nodes);
     }
 
@@ -310,7 +310,7 @@ public class Utils {
     //  /\   /\
     // a  b c  d
     public static ScalarOperator createCompound(CompoundPredicateOperator.CompoundType type,
-                                                Collection<ScalarOperator> nodes) {
+                                                Collection<? extends ScalarOperator> nodes) {
         LinkedList<ScalarOperator> link =
                 nodes.stream().filter(Objects::nonNull).collect(Collectors.toCollection(Lists::newLinkedList));
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalJoinOperator.java
@@ -31,7 +31,7 @@ import java.util.Set;
 
 public abstract class PhysicalJoinOperator extends PhysicalOperator {
     protected final JoinOperator joinType;
-    protected final ScalarOperator onPredicate;
+    protected ScalarOperator onPredicate;
     protected final String joinHint;
     protected boolean outputRequireHashPartition = true;
 
@@ -60,6 +60,10 @@ public abstract class PhysicalJoinOperator extends PhysicalOperator {
 
     public ScalarOperator getOnPredicate() {
         return onPredicate;
+    }
+
+    public void setOnPredicate(ScalarOperator onPredicate) {
+        this.onPredicate = onPredicate;
     }
 
     public String getJoinHint() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithCaseWhenTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithCaseWhenTest.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer;
 
 import com.google.common.collect.Lists;
 import com.starrocks.common.FeConstants;
+import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
@@ -678,22 +679,14 @@ class SelectStmtWithCaseWhenTest {
                 "FROM cte3\n" +
                 "WHERE len_bucket IS NOT NULL;";
         String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
-        Assert.assertTrue(plan.contains("  6:HASH JOIN\n" +
+        PlanTestBase.assertContains(plan, "6:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
                 "  |  equal join conjunct: [9: cast, DOUBLE, true] = [10: add, DOUBLE, true]\n" +
-                "  |  other join predicates: CASE WHEN " +
-                "array_length[(array_concat[([4: col_arr, ARRAY<VARCHAR(100)>, true], " +
-                "[6: col_arr, ARRAY<VARCHAR(100)>, true]); args: INVALID_TYPE; result:" +
-                " ARRAY<VARCHAR>; args nullable: true; result nullable: true]); args:" +
-                " INVALID_TYPE; result: INT; args nullable: true; result nullable: true] < 2 " +
-                "THEN 'bucket1' WHEN (array_length[(array_concat[([4: col_arr, ARRAY<VARCHAR(100)>, true]," +
-                " [6: col_arr, ARRAY<VARCHAR(100)>, true]); args: INVALID_TYPE; result: ARRAY<VARCHAR>; " +
-                "args nullable: true; result nullable: true]); args: INVALID_TYPE; result: INT; " +
-                "args nullable: true; result nullable: true] >= 2) AND " +
-                "(array_length[(array_concat[([4: col_arr, ARRAY<VARCHAR(100)>, true], " +
-                "[6: col_arr, ARRAY<VARCHAR(100)>, true]); args: INVALID_TYPE; result: " +
-                "ARRAY<VARCHAR>; args nullable: true; result nullable: true]); args: INVALID_TYPE; " +
-                "result: INT; args nullable: true; result nullable: true] < 4) THEN 'bucket2' " +
-                "ELSE NULL END IS NOT NULL\n"));
+                "  |  other predicates: CASE WHEN [16: array_length, INT, true] < 2 THEN 'bucket1' " +
+                "WHEN ([16: array_length, INT, true] >= 2) AND ([16: array_length, INT, true] < 4) " +
+                "THEN 'bucket2' ELSE NULL END IS NOT NULL\n" +
+                "  |    common sub expr:\n" +
+                "  |    <slot 16> : array_length(15: array_concat)\n" +
+                "  |    <slot 15> : array_concat(4: col_arr, 6: col_arr)");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -434,10 +434,14 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Assertions.assertTrue(replayPair.second.contains("  22:NESTLOOP JOIN\n" +
                 "  |  join op: INNER JOIN\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  other join predicates: if(19: c_0_0 != 1: c_0_0, 4: c_0_3, 20: c_0_3) = '1969-12-28', " +
-                "if(((1: c_0_0 IS NULL) AND (NOT ((21: countRows IS NULL) OR (21: countRows = 0)))) OR " +
-                "((22: countNotNulls < 21: countRows) AND (((NOT ((21: countRows IS NULL) OR (21: countRows = 0))) " +
-                "AND (1: c_0_0 IS NOT NULL)) AND (16: c_0_0 IS NULL))), TRUE, FALSE)\n"), replayPair.second);
+                "  |  other predicates: if(19: c_0_0 != 1: c_0_0, 4: c_0_3, 20: c_0_3) = '1969-12-28', " +
+                "if(((1: c_0_0 IS NULL) AND (27: expr)) OR ((22: countNotNulls < 21: countRows) " +
+                "AND (((27: expr) AND (1: c_0_0 IS NOT NULL)) AND (16: c_0_0 IS NULL))), TRUE, FALSE)\n" +
+                "  |    common sub expr:\n" +
+                "  |    <slot 24> : 21: countRows IS NULL\n" +
+                "  |    <slot 25> : 21: countRows = 0\n" +
+                "  |    <slot 26> : (24: expr) OR (25: expr)\n" +
+                "  |    <slot 27> : NOT (26: expr)"), replayPair.second);
         Assertions.assertTrue(replayPair.second.contains("  20:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (PARTITIONED)\n" +
                 "  |  colocate: false, reason: \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -31,13 +31,17 @@ public class SubqueryTest extends PlanTestBase {
     public void testCorrelatedSubqueryWithEqualsExpressions() throws Exception {
         String sql = "select t0.v1 from t0 where (t0.v2 in (select t1.v4 from t1 where t0.v3 + t1.v5 = 1)) is NULL";
         String plan = getFragmentPlan(sql);
-        Assertions.assertTrue(plan.contains("  15:NESTLOOP JOIN\n" +
+        Assertions.assertTrue(plan.contains("15:NESTLOOP JOIN\n" +
                 "  |  join op: INNER JOIN\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  other join predicates: 3: v3 + 11: v5 = 1, if(((2: v2 IS NULL) AND " +
-                "(NOT ((12: countRows IS NULL) OR (12: countRows = 0)))) OR " +
-                "((13: countNotNulls < 12: countRows) AND (((NOT ((12: countRows IS NULL) OR " +
-                "(12: countRows = 0))) AND (2: v2 IS NOT NULL)) AND (8: v4 IS NULL))), TRUE, FALSE)"), plan);
+                "  |  other predicates: 3: v3 + 11: v5 = 1, if(((2: v2 IS NULL) AND (17: expr)) " +
+                "OR ((13: countNotNulls < 12: countRows) AND (((17: expr) AND (2: v2 IS NOT NULL)) " +
+                "AND (8: v4 IS NULL))), TRUE, FALSE)\n" +
+                "  |    common sub expr:\n" +
+                "  |    <slot 16> : (14: expr) OR (15: expr)\n" +
+                "  |    <slot 17> : NOT (16: expr)\n" +
+                "  |    <slot 14> : 12: countRows IS NULL\n" +
+                "  |    <slot 15> : 12: countRows = 0"), plan);
         assertContains(plan, "8:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
                 "  |  colocate: false, reason: \n" +

--- a/fe/fe-core/src/test/resources/sql/subquery/scalar-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/scalar-subquery.sql
@@ -658,7 +658,7 @@ LEFT OUTER JOIN (join-predicate [add(add(1: v1, 4: v4), 9: v9) = if(23: expr, 1,
 [sql]
 select t0.v1, t1.v4, t2.v7 from t0 left join t1 on t0.v1 = t1.v4 left join t2 on t0.v2 = t2.v8 where t1.v5 = (select max(t1d - 1) from test_all_type where t0.v1 + t1.v4 + t2.v9 = case when t1c + t1.v5 = 1 then 1 else t0.v1 + t1.v4 + t2.v9 end);
 [result]
-INNER JOIN (join-predicate [5: v5 = 21: max AND add(add(1: v1, 4: v4), 9: v9) = if(add(23: cast, 5: v5) = 1, 1, add(add(1: v1, 4: v4), 9: v9))] post-join-predicate [null])
+INNER JOIN (join-predicate [5: v5 = 21: max] post-join-predicate [25: add = if(add(23: cast, 5: v5) = 1, 1, 25: add)])
     LEFT OUTER JOIN (join-predicate [2: v2 = 8: v8] post-join-predicate [null])
         INNER JOIN (join-predicate [1: v1 = 4: v4] post-join-predicate [null])
             SCAN (columns[1: v1, 2: v2] predicate[1: v1 IS NOT NULL])

--- a/test/sql/test_join/R/test_predicate_expr_reuse
+++ b/test/sql/test_join/R/test_predicate_expr_reuse
@@ -133,3 +133,25 @@ WHERE (t0.v1 + t1.v4) * 2 = (t0.v2 + t1.v5) * 2
 -- result:
 0
 -- !result
+SELECT COUNT(*) FROM t0 JOIN t1 ON t0.v1 = t1.v4  WHERE abs(t0.v1 + t1.v4) = abs(t0.v2 + t1.v5) AND abs(t0.v1 + t1.v4) > 5;
+-- result:
+0
+-- !result
+SELECT COUNT(*) FROM t0 JOIN t1 ON t0.v1 = t1.v4 and abs(t0.v1 + t1.v4) = abs(t0.v2 + t1.v5) AND abs(t0.v1 + t1.v4) > 5;
+-- result:
+0
+-- !result
+SELECT COUNT(*) FROM t0 JOIN t1 WHERE abs(t0.v1 + t1.v4) = abs(t0.v2 + t1.v5) AND abs(t0.v1 + t1.v4) > 5;
+-- result:
+0
+-- !result
+SELECT COUNT(*), abs(t0.v1) FROM t0 LEFT SEMI JOIN t1 ON t0.v1 = t1.v4 where abs(t0.v1) + abs(t0.v2) > 10 AND abs(t0.v1) + abs(t0.v2) < 100 AND abs(t0.v1) > 5 group by abs(t0.v1);
+-- result:
+1	6
+1	7
+1	8
+1	9
+-- !result
+SELECT COUNT(*), abs(t0.v1) FROM t0 LEFT ANTI JOIN t1 ON t0.v1 = t1.v4 where abs(t0.v1) + abs(t0.v2) > 10 AND abs(t0.v1) + abs(t0.v2) < 100 AND abs(t0.v1) > 5 group by abs(t0.v1);
+-- result:
+-- !result

--- a/test/sql/test_join/T/test_predicate_expr_reuse
+++ b/test/sql/test_join/T/test_predicate_expr_reuse
@@ -104,3 +104,16 @@ SELECT COUNT(*) FROM t0 RIGHT JOIN t1 ON t0.v1 = t1.v4
 WHERE (t0.v1 + t1.v4) * 2 = (t0.v2 + t1.v5) * 2 
   AND (t0.v1 + t1.v4) * 2 > 10 
   AND (t0.v1 + t1.v4) * 2 < 100;
+
+-- inner join
+SELECT COUNT(*) FROM t0 JOIN t1 ON t0.v1 = t1.v4  WHERE abs(t0.v1 + t1.v4) = abs(t0.v2 + t1.v5) AND abs(t0.v1 + t1.v4) > 5;
+SELECT COUNT(*) FROM t0 JOIN t1 ON t0.v1 = t1.v4 and abs(t0.v1 + t1.v4) = abs(t0.v2 + t1.v5) AND abs(t0.v1 + t1.v4) > 5;
+
+-- cross join
+SELECT COUNT(*) FROM t0 JOIN t1 WHERE abs(t0.v1 + t1.v4) = abs(t0.v2 + t1.v5) AND abs(t0.v1 + t1.v4) > 5;
+
+-- semi join
+SELECT COUNT(*), abs(t0.v1) FROM t0 LEFT SEMI JOIN t1 ON t0.v1 = t1.v4 where abs(t0.v1) + abs(t0.v2) > 10 AND abs(t0.v1) + abs(t0.v2) < 100 AND abs(t0.v1) > 5 group by abs(t0.v1);
+
+-- anti join
+SELECT COUNT(*), abs(t0.v1) FROM t0 LEFT ANTI JOIN t1 ON t0.v1 = t1.v4 where abs(t0.v1) + abs(t0.v2) > 10 AND abs(t0.v1) + abs(t0.v2) < 100 AND abs(t0.v1) > 5 group by abs(t0.v1);


### PR DESCRIPTION
## Why I'm doing:

InnerJoin's predicate is null, and its predicate is all in on-predicates, which causes its predicates to not be able to be used for `ScalarOperatorsReuseRule`.

## What I'm doing:
- Support to reuse `otherJoinPredicates` (not equal predicates) when there are common expressions; If there are no common expressions, the joins on predicates are not changed.

Why not handle join's on predicates to resue common epressions？
- In BE, join's on predicates are evaluated separately from where predicates, so we cannot generate one common expressions with on predicates and wehre predicates.
- But for inner join, it's safe to treat some on predicates with where predicates so can be used for common expressions.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves predicate CSE and join predicate handling across FE and BE.
> 
> - **Optimizer:** Add `JoinHelper.splitJoinOnPredicate` and `canTreatOnPredicateAsPredicate` to split `ON` into equi vs residual (and ASOF temporal) predicates; allow `PhysicalJoinOperator.setOnPredicate`; make `Utils.compoundAnd` generic-friendly
> - **Expr reuse:** Update `ScalarOperatorsReuseRule` to rewrite join residual predicates for inner `HashJoin` and `NestLoopJoin`, moving residuals to `predicate` with common-subexprs and keeping equi-keys in `onPredicate`
> - **Planning:** `PlanFragmentBuilder` now uses `JoinHelper` for eq/other/asof predicates and removes duplicate ASOF helpers
> - **BE (NLJ):** Factor `_eval_conjuncts` and use it consistently in probe/right-join paths
> - **Tests:** Add/adjust unit and SQL tests covering inner/cross/semi/anti joins and subqueries with predicate expr reuse
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7cbf817b2cf1c407491c8adfaecb5d73ecf1ef67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->