### PR TITLE
[BugFix] Fix the wrong access path after column rename

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/EliminateOveruseColumnAccessPathRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/EliminateOveruseColumnAccessPathRule.java
@@ -110,7 +110,7 @@ public class EliminateOveruseColumnAccessPathRule implements TreeRewriteRule {
 
             Map<String, ColumnRefOperator> columnNameToIdMap = scan.getColRefToColumnMetaMap().entrySet()
                     .stream()
-                    .collect(Collectors.toMap(e -> e.getValue().getName(), Map.Entry::getKey));
+                    .collect(Collectors.toMap(e -> e.getValue().getColumnId().getId(), Map.Entry::getKey));
 
             Predicate<ColumnAccessPath> isOveruseProjecting = accessPath ->
                     columnNameToIdMap.containsKey(accessPath.getPath()) &&

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -464,9 +464,9 @@ public class JsonPathRewriteRule extends TransformationRule {
                     "ColumnRefOperator %s must be attached to a table when creating column access expression",
                     jsonColumn);
 
-            // Build full path: columnName.field1.field2
+            // Build full path: columnId.field1.field2
             List<String> fullPath = Lists.newArrayList();
-            fullPath.add(tableAndColumn.second.getName());
+            fullPath.add(tableAndColumn.second.getColumnId().getId());
             fullPath.addAll(fields);
 
             ColumnAccessPath accessPath = ColumnAccessPath.createLinearPath(fullPath, resultType);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -1091,9 +1091,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
     // complex type may be support prune subfield, doesn't read data
     private boolean checkComplexTypeInvalid(PhysicalOlapScanOperator scan, ColumnRefOperator column) {
-        String colName = scan.getColRefToColumnMetaMap().get(column).getName();
+        String colId = scan.getColRefToColumnMetaMap().get(column).getColumnId().getId();
         for (ColumnAccessPath path : scan.getColumnAccessPaths()) {
-            if (!StringUtils.equalsIgnoreCase(colName, path.getPath()) || path.getType() != TAccessPathType.ROOT) {
+            if (!StringUtils.equalsIgnoreCase(colId, path.getPath()) || path.getType() != TAccessPathType.ROOT) {
                 continue;
             }
             // check the read path
@@ -1111,10 +1111,10 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         if (!sessionVariable.isEnableJSONV2DictOpt()) {
             return false;
         }
-        String colName = scan.getColRefToColumnMetaMap().get(column).getName();
+        String colId = scan.getColRefToColumnMetaMap().get(column).getColumnId().getId();
         for (ColumnAccessPath path : scan.getColumnAccessPaths()) {
             if (path.isExtended() &&
-                    path.getLinearPath().equals(colName) &&
+                    path.getLinearPath().equals(colId) &&
                     path.getType() == TAccessPathType.ROOT &&
                     path.getValueType().isStringType()) {
                 return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
@@ -116,7 +116,7 @@ public class PruneSubfieldRule extends TransformationRule {
             if (!normalizer.hasPath(ref)) {
                 continue;
             }
-            String columnName = scan.getColRefToColumnMetaMap().get(ref).getName();
+            String columnName = scan.getColRefToColumnMetaMap().get(ref).getColumnId().getId();
             ColumnAccessPath p = normalizer.normalizePath(ref, columnName);
 
             if (p.hasChildPath()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -893,7 +893,7 @@ public class PlanFragmentBuilder {
                 return scan.getColumnAccessPaths();
             }
 
-            Set<String> checkNames = scan.getColRefToColumnMetaMap().keySet().stream().map(ColumnRefOperator::getName)
+            Set<String> checkNames = scan.getColRefToColumnMetaMap().values().stream().map(col -> col.getColumnId().getId())
                     .collect(Collectors.toSet());
             if (scan.getPredicate() == null) {
                 // remove path which has pruned
@@ -915,7 +915,7 @@ public class PlanFragmentBuilder {
                     continue;
                 }
 
-                String name = scan.getColRefToColumnMetaMap().get(key).getName();
+                String name = scan.getColRefToColumnMetaMap().get(key).getColumnId().getId();
                 ColumnAccessPath path = normalizer.normalizePath(key, name);
                 if (path.onlyRoot()) {
                     continue;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/EliminateOveruseColumnAccessPathRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/EliminateOveruseColumnAccessPathRuleTest.java
@@ -1,0 +1,104 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnAccessPath;
+import com.starrocks.catalog.Table;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalProjectOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.thrift.TAccessPathType;
+import com.starrocks.type.InvalidType;
+import com.starrocks.type.TypeFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link EliminateOveruseColumnAccessPathRule}.
+ *
+ * These tests focus on the behavior when column name and ColumnId differ
+ * (e.g. after a column rename), to ensure that the rule matches access
+ * paths using ColumnId instead of the mutable column name.
+ */
+public class EliminateOveruseColumnAccessPathRuleTest {
+
+    @Test
+    public void testOveruseColumnAccessPathMatchedByColumnIdAfterRename() {
+        // Simulate a renamed column: ColumnId = "c", current name = "c_new"
+        ColumnRefOperator colRef = new ColumnRefOperator(1, TypeFactory.createVarcharType(10), "c_new", true);
+        Column columnMeta = new Column("c", TypeFactory.createVarcharType(10), true, "");
+        // Rename the column logically, ColumnId should remain "c"
+        columnMeta.setName("c_new");
+
+        Map<ColumnRefOperator, Column> colRefToMeta = Map.of(colRef, columnMeta);
+
+        // Minimal table stub, EliminateOveruseColumnAccessPathRule does not touch table metadata
+        Table table = new Table(Table.TableType.OLAP) { };
+        table.setId(1L);
+        table.setName("t");
+
+        PhysicalOlapScanOperator scan = new PhysicalOlapScanOperator(
+                table,
+                colRefToMeta,
+                null,
+                Operator.DEFAULT_LIMIT,
+                null,
+                0L,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                null,
+                false,
+                null);
+
+        // Build a subfield-pruning ColumnAccessPath for this columnId "c"
+        ColumnAccessPath rootPath = new ColumnAccessPath(
+                TAccessPathType.ROOT,
+                columnMeta.getColumnId().getId(),
+                InvalidType.INVALID);
+        ColumnAccessPath childField = new ColumnAccessPath(
+                TAccessPathType.FIELD,
+                "f",
+                InvalidType.INVALID);
+        rootPath.addChildPath(childField);
+        scan.setColumnAccessPaths(ImmutableList.of(rootPath));
+
+        // Parent project outputs the whole column, so the subfield path should be treated as "overuse"
+        Map<ColumnRefOperator, com.starrocks.sql.optimizer.operator.scalar.ScalarOperator> projectMap =
+                Map.of(colRef, colRef);
+        PhysicalProjectOperator project = new PhysicalProjectOperator(projectMap, Map.of());
+
+        OptExpression scanExpr = OptExpression.create(scan, List.of());
+        OptExpression root = OptExpression.create(project, List.of(scanExpr));
+
+        EliminateOveruseColumnAccessPathRule rule = new EliminateOveruseColumnAccessPathRule();
+        rule.rewrite(root, null);
+
+        // After the rule, the overused ColumnAccessPath for column "c" should be eliminated.
+        Assertions.assertTrue(
+                scan.getColumnAccessPaths().isEmpty(),
+                "Overused column access path should be eliminated when matching by ColumnId");
+    }
+}
+
+

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollectorTest.java
@@ -1,0 +1,98 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree.lowcardinality;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnAccessPath;
+import com.starrocks.catalog.Table;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.thrift.TAccessPathType;
+import com.starrocks.type.InvalidType;
+import com.starrocks.type.TypeFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link DecodeCollector} focusing on ColumnId-based access path matching.
+ */
+public class DecodeCollectorTest {
+
+    @Test
+    public void testCheckComplexTypeInvalidUsesColumnIdForRenamedColumn() throws Exception {
+        SessionVariable session = new SessionVariable();
+        DecodeCollector collector = new DecodeCollector(session, true);
+
+        // Simulate a renamed complex column: ColumnId = "j", current name = "j_new"
+        ColumnRefOperator colRef = new ColumnRefOperator(1, TypeFactory.createVarcharType(10), "j_new", true);
+        Column columnMeta = new Column("j", TypeFactory.createVarcharType(10), true, "");
+        // Rename the logical column name, ColumnId should remain "j"
+        columnMeta.setName("j_new");
+
+        Map<ColumnRefOperator, Column> colRefToMeta = Map.of(colRef, columnMeta);
+
+        // Minimal table stub, DecodeCollector does not depend on table metadata in this path
+        Table table = new Table(Table.TableType.OLAP) { };
+        table.setId(1L);
+        table.setName("t");
+
+        PhysicalOlapScanOperator scan = new PhysicalOlapScanOperator(
+                table,
+                colRefToMeta,
+                null,
+                Operator.DEFAULT_LIMIT,
+                null,
+                0L,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                null,
+                false,
+                null);
+
+        // Build a ColumnAccessPath whose root path is ColumnId "j" and children are all OFFSET,
+        // so checkComplexTypeInvalid should return false when matched correctly.
+        ColumnAccessPath root = new ColumnAccessPath(
+                TAccessPathType.ROOT,
+                columnMeta.getColumnId().getId(),
+                InvalidType.INVALID);
+        ColumnAccessPath offsetChild = new ColumnAccessPath(
+                TAccessPathType.OFFSET,
+                ColumnAccessPath.PATH_PLACEHOLDER,
+                InvalidType.INVALID);
+        root.addChildPath(offsetChild);
+        scan.setColumnAccessPaths(List.of(root));
+
+        Method method = DecodeCollector.class.getDeclaredMethod(
+                "checkComplexTypeInvalid",
+                com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator.class,
+                ColumnRefOperator.class);
+        method.setAccessible(true);
+        boolean valid = (boolean) method.invoke(collector, scan, colRef);
+
+        // When matching by ColumnId, the complex column should be considered invalid for dict optimization.
+        Assertions.assertFalse(valid,
+                "checkComplexTypeInvalid should return false for renamed complex column when matching by ColumnId");
+    }
+}
+
+

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
@@ -383,4 +383,31 @@ public class JsonPathRewriteTest extends PlanTestBase {
         starRocksAssert.dropMaterializedView("test_json_mv");
         starRocksAssert.dropTable("test_json_mv_base");
     }
+
+    /**
+     * Verify that JsonPathRewriteRule uses ColumnId rather than the mutable column name
+     * when constructing extended column access paths for JSON columns that have been renamed.
+     */
+    @Test
+    public void testJsonPathRewriteWithRenamedJsonColumn() throws Exception {
+        connectContext.getSessionVariable().setEnableJSONV2Rewrite(true);
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(false);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(false);
+
+        starRocksAssert.withTable(
+                "create table json_rename (\n" +
+                        "  id int,\n" +
+                        "  j json\n" +
+                        ") properties('replication_num'='1')");
+        try {
+            starRocksAssert.ddl("alter table json_rename rename column j to j_new");
+            String sql = "select get_json_string(j_new, 'f1') from json_rename";
+            String verbosePlan = getVerboseExplain(sql);
+            // The ExtendedColumnAccessPath should still be rooted at the original ColumnId "j"
+            assertContains(verbosePlan, "ExtendedColumnAccessPath: [/j(varchar)/f1(varchar)]");
+        } finally {
+            starRocksAssert.dropTable("json_rename");
+        }
+    }
 }
+

--- a/test/sql/test_column_rename/R/test_column_rename
+++ b/test/sql/test_column_rename/R/test_column_rename
@@ -339,4 +339,37 @@ SELECT a, e FROM t_rename_column_unused_output_column_name WHERE t_rename_column
 -- !result
 drop table t_rename_column_unused_output_column_name force;
 -- result:
+-- name: test_wrong_access_path_after_column_rename
+CREATE TABLE `t_wrong_access_path_after_column_rename` (
+  `k` STRING NOT NULL COMMENT "",
+  `v` int,
+  `JOB_NAME` array<Varchar(2)>,
+  `JOB_NAME_NEW` array<Varchar(2)>
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t_wrong_access_path_after_column_rename values (1,2,["aa", "bb"], null);
+-- result:
+-- !result
+alter table t_wrong_access_path_after_column_rename rename column JOB_NAME to JOB_NAME_OLD;
+-- result:
+-- !result
+alter table t_wrong_access_path_after_column_rename rename column JOB_NAME_NEW to JOB_NAME;
+-- result:
+-- !result
+select * from t_wrong_access_path_after_column_rename;
+-- result:
+1	2	["aa","bb"]	null
+-- !result
+select JOB_NAME_OLD from t_wrong_access_path_after_column_rename where JOB_NAME is NULL;
+-- result:
+["aa","bb"]
 -- !result

--- a/test/sql/test_column_rename/T/test_column_rename
+++ b/test/sql/test_column_rename/T/test_column_rename
@@ -140,3 +140,27 @@ insert into t_rename_column_unused_output_column_name values(2, 2, 2, 2, 2, ["1"
 SELECT a, e FROM t_rename_column_unused_output_column_name WHERE t_rename_column_unused_output_column_name.new_d IS NOT NULL LIMIT 9;
 
 drop table t_rename_column_unused_output_column_name force;
+
+-- name: test_wrong_access_path_after_column_rename
+CREATE TABLE `t_wrong_access_path_after_column_rename` (
+  `k` STRING NOT NULL COMMENT "",
+  `v` int,
+  `JOB_NAME` array<Varchar(2)>,
+  `JOB_NAME_NEW` array<Varchar(2)>
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+insert into t_wrong_access_path_after_column_rename values (1,2,["aa", "bb"], null);
+
+alter table t_wrong_access_path_after_column_rename rename column JOB_NAME to JOB_NAME_OLD;
+alter table t_wrong_access_path_after_column_rename rename column JOB_NAME_NEW to JOB_NAME;
+
+select * from t_wrong_access_path_after_column_rename;
+select JOB_NAME_OLD from t_wrong_access_path_after_column_rename where JOB_NAME is NULL;


### PR DESCRIPTION
## What I'm doing:
Currently, optimizer will generate the access path using column name but not ColumnId. After column rename, the column name will change, but the ColumnId will not change. When BE apply the access path, it always use the columnId to access the column, so the access path is wrong.

Fix this bug by using ColumnId to generate the access path.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3