### PR TITLE
[BugFix] Add min_readable_version to publish-version updates for queries after a replication transaction

### DIFF
--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -285,6 +285,9 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
                     auto& pair = tablet_versions.emplace_back();
                     pair.__set_tablet_id(tablet_info.tablet_id);
                     pair.__set_version(max_continuous_version);
+                    if (is_replication_txn) {
+                        pair.__set_min_readable_version(tablet->min_readable_version());
+                    }
                 }
 
                 if (enable_sync_publish && tablet_tasks.empty() && max_continuous_version < partition_version.version) {

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1097,6 +1097,15 @@ int64_t Tablet::max_readable_version() const {
     }
 }
 
+int64_t Tablet::min_readable_version() const {
+    if (_updates != nullptr) {
+        return _updates->min_readable_version();
+    } else {
+        std::shared_lock rdlock(_meta_lock);
+        return _timestamped_version_tracker.get_min_readable_version();
+    }
+}
+
 void Tablet::calculate_cumulative_point() {
     std::unique_lock wrlock(_meta_lock);
     if (_cumulative_point != kInvalidCumulativePoint) {

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -215,6 +215,7 @@ public:
     // Same as max_continuous_version_from_beginning, only return end version, using a more efficient implementation
     int64_t max_continuous_version() const;
     int64_t max_readable_version() const;
+    int64_t min_readable_version() const;
 
     int64_t last_cumu_compaction_failure_time() { return _last_cumu_compaction_failure_millis; }
     void set_last_cumu_compaction_failure_time(int64_t millis) { _last_cumu_compaction_failure_millis = millis; }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -504,6 +504,11 @@ int64_t TabletUpdates::max_version() const {
     return _edit_version_infos.empty() ? 0 : _edit_version_infos.back()->version.major_number();
 }
 
+int64_t TabletUpdates::min_readable_version() const {
+    std::lock_guard rl(_lock);
+    return _edit_version_infos.empty() ? 0 : _edit_version_infos.front()->version.major_number();
+}
+
 int64_t TabletUpdates::max_readable_version() const {
     std::lock_guard rl(_lock);
     return _edit_version_infos.empty() ? 0 : _edit_version_infos[_apply_version_idx]->version.major_number();

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -139,6 +139,7 @@ public:
 
     // get latest version's version
     int64_t max_version() const;
+    int64_t min_readable_version() const;
 
     int64_t max_readable_version() const;
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -880,6 +880,8 @@ void TabletUpdatesTest::test_remove_expired_versions(bool enable_persistent_inde
     ASSERT_TRUE(_tablet->rowset_commit(4, create_rowset(_tablet, keys)).ok());
     ASSERT_EQ(4, _tablet->updates()->version_history_count());
     ASSERT_EQ(4, _tablet->updates()->max_version());
+    ASSERT_EQ(1, _tablet->updates()->min_readable_version());
+    ASSERT_EQ(1, _tablet->min_readable_version());
 
     // Read from the latest version, this can ensure that all versions are applied.
     ASSERT_EQ(N, read_tablet(_tablet, 4));
@@ -902,6 +904,8 @@ void TabletUpdatesTest::test_remove_expired_versions(bool enable_persistent_inde
     _tablet->updates()->remove_expired_versions(time(nullptr));
     ASSERT_EQ(1, _tablet->updates()->version_history_count());
     ASSERT_EQ(4, _tablet->updates()->max_version());
+    ASSERT_EQ(4, _tablet->updates()->min_readable_version());
+    ASSERT_EQ(4, _tablet->min_readable_version());
 
     EXPECT_EQ(N, read_tablet(_tablet, 4));
     EXPECT_EQ(N, read_until_eof(iter_v4));

--- a/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
@@ -213,7 +213,10 @@ public class PublishVersionTask extends AgentTask {
                 if (replica == null) {
                     continue;
                 }
-                replica.updateVersion(tabletVersion.version);
+                long reportedVersion = tabletVersion.version;
+                long minReadableVersion = tabletVersion.isSetMin_readable_version() ?
+                        tabletVersion.getMin_readable_version() : replica.getMinReadableVersion();
+                replica.updateRowCount(reportedVersion, minReadableVersion, replica.getDataSize(), replica.getRowCount());
             }
         } finally {
             locker.unLockDatabase(db.getId(), LockType.WRITE);

--- a/fe/fe-core/src/test/java/com/starrocks/task/PublishVersionTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/PublishVersionTaskTest.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.task;
+
+import com.starrocks.catalog.GlobalStateMgrTestUtil;
+import com.starrocks.catalog.Replica;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TTabletVersionPair;
+import com.starrocks.transaction.TransactionType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+
+public class PublishVersionTaskTest {
+
+    @BeforeEach
+    public void setUp() throws InvocationTargetException, NoSuchMethodException, InstantiationException,
+            IllegalAccessException {
+        GlobalStateMgrTestUtil.createTestState();
+    }
+
+    @Test
+    public void testUpdateReplicaVersionsWithMinReadableVersion() {
+        long backendId = GlobalStateMgrTestUtil.testBackendId1;
+        long dbId = GlobalStateMgrTestUtil.testDbId1;
+        long tabletId = GlobalStateMgrTestUtil.testTabletId1;
+        long baseVersion = GlobalStateMgrTestUtil.testStartVersion;
+
+        Replica replica = GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getReplica(tabletId, backendId);
+        Assertions.assertNotNull(replica);
+        Assertions.assertEquals(baseVersion, replica.getVersion());
+        Assertions.assertEquals(0, replica.getMinReadableVersion());
+
+        PublishVersionTask task = new PublishVersionTask(backendId, 1L, 1L, dbId, 0L,
+                Collections.emptyList(), null, null, 0L, null, false, TransactionType.TXN_REPLICATION);
+
+        TTabletVersionPair tabletVersionPair = new TTabletVersionPair();
+        tabletVersionPair.setTablet_id(tabletId);
+        tabletVersionPair.setVersion(baseVersion + 5);
+        tabletVersionPair.setMin_readable_version(baseVersion + 3);
+
+        task.updateReplicaVersions(Collections.singletonList(tabletVersionPair));
+
+        Assertions.assertEquals(baseVersion + 3, replica.getMinReadableVersion());
+        Assertions.assertEquals(baseVersion + 5, replica.getVersion());
+    }
+}

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -71,6 +71,7 @@ struct TTabletInfo {
 struct TTabletVersionPair {
     1: optional Types.TTabletId tablet_id
     2: optional Types.TVersion version
+    3: optional Types.TVersion min_readable_version
 }
 
 struct TFinishTaskRequest {


### PR DESCRIPTION
## Why I'm doing:
In shared-nothing cluster, during full replication, publishing three replicas happens at different speeds. One fast replica has already been updated to the new version, while the two slower replicas haven't finished yet. At this point, the partition's visible version is still the old version. If a query arrives at this time, it might retrieve the old version. If the query reaches the replica that has already been updated to the new version, it may report a version not found error.

## What I'm doing:
  - Add min_readable_version to TTabletVersionPair and propagate it from BE to FE during replication publish.
  - Introduce Tablet::min_readable_version()/TabletUpdates::min_readable_version() and use it when reporting.
  - Update publish-version replica handling and adjust the unit test accordingly.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures FE replicas receive the earliest readable version during replication publish to avoid version gaps on queries.
> 
> - Extend thrift `TTabletVersionPair` with optional `min_readable_version`; BE sets it for replication in `publish_version.cpp`
> - Add `Tablet::min_readable_version()` and `TabletUpdates::min_readable_version()` and report via BE
> - FE `PublishVersionTask` consumes `min_readable_version` and updates replicas with `updateRowCount(...)`
> - Add/adjust unit tests in BE (`tablet_updates_test.cpp`) and FE (`PublishVersionTaskTest.java`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f03f995bcc40d1491bb172449000c597f054c40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->