### PR TITLE
[Enhancement] Add one config for hudi lib internal metadata table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4099,4 +4099,7 @@ public class Config extends ConfigBase {
     public static int compound_predicate_flatten_threshold = 512;
 
     @ConfField public static int ui_queries_sql_statement_max_length = 128;
+
+    @ConfField(mutable = true)
+    public static boolean enable_hudi_lib_internal_metadata_table = true;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.starrocks.common.Config;
 import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileIO;
 import com.starrocks.connector.RemoteFileScanContext;
@@ -67,7 +68,8 @@ public class HudiRemoteFileIO implements RemoteFileIO {
             ctx.usedCount++;
             if (ctx.usedCount == 1) {
                 HoodieLocalEngineContext engineContext = new HoodieLocalEngineContext(configuration);
-                HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder().enable(true).build();
+                HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
+                        .enable(Config.enable_hudi_lib_internal_metadata_table).build();
                 HoodieTableMetaClient metaClient =
                         HoodieTableMetaClient.builder().setConf(configuration).setBasePath(ctx.tableLocation).build();
                 // metaClient.reloadActiveTimeline();


### PR DESCRIPTION
## Why I'm doing:

In some user scenarios, after upgrading the Hudi library from version 0.15 to 1.0.2, enabling this Cache will lead to a significant increase in the ListFiles execution time. Disabling the Cache will restore the performance to normal levels. However, I was unable to reproduce this issue in the local environment. Therefore, we will first add a configuration to control the enabling/disabling of the Cache, which will be enabled by default. If similar issues are encountered, users can manually disable it. I will attempt to reproduce this issue in subsequent tests.

```
 at org.apache.hudi.common.table.log.AbstractHoodieLogRecordScanner.scanInternal(AbstractHoodieLogRecordScanner.java:252)
        - locked <0x000070a905f62d88> (a org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner)
        at org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner.performScan(HoodieMergedLogRecordScanner.java:207)
        at org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner.<init>(HoodieMergedLogRecordScanner.java:123)
        at org.apache.hudi.common.table.log.HoodieMergedLogRecordScanner$Builder.build(HoodieMergedLogRecordScanner.java:490)
        at org.apache.hudi.metadata.HoodieMetadataLogRecordReader$Builder.build(HoodieMetadataLogRecordReader.java:230)
        at org.apache.hudi.metadata.HoodieBackedTableMetadata.getLogRecordScanner(HoodieBackedTableMetadata.java:521)
        at org.apache.hudi.metadata.HoodieBackedTableMetadata.openReaders(HoodieBackedTableMetadata.java:446)
        at org.apache.hudi.metadata.HoodieBackedTableMetadata.getOrCreateReaders(HoodieBackedTableMetadata.java:431)
        at org.apache.hudi.metadata.HoodieBackedTableMetadata.lookupKeysFromFileSlice(HoodieBackedTableMetadata.java:308)
        at org.apache.hudi.metadata.HoodieBackedTableMetadata.getRecordsByKeys(HoodieBackedTableMetadata.java:268)
        at org.apache.hudi.metadata.HoodieBackedTableMetadata.getRecordByKey(HoodieBackedTableMetadata.java:158)
        at org.apache.hudi.metadata.BaseTableMetadata.fetchAllFilesInPartition(BaseTableMetadata.java:373)
        at org.apache.hudi.metadata.BaseTableMetadata.getAllFilesInPartition(BaseTableMetadata.java:144)
        at org.apache.hudi.common.table.view.AbstractTableFileSystemView.getAllFilesInPartition(AbstractTableFileSystemView.java:426)
        at org.apache.hudi.common.table.view.AbstractTableFileSystemView.lambda$ensurePartitionLoadedCorrectly$17(AbstractTableFileSystemView.java:449)
        at org.apache.hudi.common.table.view.AbstractTableFileSystemView$$Lambda$4592/0x000070a60c64c4b0.apply(Unknown Source)
        at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(java.base@11.0.29/ConcurrentHashMap.java:1705)
        - locked <0x000070a77a30eff8> (a java.util.concurrent.ConcurrentHashMap$ReservationNode)
        at org.apache.hudi.common.table.view.AbstractTableFileSystemView.ensurePartitionLoadedCorrectly(AbstractTableFileSystemView.java:443)
        at org.apache.hudi.common.table.view.AbstractTableFileSystemView.getLatestMergedFileSlicesBeforeOrOn(AbstractTableFileSystemView.java:1037)
        at com.starrocks.connector.hudi.HudiRemoteFileIO.getRemoteFiles(HudiRemoteFileIO.java:123)
        at com.starrocks.connector.CachingRemoteFileIO.loadRemoteFiles(CachingRemoteFileIO.java:95)
        at com.starrocks.connector.CachingRemoteFileIO$1.load(CachingRemoteFileIO.java:57)
        at com.starrocks.connector.CachingRemoteFileIO$1.load(CachingRemoteFileIO.java:54)
        at com.google.common.cache.CacheLoader$1.load(CacheLoader.java:192)
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3570)
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2312)
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2189)
        - locked <0x000070a77a30f150> (a com.google.common.cache.LocalCache$StrongAccessEntry)
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2079)
        at com.google.common.cache.LocalCache.get(LocalCache.java:4011)
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4034)
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:5010)
        at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:5017)
        at com.starrocks.connector.CachingRemoteFileIO.getRemoteFiles(CachingRemoteFileIO.java:86)
        at com.starrocks.connector.RemoteFileOperations.lambda$getRemoteFiles$0(RemoteFileOperations.java:113)
        at com.starrocks.connector.RemoteFileOperations$$Lambda$4509/0x000070a61bae3900.call(Unknown Source)
        at java.util.concurrent.FutureTask.run(java.base@11.0.29/FutureTask.java:264)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.29/ThreadPoolExecutor.java:1128)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.29/ThreadPoolExecutor.java:628)
        at java.lang.Thread.run(java.base@11.0.29/Thread.java:829)
```

## What I'm doing:

Add one config for hudi lib internal metadata table

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a config switch to control Hudi’s internal metadata table usage and applies it in the Hudi file reader.
> 
> - Introduces mutable `Config.enable_hudi_lib_internal_metadata_table` (default `true`)
> - `HudiRemoteFileIO` now sets `HoodieMetadataConfig` `.enable(...)` based on this config instead of hardcoding `true`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85d50ee1ed6f5f9d99a584d18fea765496337165. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->