### PR TITLE
[Doc] Fix typos, grammar, and improve SQL examples in Blacklist Management

### DIFF
--- a/docs/en/administration/management/resource_management/Blacklist.md
+++ b/docs/en/administration/management/resource_management/Blacklist.md
@@ -11,28 +11,28 @@ StarRocks allows users to add, view, and delete SQL blacklists.
 
 ## Syntax
 
-EnableSQL blacklisting via `enable_sql_blacklist`. The default is False (off).
+Enable SQL blacklisting via `enable_sql_blacklist`. The default is False (off).
 
 ~~~sql
-admin set frontend config ("enable_sql_blacklist" = "true")
+admin set frontend config ("enable_sql_blacklist" = "true");
 ~~~
 
 The admin user who has ADMIN_PRIV privileges can manage blacklists by executing the following commands:
 
 ~~~sql
-ADD SQLBLACKLIST "<sql>"
-DELETE SQLBLACKLIST <sql_index_number>
-SHOW SQLBLACKLIST
+ADD SQLBLACKLIST "<sql>";
+DELETE SQLBLACKLIST <sql_index_number>;
+SHOW SQLBLACKLIST;
 ~~~
 
-* When `enable_sql_blacklist` is true, every SQL query needs to be filtered by sqlblacklist. If it matches, the user will be informed that theSQL is in the blacklist. Otherwise, the SQL will be executed normally. The message may be as follows when the SQL is blacklisted:
+* When `enable_sql_blacklist` is true, every SQL query needs to be filtered by sqlblacklist. If it matches, the user will be informed that the SQL is in the blacklist. Otherwise, the SQL will be executed normally. The message may be as follows when the SQL is blacklisted:
 
 `ERROR 1064 (HY000): Access denied; sql 'select count (*) from test_all_type_select_2556' is in blacklist`
 
 ## Add blacklist
 
 ~~~sql
-ADD SQLBLACKLIST "<sql>"
+ADD SQLBLACKLIST "<sql>";
 ~~~
 
 **sql** is a regular expression for a certain type of SQL.
@@ -41,30 +41,30 @@ ADD SQLBLACKLIST "<sql>"
 Currently, StarRocks supports adding SELECT statements to the SQL Blacklist.
 :::
 
-Since SQL itself contains the common characters `(`, `)`, `*`, `.` that may be mixed up with the semantics of regular expressions, so we need to distinguish those by  using escape characters. Given that `(` and `)` are used too often in SQL, there is no need to use escape characters. Other special characters need to use the escape character `\` as a prefix. For example:
+Since SQL itself contains the common characters `(`, `)`, `*`, `.` that may be mixed up with the semantics of regular expressions, we need to distinguish those by using escape characters. Given that `(` and `)` are used too often in SQL, there is no need to use escape characters. Other special characters need to use the escape character `\` as a prefix. For example:
 
 * Prohibit `count(\*)`:
 
 ~~~sql
-ADD SQLBLACKLIST "select count(\\*) from .+"
+ADD SQLBLACKLIST "select count(\\*) from .+";
 ~~~
 
 * Prohibit `count(distinct)`:
 
 ~~~sql
-ADD SQLBLACKLIST "select count(distinct .+) from .+"
+ADD SQLBLACKLIST "select count(distinct .+) from .+";
 ~~~
 
 * Prohibit order by limit `x`, `y`, `1 <= x <=7`, `5 <=y <=7`:
 
 ~~~sql
-ADD SQLBLACKLIST "select id_int from test_all_type_select1 order by id_int limit [1-7], [5-7]"
+ADD SQLBLACKLIST "select id_int from test_all_type_select1 order by id_int limit [1-7], [5-7]";
 ~~~
 
 * Prohibit complex SQL:
 
 ~~~sql
-ADD SQLBLACKLIST "select id_int \\* 4, id_tinyint, id_varchar from test_all_type_nullable except select id_int, id_tinyint, id_varchar from test_basic except select (id_int \\* 9 \\- 8) \\/ 2, id_tinyint, id_varchar from test_all_type_nullable2 except select id_int, id_tinyint, id_varchar from test_basic_nullable"
+ADD SQLBLACKLIST "select id_int \\* 4, id_tinyint, id_varchar from test_all_type_nullable except select id_int, id_tinyint, id_varchar from test_basic except select (id_int \\* 9 \\- 8) \\/ 2, id_tinyint, id_varchar from test_all_type_nullable2 except select id_int, id_tinyint, id_varchar from test_basic_nullable";
 ~~~
 
 * Prohibit all INSERT INTO statements:
@@ -88,7 +88,7 @@ ADD SQLBLACKLIST "(?i)^insert\\s+into\\s+(?!column_statistics\\b).*values\\s*\\(
 ## View blacklist
 
 ~~~sql
-SHOW SQLBLACKLIST
+SHOW SQLBLACKLIST;
 ~~~
 
 Result format: `Index | Forbidden SQL`
@@ -113,7 +113,7 @@ The SQL shown in `Forbidden SQL` is escaped for all SQL semantic characters.
 ## Delete blacklist
 
 ~~~sql
-DELETE SQLBLACKLIST <sql_index_number>
+DELETE SQLBLACKLIST <sql_index_number>;
 ~~~
 
 `<sql_index_number>` is a list of SQL IDs separated by comma (,).
@@ -121,7 +121,7 @@ DELETE SQLBLACKLIST <sql_index_number>
 For example, delete the No.3 and No.4 SQLs in the above blacklist:
 
 ~~~sql
-delete sqlblacklist  3, 4;
+delete sqlblacklist 3, 4;
 ~~~
 
 Then, the remaining sqlblacklist is as follows:

--- a/docs/ja/administration/management/resource_management/Blacklist.md
+++ b/docs/ja/administration/management/resource_management/Blacklist.md
@@ -14,15 +14,15 @@ StarRocksは、ユーザーがSQLブラックリストを追加、表示、削�
 `enable_sql_blacklist` を使用してSQLブラックリストを有効にします。デフォルトはFalse（オフ）です。
 
 ~~~sql
-admin set frontend config ("enable_sql_blacklist" = "true")
+admin set frontend config ("enable_sql_blacklist" = "true");
 ~~~
 
 ADMIN_PRIV権限を持つ管理者ユーザーは、次のコマンドを実行してブラックリストを管理できます。
 
 ~~~sql
-ADD SQLBLACKLIST "<sql>"
-DELETE SQLBLACKLIST <sql_index_number>
-SHOW SQLBLACKLIST
+ADD SQLBLACKLIST "<sql>";
+DELETE SQLBLACKLIST <sql_index_number>;
+SHOW SQLBLACKLIST;
 ~~~
 
 * `enable_sql_blacklist` がtrueの場合、すべてのSQLクエリはsqlblacklistによってフィルタリングされる必要があります。一致する場合、ユーザーはそのSQLがブラックリストにあることを通知されます。それ以外の場合、SQLは通常通り実行されます。SQLがブラックリストにある場合、メッセージは次のようになります。
@@ -32,7 +32,7 @@ SHOW SQLBLACKLIST
 ## ブラックリストの追加
 
 ~~~sql
-ADD SQLBLACKLIST "<sql>"
+ADD SQLBLACKLIST "<sql>";
 ~~~
 
 **sql** は特定のタイプのSQLに対する正規表現です。
@@ -46,25 +46,25 @@ SQL自体には、正規表現のセマンティクスと混同される可能�
 * `count(\*)` を禁止する：
 
 ~~~sql
-ADD SQLBLACKLIST "select count(\\*) from .+"
+ADD SQLBLACKLIST "select count(\\*) from .+";
 ~~~
 
 * `count(distinct)` を禁止する：
 
 ~~~sql
-ADD SQLBLACKLIST "select count(distinct .+) from .+"
+ADD SQLBLACKLIST "select count(distinct .+) from .+";
 ~~~
 
 * order by limit `x`, `y`, `1 <= x <=7`, `5 <=y <=7` を禁止する：
 
 ~~~sql
-ADD SQLBLACKLIST "select id_int from test_all_type_select1 order by id_int limit [1-7], [5-7]"
+ADD SQLBLACKLIST "select id_int from test_all_type_select1 order by id_int limit [1-7], [5-7]";
 ~~~
 
 * 複雑なSQLを禁止する：
 
 ~~~sql
-ADD SQLBLACKLIST "select id_int \\* 4, id_tinyint, id_varchar from test_all_type_nullable except select id_int, id_tinyint, id_varchar from test_basic except select (id_int \\* 9 \\- 8) \\/ 2, id_tinyint, id_varchar from test_all_type_nullable2 except select id_int, id_tinyint, id_varchar from test_basic_nullable"
+ADD SQLBLACKLIST "select id_int \\* 4, id_tinyint, id_varchar from test_all_type_nullable except select id_int, id_tinyint, id_varchar from test_basic except select (id_int \\* 9 \\- 8) \\/ 2, id_tinyint, id_varchar from test_all_type_nullable2 except select id_int, id_tinyint, id_varchar from test_basic_nullable";
 ~~~
 
 * すべての INSERT INTO ステートメントを禁止する:
@@ -88,7 +88,7 @@ ADD SQLBLACKLIST "(?i)^insert\\s+into\\s+(?!column_statistics\\b).*values\\s*\\(
 ## ブラックリストの表示
 
 ~~~sql
-SHOW SQLBLACKLIST
+SHOW SQLBLACKLIST;
 ~~~
 
 結果形式：`Index | Forbidden SQL`
@@ -113,7 +113,7 @@ mysql> show sqlblacklist;
 ## ブラックリストの削除
 
 ~~~sql
-DELETE SQLBLACKLIST <sql_index_number>
+DELETE SQLBLACKLIST <sql_index_number>;
 ~~~
 
 `<sql_index_number>` はカンマ（,）で区切られたSQL IDのリストです。
@@ -121,7 +121,7 @@ DELETE SQLBLACKLIST <sql_index_number>
 例えば、上記のブラックリストのNo.3とNo.4のSQLを削除します：
 
 ~~~sql
-delete sqlblacklist  3, 4;
+delete sqlblacklist 3, 4;
 ~~~
 
 その後、残りのsqlblacklistは次のようになります：


### PR DESCRIPTION
## Why I'm doing:
I noticed a few typos (e.g., "EnableSQL", "theSQL") and grammatical issues in the Blacklist Management documentation. Additionally, the SQL examples lacked semicolons, making them harder to copy-paste and run directly.

## What I'm doing:
I have updated the English and Japanese documentation files (`docs/en` and `docs/ja`):

1. **Fixed Typos:**
   - Changed "EnableSQL" to "Enable SQL".
   - Changed "theSQL" to "the SQL".

2. **Code Usability:**
   - Added semicolons (`;`) to the end of SQL statements in the examples so users can execute them immediately.
   - Fixed spacing in the `DELETE` command example.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3