### PR TITLE
Transform expr shuffle

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorSinkShuffleMode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorSinkShuffleMode.java
@@ -1,0 +1,48 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public enum ConnectorSinkShuffleMode {
+    FORCE("force"),
+    AUTO("auto"),
+    NEVER("never");
+
+    private final String modeName;
+
+    ConnectorSinkShuffleMode(String modeName) {
+        this.modeName = modeName;
+    }
+
+    public static ConnectorSinkShuffleMode fromName(String modeName) {
+        checkArgument(modeName != null, "Connector sink shuffle mode name is null");
+
+        if (FORCE.modeName().equalsIgnoreCase(modeName)) {
+            return FORCE;
+        } else if (AUTO.modeName().equalsIgnoreCase(modeName)) {
+            return AUTO;
+        } else if (NEVER.modeName().equalsIgnoreCase(modeName)) {
+            return NEVER;
+        } else {
+            throw new IllegalArgumentException(
+                    "Unknown connector sink shuffle mode: " + modeName + ", only support force, auto, and never");
+        }
+    }
+
+    public String modeName() {
+        return modeName;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -53,6 +53,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.connector.ConnectorSinkShuffleMode;
 import com.starrocks.connector.PlanMode;
 import com.starrocks.datacache.DataCachePopulateMode;
 import com.starrocks.monitor.unit.TimeValue;
@@ -549,24 +550,26 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // when writing to fewer partitions. Therefore, we introduce a new invisible session variable with a default
     // false value temporarily. Once we can handle the shuffle behavior automatically to avoid some bad cases,
     // We will make it be controlled by the common connector session.
+    // Deprecated: Use connector_sink_shuffle_mode instead
     public static final String ENABLE_ICEBERG_SINK_GLOBAL_SHUFFLE = "enable_iceberg_sink_global_shuffle";
 
-    // Enable adaptive global shuffle for Iceberg table sink based on partition count and backend count.
-    // When enabled, the system will automatically decide whether to use global shuffle based on:
-    // 1. The estimated number of partitions being written
-    // 2. The number of available backends
-    // This allows automatic optimization without manual configuration.
-    public static final String ENABLE_ICEBERG_SINK_ADAPTIVE_SHUFFLE = "enable_iceberg_sink_adaptive_shuffle";
+    // Control global shuffle mode for connector table sink (Iceberg, Hive, File, etc.)
+    // Supports three modes:
+    // - force: Always enable global shuffle
+    // - auto: Automatically decide based on partition count and backend count (adaptive)
+    // - never: Never enable global shuffle
+    // Default is "auto" for adaptive optimization.
+    public static final String CONNECTOR_SINK_SHUFFLE_MODE = "connector_sink_shuffle_mode";
 
     // The absolute threshold of partition count to enable adaptive global shuffle.
     // When the estimated partition count is >= this value, adaptive shuffle will be enabled.
-    // Default is 100 partitions.
-    public static final String ICEBERG_SINK_SHUFFLE_PARTITION_THRESHOLD = "iceberg_sink_shuffle_partition_threshold";
+    // Default is 500 partitions.
+    public static final String CONNECTOR_SINK_SHUFFLE_PARTITION_THRESHOLD = "connector_sink_shuffle_partition_threshold";
 
     // The ratio of partition count to backend count to enable adaptive global shuffle.
     // When estimated partition count >= backend count * this ratio, adaptive shuffle will be enabled.
     // Default is 2.0 (i.e., enable shuffle when partitions >= backends * 2).
-    public static final String ICEBERG_SINK_SHUFFLE_PARTITION_NODE_RATIO = "iceberg_sink_shuffle_partition_node_ratio";
+    public static final String CONNECTOR_SINK_SHUFFLE_PARTITION_NODE_RATIO = "connector_sink_shuffle_partition_node_ratio";
 
     public static final String ENABLE_CONNECTOR_SINK_SPILL = "enable_connector_sink_spill";
     public static final String CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD = "connector_sink_spill_mem_limit_threshold";
@@ -1441,17 +1444,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkGlobalShuffle = true;
 
-    @VariableMgr.VarAttr(name = ENABLE_ICEBERG_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE)
-    private boolean enableIcebergSinkGlobalShuffle = false;
+    @VariableMgr.VarAttr(name = CONNECTOR_SINK_SHUFFLE_MODE)
+    private String connectorSinkShuffleMode = ConnectorSinkShuffleMode.AUTO.modeName();
 
-    @VariableMgr.VarAttr(name = ENABLE_ICEBERG_SINK_ADAPTIVE_SHUFFLE, flag = VariableMgr.INVISIBLE)
-    private boolean enableIcebergSinkAdaptiveShuffle = true;
+    @VariableMgr.VarAttr(name = CONNECTOR_SINK_SHUFFLE_PARTITION_THRESHOLD, flag = VariableMgr.INVISIBLE)
+    private long connectorSinkShufflePartitionThreshold = 500;
 
-    @VariableMgr.VarAttr(name = ICEBERG_SINK_SHUFFLE_PARTITION_THRESHOLD, flag = VariableMgr.INVISIBLE)
-    private long icebergSinkShufflePartitionThreshold = 100;
-
-    @VariableMgr.VarAttr(name = ICEBERG_SINK_SHUFFLE_PARTITION_NODE_RATIO, flag = VariableMgr.INVISIBLE)
-    private double icebergSinkShufflePartitionNodeRatio = 2.0;
+    @VariableMgr.VarAttr(name = CONNECTOR_SINK_SHUFFLE_PARTITION_NODE_RATIO, flag = VariableMgr.INVISIBLE)
+    private double connectorSinkShufflePartitionNodeRatio = 2.0;
 
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_SPILL, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkSpill = true;
@@ -4262,20 +4262,16 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableConnectorSinkGlobalShuffle;
     }
 
-    public boolean isEnableIcebergSinkGlobalShuffle() {
-        return enableIcebergSinkGlobalShuffle;
+    public ConnectorSinkShuffleMode getConnectorSinkShuffleMode() {
+        return ConnectorSinkShuffleMode.fromName(this.connectorSinkShuffleMode);
     }
 
-    public boolean isEnableIcebergSinkAdaptiveShuffle() {
-        return enableIcebergSinkAdaptiveShuffle;
+    public long getConnectorSinkShufflePartitionThreshold() {
+        return connectorSinkShufflePartitionThreshold;
     }
 
-    public long getIcebergSinkShufflePartitionThreshold() {
-        return icebergSinkShufflePartitionThreshold;
-    }
-
-    public double getIcebergSinkShufflePartitionNodeRatio() {
-        return icebergSinkShufflePartitionNodeRatio;
+    public double getConnectorSinkShufflePartitionNodeRatio() {
+        return connectorSinkShufflePartitionNodeRatio;
     }
 
     public boolean isEnableConnectorSinkSpill() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -551,6 +551,23 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // We will make it be controlled by the common connector session.
     public static final String ENABLE_ICEBERG_SINK_GLOBAL_SHUFFLE = "enable_iceberg_sink_global_shuffle";
 
+    // Enable adaptive global shuffle for Iceberg table sink based on partition count and backend count.
+    // When enabled, the system will automatically decide whether to use global shuffle based on:
+    // 1. The estimated number of partitions being written
+    // 2. The number of available backends
+    // This allows automatic optimization without manual configuration.
+    public static final String ENABLE_ICEBERG_SINK_ADAPTIVE_SHUFFLE = "enable_iceberg_sink_adaptive_shuffle";
+
+    // The absolute threshold of partition count to enable adaptive global shuffle.
+    // When the estimated partition count is >= this value, adaptive shuffle will be enabled.
+    // Default is 100 partitions.
+    public static final String ICEBERG_SINK_SHUFFLE_PARTITION_THRESHOLD = "iceberg_sink_shuffle_partition_threshold";
+
+    // The ratio of partition count to backend count to enable adaptive global shuffle.
+    // When estimated partition count >= backend count * this ratio, adaptive shuffle will be enabled.
+    // Default is 2.0 (i.e., enable shuffle when partitions >= backends * 2).
+    public static final String ICEBERG_SINK_SHUFFLE_PARTITION_NODE_RATIO = "iceberg_sink_shuffle_partition_node_ratio";
+
     public static final String ENABLE_CONNECTOR_SINK_SPILL = "enable_connector_sink_spill";
     public static final String CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD = "connector_sink_spill_mem_limit_threshold";
     public static final String PIPELINE_SINK_DOP = "pipeline_sink_dop";
@@ -1426,6 +1443,16 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_ICEBERG_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean enableIcebergSinkGlobalShuffle = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_ICEBERG_SINK_ADAPTIVE_SHUFFLE, flag = VariableMgr.INVISIBLE)
+    private boolean enableIcebergSinkAdaptiveShuffle = true;
+
+    @VariableMgr.VarAttr(name = ICEBERG_SINK_SHUFFLE_PARTITION_THRESHOLD, flag = VariableMgr.INVISIBLE)
+    private long icebergSinkShufflePartitionThreshold = 100;
+
+    @VariableMgr.VarAttr(name = ICEBERG_SINK_SHUFFLE_PARTITION_NODE_RATIO, flag = VariableMgr.INVISIBLE)
+    private double icebergSinkShufflePartitionNodeRatio = 2.0;
+
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_SPILL, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkSpill = true;
 
@@ -4237,6 +4264,18 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableIcebergSinkGlobalShuffle() {
         return enableIcebergSinkGlobalShuffle;
+    }
+
+    public boolean isEnableIcebergSinkAdaptiveShuffle() {
+        return enableIcebergSinkAdaptiveShuffle;
+    }
+
+    public long getIcebergSinkShufflePartitionThreshold() {
+        return icebergSinkShufflePartitionThreshold;
+    }
+
+    public double getIcebergSinkShufflePartitionNodeRatio() {
+        return icebergSinkShufflePartitionNodeRatio;
     }
 
     public boolean isEnableConnectorSinkSpill() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -1234,7 +1234,6 @@ public class InsertPlanner {
         }
 
         // When partition metadata is unavailable (empty list or exception), fall back to statistics
-        // This is useful for new tables or when metadata cannot be accessed
         long statsEstimate = estimatePartitionCountFromStatistics(icebergTable, partitionNdv);
         if (statsEstimate > 0) {
             // Cap the statistics-based estimate to avoid overly aggressive partition counts

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -28,6 +28,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.ParseUtil;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.connector.ConnectorSinkShuffleMode;
 import com.starrocks.connector.PlanMode;
 import com.starrocks.datacache.DataCachePopulateMode;
 import com.starrocks.monitor.unit.TimeValue;
@@ -345,6 +346,11 @@ public class SetStmtAnalyzer {
         // check populate datacache mode
         if (variable.equalsIgnoreCase(SessionVariable.POPULATE_DATACACHE_MODE)) {
             DataCachePopulateMode.fromName(resolvedExpression.getStringValue());
+        }
+
+        // check connector sink shuffle mode
+        if (variable.equalsIgnoreCase(SessionVariable.CONNECTOR_SINK_SHUFFLE_MODE)) {
+            ConnectorSinkShuffleMode.fromName(resolvedExpression.getStringValue());
         }
 
         // count_distinct_implementation

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1126,7 +1126,7 @@ public class PlanFragmentBuilder {
         }
 
         private void prepareContextSlots(PhysicalScanOperator node, ExecPlan context, TupleDescriptor tupleDescriptor) {
-            // set slot
+            // set slot for normal scan columns
             for (Map.Entry<ColumnRefOperator, Column> entry : node.getColRefToColumnMetaMap().entrySet()) {
                 SlotDescriptor slotDescriptor =
                         context.getDescTbl().addSlotDescriptor(tupleDescriptor, new SlotId(entry.getKey().getId()));
@@ -1140,6 +1140,57 @@ public class PlanFragmentBuilder {
                 }
                 context.getColRefToExpr().put(entry.getKey(), new SlotRef(entry.getKey().toString(), slotDescriptor));
             }
+
+            // Handle additional transform partition columns that were added by fillTransformPartitionColumns
+            // These columns are in context.getOutputColumns() but not in node.getColRefToColumnMetaMap()
+            Set<ColumnRefOperator> scanColumns = node.getColRefToColumnMetaMap().keySet();
+            for (ColumnRefOperator outputColumn : context.getOutputColumns()) {
+                if (!scanColumns.contains(outputColumn)) {
+                    // This is a generated column (e.g., transform partition column)
+                    // Get its expression from the physical plan's root project operator
+                    Map<ColumnRefOperator, ScalarOperator> projectOperatorMap = getProjectOperatorMap(context);
+                    if (projectOperatorMap != null && projectOperatorMap.containsKey(outputColumn)) {
+                        ScalarOperator expr = projectOperatorMap.get(outputColumn);
+                        // Build the expression and add to colRefToExpr
+                        Expr slotExpr = ScalarOperatorToExpr.buildExecExpression(expr,
+                                new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr(), projectOperatorMap));
+                        context.getColRefToExpr().put(outputColumn, slotExpr);
+
+                        // Also create slot descriptor for this column
+                        SlotDescriptor slotDescriptor =
+                                context.getDescTbl().addSlotDescriptor(tupleDescriptor, new SlotId(outputColumn.getId()));
+                        slotDescriptor.setIsNullable(expr.isNullable());
+                        slotDescriptor.setIsMaterialized(true);
+                        slotDescriptor.setIsOutputColumn(true);
+                        slotDescriptor.setType(expr.getType());
+                        if (expr.getType().isComplexType()) {
+                            slotDescriptor.setOriginType(outputColumn.getType());
+                            slotDescriptor.setType(outputColumn.getType());
+                        }
+                    }
+                }
+            }
+        }
+
+        /**
+         * Get the project operator map from the physical plan root if it's a PhysicalProjectOperator.
+         * This is used to find expressions for generated/transform columns.
+         */
+        private Map<ColumnRefOperator, ScalarOperator> getProjectOperatorMap(ExecPlan context) {
+            if (context.getPhysicalPlan() == null) {
+                return null;
+            }
+
+            Operator op = context.getPhysicalPlan().getOp();
+            if (op instanceof PhysicalProjectOperator) {
+                return ((PhysicalProjectOperator) op).getColumnRefMap();
+            }
+
+            if (op instanceof PhysicalScanOperator && ((PhysicalScanOperator) op).getProjection() != null) {
+                return ((PhysicalScanOperator) op).getProjection().getColumnRefMap();
+            }
+
+            return null;
         }
 
         private void prepareCommonExpr(HDFSScanNodePredicates scanNodePredicates,
@@ -2535,8 +2586,16 @@ public class PlanFragmentBuilder {
             ExchangeNode exchangeNode = new ExchangeNode(context.getNextNodeId(),
                     inputFragment.getPlanRoot(), distribution.getDistributionSpec().getType());
             currentExecGroup.add(exchangeNode, true);
+            Map<ColumnRefOperator, ScalarOperator> projectOperatorMap = null;
+            if (optExpr.inputAt(0).getOp() instanceof PhysicalProjectOperator) {
+                projectOperatorMap = ((PhysicalProjectOperator) optExpr.inputAt(0).getOp()).getColumnRefMap();
+            } else if (optExpr.inputAt(0).getOp() instanceof PhysicalScanOperator
+                    && ((PhysicalScanOperator) optExpr.inputAt(0).getOp()).getProjection() != null) {
+                projectOperatorMap = ((PhysicalScanOperator) optExpr.inputAt(0).getOp()).getProjection().getColumnRefMap();
+            }
+
             DataPartition dataPartition =
-                    translateDistributionToDataPartition(distribution.getDistributionSpec(), context);
+                    translateDistributionToDataPartition(distribution.getDistributionSpec(), context, projectOperatorMap);
             exchangeNode.setDataPartition(dataPartition);
 
             PlanFragment fragment =
@@ -4337,6 +4396,12 @@ public class PlanFragmentBuilder {
 
         private DataPartition translateDistributionToDataPartition(DistributionSpec distributionSpec,
                                                                    ExecPlan context) {
+            return translateDistributionToDataPartition(distributionSpec, context, null);
+        }
+
+        private DataPartition translateDistributionToDataPartition(DistributionSpec distributionSpec,
+                                                                   ExecPlan context,
+                                                                   Map<ColumnRefOperator, ScalarOperator> projectOperatorMap) {
             DataPartition dataPartition;
             if (DistributionSpec.DistributionType.GATHER.equals(distributionSpec.getType())) {
                 dataPartition = DataPartition.UNPARTITIONED;
@@ -4346,10 +4411,19 @@ public class PlanFragmentBuilder {
             } else if (DistributionSpec.DistributionType.SHUFFLE.equals(distributionSpec.getType())) {
                 List<ColumnRefOperator> partitionColumns =
                         getShuffleColumns((HashDistributionSpec) distributionSpec, columnRefFactory);
-                List<Expr> distributeExpressions =
-                        partitionColumns.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
-                                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))
-                                .collect(Collectors.toList());
+
+                // For Iceberg global shuffle on partition transform expressions, the shuffle keys may refer to
+                // generated/transform columns that are not materialized as SlotRef in colRefToExpr.
+                // Prefer the project map from the Distribution child (passed in), and fall back to the plan root.
+                Map<ColumnRefOperator, ScalarOperator> projectOperatorMapToUse =
+                        projectOperatorMap != null ? projectOperatorMap : getProjectOperatorMap(context);
+                ScalarOperatorToExpr.FormatterContext formatterContext = projectOperatorMapToUse == null ?
+                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr()) :
+                        new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr(), projectOperatorMapToUse);
+
+                List<Expr> distributeExpressions = partitionColumns.stream()
+                        .map(e -> ScalarOperatorToExpr.buildExecExpression(e, formatterContext))
+                        .collect(Collectors.toList());
                 dataPartition = DataPartition.hashPartitioned(distributeExpressions);
             } else if (DistributionSpec.DistributionType.ROUND_ROBIN.equals(
                     distributionSpec.getType())) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/InsertPlannerAdaptiveShuffleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/InsertPlannerAdaptiveShuffleTest.java
@@ -1,0 +1,359 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Type;
+import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.PartitionRef;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.ast.expression.CompoundPredicate;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.InPredicate;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import mockit.Deencapsulation;
+import mockit.Delegate;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for Iceberg adaptive global shuffle feature in InsertPlanner
+ */
+public class InsertPlannerAdaptiveShuffleTest {
+
+    private InsertPlanner insertPlanner;
+
+    @BeforeEach
+    public void setUp() {
+        insertPlanner = new InsertPlanner();
+    }
+
+    /**
+     * Test adaptive shuffle is enabled when partition count exceeds backend count * ratio
+     */
+    @Test
+    public void testAdaptiveShuffleEnabledByPartitionRatio(@Mocked GlobalStateMgr gsm,
+                                                            @Mocked MetadataMgr metadataMgr,
+                                                            @Mocked IcebergTable icebergTable,
+                                                            @Mocked InsertStmt insertStmt,
+                                                            @Mocked SessionVariable sessionVariable,
+                                                            @Mocked QueryStatement queryStatement,
+                                                            @Mocked SelectRelation selectRelation) {
+        // Setup: 10 backends, 50 partitions, ratio = 2.0
+        // Expected: 50 >= 10 * 2.0 = 20, so should enable shuffle
+        setupMockExpectations(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 10, 50, 100L, 2.0, false, null, null, false);
+
+        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                insertStmt, icebergTable, sessionVariable);
+        assertTrue(enabled);
+    }
+
+    /**
+     * Test adaptive shuffle is enabled when partition count exceeds absolute threshold
+     */
+    @Test
+    public void testAdaptiveShuffleEnabledByAbsoluteThreshold(@Mocked GlobalStateMgr gsm,
+                                                               @Mocked MetadataMgr metadataMgr,
+                                                               @Mocked IcebergTable icebergTable,
+                                                               @Mocked InsertStmt insertStmt,
+                                                               @Mocked SessionVariable sessionVariable,
+                                                               @Mocked QueryStatement queryStatement,
+                                                               @Mocked SelectRelation selectRelation) {
+        // Setup: 10 backends, 150 partitions, threshold = 100, ratio = 2.0
+        // Expected: 150 >= 100, so should enable shuffle
+        setupMockExpectations(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 10, 150, 100L, 2.0, false, null, null, false);
+
+        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                insertStmt, icebergTable, sessionVariable);
+        assertTrue(enabled);
+    }
+
+    /**
+     * Test adaptive shuffle is disabled when partition count is below both thresholds
+     */
+    @Test
+    public void testAdaptiveShuffleDisabledWhenPartitionsLow(@Mocked GlobalStateMgr gsm,
+                                                               @Mocked MetadataMgr metadataMgr,
+                                                               @Mocked IcebergTable icebergTable,
+                                                               @Mocked InsertStmt insertStmt,
+                                                               @Mocked SessionVariable sessionVariable,
+                                                               @Mocked QueryStatement queryStatement,
+                                                               @Mocked SelectRelation selectRelation) {
+        // Setup: 10 backends, 5 partitions, threshold = 100, ratio = 2.0
+        // Expected: 5 < 100 and 5 < 10 * 2.0 = 20, so should NOT enable shuffle
+        setupMockExpectations(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 10, 5, 100L, 2.0, false, null, null, false);
+
+        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                insertStmt, icebergTable, sessionVariable);
+        assertFalse(enabled);
+    }
+
+    /**
+     * Test static partition insert returns partition count of 1
+     */
+    @Test
+    public void testStaticPartitionInsert(@Mocked GlobalStateMgr gsm,
+                                          @Mocked MetadataMgr metadataMgr,
+                                          @Mocked IcebergTable icebergTable,
+                                          @Mocked InsertStmt insertStmt,
+                                          @Mocked SessionVariable sessionVariable,
+                                          @Mocked PartitionRef partitionRef,
+                                          @Mocked QueryStatement queryStatement,
+                                          @Mocked SelectRelation selectRelation) {
+        // Setup: static partition insert
+        setupMockExpectations(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 10, 100, 100L, 2.0, true, partitionRef, null, false);
+
+        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
+                insertStmt, icebergTable);
+        assertEquals(1L, partitionCount);
+    }
+
+    /**
+     * Test adaptive shuffle is disabled when no backends available
+     */
+    @Test
+    public void testAdaptiveShuffleDisabledWhenNoBackends(@Mocked GlobalStateMgr gsm,
+                                                           @Mocked MetadataMgr metadataMgr,
+                                                           @Mocked IcebergTable icebergTable,
+                                                           @Mocked InsertStmt insertStmt,
+                                                           @Mocked SessionVariable sessionVariable,
+                                                           @Mocked QueryStatement queryStatement,
+                                                           @Mocked SelectRelation selectRelation) {
+        // Setup: 0 backends
+        setupMockExpectations(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 0, 50, 100L, 2.0, false, null, null, false);
+
+        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                insertStmt, icebergTable, sessionVariable);
+        assertFalse(enabled);
+    }
+
+    /**
+     * Test behavior when partition list is empty
+     */
+    @Test
+    public void testEmptyPartitionList(@Mocked GlobalStateMgr gsm,
+                                       @Mocked MetadataMgr metadataMgr,
+                                       @Mocked IcebergTable icebergTable,
+                                       @Mocked InsertStmt insertStmt,
+                                       @Mocked SessionVariable sessionVariable) {
+        // Setup: empty partition list (should return MAX_VALUE to enable shuffle)
+        new Expectations() {{
+            GlobalStateMgr.getCurrentState();
+            result = gsm;
+            minTimes = 0;
+
+            gsm.getMetadataMgr();
+            result = metadataMgr;
+            minTimes = 0;
+
+            metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                    withInstanceOf(ConnectorMetadatRequestContext.class));
+            result = new ArrayList<String>(); // Empty partition list
+            minTimes = 0;
+        }};
+
+        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
+                insertStmt, icebergTable);
+        assertEquals(Long.MAX_VALUE, partitionCount);
+    }
+
+    /**
+     * Test behavior when partition list retrieval throws exception
+     */
+    @Test
+    public void testPartitionListException(@Mocked GlobalStateMgr gsm,
+                                           @Mocked MetadataMgr metadataMgr,
+                                           @Mocked IcebergTable icebergTable,
+                                           @Mocked InsertStmt insertStmt,
+                                           @Mocked SessionVariable sessionVariable) {
+        // Setup: exception when getting partition list
+        new Expectations() {{
+            GlobalStateMgr.getCurrentState();
+            result = gsm;
+            minTimes = 0;
+
+            gsm.getMetadataMgr();
+            result = metadataMgr;
+            minTimes = 0;
+
+            metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                    withInstanceOf(ConnectorMetadatRequestContext.class));
+            result = new Exception("Failed to get partitions");
+            minTimes = 0;
+        }};
+
+        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
+                insertStmt, icebergTable);
+        assertEquals(Long.MAX_VALUE, partitionCount);
+    }
+
+    /**
+     * Test partition predicate estimation reduces partition count.
+     */
+    @Test
+    public void testPartitionPredicateEstimation(@Mocked GlobalStateMgr gsm,
+                                                 @Mocked MetadataMgr metadataMgr,
+                                                 @Mocked IcebergTable icebergTable,
+                                                 @Mocked InsertStmt insertStmt,
+                                                 @Mocked SessionVariable sessionVariable,
+                                                 @Mocked QueryStatement queryStatement,
+                                                 @Mocked SelectRelation selectRelation) {
+        Expr dtPredicate = new BinaryPredicate(BinaryType.EQ, new SlotRef(null, "dt"),
+                new StringLiteral("2024-01-01"));
+        Expr countryPredicate = new InPredicate(new SlotRef(null, "country"),
+                Lists.newArrayList(new StringLiteral("US"), new StringLiteral("CA")), false);
+        Expr predicate = new CompoundPredicate(CompoundPredicate.Operator.AND, dtPredicate, countryPredicate);
+
+        setupMockExpectations(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 10, 100, 200L, 10.0, false, null, predicate, true);
+
+        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
+                insertStmt, icebergTable);
+        assertEquals(2L, partitionCount);
+    }
+
+    // Helper method to setup common mock expectations
+    private void setupMockExpectations(GlobalStateMgr gsm,
+                                       MetadataMgr metadataMgr,
+                                       IcebergTable icebergTable,
+                                       InsertStmt insertStmt,
+                                       SessionVariable sessionVariable,
+                                       QueryStatement queryStatement,
+                                       SelectRelation selectRelation,
+                                       int backendCount,
+                                       int partitionCount,
+                                       long threshold,
+                                       double ratio,
+                                       boolean isStaticPartitionInsert,
+                                       PartitionRef partitionRef,
+                                       Expr predicate,
+                                       boolean hasWhereClause) {
+
+        new Expectations() {{
+            // GlobalStateMgr setup
+            GlobalStateMgr.getCurrentState();
+            result = gsm;
+            minTimes = 0;
+
+            gsm.getMetadataMgr();
+            result = metadataMgr;
+            minTimes = 0;
+
+            gsm.getNodeMgr().getClusterInfo().getAliveBackendNumber();
+            result = backendCount;
+            minTimes = 0;
+
+            // MetadataMgr setup for partition names
+            metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                    withInstanceOf(ConnectorMetadatRequestContext.class));
+            result = new Delegate<List<String>>() {
+                @SuppressWarnings("unused")
+                List<String> delegate(String catalog, String db, String table,
+                                     ConnectorMetadatRequestContext context) {
+                    List<String> partitions = new ArrayList<>();
+                    for (int i = 0; i < partitionCount; i++) {
+                        partitions.add("p" + i);
+                    }
+                    return partitions;
+                }
+            };
+            minTimes = 0;
+
+            // IcebergTable setup
+            icebergTable.getCatalogName();
+            result = "test_catalog";
+            minTimes = 0;
+
+            icebergTable.getDbName();
+            result = "test_db";
+            minTimes = 0;
+
+            icebergTable.getTableName();
+            result = "test_table";
+            minTimes = 0;
+
+            icebergTable.getPartitionColumns();
+            result = Lists.newArrayList(
+                    new Column("dt", Type.DATE),
+                    new Column("country", Type.VARCHAR)
+            );
+            minTimes = 0;
+
+            // InsertStmt setup
+            insertStmt.isStaticKeyPartitionInsert();
+            result = isStaticPartitionInsert;
+            minTimes = 0;
+
+            insertStmt.getTargetPartitionNames();
+            result = partitionRef;
+            minTimes = 0;
+
+            if (partitionRef != null) {
+                partitionRef.getPartitionColNames();
+                result = Lists.newArrayList("p1");
+                minTimes = 0;
+            }
+
+            insertStmt.getQueryStatement();
+            result = queryStatement;
+            minTimes = 0;
+
+            queryStatement.getQueryRelation();
+            result = selectRelation;
+            minTimes = 0;
+
+            selectRelation.hasWhereClause();
+            result = hasWhereClause;
+            minTimes = 0;
+
+            selectRelation.getPredicate();
+            result = predicate;
+            minTimes = 0;
+
+            // SessionVariable setup
+            sessionVariable.getIcebergSinkShufflePartitionThreshold();
+            result = threshold;
+            minTimes = 0;
+
+            sessionVariable.getIcebergSinkShufflePartitionNodeRatio();
+            result = ratio;
+            minTimes = 0;
+        }};
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/InsertPlannerAdaptiveShuffleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/InsertPlannerAdaptiveShuffleTest.java
@@ -304,11 +304,11 @@ public class InsertPlannerAdaptiveShuffleTest {
                 result = false;
                 minTimes = 0;
 
-                sessionVariable.getIcebergSinkShufflePartitionThreshold();
+                sessionVariable.getConnectorSinkShufflePartitionThreshold();
                 result = 100L;
                 minTimes = 0;
 
-                sessionVariable.getIcebergSinkShufflePartitionNodeRatio();
+                sessionVariable.getConnectorSinkShufflePartitionNodeRatio();
                 result = 2.0;
                 minTimes = 0;
 
@@ -448,11 +448,11 @@ public class InsertPlannerAdaptiveShuffleTest {
                 minTimes = 0;
 
                 // SessionVariable setup
-                sessionVariable.getIcebergSinkShufflePartitionThreshold();
+                sessionVariable.getConnectorSinkShufflePartitionThreshold();
                 result = threshold;
                 minTimes = 0;
 
-                sessionVariable.getIcebergSinkShufflePartitionNodeRatio();
+                sessionVariable.getConnectorSinkShufflePartitionNodeRatio();
                 result = ratio;
                 minTimes = 0;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.connector.ConnectorSinkShuffleMode;
 import com.starrocks.planner.DataSink;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
@@ -998,8 +999,8 @@ public class InsertPlanTest extends PlanTestBase {
 
         new MockUp<SessionVariable>() {
             @Mock
-            public boolean isEnableIcebergSinkGlobalShuffle() {
-                return true;
+            public ConnectorSinkShuffleMode getConnectorSinkShuffleMode() {
+                return ConnectorSinkShuffleMode.FORCE;
             }
         };
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements configurable and adaptive global shuffle for connector table sinks, centered on Iceberg.
> 
> - **New shuffle modes**: `ConnectorSinkShuffleMode {force, auto, never}` exposed via session var `connector_sink_shuffle_mode`; deprecates `enable_iceberg_sink_global_shuffle`
> - **Adaptive enablement**: In AUTO, estimate partitions using table metadata, predicates, and NDV; compare against BE count and thresholds (`connector_sink_shuffle_partition_threshold`, `connector_sink_shuffle_partition_node_ratio`)
> - **Transform-aware shuffling**: Generate computed partition columns (prefixed with `GENERATED_PARTITION_COLUMN_PREFIX`) for Iceberg transforms (year/month/day/hour/bucket/truncate) and use them as shuffle keys
> - **Planner/executor updates**: Preserve generated columns through casts/projects; create hash distribution from partition keys; PlanFragmentBuilder now materializes generated expressions and uses project maps when translating shuffle keys
> - **Session/validation**: `SetStmtAnalyzer` validates shuffle mode; `SessionVariable` adds new vars with defaults (AUTO, 500, 2.0)
> - **Tests**: New unit tests for adaptive decisions, partition estimation, transform expression creation, and plan behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cc35b18b3da8418dcd5e56f1a4f2c46f0d9c297. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->