### PR TITLE
[Enhancement] Add table-level table_query_timeout.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -584,6 +584,8 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD)) {
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
+                    } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT)) {
+                        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else {
                         schemaChangeHandler.process(Lists.newArrayList(clause), db, olapTable);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2176,6 +2176,30 @@ public class OlapTable extends Table {
         tableProperty.buildEnableStatisticCollectOnFirstLoad();
     }
 
+    public int getTableQueryTimeout() {
+        if (tableProperty != null) {
+            return tableProperty.getTableQueryTimeout();
+        }
+        return -1;
+    }
+
+    public void setTableQueryTimeout(int tableQueryTimeout) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        if (tableQueryTimeout == -1) {
+            // Unset table_query_timeout to fallback to default behavior.
+            tableProperty.getProperties().remove(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT);
+            tableProperty.buildTableQueryTimeout();
+            return;
+        }
+        if (tableQueryTimeout <= 0) {
+            throw new IllegalArgumentException("table_query_timeout must be greater than 0, or -1 to reset to default");
+        }
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT, String.valueOf(tableQueryTimeout));
+        tableProperty.buildTableQueryTimeout();
+    }
+
     public boolean allowBucketSizeSetting() {
         return (defaultDistributionInfo instanceof RandomDistributionInfo) && Config.enable_automatic_bucket;
     }
@@ -2932,7 +2956,21 @@ public class OlapTable extends Table {
                     TableProperty.compactionStrategyToString(getCompactionStrategy()));
         }
 
-        Map<String, String> tableProperties = tableProperty.getProperties();
+        Map<String, String> tableProperties = tableProperty != null ? tableProperty.getProperties() : Maps.newLinkedHashMap();
+
+        // table query timeout (only show if explicitly set, not default)
+        String tableQueryTimeoutStr = tableProperties.get(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT);
+        if (tableQueryTimeoutStr != null) {
+            try {
+                int timeout = Integer.parseInt(tableQueryTimeoutStr);
+                if (timeout > 0) {
+                    properties.put(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT, tableQueryTimeoutStr);
+                }
+            } catch (NumberFormatException e) {
+                LOG.warn("fail to parse table query_timeout.", e);
+            }
+        }
+
         // partition live number
         String partitionLiveNumber = tableProperties.get(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER);
         if (partitionLiveNumber != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -337,6 +337,11 @@ public class TableProperty implements Writable, GsonPostProcessable {
     @SerializedName(value = "enableStatisticCollectOnFirstLoad")
     private boolean enableStatisticCollectOnFirstLoad = true;
 
+    // table level query timeout in seconds
+    // default value -1 means use cluster query_timeout
+    @SerializedName(value = "tableQueryTimeout")
+    private int tableQueryTimeout = -1;
+
     /**
      * Whether to enable the v2 implementation of fast schema evolution for cloud-native tables.
      * This version is more lightweight, modifying only FE metadata instead of both FE and tablet metadata.
@@ -433,6 +438,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 buildEnableStatisticCollectOnFirstLoad();
                 buildCloudNativeFastSchemaEvolutionV2();
                 buildLakeCompactionMaxParallel();
+                buildTableQueryTimeout();
                 break;
             case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY:
                 buildConstraint();
@@ -1299,6 +1305,41 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return cloudNativeFastSchemaEvolutionV2;
     }
 
+    public TableProperty buildTableQueryTimeout() {
+        String timeoutStr = properties.get(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT);
+
+        if (timeoutStr == null) {
+            tableQueryTimeout = -1;
+            return this;
+        }
+        try {
+            int timeout = Integer.parseInt(timeoutStr);
+            if (timeout > 0) {
+                tableQueryTimeout = timeout;
+                return this;
+            }
+
+            // -1 means unset table_query_timeout and fallback to default behavior.
+            if (timeout == -1) {
+                LOG.info("table_query_timeout reset to default");
+            } else {
+                LOG.warn("Invalid table_query_timeout value: {}. Must be > 0 or -1 for default. Using default (-1).",
+                        timeoutStr);
+            }
+        } catch (NumberFormatException e) {
+            LOG.warn("Invalid table_query_timeout value: {}. Must be a valid integer. Using default (-1).",
+                    timeoutStr, e);
+        }
+
+        properties.remove(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT);
+        tableQueryTimeout = -1;
+        return this;
+    }
+
+    public int getTableQueryTimeout() {
+        return tableQueryTimeout;
+    }
+
     @Override
     public void gsonPostProcess() throws IOException {
         try {
@@ -1336,5 +1377,6 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildCompactionStrategy();
         buildLakeCompactionMaxParallel();
         buildEnableStatisticCollectOnFirstLoad();
+        buildTableQueryTimeout();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -212,6 +212,9 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_PARTITION_RETENTION_CONDITION = "partition_retention_condition";
     public static final String PROPERTIES_TIME_DRIFT_CONSTRAINT = "time_drift_constraint";
 
+    // default: same as cluster query_timeout
+    public static final String PROPERTIES_TABLE_QUERY_TIMEOUT = "table_query_timeout";
+
     public static final String PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT = "auto_refresh_partitions_limit";
     public static final String PROPERTIES_PARTITION_REFRESH_STRATEGY = "partition_refresh_strategy";
     public static final String PROPERTIES_PARTITION_REFRESH_NUMBER = "partition_refresh_number";
@@ -1351,6 +1354,37 @@ public class PropertyAnalyzer {
             properties.remove(PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC);
         }
         return val;
+    }
+
+    /**
+     * Analyze table_query_timeout property.
+     * @param properties table properties
+     * @return table query timeout in seconds, -1 means use cluster query_timeout
+     * @throws AnalysisException if the value is invalid
+     */
+    public static int analyzeTableQueryTimeout(Map<String, String> properties)
+            throws AnalysisException {
+        if (properties == null || !properties.containsKey(PROPERTIES_TABLE_QUERY_TIMEOUT)) {
+            return -1;
+        }
+        String tableQueryTimeoutStr = properties.get(PROPERTIES_TABLE_QUERY_TIMEOUT);
+        properties.remove(PROPERTIES_TABLE_QUERY_TIMEOUT);
+        int tableQueryTimeout;
+        try {
+            tableQueryTimeout = Integer.parseInt(tableQueryTimeoutStr);
+            // -1 means unset table_query_timeout and fallback to default behavior (cluster/session timeout).
+            if (tableQueryTimeout == -1) {
+                return -1;
+            }
+            if (tableQueryTimeout <= 0) {
+                throw new AnalysisException("Property " + PROPERTIES_TABLE_QUERY_TIMEOUT
+                        + " must be greater than 0, or -1 to reset to default, got: " + tableQueryTimeoutStr);
+            }
+        } catch (NumberFormatException e) {
+            throw new AnalysisException("Property " + PROPERTIES_TABLE_QUERY_TIMEOUT
+                    + " must be a valid integer, got: " + tableQueryTimeoutStr);
+        }
+        return tableQueryTimeout;
     }
 
     public static List<UniqueConstraint> analyzeUniqueConstraint(Map<String, String> properties, Database db, Table table) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -53,6 +53,7 @@ import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.SqlUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
@@ -577,6 +578,26 @@ public class ConnectContext {
             modifiedSessionVariables.put(setVar.getVariable(), setVar);
         }
         return true;
+    }
+
+    /**
+     * Whether {@link SessionVariable#QUERY_TIMEOUT} is explicitly overridden in the current session.
+     * <p>
+     * This is used to decide whether table-level timeout should take effect when the user didn't set
+     * the session query_timeout
+     */
+    public boolean isSessionQueryTimeoutOverridden() {
+        if (modifiedSessionVariables.containsKey(SessionVariable.QUERY_TIMEOUT)) {
+            return true;
+        }
+
+        try {
+            int defaultTimeout = globalStateMgr.getVariableMgr().getDefaultSessionVariable().getQueryTimeoutS();
+            return sessionVariable.getQueryTimeoutS() != defaultTimeout;
+        } catch (Exception e) {
+            LOG.warn("Failed to judge session query timeout override.", e);
+            return false;
+        }
     }
 
     public void modifyUserVariable(UserVariable userVariable) {
@@ -1384,9 +1405,19 @@ public class ConnectContext {
                 // Only kill
                 killFlag = true;
 
-                String suggestedMsg = String.format("please increase the '%s' session variable, pending time:%s",
-                        isExecLoadType() ? SessionVariable.INSERT_TIMEOUT : SessionVariable.QUERY_TIMEOUT, pendingTime);
-                errMsg = ErrorCode.ERR_TIMEOUT.formatErrorMsg(getExecType(), execTimeout, suggestedMsg);
+                String msg;
+
+                if (!isSessionQueryTimeoutOverridden() && executor != null && executor.getTableQueryTimeoutInfo() != null) {
+                    Pair<String, Integer> tableTimeoutInfo = executor.getTableQueryTimeoutInfo();
+                    String tableName = tableTimeoutInfo.first;
+                    int tableTimeout = tableTimeoutInfo.second;
+                    msg = String.format("the table %s table_query_timeout is %ds, pending time:%s",
+                            tableName, tableTimeout, pendingTime);
+                } else {
+                    msg = String.format("please increase the '%s' session variable, pending time:%s",
+                            isExecLoadType() ? SessionVariable.INSERT_TIMEOUT : SessionVariable.QUERY_TIMEOUT, pendingTime);
+                }
+                errMsg = ErrorCode.ERR_TIMEOUT.formatErrorMsg(getExecType(), execTimeout, msg);
             }
         }
         if (killFlag) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -337,6 +337,10 @@ public class StmtExecutor {
     private HttpResultSender httpResultSender;
     private PrepareStmtContext prepareStmtContext = null;
     private boolean isInternalStmt = false;
+    
+    // Store table query timeout info for error message
+    private String tableQueryTimeoutTableName = null;
+    private int tableQueryTimeoutValue = -1;
 
     private final CompletableFuture<ArrowFlightSqlResultDescriptor> deploymentFinished;
 
@@ -580,7 +584,9 @@ public class StmtExecutor {
 
     /**
      * The execution timeout varies among different statements:
-     * 1. SELECT: use query_timeout
+     * 1. SELECT:
+     *    - If session query_timeout is not explicitly overridden, table_query_timeout (if set) can take effect.
+     *    - If session query_timeout is explicitly overridden, always use session query_timeout.
      * 2. DML: use insert_timeout or statement-specified timeout
      * 3. ANALYZE: use fe_conf.statistic_collect_query_timeout
      */
@@ -608,7 +614,51 @@ public class StmtExecutor {
         } else if (parsedStmt instanceof AnalyzeStmt) {
             return (int) Config.statistic_collect_query_timeout;
         } else {
-            return ConnectContext.get().getSessionVariable().getQueryTimeoutS();
+            // For SELECT queries:
+            // session query_timeout is authoritative if explicitly overridden
+            ConnectContext ctx = ConnectContext.get();
+            int sessionQueryTimeout = ctx.getSessionVariable().getQueryTimeoutS();
+            boolean sessionTimeoutOverridden = ctx.isSessionQueryTimeoutOverridden();
+            if (parsedStmt instanceof QueryStatement) {
+                try {
+                    Map<TableName, Table> tables = AnalyzerUtils.collectAllTable(parsedStmt);
+                    int minTableTimeout = -1;
+                    String tableName = null;
+
+                    // get minimum timeout among all tables
+                    for (Map.Entry<TableName, Table> entry : tables.entrySet()) {
+                        Table table = entry.getValue();
+                        if (table instanceof OlapTable) {
+                            OlapTable olapTable = (OlapTable) table;
+                            int tableTimeout = olapTable.getTableQueryTimeout();
+                            if (tableTimeout > 0) {
+                                if (minTableTimeout < 0 || tableTimeout < minTableTimeout) {
+                                    minTableTimeout = tableTimeout;
+                                    tableName = entry.getKey() != null ? entry.getKey().toString() : table.getName();
+                                }
+                            }
+                        }
+                    }
+
+                    // If table timeout is set, use it when session timeout is not explicitly overridden.
+                    if (minTableTimeout > 0) {
+                        tableQueryTimeoutTableName = tableName;
+                        tableQueryTimeoutValue = minTableTimeout;
+                        if (!sessionTimeoutOverridden) {
+                            return minTableTimeout;
+                        }
+                        return sessionQueryTimeout;
+                    } else {
+                        tableQueryTimeoutTableName = null;
+                        tableQueryTimeoutValue = -1;
+                    }
+                } catch (Exception e) {
+                    LOG.warn("Cannot collect tables for table_query_timeout check, use cluster timeout", e);
+                    tableQueryTimeoutTableName = null;
+                    tableQueryTimeoutValue = -1;
+                }
+            }
+            return sessionQueryTimeout;
         }
     }
 
@@ -626,6 +676,13 @@ public class StmtExecutor {
 
     public boolean isExecLoadType() {
         return parsedStmt instanceof DmlStmt || parsedStmt instanceof CreateTableAsSelectStmt;
+    }
+
+    public Pair<String, Integer> getTableQueryTimeoutInfo() {
+        if (tableQueryTimeoutTableName != null && tableQueryTimeoutValue > 0) {
+            return Pair.create(tableQueryTimeoutTableName, tableQueryTimeoutValue);
+        }
+        return null;
     }
 
     private ExecPlan generateExecPlan() throws Exception {

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -777,6 +777,16 @@ public class OlapTableFactory implements AbstractTableFactory {
                 table.getTableProperty().setTimeDriftConstraintSpec(timeDriftConstraintSpec);
             }
 
+            // analyze table_query_timeout
+            if (properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT)) {
+                try {
+                    int tableQueryTimeout = PropertyAnalyzer.analyzeTableQueryTimeout(properties);
+                    table.setTableQueryTimeout(tableQueryTimeout);
+                } catch (AnalysisException ex) {
+                    throw new DdlException(ex.getMessage());
+                }
+            }
+
             try {
                 processConstraint(db, table, properties);
             } catch (AnalysisException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -479,6 +479,12 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
                         "Invalid lake_compaction_max_parallel value: " + value + ". Value must be an integer.");
             }
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT)) {
+            try {
+                PropertyAnalyzer.analyzeTableQueryTimeout(Maps.newHashMap(properties));
+            } catch (AnalysisException e) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, e.getMessage());
+            }
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -650,6 +650,11 @@ public class AlterTest {
         alterTableWithNewParser(stmt, false);
         Assertions.assertEquals(Short.valueOf("3"), tbl.getDefaultReplicationNum());
 
+        // set table_query_timeout
+        stmt = "alter table test.tbl1 set ('table_query_timeout' = '120');";
+        alterTableWithNewParser(stmt, false);
+        Assertions.assertEquals(120, tbl.getTableQueryTimeout());
+
         // set range table's real replication num
         Partition p1 = tbl.getPartition("p1");
         Assertions.assertEquals(Short.valueOf("1"), Short.valueOf(tbl.getPartitionInfo().getReplicationNum(p1.getId())));

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectContextTest.java
@@ -35,7 +35,9 @@
 package com.starrocks.qe;
 
 import com.google.common.collect.Lists;
+import com.starrocks.common.Pair;
 import com.starrocks.common.Status;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.mysql.MysqlCapability;
 import com.starrocks.mysql.MysqlChannel;
@@ -46,6 +48,7 @@ import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.parser.NodePosition;
@@ -55,6 +58,7 @@ import com.starrocks.thrift.TUniqueId;
 import com.starrocks.warehouse.DefaultWarehouse;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import com.starrocks.warehouse.cngroup.WarehouseComputeResource;
+import mockit.Delegate;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -65,6 +69,7 @@ import org.junit.jupiter.api.Test;
 import org.xnio.StreamConnection;
 
 import java.util.List;
+import java.util.Map;
 
 public class ConnectContextTest {
     @Mocked
@@ -229,6 +234,130 @@ public class ConnectContextTest {
         Assertions.assertTrue(ctx.isKilled());
 
         // clean up
+        ctx.cleanup();
+    }
+
+    @Test
+    public void testQueryTimeoutErrorMessageUsesTableQueryTimeoutHint() {
+        ConnectContext ctx = new ConnectContext(connection);
+        ctx.setCommand(MysqlCommand.COM_QUERY);
+        ctx.setThreadLocalInfo();
+
+        // Cover ConnectContext.isSessionQueryTimeoutOverridden() exception path (ConnectContext.java:596-598).
+        // Make VariableMgr.getDefaultSessionVariable() throw, then isSessionQueryTimeoutOverridden() should return false.
+        new MockUp<VariableMgr>() {
+            @Mock
+            public SessionVariable getDefaultSessionVariable() {
+                throw new RuntimeException("mock default session variable failure");
+            }
+        };
+        Assertions.assertFalse(ctx.isSessionQueryTimeoutOverridden());
+
+        // Prepare an executor with table_query_timeout info, so ConnectContext.checkTimeout() builds the table hint
+        // (ConnectContext.java:1376-1381).
+        StmtExecutor executor = new StmtExecutor(ctx, new QueryStatement(ValuesRelation.newDualRelation()));
+        // Manually set table timeout info so getTableQueryTimeoutInfo() returns non-null
+        Deencapsulation.setField(executor, "tableQueryTimeoutTableName", "test.t1");
+        Deencapsulation.setField(executor, "tableQueryTimeoutValue", 120);
+        ctx.setExecutor(executor);
+        
+        // Mock getExecTimeout() and getTableQueryTimeoutInfo() for this specific executor instance
+        // This is needed because getExecTimeout() resets the fields when no tables are found,
+        // but we want to test the case where table timeout info is available
+        final Pair<String, Integer> mockTableTimeoutInfo = Pair.create("test.t1", 120);
+        new Expectations(executor) {
+            {
+                // Mock getExecTimeout() to return 1 second (session timeout) without resetting fields
+                executor.getExecTimeout();
+                result = 1; // Return 1 second to match session timeout
+                minTimes = 0;
+                
+                // Mock getTableQueryTimeoutInfo() to always return table timeout info
+                executor.getTableQueryTimeoutInfo();
+                result = mockTableTimeoutInfo;
+                minTimes = 0;
+                
+                // Mock cancel() to set error message in context state
+                executor.cancel(anyString);
+                result = new Delegate<Void>() {
+                    @SuppressWarnings("unused")
+                    void cancel(String cancelledMessage) {
+                        ctx.getState().setError(cancelledMessage);
+                    }
+                };
+                minTimes = 0;
+            }
+        };
+        
+        // Ensure pendingTimeSecond is 0 so getExecTimeout() returns exactly 1
+        ctx.setPendingTimeSecond(0);
+        
+        // Verify that getExecTimeout() returns the expected value
+        int execTimeout = ctx.getExecTimeout();
+        Assertions.assertEquals(1, execTimeout, "getExecTimeout() should return 1 (session timeout + pending time)");
+
+        // Ensure modifiedSessionVariables doesn't contain QUERY_TIMEOUT so isSessionQueryTimeoutOverridden() returns false
+        // (unless getDefaultSessionVariable() throws, which we've mocked)
+        Map<String, SystemVariable> modifiedVars = ctx.getModifiedSessionVariablesMap();
+        modifiedVars.remove(SessionVariable.QUERY_TIMEOUT);
+        
+        // Set session timeout to 1 second to make the query timeout quickly.
+        // Since the statement has no tables, executor.getExecTimeout() will return session timeout (1).
+        ctx.getSessionVariable().setQueryTimeoutS(1);
+        // Verify isSessionQueryTimeoutOverridden() still returns false after setting timeout
+        Assertions.assertFalse(ctx.isSessionQueryTimeoutOverridden(), 
+                "isSessionQueryTimeoutOverridden() should return false even after setting timeout");
+        // Verify getTableQueryTimeoutInfo() returns non-null
+        Pair<String, Integer> tableTimeoutInfo = executor.getTableQueryTimeoutInfo();
+        Assertions.assertNotNull(tableTimeoutInfo, "getTableQueryTimeoutInfo() should return non-null");
+        Assertions.assertEquals("test.t1", tableTimeoutInfo.first);
+        Assertions.assertEquals(120, tableTimeoutInfo.second.intValue());
+        
+        // Verify conditions are met BEFORE checkTimeout() is called
+        // (Note: getExecTimeout() will reset table timeout info when no tables are found,
+        //  but checkTimeout() uses the info at the time it's called)
+        Assertions.assertFalse(ctx.isSessionQueryTimeoutOverridden(), 
+                "isSessionQueryTimeoutOverridden() should return false before checkTimeout()");
+        Assertions.assertNotNull(executor.getTableQueryTimeoutInfo(), 
+                "getTableQueryTimeoutInfo() should return non-null before checkTimeout()");
+        
+        ctx.setStartTime();
+        // Wait 2 seconds to exceed the 1 second timeout
+        long now = ctx.getStartTime() + 2_000L;
+        
+        // Verify conditions before calling checkTimeout()
+        boolean isOverridden = ctx.isSessionQueryTimeoutOverridden();
+        Pair<String, Integer> timeoutInfo = executor.getTableQueryTimeoutInfo();
+        int execTimeoutValue = ctx.getExecTimeout();
+        long delta = now - ctx.getStartTime();
+        
+        Assertions.assertFalse(isOverridden, "isSessionQueryTimeoutOverridden() should be false");
+        Assertions.assertNotNull(timeoutInfo, "getTableQueryTimeoutInfo() should return non-null");
+        Assertions.assertNotNull(ctx.getExecutor(), "executor should not be null");
+        Assertions.assertEquals(1, execTimeoutValue, "getExecTimeout() should return 1");
+        Assertions.assertTrue(delta > execTimeoutValue * 1000L, 
+                "delta (" + delta + ") should be greater than timeout (" + execTimeoutValue * 1000L + ")");
+        
+        boolean killed = ctx.checkTimeout(now);
+
+        // The query should be killed because 2 seconds > 1 second timeout
+        // Note: For query timeouts, killConnection is false, so isKilled() won't be set to true.
+        // We check the return value of checkTimeout() instead.
+        Assertions.assertTrue(killed, "checkTimeout() should return true when query times out");
+        Assertions.assertNotNull(ctx.getState().getErrorMessage());
+        
+        // Since isSessionQueryTimeoutOverridden() returned false and getTableQueryTimeoutInfo() returned non-null
+        // at the time checkTimeout() was called, the error message should contain the table timeout hint
+        // (ConnectContext.java:1375-1381)
+        String errorMsg = ctx.getState().getErrorMessage();
+        // The error message should contain either "table_query_timeout" or the table name "test.t1"
+        // Note: The actual format is "the table test.t1 table_query_timeout is 120s, pending time:0"
+        Assertions.assertTrue(errorMsg != null && (errorMsg.contains("table_query_timeout") || errorMsg.contains("test.t1")),
+                "Error message should contain table_query_timeout hint. " +
+                "isOverridden=" + isOverridden + ", timeoutInfo=" + timeoutInfo + ", " +
+                "executor=" + ctx.getExecutor() + ", " +
+                "Actual error: " + (errorMsg != null ? errorMsg : "null"));
+
         ctx.cleanup();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -19,6 +19,8 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.Status;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.planner.AggregateInfo;
 import com.starrocks.planner.BinlogScanNode;
 import com.starrocks.planner.DataPartition;
@@ -37,8 +39,11 @@ import com.starrocks.planner.TupleId;
 import com.starrocks.planner.stream.StreamAggNode;
 import com.starrocks.qe.scheduler.dag.ExecutionFragment;
 import com.starrocks.qe.scheduler.dag.FragmentInstance;
+import com.starrocks.qe.scheduler.dag.JobSpec;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.system.Backend;
@@ -46,10 +51,12 @@ import com.starrocks.thrift.TBinlogOffset;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TPartitionType;
 import com.starrocks.thrift.TScanRangeParams;
+import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.compress.utils.Lists;
@@ -137,6 +144,56 @@ public class CoordinatorTest extends PlanTestBase {
     @Test
     public void testBucketShuffleRuntimeFilter() throws IOException, StarRocksException {
         testComputeBucketSeq2InstanceOrdinal(JoinNode.DistributionMode.LOCAL_HASH_BUCKET);
+    }
+
+    @Test
+    public void testTimeoutHintUsesTableQueryTimeout() {
+        // Cover DefaultCoordinator timeout hint branch:
+        // DefaultCoordinator.java:960-963, 967-975
+
+        // Prepare an executor with table timeout info
+        StmtExecutor executor = new StmtExecutor(ctx, new QueryStatement(ValuesRelation.newDualRelation()));
+        Deencapsulation.setField(executor, "tableQueryTimeoutTableName", "test.t0");
+        Deencapsulation.setField(executor, "tableQueryTimeoutValue", 120);
+        ctx.setExecutor(executor);
+
+        // Make jobSpec.query_timeout match the table timeout, so DefaultCoordinator uses table_query_timeout hint.
+        JobSpec jobSpec = Deencapsulation.getField(coordinator, "jobSpec");
+        jobSpec.getQueryOptions().setQuery_timeout(120);
+
+        Status timeoutStatus = new Status(TStatusCode.TIMEOUT, "timeout");
+
+        com.starrocks.common.TimeoutException ex = Assertions.assertThrows(
+                com.starrocks.common.TimeoutException.class,
+                () -> Deencapsulation.invoke(coordinator, "dealStatusToTryRetry", timeoutStatus));
+        Assertions.assertTrue(ex.getMessage().contains("table_query_timeout"));
+        Assertions.assertTrue(ex.getMessage().contains("please increase"));
+    }
+
+    @Test
+    public void testTimeoutHintFallbackWhenBuildHintThrows() {
+        // Force DefaultCoordinator.java:967-969 (catch) and 975 (reportTimeoutException) to execute.
+        // Ensure executor is present so the code enters the try-block.
+        StmtExecutor executor = new StmtExecutor(ctx, new QueryStatement(ValuesRelation.newDualRelation()));
+        ctx.setExecutor(executor);
+        new Expectations(executor) {
+            {
+                executor.getTableQueryTimeoutInfo();
+                result = new RuntimeException("mock exception for hint building");
+                minTimes = 0;
+            }
+        };
+
+        JobSpec jobSpec = Deencapsulation.getField(coordinator, "jobSpec");
+        jobSpec.getQueryOptions().setQuery_timeout(120);
+
+        Status timeoutStatus = new Status(TStatusCode.TIMEOUT, "timeout");
+        com.starrocks.common.TimeoutException ex = Assertions.assertThrows(
+                com.starrocks.common.TimeoutException.class,
+                () -> Deencapsulation.invoke(coordinator, "dealStatusToTryRetry", timeoutStatus));
+        // After catch, hint falls back to session variable query_timeout.
+        Assertions.assertTrue(ex.getMessage().contains("query_timeout"));
+        Assertions.assertTrue(ex.getMessage().contains("please increase"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorTest.java
@@ -15,15 +15,20 @@
 package com.starrocks.qe;
 
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.mysql.MysqlSerializer;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.AstBuilder;
 import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import mockit.Expectations;
@@ -184,6 +189,261 @@ public class StmtExecutorTest {
                     SqlModeHelper.MODE_DEFAULT);
             StmtExecutor executor = new StmtExecutor(new ConnectContext(), stmt);
             Assertions.assertEquals(ctx.getSessionVariable().getInsertTimeoutS(), executor.getExecTimeout());
+        }
+    }
+
+    @Test
+    public void testExecTimeoutWithTableQueryTimeout() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(ctx);
+
+        // Create test database
+        String dbName = "test_table_timeout_db";
+        starRocksAssert.withDatabase(dbName).useDatabase(dbName);
+
+        // Create table without table_query_timeout
+        String createTableStmt1 = "CREATE TABLE `t1` (\n" +
+                "  `k1` int NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");";
+        starRocksAssert.withTable(createTableStmt1);
+
+        // Create table with table_query_timeout = 120
+        String createTableStmt2 = "CREATE TABLE `t2` (\n" +
+                "  `k1` int NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"table_query_timeout\" = \"120\"\n" +
+                ");";
+        starRocksAssert.withTable(createTableStmt2);
+
+        // Create table with table_query_timeout = 600 (greater than cluster timeout 300)
+        String createTableStmt3 = "CREATE TABLE `t3` (\n" +
+                "  `k1` int NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"table_query_timeout\" = \"600\"\n" +
+                ");";
+        starRocksAssert.withTable(createTableStmt3);
+
+        // Create table with table_query_timeout = 60
+        String createTableStmt4 = "CREATE TABLE `t4` (\n" +
+                "  `k1` int NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"table_query_timeout\" = \"60\"\n" +
+                ");";
+        starRocksAssert.withTable(createTableStmt4);
+
+        // Test 1: User not explicitly set session timeout, table has no table_query_timeout
+        // Should use cluster timeout (default 300)
+        {
+            ConnectContext testCtx = UtFrameUtils.createDefaultCtx();
+            testCtx.setDatabase(dbName);
+            StatementBase stmt = SqlParser.parseSingleStatement("select * from t1", SqlModeHelper.MODE_DEFAULT);
+            StmtExecutor executor = new StmtExecutor(testCtx, stmt);
+            int defaultTimeout = testCtx.getSessionVariable().getQueryTimeoutS();
+            Assertions.assertEquals(defaultTimeout, executor.getExecTimeout());
+        }
+
+        // Test 2: User not explicitly set session timeout, table has table_query_timeout = 120
+        // Should use table_query_timeout (120)
+        {
+            ConnectContext testCtx = UtFrameUtils.createDefaultCtx();
+            testCtx.setDatabase(dbName);
+            StatementBase stmt = SqlParser.parseSingleStatement("select * from t2", SqlModeHelper.MODE_DEFAULT);
+            Analyzer.analyze(stmt, testCtx); // Analyze SQL to resolve table references
+            StmtExecutor executor = new StmtExecutor(testCtx, stmt);
+            Assertions.assertEquals(120, executor.getExecTimeout());
+            // Verify table timeout info
+            Assertions.assertNotNull(executor.getTableQueryTimeoutInfo());
+            Assertions.assertEquals("test_table_timeout_db.t2", executor.getTableQueryTimeoutInfo().first);
+            Assertions.assertEquals(120, executor.getTableQueryTimeoutInfo().second.intValue());
+        }
+
+        // Test 3: User not explicitly set session timeout, table has table_query_timeout = 600 (greater than cluster timeout)
+        // Should use table_query_timeout (600) - this is the new behavior
+        {
+            ConnectContext testCtx = UtFrameUtils.createDefaultCtx();
+            testCtx.setDatabase(dbName);
+            StatementBase stmt = SqlParser.parseSingleStatement("select * from t3", SqlModeHelper.MODE_DEFAULT);
+            Analyzer.analyze(stmt, testCtx); // Analyze SQL to resolve table references
+            StmtExecutor executor = new StmtExecutor(testCtx, stmt);
+            Assertions.assertEquals(600, executor.getExecTimeout());
+            // Verify table timeout info
+            Assertions.assertNotNull(executor.getTableQueryTimeoutInfo());
+            Assertions.assertEquals("test_table_timeout_db.t3", executor.getTableQueryTimeoutInfo().first);
+            Assertions.assertEquals(600, executor.getTableQueryTimeoutInfo().second.intValue());
+        }
+
+        // Test 4: User explicitly set session timeout = 200, table has table_query_timeout = 120
+        // Should use session timeout (200) - session timeout has higher priority
+        {
+            ConnectContext testCtx = UtFrameUtils.createDefaultCtx();
+            testCtx.setDatabase(dbName);
+            testCtx.getSessionVariable().setQueryTimeoutS(200);
+            StatementBase stmt = SqlParser.parseSingleStatement("select * from t2", SqlModeHelper.MODE_DEFAULT);
+            Analyzer.analyze(stmt, testCtx); // Analyze SQL to resolve table references
+            StmtExecutor executor = new StmtExecutor(testCtx, stmt);
+            Assertions.assertEquals(200, executor.getExecTimeout());
+        }
+
+        // Test 5: User explicitly set session timeout = 100, table has table_query_timeout = 600
+        // Should use session timeout (100) - session timeout has higher priority
+        {
+            ConnectContext testCtx = UtFrameUtils.createDefaultCtx();
+            testCtx.setDatabase(dbName);
+            testCtx.getSessionVariable().setQueryTimeoutS(100);
+            StatementBase stmt = SqlParser.parseSingleStatement("select * from t3", SqlModeHelper.MODE_DEFAULT);
+            Analyzer.analyze(stmt, testCtx); // Analyze SQL to resolve table references
+            StmtExecutor executor = new StmtExecutor(testCtx, stmt);
+            Assertions.assertEquals(100, executor.getExecTimeout());
+        }
+
+        // Test 6: Multiple tables with different table_query_timeout, should use minimum
+        // t2 has 120, t4 has 60, should use 60
+        {
+            ConnectContext testCtx = UtFrameUtils.createDefaultCtx();
+            testCtx.setDatabase(dbName);
+            StatementBase stmt = SqlParser.parseSingleStatement("select * from t2, t4", SqlModeHelper.MODE_DEFAULT);
+            Analyzer.analyze(stmt, testCtx); // Analyze SQL to resolve table references
+            StmtExecutor executor = new StmtExecutor(testCtx, stmt);
+            Assertions.assertEquals(60, executor.getExecTimeout());
+            // Verify table timeout info points to the table with minimum timeout
+            Assertions.assertNotNull(executor.getTableQueryTimeoutInfo());
+            Assertions.assertEquals(60, executor.getTableQueryTimeoutInfo().second.intValue());
+        }
+
+        // Test 7: Test getTableQueryTimeoutInfo when no table timeout is set
+        {
+            ConnectContext testCtx = UtFrameUtils.createDefaultCtx();
+            testCtx.setDatabase(dbName);
+            StatementBase stmt = SqlParser.parseSingleStatement("select * from t1", SqlModeHelper.MODE_DEFAULT);
+            Analyzer.analyze(stmt, testCtx); // Analyze SQL to resolve table references
+            StmtExecutor executor = new StmtExecutor(testCtx, stmt);
+            executor.getExecTimeout(); // Initialize timeout
+            Assertions.assertNull(executor.getTableQueryTimeoutInfo());
+        }
+
+        // Test 8: Test getTableQueryTimeoutInfo when table timeout is set
+        {
+            ConnectContext testCtx = UtFrameUtils.createDefaultCtx();
+            testCtx.setDatabase(dbName);
+            StatementBase stmt = SqlParser.parseSingleStatement("select * from t2", SqlModeHelper.MODE_DEFAULT);
+            Analyzer.analyze(stmt, testCtx); // Analyze SQL to resolve table references
+            StmtExecutor executor = new StmtExecutor(testCtx, stmt);
+            executor.getExecTimeout(); // Initialize timeout
+            Pair<String, Integer> timeoutInfo = executor.getTableQueryTimeoutInfo();
+            Assertions.assertNotNull(timeoutInfo);
+            Assertions.assertEquals("test_table_timeout_db.t2", timeoutInfo.first);
+            Assertions.assertEquals(120, timeoutInfo.second.intValue());
+        }
+
+        // Test 9: Test with non-QueryStatement (should use session timeout)
+        {
+            ConnectContext testCtx = UtFrameUtils.createDefaultCtx();
+            testCtx.setDatabase(dbName);
+            // Use a non-query statement like SHOW
+            StatementBase stmt = SqlParser.parseSingleStatement("SHOW TABLES", SqlModeHelper.MODE_DEFAULT);
+            StmtExecutor executor = new StmtExecutor(testCtx, stmt);
+            int timeout = executor.getExecTimeout();
+            int defaultTimeout = testCtx.getSessionVariable().getQueryTimeoutS();
+            Assertions.assertEquals(defaultTimeout, timeout);
+            Assertions.assertNull(executor.getTableQueryTimeoutInfo());
+        }
+
+        // Test 10: Test getTableQueryTimeoutInfo coverage (lines 685, 687, 688)
+        // This test ensures both return paths of getTableQueryTimeoutInfo are covered
+        {
+            ConnectContext testCtx = UtFrameUtils.createDefaultCtx();
+            testCtx.setDatabase(dbName);
+            
+            // Test with table timeout set
+            StatementBase stmt1 = SqlParser.parseSingleStatement("select * from t2", SqlModeHelper.MODE_DEFAULT);
+            Analyzer.analyze(stmt1, testCtx); // Analyze SQL to resolve table references
+            StmtExecutor executor1 = new StmtExecutor(testCtx, stmt1);
+            executor1.getExecTimeout();
+            Pair<String, Integer> info1 = executor1.getTableQueryTimeoutInfo();
+            Assertions.assertNotNull(info1);
+            Assertions.assertEquals("test_table_timeout_db.t2", info1.first);
+            Assertions.assertEquals(120, info1.second.intValue());
+            
+            // Test without table timeout
+            StatementBase stmt2 = SqlParser.parseSingleStatement("select * from t1", SqlModeHelper.MODE_DEFAULT);
+            Analyzer.analyze(stmt2, testCtx); // Analyze SQL to resolve table references
+            StmtExecutor executor2 = new StmtExecutor(testCtx, stmt2);
+            executor2.getExecTimeout();
+            Assertions.assertNull(executor2.getTableQueryTimeoutInfo());
+        }
+
+        // Test 11: Test exception handling when collectAllTable throws exception
+        {
+            ConnectContext testCtx = UtFrameUtils.createDefaultCtx();
+            testCtx.setDatabase(dbName);
+            StatementBase stmt = SqlParser.parseSingleStatement("select * from t2", SqlModeHelper.MODE_DEFAULT);
+            Analyzer.analyze(stmt, testCtx); // Analyze SQL to resolve table references
+            
+            // Use a local scope to ensure the mock is cleaned up after the test
+            {
+                new MockUp<AnalyzerUtils>() {
+                    @Mock
+                    public java.util.Map<com.starrocks.catalog.TableName, com.starrocks.catalog.Table> collectAllTable(
+                            StatementBase statementBase) {
+                        throw new RuntimeException("Mock exception for testing");
+                    }
+                };
+                
+                StmtExecutor executor = new StmtExecutor(testCtx, stmt);
+                // Should fall back to session timeout when exception occurs
+                int timeout = executor.getExecTimeout();
+                int defaultTimeout = testCtx.getSessionVariable().getQueryTimeoutS();
+                Assertions.assertEquals(defaultTimeout, timeout);
+                Assertions.assertNull(executor.getTableQueryTimeoutInfo());
+            }
+            // Mock is automatically cleaned up when it goes out of scope
+        }
+
+        // Test 12: Test that isSessionQueryTimeoutOverridden() exception propagates to getExecTimeout()
+        {
+            ConnectContext testCtx = UtFrameUtils.createDefaultCtx();
+            testCtx.setDatabase(dbName);
+            // Ensure ConnectContext.get() is not null for getExecTimeout()
+            ConnectContext.set(testCtx);
+
+            // Use a table without table_query_timeout so the result is deterministic (falls back to session timeout).
+            StatementBase stmt = SqlParser.parseSingleStatement("select * from t1", SqlModeHelper.MODE_DEFAULT);
+            Analyzer.analyze(stmt, testCtx);
+
+            // Mock isSessionQueryTimeoutOverridden() to throw, so getExecTimeout() should also throw
+            new MockUp<ConnectContext>() {
+                @Mock
+                public boolean isSessionQueryTimeoutOverridden() {
+                    throw new RuntimeException("Mock exception for isSessionQueryTimeoutOverridden()");
+                }
+            };
+
+            try {
+                StmtExecutor executor = new StmtExecutor(testCtx, stmt);
+                // Since isSessionQueryTimeoutOverridden() throws, getExecTimeout() should also throw
+                Assertions.assertThrows(RuntimeException.class, () -> executor.getExecTimeout());
+            } finally {
+                ConnectContext.remove();
+            }
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/OlapTableFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/OlapTableFactoryTest.java
@@ -1,0 +1,105 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.server;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for OlapTableFactory, specifically for table_query_timeout property handling
+ * during CREATE TABLE (covers OlapTableFactory.java lines 775-781).
+ */
+public class OlapTableFactoryTest {
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+    private static final String DB_NAME = "test_olap_table_factory_db";
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    /**
+     * Test CREATE TABLE with valid table_query_timeout property.
+     * This test covers OlapTableFactory.java lines 773-778 (success path).
+     */
+    @Test
+    public void testCreateTableWithValidTableQueryTimeout() throws Exception {
+        String createTableSql = "CREATE TABLE `test_timeout_valid` (\n" +
+                "  `k1` int NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"table_query_timeout\" = \"200\"\n" +
+                ");";
+        CreateTableStmt stmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createTableSql, connectContext);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        Assertions.assertNotNull(db);
+
+        // Call OlapTableFactory directly to ensure we hit OlapTableFactory.java's table_query_timeout branch.
+        Table table = OlapTableFactory.INSTANCE.createTable(GlobalStateMgr.getCurrentState().getLocalMetastore(), db, stmt);
+        Assertions.assertNotNull(table);
+        Assertions.assertTrue(table instanceof OlapTable);
+        Assertions.assertEquals(200, ((OlapTable) table).getTableQueryTimeout());
+    }
+
+    /**
+     * Test CREATE TABLE with table_query_timeout = 0 (invalid, should throw DdlException).
+     * This test covers OlapTableFactory.java lines 779-781 (exception path).
+     */
+    @Test
+    public void testCreateTableWithZeroTableQueryTimeout() throws Exception {
+        String createTableSql = "CREATE TABLE `test_timeout_zero` (\n" +
+                "  `k1` int NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"table_query_timeout\" = \"0\"\n" +
+                ");";
+        CreateTableStmt stmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createTableSql, connectContext);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        Assertions.assertNotNull(db);
+
+        DdlException e = Assertions.assertThrows(DdlException.class,
+                () -> OlapTableFactory.INSTANCE.createTable(GlobalStateMgr.getCurrentState().getLocalMetastore(), db, stmt));
+        Assertions.assertTrue(e.getMessage().contains("must be greater than 0"),
+                "Expected error message about value must be greater than 0, but got: " + e.getMessage());
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -133,6 +133,18 @@ public class AnalyzeAlterTableStatementTest {
     }
 
     @Test
+    public void testAlterTableSetTableQueryTimeoutAnalyze() {
+        // Cover AlterTableClauseAnalyzer's table_query_timeout branch (AlterTableClauseAnalyzer.java:465-472).
+        analyzeSuccess("alter table test.t0 set (\"table_query_timeout\" = \"120\")");
+        // -1 is accepted and means reset to default behavior.
+        analyzeSuccess("alter table test.t0 set (\"table_query_timeout\" = \"-1\")");
+
+        // Invalid value should be rejected by analyzer (it catches AnalysisException and reports SemanticException).
+        analyzeFail("alter table test.t0 set (\"table_query_timeout\" = \"0\")");
+        analyzeFail("alter table test.t0 set (\"table_query_timeout\" = \"abc\")");
+    }
+
+    @Test
     public void testDropIndex() {
         String sql = "DROP INDEX index1 ON test.t0";
         analyzeSuccess(sql);


### PR DESCRIPTION
## Why I'm doing:
On-Demand Customization: Allows setting dedicated timeout durations for each table based on its data volume, query complexity, and business importance.

Independent Adjustment: Modifying the timeout policy for a single table does not affect other tables or the cluster configuration.

Resource Isolation: Prevents abnormal queries on a single table from exhausting cluster resources, enhancing overall system stability.


## What I'm doing:
Add table level query timeout:
• Session Timeout overrides everything (if set)
• No Session Timeout? Use Table Timeout (if set and > 0)
• No Session and Table Timeout = -1 or not set?  Use Cluster Timeout (default 300s)
• Multi‑table queries use the smallest Table Timeout
• SHOW CREATE TABLE only displays Table Timeout if explicitly set(excluding Table Timeout = -1)

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/admin/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/admin/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-number-format:General;
	text-align:general;
	vertical-align:middle;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{color:black;
	font-size:14.0pt;
	font-weight:700;
	font-family:Arial;
	mso-generic-font-family:auto;
	mso-font-charset:0;
	text-align:left;}
.xl66
	{color:black;
	font-size:14.0pt;
	font-family:Arial;
	mso-generic-font-family:auto;
	mso-font-charset:0;
	text-align:left;}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-char-type:none;
	display:none;}
-->

</head>

<body link="#0563C1" vlink="#954F72">
<meta charset=utf-8>


Timeout   Type | Configuration Level | Priority
-- | -- | --
Session Timeout | Session Level | 1 (Highest)
Table Timeout | Table Level | 2
Cluster Timeout | Cluster Level | 3 (Default)



</body>

</html>




## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a table-scoped query timeout to complement session/cluster timeouts.
> 
> - New `table_query_timeout` property: parsed/validated in `PropertyAnalyzer`, stored in `TableProperty` (default `-1`), with `OlapTable` getters/setters (supports reset via `-1`) and exported in `getProperties()` only when explicitly set
> - DDL support: handled on CREATE (`OlapTableFactory`) and ALTER (`AlterJobExecutor` → `LocalMetastore.alterTableProperties`), plus analyzer validation for ALTER
> - Execution behavior: `StmtExecutor#getExecTimeout()` uses session timeout if explicitly overridden; otherwise uses the smallest table-level timeout across referenced OLAP tables; `ConnectContext#isSessionQueryTimeoutOverridden()` detects overrides
> - Error/hinting: timeout messages in `ConnectContext` and `DefaultCoordinator` now reference table-level timeout when applicable; otherwise fall back to session guidance
> - Tests: extensive UTs covering analyze, DDL create/alter, property persistence/export, execution selection logic (multi-table/min), override detection, and error hint paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3898070d49afdc733c78dec8c86cd75ca5c0a8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->