### PR TITLE
[BugFix] Fix incorrect ContentType metadata for S3 exports

### DIFF
--- a/be/src/common/http/content_type.h
+++ b/be/src/common/http/content_type.h
@@ -1,0 +1,27 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace starrocks::http {
+
+// Common HTTP Content-Type constants for file exports
+struct ContentType {
+    static constexpr const char* OCTET_STREAM = "application/octet-stream";
+    static constexpr const char* CSV = "text/csv";
+    static constexpr const char* PARQUET = "application/parquet";
+    static constexpr const char* ORC = "application/x-orc";
+};
+
+} // namespace starrocks::http

--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -17,6 +17,7 @@
 #include <boost/algorithm/string.hpp>
 #include <utility>
 
+#include "common/http/content_type.h"
 #include "csv_escape.h"
 #include "exec/hdfs_scanner/hdfs_scanner_text.h"
 #include "formats/utils.h"
@@ -207,7 +208,9 @@ Status CSVFileWriterFactory::init() {
 }
 
 StatusOr<WriterAndStream> CSVFileWriterFactory::create(const std::string& path) const {
-    ASSIGN_OR_RETURN(auto file, _fs->new_writable_file(WritableFileOptions{.direct_write = true}, path));
+    ASSIGN_OR_RETURN(auto file,
+                     _fs->new_writable_file(
+                             WritableFileOptions{.direct_write = true, .content_type = http::ContentType::CSV}, path));
     auto rollback_action = [fs = _fs, path = path]() {
         WARN_IF_ERROR(ignore_not_found(fs->delete_file(path)), "fail to delete file");
     };

--- a/be/src/formats/orc/orc_file_writer.cpp
+++ b/be/src/formats/orc/orc_file_writer.cpp
@@ -21,6 +21,7 @@
 #include "column/array_column.h"
 #include "column/column_helper.h"
 #include "column/map_column.h"
+#include "common/http/content_type.h"
 #include "formats/orc/orc_memory_pool.h"
 #include "formats/orc/utils.h"
 #include "formats/utils.h"
@@ -493,7 +494,9 @@ Status ORCFileWriterFactory::init() {
 }
 
 StatusOr<WriterAndStream> ORCFileWriterFactory::create(const string& path) const {
-    ASSIGN_OR_RETURN(auto file, _fs->new_writable_file(WritableFileOptions{.direct_write = true}, path));
+    ASSIGN_OR_RETURN(auto file,
+                     _fs->new_writable_file(
+                             WritableFileOptions{.direct_write = true, .content_type = http::ContentType::ORC}, path));
     auto rollback_action = [fs = _fs, path = path]() {
         WARN_IF_ERROR(ignore_not_found(fs->delete_file(path)), "fail to delete file");
     };

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -29,6 +29,7 @@
 #include <utility>
 
 #include "column/column_helper.h"
+#include "common/http/content_type.h"
 #include "formats/file_writer.h"
 #include "formats/parquet/arrow_memory_pool.h"
 #include "formats/parquet/chunk_writer.h"
@@ -504,7 +505,9 @@ Status ParquetFileWriterFactory::init() {
 }
 
 StatusOr<WriterAndStream> ParquetFileWriterFactory::create(const std::string& path) const {
-    ASSIGN_OR_RETURN(auto file, _fs->new_writable_file(WritableFileOptions{.direct_write = true}, path));
+    ASSIGN_OR_RETURN(auto file, _fs->new_writable_file(WritableFileOptions{.direct_write = true,
+                                                                           .content_type = http::ContentType::PARQUET},
+                                                       path));
     VLOG(3) << "create parquet file, path=" << path;
     auto rollback_action = [fs = _fs, path = path]() {
         WARN_IF_ERROR(ignore_not_found(fs->delete_file(path)), "fail to delete file");

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -347,6 +347,12 @@ struct WritableFileOptions {
     // See OpenMode for details.
     FileSystem::OpenMode mode = FileSystem::MUST_CREATE;
     FileEncryptionInfo encryption_info;
+
+    // Content type for cloud storage (S3, Azure, etc.)
+    // Use constants from common/http/content_type.h:
+    //   http::ContentType::CSV, http::ContentType::PARQUET, http::ContentType::ORC, http::ContentType::OCTET_STREAM
+    // If empty, defaults to http::ContentType::OCTET_STREAM ("application/octet-stream")
+    std::string content_type;
 };
 
 // A `SequentialFile` is an `io::InputStream` with a name.

--- a/be/src/io/direct_s3_output_stream.cpp
+++ b/be/src/io/direct_s3_output_stream.cpp
@@ -38,8 +38,11 @@ public:
 };
 
 DirectS3OutputStream::DirectS3OutputStream(std::shared_ptr<Aws::S3::S3Client> client, std::string bucket,
-                                           std::string object)
-        : _client(std::move(client)), _bucket(std::move(bucket)), _object(std::move(object)) {
+                                           std::string object, std::string content_type)
+        : _client(std::move(client)),
+          _bucket(std::move(bucket)),
+          _object(std::move(object)),
+          _content_type(std::move(content_type)) {
     DCHECK(_client != nullptr);
 }
 
@@ -95,6 +98,7 @@ Status DirectS3OutputStream::create_multipart_upload() {
     Aws::S3::Model::CreateMultipartUploadRequest req;
     req.SetBucket(_bucket);
     req.SetKey(_object);
+    req.SetContentType(_content_type);
     FAIL_POINT_TRIGGER_RETURN(output_stream_io_error, Status::IOError("injected output_stream_io_error"));
     Aws::S3::Model::CreateMultipartUploadOutcome outcome = _client->CreateMultipartUpload(req);
     if (outcome.IsSuccess()) {

--- a/be/src/io/direct_s3_output_stream.h
+++ b/be/src/io/direct_s3_output_stream.h
@@ -16,6 +16,7 @@
 
 #include <aws/s3/S3Client.h>
 
+#include "common/http/content_type.h"
 #include "io/output_stream.h"
 
 namespace starrocks::io {
@@ -25,7 +26,8 @@ namespace starrocks::io {
 /// 2. use multi-part upload by default
 class DirectS3OutputStream : public OutputStream {
 public:
-    explicit DirectS3OutputStream(std::shared_ptr<Aws::S3::S3Client> client, std::string bucket, std::string object);
+    explicit DirectS3OutputStream(std::shared_ptr<Aws::S3::S3Client> client, std::string bucket, std::string object,
+                                  std::string content_type = http::ContentType::OCTET_STREAM);
 
     ~DirectS3OutputStream() override = default;
 
@@ -61,6 +63,7 @@ private:
     std::shared_ptr<Aws::S3::S3Client> _client;
     const Aws::String _bucket;
     const Aws::String _object;
+    const Aws::String _content_type;
 
     Aws::String _upload_id;
     std::vector<Aws::String> _etags;

--- a/be/src/io/s3_output_stream.h
+++ b/be/src/io/s3_output_stream.h
@@ -16,6 +16,7 @@
 
 #include <aws/s3/S3Client.h>
 
+#include "common/http/content_type.h"
 #include "io/output_stream.h"
 
 namespace starrocks::io {
@@ -23,7 +24,8 @@ namespace starrocks::io {
 class S3OutputStream : public OutputStream {
 public:
     explicit S3OutputStream(std::shared_ptr<Aws::S3::S3Client> client, std::string bucket, std::string object,
-                            int64_t max_single_part_size, int64_t min_upload_part_size);
+                            int64_t max_single_part_size, int64_t min_upload_part_size,
+                            std::string content_type = http::ContentType::OCTET_STREAM);
 
     ~S3OutputStream() override = default;
 
@@ -60,6 +62,7 @@ private:
     const Aws::String _object;
     const int64_t _max_single_part_size;
     const int64_t _min_upload_part_size;
+    const Aws::String _content_type;
     Aws::String _buffer;
     Aws::String _upload_id;
     std::vector<Aws::String> _etags;


### PR DESCRIPTION
Previously, files exported to S3 (CSV, Parquet, ORC) had incorrect ContentType metadata set to "application/xml" by default, which caused issues with tools that rely on ContentType to identify files.

This PR adds proper ContentType support:
- Add content_type field to WritableFileOptions
- Pass content_type through S3OutputStream and DirectS3OutputStream
- Set appropriate ContentType for each file format:
  - CSV: text/csv
  - Parquet: application/parquet
  - ORC: application/x-orc
  - Default: application/octet-stream

Also adds comprehensive unit tests and test documentation.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures S3 objects have accurate Content-Type for exported files and provides a default when unspecified.
> 
> - Introduces `common/http/content_type.h` with `ContentType` constants and adds `WritableFileOptions.content_type` (defaulting to `application/octet-stream`)
> - Propagates content type through S3 I/O: updates `S3OutputStream` and `DirectS3OutputStream` to accept and set `ContentType` in `CreateMultipartUpload`/`PutObject`
> - Sets explicit content types in writer factories: CSV (`text/csv`), Parquet (`application/parquet`), ORC (`application/x-orc`)
> - Modifies S3 filesystem to use provided `content_type` (or default) when creating writable files, including `direct_write` path
> - Adds tests verifying Content-Type for singlepart/multipart and direct writes in `fs_s3_test.cpp` and `s3_output_stream_test.cpp`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10c550c44183275687b615c7e03f73207b01352b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->