### PR TITLE
[BugFix] iceberg partition grammar fix

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -415,16 +415,16 @@ public class AstToStringBuilder {
         // Partition column names
         List<String> partitionNames;
         if (table.getType() != JDBC && !table.isUnPartitioned()) {
-            createTableSql.append("\nPARTITION BY (");
-
             if (!table.isIcebergTable()) {
+                createTableSql.append("\nPARTITION BY (");
                 partitionNames = table.getPartitionColumnNames();
+                createTableSql.append(String.join(", ", partitionNames)).append(")");
             } else {
                 partitionNames = ((IcebergTable) table).getPartitionColumnNamesWithTransform();
+                createTableSql.append("\nPARTITION BY ").append(String.join(", ", partitionNames));
             }
-
-            createTableSql.append(String.join(", ", partitionNames)).append(")");
         }
+
 
         // Comment
         if (!Strings.isNullOrEmpty(table.getComment())) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -351,12 +351,17 @@ public class IcebergMetadataTest extends TableTestBase {
         new MockUp<IcebergTable>() {
             @Mock
             public boolean isUnPartitioned() {
-                return true;
+                return false;
             }
 
             @Mock
             public List<Integer> getSortKeyIndexes() {
                 return ImmutableList.of(0, 1);
+            }
+
+            @Mock
+            public List<String> getPartitionColumnNamesWithTransform() {
+                return ImmutableList.of("hour(`c1`)");
             }
         };
 
@@ -389,6 +394,7 @@ public class IcebergMetadataTest extends TableTestBase {
                         "  `c1` int(11) DEFAULT NULL,\n" +
                         "  `c2` varchar(1048576) DEFAULT NULL\n" +
                         ")\n" +
+                        "PARTITION BY hour(`c1`)\n" +
                         "ORDER BY (c1 ASC NULLS FIRST,c2 DESC NULLS LAST);",
                 createSql);
     }

--- a/test/sql/test_iceberg/R/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/R/test_iceberg_alter_table
@@ -86,7 +86,7 @@ insert into test_part_evo values (3, 'data3', '2023-01-03', 300);
 insert into test_part_evo values (4, 'data4', '2023-01-04', 400);
 -- result:
 -- !result
-function: assert_query_contains("show create table test_part_evo", "PARTITION BY (`dt`, truncate(`value`, 10), bucket(`id`, 10))")
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY `dt`, truncate(`value`, 10), bucket(`id`, 10)")
 -- result:
 None
 -- !result
@@ -99,7 +99,7 @@ alter table test_part_evo add partition column month(dt);
 insert into test_part_evo values (5, 'data5', '2023-01-05', 500);
 -- result:
 -- !result
-function: assert_query_contains("show create table test_part_evo", "PARTITION BY (truncate(`value`, 10), bucket(`id`, 10), month(`dt`))")
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY truncate(`value`, 10), bucket(`id`, 10), month(`dt`)")
 -- result:
 None
 -- !result
@@ -114,7 +114,7 @@ select * from test_part_evo order by id;
 alter table test_part_evo drop partition column truncate(value, 10), bucket(id, 10);
 -- result:
 -- !result
-function: assert_query_contains("show create table test_part_evo", "PARTITION BY (month(`dt`))")
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY month(`dt`)")
 -- result:
 None
 -- !result

--- a/test/sql/test_iceberg/R/test_iceberg_show_stmt
+++ b/test/sql/test_iceberg/R/test_iceberg_show_stmt
@@ -13,7 +13,7 @@ partition_transform_table	CREATE TABLE `partition_transform_table` (
   `p1` varchar(1073741824) DEFAULT NULL,
   `p2` varchar(1073741824) DEFAULT NULL
 )
-PARTITION BY (year(`t1`), month(`t2`), day(`t3`), hour(`t4`), truncate(`p1`, 5), bucket(`p2`, 3))
+PARTITION BY year(`t1`), month(`t2`), day(`t3`), hour(`t4`), truncate(`p1`, 5), bucket(`p2`, 3)
 PROPERTIES ("owner" = "root", "location" = "oss://starrocks-ci-test/iceberg_ci_db/partition_transform_table");
 -- !result
 drop catalog iceberg_sql_test_${uuid0};

--- a/test/sql/test_iceberg/T/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/T/test_iceberg_alter_table
@@ -62,19 +62,19 @@ insert into test_part_evo values (2, 'data2', '2023-01-02', 200);
 insert into test_part_evo values (3, 'data3', '2023-01-03', 300);
 insert into test_part_evo values (4, 'data4', '2023-01-04', 400);
 
-function: assert_query_contains("show create table test_part_evo", "PARTITION BY (`dt`, truncate(`value`, 10), bucket(`id`, 10))")
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY `dt`, truncate(`value`, 10), bucket(`id`, 10)")
 
 alter table test_part_evo drop partition column dt;
 alter table test_part_evo add partition column month(dt);
 insert into test_part_evo values (5, 'data5', '2023-01-05', 500);
 
-function: assert_query_contains("show create table test_part_evo", "PARTITION BY (truncate(`value`, 10), bucket(`id`, 10), month(`dt`))")
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY truncate(`value`, 10), bucket(`id`, 10), month(`dt`)")
 
 select * from test_part_evo order by id;
 
 alter table test_part_evo drop partition column truncate(value, 10), bucket(id, 10);
 
-function: assert_query_contains("show create table test_part_evo", "PARTITION BY (month(`dt`))")
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY month(`dt`)")
 
 select * from test_part_evo order by id;
 


### PR DESCRIPTION
## Why I'm doing:
show create table result should be executed successfully.
## What I'm doing:

Fixes [#10814](https://github.com/StarRocks/StarRocksTest/issues/10814)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes Iceberg SHOW CREATE TABLE partition formatting to drop parentheses and include transform expressions, and updates tests accordingly.
> 
> - Updates `AstToStringBuilder.getExternalCatalogTableDdlStmt` to render Iceberg `PARTITION BY` using `getPartitionColumnNamesWithTransform()` without surrounding parentheses; non-Iceberg still uses `PARTITION BY (...)`
> - Adjusts `IcebergMetadataTest` and SQL tests to expect the new `PARTITION BY` syntax (e.g., `PARTITION BY hour(`c1`)`, `PARTITION BY year(`t1`), ...`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ada929fada152d825799423261d21ecd56534f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->