### PR TITLE
[Enhancement] Support null range value for range distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ cmake-build-debug/
 CMakeLists.txt
 .claude
 CLAUDE.md
+AGENTS.md
 .clangd
 .cursor/
 
@@ -115,3 +116,4 @@ build-mac/build.ninja
 build-mac/build_version.cc
 build-mac/cmake_install.cmake
 _codeql_detected_source_root
+

--- a/be/src/storage/lake/tablet_range_helper.h
+++ b/be/src/storage/lake/tablet_range_helper.h
@@ -51,9 +51,6 @@ public:
                                                              const TabletSchemaCSPtr& tablet_schema);
 
 private:
-    static Status _parse_string_to_datum(const TypeDescriptor& type_desc, const std::string& value_str, Datum* datum,
-                                         MemPool* mem_pool);
-
     // check if the tablet range is closedOpen
     static Status _validate_tablet_range(const TabletRangePB& tablet_range_pb);
 };

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -489,6 +489,7 @@ SET(DW_TEST_FILES
     ./storage/convert_helper_test.cpp
     ./storage/cumulative_compaction_test.cpp
     ./storage/data_dir_test.cpp
+    ./storage/datum_variant_test.cpp
     ./storage/decimal12_test.cpp
     ./storage/default_compaction_policy_test.cpp
     ./storage/delete_handler_test.cpp

--- a/be/test/exec/range_router_test.cpp
+++ b/be/test/exec/range_router_test.cpp
@@ -22,8 +22,10 @@
 
 #include "column/binary_column.h"
 #include "column/chunk.h"
+#include "column/datum.h"
 #include "column/field.h"
 #include "column/fixed_length_column.h"
+#include "column/nullable_column.h"
 #include "column/schema.h"
 #include "runtime/descriptors.h"
 #include "runtime/types.h"
@@ -42,6 +44,13 @@ protected:
         TVariant tv;
         tv.__set_type(TYPE_INT_DESC.to_thrift());
         tv.__set_value(std::to_string(v));
+        return tv;
+    }
+
+    TVariant make_null_variant(const TypeDescriptor& type_desc) {
+        TVariant tv;
+        tv.__set_type(type_desc.to_thrift());
+        tv.__set_variant_type(TVariantType::NULL_VALUE);
         return tv;
     }
 
@@ -513,9 +522,146 @@ TEST_F(RangeRouterTest, VarcharThreeRangesFullCoverage) {
     }
 }
 
+// NULL_TYPE boundary values should be treated as NULL and route with NULL as minimum.
+// Ranges:
+//   R0: (-inf, NULL)
+//   R1: [NULL, 10)
+//   R2: [10, +inf)
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, NullTypeBoundaryRouting) {
+    std::vector<TTabletRange> ranges;
+
+    TTabletRange r0;
+    {
+        TTuple upper;
+        upper.__set_values(std::vector<TVariant>{make_null_variant(TYPE_INT_DESC)});
+        r0.__set_upper_bound(upper);
+        r0.__set_upper_bound_included(false);
+    }
+
+    TTabletRange r1;
+    {
+        TTuple lower;
+        lower.__set_values(std::vector<TVariant>{make_null_variant(TYPE_INT_DESC)});
+        r1.__set_lower_bound(lower);
+        r1.__set_lower_bound_included(true);
+
+        TTuple upper;
+        upper.__set_values(std::vector<TVariant>{make_int_variant(10)});
+        r1.__set_upper_bound(upper);
+        r1.__set_upper_bound_included(false);
+    }
+
+    TTabletRange r2;
+    {
+        TTuple lower;
+        lower.__set_values(std::vector<TVariant>{make_int_variant(10)});
+        r2.__set_lower_bound(lower);
+        r2.__set_lower_bound_included(true);
+    }
+
+    ranges.push_back(r0);
+    ranges.push_back(r1);
+    ranges.push_back(r2);
+
+    std::vector<int64_t> tablet_ids{10, 20, 30};
+
+    RangeRouter router;
+    ASSERT_TRUE(router.init(ranges, 1).ok());
+
+    auto data = FixedLengthColumn<int32_t>::create();
+    auto nulls = NullColumn::create();
+    auto nullable = NullableColumn::create(std::move(data), std::move(nulls));
+    nullable->append_nulls(1);
+    nullable->append_datum(Datum(0));
+    nullable->append_datum(Datum(5));
+    nullable->append_datum(Datum(10));
+    nullable->append_datum(Datum(20));
+
+    Chunk chunk;
+    chunk.append_column(nullable, 0);
+
+    SlotDescriptor slot_desc(0, "v1", TypeDescriptor::from_logical_type(TYPE_INT));
+    std::vector<SlotDescriptor*> slot_descs{&slot_desc};
+    chunk.set_slot_id_to_index(slot_desc.id(), 0);
+
+    std::vector<uint16_t> row_indices;
+    for (int i = 0; i < chunk.num_rows(); ++i) {
+        row_indices.emplace_back(i);
+    }
+    std::vector<int64_t> routed_ids;
+
+    ASSERT_TRUE(router.route_chunk_rows(&chunk, slot_descs, row_indices, tablet_ids, &routed_ids).ok());
+
+    std::vector<int64_t> expected = {20, 20, 20, 30, 30};
+    ASSERT_EQ(expected.size(), routed_ids.size());
+    for (int i = 0; i < static_cast<int>(expected.size()); ++i) {
+        ASSERT_EQ(expected[i], routed_ids[i]) << "row " << i << " mismatch";
+    }
+}
+
 // ----------------------------------------------------------------------
 // Tests that explicitly exercise RangeRouter::_validate_range() error
 // branches.
+
+TEST_F(RangeRouterTest, InitRejectsInvalidBoundVariantType) {
+    TVariant invalid_variant;
+    invalid_variant.__set_type(TYPE_INT_DESC.to_thrift());
+    invalid_variant.__set_variant_type(TVariantType::MINIMUM);
+    invalid_variant.__set_value("0");
+
+    TTabletRange r0;
+    {
+        TTuple upper;
+        upper.__set_values(std::vector<TVariant>{invalid_variant});
+        r0.__set_upper_bound(upper);
+        r0.__set_upper_bound_included(false);
+    }
+
+    TTabletRange r1;
+    {
+        TTuple lower;
+        lower.__set_values(std::vector<TVariant>{invalid_variant});
+        r1.__set_lower_bound(lower);
+        r1.__set_lower_bound_included(true);
+    }
+
+    std::vector<TTabletRange> ranges{r0, r1};
+    RangeRouter router;
+    auto status = router.init(ranges, 1);
+    ASSERT_FALSE(status.ok());
+    ASSERT_TRUE(status.is_internal_error());
+    ASSERT_EQ("Invalid value in range bound", status.message());
+}
+
+TEST_F(RangeRouterTest, ValidateRangeRejectsInvalidVariantValue) {
+    TVariant invalid_variant;
+    invalid_variant.__set_type(TYPE_INT_DESC.to_thrift());
+    invalid_variant.__set_variant_type(TVariantType::NORMAL_VALUE);
+
+    TTabletRange r0;
+    {
+        TTuple upper;
+        upper.__set_values(std::vector<TVariant>{invalid_variant});
+        r0.__set_upper_bound(upper);
+        r0.__set_upper_bound_included(false);
+    }
+
+    TTabletRange r1;
+    {
+        TTuple lower;
+        lower.__set_values(std::vector<TVariant>{invalid_variant});
+        r1.__set_lower_bound(lower);
+        r1.__set_lower_bound_included(true);
+    }
+
+    std::vector<TTabletRange> ranges{r0, r1};
+    RangeRouter router;
+    auto status = router.init(ranges, 1);
+    ASSERT_FALSE(status.ok());
+    ASSERT_TRUE(status.is_internal_error());
+    ASSERT_EQ("Invalid variant for range validation", status.message());
+}
 // ----------------------------------------------------------------------
 
 // NOLINTNEXTLINE

--- a/be/test/storage/datum_variant_test.cpp
+++ b/be/test/storage/datum_variant_test.cpp
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/datum_variant.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "runtime/types.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+TEST(DatumVariantTest, FromProtoNullValueAndTypeInfo) {
+    VariantPB variant_pb;
+    TypeDescriptor type_desc(TYPE_INT);
+    variant_pb.mutable_type()->CopyFrom(type_desc.to_protobuf());
+    variant_pb.set_variant_type(VariantTypePB::NULL_VALUE);
+
+    Datum datum;
+    TypeDescriptor out_type_desc;
+    TypeInfoPtr out_type_info;
+    ASSERT_OK(DatumVariant::from_proto(variant_pb, &datum, &out_type_desc, &out_type_info));
+    ASSERT_TRUE(datum.is_null());
+    ASSERT_EQ(TYPE_INT, out_type_desc.type);
+    ASSERT_TRUE(out_type_info != nullptr);
+}
+
+TEST(DatumVariantTest, FromProtoMissingType) {
+    VariantPB variant_pb;
+    Datum datum;
+    auto status = DatumVariant::from_proto(variant_pb, &datum);
+    ASSERT_TRUE(status.is_invalid_argument());
+    ASSERT_EQ("No type in variant", status.message());
+}
+
+TEST(DatumVariantTest, FromProtoUnsupportedType) {
+    VariantPB variant_pb;
+    PTypeDesc type_desc;
+    auto* node = type_desc.add_types();
+    node->set_type(TTypeNodeType::SCALAR);
+    node->mutable_scalar_type()->set_type(TPrimitiveType::INVALID_TYPE);
+    variant_pb.mutable_type()->CopyFrom(type_desc);
+    variant_pb.set_variant_type(VariantTypePB::NORMAL_VALUE);
+    variant_pb.set_value("1");
+
+    Datum datum;
+    auto status = DatumVariant::from_proto(variant_pb, &datum);
+    ASSERT_TRUE(status.is_not_supported());
+    ASSERT_NE(std::string::npos, status.message().find("not supported"));
+}
+
+TEST(DatumVariantTest, FromProtoInvalidVariantValue) {
+    VariantPB variant_pb;
+    TypeDescriptor type_desc(TYPE_INT);
+    variant_pb.mutable_type()->CopyFrom(type_desc.to_protobuf());
+    variant_pb.set_variant_type(VariantTypePB::NORMAL_VALUE);
+
+    Datum datum;
+    auto status = DatumVariant::from_proto(variant_pb, &datum);
+    ASSERT_TRUE(status.is_invalid_argument());
+    ASSERT_EQ("Invalid variant value", status.message());
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/BoolVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/BoolVariant.java
@@ -15,8 +15,8 @@
 package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.thrift.TInfinityType;
 import com.starrocks.thrift.TVariant;
+import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.TypeSerializer;
 
@@ -61,7 +61,7 @@ public class BoolVariant extends Variant {
         TVariant variant = new TVariant();
         variant.setType(TypeSerializer.toThrift(type));
         variant.setValue(getStringValue());
-        variant.setInfinity_type(TInfinityType.NONE_INFINITY);
+        variant.setVariant_type(TVariantType.NORMAL_VALUE);
         return variant;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DateVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DateVariant.java
@@ -17,8 +17,8 @@ package com.starrocks.catalog;
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.util.DateUtils;
-import com.starrocks.thrift.TInfinityType;
 import com.starrocks.thrift.TVariant;
+import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeSerializer;
 
@@ -63,7 +63,7 @@ public class DateVariant extends Variant {
         TVariant variant = new TVariant();
         variant.setType(TypeSerializer.toThrift(type));
         variant.setValue(getStringValue());
-        variant.setInfinity_type(TInfinityType.NONE_INFINITY);
+        variant.setVariant_type(TVariantType.NORMAL_VALUE);
         return variant;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IntVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IntVariant.java
@@ -16,8 +16,8 @@ package com.starrocks.catalog;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.thrift.TInfinityType;
 import com.starrocks.thrift.TVariant;
+import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeSerializer;
 
@@ -64,7 +64,7 @@ public class IntVariant extends Variant {
         TVariant variant = new TVariant();
         variant.setType(TypeSerializer.toThrift(type));
         variant.setValue(getStringValue());
-        variant.setInfinity_type(TInfinityType.NONE_INFINITY);
+        variant.setVariant_type(TVariantType.NORMAL_VALUE);
         return variant;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LargeIntVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LargeIntVariant.java
@@ -16,8 +16,8 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Int128;
-import com.starrocks.thrift.TInfinityType;
 import com.starrocks.thrift.TVariant;
+import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.TypeSerializer;
 
@@ -63,7 +63,7 @@ public class LargeIntVariant extends Variant {
         TVariant variant = new TVariant();
         variant.setType(TypeSerializer.toThrift(type));
         variant.setValue(getStringValue());
-        variant.setInfinity_type(TInfinityType.NONE_INFINITY);
+        variant.setVariant_type(TVariantType.NORMAL_VALUE);
         return variant;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaxVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaxVariant.java
@@ -14,8 +14,8 @@
 
 package com.starrocks.catalog;
 
-import com.starrocks.thrift.TInfinityType;
 import com.starrocks.thrift.TVariant;
+import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.Type;
 
 import java.util.Objects;
@@ -39,7 +39,7 @@ public class MaxVariant extends Variant {
     public TVariant toThrift() {
         TVariant variant = new TVariant();
         variant.setType(com.starrocks.type.TypeSerializer.toThrift(type));
-        variant.setInfinity_type(TInfinityType.MAXIMUM);
+        variant.setVariant_type(TVariantType.MAXIMUM);
         return variant;
     }
 
@@ -65,4 +65,3 @@ public class MaxVariant extends Variant {
         return Objects.hash(MaxVariant.class, type);
     }
 }
-

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/NullVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/NullVariant.java
@@ -17,29 +17,30 @@ package com.starrocks.catalog;
 import com.starrocks.thrift.TVariant;
 import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeSerializer;
 
 import java.util.Objects;
 
-public class MinVariant extends Variant {
-    public MinVariant(Type type) {
+public class NullVariant extends Variant {
+    public NullVariant(Type type) {
         super(type);
     }
 
     @Override
     public String getStringValue() {
-        return "MIN";
+        return "NULL";
     }
 
     @Override
     public long getLongValue() {
-        return Long.MIN_VALUE;
+        throw new IllegalStateException("NullVariant has no numeric value");
     }
 
     @Override
     public TVariant toThrift() {
         TVariant variant = new TVariant();
-        variant.setType(com.starrocks.type.TypeSerializer.toThrift(type));
-        variant.setVariant_type(TVariantType.MINIMUM);
+        variant.setType(TypeSerializer.toThrift(type));
+        variant.setVariant_type(TVariantType.NULL_VALUE);
         return variant;
     }
 
@@ -53,15 +54,15 @@ public class MinVariant extends Variant {
         if (this == object) {
             return true;
         }
-        if (!(object instanceof MinVariant)) {
+        if (!(object instanceof NullVariant)) {
             return false;
         }
-        MinVariant other = (MinVariant) object;
+        NullVariant other = (NullVariant) object;
         return Objects.equals(this.type, other.type);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(MinVariant.class, type);
+        return Objects.hash(NullVariant.class, type);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StringVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StringVariant.java
@@ -16,8 +16,8 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.util.StringUtils;
-import com.starrocks.thrift.TInfinityType;
 import com.starrocks.thrift.TVariant;
+import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeSerializer;
 
@@ -49,7 +49,7 @@ public class StringVariant extends Variant {
         TVariant variant = new TVariant();
         variant.setType(TypeSerializer.toThrift(type));
         variant.setValue(getStringValue());
-        variant.setInfinity_type(TInfinityType.NONE_INFINITY);
+        variant.setVariant_type(TVariantType.NORMAL_VALUE);
         return variant;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
@@ -14,11 +14,11 @@
 
 package com.starrocks.catalog;
 
-import com.starrocks.proto.InfinityTypePB;
 import com.starrocks.proto.PScalarType;
 import com.starrocks.proto.PTypeDesc;
 import com.starrocks.proto.PTypeNode;
 import com.starrocks.proto.VariantPB;
+import com.starrocks.proto.VariantTypePB;
 import com.starrocks.thrift.TPrimitiveType;
 import com.starrocks.thrift.TTuple;
 import com.starrocks.thrift.TTypeNodeType;
@@ -968,27 +968,27 @@ public class VariantTest {
     public void testMinMaxVariantToThrift() {
         Variant minDate = Variant.minVariant(DateType.DATE);
         TVariant tMin = minDate.toThrift();
-        Assertions.assertTrue(tMin.isSetInfinity_type());
-        Assertions.assertEquals(com.starrocks.thrift.TInfinityType.MINIMUM, tMin.getInfinity_type());
+        Assertions.assertTrue(tMin.isSetVariant_type());
+        Assertions.assertEquals(com.starrocks.thrift.TVariantType.MINIMUM, tMin.getVariant_type());
 
         Variant maxDate = Variant.maxVariant(DateType.DATE);
         TVariant tMax = maxDate.toThrift();
-        Assertions.assertTrue(tMax.isSetInfinity_type());
-        Assertions.assertEquals(com.starrocks.thrift.TInfinityType.MAXIMUM, tMax.getInfinity_type());
+        Assertions.assertTrue(tMax.isSetVariant_type());
+        Assertions.assertEquals(com.starrocks.thrift.TVariantType.MAXIMUM, tMax.getVariant_type());
     }
 
     @Test
     public void testMinMaxVariantFromThrift() {
         TVariant tMin = new TVariant();
         tMin.setType(TypeSerializer.toThrift(DateType.DATE));
-        tMin.setInfinity_type(com.starrocks.thrift.TInfinityType.MINIMUM);
+        tMin.setVariant_type(com.starrocks.thrift.TVariantType.MINIMUM);
         Variant minVariant = Variant.fromThrift(tMin);
         Assertions.assertTrue(minVariant instanceof MinVariant);
         Assertions.assertEquals(DateType.DATE, minVariant.getType());
 
         TVariant tMax = new TVariant();
         tMax.setType(TypeSerializer.toThrift(DateType.DATE));
-        tMax.setInfinity_type(com.starrocks.thrift.TInfinityType.MAXIMUM);
+        tMax.setVariant_type(com.starrocks.thrift.TVariantType.MAXIMUM);
         Variant maxVariant = Variant.fromThrift(tMax);
         Assertions.assertTrue(maxVariant instanceof MaxVariant);
         Assertions.assertEquals(DateType.DATE, maxVariant.getType());
@@ -1008,17 +1008,80 @@ public class VariantTest {
 
         VariantPB pbMin = new VariantPB();
         pbMin.type = typeDesc;
-        pbMin.infinityType = InfinityTypePB.MINIMUM;
+        pbMin.variantType = VariantTypePB.MINIMUM;
         Variant minVariant = Variant.fromProto(pbMin);
         Assertions.assertTrue(minVariant instanceof MinVariant);
         Assertions.assertEquals(DateType.DATE, minVariant.getType());
 
         VariantPB pbMax = new VariantPB();
         pbMax.type = typeDesc;
-        pbMax.infinityType = InfinityTypePB.MAXIMUM;
+        pbMax.variantType = VariantTypePB.MAXIMUM;
         Variant maxVariant = Variant.fromProto(pbMax);
         Assertions.assertTrue(maxVariant instanceof MaxVariant);
         Assertions.assertEquals(DateType.DATE, maxVariant.getType());
+    }
+
+    @Test
+    public void testNullVariantFromThrift() {
+        TVariant tNull = new TVariant();
+        tNull.setType(TypeSerializer.toThrift(IntegerType.INT));
+        tNull.setVariant_type(com.starrocks.thrift.TVariantType.NULL_VALUE);
+        Variant nullVariant = Variant.fromThrift(tNull);
+        Assertions.assertTrue(nullVariant instanceof NullVariant);
+        Assertions.assertEquals(IntegerType.INT, nullVariant.getType());
+    }
+
+    @Test
+    public void testNullVariantFromProto() {
+        PTypeDesc typeDesc = new PTypeDesc();
+        typeDesc.types = new ArrayList<>();
+
+        PTypeNode node = new PTypeNode();
+        node.type = TTypeNodeType.SCALAR.getValue();
+        node.scalarType = new PScalarType();
+        node.scalarType.type = TPrimitiveType.INT.getValue();
+        typeDesc.types.add(node);
+
+        VariantPB pbNull = new VariantPB();
+        pbNull.type = typeDesc;
+        pbNull.variantType = VariantTypePB.NULL_VALUE;
+        Variant nullVariant = Variant.fromProto(pbNull);
+        Assertions.assertTrue(nullVariant instanceof NullVariant);
+        Assertions.assertEquals(IntegerType.INT, nullVariant.getType());
+    }
+
+    @Test
+    public void testNullVariantCompareOrder() {
+        Variant min = Variant.minVariant(IntegerType.INT);
+        Variant max = Variant.maxVariant(IntegerType.INT);
+        Variant nullVar = Variant.nullVariant(IntegerType.INT);
+        Variant intVar = new IntVariant(IntegerType.INT, 1);
+
+        Assertions.assertTrue(min.compareTo(nullVar) < 0);
+        Assertions.assertTrue(nullVar.compareTo(intVar) < 0);
+        Assertions.assertTrue(intVar.compareTo(max) < 0);
+    }
+
+    @Test
+    public void testNullVariantToThriftAndStringValue() {
+        Variant nullVar = Variant.nullVariant(IntegerType.INT);
+        TVariant tNull = nullVar.toThrift();
+        Assertions.assertTrue(tNull.isSetVariant_type());
+        Assertions.assertEquals(com.starrocks.thrift.TVariantType.NULL_VALUE, tNull.getVariant_type());
+        Assertions.assertFalse(tNull.isSetValue());
+        Assertions.assertEquals("NULL", nullVar.toString());
+    }
+
+    @Test
+    public void testNullVariantEqualsHashCodeAndLongValue() {
+        Variant nullInt1 = Variant.nullVariant(IntegerType.INT);
+        Variant nullInt2 = Variant.nullVariant(IntegerType.INT);
+        Variant nullBigint = Variant.nullVariant(IntegerType.BIGINT);
+
+        Assertions.assertEquals(nullInt1, nullInt2);
+        Assertions.assertEquals(nullInt1.hashCode(), nullInt2.hashCode());
+        Assertions.assertNotEquals(nullInt1, nullBigint);
+        Assertions.assertThrows(IllegalStateException.class, nullInt1::getLongValue);
     }
 
     // ==================== Cross-Variant equals() Tests ====================

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -232,16 +232,17 @@ message TransactionStatePB {
     optional string reason = 3;
 }
 
-enum InfinityTypePB {
-    NONE_INFINITY = 0;
-    MINIMUM = 1;
-    MAXIMUM = 2;
+enum VariantTypePB {
+    NORMAL_VALUE = 0;
+    NULL_VALUE = 1;
+    MINIMUM = 2;
+    MAXIMUM = 3;
 }
 
 message VariantPB {
     optional PTypeDesc type = 1;
     optional string value = 2;
-    optional InfinityTypePB infinity_type = 3;
+    optional VariantTypePB variant_type = 3;
 }
 
 message TuplePB {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -639,16 +639,17 @@ struct TParquetOptions {
     4: optional string version
 }
 
-enum TInfinityType {
-    NONE_INFINITY = 0,
-    MINIMUM = 1,
-    MAXIMUM = 2,
+enum TVariantType {
+    NORMAL_VALUE = 0,
+    NULL_VALUE = 1,
+    MINIMUM = 2,
+    MAXIMUM = 3,
 }
 
 struct TVariant {
     1: optional TTypeDesc type
     2: optional string value
-    3: optional TInfinityType infinity_type
+    3: optional TVariantType variant_type
 }
 
 struct TTuple {


### PR DESCRIPTION
## Why I'm doing:
Support null range value for range distribution

## What I'm doing:
  - Introduced VariantType (NORMAL_VALUE, NULL_VALUE, MINIMUM, MAXIMUM) in Thrift/Proto and migrated FE/BE Variant handling to use it, including a typed NullVariant.
  - Updated range routing to treat NULL boundary values correctly and added coverage in RangeRouterTest.
  - Simplified variant serialization logic and removed legacy infinity-type usage throughout FE/BE.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces explicit variant typing and NULL handling in range distribution.
> 
> - Replace legacy infinity-type with `VariantType` in Thrift/Proto and migrate FE/BE `Variant`/`DatumVariant` (incl. new `NullVariant`) with updated (de)serialization
> - Range routing: infer boundary types, build nullable columns, accept `NULL_VALUE` in bounds, and validate adjacent boundaries with null-awareness; adds BE tests incl. `NullTypeBoundaryRouting`
> - Lake `TabletRangeHelper`: parse bounds via `DatumVariant.from_proto`, enabling NULL-aware seek tuple/string construction and simplifying parsing
> - Update unit tests in FE (`VariantTest`) for min/max/null variants and in BE (`range_router_test.cpp`); minor housekeeping (e.g., guard checks, messages)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d005d94f95af486f56cc08290a59c711ebb04e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->