### PR TITLE
[UT] Fix MemTracker destruction failure in debug mode

### DIFF
--- a/be/src/testutil/init_test_env.h
+++ b/be/src/testutil/init_test_env.h
@@ -115,11 +115,11 @@ int init_test_env(int argc, char** argv) {
     int r = RUN_ALL_TESTS();
 
     // clear some trash objects kept in tablet_manager so mem_tracker checks will not fail
-    CHECK(StorageEngine::instance()->tablet_manager()->start_trash_sweep().ok());
+    CHECK(engine->tablet_manager()->start_trash_sweep().ok());
     (void)butil::DeleteFile(storage_root, true);
     exec_env->wait_for_finish();
     // delete engine
-    StorageEngine::instance()->stop();
+    engine->stop();
     // destroy exec env
     tls_thread_status.set_mem_tracker(nullptr);
     exec_env->stop();
@@ -128,6 +128,7 @@ int init_test_env(int argc, char** argv) {
         exec_env->lake_tablet_manager()->stop();
     }
 #endif
+    delete engine;
     exec_env->destroy();
     cache_env->destroy();
     global_env->stop();


### PR DESCRIPTION
## Why I'm doing:

https://github.com/StarRocks/starrocks/pull/67027 will check whether the child mem_trackers are empty.
 
```
F20260106 13:38:23.485664 140227155389056 mem_tracker.cpp:205] Check failed: _child_trackers.empty() Memory of  exceed limit. Child mem trackers have not been released, may cause corruption Backend: , Used: 0, Limit: -1. 

*** SIGABRT (@0x27be) received by PID 10174 (TID 0x7f892dc8ea80) LWP(10174) from PID 10174; stack trace: ***
    @     0x7f892da99ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x29c92c28 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f892da42520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7f892da969fc pthread_kill
    @     0x7f892da42476 raise
    @     0x7f892da287f3 abort
    @         0x1dd2e7b8 starrocks::failure_function()
    @         0x29c86fee google::LogMessage::Fail()
    @         0x29c887c8 google::LogMessageFatal::~LogMessageFatal()
    @         0x25b6ad5c starrocks::MemTracker::~MemTracker()
    @         0x1a2fde42 std::default_delete<starrocks::MemTracker>::operator()(starrocks::MemTracker*) const
    @         0x1a2f7502 std::unique_ptr<starrocks::MemTracker, std::default_delete<starrocks::MemTracker> >::~unique_ptr()
    @         0x1a2eaf34 starrocks::init_test_env(int, char**)
    @         0x1a2eb296 main
    @     0x7f892da29d90 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
    @   
```

## What I'm doing:

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
