### PR TITLE
[BugFix] Fix OlapTableSink::is_full to prevent race condition

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -426,7 +426,7 @@ Status OlapTableSink::open_wait() {
 }
 
 bool OlapTableSink::is_full() {
-    return _tablet_sink_sender->is_full() || _is_automatic_partition_running.load(std::memory_order_acquire);
+    return _is_automatic_partition_running.load(std::memory_order_acquire) || _tablet_sink_sender->is_full();
 }
 
 Status OlapTableSink::_automatic_create_partition() {

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -1242,45 +1242,52 @@ IndexChannel::~IndexChannel() {
 }
 
 Status IndexChannel::init(RuntimeState* state, const std::vector<PTabletWithPartition>& tablets, bool is_incremental) {
-    for (const auto& tablet : tablets) {
-        auto* location = _parent->_location->find_tablet(tablet.tablet_id());
-        if (location == nullptr) {
-            auto msg = fmt::format("Not found tablet: {}", tablet.tablet_id());
-            return Status::NotFound(msg);
-        }
-        auto node_ids_size = location->node_ids.size();
-        for (size_t i = 0; i < node_ids_size; ++i) {
-            auto& node_id = location->node_ids[i];
-            NodeChannel* channel = nullptr;
-            auto it = _node_channels.find(node_id);
-            if (it == std::end(_node_channels)) {
-                auto channel_ptr = std::make_unique<NodeChannel>(_parent, node_id, is_incremental, _where_clause);
-                channel = channel_ptr.get();
-                _node_channels.emplace(node_id, std::move(channel_ptr));
-                if (is_incremental) {
-                    _has_incremental_node_channel = true;
+    {
+        std::unique_lock<std::shared_mutex> lock(_node_channels_mutex);
+        for (const auto& tablet : tablets) {
+            auto* location = _parent->_location->find_tablet(tablet.tablet_id());
+            if (location == nullptr) {
+                auto msg = fmt::format("Not found tablet: {}", tablet.tablet_id());
+                return Status::NotFound(msg);
+            }
+            auto node_ids_size = location->node_ids.size();
+            for (size_t i = 0; i < node_ids_size; ++i) {
+                auto& node_id = location->node_ids[i];
+                NodeChannel* channel = nullptr;
+                auto it = _node_channels.find(node_id);
+                if (it == std::end(_node_channels)) {
+                    auto channel_ptr = std::make_unique<NodeChannel>(_parent, node_id, is_incremental, _where_clause);
+                    channel = channel_ptr.get();
+                    _node_channels.emplace(node_id, std::move(channel_ptr));
+                    if (is_incremental) {
+                        _has_incremental_node_channel = true;
+                    }
+                } else {
+                    channel = it->second.get();
                 }
-            } else {
-                channel = it->second.get();
-            }
-            channel->add_tablet(_index_id, tablet);
-            if (_parent->_enable_replicated_storage && i == 0) {
-                channel->set_has_primary_replica(true);
+                channel->add_tablet(_index_id, tablet);
+                if (_parent->_enable_replicated_storage && i == 0) {
+                    channel->set_has_primary_replica(true);
+                }
             }
         }
-    }
-    for (auto& it : _node_channels) {
-        RETURN_IF_ERROR(it.second->init(state));
+        for (auto& it : _node_channels) {
+            RETURN_IF_ERROR(it.second->init(state));
+        }
     }
     if (_where_clause != nullptr) {
         RETURN_IF_ERROR(_where_clause->prepare(_parent->_state));
         RETURN_IF_ERROR(_where_clause->open(_parent->_state));
     }
-    _write_quorum_type = _parent->_write_quorum_type;
+    {
+        std::unique_lock<std::shared_mutex> lock(_failure_state_mutex);
+        _write_quorum_type = _parent->_write_quorum_type;
+    }
     return Status::OK();
 }
 
 void IndexChannel::mark_as_failed(const NodeChannel* ch) {
+    std::unique_lock<std::shared_mutex> lock(_failure_state_mutex);
     // primary replica use for replicated storage
     // if primary replica failed, we should mark this index as failed
     if (ch->has_primary_replica()) {
@@ -1290,6 +1297,7 @@ void IndexChannel::mark_as_failed(const NodeChannel* ch) {
 }
 
 bool IndexChannel::has_intolerable_failure() {
+    std::shared_lock<std::shared_mutex> lock(_failure_state_mutex);
     if (_has_intolerable_failure) {
         return _has_intolerable_failure;
     }

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <queue>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -285,12 +286,14 @@ public:
     Status init(RuntimeState* state, const std::vector<PTabletWithPartition>& tablets, bool is_incremental);
 
     void for_each_node_channel(const std::function<void(NodeChannel*)>& func) {
+        std::shared_lock<std::shared_mutex> lock(_node_channels_mutex);
         for (auto& it : _node_channels) {
             func(it.second.get());
         }
     }
 
     void for_each_initial_node_channel(const std::function<void(NodeChannel*)>& func) {
+        std::shared_lock<std::shared_mutex> lock(_node_channels_mutex);
         for (auto& it : _node_channels) {
             if (!it.second->is_incremental()) {
                 func(it.second.get());
@@ -299,6 +302,7 @@ public:
     }
 
     void for_each_incremental_node_channel(const std::function<void(NodeChannel*)>& func) {
+        std::shared_lock<std::shared_mutex> lock(_node_channels_mutex);
         for (auto& it : _node_channels) {
             if (it.second->is_incremental()) {
                 func(it.second.get());
@@ -308,11 +312,17 @@ public:
 
     void mark_as_failed(const NodeChannel* ch);
 
-    bool is_failed_channel(const NodeChannel* ch) { return _failed_channels.count(ch->node_id()) != 0; }
+    bool is_failed_channel(const NodeChannel* ch) {
+        std::shared_lock<std::shared_mutex> lock(_failure_state_mutex);
+        return _failed_channels.count(ch->node_id()) != 0;
+    }
 
     bool has_intolerable_failure();
 
-    bool has_incremental_node_channel() const { return _has_incremental_node_channel; }
+    bool has_incremental_node_channel() const {
+        std::shared_lock<std::shared_mutex> lock(_node_channels_mutex);
+        return _has_incremental_node_channel;
+    }
 
     int64_t index_id() const { return _index_id; }
 
@@ -322,10 +332,21 @@ private:
     OlapTableSink* _parent;
     int64_t _index_id;
 
+    // Mutex to protect _node_channels and _has_incremental_node_channel from concurrent access.
+    // Read operations (for_each_*_node_channel, has_incremental_node_channel) acquire shared lock.
+    // Write operation (init) acquires exclusive lock.
+    mutable std::shared_mutex _node_channels_mutex;
     // BeId -> channel
     std::unordered_map<int64_t, std::unique_ptr<NodeChannel>> _node_channels;
     // map be_id to tablet num
     std::unordered_map<int64_t, int64_t> _be_to_tablet_num;
+
+    // Mutex to protect failure state variables (_failed_channels, _has_intolerable_failure,
+    // _write_quorum_type) from concurrent access. These variables are used together in
+    // has_intolerable_failure() to determine if the failure is intolerable.
+    // Read operations (is_failed_channel, has_intolerable_failure) acquire shared lock.
+    // Write operations (mark_as_failed, init for _write_quorum_type) acquire exclusive lock.
+    mutable std::shared_mutex _failure_state_mutex;
     // BeId
     std::set<int64_t> _failed_channels;
 


### PR DESCRIPTION
## Why I'm doing:
Fix a race condition in OlapTableSink::is_full() that causes SIGSEGV crash during automatic partition creation. The crash occurs when PipelineDriverPoller thread iterates over IndexChannel::_node_channels while the automatic partition thread is concurrently modifying it via _incremental_open_node_channel(), leading to use-after-free.

## What I'm doing:
Reorder the check in is_full() to evaluate _is_automatic_partition_running flag before accessing _tablet_sink_sender. This leverages short-circuit evaluation to skip iterating over _node_channels when automatic partition is in progress, preventing concurrent access to the data structure being modified.

Fixes #issue

```
PC: @          0xa8e2088 starrocks::NodeChannel::is_full()
*** SIGSEGV (@0x86e54c046897ee40) received by PID 27 (TID 0xfffed4c500c0) from PID 1754787392; stack trace: ***
    @     0xffffb9bf53dc (/usr/lib/aarch64-linux-gnu/libc.so.6+0x853db)
    @          0xe3c33d8 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0xffffbb050820 ([vdso]+0x81f)
    @          0xa8e2088 starrocks::NodeChannel::is_full()
    @          0xa8dc0ac std::_Function_handler<void (starrocks::NodeChannel*), starrocks::TabletSinkSender::is_full()::{lambda(starrocks::NodeChannel*)#1}>::_M_invoke(std::_Any_data const&, starrocks::NodeChannel*&&)
    @          0xa8dc8cc starrocks::TabletSinkSender::is_full()
    @          0xa8f01e4 starrocks::OlapTableSink::is_full()
    @          0xa8ae228 starrocks::pipeline::OlapTableSinkOperator::need_input() const
    @          0xa7c1374 starrocks::pipeline::PipelineDriver::is_not_blocked()
    @          0xa7bf820 starrocks::pipeline::PipelineDriverPoller::run_internal()
    @          0xabde8bc starrocks::Thread::supervise_thread(void*)
    @     0xffffb9bf0398 (/usr/lib/aarch64-linux-gnu/libc.so.6+0x80397)
    @     0xffffb9c59e9c (/usr/lib/aarch64-linux-gnu/libc.so.6+0xe9e9b)
[1766544925.42][thread: 281469956456640] je_mallctl execute purge success
[1766544925.42][thread: 281469956456640] je_mallctl execute dontdump success
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens thread-safety during automatic partitioning and prevents race-induced crashes.
> 
> - Reorders `OlapTableSink::is_full()` to short-circuit on `_is_automatic_partition_running` before touching `_tablet_sink_sender`
> - Adds `shared_mutex` guards in `IndexChannel` for `_node_channels`, `_has_incremental_node_channel`, and failure state (`_failed_channels`, `_has_intolerable_failure`, `_write_quorum_type`); applies locks in `init`, `for_each_*`, `is_failed_channel`, `mark_as_failed`, and `has_intolerable_failure`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 997f27fe8ea96b686b42bc94e8e3d86896e6d786. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->