### PR TITLE
[Enhancement] Implement iceberg delete commit operation

### DIFF
--- a/be/src/formats/file_writer.h
+++ b/be/src/formats/file_writer.h
@@ -50,8 +50,13 @@ public:
         std::string location;
         std::function<void()> rollback_action;
         std::string extra_data;
+        std::string referenced_data_file;
         CommitResult& set_extra_data(std::string extra_data) {
             this->extra_data = std::move(extra_data);
+            return *this;
+        }
+        CommitResult& set_referenced_data_file(std::string referenced_data_file) {
+            this->referenced_data_file = std::move(referenced_data_file);
             return *this;
         }
     };

--- a/be/test/connector_sink/iceberg_delete_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_delete_sink_test.cpp
@@ -232,18 +232,18 @@ TEST_F(IcebergDeleteSinkTest, callback_on_commit_empty) {
 
     // Call the callback function with empty result
     CommitResult result_obj;
-    result_obj.location = "/test/path/delete_file.parquet";  // Provide a valid location to avoid PathUtils failure
-    
+    result_obj.location = "/test/path/delete_file.parquet"; // Provide a valid location to avoid PathUtils failure
+
     // Get the runtime state before the callback to check sink commit info
     auto runtime_state = _fragment_context->runtime_state_ptr();
     size_t initial_sink_commit_info_count = runtime_state->sink_commit_infos().size();
-    
+
     delete_sink->callback_on_commit(result_obj);
-    
+
     // Should not crash and should handle empty result gracefully
     // Since io_status is OK by default, it should add a commit info
     ASSERT_EQ(runtime_state->sink_commit_infos().size(), initial_sink_commit_info_count + 1);
-    
+
     // Verify the last added sink commit info
     const auto& last_commit_info = runtime_state->sink_commit_infos().back();
     ASSERT_TRUE(last_commit_info.__isset.iceberg_data_file);
@@ -290,7 +290,7 @@ TEST_F(IcebergDeleteSinkTest, callback_on_commit_with_delete_file) {
     // Verify that the sink processed the commit result correctly
     // The callback should have updated the runtime state with sink commit info
     ASSERT_EQ(runtime_state->sink_commit_infos().size(), initial_sink_commit_info_count + 1);
-    
+
     // Verify the last added sink commit info has the expected iceberg data file
     const auto& last_commit_info = runtime_state->sink_commit_infos().back();
     ASSERT_TRUE(last_commit_info.__isset.iceberg_data_file);
@@ -319,14 +319,14 @@ TEST_F(IcebergDeleteSinkTest, callback_on_commit_io_failure) {
     CommitResult result_obj;
     result_obj.io_status = Status::IOError("Write failed");
     result_obj.location = "/test/path/delete_file.parquet";
-    
+
     // Get the runtime state before the callback to check sink commit info
     auto runtime_state = _fragment_context->runtime_state_ptr();
     size_t initial_sink_commit_info_count = runtime_state->sink_commit_infos().size();
 
     // Call the callback function - it should handle the failure gracefully
     delete_sink->callback_on_commit(result_obj);
-    
+
     // Should not crash even with IO failure
     // Since io_status is not OK, no commit info should be added
     ASSERT_EQ(runtime_state->sink_commit_infos().size(), initial_sink_commit_info_count);
@@ -354,17 +354,17 @@ TEST_F(IcebergDeleteSinkTest, callback_on_commit_partial_stats) {
     result_obj.file_statistics.value_counts = std::map<int, int64_t>{{1, 50}};
     result_obj.file_statistics.null_value_counts = std::map<int, int64_t>{{1, 5}};
     // Lower and upper bounds not set
-    
+
     // Get the runtime state before the callback to check sink commit info
     auto runtime_state = _fragment_context->runtime_state_ptr();
     size_t initial_sink_commit_info_count = runtime_state->sink_commit_infos().size();
 
     // Call the callback function
     delete_sink->callback_on_commit(result_obj);
-    
+
     // Should handle partial statistics correctly
     ASSERT_EQ(runtime_state->sink_commit_infos().size(), initial_sink_commit_info_count + 1);
-    
+
     // Verify the last added sink commit info has the expected iceberg data file
     const auto& last_commit_info = runtime_state->sink_commit_infos().back();
     ASSERT_TRUE(last_commit_info.__isset.iceberg_data_file);

--- a/be/test/connector_sink/iceberg_delete_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_delete_sink_test.cpp
@@ -219,8 +219,8 @@ TEST_F(IcebergDeleteSinkTest, context_required_fields) {
     EXPECT_NE(context->column_slot_map.find("_pos"), context->column_slot_map.end());
 }
 
-// Test callback_on_commit function
-TEST_F(IcebergDeleteSinkTest, callback_on_commit) {
+// Test callback_on_commit function with empty result
+TEST_F(IcebergDeleteSinkTest, callback_on_commit_empty) {
     auto context = create_delete_sink_context();
     auto provider = std::make_unique<IcebergDeleteSinkProvider>();
     auto result = provider->create_chunk_sink(context, 0);
@@ -230,10 +230,167 @@ TEST_F(IcebergDeleteSinkTest, callback_on_commit) {
     auto delete_sink = dynamic_cast<IcebergDeleteSink*>(sink.get());
     ASSERT_NE(delete_sink, nullptr);
 
-    // Call the callback function - it should not crash
+    // Call the callback function with empty result
     CommitResult result_obj;
+    result_obj.location = "/test/path/delete_file.parquet";  // Provide a valid location to avoid PathUtils failure
+    
+    // Get the runtime state before the callback to check sink commit info
+    auto runtime_state = _fragment_context->runtime_state_ptr();
+    size_t initial_sink_commit_info_count = runtime_state->sink_commit_infos().size();
+    
     delete_sink->callback_on_commit(result_obj);
-    // Callback is currently empty (TODO), but should not crash
+    
+    // Should not crash and should handle empty result gracefully
+    // Since io_status is OK by default, it should add a commit info
+    ASSERT_EQ(runtime_state->sink_commit_infos().size(), initial_sink_commit_info_count + 1);
+    
+    // Verify the last added sink commit info
+    const auto& last_commit_info = runtime_state->sink_commit_infos().back();
+    ASSERT_TRUE(last_commit_info.__isset.iceberg_data_file);
+    const auto& iceberg_data_file = last_commit_info.iceberg_data_file;
+    EXPECT_EQ(iceberg_data_file.path, result_obj.location);
+    EXPECT_EQ(iceberg_data_file.file_content, TIcebergFileContent::POSITION_DELETES);
+}
+
+// Test callback_on_commit function with complete delete file information
+TEST_F(IcebergDeleteSinkTest, callback_on_commit_with_delete_file) {
+    auto context = create_delete_sink_context();
+    auto provider = std::make_unique<IcebergDeleteSinkProvider>();
+    auto result = provider->create_chunk_sink(context, 0);
+    ASSERT_TRUE(result.ok());
+
+    auto sink = std::move(result).value();
+    auto delete_sink = dynamic_cast<IcebergDeleteSink*>(sink.get());
+    ASSERT_NE(delete_sink, nullptr);
+
+    // Prepare a complete CommitResult with delete file information
+    CommitResult result_obj;
+    result_obj.io_status = Status::OK();
+    result_obj.location = "/test/path/delete_file.parquet";
+    result_obj.format = "parquet";
+    result_obj.file_statistics.record_count = 100;
+    result_obj.file_statistics.file_size = 1024 * 1024;
+    result_obj.extra_data = "partition_null_fingerprint";
+    result_obj.referenced_data_file = "s3://test-bucket/test-table/data/data_file.parquet";
+
+    // Set column statistics
+    result_obj.file_statistics.column_sizes = {{1, 1000}, {2, 2000}};
+    result_obj.file_statistics.value_counts = {{1, 100}, {2, 100}};
+    result_obj.file_statistics.null_value_counts = {{1, 0}, {2, 10}};
+    result_obj.file_statistics.lower_bounds = {{1, "min_val"}, {2, "min_val2"}};
+    result_obj.file_statistics.upper_bounds = {{1, "max_val"}, {2, "max_val2"}};
+
+    // Get the runtime state before the callback to check sink commit info
+    auto runtime_state = _fragment_context->runtime_state_ptr();
+    size_t initial_sink_commit_info_count = runtime_state->sink_commit_infos().size();
+
+    // Call the callback function
+    delete_sink->callback_on_commit(result_obj);
+
+    // Verify that the sink processed the commit result correctly
+    // The callback should have updated the runtime state with sink commit info
+    ASSERT_EQ(runtime_state->sink_commit_infos().size(), initial_sink_commit_info_count + 1);
+    
+    // Verify the last added sink commit info has the expected iceberg data file
+    const auto& last_commit_info = runtime_state->sink_commit_infos().back();
+    ASSERT_TRUE(last_commit_info.__isset.iceberg_data_file);
+    const auto& iceberg_data_file = last_commit_info.iceberg_data_file;
+    EXPECT_EQ(iceberg_data_file.path, result_obj.location);
+    EXPECT_EQ(iceberg_data_file.format, result_obj.format);
+    EXPECT_EQ(iceberg_data_file.record_count, result_obj.file_statistics.record_count);
+    EXPECT_EQ(iceberg_data_file.file_size_in_bytes, result_obj.file_statistics.file_size);
+    EXPECT_EQ(iceberg_data_file.partition_null_fingerprint, result_obj.extra_data);
+    EXPECT_EQ(iceberg_data_file.referenced_data_file, result_obj.referenced_data_file);
+    EXPECT_EQ(iceberg_data_file.file_content, TIcebergFileContent::POSITION_DELETES);
+}
+
+// Test callback_on_commit function with IO failure
+TEST_F(IcebergDeleteSinkTest, callback_on_commit_io_failure) {
+    auto context = create_delete_sink_context();
+    auto provider = std::make_unique<IcebergDeleteSinkProvider>();
+    auto result = provider->create_chunk_sink(context, 0);
+    ASSERT_TRUE(result.ok());
+
+    auto sink = std::move(result).value();
+    auto delete_sink = dynamic_cast<IcebergDeleteSink*>(sink.get());
+    ASSERT_NE(delete_sink, nullptr);
+
+    // Prepare a CommitResult with IO failure
+    CommitResult result_obj;
+    result_obj.io_status = Status::IOError("Write failed");
+    result_obj.location = "/test/path/delete_file.parquet";
+    
+    // Get the runtime state before the callback to check sink commit info
+    auto runtime_state = _fragment_context->runtime_state_ptr();
+    size_t initial_sink_commit_info_count = runtime_state->sink_commit_infos().size();
+
+    // Call the callback function - it should handle the failure gracefully
+    delete_sink->callback_on_commit(result_obj);
+    
+    // Should not crash even with IO failure
+    // Since io_status is not OK, no commit info should be added
+    ASSERT_EQ(runtime_state->sink_commit_infos().size(), initial_sink_commit_info_count);
+}
+
+// Test callback_on_commit function with partial statistics
+TEST_F(IcebergDeleteSinkTest, callback_on_commit_partial_stats) {
+    auto context = create_delete_sink_context();
+    auto provider = std::make_unique<IcebergDeleteSinkProvider>();
+    auto result = provider->create_chunk_sink(context, 0);
+    ASSERT_TRUE(result.ok());
+
+    auto sink = std::move(result).value();
+    auto delete_sink = dynamic_cast<IcebergDeleteSink*>(sink.get());
+    ASSERT_NE(delete_sink, nullptr);
+
+    // Prepare a CommitResult with partial statistics
+    CommitResult result_obj;
+    result_obj.io_status = Status::OK();
+    result_obj.location = "/test/path/delete_file.parquet";
+    result_obj.format = "parquet";
+    result_obj.file_statistics.record_count = 50;
+    result_obj.file_statistics.file_size = 512 * 1024;
+    // Only set some statistics, not all
+    result_obj.file_statistics.value_counts = std::map<int, int64_t>{{1, 50}};
+    result_obj.file_statistics.null_value_counts = std::map<int, int64_t>{{1, 5}};
+    // Lower and upper bounds not set
+    
+    // Get the runtime state before the callback to check sink commit info
+    auto runtime_state = _fragment_context->runtime_state_ptr();
+    size_t initial_sink_commit_info_count = runtime_state->sink_commit_infos().size();
+
+    // Call the callback function
+    delete_sink->callback_on_commit(result_obj);
+    
+    // Should handle partial statistics correctly
+    ASSERT_EQ(runtime_state->sink_commit_infos().size(), initial_sink_commit_info_count + 1);
+    
+    // Verify the last added sink commit info has the expected iceberg data file
+    const auto& last_commit_info = runtime_state->sink_commit_infos().back();
+    ASSERT_TRUE(last_commit_info.__isset.iceberg_data_file);
+    const auto& iceberg_data_file = last_commit_info.iceberg_data_file;
+    EXPECT_EQ(iceberg_data_file.path, result_obj.location);
+    EXPECT_EQ(iceberg_data_file.format, result_obj.format);
+    EXPECT_EQ(iceberg_data_file.record_count, result_obj.file_statistics.record_count);
+    EXPECT_EQ(iceberg_data_file.file_size_in_bytes, result_obj.file_statistics.file_size);
+    EXPECT_EQ(iceberg_data_file.file_content, TIcebergFileContent::POSITION_DELETES);
+}
+
+// Test CommitResult set_referenced_data_file method
+TEST_F(IcebergDeleteSinkTest, commit_result_set_referenced_data_file) {
+    CommitResult result_obj;
+
+    // Test setting referenced data file
+    std::string referenced_file = "s3://test-bucket/test-table/data/data_file_001.parquet";
+    result_obj.set_referenced_data_file(referenced_file);
+
+    EXPECT_EQ(result_obj.referenced_data_file, referenced_file);
+
+    // Test chaining
+    std::string referenced_file2 = "s3://test-bucket/test-table/data/data_file_002.parquet";
+    auto& result_ref = result_obj.set_referenced_data_file(referenced_file2);
+    EXPECT_EQ(&result_ref, &result_obj); // Should return self reference
+    EXPECT_EQ(result_obj.referenced_data_file, referenced_file2);
 }
 
 // Test IcebergDeleteSink::finish function

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector.iceberg;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
@@ -89,6 +90,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.thrift.TIcebergDataFile;
+import com.starrocks.thrift.TIcebergFileContent;
 import com.starrocks.thrift.TSinkCommitInfo;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
@@ -102,9 +104,12 @@ import org.apache.iceberg.DataOperations;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.DeleteFiles;
 import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.IncrementalAppendScan;
+import org.apache.iceberg.IsolationLevel;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
@@ -114,6 +119,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.Scan;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
@@ -176,6 +182,8 @@ import static com.starrocks.connector.iceberg.IcebergApiConverter.toIcebergApiSc
 import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.isResourceMappingCatalog;
 import static java.util.Comparator.comparing;
 import static org.apache.iceberg.TableProperties.DEFAULT_WRITE_METRICS_MODE_DEFAULT;
+import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
+import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL_DEFAULT;
 
 public class IcebergMetadata implements ConnectorMetadata {
 
@@ -1309,6 +1317,120 @@ public class IcebergMetadata implements ConnectorMetadata {
         IcebergTable table = (IcebergTable) getTable(new ConnectContext(), dbName, tableName);
         org.apache.iceberg.Table nativeTbl = table.getNativeTable();
         Transaction transaction = nativeTbl.newTransaction();
+
+        // Check if this is a delete operation (any file is marked as POSITION_DELETES)
+        boolean isDeleteOperation = dataFiles.stream().anyMatch(dataFile ->
+                dataFile.isSetFile_content() &&
+                        (dataFile.getFile_content() == TIcebergFileContent.POSITION_DELETES));
+        if (isDeleteOperation) {
+            commitDeleteOperation(transaction, nativeTbl, dataFiles, branch, dbName, tableName, extra);
+        } else {
+            commitDataOperation(transaction, nativeTbl, dataFiles, branch, isOverwrite, isRewrite, extra, dbName, tableName);
+        }
+    }
+
+    private void commitWithCleanup(Runnable commitAction, Runnable cleanupAction,
+                                   List<TIcebergDataFile> dataFiles, String dbName, String tableName) {
+        try {
+            commitAction.run();
+        } catch (Exception e) {
+            if (!(e instanceof CommitStateUnknownException)) {
+                List<String> toDeleteFiles = dataFiles.stream()
+                        .map(TIcebergDataFile::getPath)
+                        .collect(Collectors.toList());
+                icebergCatalog.deleteUncommittedDataFiles(toDeleteFiles);
+            }
+            LOG.error("Failed to commit iceberg transaction on {}.{}", dbName, tableName, e);
+            throw new StarRocksConnectorException(e.getMessage());
+        } finally {
+            cleanupAction.run();
+        }
+    }
+
+    private void invalidateCacheAfterCommit(String dbName, String tableName) {
+        // Invalidate cache after commit
+        tables.remove(TableIdentifier.of(dbName, tableName));
+        icebergCatalog.invalidateTableCache(dbName, tableName);
+        icebergCatalog.invalidatePartitionCache(dbName, tableName);
+    }
+
+    private void commitDeleteOperation(Transaction transaction, org.apache.iceberg.Table nativeTbl,
+                                       List<TIcebergDataFile> dataFiles, String branch,
+                                       String dbName, String tableName, Object extra) {
+        // DELETE operations - use RowDelta
+        RowDelta rowDelta = transaction.newRowDelta();
+        if (branch != null) {
+            rowDelta.toBranch(branch);
+        }
+
+        PartitionSpec partitionSpec = nativeTbl.spec();
+        ImmutableSet.Builder<String> referencedDataFiles = ImmutableSet.builder();
+        for (TIcebergDataFile dataFile : dataFiles) {
+            // All files should be delete files in a delete operation
+            FileMetadata.Builder builder = FileMetadata.deleteFileBuilder(partitionSpec)
+                    .ofPositionDeletes()
+                    .withPath(dataFile.path)
+                    .withFormat(FileFormat.PARQUET)
+                    .withFileSizeInBytes(dataFile.file_size_in_bytes)
+                    .withRecordCount(dataFile.record_count)
+                    .withPartition(partitionSpec.isPartitioned() ?
+                            IcebergPartitionData.partitionDataFromPath(
+                                    getIcebergRelativePartitionPath(
+                                            IcebergUtil.tableDataLocation(nativeTbl),
+                                            dataFile.partition_path),
+                                    dataFile.isSetPartition_null_fingerprint() ?
+                                            dataFile.getPartition_null_fingerprint() :
+                                            "0".repeat(partitionSpec.fields().size()),
+                                    partitionSpec) : null)
+                    .withMetrics(dataFile.isSetColumn_stats() ?
+                            IcebergApiConverter.buildDataFileMetrics(dataFile, nativeTbl) : null);
+
+            // Set referenced data file if available
+            if (dataFile.isSetReferenced_data_file()) {
+                String referencedFile = dataFile.getReferenced_data_file();
+                builder.withReferencedDataFile(referencedFile);
+                referencedDataFiles.add(referencedFile);
+            }
+
+            org.apache.iceberg.DeleteFile deleteFile = builder.build();
+            rowDelta.addDeletes(deleteFile);
+        }
+
+        // Validate from snapshot if table has current snapshot
+        if (nativeTbl.currentSnapshot() != null) {
+            rowDelta.validateFromSnapshot(nativeTbl.currentSnapshot().snapshotId());
+        }
+
+        // Validate that referenced data files exist and haven't been deleted
+        rowDelta.validateDataFilesExist(referencedDataFiles.build());
+        rowDelta.validateDeletedFiles();
+
+        // Set conflict detection filter if available
+        // This filter defines which data files should be checked for conflicts during validation
+        if (extra instanceof IcebergSinkExtra) {
+            Expression conflictDetectionFilterObj = ((IcebergSinkExtra) extra).getConflictDetectionFilter();
+            if (conflictDetectionFilterObj != null) {
+                rowDelta.conflictDetectionFilter(conflictDetectionFilterObj);
+            }
+        }
+
+        IsolationLevel isolationLevel = IsolationLevel.fromName(nativeTbl.properties().
+                getOrDefault(DELETE_ISOLATION_LEVEL, DELETE_ISOLATION_LEVEL_DEFAULT));
+        if (isolationLevel == IsolationLevel.SERIALIZABLE) {
+            rowDelta.validateNoConflictingDataFiles();
+        }
+
+        commitWithCleanup(() -> {
+            rowDelta.commit();
+            transaction.commitTransaction();
+            asyncRefreshOthersFeMetadataCache(dbName, tableName);
+        }, () -> invalidateCacheAfterCommit(dbName, tableName), dataFiles, dbName, tableName);
+    }
+
+    private void commitDataOperation(Transaction transaction, org.apache.iceberg.Table nativeTbl,
+                                     List<TIcebergDataFile> dataFiles, String branch,
+                                     boolean isOverwrite, boolean isRewrite, Object extra,
+                                     String dbName, String tableName) {
         BatchWrite batchWrite = getBatchWrite(transaction, isOverwrite, isRewrite);
 
         if (branch != null) {
@@ -1348,25 +1470,11 @@ public class IcebergMetadata implements ConnectorMetadata {
             ((RewriteData) batchWrite).setSnapshotId(nativeTbl.currentSnapshot().snapshotId());
         }
 
-        try {
+        commitWithCleanup(() -> {
             batchWrite.commit();
             transaction.commitTransaction();
             asyncRefreshOthersFeMetadataCache(dbName, tableName);
-        } catch (Exception e) {
-            if (!(e instanceof CommitStateUnknownException)) {
-                List<String> toDeleteFiles = dataFiles.stream()
-                        .map(TIcebergDataFile::getPath)
-                        .collect(Collectors.toList());
-                icebergCatalog.deleteUncommittedDataFiles(toDeleteFiles);
-            }
-            LOG.error("Failed to commit iceberg transaction on {}.{}", dbName, tableName, e);
-            throw new StarRocksConnectorException(e.getMessage());
-        } finally {
-            // Invalidate cache after commit
-            tables.remove(TableIdentifier.of(dbName, tableName));
-            icebergCatalog.invalidateTableCache(dbName, tableName);
-            icebergCatalog.invalidatePartitionCache(dbName, tableName);
-        }
+        }, () -> invalidateCacheAfterCommit(dbName, tableName), dataFiles, dbName, tableName);
     }
 
     private void asyncRefreshOthersFeMetadataCache(String dbName, String tableName) {
@@ -1486,6 +1594,7 @@ public class IcebergMetadata implements ConnectorMetadata {
     public static class IcebergSinkExtra {
         private final Set<DataFile> scannedDataFiles;
         private final Set<DeleteFile> appliedDeleteFiles;
+        private Expression conflictDetectionFilter;
 
         public IcebergSinkExtra() {
             this.scannedDataFiles = new HashSet<>();
@@ -1506,6 +1615,14 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         public Set<DeleteFile> getAppliedDeleteFiles() {
             return appliedDeleteFiles;
+        }
+
+        public void setConflictDetectionFilter(Expression conflictDetectionFilter) {
+            this.conflictDetectionFilter = conflictDetectionFilter;
+        }
+
+        public Expression getConflictDetectionFilter() {
+            return conflictDetectionFilter;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1397,8 +1397,9 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
 
         // Validate from snapshot if table has current snapshot
-        if (nativeTbl.currentSnapshot() != null) {
-            rowDelta.validateFromSnapshot(nativeTbl.currentSnapshot().snapshotId());
+        Snapshot currentSnapshot = nativeTbl.currentSnapshot();
+        if (currentSnapshot != null) {
+            rowDelta.validateFromSnapshot(currentSnapshot.snapshotId());
         }
 
         // Validate that referenced data files exist and haven't been deleted

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergDeleteSink.java
@@ -46,6 +46,7 @@ public class IcebergDeleteSink extends DataSink {
     private final long targetMaxFileSize;
     private final String tableIdentifier;
     private CloudConfiguration cloudConfiguration;
+    private com.starrocks.connector.iceberg.IcebergMetadata.IcebergSinkExtra sinkExtraInfo;
 
     /**
      * Constructor for IcebergDeleteSink
@@ -155,5 +156,23 @@ public class IcebergDeleteSink extends DataSink {
     @Override
     public boolean canUseRuntimeAdaptiveDop() {
         return true;
+    }
+
+    /**
+     * Sets the sink extra info for this delete operation
+     *
+     * @param sinkExtraInfo The extra info to set
+     */
+    public void setSinkExtraInfo(com.starrocks.connector.iceberg.IcebergMetadata.IcebergSinkExtra sinkExtraInfo) {
+        this.sinkExtraInfo = sinkExtraInfo;
+    }
+
+    /**
+     * Gets the sink extra info for this delete operation
+     *
+     * @return The extra info, or null if not set
+     */
+    public com.starrocks.connector.iceberg.IcebergMetadata.IcebergSinkExtra getSinkExtraInfo() {
+        return sinkExtraInfo;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -206,6 +206,10 @@ public class IcebergScanNode extends ScanNode {
         this.icebergJobPlanningPredicate = predicate;
     }
 
+    public IcebergTable getIcebergTable() {
+        return icebergTable;
+    }
+
     // for unit tests
     public ScalarOperator getIcebergJobPlanningPredicate() {
         return icebergJobPlanningPredicate;

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -311,16 +311,10 @@ struct TEsScanRange {
   4: required i32 shard_id
 }
 
-enum TIcebergFileContent {
-    DATA,
-    POSITION_DELETES,
-    EQUALITY_DELETES,
-}
-
 struct TIcebergDeleteFile {
     1: optional string full_path
     2: optional Descriptors.THdfsFileFormat file_format
-    3: optional TIcebergFileContent file_content
+    3: optional Types.TIcebergFileContent file_content
     4: optional i64 length
 }
 

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -578,6 +578,12 @@ struct TIcebergColumnStats {
     6: optional map<i32, binary> upper_bounds;
 }
 
+enum TIcebergFileContent {
+    DATA,
+    POSITION_DELETES,
+    EQUALITY_DELETES,
+}
+
 struct TIcebergDataFile {
     1: optional string path
     2: optional string format
@@ -587,6 +593,8 @@ struct TIcebergDataFile {
     6: optional list<i64> split_offsets;
     7: optional TIcebergColumnStats column_stats;
     8: optional string partition_null_fingerprint;
+    9: optional TIcebergFileContent file_content;
+    10: optional string referenced_data_file;
 }
 
 struct THiveFileInfo {


### PR DESCRIPTION
## Why I'm doing:
#66944

## What I'm doing:
This pull request enhances the Iceberg delete file commit flow, ensuring that delete operations are properly committed and validated, and adds robust handling and testing for delete file metadata. The changes introduce a clear distinction between data and delete operations on the FE side, improve the commit callback logic on the BE side, and add comprehensive unit tests for delete file commits.

**Iceberg Delete File Commit Handling:**

- **FE (Frontend) Improvements:**
  - Added logic in `IcebergMetadata` to distinguish delete operations (using `POSITION_DELETES`) and handle them with a new `commitDeleteOperation` method, which uses Iceberg's `RowDelta` for delete file commits. This includes validation of referenced data files, conflict detection, and isolation level handling.
  - Refactored commit and cleanup logic into a reusable `commitWithCleanup` method for both data and delete operations, improving code structure and error handling. 
  - Ensured cache invalidation and metadata refresh after commits to keep the system state consistent.

**BE (Backend) Delete Sink Enhancements:**

- **Commit Callback Logic:**
  - Improved `callback_on_commit` in `IcebergDeleteSink` to construct and record detailed `TIcebergDataFile` metadata when a delete file is committed, including statistics and referenced data file.
  - Updated the file writer callback to set the `referenced_data_file` in the commit result, ensuring correct metadata propagation.
  - Extended `CommitResult` to support setting and storing `referenced_data_file`.

**Testing and Validation:**

- **Unit Test Coverage:**
  - Added comprehensive tests for `callback_on_commit` in `IcebergDeleteSinkTest`, covering cases with empty, partial, complete, and failed commit results, as well as verifying the `referenced_data_file` setter. 

**Dependency and Import Updates:**

- Updated imports in `IcebergMetadata.java` to support new logic for delete file handling and Iceberg APIs. 


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds proper handling and commit of Iceberg position delete files and refactors commit flow.
> 
> - FE: Detects delete operations and commits via `RowDelta` with validations (`validateFromSnapshot`, `validateDataFilesExist`, `validateDeletedFiles`, optional `validateNoConflictingDataFiles`), supports branch, and factors shared logic into `commitWithCleanup`; invalidates caches post-commit
> - FE: `DeletePlanner` builds `IcebergSinkExtra` with conflict detection filter from `IcebergScanNode` predicate; `StmtExecutor` routes Iceberg DELETE vs INSERT/OVERWRITE sinks accordingly
> - BE: `IcebergDeleteSink::callback_on_commit` constructs `TIcebergDataFile` with `POSITION_DELETES` and `referenced_data_file`; writer callback injects referenced data file; `CommitResult` gains `referenced_data_file` setter
> - Thrift: Moves `TIcebergFileContent` enum to `Types.thrift` and wires through to data/delete file structs
> - Tests: Extensive UTs for BE commit callback scenarios and FE delete commit (including conflict detection)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 763b4fff7fe3955087831d3ee5e9fe51682b2af8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->