### PR TITLE
[BugFix] Fix qualified column references in JOIN USING (#67548)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1143,11 +1143,11 @@ public class QueryAnalyzer {
          * - id → COALESCE(CAST(t1.id AS BIGINT), t2.id)
          * - name → COALESCE(t1.name, t2.name)
          * </pre>
-         * 
-         * Special Handling for FULL OUTER JOIN USING:
-         * Sets {@code fromFullOuterJoinUsing} flag to true, which affects downstream resolution:
+         *
+         * Special Handling for JOIN USING:
+         * Sets {@code fromJoinUsing} flag to true, which affects downstream resolution:
          * - Prevents ambiguity errors when unqualified USING columns are referenced in subsequent joins
-         * - The flag is propagated through join chains (e.g., t1 FULL JOIN t2 ... LEFT JOIN t3)
+         * - The flag is propagated through join chains (e.g., t1 JOIN t2 USING(col) ... LEFT JOIN t3)
          * 
          * @param joinedFields Combined fields from left.joinWith(right), containing potential duplicates for USING columns
          * @param join The JOIN relation, may or may not have USING clause

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/RelationFields.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/RelationFields.java
@@ -34,8 +34,9 @@ public class RelationFields {
     private final Multimap<String, Field> names;
     private final boolean resolveStruct;
     
-    // Track if this RelationFields comes from FULL OUTER JOIN USING
+    // Track if this RelationFields comes from any JOIN with USING clause
     // Used to handle unqualified USING columns specially in resolveFields
+    // When true, unqualified column references prefer unqualified fields over qualified ones
     private final boolean fromFullOuterJoinUsing;
 
     public RelationFields(Field... fields) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
@@ -127,6 +127,15 @@ public class AnalyzeJoinTest {
         analyzeSuccess("select * from t0 a join tnotnull b using(v1) join t0 c using(v1)");
         analyzeSuccess("select a.v1, b.v1, c.v1 from t0 a join tnotnull b using(v1) join t0 c using(v1)");
 
+        // Test chained FULL OUTER JOIN USING (preserves COALESCE semantics)
+        analyzeSuccess("select * from t0 a full join tnotnull b using(v1) full join t0 c using(v1)");
+        analyzeSuccess("select a.v1, b.v1, c.v1 from t0 a full join tnotnull b using(v1) full join t0 c using(v1)");
+
+        // Test mixed join types after FULL OUTER JOIN USING (preserves unqualified field expression)
+        analyzeSuccess("select * from t0 a full join tnotnull b using(v1) inner join t0 c using(v1)");
+        analyzeSuccess("select * from t0 a full join tnotnull b using(v1) left join t0 c using(v1)");
+        analyzeSuccess("select * from t0 a full join tnotnull b using(v1) right join t0 c using(v1)");
+
         // Test USING with aggregations
         analyzeSuccess("select count(a.v1), count(b.v1) from t0 a join tnotnull b using(v1)");
         analyzeSuccess("select a.v1, count(*) from t0 a join tnotnull b using(v1) group by a.v1");


### PR DESCRIPTION
 ## Why I'm doing:

  Problem 1: Qualified Column References Fail
  According to SQL standards, `JOIN USING(col)` should deduplicate the USING column in `SELECT *` output (appears once instead of twice), but qualified references to both sides (`A.col` and `B.col`) should remain accessible. The original implementation only kept the left table's field and completely removed the right table's field from scope. This caused "Column cannot be resolved" errors when trying to reference the right table's USING column in subsequent operations.

  **Example:**
  ```sql
  SELECT * FROM A JOIN B USING(id) JOIN C ON B.id = C.id;
                                             ^^^^
                                       ERROR: B.id cannot be resolved
```

  This breaks real-world queries, particularly those generated by ORMs and database introspection tools (like the INFORMATION_SCHEMA query in #67548).

  Problem 2: Chained FULL OUTER JOIN USING Loses COALESCE Semantics

  SQL standard requires FULL OUTER JOIN USING to produce COALESCE(left.col, right.col) for the USING column. In chained FULL OUTER JOIN USING queries like A FULL JOIN B USING(c) FULL JOIN D USING(c), the implementation was creating COALESCE(A.c, D.c) instead of the semantically correct COALESCE(COALESCE(A.c, B.c), D.c).

  Impact: When A.c = NULL, B.c = 5, D.c = NULL, the query incorrectly returns NULL instead of 5, producing wrong results.

   ## What I'm doing:

  Algorithm Overview

  The fix maintains three types of fields for each USING column in the join result:
  1. One visible unqualified field (col) - appears in SELECT *, used for unqualified references
  2. Hidden qualified field from left table (A.col) - invisible in SELECT *, resolves qualified references
  3. Hidden qualified field from right table (B.col) - invisible in SELECT *, resolves qualified references

  This preserves SQL standard semantics: USING columns are deduplicated in output but remain individually accessible via table qualifiers.

  Implementation Details

  1. Primary Fix: Hidden Qualified Fields

  For each USING column:
  - Create unqualified field (visible=true) for SELECT * and unqualified references
  - Copy all matching qualified fields from both left and right scopes as hidden (visible=false)
  - Only copy fields with relationAlias != null to avoid duplicating unqualified fields from previous USING joins

  Field Resolution:
  - Mark the scope with fromJoinUsing flag
  - When resolving unqualified column names with multiple matches, prefer unqualified fields (avoids "ambiguous column" errors)
  - Qualified references (e.g., B.col) match by table name and resolve to hidden fields

  Example after A JOIN B USING(id):
  Scope contains:
    - id (unqualified, visible=true)    -> appears in SELECT *, resolves unqualified refs
    - A.id (qualified, visible=false)   -> hidden, resolves A.id refs
    - B.id (qualified, visible=false)   ->  hidden, resolves B.id refs       Correct 

  2. Chained Semantics Fix: COALESCE Preservation
    For chained joins, before creating new field:
    - Check if the input scope already has an unqualified field for this column
    - If found and it's a FULL OUTER JOIN, use its expression as the left side of new COALESCE
    - This preserves nested COALESCE structure: COALESCE(existing_expr, new_right)

     Algorithm for FULL OUTER JOIN USING:
```sql
  // Check for existing unqualified field (may contain COALESCE from previous join)
  Optional<Field> existingCoalesce = leftAllFields.stream()
      .filter(f -> f.getName().equals(colName) && f.getRelationAlias() == null)
      .findFirst();

  Expr leftExpr = existingCoalesce.isPresent()
      ? existingCoalesce.get().getOriginExpression()  // Use existing (may be nested COALESCE)
      : new SlotRef(leftFields.get(0).getRelationAlias(), colName);  // First join, use base field

  // Create nested COALESCE
  FunctionCallExpr coalesceExpr = new FunctionCallExpr(COALESCE, [leftExpr, rightExpr]);
```

  For INNER/LEFT/RIGHT JOIN USING:
  Similarly check for existing unqualified field and preserve its expression (which might be a COALESCE from a previous FULL OUTER JOIN), ensuring expression propagation through mixed join type chains.

  Example chain A FULL JOIN B USING(c) FULL JOIN D USING(c):
  - After 1st join: c = COALESCE(A.c, B.c)
  - After 2nd join: finds existing COALESCE -> c = COALESCE(COALESCE(A.c, B.c), D.c)   Correct 

  3. Refactoring: Naming Accuracy

  Renamed fromFullOuterJoinUsing -> fromJoinUsing because the flag now applies to all JOIN USING operations (INNER, LEFT, RIGHT, FULL), not just FULL OUTER. This flag tells the field resolution logic to prefer unqualified fields when resolving unqualified column names to avoid ambiguity.

  Fixes #67548

  ## What type of PR is this:

  - [x] BugFix
  - [ ] Feature
  - [ ] Enhancement
  - [ ] Refactor
  - [ ] UT
  - [ ] Doc
  - [ ] Tool

  Does this PR entail a change in behavior?

  - [x] Yes, this PR will result in a change in behavior.
  - [ ] No, this PR will not result in a change in behavior.

  If yes, please specify the type of change:

  - [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
  - [ ] Parameter changes: default values, similar parameters but with different default values
  - [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
  - [ ] Feature removed
  - [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

  ## Checklist:

  - [x] I have added test cases for my bug fix or my new feature
  - [ ] This pr needs user documentation (for new or modified features or behaviors)
    - [ ] I have added documentation for my new feature or new function
    - [ ] This pr needs auto generate documentation
  - [ ] This is a backport pr

  ## Bugfix cherry-pick branch check:
  - [x] I have checked the version labels which the pr will be auto-backported to the target branch
    - [x] 4.1
    - [x] 4.0
    - [ ] 3.5
    - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves `JOIN USING` column resolution to support qualified references and prevent ambiguity.
> 
> - In `QueryAnalyzer#createJoinRelationFields`, for USING columns: create a single visible unqualified field; add hidden qualified fields for both sides; for FULL OUTER JOIN, build an unqualified field with a `COALESCE` expression and compatible type; only collect qualified inputs to avoid duplicates in chained USING joins
> - Introduces `RelationFields.fromJoinUsing` (replacing FULL-OUTER-specific flag) and updates resolution to prefer unqualified fields for unqualified references when ambiguity exists; flag propagates via `joinWith`
> - Updates tests in `AnalyzeJoinTest` to cover qualified/unqualified references after USING across INNER/LEFT/RIGHT/FULL joins, chained USING joins, aggregations, and expressions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c485fd328aabe1bcfe26a92a6757dde12613f4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->