### PR TITLE
[BugFix] Fix transaction stream load put incorrect RPC timeout

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -863,8 +863,11 @@ CONF_Int32(thrift_rpc_max_body_size, "0");
 // The connection will be closed if it has existed in the connection pool for longer than this value.
 CONF_Int32(thrift_rpc_connection_max_valid_time_ms, "5000");
 
-// txn commit rpc timeout
-CONF_mInt32(txn_commit_rpc_timeout_ms, "60000");
+// The Thrift RPC timeout (in milliseconds) used by BE stream-load plan (put) and
+// txn prepare/commit calls sent to the FE.
+// NOTE: renamed from `txn_commit_rpc_timeout_ms`, which is kept as a backward-compatible alias.
+CONF_mInt32(stream_load_thrift_rpc_timeout_ms, "60000");
+CONF_Alias(stream_load_thrift_rpc_timeout_ms, txn_commit_rpc_timeout_ms);
 
 // If set to true, metric calculator will run
 CONF_Bool(enable_metric_calculator, "true");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -418,7 +418,7 @@
         "write_buffer_size",
         "load_process_max_memory_hard_limit_ratio",
         "enable_new_load_on_memory_limit_exceeded",
-        "txn_commit_rpc_timeout_ms",
+        "stream_load_thrift_rpc_timeout_ms",
         "max_tablet_write_chunk_bytes",
         "max_load_dop",
         "enable_load_colocate_mv",

--- a/be/src/common/config_ingest_fwd.h
+++ b/be/src/common/config_ingest_fwd.h
@@ -142,8 +142,12 @@ CONF_mDouble(load_process_max_memory_hard_limit_ratio, "2");
 
 CONF_mBool(enable_new_load_on_memory_limit_exceeded, "false");
 
-// txn commit rpc timeout
-CONF_mInt32(txn_commit_rpc_timeout_ms, "60000");
+// The Thrift RPC timeout (in milliseconds) used by BE stream-load plan (put) and
+// txn prepare/commit calls sent to the FE.
+// NOTE: renamed from `txn_commit_rpc_timeout_ms`, which is kept as a backward-compatible alias.
+CONF_mInt32(stream_load_thrift_rpc_timeout_ms, "60000");
+
+CONF_Alias(stream_load_thrift_rpc_timeout_ms, txn_commit_rpc_timeout_ms);
 
 // Max consumer num in one data consumer group, for routine load.
 CONF_mInt32(max_consumer_num_per_group, "3");

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -48,6 +48,7 @@
 
 #include "base/auth/auth_info.h"
 #include "base/string/string_parser.hpp"
+#include "base/testutil/sync_point.h"
 #include "base/time/time.h"
 #include "base/uid_util.h"
 #include "base/url_coding.h"
@@ -632,13 +633,12 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
             return Status::InvalidArgument("Invalid log_rejected_record_num format");
         }
     }
-    int32_t rpc_timeout_ms = config::txn_commit_rpc_timeout_ms;
     if (ctx->timeout_second != -1) {
         request.__set_timeout(ctx->timeout_second);
-        rpc_timeout_ms = std::min(ctx->timeout_second * 1000 / 2, rpc_timeout_ms);
-        rpc_timeout_ms = std::max(ctx->timeout_second * 1000 / 4, rpc_timeout_ms);
     }
+    int32_t rpc_timeout_ms = ctx->calc_put_and_commit_rpc_timeout_ms();
     request.__set_thrift_rpc_timeout_ms(rpc_timeout_ms);
+    TEST_SYNC_POINT_CALLBACK("StreamLoadAction::_process_put::rpc_timeout", &request);
     if (!http_req->header(HTTP_MAX_FILTER_RATIO).empty()) {
         ctx->max_filter_ratio = strtod(http_req->header(HTTP_MAX_FILTER_RATIO).c_str(), nullptr);
     }

--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -536,7 +536,9 @@ Status TransactionStreamLoadAction::_exec_plan_fragment(HttpRequest* http_req, S
         return Status::OK();
     }
 
-    request.__set_thrift_rpc_timeout_ms(config::thrift_rpc_timeout_ms);
+    int32_t rpc_timeout_ms = ctx->calc_put_and_commit_rpc_timeout_ms();
+    request.__set_thrift_rpc_timeout_ms(rpc_timeout_ms);
+    TEST_SYNC_POINT_CALLBACK("TransactionStreamLoadAction::_exec_plan_fragment::rpc_timeout", &request);
     // plan this load
     auto master_addr = get_master_address();
 #ifndef BE_TEST
@@ -547,7 +549,8 @@ Status TransactionStreamLoadAction::_exec_plan_fragment(HttpRequest* http_req, S
     int64_t stream_load_put_start_time = MonotonicNanos();
     RETURN_IF_ERROR(ThriftRpcHelper::rpc<FrontendServiceClient>(
             master_addr.hostname, master_addr.port,
-            [&request, ctx](FrontendServiceConnection& client) { client->streamLoadPut(ctx->put_result, request); }));
+            [&request, ctx](FrontendServiceConnection& client) { client->streamLoadPut(ctx->put_result, request); },
+            rpc_timeout_ms));
     ctx->stream_load_put_cost_nanos = MonotonicNanos() - stream_load_put_start_time;
     ctx->timeout_second = ctx->put_result.params.query_options.query_timeout;
     ctx->request.__set_timeout(ctx->timeout_second);

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -46,6 +46,7 @@
 #include "base/string/string_util.h"
 #include "base/time/time.h"
 #include "base/uid_util.h"
+#include "common/config_ingest_fwd.h"
 #include "common/status.h"
 #include "common/system/backend_options.h"
 #include "gen_cpp/BackendService_types.h"
@@ -176,6 +177,32 @@ public:
     bool check_and_set_http_limiter(ConcurrentLimiter* limiter);
 
     static void release(StreamLoadContext* context);
+
+    // Returns the Thrift RPC timeout (in milliseconds) shared by the stream-load plan (put)
+    // and the txn prepare/commit RPCs sent to the FE.
+    //
+    // The base value is the configurable `stream_load_thrift_rpc_timeout_ms`. When the caller
+    // specifies a load timeout (`timeout_second`), the RPC timeout is clamped into the range
+    // [timeout_ms / 4, timeout_ms / 2], so that a single RPC is never allowed to take longer
+    // than half of the whole load timeout, nor be shorter than a quarter of it.
+    //
+    // The bounds are computed in 64-bit because `timeout_second` comes from a user-supplied
+    // header and `timeout_second * 1000` would overflow int32 once timeout_second > 2147483;
+    // the result is capped at INT32_MAX before narrowing back to the int32 RPC timeout.
+    int32_t calc_put_and_commit_rpc_timeout_ms() {
+        int32_t rpc_timeout_ms = config::stream_load_thrift_rpc_timeout_ms;
+        if (timeout_second != -1) {
+            int64_t timeout_ms = static_cast<int64_t>(timeout_second) * 1000;
+            int64_t min_rpc_timeout_ms = timeout_ms / 4;
+            int64_t max_rpc_timeout_ms = timeout_ms / 2;
+            if (rpc_timeout_ms < min_rpc_timeout_ms) {
+                rpc_timeout_ms = min_rpc_timeout_ms > INT32_MAX ? INT32_MAX : static_cast<int32_t>(min_rpc_timeout_ms);
+            } else if (rpc_timeout_ms > max_rpc_timeout_ms) {
+                rpc_timeout_ms = static_cast<int32_t>(max_rpc_timeout_ms);
+            }
+        }
+        return rpc_timeout_ms;
+    }
 
     // ========================== transaction stream load ==========================
     // try to get the lock when receiving http requests.

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -229,11 +229,7 @@ Status StreamLoadExecutor::commit_txn(StreamLoadContext* ctx) {
     request.__isset.commitInfos = true;
     request.failInfos = std::move(ctx->fail_infos);
     request.__isset.failInfos = true;
-    int32_t rpc_timeout_ms = config::txn_commit_rpc_timeout_ms;
-    if (ctx->timeout_second != -1) {
-        rpc_timeout_ms = std::min(ctx->timeout_second * 1000 / 2, rpc_timeout_ms);
-        rpc_timeout_ms = std::max(ctx->timeout_second * 1000 / 4, rpc_timeout_ms);
-    }
+    int32_t rpc_timeout_ms = ctx->calc_put_and_commit_rpc_timeout_ms();
     request.__set_thrift_rpc_timeout_ms(rpc_timeout_ms);
 
     // set attachment if has
@@ -303,7 +299,7 @@ StatusOr<TTransactionStatus::type> get_txn_status(const AuthInfo& auth, std::str
     auto st = ThriftRpcHelper::rpc<FrontendServiceClient>(
             master_addr.hostname, master_addr.port,
             [&request, &result](FrontendServiceConnection& client) { client->getLoadTxnStatus(result, request); },
-            config::txn_commit_rpc_timeout_ms);
+            config::stream_load_thrift_rpc_timeout_ms);
     if (!st.ok()) {
         return st;
     } else {
@@ -346,11 +342,7 @@ Status StreamLoadExecutor::prepare_txn(StreamLoadContext* ctx) {
     request.__isset.commitInfos = true;
     request.failInfos = std::move(ctx->fail_infos);
     request.__isset.failInfos = true;
-    int32_t rpc_timeout_ms = config::txn_commit_rpc_timeout_ms;
-    if (ctx->timeout_second != -1) {
-        rpc_timeout_ms = std::min(ctx->timeout_second * 1000 / 2, rpc_timeout_ms);
-        rpc_timeout_ms = std::max(ctx->timeout_second * 1000 / 4, rpc_timeout_ms);
-    }
+    int32_t rpc_timeout_ms = ctx->calc_put_and_commit_rpc_timeout_ms();
     request.__set_thrift_rpc_timeout_ms(rpc_timeout_ms);
     if (ctx->prepared_timeout_second != -1) {
         request.__set_prepared_timeout_second(ctx->prepared_timeout_second);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -288,6 +288,7 @@ set(EXEC_FILES
         ./runtime/batch_write/batch_write_util_test.cpp
         ./runtime/batch_write/isomorphic_batch_write_test.cpp
         ./runtime/batch_write/txn_state_cache_test.cpp
+        ./runtime/stream_load/stream_load_context_test.cpp
         #./runtime/routine_load_task_executor_test.cpp
         ./runtime/routine_load/data_consumer_test.cpp
         ./runtime/small_file_mgr_test.cpp

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -46,6 +46,7 @@
 #include "base/metrics.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/sync_point.h"
+#include "base/utility/defer_op.h"
 #include "common/config_ingest_fwd.h"
 #include "common/process_exit.h"
 #include "common/system/cpu_info.h"
@@ -661,6 +662,44 @@ TEST_F(StreamLoadActionTest, invalid_envelope) {
     doc.Parse(k_response_str.c_str());
     ASSERT_STREQ("Fail", doc["Status"].GetString());
     ASSERT_NE(nullptr, std::strstr(doc["Message"].GetString(), "Unknown envelope type: custom"));
+}
+
+TEST_F(StreamLoadActionTest, stream_load_put_rpc_timeout_setting) {
+    struct TestCase {
+        const char* timeout_header;
+        int32_t expected_timeout_ms;
+    };
+    TestCase test_cases[] = {
+            {nullptr, config::stream_load_thrift_rpc_timeout_ms}, // default timeout
+            {"30", 15000},                                        // custom timeout: 30s -> 15000ms
+    };
+
+    for (const auto& tc : test_cases) {
+        StreamLoadAction action(&_env, _limiter.get());
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp defer([]() {
+            SyncPoint::GetInstance()->ClearCallBack("StreamLoadAction::_process_put::rpc_timeout");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
+        int32_t captured_timeout = -1;
+        SyncPoint::GetInstance()->SetCallBack("StreamLoadAction::_process_put::rpc_timeout", [&](void* arg) {
+            auto* request = static_cast<TStreamLoadPutRequest*>(arg);
+            captured_timeout = request->thrift_rpc_timeout_ms;
+        });
+
+        HttpRequest request(_evhttp_req);
+        request._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+        request._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+        if (tc.timeout_header != nullptr) {
+            request._headers.emplace(HTTP_TIMEOUT, tc.timeout_header);
+        }
+        request.set_handler(&action);
+        action.on_header(&request);
+        action.handle(&request);
+
+        EXPECT_EQ(tc.expected_timeout_ms, captured_timeout);
+    }
 }
 
 } // namespace starrocks

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -26,6 +26,7 @@
 #include "base/metrics.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/sync_point.h"
+#include "base/utility/defer_op.h"
 #include "common/config_ingest_fwd.h"
 #include "common/system/cpu_info.h"
 #include "gen_cpp/FrontendService_types.h"
@@ -1128,6 +1129,60 @@ TEST_F(TransactionStreamLoadActionTest, release_resource_for_not_handle) {
     ASSERT_EQ(2, ctx->num_refs());
     ASSERT_TRUE(ctx->lock.try_lock());
     ctx->lock.unlock();
+}
+
+TEST_F(TransactionStreamLoadActionTest, stream_load_put_rpc_timeout_setting) {
+    // Test cases: {label, timeout_header, expected_timeout_ms}
+    struct TestCase {
+        const char* label;
+        const char* timeout_header;
+        int32_t expected_timeout_ms;
+    };
+    TestCase test_cases[] = {
+            {"rpc_timeout_default", nullptr, config::stream_load_thrift_rpc_timeout_ms}, // default timeout
+            {"rpc_timeout_custom", "30", 15000}, // custom timeout: 30s -> 15000ms
+    };
+
+    for (const auto& tc : test_cases) {
+        TransactionManagerAction txn_action(&_env);
+        HttpRequest begin_req(_evhttp_req);
+        begin_req._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+        begin_req._headers.emplace(HttpHeaders::CONTENT_LENGTH, "0");
+        begin_req._headers.emplace(HTTP_LABEL_KEY, tc.label);
+        if (tc.timeout_header != nullptr) {
+            begin_req._headers.emplace(HTTP_TIMEOUT, tc.timeout_header);
+        }
+        begin_req._params.emplace(HTTP_TXN_OP_KEY, TXN_BEGIN);
+        txn_action.handle(&begin_req);
+
+        rapidjson::Document doc;
+        doc.Parse(k_response_str.c_str());
+        ASSERT_STREQ("OK", doc["Status"].GetString());
+
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp defer([]() {
+            SyncPoint::GetInstance()->ClearCallBack("TransactionStreamLoadAction::_exec_plan_fragment::rpc_timeout");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
+        int32_t captured_timeout = -1;
+        SyncPoint::GetInstance()->SetCallBack("TransactionStreamLoadAction::_exec_plan_fragment::rpc_timeout",
+                                              [&](void* arg) {
+                                                  auto* request = static_cast<TStreamLoadPutRequest*>(arg);
+                                                  captured_timeout = request->thrift_rpc_timeout_ms;
+                                              });
+
+        TransactionStreamLoadAction action(&_env);
+        HttpRequest request(_evhttp_req);
+        request.set_handler(&action);
+        request._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+        request._headers.emplace(HttpHeaders::CONTENT_LENGTH, "16");
+        request._headers.emplace(HTTP_LABEL_KEY, tc.label);
+        action.on_header(&request);
+        action.handle(&request);
+
+        EXPECT_EQ(tc.expected_timeout_ms, captured_timeout);
+    }
 }
 
 } // namespace starrocks

--- a/be/test/runtime/stream_load/stream_load_context_test.cpp
+++ b/be/test/runtime/stream_load/stream_load_context_test.cpp
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/stream_load/stream_load_context.h"
+
+#include <gtest/gtest.h>
+
+#include "runtime/exec_env.h"
+
+namespace starrocks {
+
+class StreamLoadContextTest : public testing::Test {
+public:
+    StreamLoadContextTest() = default;
+    ~StreamLoadContextTest() override = default;
+
+    void SetUp() override { _exec_env = ExecEnv::GetInstance(); }
+
+protected:
+    ExecEnv* _exec_env;
+};
+
+TEST_F(StreamLoadContextTest, calc_put_and_commit_rpc_timeout_ms) {
+    // Test case structure: {timeout_second, expected_rpc_timeout_ms, description}
+    struct TestCase {
+        int32_t timeout_second;
+        int32_t expected_rpc_timeout_ms;
+        const char* description;
+    };
+
+    const int32_t default_timeout_ms = config::stream_load_thrift_rpc_timeout_ms; // 60000
+
+    TestCase test_cases[] = {
+            // Default behavior: timeout_second = -1
+            {-1, default_timeout_ms, "Default timeout when timeout_second is -1"},
+
+            // Small timeout values where timeout_ms/2 < default_timeout_ms
+            {30, 15000, "Small timeout (30s): timeout_ms/2 = 15000"},
+            {10, 5000, "Very small timeout (10s): timeout_ms/2 = 5000"},
+
+            // Large timeout values where timeout_ms/2 >= default_timeout_ms
+            {200, 60000, "Large timeout (200s): min(100000, 60000) = 60000, max(50000, 60000) = 60000"},
+            {1000, 250000, "Very large timeout (1000s): min(500000, 60000) = 60000, max(250000, 60000) = 250000"},
+
+            // Boundary cases
+            {120, 60000, "Boundary: timeout_ms/2 equals default (120s)"},
+            {240, 60000, "Boundary: timeout_ms/4 equals default (240s)"},
+            {180, 60000, "Boundary: timeout_ms/4 between timeout_ms/2 and default (180s)"},
+
+            // Edge cases
+            {0, 0, "Zero timeout: timeout_ms/2 = 0, timeout_ms/4 = 0"},
+            {500, 125000, "Lower bound dominates: min(250000, 60000) = 60000, max(125000, 60000) = 125000"},
+
+            // Overflow guard: timeout_second * 1000 must be computed in 64-bit (int32 would overflow
+            // once timeout_second > 2147483), and the result is capped at INT32_MAX.
+            {2147484, 536871000, "No int32 overflow (64-bit): timeout_ms/4 = 536871000 dominates the default"},
+            {9000000, 2147483647, "Huge timeout: timeout_ms/4 exceeds INT32_MAX, capped to INT32_MAX"},
+    };
+
+    for (const auto& tc : test_cases) {
+        SCOPED_TRACE(tc.description);
+        StreamLoadContext ctx(_exec_env);
+        ctx.timeout_second = tc.timeout_second;
+
+        int32_t original_timeout_second = ctx.timeout_second;
+        int32_t result = ctx.calc_put_and_commit_rpc_timeout_ms();
+
+        EXPECT_EQ(tc.expected_rpc_timeout_ms, result) << "Failed for timeout_second=" << tc.timeout_second;
+        EXPECT_EQ(original_timeout_second, ctx.timeout_second) << "Method should not modify timeout_second";
+    }
+}
+
+} // namespace starrocks

--- a/docs/en/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/BE_parameters/log_server_meta.md
@@ -634,13 +634,13 @@ This topic introduces the following types of BE configurations:
 - Description: Maximum cumulative retry time (in seconds) allowed for applying a pending version before the apply process gives up and the tablet enters an error state. The apply logic accumulates exponential/backoff intervals based on `retry_apply_interval_second` and compares the total duration against `retry_apply_timeout_second`. If `enable_retry_apply` is true and the error is considered retryable, apply attempts will be rescheduled until the accumulated backoff exceeds `retry_apply_timeout_second`; then apply stops and the tablet transitions to error. Explicitly non-retryable errors (e.g., Corruption) are not retried regardless of this setting. Tune this value to control how long StarRocks will keep retrying apply operations (default 7200s = 2 hours).
 - Introduced in: v3.3.13, v3.4.3, v3.5.0
 
-### txn_commit_rpc_timeout_ms
+### stream_load_thrift_rpc_timeout_ms
 
 - Default: 60000
 - Type: Int
 - Unit: Milliseconds
 - Is mutable: Yes
-- Description: Maximum allowed lifetime (in milliseconds) for Thrift RPC connections used by BE stream-load and transaction commit calls. StarRocks sets this value as the `thrift_rpc_timeout_ms` on requests sent to FE (used in stream_load planning, loadTxnBegin/loadTxnPrepare/loadTxnCommit, and getLoadTxnStatus). If a connection has been pooled longer than this value it will be closed. When a per-request timeout (`ctx->timeout_second`) is provided, the BE computes the RPC timeout as rpc_timeout_ms = max(ctx*1000/4, min(ctx*1000/2, txn_commit_rpc_timeout_ms)), so the effective RPC timeout is bounded by the context and this configuration. Keep this consistent with FE's `thrift_client_timeout_ms` to avoid mismatched timeouts.
+- Description: Maximum allowed lifetime (in milliseconds) for Thrift RPC connections used by BE stream-load and transaction commit calls. StarRocks sets this value as the `thrift_rpc_timeout_ms` on requests sent to FE (used in stream_load planning, loadTxnBegin/loadTxnPrepare/loadTxnCommit, and getLoadTxnStatus). If a connection has been pooled longer than this value it will be closed. When a per-request timeout (`ctx->timeout_second`) is provided, the BE computes the RPC timeout as rpc_timeout_ms = max(ctx*1000/4, min(ctx*1000/2, stream_load_thrift_rpc_timeout_ms)), so the effective RPC timeout is bounded by the context and this configuration. Keep this consistent with FE's `thrift_client_timeout_ms` to avoid mismatched timeouts. The legacy name `txn_commit_rpc_timeout_ms` is still accepted as a backward-compatible alias.
 - Introduced in: v3.2.0
 
 ### txn_map_shard_size

--- a/docs/ja/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/BE_parameters/log_server_meta.md
@@ -438,6 +438,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: thrift RPC のタイムアウト。
 - 導入バージョン: -
 
+### stream_load_thrift_rpc_timeout_ms
+
+- デフォルト: 60000
+- タイプ: Int
+- 単位: ミリ秒
+- 変更可能: はい
+- 説明: BE の stream load およびトランザクションコミット呼び出しで使用される Thrift RPC 接続の最大有効時間（ミリ秒）。StarRocks はこの値を FE へ送るリクエストの `thrift_rpc_timeout_ms` として設定します（stream load のプランニング、loadTxnBegin/loadTxnPrepare/loadTxnCommit、および getLoadTxnStatus で使用されます）。接続がこの値より長くコネクションプールに留まっている場合は閉じられます。リクエストごとのタイムアウト（`ctx->timeout_second`）が指定されている場合、BE は RPC タイムアウトを rpc_timeout_ms = max(ctx*1000/4, min(ctx*1000/2, stream_load_thrift_rpc_timeout_ms)) として計算するため、実効 RPC タイムアウトはコンテキストとこの設定の両方によって制限されます。タイムアウトの不一致を避けるため、FE の `thrift_client_timeout_ms` と一致させてください。旧名称 `txn_commit_rpc_timeout_ms` は後方互換のエイリアスとして引き続き使用できます。
+- 導入バージョン: v3.2.0
+
 ### transaction_apply_thread_pool_num_min
 
 - デフォルト: 0

--- a/docs/zh/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/BE_parameters/log_server_meta.md
@@ -596,13 +596,13 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：事务 apply 重试的超时时间。
 - 引入版本：-
 
-### txn_commit_rpc_timeout_ms
+### stream_load_thrift_rpc_timeout_ms
 
 - 默认值：60000
 - 类型：Int
 - 单位：Milliseconds
 - 是否动态：是
-- 描述：BE 发往 FE 的事务提交/stream load 相关 Thrift RPC 的超时时长上限，也用于连接池中超时连接的关闭。实际超时会结合请求上下文计算，但不会超过该值；需与 FE `thrift_client_timeout_ms` 保持一致以避免不匹配。
+- 描述：BE 发往 FE 的事务提交/stream load 相关 Thrift RPC 的超时时长上限，也用于连接池中超时连接的关闭。实际超时会结合请求上下文计算，但不会超过该值；需与 FE `thrift_client_timeout_ms` 保持一致以避免不匹配。旧名称 `txn_commit_rpc_timeout_ms` 仍作为向后兼容的别名保留。
 - 引入版本：v3.2.0
 
 ### enable_retry_apply


### PR DESCRIPTION
## Why I'm doing:

The regular stream load correctly calculates the RPC timeout based on the user-specified timeout and passes it to the RPC call. However, the transaction stream load was not using the same logic - it was using the default `config::thrift_rpc_timeout_ms` and did not pass the timeout to the actual RPC call. This inconsistency could lead to RPC timeout issues for transaction stream load operations.

## What I'm doing:

- Extract the RPC timeout calculation logic into a reusable method `calc_put_and_commit_rpc_timeout_ms()` in `StreamLoadContext` class
- Fix `TransactionStreamLoadAction::_exec_plan_fragment()` to use the same RPC timeout calculation as regular stream load
- Pass the calculated `rpc_timeout_ms` to the `ThriftRpcHelper::rpc()` call
- Refactor existing code in `StreamLoadAction` and `StreamLoadExecutor` to use the centralized timeout calculation method
- Add comprehensive unit tests for the timeout calculation logic and the RPC timeout setting

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies and applies consistent RPC timeouts for stream load paths and adds verification.
> 
> - Introduces `StreamLoadContext::calc_put_and_commit_rpc_timeout_ms()` and uses it in `stream_load.cpp`, `transaction_stream_load.cpp`, and `stream_load_executor.cpp` to set `request.thrift_rpc_timeout_ms`
> - `TransactionStreamLoadAction::_exec_plan_fragment` now computes timeout and passes it to `ThriftRpcHelper::rpc(...)`; similar refactor for regular stream load via `stream_load_put_internal`
> - Adds sync points for capturing RPC timeout in tests (`StreamLoadAction::_process_put::rpc_timeout`, `TransactionStreamLoadAction::_exec_plan_fragment::rpc_timeout`)
> - New/updated unit tests: `stream_load_context_test.cpp` (timeout calc), HTTP tests for both stream and transaction load RPC timeout settings; CMake updated to include new test
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28ea989b39de6105114fb4a7b96c6e4627e353fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->