### PR TITLE
[UT] make blacklist UT more stable

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
@@ -106,6 +106,7 @@ public class QueryPlannerTest {
         // Make each case independent so running the whole class/suite doesn't leak state between cases.
         clearSqlBlackList();
         clearSqlDigestBlackList();
+        connectContext.getState().setError("");
     }
 
     @AfterEach
@@ -115,6 +116,7 @@ public class QueryPlannerTest {
         // Reset configs to avoid affecting other test classes in the same JVM.
         setFrontendConfig("enable_sql_blacklist", "false");
         setFrontendConfig("enable_sql_digest", "false");
+        connectContext.getState().setError("");
     }
 
     private static void clearSqlBlackList() {


### PR DESCRIPTION
## Why I'm doing:
QueryPlannerTest share the same connect context, so one test failed can cause other test fail too.

## What I'm doing:
clear context' error every time

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
