### PR TITLE
[BugFix] Fix missing TSchemaTableType in SchemaScanner::create for creating SchemaTabletReshardJobsScanner

### DIFF
--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -246,6 +246,8 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return std::make_unique<WarehouseMetricsScanner>();
     case TSchemaTableType::SCH_WAREHOUSE_QUERIES:
         return std::make_unique<WarehouseQueriesScanner>();
+    case TSchemaTableType::SCH_TABLET_RESHARD_JOBS:
+        return std::make_unique<SchemaTabletReshardJobsScanner>();
     default:
         return std::make_unique<SchemaDummyScanner>();
     }

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -57,6 +57,7 @@
 #include "exec/schema_scanner/schema_table_privileges_scanner.h"
 #include "exec/schema_scanner/schema_tables_config_scanner.h"
 #include "exec/schema_scanner/schema_tables_scanner.h"
+#include "exec/schema_scanner/schema_tablet_reshard_jobs_scanner.h"
 #include "exec/schema_scanner/schema_task_runs_scanner.h"
 #include "exec/schema_scanner/schema_tasks_scanner.h"
 #include "exec/schema_scanner/schema_temp_tables_scanner.h"

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -90,7 +90,8 @@ set(EXEC_FILES
         ./exec/schema_fe_tablet_schedules_scanner_test.cpp
         ./exec/schema_materialized_views_scanner_test.cpp
         ./exec/schema_task_runs_scanner_test.cpp
-	    ./exec/schema_scanner/schema_be_tablet_write_log_scanner_test.cpp
+        ./exec/schema_scanner/schema_be_tablet_write_log_scanner_test.cpp
+        ./exec/schema_scanner/schema_scanner_test.cpp
         ./exec/sink/connector_sink_operator_test.cpp
         ./exec/sink/sink_io_buffer_test.cpp
         ./exec/stream/mem_state_table_test.cpp

--- a/be/test/exec/schema_scanner/schema_scanner_test.cpp
+++ b/be/test/exec/schema_scanner/schema_scanner_test.cpp
@@ -1,0 +1,46 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner.h"
+
+#include <gtest/gtest.h>
+
+#include "exec/schema_scanner/schema_tablet_reshard_jobs_scanner.h"
+#include "gen_cpp/Descriptors_types.h"
+
+namespace starrocks {
+
+class SchemaScannerTest : public ::testing::Test {};
+
+TEST_F(SchemaScannerTest, test_create) {
+    {
+        auto scanner = SchemaScanner::create(TSchemaTableType::SCH_TABLET_RESHARD_JOBS);
+        ASSERT_NE(scanner, nullptr);
+        auto* reshard_jobs_scanner = dynamic_cast<SchemaTabletReshardJobsScanner*>(scanner.get());
+        ASSERT_NE(reshard_jobs_scanner, nullptr);
+    }
+    {
+        // Test an existing one to ensure it still works
+        auto scanner = SchemaScanner::create(TSchemaTableType::SCH_TABLES);
+        ASSERT_NE(scanner, nullptr);
+    }
+    {
+        // Test default case
+        auto scanner = SchemaScanner::create(static_cast<TSchemaTableType::type>(-1));
+        ASSERT_NE(scanner, nullptr);
+    }
+}
+
+} // namespace starrocks
+

--- a/be/test/exec/schema_scanner/schema_scanner_test.cpp
+++ b/be/test/exec/schema_scanner/schema_scanner_test.cpp
@@ -43,4 +43,3 @@ TEST_F(SchemaScannerTest, test_create) {
 }
 
 } // namespace starrocks
-


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `SchemaScanner::create` can instantiate the reshard jobs scanner.
> 
> - Adds `TSchemaTableType::SCH_TABLET_RESHARD_JOBS` branch returning `SchemaTabletReshardJobsScanner` in `exec/schema_scanner.cpp`
> - Introduces `exec/schema_scanner/schema_scanner_test.cpp` verifying creation for reshard jobs, an existing type, and default case
> - Updates `test/CMakeLists.txt` to include the new test (and fixes listing for `schema_be_tablet_write_log_scanner_test.cpp`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cebf5ea659063b4d03d838b9390f524fd23f9c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->