### PR TITLE
[BugFix] Fix domain predicate deriver error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/property/DomainPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/property/DomainPropertyDeriver.java
@@ -70,10 +70,6 @@ public class DomainPropertyDeriver extends ScalarOperatorVisitor<Map<ScalarOpera
         }
 
         domainMap.put(left, new DomainMessage(binaryPredicate));
-        List<ColumnRefOperator> usedCols = left.getColumnRefs();
-        if (Sets.newHashSet(usedCols).size() == 1 && !domainMap.containsKey(usedCols.get(0))) {
-            domainMap.put(usedCols.get(0), new DomainMessage(binaryPredicate, false));
-        }
         return domainMap;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -3632,4 +3632,18 @@ public class JoinTest extends PlanTestBase {
                 "  |  offset: 0");
         FeConstants.runningUnitTest = false;
     }
+
+    @Test
+    public void testLeftPredicate() throws Exception {
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
+        String sql1 = "with tt as (select * from test_all_type_not_null) "
+                + "select t1.* "
+                + "from tt t1 left join "
+                + "     tt t2 on t1.t1c = t2.t1c "
+                + " and t1.t1a between t2.id_datetime and t2.id_date "
+                + "where t1.t1a>=date_add('2026-01-01',-200) and t1.t1a<=date_format(date_add('2026-01-01',0) , '%Y-%m-31');";
+
+        String plan = getFragmentPlan(sql1);
+        assertNotContains(plan, "CAST(29: id_date AS VARCHAR) >= '2025-06-15 00:00:00'");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes domain extraction logic for predicates.
> 
> - Updates `DomainPropertyDeriver.visitBinaryPredicate` to only record the left operand’s domain (when RHS is constant and deterministic) and remove extra propagation to `left`’s underlying column refs
> - Adds `JoinTest.testLeftPredicate` to verify no incorrect casted predicate is produced for a LEFT JOIN with date range conditions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d972a977243ba1ffe134075de57076aa26fd03e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->