### PR TITLE
[Enhancement] Support for glue catalog tables with partition projection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
@@ -27,6 +27,7 @@ import com.starrocks.connector.ConnectorTableId;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.hive.glue.projection.PartitionProjectionService;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.ListPartitionDesc;
@@ -65,6 +66,7 @@ public class HiveMetastoreOperations {
     private final Configuration hadoopConf;
     private final MetastoreType metastoreType;
     private final String catalogName;
+    private final PartitionProjectionService partitionProjectionService;
 
     public HiveMetastoreOperations(CachingHiveMetastore cachingHiveMetastore,
                                    boolean enableCatalogLevelCache,
@@ -76,6 +78,7 @@ public class HiveMetastoreOperations {
         this.hadoopConf = hadoopConf;
         this.metastoreType = metastoreType;
         this.catalogName = catalogName;
+        this.partitionProjectionService = new PartitionProjectionService();
     }
 
     public List<String> getAllDatabaseNames() {
@@ -256,10 +259,24 @@ public class HiveMetastoreOperations {
     }
 
     public List<String> getPartitionKeys(String dbName, String tableName) {
+        Table table = getTable(dbName, tableName);
+        if (table instanceof HiveTable) {
+            HiveTable hiveTable = (HiveTable) table;
+            if (partitionProjectionService.isEnabled(table)) {
+                return partitionProjectionService.getProjectedPartitionNames(hiveTable);
+            }
+        }
         return metastore.getPartitionKeysByValue(dbName, tableName, HivePartitionValue.ALL_PARTITION_VALUES);
     }
 
     public List<String> getPartitionKeysByValue(String dbName, String tableName, List<Optional<String>> partitionValues) {
+        Table table = getTable(dbName, tableName);
+        if (table instanceof HiveTable) {
+            HiveTable hiveTable = (HiveTable) table;
+            if (partitionProjectionService.isEnabled(table)) {
+                return partitionProjectionService.getProjectedPartitionNamesByValue(hiveTable, partitionValues);
+            }
+        }
         return metastore.getPartitionKeysByValue(dbName, tableName, partitionValues);
     }
 
@@ -280,9 +297,16 @@ public class HiveMetastoreOperations {
     }
 
     public Map<String, Partition> getPartitionByPartitionKeys(Table table, List<PartitionKey> partitionKeys) {
-        String dbName = (table).getCatalogDBName();
-        String tblName = (table).getCatalogTableName();
-        List<String> partitionColumnNames = (table).getPartitionColumnNames();
+        if (table instanceof HiveTable) {
+            HiveTable hiveTable = (HiveTable) table;
+            if (partitionProjectionService.isEnabled(table)) {
+                return partitionProjectionService.getProjectedPartitions(hiveTable, partitionKeys);
+            }
+        }
+
+        String dbName = table.getCatalogDBName();
+        String tblName = table.getCatalogTableName();
+        List<String> partitionColumnNames = table.getPartitionColumnNames();
         List<String> partitionNames = partitionKeys.stream()
                 .map(partitionKey -> PartitionUtil.toHivePartitionName(partitionColumnNames, partitionKey))
                 .collect(Collectors.toList());
@@ -291,8 +315,15 @@ public class HiveMetastoreOperations {
     }
 
     public Map<String, Partition> getPartitionByNames(Table table, List<String> partitionNames) {
-        String dbName = (table).getCatalogDBName();
-        String tblName = (table).getCatalogTableName();
+        if (table instanceof HiveTable) {
+            HiveTable hiveTable = (HiveTable) table;
+            if (partitionProjectionService.isEnabled(table)) {
+                return partitionProjectionService.getProjectedPartitionsFromNames(hiveTable, partitionNames);
+            }
+        }
+
+        String dbName = table.getCatalogDBName();
+        String tblName = table.getCatalogTableName();
         return metastore.getPartitionsByNames(dbName, tblName, partitionNames);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/ColumnProjection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/ColumnProjection.java
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import com.starrocks.type.Type;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Interface for partition column projection.
+ *
+ * Each partition column with projection enabled has an associated ColumnProjection
+ * that generates partition values based on the projection type and configuration.
+ *
+ * Implementations handle different projection types:
+ * - EnumProjection: enumerated list of values
+ * - IntegerProjection: integer range with optional interval
+ * - DateProjection: date range with format and interval
+ * - InjectedProjection: values injected from query WHERE clause
+ */
+public interface ColumnProjection {
+
+    /**
+     * Gets the column name this projection is for.
+     *
+     * @return the partition column name
+     */
+    String getColumnName();
+
+    /**
+     * Generates projected partition values based on an optional filter.
+     *
+     * When a filter value is present (from WHERE clause), only matching values
+     * are returned. When no filter is present, all possible values within the
+     * projection range are generated.
+     *
+     * @param filterValue optional filter value from query predicate
+     * @return list of projected partition values
+     * @throws IllegalArgumentException if the projection requires a filter value
+     *         but none is provided (e.g., INJECTED type)
+     */
+    List<String> getProjectedValues(Optional<Object> filterValue);
+
+    /**
+     * Formats a value for use in partition paths.
+     *
+     * @param value the value to format
+     * @return formatted string representation
+     */
+    String formatValue(Object value);
+
+    /**
+     * Gets the StarRocks column type for this projection.
+     *
+     * @return the column type
+     */
+    Type getColumnType();
+
+    /**
+     * Checks if this projection requires a filter value in the WHERE clause.
+     *
+     * @return true if a filter is required (e.g., INJECTED type)
+     */
+    default boolean requiresFilter() {
+        return false;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/DateProjection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/DateProjection.java
@@ -204,7 +204,8 @@ public class DateProjection implements ColumnProjection {
                     // Filter value is outside the range - return empty list
                     return Collections.emptyList();
                 }
-                return Collections.singletonList(filter);
+                // Return formatted date, not raw filter (e.g., 'NOW' -> '2024-01-15')
+                return Collections.singletonList(formatInstant(filterInstant));
             } catch (IllegalArgumentException e) {
                 // Invalid date format - return empty list
                 return Collections.emptyList();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/DateProjection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/DateProjection.java
@@ -156,24 +156,27 @@ public class DateProjection implements ColumnProjection {
             return ChronoUnit.HOURS;
         }
 
-        // Check for day-of-month pattern (d or dd, but not D which is day-of-year)
-        boolean hasDay = format.matches(".*(?<![DdM])d{1,2}(?![dDM]).*");
+        // Check for day patterns: 'd' is day-of-month (1-31), 'D' is day-of-year (1-366)
+        // Both require daily iteration
+        boolean hasDayOfMonth = format.contains("d");
+        boolean hasDayOfYear = format.contains("D");
+        boolean hasDay = hasDayOfMonth || hasDayOfYear;
 
         // Check for month pattern (M or MM, but not m which is minutes)
         boolean hasMonth = format.contains("M");
 
-        // If format has no day component
-        if (!hasDay) {
-            // If format has no month component either, it's year-only
-            if (!hasMonth) {
-                return ChronoUnit.YEARS;
-            }
-            // Format has month but no day, e.g., yyyy-MM
+        // If format has any day component (day-of-month or day-of-year), use DAYS
+        if (hasDay) {
+            return ChronoUnit.DAYS;
+        }
+
+        // If format has month but no day, e.g., yyyy-MM
+        if (hasMonth) {
             return ChronoUnit.MONTHS;
         }
 
-        // Default to days for formats with day component
-        return ChronoUnit.DAYS;
+        // Year-only format, e.g., yyyy
+        return ChronoUnit.YEARS;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/DateProjection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/DateProjection.java
@@ -1,0 +1,344 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import com.starrocks.type.Type;
+import com.starrocks.type.VarcharType;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Partition projection for date/time ranges.
+ *
+ * The date projection type defines a range of dates with a format and interval.
+ * Supports both absolute dates and relative expressions (NOW, NOW-3DAYS, etc.).
+ *
+ * Example table properties:
+ * <pre>
+ *   'projection.dt.type' = 'date',
+ *   'projection.dt.range' = '2024-01-01,NOW',
+ *   'projection.dt.format' = 'yyyy-MM-dd',
+ *   'projection.dt.interval' = '1',
+ *   'projection.dt.interval.unit' = 'DAYS'
+ * </pre>
+ *
+ * Supported interval units: YEARS, MONTHS, WEEKS, DAYS, HOURS, MINUTES, SECONDS
+ */
+public class DateProjection implements ColumnProjection {
+
+    // Maximum number of values to generate to prevent memory issues
+    private static final int MAX_VALUES = 100000;
+
+    // Pattern for relative date expressions: NOW, NOW-3DAYS, NOW+1MONTH, etc.
+    private static final Pattern RELATIVE_DATE_PATTERN = Pattern.compile(
+            "\\s*NOW\\s*(?:([-+])\\s*(\\d+)\\s*(YEARS?|MONTHS?|WEEKS?|DAYS?|HOURS?|MINUTES?|SECONDS?)\\s*)?",
+            Pattern.CASE_INSENSITIVE);
+
+    private final String columnName;
+    private final String rangeProperty;
+    private final DateTimeFormatter dateFormat;
+    private final String formatPattern;
+    private final long interval;
+    private final ChronoUnit intervalUnit;
+
+    /**
+     * Creates a date projection for a partition column.
+     *
+     * @param columnName the partition column name
+     * @param rangeProperty range as "start,end" where each can be a date or NOW expression
+     * @param formatProperty date format pattern (e.g., "yyyy-MM-dd")
+     * @param intervalProperty optional interval between values (default: 1)
+     * @param intervalUnitProperty optional interval unit (default: inferred from format)
+     */
+    public DateProjection(String columnName, String rangeProperty, String formatProperty,
+                          Optional<String> intervalProperty,
+                          Optional<String> intervalUnitProperty) {
+        if (rangeProperty == null || rangeProperty.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Date projection for column '" + columnName + "' requires a range property");
+        }
+        if (formatProperty == null || formatProperty.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Date projection for column '" + columnName + "' requires a format property");
+        }
+
+        this.columnName = columnName;
+        this.rangeProperty = rangeProperty;
+        this.formatPattern = formatProperty;
+
+        try {
+            this.dateFormat = DateTimeFormatter.ofPattern(formatProperty, Locale.ENGLISH);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Invalid date format for column '" + columnName + "': " + formatProperty, e);
+        }
+
+        // Parse interval (default: 1)
+        this.interval = intervalProperty
+                .map(s -> {
+                    try {
+                        long val = Long.parseLong(s.trim());
+                        if (val <= 0) {
+                            throw new IllegalArgumentException(
+                                    "Date projection interval must be positive, got: " + val);
+                        }
+                        return val;
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException(
+                                "Invalid interval value for column '" + columnName + "': " + s, e);
+                    }
+                })
+                .orElse(1L);
+
+        // Parse interval unit (default: inferred from format)
+        this.intervalUnit = intervalUnitProperty
+                .map(this::parseIntervalUnit)
+                .orElseGet(() -> inferIntervalUnit(formatProperty));
+    }
+
+    private ChronoUnit parseIntervalUnit(String unit) {
+        if (unit == null) {
+            return ChronoUnit.DAYS;
+        }
+        // Normalize: remove trailing 'S' and convert to uppercase
+        String normalized = unit.toUpperCase().replaceAll("S$", "");
+        switch (normalized) {
+            case "YEAR":
+                return ChronoUnit.YEARS;
+            case "MONTH":
+                return ChronoUnit.MONTHS;
+            case "WEEK":
+                return ChronoUnit.WEEKS;
+            case "DAY":
+                return ChronoUnit.DAYS;
+            case "HOUR":
+                return ChronoUnit.HOURS;
+            case "MINUTE":
+                return ChronoUnit.MINUTES;
+            case "SECOND":
+                return ChronoUnit.SECONDS;
+            default:
+                throw new IllegalArgumentException("Unknown interval unit: " + unit);
+        }
+    }
+
+    private ChronoUnit inferIntervalUnit(String format) {
+        // If format includes time components, default to hours
+        if (format.contains("HH") || format.contains("hh") ||
+                format.contains("mm") || format.contains("ss")) {
+            return ChronoUnit.HOURS;
+        }
+        return ChronoUnit.DAYS;
+    }
+
+    @Override
+    public String getColumnName() {
+        return columnName;
+    }
+
+    @Override
+    public List<String> getProjectedValues(Optional<Object> filterValue) {
+        // Parse bounds at query time to handle NOW expressions correctly
+        Instant now = Instant.now();
+        Instant leftBound = parseDate(getRangeStart(), now);
+        Instant rightBound = parseDate(getRangeEnd(), now);
+
+        if (filterValue.isPresent()) {
+            // Validate filter value is within range
+            String filter = filterValue.get().toString();
+            try {
+                Instant filterInstant = parseDate(filter, now);
+                if (filterInstant.isBefore(leftBound) || filterInstant.isAfter(rightBound)) {
+                    // Filter value is outside the range - return empty list
+                    return Collections.emptyList();
+                }
+                return Collections.singletonList(filter);
+            } catch (IllegalArgumentException e) {
+                // Invalid date format - return empty list
+                return Collections.emptyList();
+            }
+        }
+
+        if (leftBound.isAfter(rightBound)) {
+            throw new IllegalArgumentException(
+                    "Date projection for column '" + columnName +
+                            "' has invalid range: start is after end");
+        }
+
+        // Generate all values in range
+        List<String> result = new ArrayList<>();
+        Instant current = leftBound;
+        int count = 0;
+
+        while (!current.isAfter(rightBound) && count < MAX_VALUES) {
+            result.add(formatInstant(current));
+            current = plus(current, interval, intervalUnit);
+            count++;
+        }
+
+        if (count >= MAX_VALUES) {
+            throw new IllegalArgumentException(
+                    "Date projection for column '" + columnName +
+                            "' would generate too many values (limit: " + MAX_VALUES + ")");
+        }
+
+        return result;
+    }
+
+    private String getRangeStart() {
+        String[] parts = rangeProperty.split(",");
+        return parts[0].trim();
+    }
+
+    private String getRangeEnd() {
+        String[] parts = rangeProperty.split(",");
+        if (parts.length < 2) {
+            throw new IllegalArgumentException(
+                    "Date projection range must be in format 'start,end', got: " + rangeProperty);
+        }
+        return parts[1].trim();
+    }
+
+    private Instant parseDate(String dateStr, Instant now) {
+        Matcher matcher = RELATIVE_DATE_PATTERN.matcher(dateStr);
+        if (matcher.matches()) {
+            // Relative date (NOW, NOW-3DAYS, etc.)
+            if (matcher.group(1) == null) {
+                // Just "NOW"
+                return now;
+            }
+            String sign = matcher.group(1);
+            long amount = Long.parseLong(matcher.group(2));
+            ChronoUnit unit = parseIntervalUnit(matcher.group(3));
+
+            if ("-".equals(sign)) {
+                return minus(now, amount, unit);
+            } else {
+                return plus(now, amount, unit);
+            }
+        }
+
+        // Absolute date - parse with the configured format
+        try {
+            // Try parsing as LocalDateTime first
+            LocalDateTime dateTime = LocalDateTime.parse(dateStr, dateFormat);
+            return dateTime.atZone(ZoneId.systemDefault()).toInstant();
+        } catch (DateTimeParseException e1) {
+            try {
+                // Try parsing as LocalDate
+                LocalDate date = LocalDate.parse(dateStr, dateFormat);
+                return date.atStartOfDay(ZoneId.systemDefault()).toInstant();
+            } catch (DateTimeParseException e2) {
+                throw new IllegalArgumentException(
+                        "Cannot parse date '" + dateStr + "' with format '" + formatPattern + "'", e2);
+            }
+        }
+    }
+
+    private Instant plus(Instant instant, long amount, ChronoUnit unit) {
+        // For date-based units, we need to work with LocalDateTime
+        if (unit == ChronoUnit.YEARS || unit == ChronoUnit.MONTHS || unit == ChronoUnit.WEEKS) {
+            LocalDateTime ldt = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+            switch (unit) {
+                case YEARS:
+                    ldt = ldt.plusYears(amount);
+                    break;
+                case MONTHS:
+                    ldt = ldt.plusMonths(amount);
+                    break;
+                case WEEKS:
+                    ldt = ldt.plusWeeks(amount);
+                    break;
+                default:
+                    break;
+            }
+            return ldt.atZone(ZoneId.systemDefault()).toInstant();
+        }
+        return instant.plus(amount, unit);
+    }
+
+    private Instant minus(Instant instant, long amount, ChronoUnit unit) {
+        // For date-based units, we need to work with LocalDateTime
+        if (unit == ChronoUnit.YEARS || unit == ChronoUnit.MONTHS || unit == ChronoUnit.WEEKS) {
+            LocalDateTime ldt = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+            switch (unit) {
+                case YEARS:
+                    ldt = ldt.minusYears(amount);
+                    break;
+                case MONTHS:
+                    ldt = ldt.minusMonths(amount);
+                    break;
+                case WEEKS:
+                    ldt = ldt.minusWeeks(amount);
+                    break;
+                default:
+                    break;
+            }
+            return ldt.atZone(ZoneId.systemDefault()).toInstant();
+        }
+        return instant.minus(amount, unit);
+    }
+
+    private String formatInstant(Instant instant) {
+        LocalDateTime dateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+        return dateFormat.format(dateTime);
+    }
+
+    @Override
+    public String formatValue(Object value) {
+        return value.toString();
+    }
+
+    @Override
+    public Type getColumnType() {
+        return VarcharType.VARCHAR;
+    }
+
+    public String getFormatPattern() {
+        return formatPattern;
+    }
+
+    public long getInterval() {
+        return interval;
+    }
+
+    public ChronoUnit getIntervalUnit() {
+        return intervalUnit;
+    }
+
+    @Override
+    public String toString() {
+        return "DateProjection{" +
+                "columnName='" + columnName + '\'' +
+                ", rangeProperty='" + rangeProperty + '\'' +
+                ", formatPattern='" + formatPattern + '\'' +
+                ", interval=" + interval +
+                ", intervalUnit=" + intervalUnit +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/EnumProjection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/EnumProjection.java
@@ -1,0 +1,118 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.type.Type;
+import com.starrocks.type.VarcharType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Partition projection for enumerated values.
+ *
+ * The enum projection type defines a comma-separated list of possible partition values.
+ * When a query filter matches one of these values, only that value is projected.
+ * Without a filter, all enum values are projected.
+ *
+ * Example table property:
+ * <pre>
+ *   'projection.region.type' = 'enum',
+ *   'projection.region.values' = 'us-east-1,us-west-2,eu-west-1'
+ * </pre>
+ */
+public class EnumProjection implements ColumnProjection {
+
+    private final String columnName;
+    private final List<String> values;
+
+    /**
+     * Creates an enum projection for a partition column.
+     *
+     * @param columnName the partition column name
+     * @param valuesProperty comma-separated list of enumerated values
+     * @throws IllegalArgumentException if valuesProperty is null or empty
+     */
+    public EnumProjection(String columnName, String valuesProperty) {
+        if (valuesProperty == null || valuesProperty.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Enum projection for column '" + columnName + "' requires non-empty values property");
+        }
+
+        this.columnName = columnName;
+        this.values = ImmutableList.copyOf(
+                Arrays.stream(valuesProperty.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toList())
+        );
+
+        if (this.values.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Enum projection for column '" + columnName + "' has no valid values");
+        }
+    }
+
+    @Override
+    public String getColumnName() {
+        return columnName;
+    }
+
+    @Override
+    public List<String> getProjectedValues(Optional<Object> filterValue) {
+        if (filterValue.isPresent()) {
+            String filter = filterValue.get().toString();
+            // Return only matching values
+            if (values.contains(filter)) {
+                return Collections.singletonList(filter);
+            }
+            // Filter value not in enum list - return empty
+            return Collections.emptyList();
+        }
+        // No filter - return all enum values
+        return values;
+    }
+
+    @Override
+    public String formatValue(Object value) {
+        return value.toString();
+    }
+
+    @Override
+    public Type getColumnType() {
+        return VarcharType.VARCHAR;
+    }
+
+    /**
+     * Gets all possible enum values.
+     *
+     * @return immutable list of enum values
+     */
+    public List<String> getValues() {
+        return values;
+    }
+
+    @Override
+    public String toString() {
+        return "EnumProjection{" +
+                "columnName='" + columnName + '\'' +
+                ", values=" + values +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/EnumProjection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/EnumProjection.java
@@ -77,7 +77,11 @@ public class EnumProjection implements ColumnProjection {
     @Override
     public List<String> getProjectedValues(Optional<Object> filterValue) {
         if (filterValue.isPresent()) {
-            String filter = filterValue.get().toString();
+            Object val = filterValue.get();
+            if (val == null) {
+                return Collections.emptyList();
+            }
+            String filter = val.toString();
             // Return only matching values
             if (values.contains(filter)) {
                 return Collections.singletonList(filter);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/InjectedProjection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/InjectedProjection.java
@@ -1,0 +1,93 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import com.starrocks.type.Type;
+import com.starrocks.type.VarcharType;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Partition projection for injected values.
+ *
+ * The injected projection type requires the partition value to be provided
+ * in the query's WHERE clause. This is useful for partitions where the set
+ * of valid values is not known in advance or is too large to enumerate.
+ *
+ * Example table properties:
+ * <pre>
+ *   'projection.user_id.type' = 'injected'
+ * </pre>
+ *
+ * Query requirement:
+ * <pre>
+ *   SELECT * FROM table WHERE user_id = 'some_value'
+ * </pre>
+ *
+ * Without a filter on the injected column, the query will fail.
+ */
+public class InjectedProjection implements ColumnProjection {
+
+    private final String columnName;
+
+    /**
+     * Creates an injected projection for a partition column.
+     *
+     * @param columnName the partition column name
+     */
+    public InjectedProjection(String columnName) {
+        this.columnName = columnName;
+    }
+
+    @Override
+    public String getColumnName() {
+        return columnName;
+    }
+
+    @Override
+    public List<String> getProjectedValues(Optional<Object> filterValue) {
+        if (!filterValue.isPresent()) {
+            throw new IllegalArgumentException(
+                    "Injected partition column '" + columnName +
+                            "' requires a filter value in the WHERE clause. " +
+                            "Please add a predicate like: WHERE " + columnName + " = 'value'");
+        }
+        return Collections.singletonList(filterValue.get().toString());
+    }
+
+    @Override
+    public String formatValue(Object value) {
+        return value.toString();
+    }
+
+    @Override
+    public Type getColumnType() {
+        return VarcharType.VARCHAR;
+    }
+
+    @Override
+    public boolean requiresFilter() {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "InjectedProjection{" +
+                "columnName='" + columnName + '\'' +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/IntegerProjection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/IntegerProjection.java
@@ -1,0 +1,207 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.Type;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Partition projection for integer ranges.
+ *
+ * The integer projection type defines a range of integer values with an optional interval.
+ * Values can be formatted with leading zeros using the digits property.
+ *
+ * Example table properties:
+ * <pre>
+ *   'projection.year.type' = 'integer',
+ *   'projection.year.range' = '2020,2030',
+ *   'projection.year.interval' = '1',
+ *   'projection.year.digits' = '4'
+ * </pre>
+ */
+public class IntegerProjection implements ColumnProjection {
+
+    // Maximum number of values to generate to prevent memory issues
+    private static final int MAX_VALUES = 100000;
+
+    private final String columnName;
+    private final long leftBound;
+    private final long rightBound;
+    private final long interval;
+    private final Optional<Integer> digits;
+
+    /**
+     * Creates an integer projection for a partition column.
+     *
+     * @param columnName the partition column name
+     * @param rangeProperty range as "min,max" (e.g., "2020,2030")
+     * @param intervalProperty optional interval between values (default: 1)
+     * @param digitsProperty optional minimum digits for zero-padding
+     * @throws IllegalArgumentException if range is invalid or bounds are reversed
+     */
+    public IntegerProjection(String columnName, String rangeProperty,
+                             Optional<String> intervalProperty,
+                             Optional<String> digitsProperty) {
+        if (rangeProperty == null || rangeProperty.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Integer projection for column '" + columnName + "' requires a range property");
+        }
+
+        this.columnName = columnName;
+
+        // Parse range: "min,max"
+        String[] parts = rangeProperty.split(",");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException(
+                    "Integer projection range for column '" + columnName +
+                            "' must be in format 'min,max', got: " + rangeProperty);
+        }
+
+        try {
+            this.leftBound = Long.parseLong(parts[0].trim());
+            this.rightBound = Long.parseLong(parts[1].trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "Integer projection range for column '" + columnName +
+                            "' contains invalid numbers: " + rangeProperty, e);
+        }
+
+        if (leftBound > rightBound) {
+            throw new IllegalArgumentException(
+                    "Integer projection for column '" + columnName +
+                            "' has invalid range: min (" + leftBound + ") > max (" + rightBound + ")");
+        }
+
+        // Parse interval (default: 1)
+        this.interval = intervalProperty
+                .map(s -> {
+                    try {
+                        long val = Long.parseLong(s.trim());
+                        if (val <= 0) {
+                            throw new IllegalArgumentException(
+                                    "Integer projection interval must be positive, got: " + val);
+                        }
+                        return val;
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException(
+                                "Invalid interval value for column '" + columnName + "': " + s, e);
+                    }
+                })
+                .orElse(1L);
+
+        // Parse digits (optional)
+        this.digits = digitsProperty.map(s -> {
+            try {
+                int val = Integer.parseInt(s.trim());
+                if (val <= 0) {
+                    throw new IllegalArgumentException(
+                            "Integer projection digits must be positive, got: " + val);
+                }
+                return val;
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(
+                        "Invalid digits value for column '" + columnName + "': " + s, e);
+            }
+        });
+
+        // Validate that the range won't generate too many values
+        long estimatedCount = (rightBound - leftBound) / interval + 1;
+        if (estimatedCount > MAX_VALUES) {
+            throw new IllegalArgumentException(
+                    "Integer projection for column '" + columnName +
+                            "' would generate " + estimatedCount + " values, exceeding limit of " + MAX_VALUES);
+        }
+    }
+
+    @Override
+    public String getColumnName() {
+        return columnName;
+    }
+
+    @Override
+    public List<String> getProjectedValues(Optional<Object> filterValue) {
+        if (filterValue.isPresent()) {
+            // Single value filter
+            long filter = toLong(filterValue.get());
+            if (filter >= leftBound && filter <= rightBound) {
+                // Check if the filter value aligns with the interval
+                if ((filter - leftBound) % interval == 0) {
+                    return Collections.singletonList(formatValue(filter));
+                }
+            }
+            return Collections.emptyList();
+        }
+
+        // Generate all values in range
+        List<String> result = new ArrayList<>();
+        for (long current = leftBound; current <= rightBound; current += interval) {
+            result.add(formatValue(current));
+        }
+        return result;
+    }
+
+    private long toLong(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        return Long.parseLong(value.toString().trim());
+    }
+
+    @Override
+    public String formatValue(Object value) {
+        long v = toLong(value);
+        if (digits.isPresent()) {
+            return String.format("%0" + digits.get() + "d", v);
+        }
+        return String.valueOf(v);
+    }
+
+    @Override
+    public Type getColumnType() {
+        return IntegerType.BIGINT;
+    }
+
+    public long getLeftBound() {
+        return leftBound;
+    }
+
+    public long getRightBound() {
+        return rightBound;
+    }
+
+    public long getInterval() {
+        return interval;
+    }
+
+    public Optional<Integer> getDigits() {
+        return digits;
+    }
+
+    @Override
+    public String toString() {
+        return "IntegerProjection{" +
+                "columnName='" + columnName + '\'' +
+                ", leftBound=" + leftBound +
+                ", rightBound=" + rightBound +
+                ", interval=" + interval +
+                ", digits=" + digits +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/IntegerProjection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/IntegerProjection.java
@@ -154,7 +154,13 @@ public class IntegerProjection implements ColumnProjection {
                 return Collections.emptyList();
             }
             // Single value filter
-            long filter = toLong(val);
+            long filter;
+            try {
+                filter = toLong(val);
+            } catch (NumberFormatException e) {
+                // Invalid number format - return empty list (consistent with DateProjection)
+                return Collections.emptyList();
+            }
             if (filter >= leftBound && filter <= rightBound) {
                 // Check if the filter value aligns with the interval
                 if ((filter - leftBound) % interval == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/IntegerProjection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/IntegerProjection.java
@@ -121,12 +121,15 @@ public class IntegerProjection implements ColumnProjection {
             }
         });
 
-        // Validate that the range won't generate too many values
+        // Validate that the range won't generate too many values.
+        // Note: estimatedCount is an upper-bound estimate. When the range does not align perfectly
+        // with the interval, the actual number of generated values may be smaller.
         long estimatedCount = (rightBound - leftBound) / interval + 1;
         if (estimatedCount > MAX_VALUES) {
             throw new IllegalArgumentException(
                     "Integer projection for column '" + columnName +
-                            "' would generate " + estimatedCount + " values, exceeding limit of " + MAX_VALUES);
+                            "' is estimated to generate up to " + estimatedCount +
+                            " values, exceeding limit of " + MAX_VALUES);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjection.java
@@ -164,20 +164,22 @@ public class PartitionProjection {
      * Expands a storage location template with partition values.
      *
      * Template format: s3://bucket/data/${region}/${year}/${date}/
+     * Note: Template variable matching is case-insensitive to handle AWS Athena's
+     * case-insensitive property handling.
      */
     private String expandTemplate(String template, List<String> values) {
-        // Build value map
+        // Build value map with lowercase keys for case-insensitive lookup
         Map<String, String> valueMap = new HashMap<>();
         for (int i = 0; i < partitionColumnNames.size(); i++) {
-            valueMap.put(partitionColumnNames.get(i), values.get(i));
+            valueMap.put(partitionColumnNames.get(i).toLowerCase(), values.get(i));
         }
 
-        // Replace template variables
+        // Replace template variables (case-insensitive lookup)
         Matcher matcher = TEMPLATE_PATTERN.matcher(template);
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
             String columnName = matcher.group(1);
-            String value = valueMap.getOrDefault(columnName, "");
+            String value = valueMap.getOrDefault(columnName.toLowerCase(), "");
             // Escape special regex characters in replacement
             matcher.appendReplacement(sb, Matcher.quoteReplacement(value));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjection.java
@@ -1,0 +1,289 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.connector.hive.Partition;
+import com.starrocks.connector.hive.RemoteFileInputFormat;
+import com.starrocks.connector.hive.TextFileFormatDesc;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Generates partitions dynamically based on projection configuration.
+ *
+ * This class takes column projections and filter values, generates all
+ * possible partition combinations (Cartesian product), and creates
+ * Partition objects with computed storage locations.
+ */
+public class PartitionProjection {
+
+    // Pattern for template variables: ${column_name}
+    private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\$\\{([^}]+)\\}");
+
+    // Maximum number of partitions to generate
+    private static final int MAX_PARTITIONS = 100000;
+
+    private final String baseLocation;
+    private final Optional<String> storageLocationTemplate;
+    private final Map<String, ColumnProjection> columnProjections;
+    private final List<String> partitionColumnNames;
+    private final RemoteFileInputFormat inputFormat;
+    private final TextFileFormatDesc textFileFormatDesc;
+
+    /**
+     * Creates a partition projection.
+     *
+     * @param baseLocation the table's base storage location
+     * @param storageLocationTemplate optional custom location template
+     * @param columnProjections map of column name to projection
+     * @param partitionColumnNames ordered list of partition column names
+     * @param inputFormat the file input format
+     * @param textFileFormatDesc text file format descriptor (may be null)
+     */
+    public PartitionProjection(String baseLocation,
+                               Optional<String> storageLocationTemplate,
+                               Map<String, ColumnProjection> columnProjections,
+                               List<String> partitionColumnNames,
+                               RemoteFileInputFormat inputFormat,
+                               TextFileFormatDesc textFileFormatDesc) {
+        this.baseLocation = baseLocation;
+        this.storageLocationTemplate = storageLocationTemplate;
+        this.columnProjections = ImmutableMap.copyOf(columnProjections);
+        this.partitionColumnNames = ImmutableList.copyOf(partitionColumnNames);
+        this.inputFormat = inputFormat;
+        this.textFileFormatDesc = textFileFormatDesc;
+    }
+
+    /**
+     * Generates partitions based on the projection configuration and filters.
+     *
+     * @param partitionFilters map of column name to filter value from query
+     * @return map of partition name to Partition object
+     * @throws IllegalArgumentException if too many partitions would be generated
+     *         or if a required filter is missing
+     */
+    public Map<String, Partition> getProjectedPartitions(
+            Map<String, Optional<Object>> partitionFilters) {
+
+        // 1. Generate projected values for each column
+        List<List<String>> projectedColumnValues = new ArrayList<>();
+        for (String columnName : partitionColumnNames) {
+            ColumnProjection projection = columnProjections.get(columnName);
+            if (projection == null) {
+                throw new IllegalArgumentException(
+                        "No projection defined for partition column: " + columnName);
+            }
+            Optional<Object> filter = partitionFilters.getOrDefault(columnName, Optional.empty());
+            List<String> values = projection.getProjectedValues(filter);
+            if (values.isEmpty()) {
+                // No matching values for this column - return empty result
+                return new HashMap<>();
+            }
+            projectedColumnValues.add(values);
+        }
+
+        // 2. Calculate total combinations and validate (use multiplyExact to prevent overflow)
+        long totalCombinations = 1;
+        for (List<String> values : projectedColumnValues) {
+            try {
+                totalCombinations = Math.multiplyExact(totalCombinations, values.size());
+            } catch (ArithmeticException e) {
+                throw new IllegalArgumentException(
+                        "Partition projection would generate too many partitions (overflow). " +
+                                "Please add more specific filters to the query.");
+            }
+            if (totalCombinations > MAX_PARTITIONS) {
+                throw new IllegalArgumentException(
+                        "Partition projection would generate more than " + MAX_PARTITIONS +
+                                " partitions. Please add more specific filters to the query.");
+            }
+        }
+
+        // 3. Generate Cartesian product of all values
+        List<List<String>> allCombinations = cartesianProduct(projectedColumnValues);
+
+        // 4. Create Partition object for each combination
+        Map<String, Partition> result = new HashMap<>();
+        for (List<String> combination : allCombinations) {
+            String partitionName = buildPartitionName(combination);
+            String partitionLocation = buildPartitionLocation(combination);
+            Partition partition = buildPartitionObject(partitionLocation);
+            result.put(partitionName, partition);
+        }
+
+        return result;
+    }
+
+    /**
+     * Builds the Hive-style partition name (e.g., "region=us/year=2024").
+     */
+    private String buildPartitionName(List<String> values) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < partitionColumnNames.size(); i++) {
+            if (i > 0) {
+                sb.append("/");
+            }
+            sb.append(partitionColumnNames.get(i))
+                    .append("=")
+                    .append(values.get(i));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Builds the storage location for a partition.
+     */
+    private String buildPartitionLocation(List<String> values) {
+        if (storageLocationTemplate.isPresent()) {
+            // Use custom template
+            return expandTemplate(storageLocationTemplate.get(), values);
+        }
+
+        // Default: baseLocation/column1=value1/column2=value2/...
+        String partitionPath = buildPartitionName(values);
+        String location = baseLocation;
+        if (!location.endsWith("/")) {
+            location += "/";
+        }
+        return location + partitionPath;
+    }
+
+    /**
+     * Expands a storage location template with partition values.
+     *
+     * Template format: s3://bucket/data/${region}/${year}/${date}/
+     */
+    private String expandTemplate(String template, List<String> values) {
+        // Build value map
+        Map<String, String> valueMap = new HashMap<>();
+        for (int i = 0; i < partitionColumnNames.size(); i++) {
+            valueMap.put(partitionColumnNames.get(i), values.get(i));
+        }
+
+        // Replace template variables
+        Matcher matcher = TEMPLATE_PATTERN.matcher(template);
+        StringBuffer sb = new StringBuffer();
+        while (matcher.find()) {
+            String columnName = matcher.group(1);
+            String value = valueMap.getOrDefault(columnName, "");
+            // Escape special regex characters in replacement
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(value));
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    /**
+     * Creates a Partition object for the given location.
+     */
+    private Partition buildPartitionObject(String location) {
+        // Create partition parameters with current timestamp
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(Partition.TRANSIENT_LAST_DDL_TIME,
+                String.valueOf(System.currentTimeMillis() / 1000));
+
+        return new Partition(
+                parameters,
+                inputFormat,
+                textFileFormatDesc,
+                location,
+                isSplittable(inputFormat)
+        );
+    }
+
+    /**
+     * Determines if the file format is splittable.
+     */
+    private boolean isSplittable(RemoteFileInputFormat format) {
+        if (format == null) {
+            return true;
+        }
+        switch (format) {
+            case PARQUET:
+            case ORC:
+            case TEXTFILE:
+            case AVRO:
+            case RCFILE:
+            case SEQUENCE:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Computes the Cartesian product of lists.
+     *
+     * Example: [[a, b], [1, 2]] -> [[a, 1], [a, 2], [b, 1], [b, 2]]
+     */
+    private List<List<String>> cartesianProduct(List<List<String>> lists) {
+        List<List<String>> result = new ArrayList<>();
+        if (lists.isEmpty()) {
+            result.add(new ArrayList<>());
+            return result;
+        }
+
+        cartesianProductHelper(lists, 0, new ArrayList<>(), result);
+        return result;
+    }
+
+    private void cartesianProductHelper(List<List<String>> lists, int index,
+                                        List<String> current, List<List<String>> result) {
+        if (index == lists.size()) {
+            result.add(new ArrayList<>(current));
+            return;
+        }
+
+        for (String value : lists.get(index)) {
+            current.add(value);
+            cartesianProductHelper(lists, index + 1, current, result);
+            current.remove(current.size() - 1);
+        }
+    }
+
+    public String getBaseLocation() {
+        return baseLocation;
+    }
+
+    public Optional<String> getStorageLocationTemplate() {
+        return storageLocationTemplate;
+    }
+
+    public Map<String, ColumnProjection> getColumnProjections() {
+        return columnProjections;
+    }
+
+    public List<String> getPartitionColumnNames() {
+        return partitionColumnNames;
+    }
+
+    @Override
+    public String toString() {
+        return "PartitionProjection{" +
+                "baseLocation='" + baseLocation + '\'' +
+                ", storageLocationTemplate=" + storageLocationTemplate +
+                ", partitionColumnNames=" + partitionColumnNames +
+                ", columnProjections=" + columnProjections.keySet() +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjection.java
@@ -207,8 +207,9 @@ public class PartitionProjection {
 
     /**
      * Determines if the file format is splittable.
+     * Package-private static method to allow reuse by PartitionProjectionService.
      */
-    private boolean isSplittable(RemoteFileInputFormat format) {
+    static boolean isSplittable(RemoteFileInputFormat format) {
         if (format == null) {
             return true;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjection.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.hive.glue.projection;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.hive.Partition;
 import com.starrocks.connector.hive.RemoteFileInputFormat;
 import com.starrocks.connector.hive.TextFileFormatDesc;
@@ -138,16 +139,7 @@ public class PartitionProjection {
      * Builds the Hive-style partition name (e.g., "region=us/year=2024").
      */
     private String buildPartitionName(List<String> values) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < partitionColumnNames.size(); i++) {
-            if (i > 0) {
-                sb.append("/");
-            }
-            sb.append(partitionColumnNames.get(i))
-                    .append("=")
-                    .append(values.get(i));
-        }
-        return sb.toString();
+        return PartitionUtil.toHivePartitionName(partitionColumnNames, values);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionProperties.java
@@ -1,0 +1,246 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Parses and holds partition projection configuration from table properties.
+ *
+ * AWS Athena Partition Projection allows defining partition values dynamically
+ * without storing them in the metastore. This class parses the table properties
+ * following the AWS Athena specification.
+ *
+ * @see <a href="https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html">
+ *      AWS Athena Partition Projection</a>
+ */
+public class PartitionProjectionProperties {
+
+    // Property keys for partition projection
+    public static final String PROJECTION_ENABLED = "projection.enabled";
+    // Alternative key used by some implementations
+    public static final String PROJECTION_ENABLE = "projection.enable";
+    public static final String STORAGE_LOCATION_TEMPLATE = "storage.location.template";
+
+    // Property suffixes for column-specific settings
+    public static final String TYPE_SUFFIX = ".type";
+    public static final String VALUES_SUFFIX = ".values";
+    public static final String RANGE_SUFFIX = ".range";
+    public static final String FORMAT_SUFFIX = ".format";
+    public static final String INTERVAL_SUFFIX = ".interval";
+    public static final String INTERVAL_UNIT_SUFFIX = ".interval.unit";
+    public static final String DIGITS_SUFFIX = ".digits";
+
+    private final boolean enabled;
+    private final Map<String, ColumnProjectionConfig> columnConfigs;
+    private final Optional<String> storageLocationTemplate;
+
+    private PartitionProjectionProperties(boolean enabled,
+                                          Map<String, ColumnProjectionConfig> columnConfigs,
+                                          Optional<String> storageLocationTemplate) {
+        this.enabled = enabled;
+        this.columnConfigs = ImmutableMap.copyOf(columnConfigs);
+        this.storageLocationTemplate = storageLocationTemplate;
+    }
+
+    /**
+     * Parses table properties to extract partition projection configuration.
+     *
+     * @param tableProperties the table properties from Hive/Glue metastore
+     * @return parsed partition projection properties
+     */
+    public static PartitionProjectionProperties parse(Map<String, String> tableProperties) {
+        if (tableProperties == null) {
+            return new PartitionProjectionProperties(false, new HashMap<>(), Optional.empty());
+        }
+
+        // Check if projection is enabled (support both 'projection.enabled' and 'projection.enable')
+        boolean enabled = isProjectionEnabled(tableProperties);
+        if (!enabled) {
+            return new PartitionProjectionProperties(false, new HashMap<>(), Optional.empty());
+        }
+
+        // Parse storage location template
+        Optional<String> storageTemplate = Optional.ofNullable(
+                tableProperties.get(STORAGE_LOCATION_TEMPLATE));
+
+        // Parse column-specific configurations
+        Map<String, ColumnProjectionConfig> columnConfigs = parseColumnConfigs(tableProperties);
+
+        return new PartitionProjectionProperties(enabled, columnConfigs, storageTemplate);
+    }
+
+    /**
+     * Checks if partition projection is enabled in table properties.
+     */
+    public static boolean isProjectionEnabled(Map<String, String> tableProperties) {
+        if (tableProperties == null) {
+            return false;
+        }
+        String enabledValue = tableProperties.get(PROJECTION_ENABLED);
+        if (enabledValue == null) {
+            // Fallback to alternative key
+            enabledValue = tableProperties.get(PROJECTION_ENABLE);
+        }
+        return "true".equalsIgnoreCase(enabledValue);
+    }
+
+    private static Map<String, ColumnProjectionConfig> parseColumnConfigs(Map<String, String> properties) {
+        Map<String, ColumnProjectionConfig> configs = new HashMap<>();
+
+        // Find all column names by looking for projection.<column>.type entries
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            String key = entry.getKey();
+            if (key.startsWith("projection.") && key.endsWith(TYPE_SUFFIX)) {
+                // Extract column name: projection.<column>.type
+                String columnName = extractColumnName(key);
+                if (columnName != null) {
+                    ColumnProjectionConfig config = parseColumnConfig(columnName, properties);
+                    configs.put(columnName, config);
+                }
+            }
+        }
+
+        return configs;
+    }
+
+    private static String extractColumnName(String typeKey) {
+        // Format: projection.<column>.type
+        String prefix = "projection.";
+        String suffix = TYPE_SUFFIX;
+        if (typeKey.startsWith(prefix) && typeKey.endsWith(suffix)) {
+            return typeKey.substring(prefix.length(), typeKey.length() - suffix.length());
+        }
+        return null;
+    }
+
+    private static ColumnProjectionConfig parseColumnConfig(String columnName, Map<String, String> properties) {
+        String prefix = "projection." + columnName;
+        String typeStr = properties.get(prefix + TYPE_SUFFIX);
+        ProjectionType type = ProjectionType.fromString(typeStr);
+
+        Map<String, String> columnProperties = new HashMap<>();
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            String key = entry.getKey();
+            if (key.startsWith(prefix + ".") && !key.equals(prefix + TYPE_SUFFIX)) {
+                // Extract property name after prefix
+                String propName = key.substring(prefix.length() + 1);
+                columnProperties.put(propName, entry.getValue());
+            }
+        }
+
+        return new ColumnProjectionConfig(type, columnProperties);
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public Map<String, ColumnProjectionConfig> getColumnConfigs() {
+        return columnConfigs;
+    }
+
+    public Optional<String> getStorageLocationTemplate() {
+        return storageLocationTemplate;
+    }
+
+    /**
+     * Gets the projection configuration for a specific column.
+     *
+     * @param columnName the partition column name
+     * @return the column projection config, or null if not found
+     */
+    public ColumnProjectionConfig getColumnConfig(String columnName) {
+        return columnConfigs.get(columnName);
+    }
+
+    /**
+     * Configuration for a single partition column's projection.
+     */
+    public static class ColumnProjectionConfig {
+        private final ProjectionType type;
+        private final Map<String, String> properties;
+
+        public ColumnProjectionConfig(ProjectionType type, Map<String, String> properties) {
+            this.type = type;
+            this.properties = ImmutableMap.copyOf(properties);
+        }
+
+        public ProjectionType getType() {
+            return type;
+        }
+
+        public Map<String, String> getProperties() {
+            return properties;
+        }
+
+        public String getProperty(String key) {
+            return properties.get(key);
+        }
+
+        public Optional<String> getOptionalProperty(String key) {
+            return Optional.ofNullable(properties.get(key));
+        }
+
+        @Override
+        public String toString() {
+            return "ColumnProjectionConfig{" +
+                    "type=" + type +
+                    ", properties=" + properties +
+                    '}';
+        }
+    }
+
+    /**
+     * Supported partition projection types.
+     */
+    public enum ProjectionType {
+        ENUM,
+        INTEGER,
+        DATE,
+        INJECTED;
+
+        public static ProjectionType fromString(String type) {
+            if (type == null) {
+                throw new IllegalArgumentException("Projection type cannot be null");
+            }
+            switch (type.toLowerCase()) {
+                case "enum":
+                    return ENUM;
+                case "integer":
+                    return INTEGER;
+                case "date":
+                    return DATE;
+                case "injected":
+                    return INJECTED;
+                default:
+                    throw new IllegalArgumentException("Unknown projection type: " + type);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "PartitionProjectionProperties{" +
+                "enabled=" + enabled +
+                ", columnConfigs=" + columnConfigs +
+                ", storageLocationTemplate=" + storageLocationTemplate +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionService.java
@@ -1,0 +1,335 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.hive.Partition;
+import com.starrocks.connector.hive.RemoteFileInputFormat;
+import com.starrocks.connector.hive.TextFileFormatDesc;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Service for handling Partition Projection in AWS Glue/Athena tables.
+ *
+ * Partition Projection allows defining partition values dynamically through
+ * table properties, eliminating the need to store partition metadata in the
+ * metastore. This is particularly useful for:
+ * - Time-series data with predictable partition patterns
+ * - Tables with a large number of partitions
+ * - Reducing metastore load and query latency
+ *
+ * @see <a href="https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html">
+ *      AWS Athena Partition Projection</a>
+ */
+public class PartitionProjectionService {
+
+    /**
+     * Checks if partition projection is enabled for the given table.
+     *
+     * @param table the table to check
+     * @return true if partition projection is enabled
+     */
+    public boolean isEnabled(Table table) {
+        if (!(table instanceof HiveTable)) {
+            return false;
+        }
+        HiveTable hiveTable = (HiveTable) table;
+        Map<String, String> properties = hiveTable.getProperties();
+        return PartitionProjectionProperties.isProjectionEnabled(properties);
+    }
+
+    /**
+     * Creates a PartitionProjection configuration from table properties.
+     *
+     * @param table the Hive table
+     * @return the partition projection configuration
+     * @throws IllegalArgumentException if the configuration is invalid
+     */
+    public PartitionProjection createProjection(HiveTable table) {
+        Map<String, String> properties = table.getProperties();
+        List<String> partitionColumnNames = table.getPartitionColumnNames();
+        String baseLocation = table.getTableLocation();
+
+        // Parse projection properties
+        PartitionProjectionProperties projProps = PartitionProjectionProperties.parse(properties);
+
+        // Get storage location template
+        Optional<String> storageLocationTemplate = projProps.getStorageLocationTemplate();
+
+        // Get input format and text file format desc from storage format
+        RemoteFileInputFormat inputFormat = getInputFormat(table);
+        TextFileFormatDesc textFileFormatDesc = getTextFileFormatDesc(table);
+
+        // Create column projections for each partition column
+        Map<String, ColumnProjection> columnProjections = new HashMap<>();
+        for (String columnName : partitionColumnNames) {
+            ColumnProjection projection = createColumnProjection(columnName, projProps);
+            columnProjections.put(columnName, projection);
+        }
+
+        return new PartitionProjection(
+                baseLocation,
+                storageLocationTemplate,
+                columnProjections,
+                partitionColumnNames,
+                inputFormat,
+                textFileFormatDesc
+        );
+    }
+
+    private RemoteFileInputFormat getInputFormat(HiveTable table) {
+        if (table.getStorageFormat() == null) {
+            return RemoteFileInputFormat.PARQUET;
+        }
+        switch (table.getStorageFormat()) {
+            case PARQUET:
+                return RemoteFileInputFormat.PARQUET;
+            case ORC:
+                return RemoteFileInputFormat.ORC;
+            case TEXTFILE:
+                return RemoteFileInputFormat.TEXTFILE;
+            case AVRO:
+                return RemoteFileInputFormat.AVRO;
+            case SEQUENCE:
+                return RemoteFileInputFormat.SEQUENCE;
+            case RCBINARY:
+            case RCTEXT:
+                return RemoteFileInputFormat.RCFILE;
+            default:
+                return RemoteFileInputFormat.UNKNOWN;
+        }
+    }
+
+    private TextFileFormatDesc getTextFileFormatDesc(HiveTable table) {
+        // Return null for non-text formats
+        if (table.getStorageFormat() == null ||
+                table.getStorageFormat() != com.starrocks.connector.hive.HiveStorageFormat.TEXTFILE) {
+            return null;
+        }
+        // For text format, use default delimiters if not specified
+        Map<String, String> serdeProps = table.getSerdeProperties();
+        String fieldDelimiter = serdeProps.getOrDefault("field.delim", "\001");
+        String lineDelimiter = serdeProps.getOrDefault("line.delim", "\n");
+        String collectionDelimiter = serdeProps.getOrDefault("collection.delim", "\002");
+        String mapKeyDelimiter = serdeProps.getOrDefault("mapkey.delim", "\003");
+
+        return new TextFileFormatDesc(fieldDelimiter, lineDelimiter, collectionDelimiter, mapKeyDelimiter);
+    }
+
+    private ColumnProjection createColumnProjection(String columnName,
+                                                     PartitionProjectionProperties projProps) {
+        PartitionProjectionProperties.ColumnProjectionConfig config = projProps.getColumnConfig(columnName);
+        if (config == null) {
+            throw new IllegalArgumentException(
+                    "Missing projection configuration for partition column: " + columnName +
+                            ". Please add 'projection." + columnName + ".type' property.");
+        }
+
+        PartitionProjectionProperties.ProjectionType type = config.getType();
+        Map<String, String> props = config.getProperties();
+
+        switch (type) {
+            case ENUM:
+                return new EnumProjection(
+                        columnName,
+                        getRequiredProperty(props, "values", columnName)
+                );
+
+            case INTEGER:
+                return new IntegerProjection(
+                        columnName,
+                        getRequiredProperty(props, "range", columnName),
+                        config.getOptionalProperty("interval"),
+                        config.getOptionalProperty("digits")
+                );
+
+            case DATE:
+                return new DateProjection(
+                        columnName,
+                        getRequiredProperty(props, "range", columnName),
+                        getRequiredProperty(props, "format", columnName),
+                        config.getOptionalProperty("interval"),
+                        config.getOptionalProperty("interval.unit")
+                );
+
+            case INJECTED:
+                return new InjectedProjection(columnName);
+
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown projection type: " + type + " for column: " + columnName);
+        }
+    }
+
+    private String getRequiredProperty(Map<String, String> props, String key, String columnName) {
+        String value = props.get(key);
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Missing required property 'projection." + columnName + "." + key + "'");
+        }
+        return value;
+    }
+
+    /**
+     * Gets projected partitions for the given partition keys.
+     *
+     * This method creates virtual partitions based on the projection configuration
+     * without querying the metastore. The partition locations are computed from
+     * the table's base location and optional storage location template.
+     *
+     * @param table the Hive table with projection enabled
+     * @param partitionKeys partition keys from query predicates
+     * @return map of partition name to Partition object
+     */
+    public Map<String, Partition> getProjectedPartitions(HiveTable table,
+                                                          List<PartitionKey> partitionKeys) {
+        PartitionProjection projection = createProjection(table);
+        List<String> partitionColumnNames = table.getPartitionColumnNames();
+
+        // Extract filter values from partition keys
+        Map<String, Optional<Object>> partitionFilters = new HashMap<>();
+
+        if (!partitionKeys.isEmpty()) {
+            // Use the first partition key to extract filter values
+            // This assumes all partition keys have the same column structure
+            PartitionKey firstKey = partitionKeys.get(0);
+            for (int i = 0; i < partitionColumnNames.size() && i < firstKey.getKeys().size(); i++) {
+                String columnName = partitionColumnNames.get(i);
+                String value = firstKey.getKeys().get(i).getStringValue();
+                partitionFilters.put(columnName, Optional.ofNullable(value));
+            }
+        } else {
+            // No filter values - use empty optionals
+            for (String columnName : partitionColumnNames) {
+                partitionFilters.put(columnName, Optional.empty());
+            }
+        }
+
+        Map<String, Partition> result = projection.getProjectedPartitions(partitionFilters);
+        return result;
+    }
+
+    /**
+     * Gets projected partitions using explicit filter values.
+     *
+     * @param table the Hive table with projection enabled
+     * @param partitionFilters map of column name to filter value
+     * @return map of partition name to Partition object
+     */
+    public Map<String, Partition> getProjectedPartitions(HiveTable table,
+                                                          Map<String, Optional<Object>> partitionFilters) {
+        PartitionProjection projection = createProjection(table);
+        return projection.getProjectedPartitions(partitionFilters);
+    }
+
+    /**
+     * Gets all projected partition names for a table.
+     * This is used to list all possible partitions based on projection configuration.
+     *
+     * @param table the Hive table with projection enabled
+     * @return list of partition names in the format "col1=val1/col2=val2"
+     */
+    public List<String> getProjectedPartitionNames(HiveTable table) {
+        PartitionProjection projection = createProjection(table);
+
+        // Get all projected partitions without any filter
+        Map<String, Optional<Object>> emptyFilters = new HashMap<>();
+        for (String columnName : table.getPartitionColumnNames()) {
+            emptyFilters.put(columnName, Optional.empty());
+        }
+
+        Map<String, Partition> partitions = projection.getProjectedPartitions(emptyFilters);
+        List<String> partitionNames = new ArrayList<>(partitions.keySet());
+        return partitionNames;
+    }
+
+    /**
+     * Gets projected partition names filtered by partition values.
+     * This is used when the query has partition predicates.
+     *
+     * @param table the Hive table with projection enabled
+     * @param partitionValues list of partition values (Optional.empty() means no filter for that column)
+     * @return list of partition names matching the filter
+     */
+    public List<String> getProjectedPartitionNamesByValue(HiveTable table, List<Optional<String>> partitionValues) {
+        PartitionProjection projection = createProjection(table);
+        List<String> partitionColumnNames = table.getPartitionColumnNames();
+
+        // Convert partition values to filter map
+        Map<String, Optional<Object>> filters = new HashMap<>();
+        for (int i = 0; i < partitionColumnNames.size(); i++) {
+            String columnName = partitionColumnNames.get(i);
+            if (i < partitionValues.size() && partitionValues.get(i).isPresent()) {
+                filters.put(columnName, Optional.of(partitionValues.get(i).get()));
+            } else {
+                filters.put(columnName, Optional.empty());
+            }
+        }
+
+        Map<String, Partition> partitions = projection.getProjectedPartitions(filters);
+        List<String> partitionNames = new ArrayList<>(partitions.keySet());
+        return partitionNames;
+    }
+
+    /**
+     * Gets projected partitions from partition names.
+     * Partition names are in the format "col1=val1/col2=val2".
+     *
+     * @param table the Hive table with projection enabled
+     * @param partitionNames list of partition names
+     * @return map of partition name to Partition object
+     */
+    public Map<String, Partition> getProjectedPartitionsFromNames(HiveTable table,
+                                                                   List<String> partitionNames) {
+        // Directly create partitions without going through full projection logic
+        // This is more efficient when we have specific partition names
+        String baseLocation = table.getTableLocation();
+        RemoteFileInputFormat inputFormat = getInputFormat(table);
+        TextFileFormatDesc textFileFormatDesc = getTextFileFormatDesc(table);
+
+        Map<String, Partition> result = new HashMap<>();
+        for (String partitionName : partitionNames) {
+            // Build partition location directly from partition name
+            String partitionLocation = baseLocation;
+            if (!partitionLocation.endsWith("/")) {
+                partitionLocation += "/";
+            }
+            partitionLocation += partitionName;
+
+            // Create partition object
+            Map<String, String> parameters = new HashMap<>();
+            parameters.put(Partition.TRANSIENT_LAST_DDL_TIME,
+                    String.valueOf(System.currentTimeMillis() / 1000));
+
+            Partition partition = new Partition(
+                    parameters,
+                    inputFormat,
+                    textFileFormatDesc,
+                    partitionLocation,
+                    true  // isSplittable
+            );
+            result.put(partitionName, partition);
+        }
+
+        return result;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionService.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.hive.glue.projection;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
+import com.starrocks.connector.hive.HiveMetastoreApiConverter;
 import com.starrocks.connector.hive.Partition;
 import com.starrocks.connector.hive.RemoteFileInputFormat;
 import com.starrocks.connector.hive.TextFileFormatDesc;
@@ -125,14 +126,8 @@ public class PartitionProjectionService {
                 table.getStorageFormat() != com.starrocks.connector.hive.HiveStorageFormat.TEXTFILE) {
             return null;
         }
-        // For text format, use default delimiters if not specified
-        Map<String, String> serdeProps = table.getSerdeProperties();
-        String fieldDelimiter = serdeProps.getOrDefault("field.delim", "\001");
-        String lineDelimiter = serdeProps.getOrDefault("line.delim", "\n");
-        String collectionDelimiter = serdeProps.getOrDefault("collection.delim", "\002");
-        String mapKeyDelimiter = serdeProps.getOrDefault("mapkey.delim", "\003");
-
-        return new TextFileFormatDesc(fieldDelimiter, lineDelimiter, collectionDelimiter, mapKeyDelimiter);
+        // Reuse the converter method for consistency with other Hive metadata handling
+        return HiveMetastoreApiConverter.toTextFileFormatDesc(table.getSerdeProperties());
     }
 
     private ColumnProjection createColumnProjection(String columnName,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionService.java
@@ -46,6 +46,9 @@ import java.util.regex.Pattern;
  */
 public class PartitionProjectionService {
 
+    // Pre-compiled pattern for template variable expansion (e.g., ${column_name})
+    private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\$\\{([^}]+)\\}");
+
     /**
      * Checks if partition projection is enabled for the given table.
      *
@@ -411,9 +414,8 @@ public class PartitionProjectionService {
             lowercaseKeyMap.put(entry.getKey().toLowerCase(), entry.getValue());
         }
 
-        // Use regex to replace template variables case-insensitively
-        Pattern pattern = Pattern.compile("\\$\\{([^}]+)\\}");
-        Matcher matcher = pattern.matcher(template);
+        // Use pre-compiled pattern to replace template variables case-insensitively
+        Matcher matcher = TEMPLATE_PATTERN.matcher(template);
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
             String columnName = matcher.group(1);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionService.java
@@ -278,8 +278,13 @@ public class PartitionProjectionService {
         Map<String, Optional<Object>> filters = new HashMap<>();
         for (int i = 0; i < partitionColumnNames.size(); i++) {
             String columnName = partitionColumnNames.get(i);
-            if (i < partitionValues.size() && partitionValues.get(i).isPresent()) {
-                filters.put(columnName, Optional.of(partitionValues.get(i).get()));
+            if (i < partitionValues.size()) {
+                Optional<String> optValue = partitionValues.get(i);
+                if (optValue.isPresent()) {
+                    filters.put(columnName, Optional.of(optValue.get()));
+                } else {
+                    filters.put(columnName, Optional.empty());
+                }
             } else {
                 filters.put(columnName, Optional.empty());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionService.java
@@ -355,7 +355,7 @@ public class PartitionProjectionService {
                     inputFormat,
                     textFileFormatDesc,
                     partitionLocation,
-                    true  // isSplittable
+                    PartitionProjection.isSplittable(inputFormat)
             );
             result.put(partitionName, partition);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/HiveTableValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/HiveTableValidator.java
@@ -17,11 +17,9 @@ package com.starrocks.connector.hive.glue.util;
 
 import com.starrocks.connector.hive.glue.metastore.AWSGlueMetastore;
 import org.apache.hadoop.hive.metastore.TableType;
-import org.apache.thrift.TException;
 import software.amazon.awssdk.services.glue.model.InvalidInputException;
 import software.amazon.awssdk.services.glue.model.Table;
 
-import java.util.List;
 import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
@@ -60,22 +58,18 @@ public enum HiveTableValidator {
                         .build();
             }
 
-            for (Map.Entry<String, String> entry : table.parameters().entrySet()) {
-                String key = entry.getKey();
-                String value = entry.getValue();
-                if (key.equalsIgnoreCase("projection.enable") && "true".equalsIgnoreCase(value)) {
-                    // With partition projection enabled, the metadata may not store in glue.
-                    // Thus we can not get the partition meta
-                    // So read these tables may return no data
-                    // Just throw some exception to remind user
-                    List<software.amazon.awssdk.services.glue.model.Partition> partitions = null;
-                    try {
-                        partitions = metastore.getPartitions(table.databaseName(), table.name(), null, 1);
-                    } catch (TException e) {
-                        throw new RuntimeException("Get partitions failed", e);
-                    }
-                    if (partitions.isEmpty()) {
-                        throw new IllegalArgumentException("Partition projection table may not readable");
+            // Check for partition projection tables
+            // Support both 'projection.enabled' (AWS standard) and 'projection.enable' (legacy)
+            if (table.parameters() != null) {
+                for (Map.Entry<String, String> entry : table.parameters().entrySet()) {
+                    String key = entry.getKey();
+                    String value = entry.getValue();
+                    if ((key.equalsIgnoreCase("projection.enabled") || key.equalsIgnoreCase("projection.enable"))
+                            && "true".equalsIgnoreCase(value)) {
+                        // Partition projection is now supported - no need to check metastore partitions
+                        // The PartitionProjectionService will dynamically generate partitions based on
+                        // table properties, so empty metastore partitions are expected and valid.
+                        return;
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/HiveTableValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/HiveTableValidator.java
@@ -66,9 +66,9 @@ public enum HiveTableValidator {
                     String value = entry.getValue();
                     if ((key.equalsIgnoreCase("projection.enabled") || key.equalsIgnoreCase("projection.enable"))
                             && "true".equalsIgnoreCase(value)) {
-                        // Partition projection is now supported - no need to check metastore partitions
-                        // The PartitionProjectionService will dynamically generate partitions based on
-                        // table properties, so empty metastore partitions are expected and valid.
+                        // Tables with partition projection enabled are treated as valid here and do not require
+                        // metastore partition validation, because partitions are dynamically generated from
+                        // table properties, so empty metastore partitions are expected and acceptable.
                         return;
                     }
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/DateProjectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/DateProjectionTest.java
@@ -235,4 +235,58 @@ public class DateProjectionTest {
         assertEquals("2021", values.get(1));
         assertEquals("2024", values.get(4));
     }
+
+    @Test
+    public void testYearOnlyFormatInfersYearsInterval() {
+        // Test that year-only format (yyyy) automatically infers YEARS interval unit
+        // without explicit interval.unit property - this prevents generating duplicate values
+        DateProjection projection = new DateProjection(
+                "year", "2020,2024", "yyyy",
+                Optional.empty(), Optional.empty());
+
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        // Should generate 5 unique years, not thousands of duplicate days
+        assertEquals(5, values.size());
+        assertEquals("2020", values.get(0));
+        assertEquals("2021", values.get(1));
+        assertEquals("2022", values.get(2));
+        assertEquals("2023", values.get(3));
+        assertEquals("2024", values.get(4));
+    }
+
+    @Test
+    public void testMonthOnlyFormatInfersMonthsInterval() {
+        // Test that month-only format (yyyy-MM) automatically infers MONTHS interval unit
+        // without explicit interval.unit property - this prevents generating duplicate values
+        DateProjection projection = new DateProjection(
+                "month", "2024-01,2024-06", "yyyy-MM",
+                Optional.empty(), Optional.empty());
+
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        // Should generate 6 unique months, not duplicates
+        assertEquals(6, values.size());
+        assertEquals("2024-01", values.get(0));
+        assertEquals("2024-02", values.get(1));
+        assertEquals("2024-03", values.get(2));
+        assertEquals("2024-04", values.get(3));
+        assertEquals("2024-05", values.get(4));
+        assertEquals("2024-06", values.get(5));
+    }
+
+    @Test
+    public void testYearMonthFormatWithoutDayInfersMonths() {
+        // Alternative month format without separator (yyyyMM)
+        DateProjection projection = new DateProjection(
+                "month", "202401,202403", "yyyyMM",
+                Optional.empty(), Optional.empty());
+
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        assertEquals(3, values.size());
+        assertEquals("202401", values.get(0));
+        assertEquals("202402", values.get(1));
+        assertEquals("202403", values.get(2));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/DateProjectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/DateProjectionTest.java
@@ -1,0 +1,238 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DateProjectionTest {
+
+    @Test
+    public void testGetProjectedValuesNoFilter() {
+        DateProjection projection = new DateProjection(
+                "dt", "2024-01-01,2024-01-05", "yyyy-MM-dd",
+                Optional.empty(), Optional.empty());
+
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        assertEquals(5, values.size());
+        assertEquals("2024-01-01", values.get(0));
+        assertEquals("2024-01-02", values.get(1));
+        assertEquals("2024-01-03", values.get(2));
+        assertEquals("2024-01-04", values.get(3));
+        assertEquals("2024-01-05", values.get(4));
+    }
+
+    @Test
+    public void testGetProjectedValuesWithInterval() {
+        DateProjection projection = new DateProjection(
+                "dt", "2024-01-01,2024-01-10", "yyyy-MM-dd",
+                Optional.of("2"), Optional.of("DAYS"));
+
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        assertEquals(5, values.size());
+        assertEquals("2024-01-01", values.get(0));
+        assertEquals("2024-01-03", values.get(1));
+        assertEquals("2024-01-05", values.get(2));
+        assertEquals("2024-01-07", values.get(3));
+        assertEquals("2024-01-09", values.get(4));
+    }
+
+    @Test
+    public void testGetProjectedValuesWithMonthInterval() {
+        DateProjection projection = new DateProjection(
+                "month", "2024-01,2024-06", "yyyy-MM",
+                Optional.of("1"), Optional.of("MONTHS"));
+
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        assertEquals(6, values.size());
+        assertEquals("2024-01", values.get(0));
+        assertEquals("2024-02", values.get(1));
+        assertEquals("2024-06", values.get(5));
+    }
+
+    @Test
+    public void testGetProjectedValuesWithMatchingFilter() {
+        DateProjection projection = new DateProjection(
+                "dt", "2024-01-01,2024-01-31", "yyyy-MM-dd",
+                Optional.empty(), Optional.empty());
+
+        List<String> values = projection.getProjectedValues(Optional.of("2024-01-15"));
+
+        assertEquals(1, values.size());
+        assertEquals("2024-01-15", values.get(0));
+    }
+
+    @Test
+    public void testGetProjectedValuesWithFilterOutOfRange() {
+        DateProjection projection = new DateProjection(
+                "dt", "2024-01-01,2024-01-31", "yyyy-MM-dd",
+                Optional.empty(), Optional.empty());
+
+        // Before range
+        List<String> values = projection.getProjectedValues(Optional.of("2023-12-31"));
+        assertTrue(values.isEmpty());
+
+        // After range
+        values = projection.getProjectedValues(Optional.of("2024-02-01"));
+        assertTrue(values.isEmpty());
+    }
+
+    @Test
+    public void testGetProjectedValuesWithInvalidFilterFormat() {
+        DateProjection projection = new DateProjection(
+                "dt", "2024-01-01,2024-01-31", "yyyy-MM-dd",
+                Optional.empty(), Optional.empty());
+
+        // Invalid date format
+        List<String> values = projection.getProjectedValues(Optional.of("invalid-date"));
+        assertTrue(values.isEmpty());
+    }
+
+    @Test
+    public void testGetColumnType() {
+        DateProjection projection = new DateProjection(
+                "dt", "2024-01-01,2024-01-31", "yyyy-MM-dd",
+                Optional.empty(), Optional.empty());
+
+        assertEquals(VarcharType.VARCHAR, projection.getColumnType());
+    }
+
+    @Test
+    public void testGetColumnName() {
+        DateProjection projection = new DateProjection(
+                "dt", "2024-01-01,2024-01-31", "yyyy-MM-dd",
+                Optional.empty(), Optional.empty());
+
+        assertEquals("dt", projection.getColumnName());
+    }
+
+    @Test
+    public void testConstructorWithNullRange() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new DateProjection("dt", null, "yyyy-MM-dd",
+                        Optional.empty(), Optional.empty()));
+    }
+
+    @Test
+    public void testConstructorWithEmptyRange() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new DateProjection("dt", "", "yyyy-MM-dd",
+                        Optional.empty(), Optional.empty()));
+    }
+
+    @Test
+    public void testConstructorWithNullFormat() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new DateProjection("dt", "2024-01-01,2024-01-31", null,
+                        Optional.empty(), Optional.empty()));
+    }
+
+    @Test
+    public void testConstructorWithInvalidFormat() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new DateProjection("dt", "2024-01-01,2024-01-31", "invalid-format-zzz",
+                        Optional.empty(), Optional.empty()));
+    }
+
+    @Test
+    public void testConstructorWithZeroInterval() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new DateProjection("dt", "2024-01-01,2024-01-31", "yyyy-MM-dd",
+                        Optional.of("0"), Optional.empty()));
+    }
+
+    @Test
+    public void testConstructorWithNegativeInterval() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new DateProjection("dt", "2024-01-01,2024-01-31", "yyyy-MM-dd",
+                        Optional.of("-1"), Optional.empty()));
+    }
+
+    @Test
+    public void testRequiresFilter() {
+        DateProjection projection = new DateProjection(
+                "dt", "2024-01-01,2024-01-31", "yyyy-MM-dd",
+                Optional.empty(), Optional.empty());
+
+        assertFalse(projection.requiresFilter());
+    }
+
+    @Test
+    public void testFormatValue() {
+        DateProjection projection = new DateProjection(
+                "dt", "2024-01-01,2024-01-31", "yyyy-MM-dd",
+                Optional.empty(), Optional.empty());
+
+        assertEquals("2024-01-15", projection.formatValue("2024-01-15"));
+        assertEquals("123", projection.formatValue(123));
+    }
+
+    @Test
+    public void testGetFormatPattern() {
+        DateProjection projection = new DateProjection(
+                "dt", "2024-01-01,2024-01-31", "yyyy-MM-dd",
+                Optional.empty(), Optional.empty());
+
+        assertEquals("yyyy-MM-dd", projection.getFormatPattern());
+    }
+
+    @Test
+    public void testInvalidRangeStartAfterEnd() {
+        DateProjection projection = new DateProjection(
+                "dt", "2024-01-31,2024-01-01", "yyyy-MM-dd",
+                Optional.empty(), Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () ->
+                projection.getProjectedValues(Optional.empty()));
+    }
+
+    @Test
+    public void testDifferentIntervalUnits() {
+        // Test WEEKS
+        DateProjection weekProjection = new DateProjection(
+                "week", "2024-01-01,2024-01-29", "yyyy-MM-dd",
+                Optional.of("1"), Optional.of("WEEKS"));
+
+        List<String> weekValues = weekProjection.getProjectedValues(Optional.empty());
+        assertEquals(5, weekValues.size());
+        assertEquals("2024-01-01", weekValues.get(0));
+        assertEquals("2024-01-08", weekValues.get(1));
+    }
+
+    @Test
+    public void testYearInterval() {
+        DateProjection projection = new DateProjection(
+                "year", "2020,2024", "yyyy",
+                Optional.of("1"), Optional.of("YEARS"));
+
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        assertEquals(5, values.size());
+        assertEquals("2020", values.get(0));
+        assertEquals("2021", values.get(1));
+        assertEquals("2024", values.get(4));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/DateProjectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/DateProjectionTest.java
@@ -153,7 +153,7 @@ public class DateProjectionTest {
     @Test
     public void testConstructorWithInvalidFormat() {
         assertThrows(IllegalArgumentException.class, () ->
-                new DateProjection("dt", "2024-01-01,2024-01-31", "invalid-format-zzz",
+                new DateProjection("dt", "2024-01-01,2024-01-31", "invalid{format}",
                         Optional.empty(), Optional.empty()));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/DateProjectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/DateProjectionTest.java
@@ -112,6 +112,21 @@ public class DateProjectionTest {
     }
 
     @Test
+    public void testGetProjectedValuesWithNowFilterReturnsFormattedDate() {
+        // Test that 'NOW' filter returns formatted date, not literal 'NOW'
+        DateProjection projection = new DateProjection(
+                "dt", "2020-01-01,2030-12-31", "yyyy-MM-dd",
+                Optional.empty(), Optional.empty());
+
+        List<String> values = projection.getProjectedValues(Optional.of("NOW"));
+
+        assertEquals(1, values.size());
+        // Should return formatted date like '2024-01-15', not 'NOW'
+        assertFalse(values.get(0).contains("NOW"));
+        assertTrue(values.get(0).matches("\\d{4}-\\d{2}-\\d{2}"));
+    }
+
+    @Test
     public void testGetColumnType() {
         DateProjection projection = new DateProjection(
                 "dt", "2024-01-01,2024-01-31", "yyyy-MM-dd",

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/DateProjectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/DateProjectionTest.java
@@ -289,4 +289,41 @@ public class DateProjectionTest {
         assertEquals("202402", values.get(1));
         assertEquals("202403", values.get(2));
     }
+
+    @Test
+    public void testCompactDateFormatInfersDays() {
+        // Compact date format without separators (yyyyMMdd) should infer DAYS
+        DateProjection projection = new DateProjection(
+                "dt", "20240101,20240105", "yyyyMMdd",
+                Optional.empty(), Optional.empty());
+
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        // Should generate 5 daily values, not 1 monthly value
+        assertEquals(5, values.size());
+        assertEquals("20240101", values.get(0));
+        assertEquals("20240102", values.get(1));
+        assertEquals("20240103", values.get(2));
+        assertEquals("20240104", values.get(3));
+        assertEquals("20240105", values.get(4));
+    }
+
+    @Test
+    public void testDayOfYearFormatInfersDays() {
+        // Day-of-year format (yyyyDDD) should infer DAYS, not YEARS
+        // D = day-of-year (1-366), different from d = day-of-month (1-31)
+        DateProjection projection = new DateProjection(
+                "dt", "2024001,2024005", "yyyyDDD",
+                Optional.empty(), Optional.empty());
+
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        // Should generate 5 daily values
+        assertEquals(5, values.size());
+        assertEquals("2024001", values.get(0));
+        assertEquals("2024002", values.get(1));
+        assertEquals("2024003", values.get(2));
+        assertEquals("2024004", values.get(3));
+        assertEquals("2024005", values.get(4));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/EnumProjectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/EnumProjectionTest.java
@@ -1,0 +1,134 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EnumProjectionTest {
+
+    @Test
+    public void testGetProjectedValuesNoFilter() {
+        EnumProjection projection = new EnumProjection("region", "us-east-1,us-west-2,eu-west-1");
+
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        assertEquals(3, values.size());
+        assertTrue(values.contains("us-east-1"));
+        assertTrue(values.contains("us-west-2"));
+        assertTrue(values.contains("eu-west-1"));
+    }
+
+    @Test
+    public void testGetProjectedValuesWithMatchingFilter() {
+        EnumProjection projection = new EnumProjection("region", "us-east-1,us-west-2,eu-west-1");
+
+        List<String> values = projection.getProjectedValues(Optional.of("us-east-1"));
+
+        assertEquals(1, values.size());
+        assertEquals("us-east-1", values.get(0));
+    }
+
+    @Test
+    public void testGetProjectedValuesWithNonMatchingFilter() {
+        EnumProjection projection = new EnumProjection("region", "us-east-1,us-west-2,eu-west-1");
+
+        List<String> values = projection.getProjectedValues(Optional.of("ap-northeast-1"));
+
+        assertTrue(values.isEmpty());
+    }
+
+    @Test
+    public void testGetProjectedValuesWithSpaces() {
+        EnumProjection projection = new EnumProjection("region", " us-east-1 , us-west-2 , eu-west-1 ");
+
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        assertEquals(3, values.size());
+        assertEquals("us-east-1", values.get(0));
+        assertEquals("us-west-2", values.get(1));
+        assertEquals("eu-west-1", values.get(2));
+    }
+
+    @Test
+    public void testFormatValue() {
+        EnumProjection projection = new EnumProjection("region", "us,eu");
+
+        assertEquals("us", projection.formatValue("us"));
+        assertEquals("123", projection.formatValue(123));
+    }
+
+    @Test
+    public void testGetColumnType() {
+        EnumProjection projection = new EnumProjection("region", "us,eu");
+
+        assertEquals(VarcharType.VARCHAR, projection.getColumnType());
+    }
+
+    @Test
+    public void testGetColumnName() {
+        EnumProjection projection = new EnumProjection("region", "us,eu");
+
+        assertEquals("region", projection.getColumnName());
+    }
+
+    @Test
+    public void testGetValues() {
+        EnumProjection projection = new EnumProjection("region", "us,eu,ap");
+
+        List<String> values = projection.getValues();
+
+        assertEquals(3, values.size());
+        assertEquals("us", values.get(0));
+        assertEquals("eu", values.get(1));
+        assertEquals("ap", values.get(2));
+    }
+
+    @Test
+    public void testConstructorWithNullValues() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new EnumProjection("region", null));
+    }
+
+    @Test
+    public void testConstructorWithEmptyValues() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new EnumProjection("region", ""));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new EnumProjection("region", "   "));
+    }
+
+    @Test
+    public void testConstructorWithOnlyCommas() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new EnumProjection("region", ",,,"));
+    }
+
+    @Test
+    public void testRequiresFilter() {
+        EnumProjection projection = new EnumProjection("region", "us,eu");
+
+        assertFalse(projection.requiresFilter());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/InjectedProjectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/InjectedProjectionTest.java
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class InjectedProjectionTest {
+
+    @Test
+    public void testGetProjectedValuesWithFilter() {
+        InjectedProjection projection = new InjectedProjection("user_id");
+
+        List<String> values = projection.getProjectedValues(Optional.of("12345"));
+
+        assertEquals(1, values.size());
+        assertEquals("12345", values.get(0));
+    }
+
+    @Test
+    public void testGetProjectedValuesWithIntegerFilter() {
+        InjectedProjection projection = new InjectedProjection("user_id");
+
+        List<String> values = projection.getProjectedValues(Optional.of(12345));
+
+        assertEquals(1, values.size());
+        assertEquals("12345", values.get(0));
+    }
+
+    @Test
+    public void testGetProjectedValuesWithoutFilter() {
+        InjectedProjection projection = new InjectedProjection("user_id");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                projection.getProjectedValues(Optional.empty()));
+
+        assertTrue(exception.getMessage().contains("user_id"));
+        assertTrue(exception.getMessage().contains("requires a filter"));
+    }
+
+    @Test
+    public void testFormatValue() {
+        InjectedProjection projection = new InjectedProjection("user_id");
+
+        assertEquals("test", projection.formatValue("test"));
+        assertEquals("123", projection.formatValue(123));
+    }
+
+    @Test
+    public void testGetColumnType() {
+        InjectedProjection projection = new InjectedProjection("user_id");
+
+        assertEquals(VarcharType.VARCHAR, projection.getColumnType());
+    }
+
+    @Test
+    public void testGetColumnName() {
+        InjectedProjection projection = new InjectedProjection("user_id");
+
+        assertEquals("user_id", projection.getColumnName());
+    }
+
+    @Test
+    public void testRequiresFilter() {
+        InjectedProjection projection = new InjectedProjection("user_id");
+
+        assertTrue(projection.requiresFilter());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/IntegerProjectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/IntegerProjectionTest.java
@@ -1,0 +1,212 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class IntegerProjectionTest {
+
+    @Test
+    public void testGetProjectedValuesNoFilter() {
+        IntegerProjection projection = new IntegerProjection(
+                "year", "2020,2025", Optional.empty(), Optional.empty());
+
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        assertEquals(6, values.size());
+        assertEquals("2020", values.get(0));
+        assertEquals("2021", values.get(1));
+        assertEquals("2022", values.get(2));
+        assertEquals("2023", values.get(3));
+        assertEquals("2024", values.get(4));
+        assertEquals("2025", values.get(5));
+    }
+
+    @Test
+    public void testGetProjectedValuesWithInterval() {
+        IntegerProjection projection = new IntegerProjection(
+                "year", "2020,2030", Optional.of("2"), Optional.empty());
+
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        assertEquals(6, values.size());
+        assertEquals("2020", values.get(0));
+        assertEquals("2022", values.get(1));
+        assertEquals("2024", values.get(2));
+        assertEquals("2026", values.get(3));
+        assertEquals("2028", values.get(4));
+        assertEquals("2030", values.get(5));
+    }
+
+    @Test
+    public void testGetProjectedValuesWithDigits() {
+        IntegerProjection projection = new IntegerProjection(
+                "month", "1,12", Optional.empty(), Optional.of("2"));
+
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        assertEquals(12, values.size());
+        assertEquals("01", values.get(0));
+        assertEquals("02", values.get(1));
+        assertEquals("10", values.get(9));
+        assertEquals("12", values.get(11));
+    }
+
+    @Test
+    public void testGetProjectedValuesWithMatchingFilter() {
+        IntegerProjection projection = new IntegerProjection(
+                "year", "2020,2025", Optional.empty(), Optional.empty());
+
+        List<String> values = projection.getProjectedValues(Optional.of(2023));
+
+        assertEquals(1, values.size());
+        assertEquals("2023", values.get(0));
+    }
+
+    @Test
+    public void testGetProjectedValuesWithMatchingFilterString() {
+        IntegerProjection projection = new IntegerProjection(
+                "year", "2020,2025", Optional.empty(), Optional.empty());
+
+        List<String> values = projection.getProjectedValues(Optional.of("2023"));
+
+        assertEquals(1, values.size());
+        assertEquals("2023", values.get(0));
+    }
+
+    @Test
+    public void testGetProjectedValuesWithFilterOutOfRange() {
+        IntegerProjection projection = new IntegerProjection(
+                "year", "2020,2025", Optional.empty(), Optional.empty());
+
+        List<String> values = projection.getProjectedValues(Optional.of(2019));
+        assertTrue(values.isEmpty());
+
+        values = projection.getProjectedValues(Optional.of(2026));
+        assertTrue(values.isEmpty());
+    }
+
+    @Test
+    public void testGetProjectedValuesWithFilterNotOnInterval() {
+        IntegerProjection projection = new IntegerProjection(
+                "year", "2020,2030", Optional.of("5"), Optional.empty());
+
+        // 2023 is not on the interval (2020, 2025, 2030)
+        List<String> values = projection.getProjectedValues(Optional.of(2023));
+        assertTrue(values.isEmpty());
+
+        // 2025 is on the interval
+        values = projection.getProjectedValues(Optional.of(2025));
+        assertEquals(1, values.size());
+        assertEquals("2025", values.get(0));
+    }
+
+    @Test
+    public void testFormatValueWithDigits() {
+        IntegerProjection projection = new IntegerProjection(
+                "month", "1,12", Optional.empty(), Optional.of("2"));
+
+        assertEquals("01", projection.formatValue(1));
+        assertEquals("05", projection.formatValue(5));
+        assertEquals("12", projection.formatValue(12));
+    }
+
+    @Test
+    public void testFormatValueWithoutDigits() {
+        IntegerProjection projection = new IntegerProjection(
+                "year", "2020,2025", Optional.empty(), Optional.empty());
+
+        assertEquals("2023", projection.formatValue(2023));
+        assertEquals("1", projection.formatValue(1));
+    }
+
+    @Test
+    public void testGetColumnType() {
+        IntegerProjection projection = new IntegerProjection(
+                "year", "2020,2025", Optional.empty(), Optional.empty());
+
+        assertEquals(IntegerType.BIGINT, projection.getColumnType());
+    }
+
+    @Test
+    public void testGetColumnName() {
+        IntegerProjection projection = new IntegerProjection(
+                "year", "2020,2025", Optional.empty(), Optional.empty());
+
+        assertEquals("year", projection.getColumnName());
+    }
+
+    @Test
+    public void testConstructorWithNullRange() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new IntegerProjection("year", null, Optional.empty(), Optional.empty()));
+    }
+
+    @Test
+    public void testConstructorWithEmptyRange() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new IntegerProjection("year", "", Optional.empty(), Optional.empty()));
+    }
+
+    @Test
+    public void testConstructorWithInvalidRange() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new IntegerProjection("year", "2020", Optional.empty(), Optional.empty()));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                new IntegerProjection("year", "abc,def", Optional.empty(), Optional.empty()));
+    }
+
+    @Test
+    public void testConstructorWithReversedRange() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new IntegerProjection("year", "2025,2020", Optional.empty(), Optional.empty()));
+    }
+
+    @Test
+    public void testConstructorWithZeroInterval() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new IntegerProjection("year", "2020,2025", Optional.of("0"), Optional.empty()));
+    }
+
+    @Test
+    public void testConstructorWithNegativeInterval() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new IntegerProjection("year", "2020,2025", Optional.of("-1"), Optional.empty()));
+    }
+
+    @Test
+    public void testConstructorWithZeroDigits() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new IntegerProjection("year", "2020,2025", Optional.empty(), Optional.of("0")));
+    }
+
+    @Test
+    public void testRequiresFilter() {
+        IntegerProjection projection = new IntegerProjection(
+                "year", "2020,2025", Optional.empty(), Optional.empty());
+
+        assertFalse(projection.requiresFilter());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/IntegerProjectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/IntegerProjectionTest.java
@@ -261,14 +261,28 @@ public class IntegerProjectionTest {
     }
 
     @Test
-    public void testNullFilterValueReturnsEmpty() {
+    public void testEmptyOptionalReturnsAllValues() {
         IntegerProjection projection = new IntegerProjection(
                 "year", "2020,2025", Optional.empty(), Optional.empty());
 
-        // Simulate a null value wrapped in Optional (defensive check)
+        // Optional.ofNullable(null) returns Optional.empty(), meaning no filter applied
         List<String> values = projection.getProjectedValues(Optional.ofNullable(null));
 
-        // Optional.ofNullable(null) returns Optional.empty(), so all values returned
+        // No filter means all values are returned
         assertEquals(6, values.size());
+    }
+
+    @Test
+    public void testInvalidFilterValueReturnsEmpty() {
+        IntegerProjection projection = new IntegerProjection(
+                "year", "2020,2025", Optional.empty(), Optional.empty());
+
+        // Invalid non-numeric string should return empty list (consistent with DateProjection)
+        List<String> values = projection.getProjectedValues(Optional.of("invalid"));
+        assertTrue(values.isEmpty());
+
+        // Another invalid format
+        values = projection.getProjectedValues(Optional.of("abc123"));
+        assertTrue(values.isEmpty());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/IntegerProjectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/IntegerProjectionTest.java
@@ -243,4 +243,32 @@ public class IntegerProjectionTest {
         assertTrue(exception.getMessage().contains("overflow") ||
                    exception.getMessage().contains("exceeding limit"));
     }
+
+    @Test
+    public void testLoopOverflowProtection() {
+        // Test that loop doesn't overflow when current + interval would exceed Long.MAX_VALUE
+        // Range near Long.MAX_VALUE with interval that would cause overflow
+        long start = Long.MAX_VALUE - 5;
+        long end = Long.MAX_VALUE;
+        IntegerProjection projection = new IntegerProjection(
+                "id", start + "," + end, Optional.of("10"), Optional.empty());
+
+        // Should generate only one value (start) and break before overflow
+        List<String> values = projection.getProjectedValues(Optional.empty());
+
+        assertEquals(1, values.size());
+        assertEquals(String.valueOf(start), values.get(0));
+    }
+
+    @Test
+    public void testNullFilterValueReturnsEmpty() {
+        IntegerProjection projection = new IntegerProjection(
+                "year", "2020,2025", Optional.empty(), Optional.empty());
+
+        // Simulate a null value wrapped in Optional (defensive check)
+        List<String> values = projection.getProjectedValues(Optional.ofNullable(null));
+
+        // Optional.ofNullable(null) returns Optional.empty(), so all values returned
+        assertEquals(6, values.size());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionPropertiesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionPropertiesTest.java
@@ -1,0 +1,156 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PartitionProjectionPropertiesTest {
+
+    @Test
+    public void testParseDisabled() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("some.other.property", "value");
+
+        PartitionProjectionProperties props = PartitionProjectionProperties.parse(properties);
+
+        assertFalse(props.isEnabled());
+        assertTrue(props.getColumnConfigs().isEmpty());
+    }
+
+    @Test
+    public void testParseEnabledWithProjectionEnabled() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("projection.enabled", "true");
+        properties.put("projection.region.type", "enum");
+        properties.put("projection.region.values", "us-east-1,us-west-2,eu-west-1");
+
+        PartitionProjectionProperties props = PartitionProjectionProperties.parse(properties);
+
+        assertTrue(props.isEnabled());
+        assertEquals(1, props.getColumnConfigs().size());
+        assertNotNull(props.getColumnConfig("region"));
+        assertEquals(PartitionProjectionProperties.ProjectionType.ENUM,
+                props.getColumnConfig("region").getType());
+    }
+
+    @Test
+    public void testParseEnabledWithProjectionEnable() {
+        // Test legacy property key
+        Map<String, String> properties = new HashMap<>();
+        properties.put("projection.enable", "true");
+        properties.put("projection.year.type", "integer");
+        properties.put("projection.year.range", "2020,2025");
+
+        PartitionProjectionProperties props = PartitionProjectionProperties.parse(properties);
+
+        assertTrue(props.isEnabled());
+        assertEquals(1, props.getColumnConfigs().size());
+    }
+
+    @Test
+    public void testParseMultipleColumns() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("projection.enabled", "true");
+        properties.put("projection.region.type", "enum");
+        properties.put("projection.region.values", "us,eu");
+        properties.put("projection.year.type", "integer");
+        properties.put("projection.year.range", "2020,2025");
+        properties.put("projection.dt.type", "date");
+        properties.put("projection.dt.range", "2024-01-01,NOW");
+        properties.put("projection.dt.format", "yyyy-MM-dd");
+
+        PartitionProjectionProperties props = PartitionProjectionProperties.parse(properties);
+
+        assertTrue(props.isEnabled());
+        assertEquals(3, props.getColumnConfigs().size());
+        assertEquals(PartitionProjectionProperties.ProjectionType.ENUM,
+                props.getColumnConfig("region").getType());
+        assertEquals(PartitionProjectionProperties.ProjectionType.INTEGER,
+                props.getColumnConfig("year").getType());
+        assertEquals(PartitionProjectionProperties.ProjectionType.DATE,
+                props.getColumnConfig("dt").getType());
+    }
+
+    @Test
+    public void testParseStorageLocationTemplate() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("projection.enabled", "true");
+        properties.put("projection.region.type", "enum");
+        properties.put("projection.region.values", "us,eu");
+        properties.put("storage.location.template", "s3://bucket/data/${region}/");
+
+        PartitionProjectionProperties props = PartitionProjectionProperties.parse(properties);
+
+        assertTrue(props.getStorageLocationTemplate().isPresent());
+        assertEquals("s3://bucket/data/${region}/",
+                props.getStorageLocationTemplate().get());
+    }
+
+    @Test
+    public void testParseNullProperties() {
+        PartitionProjectionProperties props = PartitionProjectionProperties.parse(null);
+        assertFalse(props.isEnabled());
+    }
+
+    @Test
+    public void testIsProjectionEnabled() {
+        Map<String, String> properties = new HashMap<>();
+
+        assertFalse(PartitionProjectionProperties.isProjectionEnabled(null));
+        assertFalse(PartitionProjectionProperties.isProjectionEnabled(properties));
+
+        properties.put("projection.enabled", "false");
+        assertFalse(PartitionProjectionProperties.isProjectionEnabled(properties));
+
+        properties.put("projection.enabled", "true");
+        assertTrue(PartitionProjectionProperties.isProjectionEnabled(properties));
+
+        properties.clear();
+        properties.put("projection.enable", "true");
+        assertTrue(PartitionProjectionProperties.isProjectionEnabled(properties));
+    }
+
+    @Test
+    public void testProjectionTypeFromString() {
+        assertEquals(PartitionProjectionProperties.ProjectionType.ENUM,
+                PartitionProjectionProperties.ProjectionType.fromString("enum"));
+        assertEquals(PartitionProjectionProperties.ProjectionType.ENUM,
+                PartitionProjectionProperties.ProjectionType.fromString("ENUM"));
+
+        assertEquals(PartitionProjectionProperties.ProjectionType.INTEGER,
+                PartitionProjectionProperties.ProjectionType.fromString("integer"));
+
+        assertEquals(PartitionProjectionProperties.ProjectionType.DATE,
+                PartitionProjectionProperties.ProjectionType.fromString("date"));
+
+        assertEquals(PartitionProjectionProperties.ProjectionType.INJECTED,
+                PartitionProjectionProperties.ProjectionType.fromString("injected"));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                PartitionProjectionProperties.ProjectionType.fromString("unknown"));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                PartitionProjectionProperties.ProjectionType.fromString(null));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionServiceTest.java
@@ -17,9 +17,12 @@ package com.starrocks.connector.hive.glue.projection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.hive.HiveStorageFormat;
 import com.starrocks.connector.hive.Partition;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.type.PrimitiveType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +35,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -248,5 +252,144 @@ public class PartitionProjectionServiceTest {
         when(table.getStorageFormat()).thenReturn(HiveStorageFormat.PARQUET);
         when(table.getSerdeProperties()).thenReturn(new HashMap<>());
         return table;
+    }
+
+    // ==================== Bug Fix Tests ====================
+
+    /**
+     * Test for Bug 1 fix: Multiple partition keys should all be processed
+     * Previously only the first partition key was used, ignoring others.
+     * e.g., WHERE year IN (2023, 2024) should return partitions for both years.
+     */
+    @Test
+    public void testGetProjectedPartitionsWithMultiplePartitionKeys() throws Exception {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "true",
+                        "projection.year.type", "integer",
+                        "projection.year.range", "2020,2025"
+                ),
+                ImmutableList.of("year")
+        );
+
+        // Create multiple partition keys simulating WHERE year IN (2023, 2024)
+        PartitionKey key2023 = new PartitionKey();
+        key2023.pushColumn(new StringLiteral("2023"), PrimitiveType.VARCHAR);
+
+        PartitionKey key2024 = new PartitionKey();
+        key2024.pushColumn(new StringLiteral("2024"), PrimitiveType.VARCHAR);
+
+        List<PartitionKey> partitionKeys = Arrays.asList(key2023, key2024);
+
+        Map<String, Partition> partitions = service.getProjectedPartitions(table, partitionKeys);
+
+        // Should return partitions for BOTH years, not just the first one
+        assertEquals(2, partitions.size());
+        assertNotNull(partitions.get("year=2023"));
+        assertNotNull(partitions.get("year=2024"));
+    }
+
+    /**
+     * Test for Bug 2 fix: Storage location template should be used in getProjectedPartitionsFromNames
+     */
+    @Test
+    public void testGetProjectedPartitionsFromNamesWithStorageLocationTemplate() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "true",
+                        "projection.region.type", "enum",
+                        "projection.region.values", "us,eu",
+                        "projection.year.type", "integer",
+                        "projection.year.range", "2023,2024",
+                        "storage.location.template", "s3://bucket/data/${region}/${year}/"
+                ),
+                ImmutableList.of("region", "year")
+        );
+
+        List<String> partitionNames = Arrays.asList("region=us/year=2024");
+        Map<String, Partition> partitions = service.getProjectedPartitionsFromNames(table, partitionNames);
+
+        assertEquals(1, partitions.size());
+        Partition partition = partitions.get("region=us/year=2024");
+        assertNotNull(partition);
+
+        // Verify that storage location template is used
+        // Should be "s3://bucket/data/us/2024/" instead of "s3://bucket/table/region=us/year=2024"
+        String location = partition.getFullPath();
+        assertEquals("s3://bucket/data/us/2024/", location);
+    }
+
+    /**
+     * Test for Bug 2 fix: Default location when no storage template is defined
+     */
+    @Test
+    public void testGetProjectedPartitionsFromNamesWithoutStorageLocationTemplate() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "true",
+                        "projection.region.type", "enum",
+                        "projection.region.values", "us,eu"
+                ),
+                ImmutableList.of("region")
+        );
+
+        List<String> partitionNames = Arrays.asList("region=us");
+        Map<String, Partition> partitions = service.getProjectedPartitionsFromNames(table, partitionNames);
+
+        assertEquals(1, partitions.size());
+        Partition partition = partitions.get("region=us");
+        assertNotNull(partition);
+
+        // Without template, should use default format: baseLocation/partitionName
+        String location = partition.getFullPath();
+        assertEquals("s3://bucket/table/region=us", location);
+    }
+
+    /**
+     * Test for Issue 3 improvement: INJECTED columns should throw clear error in getProjectedPartitionNames
+     */
+    @Test
+    public void testGetProjectedPartitionNamesWithInjectedColumnThrowsError() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "true",
+                        "projection.user_id.type", "injected"
+                ),
+                ImmutableList.of("user_id")
+        );
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> service.getProjectedPartitionNames(table)
+        );
+
+        // Verify the error message is clear and helpful
+        assertTrue(exception.getMessage().contains("INJECTED"));
+        assertTrue(exception.getMessage().contains("user_id"));
+        assertTrue(exception.getMessage().contains("WHERE clause"));
+    }
+
+    /**
+     * Test for Issue 3: Mixed columns with INJECTED should still throw error
+     */
+    @Test
+    public void testGetProjectedPartitionNamesWithMixedColumnsIncludingInjected() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "true",
+                        "projection.year.type", "integer",
+                        "projection.year.range", "2020,2024",
+                        "projection.user_id.type", "injected"
+                ),
+                ImmutableList.of("year", "user_id")
+        );
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> service.getProjectedPartitionNames(table)
+        );
+
+        assertTrue(exception.getMessage().contains("INJECTED"));
+        assertTrue(exception.getMessage().contains("user_id"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionServiceTest.java
@@ -1,0 +1,252 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.hive.HiveStorageFormat;
+import com.starrocks.connector.hive.Partition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PartitionProjectionServiceTest {
+
+    private PartitionProjectionService service;
+
+    @BeforeEach
+    public void setUp() {
+        service = new PartitionProjectionService();
+    }
+
+    @Test
+    public void testIsEnabledWithProjectionEnabled() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "true",
+                        "projection.region.type", "enum",
+                        "projection.region.values", "us,eu"
+                ),
+                ImmutableList.of("region")
+        );
+
+        assertTrue(service.isEnabled(table));
+    }
+
+    @Test
+    public void testIsEnabledWithProjectionDisabled() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "false"
+                ),
+                ImmutableList.of("region")
+        );
+
+        assertFalse(service.isEnabled(table));
+    }
+
+    @Test
+    public void testIsEnabledWithNoProjectionProperty() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(),
+                ImmutableList.of("region")
+        );
+
+        assertFalse(service.isEnabled(table));
+    }
+
+    @Test
+    public void testIsEnabledWithNonHiveTable() {
+        Table table = mock(Table.class);
+        assertFalse(service.isEnabled(table));
+    }
+
+    @Test
+    public void testGetProjectedPartitionNamesWithEnumProjection() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "true",
+                        "projection.region.type", "enum",
+                        "projection.region.values", "us,eu,asia"
+                ),
+                ImmutableList.of("region")
+        );
+
+        List<String> partitionNames = service.getProjectedPartitionNames(table);
+
+        assertEquals(3, partitionNames.size());
+        assertTrue(partitionNames.contains("region=us"));
+        assertTrue(partitionNames.contains("region=eu"));
+        assertTrue(partitionNames.contains("region=asia"));
+    }
+
+    @Test
+    public void testGetProjectedPartitionNamesByValueWithFilter() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "true",
+                        "projection.region.type", "enum",
+                        "projection.region.values", "us,eu,asia"
+                ),
+                ImmutableList.of("region")
+        );
+
+        List<Optional<String>> partitionValues = ImmutableList.of(Optional.of("us"));
+        List<String> partitionNames = service.getProjectedPartitionNamesByValue(table, partitionValues);
+
+        assertEquals(1, partitionNames.size());
+        assertEquals("region=us", partitionNames.get(0));
+    }
+
+    @Test
+    public void testGetProjectedPartitionNamesByValueWithNoFilter() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "true",
+                        "projection.region.type", "enum",
+                        "projection.region.values", "us,eu"
+                ),
+                ImmutableList.of("region")
+        );
+
+        List<Optional<String>> partitionValues = ImmutableList.of(Optional.empty());
+        List<String> partitionNames = service.getProjectedPartitionNamesByValue(table, partitionValues);
+
+        assertEquals(2, partitionNames.size());
+    }
+
+    @Test
+    public void testGetProjectedPartitionsFromNames() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "true",
+                        "projection.region.type", "enum",
+                        "projection.region.values", "us,eu,asia"
+                ),
+                ImmutableList.of("region")
+        );
+
+        List<String> partitionNames = Arrays.asList("region=us", "region=eu");
+        Map<String, Partition> partitions = service.getProjectedPartitionsFromNames(table, partitionNames);
+
+        assertEquals(2, partitions.size());
+        assertNotNull(partitions.get("region=us"));
+        assertNotNull(partitions.get("region=eu"));
+
+        // Verify partition locations
+        assertTrue(partitions.get("region=us").getFullPath().endsWith("region=us"));
+        assertTrue(partitions.get("region=eu").getFullPath().endsWith("region=eu"));
+    }
+
+    @Test
+    public void testGetProjectedPartitionsFromNamesWithMultipleColumns() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "true",
+                        "projection.year.type", "integer",
+                        "projection.year.range", "2023,2024",
+                        "projection.region.type", "enum",
+                        "projection.region.values", "us,eu"
+                ),
+                ImmutableList.of("year", "region")
+        );
+
+        List<String> partitionNames = Arrays.asList("year=2023/region=us", "year=2024/region=eu");
+        Map<String, Partition> partitions = service.getProjectedPartitionsFromNames(table, partitionNames);
+
+        assertEquals(2, partitions.size());
+        assertNotNull(partitions.get("year=2023/region=us"));
+        assertNotNull(partitions.get("year=2024/region=eu"));
+    }
+
+    @Test
+    public void testGetProjectedPartitionsFromNamesWithEmptyList() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "true",
+                        "projection.region.type", "enum",
+                        "projection.region.values", "us,eu"
+                ),
+                ImmutableList.of("region")
+        );
+
+        List<String> partitionNames = ImmutableList.of();
+        Map<String, Partition> partitions = service.getProjectedPartitionsFromNames(table, partitionNames);
+
+        assertTrue(partitions.isEmpty());
+    }
+
+    @Test
+    public void testCreateProjectionWithIntegerType() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "true",
+                        "projection.year.type", "integer",
+                        "projection.year.range", "2020,2024"
+                ),
+                ImmutableList.of("year")
+        );
+
+        List<String> partitionNames = service.getProjectedPartitionNames(table);
+
+        assertEquals(5, partitionNames.size());
+        assertTrue(partitionNames.contains("year=2020"));
+        assertTrue(partitionNames.contains("year=2024"));
+    }
+
+    @Test
+    public void testCreateProjectionWithDateType() {
+        HiveTable table = createMockHiveTable(
+                ImmutableMap.of(
+                        "projection.enabled", "true",
+                        "projection.dt.type", "date",
+                        "projection.dt.range", "2024-01-01,2024-01-03",
+                        "projection.dt.format", "yyyy-MM-dd"
+                ),
+                ImmutableList.of("dt")
+        );
+
+        List<String> partitionNames = service.getProjectedPartitionNames(table);
+
+        assertEquals(3, partitionNames.size());
+        assertTrue(partitionNames.contains("dt=2024-01-01"));
+        assertTrue(partitionNames.contains("dt=2024-01-02"));
+        assertTrue(partitionNames.contains("dt=2024-01-03"));
+    }
+
+    private HiveTable createMockHiveTable(Map<String, String> properties, List<String> partitionColumns) {
+        HiveTable table = mock(HiveTable.class);
+        when(table.getProperties()).thenReturn(new HashMap<>(properties));
+        when(table.getPartitionColumnNames()).thenReturn(partitionColumns);
+        when(table.getTableLocation()).thenReturn("s3://bucket/table");
+        when(table.getStorageFormat()).thenReturn(HiveStorageFormat.PARQUET);
+        when(table.getSerdeProperties()).thenReturn(new HashMap<>());
+        return table;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionTest.java
@@ -1,0 +1,210 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.projection;
+
+import com.starrocks.connector.hive.Partition;
+import com.starrocks.connector.hive.RemoteFileInputFormat;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PartitionProjectionTest {
+
+    @Test
+    public void testGetProjectedPartitionsSingleColumn() {
+        Map<String, ColumnProjection> projections = new HashMap<>();
+        projections.put("region", new EnumProjection("region", "us,eu"));
+
+        PartitionProjection projection = new PartitionProjection(
+                "s3://bucket/data",
+                Optional.empty(),
+                projections,
+                Arrays.asList("region"),
+                RemoteFileInputFormat.PARQUET,
+                null
+        );
+
+        Map<String, Partition> partitions = projection.getProjectedPartitions(new HashMap<>());
+
+        assertEquals(2, partitions.size());
+        assertTrue(partitions.containsKey("region=us"));
+        assertTrue(partitions.containsKey("region=eu"));
+
+        // Check locations
+        assertEquals("s3://bucket/data/region=us", partitions.get("region=us").getFullPath());
+        assertEquals("s3://bucket/data/region=eu", partitions.get("region=eu").getFullPath());
+    }
+
+    @Test
+    public void testGetProjectedPartitionsMultipleColumns() {
+        Map<String, ColumnProjection> projections = new HashMap<>();
+        projections.put("region", new EnumProjection("region", "us,eu"));
+        projections.put("year", new IntegerProjection("year", "2020,2021", Optional.empty(), Optional.empty()));
+
+        PartitionProjection projection = new PartitionProjection(
+                "s3://bucket/data",
+                Optional.empty(),
+                projections,
+                Arrays.asList("region", "year"),
+                RemoteFileInputFormat.PARQUET,
+                null
+        );
+
+        Map<String, Partition> partitions = projection.getProjectedPartitions(new HashMap<>());
+
+        // 2 regions * 2 years = 4 partitions
+        assertEquals(4, partitions.size());
+        assertTrue(partitions.containsKey("region=us/year=2020"));
+        assertTrue(partitions.containsKey("region=us/year=2021"));
+        assertTrue(partitions.containsKey("region=eu/year=2020"));
+        assertTrue(partitions.containsKey("region=eu/year=2021"));
+    }
+
+    @Test
+    public void testGetProjectedPartitionsWithFilter() {
+        Map<String, ColumnProjection> projections = new HashMap<>();
+        projections.put("region", new EnumProjection("region", "us,eu,ap"));
+        projections.put("year", new IntegerProjection("year", "2020,2025", Optional.empty(), Optional.empty()));
+
+        PartitionProjection projection = new PartitionProjection(
+                "s3://bucket/data",
+                Optional.empty(),
+                projections,
+                Arrays.asList("region", "year"),
+                RemoteFileInputFormat.PARQUET,
+                null
+        );
+
+        Map<String, Optional<Object>> filters = new HashMap<>();
+        filters.put("region", Optional.of("us"));
+        filters.put("year", Optional.of(2023));
+
+        Map<String, Partition> partitions = projection.getProjectedPartitions(filters);
+
+        assertEquals(1, partitions.size());
+        assertTrue(partitions.containsKey("region=us/year=2023"));
+    }
+
+    @Test
+    public void testGetProjectedPartitionsWithStorageTemplate() {
+        Map<String, ColumnProjection> projections = new HashMap<>();
+        projections.put("region", new EnumProjection("region", "us"));
+        projections.put("year", new IntegerProjection("year", "2024,2024", Optional.empty(), Optional.empty()));
+
+        PartitionProjection projection = new PartitionProjection(
+                "s3://bucket/data",
+                Optional.of("s3://bucket/data/${region}/${year}/"),
+                projections,
+                Arrays.asList("region", "year"),
+                RemoteFileInputFormat.PARQUET,
+                null
+        );
+
+        Map<String, Partition> partitions = projection.getProjectedPartitions(new HashMap<>());
+
+        assertEquals(1, partitions.size());
+        Partition partition = partitions.get("region=us/year=2024");
+        assertNotNull(partition);
+        assertEquals("s3://bucket/data/us/2024/", partition.getFullPath());
+    }
+
+    @Test
+    public void testGetProjectedPartitionsEmptyResult() {
+        Map<String, ColumnProjection> projections = new HashMap<>();
+        projections.put("region", new EnumProjection("region", "us,eu"));
+
+        PartitionProjection projection = new PartitionProjection(
+                "s3://bucket/data",
+                Optional.empty(),
+                projections,
+                Arrays.asList("region"),
+                RemoteFileInputFormat.PARQUET,
+                null
+        );
+
+        Map<String, Optional<Object>> filters = new HashMap<>();
+        filters.put("region", Optional.of("ap")); // Not in enum list
+
+        Map<String, Partition> partitions = projection.getProjectedPartitions(filters);
+
+        assertTrue(partitions.isEmpty());
+    }
+
+    @Test
+    public void testGetProjectedPartitionsMissingProjection() {
+        Map<String, ColumnProjection> projections = new HashMap<>();
+        projections.put("region", new EnumProjection("region", "us,eu"));
+        // Missing projection for "year"
+
+        PartitionProjection projection = new PartitionProjection(
+                "s3://bucket/data",
+                Optional.empty(),
+                projections,
+                Arrays.asList("region", "year"),
+                RemoteFileInputFormat.PARQUET,
+                null
+        );
+
+        assertThrows(IllegalArgumentException.class, () ->
+                projection.getProjectedPartitions(new HashMap<>()));
+    }
+
+    @Test
+    public void testPartitionInputFormat() {
+        Map<String, ColumnProjection> projections = new HashMap<>();
+        projections.put("region", new EnumProjection("region", "us"));
+
+        PartitionProjection projection = new PartitionProjection(
+                "s3://bucket/data",
+                Optional.empty(),
+                projections,
+                Arrays.asList("region"),
+                RemoteFileInputFormat.ORC,
+                null
+        );
+
+        Map<String, Partition> partitions = projection.getProjectedPartitions(new HashMap<>());
+
+        Partition partition = partitions.get("region=us");
+        assertEquals(RemoteFileInputFormat.ORC, partition.getFileFormat());
+    }
+
+    @Test
+    public void testBaseLocationWithTrailingSlash() {
+        Map<String, ColumnProjection> projections = new HashMap<>();
+        projections.put("region", new EnumProjection("region", "us"));
+
+        PartitionProjection projection = new PartitionProjection(
+                "s3://bucket/data/",
+                Optional.empty(),
+                projections,
+                Arrays.asList("region"),
+                RemoteFileInputFormat.PARQUET,
+                null
+        );
+
+        Map<String, Partition> partitions = projection.getProjectedPartitions(new HashMap<>());
+
+        assertEquals("s3://bucket/data/region=us", partitions.get("region=us").getFullPath());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -254,5 +255,28 @@ public class PartitionProjectionTest {
         Partition partition = partitions.get("region=us/year=2024");
         assertNotNull(partition);
         assertEquals("s3://bucket/data/us/2024/", partition.getFullPath());
+    }
+
+    @Test
+    public void testIsSplittableForKnownFormats() {
+        // Test that known splittable formats return true
+        assertTrue(PartitionProjection.isSplittable(RemoteFileInputFormat.PARQUET));
+        assertTrue(PartitionProjection.isSplittable(RemoteFileInputFormat.ORC));
+        assertTrue(PartitionProjection.isSplittable(RemoteFileInputFormat.TEXTFILE));
+        assertTrue(PartitionProjection.isSplittable(RemoteFileInputFormat.AVRO));
+        assertTrue(PartitionProjection.isSplittable(RemoteFileInputFormat.RCFILE));
+        assertTrue(PartitionProjection.isSplittable(RemoteFileInputFormat.SEQUENCE));
+    }
+
+    @Test
+    public void testIsSplittableForUnknownFormat() {
+        // Test that unknown formats return false
+        assertFalse(PartitionProjection.isSplittable(RemoteFileInputFormat.UNKNOWN));
+    }
+
+    @Test
+    public void testIsSplittableForNullFormat() {
+        // Test that null format returns true (default behavior)
+        assertTrue(PartitionProjection.isSplittable(null));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/util/HiveTableValidatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/util/HiveTableValidatorTest.java
@@ -1,0 +1,144 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.util;
+
+import com.starrocks.connector.hive.glue.metastore.AWSGlueMetastore;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.glue.model.StorageDescriptor;
+import software.amazon.awssdk.services.glue.model.Table;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+
+public class HiveTableValidatorTest {
+
+    private AWSGlueMetastore mockMetastore = mock(AWSGlueMetastore.class);
+
+    @Test
+    public void testPartitionProjectionEnabledSkipsValidation() {
+        // Table with projection.enabled = true should skip metastore partition validation
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("projection.enabled", "true");
+        parameters.put("projection.region.type", "enum");
+        parameters.put("projection.region.values", "us-east,us-west");
+
+        Table table = Table.builder()
+                .name("projection_table")
+                .tableType("EXTERNAL_TABLE")
+                .parameters(parameters)
+                .storageDescriptor(StorageDescriptor.builder()
+                        .location("s3://bucket/path")
+                        .build())
+                .build();
+
+        assertDoesNotThrow(() ->
+                HiveTableValidator.REQUIRED_PROPERTIES_VALIDATOR.validate(table, mockMetastore));
+    }
+
+    @Test
+    public void testPartitionProjectionEnableLegacySkipsValidation() {
+        // Table with projection.enable = true (legacy) should also skip validation
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("projection.enable", "true");
+        parameters.put("projection.dt.type", "date");
+
+        Table table = Table.builder()
+                .name("projection_table_legacy")
+                .tableType("EXTERNAL_TABLE")
+                .parameters(parameters)
+                .storageDescriptor(StorageDescriptor.builder()
+                        .location("s3://bucket/path")
+                        .build())
+                .build();
+
+        assertDoesNotThrow(() ->
+                HiveTableValidator.REQUIRED_PROPERTIES_VALIDATOR.validate(table, mockMetastore));
+    }
+
+    @Test
+    public void testPartitionProjectionEnabledCaseInsensitive() {
+        // projection.enabled should be case-insensitive
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("PROJECTION.ENABLED", "TRUE");
+
+        Table table = Table.builder()
+                .name("projection_table_upper")
+                .tableType("EXTERNAL_TABLE")
+                .parameters(parameters)
+                .storageDescriptor(StorageDescriptor.builder()
+                        .location("s3://bucket/path")
+                        .build())
+                .build();
+
+        assertDoesNotThrow(() ->
+                HiveTableValidator.REQUIRED_PROPERTIES_VALIDATOR.validate(table, mockMetastore));
+    }
+
+    @Test
+    public void testPartitionProjectionDisabledDoesNotSkip() {
+        // Table with projection.enabled = false should NOT skip validation
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("projection.enabled", "false");
+
+        Table table = Table.builder()
+                .name("non_projection_table")
+                .tableType("EXTERNAL_TABLE")
+                .parameters(parameters)
+                .storageDescriptor(StorageDescriptor.builder()
+                        .location("s3://bucket/path")
+                        .build())
+                .build();
+
+        // Should not throw because it has storageDescriptor
+        assertDoesNotThrow(() ->
+                HiveTableValidator.REQUIRED_PROPERTIES_VALIDATOR.validate(table, mockMetastore));
+    }
+
+    @Test
+    public void testNullParametersDoesNotThrowNPE() {
+        // Table with null parameters should not cause NPE
+        Table table = Table.builder()
+                .name("null_params_table")
+                .tableType("EXTERNAL_TABLE")
+                .storageDescriptor(StorageDescriptor.builder()
+                        .location("s3://bucket/path")
+                        .build())
+                .build();
+
+        assertDoesNotThrow(() ->
+                HiveTableValidator.REQUIRED_PROPERTIES_VALIDATOR.validate(table, mockMetastore));
+    }
+
+    @Test
+    public void testEmptyParametersDoesNotThrowNPE() {
+        // Table with empty parameters should not cause NPE
+        Map<String, String> parameters = new HashMap<>();
+
+        Table table = Table.builder()
+                .name("empty_params_table")
+                .tableType("EXTERNAL_TABLE")
+                .parameters(parameters)
+                .storageDescriptor(StorageDescriptor.builder()
+                        .location("s3://bucket/path")
+                        .build())
+                .build();
+
+        assertDoesNotThrow(() ->
+                HiveTableValidator.REQUIRED_PROPERTIES_VALIDATOR.validate(table, mockMetastore));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtilsTest.java
@@ -43,7 +43,7 @@ public class MetastoreClientUtilsTest {
     private DefaultAWSGlueMetastore metastore;
 
     @Test
-    public void testGluePartitionProjection() {
+    public void testGluePartitionProjectionTablesAreValid() {
         software.amazon.awssdk.services.glue.model.Table.Builder tableBuilder = 
                 software.amazon.awssdk.services.glue.model.Table.builder();
         tableBuilder


### PR DESCRIPTION
## Why I'm doing:

Currently, StarRocks cannot read AWS Glue tables that use **Partition Projection**. When querying these tables, StarRocks attempts to fetch partition metadata from the Glue metastore, but Partition Projection tables don't store partition information in the metastore - they dynamically generate partitions based on table properties.

Why users rely on Partition Projection:
- No need to run MSCK REPAIR TABLE or ADD PARTITION for new partitions
- Eliminates Glue Crawler setup and scheduled metadata sync jobs

**Additional Issue:** The existing PR #58576 for this feature appears to have outdated configurations, causing error messages to not be displayed properly. This makes debugging difficult as users cannot see the actual failure reason.

for the recant Athena table using 'projection.enabled' not 'projection.enable'
```
CREATE EXTERNAL TABLE `date_test`(
  `id` int, 
  `user_id` string, 
  `action` string, 
  `timestamp` bigint)
PARTITIONED BY ( 
  `dt` string)
ROW FORMAT SERDE 
  'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe' 
STORED AS INPUTFORMAT 
  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat' 
OUTPUTFORMAT 
  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
LOCATION
  's3://*********/partition_projection/date_test'
TBLPROPERTIES (
  'projection.dt.format'='yyyy-MM-dd', 
  'projection.dt.interval'='1', 
  'projection.dt.interval.unit'='DAYS', 
  'projection.dt.range'='2024-01-01,NOW', 
  'projection.dt.type'='date', 
  'projection.enabled'='true', 
  'transient_lastDdlTime'='1767855755') 
```

## What I'm doing:

Implement support for AWS Glue Partition Projection in StarRocks, enabling users to query Athena-style partitioned tables without manual partition registration.

### Supported Projection Types:
- **enum**: Predefined list of partition values (e.g., regions: `us-east,us-west,eu-west`)
- **integer**: Numeric range with optional interval (e.g., years: `2020-2025`)
- **date**: Date range with format and interval (e.g., `2024-01-01,NOW` with daily interval)
- **injected**: Dynamic values provided at query time via WHERE clause

### Key Changes:
1. **New Package**: `com.starrocks.connector.hive.glue.projection`
   - `ColumnProjection` - Interface for projection types
   - `EnumProjection`, `IntegerProjection`, `DateProjection`, `InjectedProjection` - Implementations
   - `PartitionProjection` - Generates partition combinations (Cartesian product)
   - `PartitionProjectionProperties` - Parses table properties
   - `PartitionProjectionService` - Main service coordinating projection logic

2. **Modified Files**:
   - `HiveMetastoreOperations.java` - Intercepts partition retrieval to use projection when enabled
   - `HiveTableValidator.java` - Skips metastore partition validation for projection-enabled tables

### Example Usage:
```sql
-- Query a Glue table with partition projection enabled
SELECT * FROM glue_catalog.db.partition_projection_table
WHERE region = 'us-east' AND dt = '2024-01-15';
```

Fixes [#51239](https://github.com/StarRocks/starrocks/issues/51239)

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

**Behavior Change Details:**
- Tables with `projection.enabled=true` property will now dynamically generate partitions instead of querying the metastore
- This is automatic and transparent to users - no configuration required
- Existing tables without partition projection are unaffected

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [x] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Test Plan:

### 1. FE Unit Tests
Unit tests covering all projection types and edge cases:
- `EnumProjectionTest.java` - Tests enum value generation and filtering
- `IntegerProjectionTest.java` - Tests integer range with intervals
- `DateProjectionTest.java` - Tests date ranges, NOW expressions, various formats (yyyy-MM-dd, yyyy-MM, yyyy)
- `InjectedProjectionTest.java` - Tests injected type requiring query filters
- `PartitionProjectionTest.java` - Tests Cartesian product generation
- `PartitionProjectionPropertiesTest.java` - Tests property parsing
- `PartitionProjectionServiceTest.java` - Tests service integration

### 2. Integration Testing with Personal AWS Environment
End-to-end testing using personal AWS S3 & Athena environment:
- Created test tables in AWS Glue with various partition projection configurations
- Uploaded sample Parquet data to S3 with proper partition directory structure
- Executed queries from StarRocks against Glue catalog and verified results match Athena output

**Before Changes**
<img width="1261" height="690" alt="image" src="https://github.com/user-attachments/assets/f90c9fa5-eed1-4a24-8f9d-c2ab4b6991c6" />
<img width="1248" height="386" alt="image" src="https://github.com/user-attachments/assets/e3e41f90-cbb1-47b9-aebb-6db9760a887a" />

**After Changes**
<img width="1273" height="1272" alt="image" src="https://github.com/user-attachments/assets/667681b2-fa90-4724-a527-7144ff8ef48c" />
<img width="1258" height="689" alt="image" src="https://github.com/user-attachments/assets/29bd6b78-4d22-499f-91cc-6494464bbfb3" />

**Test scenarios:**
- Single column enum projection
- Single column integer projection
- Single column date projection with NOW expression
- Multi-column mixed projection (enum + integer + date)
- Injected projection with storage location template

**Screenshots of test results will be provided below to demonstrate functionality.**

## Related Issues:
- Closes #51239
- Supersedes #51254 (outdated configuration issues)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds first-class support for AWS Glue/Athena Partition Projection so partitions are generated dynamically from table properties instead of the metastore.
> 
> - Integrates projection path in `HiveMetastoreOperations` for `getPartitionKeys*`, `getPartitionBy*` to return projected names/partitions when enabled
> - New projection framework (`com.starrocks.connector.hive.glue.projection`): `EnumProjection`, `IntegerProjection`, `DateProjection`, `InjectedProjection`, `PartitionProjection`, `PartitionProjectionProperties`, `PartitionProjectionService`
> - Supports storage location templates, case-insensitive properties (`projection.enabled`/`projection.enable`), and safe bounds/limits (overflow checks, max values/partitions)
> - Updates `HiveTableValidator` to treat projection tables as valid without metastore partitions
> - Unit tests covering all projection types, service integration, validator behavior, and template handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbd13814e91313208bad82a5ba3599f2c4fe435d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->