### PR TITLE
[Enhancement] Skip agg pushdown work when no aggregation exists

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -33,6 +33,7 @@ import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.cost.CostEstimate;
 import com.starrocks.sql.optimizer.cost.feature.PlanFeatures;
 import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
@@ -835,7 +836,8 @@ public class QueryOptimizer extends Optimizer {
         }
 
         if (context.getSessionVariable().getCboPushDownAggregateMode() != -1) {
-            if (context.getSessionVariable().isCboPushDownAggregateOnBroadcastJoin()) {
+            boolean hasAgg = Util.getStream(tree).anyMatch(op -> op instanceof LogicalAggregationOperator);
+            if (hasAgg && context.getSessionVariable().isCboPushDownAggregateOnBroadcastJoin()) {
                 if (pushDistinctBelowWindowFlag) {
                     deriveLogicalProperty(tree);
                 }
@@ -845,11 +847,13 @@ public class QueryOptimizer extends Optimizer {
                 joinReorder = true;
             }
 
-            PushDownAggregateRule rule = new PushDownAggregateRule(rootTaskContext);
-            rule.getRewriter().collectRewriteContext(tree);
-            if (rule.getRewriter().isNeedRewrite()) {
-                pushAggFlag = true;
-                tree = rule.rewrite(tree, rootTaskContext);
+            if (hasAgg) {
+                PushDownAggregateRule rule = new PushDownAggregateRule(rootTaskContext);
+                rule.getRewriter().collectRewriteContext(tree);
+                if (rule.getRewriter().isNeedRewrite()) {
+                    pushAggFlag = true;
+                    tree = rule.rewrite(tree, rootTaskContext);
+                }
             }
         }
 

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -3038,6 +3038,23 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
                 "assert expect {} is not found in plan {}".format(expect, res["result"]),
             )
 
+    def assert_query_contains_times(self, query, expect, expected_times: int):
+        """
+        Assert query result contains `expect` exactly `expected_times` times.
+
+        This is useful for validating trace outputs, e.g. making sure a specific optimizer phase
+        runs only once.
+        """
+        res = self.execute_sql(query, True)
+        haystack = str(res["result"])
+        actual_times = haystack.count(str(expect))
+        tools.assert_true(
+            actual_times == int(expected_times),
+            "assert expect {} appears {} times (expected {}), result: {}".format(
+                expect, actual_times, expected_times, res["result"]
+            ),
+        )
+
     def assert_query_error_contains(self, query, *expects):
         """
         assert error message contains expect string

--- a/test/sql/test_join/R/test_join_reorder_times.sql
+++ b/test/sql/test_join/R/test_join_reorder_times.sql
@@ -1,0 +1,94 @@
+-- name: test_join_reorder_times
+drop database if exists test_join_reorder_times;
+-- result:
+-- !result
+create database test_join_reorder_times;
+-- result:
+-- !result
+use test_join_reorder_times;
+-- result:
+-- !result
+create table if not exists jrdp_t0 (k int, v int)
+engine=olap
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+-- result:
+-- !result
+create table if not exists jrdp_t1 (k int, v int)
+engine=olap
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+-- result:
+-- !result
+create table if not exists jrdp_t2 (k int, v int)
+engine=olap
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+-- result:
+-- !result
+create table if not exists jrdp_t3 (k int, v int)
+engine=olap
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+-- result:
+-- !result
+create table if not exists jrdp_t4 (k int, v int)
+engine=olap
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+-- result:
+-- !result
+insert into jrdp_t0 values (1,10),(2,20),(3,30);
+-- result:
+-- !result
+insert into jrdp_t1 values (1,10),(2,20),(3,30);
+-- result:
+-- !result
+insert into jrdp_t2 values (1,10),(2,20),(3,30);
+-- result:
+-- !result
+insert into jrdp_t3 values (1,10),(2,20),(3,30);
+-- result:
+-- !result
+insert into jrdp_t4 values (1,10),(2,20),(3,30);
+-- result:
+-- !result
+analyze table jrdp_t0;
+-- result:
+test_join_reorder_times.jrdp_t0	analyze	status	OK
+-- !result
+[UC] analyze table jrdp_t1;
+-- result:
+test_join_reorder_times.jrdp_t1	analyze	status	OK
+-- !result
+[UC] analyze table jrdp_t2;
+-- result:
+test_join_reorder_times.jrdp_t2	analyze	status	OK
+-- !result
+[UC] analyze table jrdp_t3;
+-- result:
+test_join_reorder_times.jrdp_t3	analyze	status	OK
+-- !result
+[UC] analyze table jrdp_t4;
+-- result:
+test_join_reorder_times.jrdp_t4	analyze	status	OK
+-- !result
+set cbo_max_reorder_node_use_exhaustive=3;
+-- result:
+-- !result
+function: assert_query_contains_times("trace times optimizer select * from jrdp_t0 join jrdp_t1 on jrdp_t0.k=jrdp_t1.k join jrdp_t2 on jrdp_t1.k=jrdp_t2.k join jrdp_t3 on jrdp_t2.k=jrdp_t3.k join jrdp_t4 on jrdp_t3.k=jrdp_t4.k","JoinReorderDP", 1)
+-- result:
+None
+-- !result
+function: assert_query_contains_times("trace times optimizer select jrdp_t0.k, sum(jrdp_t4.v) from jrdp_t0 join jrdp_t1 on jrdp_t0.k=jrdp_t1.k join jrdp_t2 on jrdp_t1.k=jrdp_t2.k join jrdp_t3 on jrdp_t2.k=jrdp_t3.k join jrdp_t4 on jrdp_t3.k=jrdp_t4.k group by jrdp_t0.k","JoinReorderDP", 2)
+-- result:
+None
+-- !result
+set cbo_max_reorder_node_use_exhaustive=4;
+-- result:
+-- !result

--- a/test/sql/test_join/T/test_join_reorder_times.sql
+++ b/test/sql/test_join/T/test_join_reorder_times.sql
@@ -1,0 +1,54 @@
+-- name: test_join_reorder_times
+
+drop database if exists test_join_reorder_times;
+create database test_join_reorder_times;
+use test_join_reorder_times;
+create table if not exists jrdp_t0 (k int, v int)
+engine=olap
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+
+create table if not exists jrdp_t1 (k int, v int)
+engine=olap
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+
+create table if not exists jrdp_t2 (k int, v int)
+engine=olap
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+
+create table if not exists jrdp_t3 (k int, v int)
+engine=olap
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+
+create table if not exists jrdp_t4 (k int, v int)
+engine=olap
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+
+insert into jrdp_t0 values (1,10),(2,20),(3,30);
+insert into jrdp_t1 values (1,10),(2,20),(3,30);
+insert into jrdp_t2 values (1,10),(2,20),(3,30);
+insert into jrdp_t3 values (1,10),(2,20),(3,30);
+insert into jrdp_t4 values (1,10),(2,20),(3,30);
+analyze table jrdp_t0;
+analyze table jrdp_t1;
+analyze table jrdp_t2;
+analyze table jrdp_t3;
+analyze table jrdp_t4;
+
+set cbo_max_reorder_node_use_exhaustive=3;
+-- No aggregation: JoinReorderDP should be executed only once.
+function: assert_query_contains_times("trace times optimizer select * from jrdp_t0 join jrdp_t1 on jrdp_t0.k=jrdp_t1.k join jrdp_t2 on jrdp_t1.k=jrdp_t2.k join jrdp_t3 on jrdp_t2.k=jrdp_t3.k join jrdp_t4 on jrdp_t3.k=jrdp_t4.k","JoinReorderDP", 1)
+
+-- With aggregation: pushDownAggregation may reorder once, and memo phase may reorder again -> expect 2.
+function: assert_query_contains_times("trace times optimizer select jrdp_t0.k, sum(jrdp_t4.v) from jrdp_t0 join jrdp_t1 on jrdp_t0.k=jrdp_t1.k join jrdp_t2 on jrdp_t1.k=jrdp_t2.k join jrdp_t3 on jrdp_t2.k=jrdp_t3.k join jrdp_t4 on jrdp_t3.k=jrdp_t4.k group by jrdp_t0.k","JoinReorderDP", 2)
+set cbo_max_reorder_node_use_exhaustive=4;
+


### PR DESCRIPTION
## Why I'm doing:
`pushDownAggregation()` may trigger an extra join reorder before applying aggregate pushdown (to better choose the pushdown position). This extra reorder has a non-trivial cost. When the plan contains **no aggregation**, this reorder (and the aggregate-pushdown context collection) cannot affect the result, so doing it is pure overhead.

## What I'm doing:
Add a short-circuit in `QueryOptimizer.pushDownAggregation()` so that when the logical plan contains **no `LogicalAggregationOperator`**

Aggregation queries keep the original behavior; only the no-aggregation path avoids unnecessary work.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes the logical rewrite pipeline to avoid unnecessary work on non-aggregation queries and adds targeted tests to validate optimizer phase execution counts.
> 
> - In `QueryOptimizer.pushDownAggregation()`, detect presence of `LogicalAggregationOperator` before triggering broadcast-join reorder and `PushDownAggregateRule`; no-op if absent
> - Add `assert_query_contains_times()` in `sr_sql_lib.py` to assert exact occurrence counts in `trace times` output
> - New SQL tests (`test_join_reorder_times.sql`) ensure `JoinReorderDP` runs once without aggregation and twice with aggregation (pushdown stage + memo)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f25116d5fa77ff8b993d86e57caa52383a7a7db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->