### PR TITLE
[Refactor] Transform Job related edit logs to WAL format

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -146,6 +146,21 @@ public abstract class AlterJobV2 implements Writable {
         this.span = TraceManager.startNoopSpan();
     }
 
+    protected AlterJobV2(AlterJobV2 job) {
+        this.type = job.type;
+        this.jobId = job.jobId;
+        this.jobState = job.jobState;
+        this.dbId = job.dbId;
+        this.tableId = job.tableId;
+        this.tableName = job.tableName;
+        this.errMsg = job.errMsg;
+        this.createTimeMs = job.createTimeMs;
+        this.finishedTimeMs = job.finishedTimeMs;
+        this.timeoutMs = job.timeoutMs;
+        this.warehouseId = job.warehouseId;
+        this.computeResource = job.computeResource;
+    }
+
     public long getJobId() {
         return jobId;
     }
@@ -216,6 +231,45 @@ public abstract class AlterJobV2 implements Writable {
 
     public long getWarehouseId() {
         return warehouseId;
+    }
+
+    public abstract AlterJobV2 copyForPersist();
+
+    protected void copyBaseFields(AlterJobV2 copy) {
+        copy.type = this.type;
+        copy.jobId = this.jobId;
+        copy.jobState = this.jobState;
+        copy.dbId = this.dbId;
+        copy.tableId = this.tableId;
+        copy.tableName = this.tableName;
+        copy.errMsg = this.errMsg;
+        copy.createTimeMs = this.createTimeMs;
+        copy.finishedTimeMs = this.finishedTimeMs;
+        copy.timeoutMs = this.timeoutMs;
+        copy.warehouseId = this.warehouseId;
+        copy.computeResource = this.computeResource;
+    }
+
+    public static void persistStateChange(AlterJobV2 job, JobState newState) {
+        persistStateChange(job, newState, false, null);
+    }
+
+    public static void persistStateChange(AlterJobV2 job, JobState newState, Runnable applier) {
+        persistStateChange(job, newState, false, applier);
+    }
+
+    public static void persistStateChange(AlterJobV2 job, JobState newState, boolean pruneMeta, Runnable applier) {
+        AlterJobV2 persistJob = job.copyForPersist();
+        persistJob.setJobState(newState);
+        if (pruneMeta) {
+            persistJob.pruneMeta();
+        }
+        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(persistJob, wal -> {
+            if (applier != null) {
+                applier.run();
+            }
+            job.jobState = newState;
+        });
     }
 
     /**
@@ -420,5 +474,8 @@ public abstract class AlterJobV2 implements Writable {
 
     public Map<Long, MaterializedIndex> getPartitionIdToRollupIndex() {
         return Collections.emptyMap();
+    }
+
+    public void pruneMeta() {
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -67,6 +67,15 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
         this.compactionStrategy = compactionStrategy;
     }
 
+    protected LakeTableAlterMetaJob(LakeTableAlterMetaJob job) {
+        super(job);
+        this.metaType = job.metaType;
+        this.metaValue = job.metaValue;
+        this.persistentIndexType = job.persistentIndexType;
+        this.enableFileBundling = job.enableFileBundling;
+        this.compactionStrategy = job.compactionStrategy;
+    }
+
     @Override
     protected TabletMetadataUpdateAgentTask createTask(PhysicalPartition partition,
             MaterializedIndex index, long nodeId, Set<Long> tablets) {
@@ -126,6 +135,8 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
         this.compactionStrategy = other.compactionStrategy;
     }
 
-
-
+    @Override
+    public AlterJobV2 copyForPersist() {
+        return new LakeTableAlterMetaJob(this);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -83,6 +83,24 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         super(jobId, jobType, dbId, tableId, tableName, timeoutMs);
     }
 
+    protected LakeTableAlterMetaJobBase(LakeTableAlterMetaJobBase job) {
+        super(job);
+        this.watershedTxnId = job.watershedTxnId;
+        this.watershedGtid = job.watershedGtid;
+        if (job.physicalPartitionIndexMap != null) {
+            this.physicalPartitionIndexMap = HashBasedTable.create();
+            this.physicalPartitionIndexMap.putAll(job.physicalPartitionIndexMap);
+        } else {
+            this.physicalPartitionIndexMap = null;
+        }
+        if (job.commitVersionMap != null) {
+            this.commitVersionMap = new HashMap<>();
+            this.commitVersionMap.putAll(job.commitVersionMap);
+        } else {
+            this.commitVersionMap = null;
+        }
+    }
+
     @Override
     protected void runPendingJob() throws AlterCancelException {
         // send task to be
@@ -111,7 +129,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             this.watershedTxnId = globalStateMgr.getGlobalTransactionMgr().getTransactionIDGenerator()
                     .getNextTransactionId();
             this.watershedGtid = globalStateMgr.getGtidGenerator().nextGtid();
-            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
+            persistStateChange(this, this.jobState);
         }
 
         try {
@@ -129,6 +147,15 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
                                                                 MaterializedIndex index, long nodeId, Set<Long> tablets);
 
     protected abstract void updateCatalog(Database db, LakeTable table, boolean isReplay);
+
+    /**
+     * Hook method to prepare data that needs to be persisted before calling persistStateChange.
+     * This method is called before copyForPersist(), so any data created here will be included
+     * in the persisted job.
+     */
+    protected void prepareForPersist(Database db, LakeTable table) {
+        // Default implementation is empty. Subclasses can override this to prepare data.
+    }
 
     protected abstract void restoreState(LakeTableAlterMetaJobBase job);
 
@@ -168,13 +195,13 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
                         commitVersion, jobId);
             }
 
-            this.jobState = JobState.FINISHED_REWRITING;
             this.finishedTimeMs = System.currentTimeMillis();
 
-            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
+            persistStateChange(this, JobState.FINISHED_REWRITING, () -> {
+                // NOTE: !!! below this point, this update meta job must success unless the database or table been dropped. !!!
+                updateNextVersion(table);
+            });
 
-            // NOTE: !!! below this point, this update meta job must success unless the database or table been dropped. !!!
-            updateNextVersion(table);
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
         }
@@ -211,14 +238,15 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
         try {
-            updateCatalog(db, table, false);
-            this.jobState = JobState.FINISHED;
             this.finishedTimeMs = System.currentTimeMillis();
-            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
-            // set visible version
-            updateVisibleVersion(table);
-            table.setState(OlapTable.OlapTableState.NORMAL);
-
+            // Prepare data before persist, so that copyForPersist() can include this data
+            prepareForPersist(db, table);
+            persistStateChange(this, JobState.FINISHED, () -> {
+                updateCatalog(db, table, false);
+                // set visible version
+                updateVisibleVersion(table);
+                table.setState(OlapTable.OlapTableState.NORMAL);
+            });
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
         }
@@ -458,22 +486,31 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
                     // Cancel a job of state `FINISHED_REWRITING` only when the database or table has been dropped.
                     if (jobState == JobState.FINISHED_REWRITING) {
                         return false;
+                    } else {
+                        updateErrorInfo(errMsg);
+                        persistStateChange(this, JobState.CANCELLED, () -> {
+                            table.setState(OlapTable.OlapTableState.NORMAL);
+                        });
                     }
-                    table.setState(OlapTable.OlapTableState.NORMAL);
                 } finally {
                     locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
                 }
             }
         }
+        if (jobState != JobState.CANCELLED) {
+            updateErrorInfo(errMsg);
+            persistStateChange(this, JobState.CANCELLED);
+        }
+        return true;
+    }
+
+    private void updateErrorInfo(String errMsg) {
         if (span != null) {
             span.setStatus(StatusCode.ERROR, errMsg);
             span.end();
         }
-        this.jobState = JobState.CANCELLED;
         this.errMsg = errMsg;
         this.finishedTimeMs = System.currentTimeMillis();
-        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
-        return true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJobBase.java
@@ -53,6 +53,12 @@ public abstract class LakeTableSchemaChangeJobBase extends AlterJobV2 {
         super(jobType);
     }
 
+    protected LakeTableSchemaChangeJobBase(LakeTableSchemaChangeJobBase job) {
+        super(job);
+        this.watershedTxnId = job.watershedTxnId;
+        this.watershedGtid = job.watershedGtid;
+    }
+
     @Nullable
     protected ReadLockedDatabase getReadLockedDatabase(long dbId) {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
@@ -161,8 +167,4 @@ public abstract class LakeTableSchemaChangeJobBase extends AlterJobV2 {
         AgentTaskQueue.addBatchTask(batchTask);
         AgentTaskExecutor.submit(batchTask);
     }
-
-
-
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/MergePartitionJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MergePartitionJob.java
@@ -132,6 +132,26 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
         this.postfix = "job" + jobId;
     }
 
+    protected MergePartitionJob(MergePartitionJob job) {
+        super(job);
+        this.watershedTxnId = job.watershedTxnId;
+        if (job.tempPartitionIdToSourcePartitionIds != null) {
+            this.tempPartitionIdToSourcePartitionIds = ArrayListMultimap.create();
+            this.tempPartitionIdToSourcePartitionIds.putAll(job.tempPartitionIdToSourcePartitionIds);
+        } else {
+            this.tempPartitionIdToSourcePartitionIds = null;
+        }
+        if (job.tempPartitionNameToSourcePartitionNames != null) {
+            this.tempPartitionNameToSourcePartitionNames = ArrayListMultimap.create();
+            this.tempPartitionNameToSourcePartitionNames.putAll(job.tempPartitionNameToSourcePartitionNames);
+        } else {
+            this.tempPartitionNameToSourcePartitionNames = null;
+        }
+        this.rewriteTasks = job.rewriteTasks == null ? null : Lists.newArrayList(job.rewriteTasks);
+        this.distributionInfo = job.distributionInfo;
+        this.optimizeOperation = job.optimizeOperation;
+    }
+
     public List<Long> getTmpPartitionIds() {
         return tempPartitionIdToSourcePartitionIds.keySet().stream().collect(Collectors.toList());
     }
@@ -273,7 +293,6 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
 
             List<String> partitionValues = Lists.newArrayList();
             partitionValues.add(range.lowerEndpoint().getKeys().get(0).getStringValue());
-            String targetPartitionKey = partitionValues.get(0);
 
             Partition sourcePartition = olapTable.getPartition(sourcePartitionId);
             if (sourcePartition == null) {
@@ -392,13 +411,14 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
         // wait previous transactions finished
         this.watershedTxnId =
                     GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
-        this.jobState = JobState.WAITING_TXN;
         span.setAttribute("createPartitionElapse", createPartitionElapse);
         span.setAttribute("watershedTxnId", this.watershedTxnId);
         span.addEvent("setWaitingTxn");
 
         // write edit log
-        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
+        // AddPartitions log will be written when creating temp partitions,
+        // so do not need to add createMergedTempPartitionsFromPartitions into applier.
+        persistStateChange(this, JobState.WAITING_TXN);
         LOG.info("transfer merge partition job {} state to {}, watershed txn_id: {}", jobId, this.jobState, watershedTxnId);
     }
 
@@ -615,10 +635,10 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
         }
 
         this.progress = 100;
-        this.jobState = JobState.FINISHED;
         this.finishedTimeMs = System.currentTimeMillis();
 
-        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
+        // Replace partition log will be written in onFinished function, so do not need to add onFinished into applier.
+        persistStateChange(this, JobState.FINISHED);
         LOG.info("optimize job finished: {}", jobId);
         this.span.end();
     }
@@ -775,16 +795,19 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
         if (jobState.isFinalState()) {
             return false;
         }
-        cancelInternal();
-
-        jobState = JobState.CANCELLED;
         this.errMsg = errMsg;
         this.finishedTimeMs = System.currentTimeMillis();
+        persistStateChange(this, JobState.CANCELLED, this::cancelInternal);
+
         LOG.info("cancel {} job {}, err: {}", this.type, jobId, errMsg);
-        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
         span.setStatus(StatusCode.ERROR, errMsg);
         span.end();
         return true;
+    }
+
+    @Override
+    public AlterJobV2 copyForPersist() {
+        return new MergePartitionJob(this);
     }
 
     private void cancelInternal() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
@@ -132,6 +132,18 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
         this.postfix = "_" + jobId;
     }
 
+    protected OnlineOptimizeJobV2(OnlineOptimizeJobV2 job) {
+        super(job);
+        this.watershedTxnId = job.watershedTxnId;
+        this.tmpPartitionIds = job.tmpPartitionIds == null ? null : Lists.newArrayList(job.tmpPartitionIds);
+        this.rewriteTasks = job.rewriteTasks == null ? null : Lists.newArrayList(job.rewriteTasks);
+        this.sourcePartitionNames = job.sourcePartitionNames == null ? null : Lists.newArrayList(job.sourcePartitionNames);
+        this.tmpPartitionNames = job.tmpPartitionNames == null ? null : Lists.newArrayList(job.tmpPartitionNames);
+        this.allPartitionOptimized = job.allPartitionOptimized;
+        this.distributionInfo = job.distributionInfo;
+        this.optimizeOperation = job.optimizeOperation;
+    }
+
     public List<Long> getTmpPartitionIds() {
         return tmpPartitionIds;
     }
@@ -206,14 +218,14 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
         long createPartitionElapse = System.currentTimeMillis() - createPartitionStartTimestamp;
 
         // wait previous transactions finished
-        this.jobState = JobState.WAITING_TXN;
         this.optimizeOperation = optimizeClause.toString();
         span.setAttribute("createPartitionElapse", createPartitionElapse);
         span.setAttribute("watershedTxnId", this.watershedTxnId);
         span.addEvent("setWaitingTxn");
 
         // write edit log
-        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
+        // createAndAddTempPartitionsForTable will write edit log for creating temp partitions, so do not need to apply here.
+        persistStateChange(this, JobState.WAITING_TXN);
         LOG.info("transfer optimize job {} state to {}, watershed txn_id: {}", jobId, this.jobState, watershedTxnId);
     }
 
@@ -421,10 +433,10 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
         LOG.debug("all insert overwrite tasks finished, optimize job: {}", jobId);
 
         this.progress = 100;
-        this.jobState = JobState.FINISHED;
         this.finishedTimeMs = System.currentTimeMillis();
 
-        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
+        // Replace tmp partitions log with be written in onFinished(), so do not need to apply here.
+        persistStateChange(this, JobState.FINISHED);
         LOG.info("optimize job finished: {}", jobId);
         this.span.end();
     }
@@ -518,16 +530,20 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
         if (jobState.isFinalState()) {
             return false;
         }
-        cancelInternal();
 
-        jobState = JobState.CANCELLED;
         this.errMsg = errMsg;
         this.finishedTimeMs = System.currentTimeMillis();
+        persistStateChange(this, JobState.CANCELLED, this::cancelInternal);
+
         LOG.info("cancel {} job {}, err: {}", this.type, jobId, errMsg);
-        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
         span.setStatus(StatusCode.ERROR, errMsg);
         span.end();
         return true;
+    }
+
+    @Override
+    public AlterJobV2 copyForPersist() {
+        return new OnlineOptimizeJobV2(this);
     }
 
     private void cancelInternal() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2156,18 +2156,16 @@ public class SchemaChangeHandler extends AlterHandler {
             return null;
         }
 
-        // set table state
-        if (schemaChangeJob.getType() == AlterJobV2.JobType.OPTIMIZE) {
-            olapTable.setState(OlapTableState.OPTIMIZE);
-        } else {
-            olapTable.setState(OlapTableState.SCHEMA_CHANGE);
-        }
-
-        // 2. add schemaChangeJob
-        addAlterJobV2(schemaChangeJob);
-
-        // 3. write edit log
-        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(schemaChangeJob);
+        // 2. write edit log
+        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(schemaChangeJob, wal -> {
+            // set table state
+            if (schemaChangeJob.getType() == AlterJobV2.JobType.OPTIMIZE) {
+                olapTable.setState(OlapTableState.OPTIMIZE);
+            } else {
+                olapTable.setState(OlapTableState.SCHEMA_CHANGE);
+            }
+            addAlterJobV2(schemaChangeJob);
+        });
         LOG.info("finished to create schema change job: {}", schemaChangeJob.getJobId());
         return null;
     }
@@ -2274,14 +2272,13 @@ public class SchemaChangeHandler extends AlterHandler {
         if (alterMetaJob == null) {
             return null;
         }
-        // set table state
-        olapTable.setState(OlapTableState.SCHEMA_CHANGE);
 
-        // 2. add schemaChangeJob
-        addAlterJobV2(alterMetaJob);
-
-        // 3. write edit log
-        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(alterMetaJob);
+        // 2. write edit log
+        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(alterMetaJob, wal -> {
+            // set table state
+            olapTable.setState(OlapTableState.SCHEMA_CHANGE);
+            addAlterJobV2(alterMetaJob);
+        });
         LOG.info("finished to create alter meta job {} of cloud table: {}", alterMetaJob.getJobId(),
                 olapTable.getName());
         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -72,8 +72,6 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
-import com.starrocks.journal.JournalTask;
-import com.starrocks.persist.EditLog;
 import com.starrocks.planner.DescriptorTable;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.TupleDescriptor;
@@ -115,6 +113,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -139,31 +138,31 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
     // physical partition id -> (shadow index meta id -> (shadow tablet id -> origin tablet id))
     @SerializedName(value = "partitionIndexTabletMap")
-    private Table<Long, Long, Map<Long, Long>> physicalPartitionIndexTabletMap = HashBasedTable.create();
+    protected Table<Long, Long, Map<Long, Long>> physicalPartitionIndexTabletMap = HashBasedTable.create();
     // physical partition id -> (shadow index meta id -> shadow index))
     @SerializedName(value = "partitionIndexMap")
-    private Table<Long, Long, MaterializedIndex> physicalPartitionIndexMap = HashBasedTable.create();
+    protected Table<Long, Long, MaterializedIndex> physicalPartitionIndexMap = HashBasedTable.create();
     // shadow index meta id -> origin index meta id
     @SerializedName(value = "indexIdMap")
-    private Map<Long, Long> indexMetaIdMap = Maps.newHashMap();
+    protected Map<Long, Long> indexMetaIdMap = Maps.newHashMap();
     // shadow index meta id -> shadow index name(__starrocks_shadow_xxx)
     @SerializedName(value = "indexIdToName")
-    private Map<Long, String> indexMetaIdToName = Maps.newHashMap();
+    protected Map<Long, String> indexMetaIdToName = Maps.newHashMap();
     // shadow index meta id -> index schema
     @SerializedName(value = "indexSchemaMap")
-    private Map<Long, List<Column>> indexMetaIdToSchema = Maps.newHashMap();
+    protected Map<Long, List<Column>> indexMetaIdToSchema = Maps.newHashMap();
     // shadow index meta id -> (shadow index schema version : schema hash)
     @SerializedName(value = "indexSchemaVersionAndHashMap")
-    private Map<Long, SchemaVersionAndHash> indexMetaIdToSchemaVersionAndHash = Maps.newHashMap();
+    protected Map<Long, SchemaVersionAndHash> indexMetaIdToSchemaVersionAndHash = Maps.newHashMap();
     // shadow index meta id -> shadow index short key count
     @SerializedName(value = "indexShortKeyMap")
-    private Map<Long, Short> indexMetaIdToShortKey = Maps.newHashMap();
+    protected Map<Long, Short> indexMetaIdToShortKey = Maps.newHashMap();
 
     // bloom filter info
     @SerializedName(value = "hasBfChange")
     private boolean hasBfChange;
     @SerializedName(value = "bfColumns")
-    private Set<ColumnId> bfColumns = null;
+    protected Set<ColumnId> bfColumns = null;
     @SerializedName(value = "bfFpp")
     private double bfFpp = 0;
 
@@ -171,7 +170,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
     @SerializedName(value = "indexChange")
     private boolean indexChange = false;
     @SerializedName(value = "indexes")
-    private List<Index> indexes = null;
+    protected List<Index> indexes = null;
 
     // The schema change job will wait all transactions before this txn id finished, then send the schema change tasks.
     @SerializedName(value = "watershedTxnId")
@@ -204,6 +203,53 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
     // for deserialization
     private SchemaChangeJobV2() {
         super(JobType.SCHEMA_CHANGE);
+    }
+
+    protected SchemaChangeJobV2(SchemaChangeJobV2 job) {
+        super(job);
+        if (job.physicalPartitionIndexTabletMap != null) {
+            this.physicalPartitionIndexTabletMap = HashBasedTable.create();
+            for (Cell<Long, Long, Map<Long, Long>> cell : job.physicalPartitionIndexTabletMap.cellSet()) {
+                Map<Long, Long> tabletMap = Maps.newHashMap();
+                if (cell.getValue() != null) {
+                    tabletMap.putAll(cell.getValue());
+                }
+                this.physicalPartitionIndexTabletMap.put(cell.getRowKey(), cell.getColumnKey(), tabletMap);
+            }
+        } else {
+            this.physicalPartitionIndexTabletMap = null;
+        }
+        if (job.physicalPartitionIndexMap != null) {
+            this.physicalPartitionIndexMap = HashBasedTable.create();
+            this.physicalPartitionIndexMap.putAll(job.physicalPartitionIndexMap);
+        } else {
+            this.physicalPartitionIndexMap = null;
+        }
+        this.indexMetaIdMap = job.indexMetaIdMap == null ? null : Maps.newHashMap(job.indexMetaIdMap);
+        this.indexMetaIdToName = job.indexMetaIdToName == null ? null : Maps.newHashMap(job.indexMetaIdToName);
+        if (job.indexMetaIdToSchema != null) {
+            this.indexMetaIdToSchema = Maps.newHashMap();
+            for (Map.Entry<Long, List<Column>> entry : job.indexMetaIdToSchema.entrySet()) {
+                List<Column> columns = entry.getValue() == null ? null : new ArrayList<>(entry.getValue());
+                this.indexMetaIdToSchema.put(entry.getKey(), columns);
+            }
+        } else {
+            this.indexMetaIdToSchema = null;
+        }
+        this.indexMetaIdToSchemaVersionAndHash = job.indexMetaIdToSchemaVersionAndHash == null ? null
+                : Maps.newHashMap(job.indexMetaIdToSchemaVersionAndHash);
+        this.indexMetaIdToShortKey = job.indexMetaIdToShortKey == null ? null : Maps.newHashMap(job.indexMetaIdToShortKey);
+        this.hasBfChange = job.hasBfChange;
+        this.bfColumns = job.bfColumns == null ? null : Sets.newHashSet(job.bfColumns);
+        this.bfFpp = job.bfFpp;
+        this.indexChange = job.indexChange;
+        this.indexes = job.indexes == null ? null : new ArrayList<>(job.indexes);
+        this.watershedTxnId = job.watershedTxnId;
+        this.startTime = job.startTime;
+        this.sortKeyIdxes = job.sortKeyIdxes == null ? null : new ArrayList<>(job.sortKeyIdxes);
+        this.sortKeyUniqueIds = job.sortKeyUniqueIds == null ? null : new ArrayList<>(job.sortKeyUniqueIds);
+        this.disableReplicatedStorageForGIN = job.disableReplicatedStorageForGIN;
+        this.historySchema = job.historySchema;
     }
 
     public void addTabletIdMap(long physicalPartitionId, long shadowIdxMetaId, long shadowTabletId, long originTabletId) {
@@ -316,7 +362,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
      * clear some date structure in this job to save memory
      * these data structures must not used in getInfo method
      */
-    private void pruneMeta() {
+    @Override
+    public void pruneMeta() {
         physicalPartitionIndexTabletMap.clear();
         physicalPartitionIndexMap.clear();
         indexMetaIdToSchema.clear();
@@ -483,22 +530,21 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.WRITE);
         try {
             Preconditions.checkState(tbl.getState() == OlapTableState.SCHEMA_CHANGE);
-            addShadowIndexToCatalog(tbl);
-            if (disableReplicatedStorageForGIN) {
-                tbl.setEnableReplicatedStorage(false);
-            }
+            final OlapTable finalTbl = tbl;
+            this.watershedTxnId =
+                    GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
+            persistStateChange(this, JobState.WAITING_TXN, () -> {
+                addShadowIndexToCatalog(finalTbl);
+                if (disableReplicatedStorageForGIN) {
+                    finalTbl.setEnableReplicatedStorage(false);
+                }
+            });
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.WRITE);
         }
 
-        this.watershedTxnId =
-                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
-        this.jobState = JobState.WAITING_TXN;
         span.setAttribute("watershedTxnId", this.watershedTxnId);
         span.addEvent("setWaitingTxn");
-
-        // write edit log
-        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
         LOG.info("transfer schema change job {} state to {}, watershed txn_id: {}", jobId, this.jobState,
                 watershedTxnId);
     }
@@ -788,9 +834,6 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
          * all tasks are finished. check the integrity.
          * we just check whether all new replicas are healthy.
          */
-        EditLog editLog = GlobalStateMgr.getCurrentState().getEditLog();
-        JournalTask journalTask;
-
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.WRITE);
         try {
@@ -837,23 +880,20 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                 }
             } // end for partitions
 
-            // all partitions are good
-            onFinished(tbl);
-
-            // If schema changes include fields which defined in related mv, set those mv state to inactive.
-            AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(tbl, modifiedColumns);
-
-            pruneMeta();
-            tbl.onReload();
-            this.jobState = JobState.FINISHED;
             this.finishedTimeMs = System.currentTimeMillis();
+            // all partitions are good
+            persistStateChange(this, JobState.FINISHED, true, () -> {
+                onFinished(tbl);
+                // If schema changes include fields which defined in related mv, set those mv state to inactive.
+                AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(tbl, modifiedColumns);
 
-            journalTask = editLog.logAlterJobNoWait(this);
+                pruneMeta();
+                tbl.onReload();
+            });
+
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.WRITE);
         }
-
-        EditLog.waitInfinity(journalTask);
 
         LOG.info("schema change job finished: {}", jobId);
         this.span.end();
@@ -1017,13 +1057,13 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             return false;
         }
 
-        cancelInternal();
-
-        pruneMeta();
         this.errMsg = errMsg;
         this.finishedTimeMs = System.currentTimeMillis();
+
+        persistStateChange(this, JobState.CANCELLED, true, this::cancelInternal);
+
+        pruneMeta();
         LOG.info("cancel {} job {}, err: {}", this.type, jobId, errMsg);
-        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
         span.setStatus(StatusCode.ERROR, errMsg);
         span.end();
         return true;
@@ -1067,7 +1107,12 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             }
         }
 
-        jobState = JobState.CANCELLED;
+        // Job state is updated after WAL is persisted.
+    }
+
+    @Override
+    public AlterJobV2 copyForPersist() {
+        return new SchemaChangeJobV2(this);
     }
 
     // Check whether transactions of the given database which txnId is less than 'watershedTxnId' are finished.
@@ -1274,9 +1319,6 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         }
         return taskInfos;
     }
-
-
-
 
     @Override
     public Optional<Long> getTransactionId() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
@@ -177,8 +177,9 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
 
             // Job is done, remove expired job
             if (job.isExpired()) {
-                iterator.remove();
-                GlobalStateMgr.getCurrentState().getEditLog().logRemoveTabletReshardJob(job.getJobId());
+                GlobalStateMgr.getCurrentState().getEditLog().logRemoveTabletReshardJob(job.getJobId(), wal -> {
+                    iterator.remove();
+                });
                 LOG.info("Removed expired tablet reshard job. {}", job);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/AbstractJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/AbstractJob.java
@@ -94,8 +94,6 @@ public abstract class AbstractJob implements Writable {
     // task signature -> <finished num / total num>
     protected Map<Long, Pair<Integer, Integer>> taskProgress = Maps.newConcurrentMap();
 
-    protected boolean isTypeRead = false;
-
     // save err msg of tasks
     @SerializedName(value = "taskErrMsg")
     protected Map<Long, String> taskErrMsg = Maps.newHashMap();
@@ -114,6 +112,20 @@ public abstract class AbstractJob implements Writable {
         this.timeoutMs = timeoutMs;
         this.globalStateMgr = globalStateMgr;
         this.repoId = repoId;
+    }
+
+    protected AbstractJob(AbstractJob job) {
+        this.type = job.type;
+        this.repoId = job.repoId;
+        this.jobId = job.jobId;
+        this.label = job.label;
+        this.dbId = job.dbId;
+        this.dbName = job.dbName;
+        this.status = job.status;
+        this.createTime = job.createTime;
+        this.finishedTime = job.finishedTime;
+        this.timeoutMs = job.timeoutMs;
+        this.taskErrMsg = job.taskErrMsg;
     }
 
     public JobType getType() {
@@ -160,10 +172,6 @@ public abstract class AbstractJob implements Writable {
         return repoId;
     }
 
-    public void setTypeRead(boolean isTypeRead) {
-        this.isTypeRead = isTypeRead;
-    }
-
     public abstract void run();
 
     public abstract Status cancel();
@@ -191,4 +199,3 @@ public abstract class AbstractJob implements Writable {
         return sb.toString();
     }
 }
-

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -547,7 +547,7 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
         // write log
         globalStateMgr.getEditLog().logBackupJob(backupJob, wal -> {
             // must put to dbIdToBackupOrRestoreJob after edit log, otherwise the state of job may be changed.
-            dbIdToBackupOrRestoreJob.put(backupJob.jobId, backupJob);
+            dbIdToBackupOrRestoreJob.put(backupJob.dbId, backupJob);
         });
     }
 
@@ -620,7 +620,7 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
         // write log
         globalStateMgr.getEditLog().logRestoreJob(restoreJob, wal -> {
             // must put to dbIdToBackupOrRestoreJob after edit log, otherwise the state of job may be changed.
-            dbIdToBackupOrRestoreJob.put(restoreJob.jobId, restoreJob);
+            dbIdToBackupOrRestoreJob.put(restoreJob.dbId, restoreJob);
         });
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -538,13 +538,17 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
         }
         backupJob.setBackupCatalogs(backupCatalogs);
 
-        // write log
-        globalStateMgr.getEditLog().logBackupJob(backupJob);
-
-        // must put to dbIdToBackupOrRestoreJob after edit log, otherwise the state of job may be changed.
-        dbIdToBackupOrRestoreJob.put(dbId, backupJob);
+        addBackupJob(backupJob);
 
         LOG.info("finished to submit backup job: {}", backupJob);
+    }
+
+    protected void addBackupJob(BackupJob backupJob) {
+        // write log
+        globalStateMgr.getEditLog().logBackupJob(backupJob, wal -> {
+            // must put to dbIdToBackupOrRestoreJob after edit log, otherwise the state of job may be changed.
+            dbIdToBackupOrRestoreJob.put(backupJob.jobId, backupJob);
+        });
     }
 
     private Catalog getCatalog(String catalogName) throws DdlException {
@@ -582,8 +586,6 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
             checkAndFilterRestoreCatalogsInBackupMeta(stmt, backupMeta);
         }
 
-        // Create a restore job
-        RestoreJob restoreJob = null;
         if (backupMeta != null) {
             for (BackupTableInfo tblInfo : jobInfo.tables.values()) {
                 Table remoteTbl = backupMeta.getTable(tblInfo.name);
@@ -605,15 +607,21 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
             replicationNum = Integer.parseInt(replicationNumProp);
         }
 
-        restoreJob = new RestoreJob(stmt.getLabel(), stmt.getBackupTimestamp(),
+        // Create a restore job
+        RestoreJob  restoreJob = new RestoreJob(stmt.getLabel(), stmt.getBackupTimestamp(),
                 dbId, dbName, jobInfo, stmt.allowLoad(), replicationNum,
                 stmt.getTimeoutMs(), globalStateMgr, repository.getId(), backupMeta, mvRestoreContext);
-        globalStateMgr.getEditLog().logRestoreJob(restoreJob);
-
-        // must put to dbIdToBackupOrRestoreJob after edit log, otherwise the state of job may be changed.
-        dbIdToBackupOrRestoreJob.put(dbId, restoreJob);
+        addRestoreJob(restoreJob);
 
         LOG.info("finished to submit restore job: {}", restoreJob);
+    }
+
+    protected void addRestoreJob(RestoreJob restoreJob) {
+        // write log
+        globalStateMgr.getEditLog().logRestoreJob(restoreJob, wal -> {
+            // must put to dbIdToBackupOrRestoreJob after edit log, otherwise the state of job may be changed.
+            dbIdToBackupOrRestoreJob.put(restoreJob.jobId, restoreJob);
+        });
     }
 
     protected BackupMeta downloadAndDeserializeMetaInfo(BackupJobInfo jobInfo, Repository repo, RestoreStmt stmt) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2383,6 +2383,13 @@ public class OlapTable extends Table {
      */
     public void replaceTempPartitions(long dbId, List<String> partitionNames, List<String> tempPartitionNames,
                                       boolean strictRange, boolean useTempPartitionName) throws DdlException {
+        checkReplaceTempPartitions(partitionNames, tempPartitionNames, strictRange);
+        replaceTempPartitionsWithoutCheck(dbId, partitionNames, tempPartitionNames, useTempPartitionName);
+    }
+
+    public void checkReplaceTempPartitions(List<String> partitionNames,
+                                           List<String> tempPartitionNames,
+                                           boolean strictRange) throws DdlException {
         if (partitionInfo instanceof RangePartitionInfo) {
             RangePartitionInfo rangeInfo = (RangePartitionInfo) partitionInfo;
 
@@ -2439,7 +2446,10 @@ public class OlapTable extends Table {
                 CatalogUtils.checkTempPartitionConflict(partitionList, tempPartitionList, listInfo);
             }
         }
+    }
 
+    public void replaceTempPartitionsWithoutCheck(long dbId, List<String> partitionNames,
+                                                  List<String> tempPartitionNames, boolean useTempPartitionName) {
         // begin to replace
         // 1. drop old partitions
         for (String partitionName : partitionNames) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshot.java
@@ -57,6 +57,17 @@ public class ClusterSnapshot {
         this.starMgrJournalId = starMgrJournalId;
     }
 
+    private ClusterSnapshot(ClusterSnapshot snapshot) {
+        this.id = snapshot.id;
+        this.snapshotName = snapshot.snapshotName;
+        this.type = snapshot.type;
+        this.storageVolumeName = snapshot.storageVolumeName;
+        this.createdTimeMs = snapshot.createdTimeMs;
+        this.finishedTimeMs = snapshot.finishedTimeMs;
+        this.feJournalId = snapshot.feJournalId;
+        this.starMgrJournalId = snapshot.starMgrJournalId;
+    }
+
     public void setJournalIds(long feJournalId, long starMgrJournalId) {
         this.feJournalId = feJournalId;
         this.starMgrJournalId = starMgrJournalId;
@@ -100,6 +111,10 @@ public class ClusterSnapshot {
 
     public void setClusterSnapshotInfo(ClusterSnapshotInfo clusterSnapshotInfo) {
         return;
+    }
+
+    public ClusterSnapshot copyForPersist() {
+        return new ClusterSnapshot(this);
     }
 
     public TClusterSnapshotsItem getInfo() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -161,7 +161,7 @@ public class InsertOverwriteJobRunner {
                 doLoad();
                 break;
             case OVERWRITE_FAILED:
-                gc(false);
+                gc();
                 LOG.warn("insert overwrite job:{} failed. createPartitionElapse:{} ms, insertElapse:{} ms",
                         job.getJobId(), createPartitionElapse, insertElapse);
                 break;
@@ -179,7 +179,7 @@ public class InsertOverwriteJobRunner {
         createTempPartitions();
         prepareInsert();
         executeInsert();
-        doCommit(false);
+        doCommit();
         transferTo(InsertOverwriteJobState.OVERWRITE_SUCCESS);
     }
 
@@ -191,7 +191,7 @@ public class InsertOverwriteJobRunner {
             job.setTxnId(info.getTxnId());
             job.setJobState(OVERWRITE_FAILED);
             LOG.info("replay insert overwrite job:{} to FAILED", job.getJobId());
-            gc(true);
+            replayGC();
             return;
         } else if (job.getJobState() != info.getFromState()) {
             LOG.warn("invalid job info. current state:{}, from state:{}", job.getJobState(), info.getFromState());
@@ -210,7 +210,7 @@ public class InsertOverwriteJobRunner {
                 job.setTmpPartitionIds(info.getTmpPartitionIds());
                 job.setTxnId(info.getTxnId());
                 job.setJobState(InsertOverwriteJobState.OVERWRITE_SUCCESS);
-                doCommit(true);
+                replayCommit();
                 LOG.info("replay insert overwrite job:{} to SUCCESS", job.getJobId());
                 break;
             default:
@@ -272,7 +272,7 @@ public class InsertOverwriteJobRunner {
             InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
                     InsertOverwriteJobState.OVERWRITE_RUNNING, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
                     job.getTmpPartitionIds(), job.getTxnId());
-            GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info);
+            GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info, wal -> {});
         } finally {
             locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
         }
@@ -442,7 +442,7 @@ public class InsertOverwriteJobRunner {
         createPartitionElapse = System.currentTimeMillis() - createPartitionStartTimestamp;
     }
 
-    private void gc(boolean isReplay) {
+    protected void gc() {
         LOG.info("insert overwrite job {} start to garbage collect", job.getJobId());
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
@@ -462,15 +462,15 @@ public class InsertOverwriteJobRunner {
         }
         try {
             Set<Tablet> sourceTablets = Sets.newHashSet();
-
             // Drop temp partitions by partition IDs (for non-dynamic overwrite)
+            List<String> partitionNamesToDrop = new ArrayList<>();
             if (job.getTmpPartitionIds() != null) {
                 for (long pid : job.getTmpPartitionIds()) {
                     LOG.info("drop temp partition:{}", pid);
                     Partition partition = targetTable.getPartition(pid);
                     if (partition != null) {
                         collectTabletsFromPartition(partition, sourceTablets);
-                        targetTable.dropTempPartition(partition.getName(), true);
+                        partitionNamesToDrop.add(partition.getName());
                     } else {
                         LOG.warn("partition {} is null", pid);
                     }
@@ -479,30 +479,42 @@ public class InsertOverwriteJobRunner {
 
             // Drop temp partitions for dynamic overwrite
             if (job.isDynamicOverwrite()) {
-                gcDropDynamicOverwriteTempPartitions(targetTable, sourceTablets, isReplay);
-            }
-
-            if (!isReplay) {
-                // Mark all source tablet ids force delete to drop it directly on BE
-                sourceTablets.forEach(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()::markTabletForceDelete);
-
-                // Abort the transaction if it was created in prepare()
-                if (job.isDynamicOverwrite() && job.getTxnId() > 0) {
-                    try {
-                        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
-                                dbId, job.getTxnId(), "insert overwrite job failed");
-                        LOG.info("dynamic overwrite job {} aborted transaction {}", job.getJobId(), job.getTxnId());
-                    } catch (Exception e) {
-                        LOG.warn("failed to abort transaction {} for dynamic overwrite job {}: {}",
-                                job.getTxnId(), job.getJobId(), e.getMessage());
+                List<String> tmpPartitions = getDynamicOverwriteTempPartitions(targetTable);
+                List<Long> tmpPartitionIds = new ArrayList<>();
+                for (String partitionName : tmpPartitions) {
+                    Partition partition = targetTable.getPartition(partitionName, true);
+                    if (partition != null) {
+                        collectTabletsFromPartition(partition, sourceTablets);
+                        partitionNamesToDrop.add(partitionName);
+                        tmpPartitionIds.add(partition.getId());
                     }
                 }
-
-                InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
-                        OVERWRITE_FAILED, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
-                        job.getTmpPartitionIds(), job.getTxnId());
-                GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info);
+                job.setTmpPartitionIds(tmpPartitionIds);
             }
+
+            // Mark all source tablet ids force delete to drop it directly on BE
+            sourceTablets.forEach(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()::markTabletForceDelete);
+
+            // Abort the transaction if it was created in prepare()
+            if (job.isDynamicOverwrite() && job.getTxnId() > 0) {
+                try {
+                    GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
+                            dbId, job.getTxnId(), "insert overwrite job failed");
+                    LOG.info("dynamic overwrite job {} aborted transaction {}", job.getJobId(), job.getTxnId());
+                } catch (Exception e) {
+                    LOG.warn("failed to abort transaction {} for dynamic overwrite job {}: {}",
+                            job.getTxnId(), job.getJobId(), e.getMessage());
+                }
+            }
+
+            InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
+                    OVERWRITE_FAILED, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
+                    job.getTmpPartitionIds(), job.getTxnId());
+            GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info, wal -> {
+                for (String pName : partitionNamesToDrop) {
+                    targetTable.dropTempPartition(pName, true);
+                }
+            });
         } catch (Exception e) {
             LOG.warn("exception when gc insert overwrite job.", e);
         } finally {
@@ -511,46 +523,37 @@ public class InsertOverwriteJobRunner {
     }
 
     /**
-     * Drop temp partitions for dynamic overwrite during GC.
+     * Get temp partitions for dynamic overwrite during GC.
      * Handles three scenarios:
      * 1. Normal execution: get temp partition names from TransactionState
      * 2. After FE restart: identify temp partitions by prefix "txn{txnId}_"
      * 3. Cancelled before prepare: no temp partitions to clean up
      */
-    private void gcDropDynamicOverwriteTempPartitions(OlapTable targetTable, Set<Tablet> sourceTablets,
-                                                      boolean isReplay) throws InterruptedException {
+    private List<String> getDynamicOverwriteTempPartitions(OlapTable targetTable)
+            throws InterruptedException {
         List<String> tmpPartitionNames = Lists.newArrayList();
-        if (!isReplay) {
-            if (insertStmt != null && job.getTxnId() > 0) {
-                // Normal execution: get temp partition names from TransactionState
-                tmpPartitionNames = gcGetTempPartitionNamesFromTxnState(targetTable);
-            } else if (job.getTxnId() > 0) {
-                // After FE restart: identify temp partitions by prefix "txn{txnId}_"
-                String tempPartitionPrefix = "txn" + job.getTxnId() + "_";
-                tmpPartitionNames = targetTable.getTempPartitions().stream()
-                        .map(Partition::getName)
-                        .filter(name -> name.startsWith(tempPartitionPrefix))
-                        .collect(Collectors.toList());
-                gcUpdateTmpPartitionIds(targetTable, tmpPartitionNames);
-                LOG.info("dynamic overwrite job {} (FE restarted) drop temp partitions with prefix '{}': {}",
-                        job.getJobId(), tempPartitionPrefix, tmpPartitionNames);
-            } else {
-                // Cancelled before prepare: no temp partitions to clean up
-                LOG.info("dynamic overwrite job {} cancelled before prepare phase, no temp partitions to clean up",
-                        job.getJobId());
-            }
+        if (insertStmt != null && job.getTxnId() > 0) {
+            // Normal execution: get temp partition names from TransactionState
+            tmpPartitionNames = getTempPartitionNamesFromTxnState();
+        } else if (job.getTxnId() > 0) {
+            // After FE restart: identify temp partitions by prefix "txn{txnId}_"
+            String tempPartitionPrefix = "txn" + job.getTxnId() + "_";
+            tmpPartitionNames = targetTable.getTempPartitions().stream()
+                    .map(Partition::getName)
+                    .filter(name -> name.startsWith(tempPartitionPrefix))
+                    .collect(Collectors.toList());
+            LOG.info("dynamic overwrite job {} (FE restarted) drop temp partitions with prefix '{}': {}",
+                    job.getJobId(), tempPartitionPrefix, tmpPartitionNames);
+        } else {
+            // Cancelled before prepare: no temp partitions to clean up
+            LOG.info("dynamic overwrite job {} cancelled before prepare phase, no temp partitions to clean up",
+                    job.getJobId());
         }
 
-        for (String partitionName : tmpPartitionNames) {
-            Partition partition = targetTable.getPartition(partitionName, true);
-            if (partition != null) {
-                collectTabletsFromPartition(partition, sourceTablets);
-                targetTable.dropTempPartition(partitionName, true);
-            }
-        }
+        return tmpPartitionNames;
     }
 
-    private List<String> gcGetTempPartitionNamesFromTxnState(OlapTable targetTable) throws InterruptedException {
+    private List<String> getTempPartitionNamesFromTxnState() throws InterruptedException {
         int waitTimes = 10;
         TransactionState txnState = null;
         do {
@@ -563,24 +566,8 @@ public class InsertOverwriteJobRunner {
         } while (txnState.isRunning() && --waitTimes > 0);
 
         List<String> tmpPartitionNames = txnState.getCreatedPartitionNames(tableId);
-        gcUpdateTmpPartitionIds(targetTable, tmpPartitionNames);
         LOG.info("dynamic overwrite job {} drop tmpPartitionNames:{}", job.getJobId(), tmpPartitionNames);
         return tmpPartitionNames;
-    }
-
-    private void gcUpdateTmpPartitionIds(OlapTable targetTable, List<String> partitionNames) {
-        job.setTmpPartitionIds(partitionNames.stream()
-                .map(name -> {
-                    Partition partition = targetTable.getPartition(name, true);
-                    if (partition == null) {
-                        LOG.warn("dynamic overwrite job {} temp partition {} does not exist during gc, skip",
-                                job.getJobId(), name);
-                        return null;
-                    }
-                    return partition.getId();
-                })
-                .filter(id -> id != null)
-                .collect(Collectors.toList()));
     }
 
     private void collectTabletsFromPartition(Partition partition, Set<Tablet> tablets) {
@@ -591,7 +578,38 @@ public class InsertOverwriteJobRunner {
         }
     }
 
-    private void doCommit(boolean isReplay) {
+    protected void replayGC() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+        if (db == null) {
+            return;
+        }
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+        if (table == null) {
+            return;
+        }
+        OlapTable targetTable = (OlapTable) table;
+        Locker locker = new Locker();
+        if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.WRITE)) {
+            return;
+        }
+        try {
+            if (job.getTmpPartitionIds() != null) {
+                for (long pid : job.getTmpPartitionIds()) {
+                    LOG.info("drop temp partition:{}", pid);
+                    Partition partition = targetTable.getPartition(pid);
+                    if (partition != null) {
+                        targetTable.dropTempPartition(partition.getName(), true);
+                    } else {
+                        LOG.warn("partition {} is null", pid);
+                    }
+                }
+            }
+        } finally {
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
+        }
+    }
+
+    protected void doCommit() {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
             throw new DmlException("database id:%s does not exist", dbId);
@@ -656,71 +674,67 @@ public class InsertOverwriteJobRunner {
             PartitionInfo partitionInfo = targetTable.getPartitionInfo();
             if (partitionInfo.isRangePartition() || partitionInfo.getType() == PartitionType.LIST) {
                 if (job.isDynamicOverwrite()) {
-                    if (!isReplay) {
-                        TransactionState txnState = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                                .getTransactionState(dbId, insertStmt.getTxnId());
-                        if (txnState == null) {
-                            throw new DmlException("transaction state is null dbId:%s, txnId:%s", dbId, insertStmt.getTxnId());
+                    TransactionState txnState = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                            .getTransactionState(dbId, insertStmt.getTxnId());
+                    if (txnState == null) {
+                        throw new DmlException("transaction state is null dbId:%s, txnId:%s", dbId, insertStmt.getTxnId());
+                    }
+                    tmpPartitionNames = txnState.getCreatedPartitionNames(tableId);
+
+                    List<Long> dynamicSourcePartitionIds = new ArrayList<>();
+                    for (String tempPartitionName : tmpPartitionNames) {
+                        String oldPartitionName = tempPartitionName.substring(
+                                tempPartitionName.indexOf(AnalyzerUtils.PARTITION_NAME_PREFIX_SPLIT) + 1);
+                        Partition oldPartition = targetTable.getPartition(oldPartitionName, false);
+                        if (oldPartition != null) {
+                            dynamicSourcePartitionIds.add(oldPartition.getId());
                         }
-                        tmpPartitionNames = txnState.getCreatedPartitionNames(tableId);
+                    }
 
-                        List<Long> dynamicSourcePartitionIds = new ArrayList<>();
-                        for (String tempPartitionName : tmpPartitionNames) {
-                            String oldPartitionName = tempPartitionName.substring(
-                                    tempPartitionName.indexOf(AnalyzerUtils.PARTITION_NAME_PREFIX_SPLIT) + 1);
-                            Partition oldPartition = targetTable.getPartition(oldPartitionName, false);
-                            if (oldPartition != null) {
-                                dynamicSourcePartitionIds.add(oldPartition.getId());
-                            }
-                        }
+                    // Collect target partition IDs for stats (the new temp partitions)
+                    List<Long> dynamicTargetPartitionIds = tmpPartitionNames.stream()
+                            .map(name -> {
+                                Partition partition = targetTable.getPartition(name, true);
+                                if (partition == null) {
+                                    throw new DmlException("temp partition %s does not exist", name);
+                                }
+                                return partition.getId();
+                            })
+                            .collect(Collectors.toList());
 
-                        // Collect target partition IDs for stats (the new temp partitions)
-                        List<Long> dynamicTargetPartitionIds = tmpPartitionNames.stream()
-                                .map(name -> {
-                                    Partition partition = targetTable.getPartition(name, true);
-                                    if (partition == null) {
-                                        throw new DmlException("temp partition %s does not exist", name);
-                                    }
-                                    return partition.getId();
-                                })
-                                .collect(Collectors.toList());
+                    job.setTmpPartitionIds(dynamicTargetPartitionIds);
+                    tmpPartitionIds = dynamicTargetPartitionIds;
 
-                        job.setTmpPartitionIds(dynamicTargetPartitionIds);
-                        tmpPartitionIds = dynamicTargetPartitionIds;
+                    if (stats.getSourcePartitionIds().isEmpty()) {
+                        stats.setSourcePartitionIds(dynamicSourcePartitionIds);
+                    }
 
-                        if (stats.getSourcePartitionIds().isEmpty()) {
-                            stats.setSourcePartitionIds(dynamicSourcePartitionIds);
-                        }
+                    if (stats.getTargetPartitionIds().isEmpty()) {
+                        stats.setTargetPartitionIds(dynamicTargetPartitionIds);
+                    }
 
-                        if (stats.getTargetPartitionIds().isEmpty()) {
-                            stats.setTargetPartitionIds(dynamicTargetPartitionIds);
-                        }
-
-                        if (stats.getSourceRows() == 0) {
-                            // Recalculate sumSourceRows for dynamic overwrite
-                            sumSourceRows = dynamicSourcePartitionIds.stream()
-                                    .mapToLong(pid -> targetTable.mayGetPartition(pid).stream()
-                                            .mapToLong(Partition::getRowCount).sum())
-                                    .sum();
-                            stats.setSourceRows(sumSourceRows);
-                        }
+                    if (stats.getSourceRows() == 0) {
+                        // Recalculate sumSourceRows for dynamic overwrite
+                        sumSourceRows = dynamicSourcePartitionIds.stream()
+                                .mapToLong(pid -> targetTable.mayGetPartition(pid).stream()
+                                        .mapToLong(Partition::getRowCount).sum())
+                                .sum();
+                        stats.setSourceRows(sumSourceRows);
                     }
                     LOG.info("dynamic overwrite job {} replace tmpPartitionNames:{}", job.getJobId(), tmpPartitionNames);
                     ensureTempPartitionsVisible(targetTable, tmpPartitionIds);
-                    targetTable.replaceMatchPartitions(dbId, tmpPartitionNames);
                 } else {
                     ensureTempPartitionsVisible(targetTable, tmpPartitionIds);
-                    targetTable.replaceTempPartitions(dbId, sourcePartitionNames, tmpPartitionNames, true, false);
+                    targetTable.checkReplaceTempPartitions(sourcePartitionNames, tmpPartitionNames, true);
                 }
             } else if (partitionInfo instanceof SinglePartitionInfo) {
                 ensureTempPartitionsVisible(targetTable, tmpPartitionIds);
-                targetTable.replacePartition(dbId, sourcePartitionNames.get(0), tmpPartitionNames.get(0));
             } else {
                 throw new DdlException("partition type " + partitionInfo.getType() + " is not supported");
             }
 
             long sumTargetRows = 0;
-            if (insertStmt != null && !isReplay) {
+            if (insertStmt != null) {
                 TransactionState txnState = GlobalStateMgr.getCurrentState()
                         .getGlobalTransactionMgr()
                         .getTransactionState(dbId, insertStmt.getTxnId());
@@ -758,7 +772,7 @@ public class InsertOverwriteJobRunner {
 
             if (sumTargetRows == 0) {
                 LOG.warn("TxnCommitAttachment is null or invalid, fallback to partition.getRowCount() for " +
-                                "table_id={}, partition_ids={}, txn_id={}",
+                        "table_id={}, partition_ids={}, txn_id={}",
                         tableId, job.getTmpPartitionIds(), insertStmt != null ? insertStmt.getTxnId() : "null");
                 sumTargetRows = job.getTmpPartitionIds().stream()
                         .mapToLong(p -> targetTable.mayGetPartition(p).stream().mapToLong(Partition::getRowCount).sum())
@@ -767,26 +781,28 @@ public class InsertOverwriteJobRunner {
 
             stats.setTargetRows(sumTargetRows);
             stats.setPartitionTabletRowCounts(partitionTabletRowCounts);
-            if (!isReplay) {
-                // mark all source tablet ids force delete to drop it directly on BE,
-                // not to move it to trash
-                sourceTablets.forEach(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()::markTabletForceDelete);
+            // mark all source tablet ids force delete to drop it directly on BE,
+            // not to move it to trash
+            sourceTablets.forEach(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()::markTabletForceDelete);
 
-                InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
-                        InsertOverwriteJobState.OVERWRITE_SUCCESS, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
-                        job.getTmpPartitionIds(), job.getTxnId());
-                GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info);
+            InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
+                    InsertOverwriteJobState.OVERWRITE_SUCCESS, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
+                    job.getTmpPartitionIds(), job.getTxnId());
+            final List<String> finalSourcePartitionNames = sourcePartitionNames;
+            final List<String> finalTmpPartitionNames = tmpPartitionNames;
+            GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info, wal -> {
+                replacePartition(targetTable, finalSourcePartitionNames, finalTmpPartitionNames);
+            });
 
-                try {
-                    GlobalStateMgr.getCurrentState().getColocateTableIndex().updateLakeTableColocationInfo(targetTable,
-                            true /* isJoin */, null /* expectGroupId */);
-                } catch (DdlException e) {
-                    // log an error if update colocation info failed, insert overwrite already succeeded
-                    LOG.error("table {} update colocation info failed after insert overwrite, {}.", tableId, e.getMessage());
-                }
-
-                targetTable.lastSchemaUpdateTime.set(System.nanoTime());
+            try {
+                GlobalStateMgr.getCurrentState().getColocateTableIndex().updateLakeTableColocationInfo(targetTable,
+                        true /* isJoin */, null /* expectGroupId */);
+            } catch (DdlException e) {
+                // log an error if update colocation info failed, insert overwrite already succeeded
+                LOG.error("table {} update colocation info failed after insert overwrite, {}.", tableId, e.getMessage());
             }
+
+            targetTable.lastSchemaUpdateTime.set(System.nanoTime());
         } catch (Exception e) {
             LOG.warn("replace partitions failed when insert overwrite into dbId:{}, tableId:{}",
                     job.getTargetDbId(), job.getTargetTableId(), e);
@@ -795,11 +811,44 @@ public class InsertOverwriteJobRunner {
             locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
         }
 
-        if (!isReplay) {
-            // trigger listeners after insert overwrite committed, trigger listeners after
-            // write unlock to avoid holding lock too long
-            GlobalStateMgr.getCurrentState().getOperationListenerBus()
-                    .onInsertOverwriteJobCommitFinish(db, tmpTargetTable, stats);
+        // trigger listeners after insert overwrite committed, trigger listeners after
+        // write unlock to avoid holding lock too long
+        GlobalStateMgr.getCurrentState().getOperationListenerBus()
+                .onInsertOverwriteJobCommitFinish(db, tmpTargetTable, stats);
+    }
+
+    private void replacePartition(OlapTable targetTable,
+                                  List<String> sourcePartitionNames,
+                                  List<String> tmpPartitionNames) {
+        PartitionInfo partitionInfo = targetTable.getPartitionInfo();
+        if (partitionInfo.isRangePartition() || partitionInfo.getType() == PartitionType.LIST) {
+            if (job.isDynamicOverwrite()) {
+                targetTable.replaceMatchPartitions(dbId, tmpPartitionNames);
+            } else {
+                targetTable.replaceTempPartitionsWithoutCheck(dbId, sourcePartitionNames, tmpPartitionNames,  false);
+            }
+        } else {
+            targetTable.replacePartition(dbId, sourcePartitionNames.get(0), tmpPartitionNames.get(0));
+        }
+    }
+
+    protected void replayCommit() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+        if (db == null) {
+            return;
+        }
+        Locker locker = new Locker();
+        if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.WRITE)) {
+            return;
+        }
+        try {
+            final OlapTable targetTable = checkAndGetTable(db, tableId);
+            List<String> tmpPartitionNames = job.getTmpPartitionIds().stream()
+                    .map(partitionId -> targetTable.getPartition(partitionId).getName())
+                    .toList();
+            replacePartition(targetTable, job.getSourcePartitionNames(), tmpPartitionNames);
+        } finally {
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
         }
     }
 
@@ -853,8 +902,8 @@ public class InsertOverwriteJobRunner {
         return (OlapTable) table;
     }
 
-    protected void testDoCommit(boolean isReplay) {
-        doCommit(isReplay);
+    protected void testDoCommit() {
+        doCommit();
     }
 
     protected void ensureTempPartitionsVisible(OlapTable targetTable, List<Long> partitionIds) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -245,7 +245,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                     .add("database_id", dbId)
                     .add("error_msg", "Failed to divide job into loading task.")
                     .build(), e);
-            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_RUN_FAIL, e.getMessage()), true, true);
+            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_RUN_FAIL, e.getMessage()), true);
             return;
         }
     }
@@ -376,7 +376,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                 // record attachment in load job
                 unprotectUpdateLoadingStatus(txnState);
                 // cancel load job
-                unprotectedExecuteCancel(failMsg, true);
+                unprotectedExecuteCancel(failMsg, true, false);
                 return;
             }
 
@@ -389,7 +389,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                 state = JobState.PENDING;
                 unprotectedExecute();
             } catch (Exception e) {
-                cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_RUN_FAIL, e.getMessage()), true, true);
+                cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_RUN_FAIL, e.getMessage()), true);
             }
         } finally {
             writeUnlock();
@@ -500,7 +500,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                     new FailMsg(FailMsg.CancelType.ETL_QUALITY_UNSATISFIED,
                             DataQualityException.QUALITY_FAIL_MSG +
                                     ". You can find detailed error message from running `TrackingSQL`."),
-                    true, true);
+                    true);
             return;
         }
         Database db = null;
@@ -511,7 +511,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                     .add("database_id", dbId)
                     .add("error_msg", "db has been deleted when job is loading")
                     .build(), e);
-            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), true, true);
+            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), true);
             return;
         }
         while (true) {
@@ -522,7 +522,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                 // Sleep and retry.
                 ThreadUtil.sleepAtLeastIgnoreInterrupts(Math.max(e.getAllowCommitTime() - System.currentTimeMillis(), 0));
             } catch (StarRocksException e) {
-                cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), true, true);
+                cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), true);
                 break;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -292,8 +292,7 @@ public abstract class BulkLoadJob extends LoadJob {
             boolean needRetry = isRetryable(failMsg);
             if (!needRetry) {
                 // For not retryable failure, cancel job and return
-                unprotectedExecuteCancel(failMsg, true);
-                logFinalOperation();
+                unprotectedExecuteCancel(failMsg, true, true);
                 return;
             }
         } finally {
@@ -341,7 +340,7 @@ public abstract class BulkLoadJob extends LoadJob {
                     .add("msg", "The failure happens in analyze, the load job will be cancelled with error:"
                             + e.getMessage())
                     .build(), e);
-            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), false, true);
+            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), false);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -582,8 +582,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                 return;
             }
 
-            unprotectedExecuteCancel(new FailMsg(FailMsg.CancelType.TIMEOUT, "loading timeout to cancel"), false);
-            logFinalOperation();
+            unprotectedExecuteCancel(new FailMsg(FailMsg.CancelType.TIMEOUT, "loading timeout to cancel"),
+                    false, true);
         } finally {
             writeUnlock();
         }
@@ -643,13 +643,10 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     }
 
     // if needLog is false, no need to write edit log.
-    public void cancelJobWithoutCheck(FailMsg failMsg, boolean abortTxn, boolean needLog) {
+    public void cancelJobWithoutCheck(FailMsg failMsg, boolean abortTxn) {
         writeLock();
         try {
-            unprotectedExecuteCancel(failMsg, abortTxn);
-            if (needLog) {
-                logFinalOperation();
-            }
+            unprotectedExecuteCancel(failMsg, abortTxn, true);
         } finally {
             writeUnlock();
         }
@@ -676,8 +673,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                 throw new DdlException("Job could not be cancelled when job is finished or cancelled");
             }
 
-            unprotectedExecuteCancel(failMsg, true);
-            logFinalOperation();
+            unprotectedExecuteCancel(failMsg, true, true);
         } finally {
             writeUnlock();
         }
@@ -695,7 +691,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
      * @param failMsg
      * @param abortTxn true: abort txn when cancel job, false: only change the state of job and ignore abort txn
      */
-    protected void unprotectedExecuteCancel(FailMsg failMsg, boolean abortTxn) {
+    protected void unprotectedExecuteCancel(FailMsg failMsg, boolean abortTxn, boolean needLog) {
         LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id).add("transaction_id", transactionId)
                 .add("error_msg", "Failed to execute load with error: " + failMsg.getMsg()).build());
 
@@ -750,7 +746,14 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         }
 
         // change state
-        state = JobState.CANCELLED;
+        if (needLog) {
+            LoadJobFinalOperation operation = new LoadJobFinalOperation(id, loadingStatus,
+                    progress, loadStartTimestamp, finishTimestamp, JobState.CANCELLED, failMsg);
+            GlobalStateMgr.getCurrentState().getEditLog().logEndLoadJob(
+                    operation, wal -> this.state = JobState.CANCELLED);
+        } else {
+            state = JobState.CANCELLED;
+        }
     }
 
     private void executeFinish() {
@@ -780,12 +783,6 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         }
 
         return true;
-    }
-
-    protected void logFinalOperation() {
-        GlobalStateMgr.getCurrentState().getEditLog().logEndLoadJob(
-                new LoadJobFinalOperation(id, loadingStatus, progress, loadStartTimestamp, finishTimestamp,
-                        state, failMsg));
     }
 
     public void unprotectReadEndOperation(LoadJobFinalOperation loadJobFinalOperation, boolean isReplay) {
@@ -1168,7 +1165,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             // record attachment in load job
             unprotectUpdateLoadingStatus(txnState);
             // cancel load job
-            unprotectedExecuteCancel(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, txnStatusChangeReason), false);
+            unprotectedExecuteCancel(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, txnStatusChangeReason),
+                    false, false);
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJobScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJobScheduler.java
@@ -93,14 +93,14 @@ public class LoadJobScheduler extends FrontendDaemon {
                         .build(), e);
                 // transaction not begin, so need not abort
                 loadJob.cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_SUBMIT_FAIL, e.getMessage()),
-                        false, true);
+                        false);
             } catch (LoadException e) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, loadJob.getId())
                         .add("error_msg", "Failed to submit etl job. Job will be cancelled")
                         .build(), e);
                 // transaction already begin, so need abort
                 loadJob.cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_SUBMIT_FAIL, e.getMessage()),
-                        true, true);
+                        true);
             } catch (DuplicatedRequestException e) {
                 // should not happen in load job scheduler, there is no request id.
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, loadJob.getId())
@@ -120,7 +120,7 @@ public class LoadJobScheduler extends FrontendDaemon {
                         .add("error_msg", "Failed to submit etl job. Job queue is full.")
                         .build(), e);
                 loadJob.cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_SUBMIT_FAIL, e.getMessage()),
-                        true, true);
+                        true);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -528,13 +528,13 @@ public class LoadMgr implements MemoryTrackable {
                         LOG.info("update load job etl status failed. job id: {}", job.getId(), e);
                         job.cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_QUALITY_UNSATISFIED,
                                         DataQualityException.QUALITY_FAIL_MSG),
-                                true, true);
+                                true);
                     } catch (TimeoutException e) {
                         // timeout, retry next time
                         LOG.warn("update load job etl status failed. job id: {}", job.getId(), e);
                     } catch (StarRocksException e) {
                         LOG.warn("update load job etl status failed. job id: {}", job.getId(), e);
-                        job.cancelJobWithoutCheck(new FailMsg(CancelType.ETL_RUN_FAIL, e.getMessage()), true, true);
+                        job.cancelJobWithoutCheck(new FailMsg(CancelType.ETL_RUN_FAIL, e.getMessage()), true);
                     } catch (Exception e) {
                         LOG.warn("update load job etl status failed. job id: {}", job.getId(), e);
                     }
@@ -549,7 +549,7 @@ public class LoadMgr implements MemoryTrackable {
                         ((SparkLoadJob) job).updateLoadingStatus();
                     } catch (StarRocksException e) {
                         LOG.warn("update load job loading status failed. job id: {}", job.getId(), e);
-                        job.cancelJobWithoutCheck(new FailMsg(CancelType.LOAD_RUN_FAIL, e.getMessage()), true, true);
+                        job.cancelJobWithoutCheck(new FailMsg(CancelType.LOAD_RUN_FAIL, e.getMessage()), true);
                     } catch (Exception e) {
                         LOG.warn("update load job loading status failed. job id: {}", job.getId(), e);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -1749,8 +1749,8 @@ public class EditLog {
         logJsonObject(OperationType.OP_UPSERT_TRANSACTION_STATE_BATCH, stateBatch);
     }
 
-    public void logBackupJob(BackupJob job) {
-        logJsonObject(OperationType.OP_BACKUP_JOB_V2, job);
+    public void logBackupJob(BackupJob job, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_BACKUP_JOB_V2, job, walApplier);
     }
 
     public void logCreateRepository(Repository repo, WALApplier walApplier) {
@@ -1761,8 +1761,8 @@ public class EditLog {
         logJsonObject(OperationType.OP_DROP_REPOSITORY_V2, new DropRepositoryLog(repoName), walApplier);
     }
 
-    public void logRestoreJob(RestoreJob job) {
-        logJsonObject(OperationType.OP_RESTORE_JOB_V2, job);
+    public void logRestoreJob(RestoreJob job, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_RESTORE_JOB_V2, job, walApplier);
     }
 
     public void logTruncateTable(TruncateTableInfo info, WALApplier walApplier) {
@@ -1833,12 +1833,12 @@ public class EditLog {
         logJsonObject(OperationType.OP_CREATE_LOAD_JOB_V2, loadJob, walApplier);
     }
 
-    public void logEndLoadJob(LoadJobFinalOperation loadJobFinalOperation) {
-        logJsonObject(OperationType.OP_END_LOAD_JOB_V2, loadJobFinalOperation);
+    public void logEndLoadJob(LoadJobFinalOperation loadJobFinalOperation, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_END_LOAD_JOB_V2, loadJobFinalOperation, walApplier);
     }
 
-    public void logUpdateLoadJob(LoadJobStateUpdateInfo info) {
-        logJsonObject(OperationType.OP_UPDATE_LOAD_JOB, info);
+    public void logUpdateLoadJob(LoadJobStateUpdateInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_UPDATE_LOAD_JOB, info, walApplier);
     }
 
     public void logCreateResource(Resource resource, WALApplier walApplier) {
@@ -1861,21 +1861,12 @@ public class EditLog {
         logJsonObject(OperationType.OP_DROP_SMALL_FILE_V2, log, walApplier);
     }
 
-    public void logAlterJob(AlterJobV2 alterJob) {
-        logJsonObject(OperationType.OP_ALTER_JOB_V2, alterJob);
+    public void logAlterJob(AlterJobV2 alterJob, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_ALTER_JOB_V2, alterJob, walApplier);
     }
 
-    public JournalTask logAlterJobNoWait(AlterJobV2 alterJob) {
-        return submitLog(OperationType.OP_ALTER_JOB_V2, new Writable() {
-            @Override
-            public void write(DataOutput out) throws IOException {
-                Text.writeString(out, GsonUtils.GSON.toJson(alterJob));
-            }
-        }, -1);
-    }
-
-    public void logBatchAlterJob(BatchAlterJobPersistInfo batchAlterJobV2) {
-        logJsonObject(OperationType.OP_BATCH_ADD_ROLLUP_V2, batchAlterJobV2);
+    public void logBatchAlterJob(BatchAlterJobPersistInfo batchAlterJobV2, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_BATCH_ADD_ROLLUP_V2, batchAlterJobV2, walApplier);
     }
 
     public void logDynamicPartition(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
@@ -2072,8 +2063,8 @@ public class EditLog {
         logJsonObject(OperationType.OP_CREATE_INSERT_OVERWRITE, info);
     }
 
-    public void logInsertOverwriteStateChange(InsertOverwriteStateChangeInfo info) {
-        logJsonObject(OperationType.OP_INSERT_OVERWRITE_STATE_CHANGE, info);
+    public void logInsertOverwriteStateChange(InsertOverwriteStateChangeInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_INSERT_OVERWRITE_STATE_CHANGE, info, walApplier);
     }
 
     public void logAlterMvStatus(AlterMaterializedViewStatusLog log) {
@@ -2220,14 +2211,14 @@ public class EditLog {
         logJsonObject(OperationType.OP_UPDATE_TABLE_STORAGE_INFOS, tableStorageInfos, walApplier);
     }
 
-    public void logReplicationJob(ReplicationJob replicationJob) {
+    public void logReplicationJob(ReplicationJob replicationJob, WALApplier walApplier) {
         ReplicationJobLog replicationJobLog = new ReplicationJobLog(replicationJob);
-        logJsonObject(OperationType.OP_REPLICATION_JOB, replicationJobLog);
+        logJsonObject(OperationType.OP_REPLICATION_JOB, replicationJobLog, walApplier);
     }
 
-    public void logDeleteReplicationJob(ReplicationJob replicationJob) {
+    public void logDeleteReplicationJob(ReplicationJob replicationJob, WALApplier walApplier) {
         ReplicationJobLog replicationJobLog = new ReplicationJobLog(replicationJob);
-        logJsonObject(OperationType.OP_DELETE_REPLICATION_JOB, replicationJobLog);
+        logJsonObject(OperationType.OP_DELETE_REPLICATION_JOB, replicationJobLog, walApplier);
     }
 
     public void logColumnRename(ColumnRenameInfo columnRenameInfo, WALApplier walApplier) {
@@ -2262,8 +2253,8 @@ public class EditLog {
         logJsonObject(OperationType.OP_RECOVER_PARTITION_VERSION, info, walApplier);
     }
 
-    public void logClusterSnapshotLog(ClusterSnapshotLog info) {
-        logJsonObject(OperationType.OP_CLUSTER_SNAPSHOT_LOG, info);
+    public void logClusterSnapshotLog(ClusterSnapshotLog info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_CLUSTER_SNAPSHOT_LOG, info, walApplier);
     }
 
     public void logCreateSPMBaseline(BaselinePlan.Info info, WALApplier walApplier) {
@@ -2286,8 +2277,8 @@ public class EditLog {
         logJsonObject(OperationType.OP_UPDATE_TABLET_RESHARD_JOB_LOG, job);
     }
 
-    public void logRemoveTabletReshardJob(long jobId) {
-        logJsonObject(OperationType.OP_REMOVE_TABLET_RESHARD_JOB_LOG, new RemoveTabletReshardJobLog(jobId));
+    public void logRemoveTabletReshardJob(long jobId, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_REMOVE_TABLET_RESHARD_JOB_LOG, new RemoveTabletReshardJobLog(jobId), walApplier);
     }
 
     public void logCreateGroupProvider(GroupProviderLog provider, WALApplier walApplier) {

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationMgr.java
@@ -227,15 +227,16 @@ public class ReplicationMgr extends FrontendDaemon {
         }
     }
 
-    private void clearExpiredJobs() {
+    protected void clearExpiredJobs() {
         for (Iterator<Map.Entry<Long, ReplicationJob>> it = committedJobs.entrySet().iterator(); it.hasNext();) {
             ReplicationJob job = it.next().getValue();
             if (!job.isExpired()) {
                 continue;
             }
 
-            GlobalStateMgr.getServingState().getEditLog().logDeleteReplicationJob(job);
-            it.remove();
+            GlobalStateMgr.getServingState().getEditLog().logDeleteReplicationJob(job, wal -> {
+                it.remove();
+            });
         }
 
         for (Iterator<Map.Entry<Long, ReplicationJob>> it = abortedJobs.entrySet().iterator(); it.hasNext();) {
@@ -244,8 +245,9 @@ public class ReplicationMgr extends FrontendDaemon {
                 continue;
             }
 
-            GlobalStateMgr.getServingState().getEditLog().logDeleteReplicationJob(job);
-            it.remove();
+            GlobalStateMgr.getServingState().getEditLog().logDeleteReplicationJob(job, wal -> {
+                it.remove();
+            });
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskQueue.java
@@ -194,7 +194,7 @@ public class AgentTaskQueue {
     // this is just for unit test
     public static synchronized List<AgentTask> getTask(TTaskType type) {
         List<AgentTask> res = Lists.newArrayList();
-        for (Map<Long, AgentTask> agentTasks : tasks.column(TTaskType.ALTER).values()) {
+        for (Map<Long, AgentTask> agentTasks : tasks.column(type).values()) {
             res.addAll(agentTasks.values());
         }
         return res;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterHandlerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterHandlerEditLogTest.java
@@ -192,6 +192,11 @@ public class AlterHandlerEditLogTest {
         public void write(java.io.DataOutput out) throws java.io.IOException {
             // Mock implementation
         }
+
+        @Override
+        public AlterJobV2 copyForPersist() {
+            return new MockAlterJobV2(getJobId(), getType(), getDbId(), getTableId(), getTableName(), getTimeoutMs());
+        }
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2CopyForPersistTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2CopyForPersistTest.java
@@ -1,0 +1,689 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Table;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
+import com.starrocks.catalog.Index;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.RandomDistributionInfo;
+import com.starrocks.catalog.SchemaInfo;
+import com.starrocks.common.SchemaVersionAndHash;
+import com.starrocks.persist.OriginStatementInfo;
+import com.starrocks.sql.ast.IndexDef;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TTabletMetaType;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class AlterJobV2CopyForPersistTest {
+    @Test
+    public void testSchemaChangeJobV2CopyForPersist() throws Exception {
+        SchemaChangeJobV2 job = newSchemaChangeJobV2();
+        SchemaChangeJobV2 copy = (SchemaChangeJobV2) job.copyForPersist();
+        assertCollectionsEqual(job, copy,
+                "physicalPartitionIndexTabletMap",
+                "physicalPartitionIndexMap",
+                "indexMetaIdMap",
+                "indexMetaIdToName",
+                "indexMetaIdToSchema",
+                "indexMetaIdToSchemaVersionAndHash",
+                "indexMetaIdToShortKey",
+                "bfColumns",
+                "indexes",
+                "sortKeyIdxes",
+                "sortKeyUniqueIds");
+        assertFieldsEqual(job, copy,
+                "hasBfChange",
+                "bfFpp",
+                "indexChange",
+                "watershedTxnId",
+                "startTime",
+                "disableReplicatedStorageForGIN",
+                "historySchema");
+        assertCollectionsIndependent(AlterJobV2CopyForPersistTest::newSchemaChangeJobV2,
+                "physicalPartitionIndexTabletMap",
+                "physicalPartitionIndexMap",
+                "indexMetaIdMap",
+                "indexMetaIdToName",
+                "indexMetaIdToSchema",
+                "indexMetaIdToSchemaVersionAndHash",
+                "indexMetaIdToShortKey",
+                "bfColumns",
+                "indexes",
+                "sortKeyIdxes",
+                "sortKeyUniqueIds");
+        assertTableValueMapIndependent(AlterJobV2CopyForPersistTest::newSchemaChangeJobV2,
+                "physicalPartitionIndexTabletMap", 1L, 10L);
+        assertMapValueListIndependent(AlterJobV2CopyForPersistTest::newSchemaChangeJobV2,
+                "indexMetaIdToSchema", 10L);
+    }
+
+    @Test
+    public void testLakeTableSchemaChangeJobCopyForPersist() throws Exception {
+        LakeTableSchemaChangeJob job = newLakeTableSchemaChangeJob();
+        LakeTableSchemaChangeJob copy = (LakeTableSchemaChangeJob) job.copyForPersist();
+        assertCollectionsEqual(job, copy,
+                "physicalPartitionIndexTabletMap",
+                "physicalPartitionIndexMap",
+                "indexMetaIdMap",
+                "indexMetaIdToName",
+                "indexMetaIdToSchema",
+                "indexMetaIdToShortKey",
+                "bfColumns",
+                "indexes",
+                "commitVersionMap",
+                "sortKeyIdxes",
+                "sortKeyUniqueIds");
+        assertFieldsEqual(job, copy,
+                "hasBfChange",
+                "bfFpp",
+                "indexChange",
+                "startTime",
+                "watershedTxnId",
+                "watershedGtid");
+        assertCollectionsIndependent(AlterJobV2CopyForPersistTest::newLakeTableSchemaChangeJob,
+                "physicalPartitionIndexTabletMap",
+                "physicalPartitionIndexMap",
+                "indexMetaIdMap",
+                "indexMetaIdToName",
+                "indexMetaIdToSchema",
+                "indexMetaIdToShortKey",
+                "bfColumns",
+                "indexes",
+                "commitVersionMap",
+                "sortKeyIdxes",
+                "sortKeyUniqueIds");
+        assertTableValueMapIndependent(AlterJobV2CopyForPersistTest::newLakeTableSchemaChangeJob,
+                "physicalPartitionIndexTabletMap", 1L, 10L);
+        assertMapValueListIndependent(AlterJobV2CopyForPersistTest::newLakeTableSchemaChangeJob,
+                "indexMetaIdToSchema", 10L);
+    }
+
+    @Test
+    public void testRollupJobV2CopyForPersist() throws Exception {
+        RollupJobV2 job = newRollupJobV2();
+        RollupJobV2 copy = (RollupJobV2) job.copyForPersist();
+        assertCollectionsEqual(job, copy,
+                "physicalPartitionIdToBaseRollupTabletIdMap",
+                "physicalPartitionIdToRollupIndex",
+                "rollupSchema");
+        assertFieldsEqual(job, copy,
+                "baseIndexMetaId",
+                "rollupIndexMetaId",
+                "baseIndexName",
+                "rollupIndexName",
+                "rollupSchemaVersion",
+                "baseSchemaHash",
+                "rollupSchemaHash",
+                "rollupKeysType",
+                "rollupShortKeyColumnCount",
+                "origStmt",
+                "watershedTxnId",
+                "viewDefineSql",
+                "isColocateMVIndex");
+        assertCollectionsIndependent(AlterJobV2CopyForPersistTest::newRollupJobV2,
+                "physicalPartitionIdToBaseRollupTabletIdMap",
+                "physicalPartitionIdToRollupIndex",
+                "rollupSchema");
+        assertMapValueMapIndependent(AlterJobV2CopyForPersistTest::newRollupJobV2,
+                "physicalPartitionIdToBaseRollupTabletIdMap", 1L);
+    }
+
+    @Test
+    public void testLakeRollupJobCopyForPersist() throws Exception {
+        LakeRollupJob job = newLakeRollupJob();
+        LakeRollupJob copy = (LakeRollupJob) job.copyForPersist();
+        assertCollectionsEqual(job, copy,
+                "commitVersionMap",
+                "physicalPartitionIdToBaseRollupTabletIdMap",
+                "physicalPartitionIdToRollupIndex",
+                "rollupSchema");
+        assertFieldsEqual(job, copy,
+                "baseIndexMetaId",
+                "rollupIndexMetaId",
+                "baseIndexName",
+                "rollupIndexName",
+                "rollupSchemaVersion",
+                "baseSchemaHash",
+                "rollupSchemaHash",
+                "rollupKeysType",
+                "rollupShortKeyColumnCount",
+                "origStmt",
+                "viewDefineSql",
+                "isColocateMVIndex",
+                "watershedTxnId",
+                "watershedGtid");
+        assertCollectionsIndependent(AlterJobV2CopyForPersistTest::newLakeRollupJob,
+                "commitVersionMap",
+                "physicalPartitionIdToBaseRollupTabletIdMap",
+                "physicalPartitionIdToRollupIndex",
+                "rollupSchema");
+        assertMapValueMapIndependent(AlterJobV2CopyForPersistTest::newLakeRollupJob,
+                "physicalPartitionIdToBaseRollupTabletIdMap", 1L);
+    }
+
+    @Test
+    public void testOptimizeJobV2CopyForPersist() throws Exception {
+        OptimizeJobV2 job = newOptimizeJobV2();
+        OptimizeJobV2 copy = (OptimizeJobV2) job.copyForPersist();
+        assertCollectionsEqual(job, copy,
+                "tmpPartitionIds",
+                "rewriteTasks",
+                "sourcePartitionNames",
+                "tmpPartitionNames");
+        assertFieldsEqual(job, copy,
+                "watershedTxnId",
+                "allPartitionOptimized",
+                "distributionInfo",
+                "optimizeOperation");
+        assertCollectionsIndependent(AlterJobV2CopyForPersistTest::newOptimizeJobV2,
+                "tmpPartitionIds",
+                "rewriteTasks",
+                "sourcePartitionNames",
+                "tmpPartitionNames");
+    }
+
+    @Test
+    public void testOnlineOptimizeJobV2CopyForPersist() throws Exception {
+        OnlineOptimizeJobV2 job = newOnlineOptimizeJobV2();
+        OnlineOptimizeJobV2 copy = (OnlineOptimizeJobV2) job.copyForPersist();
+        assertCollectionsEqual(job, copy,
+                "tmpPartitionIds",
+                "rewriteTasks",
+                "sourcePartitionNames",
+                "tmpPartitionNames");
+        assertFieldsEqual(job, copy,
+                "watershedTxnId",
+                "allPartitionOptimized",
+                "distributionInfo",
+                "optimizeOperation");
+        assertCollectionsIndependent(AlterJobV2CopyForPersistTest::newOnlineOptimizeJobV2,
+                "tmpPartitionIds",
+                "rewriteTasks",
+                "sourcePartitionNames",
+                "tmpPartitionNames");
+    }
+
+    @Test
+    public void testMergePartitionJobCopyForPersist() throws Exception {
+        MergePartitionJob job = newMergePartitionJob();
+        MergePartitionJob copy = (MergePartitionJob) job.copyForPersist();
+        assertCollectionsEqual(job, copy,
+                "tempPartitionIdToSourcePartitionIds",
+                "tempPartitionNameToSourcePartitionNames",
+                "rewriteTasks");
+        assertFieldsEqual(job, copy,
+                "watershedTxnId",
+                "distributionInfo",
+                "optimizeOperation");
+        assertCollectionsIndependent(AlterJobV2CopyForPersistTest::newMergePartitionJob,
+                "tempPartitionIdToSourcePartitionIds",
+                "tempPartitionNameToSourcePartitionNames",
+                "rewriteTasks");
+    }
+
+    @Test
+    public void testLakeTableAsyncFastSchemaChangeJobCopyForPersist() throws Exception {
+        LakeTableAsyncFastSchemaChangeJob job = newLakeTableAsyncFastSchemaChangeJob();
+        LakeTableAsyncFastSchemaChangeJob copy = (LakeTableAsyncFastSchemaChangeJob) job.copyForPersist();
+        assertCollectionsEqual(job, copy,
+                "schemaInfos",
+                "physicalPartitionIndexMap",
+                "commitVersionMap");
+        assertFieldsEqual(job, copy,
+                "disableFastSchemaEvolutionV2",
+                "historySchema");
+        assertCollectionsIndependent(AlterJobV2CopyForPersistTest::newLakeTableAsyncFastSchemaChangeJob,
+                "schemaInfos",
+                "physicalPartitionIndexMap",
+                "commitVersionMap");
+    }
+
+    @Test
+    public void testLakeTableAlterMetaJobCopyForPersist() throws Exception {
+        LakeTableAlterMetaJob job = newLakeTableAlterMetaJob();
+        LakeTableAlterMetaJob copy = (LakeTableAlterMetaJob) job.copyForPersist();
+        assertCollectionsEqual(job, copy,
+                "physicalPartitionIndexMap",
+                "commitVersionMap");
+        assertFieldsEqual(job, copy,
+                "metaType",
+                "metaValue",
+                "persistentIndexType",
+                "enableFileBundling",
+                "compactionStrategy");
+        assertCollectionsIndependent(AlterJobV2CopyForPersistTest::newLakeTableAlterMetaJob,
+                "physicalPartitionIndexMap",
+                "commitVersionMap");
+    }
+
+    private static SchemaChangeJobV2 newSchemaChangeJobV2() {
+        SchemaChangeJobV2 job = new SchemaChangeJobV2(1L, 2L, 3L, "tbl", 1000L);
+        populateSchemaChangeJobFields(job, true, false);
+        return job;
+    }
+
+    private static LakeTableSchemaChangeJob newLakeTableSchemaChangeJob() {
+        LakeTableSchemaChangeJob job = new LakeTableSchemaChangeJob();
+        populateSchemaChangeJobFields(job, false, true);
+        setField(job, "watershedGtid", 77L);
+        return job;
+    }
+
+    private static RollupJobV2 newRollupJobV2() {
+        RollupJobV2 job = new RollupJobV2();
+        populateRollupJobFields(job, false);
+        return job;
+    }
+
+    private static LakeRollupJob newLakeRollupJob() {
+        LakeRollupJob job = new LakeRollupJob();
+        populateRollupJobFields(job, true);
+        setField(job, "watershedGtid", 77L);
+        return job;
+    }
+
+    private static OptimizeJobV2 newOptimizeJobV2() {
+        OptimizeJobV2 job = new OptimizeJobV2();
+        populateOptimizeJobFields(job);
+        return job;
+    }
+
+    private static OnlineOptimizeJobV2 newOnlineOptimizeJobV2() {
+        OnlineOptimizeJobV2 job = new OnlineOptimizeJobV2();
+        populateOptimizeJobFields(job);
+        return job;
+    }
+
+    private static MergePartitionJob newMergePartitionJob() {
+        MergePartitionJob job = new MergePartitionJob();
+        populateMergePartitionJobFields(job);
+        return job;
+    }
+
+    private static LakeTableAsyncFastSchemaChangeJob newLakeTableAsyncFastSchemaChangeJob() {
+        LakeTableAsyncFastSchemaChangeJob job = new LakeTableAsyncFastSchemaChangeJob();
+        populateAlterMetaBaseFields(job);
+        List<IndexSchemaInfo> schemaInfos = Lists.newArrayList(
+                new IndexSchemaInfo(1L, "idx1", buildSchemaInfo()));
+        setField(job, "schemaInfos", schemaInfos);
+        setField(job, "disableFastSchemaEvolutionV2", true);
+        setField(job, "historySchema", buildHistorySchema());
+        return job;
+    }
+
+    private static LakeTableAlterMetaJob newLakeTableAlterMetaJob() {
+        LakeTableAlterMetaJob job = new LakeTableAlterMetaJob();
+        populateAlterMetaBaseFields(job);
+        setField(job, "metaType", TTabletMetaType.ENABLE_PERSISTENT_INDEX);
+        setField(job, "metaValue", true);
+        setField(job, "persistentIndexType", "BITMAP");
+        setField(job, "enableFileBundling", true);
+        setField(job, "compactionStrategy", "DEFAULT");
+        return job;
+    }
+
+    private static void populateSchemaChangeJobFields(Object job, boolean includeSchemaVersionMap,
+                                                      boolean includeCommitVersionMap) {
+        Table<Long, Long, Map<Long, Long>> partitionIndexTabletMap = HashBasedTable.create();
+        Map<Long, Long> tabletMap = Maps.newHashMap();
+        tabletMap.put(100L, 200L);
+        partitionIndexTabletMap.put(1L, 10L, tabletMap);
+        setField(job, "physicalPartitionIndexTabletMap", partitionIndexTabletMap);
+
+        Table<Long, Long, MaterializedIndex> partitionIndexMap = HashBasedTable.create();
+        partitionIndexMap.put(1L, 10L, new MaterializedIndex(10L));
+        setField(job, "physicalPartitionIndexMap", partitionIndexMap);
+
+        Map<Long, Long> indexIdMap = Maps.newHashMap();
+        indexIdMap.put(10L, 20L);
+        setField(job, "indexMetaIdMap", indexIdMap);
+
+        Map<Long, String> indexIdToName = Maps.newHashMap();
+        indexIdToName.put(10L, "idx");
+        setField(job, "indexMetaIdToName", indexIdToName);
+
+        Map<Long, List<Column>> indexSchemaMap = Maps.newHashMap();
+        indexSchemaMap.put(10L, Lists.newArrayList(new Column("c1", IntegerType.INT)));
+        setField(job, "indexMetaIdToSchema", indexSchemaMap);
+
+        Map<Long, Short> indexShortKeyMap = Maps.newHashMap();
+        indexShortKeyMap.put(10L, (short) 1);
+        setField(job, "indexMetaIdToShortKey", indexShortKeyMap);
+
+        Set<ColumnId> bfColumns = Sets.newHashSet(ColumnId.create("c1"));
+        setField(job, "bfColumns", bfColumns);
+        setField(job, "hasBfChange", true);
+        setField(job, "bfFpp", 0.12);
+
+        Index index = new Index("idx", Lists.newArrayList(ColumnId.create("c1")), IndexDef.IndexType.BITMAP, "");
+        setField(job, "indexes", Lists.newArrayList(index));
+        setField(job, "indexChange", true);
+        setField(job, "watershedTxnId", 88L);
+        setField(job, "startTime", 1234L);
+
+        setField(job, "sortKeyIdxes", Lists.newArrayList(1));
+        setField(job, "sortKeyUniqueIds", Lists.newArrayList(1001));
+
+        if (includeSchemaVersionMap) {
+            Map<Long, SchemaVersionAndHash> schemaVersionMap = Maps.newHashMap();
+            schemaVersionMap.put(10L, new SchemaVersionAndHash(1, 2));
+            setField(job, "indexMetaIdToSchemaVersionAndHash", schemaVersionMap);
+        }
+
+        if (hasField(job.getClass(), "disableReplicatedStorageForGIN")) {
+            setField(job, "disableReplicatedStorageForGIN", true);
+        }
+        if (hasField(job.getClass(), "historySchema")) {
+            setField(job, "historySchema", buildHistorySchema());
+        }
+
+        if (includeCommitVersionMap) {
+            Map<Long, Long> commitVersionMap = Maps.newHashMap();
+            commitVersionMap.put(1L, 100L);
+            setField(job, "commitVersionMap", commitVersionMap);
+        }
+    }
+
+    private static void populateRollupJobFields(Object job, boolean includeCommitVersionMap) {
+        Map<Long, Map<Long, Long>> baseRollupTabletMap = Maps.newHashMap();
+        Map<Long, Long> innerMap = Maps.newHashMap();
+        innerMap.put(11L, 22L);
+        baseRollupTabletMap.put(1L, innerMap);
+        setField(job, "physicalPartitionIdToBaseRollupTabletIdMap", baseRollupTabletMap);
+
+        Map<Long, MaterializedIndex> rollupIndexMap = Maps.newHashMap();
+        rollupIndexMap.put(1L, new MaterializedIndex(100L));
+        setField(job, "physicalPartitionIdToRollupIndex", rollupIndexMap);
+
+        setField(job, "rollupSchema", Lists.newArrayList(new Column("c1", IntegerType.INT)));
+        setField(job, "baseIndexMetaId", 1001L);
+        setField(job, "rollupIndexMetaId", 1002L);
+        setField(job, "baseIndexName", "base_idx");
+        setField(job, "rollupIndexName", "rollup_idx");
+        setField(job, "rollupSchemaVersion", 3);
+        setField(job, "baseSchemaHash", 4);
+        setField(job, "rollupSchemaHash", 5);
+        setField(job, "rollupKeysType", KeysType.DUP_KEYS);
+        setField(job, "rollupShortKeyColumnCount", (short) 2);
+        setField(job, "origStmt", new OriginStatementInfo("select 1", 0));
+        setField(job, "watershedTxnId", 66L);
+        setField(job, "viewDefineSql", "select 1");
+        setField(job, "isColocateMVIndex", true);
+
+        if (includeCommitVersionMap) {
+            Map<Long, Long> commitVersionMap = Maps.newHashMap();
+            commitVersionMap.put(1L, 100L);
+            setField(job, "commitVersionMap", commitVersionMap);
+        }
+    }
+
+    private static void populateOptimizeJobFields(Object job) {
+        setField(job, "tmpPartitionIds", Lists.newArrayList(1L, 2L));
+        OptimizeTask task = new OptimizeTask("task1");
+        setField(job, "rewriteTasks", Lists.newArrayList(task));
+        setField(job, "sourcePartitionNames", Lists.newArrayList("p1"));
+        setField(job, "tmpPartitionNames", Lists.newArrayList("tmp_p1"));
+        setField(job, "watershedTxnId", 77L);
+        setField(job, "allPartitionOptimized", true);
+        setField(job, "distributionInfo", new RandomDistributionInfo(3));
+        setField(job, "optimizeOperation", "TEST");
+    }
+
+    private static void populateMergePartitionJobFields(Object job) {
+        Multimap<Long, Long> idMapping = ArrayListMultimap.create();
+        idMapping.put(1L, 10L);
+        setField(job, "tempPartitionIdToSourcePartitionIds", idMapping);
+
+        Multimap<String, String> nameMapping = ArrayListMultimap.create();
+        nameMapping.put("tmp_p1", "p1");
+        setField(job, "tempPartitionNameToSourcePartitionNames", nameMapping);
+
+        OptimizeTask task = new OptimizeTask("task1");
+        setField(job, "rewriteTasks", Lists.newArrayList(task));
+        setField(job, "watershedTxnId", 99L);
+        setField(job, "distributionInfo", new RandomDistributionInfo(4));
+        setField(job, "optimizeOperation", "MERGE");
+    }
+
+    private static void populateAlterMetaBaseFields(Object job) {
+        Table<Long, Long, MaterializedIndex> partitionIndexMap = HashBasedTable.create();
+        partitionIndexMap.put(1L, 10L, new MaterializedIndex(10L));
+        setField(job, "physicalPartitionIndexMap", partitionIndexMap);
+
+        Map<Long, Long> commitVersionMap = Maps.newHashMap();
+        commitVersionMap.put(1L, 100L);
+        setField(job, "commitVersionMap", commitVersionMap);
+    }
+
+    private static SchemaInfo buildSchemaInfo() {
+        return SchemaInfo.newBuilder()
+                .setId(1L)
+                .setVersion(1)
+                .setSchemaHash(10)
+                .setKeysType(KeysType.DUP_KEYS)
+                .setShortKeyColumnCount((short) 1)
+                .setStorageType(TStorageType.COLUMN)
+                .addColumn(new Column("c1", IntegerType.INT))
+                .build();
+    }
+
+    private static OlapTableHistorySchema buildHistorySchema() {
+        return OlapTableHistorySchema.newBuilder()
+                .setHistoryTxnIdThreshold(100L)
+                .addIndexSchema(new IndexSchemaInfo(1L, "idx1", buildSchemaInfo()))
+                .build();
+    }
+
+    private static void assertCollectionsEqual(Object original, Object copy, String... fieldNames) throws Exception {
+        for (String fieldName : fieldNames) {
+            Object originalValue = getField(original, fieldName);
+            Object copyValue = getField(copy, fieldName);
+            Assertions.assertEquals(originalValue, copyValue, fieldName);
+        }
+    }
+
+    private static void assertFieldsEqual(Object original, Object copy, String... fieldNames) throws Exception {
+        for (String fieldName : fieldNames) {
+            Object originalValue = getField(original, fieldName);
+            Object copyValue = getField(copy, fieldName);
+            Assertions.assertEquals(originalValue, copyValue, fieldName);
+        }
+    }
+
+    private static boolean hasField(Class<?> type, String fieldName) {
+        Class<?> current = type;
+        while (current != null) {
+            try {
+                current.getDeclaredField(fieldName);
+                return true;
+            } catch (NoSuchFieldException ex) {
+                current = current.getSuperclass();
+            }
+        }
+        return false;
+    }
+
+    private static void assertCollectionsIndependent(Supplier<? extends AlterJobV2> supplier, String... fieldNames)
+            throws Exception {
+        AlterJobV2 job = supplier.get();
+        AlterJobV2 copy = job.copyForPersist();
+        for (String fieldName : fieldNames) {
+            Object copyValue = getField(copy, fieldName);
+            clearCollection(copyValue);
+            Object originalValue = getField(job, fieldName);
+            Assertions.assertTrue(collectionSize(originalValue) > 0, fieldName);
+        }
+
+        AlterJobV2 job2 = supplier.get();
+        AlterJobV2 copy2 = job2.copyForPersist();
+        for (String fieldName : fieldNames) {
+            Object originalValue = getField(job2, fieldName);
+            clearCollection(originalValue);
+            Object copyValue = getField(copy2, fieldName);
+            Assertions.assertTrue(collectionSize(copyValue) > 0, fieldName);
+        }
+    }
+
+    private static void assertTableValueMapIndependent(Supplier<? extends AlterJobV2> supplier, String fieldName,
+                                                       long rowKey, long columnKey) throws Exception {
+        AlterJobV2 job = supplier.get();
+        AlterJobV2 copy = job.copyForPersist();
+        Map<Long, Long> copyMap = getTableValueMap(copy, fieldName, rowKey, columnKey);
+        Map<Long, Long> originalMap = getTableValueMap(job, fieldName, rowKey, columnKey);
+        copyMap.clear();
+        Assertions.assertTrue(collectionSize(originalMap) > 0, fieldName);
+
+        AlterJobV2 job2 = supplier.get();
+        AlterJobV2 copy2 = job2.copyForPersist();
+        Map<Long, Long> copyMap2 = getTableValueMap(copy2, fieldName, rowKey, columnKey);
+        Map<Long, Long> originalMap2 = getTableValueMap(job2, fieldName, rowKey, columnKey);
+        originalMap2.clear();
+        Assertions.assertTrue(collectionSize(copyMap2) > 0, fieldName);
+    }
+
+    private static void assertMapValueMapIndependent(Supplier<? extends AlterJobV2> supplier, String fieldName,
+                                                     long key) throws Exception {
+        AlterJobV2 job = supplier.get();
+        AlterJobV2 copy = job.copyForPersist();
+        Map<Long, Long> copyMap = getMapValueMap(copy, fieldName, key);
+        Map<Long, Long> originalMap = getMapValueMap(job, fieldName, key);
+        copyMap.clear();
+        Assertions.assertTrue(collectionSize(originalMap) > 0, fieldName);
+
+        AlterJobV2 job2 = supplier.get();
+        AlterJobV2 copy2 = job2.copyForPersist();
+        Map<Long, Long> copyMap2 = getMapValueMap(copy2, fieldName, key);
+        Map<Long, Long> originalMap2 = getMapValueMap(job2, fieldName, key);
+        originalMap2.clear();
+        Assertions.assertTrue(collectionSize(copyMap2) > 0, fieldName);
+    }
+
+    private static void assertMapValueListIndependent(Supplier<? extends AlterJobV2> supplier, String fieldName,
+                                                      long key) throws Exception {
+        AlterJobV2 job = supplier.get();
+        AlterJobV2 copy = job.copyForPersist();
+        List<?> copyList = getMapValueList(copy, fieldName, key);
+        List<?> originalList = getMapValueList(job, fieldName, key);
+        copyList.clear();
+        Assertions.assertTrue(collectionSize(originalList) > 0, fieldName);
+
+        AlterJobV2 job2 = supplier.get();
+        AlterJobV2 copy2 = job2.copyForPersist();
+        List<?> copyList2 = getMapValueList(copy2, fieldName, key);
+        List<?> originalList2 = getMapValueList(job2, fieldName, key);
+        originalList2.clear();
+        Assertions.assertTrue(collectionSize(copyList2) > 0, fieldName);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<Long, Long> getTableValueMap(Object job, String fieldName, long rowKey, long columnKey)
+            throws Exception {
+        Table<Long, Long, Map<Long, Long>> table =
+                (Table<Long, Long, Map<Long, Long>>) getField(job, fieldName);
+        return table.get(rowKey, columnKey);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<Long, Long> getMapValueMap(Object job, String fieldName, long key) throws Exception {
+        Map<Long, Map<Long, Long>> map = (Map<Long, Map<Long, Long>>) getField(job, fieldName);
+        return map.get(key);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<?> getMapValueList(Object job, String fieldName, long key) throws Exception {
+        Map<Long, List<?>> map = (Map<Long, List<?>>) getField(job, fieldName);
+        return map.get(key);
+    }
+
+    private static Object getField(Object target, String fieldName) throws Exception {
+        Field field = findField(target.getClass(), fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = findField(target.getClass(), fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new AssertionError("Failed to set field: " + fieldName, e);
+        }
+    }
+
+    private static Field findField(Class<?> type, String fieldName) throws NoSuchFieldException {
+        Class<?> current = type;
+        while (current != null) {
+            try {
+                return current.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException ex) {
+                current = current.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+
+    private static void clearCollection(Object value) {
+        if (value instanceof Table) {
+            ((Table<?, ?, ?>) value).clear();
+        } else if (value instanceof Multimap) {
+            ((Multimap<?, ?>) value).clear();
+        } else if (value instanceof Map) {
+            ((Map<?, ?>) value).clear();
+        } else if (value instanceof List) {
+            ((List<?>) value).clear();
+        } else if (value instanceof Set) {
+            ((Set<?>) value).clear();
+        } else {
+            throw new IllegalArgumentException("Unsupported collection type: " + value);
+        }
+    }
+
+    private static int collectionSize(Object value) {
+        if (value instanceof Table) {
+            return ((Table<?, ?, ?>) value).size();
+        }
+        if (value instanceof Multimap) {
+            return ((Multimap<?, ?>) value).size();
+        }
+        if (value instanceof Map) {
+            return ((Map<?, ?>) value).size();
+        }
+        if (value instanceof List) {
+            return ((List<?>) value).size();
+        }
+        if (value instanceof Set) {
+            return ((Set<?>) value).size();
+        }
+        throw new IllegalArgumentException("Unsupported collection type: " + value);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobEditLogTest.java
@@ -1,0 +1,213 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.Config;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class LakeTableSchemaChangeJobEditLogTest {
+    private static final String DB_NAME = "test_lake_schema_change_editlog";
+    private static final String TABLE_NAME = "tbl";
+
+    private Database db;
+    private OlapTable table;
+    private long dbId;
+    private long tableId;
+    private long partitionId;
+    private long physicalPartitionId;
+    private long tabletId;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        dbId = GlobalStateMgr.getCurrentState().getNextId();
+        tableId = GlobalStateMgr.getCurrentState().getNextId();
+        partitionId = GlobalStateMgr.getCurrentState().getNextId();
+        physicalPartitionId = GlobalStateMgr.getCurrentState().getNextId();
+        tabletId = GlobalStateMgr.getCurrentState().getNextId();
+
+        db = new Database(dbId, DB_NAME);
+        metastore.unprotectCreateDb(db);
+        table = createHashOlapTable(dbId, tableId, TABLE_NAME, partitionId, physicalPartitionId, tabletId);
+        db.registerTableUnlocked(table);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testRunFinishedRewritingJobEditLog() throws Exception {
+        TestLakeTableSchemaChangeJob job = new TestLakeTableSchemaChangeJob(
+                GlobalStateMgr.getCurrentState().getNextId(), dbId, tableId, TABLE_NAME, Config.alter_table_timeout_second);
+        job.setJobState(AlterJobV2.JobState.FINISHED_REWRITING);
+
+        job.runFinishedRewritingJob();
+
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
+        AlterJobV2 loggedJob = (AlterJobV2) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ALTER_JOB_V2);
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED, loggedJob.getJobState());
+        Assertions.assertEquals(job.getJobId(), loggedJob.getJobId());
+    }
+
+    @Test
+    public void testRunFinishedRewritingJobEditLogException() {
+        TestLakeTableSchemaChangeJob job = new TestLakeTableSchemaChangeJob(
+                GlobalStateMgr.getCurrentState().getNextId(), dbId, tableId, TABLE_NAME, Config.alter_table_timeout_second);
+        job.setJobState(AlterJobV2.JobState.FINISHED_REWRITING);
+
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logAlterJob(any(AlterJobV2.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class, job::runFinishedRewritingJob);
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    @Test
+    public void testCancelImplEditLog() throws Exception {
+        TestLakeTableSchemaChangeJob job = new TestLakeTableSchemaChangeJob(
+                GlobalStateMgr.getCurrentState().getNextId(), dbId, tableId, TABLE_NAME, Config.alter_table_timeout_second);
+        job.setJobState(AlterJobV2.JobState.RUNNING);
+
+        Assertions.assertTrue(job.cancelImpl("cancel"));
+        Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
+
+        AlterJobV2 loggedJob = (AlterJobV2) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ALTER_JOB_V2);
+        Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, loggedJob.getJobState());
+        Assertions.assertEquals(job.getJobId(), loggedJob.getJobId());
+    }
+
+    @Test
+    public void testCancelImplEditLogException() {
+        TestLakeTableSchemaChangeJob job = new TestLakeTableSchemaChangeJob(
+                GlobalStateMgr.getCurrentState().getNextId(), dbId, tableId, TABLE_NAME, Config.alter_table_timeout_second);
+        job.setJobState(AlterJobV2.JobState.RUNNING);
+
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logAlterJob(any(AlterJobV2.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                    () -> job.cancelImpl("cancel"));
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    private static OlapTable createHashOlapTable(long dbId, long tableId, String tableName, long partitionId,
+                                                 long physicalPartitionId, long tabletId) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("k1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("k2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(partitionId, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(partitionId, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(1, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(1L, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(tabletId);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, 1L, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(partitionId, physicalPartitionId, tableName, baseIndex, distributionInfo);
+
+        OlapTable olapTable = new OlapTable(tableId, tableName, columns, KeysType.DUP_KEYS,
+                partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(1L, tableName, columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(1L);
+        olapTable.setDefaultDistributionInfo(distributionInfo);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new TableProperty(new HashMap<>()));
+        return olapTable;
+    }
+
+    private static class TestLakeTableSchemaChangeJob extends LakeTableSchemaChangeJob {
+        TestLakeTableSchemaChangeJob(long jobId, long dbId, long tableId, String tableName, long timeoutMs) {
+            super(jobId, dbId, tableId, tableName, timeoutMs);
+        }
+
+        @Override
+        boolean readyToPublishVersion() {
+            return true;
+        }
+
+        @Override
+        protected boolean publishVersion() {
+            return true;
+        }
+
+        @Override
+        List<MaterializedIndex> visualiseShadowIndex(OlapTable table) {
+            return new ArrayList<>();
+        }
+
+        @Override
+        void removeShadowIndex(OlapTable table) {
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/MaterializedViewHandlerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/MaterializedViewHandlerEditLogTest.java
@@ -1,0 +1,214 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.sql.ast.AddRollupClause;
+import com.starrocks.sql.ast.AlterClause;
+import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.system.Backend;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class MaterializedViewHandlerEditLogTest {
+    private static final String DB_NAME = "test_mv_handler_editlog";
+    private static final String TABLE_NAME = "tbl";
+
+    private Database db;
+    private OlapTable table;
+    private ConnectContext connectContext;
+    private long backendId;
+    private long replicaId;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setDatabase(DB_NAME);
+
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        long dbId = GlobalStateMgr.getCurrentState().getNextId();
+        long tableId = GlobalStateMgr.getCurrentState().getNextId();
+        long partitionId = GlobalStateMgr.getCurrentState().getNextId();
+        long physicalPartitionId = GlobalStateMgr.getCurrentState().getNextId();
+        long tabletId = GlobalStateMgr.getCurrentState().getNextId();
+        long indexId = GlobalStateMgr.getCurrentState().getNextId();
+        backendId = GlobalStateMgr.getCurrentState().getNextId();
+        replicaId = GlobalStateMgr.getCurrentState().getNextId();
+
+        db = new Database(dbId, DB_NAME);
+        metastore.unprotectCreateDb(db);
+        if (GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(backendId) == null) {
+            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                    .addBackend(new Backend(backendId, "127.0.0.1", 9050));
+        }
+        table = createHashOlapTable(dbId, tableId, indexId, TABLE_NAME, partitionId, physicalPartitionId, tabletId,
+                backendId, replicaId);
+        db.registerTableUnlocked(table);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testProcessCreateMaterializedViewEditLog() throws Exception {
+        String sql = "create materialized view mv1 as select k1, sum(v1) from " + TABLE_NAME + " group by k1";
+        CreateMaterializedViewStmt stmt = (CreateMaterializedViewStmt) UtFrameUtils
+                .parseStmtWithNewParser(sql, connectContext);
+
+        MaterializedViewHandler handler = new MaterializedViewHandler();
+        handler.processCreateMaterializedView(stmt, db, table);
+
+        Assertions.assertEquals(OlapTable.OlapTableState.ROLLUP, table.getState());
+        AlterJobV2 loggedJob = (AlterJobV2) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ALTER_JOB_V2);
+        Assertions.assertEquals(AlterJobV2.JobState.PENDING, loggedJob.getJobState());
+        Assertions.assertTrue(handler.getAlterJobsV2().containsKey(loggedJob.getJobId()));
+    }
+
+    @Test
+    public void testProcessCreateMaterializedViewEditLogException() throws Exception {
+        String sql = "create materialized view mv2 as select k1, sum(v1) from " + TABLE_NAME + " group by k1";
+        CreateMaterializedViewStmt stmt = (CreateMaterializedViewStmt) UtFrameUtils
+                .parseStmtWithNewParser(sql, connectContext);
+
+        MaterializedViewHandler handler = new MaterializedViewHandler();
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logAlterJob(any(AlterJobV2.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                    () -> handler.processCreateMaterializedView(stmt, db, table));
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+            Assertions.assertTrue(handler.getAlterJobsV2().isEmpty());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    @Test
+    public void testProcessBatchAddRollupEditLog() throws Exception {
+        MaterializedViewHandler handler = new MaterializedViewHandler();
+        AddRollupClause clause = new AddRollupClause("r1", List.of("k1", "v1"), null, TABLE_NAME, null);
+        List<AlterClause> alterClauses = List.of(clause);
+
+        handler.processBatchAddRollup(alterClauses, db, table);
+
+        Assertions.assertEquals(OlapTable.OlapTableState.ROLLUP, table.getState());
+        Assertions.assertEquals(1, handler.getAlterJobsV2().size());
+
+        BatchAlterJobPersistInfo logInfo = (BatchAlterJobPersistInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_BATCH_ADD_ROLLUP_V2);
+        Assertions.assertEquals(1, logInfo.getAlterJobV2List().size());
+        AlterJobV2 loggedJob = logInfo.getAlterJobV2List().get(0);
+        Assertions.assertEquals(AlterJobV2.JobState.PENDING, loggedJob.getJobState());
+        Assertions.assertTrue(handler.getAlterJobsV2().containsKey(loggedJob.getJobId()));
+    }
+
+    @Test
+    public void testProcessBatchAddRollupEditLogException() {
+        MaterializedViewHandler handler = new MaterializedViewHandler();
+        AddRollupClause clause = new AddRollupClause("r2", List.of("k1", "v1"), null, TABLE_NAME, null);
+        List<AlterClause> alterClauses = List.of(clause);
+
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logBatchAlterJob(any(BatchAlterJobPersistInfo.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                    () -> handler.processBatchAddRollup(alterClauses, db, table));
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
+            Assertions.assertTrue(handler.getAlterJobsV2().isEmpty());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    private static OlapTable createHashOlapTable(long dbId, long tableId, long indexId, String tableName,
+                                                 long partitionId, long physicalPartitionId, long tabletId,
+                                                 long backendId, long replicaId) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("k1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("v1", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(partitionId, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(partitionId, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(1, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(tabletId);
+        tablet.addReplica(new com.starrocks.catalog.Replica(replicaId, backendId,
+                com.starrocks.catalog.Replica.ReplicaState.NORMAL, 1, 0), false);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(partitionId, physicalPartitionId, tableName, baseIndex, distributionInfo);
+
+        OlapTable olapTable = new OlapTable(tableId, tableName, columns, KeysType.DUP_KEYS,
+                partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(indexId, tableName, columns, 0, 0, (short) 1,
+                TStorageType.COLUMN, KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(indexId);
+        olapTable.setDefaultDistributionInfo(distributionInfo);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new TableProperty(new HashMap<>()));
+        return olapTable;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2EditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2EditLogTest.java
@@ -1,0 +1,442 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Table;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndex.IndexExtState;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.SchemaVersionAndHash;
+import com.starrocks.persist.OperationType;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.system.Backend;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SchemaChangeJobV2EditLogTest {
+    private static final String DB_NAME = "test_schema_change_job_v2_editlog";
+    private static final String TABLE_NAME = "tbl";
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ConnectContext.remove();
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testRunPendingJobEditLog() throws Exception {
+        TableContext ctx = createTableContext(false, false);
+        SchemaChangeJobV2 job = new TestSchemaChangeJobV2(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                ctx.db.getId(),
+                ctx.table.getId(),
+                ctx.table.getName(),
+                1000L);
+        job.setJobState(AlterJobV2.JobState.PENDING);
+
+        populateJobFields(job, ctx, ctx.shadowIndex);
+        ctx.table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+
+        job.runPendingJob();
+
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, job.getJobState());
+        AlterJobV2 loggedJob = (AlterJobV2) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ALTER_JOB_V2);
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, loggedJob.getJobState());
+        Assertions.assertEquals(job.getJobId(), loggedJob.getJobId());
+    }
+
+    @Test
+    public void testRunPendingJobEditLogException() throws Exception {
+        TableContext ctx = createTableContext(false, false);
+        SchemaChangeJobV2 job = new TestSchemaChangeJobV2(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                ctx.db.getId(),
+                ctx.table.getId(),
+                ctx.table.getName(),
+                1000L);
+        job.setJobState(AlterJobV2.JobState.PENDING);
+
+        populateJobFields(job, ctx, ctx.shadowIndex);
+        ctx.table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+
+        com.starrocks.persist.EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        com.starrocks.persist.EditLog spyEditLog = org.mockito.Mockito.spy(originalEditLog);
+        org.mockito.Mockito.doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logAlterJob(org.mockito.ArgumentMatchers.any(AlterJobV2.class),
+                        org.mockito.ArgumentMatchers.any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class, job::runPendingJob);
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertEquals(AlterJobV2.JobState.PENDING, job.getJobState());
+            PhysicalPartition physicalPartition = ctx.table.getPartition(ctx.partitionId).getDefaultPhysicalPartition();
+            Assertions.assertEquals(0, physicalPartition.getLatestMaterializedIndices(IndexExtState.SHADOW).size());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    @Test
+    public void testRunPendingJobException() {
+        SchemaChangeJobV2 job = new TestSchemaChangeJobV2(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                -1L,
+                -1L,
+                "missing",
+                1000L);
+        job.setJobState(AlterJobV2.JobState.PENDING);
+
+        AlterCancelException exception = Assertions.assertThrows(AlterCancelException.class, job::runPendingJob);
+        Assertions.assertTrue(exception.getMessage().contains("does not exist"));
+    }
+
+    @Test
+    public void testRunRunningJobEditLogAndPruneMeta() throws Exception {
+        TableContext ctx = createTableContext(true, true);
+        SchemaChangeJobV2 job = new SchemaChangeJobV2(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                ctx.db.getId(),
+                ctx.table.getId(),
+                ctx.table.getName(),
+                1000L);
+        job.setJobState(AlterJobV2.JobState.RUNNING);
+
+        populateJobFields(job, ctx, ctx.shadowIndex);
+        ctx.table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+
+        job.runRunningJob();
+
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED, job.getJobState());
+        AlterJobV2 loggedJob = (AlterJobV2) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ALTER_JOB_V2);
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED, loggedJob.getJobState());
+        Assertions.assertEquals(job.getJobId(), loggedJob.getJobId());
+        assertPruned(job);
+    }
+
+    @Test
+    public void testRunRunningJobEditLogException() throws Exception {
+        TableContext ctx = createTableContext(true, true);
+        SchemaChangeJobV2 job = new SchemaChangeJobV2(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                ctx.db.getId(),
+                ctx.table.getId(),
+                ctx.table.getName(),
+                1000L);
+        job.setJobState(AlterJobV2.JobState.RUNNING);
+
+        populateJobFields(job, ctx, ctx.shadowIndex);
+        ctx.table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+
+        com.starrocks.persist.EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        com.starrocks.persist.EditLog spyEditLog = org.mockito.Mockito.spy(originalEditLog);
+        org.mockito.Mockito.doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logAlterJob(org.mockito.ArgumentMatchers.any(AlterJobV2.class),
+                        org.mockito.ArgumentMatchers.any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class, job::runRunningJob);
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
+            Assertions.assertFalse(job.physicalPartitionIndexMap.isEmpty());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    @Test
+    public void testRunRunningJobException() throws Exception {
+        TableContext ctx = createTableContext(true, true);
+        SchemaChangeJobV2 job = new SchemaChangeJobV2(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                ctx.db.getId(),
+                ctx.table.getId(),
+                ctx.table.getName(),
+                1000L);
+        job.setJobState(AlterJobV2.JobState.RUNNING);
+
+        populateJobFields(job, ctx, ctx.shadowIndex);
+        ctx.db.dropTable(ctx.table.getId());
+
+        AlterCancelException exception = Assertions.assertThrows(AlterCancelException.class, job::runRunningJob);
+        Assertions.assertTrue(exception.getMessage().contains("does not exist"));
+    }
+
+    @Test
+    public void testCancelImplEditLogAndPruneMeta() throws Exception {
+        TableContext ctx = createTableContext(true, true);
+        SchemaChangeJobV2 job = new SchemaChangeJobV2(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                ctx.db.getId(),
+                ctx.table.getId(),
+                ctx.table.getName(),
+                1000L);
+        job.setJobState(AlterJobV2.JobState.RUNNING);
+
+        populateJobFields(job, ctx, ctx.shadowIndex);
+        ctx.table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+
+        Assertions.assertTrue(job.cancelImpl("cancel"));
+        Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, job.getJobState());
+
+        AlterJobV2 loggedJob = (AlterJobV2) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ALTER_JOB_V2);
+        Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, loggedJob.getJobState());
+        Assertions.assertEquals(job.getJobId(), loggedJob.getJobId());
+        assertPruned(job);
+    }
+
+    @Test
+    public void testCancelImplException() throws Exception {
+        TableContext ctx = createTableContext(true, true);
+        SchemaChangeJobV2 job = new SchemaChangeJobV2(
+                GlobalStateMgr.getCurrentState().getNextId(),
+                ctx.db.getId(),
+                ctx.table.getId(),
+                ctx.table.getName(),
+                1000L);
+        job.setJobState(AlterJobV2.JobState.RUNNING);
+
+        com.starrocks.persist.EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        com.starrocks.persist.EditLog spyEditLog = org.mockito.Mockito.spy(originalEditLog);
+        org.mockito.Mockito.doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logAlterJob(org.mockito.ArgumentMatchers.any(AlterJobV2.class),
+                        org.mockito.ArgumentMatchers.any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> job.cancelImpl("cancel"));
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertEquals(AlterJobV2.JobState.RUNNING, job.getJobState());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    private static void populateJobFields(SchemaChangeJobV2 job, TableContext ctx, MaterializedIndex shadowIndex)
+            throws Exception {
+        Table<Long, Long, MaterializedIndex> partitionIndexMap = HashBasedTable.create();
+        partitionIndexMap.put(ctx.physicalPartitionId, ctx.shadowIndexId, shadowIndex);
+        job.physicalPartitionIndexMap = partitionIndexMap;
+
+        Table<Long, Long, Map<Long, Long>> partitionIndexTabletMap = HashBasedTable.create();
+        Map<Long, Long> tabletMap = new HashMap<>();
+        tabletMap.put(ctx.shadowTabletId, ctx.baseTabletId);
+        partitionIndexTabletMap.put(ctx.physicalPartitionId, ctx.shadowIndexId, tabletMap);
+        job.physicalPartitionIndexTabletMap = partitionIndexTabletMap;
+
+        Map<Long, Long> indexMetaIdMap = Maps.newHashMap();
+        indexMetaIdMap.put(ctx.shadowIndexId, ctx.baseIndexId);
+        job.indexMetaIdMap = indexMetaIdMap;
+
+        Map<Long, String> indexMetaIdToName = Maps.newHashMap();
+        indexMetaIdToName.put(ctx.shadowIndexId, ctx.shadowIndexName);
+        job.indexMetaIdToName = indexMetaIdToName;
+
+        Map<Long, List<Column>> indexMetaIdToSchema = Maps.newHashMap();
+        indexMetaIdToSchema.put(ctx.shadowIndexId, ctx.table.getBaseSchema());
+        job.indexMetaIdToSchema = indexMetaIdToSchema;
+
+        Map<Long, SchemaVersionAndHash> schemaVersionMap = Maps.newHashMap();
+        schemaVersionMap.put(ctx.shadowIndexId, new SchemaVersionAndHash(ctx.schemaVersion, ctx.schemaHash));
+        job.indexMetaIdToSchemaVersionAndHash = schemaVersionMap;
+
+        Map<Long, Short> shortKeyMap = Maps.newHashMap();
+        shortKeyMap.put(ctx.shadowIndexId, (short) 1);
+        job.indexMetaIdToShortKey = shortKeyMap;
+
+        job.indexes = Lists.newArrayList();
+        job.bfColumns = java.util.Collections.emptySet();
+    }
+
+    private static void assertPruned(SchemaChangeJobV2 job) throws Exception {
+        Assertions.assertTrue(job.physicalPartitionIndexTabletMap.isEmpty());
+        Assertions.assertTrue(job.physicalPartitionIndexMap.isEmpty());
+        Assertions.assertTrue(job.indexMetaIdToSchema.isEmpty());
+        Assertions.assertTrue(job.indexMetaIdToShortKey.isEmpty());
+    }
+
+    private static TableContext createTableContext(boolean addShadowIndexToTable, boolean shadowHasReplica) {
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        long dbId = GlobalStateMgr.getCurrentState().getNextId();
+        long tableId = GlobalStateMgr.getCurrentState().getNextId();
+        long partitionId = GlobalStateMgr.getCurrentState().getNextId();
+        long physicalPartitionId = GlobalStateMgr.getCurrentState().getNextId();
+        long baseIndexId = GlobalStateMgr.getCurrentState().getNextId();
+        long baseTabletId = GlobalStateMgr.getCurrentState().getNextId();
+        long backendId = GlobalStateMgr.getCurrentState().getNextId();
+        long replicaId = GlobalStateMgr.getCurrentState().getNextId();
+        long shadowIndexId = GlobalStateMgr.getCurrentState().getNextId();
+        long shadowTabletId = GlobalStateMgr.getCurrentState().getNextId();
+        long shadowReplicaId = GlobalStateMgr.getCurrentState().getNextId();
+
+        Database db = new Database(dbId, DB_NAME);
+        metastore.unprotectCreateDb(db);
+        Backend backend = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(backendId);
+        if (backend == null) {
+            backend = new Backend(backendId, "127.0.0.1", 9050);
+            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().addBackend(backend);
+        }
+        backend.setAlive(true);
+
+        OlapTable table = createHashOlapTable(dbId, tableId, baseIndexId, baseTabletId,
+                backendId, replicaId, partitionId, physicalPartitionId);
+        db.registerTableUnlocked(table);
+
+        MaterializedIndex shadowIndex = new MaterializedIndex(shadowIndexId, MaterializedIndex.IndexState.SHADOW);
+        LocalTablet shadowTablet = new LocalTablet(shadowTabletId);
+        if (shadowHasReplica) {
+            shadowTablet.addReplica(new com.starrocks.catalog.Replica(shadowReplicaId, backendId,
+                    com.starrocks.catalog.Replica.ReplicaState.NORMAL, 1, 0), false);
+        }
+        TabletMeta shadowTabletMeta = new TabletMeta(dbId, tableId, partitionId, shadowIndexId, TStorageMedium.HDD);
+        shadowIndex.addTablet(shadowTablet, shadowTabletMeta);
+
+        if (addShadowIndexToTable) {
+            PhysicalPartition physicalPartition = table.getPartition(partitionId).getDefaultPhysicalPartition();
+            physicalPartition.createRollupIndex(shadowIndex);
+            table.setIndexMeta(shadowIndexId, shadowIndexName(), table.getBaseSchema(),
+                    1, 1, (short) 1, TStorageType.COLUMN, table.getKeysType());
+        }
+
+        return new TableContext(db, table, partitionId, physicalPartitionId, baseIndexId, baseTabletId,
+                shadowIndexId, shadowTabletId, shadowIndex, backendId, replicaId, shadowReplicaId, 1, 1);
+    }
+
+    private static String shadowIndexName() {
+        return SchemaChangeHandler.SHADOW_NAME_PREFIX + TABLE_NAME;
+    }
+
+    private static OlapTable createHashOlapTable(long dbId, long tableId, long indexId, long tabletId,
+                                                 long backendId, long replicaId, long partitionId,
+                                                 long physicalPartitionId) {
+        List<Column> columns = Lists.newArrayList();
+        Column col1 = new Column("k1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("v1", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(partitionId, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(partitionId, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(1, Lists.newArrayList(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(tabletId);
+        tablet.addReplica(new com.starrocks.catalog.Replica(replicaId, backendId,
+                com.starrocks.catalog.Replica.ReplicaState.NORMAL, 1, 0), false);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(partitionId, physicalPartitionId, "p1", baseIndex, distributionInfo);
+
+        OlapTable olapTable = new OlapTable(tableId, TABLE_NAME, columns, com.starrocks.sql.ast.KeysType.DUP_KEYS,
+                partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(indexId, TABLE_NAME, columns, 1, 1, (short) 1,
+                TStorageType.COLUMN, com.starrocks.sql.ast.KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(indexId);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new TableProperty(new HashMap<>()));
+
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(tabletId, tabletMeta);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addReplica(tabletId, tablet.getReplicaByBackendId(backendId));
+        return olapTable;
+    }
+
+    private static class TableContext {
+        private final Database db;
+        private final OlapTable table;
+        private final long partitionId;
+        private final long physicalPartitionId;
+        private final long baseIndexId;
+        private final long baseTabletId;
+        private final long shadowIndexId;
+        private final long shadowTabletId;
+        private final MaterializedIndex shadowIndex;
+        private final long backendId;
+        private final long replicaId;
+        private final long shadowReplicaId;
+        private final int schemaVersion;
+        private final int schemaHash;
+        private final String shadowIndexName;
+
+        private TableContext(Database db, OlapTable table, long partitionId, long physicalPartitionId,
+                             long baseIndexId, long baseTabletId, long shadowIndexId, long shadowTabletId,
+                             MaterializedIndex shadowIndex, long backendId, long replicaId, long shadowReplicaId,
+                             int schemaVersion, int schemaHash) {
+            this.db = db;
+            this.table = table;
+            this.partitionId = partitionId;
+            this.physicalPartitionId = physicalPartitionId;
+            this.baseIndexId = baseIndexId;
+            this.baseTabletId = baseTabletId;
+            this.shadowIndexId = shadowIndexId;
+            this.shadowTabletId = shadowTabletId;
+            this.shadowIndex = shadowIndex;
+            this.backendId = backendId;
+            this.replicaId = replicaId;
+            this.shadowReplicaId = shadowReplicaId;
+            this.schemaVersion = schemaVersion;
+            this.schemaHash = schemaHash;
+            this.shadowIndexName = shadowIndexName();
+        }
+    }
+
+    private static class TestSchemaChangeJobV2 extends SchemaChangeJobV2 {
+        TestSchemaChangeJobV2(long jobId, long dbId, long tableId, String tableName, long timeoutMs) {
+            super(jobId, dbId, tableId, tableName, timeoutMs);
+        }
+
+        @Override
+        protected boolean checkTableStable(Database db) {
+            return true;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/lake/AlterJobV2HookTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/lake/AlterJobV2HookTest.java
@@ -89,6 +89,13 @@ public class AlterJobV2HookTest {
         }
 
         @Override
+        public AlterJobV2 copyForPersist() {
+            MockedAlterJobV2 copy = new MockedAlterJobV2(this.type);
+            copyBaseFields(copy);
+            return copy;
+        }
+
+        @Override
         public void write(DataOutput out) throws IOException {
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerEditLogTest.java
@@ -1,0 +1,139 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.backup;
+
+import com.starrocks.backup.mv.MvRestoreContext;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class BackupHandlerEditLogTest {
+    private static final long DB_ID = 10001L;
+    private static final String DB_NAME = "test_db";
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testAddBackupJobEditLogAndReplay() throws Exception {
+        BackupHandler handler = new BackupHandler(GlobalStateMgr.getCurrentState());
+        BackupJob job = createBackupJob("backup_label");
+
+        handler.addBackupJob(job);
+        Assertions.assertSame(job, handler.dbIdToBackupOrRestoreJob.get(job.getJobId()));
+
+        BackupJob logJob = (BackupJob) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_BACKUP_JOB_V2);
+        Assertions.assertEquals(job.getJobId(), logJob.getJobId());
+        Assertions.assertEquals(job.getLabel(), logJob.getLabel());
+
+        BackupHandler follower = new BackupHandler(GlobalStateMgr.getCurrentState());
+        follower.replayAddJob(logJob);
+        Assertions.assertEquals(logJob.getJobId(),
+                follower.dbIdToBackupOrRestoreJob.get(logJob.getDbId()).getJobId());
+    }
+
+    @Test
+    public void testAddRestoreJobEditLogAndReplay() throws Exception {
+        BackupHandler handler = new BackupHandler(GlobalStateMgr.getCurrentState());
+        RestoreJob job = createRestoreJob("restore_label");
+
+        handler.addRestoreJob(job);
+        Assertions.assertSame(job, handler.dbIdToBackupOrRestoreJob.get(job.getJobId()));
+
+        RestoreJob logJob = (RestoreJob) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_RESTORE_JOB_V2);
+        Assertions.assertEquals(job.getJobId(), logJob.getJobId());
+        Assertions.assertEquals(job.getLabel(), logJob.getLabel());
+
+        BackupHandler follower = new BackupHandler(GlobalStateMgr.getCurrentState());
+        follower.replayAddJob(logJob);
+        Assertions.assertEquals(logJob.getJobId(),
+                follower.dbIdToBackupOrRestoreJob.get(logJob.getDbId()).getJobId());
+    }
+
+    @Test
+    public void testAddBackupJobEditLogException() {
+        BackupHandler handler = new BackupHandler(GlobalStateMgr.getCurrentState());
+        BackupJob job = createBackupJob("backup_exception");
+
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logBackupJob(any(BackupJob.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                    () -> handler.addBackupJob(job));
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertTrue(handler.dbIdToBackupOrRestoreJob.isEmpty());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    @Test
+    public void testAddRestoreJobEditLogException() {
+        BackupHandler handler = new BackupHandler(GlobalStateMgr.getCurrentState());
+        RestoreJob job = createRestoreJob("restore_exception");
+
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logRestoreJob(any(RestoreJob.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                    () -> handler.addRestoreJob(job));
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertTrue(handler.dbIdToBackupOrRestoreJob.isEmpty());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    private static BackupJob createBackupJob(String label) {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        return new BackupJob(label, DB_ID, DB_NAME, new ArrayList<>(), 1000L, globalStateMgr, 1L);
+    }
+
+    private static RestoreJob createRestoreJob(String label) {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        BackupJobInfo jobInfo = new BackupJobInfo();
+        BackupMeta backupMeta = new BackupMeta(new ArrayList<>());
+        return new RestoreJob(label, "backup_ts", DB_ID, DB_NAME, jobInfo, false, 3, 1000L,
+                globalStateMgr, 1L, backupMeta, new MvRestoreContext());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerEditLogTest.java
@@ -50,7 +50,7 @@ public class BackupHandlerEditLogTest {
         BackupJob job = createBackupJob("backup_label");
 
         handler.addBackupJob(job);
-        Assertions.assertSame(job, handler.dbIdToBackupOrRestoreJob.get(job.getJobId()));
+        Assertions.assertSame(job, handler.dbIdToBackupOrRestoreJob.get(DB_ID));
 
         BackupJob logJob = (BackupJob) UtFrameUtils.PseudoJournalReplayer
                 .replayNextJournal(OperationType.OP_BACKUP_JOB_V2);
@@ -69,7 +69,7 @@ public class BackupHandlerEditLogTest {
         RestoreJob job = createRestoreJob("restore_label");
 
         handler.addRestoreJob(job);
-        Assertions.assertSame(job, handler.dbIdToBackupOrRestoreJob.get(job.getJobId()));
+        Assertions.assertSame(job, handler.dbIdToBackupOrRestoreJob.get(DB_ID));
 
         RestoreJob logJob = (RestoreJob) UtFrameUtils.PseudoJournalReplayer
                 .replayNextJournal(OperationType.OP_RESTORE_JOB_V2);

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
@@ -28,7 +28,6 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.UnitTestUtil;
 import com.starrocks.metric.MetricRepo;
-import com.starrocks.persist.EditLog;
 import com.starrocks.persist.TableRefPersist;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.KeysType;
@@ -43,12 +42,12 @@ import com.starrocks.thrift.TFinishTaskRequest;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTaskType;
-import mockit.Delegate;
+import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -87,9 +86,6 @@ public class BackupJobMaterializedViewTest {
 
     private static List<Path> pathsNeedToBeDeleted = Lists.newArrayList();
 
-    @Mocked
-    private GlobalStateMgr globalStateMgr;
-
     private MockBackupHandler backupHandler;
 
     private MockRepositoryMgr repoMgr;
@@ -118,9 +114,6 @@ public class BackupJobMaterializedViewTest {
         }
     }
 
-    @Mocked
-    private EditLog editLog;
-
     private Repository repo = new Repository(repoId, "repo", false, "my_repo",
                 new BlobStorage("broker", Maps.newHashMap()));
 
@@ -148,7 +141,8 @@ public class BackupJobMaterializedViewTest {
 
     @BeforeEach
     public void setUp() {
-
+        UtFrameUtils.setUpForPersistTest();
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         repoMgr = new MockRepositoryMgr();
         backupHandler = new MockBackupHandler(globalStateMgr);
 
@@ -158,41 +152,7 @@ public class BackupJobMaterializedViewTest {
         db = UnitTestUtil.createDbWithMaterializedView(dbId, tblId, partId, idxId, tabletId,
                     backendId, version, KeysType.DUP_KEYS);
 
-        new Expectations(globalStateMgr) {
-            {
-                globalStateMgr.getLocalMetastore().getDb(anyLong);
-                minTimes = 0;
-                result = db;
-
-                globalStateMgr.getNextId();
-                minTimes = 0;
-                result = id.getAndIncrement();
-
-                globalStateMgr.getEditLog();
-                minTimes = 0;
-                result = editLog;
-
-                globalStateMgr.getLocalMetastore().getTable("testDb", "unknown_mv");
-                minTimes = 0;
-                result = null;
-
-                globalStateMgr.getLocalMetastore().getTable("testDb", "unknown_tbl");
-                minTimes = 0;
-                result = null;
-            }
-        };
-
-        new Expectations() {
-            {
-                editLog.logBackupJob((BackupJob) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    public void logBackupJob(BackupJob job) {
-                        System.out.println("log backup job: " + job);
-                    }
-                };
-            }
-        };
+        globalStateMgr.getLocalMetastore().replayCreateDb(db);
 
         new MockUp<AgentTaskExecutor>() {
             @Mock
@@ -227,6 +187,11 @@ public class BackupJobMaterializedViewTest {
                 result = true;
             }
         };
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
     }
 
     @Disabled
@@ -430,7 +395,7 @@ public class BackupJobMaterializedViewTest {
         tableRefs.add(new TableRefPersist(new TableName(UnitTestUtil.DB_NAME, "unknown_mv"), null));
 
         job = new BackupJob("mv_label_abnormal", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000,
-                    globalStateMgr, repo.getId());
+                    GlobalStateMgr.getCurrentState(), repo.getId());
         job.run();
         Assertions.assertEquals(Status.ErrCode.NOT_FOUND, job.getStatus().getErrCode());
         Assertions.assertEquals(BackupJobState.CANCELLED, job.getState());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupRestoreEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupRestoreEditLogTest.java
@@ -1,0 +1,125 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.backup;
+
+import com.starrocks.backup.BackupJob.BackupJobState;
+import com.starrocks.backup.RestoreJob.RestoreJobState;
+import com.starrocks.backup.mv.MvRestoreContext;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class BackupRestoreEditLogTest {
+    private static final long DB_ID = 10001L;
+    private static final String DB_NAME = "test_db";
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testBackupJobPersistStateChangeAndReplayLog() throws Exception {
+        BackupJob job = createBackupJob("backup_label");
+        job.persistStateChange(BackupJobState.UPLOAD_INFO);
+        Assertions.assertEquals(BackupJobState.UPLOAD_INFO, job.getState());
+
+        BackupJob logJob = (BackupJob) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_BACKUP_JOB_V2);
+        Assertions.assertEquals(job.getJobId(), logJob.getJobId());
+        Assertions.assertEquals(BackupJobState.UPLOAD_INFO, logJob.getState());
+        Assertions.assertEquals(job.getLabel(), logJob.getLabel());
+    }
+
+    @Test
+    public void testRestoreJobPersistStateChangeAndReplayLog() throws Exception {
+        RestoreJob job = createRestoreJob("restore_label");
+        job.persistStateChange(RestoreJobState.DOWNLOAD);
+        Assertions.assertEquals(RestoreJobState.DOWNLOAD, job.getState());
+
+        RestoreJob logJob = (RestoreJob) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_RESTORE_JOB_V2);
+        Assertions.assertEquals(job.getJobId(), logJob.getJobId());
+        Assertions.assertEquals(RestoreJobState.DOWNLOAD, logJob.getState());
+        Assertions.assertEquals(job.getLabel(), logJob.getLabel());
+    }
+
+    @Test
+    public void testBackupJobPersistStateChangeEditLogException() {
+        BackupJob job = createBackupJob("backup_exception");
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logBackupJob(any(BackupJob.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                    () -> job.persistStateChange(BackupJobState.UPLOAD_INFO));
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertEquals(BackupJobState.PENDING, job.getState());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    @Test
+    public void testRestoreJobPersistStateChangeEditLogException() {
+        RestoreJob job = createRestoreJob("restore_exception");
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logRestoreJob(any(RestoreJob.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                    () -> job.persistStateChange(RestoreJobState.DOWNLOAD));
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertEquals(RestoreJobState.PENDING, job.getState());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    private static BackupJob createBackupJob(String label) {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        return new BackupJob(label, DB_ID, DB_NAME, new ArrayList<>(), 1000L, globalStateMgr, 1L);
+    }
+
+    private static RestoreJob createRestoreJob(String label) {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        BackupJobInfo jobInfo = new BackupJobInfo();
+        BackupMeta backupMeta = new BackupMeta(new ArrayList<>());
+        return new RestoreJob(label, "backup_ts", DB_ID, DB_NAME, jobInfo, false, 3, 1000L,
+                globalStateMgr, 1L, backupMeta, new MvRestoreContext());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupRestoreJobCopyForPersistTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupRestoreJobCopyForPersistTest.java
@@ -1,0 +1,198 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.backup;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.TableName;
+import com.starrocks.persist.ColocatePersistInfo;
+import com.starrocks.persist.TableRefPersist;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+public class BackupRestoreJobCopyForPersistTest {
+    @Test
+    public void testBackupJobCopyForPersist() throws Exception {
+        BackupJob job = new BackupJob();
+        setField(job, "type", AbstractJob.JobType.BACKUP);
+        setField(job, "repoId", 10L);
+        setField(job, "jobId", 11L);
+        setField(job, "label", "label");
+        setField(job, "dbId", 12L);
+        setField(job, "dbName", "db");
+        setField(job, "status", new Status(Status.ErrCode.BAD_FILE, "bad"));
+        setField(job, "createTime", 100L);
+        setField(job, "finishedTime", 200L);
+        setField(job, "timeoutMs", 300L);
+        Map<Long, String> backupTaskErrMsg = Maps.newHashMap();
+        backupTaskErrMsg.put(1L, "err");
+        setField(job, "taskErrMsg", backupTaskErrMsg);
+
+        List<TableRefPersist> tableRefs = Lists.newArrayList(new TableRefPersist(new TableName("db", "tbl"), "t"));
+        setField(job, "tableRefs", tableRefs);
+        setField(job, "state", BackupJob.BackupJobState.SNAPSHOTING);
+        setField(job, "snapshotFinishedTime", 400L);
+        setField(job, "snapshotUploadFinishedTime", 500L);
+        Map<Long, SnapshotInfo> snapshotInfoMap = Maps.newConcurrentMap();
+        snapshotInfoMap.put(1L,
+                new SnapshotInfo(1L, 2L, 3L, 4L, 5L, 6L, 7, "/path", Lists.newArrayList("f1")));
+        setField(job, "snapshotInfos", snapshotInfoMap);
+        setField(job, "backupMeta", new BackupMeta(Lists.newArrayList()));
+        setField(job, "localMetaInfoFilePath", "/tmp/meta");
+        setField(job, "localJobInfoFilePath", "/tmp/job");
+        setField(job, "backupFunctions", Lists.newArrayList());
+        setField(job, "backupCatalogs", Lists.newArrayList());
+
+        BackupJob copy = job.copyForPersist();
+        assertFieldsEqual(job, copy,
+                "type",
+                "repoId",
+                "jobId",
+                "label",
+                "dbId",
+                "dbName",
+                "status",
+                "createTime",
+                "finishedTime",
+                "timeoutMs",
+                "taskErrMsg",
+                "tableRefs",
+                "state",
+                "snapshotFinishedTime",
+                "snapshotUploadFinishedTime",
+                "snapshotInfos",
+                "backupMeta",
+                "localMetaInfoFilePath",
+                "localJobInfoFilePath",
+                "backupFunctions",
+                "backupCatalogs");
+    }
+
+    @Test
+    public void testRestoreJobCopyForPersist() throws Exception {
+        RestoreJob job = new RestoreJob();
+        setField(job, "type", AbstractJob.JobType.RESTORE);
+        setField(job, "repoId", 10L);
+        setField(job, "jobId", 11L);
+        setField(job, "label", "label");
+        setField(job, "dbId", 12L);
+        setField(job, "dbName", "db");
+        setField(job, "status", new Status(Status.ErrCode.BAD_FILE, "bad"));
+        setField(job, "createTime", 100L);
+        setField(job, "finishedTime", 200L);
+        setField(job, "timeoutMs", 300L);
+        Map<Long, String> restoreTaskErrMsg = Maps.newHashMap();
+        restoreTaskErrMsg.put(1L, "err");
+        setField(job, "taskErrMsg", restoreTaskErrMsg);
+
+        BackupJobInfo jobInfo = new BackupJobInfo();
+        jobInfo.name = "job";
+        jobInfo.dbName = "db";
+        jobInfo.dbId = 12L;
+        setField(job, "backupTimestamp", "ts");
+        setField(job, "jobInfo", jobInfo);
+        setField(job, "allowLoad", true);
+        setField(job, "state", RestoreJob.RestoreJobState.DOWNLOADING);
+        setField(job, "backupMeta", new BackupMeta(Lists.newArrayList()));
+
+        RestoreFileMapping fileMapping = new RestoreFileMapping();
+        fileMapping.putMapping(new RestoreFileMapping.IdChain(1L, 2L, 3L, 4L, 5L),
+                new RestoreFileMapping.IdChain(6L, 7L, 8L, 9L, 10L), true);
+        setField(job, "fileMapping", fileMapping);
+        setField(job, "metaPreparedTime", 400L);
+        setField(job, "snapshotFinishedTime", 500L);
+        setField(job, "downloadFinishedTime", 600L);
+        setField(job, "restoreReplicationNum", 3);
+        setField(job, "restoredPartitions", Lists.newArrayList());
+        setField(job, "restoredTbls", Lists.newArrayList());
+
+        HashBasedTable<Long, Long, Long> restoredVersionInfo = HashBasedTable.create();
+        restoredVersionInfo.put(1L, 2L, 3L);
+        setField(job, "restoredVersionInfo", restoredVersionInfo);
+
+        HashBasedTable<Long, Long, SnapshotInfo> snapshotInfos = HashBasedTable.create();
+        snapshotInfos.put(1L, 2L, new SnapshotInfo(1L, 2L, 3L, 4L, 5L, 6L, 7, "/path", Lists.newArrayList("f1")));
+        setField(job, "snapshotInfos", snapshotInfos);
+
+        setField(job, "colocatePersistInfos",
+                Lists.newArrayList(ColocatePersistInfo.createForRemoveTable(10L)));
+
+        RestoreJob copy = job.copyForPersist();
+        assertFieldsEqual(job, copy,
+                "type",
+                "repoId",
+                "jobId",
+                "label",
+                "dbId",
+                "dbName",
+                "status",
+                "createTime",
+                "finishedTime",
+                "timeoutMs",
+                "taskErrMsg",
+                "backupTimestamp",
+                "jobInfo",
+                "allowLoad",
+                "state",
+                "backupMeta",
+                "fileMapping",
+                "metaPreparedTime",
+                "snapshotFinishedTime",
+                "downloadFinishedTime",
+                "restoreReplicationNum",
+                "restoredPartitions",
+                "restoredTbls",
+                "restoredVersionInfo",
+                "snapshotInfos",
+                "colocatePersistInfos");
+    }
+
+    private static void assertFieldsEqual(Object original, Object copy, String... fieldNames) throws Exception {
+        for (String fieldName : fieldNames) {
+            Object originalValue = getField(original, fieldName);
+            Object copyValue = getField(copy, fieldName);
+            Assertions.assertEquals(originalValue, copyValue, fieldName);
+        }
+    }
+
+    private static Object getField(Object target, String fieldName) throws Exception {
+        Field field = findField(target.getClass(), fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = findField(target.getClass(), fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Field findField(Class<?> type, String fieldName) throws NoSuchFieldException {
+        Class<?> current = type;
+        while (current != null) {
+            try {
+                return current.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException ex) {
+                current = current.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
@@ -227,16 +227,6 @@ public class RestoreJobMaterializedViewTest extends StarRocksTestBase {
             }
 
             {
-                editLog.logBackupJob((BackupJob) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    public void logBackupJob(BackupJob job) {
-                        logSysInfo("log backup job: " + job);
-                    }
-                };
-            }
-
-            {
                 repo.upload(anyString, anyString);
                 result = Status.OK;
                 minTimes = 0;

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
@@ -183,18 +183,6 @@ public class RestoreJobPrimaryKeyTest {
 
         new Expectations() {
             {
-                editLog.logBackupJob((BackupJob) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    public void logBackupJob(BackupJob job) {
-                        System.out.println("log backup job: " + job);
-                    }
-                };
-            }
-        };
-
-        new Expectations() {
-            {
                 repo.upload(anyString, anyString);
                 result = Status.OK;
                 minTimes = 0;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/FakeEditLog.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/FakeEditLog.java
@@ -36,28 +36,125 @@ package com.starrocks.catalog;
 
 import com.starrocks.alter.AlterJobV2;
 import com.starrocks.alter.BatchAlterJobPersistInfo;
+import com.starrocks.authentication.UserPropertyInfo;
 import com.starrocks.backup.BackupJob;
+import com.starrocks.backup.Repository;
+import com.starrocks.backup.RestoreJob;
+import com.starrocks.common.util.SmallFileMgr.SmallFile;
+import com.starrocks.ha.LeaderInfo;
+import com.starrocks.load.ExportJob;
+import com.starrocks.load.MultiDeleteInfo;
+import com.starrocks.load.loadv2.LoadJob;
+import com.starrocks.load.loadv2.LoadJob.LoadJobStateUpdateInfo;
+import com.starrocks.load.loadv2.LoadJobFinalOperation;
 import com.starrocks.load.routineload.RoutineLoadJob;
 import com.starrocks.load.streamload.StreamLoadMultiStmtTask;
 import com.starrocks.load.streamload.StreamLoadTask;
+import com.starrocks.persist.AlterCatalogLog;
+import com.starrocks.persist.AlterLoadJobOperationLog;
+import com.starrocks.persist.AlterPipeLog;
+import com.starrocks.persist.AlterResourceGroupLog;
+import com.starrocks.persist.AlterResourceInfo;
 import com.starrocks.persist.AlterRoutineLoadJobOperationLog;
+import com.starrocks.persist.AlterTaskInfo;
+import com.starrocks.persist.AlterUserInfo;
+import com.starrocks.persist.AlterViewInfo;
+import com.starrocks.persist.AutoIncrementInfo;
+import com.starrocks.persist.BackendTabletsInfo;
+import com.starrocks.persist.BatchDeleteReplicaInfo;
+import com.starrocks.persist.CancelDecommissionDiskInfo;
+import com.starrocks.persist.ClusterSnapshotLog;
+import com.starrocks.persist.ColumnRenameInfo;
+import com.starrocks.persist.CreateUserInfo;
+import com.starrocks.persist.DatabaseInfo;
+import com.starrocks.persist.DecommissionDiskInfo;
+import com.starrocks.persist.DeleteSqlBlackLists;
+import com.starrocks.persist.DeleteSqlDigestBlackLists;
+import com.starrocks.persist.DisableDiskInfo;
+import com.starrocks.persist.DisablePartitionRecoveryInfo;
+import com.starrocks.persist.DisableTableRecoveryInfo;
 import com.starrocks.persist.DropBackendInfo;
+import com.starrocks.persist.DropBrokerLog;
+import com.starrocks.persist.DropCatalogLog;
 import com.starrocks.persist.DropComputeNodeLog;
+import com.starrocks.persist.DropDictionaryInfo;
+import com.starrocks.persist.DropFrontendInfo;
+import com.starrocks.persist.DropPartitionsInfo;
+import com.starrocks.persist.DropRepositoryLog;
+import com.starrocks.persist.DropResourceOperationLog;
+import com.starrocks.persist.DropStorageVolumeLog;
 import com.starrocks.persist.EditLog;
+import com.starrocks.persist.EraseDbLog;
+import com.starrocks.persist.ErasePartitionLog;
+import com.starrocks.persist.GlobalVarPersistInfo;
+import com.starrocks.persist.GroupProviderLog;
+import com.starrocks.persist.InsertOverwriteStateChangeInfo;
+import com.starrocks.persist.ModifyBrokerInfo;
+import com.starrocks.persist.ModifyColumnCommentLog;
+import com.starrocks.persist.ModifyPartitionInfo;
+import com.starrocks.persist.ModifyTableColumnOperationLog;
 import com.starrocks.persist.ModifyTablePropertyOperationLog;
+import com.starrocks.persist.MultiEraseTableInfo;
 import com.starrocks.persist.NextIdLog;
+import com.starrocks.persist.PartitionVersionRecoveryInfo;
+import com.starrocks.persist.PipeOpEntry;
+import com.starrocks.persist.RecoverInfo;
+import com.starrocks.persist.RemoveAlterJobV2OperationLog;
+import com.starrocks.persist.RemoveSmallFileLog;
+import com.starrocks.persist.RemoveTabletReshardJobLog;
+import com.starrocks.persist.RenameMaterializedViewLog;
 import com.starrocks.persist.ReplicaPersistInfo;
+import com.starrocks.persist.ReplicationJobLog;
+import com.starrocks.persist.ResourceGroupOpEntry;
+import com.starrocks.persist.RolePrivilegeCollectionInfo;
 import com.starrocks.persist.RoutineLoadOperation;
+import com.starrocks.persist.SecurityIntegrationPersistInfo;
+import com.starrocks.persist.SetDefaultStorageVolumeLog;
+import com.starrocks.persist.SetReplicaStatusOperationLog;
+import com.starrocks.persist.SqlBlackListPersistInfo;
+import com.starrocks.persist.SqlDigestBlackListPersistInfo;
+import com.starrocks.persist.TableInfo;
+import com.starrocks.persist.TableStorageInfos;
+import com.starrocks.persist.TransactionIdInfo;
+import com.starrocks.persist.TruncateTableInfo;
+import com.starrocks.persist.UninstallPluginLog;
 import com.starrocks.persist.UpdateBackendInfo;
+import com.starrocks.persist.UpdateDictionaryMgrLog;
+import com.starrocks.persist.UpdateFrontendInfo;
+import com.starrocks.persist.UpdateHistoricalNodeLog;
+import com.starrocks.persist.UserPrivilegeCollectionInfo;
 import com.starrocks.persist.WALApplier;
+import com.starrocks.plugin.PluginInfo;
+import com.starrocks.proto.EncryptionKeyPB;
+import com.starrocks.replication.ReplicationJob;
+import com.starrocks.scheduler.Task;
+import com.starrocks.scheduler.mv.MVMaintenanceJob;
+import com.starrocks.scheduler.persist.ArchiveTaskRunsLog;
+import com.starrocks.scheduler.persist.DropTasksLog;
+import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.scheduler.persist.TaskRunStatusChange;
+import com.starrocks.sql.spm.BaselinePlan;
+import com.starrocks.statistic.AnalyzeJob;
+import com.starrocks.statistic.AnalyzeStatus;
+import com.starrocks.statistic.BasicStatsMeta;
+import com.starrocks.statistic.BatchRemoveBasicStatsMetaLog;
+import com.starrocks.statistic.BatchRemoveHistogramStatsMetaLog;
+import com.starrocks.statistic.BatchRemoveMultiColumnStatsMetaLog;
+import com.starrocks.statistic.ExternalBasicStatsMeta;
+import com.starrocks.statistic.ExternalHistogramStatsMeta;
+import com.starrocks.statistic.HistogramStatsMeta;
+import com.starrocks.statistic.MultiColumnStatsMeta;
+import com.starrocks.storagevolume.StorageVolume;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
+import com.starrocks.system.Frontend;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStateBatch;
 import mockit.Mock;
 import mockit.MockUp;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class FakeEditLog extends MockUp<EditLog> {
@@ -78,7 +175,6 @@ public class FakeEditLog extends MockUp<EditLog> {
         for (TransactionState transactionState : stateBatch.getTransactionStates()) {
             allTransactionState.put(transactionState.getTransactionId(), transactionState);
         }
-
     }
 
     @Mock
@@ -87,8 +183,28 @@ public class FakeEditLog extends MockUp<EditLog> {
     }
 
     @Mock
+    public void logJsonObject(short op, Object obj, WALApplier walApplier) {
+        apply(walApplier, obj);
+    }
+
+    @Mock
     public void logSaveNextId(long nextId, WALApplier walApplier) {
-        walApplier.apply(new NextIdLog(nextId));
+        apply(walApplier, new NextIdLog(nextId));
+    }
+
+    @Mock
+    public void logSaveTransactionId(long transactionId, WALApplier walApplier) {
+        apply(walApplier, new TransactionIdInfo(transactionId));
+    }
+
+    @Mock
+    public void logSaveAutoIncrementId(AutoIncrementInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logSaveDeleteAutoIncrementId(AutoIncrementInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
     }
 
     @Mock
@@ -96,84 +212,786 @@ public class FakeEditLog extends MockUp<EditLog> {
     }
 
     @Mock
-    public void logOpRoutineLoadJob(RoutineLoadOperation operation) {
+    public void logEraseDb(long dbId, WALApplier walApplier) {
+        apply(walApplier, new EraseDbLog(dbId));
+    }
+
+    @Mock
+    public void logAlterDb(DatabaseInfo dbInfo, WALApplier walApplier) {
+        apply(walApplier, dbInfo);
+    }
+
+    @Mock
+    public void logResourceGroupOp(ResourceGroupOpEntry op, WALApplier applier) {
+        apply(applier, op);
+    }
+
+    @Mock
+    public void logAlterResourceGroup(AlterResourceGroupLog log, WALApplier applier) {
+        apply(applier, log);
+    }
+
+    @Mock
+    public void logCreateTask(Task info, WALApplier applier) {
+        apply(applier, info);
+    }
+
+    @Mock
+    public void logDropTasks(DropTasksLog tasksLog, WALApplier applier) {
+        apply(applier, tasksLog);
+    }
+
+    @Mock
+    public void logTaskRunCreateStatus(TaskRunStatus status, WALApplier applier) {
+        apply(applier, status);
+    }
+
+    @Mock
+    public void logUpdateTaskRun(TaskRunStatusChange statusChange, WALApplier applier) {
+        apply(applier, statusChange);
+    }
+
+    @Mock
+    public void logArchiveTaskRuns(ArchiveTaskRunsLog log, WALApplier applier) {
+        apply(applier, log);
+    }
+
+    @Mock
+    public void logDropPartitions(DropPartitionsInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logErasePartition(long partitionId, WALApplier walApplier) {
+        apply(walApplier, new ErasePartitionLog(partitionId));
+    }
+
+    @Mock
+    public void logRecoverPartition(RecoverInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logModifyPartition(ModifyPartitionInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logDisablePartitionRecovery(long partitionId, WALApplier walApplier) {
+        apply(walApplier, new DisablePartitionRecoveryInfo(partitionId));
+    }
+
+    @Mock
+    public void logDisableTableRecovery(List<Long> tableIds, WALApplier walApplier) {
+        apply(walApplier, new DisableTableRecoveryInfo(tableIds));
+    }
+
+    @Mock
+    public void logEraseMultiTables(List<Long> tableIds, WALApplier walApplier) {
+        apply(walApplier, new MultiEraseTableInfo(tableIds));
+    }
+
+    @Mock
+    public void logRecoverTable(RecoverInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
     }
 
     @Mock
     public void logBackendStateChange(UpdateBackendInfo info, WALApplier applier) {
-        applier.apply(info);
+        apply(applier, info);
     }
 
     @Mock
-    public void logAlterJob(AlterJobV2 alterJob) {
-
+    public void logAlterJob(AlterJobV2 alterJob, WALApplier applier) {
+        apply(applier, alterJob);
     }
 
     @Mock
-    public void logBatchAlterJob(BatchAlterJobPersistInfo batchAlterJobV2) {
-
+    public void logBatchAlterJob(BatchAlterJobPersistInfo batchAlterJobV2, WALApplier walApplier) {
+        apply(walApplier, batchAlterJobV2);
     }
 
     @Mock
-    public void logDynamicPartition(ModifyTablePropertyOperationLog info) {
+    public void logDynamicPartition(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
 
+    @Mock
+    public void logModifyReplicationNum(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logModifyConstraint(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logModifyEnablePersistentIndex(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logModifyPrimaryIndexCacheExpireSec(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logModifyWriteQuorum(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logModifyReplicatedStorage(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logModifyBucketSize(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logModifyMutableBucketNum(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logModifyDefaultBucketNum(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logModifyEnableLoadProfile(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logModifyBaseCompactionForbiddenTimeRanges(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
     }
 
     @Mock
     public void logAddReplica(ReplicaPersistInfo info) {
-
     }
 
     @Mock
-    public void logBackupJob(BackupJob job) {
+    public void logBackupJob(BackupJob job, WALApplier walApplier) {
+        apply(walApplier, job);
+    }
+
+    @Mock
+    public void logCreateRepository(Repository repo, WALApplier walApplier) {
+        apply(walApplier, repo);
+    }
+
+    @Mock
+    public void logDropRepository(String repoName, WALApplier walApplier) {
+        apply(walApplier, new DropRepositoryLog(repoName));
+    }
+
+    @Mock
+    public void logRestoreJob(RestoreJob job, WALApplier walApplier) {
+        apply(walApplier, job);
+    }
+
+    @Mock
+    public void logTruncateTable(TruncateTableInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
     }
 
     @Mock
     public void logAddBackend(Backend be, WALApplier applier) {
-        applier.apply(be);
+        apply(applier, be);
     }
 
     @Mock
     public void logAddComputeNode(ComputeNode computeNode, WALApplier applier) {
-        applier.apply(computeNode);
+        apply(applier, computeNode);
     }
 
     @Mock
     public void logDropBackend(DropBackendInfo info, WALApplier applier) {
-        applier.apply(info);
+        apply(applier, info);
     }
 
     @Mock
     public void logDropComputeNode(DropComputeNodeLog log, WALApplier applier) {
-        applier.apply(log);
+        apply(applier, log);
+    }
+
+    @Mock
+    public void logUpdateHistoricalNode(UpdateHistoricalNodeLog log, WALApplier applier) {
+        apply(applier, log);
+    }
+
+    @Mock
+    public void logAddFrontend(Frontend fe, WALApplier applier) {
+        apply(applier, fe);
+    }
+
+    @Mock
+    public void logRemoveFrontend(DropFrontendInfo dropFrontendInfo, WALApplier applier) {
+        apply(applier, dropFrontendInfo);
+    }
+
+    @Mock
+    public void logUpdateFrontend(UpdateFrontendInfo info, WALApplier applier) {
+        apply(applier, info);
+    }
+
+    @Mock
+    public void logFinishMultiDelete(MultiDeleteInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logDeleteReplica(ReplicaPersistInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logBatchDeleteReplica(BatchDeleteReplicaInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logAddKey(EncryptionKeyPB key, WALApplier walApplier) {
+        apply(walApplier, key);
+    }
+
+    @Mock
+    public void logLeaderInfo(LeaderInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logResetFrontends(Frontend frontend, WALApplier walApplier) {
+        apply(walApplier, frontend);
+    }
+
+    @Mock
+    public void logDatabaseRename(DatabaseInfo databaseInfo, WALApplier walApplier) {
+        apply(walApplier, databaseInfo);
+    }
+
+    @Mock
+    public void logTableRename(TableInfo tableInfo, WALApplier walApplier) {
+        apply(walApplier, tableInfo);
+    }
+
+    @Mock
+    public void logModifyViewDef(AlterViewInfo alterViewInfo, WALApplier walApplier) {
+        apply(walApplier, alterViewInfo);
+    }
+
+    @Mock
+    public void logRollupRename(TableInfo tableInfo, WALApplier walApplier) {
+        apply(walApplier, tableInfo);
+    }
+
+    @Mock
+    public void logPartitionRename(TableInfo tableInfo, WALApplier walApplier) {
+        apply(walApplier, tableInfo);
+    }
+
+    @Mock
+    public void logAddBroker(ModifyBrokerInfo info, WALApplier applier) {
+        apply(applier, info);
+    }
+
+    @Mock
+    public void logDropBroker(ModifyBrokerInfo info, WALApplier applier) {
+        apply(applier, info);
+    }
+
+    @Mock
+    public void logDropAllBroker(String brokerName, WALApplier applier) {
+        apply(applier, new DropBrokerLog(brokerName));
+    }
+
+    @Mock
+    public void logExportCreate(ExportJob job, WALApplier walApplier) {
+        apply(walApplier, job);
+    }
+
+    @Mock
+    public void logExportUpdateState(ExportJob.ExportUpdateInfo updateInfo, WALApplier applier) {
+        apply(applier, updateInfo);
+    }
+
+    @Mock
+    public void logAddFunction(Function function, WALApplier walApplier) {
+        apply(walApplier, function);
+    }
+
+    @Mock
+    public void logDropFunction(FunctionSearchDesc function, WALApplier walApplier) {
+        apply(walApplier, function);
+    }
+
+    @Mock
+    public void logSetHasForbiddenGlobalDict(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logSetHasDelete(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logBackendTabletsInfo(BackendTabletsInfo backendTabletsInfo, WALApplier walApplier) {
+        apply(walApplier, backendTabletsInfo);
     }
 
     @Mock
     public void logCreateRoutineLoadJob(RoutineLoadJob routineLoadJob, WALApplier walApplier) {
-        walApplier.apply(routineLoadJob);
+        apply(walApplier, routineLoadJob);
     }
 
     @Mock
     public void logOpRoutineLoadJob(RoutineLoadOperation routineLoadOperation, WALApplier walApplier) {
-        walApplier.apply(routineLoadOperation);
-    }
-
-    @Mock
-    public void logAlterRoutineLoadJob(AlterRoutineLoadJobOperationLog log, WALApplier walApplier) {
-        walApplier.apply(log);
+        apply(walApplier, routineLoadOperation);
     }
 
     @Mock
     public void logCreateStreamLoadJob(StreamLoadTask streamLoadTask, WALApplier walApplier) {
-        walApplier.apply(streamLoadTask);
+        apply(walApplier, streamLoadTask);
     }
 
     @Mock
     public void logCreateMultiStmtStreamLoadJob(StreamLoadMultiStmtTask streamLoadTask, WALApplier walApplier) {
-        walApplier.apply(streamLoadTask);
+        apply(walApplier, streamLoadTask);
+    }
+
+    @Mock
+    public void logCreateLoadJob(LoadJob loadJob, WALApplier walApplier) {
+        apply(walApplier, loadJob);
+    }
+
+    @Mock
+    public void logEndLoadJob(LoadJobFinalOperation loadJobFinalOperation, WALApplier walApplier) {
+        apply(walApplier, loadJobFinalOperation);
+    }
+
+    @Mock
+    public void logUpdateLoadJob(LoadJobStateUpdateInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logCreateResource(Resource resource, WALApplier walApplier) {
+        apply(walApplier, resource);
+    }
+
+    @Mock
+    public void logAlterResource(AlterResourceInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logDropResource(DropResourceOperationLog operationLog, WALApplier walApplier) {
+        apply(walApplier, operationLog);
+    }
+
+    @Mock
+    public void logCreateSmallFile(SmallFile info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logDropSmallFile(RemoveSmallFileLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logInstallPlugin(PluginInfo plugin, WALApplier walApplier) {
+        apply(walApplier, plugin);
+    }
+
+    @Mock
+    public void logUninstallPlugin(UninstallPluginLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logSetReplicaStatus(SetReplicaStatusOperationLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logRemoveExpiredAlterJobV2(RemoveAlterJobV2OperationLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logAlterRoutineLoadJob(AlterRoutineLoadJobOperationLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logAlterLoadJob(AlterLoadJobOperationLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logGlobalVariableV2(GlobalVarPersistInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logAddAnalyzeJob(AnalyzeJob job, WALApplier walApplier) {
+        apply(walApplier, job);
+    }
+
+    @Mock
+    public void logRemoveAnalyzeJob(AnalyzeJob job, WALApplier walApplier) {
+        apply(walApplier, job);
+    }
+
+    @Mock
+    public void logAddAnalyzeStatus(AnalyzeStatus status, WALApplier walApplier) {
+        apply(walApplier, status);
+    }
+
+    @Mock
+    public void logRemoveAnalyzeStatus(AnalyzeStatus status, WALApplier walApplier) {
+        apply(walApplier, status);
+    }
+
+    @Mock
+    public void logAddBasicStatsMeta(BasicStatsMeta meta, WALApplier walApplier) {
+        apply(walApplier, meta);
+    }
+
+    @Mock
+    public void logRemoveBasicStatsMeta(BasicStatsMeta meta, WALApplier walApplier) {
+        apply(walApplier, meta);
+    }
+
+    @Mock
+    public void logRemoveBasicStatsMetaBatch(List<BasicStatsMeta> metas, WALApplier walApplier) {
+        apply(walApplier, new BatchRemoveBasicStatsMetaLog(metas));
+    }
+
+    @Mock
+    public void logAddHistogramStatsMeta(HistogramStatsMeta meta, WALApplier walApplier) {
+        apply(walApplier, meta);
+    }
+
+    @Mock
+    public void logRemoveHistogramStatsMeta(HistogramStatsMeta meta, WALApplier walApplier) {
+        apply(walApplier, meta);
+    }
+
+    @Mock
+    public void logRemoveHistogramStatsMetaBatch(List<HistogramStatsMeta> metas, WALApplier walApplier) {
+        apply(walApplier, new BatchRemoveHistogramStatsMetaLog(metas));
+    }
+
+    @Mock
+    public void logAddMultiColumnStatsMeta(MultiColumnStatsMeta meta, WALApplier walApplier) {
+        apply(walApplier, meta);
+    }
+
+    @Mock
+    public void logRemoveMultiColumnStatsMeta(MultiColumnStatsMeta meta, WALApplier walApplier) {
+        apply(walApplier, meta);
+    }
+
+    @Mock
+    public void logRemoveMultiColumnStatsMetaBatch(List<MultiColumnStatsMeta> metas, WALApplier walApplier) {
+        apply(walApplier, new BatchRemoveMultiColumnStatsMetaLog(metas));
+    }
+
+    @Mock
+    public void logAddExternalBasicStatsMeta(ExternalBasicStatsMeta meta, WALApplier walApplier) {
+        apply(walApplier, meta);
+    }
+
+    @Mock
+    public void logRemoveExternalBasicStatsMeta(ExternalBasicStatsMeta meta, WALApplier walApplier) {
+        apply(walApplier, meta);
+    }
+
+    @Mock
+    public void logAddExternalHistogramStatsMeta(ExternalHistogramStatsMeta meta, WALApplier walApplier) {
+        apply(walApplier, meta);
+    }
+
+    @Mock
+    public void logRemoveExternalHistogramStatsMeta(ExternalHistogramStatsMeta meta, WALApplier walApplier) {
+        apply(walApplier, meta);
+    }
+
+    @Mock
+    public void logModifyTableColumn(ModifyTableColumnOperationLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logModifyColumnComment(ModifyColumnCommentLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logCreateCatalog(Catalog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logDropCatalog(DropCatalogLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logAlterCatalog(AlterCatalogLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logInsertOverwriteStateChange(InsertOverwriteStateChangeInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logMvRename(RenameMaterializedViewLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logAlterMaterializedViewProperties(ModifyTablePropertyOperationLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logAddSQLBlackList(SqlBlackListPersistInfo addBlackList, WALApplier walApplier) {
+        apply(walApplier, addBlackList);
+    }
+
+    @Mock
+    public void logDeleteSQLBlackList(DeleteSqlBlackLists deleteBlacklists, WALApplier walApplier) {
+        apply(walApplier, deleteBlacklists);
+    }
+
+    @Mock
+    public void logAddSqlDigestBlackList(SqlDigestBlackListPersistInfo addBlackList, WALApplier walApplier) {
+        apply(walApplier, addBlackList);
+    }
+
+    @Mock
+    public void logDeleteSqlDigestBlackList(DeleteSqlDigestBlackLists deleteBlacklists, WALApplier walApplier) {
+        apply(walApplier, deleteBlacklists);
+    }
+
+    @Mock
+    public void logCreateUser(CreateUserInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logAlterUser(AlterUserInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logUpdateUserPropertyV2(UserPropertyInfo propertyInfo, WALApplier walApplier) {
+        apply(walApplier, propertyInfo);
+    }
+
+    @Mock
+    public void logDropUser(UserIdentity userIdentity, WALApplier walApplier) {
+        apply(walApplier, userIdentity);
+    }
+
+    @Mock
+    public void logUpdateUserPrivilege(UserPrivilegeCollectionInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logUpdateRolePrivilege(RolePrivilegeCollectionInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logDropRole(RolePrivilegeCollectionInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logCreateSecurityIntegration(SecurityIntegrationPersistInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logAlterSecurityIntegration(SecurityIntegrationPersistInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logDropSecurityIntegration(SecurityIntegrationPersistInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logModifyBinlogConfig(ModifyTablePropertyOperationLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logModifyFlatJsonConfig(ModifyTablePropertyOperationLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logModifyBinlogAvailableVersion(ModifyTablePropertyOperationLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logMVJobState(MVMaintenanceJob job, WALApplier walApplier) {
+        apply(walApplier, job);
+    }
+
+    @Mock
+    public void logAlterTableProperties(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logPipeOp(PipeOpEntry opEntry, WALApplier walApplier) {
+        apply(walApplier, opEntry);
+    }
+
+    @Mock
+    public void logAlterPipe(AlterPipeLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logAlterTask(AlterTaskInfo info, WALApplier applier) {
+        apply(applier, info);
+    }
+
+    @Mock
+    public void logSetDefaultStorageVolume(SetDefaultStorageVolumeLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logCreateStorageVolume(StorageVolume storageVolume, WALApplier walApplier) {
+        apply(walApplier, storageVolume);
+    }
+
+    @Mock
+    public void logUpdateStorageVolume(StorageVolume storageVolume, WALApplier walApplier) {
+        apply(walApplier, storageVolume);
+    }
+
+    @Mock
+    public void logDropStorageVolume(DropStorageVolumeLog log, WALApplier walApplier) {
+        apply(walApplier, log);
+    }
+
+    @Mock
+    public void logUpdateTableStorageInfos(TableStorageInfos tableStorageInfos, WALApplier walApplier) {
+        apply(walApplier, tableStorageInfos);
+    }
+
+    @Mock
+    public void logReplicationJob(ReplicationJob replicationJob, WALApplier walApplier) {
+        apply(walApplier, new ReplicationJobLog(replicationJob));
+    }
+
+    @Mock
+    public void logDeleteReplicationJob(ReplicationJob replicationJob, WALApplier walApplier) {
+        apply(walApplier, new ReplicationJobLog(replicationJob));
+    }
+
+    @Mock
+    public void logColumnRename(ColumnRenameInfo columnRenameInfo, WALApplier walApplier) {
+        apply(walApplier, columnRenameInfo);
+    }
+
+    @Mock
+    public void logCreateDictionary(Dictionary info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logDropDictionary(DropDictionaryInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logModifyDictionaryMgr(UpdateDictionaryMgrLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logDecommissionDisk(DecommissionDiskInfo info, WALApplier applier) {
+        apply(applier, info);
+    }
+
+    @Mock
+    public void logCancelDecommissionDisk(CancelDecommissionDiskInfo info, WALApplier applier) {
+        apply(applier, info);
+    }
+
+    @Mock
+    public void logDisableDisk(DisableDiskInfo info, WALApplier applier) {
+        apply(applier, info);
+    }
+
+    @Mock
+    public void logRecoverPartitionVersion(PartitionVersionRecoveryInfo info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logClusterSnapshotLog(ClusterSnapshotLog info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logCreateSPMBaseline(BaselinePlan.Info info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logDropSPMBaseline(BaselinePlan.Info info, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logUpdateSPMBaseline(BaselinePlan.Info info, boolean isEnable, WALApplier walApplier) {
+        apply(walApplier, info);
+    }
+
+    @Mock
+    public void logRemoveTabletReshardJob(long jobId, WALApplier walApplier) {
+        apply(walApplier, new RemoveTabletReshardJobLog(jobId));
+    }
+
+    @Mock
+    public void logCreateGroupProvider(GroupProviderLog provider, WALApplier walApplier) {
+        apply(walApplier, provider);
+    }
+
+    @Mock
+    public void logDropGroupProvider(GroupProviderLog groupProviderLog, WALApplier walApplier) {
+        apply(walApplier, groupProviderLog);
     }
 
     public TransactionState getTransaction(long transactionId) {
         return allTransactionState.get(transactionId);
+    }
+
+    private void apply(WALApplier walApplier, Object wal) {
+        if (walApplier != null) {
+            walApplier.apply(wal);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotCopyForPersistTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotCopyForPersistTest.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake.snapshot;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+public class ClusterSnapshotCopyForPersistTest {
+    @Test
+    public void testClusterSnapshotCopyForPersist() {
+        ClusterSnapshot snapshot = new ClusterSnapshot(1L, "snap",
+                ClusterSnapshot.ClusterSnapshotType.MANUAL, "sv", 10L, 20L, 30L, 40L);
+        ClusterSnapshot copy = snapshot.copyForPersist();
+        Assertions.assertEquals(snapshot.getId(), copy.getId());
+        Assertions.assertEquals(snapshot.getSnapshotName(), copy.getSnapshotName());
+        Assertions.assertEquals(snapshot.getStorageVolumeName(), copy.getStorageVolumeName());
+        Assertions.assertEquals(snapshot.getCreatedTimeMs(), copy.getCreatedTimeMs());
+        Assertions.assertEquals(snapshot.getFinishedTimeMs(), copy.getFinishedTimeMs());
+        Assertions.assertEquals(snapshot.getFeJournalId(), copy.getFeJournalId());
+        Assertions.assertEquals(snapshot.getStarMgrJournalId(), copy.getStarMgrJournalId());
+        Assertions.assertNotSame(snapshot, copy);
+    }
+
+    @Test
+    public void testClusterSnapshotJobCopyForPersist() {
+        ClusterSnapshotJob job = new ClusterSnapshotJob(2L, "snap-job", "sv", 10L);
+        job.setState(ClusterSnapshotJob.ClusterSnapshotJobState.UPLOADING);
+        job.setErrMsg("err");
+        job.setDetailInfo("detail");
+        ClusterSnapshotJob copy = job.copyForPersist();
+        Assertions.assertEquals(job.getState(), copy.getState());
+        Assertions.assertEquals(getField(job, "errMsg"), getField(copy, "errMsg"));
+        Assertions.assertEquals(getField(job, "detailInfo"), getField(copy, "detailInfo"));
+        Assertions.assertEquals(job.getSnapshot().getId(), copy.getSnapshot().getId());
+        Assertions.assertNotSame(job, copy);
+        Assertions.assertNotSame(job.getSnapshot(), copy.getSnapshot());
+    }
+
+    private static Object getField(Object target, String fieldName) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(target);
+        } catch (Exception e) {
+            throw new AssertionError("Failed to access field: " + fieldName, e);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotJobEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotJobEditLogTest.java
@@ -1,0 +1,93 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake.snapshot;
+
+import com.starrocks.lake.snapshot.ClusterSnapshotJob.ClusterSnapshotJobState;
+import com.starrocks.persist.ClusterSnapshotLog;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TClusterSnapshotJobsItem;
+import com.starrocks.thrift.TClusterSnapshotJobsResponse;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class ClusterSnapshotJobEditLogTest {
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testPersistStateChangeAndReplay() throws Exception {
+        long jobId = 101L;
+        ClusterSnapshotJob job = new ClusterSnapshotJob(jobId, "snapshot_editlog", "sv", System.currentTimeMillis());
+
+        ClusterSnapshotJob.persistStateChange(job, ClusterSnapshotJobState.SNAPSHOTING);
+        Assertions.assertEquals(ClusterSnapshotJobState.SNAPSHOTING, job.getState());
+
+        ClusterSnapshotLog log = (ClusterSnapshotLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_CLUSTER_SNAPSHOT_LOG);
+        Assertions.assertEquals(ClusterSnapshotLog.ClusterSnapshotLogType.UPDATE_SNAPSHOT_JOB, log.getType());
+        Assertions.assertNotNull(log.getSnapshotJob());
+        Assertions.assertEquals(jobId, log.getSnapshotJob().getId());
+        Assertions.assertEquals(ClusterSnapshotJobState.SNAPSHOTING, log.getSnapshotJob().getState());
+
+        ClusterSnapshotMgr mgr = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr();
+        mgr.replayLog(log);
+
+        TClusterSnapshotJobsResponse response = mgr.getAllSnapshotJobsInfo();
+        Optional<TClusterSnapshotJobsItem> replayed = response.getItems().stream()
+                .filter(item -> item.getJob_id() == jobId)
+                .findFirst();
+        Assertions.assertTrue(replayed.isPresent());
+        Assertions.assertEquals(ClusterSnapshotJobState.SNAPSHOTING.name(), replayed.get().getState());
+    }
+
+    @Test
+    public void testPersistStateChangeEditLogException() {
+        ClusterSnapshotJob job = new ClusterSnapshotJob(102L, "snapshot_editlog_exception", "sv",
+                System.currentTimeMillis());
+
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logClusterSnapshotLog(any(ClusterSnapshotLog.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                    () -> ClusterSnapshotJob.persistStateChange(job, ClusterSnapshotJobState.SNAPSHOTING));
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertEquals(ClusterSnapshotJobState.INITIALIZING, job.getState());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotMgrEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotMgrEditLogTest.java
@@ -1,0 +1,221 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake.snapshot;
+
+import com.starrocks.lake.snapshot.ClusterSnapshotJob.ClusterSnapshotJobState;
+import com.starrocks.persist.ClusterSnapshotLog;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.AdminAlterAutomatedSnapshotIntervalStmt;
+import com.starrocks.sql.ast.AdminSetAutomatedSnapshotOffStmt;
+import com.starrocks.sql.ast.AdminSetAutomatedSnapshotOnStmt;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class ClusterSnapshotMgrEditLogTest {
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testSetAutomatedSnapshotOnEditLogAndReplay() throws Exception {
+        ClusterSnapshotMgr mgr = new ClusterSnapshotMgr();
+        AdminSetAutomatedSnapshotOnStmt stmt = new AdminSetAutomatedSnapshotOnStmt("sv_on", null);
+        stmt.setIntervalSeconds(120);
+
+        mgr.setAutomatedSnapshotOn(stmt);
+        Assertions.assertEquals("sv_on", mgr.getAutomatedSnapshotSvName());
+        Assertions.assertEquals(120, mgr.getAutomatedSnapshotIntervalSeconds());
+
+        ClusterSnapshotLog log = (ClusterSnapshotLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_CLUSTER_SNAPSHOT_LOG);
+        Assertions.assertEquals(ClusterSnapshotLog.ClusterSnapshotLogType.AUTOMATED_SNAPSHOT_ON, log.getType());
+        Assertions.assertEquals("sv_on", log.getStorageVolumeName());
+        Assertions.assertEquals(120, log.getAutomatedSnapshotIntervalSeconds());
+
+        ClusterSnapshotMgr follower = new ClusterSnapshotMgr();
+        follower.replayLog(log);
+        Assertions.assertEquals("sv_on", follower.getAutomatedSnapshotSvName());
+        Assertions.assertEquals(120, follower.getAutomatedSnapshotIntervalSeconds());
+    }
+
+    @Test
+    public void testSetAutomatedSnapshotOffEditLogAndReplay() throws Exception {
+        ClusterSnapshotMgr mgr = new ClusterSnapshotMgr();
+        mgr.setAutomatedSnapshotOn("sv_off", 60);
+
+        AdminSetAutomatedSnapshotOffStmt stmt = new AdminSetAutomatedSnapshotOffStmt();
+        mgr.setAutomatedSnapshotOff(stmt);
+        Assertions.assertNull(mgr.getAutomatedSnapshotSvName());
+
+        ClusterSnapshotLog log = (ClusterSnapshotLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_CLUSTER_SNAPSHOT_LOG);
+        Assertions.assertEquals(ClusterSnapshotLog.ClusterSnapshotLogType.AUTOMATED_SNAPSHOT_OFF, log.getType());
+
+        ClusterSnapshotMgr follower = new ClusterSnapshotMgr();
+        follower.setAutomatedSnapshotOn("sv_off", 60);
+        follower.replayLog(log);
+        Assertions.assertNull(follower.getAutomatedSnapshotSvName());
+    }
+
+    @Test
+    public void testSetAutomatedSnapshotIntervalEditLogAndReplay() throws Exception {
+        ClusterSnapshotMgr mgr = new ClusterSnapshotMgr();
+        AdminAlterAutomatedSnapshotIntervalStmt stmt = new AdminAlterAutomatedSnapshotIntervalStmt(null);
+        stmt.setIntervalSeconds(300);
+
+        mgr.setAutomatedSnapshotInterval(stmt);
+        Assertions.assertEquals(300, mgr.getAutomatedSnapshotIntervalSeconds());
+
+        ClusterSnapshotLog log = (ClusterSnapshotLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_CLUSTER_SNAPSHOT_LOG);
+        Assertions.assertEquals(ClusterSnapshotLog.ClusterSnapshotLogType.AUTOMATED_SNAPSHOT_INTERVAL, log.getType());
+        Assertions.assertEquals(300, log.getAutomatedSnapshotIntervalSeconds());
+
+        ClusterSnapshotMgr follower = new ClusterSnapshotMgr();
+        follower.setAutomatedSnapshotInterval(60);
+        follower.replayLog(log);
+        Assertions.assertEquals(300, follower.getAutomatedSnapshotIntervalSeconds());
+    }
+
+    @Test
+    public void testCreateAutomatedSnapshotJobEditLogAndReplay() throws Exception {
+        ClusterSnapshotMgr mgr = new ClusterSnapshotMgr();
+        mgr.setAutomatedSnapshotOn("sv_job", 60);
+
+        ClusterSnapshotJob job = mgr.createAutomatedSnapshotJob();
+        Assertions.assertNotNull(job);
+        Assertions.assertEquals("sv_job", job.getStorageVolumeName());
+        Assertions.assertEquals(ClusterSnapshotJobState.INITIALIZING, job.getState());
+        Assertions.assertTrue(job.getSnapshotName().startsWith(ClusterSnapshotMgr.AUTOMATED_NAME_PREFIX));
+
+        ClusterSnapshotLog log = (ClusterSnapshotLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_CLUSTER_SNAPSHOT_LOG);
+        Assertions.assertEquals(ClusterSnapshotLog.ClusterSnapshotLogType.UPDATE_SNAPSHOT_JOB, log.getType());
+        Assertions.assertNotNull(log.getSnapshotJob());
+        Assertions.assertEquals(job.getId(), log.getSnapshotJob().getId());
+
+        ClusterSnapshotMgr follower = new ClusterSnapshotMgr();
+        follower.replayLog(log);
+        ClusterSnapshotJob replayed = follower.getClusterSnapshotJobByName(job.getSnapshotName());
+        Assertions.assertNotNull(replayed);
+        Assertions.assertEquals(job.getId(), replayed.getId());
+        Assertions.assertEquals(ClusterSnapshotJobState.INITIALIZING, replayed.getState());
+        Assertions.assertEquals("sv_job", replayed.getStorageVolumeName());
+    }
+
+    @Test
+    public void testSetAutomatedSnapshotOnEditLogException() {
+        ClusterSnapshotMgr mgr = new ClusterSnapshotMgr();
+        AdminSetAutomatedSnapshotOnStmt stmt = new AdminSetAutomatedSnapshotOnStmt("sv_fail_on", null);
+        stmt.setIntervalSeconds(90);
+
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logClusterSnapshotLog(any(ClusterSnapshotLog.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                    () -> mgr.setAutomatedSnapshotOn(stmt));
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertNull(mgr.getAutomatedSnapshotSvName());
+            Assertions.assertEquals(0, mgr.getAutomatedSnapshotIntervalSeconds());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    @Test
+    public void testSetAutomatedSnapshotOffEditLogException() {
+        ClusterSnapshotMgr mgr = new ClusterSnapshotMgr();
+        mgr.setAutomatedSnapshotOn("sv_fail_off", 30);
+        AdminSetAutomatedSnapshotOffStmt stmt = new AdminSetAutomatedSnapshotOffStmt();
+
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logClusterSnapshotLog(any(ClusterSnapshotLog.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                    () -> mgr.setAutomatedSnapshotOff(stmt));
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertEquals("sv_fail_off", mgr.getAutomatedSnapshotSvName());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    @Test
+    public void testSetAutomatedSnapshotIntervalEditLogException() {
+        ClusterSnapshotMgr mgr = new ClusterSnapshotMgr();
+        mgr.setAutomatedSnapshotInterval(45);
+        AdminAlterAutomatedSnapshotIntervalStmt stmt = new AdminAlterAutomatedSnapshotIntervalStmt(null);
+        stmt.setIntervalSeconds(200);
+
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logClusterSnapshotLog(any(ClusterSnapshotLog.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                    () -> mgr.setAutomatedSnapshotInterval(stmt));
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertEquals(45, mgr.getAutomatedSnapshotIntervalSeconds());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    @Test
+    public void testCreateAutomatedSnapshotJobEditLogException() {
+        ClusterSnapshotMgr mgr = new ClusterSnapshotMgr();
+        mgr.setAutomatedSnapshotOn("sv_fail_job", 60);
+
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logClusterSnapshotLog(any(ClusterSnapshotLog.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                    mgr::createAutomatedSnapshotJob);
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertTrue(mgr.automatedSnapshotJobs.isEmpty());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerEditLogTest.java
@@ -1,0 +1,281 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.Config;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.InsertOverwriteStateChangeInfo;
+import com.starrocks.persist.OperationType;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.common.DmlException;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class InsertOverwriteJobRunnerEditLogTest {
+    private static final String DB_NAME = "test_insert_overwrite_editlog";
+    private static final String TABLE_NAME = "t1";
+
+    private static final long INDEX_ID = 41007L;
+
+    private Database db;
+    private OlapTable table;
+    private long oldPartitionRetentionSecs;
+    private long dbId;
+    private long tableId;
+    private long sourcePartitionId;
+    private long sourcePhysicalPartitionId;
+    private long tempPartitionId;
+    private long tempPhysicalPartitionId;
+    private long sourceTabletId;
+    private long tempTabletId;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        oldPartitionRetentionSecs = Config.partition_recycle_retention_period_secs;
+        Config.partition_recycle_retention_period_secs = 0;
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        dbId = GlobalStateMgr.getCurrentState().getNextId();
+        tableId = GlobalStateMgr.getCurrentState().getNextId();
+        sourcePartitionId = GlobalStateMgr.getCurrentState().getNextId();
+        sourcePhysicalPartitionId = GlobalStateMgr.getCurrentState().getNextId();
+        tempPartitionId = GlobalStateMgr.getCurrentState().getNextId();
+        tempPhysicalPartitionId = GlobalStateMgr.getCurrentState().getNextId();
+        sourceTabletId = GlobalStateMgr.getCurrentState().getNextId();
+        tempTabletId = GlobalStateMgr.getCurrentState().getNextId();
+
+        db = new Database(dbId, DB_NAME);
+        metastore.unprotectCreateDb(db);
+        table = createHashOlapTable(dbId, tableId, TABLE_NAME, sourcePartitionId, sourcePhysicalPartitionId,
+                sourceTabletId);
+        db.registerTableUnlocked(table);
+        addTempPartition(dbId, table, sourcePartitionId, tempPartitionId, tempPhysicalPartitionId, tempTabletId,
+                TABLE_NAME + "_tmp");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Config.partition_recycle_retention_period_secs = oldPartitionRetentionSecs;
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testDoCommitAndReplayCommitWithEditLog() throws Exception {
+        InsertOverwriteJob job = new InsertOverwriteJob(2002L, db.getId(), table.getId(),
+                Lists.newArrayList(sourcePartitionId), false);
+        job.setJobState(InsertOverwriteJobState.OVERWRITE_RUNNING);
+        job.setTmpPartitionIds(Lists.newArrayList(tempPartitionId));
+        job.setSourcePartitionNames(Lists.newArrayList(TABLE_NAME));
+
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(job);
+        runner.doCommit();
+
+        Partition replaced = table.getPartition(TABLE_NAME);
+        Assertions.assertNotNull(replaced);
+        Assertions.assertEquals(tempPartitionId, replaced.getId());
+        Assertions.assertFalse(table.existTempPartitions());
+
+        resetTableForReplay();
+
+        InsertOverwriteStateChangeInfo info = (InsertOverwriteStateChangeInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_INSERT_OVERWRITE_STATE_CHANGE);
+        Assertions.assertEquals(InsertOverwriteJobState.OVERWRITE_SUCCESS, info.getToState());
+        Assertions.assertEquals(Lists.newArrayList(sourcePartitionId), info.getSourcePartitionIds());
+        Assertions.assertEquals(Lists.newArrayList(tempPartitionId), info.getTmpPartitionIds());
+
+        runner.replayStateChange(info);
+
+        Partition replayed = table.getPartition(TABLE_NAME);
+        Assertions.assertNotNull(replayed);
+        Assertions.assertEquals(tempPartitionId, replayed.getId());
+        Assertions.assertFalse(table.existTempPartitions());
+    }
+
+    @Test
+    public void testGcAndReplayGCWithEditLog() throws Exception {
+        InsertOverwriteJob job = new InsertOverwriteJob(2004L, db.getId(), table.getId(),
+                Lists.newArrayList(sourcePartitionId), false);
+        job.setJobState(InsertOverwriteJobState.OVERWRITE_RUNNING);
+        job.setTmpPartitionIds(Lists.newArrayList(tempPartitionId));
+
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(job);
+        runner.gc();
+        Assertions.assertFalse(table.existTempPartitions());
+
+        addTempPartition(dbId, table, sourcePartitionId, tempPartitionId, tempPhysicalPartitionId, tempTabletId,
+                TABLE_NAME + "_tmp");
+
+        InsertOverwriteStateChangeInfo info = (InsertOverwriteStateChangeInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_INSERT_OVERWRITE_STATE_CHANGE);
+        Assertions.assertEquals(InsertOverwriteJobState.OVERWRITE_FAILED, info.getToState());
+        Assertions.assertEquals(Lists.newArrayList(tempPartitionId), info.getTmpPartitionIds());
+        runner.replayStateChange(info);
+
+        Assertions.assertFalse(table.existTempPartitions());
+    }
+
+    @Test
+    public void testDoCommitEditLogException() {
+        InsertOverwriteJob job = new InsertOverwriteJob(2005L, db.getId(), table.getId(),
+                Lists.newArrayList(sourcePartitionId), false);
+        job.setJobState(InsertOverwriteJobState.OVERWRITE_RUNNING);
+        job.setTmpPartitionIds(Lists.newArrayList(tempPartitionId));
+        job.setSourcePartitionNames(Lists.newArrayList(TABLE_NAME));
+
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logInsertOverwriteStateChange(any(InsertOverwriteStateChangeInfo.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(job);
+            DmlException exception = Assertions.assertThrows(DmlException.class, runner::doCommit);
+            Assertions.assertTrue(exception.getMessage().contains("replace partitions failed"));
+
+            Partition sourcePartition = table.getPartition(TABLE_NAME);
+            Assertions.assertNotNull(sourcePartition);
+            Assertions.assertEquals(sourcePartitionId, sourcePartition.getId());
+            Assertions.assertTrue(table.existTempPartitions());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    @Test
+    public void testGcEditLogException() {
+        InsertOverwriteJob job = new InsertOverwriteJob(2006L, db.getId(), table.getId(),
+                Lists.newArrayList(sourcePartitionId), false);
+        job.setJobState(InsertOverwriteJobState.OVERWRITE_FAILED);
+        job.setTmpPartitionIds(Lists.newArrayList(tempPartitionId));
+
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logInsertOverwriteStateChange(any(InsertOverwriteStateChangeInfo.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(job);
+            Assertions.assertDoesNotThrow(runner::gc);
+            Assertions.assertTrue(table.existTempPartitions());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    private static OlapTable createHashOlapTable(long dbId, long tableId, String tableName, long partitionId,
+                                                 long physicalPartitionId, long tabletId) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("k1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("k2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(partitionId, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(partitionId, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(1, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(tabletId);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, INDEX_ID, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(partitionId, physicalPartitionId, tableName, baseIndex, distributionInfo);
+
+        OlapTable olapTable = new OlapTable(tableId, tableName, columns, KeysType.DUP_KEYS,
+                partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(INDEX_ID, tableName, columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(INDEX_ID);
+        olapTable.setDefaultDistributionInfo(distributionInfo);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new TableProperty(new HashMap<>()));
+        return olapTable;
+    }
+
+    private static void addTempPartition(long dbId, OlapTable table, long sourcePartitionId, long partitionId,
+                                         long physicalPartitionId, long tabletId, String partitionName) {
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(tabletId);
+        TabletMeta tabletMeta = new TabletMeta(dbId, table.getId(), partitionId, INDEX_ID, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        DistributionInfo distributionInfo = table.getDefaultDistributionInfo();
+        Partition partition = new Partition(partitionId, physicalPartitionId, partitionName, baseIndex,
+                distributionInfo);
+
+        table.addTempPartition(partition);
+        table.getPartitionInfo().addPartition(partitionId,
+                table.getPartitionInfo().getDataProperty(sourcePartitionId),
+                table.getPartitionInfo().getReplicationNum(sourcePartitionId));
+    }
+
+    private void resetTableForReplay() {
+        GlobalStateMgr.getCurrentState().getRecycleBin().removePartitionFromRecycleBin(sourcePartitionId);
+        GlobalStateMgr.getCurrentState().getRecycleBin().removePartitionFromRecycleBin(tempPartitionId);
+        table.dropPartition(dbId, TABLE_NAME, true);
+        GlobalStateMgr.getCurrentState().getRecycleBin().removePartitionFromRecycleBin(tempPartitionId);
+
+        Partition sourcePartition = buildPartition(dbId, table, sourcePartitionId, sourcePhysicalPartitionId,
+                sourceTabletId, TABLE_NAME);
+        table.addPartition(sourcePartition);
+        table.getPartitionInfo().addPartition(sourcePartitionId,
+                com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY, (short) 1);
+
+        addTempPartition(dbId, table, sourcePartitionId, tempPartitionId, tempPhysicalPartitionId, tempTabletId,
+                TABLE_NAME + "_tmp");
+    }
+
+    private static Partition buildPartition(long dbId, OlapTable table, long partitionId, long physicalPartitionId,
+                                            long tabletId, String partitionName) {
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(tabletId);
+        TabletMeta tabletMeta = new TabletMeta(dbId, table.getId(), partitionId, INDEX_ID, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+        DistributionInfo distributionInfo = table.getDefaultDistributionInfo();
+        return new Partition(partitionId, physicalPartitionId, partitionName, baseIndex, distributionInfo);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
@@ -163,9 +163,9 @@ public class InsertOverwriteJobRunnerTest {
         String sql = "insert overwrite t1 partitions(t1) select * from t2";
         cluster.runSql("insert_overwrite_test", sql);
 
-        Assertions.assertThrows(DmlException.class, () -> runner.testDoCommit(false));
+        Assertions.assertThrows(DmlException.class, () -> runner.testDoCommit());
         insertOverwriteJob.setSourcePartitionNames(Lists.newArrayList("t1"));
-        Assertions.assertThrows(DmlException.class, () -> runner.testDoCommit(false));
+        Assertions.assertThrows(DmlException.class, () -> runner.testDoCommit());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/InsertLoadJobEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/InsertLoadJobEditLogTest.java
@@ -1,0 +1,117 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.loadv2;
+
+import com.starrocks.common.Config;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.qe.scheduler.Coordinator;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TLoadJobType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class InsertLoadJobEditLogTest {
+    private static final long DB_ID = 10001L;
+    private static final long TABLE_ID = 20001L;
+    private static final long TXN_ID = 30001L;
+    private static final String LOAD_ID = "load_id";
+    private static final String USER = "test_user";
+    private static final long TIMEOUT = 3600L;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testSetLoadFinishOrCancelAndReplay() throws Exception {
+        InsertLoadJob job = createLoadingJob("finish_label");
+        GlobalStateMgr.getCurrentState().getEditLog().logCreateLoadJob(job, wal -> {
+        });
+
+        String trackingUrl = "http://tracking/finish";
+        job.setLoadFinishOrCancel("", trackingUrl);
+
+        Assertions.assertEquals(JobState.FINISHED, job.getState());
+        Assertions.assertEquals(100, job.getProgress());
+        Assertions.assertEquals(trackingUrl, job.loadingStatus.getTrackingUrl());
+
+        LoadMgr followerLoadMgr = new LoadMgr(new LoadJobScheduler());
+        LoadJob replayCreateJob = (LoadJob) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_CREATE_LOAD_JOB_V2);
+        followerLoadMgr.replayCreateLoadJob(replayCreateJob);
+
+        LoadJobFinalOperation operation = (LoadJobFinalOperation) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_END_LOAD_JOB_V2);
+        Assertions.assertEquals(job.getId(), operation.getId());
+        Assertions.assertEquals(JobState.FINISHED, operation.getJobState());
+        Assertions.assertEquals(100, operation.getProgress());
+        Assertions.assertEquals(trackingUrl, operation.getLoadingStatus().getTrackingUrl());
+        Assertions.assertNull(operation.getFailMsg());
+
+        followerLoadMgr.replayEndLoadJob(operation);
+        LoadJob followerJob = followerLoadMgr.getLoadJob(job.getId());
+        Assertions.assertNotNull(followerJob);
+        Assertions.assertEquals(JobState.FINISHED, followerJob.getState());
+        Assertions.assertEquals(100, followerJob.getProgress());
+        Assertions.assertEquals(trackingUrl, followerJob.loadingStatus.getTrackingUrl());
+    }
+
+    @Test
+    public void testSetLoadFinishOrCancelEditLogException() throws Exception {
+        InsertLoadJob job = createLoadingJob("exception_label");
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logEndLoadJob(any(LoadJobFinalOperation.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                    () -> job.setLoadFinishOrCancel("fail", "http://tracking/fail"));
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertEquals(JobState.LOADING, job.getState());
+            Assertions.assertEquals(0, job.getProgress());
+            Assertions.assertNotNull(job.failMsg);
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    private static InsertLoadJob createLoadingJob(String label) {
+        Coordinator coordinator = mock(Coordinator.class);
+        when(coordinator.getLoadJobType()).thenReturn(TLoadJobType.INSERT_QUERY);
+        InsertLoadTxnCallback insertLoadTxnCallback = mock(InsertLoadTxnCallback.class);
+        long createTimestamp = System.currentTimeMillis();
+        return new InsertLoadJob(label, DB_ID, TABLE_ID, TXN_ID, LOAD_ID, USER, createTimestamp,
+                Math.max(TIMEOUT, Config.insert_load_default_timeout_second),
+                0L, coordinator, insertLoadTxnCallback);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadJobTest.java
@@ -37,6 +37,7 @@ package com.starrocks.load.loadv2;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.FakeEditLog;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.DuplicatedRequestException;
@@ -299,6 +300,7 @@ public class LoadJobTest {
 
     @Test
     public void testProcessTimeout(@Mocked EditLog editLog) {
+        new FakeEditLog();
         LoadJob loadJob = new BrokerLoadJob();
         Deencapsulation.setField(loadJob, "timeoutSecond", 0);
         new Expectations() {

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadJobTest.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.FakeEditLog;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
@@ -61,6 +62,7 @@ import com.starrocks.lake.LakeTablet;
 import com.starrocks.load.EtlJobType;
 import com.starrocks.load.EtlStatus;
 import com.starrocks.load.loadv2.etl.EtlJobConfig;
+import com.starrocks.persist.EditLog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.BrokerDesc;
@@ -257,8 +259,19 @@ public class SparkLoadJobTest {
     }
 
     @Test
-    public void testOnPendingTaskFinished(@Mocked GlobalStateMgr globalStateMgr, @Injectable String originStmt)
-            throws MetaNotFoundException {
+    public void testOnPendingTaskFinished(@Mocked GlobalStateMgr globalStateMgr,
+                                          @Mocked EditLog editLog,
+                                          @Injectable String originStmt) throws MetaNotFoundException {
+        new FakeEditLog();
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+
+                globalStateMgr.getEditLog();
+                result = editLog;
+            }
+        };
         ResourceDesc resourceDesc = new ResourceDesc(resourceName, Maps.newHashMap());
         SparkLoadJob job = new SparkLoadJob(dbId, label, resourceDesc, new OriginStatement(originStmt, 0));
         SparkPendingTaskAttachment attachment = new SparkPendingTaskAttachment(pendingTaskId);
@@ -366,10 +379,22 @@ public class SparkLoadJobTest {
     public void testUpdateEtlStatusFinishedAndCommitTransaction(
             @Mocked GlobalStateMgr globalStateMgr, @Injectable String originStmt,
             @Mocked SparkEtlJobHandler handler, @Mocked AgentTaskExecutor executor,
+            @Mocked EditLog editLog,
             @Injectable Database db, @Injectable OlapTable table, @Injectable Partition partition,
             @Injectable PhysicalPartition physicalPartition,
             @Injectable MaterializedIndex index, @Injectable LocalTablet tablet, @Injectable Replica replica,
             @Injectable GlobalTransactionMgr transactionMgr) throws Exception {
+        new FakeEditLog();
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+
+                globalStateMgr.getEditLog();
+                result = editLog;
+            }
+        };
+
         EtlStatus status = new EtlStatus();
         status.setState(TEtlState.FINISHED);
         status.getCounters().put("dpp.norm.ALL", "9");
@@ -466,11 +491,24 @@ public class SparkLoadJobTest {
     public void testUpdateEtlStatusFinishedAndCommitTransactionForLake(
             @Mocked GlobalStateMgr globalStateMgr, @Injectable String originStmt,
             @Mocked SparkEtlJobHandler handler, @Mocked AgentTaskExecutor executor,
+            @Mocked EditLog editLog,
             @Injectable Database db, @Injectable LakeTable table,
             @Injectable Partition partition,
             @Injectable PhysicalPartition physicalPartition,
             @Injectable MaterializedIndex index, @Injectable LakeTablet tablet, @Injectable Replica replica,
             @Injectable GlobalTransactionMgr transactionMgr) throws Exception {
+
+        new FakeEditLog();
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+
+                globalStateMgr.getEditLog();
+                result = editLog;
+            }
+        };
+
         EtlStatus status = new EtlStatus();
         status.setState(TEtlState.FINISHED);
         status.getCounters().put("dpp.norm.ALL", "9");

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationEditLogTest.java
@@ -1,0 +1,230 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.replication;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.Config;
+import com.starrocks.common.io.DeepCopy;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.ReplicationJobLog;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.system.Backend;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class ReplicationEditLogTest {
+    private static final String DB_NAME = "test_replication_editlog";
+    private static final String TABLE_NAME = "test_table";
+    private static final long DB_ID = 30001L;
+    private static final long TABLE_ID = 30002L;
+    private static final long PARTITION_ID = 30003L;
+    private static final long PHYSICAL_PARTITION_ID = 30004L;
+    private static final long INDEX_ID = 30005L;
+    private static final long TABLET_ID = 30006L;
+    private static final long REPLICA_ID = 30007L;
+    private static final long BACKEND_ID = 30008L;
+
+    private Database db;
+    private OlapTable table;
+    private OlapTable srcTable;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        UtFrameUtils.setUpForPersistTest();
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        db = new Database(DB_ID, DB_NAME);
+        metastore.unprotectCreateDb(db);
+        if (GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(BACKEND_ID) == null) {
+            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
+                    .addBackend(new Backend(BACKEND_ID, "127.0.0.1", 9050));
+        }
+        table = createHashOlapTable(TABLE_ID, TABLE_NAME, 1);
+        db.registerTableUnlocked(table);
+        srcTable = DeepCopy.copyWithGson(table, OlapTable.class);
+
+        Partition partition = table.getPartitions().iterator().next();
+        Partition srcPartition = srcTable.getPartitions().iterator().next();
+        partition.getDefaultPhysicalPartition().updateVersionForRestore(10);
+        srcPartition.getDefaultPhysicalPartition().updateVersionForRestore(100);
+        partition.getDefaultPhysicalPartition().setDataVersion(8);
+        partition.getDefaultPhysicalPartition().setNextDataVersion(9);
+        srcPartition.getDefaultPhysicalPartition().setDataVersion(98);
+        srcPartition.getDefaultPhysicalPartition().setNextDataVersion(99);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private static OlapTable createHashOlapTable(long tableId, String tableName, int bucketNum) {
+        List<Column> columns = new ArrayList<>();
+        Column col1 = new Column("key1", IntegerType.BIGINT);
+        col1.setIsKey(true);
+        columns.add(col1);
+        columns.add(new Column("key2", IntegerType.BIGINT));
+
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(PARTITION_ID, com.starrocks.catalog.DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 1);
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(bucketNum, List.of(col1));
+
+        MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        LocalTablet tablet = new LocalTablet(TABLET_ID);
+        tablet.addReplica(new com.starrocks.catalog.Replica(REPLICA_ID, BACKEND_ID,
+                com.starrocks.catalog.Replica.ReplicaState.NORMAL, 1, 0), false);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID, tableId, PARTITION_ID, INDEX_ID, TStorageMedium.HDD);
+        baseIndex.addTablet(tablet, tabletMeta);
+
+        Partition partition = new Partition(PARTITION_ID, PHYSICAL_PARTITION_ID, tableName, baseIndex, distributionInfo);
+
+        OlapTable olapTable = new OlapTable(tableId, tableName, columns, KeysType.DUP_KEYS, partitionInfo, distributionInfo);
+        olapTable.setIndexMeta(INDEX_ID, tableName, columns, 0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(INDEX_ID);
+        olapTable.addPartition(partition);
+        olapTable.setTableProperty(new com.starrocks.catalog.TableProperty(new HashMap<>()));
+        return olapTable;
+    }
+
+    @Test
+    public void testPersistStateChangeNormalCase() throws Exception {
+        ReplicationJob job = new ReplicationJob("test_job", "test_token", db.getId(), table, srcTable,
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+
+        Assertions.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+        job.persistStateChange(ReplicationJobState.SNAPSHOTING);
+        Assertions.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        ReplicationJobLog replayLog = (ReplicationJobLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_REPLICATION_JOB);
+        Assertions.assertNotNull(replayLog);
+        Assertions.assertEquals("test_job", replayLog.getReplicationJob().getJobId());
+        Assertions.assertEquals(ReplicationJobState.SNAPSHOTING, replayLog.getReplicationJob().getState());
+    }
+
+    @Test
+    public void testPersistStateChangeEditLogException() {
+        ReplicationJob job = new ReplicationJob("test_job_exception", "test_token", db.getId(), table, srcTable,
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logReplicationJob(any(ReplicationJob.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        Assertions.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                () -> job.persistStateChange(ReplicationJobState.SNAPSHOTING));
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+        Assertions.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+    }
+
+    @Test
+    public void testClearExpiredJobsNormalCase() throws Exception {
+        ReplicationMgr replicationMgr = new ReplicationMgr();
+
+        ReplicationJob committedJob = new ReplicationJob("committed_job", "test_token", db.getId(), table, srcTable,
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+        Deencapsulation.setField(committedJob, "state", ReplicationJobState.COMMITTED);
+        Deencapsulation.setField(committedJob, "finishedTimeMs", System.currentTimeMillis());
+        replicationMgr.replayReplicationJob(committedJob);
+
+        ReplicationJob abortedJob = new ReplicationJob("aborted_job", "test_token", db.getId(), table, srcTable,
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+        Deencapsulation.setField(abortedJob, "state", ReplicationJobState.ABORTED);
+        Deencapsulation.setField(abortedJob, "finishedTimeMs", System.currentTimeMillis());
+        replicationMgr.replayReplicationJob(abortedJob);
+
+        int old = Config.history_job_keep_max_second;
+        Config.history_job_keep_max_second = -1;
+        try {
+            Assertions.assertTrue(committedJob.isExpired());
+            Assertions.assertTrue(abortedJob.isExpired());
+
+            replicationMgr.clearExpiredJobs();
+
+            Assertions.assertTrue(replicationMgr.getCommittedJobs().isEmpty());
+            Assertions.assertTrue(replicationMgr.getAbortedJobs().isEmpty());
+
+            ReplicationJobLog firstLog = (ReplicationJobLog) UtFrameUtils.PseudoJournalReplayer
+                    .replayNextJournal(OperationType.OP_DELETE_REPLICATION_JOB);
+            ReplicationJobLog secondLog = (ReplicationJobLog) UtFrameUtils.PseudoJournalReplayer
+                    .replayNextJournal(OperationType.OP_DELETE_REPLICATION_JOB);
+
+            Set<String> jobIds = new HashSet<>();
+            jobIds.add(firstLog.getReplicationJob().getJobId());
+            jobIds.add(secondLog.getReplicationJob().getJobId());
+            Assertions.assertEquals(Set.of("committed_job", "aborted_job"), jobIds);
+        } finally {
+            Config.history_job_keep_max_second = old;
+        }
+    }
+
+    @Test
+    public void testClearExpiredJobsEditLogException() {
+        ReplicationMgr replicationMgr = new ReplicationMgr();
+        ReplicationJob committedJob = new ReplicationJob("committed_job_exception", "test_token", db.getId(), table,
+                srcTable, GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+        Deencapsulation.setField(committedJob, "state", ReplicationJobState.COMMITTED);
+        Deencapsulation.setField(committedJob, "finishedTimeMs", System.currentTimeMillis());
+        replicationMgr.replayReplicationJob(committedJob);
+
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+                .when(spyEditLog).logDeleteReplicationJob(any(ReplicationJob.class), any());
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        int old = Config.history_job_keep_max_second;
+        Config.history_job_keep_max_second = -1;
+        try {
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class, replicationMgr::clearExpiredJobs);
+            Assertions.assertEquals("EditLog write failed", exception.getMessage());
+            Assertions.assertEquals(1, replicationMgr.getCommittedJobs().size());
+        } finally {
+            Config.history_job_keep_max_second = old;
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Refer https://github.com/StarRocks/starrocks/issues/63357

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors job state persistence to WAL with appliers and copy-for-persist patterns, reducing in-memory mutation risk and improving replayability.
> 
> - Add `AlterJobV2.copyForPersist`, `persistStateChange(...)`, copy constructors, `pruneMeta()`, and `prepareForPersist()`; switch alter jobs (`SchemaChangeJobV2`, `Lake*` jobs, `RollupJobV2`, `Optimize*`, `MergePartitionJob`) from direct `editLog` calls/state mutations to WAL logging with applier callbacks
> - Update handlers (`SchemaChangeHandler`, `MaterializedViewHandler`) and managers (`TabletReshardJobMgr`) to use WAL variants (batch and single) and apply side effects within appliers
> - Backup/Restore: introduce copy constructors and `persistStateChange` via WAL (`BackupJob`, `RestoreJob`, `BackupHandler`); Cluster snapshots (`ClusterSnapshot*`) now persist via WAL as well
> - Load pipeline: move finalization/cancel/update to WAL (`LoadJob`, `BrokerLoadJob`, `BulkLoadJob`, `InsertLoadJob`, `SparkLoadJob`), simplify cancel API and remove ad-hoc logging
> - Insert Overwrite: rework to WAL-driven transitions, add replayable `commit`/`gc`, dynamic overwrite handling; `OlapTable` splits `replaceTempPartitions` into `checkReplaceTempPartitions` and `replaceTempPartitionsWithoutCheck`
> 
> Overall: replace ad-hoc edit logs with WAL + appliers across job types, add deep-copy persist models for safe logging, and adjust replay/GC flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac2567175e0cd5f5dea46e4af80f518b4666c5a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->