### PR TITLE
[Enhancement] Allow limited operations during TABLET_RESHARD state

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -843,7 +843,8 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
         Preconditions.checkArgument(locker.isDbWriteLockHeldByCurrentThread(db));
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
         List<ModifyPartitionInfo> modifyPartitionInfos = Lists.newArrayList();
-        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
+        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL
+                && olapTable.getState() != OlapTable.OlapTableState.TABLET_RESHARD) {
             throw InvalidOlapTableStateException.of(olapTable.getState(), olapTable.getName());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -73,7 +73,8 @@ public class CatalogUtils {
     // check table state
     public static void checkTableState(OlapTable olapTable, String tableName) throws DdlException {
         if (olapTable.getState() != OlapTable.OlapTableState.NORMAL
-                && olapTable.getState() != OlapTable.OlapTableState.OPTIMIZE) {
+                && olapTable.getState() != OlapTable.OlapTableState.OPTIMIZE
+                && olapTable.getState() != OlapTable.OlapTableState.TABLET_RESHARD) {
             throw InvalidOlapTableStateException.of(olapTable.getState(), tableName);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -384,7 +384,8 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
                 return true;
             }
 
-            if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
+            if (olapTable.getState() != OlapTable.OlapTableState.NORMAL
+                    && olapTable.getState() != OlapTable.OlapTableState.TABLET_RESHARD) {
                 String errorMsg = "Table[" + olapTable.getName() + "]'s state is not NORMAL." +
                             "Do not allow doing dynamic add partition. table state=" + olapTable.getState();
                 runtimeInfoCollector.recordCreatePartitionFailedMsg(db.getOriginName(), olapTable.getName(), errorMsg);

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
@@ -231,7 +231,8 @@ public class DeleteMgr implements Writable, MemoryTrackable {
                                 List<Partition> partitions)
             throws DdlException, AnalysisException, RunningTxnExceedException {
         // check table state
-        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
+        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL
+                && olapTable.getState() != OlapTable.OlapTableState.TABLET_RESHARD) {
             throw new DdlException("Table's state is not normal: " + olapTable.getName());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -276,7 +276,8 @@ public class OlapTableSink extends DataSink {
     public List<Long> getOpenPartitions() {
         // if load start after shema change, we should open all of the partitions to avoid different schema during schema change
         // if load start before schema change, it will be finished in waiting_txn state
-        if (dstTable.getState() != OlapTable.OlapTableState.NORMAL) {
+        if (dstTable.getState() != OlapTable.OlapTableState.NORMAL
+                && dstTable.getState() != OlapTable.OlapTableState.TABLET_RESHARD) {
             return partitionIds;
         }
         if (enableAutomaticPartition && enableDynamicOverwrite) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1407,7 +1407,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         long tableId = olapTable.getId();
         EditLog editLog = GlobalStateMgr.getCurrentState().getEditLog();
 
-        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
+        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL
+                && olapTable.getState() != OlapTable.OlapTableState.TABLET_RESHARD) {
             throw InvalidOlapTableStateException.of(olapTable.getState(), olapTable.getName());
         }
 
@@ -3475,7 +3476,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     @Override
     public void renameTable(Database db, Table table, TableRenameClause tableRenameClause) throws DdlException {
         OlapTable olapTable = (OlapTable) table;
-        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
+        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL
+                && olapTable.getState() != OlapTable.OlapTableState.TABLET_RESHARD) {
             throw new DdlException("Table[" + olapTable.getName() + "] is under " + olapTable.getState());
         }
 
@@ -3534,7 +3536,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     @Override
     public void renamePartition(Database db, Table table, PartitionRenameClause renameClause) throws DdlException {
         OlapTable olapTable = (OlapTable) table;
-        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
+        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL
+                && olapTable.getState() != OlapTable.OlapTableState.TABLET_RESHARD) {
             throw new DdlException("Table[" + olapTable.getName() + "] is under " + olapTable.getState());
         }
 
@@ -3595,7 +3598,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     }
 
     public void renameRollup(Database db, OlapTable table, RollupRenameClause renameClause) throws DdlException {
-        if (table.getState() != OlapTable.OlapTableState.NORMAL) {
+        if (table.getState() != OlapTable.OlapTableState.NORMAL
+                && table.getState() != OlapTable.OlapTableState.TABLET_RESHARD) {
             throw new DdlException("Table[" + table.getName() + "] is under " + table.getState());
         }
 
@@ -3659,7 +3663,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         if (db.isSystemDatabase() || db.isStatisticsDatabase()) {
             throw ErrorReportException.report(ErrorCode.ERR_CANNOT_RENAME_COLUMN_IN_INTERNAL_DB, db.getFullName());
         }
-        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
+        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL
+                && olapTable.getState() != OlapTable.OlapTableState.TABLET_RESHARD) {
             throw ErrorReportException.report(ErrorCode.ERR_CANNOT_RENAME_COLUMN_OF_NOT_NORMAL_TABLE, olapTable.getState());
         }
 
@@ -4500,7 +4505,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             throw new DdlException("Only support truncate OLAP table or LAKE table");
         }
         OlapTable olapTable = (OlapTable) table;
-        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
+        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL
+                && olapTable.getState() != OlapTable.OlapTableState.TABLET_RESHARD) {
             throw InvalidOlapTableStateException.of(olapTable.getState(), olapTable.getName());
         }
         return olapTable;
@@ -5103,7 +5109,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         locker.lockDatabase(db.getId(), LockType.READ);
         try {
             if (olapTable.getState() != OlapTable.OlapTableState.NORMAL
-                    && olapTable.getState() != OlapTable.OlapTableState.OPTIMIZE) {
+                    && olapTable.getState() != OlapTable.OlapTableState.OPTIMIZE
+                    && olapTable.getState() != OlapTable.OlapTableState.TABLET_RESHARD) {
                 throw new RuntimeException("Table' state is not NORMAL: " + olapTable.getState()
                         + ", tableId:" + olapTable.getId() + ", tabletName:" + olapTable.getName());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -434,7 +434,8 @@ public class StatisticsCollectJobFactory {
             return;
         }
         if (table instanceof OlapTable) {
-            if (((OlapTable) table).getState() != OlapTable.OlapTableState.NORMAL) {
+            if (((OlapTable) table).getState() != OlapTable.OlapTableState.NORMAL
+                    && ((OlapTable) table).getState() != OlapTable.OlapTableState.TABLET_RESHARD) {
                 return;
             }
         }


### PR DESCRIPTION
## Why I'm doing:
During tablet splitting, a table state will be set to TABLET_RESHARD, this will disable many operations.
This pr allow limited operations during TABLET_RESHARD state.

## What I'm doing:
  - Permit TABLET_RESHARD in several table-state checks so DDL/load/statistics tasks can proceed during tablet reshard
  - Extend CatalogUtils and LocalMetastore validations to accept TABLET_RESHARD
  - Enable dynamic partition add, delete jobs, and load partition selection while reshard is in progress

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
