### PR TITLE
[BugFix] fix insert overwrite hive unpartitioned table with relative temp dir

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -46,6 +46,7 @@ import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileOperations;
 import com.starrocks.connector.RemotePathKey;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.hive.HivePartitionStats;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
@@ -736,6 +737,75 @@ public class HiveMetadataTest {
             PartitionUpdate pu2 = new PartitionUpdate("", null, null, null, 1, 1);
             hiveCommitter.prepare(Lists.newArrayList(pu1, pu2));
         });
+    }
+
+    @Test
+    public void testGetRelativePathIfDescendant(@Mocked HiveMetastoreOperations hmsOps,
+                                                @Mocked RemoteFileOperations fileOps,
+                                                @Mocked HiveTable hiveTable) throws Exception {
+        HiveCommitter hiveCommitter = new HiveCommitter(hmsOps, fileOps, Executors.newSingleThreadExecutor(),
+                Executors.newSingleThreadExecutor(), hiveTable, new Path("/tmp/staging"));
+
+        java.lang.reflect.Method method =
+                HiveCommitter.class.getDeclaredMethod("getRelativePathIfDescendant", Path.class, Path.class);
+        method.setAccessible(true);
+
+        Optional<String> relative = (Optional<String>) method.invoke(hiveCommitter,
+                new Path("hdfs://127.0.0.1/base"), new Path("hdfs://127.0.0.1/base/a/b"));
+        Assertions.assertTrue(relative.isPresent());
+        Assertions.assertEquals("a/b", relative.get());
+
+        Optional<String> notDescendant = (Optional<String>) method.invoke(hiveCommitter,
+                new Path("hdfs://127.0.0.1/base"), new Path("hdfs://127.0.0.1/other"));
+        Assertions.assertFalse(notDescendant.isPresent());
+
+        Optional<String> samePath = (Optional<String>) method.invoke(hiveCommitter,
+                new Path("hdfs://127.0.0.1/base"), new Path("hdfs://127.0.0.1/base"));
+        Assertions.assertFalse(samePath.isPresent());
+    }
+
+    @Test
+    public void testPrepareOverwriteTableWithRelativeStaging(@Mocked HiveMetastoreOperations hmsOps,
+                                                             @Mocked RemoteFileOperations fileOps,
+                                                             @Mocked HiveTable hiveTable) throws Exception {
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setQueryId(UUIDUtil.genUUID());
+        ctx.setThreadLocalInfo();
+
+        try {
+            Path targetPath = new Path("hdfs://127.0.0.1:10000/warehouse/table");
+            Path writePath = new Path("hdfs://127.0.0.1:10000/warehouse/table/_staging/abc");
+            PartitionUpdate partitionUpdate = new PartitionUpdate("", writePath, targetPath,
+                    Lists.newArrayList("file"), 1, 1);
+            HiveCommitter hiveCommitter = new HiveCommitter(hmsOps, fileOps, Executors.newSingleThreadExecutor(),
+                    Executors.newSingleThreadExecutor(), hiveTable, new Path("hdfs://127.0.0.1:10000/warehouse/table/_staging"));
+
+            String queryId = ctx.getQueryId().toString();
+            Path oldTableStagingPath = new Path(targetPath.getParent(), "_temp_" + targetPath.getName() + "_" + queryId);
+            Path expectedSource = new Path(oldTableStagingPath, "_staging/abc");
+
+            new Expectations() {
+                {
+                    fileOps.renameDirectory(targetPath, oldTableStagingPath, (Runnable) any);
+                    times = 1;
+                    fileOps.renameDirectory(expectedSource, targetPath, (Runnable) any);
+                    times = 1;
+                    hiveTable.getCatalogDBName();
+                    result = "db";
+                    minTimes = 0;
+                    hiveTable.getCatalogTableName();
+                    result = "table";
+                    minTimes = 0;
+                }
+            };
+
+            java.lang.reflect.Method method = HiveCommitter.class.getDeclaredMethod(
+                    "prepareOverwriteTable", PartitionUpdate.class, HivePartitionStats.class);
+            method.setAccessible(true);
+            method.invoke(hiveCommitter, partitionUpdate, HivePartitionStats.fromCommonStats(1, 1, 1));
+        } finally {
+            ConnectContext.remove();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
when hive_temp_staging_dir is set as relative path, insert overwrite could not move the correct temp dir to target path.

the logic is:
write data into hdfs://table/tmp_dir
mv hdfs://table to temp staging dir
mv hdfs://table/tmp_dir to hdfs://table (but hdfs://table/tmp_dir is moved)
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes incorrect file move on INSERT OVERWRITE when `hive_temp_staging_dir` is relative to the table location.
> 
> - Updates `prepareOverwriteTable` to compute `writePath` relative to `targetPath` and rename from `oldTableStagingPath/<relative>` when applicable
> - Adds helpers `getRelativePathIfDescendant` and `ensureTrailingSlash` in `HiveCommitter`
> - Adds unit tests for relative-path detection and overwrite behavior with relative staging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a08158fe43f96ae8def0bf1daf775740ba6ec034. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->