### PR TITLE
[BugFix] Fix temp partitions not cleaned up after FE restart for dynamic overwrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJob.java
@@ -48,6 +48,11 @@ public class InsertOverwriteJob {
     @SerializedName(value = "dynamicOverwrite")
     private boolean dynamicOverwrite = false;
 
+    // Transaction ID for dynamic overwrite, used to identify temp partitions after FE restart.
+    // Temp partition name prefix is "txn{txnId}_".
+    @SerializedName(value = "txnId")
+    private long txnId = -1;
+
     private transient InsertStmt insertStmt;
 
     public InsertOverwriteJob() {
@@ -139,5 +144,13 @@ public class InsertOverwriteJob {
 
     public boolean isDynamicOverwrite() {
         return dynamicOverwrite;
+    }
+
+    public long getTxnId() {
+        return txnId;
+    }
+
+    public void setTxnId(long txnId) {
+        this.txnId = txnId;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -38,6 +38,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.AlterTableClauseAnalyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
@@ -51,8 +52,10 @@ import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.common.DmlException;
+import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.InsertOverwriteJobStats;
 import com.starrocks.transaction.InsertTxnCommitAttachment;
 import com.starrocks.transaction.PartitionCommitInfo;
@@ -184,6 +187,7 @@ public class InsertOverwriteJobRunner {
         // If the final status is failure, then GC must be done
         if (info.getToState() == OVERWRITE_FAILED) {
             job.setTmpPartitionIds(info.getTmpPartitionIds());
+            job.setTxnId(info.getTxnId());
             job.setJobState(OVERWRITE_FAILED);
             LOG.info("replay insert overwrite job:{} to FAILED", job.getJobId());
             gc(true);
@@ -198,10 +202,12 @@ public class InsertOverwriteJobRunner {
                 job.setSourcePartitionIds(info.getSourcePartitionIds());
                 job.setTmpPartitionIds(info.getTmpPartitionIds());
                 job.setSourcePartitionNames(info.getSourcePartitionNames());
+                job.setTxnId(info.getTxnId());
                 job.setJobState(InsertOverwriteJobState.OVERWRITE_RUNNING);
                 break;
             case OVERWRITE_SUCCESS:
                 job.setTmpPartitionIds(info.getTmpPartitionIds());
+                job.setTxnId(info.getTxnId());
                 job.setJobState(InsertOverwriteJobState.OVERWRITE_SUCCESS);
                 doCommit(true);
                 LOG.info("replay insert overwrite job:{} to SUCCESS", job.getJobId());
@@ -253,15 +259,63 @@ public class InsertOverwriteJobRunner {
             }
             job.setSourcePartitionNames(sourcePartitionNames);
 
+            // For dynamic overwrite, begin transaction here to get txnId early.
+            // This allows us to persist txnId in the log, so that after FE restart,
+            // we can identify temp partitions belonging to this job (prefix: "txn{txnId}_").
+            if (job.isDynamicOverwrite()) {
+                long txnId = beginTransactionForDynamicOverwrite(db, targetTable);
+                job.setTxnId(txnId);
+                LOG.info("dynamic overwrite job {} begin transaction, txnId: {}", job.getJobId(), txnId);
+            }
+
             InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
                     InsertOverwriteJobState.OVERWRITE_RUNNING, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
-                    job.getTmpPartitionIds());
+                    job.getTmpPartitionIds(), job.getTxnId());
             GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info);
         } finally {
             locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
         }
 
         transferTo(InsertOverwriteJobState.OVERWRITE_RUNNING);
+    }
+
+    private long beginTransactionForDynamicOverwrite(Database db, OlapTable targetTable) throws Exception {
+        GlobalTransactionMgr transactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        String label = MetaUtils.genInsertLabel(context.getExecutionId());
+        TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
+
+        long txnId = transactionMgr.beginTransaction(
+                db.getId(),
+                Lists.newArrayList(targetTable.getId()),
+                label,
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE,
+                        FrontendOptions.getLocalHostAddress()),
+                sourceType,
+                context.getExecTimeout(),
+                context.getCurrentComputeResource());
+
+        // add table indexes to transaction state
+        // If any operation fails after beginTransaction succeeds, we must abort the transaction
+        // to avoid orphaned transactions that would only timeout eventually.
+        try {
+            TransactionState txnState = transactionMgr.getTransactionState(db.getId(), txnId);
+            if (txnState == null) {
+                throw new DmlException("transaction state is null after beginTransaction, dbId:%s, txnId:%s",
+                        db.getId(), txnId);
+            }
+            txnState.addTableIndexes(targetTable);
+        } catch (Exception e) {
+            LOG.warn("failed to setup transaction state for dynamic overwrite, aborting txnId: {}", txnId, e);
+            try {
+                transactionMgr.abortTransaction(db.getId(), txnId,
+                        "failed to setup transaction state: " + e.getMessage());
+            } catch (Exception abortEx) {
+                LOG.warn("failed to abort orphaned transaction {}: {}", txnId, abortEx.getMessage());
+            }
+            throw e;
+        }
+
+        return txnId;
     }
 
     private void createPartitionByValue(InsertStmt insertStmt) {
@@ -339,6 +393,11 @@ public class InsertOverwriteJobRunner {
         long insertStartTimestamp = System.currentTimeMillis();
         // should replan here because prepareInsert has changed the targetPartitionNames of insertStmt
         try (var guard = context.bindScope()) {
+            // For dynamic overwrite, set the txnId to insertStmt so that StatementPlanner.beginTransaction()
+            // will skip creating a new transaction and reuse the one we created in prepare().
+            if (job.isDynamicOverwrite() && job.getTxnId() > 0) {
+                insertStmt.setTxnId(job.getTxnId());
+            }
             ExecPlan newPlan = StatementPlanner.plan(insertStmt, context);
             // Use `handleDMLStmt` instead of `handleDMLStmtWithProfile` because cannot call `writeProfile` in
             // InsertOverwriteJobRunner.
@@ -402,71 +461,133 @@ public class InsertOverwriteJobRunner {
         }
         try {
             Set<Tablet> sourceTablets = Sets.newHashSet();
+
+            // Drop temp partitions by partition IDs (for non-dynamic overwrite)
             if (job.getTmpPartitionIds() != null) {
                 for (long pid : job.getTmpPartitionIds()) {
                     LOG.info("drop temp partition:{}", pid);
-
                     Partition partition = targetTable.getPartition(pid);
                     if (partition != null) {
-                        for (PhysicalPartition subPartition : partition.getSubPartitions()) {
-                            for (MaterializedIndex index : subPartition.getMaterializedIndices(
-                                    MaterializedIndex.IndexExtState.ALL)) {
-                                sourceTablets.addAll(index.getTablets());
-                            }
-                        }
+                        collectTabletsFromPartition(partition, sourceTablets);
                         targetTable.dropTempPartition(partition.getName(), true);
                     } else {
                         LOG.warn("partition {} is null", pid);
                     }
                 }
             }
-            // if dynamic overwrite, drop all runtime created partitions
+
+            // Drop temp partitions for dynamic overwrite
             if (job.isDynamicOverwrite()) {
-                List<String> tmpPartitionNames = Lists.newArrayList();
-                if (!isReplay) {
-                    int waitTimes = 10;
-                    // wait for transaction state to be finished
-                    TransactionState txnState = null;
-                    do {
-                        txnState = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                                .getTransactionState(dbId, insertStmt.getTxnId());
-                        if (txnState == null) {
-                            throw new DmlException("transaction state is null dbId:%s, txnId:%s", dbId, insertStmt.getTxnId());
-                        }
-                        // wait a little bit even if txnState is finished
-                        Thread.sleep(200);
-                    } while (txnState.isRunning() && --waitTimes > 0);
-                    tmpPartitionNames = txnState.getCreatedPartitionNames(tableId);
-                    job.setTmpPartitionIds(tmpPartitionNames.stream()
-                            .map(name -> targetTable.getPartition(name, true).getId())
-                            .collect(Collectors.toList()));
-                    LOG.info("dynamic overwrite job {} drop tmpPartitionNames:{}", job.getJobId(), tmpPartitionNames);
-                }
-                for (String partitionName : tmpPartitionNames) {
-                    Partition partition = targetTable.getPartition(partitionName, true);
-                    if (partition != null) {
-                        for (MaterializedIndex index : partition.getDefaultPhysicalPartition()
-                                .getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
-                            sourceTablets.addAll(index.getTablets());
-                        }
-                        targetTable.dropTempPartition(partitionName, true);
+                gcDropDynamicOverwriteTempPartitions(targetTable, sourceTablets, isReplay);
+            }
+
+            if (!isReplay) {
+                // Mark all source tablet ids force delete to drop it directly on BE
+                sourceTablets.forEach(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()::markTabletForceDelete);
+
+                // Abort the transaction if it was created in prepare()
+                if (job.isDynamicOverwrite() && job.getTxnId() > 0) {
+                    try {
+                        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
+                                dbId, job.getTxnId(), "insert overwrite job failed");
+                        LOG.info("dynamic overwrite job {} aborted transaction {}", job.getJobId(), job.getTxnId());
+                    } catch (Exception e) {
+                        LOG.warn("failed to abort transaction {} for dynamic overwrite job {}: {}",
+                                job.getTxnId(), job.getJobId(), e.getMessage());
                     }
                 }
-            }
-            if (!isReplay) {
-                // mark all source tablet ids force delete to drop it directly on BE,
-                // not to move it to trash
-                sourceTablets.forEach(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()::markTabletForceDelete);
 
                 InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
                         OVERWRITE_FAILED, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
-                        job.getTmpPartitionIds());
+                        job.getTmpPartitionIds(), job.getTxnId());
                 GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info);
             }
         } catch (Exception e) {
             LOG.warn("exception when gc insert overwrite job.", e);
         } finally {
             locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
+        }
+    }
+
+    /**
+     * Drop temp partitions for dynamic overwrite during GC.
+     * Handles three scenarios:
+     * 1. Normal execution: get temp partition names from TransactionState
+     * 2. After FE restart: identify temp partitions by prefix "txn{txnId}_"
+     * 3. Cancelled before prepare: no temp partitions to clean up
+     */
+    private void gcDropDynamicOverwriteTempPartitions(OlapTable targetTable, Set<Tablet> sourceTablets,
+                                                       boolean isReplay) throws InterruptedException {
+        List<String> tmpPartitionNames = Lists.newArrayList();
+        if (!isReplay) {
+            if (insertStmt != null && job.getTxnId() > 0) {
+                // Normal execution: get temp partition names from TransactionState
+                tmpPartitionNames = gcGetTempPartitionNamesFromTxnState(targetTable);
+            } else if (job.getTxnId() > 0) {
+                // After FE restart: identify temp partitions by prefix "txn{txnId}_"
+                String tempPartitionPrefix = "txn" + job.getTxnId() + "_";
+                tmpPartitionNames = targetTable.getTempPartitions().stream()
+                        .map(Partition::getName)
+                        .filter(name -> name.startsWith(tempPartitionPrefix))
+                        .collect(Collectors.toList());
+                gcUpdateTmpPartitionIds(targetTable, tmpPartitionNames);
+                LOG.info("dynamic overwrite job {} (FE restarted) drop temp partitions with prefix '{}': {}",
+                        job.getJobId(), tempPartitionPrefix, tmpPartitionNames);
+            } else {
+                // Cancelled before prepare: no temp partitions to clean up
+                LOG.info("dynamic overwrite job {} cancelled before prepare phase, no temp partitions to clean up",
+                        job.getJobId());
+            }
+        }
+
+        for (String partitionName : tmpPartitionNames) {
+            Partition partition = targetTable.getPartition(partitionName, true);
+            if (partition != null) {
+                collectTabletsFromPartition(partition, sourceTablets);
+                targetTable.dropTempPartition(partitionName, true);
+            }
+        }
+    }
+
+    private List<String> gcGetTempPartitionNamesFromTxnState(OlapTable targetTable) throws InterruptedException {
+        int waitTimes = 10;
+        TransactionState txnState = null;
+        do {
+            txnState = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                    .getTransactionState(dbId, job.getTxnId());
+            if (txnState == null) {
+                throw new DmlException("transaction state is null dbId:%s, txnId:%s", dbId, job.getTxnId());
+            }
+            Thread.sleep(200);
+        } while (txnState.isRunning() && --waitTimes > 0);
+
+        List<String> tmpPartitionNames = txnState.getCreatedPartitionNames(tableId);
+        gcUpdateTmpPartitionIds(targetTable, tmpPartitionNames);
+        LOG.info("dynamic overwrite job {} drop tmpPartitionNames:{}", job.getJobId(), tmpPartitionNames);
+        return tmpPartitionNames;
+    }
+
+    private void gcUpdateTmpPartitionIds(OlapTable targetTable, List<String> partitionNames) {
+        job.setTmpPartitionIds(partitionNames.stream()
+                .map(name -> {
+                    Partition partition = targetTable.getPartition(name, true);
+                    if (partition == null) {
+                        LOG.warn("dynamic overwrite job {} temp partition {} does not exist during gc, skip",
+                                job.getJobId(), name);
+                        return null;
+                    }
+                    return partition.getId();
+                })
+                .filter(id -> id != null)
+                .collect(Collectors.toList()));
+    }
+
+    private void collectTabletsFromPartition(Partition partition, Set<Tablet> tablets) {
+        for (PhysicalPartition subPartition : partition.getSubPartitions()) {
+            for (MaterializedIndex index : subPartition.getMaterializedIndices(
+                    MaterializedIndex.IndexExtState.ALL)) {
+                tablets.addAll(index.getTablets());
+            }
         }
     }
 
@@ -653,7 +774,7 @@ public class InsertOverwriteJobRunner {
 
                 InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
                         InsertOverwriteJobState.OVERWRITE_SUCCESS, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
-                        job.getTmpPartitionIds());
+                        job.getTmpPartitionIds(), job.getTxnId());
                 GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info);
 
                 try {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/InsertOverwriteStateChangeInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/InsertOverwriteStateChangeInfo.java
@@ -39,6 +39,10 @@ public class InsertOverwriteStateChangeInfo implements Writable {
     @SerializedName(value = "sourcePartitionNames")
     private List<String> sourcePartitionNames = null;
 
+    // Transaction ID for dynamic overwrite, used to identify temp partitions after FE restart.
+    @SerializedName(value = "txnId")
+    private long txnId = -1;
+
     public InsertOverwriteStateChangeInfo(long jobId, InsertOverwriteJobState fromState,
                                           InsertOverwriteJobState toState,
                                           List<Long> sourcePartitionIds, 
@@ -50,6 +54,21 @@ public class InsertOverwriteStateChangeInfo implements Writable {
         this.sourcePartitionIds = sourcePartitionIds;
         this.sourcePartitionNames = sourcePartitionNames;
         this.tmpPartitionIds = tmpPartitionIds;
+    }
+
+    public InsertOverwriteStateChangeInfo(long jobId, InsertOverwriteJobState fromState,
+                                          InsertOverwriteJobState toState,
+                                          List<Long> sourcePartitionIds, 
+                                          List<String> sourcePartitionNames,
+                                          List<Long> tmpPartitionIds,
+                                          long txnId) {
+        this.jobId = jobId;
+        this.fromState = fromState;
+        this.toState = toState;
+        this.sourcePartitionIds = sourcePartitionIds;
+        this.sourcePartitionNames = sourcePartitionNames;
+        this.tmpPartitionIds = tmpPartitionIds;
+        this.txnId = txnId;
     }
 
     public long getJobId() {
@@ -74,6 +93,10 @@ public class InsertOverwriteStateChangeInfo implements Writable {
 
     public List<String> getSourcePartitionNames() {
         return sourcePartitionNames;
+    }
+
+    public long getTxnId() {
+        return txnId;
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:
Dynamic overwrite creates temporary partitions prefixed with "txn{txnId}_" during execution. After FE restart, these temp partitions persist and cause subsequent dynamic overwrite tasks to fail. The root cause is that `insertStmt` is a transient field which becomes null after FE restart, making it impossible to retrieve txnId from TransactionState to identify and clean up the temp partitions created by the failed job.

## What I'm doing:
1. Begin transaction early in prepare() phase for dynamic overwrite to obtain txnId before any temp partitions are created.

2. Persist txnId in InsertOverwriteStateChangeInfo log entry, so it can be restored after FE restart.

3. Add txnId field to InsertOverwriteJob and InsertOverwriteStateChangeInfo classes.

4. Modify gc() method to:
   - Normal execution: get temp partition names from TransactionState
   - After FE restart with txnId: identify temp partitions by "txn{txnId}_" prefix
   - Job cancelled before prepare(): skip cleanup as no temp partitions exist

5. Set txnId to ConnectContext so that executeInsert() reuses the existing transaction instead of creating a new one.

6. Add unit tests to verify the fix for FE restart scenarios.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures dynamic-overwrite temp partitions are reliably cleaned up, even after FE restarts, by persisting and reusing `txnId`.
> 
> - Add `txnId` to `InsertOverwriteJob` and `InsertOverwriteStateChangeInfo` and persist via edit log (`fe-core/.../InsertOverwriteJob.java`, `.../InsertOverwriteStateChangeInfo.java`)
> - Begin transaction early in `prepare()` for dynamic overwrite to obtain `txnId`; abort on failure; set `insertStmt` to reuse this txn during re-plan (`.../InsertOverwriteJobRunner.java`)
> - Enhance GC to drop temp partitions by IDs (non-dynamic) and by `"txn{txnId}_"` prefix after FE restart; refactor helpers to collect tablets and resolve partition IDs (`gcDropDynamicOverwriteTempPartitions`, `gcGetTempPartitionNamesFromTxnState`, `gcUpdateTmpPartitionIds`)
> - Update `StatementPlanner.beginTransaction()` to skip creating a new txn when `stmt.getTxnId()` is already set (`.../sql/StatementPlanner.java`)
> - Include `txnId` in all state-change log entries on RUNNING/SUCCESS/FAILED transitions
> - Add unit tests covering FE-restart GC and state replay scenarios (`.../InsertOverwriteJobRunnerTest.java`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61341925af57e0c036b832f62223ca4e54d21e2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->