### PR TITLE
[Enhancement] Optimize DP join reorder pruning and BitSet contains checks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
@@ -523,7 +523,12 @@ public abstract class JoinOrder {
     }
 
     private boolean contains(BitSet left, BitSet right) {
-        return right.stream().allMatch(left::get);
+        for (int b = right.nextSetBit(0); b >= 0; b = right.nextSetBit(b + 1)) {
+            if (!left.get(b)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private boolean existsEqOnPredicate(OptExpression optExpression) {


### PR DESCRIPTION
## Why I'm doing:
`JoinReorderDP` is a hot path for multi-join queries. In the DP search loop we were repeatedly computing the current minimum cost by scanning the entire `results` list, and `JoinOrder.contains()` used a stream/lambda-based check. Both add avoidable CPU overhead in tight loops.

## What I'm doing:
- Optimize `JoinOrder.contains(BitSet left, BitSet right)`:
  - Replace `right.stream().allMatch(left::get)` with a `nextSetBit` loop to avoid stream/lambda overhead.
- Optimize `JoinReorderDP.getBestExpr()` pruning and min-cost tracking:
  - Remove repeated `resultComparator.min(results)` scans by maintaining `bestCostSoFar` and `bestExprInfo` incrementally.
  - Keep the same pruning semantics (skip partitions when either side’s best cost already exceeds the current best).

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves hot-path performance in join reordering without changing behavior.
> 
> - Optimize `contains(BitSet left, BitSet right)` in `JoinOrder` to an indexed `nextSetBit` loop (avoid stream/lambda overhead)
> - Refactor `JoinReorderDP.getBestExpr()` to maintain `bestCostSoFar`/`bestExprInfo` for pruning and min selection instead of repeatedly scanning a `results` list
> - Add `Preconditions.checkState(bestExprInfo != null)` and remove unused comparator/ordering imports
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 720d07fe5bcb710ec5a750ed603fb404aa533b38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->