### PR TITLE
[Enhancement] support cast json to variant

### DIFF
--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -32,7 +32,6 @@
 #include "column/column_builder.h"
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
-#include "column/json_column.h"
 #include "column/nullable_column.h"
 #include "column/type_traits.h"
 #include "column/vectorized_fwd.h"
@@ -44,7 +43,6 @@
 #include "exprs/decimal_cast_expr.h"
 #include "exprs/unary_function.h"
 #include "gutil/casts.h"
-#include "gutil/strings/substitute.h"
 #include "runtime/datetime_value.h"
 #include "runtime/exception.h"
 #include "runtime/runtime_state.h"
@@ -58,6 +56,7 @@
 #include "util/mysql_global.h"
 #include "util/numeric_types.h"
 #include "util/variant_converter.h"
+#include "util/variant_encoder.h"
 
 #ifdef STARROCKS_JIT_ENABLE
 #include "exprs/jit/ir_helper.h"
@@ -282,8 +281,38 @@ static ColumnPtr cast_from_variant_fn(ColumnPtr& column) {
 
 template <LogicalType FromType, LogicalType ToType, bool AllowThrowException>
 static ColumnPtr cast_to_variant_fn(ColumnPtr& column) {
-    // TODO: require to implement variant encoding
-    THROW_RUNTIME_ERROR_WITH_TYPE(ToType);
+    if constexpr (FromType != TYPE_JSON) {
+        THROW_RUNTIME_ERROR_WITH_TYPE(ToType);
+    }
+
+    ColumnViewer<TYPE_JSON> viewer(column);
+    ColumnBuilder<TYPE_VARIANT> builder(viewer.size());
+
+    for (int row = 0; row < viewer.size(); ++row) {
+        if (viewer.is_null(row)) {
+            builder.append_null();
+            continue;
+        }
+
+        JsonValue* json = viewer.value(row);
+        if (json == nullptr) {
+            builder.append_null();
+            continue;
+        }
+
+        auto encoded = encode_json_to_variant(*json);
+        if (!encoded.ok()) {
+            VLOG_ROW << "encode json to variant failed: " << encoded.status();
+            if constexpr (AllowThrowException) {
+                THROW_RUNTIME_ERROR_WITH_TYPES_AND_VALUE(FromType, ToType, json->to_string_uncheck());
+            }
+            builder.append_null();
+            continue;
+        }
+        builder.append(std::move(encoded.value()));
+    }
+
+    return builder.build(column->is_constant());
 }
 
 SELF_CAST(TYPE_BOOLEAN);
@@ -300,6 +329,7 @@ UNARY_FN_CAST(TYPE_DATETIME, TYPE_BOOLEAN, TimestampToBoolean);
 UNARY_FN_CAST(TYPE_TIME, TYPE_BOOLEAN, ImplicitToBoolean);
 CUSTOMIZE_FN_CAST(TYPE_JSON, TYPE_BOOLEAN, cast_from_json_fn);
 CUSTOMIZE_FN_CAST(TYPE_VARIANT, TYPE_BOOLEAN, cast_from_variant_fn);
+CUSTOMIZE_FN_CAST(TYPE_JSON, TYPE_VARIANT, cast_to_variant_fn);
 
 template <LogicalType FromType, LogicalType ToType, bool AllowThrowException>
 static ColumnPtr cast_from_string_to_bool_fn(ColumnPtr& column) {
@@ -1590,6 +1620,15 @@ private:
         }                                                                     \
     }
 
+#define CASE_TO_VARIANT(FROM_TYPE, ALLOWTHROWEXCEPTION)                          \
+    case FROM_TYPE: {                                                           \
+        if (ALLOWTHROWEXCEPTION) {                                              \
+            return new VectorizedCastExpr<FROM_TYPE, TYPE_VARIANT, true>(node); \
+        } else {                                                                \
+            return new VectorizedCastExpr<FROM_TYPE, TYPE_VARIANT, false>(node);\
+        }                                                                       \
+    }
+
 #define CASE_FROM_VARIANT_TO(TO_TYPE, ALLOWTHROWEXCEPTION)                     \
     case TO_TYPE: {                                                            \
         if (ALLOWTHROWEXCEPTION) {                                             \
@@ -1961,6 +2000,7 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
                 CASE_FROM_JSON_TO(TYPE_FLOAT, allow_throw_exception);
                 CASE_FROM_JSON_TO(TYPE_DOUBLE, allow_throw_exception);
                 CASE_FROM_JSON_TO(TYPE_JSON, allow_throw_exception);
+                CASE_FROM_JSON_TO(TYPE_VARIANT, allow_throw_exception);
             default:
                 LOG(WARNING) << "Not support cast " << type_to_string(from_type) << " to " << type_to_string(to_type);
                 return nullptr;
@@ -2013,6 +2053,7 @@ Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const T
         // TODO: Support cast from other types to VARIANT after implementing string -> variant encoding
         if (to_type == TYPE_VARIANT) {
             switch (from_type) {
+                CASE_TO_VARIANT(TYPE_JSON, allow_throw_exception);
             default:
                 LOG(WARNING) << "Not support cast " << type_to_string(from_type) << " to " << type_to_string(to_type);
                 return nullptr;

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1621,12 +1621,12 @@ private:
     }
 
 #define CASE_TO_VARIANT(FROM_TYPE, ALLOWTHROWEXCEPTION)                          \
-    case FROM_TYPE: {                                                           \
-        if (ALLOWTHROWEXCEPTION) {                                              \
-            return new VectorizedCastExpr<FROM_TYPE, TYPE_VARIANT, true>(node); \
-        } else {                                                                \
-            return new VectorizedCastExpr<FROM_TYPE, TYPE_VARIANT, false>(node);\
-        }                                                                       \
+    case FROM_TYPE: {                                                            \
+        if (ALLOWTHROWEXCEPTION) {                                               \
+            return new VectorizedCastExpr<FROM_TYPE, TYPE_VARIANT, true>(node);  \
+        } else {                                                                 \
+            return new VectorizedCastExpr<FROM_TYPE, TYPE_VARIANT, false>(node); \
+        }                                                                        \
     }
 
 #define CASE_FROM_VARIANT_TO(TO_TYPE, ALLOWTHROWEXCEPTION)                     \

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -116,6 +116,7 @@ set(UTIL_FILES
   lake_service_recoverable_stub.cpp
   byte_buffer.cpp
   variant_converter.cpp
+  variant_encoder.cpp
   jvm_metrics.cpp
   llm_cache.cpp
   llm_query_service.cpp

--- a/be/src/util/variant_encoder.cpp
+++ b/be/src/util/variant_encoder.cpp
@@ -1,0 +1,327 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/variant_encoder.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "arrow/util/endian.h"
+#include "common/status.h"
+#include "util/variant.h"
+#include "velocypack/vpack.h"
+
+namespace starrocks {
+
+template <typename T>
+void append_little_endian(std::string* out, T value) {
+    T le_value = arrow::bit_util::ToLittleEndian(value);
+    out->append(reinterpret_cast<const char*>(&le_value), sizeof(T));
+}
+
+void append_uint_le(std::string* out, uint32_t value, uint8_t size) {
+    uint32_t le_value = arrow::bit_util::ToLittleEndian(value);
+    out->append(reinterpret_cast<const char*>(&le_value), size);
+}
+
+uint8_t minimal_uint_size(uint32_t value) {
+    if (value <= 0xFF) {
+        return 1;
+    }
+    if (value <= 0xFFFF) {
+        return 2;
+    }
+    if (value <= 0xFFFFFF) {
+        return 3;
+    }
+    return 4;
+}
+
+std::string encode_null_value() {
+    return std::string(VariantValue::kEmptyValue);
+}
+
+std::string encode_boolean(bool value) {
+    const auto type = value ? VariantType::BOOLEAN_TRUE : VariantType::BOOLEAN_FALSE;
+    char header = static_cast<char>((static_cast<uint8_t>(type) << VariantValue::kValueHeaderBitShift) |
+                                    static_cast<uint8_t>(VariantValue::BasicType::PRIMITIVE));
+    return std::string(1, header);
+}
+
+template <typename T>
+std::string encode_primitive_number(VariantType type, T value) {
+    std::string out;
+    out.reserve(VariantValue::kHeaderSizeBytes + sizeof(T));
+    char header = static_cast<char>((static_cast<uint8_t>(type) << VariantValue::kValueHeaderBitShift) |
+                                    static_cast<uint8_t>(VariantValue::BasicType::PRIMITIVE));
+    out.push_back(header);
+    append_little_endian(&out, value);
+    return out;
+}
+
+std::string encode_string_or_binary(VariantType type, std::string_view value) {
+    std::string out;
+    out.reserve(VariantValue::kHeaderSizeBytes + sizeof(uint32_t) + value.size());
+    char header = static_cast<char>((static_cast<uint8_t>(type) << VariantValue::kValueHeaderBitShift) |
+                                    static_cast<uint8_t>(VariantValue::BasicType::PRIMITIVE));
+    out.push_back(header);
+    append_little_endian<uint32_t>(&out, static_cast<uint32_t>(value.size()));
+    out.append(value.data(), value.size());
+    return out;
+}
+
+std::string encode_object_from_fields(const std::map<uint32_t, std::string>& fields) {
+    const uint32_t num_elements = static_cast<uint32_t>(fields.size());
+    uint8_t is_large = num_elements > 255 ? 1 : 0;
+    const uint8_t num_elements_size = is_large ? 4 : 1;
+
+    uint32_t max_field_id = 0;
+    uint32_t total_data_size = 0;
+    for (const auto& [field_id, value] : fields) {
+        max_field_id = std::max(max_field_id, field_id);
+        total_data_size += static_cast<uint32_t>(value.size());
+    }
+
+    const uint8_t field_id_size = minimal_uint_size(max_field_id);
+    const uint8_t field_offset_size = minimal_uint_size(total_data_size);
+
+    uint8_t vheader = static_cast<uint8_t>((field_offset_size - 1) | ((field_id_size - 1) << 2) | (is_large << 4));
+    char header = static_cast<char>((vheader << VariantValue::kValueHeaderBitShift) |
+                                    static_cast<uint8_t>(VariantValue::BasicType::OBJECT));
+
+    std::string out;
+    out.reserve(1 + num_elements_size + num_elements * field_id_size + (num_elements + 1) * field_offset_size +
+                total_data_size);
+    out.push_back(header);
+    append_uint_le(&out, num_elements, num_elements_size);
+
+    for (const auto& [field_id, value] : fields) {
+        append_uint_le(&out, field_id, field_id_size);
+    }
+
+    uint32_t offset = 0;
+    append_uint_le(&out, offset, field_offset_size);
+    for (const auto& [field_id, value] : fields) {
+        offset += static_cast<uint32_t>(value.size());
+        append_uint_le(&out, offset, field_offset_size);
+    }
+
+    for (const auto& [field_id, value] : fields) {
+        out.append(value.data(), value.size());
+    }
+
+    return out;
+}
+
+std::string encode_array_from_elements(const std::vector<std::string>& elements) {
+    const uint32_t num_elements = static_cast<uint32_t>(elements.size());
+    uint8_t is_large = num_elements > 255 ? 1 : 0;
+    const uint8_t num_elements_size = is_large ? 4 : 1;
+
+    uint32_t total_data_size = 0;
+    for (const auto& element : elements) {
+        total_data_size += static_cast<uint32_t>(element.size());
+    }
+
+    const uint8_t offset_size = minimal_uint_size(total_data_size);
+    uint8_t vheader = static_cast<uint8_t>((offset_size - 1) | (is_large << 2));
+    char header = static_cast<char>((vheader << VariantValue::kValueHeaderBitShift) |
+                                    static_cast<uint8_t>(VariantValue::BasicType::ARRAY));
+
+    std::string out;
+    out.reserve(1 + num_elements_size + (num_elements + 1) * offset_size + total_data_size);
+    out.push_back(header);
+    append_uint_le(&out, num_elements, num_elements_size);
+
+    uint32_t offset = 0;
+    append_uint_le(&out, offset, offset_size);
+    for (const auto& element : elements) {
+        offset += static_cast<uint32_t>(element.size());
+        append_uint_le(&out, offset, offset_size);
+    }
+
+    for (const auto& element : elements) {
+        out.append(element.data(), element.size());
+    }
+
+    return out;
+}
+
+Status collect_object_keys(const vpack::Slice& slice, std::unordered_set<std::string>* keys) {
+    try {
+        if (slice.isObject()) {
+            vpack::ObjectIterator it(slice);
+            for (; it.valid(); it.next()) {
+                auto current = *it;
+                auto key = current.key.stringView();
+                keys->emplace(key.data(), key.size());
+                RETURN_IF_ERROR(collect_object_keys(current.value, keys));
+            }
+        } else if (slice.isArray()) {
+            vpack::ArrayIterator it(slice);
+            for (; it.valid(); it.next()) {
+                RETURN_IF_ERROR(collect_object_keys(it.value(), keys));
+            }
+        }
+    } catch (const vpack::Exception& e) {
+        return fromVPackException(e);
+    }
+
+    return Status::OK();
+}
+
+constexpr uint8_t kVariantMetadataVersion = 1;
+constexpr uint8_t kVariantMetadataSortedMask = 0b10000;
+constexpr uint8_t kVariantMetadataOffsetSizeShift = 6;
+
+struct VariantMetadataBuildResult {
+    std::string metadata;
+    std::unordered_map<std::string, uint32_t> key_to_id;
+};
+
+StatusOr<VariantMetadataBuildResult> build_variant_metadata(const std::unordered_set<std::string>& keys) {
+    if (keys.empty()) {
+        VariantMetadataBuildResult result;
+        result.metadata.assign(VariantMetadata::kEmptyMetadata.data(), VariantMetadata::kEmptyMetadata.size());
+        return result;
+    }
+
+    std::vector<std::string> sorted_keys;
+    sorted_keys.reserve(keys.size());
+    for (const auto& key : keys) {
+        sorted_keys.push_back(key);
+    }
+    std::sort(sorted_keys.begin(), sorted_keys.end());
+
+    uint32_t total_string_size = 0;
+    for (const auto& key : sorted_keys) {
+        if (key.size() > std::numeric_limits<uint32_t>::max() - total_string_size) {
+            return Status::VariantError("Variant metadata string size overflow");
+        }
+        total_string_size += static_cast<uint32_t>(key.size());
+    }
+
+    const uint32_t dict_size = static_cast<uint32_t>(sorted_keys.size());
+    const uint32_t max_value = std::max(dict_size, total_string_size);
+    const uint8_t offset_size = minimal_uint_size(max_value);
+
+    uint8_t header = kVariantMetadataVersion;
+    header |= kVariantMetadataSortedMask;
+    header |= static_cast<uint8_t>((offset_size - 1) << kVariantMetadataOffsetSizeShift);
+
+    std::string metadata;
+    metadata.reserve(1 + offset_size * (dict_size + 2) + total_string_size);
+    metadata.push_back(static_cast<char>(header));
+
+    append_uint_le(&metadata, dict_size, offset_size);
+
+    uint32_t offset = 0;
+    append_uint_le(&metadata, offset, offset_size);
+    for (const auto& key : sorted_keys) {
+        offset += static_cast<uint32_t>(key.size());
+        append_uint_le(&metadata, offset, offset_size);
+    }
+
+    for (const auto& key : sorted_keys) {
+        metadata.append(key.data(), key.size());
+    }
+
+    VariantMetadataBuildResult result;
+    result.metadata = std::move(metadata);
+    result.key_to_id.reserve(sorted_keys.size());
+    for (uint32_t i = 0; i < sorted_keys.size(); ++i) {
+        result.key_to_id.emplace(sorted_keys[i], i);
+    }
+
+    return result;
+}
+
+StatusOr<std::string> encode_json_to_variant_value(const vpack::Slice& slice,
+                                                   const std::unordered_map<std::string, uint32_t>& key_to_id) {
+    try {
+        if (slice.isNone() || slice.isNull()) {
+            return encode_null_value();
+        }
+        if (slice.isBool()) {
+            return encode_boolean(slice.getBool());
+        }
+        if (slice.isInt() || slice.isSmallInt()) {
+            return encode_primitive_number<int64_t>(VariantType::INT64, slice.getIntUnchecked());
+        }
+        if (slice.isUInt()) {
+            uint64_t value = slice.getUIntUnchecked();
+            if (value <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+                return encode_primitive_number<int64_t>(VariantType::INT64, static_cast<int64_t>(value));
+            }
+            return encode_primitive_number<double>(VariantType::DOUBLE, static_cast<double>(value));
+        }
+        if (slice.isDouble()) {
+            return encode_primitive_number<double>(VariantType::DOUBLE, slice.getDouble());
+        }
+        if (slice.isString() || slice.isBinary()) {
+            vpack::ValueLength len;
+            const char* str = slice.getStringUnchecked(len);
+            return encode_string_or_binary(VariantType::STRING, std::string_view(str, len));
+        }
+        if (slice.isArray()) {
+            vpack::ArrayIterator it(slice);
+            std::vector<std::string> elements;
+            elements.reserve(slice.length());
+            for (; it.valid(); it.next()) {
+                ASSIGN_OR_RETURN(std::string element, encode_json_to_variant_value(it.value(), key_to_id));
+                elements.emplace_back(std::move(element));
+            }
+            return encode_array_from_elements(elements);
+        }
+        if (slice.isObject()) {
+            vpack::ObjectIterator it(slice);
+            std::map<uint32_t, std::string> fields;
+            for (; it.valid(); it.next()) {
+                auto current = *it;
+                auto key = current.key.stringView();
+                auto it_key = key_to_id.find(std::string(key.data(), key.size()));
+                if (it_key == key_to_id.end()) {
+                    return Status::VariantError("Variant metadata missing field: " +
+                                                std::string(key.data(), key.size()));
+                }
+                ASSIGN_OR_RETURN(std::string field_value, encode_json_to_variant_value(current.value, key_to_id));
+                fields[it_key->second] = std::move(field_value);
+            }
+            return encode_object_from_fields(fields);
+        }
+    } catch (const vpack::Exception& e) {
+        return fromVPackException(e);
+    }
+
+    return Status::NotSupported(
+            fmt::format("Unsupported JSON type {} for variant encoding type", valueTypeName(slice.type())));
+}
+
+StatusOr<VariantRowValue> encode_json_to_variant(const JsonValue& json) {
+    vpack::Slice slice = json.to_vslice();
+    std::unordered_set<std::string> keys;
+    RETURN_IF_ERROR(collect_object_keys(slice, &keys));
+    ASSIGN_OR_RETURN(auto metadata_result, build_variant_metadata(keys));
+    ASSIGN_OR_RETURN(std::string value, encode_json_to_variant_value(slice, metadata_result.key_to_id));
+    return VariantRowValue::create(metadata_result.metadata, value);
+}
+
+} // namespace starrocks

--- a/be/src/util/variant_encoder.h
+++ b/be/src/util/variant_encoder.h
@@ -1,0 +1,26 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "common/statusor.h"
+#include "types/variant_value.h"
+#include "util/json.h"
+
+namespace starrocks {
+
+// Encode a JsonValue into a VariantRowValue using Variant encoding.
+StatusOr<VariantRowValue> encode_json_to_variant(const JsonValue& json);
+
+} // namespace starrocks

--- a/docs/en/sql-reference/data-types/semi_structured/VARIANT.md
+++ b/docs/en/sql-reference/data-types/semi_structured/VARIANT.md
@@ -83,6 +83,21 @@ SELECT
 FROM iceberg_catalog.db.table_with_variants;
 ```
 
+### Casting JSON to VARIANT
+
+StarRocks supports casting JSON values to VARIANT. If your input is a STRING, convert it to JSON first.
+
+```SQL
+SELECT
+    CAST(parse_json('{"id": 1, "flags": {"active": true}, "scores": [1.5, null]}') AS VARIANT) AS variant_value;
+```
+
+```SQL
+SELECT
+    CAST(json_col AS VARIANT) AS variant_value
+FROM db.table_with_json;
+```
+
 ### Casting VARIANT Data to SQL Types
 
 You can use the CAST function to convert VARIANT data to standard SQL types:
@@ -158,4 +173,5 @@ When data is read from Parquet files with variant encoding, the following type c
 - VARIANT is supported for reading data from Iceberg tables in Parquet format with variant encoding, and for writing Parquet files using StarRocks file writers (unshredded variant encoding).
 - The size of a VARIANT value is limited to 16 MB.
 - Currently only unshredded variant values are supported for both read and write.
+- Currently, VARIANT can only be created by casting from JSON values (for example, `CAST(parse_json(...) AS VARIANT)`).
 - The maximum depth of nested structures depends on the underlying Parquet file structure.

--- a/docs/zh/sql-reference/data-types/semi_structured/VARIANT.md
+++ b/docs/zh/sql-reference/data-types/semi_structured/VARIANT.md
@@ -83,6 +83,21 @@ SELECT
 FROM iceberg_catalog.db.table_with_variants;
 ```
 
+### 将 JSON 转换为 VARIANT
+
+StarRocks 支持将 JSON 值转换为 VARIANT。如果输入是 STRING，请先转换为 JSON。
+
+```SQL
+SELECT
+    CAST(parse_json('{"id": 1, "flags": {"active": true}, "scores": [1.5, null]}') AS VARIANT) AS variant_value;
+```
+
+```SQL
+SELECT
+    CAST(json_col AS VARIANT) AS variant_value
+FROM db.table_with_json;
+```
+
 ### 将 VARIANT 数据转换为 SQL 类型
 
 您可以使用 CAST 函数将 VARIANT 数据转换为标准 SQL 类型:
@@ -158,4 +173,5 @@ $.config[\"key\"]        -- Map 风格访问
 - VARIANT 类型支持从带有 variant 编码的 Parquet 格式 Iceberg 表中读取数据，并支持通过 StarRocks 文件写入器写出 Parquet 文件（未分片的 variant 编码）。
 - VARIANT 值的大小限制为 16 MB。
 - 当前仅支持读写未分片的 variant 值。
+- 目前只能通过 JSON 值转换生成 VARIANT（例如 `CAST(parse_json(...) AS VARIANT)`）。
 - 嵌套结构的最大深度取决于底层 Parquet 文件结构。

--- a/fe/fe-type/src/main/java/com/starrocks/type/PrimitiveType.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/PrimitiveType.java
@@ -111,6 +111,7 @@ public enum PrimitiveType {
                     .add(BOOLEAN)
                     .addAll(NUMBER_TYPE_LIST)
                     .addAll(STRING_TYPE_LIST)
+                    .add(VARIANT)
                     .build();
     // TODO(mofei) support them
     public static final ImmutableList<PrimitiveType> JSON_UNCOMPATIBLE_TYPE =

--- a/test/sql/test_iceberg/R/test_iceberg_variant_json
+++ b/test/sql/test_iceberg/R/test_iceberg_variant_json
@@ -1,0 +1,186 @@
+-- name: test_iceberg_variant_json
+create external catalog iceberg_sql_test_${uuid0}
+PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hadoop", "iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_variant_json/${uuid0}/warehouse/");
+-- result:
+-- !result
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_variant_json/${uuid0}/warehouse/iceberg_variant_json > /dev/null
+-- result:
+0
+
+-- !result
+use iceberg_sql_test_${uuid0}.iceberg_variant_json;
+-- result:
+-- !result
+CREATE TABLE variant_json_roundtrip (
+    id INT,
+    json_str STRING,
+    variant_from_json VARIANT
+)
+properties(
+  'format-version' = '3'
+);
+-- result:
+-- !result
+insert into variant_json_roundtrip
+select
+    1 as id,
+    '{"id":1,"name":"alpha","scores":[1.5,2.5,3.5],"flags":{"active":true,"skip":null},"paths":{"first":"$.scores[0]"},"keys":{"key.with.dot":{"leaf":7},"key-with-dash":false}}' as json_str,
+    cast(parse_json('{"id":1,"name":"alpha","scores":[1.5,2.5,3.5],"flags":{"active":true,"skip":null},"paths":{"first":"$.scores[0]"},"keys":{"key.with.dot":{"leaf":7},"key-with-dash":false}}') as variant) as variant_from_json
+union all
+select
+    2 as id,
+    '{"id":-7,"name":"beta","scores":[-0.5,null,0.5],"flags":{"active":false,"skip":null},"paths":{"first":"$.scores[2]"},"keys":{"key.with.dot":{"leaf":-3},"key-with-dash":true}}' as json_str,
+    cast(parse_json('{"id":-7,"name":"beta","scores":[-0.5,null,0.5],"flags":{"active":false,"skip":null},"paths":{"first":"$.scores[2]"},"keys":{"key.with.dot":{"leaf":-3},"key-with-dash":true}}') as variant) as variant_from_json
+union all
+select
+    3 as id,
+    '{"id":2048,"name":"","scores":[0.0,1.0,2.0],"flags":{"active":true,"skip":false},"paths":{"first":"$.scores[1]"},"keys":{"key.with.dot":{"leaf":123},"key-with-dash":false},"deep":{"matrix":[[{"val":11},{"val":22}],[{"val":33},{"val":44}]],"layers":[{"name":"edge","segments":[{"path":"/edge/**","status":"ok"}]},{"name":"core","segments":[{"path":"/core/**","status":"warn","steps":[{"id":"prep","ok":true},{"id":"dispatch","ok":false}]}]}]}}' as json_str,
+    cast(parse_json('{"id":2048,"name":"","scores":[0.0,1.0,2.0],"flags":{"active":true,"skip":false},"paths":{"first":"$.scores[1]"},"keys":{"key.with.dot":{"leaf":123},"key-with-dash":false},"deep":{"matrix":[[{"val":11},{"val":22}],[{"val":33},{"val":44}]],"layers":[{"name":"edge","segments":[{"path":"/edge/**","status":"ok"}]},{"name":"core","segments":[{"path":"/core/**","status":"warn","steps":[{"id":"prep","ok":true},{"id":"dispatch","ok":false}]}]}]}}') as variant) as variant_from_json;
+-- result:
+-- !result
+select 'variant json roundtrip: scalar fields' as test_name;
+-- result:
+variant json roundtrip: scalar fields
+-- !result
+select
+    id,
+    case
+        when cast(variant_query(variant_from_json, '$.id') as INT) <=> cast(json_query(cast(variant_from_json as json), '$.id') as INT)
+         and get_variant_string(variant_from_json, '$.name') <=> cast(json_query(cast(variant_from_json as json), '$.name') as STRING)
+        then 'PASS' else 'FAIL' end as status,
+    cast(variant_query(variant_from_json, '$.id') as INT) as v_id,
+    cast(json_query(cast(variant_from_json as json), '$.id') as INT) as j_id,
+    get_variant_string(variant_from_json, '$.name') as v_name,
+    cast(json_query(cast(variant_from_json as json), '$.name') as STRING) as j_name
+from variant_json_roundtrip
+order by id;
+-- result:
+1	PASS	1	1	alpha	alpha
+2	PASS	-7	-7	beta	beta
+3	PASS	2048	2048		
+-- !result
+select 'variant json roundtrip: array fields' as test_name;
+-- result:
+variant json roundtrip: array fields
+-- !result
+select
+    id,
+    case
+        when get_variant_double(variant_from_json, '$.scores[0]') <=> cast(json_query(cast(variant_from_json as json), '$.scores[0]') as DOUBLE)
+         and get_variant_double(variant_from_json, '$.scores[1]') <=> cast(json_query(cast(variant_from_json as json), '$.scores[1]') as DOUBLE)
+        then 'PASS' else 'FAIL' end as status,
+    get_variant_double(variant_from_json, '$.scores[0]') as v_score0,
+    cast(json_query(cast(variant_from_json as json), '$.scores[0]') as DOUBLE) as j_score0,
+    get_variant_double(variant_from_json, '$.scores[1]') as v_score1,
+    cast(json_query(cast(variant_from_json as json), '$.scores[1]') as DOUBLE) as j_score1
+from variant_json_roundtrip
+order by id;
+-- result:
+1	PASS	1.5	1.5	2.5	2.5
+2	PASS	-0.5	-0.5	None	None
+3	PASS	0.0	0.0	1.0	1.0
+-- !result
+select 'variant json roundtrip: boolean and dotted keys' as test_name;
+-- result:
+variant json roundtrip: boolean and dotted keys
+-- !result
+select
+    id,
+    case
+        when cast(variant_query(variant_from_json, '$.flags.active') as BOOLEAN) <=> cast(json_query(cast(variant_from_json as json), '$.flags.active') as BOOLEAN)
+         and cast(variant_query(variant_from_json, '$.keys["key.with.dot"].leaf') as INT) <=> cast(json_query(cast(variant_from_json as json), '$.keys."key.with.dot".leaf') as INT)
+         and cast(variant_query(variant_from_json, '$.keys["key-with-dash"]') as BOOLEAN) <=> cast(json_query(cast(variant_from_json as json), '$.keys."key-with-dash"') as BOOLEAN)
+        then 'PASS' else 'FAIL' end as status,
+    cast(variant_query(variant_from_json, '$.flags.active') as BOOLEAN) as v_active,
+    cast(json_query(cast(variant_from_json as json), '$.flags.active') as BOOLEAN) as j_active,
+    cast(variant_query(variant_from_json, '$.keys["key.with.dot"].leaf') as INT) as v_leaf,
+    cast(json_query(cast(variant_from_json as json), '$.keys."key.with.dot".leaf') as INT) as j_leaf,
+    cast(variant_query(variant_from_json, '$.keys["key-with-dash"]') as BOOLEAN) as v_dash,
+    cast(json_query(cast(variant_from_json as json), '$.keys."key-with-dash"') as BOOLEAN) as j_dash
+from variant_json_roundtrip
+order by id;
+-- result:
+1	PASS	1	1	7	7	0	0
+2	PASS	0	0	-3	-3	1	1
+3	PASS	1	1	123	123	0	0
+-- !result
+select 'variant json roundtrip: deep nested fields' as test_name;
+-- result:
+variant json roundtrip: deep nested fields
+-- !result
+select
+    id,
+    case
+        when cast(variant_query(variant_from_json, '$.deep.matrix[1][0].val') as INT) <=> cast(json_query(cast(variant_from_json as json), '$.deep.matrix[1][0].val') as INT)
+         and cast(variant_query(variant_from_json, '$.deep.layers[1].segments[0].steps[1].id') as STRING) <=> cast(json_query(cast(variant_from_json as json), '$.deep.layers[1].segments[0].steps[1].id') as STRING)
+         and cast(variant_query(variant_from_json, '$.deep.layers[1].segments[0].steps[1].ok') as BOOLEAN) <=> cast(json_query(cast(variant_from_json as json), '$.deep.layers[1].segments[0].steps[1].ok') as BOOLEAN)
+        then 'PASS' else 'FAIL' end as status,
+    cast(variant_query(variant_from_json, '$.deep.matrix[1][0].val') as INT) as v_matrix_val,
+    cast(json_query(cast(variant_from_json as json), '$.deep.matrix[1][0].val') as INT) as j_matrix_val,
+    cast(variant_query(variant_from_json, '$.deep.layers[1].segments[0].steps[1].id') as STRING) as v_step_id,
+    cast(json_query(cast(variant_from_json as json), '$.deep.layers[1].segments[0].steps[1].id') as STRING) as j_step_id,
+    cast(variant_query(variant_from_json, '$.deep.layers[1].segments[0].steps[1].ok') as BOOLEAN) as v_step_ok,
+    cast(json_query(cast(variant_from_json as json), '$.deep.layers[1].segments[0].steps[1].ok') as BOOLEAN) as j_step_ok
+from variant_json_roundtrip
+where id = 3
+order by id;
+-- result:
+3	PASS	33	33	dispatch	dispatch	0	0
+-- !result
+CREATE TABLE variant_json_write (
+    id INT,
+    json_str STRING,
+    variant_from_json VARIANT
+)
+properties(
+  'format-version' = '3'
+);
+-- result:
+-- !result
+insert into variant_json_write
+select
+    id,
+    json_str,
+    variant_from_json
+from variant_json_roundtrip;
+-- result:
+-- !result
+select 'variant json write roundtrip' as test_name;
+-- result:
+variant json write roundtrip
+-- !result
+select
+    id,
+    case
+        when cast(variant_query(variant_from_json, '$.id') as INT) <=> cast(json_query(cast(variant_from_json as json), '$.id') as INT)
+         and get_variant_string(variant_from_json, '$.name') <=> cast(json_query(cast(variant_from_json as json), '$.name') as STRING)
+         and get_variant_double(variant_from_json, '$.scores[0]') <=> cast(json_query(cast(variant_from_json as json), '$.scores[0]') as DOUBLE)
+        then 'PASS' else 'FAIL' end as status,
+    cast(variant_query(variant_from_json, '$.id') as INT) as v_id,
+    cast(json_query(cast(variant_from_json as json), '$.id') as INT) as j_id,
+    get_variant_string(variant_from_json, '$.name') as v_name,
+    cast(json_query(cast(variant_from_json as json), '$.name') as STRING) as j_name
+from variant_json_write
+order by id;
+-- result:
+1	PASS	1	1	alpha	alpha
+2	PASS	-7	-7	beta	beta
+3	PASS	2048	2048		
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_variant_json/${uuid0}/ > /dev/null
+-- result:
+0
+
+-- !result
+drop table variant_json_roundtrip force;
+-- result:
+-- !result
+drop table variant_json_write force;
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_variant_json
+++ b/test/sql/test_iceberg/T/test_iceberg_variant_json
@@ -1,0 +1,141 @@
+-- name: test_iceberg_variant_json
+
+-- iceberg catalog on hive does not variant yet.
+
+create external catalog iceberg_sql_test_${uuid0}
+PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hadoop", "iceberg.catalog.warehouse"="oss://${oss_bucket}/test_iceberg_variant_json/${uuid0}/warehouse/");
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_variant_json/${uuid0}/warehouse/iceberg_variant_json > /dev/null
+
+use iceberg_sql_test_${uuid0}.iceberg_variant_json;
+
+CREATE TABLE variant_json_roundtrip (
+    id INT,
+    json_str STRING,
+    variant_from_json VARIANT
+)
+properties(
+  'format-version' = '3'
+);
+
+insert into variant_json_roundtrip
+select
+    1 as id,
+    '{"id":1,"name":"alpha","scores":[1.5,2.5,3.5],"flags":{"active":true,"skip":null},"paths":{"first":"$.scores[0]"},"keys":{"key.with.dot":{"leaf":7},"key-with-dash":false}}' as json_str,
+    cast(parse_json('{"id":1,"name":"alpha","scores":[1.5,2.5,3.5],"flags":{"active":true,"skip":null},"paths":{"first":"$.scores[0]"},"keys":{"key.with.dot":{"leaf":7},"key-with-dash":false}}') as variant) as variant_from_json
+union all
+select
+    2 as id,
+    '{"id":-7,"name":"beta","scores":[-0.5,null,0.5],"flags":{"active":false,"skip":null},"paths":{"first":"$.scores[2]"},"keys":{"key.with.dot":{"leaf":-3},"key-with-dash":true}}' as json_str,
+    cast(parse_json('{"id":-7,"name":"beta","scores":[-0.5,null,0.5],"flags":{"active":false,"skip":null},"paths":{"first":"$.scores[2]"},"keys":{"key.with.dot":{"leaf":-3},"key-with-dash":true}}') as variant) as variant_from_json
+union all
+select
+    3 as id,
+    '{"id":2048,"name":"","scores":[0.0,1.0,2.0],"flags":{"active":true,"skip":false},"paths":{"first":"$.scores[1]"},"keys":{"key.with.dot":{"leaf":123},"key-with-dash":false},"deep":{"matrix":[[{"val":11},{"val":22}],[{"val":33},{"val":44}]],"layers":[{"name":"edge","segments":[{"path":"/edge/**","status":"ok"}]},{"name":"core","segments":[{"path":"/core/**","status":"warn","steps":[{"id":"prep","ok":true},{"id":"dispatch","ok":false}]}]}]}}' as json_str,
+    cast(parse_json('{"id":2048,"name":"","scores":[0.0,1.0,2.0],"flags":{"active":true,"skip":false},"paths":{"first":"$.scores[1]"},"keys":{"key.with.dot":{"leaf":123},"key-with-dash":false},"deep":{"matrix":[[{"val":11},{"val":22}],[{"val":33},{"val":44}]],"layers":[{"name":"edge","segments":[{"path":"/edge/**","status":"ok"}]},{"name":"core","segments":[{"path":"/core/**","status":"warn","steps":[{"id":"prep","ok":true},{"id":"dispatch","ok":false}]}]}]}}') as variant) as variant_from_json;
+
+select 'variant json roundtrip: scalar fields' as test_name;
+
+select
+    id,
+    case
+        when cast(variant_query(variant_from_json, '$.id') as INT) <=> cast(json_query(cast(variant_from_json as json), '$.id') as INT)
+         and get_variant_string(variant_from_json, '$.name') <=> cast(json_query(cast(variant_from_json as json), '$.name') as STRING)
+        then 'PASS' else 'FAIL' end as status,
+    cast(variant_query(variant_from_json, '$.id') as INT) as v_id,
+    cast(json_query(cast(variant_from_json as json), '$.id') as INT) as j_id,
+    get_variant_string(variant_from_json, '$.name') as v_name,
+    cast(json_query(cast(variant_from_json as json), '$.name') as STRING) as j_name
+from variant_json_roundtrip
+order by id;
+
+select 'variant json roundtrip: array fields' as test_name;
+
+select
+    id,
+    case
+        when get_variant_double(variant_from_json, '$.scores[0]') <=> cast(json_query(cast(variant_from_json as json), '$.scores[0]') as DOUBLE)
+         and get_variant_double(variant_from_json, '$.scores[1]') <=> cast(json_query(cast(variant_from_json as json), '$.scores[1]') as DOUBLE)
+        then 'PASS' else 'FAIL' end as status,
+    get_variant_double(variant_from_json, '$.scores[0]') as v_score0,
+    cast(json_query(cast(variant_from_json as json), '$.scores[0]') as DOUBLE) as j_score0,
+    get_variant_double(variant_from_json, '$.scores[1]') as v_score1,
+    cast(json_query(cast(variant_from_json as json), '$.scores[1]') as DOUBLE) as j_score1
+from variant_json_roundtrip
+order by id;
+
+select 'variant json roundtrip: boolean and dotted keys' as test_name;
+
+select
+    id,
+    case
+        when cast(variant_query(variant_from_json, '$.flags.active') as BOOLEAN) <=> cast(json_query(cast(variant_from_json as json), '$.flags.active') as BOOLEAN)
+         and cast(variant_query(variant_from_json, '$.keys["key.with.dot"].leaf') as INT) <=> cast(json_query(cast(variant_from_json as json), '$.keys."key.with.dot".leaf') as INT)
+         and cast(variant_query(variant_from_json, '$.keys["key-with-dash"]') as BOOLEAN) <=> cast(json_query(cast(variant_from_json as json), '$.keys."key-with-dash"') as BOOLEAN)
+        then 'PASS' else 'FAIL' end as status,
+    cast(variant_query(variant_from_json, '$.flags.active') as BOOLEAN) as v_active,
+    cast(json_query(cast(variant_from_json as json), '$.flags.active') as BOOLEAN) as j_active,
+    cast(variant_query(variant_from_json, '$.keys["key.with.dot"].leaf') as INT) as v_leaf,
+    cast(json_query(cast(variant_from_json as json), '$.keys."key.with.dot".leaf') as INT) as j_leaf,
+    cast(variant_query(variant_from_json, '$.keys["key-with-dash"]') as BOOLEAN) as v_dash,
+    cast(json_query(cast(variant_from_json as json), '$.keys."key-with-dash"') as BOOLEAN) as j_dash
+from variant_json_roundtrip
+order by id;
+
+select 'variant json roundtrip: deep nested fields' as test_name;
+
+select
+    id,
+    case
+        when cast(variant_query(variant_from_json, '$.deep.matrix[1][0].val') as INT) <=> cast(json_query(cast(variant_from_json as json), '$.deep.matrix[1][0].val') as INT)
+         and cast(variant_query(variant_from_json, '$.deep.layers[1].segments[0].steps[1].id') as STRING) <=> cast(json_query(cast(variant_from_json as json), '$.deep.layers[1].segments[0].steps[1].id') as STRING)
+         and cast(variant_query(variant_from_json, '$.deep.layers[1].segments[0].steps[1].ok') as BOOLEAN) <=> cast(json_query(cast(variant_from_json as json), '$.deep.layers[1].segments[0].steps[1].ok') as BOOLEAN)
+        then 'PASS' else 'FAIL' end as status,
+    cast(variant_query(variant_from_json, '$.deep.matrix[1][0].val') as INT) as v_matrix_val,
+    cast(json_query(cast(variant_from_json as json), '$.deep.matrix[1][0].val') as INT) as j_matrix_val,
+    cast(variant_query(variant_from_json, '$.deep.layers[1].segments[0].steps[1].id') as STRING) as v_step_id,
+    cast(json_query(cast(variant_from_json as json), '$.deep.layers[1].segments[0].steps[1].id') as STRING) as j_step_id,
+    cast(variant_query(variant_from_json, '$.deep.layers[1].segments[0].steps[1].ok') as BOOLEAN) as v_step_ok,
+    cast(json_query(cast(variant_from_json as json), '$.deep.layers[1].segments[0].steps[1].ok') as BOOLEAN) as j_step_ok
+from variant_json_roundtrip
+where id = 3
+order by id;
+
+CREATE TABLE variant_json_write (
+    id INT,
+    json_str STRING,
+    variant_from_json VARIANT
+)
+properties(
+  'format-version' = '3'
+);
+
+insert into variant_json_write
+select
+    id,
+    json_str,
+    variant_from_json
+from variant_json_roundtrip;
+
+select 'variant json write roundtrip' as test_name;
+
+select
+    id,
+    case
+        when cast(variant_query(variant_from_json, '$.id') as INT) <=> cast(json_query(cast(variant_from_json as json), '$.id') as INT)
+         and get_variant_string(variant_from_json, '$.name') <=> cast(json_query(cast(variant_from_json as json), '$.name') as STRING)
+         and get_variant_double(variant_from_json, '$.scores[0]') <=> cast(json_query(cast(variant_from_json as json), '$.scores[0]') as DOUBLE)
+        then 'PASS' else 'FAIL' end as status,
+    cast(variant_query(variant_from_json, '$.id') as INT) as v_id,
+    cast(json_query(cast(variant_from_json as json), '$.id') as INT) as j_id,
+    get_variant_string(variant_from_json, '$.name') as v_name,
+    cast(json_query(cast(variant_from_json as json), '$.name') as STRING) as j_name
+from variant_json_write
+order by id;
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_variant_json/${uuid0}/ > /dev/null
+
+drop table variant_json_roundtrip force;
+drop table variant_json_write force;
+set catalog default_catalog;
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Support casting JSON to VARIANT so JSON inputs can be stored/processed as VARIANT and round-trip through Iceberg.

## What I'm doing:

- Implement JSON → VARIANT encoding and metadata generation in backend utilities.
- Wire JSON → VARIANT cast in cast_expr and allow VARIANT in FE JSON-compatible type list.
- Add Iceberg SQL tests covering round-trip and nested/edge JSON structures.

Fixes #62061

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements JSON → VARIANT casting end-to-end and documents/tests it.
> 
> - **Backend**: Adds `util/variant_encoder.{h,cpp}` to encode `JSON` into `VARIANT` (metadata build + value encoding); wires casting in `cast_expr.cpp` via `cast_to_variant_fn`, `CASE_TO_VARIANT`, and `CUSTOMIZE_FN_CAST` for `JSON`→`VARIANT`; updates Util CMake to build encoder
> - **FE**: Allows `VARIANT` in `JSON_COMPATIBLE_TYPE` (`PrimitiveType.java`) to enable planner-side compatibility/implicit casts
> - **Docs**: Updates EN/ZN `VARIANT.md` with examples for `CAST(parse_json(...) AS VARIANT)` and notes limitation (creation via JSON only)
> - **Tests**: Adds Iceberg SQL tests covering round-trip read/write and nested/edge structures for `JSON`→`VARIANT` casting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29dc52926c6c598b03ef3aa99abba4f531759a66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->