### PR TITLE
[BugFix] Fix Paimon averageRowSize calculation using avgLen

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -716,7 +716,9 @@ public class PaimonMetadata implements ConnectorMetadata {
                 builder.setNullsFraction(0);
             }
 
-            builder.setAverageRowSize(colStats.nullCount().isPresent() ? colStats.nullCount().getAsLong() : 1);
+            double averageRowSize = colStats.avgLen().isPresent() ?
+                    colStats.avgLen().getAsLong() : column.getType().getTypeSize();
+            builder.setAverageRowSize(Math.max(averageRowSize, 1.0));
 
             if (colStats.distinctCount().isPresent()) {
                 builder.setDistinctValuesCount(colStats.distinctCount().getAsLong());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -807,8 +807,9 @@ public class PaimonMetadataTest {
         // Verify averageRowSize is at least 1.0
         for (Map.Entry<ColumnRefOperator, com.starrocks.sql.optimizer.statistics.ColumnStatistic> entry :
                 tableStatistics.getColumnStatistics().entrySet()) {
-            assert entry.getValue().getAverageRowSize() >= 1.0 :
-                    "averageRowSize should be at least 1.0 for column: " + entry.getKey().getName();
+            org.junit.jupiter.api.Assertions.assertTrue(
+                    entry.getValue().getAverageRowSize() >= 1.0,
+                    "averageRowSize should be at least 1.0 for column: " + entry.getKey().getName());
         }
 
         // Verify row count from mergedRecordCount


### PR DESCRIPTION
## Why I'm doing:

Fix incorrect averageRowSize calculation in Paimon connector. Previously, nullCount was incorrectly used as `averageRowSize`, leading to inaccurate cost estimation in the CBO optimizer and affecting query plan selection.

## What I'm doing:

1. Fix buildColumnStatistic(): Use avgLen from Paimon ColStats instead of nullCount to calculate `averageRowSize`
2. Add fallback: When avgLen is unavailable, use column type size as fallback
3. Fix missing column handling: When a column is not in statistics, use column type size instead of the default value 1.0 from unknown()
4. Enhance unit tests: Add assertions to verify correct `averageRowSize` calculation

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes incorrect `averageRowSize` derivation in Paimon statistics.
> 
> - In `PaimonMetadata.buildColumnStatistic`, use `colStats.avgLen()` for `averageRowSize`; fallback to column type size; enforce minimum 1.0
> - Extend `PaimonMetadataTest` to validate `averageRowSize` for multiple columns, unknown-column behavior (defaults to 1.0), and `outputRowCount` from `mergedRecordCount`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b44479f21e735aff7612b68fff1d09d59b7a5c46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->