### PR TITLE
[BugFix] Fix 'Unsupported nest aggregation function inside aggregation' when enable enable_groupby_use_output_alias

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -1181,6 +1181,11 @@ public class FunctionSet {
         fns.add(fn);
     }
 
+    public boolean isAggregateFunction(String functionName) {
+        List<Function> fns = vectorizedFunctions.getOrDefault(functionName, Collections.EMPTY_LIST);
+        return !fns.isEmpty() && fns.get(0) instanceof AggregateFunction;
+    }
+
     // for vectorized engine
     public void addVectorizedScalarBuiltin(long fid, String fnName, boolean varArgs,
                                            Type retType, Type... args) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2510,6 +2510,10 @@ public class GlobalStateMgr {
         return functionSet.getFunction(desc, mode);
     }
 
+    public boolean isAggregateFunction(String functionName) {
+        return functionSet.isAggregateFunction(functionName);
+    }
+
     public List<Function> getBuiltinFunctions() {
         return functionSet.getBuiltinFunctions();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -77,6 +77,7 @@ import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.UnionRelation;
 import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.ast.ViewRelation;
+import com.starrocks.sql.ast.expression.AnalyticExpr;
 import com.starrocks.sql.ast.expression.BinaryPredicate;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.BoolLiteral;
@@ -2017,6 +2018,8 @@ public class QueryAnalyzer {
         private final LinkedList<String> resolvingAlias = new LinkedList<>();
         private final Scope sourceScope;
         private final ConnectContext session;
+        // Track whether we're currently inside a FunctionCallExpr or AnalyticExpr to detect nested aggregation/analytic
+        private boolean insideAggregateOrAnalyticFunction = false;
 
         public RewriteAliasVisitor(Scope sourceScope, ConnectContext session) {
             this.sourceScope = sourceScope;
@@ -2029,6 +2032,28 @@ public class QueryAnalyzer {
                 expr.setChild(i, visit(expr.getChild(i)));
             }
             return expr;
+        }
+
+        @Override
+        public Expr visitFunctionCall(FunctionCallExpr funcCall, Void context) {
+            // Track that we're inside a function call
+            insideAggregateOrAnalyticFunction |= ExprUtils.isAggregateFunction(funcCall.getFunctionName());
+            // Visit children
+            for (int i = 0; i < funcCall.getChildren().size(); ++i) {
+                funcCall.setChild(i, visit(funcCall.getChild(i)));
+            }
+            return funcCall;
+        }
+
+        @Override
+        public Expr visitAnalyticExpr(AnalyticExpr analyticExpr, Void context) {
+            // Track that we're inside an analytic expression
+            insideAggregateOrAnalyticFunction = true;
+            // Visit children
+            for (int i = 0; i < analyticExpr.getChildren().size(); ++i) {
+                analyticExpr.setChild(i, visit(analyticExpr.getChild(i)));
+            }
+            return analyticExpr;
         }
 
         @Override
@@ -2056,6 +2081,26 @@ public class QueryAnalyzer {
             if (sourceScope.tryResolveField(slotRef).isPresent() &&
                     !session.getSessionVariable().getEnableGroupbyUseOutputAlias()) {
                 return slotRef;
+            }
+            // If the alias matches the source column name and the alias expression is an aggregation/analytic function,
+            // and we're inside another function call or analytic expression, use the source column
+            // directly instead of the aggregation/analytic expression to avoid nested aggregation/analytic.
+            // For example: sum(input_count) as input_count, then sum(case when ... then input_count else 0 end)
+            // should use the source column input_count, not sum(input_count)
+            // Similarly: sum(input_count) over() as input_count, then sum(case when ... then input_count else 0 end) over()
+            // should use the source column input_count, not sum(input_count) over()
+            if (sourceScope.tryResolveField(slotRef).isPresent() && (insideAggregateOrAnalyticFunction)) {
+                // Check if alias expression is an AnalyticExpr
+                if (e instanceof AnalyticExpr) {
+                    return slotRef;
+                }
+                // Check if alias expression is a FunctionCallExpr that is aggregate or analytic
+                if (e instanceof FunctionCallExpr) {
+                    FunctionCallExpr funcCall = (FunctionCallExpr) e;
+                    if (ExprUtils.isAggregateFunction(funcCall.getFunctionName())) {
+                        return slotRef;
+                    }
+                }
             }
             // Referring to a duplicated alias is ambiguous
             if (aliasesMaybeAmbiguous.contains(ref)) {
@@ -2099,6 +2144,7 @@ public class QueryAnalyzer {
                 return null;
             }
             for (SelectListItem item : selectRelation.getSelectList().getItems()) {
+                insideAggregateOrAnalyticFunction = false;
                 if (item.getExpr() == null) {
                     continue;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprUtils.java
@@ -426,6 +426,10 @@ public class ExprUtils {
         return GlobalStateMgr.getCurrentState().getFunction(searchDesc, mode);
     }
 
+    public static boolean isAggregateFunction(String name) {
+        return GlobalStateMgr.getCurrentState().isAggregateFunction(name);
+    }
+
     public static boolean requiresTimestampDiffCast(String funcName) {
         if (funcName == null) {
             return false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/RewriteAliasTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/RewriteAliasTest.java
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.FeConstants;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class RewriteAliasTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        PlanTestBase.beforeClass();
+    }
+
+    @Test
+    public void testAggregateNotNested() throws Exception {
+        starRocksAssert.getCtx().getSessionVariable().setEnableGroupbyUseOutputAlias(true);
+        String sql = "select \n" +
+                "sum(v1) v1,\n" +
+                "sum(v2) v2,\n" +
+                "sum(case when v3>0 then v1 else v2 end) v3\n" +
+                "from t0";
+
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(1: v1), sum(2: v2), sum(if(3: v3 > 0, 1: v1, 2: v2))\n" +
+                "  |  group by: ");
+    }
+
+    @Test
+    public void testAnalyticalNotNested() throws Exception {
+        starRocksAssert.getCtx().getSessionVariable().setEnableGroupbyUseOutputAlias(true);
+        String sql = "select \n" +
+                "sum(v1) over() v1,\n" +
+                "sum(v2) over() v2,\n" +
+                "sum(case when v3>0 then v1 else v2 end) over() v3\n" +
+                "from t0";
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "  2:ANALYTIC\n" +
+                "  |  functions: [, sum(1: v1), ], [, sum(2: v2), ], [, sum(if(3: v3 > 0, 1: v1, 2: v2)), ]");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

when `set enable enable_groupby_use_output_alias = true`, query as follows report error "Unsupported nest aggregation function inside aggregation".

```sql
select 
sum(v1) v1;
sum(v2) v2;
sum(case when v3>0 then v1 else v2 end) v3
from t0;
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes alias rewriting to avoid creating nested aggregation/analytic expressions that trigger errors.
> 
> - QueryAnalyzer: track when inside aggregate/analytic (`insideAggregateOrAnalyticFunction`); in `visitSlot`, if alias expression is aggregate/analytic and we're inside another, use the source column instead of the alias
> - SelectAnalyzer: when resolving output aliases, if the alias expression is aggregate/analytic and a matching source column exists, return the `SlotRef` to avoid nesting
> - ExprUtils/GlobalStateMgr/FunctionSet: add `isAggregateFunction` helper to identify aggregate functions
> - Add unit tests (`RewriteAliasTest`) covering aggregate and analytic window cases to verify no nested plans are produced
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0505dd35f4de31d3bd1f1e99b6dd0e974f2379a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->