### PR TITLE
[Enhancement] Skip predicate columns collection during DP statistics estimation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderDP.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderDP.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -35,6 +36,17 @@ import static com.google.common.collect.Sets.powerSet;
 public class JoinReorderDP extends JoinOrder {
     public JoinReorderDP(OptimizerContext context) {
         super(context);
+    }
+
+    @Override
+    protected void calculateStatistics(OptExpression expr) {
+        if (StatisticsCalculator.isInSkipPredicateColumnsCollectionScope()) {
+            super.calculateStatistics(expr);
+            return;
+        }
+        try (var ignore = StatisticsCalculator.skipPredicateColumnsCollectionScope()) {
+            super.calculateStatistics(expr);
+        }
     }
 
     private final Map<BitSet, GroupInfo> bestPlanMemo = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -189,6 +189,37 @@ import static java.lang.Math.pow;
 public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContext> {
     private static final Logger LOG = LogManager.getLogger(StatisticsCalculator.class);
 
+    private static final ThreadLocal<Integer> SKIP_PREDICATE_COLUMNS_COLLECTION_DEPTH =
+            ThreadLocal.withInitial(() -> 0);
+
+    public static final class SkipPredicateColumnsCollectionScope implements AutoCloseable {
+        private SkipPredicateColumnsCollectionScope() {
+        }
+
+        @Override
+        public void close() {
+            int v = SKIP_PREDICATE_COLUMNS_COLLECTION_DEPTH.get() - 1;
+            if (v <= 0) {
+                SKIP_PREDICATE_COLUMNS_COLLECTION_DEPTH.remove();
+            } else {
+                SKIP_PREDICATE_COLUMNS_COLLECTION_DEPTH.set(v);
+            }
+        }
+    }
+
+    public static SkipPredicateColumnsCollectionScope skipPredicateColumnsCollectionScope() {
+        SKIP_PREDICATE_COLUMNS_COLLECTION_DEPTH.set(SKIP_PREDICATE_COLUMNS_COLLECTION_DEPTH.get() + 1);
+        return new SkipPredicateColumnsCollectionScope();
+    }
+
+    private static boolean shouldSkipPredicateColumnsCollection() {
+        return SKIP_PREDICATE_COLUMNS_COLLECTION_DEPTH.get() > 0;
+    }
+
+    public static boolean isInSkipPredicateColumnsCollectionScope() {
+        return shouldSkipPredicateColumnsCollection();
+    }
+
     private final ExpressionContext expressionContext;
     private final ColumnRefFactory columnRefFactory;
     private final OptimizerContext optimizerContext;
@@ -227,8 +258,10 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             limit = physical.getLimit();
         }
 
-        PredicateColumnsMgr.getInstance().recordPredicateColumns(predicate, optimizerContext.getColumnRefFactory(),
-                context.getOptExpression());
+        if (!shouldSkipPredicateColumnsCollection()) {
+            PredicateColumnsMgr.getInstance().recordPredicateColumns(predicate, optimizerContext.getColumnRefFactory(),
+                    context.getOptExpression());
+        }
 
         predicate = removePartitionPredicate(predicate, node, optimizerContext);
         Statistics statistics = context.getStatistics();


### PR DESCRIPTION
## Why I'm doing:
DP join reorder calls statistics estimation many times. `PredicateColumnsMgr.recordPredicateColumns(...)` is orthogonal to stats/cost correctness in this path, but it repeatedly walks predicate scalar trees and adds noticeable CPU overhead. We need a clean, scoped way to disable this work only for the DP statistics hot path without affecting other optimizer phases or leaving thread-local state behind.

## What I'm doing:
- Add a scoped skip switch in `StatisticsCalculator`:
  - Introduce a nestable `ThreadLocal` depth counter and `skipPredicateColumnsCollectionScope()` (try-with-resources) to temporarily disable predicate columns recording.
  - Ensure the ThreadLocal entry is removed when the outermost scope exits to avoid leaking state on long-lived threads.
- Apply the scope in `JoinReorderDP` statistics calculation:
  - Override `calculateStatistics(OptExpression)` to enter the scope only once per recursive stats calculation and reuse it for child recursion.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves DP join reorder performance by avoiding unnecessary predicate column recording during intensive statistics estimation.
> 
> - Add nestable thread-local scope in `StatisticsCalculator` (`skipPredicateColumnsCollectionScope()`, `isInSkipPredicateColumnsCollectionScope()`) to temporarily skip `PredicateColumnsMgr.recordPredicateColumns(...)`
> - Guard `visitOperator` to conditionally record predicate columns only when not in skip scope
> - Override `JoinReorderDP.calculateStatistics(OptExpression)` to run stats under the skip scope (enter once, reuse through recursion)
> - Add tests verifying scope nesting/restoration and thread-local isolation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7b612526b8e9ac78e28257f6494185419d8b7f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->