### PR TITLE
[BugFix]fix parallel prepare cause be stuck

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -980,6 +980,12 @@ CONF_Int64(pipeline_exec_thread_pool_thread_num, "0");
 // * "-n": negative integer, means n times of number of cpu cores.
 CONF_Int64(pipeline_prepare_thread_pool_thread_num, "0");
 CONF_Int64(pipeline_prepare_thread_pool_queue_size, "102400");
+// The number of threads for preparing fragment instances in batch exec_plan RPC, vCPUs by default.
+// *  "n": positive integer, fixed number of threads to n.
+// *  "0": default value, means the same as number of cpu cores.
+// * "-n": negative integer, means n times of number of cpu cores.
+CONF_Int64(fragment_prepare_thread_pool_thread_num, "0");
+CONF_Int64(fragment_prepare_thread_pool_queue_size, "102400");
 // The number of threads for executing sink io task in pipeline engine, vCPUs by default.
 CONF_Int64(pipeline_sink_io_thread_pool_thread_num, "0");
 CONF_Int64(pipeline_sink_io_thread_pool_queue_size, "102400");

--- a/be/src/exec/pipeline/adaptive/event.cpp
+++ b/be/src/exec/pipeline/adaptive/event.cpp
@@ -14,20 +14,14 @@
 
 #include "exec/pipeline/adaptive/event.h"
 
-#include <atomic>
-#include <condition_variable>
-#include <mutex>
 #include <utility>
 
-#include "exec/pipeline/group_execution/execution_group.h"
 #include "exec/pipeline/pipeline.h"
 #include "exec/pipeline/pipeline_driver.h"
 #include "exec/pipeline/pipeline_driver_executor.h"
 #include "exec/pipeline/source_operator.h"
-#include "exec/workgroup/work_group.h"
-#include "runtime/current_thread.h"
 #include "util/failpoint/fail_point.h"
-#include "util/priority_thread_pool.hpp"
+#include "util/uid_util.h"
 
 namespace starrocks::pipeline {
 
@@ -102,77 +96,17 @@ void CollectStatsSourceInitializeEvent::process(RuntimeState* state) {
     }
 
     auto prepare_drivers = [state, &pipelines = _pipelines]() {
-        size_t total_driver_size = 0;
         for (const auto& pipeline : pipelines) {
             for (const auto& driver : pipeline->drivers()) {
                 FAIL_POINT_TRIGGER_RETURN(
                         collect_stats_source_initialize_prepare_failed,
                         Status::InternalError("injected collect_stats_source_initialize_prepare_failed"));
                 RETURN_IF_ERROR(driver->prepare(state));
-                total_driver_size++;
+                RETURN_IF_ERROR(driver->prepare_local_state(state));
             }
         }
-
-        auto* prepare_thread_pool = state->exec_env()->pipeline_prepare_pool();
-        DCHECK(prepare_thread_pool != nullptr);
-
-        std::vector<DriverPtr> all_drivers;
-        all_drivers.reserve(total_driver_size);
-        for (const auto& pipeline : pipelines) {
-            for (const auto& driver : pipeline->drivers()) {
-                all_drivers.emplace_back(driver);
-            }
-        }
-
-        if (all_drivers.empty()) {
-            return Status::OK();
-        }
-
-        auto sync_ctx = std::make_shared<DriverPrepareSyncContext>();
-        sync_ctx->pending_tasks = static_cast<int>(all_drivers.size());
-
-        for (auto& driver : all_drivers) {
-            auto task_fn = [&driver, runtime_state = state, sync_ctx]() {
-                // hold mem tracker's shared ptr for thread safe
-                auto mem_tracker = runtime_state->instance_mem_tracker_ptr();
-                SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker.get());
-                Status st = driver->prepare_local_state(runtime_state);
-                if (!st.ok()) {
-                    Status* expected = nullptr;
-                    Status* new_error = new Status(std::move(st));
-                    if (!sync_ctx->first_error.compare_exchange_strong(expected, new_error)) {
-                        // Another thread already set the error, clean up our allocation
-                        delete new_error;
-                    }
-                }
-
-                if (sync_ctx->pending_tasks.fetch_sub(1) == 1) {
-                    std::lock_guard<std::mutex> l(sync_ctx->mutex);
-                    sync_ctx->cv.notify_all();
-                }
-            };
-
-            bool submit_res = prepare_thread_pool->try_offer(task_fn);
-            if (!submit_res) {
-                task_fn();
-            }
-        }
-
-        // Wait for all tasks to finish
-        {
-            std::unique_lock<std::mutex> lock(sync_ctx->mutex);
-            sync_ctx->cv.wait(lock, [&sync_ctx] { return sync_ctx->pending_tasks.load() == 0; });
-        }
-
-        Status* error = sync_ctx->first_error.load();
-        if (error != nullptr) {
-            Status result = *error;
-            return result;
-        }
-
         return Status::OK();
     };
-
     if (const auto status = prepare_drivers(); !status.ok()) {
         LOG(WARNING) << "[ADAPTIVE DOP] failed to prepare pipeline drivers [status=" << status.message() << "]";
         state->fragment_ctx()->cancel(status);

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -105,15 +105,18 @@ public:
 
     Status prepare(ExecEnv* exec_env, const TExecPlanFragmentParams& common_request,
                    const TExecPlanFragmentParams& unique_request);
-    Status execute(ExecEnv* exec_env);
+    Status execute(ExecEnv* exec_env, bool need_to_submit = true);
 
+    Status submit();
     static Status append_incremental_scan_ranges(ExecEnv* exec_env, const TExecPlanFragmentParams& request,
                                                  TExecPlanFragmentResult* response);
 
+    // used for parallel prepare
     Status prepare_global_state(ExecEnv* exec_env, const TExecPlanFragmentParams& common_request);
-    void _fail_cleanup(bool fragment_has_registed);
+    void clean_up_when_success();
 
 private:
+    void _fail_cleanup(bool fragment_has_registed);
     uint32_t _calc_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const;
     uint32_t _calc_sink_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const;
     int _calc_delivery_expired_seconds(const UnifiedExecPlanFragmentParams& request) const;
@@ -142,6 +145,9 @@ private:
     QueryContext* _query_ctx = nullptr;
     FragmentContextPtr _fragment_ctx = nullptr;
     workgroup::WorkGroupPtr _wg = nullptr;
+
+    // fragment/driver prepare all successes
+    bool _all_prepared = false;
 };
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/group_execution/execution_group.cpp
+++ b/be/src/exec/pipeline/group_execution/execution_group.cpp
@@ -82,8 +82,8 @@ void ExecutionGroup::prepare_active_drivers_parallel(RuntimeState* state,
         FragmentContextPtr fragment_ctx_holder = nullptr;
         if (auto* query_ctx = state->query_ctx(); query_ctx != nullptr) {
             fragment_ctx_holder = query_ctx->fragment_mgr()->get(driver->fragment_ctx()->fragment_instance_id());
-            DCHECK(fragment_ctx_holder != nullptr);
         }
+        DCHECK(fragment_ctx_holder != nullptr);
         DriverRawPtr driver_raw = driver.get();
         bool submitted = pipeline_prepare_pool->try_offer(
                 [sync_ctx, driver_raw, fragment_ctx_holder = std::move(fragment_ctx_holder)]() mutable {

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -361,6 +361,7 @@ void QueryContextManager::_clean_slot_unlocked(size_t i, std::vector<QueryContex
         }
     }
 }
+
 void QueryContextManager::_clean_query_contexts() {
     for (auto i = 0; i < _num_slots; ++i) {
         auto& mutex = _mutexes[i];

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -295,6 +295,7 @@ public:
 
     PriorityThreadPool* udf_call_pool() { return _udf_call_pool; }
     PriorityThreadPool* pipeline_prepare_pool() { return _pipeline_prepare_pool; }
+    PriorityThreadPool* fragment_prepare_pool() { return _fragment_prepare_pool; }
     PriorityThreadPool* pipeline_sink_io_pool() { return _pipeline_sink_io_pool; }
     PriorityThreadPool* query_rpc_pool() { return _query_rpc_pool; }
     PriorityThreadPool* datacache_rpc_pool() { return _datacache_rpc_pool; }
@@ -394,6 +395,7 @@ private:
 
     PriorityThreadPool* _udf_call_pool = nullptr;
     PriorityThreadPool* _pipeline_prepare_pool = nullptr;
+    PriorityThreadPool* _fragment_prepare_pool = nullptr;
     PriorityThreadPool* _pipeline_sink_io_pool = nullptr;
     PriorityThreadPool* _query_rpc_pool = nullptr;
     PriorityThreadPool* _datacache_rpc_pool = nullptr;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -511,7 +511,11 @@ void PInternalServiceImplBase<T>::_exec_batch_plan_fragments(google::protobuf::R
     // submit when all prepare tasks successes
     for (int i = 0; i < unique_requests.size(); ++i) {
         auto& fragment_executor = fragment_executors->at(i);
-        Status status = fragment_executor.submit();
+        status = fragment_executor.submit();
+        if (!status.ok()) {
+            query_ctx->cancel(status, true);
+            break;
+        }
     }
 
     status.to_protobuf(response->mutable_status());

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -490,7 +490,7 @@ void PInternalServiceImplBase<T>::_exec_batch_plan_fragments(google::protobuf::R
             std::future_status::timeout) {
             st =
                     Status::TimedOut(fmt::format("exec_batch_plan_fragments wait fragment prepare timed out, "
-                                                 "query_id={}, query_timeout={}s, idx={}",
+                                                 "query_id={}, query_timeout={}ms, idx={}",
                                                  print_id(common_request.params.query_id), remaining_ms, i));
         } else {
             st = prepare_futures[i].get();

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -91,6 +91,7 @@ public:
     // query execution
     pipeline::PipelineExecutorMetrics pipeline_executor_metrics;
     METRIC_DEFINE_INT_GAUGE(pipe_prepare_pool_queue_len, MetricUnit::NOUNIT);
+    METRIC_DEFINE_INT_GAUGE(fragment_prepare_pool_queue_len, MetricUnit::NOUNIT);
     METRIC_DEFINE_INT_GAUGE(pipe_driver_overloaded, MetricUnit::NOUNIT);
     METRIC_DEFINE_INT_GAUGE(query_scan_bytes_per_second, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(runtime_filter_event_queue_len, MetricUnit::NOUNIT);


### PR DESCRIPTION
## Why I'm doing:
1. in https://github.com/StarRocks/starrocks/pull/63956, fragment parallel prepare tasks will be submitted to pip_prepare pool, and every fragment prepare tasks  will submit multiple driver prepare task to pip_prepare pool again, and fragment prepare tasks will wait for all submitted driver prepare tasks finished. This can cause dead lock
2. when be exits, some submitted prepare task can never be done, so we should not wait forever
3. for current parallel fragment prepare, fragment_executors->at(i).execute is done one by one, this is not complete 
parallel

fix https://github.com/StarRocks/StarRocksTest/issues/10805

## What I'm doing:
1. add fragment prepare pool for parallel fragment prepare, keep driver parallel prepare in pip_prepare pool.
2. for prepare task, wait for timeout instead of wait forever
3. split submit driver from fragment_executors->at(i).execute, and make fragment_executors->at(i).execute totally parallel
4. since right now we only wait timeout, so if wait timeout, we need to clean up fragment context which is already prepared successfully when timeout. I choose the last finished thread to do this thing.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses deadlocks and stuck BE during parallel prepare by isolating fragment-level prepare and adding timeout handling.
> 
> - Add `fragment_prepare_thread_pool_*` configs and a new `_fragment_prepare_pool` with metrics; ensure proper shutdown/release in `ExecEnv`
> - `exec_batch_plan_fragments`: dispatch RPC handling on `query_rpc_pool`, run per-fragment prepare on `fragment_prepare_pool`, wait with query-remaining-time timeouts, mark/cancel on failure, then `submit()` only after all prepared; add cleanup sweep for timed-out/success cases
> - Make driver prepare waits timeout-aware in `FragmentContext::prepare_active_drivers`; in `ExecutionGroup`, hold `FragmentContextPtr` during async prepare to avoid UAF
> - Refactor `FragmentExecutor`: `execute(exec_env, need_to_submit)`, new `submit()`, and `clean_up_when_success()`; set `_all_prepared` flag
> - Simplify `CollectStatsSourceInitializeEvent` to prepare drivers (global + local) inline before submit
> - Expose `QueryContext::mark_prepare_failed()` and `get_query_remaining_time_ms()` for timeout/cancellation control
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5afda4ca1d7f874d6a3990e422245639a56f963e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->