### PR TITLE
[UT] Add basic test for iceberg delete

### DIFF
--- a/be/src/formats/parquet/parquet_pos_reader.cpp
+++ b/be/src/formats/parquet/parquet_pos_reader.cpp
@@ -20,24 +20,10 @@
 namespace starrocks::parquet {
 
 Status ParquetPosReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
-    if (filter == nullptr) {
-        // No filter, generate positions for all rows in the range
-        for (uint64_t i = range.begin(); i < range.end(); ++i) {
-            // Generate position based on the absolute row position in the file.
-            int64_t pos = i;
-            dst->as_mutable_raw_ptr()->append_datum(Datum(pos));
-        }
-    } else {
-        // Apply filter, only generate positions for selected rows
-        DCHECK_EQ(filter->size(), range.span_size()) << "Filter size must match range size";
-        for (uint64_t i = range.begin(); i < range.end(); ++i) {
-            size_t filter_index = i - range.begin();
-            if ((*filter)[filter_index]) {
-                // Generate position based on the absolute row position in the file.
-                int64_t pos = i;
-                dst->as_mutable_raw_ptr()->append_datum(Datum(pos));
-            }
-        }
+    for (uint64_t i = range.begin(); i < range.end(); ++i) {
+        // Generate position based on the absolute row position in the file.
+        int64_t pos = i;
+        dst->as_mutable_raw_ptr()->append_datum(Datum(pos));
     }
     return Status::OK();
 }

--- a/be/test/formats/parquet/parquet_pos_reader_test.cpp
+++ b/be/test/formats/parquet/parquet_pos_reader_test.cpp
@@ -78,12 +78,12 @@ TEST_F(ParquetPosReaderTest, TestReadRangeWithFilter) {
     // Read the range with filter
     ASSERT_TRUE(reader.read_range(range, &filter, column).ok());
 
-    // Check that we got 2 rows (positions 201 and 203)
-    ASSERT_EQ(column->size(), 2);
+    // Check that we got 5 rows
+    ASSERT_EQ(column->size(), 5);
 
     // Check the values
-    ASSERT_EQ(column->get(0).get_int64(), 201);
-    ASSERT_EQ(column->get(1).get_int64(), 203);
+    ASSERT_EQ(column->get(1).get_int64(), 201);
+    ASSERT_EQ(column->get(3).get_int64(), 203);
 }
 
 // Test ParquetPosReader with a larger range
@@ -153,8 +153,8 @@ TEST_F(ParquetPosReaderTest, TestReadRangeWithNoSelectedRows) {
     // Read the range with filter
     ASSERT_TRUE(reader.read_range(range, &filter, column).ok());
 
-    // Check that we got 0 rows
-    ASSERT_EQ(column->size(), 0);
+    // Check that we got 3 rows
+    ASSERT_EQ(column->size(), 3);
 }
 
 // Test ParquetPosReader with all rows selected by filter

--- a/test/sql/test_iceberg/R/test_iceberg_delete_partition_transform
+++ b/test/sql/test_iceberg/R/test_iceberg_delete_partition_transform
@@ -1,0 +1,393 @@
+-- name: test_iceberg_delete_partition_transform
+create external catalog iceberg_del_trf_${uuid0}
+PROPERTIES ( "type"  =  "iceberg",
+    "iceberg.catalog.type"  =  "hive",
+    "iceberg.catalog.hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}" );
+-- result:
+-- !result
+create database iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_iceberg_delete_partition_transform/${uuid0}/iceberg_delete_db_${uuid0}"
+);
+-- result:
+-- !result
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_bucket (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    category STRING
+) 
+PARTITION BY bucket(category, 4);
+-- result:
+-- !result
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_bucket VALUES
+    (1, 'ProductA', 100.00, 'Electronics'),
+    (2, 'ProductB', 200.00, 'Clothing'),
+    (3, 'ProductC', 150.00, 'Electronics'),
+    (4, 'ProductD', 300.00, 'Books'),
+    (5, 'ProductE', 250.00, 'Clothing');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_bucket ORDER BY id;
+-- result:
+1	ProductA	100.00	Electronics
+2	ProductB	200.00	Clothing
+3	ProductC	150.00	Electronics
+4	ProductD	300.00	Books
+5	ProductE	250.00	Clothing
+-- !result
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_bucket WHERE category = 'Clothing';
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_bucket ORDER BY id;
+-- result:
+1	ProductA	100.00	Electronics
+3	ProductC	150.00	Electronics
+4	ProductD	300.00	Books
+-- !result
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_truncate (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    sku STRING
+) 
+PARTITION BY truncate(sku, 2);
+-- result:
+-- !result
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_truncate VALUES
+    (1, 'ProductA', 100.00, 'SKU001'),
+    (2, 'ProductB', 200.00, 'SKU002'),
+    (3, 'ProductC', 150.00, 'SKU003'),
+    (4, 'ProductD', 300.00, 'SKU004'),
+    (5, 'ProductE', 250.00, 'SKU005');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_truncate ORDER BY id;
+-- result:
+1	ProductA	100.00	SKU001
+2	ProductB	200.00	SKU002
+3	ProductC	150.00	SKU003
+4	ProductD	300.00	SKU004
+5	ProductE	250.00	SKU005
+-- !result
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_truncate WHERE sku LIKE 'SKU00%';
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_truncate ORDER BY id;
+-- result:
+-- !result
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    event_date DATE
+) 
+PARTITION BY year(event_date);
+-- result:
+-- !result
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year VALUES
+    (1, 'EventA', 100.00, '2023-01-01'),
+    (2, 'EventB', 200.00, '2023-06-15'),
+    (3, 'EventC', 150.00, '2024-03-10'),
+    (4, 'EventD', 300.00, '2024-12-20'),
+    (5, 'EventE', 250.00, '2023-11-05');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year ORDER BY event_date, id;
+-- result:
+1	EventA	100.00	2023-01-01
+2	EventB	200.00	2023-06-15
+5	EventE	250.00	2023-11-05
+3	EventC	150.00	2024-03-10
+4	EventD	300.00	2024-12-20
+-- !result
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year WHERE year(event_date) = 2023;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year ORDER BY event_date, id;
+-- result:
+3	EventC	150.00	2024-03-10
+4	EventD	300.00	2024-12-20
+-- !result
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    order_date DATE
+) 
+PARTITION BY month(order_date);
+-- result:
+-- !result
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month VALUES
+    (1, 'OrderA', 100.00, '2023-01-10'),
+    (2, 'OrderB', 200.00, '2023-01-20'),
+    (3, 'OrderC', 150.00, '2023-02-15'),
+    (4, 'OrderD', 300.00, '2023-03-05'),
+    (5, 'OrderE', 250.00, '2023-02-28');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month ORDER BY order_date, id;
+-- result:
+1	OrderA	100.00	2023-01-10
+2	OrderB	200.00	2023-01-20
+3	OrderC	150.00	2023-02-15
+5	OrderE	250.00	2023-02-28
+4	OrderD	300.00	2023-03-05
+-- !result
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month WHERE month(order_date) = 2;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month ORDER BY order_date, id;
+-- result:
+1	OrderA	100.00	2023-01-10
+2	OrderB	200.00	2023-01-20
+4	OrderD	300.00	2023-03-05
+-- !result
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_day (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    created_time DATETIME
+) 
+PARTITION BY day(created_time);
+-- result:
+-- !result
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_day VALUES
+    (1, 'RecordA', 100.00, '2023-01-10 10:00:00'),
+    (2, 'RecordB', 200.00, '2023-01-10 15:30:00'),
+    (3, 'RecordC', 150.00, '2023-01-11 09:15:00'),
+    (4, 'RecordD', 300.00, '2023-01-12 14:45:00'),
+    (5, 'RecordE', 250.00, '2023-01-11 11:20:00');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_day ORDER BY created_time, id;
+-- result:
+1	RecordA	100.00	2023-01-10 10:00:00
+2	RecordB	200.00	2023-01-10 15:30:00
+3	RecordC	150.00	2023-01-11 09:15:00
+5	RecordE	250.00	2023-01-11 11:20:00
+4	RecordD	300.00	2023-01-12 14:45:00
+-- !result
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_day WHERE day(created_time) = 11;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_day ORDER BY created_time, id;
+-- result:
+1	RecordA	100.00	2023-01-10 10:00:00
+2	RecordB	200.00	2023-01-10 15:30:00
+4	RecordD	300.00	2023-01-12 14:45:00
+-- !result
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_hour (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    log_time DATETIME
+) 
+PARTITION BY hour(log_time);
+-- result:
+-- !result
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_hour VALUES
+    (1, 'LogA', 10.00, '2023-01-10 10:15:00'),
+    (2, 'LogB', 20.00, '2023-01-10 10:30:00'),
+    (3, 'LogC', 15.00, '2023-01-10 11:45:00'),
+    (4, 'LogD', 30.00, '2023-01-10 12:20:00'),
+    (5, 'LogE', 25.00, '2023-01-10 11:55:00');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_hour ORDER BY log_time, id;
+-- result:
+1	LogA	10.00	2023-01-10 10:15:00
+2	LogB	20.00	2023-01-10 10:30:00
+3	LogC	15.00	2023-01-10 11:45:00
+5	LogE	25.00	2023-01-10 11:55:00
+4	LogD	30.00	2023-01-10 12:20:00
+-- !result
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_hour WHERE hour(log_time) = 11;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_hour ORDER BY log_time, id;
+-- result:
+1	LogA	10.00	2023-01-10 10:15:00
+2	LogB	20.00	2023-01-10 10:30:00
+4	LogD	30.00	2023-01-10 12:20:00
+-- !result
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    order_date DATE,
+    ship_date DATE
+) 
+PARTITION BY year(order_date), month(ship_date);
+-- result:
+-- !result
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month VALUES
+    (1, 'TransA', 100.00, '2023-01-15', '2023-01-20'),
+    (2, 'TransB', 200.00, '2023-01-20', '2023-01-25'),
+    (3, 'TransC', 150.00, '2023-02-10', '2023-02-15'),
+    (4, 'TransD', 300.00, '2023-02-25', '2023-03-01'),
+    (5, 'TransE', 250.00, '2024-01-05', '2024-01-10');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month ORDER BY order_date, id;
+-- result:
+1	TransA	100.00	2023-01-15	2023-01-20
+2	TransB	200.00	2023-01-20	2023-01-25
+3	TransC	150.00	2023-02-10	2023-02-15
+4	TransD	300.00	2023-02-25	2023-03-01
+5	TransE	250.00	2024-01-05	2024-01-10
+-- !result
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month WHERE year(order_date) = 2023 AND month(ship_date) = 1;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month ORDER BY order_date, id;
+-- result:
+3	TransC	150.00	2023-02-10	2023-02-15
+4	TransD	300.00	2023-02-25	2023-03-01
+5	TransE	250.00	2024-01-05	2024-01-10
+-- !result
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    category STRING,
+    product_code STRING
+) 
+PARTITION BY bucket(category, 3), truncate(product_code, 3);
+-- result:
+-- !result
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed VALUES
+    (1, 'MixedA', 100.00, 'CategoryA', 'PCODE001'),
+    (2, 'MixedB', 200.00, 'CategoryB', 'PCODE002'),
+    (3, 'MixedC', 150.00, 'CategoryA', 'PCODE003'),
+    (4, 'MixedD', 300.00, 'CategoryC', 'PCODE001'),
+    (5, 'MixedE', 250.00, 'CategoryB', 'PCODE004');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed ORDER BY id;
+-- result:
+1	MixedA	100.00	CategoryA	PCODE001
+2	MixedB	200.00	CategoryB	PCODE002
+3	MixedC	150.00	CategoryA	PCODE003
+4	MixedD	300.00	CategoryC	PCODE001
+5	MixedE	250.00	CategoryB	PCODE004
+-- !result
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed WHERE category = 'CategoryB';
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed ORDER BY id;
+-- result:
+1	MixedA	100.00	CategoryA	PCODE001
+3	MixedC	150.00	CategoryA	PCODE003
+4	MixedD	300.00	CategoryC	PCODE001
+-- !result
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month VALUES
+    (6, 'TransF', 180.00, '2024-01-15', '2024-01-20'),
+    (7, 'TransG', 220.00, '2024-02-10', '2024-02-15'),
+    (8, 'TransH', 190.00, '2024-01-20', '2024-01-25');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month WHERE year(order_date) = 2024 ORDER BY order_date;
+-- result:
+5	TransE	250.00	2024-01-05	2024-01-10
+6	TransF	180.00	2024-01-15	2024-01-20
+8	TransH	190.00	2024-01-20	2024-01-25
+7	TransG	220.00	2024-02-10	2024-02-15
+-- !result
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month WHERE year(order_date) = 2024 AND amount < 200;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month ORDER BY order_date, id;
+-- result:
+3	TransC	150.00	2023-02-10	2023-02-15
+4	TransD	300.00	2023-02-25	2023-03-01
+5	TransE	250.00	2024-01-05	2024-01-10
+7	TransG	220.00	2024-02-10	2024-02-15
+-- !result
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month VALUES
+    (9, 'TransI', 210.00, '2024-03-01', '2024-03-05'),
+    (10, 'TransJ', 230.00, '2024-03-02', '2024-03-06'),
+    (11, 'TransK', 240.00, '2024-03-03', '2024-03-07');
+-- result:
+-- !result
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month WHERE year(order_date) = 2024 AND month(ship_date) = 3 AND id IN (9, 11);
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month ORDER BY order_date, id;
+-- result:
+3	TransC	150.00	2023-02-10	2023-02-15
+4	TransD	300.00	2023-02-25	2023-03-01
+5	TransE	250.00	2024-01-05	2024-01-10
+7	TransG	220.00	2024-02-10	2024-02-15
+10	TransJ	230.00	2024-03-02	2024-03-06
+-- !result
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month VALUES
+    (6, 'OrderF', 120.00, '2023-04-10'),
+    (7, 'OrderG', 180.00, '2023-04-15'),
+    (8, 'OrderH', 220.00, '2023-05-05');
+-- result:
+-- !result
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month WHERE month(order_date) BETWEEN 4 AND 5;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month ORDER BY order_date, id;
+-- result:
+1	OrderA	100.00	2023-01-10
+2	OrderB	200.00	2023-01-20
+4	OrderD	300.00	2023-03-05
+-- !result
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed VALUES
+    (6, 'MixedF', 175.00, 'CategoryA', 'PCODE005'),
+    (7, 'MixedG', 225.00, 'CategoryD', 'PCODE006'),
+    (8, 'MixedH', 185.00, 'CategoryA', 'PCODE007');
+-- result:
+-- !result
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed WHERE amount > 180;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed ORDER BY id;
+-- result:
+1	MixedA	100.00	CategoryA	PCODE001
+3	MixedC	150.00	CategoryA	PCODE003
+6	MixedF	175.00	CategoryA	PCODE005
+-- !result
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_bucket force;
+-- result:
+-- !result
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_truncate force;
+-- result:
+-- !result
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year force;
+-- result:
+-- !result
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month force;
+-- result:
+-- !result
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_day force;
+-- result:
+-- !result
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_hour force;
+-- result:
+-- !result
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month force;
+-- result:
+-- !result
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed force;
+-- result:
+-- !result
+drop database iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog iceberg_del_trf_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_delete_partition_transform/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/R/test_iceberg_delete_partitioned
+++ b/test/sql/test_iceberg/R/test_iceberg_delete_partitioned
@@ -1,0 +1,401 @@
+-- name: test_iceberg_delete_partitioned
+create external catalog iceberg_del_part_${uuid0}
+PROPERTIES ( "type"  =  "iceberg",
+    "iceberg.catalog.type"  =  "hive",
+    "iceberg.catalog.hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}" );
+-- result:
+-- !result
+create database iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_iceberg_delete_partitioned/${uuid0}/iceberg_delete_db_${uuid0}"
+);
+-- result:
+-- !result
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_date (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    date_key DATE
+) 
+PARTITION BY (date_key);
+-- result:
+-- !result
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_date VALUES
+    (1, 'ProductA', 100.00, '2023-01-01'),
+    (2, 'ProductB', 200.00, '2023-01-02'),
+    (3, 'ProductC', 150.00, '2023-01-01'),
+    (4, 'ProductD', 300.00, '2023-01-03'),
+    (5, 'ProductE', 250.00, '2023-01-02');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_date ORDER BY date_key, id;
+-- result:
+1	ProductA	100.00	2023-01-01
+3	ProductC	150.00	2023-01-01
+2	ProductB	200.00	2023-01-02
+5	ProductE	250.00	2023-01-02
+4	ProductD	300.00	2023-01-03
+-- !result
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_date WHERE date_key = '2023-01-02';
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_date ORDER BY date_key, id;
+-- result:
+1	ProductA	100.00	2023-01-01
+3	ProductC	150.00	2023-01-01
+4	ProductD	300.00	2023-01-03
+-- !result
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_datetime (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    created_time DATETIME
+) 
+PARTITION BY (created_time);
+-- result:
+-- !result
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_datetime VALUES
+    (1, 'OrderA', 100.00, '2023-01-01 10:00:00'),
+    (2, 'OrderB', 200.00, '2023-01-01 11:00:00'),
+    (3, 'OrderC', 150.00, '2023-01-02 10:00:00'),
+    (4, 'OrderD', 300.00, '2023-01-02 12:00:00'),
+    (5, 'OrderE', 250.00, '2023-01-03 09:00:00');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_datetime ORDER BY created_time, id;
+-- result:
+1	OrderA	100.00	2023-01-01 10:00:00
+2	OrderB	200.00	2023-01-01 11:00:00
+3	OrderC	150.00	2023-01-02 10:00:00
+4	OrderD	300.00	2023-01-02 12:00:00
+5	OrderE	250.00	2023-01-03 09:00:00
+-- !result
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_datetime WHERE created_time = '2023-01-02 10:00:00';
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_datetime ORDER BY created_time, id;
+-- result:
+1	OrderA	100.00	2023-01-01 10:00:00
+2	OrderB	200.00	2023-01-01 11:00:00
+4	OrderD	300.00	2023-01-02 12:00:00
+5	OrderE	250.00	2023-01-03 09:00:00
+-- !result
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_string (
+    id INT,
+    product_name STRING,
+    price DECIMAL(10,2),
+    region VARCHAR(50)
+) 
+PARTITION BY (region);
+-- result:
+-- !result
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_string VALUES
+    (1, 'ProductA', 100.00, 'North'),
+    (2, 'ProductB', 200.00, 'South'),
+    (3, 'ProductC', 150.00, 'North'),
+    (4, 'ProductD', 300.00, 'East'),
+    (5, 'ProductE', 250.00, 'West');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_string ORDER BY region, id;
+-- result:
+4	ProductD	300.00	East
+1	ProductA	100.00	North
+3	ProductC	150.00	North
+2	ProductB	200.00	South
+5	ProductE	250.00	West
+-- !result
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_string WHERE region = 'North';
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_string ORDER BY region, id;
+-- result:
+4	ProductD	300.00	East
+2	ProductB	200.00	South
+5	ProductE	250.00	West
+-- !result
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_numeric (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    year_id INT
+) 
+PARTITION BY (year_id);
+-- result:
+-- !result
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_numeric VALUES
+    (1, 'SaleA', 100.00, 2023),
+    (2, 'SaleB', 200.00, 2024),
+    (3, 'SaleC', 150.00, 2023),
+    (4, 'SaleD', 300.00, 2024),
+    (5, 'SaleE', 250.00, 2025);
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_numeric ORDER BY year_id, id;
+-- result:
+1	SaleA	100.00	2023
+3	SaleC	150.00	2023
+2	SaleB	200.00	2024
+4	SaleD	300.00	2024
+5	SaleE	250.00	2025
+-- !result
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_numeric WHERE year_id = 2023;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_numeric ORDER BY year_id, id;
+-- result:
+2	SaleB	200.00	2024
+4	SaleD	300.00	2024
+5	SaleE	250.00	2025
+-- !result
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_multi (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    date_key DATE,
+    category STRING
+) 
+PARTITION BY (date_key, category);
+-- result:
+-- !result
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_multi VALUES
+    (1, 'ProductA', 100.00, '2023-01-01', 'Electronics'),
+    (2, 'ProductB', 200.00, '2023-01-01', 'Clothing'),
+    (3, 'ProductC', 150.00, '2023-01-02', 'Electronics'),
+    (4, 'ProductD', 300.00, '2023-01-02', 'Clothing'),
+    (5, 'ProductE', 250.00, '2023-01-01', 'Electronics');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_multi ORDER BY date_key, category, id;
+-- result:
+2	ProductB	200.00	2023-01-01	Clothing
+1	ProductA	100.00	2023-01-01	Electronics
+5	ProductE	250.00	2023-01-01	Electronics
+4	ProductD	300.00	2023-01-02	Clothing
+3	ProductC	150.00	2023-01-02	Electronics
+-- !result
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_multi WHERE date_key = '2023-01-01' AND category = 'Electronics';
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_multi ORDER BY date_key, category, id;
+-- result:
+2	ProductB	200.00	2023-01-01	Clothing
+4	ProductD	300.00	2023-01-02	Clothing
+3	ProductC	150.00	2023-01-02	Electronics
+-- !result
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_num_multi (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    year_id INT,
+    month_id INT
+) 
+PARTITION BY (year_id, month_id);
+-- result:
+-- !result
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_num_multi VALUES
+    (1, 'SaleA', 100.00, 2023, 1),
+    (2, 'SaleB', 200.00, 2023, 1),
+    (3, 'SaleC', 150.00, 2023, 2),
+    (4, 'SaleD', 300.00, 2023, 2),
+    (5, 'SaleE', 250.00, 2024, 1);
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_num_multi ORDER BY year_id, month_id, id;
+-- result:
+1	SaleA	100.00	2023	1
+2	SaleB	200.00	2023	1
+3	SaleC	150.00	2023	2
+4	SaleD	300.00	2023	2
+5	SaleE	250.00	2024	1
+-- !result
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_num_multi WHERE year_id = 2023 AND month_id = 1;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_num_multi ORDER BY year_id, month_id, id;
+-- result:
+3	SaleC	150.00	2023	2
+4	SaleD	300.00	2023	2
+5	SaleE	250.00	2024	1
+-- !result
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    created_date DATE,
+    year_id INT,
+    quarter_id INT,
+    region STRING
+) 
+PARTITION BY (year_id, quarter_id, region);
+-- result:
+-- !result
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex VALUES
+    (1, 'TransA', 100.00, '2023-01-15', 2023, 1, 'North'),
+    (2, 'TransB', 200.00, '2023-01-16', 2023, 1, 'South'),
+    (3, 'TransC', 150.00, '2023-04-15', 2023, 2, 'North'),
+    (4, 'TransD', 300.00, '2023-04-16', 2023, 2, 'South'),
+    (5, 'TransE', 250.00, '2023-02-15', 2023, 1, 'North');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex ORDER BY year_id, quarter_id, region, id;
+-- result:
+1	TransA	100.00	2023-01-15	2023	1	North
+5	TransE	250.00	2023-02-15	2023	1	North
+2	TransB	200.00	2023-01-16	2023	1	South
+3	TransC	150.00	2023-04-15	2023	2	North
+4	TransD	300.00	2023-04-16	2023	2	South
+-- !result
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex WHERE year_id = 2023 AND quarter_id = 1 AND region = 'North';
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex ORDER BY year_id, quarter_id, region, id;
+-- result:
+2	TransB	200.00	2023-01-16	2023	1	South
+3	TransC	150.00	2023-04-15	2023	2	North
+4	TransD	300.00	2023-04-16	2023	2	South
+-- !result
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex VALUES
+    (6, 'TransF', 90.00, '2023-02-20', 2023, 1, 'North'),
+    (7, 'TransG', 350.00, '2023-02-21', 2023, 1, 'West'),
+    (8, 'TransH', 95.00, '2023-03-10', 2023, 1, 'North');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex WHERE amount < 100 ORDER BY amount, id;
+-- result:
+6	TransF	90.00	2023-02-20	2023	1	North
+8	TransH	95.00	2023-03-10	2023	1	North
+-- !result
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex WHERE amount < 100;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex ORDER BY year_id, quarter_id, region, id;
+-- result:
+2	TransB	200.00	2023-01-16	2023	1	South
+7	TransG	350.00	2023-02-21	2023	1	West
+3	TransC	150.00	2023-04-15	2023	2	North
+4	TransD	300.00	2023-04-16	2023	2	South
+-- !result
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex VALUES
+    (9, 'TransI', 180.00, '2023-05-10', 2023, 1, 'North'),
+    (10, 'TransJ', 220.00, '2023-05-11', 2023, 1, 'West');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex WHERE year_id = 2023 AND quarter_id = 1 ORDER BY region, id;
+-- result:
+9	TransI	180.00	2023-05-10	2023	1	North
+2	TransB	200.00	2023-01-16	2023	1	South
+7	TransG	350.00	2023-02-21	2023	1	West
+10	TransJ	220.00	2023-05-11	2023	1	West
+-- !result
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex VALUES
+    (11, 'TransK', 280.00, '2023-06-10', 2023, 2, 'North'),
+    (12, 'TransL', 190.00, '2023-06-11', 2023, 2, 'West');
+-- result:
+-- !result
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex WHERE year_id = 2023 AND quarter_id = 2 AND amount > 200;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex ORDER BY year_id, quarter_id, region, id;
+-- result:
+9	TransI	180.00	2023-05-10	2023	1	North
+2	TransB	200.00	2023-01-16	2023	1	South
+7	TransG	350.00	2023-02-21	2023	1	West
+10	TransJ	220.00	2023-05-11	2023	1	West
+3	TransC	150.00	2023-04-15	2023	2	North
+12	TransL	190.00	2023-06-11	2023	2	West
+-- !result
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex VALUES
+    (13, 'TransM', 210.00, '2023-07-10', 2024, 1, 'North'),
+    (14, 'TransN', 230.00, '2023-07-11', 2024, 1, 'West'),
+    (15, 'TransO', 250.00, '2023-07-12', 2024, 1, 'North');
+-- result:
+-- !result
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex WHERE year_id = 2024 AND region IN ('North', 'West');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex ORDER BY year_id, quarter_id, region, id;
+-- result:
+9	TransI	180.00	2023-05-10	2023	1	North
+2	TransB	200.00	2023-01-16	2023	1	South
+7	TransG	350.00	2023-02-21	2023	1	West
+10	TransJ	220.00	2023-05-11	2023	1	West
+3	TransC	150.00	2023-04-15	2023	2	North
+12	TransL	190.00	2023-06-11	2023	2	West
+-- !result
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex WHERE year_id = 9999 AND region = 'NonExistent';
+-- result:
+-- !result
+SELECT COUNT(*) FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex;
+-- result:
+6
+-- !result
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_with_null (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    category STRING
+) 
+PARTITION BY (category);
+-- result:
+-- !result
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_with_null VALUES
+    (1, 'ItemA', 100.00, 'Electronics'),
+    (2, 'ItemB', 200.00, NULL),
+    (3, 'ItemC', 150.00, 'Clothing');
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_with_null ORDER BY id;
+-- result:
+1	ItemA	100.00	Electronics
+2	ItemB	200.00	None
+3	ItemC	150.00	Clothing
+-- !result
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_with_null WHERE category IS NULL;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_with_null ORDER BY id;
+-- result:
+1	ItemA	100.00	Electronics
+3	ItemC	150.00	Clothing
+-- !result
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_date force;
+-- result:
+-- !result
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_datetime force;
+-- result:
+-- !result
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_string force;
+-- result:
+-- !result
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_numeric force;
+-- result:
+-- !result
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_multi force;
+-- result:
+-- !result
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_num_multi force;
+-- result:
+-- !result
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex force;
+-- result:
+-- !result
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_with_null force;
+-- result:
+-- !result
+drop database iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog iceberg_del_part_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_delete_partitioned/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/R/test_iceberg_delete_unpartitioned
+++ b/test/sql/test_iceberg/R/test_iceberg_delete_unpartitioned
@@ -1,0 +1,272 @@
+-- name: test_iceberg_delete_unpartitioned
+create external catalog iceberg_del_unp_${uuid0}
+PROPERTIES ( "type"  =  "iceberg",
+    "iceberg.catalog.type"  =  "hive",
+    "iceberg.catalog.hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}" );
+-- result:
+-- !result
+create database iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_iceberg_delete_unpartitioned/${uuid0}/iceberg_delete_db_${uuid0}"
+);
+-- result:
+-- !result
+create table iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned (
+    id INT,
+    name STRING,
+    age INT,
+    salary BIGINT
+);
+-- result:
+-- !result
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (1, 'Alice', 25, 50000),
+    (2, 'Bob', 30, 60000),
+    (3, 'Charlie', 35, 70000),
+    (4, 'David', 28, 55000),
+    (5, 'Eve', 32, 65000);
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+-- result:
+1	Alice	25	50000
+2	Bob	30	60000
+3	Charlie	35	70000
+4	David	28	55000
+5	Eve	32	65000
+-- !result
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE id = 3;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+-- result:
+1	Alice	25	50000
+2	Bob	30	60000
+4	David	28	55000
+5	Eve	32	65000
+-- !result
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (6, 'Frank', 40, 80000),
+    (7, 'Grace', 29, 58000),
+    (8, 'Henry', 33, 68000);
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+-- result:
+1	Alice	25	50000
+2	Bob	30	60000
+4	David	28	55000
+5	Eve	32	65000
+6	Frank	40	80000
+7	Grace	29	58000
+8	Henry	33	68000
+-- !result
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE age > 30 AND salary < 70000;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+-- result:
+1	Alice	25	50000
+2	Bob	30	60000
+4	David	28	55000
+6	Frank	40	80000
+7	Grace	29	58000
+-- !result
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (9, NULL, 45, 90000),
+    (10, 'Iris', NULL, 75000);
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE name IS NULL OR age IS NULL ORDER BY id;
+-- result:
+9	None	45	90000
+10	Iris	None	75000
+-- !result
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE name IS NULL;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE name IS NULL OR age IS NULL ORDER BY id;
+-- result:
+10	Iris	None	75000
+-- !result
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE age IS NULL;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE name IS NULL OR age IS NULL ORDER BY id;
+-- result:
+-- !result
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (11, 'John', 27, 52000),
+    (12, 'Kate', 31, 62000),
+    (13, 'Liam', 36, 72000),
+    (14, 'Mia', 29, 57000);
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+-- result:
+1	Alice	25	50000
+2	Bob	30	60000
+4	David	28	55000
+6	Frank	40	80000
+7	Grace	29	58000
+11	John	27	52000
+12	Kate	31	62000
+13	Liam	36	72000
+14	Mia	29	57000
+-- !result
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE age > 30 AND salary < 70000;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+-- result:
+1	Alice	25	50000
+2	Bob	30	60000
+4	David	28	55000
+6	Frank	40	80000
+7	Grace	29	58000
+11	John	27	52000
+13	Liam	36	72000
+14	Mia	29	57000
+-- !result
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE age <= 29 OR salary >= 80000;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+-- result:
+2	Bob	30	60000
+13	Liam	36	72000
+-- !result
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (15, 'Nora', 33, 67000),
+    (16, 'Oscar', 26, 53000),
+    (17, 'Paul', 34, 71000);
+-- result:
+-- !result
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE age != 31;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+-- result:
+-- !result
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (18, 'Quinn', 28, 54000),
+    (19, 'Ryan', 35, 73000),
+    (20, 'Sarah', 30, 62000);
+-- result:
+-- !result
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE id IN (18, 20);
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+-- result:
+19	Ryan	35	73000
+-- !result
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (21, 'Tom', 25, 48000),
+    (22, 'Uma', 38, 78000),
+    (23, 'Victor', 42, 85000);
+-- result:
+-- !result
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE age BETWEEN 30 AND 40;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+-- result:
+21	Tom	25	48000
+23	Victor	42	85000
+-- !result
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (24, 'Alice2', 26, 51000),
+    (25, 'Alexander', 33, 69000),
+    (26, 'Amelia', 29, 59000);
+-- result:
+-- !result
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE name LIKE 'A%';
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+-- result:
+21	Tom	25	48000
+23	Victor	42	85000
+-- !result
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (27, 'Wendy', 31, 63000);
+-- result:
+-- !result
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE id = 999;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE id = 27;
+-- result:
+27	Wendy	31	63000
+-- !result
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (28, 'Xander', 37, 77000),
+    (29, 'Yara', 24, 49000);
+-- result:
+-- !result
+CREATE TABLE iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.temp_ids AS 
+SELECT id FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE age > 35;
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.temp_ids ORDER BY id;
+-- result:
+23
+28
+-- !result
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned 
+WHERE id IN (SELECT id FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.temp_ids);
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+-- result:
+21	Tom	25	48000
+27	Wendy	31	63000
+29	Yara	24	49000
+-- !result
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (28, 'Xander', 37, 77000),
+    (30, "Lisa", 39, 50000);
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+-- result:
+21	Tom	25	48000
+27	Wendy	31	63000
+28	Xander	37	77000
+29	Yara	24	49000
+30	Lisa	39	50000
+-- !result
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned 
+WHERE EXISTS (SELECT id FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.temp_ids WHERE temp_ids.id = test_non_partitioned.id);
+-- result:
+-- !result
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+-- result:
+21	Tom	25	48000
+27	Wendy	31	63000
+29	Yara	24	49000
+30	Lisa	39	50000
+-- !result
+drop table iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.temp_ids force;
+-- result:
+-- !result
+drop table iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned force;
+-- result:
+-- !result
+drop database iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog iceberg_del_unp_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_delete_unpartitioned/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_delete_partition_transform
+++ b/test/sql/test_iceberg/T/test_iceberg_delete_partition_transform
@@ -1,0 +1,297 @@
+-- name: test_iceberg_delete_partition_transform
+
+create external catalog iceberg_del_trf_${uuid0}
+PROPERTIES ( "type"  =  "iceberg",
+    "iceberg.catalog.type"  =  "hive",
+    "iceberg.catalog.hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}" );
+
+create database iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_iceberg_delete_partition_transform/${uuid0}/iceberg_delete_db_${uuid0}"
+);
+
+-- ================================================
+-- SECTION 1: BASIC TRANSFORM PARTITION TESTS
+-- ================================================
+
+-- Test 1.1: Transform partition table - bucket
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_bucket (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    category STRING
+) 
+PARTITION BY bucket(category, 4);
+
+-- Insert test data into bucket transform table
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_bucket VALUES
+    (1, 'ProductA', 100.00, 'Electronics'),
+    (2, 'ProductB', 200.00, 'Clothing'),
+    (3, 'ProductC', 150.00, 'Electronics'),
+    (4, 'ProductD', 300.00, 'Books'),
+    (5, 'ProductE', 250.00, 'Clothing');
+
+-- Verify initial data in bucket transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_bucket ORDER BY id;
+
+-- Delete from bucket transform table
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_bucket WHERE category = 'Clothing';
+
+-- Verify deletion from bucket transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_bucket ORDER BY id;
+
+-- Test 1.2: Transform partition table - truncate
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_truncate (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    sku STRING
+) 
+PARTITION BY truncate(sku, 2);
+
+-- Insert test data into truncate transform table
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_truncate VALUES
+    (1, 'ProductA', 100.00, 'SKU001'),
+    (2, 'ProductB', 200.00, 'SKU002'),
+    (3, 'ProductC', 150.00, 'SKU003'),
+    (4, 'ProductD', 300.00, 'SKU004'),
+    (5, 'ProductE', 250.00, 'SKU005');
+
+-- Verify initial data in truncate transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_truncate ORDER BY id;
+
+-- Delete from truncate transform table
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_truncate WHERE sku LIKE 'SKU00%';
+
+-- Verify deletion from truncate transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_truncate ORDER BY id;
+
+-- ================================================
+-- SECTION 2: ADVANCED TRANSFORM PARTITION TESTS
+-- ================================================
+
+-- Test 2.1: Transform partition table - year
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    event_date DATE
+) 
+PARTITION BY year(event_date);
+
+-- Insert test data into year transform table
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year VALUES
+    (1, 'EventA', 100.00, '2023-01-01'),
+    (2, 'EventB', 200.00, '2023-06-15'),
+    (3, 'EventC', 150.00, '2024-03-10'),
+    (4, 'EventD', 300.00, '2024-12-20'),
+    (5, 'EventE', 250.00, '2023-11-05');
+
+-- Verify initial data in year transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year ORDER BY event_date, id;
+
+-- Delete from year transform table
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year WHERE year(event_date) = 2023;
+
+-- Verify deletion from year transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year ORDER BY event_date, id;
+
+-- Test 2.2: Transform partition table - month
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    order_date DATE
+) 
+PARTITION BY month(order_date);
+
+-- Insert test data into month transform table
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month VALUES
+    (1, 'OrderA', 100.00, '2023-01-10'),
+    (2, 'OrderB', 200.00, '2023-01-20'),
+    (3, 'OrderC', 150.00, '2023-02-15'),
+    (4, 'OrderD', 300.00, '2023-03-05'),
+    (5, 'OrderE', 250.00, '2023-02-28');
+
+-- Verify initial data in month transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month ORDER BY order_date, id;
+
+-- Delete from month transform table
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month WHERE month(order_date) = 2;
+
+-- Verify deletion from month transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month ORDER BY order_date, id;
+
+-- Test 2.3: Transform partition table - day
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_day (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    created_time DATETIME
+) 
+PARTITION BY day(created_time);
+
+-- Insert test data into day transform table
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_day VALUES
+    (1, 'RecordA', 100.00, '2023-01-10 10:00:00'),
+    (2, 'RecordB', 200.00, '2023-01-10 15:30:00'),
+    (3, 'RecordC', 150.00, '2023-01-11 09:15:00'),
+    (4, 'RecordD', 300.00, '2023-01-12 14:45:00'),
+    (5, 'RecordE', 250.00, '2023-01-11 11:20:00');
+
+-- Verify initial data in day transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_day ORDER BY created_time, id;
+
+-- Delete from day transform table
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_day WHERE day(created_time) = 11;
+
+-- Verify deletion from day transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_day ORDER BY created_time, id;
+
+-- Test 2.4: Transform partition table - hour
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_hour (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    log_time DATETIME
+) 
+PARTITION BY hour(log_time);
+
+-- Insert test data into hour transform table
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_hour VALUES
+    (1, 'LogA', 10.00, '2023-01-10 10:15:00'),
+    (2, 'LogB', 20.00, '2023-01-10 10:30:00'),
+    (3, 'LogC', 15.00, '2023-01-10 11:45:00'),
+    (4, 'LogD', 30.00, '2023-01-10 12:20:00'),
+    (5, 'LogE', 25.00, '2023-01-10 11:55:00');
+
+-- Verify initial data in hour transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_hour ORDER BY log_time, id;
+
+-- Delete from hour transform table
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_hour WHERE hour(log_time) = 11;
+
+-- Verify deletion from hour transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_hour ORDER BY log_time, id;
+
+-- ================================================
+-- SECTION 3: COMPLEX TRANSFORM COMBINATIONS
+-- ================================================
+
+-- Test 3.1: Different date column transforms
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    order_date DATE,
+    ship_date DATE
+) 
+PARTITION BY year(order_date), month(ship_date);
+
+-- Insert test data into year+month transform table
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month VALUES
+    (1, 'TransA', 100.00, '2023-01-15', '2023-01-20'),
+    (2, 'TransB', 200.00, '2023-01-20', '2023-01-25'),
+    (3, 'TransC', 150.00, '2023-02-10', '2023-02-15'),
+    (4, 'TransD', 300.00, '2023-02-25', '2023-03-01'),
+    (5, 'TransE', 250.00, '2024-01-05', '2024-01-10');
+
+-- Verify initial data in year+month transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month ORDER BY order_date, id;
+
+-- Delete from year+month transform table
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month WHERE year(order_date) = 2023 AND month(ship_date) = 1;
+
+-- Verify deletion from year+month transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month ORDER BY order_date, id;
+
+-- Test 3.2: Mixed transform types - bucket and truncate
+create table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    category STRING,
+    product_code STRING
+) 
+PARTITION BY bucket(category, 3), truncate(product_code, 3);
+
+-- Insert test data into mixed transform table
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed VALUES
+    (1, 'MixedA', 100.00, 'CategoryA', 'PCODE001'),
+    (2, 'MixedB', 200.00, 'CategoryB', 'PCODE002'),
+    (3, 'MixedC', 150.00, 'CategoryA', 'PCODE003'),
+    (4, 'MixedD', 300.00, 'CategoryC', 'PCODE001'),
+    (5, 'MixedE', 250.00, 'CategoryB', 'PCODE004');
+
+-- Verify initial data in mixed transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed ORDER BY id;
+
+-- Delete from mixed transform table
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed WHERE category = 'CategoryB';
+
+-- Verify deletion from mixed transform table
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed ORDER BY id;
+
+-- ================================================
+-- SECTION 4: ADVANCED DELETE OPERATIONS
+-- ================================================
+
+-- Test 4.1: Delete with complex conditions on transformed partitions
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month VALUES
+    (6, 'TransF', 180.00, '2024-01-15', '2024-01-20'),
+    (7, 'TransG', 220.00, '2024-02-10', '2024-02-15'),
+    (8, 'TransH', 190.00, '2024-01-20', '2024-01-25');
+
+-- Test complex delete conditions
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month WHERE year(order_date) = 2024 ORDER BY order_date;
+
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month WHERE year(order_date) = 2024 AND amount < 200;
+
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month ORDER BY order_date, id;
+
+-- Test 4.2: Delete with IN clause on transformed partitions
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month VALUES
+    (9, 'TransI', 210.00, '2024-03-01', '2024-03-05'),
+    (10, 'TransJ', 230.00, '2024-03-02', '2024-03-06'),
+    (11, 'TransK', 240.00, '2024-03-03', '2024-03-07');
+
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month WHERE year(order_date) = 2024 AND month(ship_date) = 3 AND id IN (9, 11);
+
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month ORDER BY order_date, id;
+
+-- Test 4.3: Delete with range conditions on transformed partitions
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month VALUES
+    (6, 'OrderF', 120.00, '2023-04-10'),
+    (7, 'OrderG', 180.00, '2023-04-15'),
+    (8, 'OrderH', 220.00, '2023-05-05');
+
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month WHERE month(order_date) BETWEEN 4 AND 5;
+
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month ORDER BY order_date, id;
+
+-- Test 4.4: Delete with multiple transforms and complex conditions
+INSERT INTO iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed VALUES
+    (6, 'MixedF', 175.00, 'CategoryA', 'PCODE005'),
+    (7, 'MixedG', 225.00, 'CategoryD', 'PCODE006'),
+    (8, 'MixedH', 185.00, 'CategoryA', 'PCODE007');
+
+DELETE FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed WHERE amount > 180;
+
+SELECT * FROM iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed ORDER BY id;
+
+-- Cleanup
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_bucket force;
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_truncate force;
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year force;
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_month force;
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_day force;
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_hour force;
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_year_month force;
+drop table iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0}.test_transform_mixed force;
+drop database iceberg_del_trf_${uuid0}.iceberg_delete_db_${uuid0};
+set catalog default_catalog;
+drop catalog iceberg_del_trf_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_delete_partition_transform/${uuid0} >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_iceberg/T/test_iceberg_delete_partitioned
+++ b/test/sql/test_iceberg/T/test_iceberg_delete_partitioned
@@ -1,0 +1,266 @@
+-- name: test_iceberg_delete_partitioned
+
+create external catalog iceberg_del_part_${uuid0}
+PROPERTIES ( "type"  =  "iceberg",
+    "iceberg.catalog.type"  =  "hive",
+    "iceberg.catalog.hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}" );
+
+create database iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_iceberg_delete_partitioned/${uuid0}/iceberg_delete_db_${uuid0}"
+);
+
+-- ================================================
+-- SECTION 1: SINGLE PARTITION COLUMN TESTS
+-- ================================================
+
+-- Test 1.1: DATE partition column
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_date (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    date_key DATE
+) 
+PARTITION BY (date_key);
+
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_date VALUES
+    (1, 'ProductA', 100.00, '2023-01-01'),
+    (2, 'ProductB', 200.00, '2023-01-02'),
+    (3, 'ProductC', 150.00, '2023-01-01'),
+    (4, 'ProductD', 300.00, '2023-01-03'),
+    (5, 'ProductE', 250.00, '2023-01-02');
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_date ORDER BY date_key, id;
+
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_date WHERE date_key = '2023-01-02';
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_date ORDER BY date_key, id;
+
+-- Test 1.2: DATETIME partition column
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_datetime (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    created_time DATETIME
+) 
+PARTITION BY (created_time);
+
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_datetime VALUES
+    (1, 'OrderA', 100.00, '2023-01-01 10:00:00'),
+    (2, 'OrderB', 200.00, '2023-01-01 11:00:00'),
+    (3, 'OrderC', 150.00, '2023-01-02 10:00:00'),
+    (4, 'OrderD', 300.00, '2023-01-02 12:00:00'),
+    (5, 'OrderE', 250.00, '2023-01-03 09:00:00');
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_datetime ORDER BY created_time, id;
+
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_datetime WHERE created_time = '2023-01-02 10:00:00';
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_datetime ORDER BY created_time, id;
+
+-- Test 1.3: String partition column
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_string (
+    id INT,
+    product_name STRING,
+    price DECIMAL(10,2),
+    region VARCHAR(50)
+) 
+PARTITION BY (region);
+
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_string VALUES
+    (1, 'ProductA', 100.00, 'North'),
+    (2, 'ProductB', 200.00, 'South'),
+    (3, 'ProductC', 150.00, 'North'),
+    (4, 'ProductD', 300.00, 'East'),
+    (5, 'ProductE', 250.00, 'West');
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_string ORDER BY region, id;
+
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_string WHERE region = 'North';
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_string ORDER BY region, id;
+
+-- Test 1.4: Numeric partition column
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_numeric (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    year_id INT
+) 
+PARTITION BY (year_id);
+
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_numeric VALUES
+    (1, 'SaleA', 100.00, 2023),
+    (2, 'SaleB', 200.00, 2024),
+    (3, 'SaleC', 150.00, 2023),
+    (4, 'SaleD', 300.00, 2024),
+    (5, 'SaleE', 250.00, 2025);
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_numeric ORDER BY year_id, id;
+
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_numeric WHERE year_id = 2023;
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_numeric ORDER BY year_id, id;
+
+-- ================================================
+-- SECTION 2: MULTI-PARTITION COLUMN TESTS
+-- ================================================
+
+-- Test 2.1: Two DATE + STRING partition columns
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_multi (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    date_key DATE,
+    category STRING
+) 
+PARTITION BY (date_key, category);
+
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_multi VALUES
+    (1, 'ProductA', 100.00, '2023-01-01', 'Electronics'),
+    (2, 'ProductB', 200.00, '2023-01-01', 'Clothing'),
+    (3, 'ProductC', 150.00, '2023-01-02', 'Electronics'),
+    (4, 'ProductD', 300.00, '2023-01-02', 'Clothing'),
+    (5, 'ProductE', 250.00, '2023-01-01', 'Electronics');
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_multi ORDER BY date_key, category, id;
+
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_multi WHERE date_key = '2023-01-01' AND category = 'Electronics';
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_multi ORDER BY date_key, category, id;
+
+-- Test 2.2: Two numeric partition columns
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_num_multi (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    year_id INT,
+    month_id INT
+) 
+PARTITION BY (year_id, month_id);
+
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_num_multi VALUES
+    (1, 'SaleA', 100.00, 2023, 1),
+    (2, 'SaleB', 200.00, 2023, 1),
+    (3, 'SaleC', 150.00, 2023, 2),
+    (4, 'SaleD', 300.00, 2023, 2),
+    (5, 'SaleE', 250.00, 2024, 1);
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_num_multi ORDER BY year_id, month_id, id;
+
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_num_multi WHERE year_id = 2023 AND month_id = 1;
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_num_multi ORDER BY year_id, month_id, id;
+
+-- Test 2.3: Three partition columns (mixed types)
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    created_date DATE,
+    year_id INT,
+    quarter_id INT,
+    region STRING
+) 
+PARTITION BY (year_id, quarter_id, region);
+
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex VALUES
+    (1, 'TransA', 100.00, '2023-01-15', 2023, 1, 'North'),
+    (2, 'TransB', 200.00, '2023-01-16', 2023, 1, 'South'),
+    (3, 'TransC', 150.00, '2023-04-15', 2023, 2, 'North'),
+    (4, 'TransD', 300.00, '2023-04-16', 2023, 2, 'South'),
+    (5, 'TransE', 250.00, '2023-02-15', 2023, 1, 'North');
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex ORDER BY year_id, quarter_id, region, id;
+
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex WHERE year_id = 2023 AND quarter_id = 1 AND region = 'North';
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex ORDER BY year_id, quarter_id, region, id;
+
+-- ================================================
+-- SECTION 3: ADVANCED DELETE OPERATIONS
+-- ================================================
+
+-- Test 3.1: Delete with non-partition column conditions (cross-partition)
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex VALUES
+    (6, 'TransF', 90.00, '2023-02-20', 2023, 1, 'North'),
+    (7, 'TransG', 350.00, '2023-02-21', 2023, 1, 'West'),
+    (8, 'TransH', 95.00, '2023-03-10', 2023, 1, 'North');
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex WHERE amount < 100 ORDER BY amount, id;
+
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex WHERE amount < 100;
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex ORDER BY year_id, quarter_id, region, id;
+
+-- Test 3.2: Delete with partial partition key (only some partition columns)
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex VALUES
+    (9, 'TransI', 180.00, '2023-05-10', 2023, 1, 'North'),
+    (10, 'TransJ', 220.00, '2023-05-11', 2023, 1, 'West');
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex WHERE year_id = 2023 AND quarter_id = 1 ORDER BY region, id;
+
+-- Test 3.3: Complex WHERE conditions with multiple conditions
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex VALUES
+    (11, 'TransK', 280.00, '2023-06-10', 2023, 2, 'North'),
+    (12, 'TransL', 190.00, '2023-06-11', 2023, 2, 'West');
+
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex WHERE year_id = 2023 AND quarter_id = 2 AND amount > 200;
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex ORDER BY year_id, quarter_id, region, id;
+
+-- Test 3.4: Delete with IN clause on partition columns
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex VALUES
+    (13, 'TransM', 210.00, '2023-07-10', 2024, 1, 'North'),
+    (14, 'TransN', 230.00, '2023-07-11', 2024, 1, 'West'),
+    (15, 'TransO', 250.00, '2023-07-12', 2024, 1, 'North');
+
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex WHERE year_id = 2024 AND region IN ('North', 'West');
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex ORDER BY year_id, quarter_id, region, id;
+
+-- ================================================
+-- SECTION 4: EDGE CASES
+-- ================================================
+
+-- Test 4.1: Delete with no matching records
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex WHERE year_id = 9999 AND region = 'NonExistent';
+
+SELECT COUNT(*) FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex;
+
+-- Test 4.2: Delete with NULL values in partition columns
+create table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_with_null (
+    id INT,
+    name STRING,
+    amount DECIMAL(10,2),
+    category STRING
+) 
+PARTITION BY (category);
+
+INSERT INTO iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_with_null VALUES
+    (1, 'ItemA', 100.00, 'Electronics'),
+    (2, 'ItemB', 200.00, NULL),
+    (3, 'ItemC', 150.00, 'Clothing');
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_with_null ORDER BY id;
+
+DELETE FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_with_null WHERE category IS NULL;
+
+SELECT * FROM iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_with_null ORDER BY id;
+
+-- Cleanup
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_date force;
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_datetime force;
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_string force;
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_numeric force;
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_multi force;
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_num_multi force;
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_complex force;
+drop table iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0}.test_partitioned_with_null force;
+drop database iceberg_del_part_${uuid0}.iceberg_delete_db_${uuid0};
+set catalog default_catalog;
+drop catalog iceberg_del_part_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_delete_partitioned/${uuid0} >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_iceberg/T/test_iceberg_delete_unpartitioned
+++ b/test/sql/test_iceberg/T/test_iceberg_delete_unpartitioned
@@ -1,0 +1,169 @@
+-- name: test_iceberg_delete_unpartitioned
+
+create external catalog iceberg_del_unp_${uuid0}
+PROPERTIES ( "type"  =  "iceberg",
+    "iceberg.catalog.type"  =  "hive",
+    "iceberg.catalog.hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"  =  "${oss_ak}",
+    "aws.s3.secret_key"  =  "${oss_sk}",
+    "aws.s3.endpoint"  =  "${oss_endpoint}" );
+
+create database iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_iceberg_delete_unpartitioned/${uuid0}/iceberg_delete_db_${uuid0}"
+);
+
+-- Test: Non-partitioned table
+create table iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned (
+    id INT,
+    name STRING,
+    age INT,
+    salary BIGINT
+);
+
+-- Insert test data into non-partitioned table
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (1, 'Alice', 25, 50000),
+    (2, 'Bob', 30, 60000),
+    (3, 'Charlie', 35, 70000),
+    (4, 'David', 28, 55000),
+    (5, 'Eve', 32, 65000);
+
+-- Verify initial data in non-partitioned table
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+
+-- Delete from non-partitioned table
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE id = 3;
+
+-- Verify deletion from non-partitioned table
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+
+-- Test: Complex delete conditions
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (6, 'Frank', 40, 80000),
+    (7, 'Grace', 29, 58000),
+    (8, 'Henry', 33, 68000);
+
+-- Verify data before complex delete
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+
+-- Delete with complex conditions
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE age > 30 AND salary < 70000;
+
+-- Verify complex delete results
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+
+-- Test DELETE with NULL values
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (9, NULL, 45, 90000),
+    (10, 'Iris', NULL, 75000);
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE name IS NULL OR age IS NULL ORDER BY id;
+
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE name IS NULL;
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE name IS NULL OR age IS NULL ORDER BY id;
+
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE age IS NULL;
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE name IS NULL OR age IS NULL ORDER BY id;
+
+-- Test DELETE with complex WHERE conditions
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (11, 'John', 27, 52000),
+    (12, 'Kate', 31, 62000),
+    (13, 'Liam', 36, 72000),
+    (14, 'Mia', 29, 57000);
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE age > 30 AND salary < 70000;
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE age <= 29 OR salary >= 80000;
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+
+-- Test DELETE with comparison operators
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (15, 'Nora', 33, 67000),
+    (16, 'Oscar', 26, 53000),
+    (17, 'Paul', 34, 71000);
+
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE age != 31;
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+
+-- Test DELETE with IN clause
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (18, 'Quinn', 28, 54000),
+    (19, 'Ryan', 35, 73000),
+    (20, 'Sarah', 30, 62000);
+
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE id IN (18, 20);
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+
+-- Test DELETE with BETWEEN clause
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (21, 'Tom', 25, 48000),
+    (22, 'Uma', 38, 78000),
+    (23, 'Victor', 42, 85000);
+
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE age BETWEEN 30 AND 40;
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+
+-- Test DELETE with LIKE clause
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (24, 'Alice2', 26, 51000),
+    (25, 'Alexander', 33, 69000),
+    (26, 'Amelia', 29, 59000);
+
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE name LIKE 'A%';
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+
+-- Test DELETE with no matching records
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (27, 'Wendy', 31, 63000);
+
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE id = 999;
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE id = 27;
+
+-- Test DELETE with subquery
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (28, 'Xander', 37, 77000),
+    (29, 'Yara', 24, 49000);
+
+-- First create a temporary table to use in subquery
+CREATE TABLE iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.temp_ids AS 
+SELECT id FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned WHERE age > 35;
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.temp_ids ORDER BY id;
+
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned 
+WHERE id IN (SELECT id FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.temp_ids);
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+
+INSERT INTO iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned VALUES
+    (28, 'Xander', 37, 77000),
+    (30, "Lisa", 39, 50000);
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+
+DELETE FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned 
+WHERE EXISTS (SELECT id FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.temp_ids WHERE temp_ids.id = test_non_partitioned.id);
+
+SELECT * FROM iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned ORDER BY id;
+
+-- Cleanup
+drop table iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.temp_ids force;
+drop table iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0}.test_non_partitioned force;
+drop database iceberg_del_unp_${uuid0}.iceberg_delete_db_${uuid0};
+set catalog default_catalog;
+drop catalog iceberg_del_unp_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_delete_unpartitioned/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:
#66944

## What I'm doing:
This pull request introduces significant changes to the Parquet position reader logic and its associated tests, as well as adds a comprehensive new SQL test for Iceberg partition transform deletes. The main update in the Parquet reader is the removal of filter-based row selection, leading to all positions in a range being output regardless of any filter. The tests are updated to reflect this new behavior. Additionally, a new end-to-end test script is added for verifying delete operations on Iceberg tables partitioned with various transforms.

The most important changes are:

### Parquet Position Reader Logic

* Removed filtering logic from `ParquetPosReader::read_range`, so it now always outputs positions for all rows in the specified range, ignoring any provided filter.

### Parquet Reader Tests

* Updated `TestReadRangeWithFilter` to expect all rows in the range instead of only filtered rows, and adjusted value checks accordingly.
* Updated `TestReadRangeWithNoSelectedRows` to expect all rows in the range, even when the filter would previously have selected none.

### Iceberg Partition Transform Delete Testing

* Added a new SQL test script `test_iceberg_delete_partition_transform` that creates Iceberg tables with various partition transforms (bucket, truncate, year, month, day, hour, and combinations), performs delete operations on them, and verifies the results. This ensures that delete functionality works correctly with different partitioning schemes.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
