### PR TITLE
[Refactor] Refactor code to remove physical partition name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -941,9 +941,6 @@ public class RestoreJob extends AbstractJob {
         idToPartition.clear();
         Map<Long, Long> physicalPartitionIdToPartitionId = remoteOlapTbl.getPhysicalPartitionIdToPartitionId();
         physicalPartitionIdToPartitionId.clear();
-        Map<String, Long> physicalPartitionNameToPartitionId = remoteOlapTbl.getPhysicalPartitionNameToPartitionId();
-        physicalPartitionNameToPartitionId.clear();
-
         for (Partition partition : partitions) {
             long newPartitionId = partitionOldIdToNewId.get(partition.getId());
             partition.setIdForRestore(newPartitionId);
@@ -963,7 +960,6 @@ public class RestoreJob extends AbstractJob {
                     partition.addSubPartition(physicalPartition);
                 }
                 physicalPartitionIdToPartitionId.put(physicalPartition.getId(), newPartitionId);
-                physicalPartitionNameToPartitionId.put(physicalPartition.getName(), newPartitionId);
             });
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
@@ -471,7 +471,6 @@ public class ExternalOlapTable extends OlapTable {
                     defaultDistributionInfo);
 
             PhysicalPartition physicalPartition = new PhysicalPartition(GlobalStateMgr.getCurrentState().getNextId(),
-                    partitionMeta.getPartition_name(),
                     partitionMeta.getPartition_id(), // TODO(wulei): fix it
                     null);
             physicalPartition.setBucketNum(defaultDistributionInfo.getBucketNum());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -49,9 +49,6 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
     @SerializedName(value = "id")
     private long id;
 
-    @SerializedName(value = "name")
-    private String name;
-
     private long beforeRestoreId;
 
     @SerializedName(value = "parentId")
@@ -142,9 +139,8 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     }
 
-    public PhysicalPartition(long id, String name, long parentId, MaterializedIndex baseIndex) {
+    public PhysicalPartition(long id, long parentId, MaterializedIndex baseIndex) {
         this.id = id;
-        this.name = name;
         this.parentId = parentId;
         this.baseIndex = baseIndex;
         this.visibleVersion = PARTITION_INIT_VERSION;
@@ -156,55 +152,8 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
         this.versionTxnType = TransactionType.TXN_NORMAL;
     }
 
-    /*
-     * Copy all the fields except materialized indexes
-     */
-    public PhysicalPartition(long id, String name, PhysicalPartition other) {
-        this.id = id;
-        this.name = name;
-
-        this.beforeRestoreId = other.beforeRestoreId;
-        this.parentId = other.parentId;
-
-        this.shardGroupId = other.shardGroupId;
-
-        this.isImmutable = other.isImmutable;
-
-        this.visibleVersion = other.visibleVersion;
-        this.visibleVersionTime = other.visibleVersionTime;
-        this.nextVersion = other.nextVersion;
-
-        this.dataVersion = other.dataVersion;
-        this.nextDataVersion = other.nextDataVersion;
-
-        this.versionEpoch = other.versionEpoch;
-        this.versionTxnType = other.versionTxnType;
-
-        this.metadataSwitchVersion = other.metadataSwitchVersion;
-
-        this.visibleTxnId = other.visibleTxnId;
-
-        this.lastVacuumTime.set(other.lastVacuumTime.get());
-
-        this.minRetainVersion.set(other.minRetainVersion.get());
-
-        this.lastSuccVacuumVersion.set(other.lastSuccVacuumVersion.get());
-
-        this.bucketNum = other.bucketNum;
-
-        this.extraFileSize.set(other.extraFileSize.get());
-    }
-
     public long getId() {
         return this.id;
-    }
-
-    public String getName() {
-        return this.name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 
     public void setIdForRestore(long id) {
@@ -584,7 +533,6 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
     public String toString() {
         StringBuilder buffer = new StringBuilder();
         buffer.append("partitionId: ").append(id).append("; ");
-        buffer.append("partitionName: ").append(name).append("; ");
         buffer.append("parentPartitionId: ").append(parentId).append("; ");
         buffer.append("shardGroupId: ").append(shardGroupId).append("; ");
         buffer.append("isImmutable: ").append(isImmutable()).append("; ");

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1606,8 +1606,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
         long id = GlobalStateMgr.getCurrentState().getNextId();
         PhysicalPartition physicalPartition = new PhysicalPartition(
-                id, partition.generatePhysicalPartitionName(id),
-                partition.getId(), indexMap.get(olapTable.getBaseIndexMetaId()));
+                id, partition.getId(), indexMap.get(olapTable.getBaseIndexMetaId()));
         // set ShardGroupId to partition for rollback to old version
         physicalPartition.setShardGroupId(shardGroupId);
         physicalPartition.setBucketNum(distributionInfo.getBucketNum());
@@ -1787,10 +1786,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
         long physicalPartitionId = GlobalStateMgr.getCurrentState().getNextId();
         PhysicalPartition physicalPartition = new PhysicalPartition(
-                physicalPartitionId,
-                logicalPartition.generatePhysicalPartitionName(physicalPartitionId),
-                partitionId,
-                indexMap.get(table.getBaseIndexMetaId()));
+                physicalPartitionId, partitionId, indexMap.get(table.getBaseIndexMetaId()));
         physicalPartition.setBucketNum(distributionInfo.getBucketNum());
 
         logicalPartition.addSubPartition(physicalPartition);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -3114,7 +3114,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 }
                 TPartitionMeta partitionMeta = new TPartitionMeta();
                 partitionMeta.setPartition_id(partitionId);
-                partitionMeta.setPartition_name(physicalPartition.getName());
+                partitionMeta.setPartition_name(partition.getName());
                 partitionMeta.setState(partition.getState().name());
                 partitionMeta.setVisible_version(physicalPartition.getVisibleVersion());
                 partitionMeta.setVisible_time(physicalPartition.getVisibleVersionTime());

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -563,8 +563,8 @@ public class PublishVersionDaemon extends FrontendDaemon {
                         // sanity check. should not happen
                         if (!index.visibleForTransaction(txnState.getTransactionId())) {
                             LOG.warn("Ignore shadow index included in the transaction but not visible, " +
-                                    "partitionId: {}, partitionName: {}, txnId: {}, indexId: {}, indexName: {}",
-                                    partition.getId(), partition.getName(), txnState.getTransactionId(),
+                                    "partitionId: {}, tableName: {}, txnId: {}, indexId: {}, indexName: {}",
+                                    partition.getId(), table.getName(), txnState.getTransactionId(),
                                     index.getId(), table.getIndexNameByMetaId(index.getMetaId()));
                             continue;
                         }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
@@ -494,9 +494,9 @@ public class CatalogMocker {
                             TEST_PARTITION1_NAME, baseIndexP1, distributionInfo4);
 
             PhysicalPartition physicalPartition2 = new PhysicalPartition(
-                        TEST_PARTITION2_ID, "pp2", TEST_PARTITION1_ID, baseIndexP2);
+                        TEST_PARTITION2_ID, TEST_PARTITION1_ID, baseIndexP2);
             PhysicalPartition physicalPartition3 = new PhysicalPartition(
-                        TEST_PARTITION3_ID, "pp3", TEST_PARTITION1_ID, baseIndexP3);
+                        TEST_PARTITION3_ID, TEST_PARTITION1_ID, baseIndexP3);
             partition1.addSubPartition(physicalPartition2);
             partition1.addSubPartition(physicalPartition3);
 

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -1137,10 +1137,6 @@ public class RestoreJobTest {
                 return Maps.newHashMap();
             }
             
-            @Mock
-            public Map<String, Long> getPhysicalPartitionNameToPartitionId() {
-                return Maps.newHashMap();
-            }
         };
         
         // Create the MaterializedView instance after MockUp is set up

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
@@ -403,17 +403,6 @@ public class OlapTableTest {
     }
 
     @Test
-    public void testGetPhysicalPartitionByName() {
-        Database db = UnitTestUtil.createDb(1, 2, 3, 4, 5, 6, 7, KeysType.AGG_KEYS);
-        List<Table> tables = db.getTables();
-        for (Table table : tables) {
-            OlapTable olapTable = (OlapTable) table;
-            PhysicalPartition partition = olapTable.getPhysicalPartition("not_existed_name");
-            Assertions.assertNull(partition);
-        }
-    }
-
-    @Test
     public void testGetIndexesBySchema() {
         List<Index> indexesInTable = Lists.newArrayList();
         Column k1 = new Column("k1", new ScalarType(PrimitiveType.VARCHAR), true, null, "", "");

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PhysicalPartitionImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PhysicalPartitionImplTest.java
@@ -40,7 +40,7 @@ public class PhysicalPartitionImplTest {
 
     @Test
     public void testPhysicalPartition() throws Exception {
-        PhysicalPartition p = new PhysicalPartition(1, "", 1, new MaterializedIndex());
+        PhysicalPartition p = new PhysicalPartition(1, 1, new MaterializedIndex());
         Assertions.assertEquals(1, p.getId());
         Assertions.assertEquals(1, p.getParentId());
         Assertions.assertFalse(p.isImmutable());
@@ -106,7 +106,7 @@ public class PhysicalPartitionImplTest {
         Assertions.assertTrue(p.equals(p));
         Assertions.assertFalse(p.equals(new Partition(0, 11, "", null, null)));
 
-        PhysicalPartition p2 = new PhysicalPartition(1, "", 1, new MaterializedIndex());
+        PhysicalPartition p2 = new PhysicalPartition(1, 1, new MaterializedIndex());
         Assertions.assertFalse(p.equals(p2));
         p2.setBaseIndex(new MaterializedIndex(1));
 
@@ -149,8 +149,8 @@ public class PhysicalPartitionImplTest {
 
     @Test
     public void testPhysicalPartitionEqual() throws Exception {
-        PhysicalPartition p1 = new PhysicalPartition(1, "", 1, new MaterializedIndex());
-        PhysicalPartition p2 = new PhysicalPartition(1, "", 1, new MaterializedIndex());
+        PhysicalPartition p1 = new PhysicalPartition(1, 1, new MaterializedIndex());
+        PhysicalPartition p2 = new PhysicalPartition(1, 1, new MaterializedIndex());
         Assertions.assertTrue(p1.equals(p2));
 
         p1.createRollupIndex(new MaterializedIndex());

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
@@ -129,8 +129,7 @@ public class DiskAndTabletLoadReBalancerTest {
         DistributionInfo distributionInfo = new HashDistributionInfo(6, Lists.newArrayList());
 
         Partition partition = new Partition(partitionId, physicalPartitionId, "partition", materializedIndex, distributionInfo);
-        PhysicalPartition physicalPartition = new PhysicalPartition(physicalPartitionId, "partition", partitionId,
-                materializedIndex);
+        PhysicalPartition physicalPartition = new PhysicalPartition(physicalPartitionId, partitionId, materializedIndex);
         partition.addSubPartition(physicalPartition);
 
         OlapTable table = new OlapTable(tableId, "table", Lists.newArrayList(), KeysType.AGG_KEYS, partitionInfo,
@@ -271,8 +270,7 @@ public class DiskAndTabletLoadReBalancerTest {
         partitionInfo.addPartition(partitionId, dataProperty, (short) 3, null);
         DistributionInfo distributionInfo = new HashDistributionInfo(3, Lists.newArrayList());
         Partition partition = new Partition(partitionId, physicalPartitionId, "partition", materializedIndex, distributionInfo);
-        PhysicalPartition physicalPartition = new PhysicalPartition(physicalPartitionId, "partition", partitionId,
-                materializedIndex);
+        PhysicalPartition physicalPartition = new PhysicalPartition(physicalPartitionId, partitionId, materializedIndex);
         partition.addSubPartition(physicalPartition);
         OlapTable table = new OlapTable(tableId, "table", Lists.newArrayList(), KeysType.AGG_KEYS, partitionInfo,
                 distributionInfo);
@@ -427,13 +425,13 @@ public class DiskAndTabletLoadReBalancerTest {
         DistributionInfo distributionInfo = new HashDistributionInfo(6, Lists.newArrayList());
         Partition partition1 = new Partition(partitionId1, physicalPartitionId1,
                 "partition1", materializedIndex, distributionInfo);
-        PhysicalPartition physicalPartition1 = new PhysicalPartition(physicalPartitionId1, "partition1", partitionId1,
+        PhysicalPartition physicalPartition1 = new PhysicalPartition(physicalPartitionId1, partitionId1,
                 materializedIndex);
         partition1.addSubPartition(physicalPartition1);
 
         Partition partition2 = new Partition(partitionId2, physicalPartitionId2,
                 "partition2", materializedIndex, distributionInfo);
-        PhysicalPartition physicalPartition2 = new PhysicalPartition(physicalPartitionId2, "partition2", partitionId2,
+        PhysicalPartition physicalPartition2 = new PhysicalPartition(physicalPartitionId2, partitionId2,
                 materializedIndex);
         partition2.addSubPartition(physicalPartition2);
 
@@ -605,8 +603,7 @@ public class DiskAndTabletLoadReBalancerTest {
         partitionInfo.addPartition(partitionId, dataProperty, (short) 1, null);
         DistributionInfo distributionInfo = new HashDistributionInfo(6, Lists.newArrayList());
         Partition partition = new Partition(partitionId, physicalPartitionId, "partition", materializedIndex, distributionInfo);
-        PhysicalPartition physicalPartition = new PhysicalPartition(physicalPartitionId, "partition", partitionId,
-                materializedIndex);
+        PhysicalPartition physicalPartition = new PhysicalPartition(physicalPartitionId, partitionId, materializedIndex);
         partition.addSubPartition(physicalPartition);
 
         OlapTable table = new OlapTable(tableId, "table", Lists.newArrayList(), KeysType.AGG_KEYS, partitionInfo,

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -557,7 +557,7 @@ public class TabletSchedulerTest {
         Database db = new Database(dbId, "db");
         OlapTable table = new OlapTable(tblId, "table", null, null, null, null);
         MaterializedIndex index = new MaterializedIndex(indexId);
-        PhysicalPartition physicalPartition = new PhysicalPartition(physicalPartitionId, "physical_part", partitionId, index);
+        PhysicalPartition physicalPartition = new PhysicalPartition(physicalPartitionId, partitionId, index);
         Partition partition = new Partition(partitionId, physicalPartitionId, "partition", index, null);
         ColocateTableIndex colocateTableIndex = new ColocateTableIndex();
 
@@ -656,7 +656,7 @@ public class TabletSchedulerTest {
         LocalTablet tablet = new LocalTablet(tabletId, Lists.newArrayList(replica));
         MaterializedIndex index = new MaterializedIndex(indexId);
         index.addTablet(tablet, new TabletMeta(dbId, tblId, physicalPartitionId, indexId, TStorageMedium.HDD));
-        PhysicalPartition physicalPartition = new PhysicalPartition(physicalPartitionId, "physical_part", partitionId, index);
+        PhysicalPartition physicalPartition = new PhysicalPartition(physicalPartitionId, partitionId, index);
 
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionJobTest.java
@@ -33,7 +33,7 @@ public class CompactionJobTest {
     public void testGetResult() {
         Database db = new Database();
         Table table = new Table(Table.TableType.CLOUD_NATIVE);
-        PhysicalPartition partition = new PhysicalPartition(0, "", 1, null);
+        PhysicalPartition partition = new PhysicalPartition(0, 1, null);
         CompactionJob job = new CompactionJob(db, table, partition, 10010, true, null, "");
 
         Assertions.assertTrue(job.getAllowPartialSuccess());
@@ -78,7 +78,7 @@ public class CompactionJobTest {
     public void testBuildTabletCommitInfo() {
         Database db = new Database();
         Table table = new Table(Table.TableType.CLOUD_NATIVE);
-        PhysicalPartition partition = new PhysicalPartition(0, "", 1, null);
+        PhysicalPartition partition = new PhysicalPartition(0, 1, null);
         CompactionJob job = new CompactionJob(db, table, partition, 10010, false, null, "");
         assertDoesNotThrow(() -> {
             job.buildTabletCommitInfo();
@@ -89,7 +89,7 @@ public class CompactionJobTest {
     public void testGetExecutionProfile() {
         Database db = new Database();
         Table table = new Table(Table.TableType.CLOUD_NATIVE);
-        PhysicalPartition partition = new PhysicalPartition(0, "", 1, null);
+        PhysicalPartition partition = new PhysicalPartition(0, 1, null);
         CompactionJob job = new CompactionJob(db, table, partition, 10010, true, null, "");
 
         Assertions.assertTrue(job.getExecutionProfile().isEmpty());
@@ -123,7 +123,7 @@ public class CompactionJobTest {
     public void testSuccessCompactInputFIleSize() {
         Database db = new Database();
         Table table = new Table(Table.TableType.CLOUD_NATIVE);
-        PhysicalPartition partition = new PhysicalPartition(0, "", 1, null);
+        PhysicalPartition partition = new PhysicalPartition(0, 1, null);
         CompactionJob job = new CompactionJob(db, table, partition, 10010, true, null, "");
 
         Assertions.assertTrue(job.getAllowPartialSuccess());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionMgrTest.java
@@ -221,7 +221,7 @@ public class CompactionMgrTest {
                 PartitionIdentifier partitionIdentifier = new PartitionIdentifier(1, 2, 3);
                 Database db = new Database();
                 Table table = new LakeTable();
-                PhysicalPartition partition = new PhysicalPartition(123, "aaa", 123,  null);
+                PhysicalPartition partition = new PhysicalPartition(123, 123, null);
                 CompactionJob job = new CompactionJob(db, table, partition, txnId, false, null, "");
                 r.put(partitionIdentifier, job);
                 return r;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -132,7 +132,7 @@ public class CompactionSchedulerTest {
         new MockUp<OlapTable>() {
             @Mock
             public PhysicalPartition getPhysicalPartition(long physicalPartitionId) {
-                return new PhysicalPartition(123, "aaa", 123, new MaterializedIndex());
+                return new PhysicalPartition(123, 123, new MaterializedIndex());
             }
         };
         CompactionWarehouseInfo info = new CompactionWarehouseInfo("aaa", WarehouseManager.DEFAULT_RESOURCE, 0, 0);
@@ -174,7 +174,7 @@ public class CompactionSchedulerTest {
         new MockUp<OlapTable>() {
             @Mock
             public PhysicalPartition getPhysicalPartition(long physicalPartitionId) {
-                return new PhysicalPartition(123, "aaa", 123, new MaterializedIndex());
+                return new PhysicalPartition(123, 123, new MaterializedIndex());
             }
         };
 
@@ -253,8 +253,8 @@ public class CompactionSchedulerTest {
                 Table table = new LakeTable();
                 PartitionIdentifier partitionIdentifier1 = new PartitionIdentifier(1, 2, 3);
                 PartitionIdentifier partitionIdentifier2 = new PartitionIdentifier(1, 2, 4);
-                PhysicalPartition partition1 = new PhysicalPartition(123, "aaa", 123, null);
-                PhysicalPartition partition2 = new PhysicalPartition(124, "bbb", 124, null);
+                PhysicalPartition partition1 = new PhysicalPartition(123, 123, null);
+                PhysicalPartition partition2 = new PhysicalPartition(124, 124, null);
                 CompactionJob job1 = new CompactionJob(db, table, partition1, 100, false, null, "");
                 try {
                     Thread.sleep(10);
@@ -342,7 +342,7 @@ public class CompactionSchedulerTest {
                 Database db = new Database();
                 Table table = new LakeTable();
                 long partitionId = partitionStatisticsSnapshot.getPartition().getPartitionId();
-                PhysicalPartition partition = new PhysicalPartition(partitionId, "aaa", partitionId, null);
+                PhysicalPartition partition = new PhysicalPartition(partitionId, partitionId, null);
                 return new CompactionJob(db, table, partition, 100, false, info.computeResource, info.warehouseName);
             }
         };
@@ -527,7 +527,7 @@ public class CompactionSchedulerTest {
                 Database db = new Database();
                 Table table = new LakeTable();
                 long partitionId = partitionStatisticsSnapshot.getPartition().getPartitionId();
-                PhysicalPartition partition = new PhysicalPartition(partitionId, "aaa", partitionId, null);
+                PhysicalPartition partition = new PhysicalPartition(partitionId, partitionId, null);
                 CompactionJob job = new CompactionJob(db, table, partition, 100, false, info.computeResource, info.warehouseName);
                 return job;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -473,10 +473,10 @@ public class OlapTableSinkTest {
         RandomDistributionInfo distInfo = new RandomDistributionInfo(3);
         Partition partition = new Partition(2, 22, "p1", index, distInfo);
 
-        PhysicalPartition physicalPartition = new PhysicalPartition(3, "", 2, index);
+        PhysicalPartition physicalPartition = new PhysicalPartition(3, 2, index);
         partition.addSubPartition(physicalPartition);
 
-        physicalPartition = new PhysicalPartition(4, "", 2, index);
+        physicalPartition = new PhysicalPartition(4, 2, index);
         physicalPartition.setImmutable(true);
         partition.addSubPartition(physicalPartition);
 
@@ -515,10 +515,10 @@ public class OlapTableSinkTest {
         RandomDistributionInfo distInfo = new RandomDistributionInfo(3);
         Partition partition = new Partition(2, 22, "p1", index, distInfo);
 
-        PhysicalPartition physicalPartition = new PhysicalPartition(3, "", 2, index);
+        PhysicalPartition physicalPartition = new PhysicalPartition(3, 2, index);
         partition.addSubPartition(physicalPartition);
 
-        physicalPartition = new PhysicalPartition(4, "", 2, index);
+        physicalPartition = new PhysicalPartition(4, 2, index);
         physicalPartition.setImmutable(true);
         partition.addSubPartition(physicalPartition);
 
@@ -561,10 +561,10 @@ public class OlapTableSinkTest {
         RandomDistributionInfo distInfo = new RandomDistributionInfo(3);
         Partition partition = new Partition(2, 22, "p1", index, distInfo);
 
-        PhysicalPartition physicalPartition = new PhysicalPartition(3, "", 2, index);
+        PhysicalPartition physicalPartition = new PhysicalPartition(3, 2, index);
         partition.addSubPartition(physicalPartition);
 
-        physicalPartition = new PhysicalPartition(4, "", 2, index);
+        physicalPartition = new PhysicalPartition(4, 2, index);
         physicalPartition.setImmutable(true);
         partition.addSubPartition(physicalPartition);
 

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
@@ -169,7 +169,7 @@ public class LocalMetaStoreTest {
                     index.getId(), table.getPartitionInfo().getDataProperty(p.getParentId()).getStorageMedium());
         index.addTablet(new LocalTablet(0), tabletMeta);
         PhysicalPartitionPersistInfoV2 info = new PhysicalPartitionPersistInfoV2(
-                    db.getId(), table.getId(), p.getParentId(), new PhysicalPartition(123, "", p.getId(), index));
+                    db.getId(), table.getId(), p.getParentId(), new PhysicalPartition(123, p.getId(), index));
 
         LocalMetastore localMetastore = connectContext.getGlobalStateMgr().getLocalMetastore();
         localMetastore.replayAddSubPartition(info);

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -1708,7 +1708,7 @@ public class FrontendServiceImplTest {
             TPartitionMeta meta = metaList.get(tabletIdMetaIndex.get(tabletId));
             PhysicalPartition physicalPartition = olapTable.getPhysicalPartition(partitionId);
             Partition partition = olapTable.getPartition(physicalPartition.getParentId());
-            Assertions.assertEquals(physicalPartition.getName(), meta.getPartition_name());
+            Assertions.assertEquals(partition.getName(), meta.getPartition_name());
             Assertions.assertEquals(partitionId, meta.getPartition_id());
             Assertions.assertEquals(partition.getState().name(), meta.getState());
             Assertions.assertEquals(physicalPartition.getVisibleVersion(), meta.getVisible_version());
@@ -1738,7 +1738,7 @@ public class FrontendServiceImplTest {
             TPartitionMeta meta = metaList.get(0);
             PhysicalPartition physicalPartition = olapTable.getPhysicalPartition(partitionId);
             Partition partition = olapTable.getPartition(physicalPartition.getParentId());
-            Assertions.assertEquals(physicalPartition.getName(), meta.getPartition_name());
+            Assertions.assertEquals(partition.getName(), meta.getPartition_name());
             Assertions.assertEquals(partitionId, meta.getPartition_id());
             Assertions.assertEquals(partition.getState().name(), meta.getState());
             Assertions.assertEquals(physicalPartition.getVisibleVersion(), meta.getVisible_version());


### PR DESCRIPTION
## Why I'm doing:
Physical partition name is useless, remove it.

## What I'm doing:
Refactor code to remove physical partition name

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes reliance on physical-partition names and standardizes ID-based operations across the codebase.
> 
> - Drop `PhysicalPartition.name`; update constructors/usages; remove name-based maps/APIs in `Partition`/`OlapTable` (e.g., `getPhysicalPartition(String)`).
> - Refactor restore and replication flows to order/map physical partitions by IDs; update version checks and file mappings accordingly.
> - `FrontendServiceImpl` now populates `TPartitionMeta.partition_name` with the logical partition name; adjust logs/messages.
> - Update `ExternalOlapTable`/`LocalMetastore` to create physical partitions without names; simplify state rebuild paths.
> - Remove/adjust affected lookups and tests to use IDs; broad test updates to new constructors and behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf169a8a72a042b136a9c43fa8a276d6506996a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->