### PR TITLE
[BugFix] Fix identifier quoting for non-MySQL JDBC tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
@@ -126,7 +126,7 @@ public class JDBCScanNode extends ScanNode {
             return "`";
         }
         if (jdbcUri.startsWith("jdbc:postgresql") ||
-                jdbcUri.startsWith("jdbc:postgres:") ||
+                jdbcUri.startsWith("jdbc:postgres") ||
                 jdbcUri.startsWith("jdbc:oracle") ||
                 jdbcUri.startsWith("jdbc:sqlserver")) {
             return "\"";

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
@@ -108,17 +108,30 @@ public class JDBCScanNode extends ScanNode {
         }
     }
 
-    private boolean isMysql() {
+    private String getJdbcUri() {
         JDBCResource resource = (JDBCResource) GlobalStateMgr.getCurrentState().getResourceMgr()
                 .getResource(table.getResourceName());
         // Compatible with jdbc catalog
-        String jdbcURI = resource != null ? resource.getProperty(JDBCResource.URI) : table.getConnectInfo(JDBCResource.URI);
-        return jdbcURI.startsWith("jdbc:mysql");
+        return resource != null ? resource.getProperty(JDBCResource.URI) : table.getConnectInfo(JDBCResource.URI);
     }
 
     private String getIdentifierSymbol() {
-        //TODO: for other jdbc table we need different objectIdentifier to support reserved key words
-        return isMysql() ? "`" : "";
+        String jdbcUri = getJdbcUri();
+        if (jdbcUri == null) {
+            return "";
+        }
+        if (jdbcUri.startsWith("jdbc:mysql") ||
+                jdbcUri.startsWith("jdbc:mariadb") ||
+                jdbcUri.startsWith("jdbc:clickhouse")) {
+            return "`";
+        }
+        if (jdbcUri.startsWith("jdbc:postgresql") ||
+                jdbcUri.startsWith("jdbc:postgres:") ||
+                jdbcUri.startsWith("jdbc:oracle") ||
+                jdbcUri.startsWith("jdbc:sqlserver")) {
+            return "\"";
+        }
+        return "";
     }
 
     private void createJDBCTableFilters() {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MySqlAndJDBCScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MySqlAndJDBCScanNodeTest.java
@@ -94,4 +94,84 @@ public class MySqlAndJDBCScanNodeTest {
                 "(`col` = 'ABC') AND ((`col` NOT IN ('ABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE')) " +
                 "OR (`col` = 'ABC'))\n"), nodeString);
     }
+
+    @Test
+    public void testFiltersInPostgreSQLJDBCScanNode() throws DdlException {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "postgres");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:postgresql://localhost:5432/testdb");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "com.postgres.Driver");
+        JDBCTable pgTable = new JDBCTable(1, "order",
+                Collections.singletonList(new Column("user", VarcharType.VARCHAR)), properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(pgTable);
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, pgTable);
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains("TABLE: \"order\""), nodeString);
+        Assertions.assertTrue(nodeString.contains("FROM \"order\""), nodeString);
+    }
+
+    @Test
+    public void testFiltersInPostgresShortURIJDBCScanNode() throws DdlException {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "postgres");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:postgres://localhost:5432/testdb");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "com.postgres.Driver");
+        JDBCTable pgTable = new JDBCTable(1, "order",
+                Collections.singletonList(new Column("user", VarcharType.VARCHAR)), properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(pgTable);
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, pgTable);
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains("TABLE: \"order\""), nodeString);
+        Assertions.assertTrue(nodeString.contains("FROM \"order\""), nodeString);
+    }
+
+    @Test
+    public void testFiltersInOracleJDBCScanNode() throws DdlException {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "oracle");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:oracle:thin:@localhost:1521:orcl");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "oracle.jdbc.driver.OracleDriver");
+        JDBCTable oracleTable = new JDBCTable(1, "select",
+                Collections.singletonList(new Column("group", VarcharType.VARCHAR)), properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(oracleTable);
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, oracleTable);
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains("TABLE: \"select\""), nodeString);
+        Assertions.assertTrue(nodeString.contains("FROM \"select\""), nodeString);
+    }
+
+    @Test
+    public void testFiltersInSqlServerJDBCScanNode() throws DdlException {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "sa");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:sqlserver://localhost:1433;databaseName=testdb");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "com.microsoft.sqlserver.jdbc.SQLServerDriver");
+        JDBCTable sqlServerTable = new JDBCTable(1, "table",
+                Collections.singletonList(new Column("index", VarcharType.VARCHAR)), properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(sqlServerTable);
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, sqlServerTable);
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains("TABLE: \"table\""), nodeString);
+        Assertions.assertTrue(nodeString.contains("FROM \"table\""), nodeString);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
@@ -43,6 +43,22 @@ public class ExternalTableTest extends PlanTestBase {
                 "\"resource\"=\"jdbc_test\",\n" +
                 "\"table\"=\"test_table\"\n" +
                 ");");
+        starRocksAssert.withResource("create external resource \"jdbc_pg\"\n" +
+                        "PROPERTIES (\n" +
+                        "\"type\"=\"jdbc\",\n" +
+                        "\"user\"=\"test_user\",\n" +
+                        "\"password\"=\"test_passwd\",\n" +
+                        "\"driver_url\"=\"test_driver_url\",\n" +
+                        "\"driver_class\"=\"org.postgresql.Driver\",\n" +
+                        "\"jdbc_uri\"=\"jdbc:postgresql://127.0.0.1:5432/testdb\"\n" +
+                        ");")
+                .withTable("create external table test.jdbc_pg_test\n" +
+                        "(a int, b varchar(20), c float)\n" +
+                        "ENGINE=jdbc\n" +
+                        "PROPERTIES (\n" +
+                        "\"resource\"=\"jdbc_pg\",\n" +
+                        "\"table\"=\"test_table\"\n" +
+                        ");");
         FeConstants.runningUnitTest = false;
     }
 
@@ -50,7 +66,7 @@ public class ExternalTableTest extends PlanTestBase {
     public void testKeyWordWhereCaluse() throws Exception {
         String sql = "select * from test.jdbc_key_words_test where `schema` = \"test\"";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "schema = 'test'");
+        assertContains(plan, "`schema` = 'test'");
     }
 
     @Test
@@ -185,8 +201,8 @@ public class ExternalTableTest extends PlanTestBase {
         String sql = "select * from test.jdbc_test where a > 10 and b < 'abc' limit 10";
         String plan = getFragmentPlan(sql);
         Assertions.assertTrue(plan.contains("0:SCAN JDBC\n" +
-                "     TABLE: test_table\n" +
-                "     QUERY: SELECT a, b, c FROM test_table WHERE (a > 10) AND (b < 'abc')\n" +
+                "     TABLE: `test_table`\n" +
+                "     QUERY: SELECT `a`, `b`, `c` FROM `test_table` WHERE (`a` > 10) AND (`b` < 'abc')\n" +
                 "     limit: 10"), plan);
         sql = "select * from test.jdbc_test where a > 10 and length(b) < 20 limit 10";
         plan = getFragmentPlan(sql);
@@ -196,8 +212,8 @@ public class ExternalTableTest extends PlanTestBase {
                         "  |  limit: 10\n" +
                         "  |  \n" +
                         "  0:SCAN JDBC\n" +
-                        "     TABLE: test_table\n" +
-                        "     QUERY: SELECT a, b, c FROM test_table WHERE (a > 10)"), plan);
+                        "     TABLE: `test_table`\n" +
+                        "     QUERY: SELECT `a`, `b`, `c` FROM `test_table` WHERE (`a` > 10)"), plan);
 
     }
 
@@ -211,8 +227,18 @@ public class ExternalTableTest extends PlanTestBase {
                         "  |  group by: b\n" +
                         "  |  \n" +
                         "  0:SCAN JDBC\n" +
-                        "     TABLE: test_table\n" +
-                        "     QUERY: SELECT a, b FROM test_table"));
+                        "     TABLE: `test_table`\n" +
+                        "     QUERY: SELECT `a`, `b` FROM `test_table`"));
+    }
+
+    @Test
+    public void testPostgreSQLJDBCTableFilter() throws Exception {
+        String sql = "select * from test.jdbc_pg_test where a > 10 and b < 'abc' limit 10";
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("0:SCAN JDBC\n" +
+                "     TABLE: \"test_table\"\n" +
+                "     QUERY: SELECT \"a\", \"b\", \"c\" FROM \"test_table\" WHERE (\"a\" > 10) AND (\"b\" < 'abc')\n" +
+                "     limit: 10"), plan);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JDBCIdentifierQuoteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JDBCIdentifierQuoteTest.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class JDBCIdentifierQuoteTest extends ConnectorPlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        ConnectorPlanTestBase.beforeClass();
+    }
+
+    @Test
+    public void testPostgreSQLIdentifierQuote() throws Exception {
+        String sql = "select a, b from jdbc_postgres.partitioned_db0.tbl0";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "SCAN JDBC");
+        assertContains(plan, "TABLE: \"tbl0\"");
+        assertContains(plan, "QUERY: SELECT \"a\", \"b\"");
+    }
+
+    @Test
+    public void testMySQLIdentifierQuote() throws Exception {
+        String sql = "select a, b from jdbc0.partitioned_db0.tbl0";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "SCAN JDBC");
+        assertContains(plan, "TABLE: `tbl0`");
+        assertContains(plan, "QUERY: SELECT `a`, `b` FROM `tbl0`");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Modified `getIdentifierSymbol()` to return database-specific quote characters based on JDBC URL prefix, otheriwise the query will fail when using keywords as column names, see #67115


Core Fix: JDBCScanNode.java
 - Modified `getIdentifierSymbol()` to return database-specific quote characters based on JDBC URL prefix
 - MySQL/MariaDB/ClickHouse: backtick
 - PostgreSQL/Oracle/SQL Server: double quote (ANSI SQL)

Tests: `MySqlAndJDBCScanNodeTest.java`
  - Added unit tests for PostgreSQL, Oracle, SQL Server identifier quoting

Tests: `JDBCIdentifierQuoteTest.java (new)`
  - Catalog-level integration tests for PostgreSQL and MySQL quoting


## What I'm doing:

Fixes #67115

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns JDBC identifier quoting with target databases to prevent failures when using reserved keywords or mixed cases.
> 
> - In `JDBCScanNode`, add `getJdbcUri()` and rework `getIdentifierSymbol()` to choose quotes by URL prefix: MySQL/MariaDB/ClickHouse use backticks; PostgreSQL/Oracle/SQL Server use double quotes
> - Apply quoting to table and column names in generated `TABLE:` and `QUERY:` strings
> - Update `ExternalTableTest` expectations and add a PostgreSQL JDBC resource/table for plans
> - Extend `MySqlAndJDBCScanNodeTest` with PostgreSQL, Oracle, and SQL Server cases; ensure proper quoting in explain output
> - New `JDBCIdentifierQuoteTest` asserting catalog-level quoting for PostgreSQL and MySQL
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6732b4c8177ed3b7ea6b88b92bb3a47d031007b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->