### PR TITLE
[Enhancement] Add mem_pool_use_ratio metric to be

### DIFF
--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -424,16 +424,9 @@ void WorkGroupManager::add_metrics_unlocked(const WorkGroupPtr& wg, UniqueLockTy
 namespace {
 double _calculate_ratio(const int64_t curr_value, const int64_t sum_value) {
     if (sum_value <= 0) {
-        return 0.0;
+        return 0;
     }
     return static_cast<double>(curr_value) / sum_value;
-}
-
-double _calculate_ratio(const std::optional<int64_t>& usage, const std::optional<int64_t>& total_usage) {
-    if (!usage.has_value() || !total_usage.has_value()) {
-        return 0.0;
-    }
-    return _calculate_ratio(*usage, *total_usage);
 }
 } // namespace
 
@@ -470,7 +463,7 @@ void WorkGroupManager::update_metrics_unlocked() {
             double connector_scan_use_ratio = _calculate_ratio(wg->connector_scan_sched_entity()->growth_runtime_ns(),
                                                                sum_connector_scan_runtime_ns);
             double mem_pool_use_ratio =
-                    _calculate_ratio(wg->parent_memory_usage_bytes(), wg->parent_memory_limit_bytes());
+                    _calculate_ratio(wg->mem_consumption_bytes(), wg->parent_memory_limit_bytes().value_or(0));
 
             wg_metrics->cpu_limit->set_value(cpu_expected_use_ratio);
             wg_metrics->inuse_cpu_ratio->set_value(cpu_use_ratio);

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -401,22 +401,42 @@ void WorkGroupManager::add_metrics_unlocked(const WorkGroupPtr& wg, UniqueLockTy
             wg_metrics->cpu_runtime_ns = wg->cpu_runtime_ns();
             wg_metrics->inuse_cpu_cores = std::move(inuse_cpu_cores);
         }
-        if (cpu_limit_registered) wg_metrics->cpu_limit = std::move(resource_group_cpu_limit_ratio);
-        if (cpu_ratio_registered) wg_metrics->inuse_cpu_ratio = std::move(resource_group_cpu_use_ratio);
-        if (scan_ratio_registered) wg_metrics->inuse_scan_ratio = std::move(resource_group_scan_use_ratio);
-        if (connector_scan_ratio_registered)
+        if (cpu_limit_registered) {
+            wg_metrics->cpu_limit = std::move(resource_group_cpu_limit_ratio);
+        }
+        if (cpu_ratio_registered) {
+            wg_metrics->inuse_cpu_ratio = std::move(resource_group_cpu_use_ratio);
+        }
+        if (scan_ratio_registered) {
+            wg_metrics->inuse_scan_ratio = std::move(resource_group_scan_use_ratio);
+        }
+        if (connector_scan_ratio_registered) {
             wg_metrics->inuse_connector_scan_ratio = std::move(resource_group_connector_scan_use_ratio);
-        if (mem_limit_registered) wg_metrics->mem_limit = std::move(resource_group_mem_limit_bytes);
-        if (mem_inuse_registered) wg_metrics->inuse_mem_bytes = std::move(resource_group_mem_allocated_bytes);
-        if (mem_connector_scan_registered)
+        }
+        if (mem_limit_registered) {
+            wg_metrics->mem_limit = std::move(resource_group_mem_limit_bytes);
+        }
+        if (mem_inuse_registered) {
+            wg_metrics->inuse_mem_bytes = std::move(resource_group_mem_allocated_bytes);
+        }
+        if (mem_connector_scan_registered) {
             wg_metrics->connector_scan_mem_bytes = std::move(resource_group_connector_scan_bytes);
-        if (running_registered) wg_metrics->running_queries = std::move(resource_group_running_queries);
-        if (total_registered) wg_metrics->total_queries = std::move(resource_group_total_queries);
-        if (concurrency_registered)
+        }
+        if (running_registered) {
+            wg_metrics->running_queries = std::move(resource_group_running_queries);
+        }
+        if (total_registered) {
+            wg_metrics->total_queries = std::move(resource_group_total_queries);
+        }
+        if (concurrency_registered) {
             wg_metrics->concurrency_overflow_count = std::move(resource_group_concurrency_overflow);
-        if (bigquery_registered) wg_metrics->bigquery_count = std::move(resource_group_bigquery_count);
-        if (mem_pool_use_ratio_registered)
+        }
+        if (bigquery_registered) {
+            wg_metrics->bigquery_count = std::move(resource_group_bigquery_count);
+        }
+        if (mem_pool_use_ratio_registered) {
             wg_metrics->mem_pool_use_ratio = std::move(resource_group_mem_pool_use_ratio);
+        }
     }
     _wg_metrics[wg->name()]->group_unique_id = wg->unique_id();
 }


### PR DESCRIPTION
## Why I'm doing:

I recently extended the `fe` metrics to include mem_pool related information:
- https://github.com/StarRocks/starrocks/pull/66690

These are not reported as `be` metrics. 

Memory pool usage percentage per resource group is a useful information that we can add as a backend metric and display in dashboards.

## What I'm doing:

This pull request adds the backend metric `resource_group_mem_pool_usage_ratio`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a per-workgroup memory pool usage ratio to backend metrics.
> 
> - Registers new `DoubleGauge` metric `resource_group_mem_pool_use_ratio` (labels: `name`, `mem_pool`) in `work_group.cpp`
> - Computes and updates the ratio using `mem_consumption_bytes / parent_memory_limit_bytes` in `update_metrics_unlocked`, and resets to `0` when a workgroup is absent
> - Minor cleanups: `_calculate_ratio` moved into anonymous namespace with safer casts; conditional assignments expanded for clarity
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a895854f995a564d50e13707a862e54e162d9db5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->