### PR TITLE
[Enhancement] Add warehouse_name label in the mv metrics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -892,6 +892,18 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return warehouseId;
     }
 
+    /**
+     * Get the warehouse name of the materialized view.
+     */
+    public String getWarehouseName() {
+        Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr()
+                .getWarehouse(warehouseId);
+        if (warehouse != null) {
+            return warehouse.getName();
+        }
+        return WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+    }
+
     public int getMaxMVRewriteStaleness() {
         return maxMVRewriteStaleness;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -896,12 +896,15 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * Get the warehouse name of the materialized view.
      */
     public String getWarehouseName() {
+        if (warehouseId == WarehouseManager.DEFAULT_WAREHOUSE_ID) {
+            return WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+        }
         Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr()
                 .getWarehouse(warehouseId);
         if (warehouse != null) {
             return warehouse.getName();
         }
-        return WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+        return "";
     }
 
     public int getMaxMVRewriteStaleness() {
@@ -1410,6 +1413,15 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         // register constraints from global state manager
         GlobalConstraintManager globalConstraintManager = GlobalStateMgr.getCurrentState().getGlobalConstraintManager();
         globalConstraintManager.registerConstraint(this);
+
+        // register into mv metrics
+        try {
+            MaterializedViewMetricsRegistry.getInstance().registerMetricsEntity(getMvId());
+        } catch (Exception e) {
+            // log and continue
+            LOG.warn("failed to register mv metrics for mv: {}", this, e);
+        }
+
         // log reload cost
         long duration = System.currentTimeMillis() - startMillis;
         LOG.info("finish reloading mv {} in {}ms, total base table count: {}", getName(), duration, baseTableInfos.size());

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -312,7 +312,7 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
         };
         metrics.add(counterPartitionCount);
 
-        mvWarehouseName = new GaugeMetric<String>("mv_warehouse_name", MetricUnit.NOUNIT,
+        mvWarehouseName = new GaugeMetric<String>("warehouse_name", MetricUnit.NOUNIT,
                 "the materialized view's warehouse name") {
             @Override
             public String getValue() {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -83,8 +83,6 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
 
     // the current materialized view's partition count, 0 if the materialized view is not partitioned
     public GaugeMetric<Integer> counterPartitionCount;
-    // the materialized view's warehouse name
-    public GaugeMetric<String> mvWarehouseName;
 
     // histogram(ms)
     // record the materialized view's refresh job duration only if it's refreshed successfully.


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Add `warehouse_name` label for each mv metrics;
- Ensure mv's metrics is registered after mv has been reloaded.

```
{"tags":{"metric":"mv_refresh_jobs","db_name":"mv_backup_tpch_test_e9bc33a7_ef8d_11f0_92dd_00163e09349d","mv_name":"partsupp_mv","mv_id":"41715","warehouse_name":"default_warehouse"},"unit":"requests","value":0},
{"tags":{"metric":"mv_refresh_total_success_jobs","db_name":"mv_backup_tpch_test_e9bc33a7_ef8d_11f0_92dd_00163e09349d","mv_name":"partsupp_mv","mv_id":"41715","warehouse_name":"default_warehouse"},"unit":"requests","value":0},
{"tags":{"metric":"mv_refresh_total_failed_jobs","db_name":"mv_backup_tpch_test_e9bc33a7_ef8d_11f0_92dd_00163e09349d","mv_name":"partsupp_mv","mv_id":"41715","warehouse_name":"default_warehouse"},"unit":"requests","value":0},
{"tags":{"metric":"mv_refresh_total_empty_jobs","db_name":"mv_backup_tpch_test_e9bc33a7_ef8d_11f0_92dd_00163e09349d","mv_name":"partsupp_mv","mv_id":"41715","warehouse_name":"default_warehouse"},"unit":"requests","value":0},
{"tags":{"metric":"mv_refresh_total_retry_meta_count","db_name":"mv_backup_tpch_test_e9bc33a7_ef8d_11f0_92dd_00163e09349d","mv_name":"partsupp_mv","mv_id":"41715","warehouse_name":"default_warehouse"},"unit":"requests","value":0},
{"tags":{"metric":"mv_query_total_count","db_name":"mv_backup_tpch_test_e9bc33a7_ef8d_11f0_92dd_00163e09349d","mv_name":"partsupp_mv","mv_id":"41715","warehouse_name":"default_warehouse"},"unit":"requests","value":0},

```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces visibility into the warehouse associated with each materialized view.
> 
> - Adds `getWarehouseName()` to `MaterializedView` to resolve the warehouse name (fallback to default)
> - Registers new gauge `mv_warehouse_name` in `MaterializedViewMetricsEntity` to report the MV's warehouse name
> - Refactors metric lookup via `getMaterializedView()` helper to avoid repeated db/table fetch logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0420a6e8b3c8e4ec9e7ae585b04c016a15a9c0b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->