### PR TITLE
[BugFix] Fix timezone offset buffer size in log prefix

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -267,7 +267,7 @@ static std::string get_timezone_offset_string(const google::LogMessageTime& time
     }
 
     // Slow path: recalculate and update cache
-    char tz_str[7] = "+0000";
+    char tz_str[16] = "+0000";
     int offset_hours = static_cast<int>(offset_seconds / 3600);
     int offset_mins = static_cast<int>((offset_seconds % 3600) / 60);
     if (offset_mins < 0) offset_mins = -offset_mins;


### PR DESCRIPTION
## Why I'm doing:

When I compile, I encounter the following errors, so fix it
```
be/src/common/logconfig.cpp:322:43:
/workspaces/starrocks/be/src/common/logconfig.cpp:276:42: note: directive argument in the range [-2147483647, 2147483647]
276 | snprintf(tz_str, sizeof(tz_str), "-%02d%02d", -offset_hours, offset_mins);
| ^~~~~~~~~~~
/workspaces/starrocks/be/src/common/logconfig.cpp:276:42: note: directive argument in the range [0, 59]
/workspaces/starrocks/be/src/common/logconfig.cpp:276:17: note: ‘snprintf’ output between 6 and 15 bytes into a destination of size 7
276 | snprintf(tz_str, sizeof(tz_str), "-%02d%02d", -offset_hours, offset_mins);
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents potential buffer overflow when composing the timezone offset used in log prefixes.
> 
> - In `be/src/common/logconfig.cpp`, increase `tz_str` from `char[7]` to `char[16]` in the slow path of `get_timezone_offset_string` to safely hold formatted `+/-HHMM` strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de1f07f2f664d2b26c69f1f2f56210f90dfbf800. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->