### PR TITLE
[Refactor] Fix/orc timezone dangling

### DIFF
--- a/be/src/formats/orc/apache-orc/c++/src/ColumnReader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/ColumnReader.cc
@@ -347,8 +347,8 @@ class TimestampColumnReader : public ColumnReader {
 private:
     std::unique_ptr<orc::RleDecoder> secondsRle;
     std::unique_ptr<orc::RleDecoder> nanoRle;
-    const Timezone& writerTimezone;
-    const Timezone& readerTimezone;
+    const Timezone* writerTimezone;
+    const Timezone* readerTimezone;
     const int64_t epochOffset;
     const bool sameTimezone;
 
@@ -365,10 +365,10 @@ public:
 
 TimestampColumnReader::TimestampColumnReader(const Type& type, StripeStreams& stripe, bool isInstantType)
         : ColumnReader(type, stripe),
-          writerTimezone(isInstantType ? getTimezoneByName("GMT") : stripe.getWriterTimezone()),
-          readerTimezone(isInstantType ? getTimezoneByName("GMT") : stripe.getReaderTimezone()),
-          epochOffset(writerTimezone.getEpoch()),
-          sameTimezone(stripe.getUseWriterTimezone() || (&writerTimezone == &readerTimezone)) {
+          writerTimezone(isInstantType ? &getTimezoneByName("GMT") : &stripe.getWriterTimezone()),
+          readerTimezone(isInstantType ? &getTimezoneByName("GMT") : &stripe.getReaderTimezone()),
+          epochOffset(writerTimezone->getEpoch()),
+          sameTimezone(stripe.getUseWriterTimezone() || (writerTimezone == readerTimezone)) {
     RleVersion vers = convertRleVersion(stripe.getEncoding(columnId).kind());
     std::unique_ptr<SeekableInputStream> stream = stripe.getStream(columnId, proto::Stream_Kind_DATA, true);
     if (stream == nullptr) throw ParseError("DATA stream not found in Timestamp column");
@@ -412,13 +412,13 @@ void TimestampColumnReader::next(ColumnVectorBatch& rowBatch, uint64_t numValues
             if (!sameTimezone) {
                 // adjust timestamp value to same wall clock time if writer and reader
                 // time zones have different rules, which is required for Apache Orc.
-                const auto& wv = writerTimezone.getVariant(writerTime);
-                const auto& rv = readerTimezone.getVariant(writerTime);
+                const auto& wv = writerTimezone->getVariant(writerTime);
+                const auto& rv = readerTimezone->getVariant(writerTime);
                 if (!wv.hasSameTzRule(rv)) {
                     // If the timezone adjustment moves the millis across a DST boundary,
                     // we need to reevaluate the offsets.
                     int64_t adjustedTime = writerTime + wv.gmtOffset - rv.gmtOffset;
-                    const auto& adjustedReader = readerTimezone.getVariant(adjustedTime);
+                    const auto& adjustedReader = readerTimezone->getVariant(adjustedTime);
                     writerTime = writerTime + wv.gmtOffset - adjustedReader.gmtOffset;
                 }
             }


### PR DESCRIPTION
## Why I'm doing:
Fix compile warning
```
/workspaces/starrocks/be/src/formats/orc/apache-orc/c++/src/ColumnWriter.cc: In constructor ‘orc::TimestampColumnWriter::TimestampColumnWriter(const orc::Type&, const orc::StreamsFactory&, const orc::WriterOptions&, bool)’:
/workspaces/starrocks/be/src/formats/orc/apache-orc/c++/src/ColumnWriter.cc:1545:21: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
1545 | const Timezone& timezone;
| ^~~~~~~~
/workspaces/starrocks/be/src/formats/orc/apache-orc/c++/src/ColumnWriter.cc:1553:53: note: the temporary was destroyed at the end of the full expression ‘orc::getTimezoneByName(std::__cxx11::basic_string<char>(((const char*)"GMT"), std::allocator<char>()))’
1553 | timezone(isInstantType ? getTimezoneByName("GMT") : options.getTimezone()),
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `Timezone` members from references to pointers to prevent potential dangling references and clean up compiler warnings.
> 
> - Update `TimestampColumnReader` and `TimestampColumnWriter` to store `const Timezone*` instead of `const Timezone&`
> - Adjust constructors: initialize from `getTimezoneByName("GMT")` or stripe/options via pointers; recompute `epochOffset` and `sameTimezone` using pointers
> - Update all dereferences and comparisons (e.g., `->getEpoch()`, `writerTimezone == readerTimezone`, `->getVariant(...)`, `->convertToUTC(...)`) accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f8e9877dc24a42cba78215404100b935475e66c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->