### PR TITLE
[Feature] Support Iceberg 1.10 Google AuthManager for REST Catalog

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -323,6 +323,17 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-gcp</artifactId>
+        </dependency>
+
+        <!-- Google Cloud Storage for iceberg-gcp GCSFileIO -->
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
         </dependency>

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -82,11 +82,6 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     public static final String USER_AGENT = "header.User-Agent";
     public static final String KEY_VIEW_ENDPOINTS_ENABLED = "rest.view-endpoints-enabled";
 
-    // FileIO configuration
-    public static final String KEY_IO_IMPL = "io-impl";
-    // Metrics reporting configuration
-    public static final String KEY_METRICS_REPORTING_ENABLED = "rest.metrics.reporting-enabled";
-
     // Google AuthManager properties (Iceberg 1.10+)
     public static final String REST_AUTH_TYPE = "rest.auth.type";
     public static final String AUTH_TYPE_GOOGLE = "google";
@@ -114,23 +109,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             }
         });
 
-        // Configure FileIO implementation
-        // Allow users to specify custom io-impl (e.g., org.apache.iceberg.gcp.gcs.GCSFileIO)
-        // Default to IcebergCachingFileIO for caching benefits
-        String ioImpl = restCatalogProperties.get(KEY_IO_IMPL);
-        if (Strings.isNullOrEmpty(ioImpl)) {
-            restCatalogProperties.put(CatalogProperties.FILE_IO_IMPL, IcebergCachingFileIO.class.getName());
-        } else {
-            restCatalogProperties.put(CatalogProperties.FILE_IO_IMPL, ioImpl);
-        }
-
-        // Configure metrics reporting
-        // Allow users to enable/disable metrics reporting via rest.metrics.reporting-enabled
-        boolean metricsReportingEnabled = PropertyUtil.propertyAsBoolean(
-                restCatalogProperties, KEY_METRICS_REPORTING_ENABLED, true);
-        if (metricsReportingEnabled) {
-            restCatalogProperties.put(CatalogProperties.METRICS_REPORTER_IMPL, IcebergMetricsReporter.class.getName());
-        }
+        restCatalogProperties.put(CatalogProperties.FILE_IO_IMPL, IcebergCachingFileIO.class.getName());
+        restCatalogProperties.put(CatalogProperties.METRICS_REPORTER_IMPL, IcebergMetricsReporter.class.getName());
 
         boolean enableVendedCredentials =
                 Boolean.parseBoolean(restCatalogProperties.getOrDefault(KEY_VENDED_CREDENTIALS_ENABLED, "true"));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/SecurityEnum.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/SecurityEnum.java
@@ -15,5 +15,5 @@
 package com.starrocks.connector.iceberg.rest;
 
 public enum SecurityEnum {
-    NONE, OAUTH2
+    NONE, OAUTH2, GOOGLE
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -595,67 +595,6 @@ public class IcebergRESTCatalogTest {
     }
 
     @Test
-    public void testCustomFileIOImplementation(@Mocked RESTSessionCatalog restCatalog) {
-        // Test that custom io-impl is properly set in catalog properties
-        String customIOImpl = "org.apache.iceberg.gcp.gcs.GCSFileIO";
-        Map<String, String> properties = new HashMap<>();
-        properties.put("iceberg.catalog.io-impl", customIOImpl);
-
-        IcebergRESTCatalog catalog = new IcebergRESTCatalog(
-                "test_catalog", new Configuration(), properties);
-
-        // Verify custom io-impl was set in the internal properties
-        Map<String, String> restCatalogProperties = Deencapsulation.getField(catalog, "restCatalogProperties");
-        assertEquals(customIOImpl, restCatalogProperties.get("io-impl"),
-                "Custom io-impl should be set for Iceberg catalog");
-    }
-
-    @Test
-    public void testDefaultFileIOImplementation(@Mocked RESTSessionCatalog restCatalog) {
-        // Test that default IcebergCachingFileIO is used when io-impl is not specified
-        Map<String, String> properties = new HashMap<>();
-
-        IcebergRESTCatalog catalog = new IcebergRESTCatalog(
-                "test_catalog", new Configuration(), properties);
-
-        // Verify default IcebergCachingFileIO was set
-        Map<String, String> restCatalogProperties = Deencapsulation.getField(catalog, "restCatalogProperties");
-        assertEquals("com.starrocks.connector.iceberg.io.IcebergCachingFileIO",
-                restCatalogProperties.get("io-impl"),
-                "Default IcebergCachingFileIO should be used when io-impl is not specified");
-    }
-
-    @Test
-    public void testMetricsReportingDisabled(@Mocked RESTSessionCatalog restCatalog) {
-        // Test that metrics reporting can be disabled via rest.metrics.reporting-enabled property
-        Map<String, String> properties = new HashMap<>();
-        properties.put("iceberg.catalog.rest.metrics.reporting-enabled", "false");
-
-        IcebergRESTCatalog catalog = new IcebergRESTCatalog(
-                "test_catalog", new Configuration(), properties);
-
-        // Verify metrics reporter is NOT set when metrics reporting is disabled
-        Map<String, String> restCatalogProperties = Deencapsulation.getField(catalog, "restCatalogProperties");
-        Assertions.assertNull(restCatalogProperties.get("metrics-reporter-impl"),
-                "Metrics reporter should not be set when metrics reporting is disabled");
-    }
-
-    @Test
-    public void testMetricsReportingEnabled(@Mocked RESTSessionCatalog restCatalog) {
-        // Test that metrics reporting is enabled by default
-        Map<String, String> properties = new HashMap<>();
-
-        IcebergRESTCatalog catalog = new IcebergRESTCatalog(
-                "test_catalog", new Configuration(), properties);
-
-        // Verify metrics reporter is set when metrics reporting is enabled (default)
-        Map<String, String> restCatalogProperties = Deencapsulation.getField(catalog, "restCatalogProperties");
-        assertEquals("com.starrocks.connector.iceberg.cost.IcebergMetricsReporter",
-                restCatalogProperties.get("metrics-reporter-impl"),
-                "Metrics reporter should be set when metrics reporting is enabled");
-    }
-
-    @Test
     public void testGoogleSecurityConfiguration(@Mocked RESTSessionCatalog restCatalog) {
         // Test Google security configuration (Iceberg 1.10+ Google AuthManager)
         Map<String, String> properties = new HashMap<>();

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -91,6 +91,7 @@ under the License.
         <lz4-java.version>1.10.1</lz4-java.version>
         <async-profiler.version>4.0</async-profiler.version>
         <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
+        <google-cloud-storage.version>2.61.0</google-cloud-storage.version>
     </properties>
 
     <profiles>
@@ -1450,7 +1451,7 @@ under the License.
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>google-cloud-storage</artifactId>
-                <version>2.43.1</version>
+                <version>${google-cloud-storage.version}</version>
             </dependency>
 
             <dependency>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1441,6 +1441,19 @@ under the License.
             </dependency>
 
             <dependency>
+                <groupId>org.apache.iceberg</groupId>
+                <artifactId>iceberg-gcp</artifactId>
+                <version>${iceberg.version}</version>
+            </dependency>
+
+            <!-- Google Cloud Storage for iceberg-gcp GCSFileIO -->
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-storage</artifactId>
+                <version>2.43.1</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.starrocks</groupId>
                 <artifactId>starclient</artifactId>
                 <version>${staros.version}</version>


### PR DESCRIPTION
## Description

### What this PR does

This PR adds support for Iceberg 1.10's Google AuthManager, enabling StarRocks to authenticate with Google BigLake-managed tables via the REST Catalog protocol using standard Google credentials.

### Why we need this

With Iceberg 1.10, Google introduced the `GoogleAuthManager` that plugs directly into the REST Catalog ecosystem. This allows users to:
- Point Spark jobs (running on GKE, Dataproc, or anywhere) directly at BigLake-managed tables
- Use standard Google authentication (Application Default Credentials or service account keys)
- Leverage the open REST protocol for Iceberg metadata operations

### Changes

#### Core Implementation
- **`SecurityEnum.java`**: Added `GOOGLE` enum value for security type
- **`OAuth2SecurityConfig.java`**: Added handling for GOOGLE security in the builder
- **`IcebergRESTCatalog.java`**: 
  - Added `rest.auth.type=google` configuration for Google AuthManager
  - Added support for `gcp.auth.credentials-path` and `gcp.auth.scopes` properties
  - Added `io-impl` property support for custom FileIO (e.g., `GCSFileIO`)
  - Added `rest.metrics.reporting-enabled` property support

#### Dependencies
- Added `iceberg-gcp` dependency (version matches existing Iceberg version)
- Added `google-cloud-storage` dependency for GCSFileIO support

#### Documentation
- Updated `docs/en/data_source/catalog/iceberg/iceberg_catalog.md` with:
  - New REST catalog properties for Google authentication
  - BigLake REST Catalog example

#### Tests
- Added test cases for GOOGLE security type in `OAuth2SecurityConfigTest.java`

### Usage Example

```
CREATE EXTERNAL CATALOG iceberg_bq
PROPERTIES (
    "type"  =  "iceberg",
    "iceberg.catalog.type"  =  "rest",
    "iceberg.catalog.uri"  = "https://biglake.googleapis.com/iceberg/v1/restcatalog",
    "iceberg.catalog.warehouse" = "bq://projects/project/locations/us-central1",
    "iceberg.catalog.nested-namespace-enabled"="true",
    "iceberg.catalog.header.x-goog-user-project" = "project",
    "iceberg.catalog.security" = "google",
    "iceberg.catalog.rest-metrics-reporting-enabled" = "false",
    "iceberg.catalog.io-impl" = "org.apache.iceberg.gcp.gcs.GCSFileIO",
    "iceberg.catalog.vended-credentials-enabled" = "true",
    "gcp.gcs.use_compute_engine_service_account" = "true"
);
```

## Why I'm doing:

## What I'm doing:

Closes #67726

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables Google authentication for Iceberg REST catalogs and adds configurability for FileIO and metrics.
> 
> - Introduces `GOOGLE` security type; sets `rest.auth.type=google` with optional `gcp.auth.credentials-path` and `gcp.auth.scopes`
> - Supports `iceberg.catalog.io-impl` (e.g., `org.apache.iceberg.gcp.gcs.GCSFileIO`) and `rest.metrics.reporting-enabled` flag
> - Adds dependencies: `iceberg-gcp` and `google-cloud-storage`
> - Updates docs (EN/JA/ZH) with new REST properties and BigLake example
> - Tests cover Google security, custom/default FileIO, and metrics reporting on/off
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ba9c5bf3184f704c59453a95496e425e7581e4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->