### PR TITLE
[BugFix] Fix bug cause INSERT statements can't use optimistic lock during plan…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -562,6 +562,9 @@ public class InsertPlanner {
             isSchemaValid =
                     olapTables.stream().allMatch(t -> OptimisticVersion.validateTableUpdate(t, planStartTime));
             if (isSchemaValid) {
+                // Restore original tables in AST after successful plan generation
+                // This ensures subsequent plan calls can access the latest table state with temp partitions
+                AnalyzerUtils.restoreOriginalTables(insertStmt, olapTables);
                 return plan;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1011,7 +1011,10 @@ public class AnalyzerUtils {
                 return null;
             }
             // Continue to visit source tables in SELECT clause
-            return visit(node.getQueryStatement());
+            if (node.getQueryStatement() != null) {
+                return visit(node.getQueryStatement());
+            }
+            return null;
         }
 
         /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1010,10 +1010,12 @@ public class AnalyzerUtils {
                 tables.put(tableName, targetTable);
                 return null;
             }
+
             // Continue to visit source tables in SELECT clause
             if (node.getQueryStatement() != null) {
                 return visit(node.getQueryStatement());
             }
+
             return null;
         }
 


### PR DESCRIPTION
## Why I'm doing:
- When an INSERT statement involves external tables.
- The plan generation process first acquires a lock on the local metadata.
- Then will access the external metadata service for external tables metadata.
- Since accessing external metadata services can be time-consuming, holding the local metadata lock during this process causes severe blocking issues for other concurrent tasks.
- In fact, although an optimistic locking optimization was introduced in newer versions to avoid holding locks for extended periods during plan generation.
- But, AnalyzerUtils.areTablesCopySafe func always returned false for INSERT statements because the target table was unconditionally added to unsafe tables map in TableCollector.visitInsertStatement without checking if it's copy safe.
- Ultimately, INSERT statements always can't use optimistic lock during plan generation.

<img width="1422" height="454" alt="image" src="https://github.com/user-attachments/assets/64b46d5f-5487-4280-befd-c96328cba48c" />

<img width="1436" height="492" alt="image" src="https://github.com/user-attachments/assets/50a2f271-2fe1-4d0a-bde7-8e44a88e57d8" />

<img width="1646" height="900" alt="image" src="https://github.com/user-attachments/assets/618f31d6-a018-4a74-8129-03446d19ec78" />

## What I'm doing:

fix this bug

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes INSERT planning deadlock risk by enabling optimistic-lock flow when possible.
> 
> - Corrects `AnalyzerUtils.areTablesCopySafe` to treat OLAP/MV (within MV limit) and immutable externals (`HIVE`, `ICEBERG`) as copy-safe; checks both target and source tables
> - Adds `OlapTableRestorer` and `AnalyzerUtils.restoreOriginalTables` to revert OLAP table snapshots in the AST after successful plan generation
> - Updates `InsertPlanner.buildExecPlanWithRetry` to call `restoreOriginalTables` upon success
> - Refactors `TableIndexId` visibility for reuse in collectors/restorer
> - Adds unit tests covering OLAP-only INSERTs, subqueries/joins, Hive (copy-safe) and MySQL (not copy-safe) targets
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee75b08d20cd530fae6102085ec35256c32706a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->