### PR TITLE
[BugFix] Fix data loss in IcebergMetadata when async cache refresh fails after successful commit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1424,8 +1424,8 @@ public class IcebergMetadata implements ConnectorMetadata {
         commitWithCleanup(() -> {
             rowDelta.commit();
             transaction.commitTransaction();
-            asyncRefreshOthersFeMetadataCache(dbName, tableName);
         }, () -> invalidateCacheAfterCommit(dbName, tableName), dataFiles, dbName, tableName);
+        asyncRefreshOthersFeMetadataCache(dbName, tableName);
     }
 
     private void commitDataOperation(Transaction transaction, org.apache.iceberg.Table nativeTbl,
@@ -1474,8 +1474,8 @@ public class IcebergMetadata implements ConnectorMetadata {
         commitWithCleanup(() -> {
             batchWrite.commit();
             transaction.commitTransaction();
-            asyncRefreshOthersFeMetadataCache(dbName, tableName);
         }, () -> invalidateCacheAfterCommit(dbName, tableName), dataFiles, dbName, tableName);
+        asyncRefreshOthersFeMetadataCache(dbName, tableName);
     }
 
     private void asyncRefreshOthersFeMetadataCache(String dbName, String tableName) {
@@ -1749,3 +1749,4 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
     }
 }
+


### PR DESCRIPTION
## Why I'm doing:
In commitDeleteOperation and commitDataOperation methods, asyncRefreshOthersFeMetadataCache was invoked inside the commit action lambda. If the async refresh threw an exception after a successful commit, the exception handler would call deleteUncommittedDataFiles, deleting already-committed data files and causing data loss.


## What I'm doing:
This pull request makes a small but important adjustment to the order in which metadata cache refresh operations are triggered after committing Iceberg table operations. Specifically, it moves the call to `asyncRefreshOthersFeMetadataCache` outside of the `commitWithCleanup` lambda to ensure the cache refresh happens after all commit and cleanup logic has completed.

**Commit operation ordering update:**

* In both `commitDeleteOperation` and `commitDataOperation` methods in `IcebergMetadata.java`, the call to `asyncRefreshOthersFeMetadataCache` was moved to occur after the `commitWithCleanup` block, ensuring cache refresh happens only after all transactional and cleanup steps are fully completed. 
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents data loss caused by treating async cache refresh failures as commit failures.
> 
> - In `commitDeleteOperation` and `commitDataOperation`, call `asyncRefreshOthersFeMetadataCache` after `commitWithCleanup` instead of inside the commit lambda
> - Commit/cleanup flow unchanged; only post-commit refresh timing is adjusted
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdcd1afcbb63e3b0122a5ee11bc9d8836e4ab76d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->