### PR TITLE
[Refactor] Use fwd to accelerate compilation

### DIFF
--- a/be/src/connector/connector_chunk_sink.h
+++ b/be/src/connector/connector_chunk_sink.h
@@ -18,7 +18,7 @@
 
 #include <map>
 
-#include "column/chunk.h"
+#include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "connector/partition_chunk_writer.h"
 #include "connector/utils.h"

--- a/be/src/connector/connector_sink_executor.cpp
+++ b/be/src/connector/connector_sink_executor.cpp
@@ -17,6 +17,7 @@
 #include "column/chunk.h"
 #include "common/status.h"
 #include "connector/partition_chunk_writer.h"
+#include "runtime/current_thread.h"
 #include "storage/load_chunk_spiller.h"
 
 namespace starrocks::connector {

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -21,6 +21,7 @@
 #include "exec/olap_scan_prepare.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exprs/jsonpath.h"
+#include "runtime/current_thread.h"
 #include "runtime/global_dict/parser.h"
 #include "storage/chunk_helper.h"
 #include "storage/column_predicate_rewriter.h"

--- a/be/src/connector/partition_chunk_writer.h
+++ b/be/src/connector/partition_chunk_writer.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "column/chunk.h"
+#include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "connector/utils.h"
 #include "exec/sorting/sorting.h"

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -92,6 +92,7 @@ ADD_BE_LIB(Formats
         parquet/row_source_reader.cpp
         parquet/parquet_pos_reader.cpp
         disk_range.hpp
+        file_writer.cpp
         )
 
 add_subdirectory(orc/apache-orc)

--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "csv_file_writer.h"
+#include "formats/csv/csv_file_writer.h"
 
 #include <boost/algorithm/string.hpp>
 #include <utility>
 
 #include "common/http/content_type.h"
-#include "csv_escape.h"
 #include "exec/hdfs_scanner/hdfs_scanner_text.h"
+#include "formats/column_evaluator.h"
+#include "formats/csv/csv_escape.h"
 #include "formats/utils.h"
 #include "output_stream_file.h"
 #include "runtime/current_thread.h"

--- a/be/src/formats/csv/csv_file_writer.h
+++ b/be/src/formats/csv/csv_file_writer.h
@@ -18,6 +18,13 @@
 #include "formats/csv/output_stream.h"
 #include "formats/file_writer.h"
 
+namespace starrocks {
+class ColumnEvaluator;
+class FileSystem;
+class PriorityThreadPool;
+class RuntimeState;
+} // namespace starrocks
+
 namespace starrocks::formats {
 
 struct CSVWriterOptions : FileWriterOptions {

--- a/be/src/formats/file_writer.cpp
+++ b/be/src/formats/file_writer.cpp
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/file_writer.h"
+
+#include <fmt/format.h>
+
+#include <utility>
+
+#include "io/async_flush_output_stream.h"
+
+namespace starrocks::formats {
+
+FileWriter::CommitResult& FileWriter::CommitResult::set_extra_data(std::string extra_data) {
+    this->extra_data = std::move(extra_data);
+    return *this;
+}
+
+FileWriter::CommitResult& FileWriter::CommitResult::set_referenced_data_file(std::string referenced_data_file) {
+    this->referenced_data_file = std::move(referenced_data_file);
+    return *this;
+}
+
+UnknownFileWriterFactory::UnknownFileWriterFactory(std::string format) : _format(std::move(format)) {}
+
+Status UnknownFileWriterFactory::init() {
+    return Status::NotSupported(fmt::format("got unsupported file format: {}", _format));
+}
+
+StatusOr<WriterAndStream> UnknownFileWriterFactory::create(const std::string& path) const {
+    return Status::NotSupported(fmt::format("got unsupported file format: {}", _format));
+}
+
+} // namespace starrocks::formats

--- a/be/src/formats/file_writer.h
+++ b/be/src/formats/file_writer.h
@@ -14,16 +14,20 @@
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <future>
+#include <map>
+#include <string>
+#include <vector>
 
-#include "column/chunk.h"
+#include "column/vectorized_fwd.h"
 #include "common/status.h"
-#include "formats/column_evaluator.h"
-#include "fs/fs.h"
-#include "io/async_flush_output_stream.h"
-#include "runtime/runtime_state.h"
-#include "util/priority_thread_pool.hpp"
+#include "common/statusor.h"
 
+namespace starrocks::io {
+class AsyncFlushOutputStream;
+}
 namespace starrocks::formats {
 
 struct FileWriterOptions {
@@ -51,14 +55,8 @@ public:
         std::function<void()> rollback_action;
         std::string extra_data;
         std::string referenced_data_file;
-        CommitResult& set_extra_data(std::string extra_data) {
-            this->extra_data = std::move(extra_data);
-            return *this;
-        }
-        CommitResult& set_referenced_data_file(std::string referenced_data_file) {
-            this->referenced_data_file = std::move(referenced_data_file);
-            return *this;
-        }
+        CommitResult& set_extra_data(std::string extra_data);
+        CommitResult& set_referenced_data_file(std::string referenced_data_file);
     };
 
     virtual ~FileWriter() = default;
@@ -86,13 +84,11 @@ public:
 
 class UnknownFileWriterFactory : public FileWriterFactory {
 public:
-    UnknownFileWriterFactory(std::string format) : _format(std::move(format)) {}
+    UnknownFileWriterFactory(std::string format);
 
-    Status init() override { return Status::NotSupported(fmt::format("got unsupported file format: {}", _format)); }
+    Status init() override;
 
-    StatusOr<WriterAndStream> create(const std::string& path) const override {
-        return Status::NotSupported(fmt::format("got unsupported file format: {}", _format));
-    }
+    StatusOr<WriterAndStream> create(const std::string& path) const override;
 
 private:
     std::string _format;

--- a/be/src/formats/orc/orc_file_writer.cpp
+++ b/be/src/formats/orc/orc_file_writer.cpp
@@ -22,9 +22,11 @@
 #include "column/column_helper.h"
 #include "column/map_column.h"
 #include "common/http/content_type.h"
+#include "formats/column_evaluator.h"
 #include "formats/orc/orc_memory_pool.h"
 #include "formats/orc/utils.h"
 #include "formats/utils.h"
+#include "io/async_flush_output_stream.h"
 #include "runtime/current_thread.h"
 #include "util/debug_util.h"
 

--- a/be/src/formats/orc/orc_file_writer.h
+++ b/be/src/formats/orc/orc_file_writer.h
@@ -18,8 +18,18 @@
 #include <orc/Writer.hh>
 #include <util/priority_thread_pool.hpp>
 
+#include "column/column.h"
 #include "formats/file_writer.h"
-#include "orc_memory_pool.h"
+#include "formats/orc/orc_memory_pool.h"
+#include "gen_cpp/Types_types.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+class ColumnEvaluator;
+class FileSystem;
+class RuntimeState;
+class TypeDescriptor;
+} // namespace starrocks
 
 namespace starrocks::formats {
 

--- a/be/src/io/async_flush_output_stream.h
+++ b/be/src/io/async_flush_output_stream.h
@@ -14,17 +14,20 @@
 
 #pragma once
 
+#include <cstdint>
 #include <future>
 #include <queue>
 #include <string>
 #include <vector>
 
 #include "common/statusor.h"
-#include "fs/fs.h"
-#include "runtime/current_thread.h"
-#include "runtime/runtime_state.h"
-#include "util/priority_thread_pool.hpp"
 #include "util/raw_container.h"
+
+namespace starrocks {
+class WritableFile;
+class PriorityThreadPool;
+class RuntimeState;
+} // namespace starrocks
 
 namespace starrocks::io {
 
@@ -58,10 +61,11 @@ public:
 
     AsyncFlushOutputStream(std::unique_ptr<WritableFile> file, PriorityThreadPool* io_executor,
                            RuntimeState* runtime_state);
+    ~AsyncFlushOutputStream();
 
     Status write(const uint8_t* data, int64_t size);
 
-    const std::string& filename() const { return _file->filename(); }
+    const std::string& filename() const;
 
     int64_t tell() const { return _total_size; }
 

--- a/be/test/connector_sink/async_flush_output_stream_test.cpp
+++ b/be/test/connector_sink/async_flush_output_stream_test.cpp
@@ -25,6 +25,7 @@
 #include "fs/fs_memory.h"
 #include "testutil/assert.h"
 #include "util/defer_op.h"
+#include "util/priority_thread_pool.hpp"
 
 namespace starrocks::connector {
 namespace {

--- a/be/test/formats/csv/csv_file_writer_test.cpp
+++ b/be/test/formats/csv/csv_file_writer_test.cpp
@@ -26,6 +26,7 @@
 #include "column/map_column.h"
 #include "column/struct_column.h"
 #include "common/object_pool.h"
+#include "formats/column_evaluator.h"
 #include "formats/csv/output_stream_file.h"
 #include "fs/fs_memory.h"
 #include "runtime/descriptor_helper.h"

--- a/be/test/formats/orc/orc_file_writer_test.cpp
+++ b/be/test/formats/orc/orc_file_writer_test.cpp
@@ -22,6 +22,7 @@
 #include "column/array_column.h"
 #include "column/struct_column.h"
 #include "common/object_pool.h"
+#include "formats/column_evaluator.h"
 #include "formats/orc/orc_chunk_reader.h"
 #include "fs/fs_memory.h"
 #include "fs/fs_posix.h"


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors build-time dependencies and file writer infrastructure, and adds CSV header support with new tests.
> 
> - Switches several headers to `column/vectorized_fwd.h` and normalizes include paths; adds `runtime/current_thread.h` where needed
> - Extracts `UnknownFileWriterFactory` and `FileWriter::CommitResult` implementations into new `formats/file_writer.cpp` and wires it in CMake
> - Enhances `io::AsyncFlushOutputStream` (explicit destructor, `filename()` out-of-line, header cleanup) and adjusts tests/imports
> - Improves `CSVFileWriter`: supports optional header rows and proper escaping; updates factory/options handling and adds comprehensive CSV tests
> - Minor include cleanups in ORC/CSV writers and lake/connector code
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1920ca737c1f75e8ddcdf8ba04486ab1e32e52ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->