### PR TITLE
[Refactor] Move column_evaluator implementation from headers to source file

### DIFF
--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -91,6 +91,7 @@ ADD_BE_LIB(Formats
         parquet/iceberg_row_id_reader.cpp
         parquet/row_source_reader.cpp
         parquet/parquet_pos_reader.cpp
+        column_evaluator.cpp
         disk_range.hpp
         file_writer.cpp
         )

--- a/be/src/formats/column_evaluator.cpp
+++ b/be/src/formats/column_evaluator.cpp
@@ -1,0 +1,114 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/column_evaluator.h"
+
+#include "column/chunk.h"
+#include "exprs/expr.h"
+#include "exprs/expr_context.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+
+Status ColumnEvaluator::init(const std::vector<std::unique_ptr<ColumnEvaluator>>& source) {
+    for (const auto& e : source) {
+        RETURN_IF_ERROR(e->init());
+    }
+    return Status::OK();
+}
+
+std::vector<std::unique_ptr<ColumnEvaluator>> ColumnEvaluator::clone(
+        const std::vector<std::unique_ptr<ColumnEvaluator>>& source) {
+    std::vector<std::unique_ptr<ColumnEvaluator>> es;
+    es.reserve(source.size());
+    for (const auto& e : source) {
+        es.push_back(e->clone());
+    }
+    return es;
+}
+
+std::vector<TypeDescriptor> ColumnEvaluator::types(const std::vector<std::unique_ptr<ColumnEvaluator>>& source) {
+    std::vector<TypeDescriptor> types;
+    types.reserve(source.size());
+    for (const auto& e : source) {
+        types.push_back(e->type());
+    }
+    return types;
+}
+
+std::vector<std::unique_ptr<ColumnEvaluator>> ColumnExprEvaluator::from_exprs(const std::vector<TExpr>& exprs,
+                                                                              RuntimeState* state) {
+    std::vector<std::unique_ptr<ColumnEvaluator>> es;
+    es.reserve(exprs.size());
+    for (const auto& e : exprs) {
+        es.push_back(std::make_unique<ColumnExprEvaluator>(e, state));
+    }
+    return es;
+}
+
+ColumnExprEvaluator::ColumnExprEvaluator(const TExpr& expr, RuntimeState* state) : _expr(expr), _state(state) {}
+
+ColumnExprEvaluator::~ColumnExprEvaluator() {
+    if (_expr_ctx) {
+        _expr_ctx->close(_state);
+    }
+}
+
+Status ColumnExprEvaluator::init() {
+    if (_expr_ctx == nullptr) {
+        RETURN_IF_ERROR(Expr::create_expr_tree(_state->obj_pool(), _expr, &_expr_ctx, _state));
+        RETURN_IF_ERROR(_expr_ctx->prepare(_state));
+        RETURN_IF_ERROR(_expr_ctx->open(_state));
+    }
+    return Status::OK();
+}
+
+std::unique_ptr<ColumnEvaluator> ColumnExprEvaluator::clone() const {
+    return std::make_unique<ColumnExprEvaluator>(_expr, _state);
+}
+
+TypeDescriptor ColumnExprEvaluator::type() const {
+    DCHECK(_expr_ctx != nullptr) << "not inited";
+    return _expr_ctx->root()->type();
+}
+
+StatusOr<ColumnPtr> ColumnExprEvaluator::evaluate(Chunk* chunk) {
+    DCHECK(_expr_ctx != nullptr) << "not inited";
+    return _expr_ctx->evaluate(chunk);
+}
+
+std::vector<std::unique_ptr<ColumnEvaluator>> ColumnSlotIdEvaluator::from_types(
+        const std::vector<TypeDescriptor>& types) {
+    std::vector<std::unique_ptr<ColumnEvaluator>> es;
+    es.reserve(types.size());
+    for (size_t i = 0; i < types.size(); i++) {
+        es.push_back(std::make_unique<ColumnSlotIdEvaluator>(i, types[i]));
+    }
+    return es;
+}
+
+Status ColumnSlotIdEvaluator::init() {
+    return Status::OK();
+}
+
+std::unique_ptr<ColumnEvaluator> ColumnSlotIdEvaluator::clone() const {
+    return std::make_unique<ColumnSlotIdEvaluator>(_slot_id, _type);
+}
+
+StatusOr<ColumnPtr> ColumnSlotIdEvaluator::evaluate(Chunk* chunk) {
+    DCHECK(chunk->is_slot_exist(_slot_id));
+    return chunk->get_column_by_slot_id(_slot_id);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `column_evaluator` by moving method implementations from the header into a new `column_evaluator.cpp`, reducing header dependencies and build impact.
> 
> - Adds `formats/column_evaluator.cpp` and updates `CMakeLists.txt` to compile it
> - Converts `column_evaluator.h` to declarations-only, using forward declarations and lighter includes
> - No functional or behavioral changes; interfaces remain the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b578210715eac7fea4ae52a97ce6a8bc2b0ce4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->