### PR TITLE
[Refactor] Move unnecessary chunk.h from headers

### DIFF
--- a/be/src/exec/except_node.h
+++ b/be/src/exec/except_node.h
@@ -16,11 +16,11 @@
 
 #include <unordered_set>
 
-#include "column/chunk.h"
 #include "column/column_hash.h"
 #include "column/column_helper.h"
 #include "column/type_traits.h"
 #include "exec/except_hash_set.h"
+#include "exec/exec_node.h"
 #include "exec/olap_common.h"
 #include "exec/pipeline/operator.h"
 #include "exprs/expr_context.h"

--- a/be/src/exec/hash_join_node.h
+++ b/be/src/exec/hash_join_node.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include "column/chunk.h"
 #include "column/fixed_length_column.h"
 #include "column/vectorized_fwd.h"
 #include "exec/exec_node.h"

--- a/be/src/formats/avro/cpp/avro_reader.cpp
+++ b/be/src/formats/avro/cpp/avro_reader.cpp
@@ -21,6 +21,7 @@
 #include <avrocpp/ValidSchema.hh>
 
 #include "column/adaptive_nullable_column.h"
+#include "column/chunk.h"
 #include "exec/file_scanner/file_scanner.h"
 #include "formats/avro/cpp/avro_schema_builder.h"
 #include "formats/avro/cpp/utils.h"

--- a/be/src/formats/avro/cpp/avro_reader.h
+++ b/be/src/formats/avro/cpp/avro_reader.h
@@ -18,7 +18,7 @@
 #include <avrocpp/Generic.hh>
 #include <avrocpp/Stream.hh>
 
-#include "column/chunk.h"
+#include "column/vectorized_fwd.h"
 #include "formats/avro/cpp/column_reader.h"
 
 namespace starrocks {

--- a/be/src/formats/parquet/chunk_writer.h
+++ b/be/src/formats/parquet/chunk_writer.h
@@ -34,14 +34,11 @@
 #include <utility>
 #include <vector>
 
-#include "column/chunk.h"
-#include "column/nullable_column.h"
+#include "column/column.h"
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "fs/fs.h"
-#include "runtime/runtime_state.h"
 #include "runtime/types.h"
-#include "util/priority_thread_pool.hpp"
 
 namespace parquet {
 class RowGroupWriter;

--- a/be/src/formats/parquet/column_chunk_writer.h
+++ b/be/src/formats/parquet/column_chunk_writer.h
@@ -30,11 +30,7 @@
 
 #include <utility>
 
-#include "column/chunk.h"
-#include "column/nullable_column.h"
 #include "fs/fs.h"
-#include "runtime/runtime_state.h"
-#include "util/priority_thread_pool.hpp"
 
 namespace parquet {
 class ColumnWriter;

--- a/be/src/formats/parquet/file_writer.h
+++ b/be/src/formats/parquet/file_writer.h
@@ -45,7 +45,6 @@
 #include <utility>
 #include <vector>
 
-#include "column/chunk.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 #include "common/status.h"

--- a/be/src/formats/parquet/level_builder.h
+++ b/be/src/formats/parquet/level_builder.h
@@ -37,7 +37,6 @@
 #include <utility>
 #include <vector>
 
-#include "column/chunk.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 #include "common/status.h"

--- a/be/src/formats/parquet/parquet_file_writer.h
+++ b/be/src/formats/parquet/parquet_file_writer.h
@@ -44,7 +44,6 @@
 #include <vector>
 
 #include "arrow_memory_pool.h"
-#include "column/chunk.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 #include "common/status.h"

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -41,7 +41,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include "column/chunk.h"
+#include "column/vectorized_fwd.h"
 #include "common/compiler_util.h"
 #include "common/status.h"
 #include "common/tracer_fwd.h"

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -21,7 +21,7 @@
 #include <sstream>
 #include <string>
 
-#include "column/chunk.h"
+#include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "exec/tablet_info.h"
 #include "gen_cpp/Types_types.h"

--- a/be/src/storage/column_predicate.h
+++ b/be/src/storage/column_predicate.h
@@ -18,7 +18,6 @@
 #include <utility>
 #include <vector>
 
-#include "column/chunk.h"
 #include "column/column.h" // Column
 #include "column/datum.h"
 #include "column/type_traits.h"

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include "column/chunk.h"
 #include "column/vectorized_fwd.h"
 #include "common/tracer_fwd.h"
 #include "gen_cpp/internal_service.pb.h"

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_writer.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_writer.cpp
@@ -24,6 +24,7 @@
 
 #include "common/status.h"
 #include "gen_cpp/segment.pb.h"
+#include "gutil/strings/substitute.h"
 #include "storage/index/inverted/builtin/builtin_simple_analyzer.h"
 #include "storage/index/inverted/inverted_index_option.h"
 #include "storage/rowset/bitmap_index_writer.h"

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -17,7 +17,7 @@
 #include <atomic>
 #include <ostream>
 
-#include "column/chunk.h"
+#include "column/vectorized_fwd.h"
 #include "exec/sorting/sort_permute.h"
 #include "gen_cpp/data.pb.h"
 #include "gen_cpp/olap_file.pb.h"

--- a/be/src/storage/predicate_tree/predicate_tree.h
+++ b/be/src/storage/predicate_tree/predicate_tree.h
@@ -18,8 +18,8 @@
 #include <set>
 #include <vector>
 
-#include "common/overloaded.h"
 #include "column/chunk.h"
+#include "common/overloaded.h"
 #include "storage/column_predicate.h"
 #include "storage/predicate_tree/predicate_tree_fwd.h"
 

--- a/be/src/storage/predicate_tree/predicate_tree.h
+++ b/be/src/storage/predicate_tree/predicate_tree.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "common/overloaded.h"
+#include "column/chunk.h"
 #include "storage/column_predicate.h"
 #include "storage/predicate_tree/predicate_tree_fwd.h"
 

--- a/be/src/storage/rowset/rowset_meta.cpp
+++ b/be/src/storage/rowset/rowset_meta.cpp
@@ -46,21 +46,21 @@ RowsetMeta::~RowsetMeta() {
     MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage);
 }
 
-static string empty_encryption_meta;
+static std::string empty_encryption_meta;
 
-const string& RowsetMeta::get_segment_encryption_meta(int segment_id) const {
+const std::string& RowsetMeta::get_segment_encryption_meta(int segment_id) const {
     const auto size = _rowset_meta_pb->segment_encryption_metas_size();
     DCHECK(segment_id >= 0 && (segment_id < size || size == 0));
     return segment_id < size ? _rowset_meta_pb->segment_encryption_metas(segment_id) : empty_encryption_meta;
 }
 
-const string& RowsetMeta::get_uptfile_encryption_meta(int upt_file_id) const {
+const std::string& RowsetMeta::get_uptfile_encryption_meta(int upt_file_id) const {
     const auto size = _rowset_meta_pb->updatefile_encryption_metas_size();
     DCHECK(upt_file_id >= 0 && (upt_file_id < size || size == 0));
     return upt_file_id < size ? _rowset_meta_pb->updatefile_encryption_metas(upt_file_id) : empty_encryption_meta;
 }
 
-const string& RowsetMeta::get_delfile_encryption_meta(int del_file_id) const {
+const std::string& RowsetMeta::get_delfile_encryption_meta(int del_file_id) const {
     const auto size = _rowset_meta_pb->delfile_encryption_metas_size();
     DCHECK(del_file_id >= 0 && (del_file_id < size || size == 0));
     return del_file_id < size ? _rowset_meta_pb->delfile_encryption_metas(del_file_id) : empty_encryption_meta;

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -289,9 +289,9 @@ public:
         return false;
     }
 
-    const string& get_segment_encryption_meta(int segment_id) const;
-    const string& get_uptfile_encryption_meta(int upt_file_id) const;
-    const string& get_delfile_encryption_meta(int del_file_id) const;
+    const std::string& get_segment_encryption_meta(int segment_id) const;
+    const std::string& get_uptfile_encryption_meta(int upt_file_id) const;
+    const std::string& get_delfile_encryption_meta(int del_file_id) const;
 
 private:
     bool _deserialize_from_pb(std::string_view value) {

--- a/be/src/storage/rowset/segment_group.cpp
+++ b/be/src/storage/rowset/segment_group.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/rowset/segment_group.h"
 
+#include <numeric>
+
 namespace starrocks {
 
 /// ShortKeyIndexGroupIterator

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -51,7 +51,6 @@
 #include <vector>
 
 #include "agent/status.h"
-#include "column/chunk.h"
 #include "common/status.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/BackendService_types.h"

--- a/be/src/storage/tablet_reader.h
+++ b/be/src/storage/tablet_reader.h
@@ -17,7 +17,7 @@
 #include <memory>
 #include <vector>
 
-#include "column/chunk.h"
+#include "column/vectorized_fwd.h"
 #include "runtime/mem_pool.h"
 #include "storage/delete_predicates.h"
 #include "storage/row_source_mask.h"

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -39,7 +39,6 @@
 #include <string_view>
 #include <vector>
 
-#include "column/chunk.h"
 #include "column/column_access_path.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/descriptors.pb.h"

--- a/be/src/util/arrow/starrocks_column_to_arrow.cpp
+++ b/be/src/util/arrow/starrocks_column_to_arrow.cpp
@@ -19,6 +19,7 @@
 #include <array>
 
 #include "column/array_column.h"
+#include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/map_column.h"
 #include "column/type_traits.h"

--- a/be/src/util/arrow/starrocks_column_to_arrow.h
+++ b/be/src/util/arrow/starrocks_column_to_arrow.h
@@ -29,11 +29,14 @@
 
 #include <memory>
 
-#include "column/chunk.h"
+#include "column/column.h"
+#include "column/vectorized_fwd.h"
 #include "common/global_types.h"
 #include "runtime/descriptors.h"
 
 namespace starrocks {
+
+class Chunk;
 
 Status convert_chunk_to_arrow_batch(Chunk* chunk, std::vector<ExprContext*>& _output_expr_ctxs,
                                     const std::shared_ptr<arrow::Schema>& schema, arrow::MemoryPool* pool,

--- a/be/test/storage/disjunctive_predicates_test.cpp
+++ b/be/test/storage/disjunctive_predicates_test.cpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "column/chunk.h"
 #include "column/type_traits.h"
 #include "column/vectorized_fwd.h"
 #include "common/object_pool.h"

--- a/be/test/storage/meta_reader_test.cpp
+++ b/be/test/storage/meta_reader_test.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include "column/array_column.h"
+#include "column/chunk.h"
 #include "column/fixed_length_column.h"
 #include "column/json_column.h"
 #include "column/nullable_column.h"

--- a/be/test/util/arrow/starrocks_column_to_arrow_test.cpp
+++ b/be/test/util/arrow/starrocks_column_to_arrow_test.cpp
@@ -19,6 +19,7 @@
 #include <set>
 
 #include "column/array_column.h"
+#include "column/chunk.h"
 #include "column/map_column.h"
 #include "common/logging.h"
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces header coupling and build dependencies by cleaning up includes and doing light type hygiene.
> 
> - Remove `#include "column/chunk.h"` from many headers (exec, avro/parquet formats, runtime, storage) in favor of `column/vectorized_fwd.h` or `column/column.h`; keep/add `chunk.h` only where directly needed (some .cpp and tests)
> - Add specific missing includes: `exec/exec_node.h`, `gutil/strings/substitute.h`, `<numeric>`, and targeted Arrow/Parquet headers
> - Standardize to `std::string` in `rowset_meta` getters and static empty meta; update declarations/definitions accordingly
> - Minor header tidy-ups in parquet writers/builders and predicate structures; no functional changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a59b2dc43e34263e3efee31514027dce2efa57d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->