### PR TITLE
[Refactor] Use std::string

### DIFF
--- a/be/src/storage/rowset/rowset_meta.cpp
+++ b/be/src/storage/rowset/rowset_meta.cpp
@@ -46,21 +46,21 @@ RowsetMeta::~RowsetMeta() {
     MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage);
 }
 
-static string empty_encryption_meta;
+static std::string empty_encryption_meta;
 
-const string& RowsetMeta::get_segment_encryption_meta(int segment_id) const {
+const std::string& RowsetMeta::get_segment_encryption_meta(int segment_id) const {
     const auto size = _rowset_meta_pb->segment_encryption_metas_size();
     DCHECK(segment_id >= 0 && (segment_id < size || size == 0));
     return segment_id < size ? _rowset_meta_pb->segment_encryption_metas(segment_id) : empty_encryption_meta;
 }
 
-const string& RowsetMeta::get_uptfile_encryption_meta(int upt_file_id) const {
+const std::string& RowsetMeta::get_uptfile_encryption_meta(int upt_file_id) const {
     const auto size = _rowset_meta_pb->updatefile_encryption_metas_size();
     DCHECK(upt_file_id >= 0 && (upt_file_id < size || size == 0));
     return upt_file_id < size ? _rowset_meta_pb->updatefile_encryption_metas(upt_file_id) : empty_encryption_meta;
 }
 
-const string& RowsetMeta::get_delfile_encryption_meta(int del_file_id) const {
+const std::string& RowsetMeta::get_delfile_encryption_meta(int del_file_id) const {
     const auto size = _rowset_meta_pb->delfile_encryption_metas_size();
     DCHECK(del_file_id >= 0 && (del_file_id < size || size == 0));
     return del_file_id < size ? _rowset_meta_pb->delfile_encryption_metas(del_file_id) : empty_encryption_meta;

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -289,9 +289,9 @@ public:
         return false;
     }
 
-    const string& get_segment_encryption_meta(int segment_id) const;
-    const string& get_uptfile_encryption_meta(int upt_file_id) const;
-    const string& get_delfile_encryption_meta(int del_file_id) const;
+    const std::string& get_segment_encryption_meta(int segment_id) const;
+    const std::string& get_uptfile_encryption_meta(int upt_file_id) const;
+    const std::string& get_delfile_encryption_meta(int del_file_id) const;
 
 private:
     bool _deserialize_from_pb(std::string_view value) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes string types in `RowsetMeta`.
> 
> - Changes signatures to return `const std::string&` for `get_segment_encryption_meta`, `get_uptfile_encryption_meta`, and `get_delfile_encryption_meta`
> - Updates static `empty_encryption_meta` to `std::string`
> 
> No functional logic modified; only type qualifiers updated in `rowset_meta.h` and `rowset_meta.cpp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9277d9dbd7139a84ef42363f1a45992472b5223. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->