### PR TITLE
[BugFix] Fix wrong compaction_inputs for target tablet meta while lake replication

### DIFF
--- a/be/src/storage/lake/txn_log_applier.h
+++ b/be/src/storage/lake/txn_log_applier.h
@@ -56,7 +56,6 @@ std::unique_ptr<TxnLogApplier> new_txn_log_applier(const Tablet& tablet, Mutable
 // Internal function exposed for testing - applies tablet metadata from replication operations
 // This function is used internally by TxnLogApplier implementations and exposed only for unit testing
 Status apply_tablet_metadata_from_replication(MutableTabletMetadataPtr metadata,
-                                              const TabletMetadataPB& copied_tablet_meta,
-                                              const RepeatedPtrField<RowsetMetadataPB>& old_rowsets);
+                                              const TabletMetadataPB& copied_tablet_meta);
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/txn_log_applier.h
+++ b/be/src/storage/lake/txn_log_applier.h
@@ -53,4 +53,10 @@ std::unique_ptr<TxnLogApplier> new_txn_log_applier(const Tablet& tablet, Mutable
                                                    int64_t new_version, bool rebuild_pindex,
                                                    bool skip_write_tablet_metadata);
 
+// Internal function exposed for testing - applies tablet metadata from replication operations
+// This function is used internally by TxnLogApplier implementations and exposed only for unit testing
+Status apply_tablet_metadata_from_replication(MutableTabletMetadataPtr metadata,
+                                              const TabletMetadataPB& copied_tablet_meta,
+                                              const RepeatedPtrField<RowsetMetadataPB>& old_rowsets);
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

This is an fix for https://github.com/StarRocks/starrocks/pull/60587.

## What I'm doing:
Fix segment dat file missed after shared-data cluster replication.

```sh
E20260105 09:42:59.283406 139868875081472 scan_operator.cpp:467] scan fragment dd8c869d-e9d7-11f0-b0da-86ac7e2fb6c4 driver 0 Scan tasks error: Not found: load_segments failed tablet:310563 rowset:947 segid:0: starlet err Object oss://sr-c-9bf21f822e4582ad-1767064014093/bdec881f-8f31-4c15-aa7e-e6d7fcb2768b/db11117/13793/310550/data/000000000000091e_a366b174-fce2-450d-ab41-c6057c9a2383.dat does not exist
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes wrong `compaction_inputs` during lake replication by consolidating tablet metadata copy logic and applying it in both PK and non-PK paths.
> 
> - Introduces `apply_tablet_metadata_from_replication` to copy `rowsets`/`dcg_meta`/`sstable_meta`/`delvec_meta`, set `next_rowset_id`/`cumulative_point`, and build `compaction_inputs` excluding ids present in new `rowsets`
> - Refactors replication handling in `txn_log_applier.cpp` (PK and non-PK) to use the helper; PK path also unloads primary index
> - Exposes the helper in `txn_log_applier.h` for unit testing
> - Adds `txn_log_applier_test.cpp` tests covering basic copy, `compaction_inputs` behavior, empty/absent old rowsets, and partial metadata
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d88a436072ffc40c1551e2ca5cf0df60da0e5b0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->