### PR TITLE
[BugFix] Expose READ and ALTER as supported operations for HudiTable/JDBCTable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -370,6 +370,11 @@ public class HudiTable extends Table {
                 Objects.equal(tableIdentifier, otherTable.getTableIdentifier());
     }
 
+    @Override
+    public Set<TableOperation> getSupportedOperations() {
+        return Sets.newHashSet(TableOperation.READ, TableOperation.ALTER);
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Resource.ResourceType;
 import com.starrocks.common.DdlException;
@@ -34,6 +35,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class JDBCTable extends Table {
 
@@ -279,5 +281,10 @@ public class JDBCTable extends Table {
         MARIADB,
 
         CLICKHOUSE
+    }
+
+    @Override
+    public Set<TableOperation> getSupportedOperations() {
+        return Sets.newHashSet(TableOperation.READ, TableOperation.ALTER);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/JDBCTableTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -289,5 +290,12 @@ public class JDBCTableTest {
             System.out.println(e.getMessage());
             Assertions.fail();
         }
+    }
+
+    @Test
+    public void testGetSupportedOperationsWithoutResource() throws Exception {
+        Map<String, String> jdbcProperties = getMockedJDBCProperties("jdbc:mysql://127.0.0.1:3306");
+        JDBCTable table = new JDBCTable(2000, "jdbc_table", columns, "db0", "catalog0", jdbcProperties);
+        Assertions.assertEquals(Set.of(TableOperation.READ, TableOperation.ALTER), table.getSupportedOperations());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Fix https://github.com/StarRocks/StarRocksTest/issues/10831
## What I'm doing:
This pull request adds support for explicitly declaring the supported operations for `HudiTable` and `JDBCTable`, and introduces corresponding unit tests to verify this functionality. The changes improve clarity and maintainability by making the supported operations for these table types explicit and testable.

### Supported Operations Implementation

* Added the `getSupportedOperations` method to both `HudiTable` and `JDBCTable`, returning a set containing `TableOperation.READ` and `TableOperation.ALTER` to explicitly declare which operations are supported by these table types. [[1]](diffhunk://#diff-b17609add53a2180d121ccd9376b5d57dfae47df1dd9f613d2f4acc42174c8cbR373-R377) [[2]](diffhunk://#diff-3ada4fad82ebcfc59982a241b2aaf31b55c5cb06043bdc4d4cb153fd5b8b2762R285-R289)

### Test Coverage

* Added unit tests in `HudiTableTest` and `JDBCTableTest` to verify that `getSupportedOperations` returns the expected set of operations for both table types. [[1]](diffhunk://#diff-2c598151d3a3a4fc5d2c4b193cbf54bf58b631f348f3e3c9aec7e6a4ca7eb0f0R309-R338) [[2]](diffhunk://#diff-4ce75c7297b9de9ab29cd23c12dbecb03b97e978e73ee81e9f61277f82c747c8R294-R300)

### Imports and Type Usage

* Updated imports in affected files to include `Sets` and `Set` for handling supported operations. [[1]](diffhunk://#diff-3ada4fad82ebcfc59982a241b2aaf31b55c5cb06043bdc4d4cb153fd5b8b2762R19) [[2]](diffhunk://#diff-3ada4fad82ebcfc59982a241b2aaf31b55c5cb06043bdc4d4cb153fd5b8b2762R38) [[3]](diffhunk://#diff-2c598151d3a3a4fc5d2c4b193cbf54bf58b631f348f3e3c9aec7e6a4ca7eb0f0R49) [[4]](diffhunk://#diff-2c598151d3a3a4fc5d2c4b193cbf54bf58b631f348f3e3c9aec7e6a4ca7eb0f0R60) [[5]](diffhunk://#diff-4ce75c7297b9de9ab29cd23c12dbecb03b97e978e73ee81e9f61277f82c747c8R36)
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes supported operations explicit and testable for external tables.
> 
> - Adds `getSupportedOperations` to `HudiTable` and `JDBCTable`, returning `{READ, ALTER}`
> - Introduces unit tests in `HudiTableTest` and `JDBCTableTest` validating the returned operation set
> - Updates imports to include `Set`/`Sets` where needed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 357518871fb6abcfdb9537bbb69f2b761ed36286. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->