### PR TITLE
[Enhancement] iceberg table cache mem limit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -69,9 +69,12 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     public static final long DEFAULT_CACHE_NUM = 100000;
     private static final int MEMORY_META_SAMPLES = 10;
     private static final int MEMORY_FILE_SAMPLES = 100;
+    private static final int MEMORY_SNAPSHOT_SIZE = 1536; // approx memory size of one snapshot object without manifests
+    private static final int MEMORY_MANIFEST_SIZE = 512; // approx memory size of one manifest object in snapshot
+    private static final ThreadLocal<ConnectContext> TABLE_LOAD_CONTEXT = new ThreadLocal<>();
     private final String catalogName;
     private final IcebergCatalog delegate;
-    private final com.github.benmanes.caffeine.cache.LoadingCache<IcebergTableCacheKey, Table> tables;
+    private final com.github.benmanes.caffeine.cache.LoadingCache<IcebergTableName, Table> tables;
     private final com.github.benmanes.caffeine.cache.Cache<String, Database> databases;
     private final ExecutorService backgroundExecutor;
 
@@ -90,31 +93,64 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         this.delegate = delegate;
         this.icebergProperties = icebergProperties;
         boolean enableCache = icebergProperties.isEnableIcebergMetadataCache();
-        boolean enableTableCache = icebergProperties.isEnableIcebergTableCache();
-        this.databases = newCacheBuilder(icebergProperties.getIcebergMetaCacheTtlSec(), NEVER_CACHE,
+        long tableCacheSize = Math.round(Runtime.getRuntime().maxMemory() *
+                icebergProperties.getIcebergTableCacheMemoryUsageRatio());
+        this.databases = newCacheBuilderWithMaximumSize(
+                icebergProperties.getIcebergMetaCacheTtlSec(),
+                NEVER_CACHE,
                 enableCache ? DEFAULT_CACHE_NUM : NEVER_CACHE).build();
         this.tables = newCacheBuilder(
                 icebergProperties.getIcebergMetaCacheTtlSec(),
-                icebergProperties.getIcebergTableCacheRefreshIntervalSec(),
-                enableTableCache ? DEFAULT_CACHE_NUM : NEVER_CACHE)
+                icebergProperties.getIcebergTableCacheRefreshIntervalSec())
                 .executor(executorService)
-                .removalListener((IcebergTableCacheKey key, Table value, RemovalCause cause) -> {
+                .maximumWeight(tableCacheSize)
+                .weigher((Weigher<IcebergTableName, Table>) (IcebergTableName key, Table table) -> {
+                    long size = SizeEstimator.estimate(key);
+                    if (table != null) {
+                        size += 1L * countSnapshotsSafe(table) * MEMORY_SNAPSHOT_SIZE;
+                        if (((BaseTable) table).operations().current().currentSnapshot() != null) {
+                            size += 1L * (((BaseTable) table).operations().current().currentSnapshot()
+                                    .allManifests(((BaseTable) table).operations().io()).size() * MEMORY_MANIFEST_SIZE);
+                        }
+                    }
+                    return (size > Integer.MAX_VALUE) ? Integer.MAX_VALUE : (int) size;
+                })
+                .removalListener((IcebergTableName key, Table value, RemovalCause cause) -> {
                     if (key != null) {
                         LOG.debug("iceberg table cache removal: {}.{}, cause={}, evicted={}",
-                                key.icebergTableName.dbName, key.icebergTableName.tableName,
+                                key.dbName, key.tableName,
                                 cause, cause.wasEvicted());
                     }
                 })
-                .build(new com.github.benmanes.caffeine.cache.CacheLoader<IcebergTableCacheKey, Table>() {
+                .build(new com.github.benmanes.caffeine.cache.CacheLoader<IcebergTableName, Table>() {
                     @Override
-                    public Table load(IcebergTableCacheKey key) throws Exception {
+                    public Table load(IcebergTableName key) throws Exception {
                         LOG.debug("Loading iceberg table {}.{} from remote catalog",
-                                key.icebergTableName.dbName, key.icebergTableName.tableName);
-                        return delegate.getTable(key.connectContext, key.icebergTableName.dbName,
-                                key.icebergTableName.tableName);
+                                key.dbName, key.tableName);
+                        ConnectContext context = TABLE_LOAD_CONTEXT.get();
+                        return delegate.getTable(context != null ? context : new ConnectContext(),
+                                key.dbName, key.tableName);
+                    }
+
+                    @Override
+                    public Table reload(IcebergTableName key, Table oldValue) {
+                        try {
+                            BaseTable updateTable = 
+                                    (BaseTable) delegate.getTable(new ConnectContext(), key.dbName, key.tableName);
+                            TableOperations newOps = updateTable.operations();
+                            TableOperations oldOps = ((BaseTable) oldValue).operations();
+                            if (oldOps.current().metadataFileLocation().equals(newOps.current().metadataFileLocation())) {
+                                return oldValue;
+                            }
+                            return updateTable;
+                        } catch (Exception e) {
+                            LOG.warn("refresh table {}.{} failed", key.dbName, key.tableName, e);
+                            return oldValue;
+                        }
                     }
                 });
-        this.partitionCache = newCacheBuilder(icebergProperties.getIcebergMetaCacheTtlSec(), NEVER_CACHE,
+        this.partitionCache = newCacheBuilderWithMaximumSize(
+                icebergProperties.getIcebergMetaCacheTtlSec(), NEVER_CACHE,
                 enableCache ? DEFAULT_CACHE_NUM : NEVER_CACHE).build(
                     new com.github.benmanes.caffeine.cache.CacheLoader<IcebergTableName, Map<String, Partition>>() {
                         @Override
@@ -226,9 +262,9 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         if (!cacheAllowed) {
             return delegate.getTable(connectContext, dbName, tableName);
         }
-        IcebergTableCacheKey key = new IcebergTableCacheKey(icebergTableName, connectContext);
         try {
-            return tables.get(key);
+            TABLE_LOAD_CONTEXT.set(connectContext);
+            return tables.get(icebergTableName);
         } catch (NoSuchTableException e) {
             throw e;
         } catch (Exception e) {
@@ -236,6 +272,8 @@ public class CachingIcebergCatalog implements IcebergCatalog {
             String errMsg = ce != null ? ce.getMessage() : e.getMessage();
             throw new StarRocksConnectorException(String.format("Failed to get iceberg table %s.%s.%s. %s",
                     catalogName, dbName, tableName, errMsg), e);
+        } finally {
+            TABLE_LOAD_CONTEXT.remove();
         }
     }
 
@@ -334,8 +372,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     @Override
     public synchronized void refreshTable(String dbName, String tableName, ConnectContext ctx, ExecutorService executorService) {
         IcebergTableName icebergTableName = new IcebergTableName(dbName, tableName);
-        IcebergTableCacheKey key = new IcebergTableCacheKey(icebergTableName, ctx);
-        Table cachedTable = tables.getIfPresent(key);
+        Table cachedTable = tables.getIfPresent(icebergTableName);
         if (cachedTable == null) {
             partitionCache.invalidate(icebergTableName);
         } else {
@@ -381,7 +418,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         long updatedSnapshotId = updatedTable.currentSnapshot().snapshotId();
         IcebergTableName baseIcebergTableName = new IcebergTableName(dbName, tableName, baseSnapshotId);
         IcebergTableName updatedIcebergTableName = new IcebergTableName(dbName, tableName, updatedSnapshotId);
-        IcebergTableCacheKey keyWithoutSnap = new IcebergTableCacheKey(new IcebergTableName(dbName, tableName), ctx);
+        IcebergTableName keyWithoutSnap = new IcebergTableName(dbName, tableName);
         long latestRefreshTime = tableLatestRefreshTime.computeIfAbsent(new IcebergTableName(dbName, tableName), ignore -> -1L);
 
         // update tables before refresh partition cache
@@ -420,22 +457,21 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     public void refreshCatalog() {
-        List<IcebergTableCacheKey> identifiers = Lists.newArrayList(tables.asMap().keySet());
-        for (IcebergTableCacheKey identifier : identifiers) {
+        List<IcebergTableName> identifiers = Lists.newArrayList(tables.asMap().keySet());
+        for (IcebergTableName identifier : identifiers) {
             try {
-                Long latestAccessTime = tableLatestAccessTime.get(identifier.icebergTableName);
+                Long latestAccessTime = tableLatestAccessTime.get(identifier);
                 if (latestAccessTime == null || (System.currentTimeMillis() - latestAccessTime) / 1000 >
                         Config.background_refresh_metadata_time_secs_since_last_access_secs) {
-                    invalidateCache(identifier.icebergTableName);
+                    invalidateCache(identifier);
                     continue;
                 }
 
-                refreshTable(identifier.icebergTableName.dbName, identifier.icebergTableName.tableName, 
-                        identifier.connectContext, backgroundExecutor);
+                refreshTable(identifier.dbName, identifier.tableName, new ConnectContext(), backgroundExecutor);
             } catch (Exception e) {
-                LOG.warn("refresh {}.{} metadata cache failed, msg : ", identifier.icebergTableName.dbName, 
-                        identifier.icebergTableName.tableName, e);
-                invalidateCache(identifier.icebergTableName);
+                LOG.warn("refresh {}.{} metadata cache failed, msg : ", identifier.dbName,
+                        identifier.tableName, e);
+                invalidateCache(identifier);
             }
         }
     }
@@ -450,7 +486,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     @Override
     public void invalidateTableCache(String dbName, String tableName) {
         IcebergTableName key = new IcebergTableName(dbName, tableName);
-        tables.invalidate(new IcebergTableCacheKey(key, new ConnectContext()));
+        tables.invalidate(key);
     }
 
     @Override
@@ -460,7 +496,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     private void invalidateCache(IcebergTableName key) {
-        tables.invalidate(new IcebergTableCacheKey(key, new ConnectContext()));
+        tables.invalidate(key);
         // will invalidate all snapshots of this table
         partitionCache.invalidate(key);
         tableLatestAccessTime.remove(key);
@@ -485,8 +521,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         return delegate.getTableScan(table, scanContext);
     }
 
-    private Caffeine<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long refreshInterval,
-                                                         long maximumSize) {
+    private Caffeine<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long refreshInterval) {
         Caffeine<Object, Object> cacheBuilder = Caffeine.newBuilder();
         if (expiresAfterWriteSec >= 0) {
             cacheBuilder.expireAfterWrite(expiresAfterWriteSec, SECONDS);
@@ -496,8 +531,12 @@ public class CachingIcebergCatalog implements IcebergCatalog {
             cacheBuilder.refreshAfterWrite(refreshInterval, SECONDS);
         }
 
-        cacheBuilder.maximumSize(maximumSize);
         return cacheBuilder;
+    }
+
+    private Caffeine<Object, Object> newCacheBuilderWithMaximumSize(long expiresAfterWriteSec, long refreshInterval,
+                                                                    long maximumSize) {
+        return newCacheBuilder(expiresAfterWriteSec, refreshInterval).maximumSize(maximumSize);
     }
 
     public static class IcebergTableName {
@@ -545,33 +584,6 @@ public class CachingIcebergCatalog implements IcebergCatalog {
             sb.append(", tableName='").append(tableName).append('\'');
             sb.append('}');
             return sb.toString();
-        }
-    }
-
-    public static class IcebergTableCacheKey {
-        IcebergTableName icebergTableName;
-        ConnectContext connectContext;
-
-        IcebergTableCacheKey(IcebergTableName icebergTableName, ConnectContext connectContext) {
-            this.icebergTableName = icebergTableName;
-            this.connectContext = connectContext;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null || getClass() != obj.getClass()) {
-                return false;
-            }
-            IcebergTableCacheKey that = (IcebergTableCacheKey) obj;
-            return icebergTableName.equals(that.icebergTableName);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(icebergTableName);
         }
     }
 
@@ -632,6 +644,10 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         List<List<String>> partitionNames = getAllCachedPartitionNames();
         counter.put("Database", databases.estimatedSize());
         counter.put("Table", tables.estimatedSize());
+        counter.put("TableSnapshot", tables.asMap().values()
+                .stream()
+                .mapToLong(this::countSnapshotsSafe)
+                .sum());
         counter.put("PartitionNames", partitionNames
                 .stream()
                 .mapToLong(List::size)
@@ -645,5 +661,17 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                 .mapToLong(Set::size)
                 .sum());
         return counter;
+    }
+
+    private long countSnapshotsSafe(Table table) {
+        if (!(table instanceof BaseTable)) {
+            return 0;
+        }
+        BaseTable baseTable = (BaseTable) table;
+        TableOperations ops = baseTable.operations();
+        if (ops == null || ops.current() == null || ops.current().snapshots() == null) {
+            return 0;
+        }
+        return ops.current().snapshots().size();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogProperties.java
@@ -43,6 +43,7 @@ public class IcebergCatalogProperties {
     public static final String ICEBERG_MANIFEST_CACHE_MAX_NUM = "iceberg_manifest_cache_max_num";
     public static final String ICEBERG_DATA_FILE_CACHE_MEMORY_SIZE_RATIO = "iceberg_data_file_cache_memory_usage_ratio";
     public static final String ICEBERG_DELETE_FILE_CACHE_MEMORY_SIZE_RATIO = "iceberg_delete_file_cache_memory_usage_ratio";
+    public static final String ICEBERG_TABLE_CACHE_MEMORY_SIZE_RATIO = "iceberg_table_cache_memory_usage_ratio";
 
     // internal config
     public static final String ICEBERG_TABLE_CACHE_TTL = "iceberg_table_cache_ttl_sec";
@@ -68,6 +69,7 @@ public class IcebergCatalogProperties {
     private boolean enableCacheDataFileIdentifierColumnStatistics;
     private double icebergDataFileCacheMemoryUsageRatio;
     private double icebergDeleteFileCacheMemoryUsageRatio;
+    private double icebergTableCacheMemoryUsageRatio;
     private long icebergTableCacheRefreshIntervalSec;
 
     public IcebergCatalogProperties(Map<String, String> catalogProperties) {
@@ -107,6 +109,8 @@ public class IcebergCatalogProperties {
                     properties, ICEBERG_DATA_FILE_CACHE_MEMORY_SIZE_RATIO, 0.1);
         this.icebergDeleteFileCacheMemoryUsageRatio = PropertyUtil.propertyAsDouble(
                     properties, ICEBERG_DELETE_FILE_CACHE_MEMORY_SIZE_RATIO, 0.1);
+        this.icebergTableCacheMemoryUsageRatio = PropertyUtil.propertyAsDouble(
+                    properties, ICEBERG_TABLE_CACHE_MEMORY_SIZE_RATIO, 0.1);
         this.icebergManifestCacheWithColumnStatistics = PropertyUtil.propertyAsBoolean(
                 properties, ICEBERG_MANIFEST_CACHE_WITH_COLUMN_STATISTICS, true);
         this.refreshIcebergManifestMinLength = PropertyUtil.propertyAsLong(properties, REFRESH_ICEBERG_MANIFEST_MIN_LENGTH,
@@ -182,6 +186,10 @@ public class IcebergCatalogProperties {
 
     public double getIcebergDeleteFileCacheMemoryUsageRatio() {
         return icebergDeleteFileCacheMemoryUsageRatio;
+    }
+
+    public double getIcebergTableCacheMemoryUsageRatio() {
+        return icebergTableCacheMemoryUsageRatio;
     }
 
     public long getRefreshIcebergManifestMinLength() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -22,7 +22,6 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.exception.StarRocksConnectorException;
-import com.starrocks.connector.iceberg.CachingIcebergCatalog.IcebergTableCacheKey;
 import com.starrocks.connector.iceberg.CachingIcebergCatalog.IcebergTableName;
 import com.starrocks.connector.iceberg.rest.IcebergRESTCatalog;
 import com.starrocks.qe.ConnectContext;
@@ -33,6 +32,7 @@ import mockit.Expectations;
 import mockit.Mocked;
 import mockit.Verifications;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
@@ -43,9 +43,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
@@ -98,18 +101,22 @@ public class CachingIcebergCatalogTest {
     }
 
     @Test
-    public void testListPartitionNames(@Mocked IcebergCatalog icebergCatalog, @Mocked Table nativeTable) {
+    public void testListPartitionNames(@Mocked IcebergCatalog icebergCatalog) {
+        PartitionSpec spec = Mockito.mock(PartitionSpec.class);
+        Mockito.when(spec.isUnpartitioned()).thenReturn(false);
+        Table nativeTable = createBaseTableWithManifests(1, 0, spec);
         new Expectations() {
             {
-                nativeTable.spec().isUnpartitioned();
-                result = false;
+                icebergCatalog.getTable((ConnectContext) any, "db", "test");
+                result = nativeTable;
                 minTimes = 0;
             }
         };
         CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, icebergCatalog,
                 DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
         IcebergTable table =
-                IcebergTable.builder().setCatalogDBName("db").setCatalogTableName("test").setNativeTable(nativeTable).build();
+                IcebergTable.builder().setSrTableName("test_sr")
+                .setCatalogDBName("db").setCatalogTableName("test").setNativeTable(nativeTable).build();
 
         Assertions.assertFalse(nativeTable.spec().isUnpartitioned());
         {
@@ -146,7 +153,8 @@ public class CachingIcebergCatalogTest {
     }
 
     @Test
-    public void testGetTable(@Mocked IcebergCatalog icebergCatalog, @Mocked Table nativeTable) {
+    public void testGetTable(@Mocked IcebergCatalog icebergCatalog) {
+        Table nativeTable = createBaseTableWithManifests(1, 1);
         new Expectations() {
             {
                 icebergCatalog.getTable(connectContext, "test", "table");
@@ -163,7 +171,7 @@ public class CachingIcebergCatalogTest {
     }
 
     @Test
-    public void testGetTableIOError(@Mocked IcebergCatalog icebergCatalog, @Mocked Table nativeTable) {
+    public void testGetTableIOError(@Mocked IcebergCatalog icebergCatalog) {
         new Expectations() {
             {
                 icebergCatalog.getTable(connectContext, "test", "table");
@@ -181,7 +189,82 @@ public class CachingIcebergCatalogTest {
     }
 
     @Test
-    public void testInvalidateCache(@Mocked IcebergCatalog icebergCatalog, @Mocked Table nativeTable) {
+    public void testTableWeigherUsesSnapshotsAndManifests() {
+        IcebergCatalog delegate = Mockito.mock(IcebergCatalog.class);
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            CachingIcebergCatalog catalog =
+                    new CachingIcebergCatalog(CATALOG_NAME, delegate, DEFAULT_CATALOG_PROPERTIES, executorService);
+
+            LoadingCache<IcebergTableName, Table> tables = Deencapsulation.getField(catalog, "tables");
+            com.github.benmanes.caffeine.cache.Policy.Eviction<IcebergTableName, Table> eviction =
+                    tables.policy().eviction().orElseThrow(() -> new AssertionError("eviction should be present"));
+
+            IcebergTableName key = new IcebergTableName("db", "tbl");
+            Table lightTable = createBaseTableWithManifests(1, 2);
+            Table heavyTable = createBaseTableWithManifests(3, 5);
+
+            tables.put(key, lightTable);
+            OptionalInt weightLight = eviction.weightOf(key);
+            tables.put(key, heavyTable);
+            OptionalInt weightHeavy = eviction.weightOf(key);
+
+            int snapshotSize = getStaticIntField("MEMORY_SNAPSHOT_SIZE");
+            int manifestSize = getStaticIntField("MEMORY_MANIFEST_SIZE");
+            int expectedDiff = (3 - 1) * snapshotSize + (5 - 2) * manifestSize;
+
+            Assertions.assertTrue(weightLight.isPresent() && weightHeavy.isPresent());
+            Assertions.assertTrue(weightHeavy.getAsInt() > weightLight.getAsInt());
+            Assertions.assertEquals(expectedDiff, weightHeavy.getAsInt() - weightLight.getAsInt());
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    private int getStaticIntField(String fieldName) {
+        try {
+            java.lang.reflect.Field f = CachingIcebergCatalog.class.getDeclaredField(fieldName);
+            f.setAccessible(true);
+            return f.getInt(null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Table createBaseTableWithManifests(int snapshotCount, int manifestCount) {
+        return createBaseTableWithManifests(snapshotCount, manifestCount, null);
+    }
+
+    private Table createBaseTableWithManifests(int snapshotCount, int manifestCount, PartitionSpec spec) {
+        TableOperations ops = Mockito.mock(TableOperations.class);
+        TableMetadata meta = Mockito.mock(TableMetadata.class);
+        Snapshot currentSnapshot = Mockito.mock(Snapshot.class);
+
+        List<Snapshot> snapshots = new ArrayList<>();
+        for (int i = 0; i < snapshotCount; i++) {
+            snapshots.add(Mockito.mock(Snapshot.class));
+        }
+        List<ManifestFile> manifests = new ArrayList<>();
+        for (int i = 0; i < manifestCount; i++) {
+            manifests.add(Mockito.mock(ManifestFile.class));
+        }
+        String uuid = UUID.randomUUID().toString();
+        Mockito.when(ops.current()).thenReturn(meta);
+        Mockito.when(meta.snapshots()).thenReturn(snapshots);
+        Mockito.when(meta.currentSnapshot()).thenReturn(currentSnapshot);
+        Mockito.when(meta.metadataFileLocation()).thenReturn("metadata-" + uuid);
+        Mockito.when(meta.uuid()).thenReturn(uuid);
+        if (spec != null) {
+            Mockito.when(meta.spec()).thenReturn(spec);
+        }
+        Mockito.when(currentSnapshot.allManifests(Mockito.any())).thenReturn(manifests);
+
+        return new BaseTable(ops, "db.tbl");
+    }
+
+    @Test
+    public void testInvalidateCache(@Mocked IcebergCatalog icebergCatalog) {
+        Table nativeTable = createBaseTableWithManifests(1, 1);
         new Expectations() {
             {
                 icebergCatalog.getTable(connectContext, "db1", "tbl1");
@@ -208,8 +291,8 @@ public class CachingIcebergCatalogTest {
     @Test
     public void testTableCacheEnabled_hitsDelegateOnce(@Mocked IcebergCatalog delegate,
                                                        @Mocked IcebergCatalogProperties props,
-                                                       @Mocked ConnectContext ctx,
-                                                       @Mocked org.apache.iceberg.Table nativeTable) throws Exception {
+                                                       @Mocked ConnectContext ctx) throws Exception {
+        Table nativeTable = createBaseTableWithManifests(1, 1);
         new Expectations() {
             {
                 props.isEnableIcebergMetadataCache(); 
@@ -222,6 +305,8 @@ public class CachingIcebergCatalogTest {
                 result = 0.0;
                 props.getIcebergDeleteFileCacheMemoryUsageRatio(); 
                 result = 0.0;
+                props.getIcebergTableCacheMemoryUsageRatio();
+                result = 1;
 
                 delegate.getTable(ctx, "db1", "t1"); 
                 result = nativeTable; 
@@ -253,9 +338,9 @@ public class CachingIcebergCatalogTest {
     @Test
     public void testTableCacheDisabled_hitsDelegateTwice(@Mocked IcebergCatalog delegate,
                                                          @Mocked IcebergCatalogProperties props,
-                                                         @Mocked ConnectContext ctx,
-                                                         @Mocked org.apache.iceberg.Table nativeTable1,
-                                                         @Mocked org.apache.iceberg.Table nativeTable2) throws Exception {
+                                                         @Mocked ConnectContext ctx) throws Exception {
+        Table nativeTable1 = createBaseTableWithManifests(1, 1);
+        Table nativeTable2 = createBaseTableWithManifests(1, 1);
         new Expectations() {
             {
                 props.isEnableIcebergMetadataCache(); 
@@ -295,7 +380,8 @@ public class CachingIcebergCatalogTest {
     }
 
     @Test
-    public void testEstimateCountReflectsTableCache(@Mocked IcebergCatalog icebergCatalog, @Mocked Table nativeTable) {
+    public void testEstimateCountReflectsTableCache(@Mocked IcebergCatalog icebergCatalog) {
+        Table nativeTable = createBaseTableWithManifests(1, 1);
         new Expectations() {
             {
                 icebergCatalog.getTable(connectContext, "db2", "tbl2");
@@ -311,10 +397,10 @@ public class CachingIcebergCatalogTest {
     }
 
     @Test
-    public void testGetTableBypassCacheForRestCatalogWhenAuthToken(@Mocked IcebergRESTCatalog restCatalog,
-                                                                   @Mocked Table nativeTable) {
+    public void testGetTableBypassCacheForRestCatalogWhenAuthToken(@Mocked IcebergRESTCatalog restCatalog) {
         ConnectContext ctx = new ConnectContext();
         ctx.setAuthToken("token");
+        Table nativeTable = createBaseTableWithManifests(1, 1);
         new Expectations() {
             {
                 restCatalog.getTable(ctx, "db3", "tbl3");
@@ -363,7 +449,7 @@ public class CachingIcebergCatalogTest {
                 delegate.getPartitions((IcebergTable) any, anyLong, null);
                 result = new HashMap<String, Partition>();
 
-                delegate.getTable(ctx, anyString, anyString);
+                delegate.getTable((ConnectContext) any, anyString, anyString);
                 result = new Delegate<Table>() {
                     AtomicLong counter = new AtomicLong();
 
@@ -413,6 +499,7 @@ public class CachingIcebergCatalogTest {
         config.put(IcebergCatalogProperties.ICEBERG_TABLE_CACHE_REFRESH_INVERVAL_SEC, "5");
         config.put(IcebergCatalogProperties.ICEBERG_META_CACHE_TTL, "30");
         config.put(IcebergCatalogProperties.ICEBERG_CATALOG_TYPE, "hive");
+        config.put(IcebergCatalogProperties.ICEBERG_TABLE_CACHE_MEMORY_SIZE_RATIO, "1");
         IcebergCatalogProperties icebergProperties = new IcebergCatalogProperties(config);
         ExecutorService exectorCatalog = Executors.newSingleThreadExecutor();
         ExecutorService exector = Executors.newSingleThreadExecutor();
@@ -420,7 +507,7 @@ public class CachingIcebergCatalogTest {
 
         CachingIcebergCatalog catalog = new CachingIcebergCatalog("test_catalog", delegate, icebergProperties, exectorCatalog);
         //Guava cache will cause bug here, now we try the caffeine
-        LoadingCache<IcebergTableCacheKey, Table> tables = Deencapsulation.getField(catalog, "tables");
+        LoadingCache<IcebergTableName, Table> tables = Deencapsulation.getField(catalog, "tables");
         Table tmp1 = delegate.getTable(ctx, dbName, tblName);
         Table tmp2 = delegate.getTable(ctx, dbName, tblName);
         Table tmp3 = delegate.getTable(ctx, dbName, tblName);
@@ -442,21 +529,21 @@ public class CachingIcebergCatalogTest {
         System.out.println("[main] begin put key val begin snap 3");
         // try to mock the concurrency in async load and put here, usually between refresh table and get table.
         // here may be break the cache
-        tables.put(new IcebergTableCacheKey(new IcebergTableName(dbName, tblName, 3L), ctx), tmp3);
+        tables.put(new IcebergTableName(dbName, tblName, 3L), tmp3);
         System.out.println("[main] finish put key val begin snap 3");
         System.out.println("[main] first get key val res:" + ((BaseTable) t1).currentSnapshot().snapshotId());
         try {
             Thread.sleep(10100);
         } catch (InterruptedException ie) {
         }
-        tables.invalidate(new IcebergTableCacheKey(new IcebergTableName(dbName, tblName), ctx));
-        tables.invalidate(new IcebergTableCacheKey(new IcebergTableName(dbName, tblName), ctx));
-        tables.invalidate(new IcebergTableCacheKey(new IcebergTableName(dbName, tblName), ctx));
-        tables.invalidate(new IcebergTableCacheKey(new IcebergTableName(dbName, tblName), ctx));
+        tables.invalidate(new IcebergTableName(dbName, tblName));
+        tables.invalidate(new IcebergTableName(dbName, tblName));
+        tables.invalidate(new IcebergTableName(dbName, tblName));
+        tables.invalidate(new IcebergTableName(dbName, tblName));
         Table t2 = catalog.getTable(ctx, dbName, tblName);
         System.out.println("Table SnapshotId:" + String.valueOf(((BaseTable) t2).currentSnapshot().snapshotId()) +
                 " should found in cache if present:" + 
-                tables.getIfPresent(new IcebergTableCacheKey(new IcebergTableName(dbName, tblName), ctx)));
+                tables.getIfPresent(new IcebergTableName(dbName, tblName)));
 
         try {
             Thread.sleep(1100);
@@ -466,17 +553,17 @@ public class CachingIcebergCatalogTest {
         Table t3 = catalog.getTable(ctx, dbName, tblName);
         System.out.println("Table SnapshotId:" + String.valueOf(((BaseTable) t3).currentSnapshot().snapshotId()) +
                 " should found in cache if present:" + 
-                tables.getIfPresent(new IcebergTableCacheKey(new IcebergTableName(dbName, tblName), ctx)));
+                tables.getIfPresent(new IcebergTableName(dbName, tblName)));
 
         catalog.refreshTable(dbName, tblName, ctx, null);
 
         Table t4 = catalog.getTable(ctx, dbName, tblName);
         System.out.println("Table SnapshotId:" + String.valueOf(((BaseTable) t4).currentSnapshot().snapshotId()) +
                 " should found in cache if present:" + 
-                tables.getIfPresent(new IcebergTableCacheKey(new IcebergTableName(dbName, tblName), ctx)));
+                tables.getIfPresent(new IcebergTableName(dbName, tblName)));
 
         Assertions.assertTrue(t4.currentSnapshot().snapshotId() > t3.currentSnapshot().snapshotId());   
-        Assertions.assertNotNull(tables.getIfPresent(new IcebergTableCacheKey(new IcebergTableName(dbName, tblName), ctx)));
+        Assertions.assertNotNull(tables.getIfPresent(new IcebergTableName(dbName, tblName)));
     }
 
     @Test
@@ -490,7 +577,7 @@ public class CachingIcebergCatalogTest {
                 delegate.getPartitions((IcebergTable) any, anyLong, null);
                 result = new HashMap<String, Partition>();
 
-                delegate.getTable(ctx, anyString, anyString);
+                delegate.getTable((ConnectContext) any, anyString, anyString);
                 result = new Delegate<Table>() {
                     AtomicLong counter = new AtomicLong();
 
@@ -540,6 +627,7 @@ public class CachingIcebergCatalogTest {
         config.put(IcebergCatalogProperties.ICEBERG_TABLE_CACHE_REFRESH_INVERVAL_SEC, "2");
         config.put(IcebergCatalogProperties.ICEBERG_META_CACHE_TTL, "6");
         config.put(IcebergCatalogProperties.ICEBERG_CATALOG_TYPE, "hive");
+        config.put(IcebergCatalogProperties.ICEBERG_TABLE_CACHE_MEMORY_SIZE_RATIO, "1");
         IcebergCatalogProperties icebergProperties = new IcebergCatalogProperties(config);
         ExecutorService exectorCatalog = Executors.newSingleThreadExecutor();
         ExecutorService exector = Executors.newSingleThreadExecutor();
@@ -547,7 +635,7 @@ public class CachingIcebergCatalogTest {
 
         CachingIcebergCatalog catalog = new CachingIcebergCatalog("test_catalog", delegate, icebergProperties, exectorCatalog);
 
-        LoadingCache<IcebergTableCacheKey, Table> tables = Deencapsulation.getField(catalog, "tables");
+        LoadingCache<IcebergTableName, Table> tables = Deencapsulation.getField(catalog, "tables");
         Table tmp1 = delegate.getTable(ctx, dbName, tblName);
         Table tmp2 = delegate.getTable(ctx, dbName, tblName);
         Table tmp3 = delegate.getTable(ctx, dbName, tblName);
@@ -589,7 +677,7 @@ public class CachingIcebergCatalogTest {
         Table t2 = catalog.getTable(ctx, dbName, tblName);
         System.out.println("Table SnapshotId:" + String.valueOf(((BaseTable) t2).currentSnapshot().snapshotId()) +
                 " should found in cache if present:" + 
-                tables.getIfPresent(new IcebergTableCacheKey(new IcebergTableName(dbName, tblName), ctx)));
+                tables.getIfPresent(new IcebergTableName(dbName, tblName)));
 
         try {
             Thread.sleep(1100);
@@ -599,17 +687,93 @@ public class CachingIcebergCatalogTest {
         Table t3 = catalog.getTable(ctx, dbName, tblName);
         System.out.println("Table SnapshotId:" + String.valueOf(((BaseTable) t3).currentSnapshot().snapshotId()) +
                 " should found in cache if present:" + 
-                tables.getIfPresent(new IcebergTableCacheKey(new IcebergTableName(dbName, tblName), ctx)));
+                tables.getIfPresent(new IcebergTableName(dbName, tblName)));
 
         catalog.refreshTable(dbName, tblName, ctx, null);
 
         Table t4 = catalog.getTable(ctx, dbName, tblName);
         System.out.println("Table SnapshotId:" + String.valueOf(((BaseTable) t4).currentSnapshot().snapshotId()) +
                 " should found in cache if present:" + 
-                tables.getIfPresent(new IcebergTableCacheKey(new IcebergTableName(dbName, tblName), ctx)));
+                tables.getIfPresent(new IcebergTableName(dbName, tblName)));
 
         Assertions.assertTrue(t4.currentSnapshot().snapshotId() > t3.currentSnapshot().snapshotId());   
-        Assertions.assertNotNull(tables.getIfPresent(new IcebergTableCacheKey(new IcebergTableName(dbName, tblName), ctx)));
+        Assertions.assertNotNull(tables.getIfPresent(new IcebergTableName(dbName, tblName)));
+    }
+
+    @Test
+    public void testReloadIsAsync(@Mocked IcebergCatalog delegate,
+                                  @Mocked IcebergCatalogProperties props,
+                                  @Mocked ConnectContext ctx) throws Exception {
+        System.out.println("===== test reload async =====");
+        Table nativeTable1 = createBaseTableWithManifests(1, 1);
+        Table nativeTable2 = createBaseTableWithManifests(2, 2);
+        Mockito.when(((BaseTable) nativeTable1).operations().current().metadataFileLocation()).thenReturn("loc1");
+        Mockito.when(((BaseTable) nativeTable2).operations().current().metadataFileLocation()).thenReturn("loc2");
+
+        AtomicLong callCount = new AtomicLong(0);
+
+        new Expectations() {
+            {
+                props.isEnableIcebergMetadataCache();
+                result = true;
+                props.isEnableIcebergTableCache();
+                result = true;
+                props.getIcebergMetaCacheTtlSec();
+                result = 60L;
+                props.getIcebergTableCacheRefreshIntervalSec();
+                result = 1L;
+                props.getIcebergTableCacheMemoryUsageRatio();
+                result = 1;
+                props.getIcebergDataFileCacheMemoryUsageRatio();
+                result = 0.0;
+                props.getIcebergDeleteFileCacheMemoryUsageRatio();
+                result = 0.0;
+
+                delegate.getTable((ConnectContext) any, "db1", "t1");
+                result = new Delegate<Table>() {
+                    Table capture(ConnectContext c, String db, String tbl) throws Exception {
+                        if (Thread.currentThread().getName().equals("main")) {
+                            System.out.println("[loader] start Loading iceberg table " + 
+                                    db + "." + tbl + " " + Thread.currentThread().getName());     
+                        } else {
+                            System.out.println("[async reloader] start ReLoading iceberg table " + 
+                                    db + "." + tbl + " " + Thread.currentThread().getName());     
+                        }
+                        long idx = callCount.incrementAndGet();
+                        if (idx == 1) {
+                            return nativeTable1;
+                        }
+                        return nativeTable2;
+                    }
+                };
+            }
+        };
+
+        ExecutorService es = Executors.newSingleThreadExecutor();
+        try {
+            CachingIcebergCatalog catalog =
+                    new CachingIcebergCatalog("iceberg0", delegate, props, es);
+            IcebergTableName key = new IcebergTableName("db1", "t1");
+
+            Table cached = catalog.getTable(ctx, "db1", "t1");
+            Assertions.assertSame(nativeTable1, cached);
+
+            LoadingCache<IcebergTableName, Table> tableCache = Deencapsulation.getField(catalog, "tables");
+
+            Table t1 = tableCache.get(key);
+            Assertions.assertTrue(callCount.get() == 1);
+            Thread.sleep(1100);
+            Table t2 = tableCache.get(key);
+            Assertions.assertSame(t1, nativeTable1, "table should be same yet");
+            Assertions.assertSame(t1, cached, "table should be same yet");
+            Assertions.assertSame(t1, t2, "table should be same yet");
+            Thread.sleep(300);
+            Assertions.assertTrue(callCount.get() == 2, "all count:" + String.valueOf(callCount.get()));
+            Table t3 = tableCache.get(key);
+            Assertions.assertSame(t3, nativeTable2, "table should be new after reload");
+        } finally {
+            es.shutdownNow();
+            System.out.println("===== test reload async end =====");
+        }
     }
 }
-


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. Add mem limit for iceberg table cache to prevent unlimited snapshots.
2. Remove ConnectContext from the table cache key to prevent from holding connections.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a memory-bound cache for Iceberg tables and a config to control its size, with minor cache refactors.
> 
> - Implement weight-based `tables` cache using `maximumWeight` derived from `Runtime.maxMemory * iceberg_table_cache_memory_usage_ratio`; custom weigher estimates key + snapshots/manifests
> - Introduce `ICEBERG_TABLE_CACHE_MEMORY_SIZE_RATIO` property with getter; used to size the table cache
> - Add `reload` for table cache entries to refresh via `refreshTable`, falling back to old value on failure
> - Use shared `DEFAULT_CONTEXT` for cache keys/invalidation and adjust `newCacheBuilder` (remove maximumSize param); explicitly set `maximumSize` for `databases` and `partitionCache`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16d7d81167740b39203cb54fabe694797c8a6f6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->