### PR TITLE
[Enhancement] improve memory tracker and thread pool metrics for load spill merge tasks

### DIFF
--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -94,8 +94,8 @@ Status SpillMemTableSink::merge_blocks_to_segments_parallel(bool do_agg, const S
     std::vector<std::shared_ptr<TabletInternalParallelMergeTask>> tasks;
     for (size_t i = 0; i < spill_block_iterator_tasks.iterators.size(); ++i) {
         tasks.push_back(std::make_shared<TabletInternalParallelMergeTask>(
-                writers[i].get(), spill_block_iterator_tasks.iterators[i].get(), _merge_mem_tracker.get(), schema.get(),
-                i, &quit_flag, get_spiller()->metrics().write_io_timer));
+                writers[i].get(), spill_block_iterator_tasks.iterators[i].get(), schema.get(), i, &quit_flag,
+                get_spiller()->metrics().write_io_timer));
     }
     // 4. Submit all tasks to thread pool
     for (size_t i = 0; i < spill_block_iterator_tasks.iterators.size(); ++i) {

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
@@ -30,16 +30,20 @@
 namespace starrocks::lake {
 
 TabletInternalParallelMergeTask::TabletInternalParallelMergeTask(TabletWriter* writer, ChunkIterator* block_iterator,
-                                                                 MemTracker* merge_mem_tracker, Schema* schema,
-                                                                 int32_t task_index, QuitFlag* quit_flag,
+                                                                 Schema* schema, int32_t task_index,
+                                                                 QuitFlag* quit_flag,
                                                                  RuntimeProfile::Counter* write_io_timer)
         : _writer(writer),
           _block_iterator(block_iterator),
-          _merge_mem_tracker(merge_mem_tracker),
           _schema(schema),
           _task_index(task_index),
           _quit_flag(quit_flag),
-          _write_io_timer(write_io_timer) {}
+          _write_io_timer(write_io_timer) {
+    std::string tracker_label = "LoadSpillMerge-" + std::to_string(writer->tablet_id()) + "-" +
+                                std::to_string(writer->txn_id()) + "-" + std::to_string(task_index);
+    _merge_mem_tracker = std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1, std::move(tracker_label),
+                                                      GlobalEnv::GetInstance()->compaction_mem_tracker());
+}
 
 TabletInternalParallelMergeTask::~TabletInternalParallelMergeTask() {
     if (_block_iterator != nullptr) {
@@ -48,7 +52,7 @@ TabletInternalParallelMergeTask::~TabletInternalParallelMergeTask() {
 }
 
 void TabletInternalParallelMergeTask::run() {
-    SCOPED_THREAD_LOCAL_MEM_SETTER(_merge_mem_tracker, false);
+    SCOPED_THREAD_LOCAL_MEM_SETTER(_merge_mem_tracker.get(), false);
     MonotonicStopWatch timer;
     timer.start();
     auto char_field_indexes = ChunkHelper::get_char_field_indexes(*_schema);

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.h
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.h
@@ -34,9 +34,8 @@ struct QuitFlag {
 
 class TabletInternalParallelMergeTask : public Runnable {
 public:
-    TabletInternalParallelMergeTask(TabletWriter* writer, ChunkIterator* block_iterator, MemTracker* merge_mem_tracker,
-                                    Schema* schema, int32_t task_index, QuitFlag* quit_flag,
-                                    RuntimeProfile::Counter* write_io_timer);
+    TabletInternalParallelMergeTask(TabletWriter* writer, ChunkIterator* block_iterator, Schema* schema,
+                                    int32_t task_index, QuitFlag* quit_flag, RuntimeProfile::Counter* write_io_timer);
 
     ~TabletInternalParallelMergeTask();
 
@@ -51,7 +50,7 @@ public:
 private:
     TabletWriter* _writer = nullptr;
     ChunkIterator* _block_iterator = nullptr;
-    MemTracker* _merge_mem_tracker = nullptr;
+    std::unique_ptr<MemTracker> _merge_mem_tracker;
     Schema* _schema = nullptr;
     int32_t _task_index = 0;
     Status _status;

--- a/be/src/storage/load_chunk_spiller.h
+++ b/be/src/storage/load_chunk_spiller.h
@@ -112,8 +112,6 @@ private:
     spill::SpillerFactoryPtr _spiller_factory;
     std::shared_ptr<spill::Spiller> _spiller;
     SchemaPtr _schema;
-    // used for spill merge, parent trakcer is compaction tracker
-    std::unique_ptr<MemTracker> _merge_mem_tracker = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/storage/load_spill_block_manager.cpp
+++ b/be/src/storage/load_spill_block_manager.cpp
@@ -56,7 +56,6 @@ Status LoadSpillBlockMergeExecutor::init() {
                             .set_max_queue_size(40960 /*a random chosen number that should big enough*/)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(/*5 minutes=*/5 * 60 * 1000))
                             .build(&_tablet_internal_parallel_merge_pool));
-    REGISTER_THREAD_POOL_METRICS(load_spill_block_merge, _merge_pool);
     REGISTER_THREAD_POOL_METRICS(tablet_internal_parallel_merge, _tablet_internal_parallel_merge_pool);
     return Status::OK();
 }

--- a/be/src/storage/load_spill_block_manager.cpp
+++ b/be/src/storage/load_spill_block_manager.cpp
@@ -22,6 +22,7 @@
 #include "fs/fs_util.h"
 #include "fs/key_cache.h"
 #include "runtime/exec_env.h"
+#include "util/starrocks_metrics.h"
 #include "util/threadpool.h"
 
 namespace starrocks {
@@ -55,7 +56,8 @@ Status LoadSpillBlockMergeExecutor::init() {
                             .set_max_queue_size(40960 /*a random chosen number that should big enough*/)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(/*5 minutes=*/5 * 60 * 1000))
                             .build(&_tablet_internal_parallel_merge_pool));
-    // TODO: add metrics
+    REGISTER_THREAD_POOL_METRICS(load_spill_block_merge, _merge_pool);
+    REGISTER_THREAD_POOL_METRICS(tablet_internal_parallel_merge, _tablet_internal_parallel_merge_pool);
     return Status::OK();
 }
 

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -371,7 +371,6 @@ public:
     METRICS_DEFINE_THREAD_POOL(exec_state_report);
     METRICS_DEFINE_THREAD_POOL(priority_exec_state_report);
     METRICS_DEFINE_THREAD_POOL(pip_prepare);
-    METRICS_DEFINE_THREAD_POOL(load_spill_block_merge);
     METRICS_DEFINE_THREAD_POOL(tablet_internal_parallel_merge);
 
     METRIC_DEFINE_UINT_GAUGE(load_rpc_threadpool_size, MetricUnit::NOUNIT);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -371,6 +371,8 @@ public:
     METRICS_DEFINE_THREAD_POOL(exec_state_report);
     METRICS_DEFINE_THREAD_POOL(priority_exec_state_report);
     METRICS_DEFINE_THREAD_POOL(pip_prepare);
+    METRICS_DEFINE_THREAD_POOL(load_spill_block_merge);
+    METRICS_DEFINE_THREAD_POOL(tablet_internal_parallel_merge);
 
     METRIC_DEFINE_UINT_GAUGE(load_rpc_threadpool_size, MetricUnit::NOUNIT);
 


### PR DESCRIPTION
## Why I'm doing:
This PR includes two modifications:
1. Each `TabletInternalParallelMergeTask` maintains an independent mem tracker to ensure 100% memory release after the task is completed.
3. Added monitoring metrics for the load spill block merge thread pool.

## What I'm doing:
This pull request refactors memory tracking and adds thread pool metrics for parallel merge tasks in the lake storage engine. The main improvements are the encapsulation of memory tracker management within `TabletInternalParallelMergeTask`, the removal of redundant memory tracker fields, and the registration of new thread pool metrics to aid in monitoring and debugging.

**Memory management improvements:**

* The `TabletInternalParallelMergeTask` class now manages its own `MemTracker` instance internally using a `std::unique_ptr`, constructing it with a descriptive label and the compaction memory tracker as its parent. The memory tracker is no longer passed in from outside. [[1]](diffhunk://#diff-de19c5c9ee355400914a4704ed011f845946f465b50e7794cc6dd5bb76d45555L33-R46) [[2]](diffhunk://#diff-166e328a1b2c584e4edff83b521e1d0dafc9c34930042abf1dbc19688572fecbL37-R38) [[3]](diffhunk://#diff-166e328a1b2c584e4edff83b521e1d0dafc9c34930042abf1dbc19688572fecbL54-R53)
* The redundant `_merge_mem_tracker` field was removed from `LoadChunkSpiller`, as it is now managed within the parallel merge task.

**Thread pool metrics registration:**

* Thread pool metrics for `load_spill_block_merge` and `tablet_internal_parallel_merge` are now registered in the `LoadSpillBlockMergeExecutor::init` method, and the corresponding metric definitions have been added. This will help with monitoring thread pool usage and diagnosing performance issues. [[1]](diffhunk://#diff-218ca624fd1b60e58fe1a96ac25667bfb30e4162d371710be1929c5bb0dbaff8L58-R60) [[2]](diffhunk://#diff-5f7ae46075bcd4cd9c8cca632f8a0a0ac6fff95f57211a970eaf731648408223R374-R375) [[3]](diffhunk://#diff-218ca624fd1b60e58fe1a96ac25667bfb30e4162d371710be1929c5bb0dbaff8R25)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
