### PR TITLE
[Enhancement] Avoid redundant Statistics map copies for rowCount-only updates

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
@@ -20,7 +20,6 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalCTEAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEProduceOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
-import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 
 import java.util.BitSet;
@@ -125,7 +124,7 @@ public class CTEUtils {
                         .anyMatch(ColumnStatistic::isUnknown)) {
             // Can't evaluated the effect of CTE if don't know statistic,
             // Mark output rows is zero, will choose inline when CTEContext check output rows
-            expr.setStatistics(Statistics.buildFrom(expressionContext.getStatistics()).setOutputRowCount(0).build());
+            expr.setStatistics(expressionContext.getStatistics().withOutputRowCount(0));
         } else {
             expr.setStatistics(expressionContext.getStatistics());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
@@ -42,14 +42,12 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.RuleType;
-import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -376,16 +374,18 @@ public class ReorderJoinRule extends Rule {
                 optExpression.setStatistics(expressionContext.getStatistics());
             }
             Preconditions.checkState(optExpression.getStatistics() != null);
-            Statistics newStats = Statistics.buildFrom(optExpression.getStatistics()).build();
-            Iterator<Map.Entry<ColumnRefOperator, ColumnStatistic>>
-                    iterator = newStats.getColumnStatistics().entrySet().iterator();
-            while (iterator.hasNext()) {
-                Map.Entry<ColumnRefOperator, ColumnStatistic> columnStatistic = iterator.next();
-                if (!newCols.contains(columnStatistic.getKey())) {
-                    iterator.remove();
+            Statistics oldStats = optExpression.getStatistics();
+            Statistics.Builder newStatsBuilder = Statistics.builder()
+                    .setOutputRowCount(oldStats.getOutputRowCount())
+                    .setTableRowCountMayInaccurate(oldStats.isTableRowCountMayInaccurate())
+                    .setShadowColumns(oldStats.getShadowColumns())
+                    .addMultiColumnStatistics(oldStats.getMultiColumnCombinedStats());
+            oldStats.getColumnStatistics().forEach((col, stat) -> {
+                if (newCols.contains(col)) {
+                    newStatsBuilder.addColumnStatistic(col, stat);
                 }
-            }
-
+            });
+            Statistics newStats = newStatsBuilder.build();
             Operator.Builder builder = OperatorBuilderFactory.build(operator);
             Operator newOp = builder.withOperator(operator)
                     .setProjection(new Projection(newOutputProjections))

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitMultiPhaseAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitMultiPhaseAggRule.java
@@ -426,7 +426,7 @@ public class SplitMultiPhaseAggRule extends SplitAggregateRule {
                 for (ColumnStatistic columnStatistic : partitionByColumnStatistics) {
                     rowCount *= columnStatistic.getDistinctValuesCount();
                 }
-                statistics = Statistics.buildFrom(inputStatistics).setOutputRowCount(rowCount).build();
+                statistics = inputStatistics.withOutputRowCount(rowCount);
             }
             double aggOutputRow = StatisticsCalculator.computeGroupByStatistics(partitionByColumns, statistics,
                     Maps.newHashMap());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -64,7 +64,7 @@ public class BinaryPredicateStatisticCalculator {
                     double rowCount = statistics.getOutputRowCount() * columnStatistic.getNullsFraction();
                     return columnRefOperator.map(operator -> Statistics.buildFrom(statistics)
                                     .setOutputRowCount(rowCount).addColumnStatistic(operator, estimatedColumnStatistic).build())
-                            .orElseGet(() -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build());
+                            .orElseGet(() -> statistics.withOutputRowCount(rowCount));
                 } else {
                     return estimateColumnEqualToConstant(columnRefOperator, columnStatistic, constant, statistics);
                 }
@@ -141,7 +141,7 @@ public class BinaryPredicateStatisticCalculator {
 
             return columnRefOperator.map(operator -> Statistics.buildFrom(statistics).setOutputRowCount(rows)
                             .addColumnStatistic(operator, estimatedColumnStatisticBuilder.build()).build())
-                    .orElseGet(() -> Statistics.buildFrom(statistics).setOutputRowCount(rows).build());
+                    .orElseGet(() -> statistics.withOutputRowCount(rows));
         }
     }
 
@@ -216,7 +216,7 @@ public class BinaryPredicateStatisticCalculator {
                     ColumnStatistic.buildFrom(columnStatistic).setNullsFraction(0).build();
             return columnRefOperator.map(operator -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).
                             addColumnStatistic(operator, newEstimateColumnStatistics).build()).
-                    orElseGet(() -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build());
+                    orElseGet(() -> statistics.withOutputRowCount(rowCount));
         } else {
             ColumnStatistic estimatedColumnStatistic = ColumnStatistic.buildFrom(columnStatistic).setNullsFraction(0).build();
             double rowCount = statistics.getOutputRowCount() -
@@ -224,7 +224,7 @@ public class BinaryPredicateStatisticCalculator {
 
             return columnRefOperator.map(operator -> Statistics.buildFrom(statistics)
                             .setOutputRowCount(rowCount).addColumnStatistic(operator, estimatedColumnStatistic).build())
-                    .orElseGet(() -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build());
+                    .orElseGet(() -> statistics.withOutputRowCount(rowCount));
         }
     }
 
@@ -264,7 +264,7 @@ public class BinaryPredicateStatisticCalculator {
 
             return columnRefOperator.map(operator -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).
                             addColumnStatistic(operator, finalNewEstimateColumnStatistics).build()).
-                    orElseGet(() -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build());
+                    orElseGet(() -> statistics.withOutputRowCount(rowCount));
         }
     }
 
@@ -303,7 +303,7 @@ public class BinaryPredicateStatisticCalculator {
                     newEstimateColumnStatistics, constant, statistics, columnRefOperator, false);
             return columnRefOperator.map(operator -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount)
                                     .addColumnStatistic(operator, finalNewEstimateColumnStatistics).build())
-                    .orElseGet(() -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build());
+                    .orElseGet(() -> statistics.withOutputRowCount(rowCount));
         }
     }
 
@@ -363,7 +363,7 @@ public class BinaryPredicateStatisticCalculator {
             case GT:
                 // 0.5 is unknown filter coefficient
                 double rowCount = statistics.getOutputRowCount() * 0.5;
-                return Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build();
+                return statistics.withOutputRowCount(rowCount);
             default:
                 throw new IllegalArgumentException("unknown binary type: " + predicate.getBinaryType());
         }
@@ -610,7 +610,7 @@ public class BinaryPredicateStatisticCalculator {
             rowCount = rowCount * (1.0 - selectivity)
                     * (1 - leftColumn.getNullsFraction()) * (1 - rightColumn.getNullsFraction());
         }
-        return Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build();
+        return statistics.withOutputRowCount(rowCount);
     }
 
     public static Statistics estimatePredicateRange(Optional<ColumnRefOperator> columnRefOperator,
@@ -642,7 +642,7 @@ public class BinaryPredicateStatisticCalculator {
                 build();
         return columnRefOperator.map(operator -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).
                         addColumnStatistic(operator, newEstimateColumnStatistics).build()).
-                orElseGet(() -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build());
+                orElseGet(() -> statistics.withOutputRowCount(rowCount));
     }
 
     public static Optional<Histogram> updateHistWithLessThan(ColumnStatistic columnStatistic,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
@@ -104,7 +104,7 @@ public class PredicateStatisticsCalculator {
             double outputRowCount =
                     statistics.getOutputRowCount() * StatisticsEstimateCoefficient.PREDICATE_UNKNOWN_FILTER_COEFFICIENT;
             return StatisticsEstimateUtils.adjustStatisticsByRowCount(
-                    Statistics.buildFrom(statistics).setOutputRowCount(outputRowCount).build(),
+                    statistics.withOutputRowCount(outputRowCount),
                     outputRowCount);
         }
 
@@ -252,7 +252,7 @@ public class PredicateStatisticsCalculator {
             Statistics inStatistics = childOpt.map(operator ->
                             Statistics.buildFrom(statistics).setOutputRowCount(rowCount).
                                     addColumnStatistic(operator, newInColumnStatistic).build()).
-                    orElseGet(() -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build());
+                    orElseGet(() -> statistics.withOutputRowCount(rowCount));
             return StatisticsEstimateUtils.adjustStatisticsByRowCount(inStatistics, rowCount);
         }
 
@@ -268,7 +268,7 @@ public class PredicateStatisticsCalculator {
                         1 - StatisticsEstimateCoefficient.IS_NULL_PREDICATE_DEFAULT_FILTER_COEFFICIENT :
                         StatisticsEstimateCoefficient.IS_NULL_PREDICATE_DEFAULT_FILTER_COEFFICIENT;
                 double rowCount = statistics.getOutputRowCount() * selectivity;
-                return Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build();
+                return statistics.withOutputRowCount(rowCount);
             }
             ColumnStatistic isNullColumnStatistic = statistics.getColumnStatistic(children.get(0));
             if (isNullColumnStatistic.isUnknown()) {
@@ -357,7 +357,7 @@ public class PredicateStatisticsCalculator {
                 double outputRowCount = statistics.getOutputRowCount() *
                         StatisticsEstimateCoefficient.CONSTANT_TO_CONSTANT_PREDICATE_COEFFICIENT;
                 return StatisticsEstimateUtils.adjustStatisticsByRowCount(
-                        Statistics.buildFrom(statistics).setOutputRowCount(outputRowCount).build(), outputRowCount);
+                        statistics.withOutputRowCount(outputRowCount), outputRowCount);
             }
         }
 
@@ -400,8 +400,7 @@ public class PredicateStatisticsCalculator {
             } else {
                 Statistics inputStatistics = predicate.getChild(0).accept(this, null);
                 double rowCount = Math.max(0, statistics.getOutputRowCount() - inputStatistics.getOutputRowCount());
-                return StatisticsEstimateUtils.adjustStatisticsByRowCount(
-                        Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build(), rowCount);
+                return StatisticsEstimateUtils.adjustStatisticsByRowCount(statistics.withOutputRowCount(rowCount), rowCount);
             }
         }
 
@@ -428,7 +427,7 @@ public class PredicateStatisticsCalculator {
             if (constant.getBoolean()) {
                 return statistics;
             } else {
-                return Statistics.buildFrom(statistics).setOutputRowCount(0.0).build();
+                return statistics.withOutputRowCount(0.0);
             }
         }
 
@@ -532,8 +531,7 @@ public class PredicateStatisticsCalculator {
             } else {
                 Statistics inputStatistics = predicate.getChild(0).accept(this, null);
                 double rowCount = Math.max(0, statistics.getOutputRowCount() - inputStatistics.getOutputRowCount());
-                return StatisticsEstimateUtils.adjustStatisticsByRowCount(
-                        Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build(), rowCount);
+                return StatisticsEstimateUtils.adjustStatisticsByRowCount(statistics.withOutputRowCount(rowCount), rowCount);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
@@ -15,7 +15,6 @@
 package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
@@ -24,6 +23,7 @@ import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -42,16 +42,47 @@ public class Statistics {
 
     private final Map<Set<ColumnRefOperator>, MultiColumnCombinedStats> multiColumnCombinedStats;
 
+    private static double clampOutputRowCount(double outputRowCount) {
+        // Due to the influence of the default filter coefficient,
+        // the number of calculated rows may be less than 1.
+        // The minimum value of rowCount is set to 1, and values less than 1 are meaningless.
+        if (outputRowCount < 1D) {
+            return 1D;
+        } else {
+            return Math.min(outputRowCount, StatisticsEstimateCoefficient.MAXIMUM_ROW_COUNT);
+        }
+    }
+
     private Statistics(Builder builder) {
         this.outputRowCount = builder.outputRowCount;
-        this.columnStatistics = builder.columnStatistics;
+        this.columnStatistics = Collections.unmodifiableMap(builder.columnStatistics);
         this.tableRowCountMayInaccurate = builder.tableRowCountMayInaccurate;
-        this.shadowColumns = builder.shadowColumns;
-        this.multiColumnCombinedStats = builder.multiColumnCombinedStats;
+        this.shadowColumns = Collections.unmodifiableCollection(builder.shadowColumns);
+        this.multiColumnCombinedStats = Collections.unmodifiableMap(builder.multiColumnCombinedStats);
+    }
+
+    private Statistics(double outputRowCount,
+                       Map<ColumnRefOperator, ColumnStatistic> columnStatistics,
+                       boolean tableRowCountMayInaccurate,
+                       Collection<ColumnRefOperator> shadowColumns,
+                       Map<Set<ColumnRefOperator>, MultiColumnCombinedStats> multiColumnCombinedStats) {
+        this.outputRowCount = outputRowCount;
+        this.columnStatistics = Collections.unmodifiableMap(columnStatistics);
+        this.tableRowCountMayInaccurate = tableRowCountMayInaccurate;
+        this.shadowColumns = Collections.unmodifiableCollection(shadowColumns);
+        this.multiColumnCombinedStats = Collections.unmodifiableMap(multiColumnCombinedStats);
     }
 
     public double getOutputRowCount() {
         return outputRowCount;
+    }
+
+    public Statistics withOutputRowCount(double newOutputRowCount) {
+        double clamped = clampOutputRowCount(newOutputRowCount);
+        if (Double.compare(this.outputRowCount, clamped) == 0) {
+            return this;
+        }
+        return new Statistics(clamped, columnStatistics, tableRowCountMayInaccurate, shadowColumns, multiColumnCombinedStats);
     }
 
     public double getOutputSize(ColumnRefSet outputColumns) {
@@ -110,18 +141,12 @@ public class Statistics {
         return columnStatistics;
     }
 
-    public Map<Set<ColumnRefOperator>, MultiColumnCombinedStats> getMultiColumnCombinedStats() {
-        return multiColumnCombinedStats;
+    public Collection<ColumnRefOperator> getShadowColumns() {
+        return shadowColumns;
     }
 
-    public Map<ColumnRefOperator, ColumnStatistic> getOutputColumnsStatistics(ColumnRefSet outputColumns) {
-        Map<ColumnRefOperator, ColumnStatistic> outputColumnsStatistics = Maps.newHashMap();
-        for (Map.Entry<ColumnRefOperator, ColumnStatistic> entry : columnStatistics.entrySet()) {
-            if (outputColumns.contains(entry.getKey().getId())) {
-                outputColumnsStatistics.put(entry.getKey(), entry.getValue());
-            }
-        }
-        return outputColumnsStatistics;
+    public Map<Set<ColumnRefOperator>, MultiColumnCombinedStats> getMultiColumnCombinedStats() {
+        return multiColumnCombinedStats;
     }
 
     public boolean isTableRowCountMayInaccurate() {
@@ -223,36 +248,23 @@ public class Statistics {
         }
 
         private Builder(double outputRowCount, Map<ColumnRefOperator, ColumnStatistic> columnStatistics,
-                        boolean tableRowCountMayInaccurate, Collection<ColumnRefOperator> shadowColumns) {
-            this(outputRowCount, columnStatistics, tableRowCountMayInaccurate, shadowColumns, new HashMap<>());
-        }
-
-        private Builder(double outputRowCount, Map<ColumnRefOperator, ColumnStatistic> columnStatistics,
                         boolean tableRowCountMayInaccurate, Collection<ColumnRefOperator> shadowColumns,
                         Map<Set<ColumnRefOperator>, MultiColumnCombinedStats> multiColumnCombinedStats) {
             this.outputRowCount = outputRowCount;
             this.columnStatistics = new HashMap<>(columnStatistics);
             this.tableRowCountMayInaccurate = tableRowCountMayInaccurate;
             this.shadowColumns = shadowColumns;
-            this.multiColumnCombinedStats = new HashMap<>(multiColumnCombinedStats);
+            this.multiColumnCombinedStats = (multiColumnCombinedStats == null || multiColumnCombinedStats.isEmpty()) ?
+                    new HashMap<>() : new HashMap<>(multiColumnCombinedStats);
         }
 
         private Builder(double outputRowCount, Map<ColumnRefOperator, ColumnStatistic> columnStatistics,
                         boolean tableRowCountMayInaccurate) {
-            this(outputRowCount, columnStatistics, tableRowCountMayInaccurate, Lists.newArrayList());
+            this(outputRowCount, columnStatistics, tableRowCountMayInaccurate, Lists.newArrayList(), new HashMap<>());
         }
 
         public Builder setOutputRowCount(double outputRowCount) {
-            // Due to the influence of the default filter coefficient,
-            // the number of calculated rows may be less than 1.
-            // The minimum value of rowCount is set to 1, and values less than 1 are meaningless.
-            if (outputRowCount < 1D) {
-                this.outputRowCount = 1D;
-            } else if (outputRowCount > StatisticsEstimateCoefficient.MAXIMUM_ROW_COUNT) {
-                this.outputRowCount = StatisticsEstimateCoefficient.MAXIMUM_ROW_COUNT;
-            } else {
-                this.outputRowCount = outputRowCount;
-            }
+            this.outputRowCount = clampOutputRowCount(outputRowCount);
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1247,7 +1247,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
             }
             innerRowCount = innerJoinStats.getOutputRowCount();
         } else {
-            innerJoinStats = Statistics.buildFrom(crossJoinStats).setOutputRowCount(innerRowCount).build();
+            innerJoinStats = crossJoinStats.withOutputRowCount(innerRowCount);
         }
 
         Statistics.Builder joinStatsBuilder;
@@ -1316,25 +1316,19 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         allJoinPredicate.removeAll(eqOnPredicates);
         Statistics estimateStatistics = estimateStatistics(allJoinPredicate, joinStats);
         if (joinType.isLeftOuterJoin()) {
-            estimateStatistics = Statistics.buildFrom(estimateStatistics)
-                    .setOutputRowCount(Math.max(estimateStatistics.getOutputRowCount(), leftRowCount))
-                    .build();
+            estimateStatistics = estimateStatistics.withOutputRowCount(
+                    Math.max(estimateStatistics.getOutputRowCount(), leftRowCount));
         } else if (joinType.isRightOuterJoin()) {
-            estimateStatistics = Statistics.buildFrom(estimateStatistics)
-                    .setOutputRowCount(Math.max(estimateStatistics.getOutputRowCount(), rightRowCount))
-                    .build();
+            estimateStatistics = estimateStatistics.withOutputRowCount(
+                    Math.max(estimateStatistics.getOutputRowCount(), rightRowCount));
         } else if (joinType.isFullOuterJoin()) {
-            estimateStatistics = Statistics.buildFrom(estimateStatistics)
-                    .setOutputRowCount(Math.max(estimateStatistics.getOutputRowCount(), joinStats.getOutputRowCount()))
-                    .build();
+            estimateStatistics = estimateStatistics.withOutputRowCount(
+                    Math.max(estimateStatistics.getOutputRowCount(), joinStats.getOutputRowCount()));
         } else if (joinType.isAsofInnerJoin()) {
-            estimateStatistics = Statistics.buildFrom(estimateStatistics)
-                    .setOutputRowCount(Math.max(Math.min(estimateStatistics.getOutputRowCount(), leftRowCount), 1))
-                    .build();
+            estimateStatistics = estimateStatistics.withOutputRowCount(
+                    Math.max(Math.min(estimateStatistics.getOutputRowCount(), leftRowCount), 1));
         } else if (joinType.isAsofLeftOuterJoin()) {
-            estimateStatistics = Statistics.buildFrom(estimateStatistics)
-                    .setOutputRowCount(Math.max(1, leftRowCount))
-                    .build();
+            estimateStatistics = estimateStatistics.withOutputRowCount(Math.max(1, leftRowCount));
         }
 
         context.setStatistics(estimateStatistics);
@@ -1669,8 +1663,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         if (ConnectContext.get().getSessionVariable().isUseCorrelatedJoinEstimate()) {
             return estimatedInnerJoinStatisticsAssumeCorrelated(statistics, eqOnPredicates);
         } else {
-            return Statistics.buildFrom(statistics)
-                    .setOutputRowCount(estimateInnerRowCountMiddleGround(statistics, eqOnPredicates)).build();
+            return statistics.withOutputRowCount(estimateInnerRowCountMiddleGround(statistics, eqOnPredicates));
         }
     }
 
@@ -1930,7 +1923,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
         // avoid sample statistics filter all data, save one rows least
         if (statistics.getOutputRowCount() > 0 && result.getOutputRowCount() == 0) {
-            return Statistics.buildFrom(result).setOutputRowCount(1).build();
+            return result.withOutputRowCount(1);
         }
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateUtils.java
@@ -72,10 +72,15 @@ public class StatisticsEstimateUtils {
                 statistics.isTableRowCountMayInaccurate()) {
             return statistics;
         }
+        double distinctValues = Math.max(1, rowCount);
+        boolean needAdjustDistinctValues = statistics.getColumnStatistics().values().stream()
+                .anyMatch(cs -> cs.getDistinctValuesCount() > distinctValues);
+        if (!needAdjustDistinctValues) {
+            return statistics.withOutputRowCount(rowCount);
+        }
+
         Statistics.Builder builder = Statistics.buildFrom(statistics);
         builder.setOutputRowCount(rowCount);
-        // use row count to adjust column statistics distinct values
-        double distinctValues = Math.max(1, rowCount);
         statistics.getColumnStatistics().forEach((column, columnStatistic) -> {
             if (columnStatistic.getDistinctValuesCount() > distinctValues) {
                 builder.addColumnStatistic(column,


### PR DESCRIPTION
## Why I'm doing:
`Statistics.buildFrom(...).setOutputRowCount(...).build()` is on a hot path in stats/cost estimation. Even when we only change `outputRowCount`, `buildFrom` still **copies the whole `columnStatistics` and multi-column stats maps** (`new HashMap<>(...)`), which shows up as high overhead (CPU + allocations/GC) in profiling.

## What I'm doing:
- Add `Statistics.withOutputRowCount(double)` to update row count **without copying** existing stats maps (reuse the same maps when only rowCount changes).
- Strengthen `Statistics` immutability via `unmodifiableXXX` wrappers so map reuse is safe and cannot be accidentally mutated.
- Replace rowCount-only `buildFrom(...).setOutputRowCount(...).build()` call sites with `withOutputRowCount()` in hot paths to eliminate redundant `HashMap` copies.
- Add an empty-map fast path for `multiColumnCombinedStats` in `Statistics.Builder` to avoid copying when it is empty.
- Fix `ReorderJoinRule.deriveNewOptExpression` to avoid mutating stats maps and rebuild a new `Statistics` safely for the new projection.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
