### PR TITLE
[Enhancement] Reduce allocations in Statistics.getUsedColumns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
@@ -86,9 +86,12 @@ public class PredicateStatisticsCalculator {
                 return false;
             }
             // extract range predicate scalar operator with unknown column statistics will not eval
-            if (predicate.isFromPredicateRangeDerive() &&
-                    statistics.getColumnStatistics().values().stream().anyMatch(ColumnStatistic::isUnknown)) {
-                return false;
+            if (predicate.isFromPredicateRangeDerive()) {
+                for (ColumnStatistic cs : statistics.getColumnStatistics().values()) {
+                    if (cs.isUnknown()) {
+                        return false;
+                    }
+                }
             }
             return true;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
@@ -20,6 +20,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
 import java.util.Collection;
@@ -129,8 +130,11 @@ public class Statistics {
 
     public ColumnRefSet getUsedColumns() {
         ColumnRefSet usedColumns = new ColumnRefSet();
-        for (Map.Entry<ColumnRefOperator, ColumnStatistic> entry : columnStatistics.entrySet()) {
-            usedColumns.union(entry.getKey().getUsedColumns());
+        for (ColumnRefOperator col : columnStatistics.keySet()) {
+            if (OperatorType.LAMBDA_ARGUMENT.equals(col.getOpType())) {
+                continue;
+            }
+            usedColumns.union(col.getId());
         }
         return usedColumns;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1152,11 +1152,10 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         Statistics rightStatistics = context.getChildStatistics(1);
         // construct cross join statistics
         Statistics.Builder crossBuilder = Statistics.builder();
-        crossBuilder.addColumnStatisticsFromOtherStatistic(leftStatistics, context.getChildOutputColumns(0),
+        addColumnStatisticsFromOtherStatisticByRefs(crossBuilder, leftStatistics, context.getChildOutputColumns(0),
                 preserveJoinHistogram);
-        crossBuilder.addColumnStatisticsFromOtherStatistic(rightStatistics, context.getChildOutputColumns(1),
+        addColumnStatisticsFromOtherStatisticByRefs(crossBuilder, rightStatistics, context.getChildOutputColumns(1),
                 preserveJoinHistogram);
-
         // Add multi-column statistics from both sides (they are independent after cross join)
         crossBuilder.addMultiColumnStatistics(leftStatistics.getMultiColumnCombinedStats());
         crossBuilder.addMultiColumnStatistics(rightStatistics.getMultiColumnCombinedStats());
@@ -1309,6 +1308,27 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
 
         context.setStatistics(estimateStatistics);
         return visitOperator(context.getOp(), context);
+    }
+
+    private void addColumnStatisticsFromOtherStatisticByRefs(Statistics.Builder builder, Statistics statistics,
+                                                             ColumnRefSet hintRefs, boolean withHist) {
+        if (statistics == null || hintRefs == null) {
+            return;
+        }
+        Map<ColumnRefOperator, ColumnStatistic> src = statistics.getColumnStatistics();
+        for (int id : hintRefs.getColumnIds()) {
+            ColumnRefOperator col = columnRefFactory.getColumnRef(id);
+            ColumnStatistic v = src.get(col);
+            if (v == null) {
+                continue;
+            }
+            if (withHist) {
+                builder.addColumnStatistic(col, v);
+            } else {
+                builder.addColumnStatistic(col, v.getHistogram() == null ? v :
+                        ColumnStatistic.buildFrom(v).setHistogram(null).build());
+            }
+        }
     }
 
     private Statistics buildStatisticsForUKFKJoin(JoinOperator joinType, UKFKConstraints constraints,


### PR DESCRIPTION
## Why I'm doing:
`Statistics.getUsedColumns()` is frequently invoked during planning and sits on a hot path. The previous implementation created a new `ColumnRefSet` per column via `ColumnRefOperator.getUsedColumns()` and unioned sets repeatedly, causing avoidable allocations and overhead (especially noticeable with many columns / lambda arguments).

## What I'm doing:
- Rework `Statistics.getUsedColumns()` to iterate `columnStatistics.keySet()` directly, **skip `LAMBDA_ARGUMENT`**, and union by **column id** to avoid per-column `ColumnRefSet` allocations.
- Minor hot-path follow-ups:
  - Replace a stream/lambda in `PredicateStatisticsCalculator` with a simple loop for unknown-stat checks.
  - Optimize cross join stats building in `StatisticsCalculator` by copying only required column statistics via `ColumnRefSet` id lookups and avoiding cloning when histogram is already null.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
