### PR TITLE
[BugFix] Fix be crash due to memtable finalize failed

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -559,6 +559,7 @@ Status DeltaWriter::manual_flush() {
 }
 
 Status DeltaWriter::flush_memtable_async(bool eos) {
+    DeferOp defer([this] { _mem_table.reset(); });
     _last_write_ts = 0;
     _write_buffer_size = 0;
     // _mem_table is nullptr means write() has not been called

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -419,6 +419,11 @@ inline Status DeltaWriterImpl::reset_memtable() {
 inline Status DeltaWriterImpl::flush_async() {
     Status st;
     if (_mem_table != nullptr) {
+        DeferOp defer([this] {
+            _mem_table.reset();
+            _last_write_ts = 0;
+        });
+
         RETURN_IF_ERROR(_mem_table->finalize());
         if (_miss_auto_increment_column && _mem_table->get_result_chunk() != nullptr) {
             RETURN_IF_ERROR(fill_auto_increment_id(*_mem_table->get_result_chunk()));
@@ -442,8 +447,6 @@ inline Status DeltaWriterImpl::flush_async() {
                                 << ", is_immutable=" << _is_immutable.load(std::memory_order_relaxed);
                     }
                 });
-        _mem_table.reset(nullptr);
-        _last_write_ts = 0;
     }
     return st;
 }


### PR DESCRIPTION
## Why I'm doing:
```
3.5.11-ee RELEASE (build 0bdd185 distro centos arch aarch64)
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000, plan_node_id:-1
*** Aborted at 1768004293 (unix time) try "date -d @1768004293" if you are using GNU date ***
PC: @          0x6ceab10 starrocks::ChunkAggregator::update_source(std::shared_ptr&, std::vector >*)
*** SIGSEGV (@0x40) received by PID 3303736 (TID 0xfffad74efe80) LWP(3305950) from PID 64; stack trace: ***
    @     0xffff8658dbc0 __pthread_once_slow
    @          0xa780810 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0xffff86a92830 ([vdso]+0x82f)
    @          0x6ceab10 starrocks::ChunkAggregator::update_source(std::shared_ptr&, std::vector >*)
    @          0x6cf768c starrocks::MemTable::_aggregate(bool)
    @          0x6cfa7a0 starrocks::MemTable::_merge()
    @          0x6cfad1c starrocks::MemTable::insert(starrocks::Chunk const&, unsigned int const*, unsigned int, unsigned int)
    @          0x6d66794 starrocks::lake::DeltaWriterImpl::write(starrocks::Chunk const&, unsigned int const*, unsigned int)
    @          0x6d66db8 starrocks::lake::DeltaWriter::write(starrocks::Chunk const&, unsigned int const*, unsigned int)
    @          0x6d55804 starrocks::lake::AsyncDeltaWriterImpl::execute(void*, bthread::TaskIterator >&)
    @          0xa923988 bthread::ExecutionQueueBase::_execute(bthread::TaskNode*, bool, int*)
    @          0xa924904 bthread::ExecutionQueueBase::_execute_tasks(void*)
    @          0x3d00b34 starrocks::ThreadPool::dispatch_thread()
    @          0x3cf80c4 starrocks::Thread::supervise_thread(void*)
    @     0xffff86588b78 start_thread
    @     0xffff865f5cdc thread_start
```

When memtable finalize failed, some members in memtable may be reset:
<img width="1730" height="536" alt="image" src="https://github.com/user-attachments/assets/c548f66b-ab65-435f-83bd-f7aa4e730c8a" />

Then next write may access an incomplete memtable, causing crash:
```
AsyncDeltaWriterImpl::execute
    └─> DeltaWriterImpl::write
          └─> MemTable::insert (Use incomplete _mem_table)
                └─> MemTable::_merge
                      └─> MemTable::_aggregate
                            └─> ChunkAggregator::update_source (_aggregator is nullptr)
                                  └─> CRASH: Access nullptr->_is_eq
```
## What I'm doing:
Fix be crash due to memtable finalize failed

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
