### PR TITLE
[Tool] Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/ci-doc-checker.yml
+++ b/.github/workflows/ci-doc-checker.yml
@@ -75,7 +75,7 @@ jobs:
           echo ${{github.base_ref}}
           echo "branch=${{github.base_ref}}" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -92,7 +92,7 @@ jobs:
           git checkout -b merge_pr;
           git merge --squash --no-edit ${BRANCH} || (echo "::error::Merge conflict, please check." && exit -1);
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/.github/workflows/ci-merged-sonarcloud-fe.yml
+++ b/.github/workflows/ci-merged-sonarcloud-fe.yml
@@ -19,7 +19,7 @@ jobs:
           rm -rf ${{ github.workspace }}
           mkdir -p ${{ github.workspace }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -30,20 +30,20 @@ jobs:
           echo "branch=${{github.base_ref}}" >> $GITHUB_OUTPUT
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'adopt'
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-pipeline-branch.yml
+++ b/.github/workflows/ci-pipeline-branch.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout code
         id: checkout_code
         if: github.base_ref != 'main'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/head
@@ -160,7 +160,7 @@ jobs:
           mkdir -p ${{ github.workspace }}
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -222,7 +222,7 @@ jobs:
           ./bin/run-pr-update-image.sh
 
       - name: Upload Thirdparty Result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: THIRDPARTY-RESULT-${{ matrix.linux }}
           path: image_cache.info
@@ -256,7 +256,7 @@ jobs:
           fi
 
       - name: Download Thirdparty Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: THIRDPARTY-RESULT-*
           path: outputs
@@ -304,7 +304,7 @@ jobs:
           eci rm ${{ steps.run_ut.outputs.ECI_ID }}
 
       - name: Upload log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: BE UT LOG
@@ -375,7 +375,7 @@ jobs:
           echo ${{github.base_ref}}
           echo "branch=${{github.base_ref}}" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -446,7 +446,7 @@ jobs:
 
       - name: Upload log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: FE UT LOG
           path: ${{ steps.run_ut.outputs.RES_LOG }}
@@ -479,7 +479,7 @@ jobs:
           echo ${GITHUB_SHA} > head_sha.txt
 
       - name: Upload the PR number
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pr_num
           path: ./pr_num.txt
@@ -487,7 +487,7 @@ jobs:
           overwrite: true
 
       - name: Upload the PR HEAD REF
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: head_sha
           path: ./head_sha.txt

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -55,7 +55,7 @@ jobs:
           echo "SHA=${SHA}" >> $GITHUB_OUTPUT
 
       - name: Upload the PR number
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pr_num
           path: ./pr_num.txt
@@ -138,7 +138,7 @@ jobs:
       - name: Checkout code
         id: checkout_code
         if: github.base_ref != 'main'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/head
@@ -189,7 +189,7 @@ jobs:
           echo "TEST_PR=${{ steps.check_test_case.outputs.TEST_PR }}" >> ./test-pr-info.txt
 
       - name: Upload the Test Case Info
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: steps.check_test_case_info.outcome == 'success'
         with:
           name: TEST_PR_INFO
@@ -245,7 +245,7 @@ jobs:
           echo ${{ steps.path-filter.outputs.thirdparty }} > thirdparty_filter.txt
 
       - name: Upload the BE Filter Info
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: be-path-filter
           path: ./be-path-filter/
@@ -291,7 +291,7 @@ jobs:
       - name: Checkout Code
         id: checkout_code
         if: needs.be-checker.outputs.be_change == 'true' || needs.be-checker.outputs.pre_format_conclusion != 'success'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -382,7 +382,7 @@ jobs:
       - name: Upload Thirdparty Result
         id: upload_thirdparty_result
         if: steps.update-image.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: THIRDPARTY-RESULT-${{ matrix.linux }}
           path: image_cache.info
@@ -412,7 +412,7 @@ jobs:
           ./scripts/check-thirdparty-result.sh
 
       - name: Download Thirdparty Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: THIRDPARTY-RESULT-*
           path: outputs
@@ -457,7 +457,7 @@ jobs:
           eci rm ${{ steps.run_ut.outputs.ECI_ID }} || true
 
       - name: Upload Log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always() && steps.run_ut.outcome == 'failure' && steps.run_ut.outputs.BE_LOG != ''
         with:
           name: BE UT LOG
@@ -573,7 +573,7 @@ jobs:
           echo ${{ steps.path-filter.outputs.pom }} > pom_filter.txt
 
       - name: Upload the FE Filter Info
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: fe-path-filter
           path: ./fe-path-filter/
@@ -616,7 +616,7 @@ jobs:
           echo ${{github.base_ref}}
           echo "branch=${{github.base_ref}}" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         id: checkout_code
         if: steps.branch.outcome == 'success'
         with:
@@ -667,7 +667,7 @@ jobs:
       BRANCH: ${{ github.base_ref }}
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         id: checkout_code
         if: needs.fe-checker.outputs.fe_change == 'true' || needs.fe-checker.outputs.pre_sonarcloud_conclusion != 'success'
         with:
@@ -696,7 +696,7 @@ jobs:
           git merge --squash --no-edit ${BRANCH} || (echo "Merge conflict, please check." && exit -1);
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         id: setup_java
         if: steps.checkout_pr.outcome == 'success'
         with:
@@ -706,7 +706,7 @@ jobs:
       - name: Cache SonarCloud packages
         id: cache_sonarcloud_packages
         if: steps.setup_java.outcome == 'success'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
@@ -715,7 +715,7 @@ jobs:
       - name: Cache Maven packages
         id: cache_maven_packages
         if: steps.cache_sonarcloud_packages.outcome == 'success'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -802,7 +802,7 @@ jobs:
 
       - name: Upload log
         if: always() && steps.run_ut.outputs.RES_LOG != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: FE UT LOG
           path: ${{ steps.run_ut.outputs.RES_LOG }}
@@ -933,7 +933,7 @@ jobs:
           fi
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.base_ref }}
           
@@ -974,7 +974,7 @@ jobs:
           echo ${{ steps.run_build.outputs.BASE_VERSION }} > ./base_version.txt
 
       - name: Upload the Base Version
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: steps.build_result.outcome == 'success'
         with:
           name: base_version
@@ -1156,7 +1156,7 @@ jobs:
           rm -rf ${{ github.workspace }} && mkdir -p ${{ github.workspace }}
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -1199,7 +1199,7 @@ jobs:
           ossutil64 --config-file ~/.ossutilconfig cp test/ ${xml_oss_path} --include "*.xml" --recursive --force --tagging="type=ci"
 
       - name: Upload log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: SQL-Tester Log
@@ -1430,7 +1430,7 @@ jobs:
           echo $PR_NUMBER > pr_num.txt
 
       - name: Upload the PR number
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pr_num
           path: ./pr_num.txt

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -239,7 +239,7 @@ jobs:
         run: |
           rm -rf ${{ github.workspace }} && mkdir -p ${{ github.workspace }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/inspection-be-coverage.yml
+++ b/.github/workflows/inspection-be-coverage.yml
@@ -61,7 +61,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.BASE_REF }}

--- a/.github/workflows/inspection-pipeline.yml
+++ b/.github/workflows/inspection-pipeline.yml
@@ -178,7 +178,7 @@ jobs:
           echo "${{ steps.run_ut.outcome }}" > ./${{ matrix.build_type }}.txt
 
       - name: Upload Log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always() && (steps.run_ut.outcome == 'success' || steps.run_ut.outcome == 'failure')
         with:
           name: BE UT LOG
@@ -187,7 +187,7 @@ jobs:
           overwrite: true
 
       - name: Upload BE UT Result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: BE-UT-RESULT-${{ matrix.build_type }}
@@ -244,7 +244,7 @@ jobs:
 
       - name: Upload log
         if: always() && (steps.run_ut.outcome == 'success' || steps.run_ut.outcome == 'failure')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: FE UT LOG
           path: ${{ steps.run_ut.outputs.RES_LOG }}
@@ -324,7 +324,7 @@ jobs:
           echo ${{ steps.run_build.outputs.FE_OUTPUT_TAR }} >> $GITHUB_STEP_SUMMARY
           echo -e "BE=${{ steps.run_build.outputs.BE_OUTPUT_TAR }}\nFE=${{ steps.run_build.outputs.FE_OUTPUT_TAR }}"> tar.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: BUILD-RESULT-${{ matrix.build_type }}-${{ matrix.linux }}
           path: tar.txt
@@ -369,7 +369,7 @@ jobs:
 
       - name: Download Build Artifact
         if: github.event_name == 'schedule' || inputs.IS_REBUILD
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: BUILD-RESULT-*
           path: outputs
@@ -534,7 +534,7 @@ jobs:
           rm -rf ${{ github.workspace }} && mkdir -p ${{ github.workspace }}
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/inspection-reusable-pipeline.yml
+++ b/.github/workflows/inspection-reusable-pipeline.yml
@@ -138,7 +138,7 @@ jobs:
           rm -rf ${{ github.workspace }} && mkdir -p ${{ github.workspace }}
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -172,7 +172,7 @@ jobs:
           report_paths: "test/*.xml"
 
       - name: Upload log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: SQL-Tester Log (${{ env.BUILD_TYPE }} ${{ env.LINUX_DISTRO }})

--- a/.github/workflows/mark-issue-pr-stale.yml
+++ b/.github/workflows/mark-issue-pr-stale.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v10
         with:
           operations-per-run: 1000
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/releasenotes404.yaml
+++ b/.github/workflows/releasenotes404.yaml
@@ -12,7 +12,7 @@ jobs:
       issues: write # required for peter-evans/create-issue-from-file
     steps:
         # Get this repo
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Link Checker
         id: lychee


### PR DESCRIPTION
## Why I'm doing:

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

## What I'm doing:

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
