### PR TITLE
[BugFix] Fix CloseableIterable resource leak in IcebergCatalog.getPartitions()

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -303,15 +303,16 @@ public interface IcebergCatalog extends MemoryTrackable {
                     // equality_delete_file_count,
                     // last_updated_at,
                     // last_updated_snapshot_id
-                    CloseableIterable<StructLike> rows = task.asDataTask().rows();
-                    for (StructLike row : rows) {
-                        // Get the last updated time of the table according to the table schema
-                        // last_updated_at can be null if the referenced snapshot has been expired.
-                        // Use Long wrapper to avoid NPE during auto-unboxing.
-                        long lastUpdated = getPartitionLastUpdatedTime(icebergTable, row, 7,
-                                EMPTY_PARTITION_NAME, snapshotId);
-                        partition = new Partition(lastUpdated);
-                        break;
+                    try (CloseableIterable<StructLike> rows = task.asDataTask().rows()) {
+                        for (StructLike row : rows) {
+                            // Get the last updated time of the table according to the table schema
+                            // last_updated_at can be null if the referenced snapshot has been expired.
+                            // Use Long wrapper to avoid NPE during auto-unboxing.
+                            long lastUpdated = getPartitionLastUpdatedTime(icebergTable, row, 7,
+                                    EMPTY_PARTITION_NAME, snapshotId);
+                            partition = new Partition(lastUpdated);
+                            break;
+                        }
                     }
                 }
                 if (partition == null) {
@@ -340,19 +341,20 @@ public interface IcebergCatalog extends MemoryTrackable {
                     // equality_delete_file_count,
                     // last_updated_at,
                     // last_updated_snapshot_id
-                    CloseableIterable<StructLike> rows = task.asDataTask().rows();
-                    for (StructLike row : rows) {
-                        // Get the partition data/spec id/last updated time according to the table schema
-                        StructProjection partitionData = row.get(0, StructProjection.class);
-                        int specId = row.get(1, Integer.class);
-                        PartitionSpec spec = nativeTable.specs().get(specId);
+                    try (CloseableIterable<StructLike> rows = task.asDataTask().rows()) {
+                        for (StructLike row : rows) {
+                            // Get the partition data/spec id/last updated time according to the table schema
+                            StructProjection partitionData = row.get(0, StructProjection.class);
+                            int specId = row.get(1, Integer.class);
+                            PartitionSpec spec = nativeTable.specs().get(specId);
 
-                        String partitionName =
-                                PartitionUtil.convertIcebergPartitionToPartitionName(nativeTable, spec, partitionData);
-                        long lastUpdated =
-                                getPartitionLastUpdatedTime(icebergTable, row, 9, partitionName, snapshotId);
-                        Partition partition = new Partition(lastUpdated, specId);
-                        partitionMap.put(partitionName, partition);
+                            String partitionName =
+                                    PartitionUtil.convertIcebergPartitionToPartitionName(nativeTable, spec, partitionData);
+                            long lastUpdated =
+                                    getPartitionLastUpdatedTime(icebergTable, row, 9, partitionName, snapshotId);
+                            Partition partition = new Partition(lastUpdated, specId);
+                            partitionMap.put(partitionName, partition);
+                        }
                     }
                 }
             } catch (IOException e) {


### PR DESCRIPTION
Please read this [issue](https://github.com/StarRocks/starrocks/issues/67791) for details
Fixes OOM issue where PartitionsTable$Partition objects (containing PartitionData) were not released because CloseableIterable<StructLike> rows was not properly closed.

Changes:
- Wrap rows iterable in try-with-resources for unpartitioned tables
- Wrap rows iterable in try-with-resources for partitioned tables

This ensures rows.close() is called automatically, releasing Iceberg's internal PartitionsTable$Partition objects and preventing memory leaks.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
