### PR TITLE
[Enhancement] Optimize dynamic partition creation with CompletableFuture deduplication

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -51,6 +51,7 @@ import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.LocalTablet;
@@ -168,13 +169,13 @@ import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.CancelAlterTableStmt;
-import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.SetType;
 import com.starrocks.sql.ast.ShowAlterStmt;
 import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.parser.NodePosition;
@@ -418,7 +419,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -431,6 +438,14 @@ import static com.starrocks.thrift.TStatusCode.SERVICE_UNAVAILABLE;
 // thrift protocol
 public class FrontendServiceImpl implements FrontendService.Iface {
     private static final Logger LOG = LogManager.getLogger(FrontendServiceImpl.class);
+
+    // Pending partition creation requests.
+    // Key = "tableId_txnId_sortedNormalizedPartitionValues" -> CompletableFuture.
+    // Used to deduplicate concurrent identical partition creation requests within the same transaction.
+    // For range partitions with interval=1, partition values are truncated to partition boundaries before keying.
+    private static final ConcurrentHashMap<String, CompletableFuture<TCreatePartitionResult>>
+            PENDING_PARTITION_REQUESTS = new ConcurrentHashMap<>();
+
     private final LeaderImpl leaderImpl;
     private final ExecuteEnv exeEnv;
     private final ProxyContextManager proxyContextManager;
@@ -2169,196 +2184,437 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
     @NotNull
     private static TCreatePartitionResult createPartitionProcess(TCreatePartitionRequest request) {
+        CreatePartitionMetrics metrics = new CreatePartitionMetrics();
+
         long dbId = request.getDb_id();
         long tableId = request.getTable_id();
-        TCreatePartitionResult result = new TCreatePartitionResult();
-        TStatus errorStatus = new TStatus(RUNTIME_ERROR);
-        String partitionNamePrefix = null;
-        boolean isTemp = false;
-        if (request.isSetIs_temp() && request.isIs_temp()) {
-            isTemp = true;
-            partitionNamePrefix = "txn" + request.getTxn_id();
+        boolean isTemp = request.isSetIs_temp() && request.isIs_temp();
+        String partitionNamePrefix = isTemp ? "txn" + request.getTxn_id() : null;
+
+        // Validate request parameters and retrieve db/table in one pass (no lock needed)
+        ValidatedTableInfo tableInfo = validateAndGetTableInfo(request, dbId, tableId);
+        metrics.recordValidateRequest();
+        if (tableInfo.errorResult != null) {
+            metrics.finish();
+            logMetrics(metrics, request);
+            return tableInfo.errorResult;
         }
 
+        Database db = tableInfo.db;
+        OlapTable olapTable = tableInfo.olapTable;
+        GlobalStateMgr state = GlobalStateMgr.getCurrentState();
+
+        // Build dedup key from txn_id + normalized partition values (no lock needed).
+        // txn_id is included because responses contain txn-specific tablet locations.
+        // For range partitions, values are truncated to partition boundaries based on granularity.
+        String requestKey = buildPartitionRequestKey(
+                tableId, request.getTxn_id(), request.partition_values, olapTable);
+        long timeoutMs = getPartitionRequestTimeoutMs(request);
+        metrics.recordBuildRequestKey();
+
+        // Use CompletableFuture to deduplicate identical concurrent requests.
+        // Only the first request will execute creation, others will wait for the result.
+        AtomicBoolean isCreator = new AtomicBoolean(false);
+        CompletableFuture<TCreatePartitionResult> future = PENDING_PARTITION_REQUESTS.computeIfAbsent(requestKey, k -> {
+            isCreator.set(true);
+            return new CompletableFuture<>();
+        });
+
+        if (!isCreator.get()) {
+            return waitForCreatorResult(future, timeoutMs, requestKey, metrics, request);
+        }
+
+        metrics.recordWaitForOtherRequest(true, false);
+
+        // This is the creator - do the actual work (parse clause, create partitions, build response).
+        // All lock-requiring operations are confined to the creator path.
+        try {
+            TCreatePartitionResult result = doCreatePartition(state, db, olapTable, tableId, request.getTxn_id(),
+                    request.partition_values, isTemp, partitionNamePrefix, metrics);
+            future.complete(result);
+            metrics.finish();
+            logMetrics(metrics, request);
+            return result;
+        } catch (Exception e) {
+            LOG.warn("Failed to create partitions for requestKey: {}", requestKey, e);
+            TCreatePartitionResult errResult = buildErrorResult(
+                    String.format("automatic create partition failed. error:%s", e.getMessage()));
+            future.completeExceptionally(e);
+            metrics.finish();
+            logMetrics(metrics, request);
+            return errResult;
+        } finally {
+            PENDING_PARTITION_REQUESTS.remove(requestKey);
+        }
+    }
+
+    private static void logMetrics(CreatePartitionMetrics metrics, TCreatePartitionRequest request) {
+        if (metrics.isSlow()) {
+            LOG.info("{}", metrics.toLogString(request));
+        } else {
+            LOG.debug("{}", metrics.toLogString(request));
+        }
+    }
+
+    private static TCreatePartitionResult waitForCreatorResult(
+            CompletableFuture<TCreatePartitionResult> future, long timeoutMs, String requestKey,
+            CreatePartitionMetrics metrics, TCreatePartitionRequest request) {
+        try {
+            TCreatePartitionResult result = future.get(timeoutMs, TimeUnit.MILLISECONDS);
+            metrics.recordWaitForOtherRequest(false, false);
+            metrics.recordBuildResponse();
+            metrics.finish();
+            logMetrics(metrics, request);
+            return result.deepCopy();
+        } catch (TimeoutException e) {
+            metrics.recordWaitForOtherRequest(false, true);
+            metrics.finish();
+            logMetrics(metrics, request);
+            LOG.warn("Timeout waiting for partition creation: {}", requestKey);
+            return buildErrorResult("Timeout waiting for partition creation");
+        } catch (ExecutionException e) {
+            metrics.recordWaitForOtherRequest(false, false);
+            metrics.finish();
+            logMetrics(metrics, request);
+            LOG.warn("Partition creation failed for requestKey: {}", requestKey, e.getCause());
+            return buildErrorResult("Partition creation failed: " + e.getCause().getMessage());
+        } catch (InterruptedException e) {
+            metrics.recordWaitForOtherRequest(false, false);
+            metrics.finish();
+            logMetrics(metrics, request);
+            Thread.currentThread().interrupt();
+            LOG.warn("Partition creation interrupted for requestKey: {}", requestKey);
+            return buildErrorResult("Partition creation interrupted");
+        }
+    }
+
+    private static String buildPartitionRequestKey(long tableId, long txnId,
+                                                       List<List<String>> partitionValues,
+                                                       OlapTable olapTable) {
+        Set<String> normalizedKeys = new TreeSet<>();
+        String granularity = null;
+
+        PartitionInfo partitionInfo = olapTable.getPartitionInfo();
+        if (partitionInfo instanceof ExpressionRangePartitionInfo) {
+            try {
+                ExpressionRangePartitionInfo exprInfo = (ExpressionRangePartitionInfo) partitionInfo;
+                List<Expr> exprs = exprInfo.getPartitionExprs(olapTable.getIdToColumn());
+                if (!exprs.isEmpty()) {
+                    PartitionMeasure measure = AnalyzerUtils.checkAndGetPartitionMeasure(exprs.get(0));
+                    if (measure.getInterval() == 1) {
+                        granularity = measure.getGranularity();
+                    }
+                }
+            } catch (Exception e) {
+                LOG.debug("Failed to get granularity for dedup key, falling back to raw values", e);
+            }
+        }
+
+        for (List<String> pv : partitionValues) {
+            String key;
+            if (granularity != null && pv.size() == 1) {
+                try {
+                    key = AnalyzerUtils.truncateToPartitionBoundary(pv.get(0), granularity);
+                } catch (Exception e) {
+                    key = String.join("|", pv);
+                }
+            } else {
+                key = String.join("|", pv);
+            }
+            normalizedKeys.add(key);
+        }
+        return tableId + "_" + txnId + "_" + String.join(",", normalizedKeys);
+    }
+
+    private static long getPartitionRequestTimeoutMs(TCreatePartitionRequest request) {
+        if (request.isSetTimeout_s()) {
+            return (long) request.getTimeout_s() * 1000;
+        }
+        return 30000L;
+    }
+
+    private static TCreatePartitionResult doCreatePartition(
+            GlobalStateMgr state, Database db, OlapTable olapTable, long tableId, long txnId,
+            List<List<String>> partitionValues, boolean isTemp, String partitionNamePrefix,
+            CreatePartitionMetrics metrics) throws Exception {
+
+        // Step 1: Parse partition clause under READ lock (only creator does this)
+        AddPartitionClause addPartitionClause = parseAddPartitionClause(
+                db, olapTable, partitionValues, isTemp, partitionNamePrefix);
+        Set<String> creatingPartitionNames = CatalogUtils.getPartitionNamesFromAddPartitionClause(addPartitionClause);
+        metrics.recordGeneratePartitionNames(creatingPartitionNames.size());
+
+        // Step 2: Validate transaction state
+        TransactionState txnState = state.getGlobalTransactionMgr().getTransactionState(db.getId(), txnId);
+        TCreatePartitionResult errorResult = validateTransactionState(txnState, txnId, tableId, olapTable.getName());
+        metrics.recordValidateTxnState();
+        if (errorResult != null) {
+            return errorResult;
+        }
+
+        ConcurrentMap<String, TOlapTablePartition> cachedPartitions = txnState.getPartitionNameToTPartition(tableId);
+
+        // Step 3: Fast path - if all partitions are already cached, skip creation
+        boolean isFastPath = areAllPartitionsCached(cachedPartitions, creatingPartitionNames);
+        metrics.recordFastPathCheck(isFastPath);
+        if (isFastPath) {
+            if (txnState.getTransactionStatus().isFinalStatus()) {
+                return buildErrorResult(String.format("automatic create partition failed. error: txn %d is %s",
+                        txnId, txnState.getTransactionStatus().name()));
+            }
+            TCreatePartitionResult result = buildResponseWithLock(
+                    db, olapTable, txnState, creatingPartitionNames, isTemp);
+            metrics.recordBuildResponse();
+            return result;
+        }
+
+        // Step 4: Acquire partition-level locks and create partitions
+        List<String> acquiredLocks = new ArrayList<>();
+        try {
+            acquirePartitionLocks(olapTable, creatingPartitionNames, acquiredLocks);
+            metrics.recordAcquireLocks();
+
+            boolean needCreate = !areAllPartitionsCached(cachedPartitions, creatingPartitionNames);
+            metrics.recordDoubleCheck();
+
+            if (needCreate) {
+                try {
+                    createPartitionsIfNeeded(state, db, olapTable, txnState, txnId,
+                            addPartitionClause, creatingPartitionNames);
+                } catch (Exception e) {
+                    txnState.setIsCreatePartitionFailed(true);
+                    throw e;
+                }
+                metrics.recordCreatePartitions();
+            }
+        } finally {
+            releasePartitionLocks(olapTable, acquiredLocks);
+            metrics.recordReleaseLocks();
+        }
+
+        // Step 5: Check txn status and build response
+        if (txnState.getTransactionStatus().isFinalStatus()) {
+            return buildErrorResult(String.format("automatic create partition failed. error: txn %d is %s",
+                    txnId, txnState.getTransactionStatus().name()));
+        }
+
+        TCreatePartitionResult result = buildResponseWithLock(db, olapTable, txnState, creatingPartitionNames, isTemp);
+        metrics.recordBuildResponse();
+        return result;
+    }
+
+    private static class ValidatedTableInfo {
+        final Database db;
+        final OlapTable olapTable;
+        final TCreatePartitionResult errorResult;
+
+        ValidatedTableInfo(Database db, OlapTable olapTable) {
+            this.db = db;
+            this.olapTable = olapTable;
+            this.errorResult = null;
+        }
+
+        ValidatedTableInfo(TCreatePartitionResult errorResult) {
+            this.db = null;
+            this.olapTable = null;
+            this.errorResult = errorResult;
+        }
+    }
+
+    private static ValidatedTableInfo validateAndGetTableInfo(TCreatePartitionRequest request,
+                                                              long dbId, long tableId) {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null) {
-            errorStatus.setError_msgs(Lists.newArrayList(String.format("dbId=%d is not exists", dbId)));
-            result.setStatus(errorStatus);
-            return result;
+            return new ValidatedTableInfo(buildErrorResult(String.format("dbId=%d is not exists", dbId)));
         }
+
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
-            errorStatus.setError_msgs(Lists.newArrayList(String.format("dbId=%d tableId=%d is not exists", dbId, tableId)));
-            result.setStatus(errorStatus);
-            return result;
+            return new ValidatedTableInfo(
+                    buildErrorResult(String.format("dbId=%d tableId=%d is not exists", dbId, tableId)));
         }
         if (!(table instanceof OlapTable)) {
-            errorStatus.setError_msgs(Lists.newArrayList(String.format("dbId=%d tableId=%d is not olap table", dbId, tableId)));
-            result.setStatus(errorStatus);
-            return result;
+            return new ValidatedTableInfo(
+                    buildErrorResult(String.format("dbId=%d tableId=%d is not olap table", dbId, tableId)));
         }
-        OlapTable olapTable = (OlapTable) table;
 
         if (request.partition_values == null) {
-            errorStatus.setError_msgs(Lists.newArrayList("partition_values should not null."));
-            result.setStatus(errorStatus);
-            return result;
+            return new ValidatedTableInfo(buildErrorResult("partition_values should not null."));
         }
 
-        // Now only supports the case of automatically creating single range partition
+        OlapTable olapTable = (OlapTable) table;
         PartitionInfo partitionInfo = olapTable.getPartitionInfo();
         if (partitionInfo.isRangePartition() && olapTable.getPartitionColumnNames().size() != 1) {
-            errorStatus.setError_msgs(Lists.newArrayList(
-                    "automatic partition only support single column for range partition."));
-            result.setStatus(errorStatus);
-            return result;
+            return new ValidatedTableInfo(
+                    buildErrorResult("automatic partition only support single column for range partition."));
         }
 
-        AddPartitionClause addPartitionClause;
-        List<String> partitionNames = Lists.newArrayList();
-        try (AutoCloseableLock ignore = new AutoCloseableLock(new Locker(), db.getId(), Lists.newArrayList(table.getId()),
-                LockType.READ)) {
-            addPartitionClause = AnalyzerUtils.getAddPartitionClauseFromPartitionValues(olapTable,
-                    request.partition_values, isTemp, partitionNamePrefix);
-            PartitionDesc partitionDesc = addPartitionClause.getPartitionDesc();
-            if (partitionDesc instanceof RangePartitionDesc) {
-                partitionNames = ((RangePartitionDesc) partitionDesc).getPartitionNames();
-            } else if (partitionDesc instanceof ListPartitionDesc) {
-                partitionNames = ((ListPartitionDesc) partitionDesc).getPartitionNames();
-            }
+        return new ValidatedTableInfo(db, olapTable);
+    }
+
+    private static TCreatePartitionResult validateTransactionState(TransactionState txnState, long txnId,
+                                                                   long tableId, String tableName) {
+        if (txnState == null) {
+            return buildErrorResult(String.format("automatic create partition failed. error: txn %d not exist", txnId));
+        }
+
+        if (txnState.getPartitionNameToTPartition(tableId).size() > Config.max_partitions_in_one_batch) {
+            return buildErrorResult(String.format(
+                    "Table %s automatic create partition failed. error: partitions in one batch exceed limit %d," +
+                            "You can modify this restriction on by setting max_partitions_in_one_batch larger.",
+                    tableName, Config.max_partitions_in_one_batch));
+        }
+
+        return null;
+    }
+
+    private static TCreatePartitionResult buildErrorResult(String errorMsg) {
+        TCreatePartitionResult result = new TCreatePartitionResult();
+        TStatus errorStatus = new TStatus(RUNTIME_ERROR);
+        errorStatus.setError_msgs(Lists.newArrayList(errorMsg));
+        result.setStatus(errorStatus);
+        return result;
+    }
+
+    private static AddPartitionClause parseAddPartitionClause(Database db, OlapTable olapTable,
+                                                              List<List<String>> partitionValues,
+                                                              boolean isTemp, String partitionNamePrefix)
+            throws AnalysisException {
+        try (AutoCloseableLock ignore = new AutoCloseableLock(new Locker(), db.getId(),
+                Lists.newArrayList(olapTable.getId()), LockType.READ)) {
+            AddPartitionClause clause = AnalyzerUtils.getAddPartitionClauseFromPartitionValues(
+                    olapTable, partitionValues, isTemp, partitionNamePrefix);
+
+            Set<String> partitionNames = CatalogUtils.getPartitionNamesFromAddPartitionClause(clause);
             if (olapTable.getNumberOfPartitions() + partitionNames.size() > Config.max_partition_number_per_table) {
                 throw new AnalysisException("Table " + olapTable.getName() +
                         " automatically created partitions exceeded the maximum limit: " +
                         Config.max_partition_number_per_table + ". You can modify this restriction on by setting" +
                         " max_partition_number_per_table larger.");
             }
-        } catch (AnalysisException ex) {
-            errorStatus.setError_msgs(Lists.newArrayList(ex.getMessage()));
-            result.setStatus(errorStatus);
-            return result;
+            return clause;
+        }
+    }
+
+    private static boolean areAllPartitionsCached(ConcurrentMap<String, TOlapTablePartition> cachedPartitions,
+                                                  Set<String> partitionNames) {
+        for (String partitionName : partitionNames) {
+            if (cachedPartitions.get(partitionName) == null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void acquirePartitionLocks(OlapTable olapTable, Set<String> partitionNames,
+                                              List<String> acquiredLocks) {
+        List<String> sortedNames = partitionNames.stream().sorted().collect(Collectors.toList());
+        for (String partitionName : sortedNames) {
+            olapTable.lockCreatePartition(partitionName);
+            acquiredLocks.add(partitionName);
+        }
+    }
+
+    private static void releasePartitionLocks(OlapTable olapTable, List<String> acquiredLocks) {
+        for (int i = acquiredLocks.size() - 1; i >= 0; i--) {
+            olapTable.unlockCreatePartition(acquiredLocks.get(i));
+        }
+    }
+
+    private static void createPartitionsIfNeeded(GlobalStateMgr state, Database db, OlapTable olapTable,
+                                                 TransactionState txnState, long txnId,
+                                                 AddPartitionClause addPartitionClause,
+                                                 Set<String> creatingPartitionNames) throws Exception {
+        if (txnState.getIsCreatePartitionFailed()) {
+            throw new StarRocksException("automatic create partition failed. error: txn " + txnId +
+                    " already create partition failed");
         }
 
-        GlobalStateMgr state = GlobalStateMgr.getCurrentState();
-
-        TransactionState txnState = state.getGlobalTransactionMgr().getTransactionState(db.getId(), request.getTxn_id());
-        if (txnState == null) {
-            errorStatus.setError_msgs(Lists.newArrayList(
-                    String.format("automatic create partition failed. error: txn %d not exist", request.getTxn_id())));
-            result.setStatus(errorStatus);
-            return result;
+        ConnectContext ctx = Util.getOrCreateInnerContext();
+        if (txnState.getWarehouseId() != WarehouseManager.DEFAULT_WAREHOUSE_ID) {
+            ctx.setCurrentWarehouseId(txnState.getWarehouseId());
         }
 
-        if (txnState.getPartitionNameToTPartition(tableId).size() > Config.max_partitions_in_one_batch) {
-            errorStatus.setError_msgs(Lists.newArrayList(
-                    String.format("Table %s automatic create partition failed. error: partitions in one batch exceed limit %d," +
-                                    "You can modify this restriction on by setting" + " max_partitions_in_one_batch larger.",
-                            olapTable.getName(), Config.max_partitions_in_one_batch)));
-            result.setStatus(errorStatus);
-            return result;
+        // Run analyzer first so that system partitions enclosed by existing partitions
+        // are removed from the resolved list before we decide whether new partitions
+        // will actually be created.
+        try (AutoCloseableLock ignore = new AutoCloseableLock(new Locker(), db.getId(),
+                Lists.newArrayList(olapTable.getId()), LockType.READ)) {
+            AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(olapTable);
+            analyzer.analyze(ctx, addPartitionClause);
         }
 
-        Set<String> creatingPartitionNames = CatalogUtils.getPartitionNamesFromAddPartitionClause(addPartitionClause);
+        // The analyzer may remap partition names when a requested partition is enclosed
+        // by an existing merged partition (e.g. p202201 -> p2022). Update
+        // creatingPartitionNames so that buildResponseWithLock looks up the correct names.
+        PartitionDesc partDesc = addPartitionClause.getPartitionDesc();
+        if (partDesc instanceof RangePartitionDesc) {
+            creatingPartitionNames.clear();
+            creatingPartitionNames.addAll(((RangePartitionDesc) partDesc).getPartitionNames());
+        }
+
+        Set<String> resolvedPartitionNames = new TreeSet<>();
+        for (PartitionDesc desc : addPartitionClause.getResolvedPartitionDescList()) {
+            resolvedPartitionNames.add(desc.getPartitionName());
+        }
+        boolean willCreateNewPartition =
+                CatalogUtils.checkIfNewPartitionExists(olapTable, resolvedPartitionNames);
+
+        cancelConflictingAlterJobs(state, db, olapTable, txnId, willCreateNewPartition);
+
+        if (willCreateNewPartition) {
+            state.getLocalMetastore().addPartitions(ctx, db, olapTable.getName(), addPartitionClause);
+        } else {
+            LOG.info("skip addPartitions for automatic create partition txn_id={}, no new partition after analyze",
+                    txnId);
+        }
+    }
+
+    private static void cancelConflictingAlterJobs(GlobalStateMgr state, Database db, OlapTable olapTable,
+                                                   long txnId, boolean willCreateNewPartition) {
+        if (!willCreateNewPartition) {
+            return;
+        }
+
+        String errMsg = "Alter job conflicts with partition creation, for more details please check "
+                + "https://docs.starrocks.io/docs/faq/Others#how-can-i-prevent-expression-partition-conflicts"
+                + "-caused-by-concurrent-execution-of-loading-tasks-and-partition-creation-tasks";
 
         try {
-            // creating partition names is ordered
-            for (String partitionName : creatingPartitionNames) {
-                olapTable.lockCreatePartition(partitionName);
+            if (olapTable.getState() == OlapTable.OlapTableState.ROLLUP) {
+                LOG.info("cancel rollup for automatic create partition txn_id={}", txnId);
+                cancelAlterJob(state, db, olapTable, ShowAlterStmt.AlterType.ROLLUP, errMsg);
             }
 
-            // if the txn is already create partition failed, we should not create partition again
-            // because create partition failed will cause the txn to be aborted
-            if (txnState.getIsCreatePartitionFailed()) {
-                throw new StarRocksException("automatic create partition failed. error: txn " + request.getTxn_id() +
-                        " already create partition failed");
-            }
-
-            // Run analyzer first so that system partitions enclosed by existing partitions
-            // are removed from the resolved list before we decide whether new partitions
-            // will actually be created.
-            ConnectContext ctx = Util.getOrCreateInnerContext();
-            if (txnState.getWarehouseId() != WarehouseManager.DEFAULT_WAREHOUSE_ID) {
-                ctx.setCurrentWarehouseId(txnState.getWarehouseId());
-            }
-            try (AutoCloseableLock ignore = new AutoCloseableLock(new Locker(), db.getId(),
-                    Lists.newArrayList(table.getId()), LockType.READ)) {
-                AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(olapTable);
-                analyzer.analyze(ctx, addPartitionClause);
-            }
-
-            Set<String> resolvedPartitionNames = new TreeSet<>();
-            for (PartitionDesc desc : addPartitionClause.getResolvedPartitionDescList()) {
-                resolvedPartitionNames.add(desc.getPartitionName());
-            }
-            boolean willCreateNewPartition =
-                    CatalogUtils.checkIfNewPartitionExists(olapTable, resolvedPartitionNames);
-
-            // ingestion is top priority, if schema change or rollup is running, cancel it
-            try {
-                String errMsg = "Alter job conflicts with partition creation, for more details please check "
-                        + "https://docs.starrocks.io/docs/faq/Others#how-can-i-prevent-expression-partition-conflicts"
-                        + "-caused-by-concurrent-execution-of-loading-tasks-and-partition-creation-tasks";
-                if (olapTable.getState() == OlapTable.OlapTableState.ROLLUP && willCreateNewPartition) {
-                    LOG.info("cancel rollup for automatic create partition txn_id={}", request.getTxn_id());
-                    QualifiedName qualifiedName = QualifiedName.of(
-                            Lists.newArrayList(db.getFullName(), olapTable.getName()));
-                    TableRef tableRef = new TableRef(qualifiedName, null, NodePosition.ZERO);
-                    state.getLocalMetastore().cancelAlter(
-                            new CancelAlterTableStmt(ShowAlterStmt.AlterType.ROLLUP, tableRef), errMsg);
-                }
-
-                if (olapTable.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE && willCreateNewPartition) {
-                    LOG.info("cancel schema change for automatic create partition txn_id={}", request.getTxn_id());
-                    QualifiedName qualifiedName = QualifiedName.of(
-                            Lists.newArrayList(db.getFullName(), olapTable.getName()));
-                    TableRef tableRef = new TableRef(qualifiedName, null, NodePosition.ZERO);
-                    state.getLocalMetastore().cancelAlter(
-                            new CancelAlterTableStmt(ShowAlterStmt.AlterType.COLUMN, tableRef), errMsg);
-                }
-            } catch (Exception e) {
-                LOG.warn("cancel schema change or rollup failed. error: {}", e.getMessage());
-            }
-
-            if (willCreateNewPartition) {
-                state.getLocalMetastore().addPartitions(ctx, db, olapTable.getName(), addPartitionClause);
-            } else {
-                LOG.info("skip addPartitions for automatic create partition txn_id={}, no new partition after analyze",
-                        request.getTxn_id());
+            if (olapTable.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE) {
+                LOG.info("cancel schema change for automatic create partition txn_id={}", txnId);
+                cancelAlterJob(state, db, olapTable, ShowAlterStmt.AlterType.COLUMN, errMsg);
             }
         } catch (Exception e) {
-            LOG.warn("failed to add partitions", e);
-            errorStatus.setError_msgs(Lists.newArrayList(
-                    String.format("automatic create partition failed. error:%s", e.getMessage())));
-            result.setStatus(errorStatus);
-            txnState.setIsCreatePartitionFailed(true);
-            return result;
-        } finally {
-            for (String partitionName : creatingPartitionNames) {
-                olapTable.unlockCreatePartition(partitionName);
-            }
+            LOG.warn("cancel schema change or rollup failed. error: {}", e.getMessage());
         }
+    }
 
-        // build partition & tablets
+    private static void cancelAlterJob(GlobalStateMgr state, Database db, OlapTable olapTable,
+                                       ShowAlterStmt.AlterType alterType, String errMsg) throws Exception {
+        QualifiedName qualifiedName = QualifiedName.of(Lists.newArrayList(db.getFullName(), olapTable.getName()));
+        TableRef tableRef = new TableRef(qualifiedName, null, NodePosition.ZERO);
+        state.getLocalMetastore().cancelAlter(new CancelAlterTableStmt(alterType, tableRef), errMsg);
+    }
+
+    private static TCreatePartitionResult buildResponseWithLock(Database db, OlapTable olapTable,
+                                                                TransactionState txnState,
+                                                                Set<String> partitionNames, boolean isTemp) {
         List<TOlapTablePartition> partitions = Lists.newArrayList();
         List<TTabletLocation> tablets = Lists.newArrayList();
+        List<String> partitionNameList = Lists.newArrayList(partitionNames);
 
-        if (txnState.getTransactionStatus().isFinalStatus()) {
-            errorStatus.setError_msgs(Lists.newArrayList(
-                    String.format("automatic create partition failed. error: txn %d is %s", request.getTxn_id(),
-                            txnState.getTransactionStatus().name())));
-            result.setStatus(errorStatus);
-            return result;
-        }
-
-        // update partition info snapshot for txn should be protected by txn lock
-        // NOTE: lock order must be: db/table lock first, then txnState lock
-        // to avoid deadlock with other transaction operations
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.READ);
         try {
             txnState.writeLock();
             try {
-                return buildCreatePartitionResponse(
-                        olapTable, txnState, partitions, tablets, partitionNames, isTemp);
+                return buildCreatePartitionResponse(olapTable, txnState, partitions, tablets, partitionNameList, isTemp);
             } finally {
                 txnState.writeUnlock();
             }
@@ -3256,5 +3512,136 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
         }
         return batchResponse;
+    }
+
+    private static class CreatePartitionMetrics {
+        private static final long SLOW_THRESHOLD_NS = 1_000_000_000L; // 1 second
+
+        private final long startTimeNs;
+        private long lastTimestampNs;
+        private long validateRequestNs;
+        private long generatePartitionNamesNs;
+        private long validateTxnStateNs;
+        private long fastPathCheckNs;
+        private long buildRequestKeyNs;
+        private long waitForOtherRequestNs;
+        private long acquireLocksNs;
+        private long doubleCheckNs;
+        private long createPartitionsNs;
+        private long releaseLocksNs;
+        private long buildResponseNs;
+        private long totalNs;
+        private boolean isCreator;
+        private boolean isFastPath;
+        private boolean isWaitTimeout;
+        private int partitionCount;
+
+        public CreatePartitionMetrics() {
+            long now = System.nanoTime();
+            this.startTimeNs = now;
+            this.lastTimestampNs = now;
+        }
+
+        private long lap() {
+            long now = System.nanoTime();
+            long elapsed = now - lastTimestampNs;
+            lastTimestampNs = now;
+            return elapsed;
+        }
+
+        public void recordValidateRequest() {
+            this.validateRequestNs = lap();
+        }
+
+        public void recordGeneratePartitionNames(int count) {
+            this.generatePartitionNamesNs = lap();
+            this.partitionCount = count;
+        }
+
+        public void recordValidateTxnState() {
+            this.validateTxnStateNs = lap();
+        }
+
+        public void recordFastPathCheck(boolean isFastPath) {
+            this.fastPathCheckNs = lap();
+            this.isFastPath = isFastPath;
+        }
+
+        public void recordBuildRequestKey() {
+            this.buildRequestKeyNs = lap();
+        }
+
+        public void recordWaitForOtherRequest(boolean isCreator, boolean isWaitTimeout) {
+            this.waitForOtherRequestNs = lap();
+            this.isCreator = isCreator;
+            this.isWaitTimeout = isWaitTimeout;
+        }
+
+        public void recordAcquireLocks() {
+            this.acquireLocksNs = lap();
+        }
+
+        public void recordDoubleCheck() {
+            this.doubleCheckNs = lap();
+        }
+
+        public void recordCreatePartitions() {
+            this.createPartitionsNs = lap();
+        }
+
+        public void recordReleaseLocks() {
+            this.releaseLocksNs = lap();
+        }
+
+        public void recordBuildResponse() {
+            this.buildResponseNs = lap();
+        }
+
+        public void finish() {
+            this.totalNs = System.nanoTime() - startTimeNs;
+        }
+
+        public boolean isSlow() {
+            return totalNs >= SLOW_THRESHOLD_NS;
+        }
+
+        private static double nsToMs(long ns) {
+            return ns / 1_000_000.0;
+        }
+
+        public String toLogString(TCreatePartitionRequest request) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("CreatePartition metrics: ");
+            sb.append("txn_id=").append(request.getTxn_id());
+            sb.append(", db_id=").append(request.getDb_id());
+            sb.append(", table_id=").append(request.getTable_id());
+            sb.append(", partition_count=").append(partitionCount);
+            sb.append(", is_temp=").append(request.isSetIs_temp() && request.isIs_temp());
+            sb.append(", is_creator=").append(isCreator);
+            sb.append(", is_fast_path=").append(isFastPath);
+            sb.append(", is_wait_timeout=").append(isWaitTimeout);
+            // Timing fields are logged in actual execution order:
+            // validate_request -> build_key -> wait_for_other -> (creator: generate_names ->
+            //   validate_txn -> fast_path_check -> acquire_locks -> double_check ->
+            //   create_partitions -> release_locks) -> build_response -> total
+            sb.append(" | Timing(ms): ");
+            sb.append("validate_request=").append(String.format("%.2f", nsToMs(validateRequestNs)));
+            sb.append(", build_key=").append(String.format("%.2f", nsToMs(buildRequestKeyNs)));
+            sb.append(", wait_for_other=").append(String.format("%.2f", nsToMs(waitForOtherRequestNs)));
+            if (isCreator) {
+                sb.append(", generate_names=").append(String.format("%.2f", nsToMs(generatePartitionNamesNs)));
+                sb.append(", validate_txn=").append(String.format("%.2f", nsToMs(validateTxnStateNs)));
+                sb.append(", fast_path_check=").append(String.format("%.2f", nsToMs(fastPathCheckNs)));
+                if (!isFastPath) {
+                    sb.append(", acquire_locks=").append(String.format("%.2f", nsToMs(acquireLocksNs)));
+                    sb.append(", double_check=").append(String.format("%.2f", nsToMs(doubleCheckNs)));
+                    sb.append(", create_partitions=").append(String.format("%.2f", nsToMs(createPartitionsNs)));
+                    sb.append(", release_locks=").append(String.format("%.2f", nsToMs(releaseLocksNs)));
+                }
+            }
+            sb.append(", build_response=").append(String.format("%.2f", nsToMs(buildResponseNs)));
+            sb.append(", total=").append(String.format("%.2f", nsToMs(totalNs)));
+            return sb.toString();
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1381,6 +1381,45 @@ public class AnalyzerUtils {
         }
     }
 
+    /**
+     * Truncate a date/datetime string value to the partition boundary defined by granularity.
+     * Returns the formatted canonical string for the partition start time.
+     * This is the single source of truth for date-to-partition-boundary mapping,
+     * used by both partition clause creation and dedup key generation.
+     */
+    public static String truncateToPartitionBoundary(String dateValue, String granularity) throws AnalysisException {
+        try {
+            if ("NULL".equalsIgnoreCase(dateValue)) {
+                dateValue = "0000-01-01";
+            }
+            DateTimeFormatter fmt = DateUtils.probeFormat(dateValue);
+            LocalDateTime dt = DateUtils.parseStringWithDefaultHSM(dateValue, fmt);
+            switch (granularity.toLowerCase()) {
+                case "minute":
+                    dt = dt.withSecond(0).withNano(0);
+                    return dt.format(DateUtils.MINUTE_FORMATTER_UNIX);
+                case "hour":
+                    dt = dt.withMinute(0).withSecond(0).withNano(0);
+                    return dt.format(DateUtils.HOUR_FORMATTER_UNIX);
+                case "day":
+                    dt = dt.withHour(0).withMinute(0).withSecond(0).withNano(0);
+                    return dt.format(DateUtils.DATEKEY_FORMATTER_UNIX);
+                case "month":
+                    dt = dt.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
+                    return dt.format(DateUtils.MONTH_FORMATTER_UNIX);
+                case "year":
+                    dt = dt.withDayOfYear(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
+                    return dt.format(DateUtils.YEAR_FORMATTER_UNIX);
+                default:
+                    throw new AnalysisException("unsupported automatic partition granularity: " + granularity);
+            }
+        } catch (AnalysisException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AnalysisException("failed to parse partition value: " + dateValue);
+        }
+    }
+
     public static PartitionMeasure checkAndGetPartitionMeasure(Expr expr)
             throws AnalysisException {
         long interval = 1;
@@ -1588,34 +1627,30 @@ public class AnalyzerUtils {
                 if ("NULL".equalsIgnoreCase(partitionItem)) {
                     partitionItem = "0000-01-01";
                 }
+                String truncated = truncateToPartitionBoundary(partitionItem, granularity);
+                partitionName = DEFAULT_PARTITION_NAME_PREFIX + truncated;
+
                 beginDateTimeFormat = DateUtils.probeFormat(partitionItem);
                 beginTime = DateUtils.parseStringWithDefaultHSM(partitionItem, beginDateTimeFormat);
-                // The start date here is passed by BE through function calculation,
-                // so it must be the start date of a certain partition.
                 switch (granularity.toLowerCase()) {
                     case "minute":
                         beginTime = beginTime.withSecond(0).withNano(0);
-                        partitionName = DEFAULT_PARTITION_NAME_PREFIX + beginTime.format(DateUtils.MINUTE_FORMATTER_UNIX);
                         endTime = beginTime.plusMinutes(interval);
                         break;
                     case "hour":
                         beginTime = beginTime.withMinute(0).withSecond(0).withNano(0);
-                        partitionName = DEFAULT_PARTITION_NAME_PREFIX + beginTime.format(DateUtils.HOUR_FORMATTER_UNIX);
                         endTime = beginTime.plusHours(interval);
                         break;
                     case "day":
                         beginTime = beginTime.withHour(0).withMinute(0).withSecond(0).withNano(0);
-                        partitionName = DEFAULT_PARTITION_NAME_PREFIX + beginTime.format(DateUtils.DATEKEY_FORMATTER_UNIX);
                         endTime = beginTime.plusDays(interval);
                         break;
                     case "month":
                         beginTime = beginTime.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
-                        partitionName = DEFAULT_PARTITION_NAME_PREFIX + beginTime.format(DateUtils.MONTH_FORMATTER_UNIX);
                         endTime = beginTime.plusMonths(interval);
                         break;
                     case "year":
                         beginTime = beginTime.withDayOfYear(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
-                        partitionName = DEFAULT_PARTITION_NAME_PREFIX + beginTime.format(DateUtils.YEAR_FORMATTER_UNIX);
                         endTime = beginTime.plusYears(interval);
                         break;
                     default:

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplCreatePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplCreatePartitionTest.java
@@ -15,7 +15,15 @@
 package com.starrocks.service;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
@@ -26,24 +34,37 @@ import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.thrift.TCreatePartitionRequest;
 import com.starrocks.thrift.TCreatePartitionResult;
+import com.starrocks.thrift.TOlapTablePartition;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TransactionState;
+import com.starrocks.type.PrimitiveType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class FrontendServiceImplCreatePartitionTest {
+    private static final Logger LOG = LogManager.getLogger(FrontendServiceImplCreatePartitionTest.class);
+
     @Mocked
     ExecuteEnv exeEnv;
 
@@ -127,5 +148,695 @@ public class FrontendServiceImplCreatePartitionTest {
         Assertions.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.RUNTIME_ERROR);
         Assertions.assertTrue(partition.getStatus().getError_msgs().get(0)
                 .contains("No alive compute node found for tablet. " + "Check if any backend is down or not. tablet_id:"));
+    }
+
+    /**
+     * Test that when partition info is already cached in txnState,
+     * the creator's fast path returns directly without acquiring partition creation locks.
+     */
+    @Test
+    public void testCreatePartitionCreatorFastPathWithCachedPartition() throws TException {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_table");
+
+        // Create a TransactionState with pre-cached partition info
+        TransactionState txnState = new TransactionState();
+        String partitionName = "p20250711";
+
+        // Pre-populate the partition cache
+        ConcurrentMap<String, TOlapTablePartition> partitionCache = txnState.getPartitionNameToTPartition(table.getId());
+        TOlapTablePartition cachedPartition = new TOlapTablePartition();
+        cachedPartition.setId(12345L);
+        cachedPartition.setIndexes(new ArrayList<>());
+        partitionCache.put(partitionName, cachedPartition);
+
+        // Track if lockCreatePartition was called
+        AtomicInteger lockCallCount = new AtomicInteger(0);
+
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                return txnState;
+            }
+        };
+
+        new MockUp<OlapTable>() {
+            @Mock
+            public void lockCreatePartition(String partitionName) {
+                lockCallCount.incrementAndGet();
+            }
+
+            @Mock
+            public void unlockCreatePartition(String partitionName) {
+                // no-op
+            }
+        };
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public Long getAliveComputeNodeId(ComputeResource computeResource, long tabletId) {
+                return 50001L;
+            }
+
+            @Mock
+            public boolean isResourceAvailable(ComputeResource resource) {
+                return true;
+            }
+        };
+
+        List<List<String>> partitionValues = Lists.newArrayList();
+        List<String> values = Lists.newArrayList();
+        values.add("2025-07-11");
+        partitionValues.add(values);
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TCreatePartitionRequest request = new TCreatePartitionRequest();
+        request.setDb_id(db.getId());
+        request.setTable_id(table.getId());
+        request.setTxn_id(1L);
+        request.setPartition_values(partitionValues);
+
+        TCreatePartitionResult result = impl.createPartition(request);
+
+        // When partition is cached, the fast path should be taken and lockCreatePartition should NOT be called
+        Assertions.assertEquals(0, lockCallCount.get(),
+                "lockCreatePartition should not be called when partition is already cached (fast path)");
+    }
+
+    /**
+     * Test CompletableFuture deduplication: when multiple concurrent requests with the same
+     * partition values arrive, only the creator executes creation; others wait on the Future.
+     */
+    @Test
+    public void testCreatePartitionFutureDeduplication() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_table");
+
+        TransactionState txnState = new TransactionState();
+        AtomicInteger addPartitionsCallCount = new AtomicInteger(0);
+        AtomicInteger lockAcquiredCount = new AtomicInteger(0);
+
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                return txnState;
+            }
+        };
+
+        new MockUp<OlapTable>() {
+            @Mock
+            public void lockCreatePartition(String partitionName) {
+                lockAcquiredCount.incrementAndGet();
+                // Simulate the first request adding partition to cache after acquiring lock
+                // This simulates what happens when the first request creates the partition
+                ConcurrentMap<String, TOlapTablePartition> cache =
+                        txnState.getPartitionNameToTPartition(table.getId());
+                if (cache.get(partitionName) == null) {
+                    // First request: add to cache (simulating partition creation)
+                    TOlapTablePartition partition = new TOlapTablePartition();
+                    partition.setId(99999L);
+                    partition.setIndexes(new ArrayList<>());
+                    cache.put(partitionName, partition);
+                    addPartitionsCallCount.incrementAndGet();
+                }
+                // Second and subsequent requests will find the partition in cache
+                // due to the double-check logic
+            }
+
+            @Mock
+            public void unlockCreatePartition(String partitionName) {
+                // no-op
+            }
+        };
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public Long getAliveComputeNodeId(ComputeResource computeResource, long tabletId) {
+                return 50001L;
+            }
+
+            @Mock
+            public boolean isResourceAvailable(ComputeResource resource) {
+                return true;
+            }
+        };
+
+        List<List<String>> partitionValues = Lists.newArrayList();
+        List<String> values = Lists.newArrayList();
+        values.add("2025-07-12");
+        partitionValues.add(values);
+
+        // Simulate concurrent requests
+        int numConcurrentRequests = 5;
+        ExecutorService executor = Executors.newFixedThreadPool(numConcurrentRequests);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(numConcurrentRequests);
+        List<TCreatePartitionResult> results = new ArrayList<>();
+
+        for (int i = 0; i < numConcurrentRequests; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await(); // Wait for all threads to be ready
+                    FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+                    TCreatePartitionRequest request = new TCreatePartitionRequest();
+                    request.setDb_id(db.getId());
+                    request.setTable_id(table.getId());
+                    request.setTxn_id(2L);
+                    request.setPartition_values(partitionValues);
+                    TCreatePartitionResult result = impl.createPartition(request);
+                    synchronized (results) {
+                        results.add(result);
+                    }
+                } catch (Exception e) {
+                    // ignore
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        // Start all threads simultaneously
+        startLatch.countDown();
+        doneLatch.await();
+        executor.shutdown();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+
+        // Due to Future deduplication, only ONE request becomes the creator and actually
+        // "creates" the partition (in our mock, this is tracked by addPartitionsCallCount)
+        Assertions.assertEquals(1, addPartitionsCallCount.get(),
+                "Only one request should actually create the partition due to Future deduplication");
+
+        Assertions.assertTrue(lockAcquiredCount.get() >= 1,
+                "At least one request should have acquired the partition lock");
+    }
+
+    /**
+     * Test that the cache check correctly identifies when partitions are not cached.
+     */
+    @Test
+    public void testCreatePartitionSlowPathWhenNotCached() throws TException {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_table");
+
+        // Empty cache - partition not cached
+        TransactionState txnState = new TransactionState();
+        AtomicInteger lockCallCount = new AtomicInteger(0);
+
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                return txnState;
+            }
+        };
+
+        new MockUp<OlapTable>() {
+            @Mock
+            public void lockCreatePartition(String partitionName) {
+                lockCallCount.incrementAndGet();
+            }
+
+            @Mock
+            public void unlockCreatePartition(String partitionName) {
+                // no-op
+            }
+        };
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public Long getAliveComputeNodeId(ComputeResource computeResource, long tabletId) {
+                return 50001L;
+            }
+        };
+
+        List<List<String>> partitionValues = Lists.newArrayList();
+        List<String> values = Lists.newArrayList();
+        values.add("2025-07-13");
+        partitionValues.add(values);
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TCreatePartitionRequest request = new TCreatePartitionRequest();
+        request.setDb_id(db.getId());
+        request.setTable_id(table.getId());
+        request.setTxn_id(3L);
+        request.setPartition_values(partitionValues);
+
+        impl.createPartition(request);
+
+        // When partition is NOT cached, the slow path should be taken and lockCreatePartition SHOULD be called
+        Assertions.assertTrue(lockCallCount.get() > 0,
+                "lockCreatePartition should be called when partition is not cached (slow path)");
+    }
+
+    /**
+     * Test that identical concurrent requests share the same result via CompletableFuture mechanism.
+     * Only the first request executes the partition creation, others wait and get the same result.
+     */
+    @Test
+    public void testIdenticalConcurrentRequestsShareResult() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_table");
+
+        TransactionState txnState = new TransactionState();
+        AtomicInteger lockCallCount = new AtomicInteger(0);
+        CountDownLatch firstRequestInProgress = new CountDownLatch(1);
+        CountDownLatch allowFirstRequestComplete = new CountDownLatch(1);
+
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                return txnState;
+            }
+        };
+
+        new MockUp<OlapTable>() {
+            @Mock
+            public void lockCreatePartition(String partitionName) {
+                int count = lockCallCount.incrementAndGet();
+                if (count == 1) {
+                    // First request: signal that we're in progress
+                    firstRequestInProgress.countDown();
+                    try {
+                        // Wait for signal to continue (to allow other requests to arrive)
+                        allowFirstRequestComplete.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+                // Add to cache after lock is acquired
+                ConcurrentMap<String, TOlapTablePartition> cache =
+                        txnState.getPartitionNameToTPartition(table.getId());
+                if (cache.get(partitionName) == null) {
+                    TOlapTablePartition partition = new TOlapTablePartition();
+                    partition.setId(88888L);
+                    partition.setIndexes(new ArrayList<>());
+                    cache.put(partitionName, partition);
+                }
+            }
+
+            @Mock
+            public void unlockCreatePartition(String partitionName) {
+                // no-op
+            }
+        };
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public Long getAliveComputeNodeId(ComputeResource computeResource, long tabletId) {
+                return 50001L;
+            }
+
+            @Mock
+            public boolean isResourceAvailable(ComputeResource resource) {
+                return true;
+            }
+        };
+
+        List<List<String>> partitionValues = Lists.newArrayList();
+        List<String> values = Lists.newArrayList();
+        values.add("2025-07-14");
+        partitionValues.add(values);
+
+        int numRequests = 3;
+        ExecutorService executor = Executors.newFixedThreadPool(numRequests);
+        CountDownLatch allDone = new CountDownLatch(numRequests);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        // Submit all requests
+        for (int i = 0; i < numRequests; i++) {
+            executor.submit(() -> {
+                try {
+                    FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+                    TCreatePartitionRequest request = new TCreatePartitionRequest();
+                    request.setDb_id(db.getId());
+                    request.setTable_id(table.getId());
+                    request.setTxn_id(4L);
+                    request.setPartition_values(partitionValues);
+                    request.setTimeout_s(30);
+                    TCreatePartitionResult result = impl.createPartition(request);
+                    if (result.getStatus().getStatus_code() == TStatusCode.OK ||
+                            result.getStatus().getStatus_code() == TStatusCode.RUNTIME_ERROR) {
+                        successCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    // ignore
+                } finally {
+                    allDone.countDown();
+                }
+            });
+        }
+
+        // Wait for first request to be in progress
+        firstRequestInProgress.await();
+
+        // Give other requests time to arrive and wait on the Future
+        Thread.sleep(100);
+
+        // Allow the first request to complete
+        allowFirstRequestComplete.countDown();
+
+        // Wait for all requests to complete
+        allDone.await();
+        executor.shutdown();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+
+        // With the Future mechanism, only the first request should acquire the lock
+        // because other requests with the same requestKey will wait on the Future
+        Assertions.assertEquals(1, lockCallCount.get(),
+                "Only the first request should acquire the lock due to Future deduplication");
+
+        // All requests should complete (either success or error)
+        Assertions.assertEquals(numRequests, successCount.get(),
+                "All requests should complete with a response");
+    }
+
+    /**
+     * Test that the request timeout is correctly used from the request parameter.
+     */
+    @Test
+    public void testRequestTimeoutFromParameter() throws TException {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_table");
+
+        TransactionState txnState = new TransactionState();
+
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                return txnState;
+            }
+        };
+
+        new MockUp<OlapTable>() {
+            @Mock
+            public void lockCreatePartition(String partitionName) {
+                ConcurrentMap<String, TOlapTablePartition> cache =
+                        txnState.getPartitionNameToTPartition(table.getId());
+                TOlapTablePartition partition = new TOlapTablePartition();
+                partition.setId(77777L);
+                partition.setIndexes(new ArrayList<>());
+                cache.put(partitionName, partition);
+            }
+
+            @Mock
+            public void unlockCreatePartition(String partitionName) {
+                // no-op
+            }
+        };
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public Long getAliveComputeNodeId(ComputeResource computeResource, long tabletId) {
+                return 50001L;
+            }
+
+            @Mock
+            public boolean isResourceAvailable(ComputeResource resource) {
+                return true;
+            }
+        };
+
+        List<List<String>> partitionValues = Lists.newArrayList();
+        List<String> values = Lists.newArrayList();
+        values.add("2025-07-15");
+        partitionValues.add(values);
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TCreatePartitionRequest request = new TCreatePartitionRequest();
+        request.setDb_id(db.getId());
+        request.setTable_id(table.getId());
+        request.setTxn_id(5L);
+        request.setPartition_values(partitionValues);
+        request.setTimeout_s(60);
+
+        // The request should complete without timeout issues
+        TCreatePartitionResult result = impl.createPartition(request);
+
+        // Just verify the request completes - timeout value is used internally
+        Assertions.assertNotNull(result);
+    }
+
+    /**
+     * Test that auto-partition creation correctly handles values that fall into a merged
+     * (year-level) partition alongside values that need new monthly partitions.
+     *
+     * Before the fix, buildResponseWithLock used pre-analyzer partition names (e.g. p202204)
+     * which don't exist in the table. The analyzer remaps them to the enclosing partition name
+     * (e.g. p2022), but creatingPartitionNames was never updated. This caused the response to
+     * skip the enclosed partitions, resulting in "Insert has filtered data" errors.
+     */
+    @Test
+    public void testCreatePartitionWithMergedPartition() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE test.merge_test_table (\n" +
+                "    event_day DATETIME,\n" +
+                "    pv BIGINT DEFAULT '0'\n" +
+                ")\n" +
+                "DUPLICATE KEY(event_day)\n" +
+                "PARTITION BY date_trunc('month', event_day)\n" +
+                "DISTRIBUTED BY HASH(event_day) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+
+        try {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState()
+                    .getLocalMetastore().getTable(db.getFullName(), "merge_test_table");
+
+            addYearlyPartition(table, "p2022", 2022, 2023, 900000L, 900001L);
+
+            Assertions.assertNotNull(table.getPartition("p2022"),
+                    "yearly partition p2022 should exist");
+
+            TransactionState txnState = new TransactionState();
+
+            new MockUp<GlobalTransactionMgr>() {
+                @Mock
+                public TransactionState getTransactionState(long dbId, long transactionId) {
+                    return txnState;
+                }
+            };
+
+            new MockUp<WarehouseManager>() {
+                @Mock
+                public Long getAliveComputeNodeId(ComputeResource computeResource, long tabletId) {
+                    return 50001L;
+                }
+
+                @Mock
+                public boolean isResourceAvailable(ComputeResource resource) {
+                    return true;
+                }
+            };
+
+            List<List<String>> partitionValues = Lists.newArrayList();
+            partitionValues.add(Lists.newArrayList("2022-04-01 00:00:00"));
+            partitionValues.add(Lists.newArrayList("2023-06-01 00:00:00"));
+
+            FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+            TCreatePartitionRequest request = new TCreatePartitionRequest();
+            request.setDb_id(db.getId());
+            request.setTable_id(table.getId());
+            request.setTxn_id(100L);
+            request.setPartition_values(partitionValues);
+
+            TCreatePartitionResult result = impl.createPartition(request);
+
+            LOG.info("createPartition result status: {}", result.getStatus().getStatus_code());
+            if (result.getPartitions() != null) {
+                LOG.info("createPartition returned {} partitions", result.getPartitions().size());
+            }
+
+            Assertions.assertEquals(TStatusCode.OK, result.getStatus().getStatus_code(),
+                    "createPartition should succeed; status: " + result.getStatus());
+            Assertions.assertNotNull(result.getPartitions(),
+                    "response should contain partitions");
+            Assertions.assertEquals(2, result.getPartitions().size(),
+                    "response should contain 2 partitions (p2022 for 2022-04-01 and p202306 for 2023-06-01)");
+        } finally {
+            try {
+                starRocksAssert.dropTable("merge_test_table");
+            } catch (Exception e) {
+                // ignore cleanup errors
+            }
+        }
+    }
+
+    /**
+     * Test with multiple values all falling into the same merged partition.
+     */
+    @Test
+    public void testCreatePartitionAllEnclosedByMergedPartition() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE test.merge_all_enclosed_table (\n" +
+                "    event_day DATETIME,\n" +
+                "    pv BIGINT DEFAULT '0'\n" +
+                ")\n" +
+                "DUPLICATE KEY(event_day)\n" +
+                "PARTITION BY date_trunc('month', event_day)\n" +
+                "DISTRIBUTED BY HASH(event_day) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+
+        try {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState()
+                    .getLocalMetastore().getTable(db.getFullName(), "merge_all_enclosed_table");
+
+            addYearlyPartition(table, "p2022", 2022, 2023, 900010L, 900011L);
+
+            TransactionState txnState = new TransactionState();
+
+            new MockUp<GlobalTransactionMgr>() {
+                @Mock
+                public TransactionState getTransactionState(long dbId, long transactionId) {
+                    return txnState;
+                }
+            };
+
+            new MockUp<WarehouseManager>() {
+                @Mock
+                public Long getAliveComputeNodeId(ComputeResource computeResource, long tabletId) {
+                    return 50001L;
+                }
+
+                @Mock
+                public boolean isResourceAvailable(ComputeResource resource) {
+                    return true;
+                }
+            };
+
+            List<List<String>> partitionValues = Lists.newArrayList();
+            partitionValues.add(Lists.newArrayList("2022-03-01 00:00:00"));
+            partitionValues.add(Lists.newArrayList("2022-06-15 00:00:00"));
+            partitionValues.add(Lists.newArrayList("2022-09-20 00:00:00"));
+
+            FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+            TCreatePartitionRequest request = new TCreatePartitionRequest();
+            request.setDb_id(db.getId());
+            request.setTable_id(table.getId());
+            request.setTxn_id(101L);
+            request.setPartition_values(partitionValues);
+
+            TCreatePartitionResult result = impl.createPartition(request);
+
+            Assertions.assertEquals(TStatusCode.OK, result.getStatus().getStatus_code(),
+                    "createPartition should succeed; status: " + result.getStatus());
+            Assertions.assertNotNull(result.getPartitions());
+            Assertions.assertEquals(1, result.getPartitions().size(),
+                    "all values fall into p2022, so response should contain exactly 1 partition");
+        } finally {
+            try {
+                starRocksAssert.dropTable("merge_all_enclosed_table");
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
+    /**
+     * Test with multiple merged partitions spanning different years.
+     */
+    @Test
+    public void testCreatePartitionMultiYearMergedPartitions() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE test.merge_multi_year_table (\n" +
+                "    event_day DATETIME,\n" +
+                "    pv BIGINT DEFAULT '0'\n" +
+                ")\n" +
+                "DUPLICATE KEY(event_day)\n" +
+                "PARTITION BY date_trunc('month', event_day)\n" +
+                "DISTRIBUTED BY HASH(event_day) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+
+        try {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState()
+                    .getLocalMetastore().getTable(db.getFullName(), "merge_multi_year_table");
+
+            addYearlyPartition(table, "p2020", 2020, 2021, 900020L, 900021L);
+            addYearlyPartition(table, "p2021", 2021, 2022, 900030L, 900031L);
+            addYearlyPartition(table, "p2022", 2022, 2023, 900040L, 900041L);
+
+            TransactionState txnState = new TransactionState();
+
+            new MockUp<GlobalTransactionMgr>() {
+                @Mock
+                public TransactionState getTransactionState(long dbId, long transactionId) {
+                    return txnState;
+                }
+            };
+
+            new MockUp<WarehouseManager>() {
+                @Mock
+                public Long getAliveComputeNodeId(ComputeResource computeResource, long tabletId) {
+                    return 50001L;
+                }
+
+                @Mock
+                public boolean isResourceAvailable(ComputeResource resource) {
+                    return true;
+                }
+            };
+
+            List<List<String>> partitionValues = Lists.newArrayList();
+            partitionValues.add(Lists.newArrayList("2020-01-15 00:00:00"));
+            partitionValues.add(Lists.newArrayList("2020-11-20 00:00:00"));
+            partitionValues.add(Lists.newArrayList("2021-03-10 00:00:00"));
+            partitionValues.add(Lists.newArrayList("2021-09-25 00:00:00"));
+            partitionValues.add(Lists.newArrayList("2022-02-14 00:00:00"));
+            partitionValues.add(Lists.newArrayList("2022-12-31 00:00:00"));
+            partitionValues.add(Lists.newArrayList("2023-07-04 00:00:00"));
+
+            FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+            TCreatePartitionRequest request = new TCreatePartitionRequest();
+            request.setDb_id(db.getId());
+            request.setTable_id(table.getId());
+            request.setTxn_id(102L);
+            request.setPartition_values(partitionValues);
+
+            TCreatePartitionResult result = impl.createPartition(request);
+
+            Assertions.assertEquals(TStatusCode.OK, result.getStatus().getStatus_code(),
+                    "createPartition should succeed; status: " + result.getStatus());
+            Assertions.assertNotNull(result.getPartitions());
+            Assertions.assertEquals(4, result.getPartitions().size(),
+                    "response should contain 4 partitions: p2020, p2021, p2022, and p202307");
+        } finally {
+            try {
+                starRocksAssert.dropTable("merge_multi_year_table");
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
+    private static void addYearlyPartition(OlapTable table, String name,
+                                           int startYear, int endYear,
+                                           long partitionId, long physicalPartitionId) throws Exception {
+        List<Column> partitionColumns = table.getPartitionInfo()
+                .getPartitionColumns(table.getIdToColumn());
+
+        PartitionKey lowerKey = new PartitionKey(
+                Lists.newArrayList(new com.starrocks.sql.ast.expression.DateLiteral(
+                        startYear, 1, 1, 0, 0, 0, 0)),
+                Lists.newArrayList(PrimitiveType.DATETIME));
+        PartitionKey upperKey = new PartitionKey(
+                Lists.newArrayList(new com.starrocks.sql.ast.expression.DateLiteral(
+                        endYear, 1, 1, 0, 0, 0, 0)),
+                Lists.newArrayList(PrimitiveType.DATETIME));
+        Range<PartitionKey> range = Range.closedOpen(lowerKey, upperKey);
+
+        RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+        rangePartitionInfo.addPartition(partitionId, false, range,
+                rangePartitionInfo.getDataProperty(table.getPartitions().iterator().hasNext()
+                        ? table.getPartitions().iterator().next().getId() : -1L),
+                (short) 1, null);
+
+        MaterializedIndex baseIndex = new MaterializedIndex(
+                table.getBaseIndexMetaId(), MaterializedIndex.IndexState.NORMAL);
+        HashDistributionInfo distInfo = new HashDistributionInfo(1, partitionColumns);
+        Partition partition = new Partition(partitionId, physicalPartitionId, name, baseIndex, distInfo);
+        table.addPartition(partition);
     }
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1450,6 +1450,8 @@ struct TCreatePartitionRequest {
     // for each partition column's partition values
     4: optional list<list<string>> partition_values
     5: optional bool is_temp
+    // timeout in seconds for partition creation request
+    6: optional i32 timeout_s
 }
 
 struct TCreatePartitionResult {


### PR DESCRIPTION
## Why I'm doing:

During dynamic overwrite operations, each BE node with m parallelism sends n × m partition creation requests to FE. Although only the first request actually creates the partition, all subsequent identical requests still need to acquire locks and build responses, causing significant performance degradation compared to pre-creating temporary partitions.

## What I'm doing:

Introduce a CompletableFuture-based deduplication mechanism for identical partition creation requests:

- Add a ConcurrentHashMap to track pending partition creation requests
- Use tableId + sorted partition names as the unique request key
- Only the first request executes the actual partition creation
- Subsequent identical requests wait on the CompletableFuture and share the same result
- Support dynamic timeout from request parameters (default 30s)


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
