### PR TITLE
[BugFix] Fix FE Queries with Arrow Flight Proxy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -660,7 +660,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
             Location endpoint = getFEEndpoint(ctx.getSessionVariable());
             return buildFlightInfo(request, descriptor, schema, endpoint);
         } catch (InvalidConfException e) {
-            throw CallStatus.INVALID_ARGUMENT.withDescription(e.getMessage()).toRuntimeException();
+            throw CallStatus.INTERNAL.withDescription(e.getMessage()).toRuntimeException();
         }
     }
 
@@ -720,18 +720,12 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
         }
     }
 
-    /**
-     * Validates and parses proxy string into Location.
-     */
     private Location getProxyLocation(String arrowFlightProxy) throws InvalidConfException {
         validateProxyFormat(arrowFlightProxy);
         String[] split = arrowFlightProxy.split(":");
         return Location.forGrpcInsecure(split[0], Integer.parseInt(split[1]));
     }
 
-    /**
-     * Gets endpoint for FE-handled queries, respecting proxy settings.
-     */
     protected Location getFEEndpoint(SessionVariable sv) throws InvalidConfException {
         if (sv.isArrowFlightProxyEnabled()) {
             String arrowFlightProxy = sv.getArrowFlightProxy();
@@ -742,9 +736,6 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
         return feEndpoint;
     }
 
-    /**
-     * Gets endpoint and ticket for BE-handled queries, respecting proxy settings.
-     */
     protected Pair<Location, ByteString> getBEEndpoint(SessionVariable sv, TUniqueId queryId,
                                                   ComputeNode worker, TUniqueId rootFragmentInstanceId)
                                                   throws InvalidConfException {

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -192,6 +192,23 @@ public class ArrowFlightSqlServiceImplTest {
     }
 
     @Test
+    public void testGetFlightInfoCatalogsWithProxy() {
+        // Configure proxy enabled with proxy endpoint
+        SessionVariable mockSv = mock(SessionVariable.class);
+        when(mockContext.getSessionVariable()).thenReturn(mockSv);
+        when(mockSv.isArrowFlightProxyEnabled()).thenReturn(true);
+        when(mockSv.getArrowFlightProxy()).thenReturn("proxy.example.com:9408");
+
+        FlightSql.CommandGetCatalogs command = FlightSql.CommandGetCatalogs.newBuilder().build();
+        FlightInfo info = service.getFlightInfoCatalogs(command, mockCallContext, FlightDescriptor.command("".getBytes()));
+
+        assertNotNull(info);
+        assertEquals(1, info.getEndpoints().size());
+        assertEquals(Location.forGrpcInsecure("proxy.example.com", 9408),
+                info.getEndpoints().get(0).getLocations().get(0));
+    }
+
+    @Test
     public void testGetFlightInfoSchemas() {
         FlightSql.CommandGetDbSchemas command = FlightSql.CommandGetDbSchemas.newBuilder().build();
         FlightInfo info = service.getFlightInfoSchemas(command, mockCallContext, FlightDescriptor.command("".getBytes()));


### PR DESCRIPTION
## Why I'm doing:
#66348 did not support data retrieval from a proxy for FE queries. This fixes that bug. 
Root cause: `buildFlightInfoFromFE` was hardcoded to use `feEndpoint` and didn't have access to the session context to check proxy settings.
## What I'm doing:
- Refactor proxy parsing to separate function
- Split FE/BE endpoint parsing
- Modified `buildFlightInfoFromFE` to accept `CallContext`, lookup session, and call `getFEEndpoint()`
- Update FE metadata RPCs to use proxy (`buildFlightInfoFromFE` related functions)
- Test for new paths

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4