### PR TITLE
[Refactor] Refactor segment options

### DIFF
--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -14,41 +14,36 @@
 
 #pragma once
 
-#include <optional>
-#include <unordered_map>
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_set>
 #include <vector>
 
-#include "column/column_access_path.h"
-#include "column/datum.h"
-#include "fs/fs.h"
 #include "runtime/global_dict/types.h"
-#include "storage/del_vector.h"
 #include "storage/disjunctive_predicates.h"
+#include "storage/olap_common.h"
 #include "storage/options.h"
 #include "storage/predicate_tree/predicate_tree.hpp"
-#include "storage/record_predicate/record_predicate.h"
 #include "storage/runtime_filter_predicate.h"
 #include "storage/runtime_range_pruner.h"
 #include "storage/seek_range.h"
-#include "storage/tablet_schema.h"
 
 namespace starrocks {
-class Condition;
-struct OlapReaderStatistics;
+class ColumnAccessPath;
+class DeltaColumnGroupLoader;
+class DelvecLoader;
+class ObjectPool;
+class RecordPredicate;
 class RuntimeProfile;
 class TabletSchema;
-class DeltaColumnGroupLoader;
-} // namespace starrocks
-
-namespace starrocks {
-
-class ColumnAccessPath;
-class ColumnPredicate;
-struct RowidRangeOption;
-using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
+class Status;
+struct OlapReaderStatistics;
 struct ShortKeyRangeOption;
-using ShortKeyRangeOptionPtr = std::shared_ptr<ShortKeyRangeOption>;
 struct VectorSearchOption;
+
+using ShortKeyRangeOptionPtr = std::shared_ptr<ShortKeyRangeOption>;
 using VectorSearchOptionPtr = std::shared_ptr<VectorSearchOption>;
 
 class SegmentReadOptions {
@@ -67,7 +62,7 @@ public:
 
     DisjunctivePredicates delete_predicates;
 
-    RecordPredicateSPtr record_predicate;
+    std::shared_ptr<RecordPredicate> record_predicate;
 
     // used for updatable tablet to get delvec
     std::shared_ptr<DelvecLoader> delvec_loader;
@@ -105,11 +100,11 @@ public:
 
     const std::atomic<bool>* is_cancelled = nullptr;
 
-    std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
+    std::vector<std::unique_ptr<ColumnAccessPath>>* column_access_paths = nullptr;
 
     RowsetId rowsetid;
 
-    TabletSchemaCSPtr tablet_schema = nullptr;
+    std::shared_ptr<const TabletSchema> tablet_schema = nullptr;
 
     bool asc_hint = true;
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `segment_options.h` to modernize types and clean up dependencies.
> 
> - Updates ownership semantics: `record_predicate` now `std::shared_ptr<RecordPredicate>`, `column_access_paths` now `std::vector<std::unique_ptr<ColumnAccessPath>>*`, and `tablet_schema` now `std::shared_ptr<const TabletSchema>`
> - Adds forward declarations (e.g., `Status`, `OlapReaderStatistics`) and reorganizes type aliases (`ShortKeyRangeOptionPtr`), reducing header coupling; adjusts includes accordingly
> - No functional logic changes observed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a930aceb8fef07a22e9a4fa7128ab7ef6900cb1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->