### PR TITLE
[Tool] Add customized cmake build directory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,10 @@ if [ -z $BUILD_TYPE ]; then
     export BUILD_TYPE=Release
 fi
 
+if [ -z $CMAKE_BUILD_PREFIX ]; then
+    CMAKE_BUILD_PREFIX=${STARROCKS_HOME}/be
+fi
+
 cd $STARROCKS_HOME
 if [ -z $STARROCKS_VERSION ]; then
     tag_name=$(git describe --tags --exact-match 2>/dev/null)
@@ -266,7 +270,7 @@ if [ -e /proc/cpuinfo ] ; then
 fi
 
 if [[ -z ${ENABLE_QUERY_DEBUG_TRACE} ]]; then
-	ENABLE_QUERY_DEBUG_TRACE=OFF
+    ENABLE_QUERY_DEBUG_TRACE=OFF
 fi
 
 if [[ -z ${ENABLE_FAULT_INJECTION} ]]; then
@@ -452,12 +456,12 @@ if [ ${BUILD_BE} -eq 1 ] || [ ${BUILD_FORMAT_LIB} -eq 1 ] ; then
 
     CMAKE_BUILD_TYPE=$BUILD_TYPE
     echo "Build Backend: ${CMAKE_BUILD_TYPE}"
-    CMAKE_BUILD_DIR=${STARROCKS_HOME}/be/build_${CMAKE_BUILD_TYPE}
+    CMAKE_BUILD_DIR=${CMAKE_BUILD_PREFIX}/build_${CMAKE_BUILD_TYPE}
     if [ "${WITH_GCOV}" = "ON" ]; then
-        CMAKE_BUILD_DIR=${STARROCKS_HOME}/be/build_${CMAKE_BUILD_TYPE}_gcov
+        CMAKE_BUILD_DIR=${CMAKE_BUILD_PREFIX}/build_${CMAKE_BUILD_TYPE}_gcov
     fi
     if [ ${BUILD_FORMAT_LIB} -eq 1 ] ; then
-        CMAKE_BUILD_DIR=${STARROCKS_HOME}/be/build_${CMAKE_BUILD_TYPE}_format-lib
+        CMAKE_BUILD_DIR=${CMAKE_BUILD_PREFIX}/build_${CMAKE_BUILD_TYPE}_format-lib
     fi
 
     if [ ${CLEAN} -eq 1 ]; then
@@ -512,7 +516,7 @@ if [ ${BUILD_BE} -eq 1 ] || [ ${BUILD_FORMAT_LIB} -eq 1 ] ; then
                   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                    \
                   -DBUILD_FORMAT_LIB=${BUILD_FORMAT_LIB}                \
                   -DWITH_RELATIVE_SRC_PATH=${WITH_RELATIVE_SRC_PATH}    \
-                  ..
+                  ${STARROCKS_HOME}/be
 
     if [ "${BUILD_BE_MODULE}" != "all" ] ; then
         echo "build Backend module: ${BUILD_BE_MODULE}"

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -174,7 +174,11 @@ if [[ -z ${USE_AVX512} ]]; then
 fi
 echo "Build Backend UT"
 
-CMAKE_BUILD_DIR=${STARROCKS_HOME}/be/ut_build_${CMAKE_BUILD_TYPE}
+if [ -z $CMAKE_BUILD_PREFIX ]; then
+    CMAKE_BUILD_PREFIX=${STARROCKS_HOME}/be
+fi
+
+CMAKE_BUILD_DIR=${CMAKE_BUILD_PREFIX}/ut_build_${CMAKE_BUILD_TYPE}
 if [ ${CLEAN} -eq 1 ]; then
     rm ${CMAKE_BUILD_DIR} -rf
     rm ${STARROCKS_HOME}/be/output/ -rf
@@ -229,7 +233,8 @@ ${CMAKE_CMD}  -G "${CMAKE_GENERATOR}" \
             -DSTARROCKS_JIT_ENABLE=ON \
             -DWITH_RELATIVE_SRC_PATH=OFF \
             -DENABLE_MULTI_DYNAMIC_LIBS=${WITH_DYNAMIC} \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            ${STARROCKS_HOME}/be
 
 ${BUILD_SYSTEM} -j${PARALLEL}
 


### PR DESCRIPTION
Add a OS environment CMAKE_BUILD_PREFIX
User can specify cmake build directory by given CMAKE_BUILD_PREFIX

CMAKE_BUILD_PREFIX=/home/you/sr-build ./build.sh --be -j 4 CMAKE_BUILD_PREFIX=/home/you/sr-build ./run-be-ut.sh -j 4

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables customizable CMake build directories for Backend and unit tests.
> 
> - Adds `CMAKE_BUILD_PREFIX` env var (default: `${STARROCKS_HOME}/be`) to control `CMAKE_BUILD_DIR` in `build.sh` and `run-be-ut.sh`
> - Replaces hardcoded `be/build_*` and `be/ut_build_*` paths with `${CMAKE_BUILD_PREFIX}/...`
> - Updates CMake source dir to `${STARROCKS_HOME}/be` instead of `..` in both scripts
> - Minor consistency/whitespace adjustments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68cd0822ba77d81192d5bc698042c1044297460c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->