### PR TITLE
[Enhancement] support shared-nothing publish transaction using thread pool

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -180,7 +180,7 @@ public class SplitTabletJob extends TabletReshardJob {
         // 1. Publish the split transaction, update new tablet ranges
         boolean allPartitionFinished = true;
         ThreadPoolExecutor publishThreadPool = GlobalStateMgr.getCurrentState().getPublishVersionDaemon()
-                .getLakeTaskExecutor();
+                .getTaskExecutor();
 
         try (LockedObject<OlapTable> lockedTable = getLockedTable(LockType.READ)) {
             OlapTable olapTable = lockedTable.get();

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3177,11 +3177,15 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "partitions which can be vacuumed immediately, test only, format:'id1;id2'")
     public static String lake_vacuum_immediately_partition_ids = "";
 
-    @ConfField(mutable = true, comment = "the max number of threads for lake table publishing version")
-    public static int lake_publish_version_max_threads = 512;
+    @ConfField(mutable = true, comment = "the max number of threads for publishing version",
+            aliases = {"lake_publish_version_max_threads"})
+    public static int publish_version_max_threads = 512;
 
     @ConfField(mutable = true, comment = "the max number of threads for lake table delete txnLog when enable batch publish")
     public static int lake_publish_delete_txnlog_max_threads = 16;
+
+    @ConfField(mutable = false, comment = "whether allow using publish thread pool for shared-nothing")
+    public static boolean shared_nothing_publish_use_thread_pool = false;
 
     @ConfField(mutable = true, comment =
             "Consider balancing between workers during tablet migration in shared data mode. Default: true")

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -674,7 +674,7 @@ public class GlobalStateMgr {
                 new MaterializedViewHandler(),
                 new SystemHandler());
         this.lakeAlterPublishExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
-                Config.lake_publish_version_max_threads, "alter-publish", false);
+                Config.publish_version_max_threads, "alter-publish", false);
 
         this.load = new Load();
         this.streamLoadMgr = new StreamLoadMgr();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -92,17 +92,21 @@ public class PublishVersionDaemon extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(PublishVersionDaemon.class);
 
     private static final long RETRY_INTERVAL_MS = 1000;
-    private static final int LAKE_PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE = 512;
-    public static final int LAKE_PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE = 4096;
-    // about 16 (2 * LAKE_PUBLISH_MAX_QUEUE_SIZE/LAKE_PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE ) tasks pending for
+    private static final int PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE = 512;
+    public static final int PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE = 4096;
+    // about 16 (2 * PUBLISH_MAX_QUEUE_SIZE/PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE ) tasks pending for
     // each thread under the default configurations
-    private static final int LAKE_PUBLISH_MAX_QUEUE_SIZE = 4096;
+    private static final int PUBLISH_MAX_QUEUE_SIZE = 4096;
 
-    private ThreadPoolExecutor lakeTaskExecutor;
+    // for shared-data, task executor thread will be responsible for sending publish tasks to BE
+    // and modify transaction state on FE
+    // for shared-nothing, task executor thread will be responsible for checking publish task
+    // result and modify transaction state on FE
+    private ThreadPoolExecutor taskExecutor;
     private ThreadPoolExecutor deleteTxnLogExecutor;
 
     @VisibleForTesting
-    protected Set<Long> publishingLakeTransactions;
+    protected Set<Long> publishingTransactionIds;
 
     @VisibleForTesting
     protected Set<Long> publishingLakeTransactionsBatchTableId;
@@ -155,55 +159,55 @@ public class PublishVersionDaemon extends FrontendDaemon {
         }
     }
 
-    private int getOrFixLakeTaskExecutorThreadPoolMaxSizeConfig() {
-        String configVarName = "lake_publish_version_max_threads";
-        int maxSize = Config.lake_publish_version_max_threads;
+    private int getOrFixTaskExecutorThreadPoolMaxSizeConfig() {
+        String configVarName = "publish_version_max_threads";
+        int maxSize = Config.publish_version_max_threads;
         if (maxSize <= 0) {
             LOG.warn("Invalid configuration value '{}' for {}, force set to default value:{}",
-                    maxSize, configVarName, LAKE_PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE);
-            maxSize = LAKE_PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE;
-            Config.lake_publish_version_max_threads = maxSize;
-        } else if (maxSize > LAKE_PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE) {
+                    maxSize, configVarName, PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE);
+            maxSize = PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE;
+            Config.publish_version_max_threads = maxSize;
+        } else if (maxSize > PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE) {
             LOG.warn(
                     "Configuration value for item {} exceeds the preset hard limit. Config value:{}," +
                             " preset hard limit:{}. Force set to default value:{}.",
-                    configVarName, maxSize, LAKE_PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE,
-                    LAKE_PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE);
-            maxSize = LAKE_PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE;
-            Config.lake_publish_version_max_threads = maxSize;
+                    configVarName, maxSize, PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE,
+                    PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE);
+            maxSize = PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE;
+            Config.publish_version_max_threads = maxSize;
         }
         return maxSize;
     }
 
-    private void adjustLakeTaskExecutor() {
-        if (lakeTaskExecutor == null) {
+    private void adjustTaskExecutor() {
+        if (taskExecutor == null) {
             return;
         }
 
         // only do update with valid setting
-        int newNumThreads = Config.lake_publish_version_max_threads;
-        if (newNumThreads > LAKE_PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE || newNumThreads <= 0) {
+        int newNumThreads = Config.publish_version_max_threads;
+        if (newNumThreads > PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE || newNumThreads <= 0) {
             // DON'T LOG, otherwise the log line will repeat everytime the listener refreshes
             return;
         }
-        ThreadPoolManager.setFixedThreadPoolSize(lakeTaskExecutor, newNumThreads);
+        ThreadPoolManager.setFixedThreadPoolSize(taskExecutor, newNumThreads);
     }
 
     /**
-     * Create a thread pool executor for LakeTable synchronizing publish.
-     * The thread pool size can be configured by `Config.lake_publish_version_max_threads` and is affected by the
+     * Create a thread pool executor for synchronizing publish tasks.
+     * The thread pool size can be configured by `Config.publish_version_max_threads` and is affected by the
      * following constant variables
-     * - LAKE_PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE
-     * - LAKE_PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE
-     * - LAKE_PUBLISH_MAX_QUEUE_SIZE
+     * - PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE
+     * - PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE
+     * - PUBLISH_MAX_QUEUE_SIZE
      * <p>
-     * The valid range for the configuration item `Config.lake_publish_version_max_threads` is
-     * (0, LAKE_PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE], if the initial value is out of range,
-     * the LAKE_PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE will be used. During the runtime update, if the new value provided
+     * The valid range for the configuration item `Config.publish_version_max_threads` is
+     * (0, PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE], if the initial value is out of range,
+     * the PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE will be used. During the runtime update, if the new value provided
      * is out of range, the value will be just ignored silently.
      * <p>
      * The thread pool is created with the corePoolSize and maxPoolSize equals to
-     * `Config.lake_publish_version_max_threads`, or set to LAKE_PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE in case exceeded.
+     * `Config.publish_version_max_threads`, or set to PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE in case exceeded.
      * core threads are also allowed to timeout when idle.
      * <p>
      * Threads in the thread pool will be created in the following way:
@@ -216,21 +220,21 @@ public class PublishVersionDaemon extends FrontendDaemon {
      *
      * @return the thread pool executor
      */
-    public @NotNull ThreadPoolExecutor getLakeTaskExecutor() {
-        if (lakeTaskExecutor == null) {
-            int numThreads = getOrFixLakeTaskExecutorThreadPoolMaxSizeConfig();
-            lakeTaskExecutor =
-                    ThreadPoolManager.newDaemonFixedThreadPool(numThreads, LAKE_PUBLISH_MAX_QUEUE_SIZE,
-                            "lake-publish-task",
+    public @NotNull ThreadPoolExecutor getTaskExecutor() {
+        if (taskExecutor == null) {
+            int numThreads = getOrFixTaskExecutorThreadPoolMaxSizeConfig();
+            taskExecutor =
+                    ThreadPoolManager.newDaemonFixedThreadPool(numThreads, PUBLISH_MAX_QUEUE_SIZE,
+                            "publish-task",
                             true);
             // allow core thread timeout as well
-            lakeTaskExecutor.allowCoreThreadTimeOut(true);
+            taskExecutor.allowCoreThreadTimeOut(true);
 
             // register ThreadPool config change listener
             GlobalStateMgr.getCurrentState().getConfigRefreshDaemon()
-                    .registerListener(() -> this.adjustLakeTaskExecutor());
+                    .registerListener(() -> this.adjustTaskExecutor());
         }
-        return lakeTaskExecutor;
+        return taskExecutor;
     }
 
     private @NotNull ThreadPoolExecutor getDeleteTxnLogExecutor() {
@@ -253,11 +257,11 @@ public class PublishVersionDaemon extends FrontendDaemon {
         return deleteTxnLogExecutor;
     }
 
-    private @NotNull Set<Long> getPublishingLakeTransactions() {
-        if (publishingLakeTransactions == null) {
-            publishingLakeTransactions = Sets.newConcurrentHashSet();
+    private @NotNull Set<Long> getPublishingTransactions() {
+        if (publishingTransactionIds == null) {
+            publishingTransactionIds = Sets.newConcurrentHashSet();
         }
-        return publishingLakeTransactions;
+        return publishingTransactionIds;
     }
 
     // Only one table in all transactionStates in transactionStateBatch
@@ -305,63 +309,93 @@ public class PublishVersionDaemon extends FrontendDaemon {
         }
 
         // try to finish the transaction, if failed just retry in next loop
+        Set<Long> publishingTransactions = getPublishingTransactions();
         for (TransactionState transactionState : readyTransactionStates) {
-            Map<Long, PublishVersionTask> transTasks = transactionState.getPublishVersionTasks();
-            Set<Long> publishErrorReplicaIds = Sets.newHashSet();
-            Set<Long> unfinishedBackends = Sets.newHashSet();
-            boolean allTaskFinished = true;
-            for (PublishVersionTask publishVersionTask : transTasks.values()) {
-                if (publishVersionTask.isFinished()) {
-                    // sometimes backend finish publish version task, but it maybe failed to change
-                    // transaction id to version for some tablets,
-                    // and it will upload the failed tablet info to fe and fe will deal with them
-                    Set<Long> errReplicas = publishVersionTask.getErrorReplicas();
-                    if (!errReplicas.isEmpty()) {
-                        publishErrorReplicaIds.addAll(errReplicas);
-                    }
-                } else {
-                    allTaskFinished = false;
-                    // Publish version task may succeed and finish in quorum replicas
-                    // but not finish in one replica.
-                    // here collect the backendId that do not finish publish version
-                    unfinishedBackends.add(publishVersionTask.getBackendId());
+            if (!Config.shared_nothing_publish_use_thread_pool) {
+                tryFinishTransaction(transactionState);
+            } else {
+                long txnId = transactionState.getTransactionId();
+                if (!publishingTransactions.add(txnId)) {
+                    LOG.debug("skip finish publish transaction {}", txnId);
+                    continue;
                 }
-            }
-            boolean shouldFinishTxn = true;
-            if (!allTaskFinished) {
-                shouldFinishTxn = globalTransactionMgr.canTxnFinished(transactionState,
-                        publishErrorReplicaIds, unfinishedBackends);
-            }
-
-            if (shouldFinishTxn) {
                 try {
-                    // Attempt to finish the transaction with a lock timeout. If it fails, it will be retried in the next cycle.
-                    // This approach prevents blocking subsequent transactions due to the current one.
-                    globalTransactionMgr.finishTransaction(transactionState.getDbId(),
-                            transactionState.getTransactionId(), publishErrorReplicaIds,
-                            Config.finish_transaction_default_lock_timeout_ms);
-                } catch (StarRocksException exception) {
-                    if (exception.getErrorCode() == ErrorCode.ERR_LOCK_ERROR) {
-                        LOG.warn("Fail to get lock to finish transaction {}, error: {}. Will retry later",
-                                transactionState.getTransactionId(), exception.getMessage());
-                        continue;
-                    } else {
-                        throw exception;
-                    }
-                }
-                if (transactionState.getTransactionStatus() != TransactionStatus.VISIBLE) {
-                    transactionState.updateSendTaskTime();
-                    LOG.debug("publish version for transaction {} failed, has {} error replicas during publish",
-                            transactionState, publishErrorReplicaIds.size());
-                } else {
-                    for (PublishVersionTask task : transactionState.getPublishVersionTasks().values()) {
-                        AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.PUBLISH_VERSION, task.getSignature());
-                    }
-                    // clear publish version tasks to reduce memory usage when state changed to visible.
-                    transactionState.clearAfterPublished();
+                    getTaskExecutor().execute(() -> {
+                        try {
+                            tryFinishTransaction(transactionState);
+                        } catch (Throwable t) {
+                            LOG.error("Error processing transaction {}", txnId, t);
+                        } finally {
+                            publishingTransactions.remove(txnId);
+                        }
+                    });
+                } catch (Throwable e) {
+                    // Task rejected, remove from processing set
+                    publishingTransactions.remove(txnId);
+                    LOG.warn("Failed to submit publish task for txn {}: {}", txnId, e.getMessage());
                 }
             }
         } // end for readyTransactionStates
+    }
+
+    private void tryFinishTransaction(TransactionState transactionState) throws StarRocksException {
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+
+        Map<Long, PublishVersionTask> transTasks = transactionState.getPublishVersionTasks();
+        Set<Long> publishErrorReplicaIds = Sets.newHashSet();
+        Set<Long> unfinishedBackends = Sets.newHashSet();
+        boolean allTaskFinished = true;
+        for (PublishVersionTask publishVersionTask : transTasks.values()) {
+            if (publishVersionTask.isFinished()) {
+                // sometimes backend finish publish version task, but it maybe failed to change
+                // transaction id to version for some tablets,
+                // and it will upload the failed tablet info to fe and fe will deal with them
+                Set<Long> errReplicas = publishVersionTask.getErrorReplicas();
+                if (!errReplicas.isEmpty()) {
+                    publishErrorReplicaIds.addAll(errReplicas);
+                }
+            } else {
+                allTaskFinished = false;
+                // Publish version task may succeed and finish in quorum replicas
+                // but not finish in one replica.
+                // here collect the backendId that do not finish publish version
+                unfinishedBackends.add(publishVersionTask.getBackendId());
+            }
+        }
+        boolean shouldFinishTxn = true;
+        if (!allTaskFinished) {
+            shouldFinishTxn = globalTransactionMgr.canTxnFinished(transactionState,
+                    publishErrorReplicaIds, unfinishedBackends);
+        }
+
+        if (shouldFinishTxn) {
+            try {
+                // Attempt to finish the transaction with a lock timeout. If it fails, it will be retried in the next cycle.
+                // This approach prevents blocking subsequent transactions due to the current one.
+                globalTransactionMgr.finishTransaction(transactionState.getDbId(),
+                        transactionState.getTransactionId(), publishErrorReplicaIds,
+                        Config.finish_transaction_default_lock_timeout_ms);
+            } catch (StarRocksException exception) {
+                if (exception.getErrorCode() == ErrorCode.ERR_LOCK_ERROR) {
+                    LOG.warn("Fail to get lock to finish transaction {}, error: {}. Will retry later",
+                            transactionState.getTransactionId(), exception.getMessage());
+                    return;
+                } else {
+                    throw exception;
+                }
+            }
+            if (transactionState.getTransactionStatus() != TransactionStatus.VISIBLE) {
+                transactionState.updateSendTaskTime();
+                LOG.debug("publish version for transaction {} failed, has {} error replicas during publish",
+                        transactionState, publishErrorReplicaIds.size());
+            } else {
+                for (PublishVersionTask task : transactionState.getPublishVersionTasks().values()) {
+                    AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.PUBLISH_VERSION, task.getSignature());
+                }
+                // clear publish version tasks to reduce memory usage when state changed to visible.
+                transactionState.clearAfterPublished();
+            }
+        }
     }
 
     private void publishVersionNew(GlobalTransactionMgr globalTransactionMgr, List<TransactionState> txns) {
@@ -392,7 +426,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
     }
 
     void publishVersionForLakeTable(List<TransactionState> readyTransactionStates) {
-        Set<Long> publishingTransactions = getPublishingLakeTransactions();
+        Set<Long> publishingTransactions = getPublishingTransactions();
         for (TransactionState txnState : readyTransactionStates) {
             long txnId = txnState.getTransactionId();
             if (!publishingTransactions.contains(txnId)) { // the set did not already contain the specified element
@@ -417,7 +451,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
 
     void publishVersionForLakeTableBatch(List<TransactionStateBatch> readyTransactionStatesBatch) {
         Set<Long> publishingLakeTransactionsBatchTableId = getPublishingLakeTransactionsBatchTableId();
-        Set<Long> publishingTransactions = getPublishingLakeTransactions();
+        Set<Long> publishingTransactions = getPublishingTransactions();
         for (TransactionStateBatch txnStateBatch : readyTransactionStatesBatch) {
             if (txnStateBatch.size() == 1) {
                 // there are two situations:
@@ -771,7 +805,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
                     commitInfo.setVersionTime(versionTime);
                 }
                 return success;
-            }, getLakeTaskExecutor()).exceptionally(ex -> {
+            }, getTaskExecutor()).exceptionally(ex -> {
                 LOG.error("Fail to publish txn batch", ex);
                 long versionTime = -System.currentTimeMillis();
                 for (PartitionCommitInfo commitInfo : publishVersionData.getPartitionCommitInfos()) {
@@ -837,7 +871,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
             boolean success = publishPartition(db, tableCommitInfo, partitionCommitInfo, txnState);
             partitionCommitInfo.setVersionTime(success ? System.currentTimeMillis() : -System.currentTimeMillis());
             return success;
-        }, getLakeTaskExecutor()).exceptionally(ex -> {
+        }, getTaskExecutor()).exceptionally(ex -> {
             LOG.error("Fail to publish txn " + txnState.getTransactionId(), ex);
             partitionCommitInfo.setVersionTime(-System.currentTimeMillis());
             return false;

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -516,16 +516,16 @@ public class LakePublishBatchTest {
         VisibleStateWaiter waiter7 = globalTransactionMgr.commitTransaction(db.getId(), transactionId7, transTablets1,
                 Lists.newArrayList(), null);
 
-        // mock the switch from single to batch by adding transactionId to publishingLakeTransactions
-        publishVersionDaemon.publishingLakeTransactions.clear();
-        publishVersionDaemon.publishingLakeTransactions.add(transactionId6);
+        // mock the switch from single to batch by adding transactionId to publishingTransactionIds
+        publishVersionDaemon.publishingTransactionIds.clear();
+        publishVersionDaemon.publishingTransactionIds.add(transactionId6);
 
         Config.lake_enable_batch_publish_version = true;
         publishVersionDaemon.runAfterCatalogReady();
         Assertions.assertFalse(waiter6.await(5, TimeUnit.SECONDS));
         Assertions.assertFalse(waiter7.await(5, TimeUnit.SECONDS));
 
-        publishVersionDaemon.publishingLakeTransactions.clear();
+        publishVersionDaemon.publishingTransactionIds.clear();
         publishVersionDaemon.runAfterCatalogReady();
         Assertions.assertTrue(waiter6.await(60, TimeUnit.SECONDS));
         Assertions.assertTrue(waiter7.await(60, TimeUnit.SECONDS));

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
@@ -14,9 +14,18 @@
 
 package com.starrocks.transaction;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.starrocks.common.Config;
 import com.starrocks.common.ConfigRefreshDaemon;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.task.PublishVersionTask;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -25,19 +34,26 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class PublishVersionDaemonTest {
     public int oldValue;
+    private boolean originalSharedNothingPublishUseThreadPool;
 
     @BeforeEach
     public void setUp() {
-        oldValue = Config.lake_publish_version_max_threads;
+        oldValue = Config.publish_version_max_threads;
+        originalSharedNothingPublishUseThreadPool = Config.shared_nothing_publish_use_thread_pool;
     }
 
     @AfterEach
     public void tearDown() {
-        Config.lake_publish_version_max_threads = oldValue;
+        Config.publish_version_max_threads = oldValue;
+        Config.shared_nothing_publish_use_thread_pool = originalSharedNothingPublishUseThreadPool;
     }
 
     @Test
@@ -45,90 +61,90 @@ public class PublishVersionDaemonTest {
             throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         PublishVersionDaemon daemon = new PublishVersionDaemon();
 
-        ThreadPoolExecutor executor = (ThreadPoolExecutor) MethodUtils.invokeMethod(daemon, true, "getLakeTaskExecutor");
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) MethodUtils.invokeMethod(daemon, true, "getTaskExecutor");
         Assertions.assertNotNull(executor);
-        Assertions.assertEquals(Config.lake_publish_version_max_threads, executor.getMaximumPoolSize());
-        Assertions.assertEquals(Config.lake_publish_version_max_threads, executor.getCorePoolSize());
+        Assertions.assertEquals(Config.publish_version_max_threads, executor.getMaximumPoolSize());
+        Assertions.assertEquals(Config.publish_version_max_threads, executor.getCorePoolSize());
 
         ConfigRefreshDaemon configDaemon = GlobalStateMgr.getCurrentState().getConfigRefreshDaemon();
 
         // scale out
-        Config.lake_publish_version_max_threads += 10;
+        Config.publish_version_max_threads += 10;
         MethodUtils.invokeMethod(configDaemon, true, "runAfterCatalogReady");
-        Assertions.assertEquals(Config.lake_publish_version_max_threads, executor.getMaximumPoolSize());
-        Assertions.assertEquals(Config.lake_publish_version_max_threads, executor.getCorePoolSize());
+        Assertions.assertEquals(Config.publish_version_max_threads, executor.getMaximumPoolSize());
+        Assertions.assertEquals(Config.publish_version_max_threads, executor.getCorePoolSize());
 
 
         // scale in
-        Config.lake_publish_version_max_threads -= 5;
+        Config.publish_version_max_threads -= 5;
         MethodUtils.invokeMethod(configDaemon, true, "runAfterCatalogReady");
-        Assertions.assertEquals(Config.lake_publish_version_max_threads, executor.getMaximumPoolSize());
-        Assertions.assertEquals(Config.lake_publish_version_max_threads, executor.getCorePoolSize());
+        Assertions.assertEquals(Config.publish_version_max_threads, executor.getMaximumPoolSize());
+        Assertions.assertEquals(Config.publish_version_max_threads, executor.getCorePoolSize());
 
         int oldNumber = executor.getMaximumPoolSize();
 
         // config set to < 0
-        Config.lake_publish_version_max_threads = -1;
+        Config.publish_version_max_threads = -1;
         MethodUtils.invokeMethod(configDaemon, true, "runAfterCatalogReady");
         Assertions.assertEquals(oldNumber, executor.getMaximumPoolSize());
         Assertions.assertEquals(oldNumber, executor.getCorePoolSize());
 
 
-        // config set to > LAKE_PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE
-        Config.lake_publish_version_max_threads = PublishVersionDaemon.LAKE_PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE + 1;
+        // config set to > PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE
+        Config.publish_version_max_threads = PublishVersionDaemon.PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE + 1;
         MethodUtils.invokeMethod(configDaemon, true, "runAfterCatalogReady");
         Assertions.assertEquals(oldNumber, executor.getMaximumPoolSize());
         Assertions.assertEquals(oldNumber, executor.getCorePoolSize());
 
 
-        // config set to LAKE_PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE
-        Config.lake_publish_version_max_threads = PublishVersionDaemon.LAKE_PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE;
+        // config set to PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE
+        Config.publish_version_max_threads = PublishVersionDaemon.PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE;
         MethodUtils.invokeMethod(configDaemon, true, "runAfterCatalogReady");
-        Assertions.assertEquals(Config.lake_publish_version_max_threads, executor.getMaximumPoolSize());
-        Assertions.assertEquals(Config.lake_publish_version_max_threads, executor.getCorePoolSize());
+        Assertions.assertEquals(Config.publish_version_max_threads, executor.getMaximumPoolSize());
+        Assertions.assertEquals(Config.publish_version_max_threads, executor.getCorePoolSize());
 
         // config set to 1
-        Config.lake_publish_version_max_threads = 1;
+        Config.publish_version_max_threads = 1;
         MethodUtils.invokeMethod(configDaemon, true, "runAfterCatalogReady");
-        Assertions.assertEquals(Config.lake_publish_version_max_threads, executor.getMaximumPoolSize());
-        Assertions.assertEquals(Config.lake_publish_version_max_threads, executor.getCorePoolSize());
+        Assertions.assertEquals(Config.publish_version_max_threads, executor.getMaximumPoolSize());
+        Assertions.assertEquals(Config.publish_version_max_threads, executor.getCorePoolSize());
     }
 
     @Test
     public void testInvalidInitConfiguration()
             throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         int hardCodeDefaultMaxThreads = (int) FieldUtils.readDeclaredStaticField(PublishVersionDaemon.class,
-                "LAKE_PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE", true);
+                "PUBLISH_THREAD_POOL_DEFAULT_MAX_SIZE", true);
 
         // <= 0
         int initValue = 0;
-        Config.lake_publish_version_max_threads = initValue;
+        Config.publish_version_max_threads = initValue;
         {
             PublishVersionDaemon daemon = new PublishVersionDaemon();
             ThreadPoolExecutor executor =
-                    (ThreadPoolExecutor) MethodUtils.invokeMethod(daemon, true, "getLakeTaskExecutor");
+                    (ThreadPoolExecutor) MethodUtils.invokeMethod(daemon, true, "getTaskExecutor");
 
             Assertions.assertNotNull(executor);
             Assertions.assertNotEquals(initValue, executor.getMaximumPoolSize());
             Assertions.assertEquals(hardCodeDefaultMaxThreads, executor.getMaximumPoolSize());
             Assertions.assertEquals(hardCodeDefaultMaxThreads, executor.getCorePoolSize());
             // configVar set to default value.
-            Assertions.assertEquals(hardCodeDefaultMaxThreads, Config.lake_publish_version_max_threads);
+            Assertions.assertEquals(hardCodeDefaultMaxThreads, Config.publish_version_max_threads);
         }
 
-        // > LAKE_PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE
-        initValue = PublishVersionDaemon.LAKE_PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE + 1;
-        Config.lake_publish_version_max_threads = initValue;
+        // > PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE
+        initValue = PublishVersionDaemon.PUBLISH_THREAD_POOL_HARD_LIMIT_SIZE + 1;
+        Config.publish_version_max_threads = initValue;
         {
             PublishVersionDaemon daemon = new PublishVersionDaemon();
             ThreadPoolExecutor executor =
-                    (ThreadPoolExecutor) MethodUtils.invokeMethod(daemon, true, "getLakeTaskExecutor");
+                    (ThreadPoolExecutor) MethodUtils.invokeMethod(daemon, true, "getTaskExecutor");
             Assertions.assertNotNull(executor);
             Assertions.assertNotEquals(initValue, executor.getMaximumPoolSize());
             Assertions.assertEquals(hardCodeDefaultMaxThreads, executor.getMaximumPoolSize());
             Assertions.assertEquals(hardCodeDefaultMaxThreads, executor.getCorePoolSize());
             // configVar set to default value.
-            Assertions.assertEquals(hardCodeDefaultMaxThreads, Config.lake_publish_version_max_threads);
+            Assertions.assertEquals(hardCodeDefaultMaxThreads, Config.publish_version_max_threads);
         }
     }
 
@@ -150,5 +166,256 @@ public class PublishVersionDaemonTest {
         Config.lake_publish_delete_txnlog_max_threads -= 5;
         MethodUtils.invokeMethod(configDaemon, true, "runAfterCatalogReady");
         Assertions.assertEquals(Config.lake_publish_delete_txnlog_max_threads, executor.getMaximumPoolSize());
+    }
+
+    /**
+     * Helper method to create a mock TransactionState for shared_nothing_publish_use_thread_pool tests
+     */
+    private TransactionState createMockTransactionState(long txnId, long dbId, boolean allTasksFinished) {
+        TransactionState txnState = new TransactionState(
+                dbId,
+                Lists.newArrayList(1L),
+                txnId,
+                "test_label_" + txnId,
+                null,
+                TransactionState.LoadJobSourceType.FRONTEND,
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, "localfe"),
+                -1,
+                Config.stream_load_default_timeout_second
+        );
+        txnState.setTransactionStatus(TransactionStatus.COMMITTED);
+
+        PublishVersionTask task1 = new PublishVersionTask(1L, txnId, 0L, dbId, System.currentTimeMillis(),
+                null, null, null, System.currentTimeMillis(), null, false, TransactionType.TXN_NORMAL);
+        task1.setIsFinished(allTasksFinished);
+        txnState.addPublishVersionTask(1L, task1);
+
+        return txnState;
+    }
+
+    private static class SynchronousExecutor extends ThreadPoolExecutor {
+        public SynchronousExecutor() {
+            super(1, 1, 0L, java.util.concurrent.TimeUnit.MILLISECONDS,
+                    new java.util.concurrent.LinkedBlockingQueue<>());
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+        }
+    }
+
+    /**
+     * Test shared_nothing_publish_use_thread_pool=true scenarios:
+     * 1. Transactions are submitted to thread pool, finishTransaction is called, and publishingTransactionIds is cleaned up
+     * 2. Duplicate transactions are skipped
+     * 3. canTxnFinished returns false - transaction should not finish
+     * 4. When thread pool submission fails, publishingTransactionIds is still cleaned up
+     */
+    @Test
+    public void testSharedNothingPublishWithThreadPool(
+            @Mocked GlobalStateMgr globalStateMgr,
+            @Mocked GlobalTransactionMgr globalTransactionMgr,
+            @Mocked NodeMgr nodeMgr,
+            @Mocked SystemInfoService systemInfoService) throws Exception {
+        Config.shared_nothing_publish_use_thread_pool = true;
+
+        long txnId1 = 1001L;
+        long txnId2 = 1002L;
+        long txnId3 = 1003L;
+        long dbId = 100L;
+
+        TransactionState txnState1 = createMockTransactionState(txnId1, dbId, true);
+        TransactionState txnState2 = createMockTransactionState(txnId2, dbId, true);
+        TransactionState txnState3 = createMockTransactionState(txnId3, dbId, false);
+
+        List<Long> finishedTxnIds = new ArrayList<>();
+        AtomicInteger canTxnFinishedCallCount = new AtomicInteger(0);
+
+        new MockUp<PublishVersionDaemon>() {
+            @Mock
+            public ThreadPoolExecutor getTaskExecutor() {
+                return new SynchronousExecutor();
+            }
+        };
+
+        // Test 1: Multiple transactions processed, finishTransaction called
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                minTimes = 0;
+                globalStateMgr.getNodeMgr();
+                result = nodeMgr;
+                minTimes = 0;
+                nodeMgr.getClusterInfo();
+                result = systemInfoService;
+                minTimes = 0;
+                systemInfoService.getBackendIds(false);
+                result = Lists.newArrayList(1L, 2L, 3L);
+                minTimes = 0;
+
+                globalTransactionMgr.getReadyToPublishTransactions(anyBoolean);
+                result = Lists.newArrayList(txnState1, txnState2);
+
+                globalTransactionMgr.canTxnFinished((TransactionState) any, (Set<Long>) any, (Set<Long>) any);
+                result = true;
+                minTimes = 0;
+
+                globalTransactionMgr.finishTransaction(anyLong, anyLong, (Set<Long>) any, anyLong);
+                result = new mockit.Delegate<Void>() {
+                    void finishTransaction(long db, long txn, Set<Long> err, long timeout) {
+                        finishedTxnIds.add(txn);
+                    }
+                };
+            }
+        };
+
+        PublishVersionDaemon daemon = new PublishVersionDaemon();
+        daemon.runAfterCatalogReady();
+
+        Assertions.assertEquals(2, finishedTxnIds.size());
+        Assertions.assertTrue(finishedTxnIds.contains(txnId1));
+        Assertions.assertTrue(finishedTxnIds.contains(txnId2));
+        // Verify publishingTransactionIds is properly cleaned up after completion
+        Assertions.assertFalse(daemon.publishingTransactionIds.contains(txnId1));
+        Assertions.assertFalse(daemon.publishingTransactionIds.contains(txnId2));
+
+        // Test 2: Duplicate transaction skipped
+        finishedTxnIds.clear();
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                minTimes = 0;
+                globalStateMgr.getNodeMgr();
+                result = nodeMgr;
+                minTimes = 0;
+                nodeMgr.getClusterInfo();
+                result = systemInfoService;
+                minTimes = 0;
+                systemInfoService.getBackendIds(false);
+                result = Lists.newArrayList(1L, 2L, 3L);
+                minTimes = 0;
+
+                globalTransactionMgr.getReadyToPublishTransactions(anyBoolean);
+                result = Lists.newArrayList(txnState1);
+
+                globalTransactionMgr.canTxnFinished((TransactionState) any, (Set<Long>) any, (Set<Long>) any);
+                result = true;
+                minTimes = 0;
+
+                globalTransactionMgr.finishTransaction(anyLong, anyLong, (Set<Long>) any, anyLong);
+                result = new mockit.Delegate<Void>() {
+                    void finishTransaction(long db, long txn, Set<Long> err, long timeout) {
+                        finishedTxnIds.add(txn);
+                    }
+                };
+                minTimes = 0;
+            }
+        };
+
+        daemon.publishingTransactionIds = Sets.newConcurrentHashSet();
+        daemon.publishingTransactionIds.add(txnId1);
+        daemon.runAfterCatalogReady();
+
+        Assertions.assertEquals(0, finishedTxnIds.size());
+
+        // Test 3: canTxnFinished returns false - transaction should not finish
+        finishedTxnIds.clear();
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                minTimes = 0;
+                globalStateMgr.getNodeMgr();
+                result = nodeMgr;
+                minTimes = 0;
+                nodeMgr.getClusterInfo();
+                result = systemInfoService;
+                minTimes = 0;
+                systemInfoService.getBackendIds(false);
+                result = Lists.newArrayList(1L, 2L, 3L);
+                minTimes = 0;
+
+                globalTransactionMgr.getReadyToPublishTransactions(anyBoolean);
+                result = Lists.newArrayList(txnState3);
+
+                globalTransactionMgr.canTxnFinished((TransactionState) any, (Set<Long>) any, (Set<Long>) any);
+                result = new mockit.Delegate<Boolean>() {
+                    boolean canTxnFinished(TransactionState state, Set<Long> err, Set<Long> unfinished) {
+                        canTxnFinishedCallCount.incrementAndGet();
+                        return false;
+                    }
+                };
+
+                globalTransactionMgr.finishTransaction(anyLong, anyLong, (Set<Long>) any, anyLong);
+                result = new mockit.Delegate<Void>() {
+                    void finishTransaction(long db, long txn, Set<Long> err, long timeout) {
+                        finishedTxnIds.add(txn);
+                    }
+                };
+                minTimes = 0;
+            }
+        };
+
+        PublishVersionDaemon daemon2 = new PublishVersionDaemon();
+        daemon2.runAfterCatalogReady();
+
+        Assertions.assertTrue(canTxnFinishedCallCount.get() > 0);
+        Assertions.assertEquals(0, finishedTxnIds.size());
+
+        // Test 4: Thread pool submission fails, publishingTransactionIds is still cleaned up
+        finishedTxnIds.clear();
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                minTimes = 0;
+                globalStateMgr.getNodeMgr();
+                result = nodeMgr;
+                minTimes = 0;
+                nodeMgr.getClusterInfo();
+                result = systemInfoService;
+                minTimes = 0;
+                systemInfoService.getBackendIds(false);
+                result = Lists.newArrayList(1L, 2L, 3L);
+                minTimes = 0;
+
+                globalTransactionMgr.getReadyToPublishTransactions(anyBoolean);
+                result = Lists.newArrayList(txnState1);
+            }
+        };
+
+        new MockUp<PublishVersionDaemon>() {
+            @Mock
+            public ThreadPoolExecutor getTaskExecutor() {
+                return new ThreadPoolExecutor(1, 1, 0L, java.util.concurrent.TimeUnit.MILLISECONDS,
+                        new java.util.concurrent.LinkedBlockingQueue<>()) {
+                    @Override
+                    public void execute(Runnable command) {
+                        throw new java.util.concurrent.RejectedExecutionException("Simulated rejection");
+                    }
+                };
+            }
+        };
+
+        PublishVersionDaemon daemon3 = new PublishVersionDaemon();
+        daemon3.runAfterCatalogReady();
+
+        // Even if submission fails, publishingTransactionIds should be cleaned up
+        Assertions.assertFalse(daemon3.publishingTransactionIds.contains(txnId1));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
allow shared-nothing cluster publish transaction use thread pool, the one that only used for shared-data before, so after the change, shared-nothing and shared-data can share the same thread pool

1. rename FE config `lake_publish_version_max_threads` to `publish_version_max_threads`;
2. introduce FE config `shared_nothing_publish_use_thread_pool`;
3. rename `lakeTaskExecutor` to `taskExecutor`;
4. rename `publishingLakeTransactions` to `publishingTransactions`;

before
```
SQL statistics:
    queries performed:
        read:                            0
        write:                           2520
        other:                           0
        total:                           2520
    transactions:                        2520   (40.89 per sec.)
    queries:                             2520   (40.89 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          61.6350s
    total number of events:              2520

Latency (ms):
         min:                                   96.20
         avg:                                 2433.57
         max:                                44709.68
         95th percentile:                     1678.14
         sum:                              6132596.31
```
after
```
SQL statistics:
    queries performed:
        read:                            0
        write:                           7984
        other:                           0
        total:                           7984
    transactions:                        7984   (131.60 per sec.)
    queries:                             7984   (131.60 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          60.6669s
    total number of events:              7984

Latency (ms):
         min:                                   64.26
         avg:                                  757.70
         max:                                 5770.34
         95th percentile:                      926.33
         sum:                              6049488.52
```
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies and generalizes the publish-version execution path, optionally enabling thread-pool processing for shared-nothing transactions.
> 
> - Introduces `Config.publish_version_max_threads` (aliasing `lake_publish_version_max_threads`), adds `Config.shared_nothing_publish_use_thread_pool`, and updates `GlobalStateMgr` to use the new config
> - Refactors `PublishVersionDaemon`: rename `lakeTaskExecutor`→`taskExecutor`, lake-specific constants→generic, `publishingLakeTransactions`→`publishingTransactionIds`; exposes `getTaskExecutor`, validates/resizes pool via new helpers
> - Adds optional async path for shared-nothing: when `shared_nothing_publish_use_thread_pool` is true, transactions are finished via `taskExecutor` with de-duplication and error handling; extracts `tryFinishTransaction`
> - Updates callers to the generic executor (e.g., `SplitTabletJob.getTaskExecutor`, async lake publish paths)
> - Adjusts/extends tests (`PublishVersionDaemonTest`, `LakePublishBatchTest`) for config rename, bounds/resize behavior, and new shared-nothing thread-pool execution
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a67deaa88bf223d78546d9569db0a7222d00d16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->