### PR TITLE
[Enhancement] Improve pruning in DP join reorder

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
@@ -531,7 +531,7 @@ public abstract class JoinOrder {
         return true;
     }
 
-    private boolean existsEqOnPredicate(OptExpression optExpression) {
+    protected boolean existsEqOnPredicate(OptExpression optExpression) {
         LogicalJoinOperator joinOp = optExpression.getOp().cast();
         List<ScalarOperator> onPredicates = Utils.extractConjuncts(joinOp.getOnPredicate());
 
@@ -541,5 +541,24 @@ public abstract class JoinOrder {
         List<BinaryPredicateOperator> eqOnPredicates = JoinHelper.getEqualsPredicate(
                 leftChildColumns, rightChildColumns, onPredicates);
         return !eqOnPredicates.isEmpty();
+    }
+
+    public static double saturatingAdd(double a, double b) {
+        double max = StatisticsEstimateCoefficient.MAXIMUM_COST;
+        if (a >= max || b >= max) {
+            return max;
+        }
+        return a > (max - b) ? max : (a + b);
+    }
+
+    public static double saturatingMul(double a, double b) {
+        double max = StatisticsEstimateCoefficient.MAXIMUM_COST;
+        if (a <= 0 || b <= 0) {
+            return 0;
+        }
+        if (a >= max || b >= max) {
+            return max;
+        }
+        return a > (max / b) ? max : (a * b);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderDP.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderDP.java
@@ -16,9 +16,12 @@ package com.starrocks.sql.optimizer.rule.join;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
+import com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -66,11 +69,7 @@ public class JoinReorderDP extends JoinOrder {
 
     private GroupInfo getBestExpr(BitSet joinKeys) {
         if (joinKeys.cardinality() == 1) {
-            int index = 0;
-            while (!joinKeys.get(index)) {
-                index++;
-            }
-
+            int index = joinKeys.nextSetBit(0);
             return groups.get(index);
         }
 
@@ -93,8 +92,30 @@ public class JoinReorderDP extends JoinOrder {
                     continue;
                 }
 
+                double childLowerBound = saturatingAdd(leftGroup.bestExprInfo.cost, rightGroup.bestExprInfo.cost);
+                if (childLowerBound > bestCostSoFar) {
+                    continue;
+                }
+
                 Optional<ExpressionInfo> joinExpr = buildJoinExpr(leftGroup, rightGroup);
-                if (!joinExpr.isPresent())  {
+                if (joinExpr.isEmpty())  {
+                    continue;
+                }
+
+                double joinLowerBound = childLowerBound;
+                LogicalJoinOperator joinOp = joinExpr.get().expr.getOp().cast();
+                if (joinOp.getJoinType().isCrossJoin()) {
+                    long penalty = ConnectContext.get().getSessionVariable().getCrossJoinCostPenalty();
+                    if (joinOp.getOnPredicate() == null && joinOp.getPredicate() == null) {
+                        double crossRows = saturatingMul(leftGroup.bestExprInfo.rowCount, rightGroup.bestExprInfo.rowCount);
+                        joinLowerBound = saturatingMul(saturatingAdd(joinLowerBound, crossRows), penalty);
+                    } else {
+                        joinLowerBound = saturatingMul(joinLowerBound, penalty);
+                    }
+                } else if (!existsEqOnPredicate(joinExpr.get().expr)) {
+                    joinLowerBound = saturatingMul(joinLowerBound, StatisticsEstimateCoefficient.EXECUTE_COST_PENALTY);
+                }
+                if (joinLowerBound > bestCostSoFar) {
                     continue;
                 }
 


### PR DESCRIPTION
## Why I'm doing:
In DP join reorder, `calculateStatistics()` is expensive and is invoked for each candidate join expression. Even with existing pruning, we still end up calling `calculateStatistics()` for many candidates that are provably worse than the current best plan. Adding tighter lower-bound pruning **before** stats estimation can significantly reduce the number of expensive `calculateStatistics()` calls.

## What I'm doing:
- Add a child-cost lower bound (`saturatingAdd(leftCost, rightCost)`) to prune candidates early before building/estimating join expressions.
- Add an additional pre-stats lower bound that incorporates CROSS JOIN penalty (and pure cross row-count lower bound) and the non-equi (nestloop) penalty via `existsEqOnPredicate`, to skip expensive candidates before calling `calculateStatistics()`.
- The CROSS JOIN / non-equi penalty handling and saturation rules are **aligned with the existing `computeCost()` implementation**, so the pruning is semantically consistent (it only skips candidates that cannot beat `bestCostSoFar` under the same cost model).
- Use `BitSet.nextSetBit(0)` for the single-atom base case to simplify and speed up index lookup.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
