### PR TITLE
[BugFix] fix type mismatch when rewriting simple agg by stats

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
@@ -375,7 +375,8 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
         if (constantMap.size() == aggregationOperator.getAggregations().size()) {
             // all aggregations can be replaced
             Preconditions.checkState(newAggCalls.isEmpty());
-            LogicalValuesOperator row = new LogicalValuesOperator(scanOperator.getOutputColumns().subList(0, 1),
+            ColumnRefOperator dummy = factory.create("dummy", IntegerType.BIGINT, true);
+            LogicalValuesOperator row = new LogicalValuesOperator(List.of(dummy),
                     List.of(List.of(ConstantOperator.createExampleValueByType(IntegerType.BIGINT))));
             return Optional.of(OptExpression.create(project, OptExpression.create(row)));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateMetaTest.java
@@ -109,5 +109,23 @@ public class AggregateMetaTest extends PlanTestBase {
                 "  0:UNION\n" +
                 "     constant exprs: \n" +
                 "         1");
+        starRocksAssert.withTable("CREATE TABLE `t_bug` (\n" +
+                "  `k1` varchar(65533) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"compression\" = \"LZ4\",\n" +
+                "\"fast_schema_evolution\" = \"true\",\n" +
+                "\"replicated_storage\" = \"true\",\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+
+        sql = "SELECT COUNT(), hex(1) FROM t_bug";
+        String thriftPlan = getThriftPlan(sql);
+        assertContains(thriftPlan, "union_node:TUnionNode(tuple_id:0,");
+        String descTbl = getDescTbl(sql);
+        assertContains(descTbl, "TSlotDescriptor(id:6, parent:0, " +
+                "slotType:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:BIGINT))])");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #67830 https://github.com/StarRocks/StarRocksTest/issues/10824

When rewriting count using meta, we need to ensure that the type of column ref is consistent with the constant.


In this case, within `UnionConstSourceOperator::pull_chunk`, the type of src_column is BIGINT, and dst_column is created based on the dst_slot. If their types do not match, an error will occur when appending data.

```cpp
    for (size_t col_i = 0; col_i < columns_count; col_i++) {
        const auto* dst_slot = _dst_slots[col_i];

        MutableColumnPtr dst_column = ColumnHelper::create_column(_allocator, dst_slot->type(), dst_slot->is_nullable());
        dst_column->reserve(rows_count);

        for (size_t row_i = 0; row_i < rows_count; row_i++) {
            // Each const_expr_list is projected to ONE dest row.
            DCHECK_EQ(_const_expr_lists[_next_processed_row_index + row_i].size(), columns_count);

            ASSIGN_OR_RETURN(ColumnPtr src_column,
                             _const_expr_lists[_next_processed_row_index + row_i][col_i]->evaluate(nullptr));

            RETURN_IF_HAS_ERROR(_const_expr_lists[_next_processed_row_index + row_i]);
            auto cur_row_dst_column =
                    ColumnHelper::move_column(_allocator, dst_slot->type(), dst_slot->is_nullable(),
                                              std::move(src_column), 1);
            dst_column->append(*cur_row_dst_column, 0, 1);
        }

        chunk->append_column(std::move(dst_column), dst_slot->id());
    }
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
