### PR TITLE
[BugFix] Fix low cardinality bugs with lamda function

### DIFF
--- a/be/src/exprs/dictmapping_expr.cpp
+++ b/be/src/exprs/dictmapping_expr.cpp
@@ -48,7 +48,9 @@ StatusOr<ColumnPtr> DictMappingExpr::evaluate_checked(ExprContext* context, Chun
         } else if (dict_func_expr != nullptr) {
             return dict_func_expr->evaluate_checked(context, ptr);
         } else {
-            return Status::InternalError("unreachable path, dict_func_expr shouldn't be nullptr");
+            // This should never happen, only when DictOptimizeParser::rewrite_conjuncts or DictMappingExpr::open function is not called.
+            return Status::InternalError(
+                    fmt::format("unreachable path, dict_func_expr shouldn't be nullptr: {}", debug_string()));
         }
     } else if (_children.size() == 3) {
         // array -> string
@@ -58,7 +60,9 @@ StatusOr<ColumnPtr> DictMappingExpr::evaluate_checked(ExprContext* context, Chun
         if (dict_func_expr != nullptr) {
             return dict_func_expr->evaluate_checked(context, &cc);
         } else {
-            return Status::InternalError("unreachable path, array_dict_func_expr shouldn't be nullptr");
+            // This should never happen, only when DictOptimizeParser::rewrite_conjuncts or DictMappingExpr::open function is not called.
+            return Status::InternalError(
+                    fmt::format("unreachable path, array_dict_func_expr shouldn't be nullptr: {}", debug_string()));
         }
     }
 

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -923,6 +923,13 @@ SlotId Expr::max_used_slot_id() const {
     return max_slot_id;
 }
 
+Status Expr::do_for_each_child(const std::function<Status(Expr*)>& callback) {
+    for (auto& child : _children) {
+        RETURN_IF_ERROR(callback(child));
+    }
+    return Status::OK();
+}
+
 } // namespace starrocks
 
 #pragma clang diagnostic pop

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -267,6 +267,16 @@ public:
 #endif
     SlotId max_used_slot_id() const;
 
+    // For each child of this expression, call the callback function.
+    // NOTE: This method only call the callback function for the children of this expression no recursively.
+    // If you want to call it recursively, you can do it like this:
+    // Status do_action(Expr* expr) {
+    //     RETURN_IF_ERROR(action_impl(expr));
+    //     RETURN_IF_ERROR(expr->do_for_each_child(do_action));
+    //     return Status::OK();
+    // }
+    virtual Status do_for_each_child(const std::function<Status(Expr*)>& callback);
+
 protected:
     friend class MathFunctions;
     friend class StringFunctions;

--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -60,10 +60,6 @@ Status LambdaFunction::extract_outer_common_exprs(RuntimeState* state, ExprConte
         }
     });
 
-    if (expr->is_dictmapping_expr()) {
-        return Status::OK();
-    }
-
     // for the lambda function, we only consider extracting the outer common expression from the lambda expr,
     // not its arguments
     int child_num = expr->is_lambda_function() ? 1 : expr->get_num_children();
@@ -72,9 +68,16 @@ Status LambdaFunction::extract_outer_common_exprs(RuntimeState* state, ExprConte
     for (int i = 0; i < child_num; i++) {
         auto child = expr->get_child(i);
 
+        // ignore dictmapping expr & its children, because it will be rewritten by DictOptimizeParser::rewrite_expr function.
+        if (child->is_dictmapping_expr()) {
+            continue;
+        }
+
         RETURN_IF_ERROR(extract_outer_common_exprs(state, expr_ctx, child, ctx));
+
         // if child is a slotref or a lambda function or a literal, we can't replace it.
-        if (child->is_slotref() || child->is_lambda_function() || child->is_literal() || child->is_constant()) {
+        if (child->is_slotref() || child->is_lambda_function() || child->is_literal() || child->is_constant() ||
+            child->is_dictmapping_expr()) {
             continue;
         }
 
@@ -263,4 +266,16 @@ std::string LambdaFunction::debug_string() const {
     return out.str();
 }
 
+Status LambdaFunction::do_for_each_child(const std::function<Status(Expr*)>& callback) {
+    // call callback for children
+    for (auto& child : _children) {
+        RETURN_IF_ERROR(callback(child));
+    }
+    // If the lambda function contains a dictmapping expr, we don't need to extract the outer common expression.
+    // because the dictmapping expr needs to be rewritten by DictOptimizeParser::rewrite_expr/DictMappingExpr::open function.
+    for (auto& child : _common_sub_expr) {
+        RETURN_IF_ERROR(callback(child));
+    }
+    return Status::OK();
+}
 } // namespace starrocks

--- a/be/src/exprs/lambda_function.h
+++ b/be/src/exprs/lambda_function.h
@@ -68,6 +68,8 @@ public:
     Expr* get_lambda_expr() const { return _children[0]; }
     std::string debug_string() const override;
 
+    Status do_for_each_child(const std::function<Status(Expr*)>& callback) override;
+
     struct ExtractContext {
         // lambda arguments id in the current scope
         std::unordered_set<SlotId> current_lambda_arguments;

--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -76,7 +76,7 @@ public:
         }
     }
 
-    PlaceHolderRef* get_place_holder(Expr* root) {
+    static PlaceHolderRef* get_place_holder(Expr* root) {
         if (auto f = dynamic_cast<PlaceHolderRef*>(root)) {
             return down_cast<PlaceHolderRef*>(f);
         }
@@ -405,8 +405,11 @@ Status DictOptimizeParser::eval_expression(ExprContext* expr_ctx, DictOptimizeCo
 }
 
 Status DictOptimizeParser::rewrite_expr(ExprContext* ctx, Expr* expr, SlotId slot_id) {
+    VLOG(2) << "rewrite_expr: " << expr->debug_string();
     // call rewrite for each DictMappingExpr
     if (auto f = dynamic_cast<DictMappingExpr*>(expr)) {
+        DCHECK_GE(f->get_num_children(), 2);
+        DCHECK_NOTNULL(DictFuncExpr::get_place_holder(f->get_child(1)));
         return f->rewrite([&]() -> StatusOr<Expr*> {
             auto* dict_ctx_handle = _runtime_state->obj_pool()->add(new DictOptimizeContext());
             RETURN_IF_ERROR(_eval_and_rewrite(ctx, f, dict_ctx_handle, slot_id));
@@ -414,9 +417,7 @@ Status DictOptimizeParser::rewrite_expr(ExprContext* ctx, Expr* expr, SlotId slo
         });
     }
 
-    for (auto child : expr->children()) {
-        RETURN_IF_ERROR(rewrite_expr(ctx, child, -1));
-    }
+    RETURN_IF_ERROR(expr->do_for_each_child([&](Expr* child_expr) { return rewrite_expr(ctx, child_expr, -1); }));
     return Status::OK();
 }
 

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_with_lamda_function
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_with_lamda_function
@@ -1,0 +1,46 @@
+-- name: test_low_cardinality_with_lamda_function
+CREATE TABLE t1 (
+    c VARCHAR(65535) NULL COMMENT ""
+)
+ENGINE = OLAP
+DUPLICATE KEY(c)
+DISTRIBUTED BY RANDOM
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t1 VALUES ('A'), ('A');
+-- result:
+-- !result
+SELECT SLEEP(3);
+-- result:
+1
+-- !result
+[UC] ANALYZE FULL TABLE t1;
+-- result:
+test_db_bf1e812a1ddf43f49bddea55b1ae64eb.t1	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('c', 't1')
+-- result:
+
+-- !result
+set enable_scan_predicate_expr_reuse=false;
+-- result:
+-- !result
+WITH T2 AS (SELECT c IS NULL AS cn, [c] AS c FROM t1), T3 AS (SELECT array_length(ARRAY_MAP((arg_811) -> cn, c)) AS l FROM T2) SELECT * FROM T3;
+-- result:
+1
+1
+-- !result
+WITH T2 AS (SELECT c IS NULL AS cn, [c] AS c FROM t1), T3 AS (SELECT array_length(ARRAY_MAP((arg_811) -> cn, c)) AS l FROM T2) SELECT * FROM T3 WHERE l > 0;
+-- result:
+1
+1
+-- !result
+WITH T2 AS (SELECT c IS NULL AS cn, [c] AS c FROM t1), T3 AS (SELECT array_length(ARRAY_MAP((arg_811) -> cn, c)) AS l FROM T2) SELECT * FROM T3 WHERE l > 1;
+-- result:
+-- !result
+drop table t1;
+-- result:
+-- !result

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_with_lamda_function
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_with_lamda_function
@@ -1,0 +1,23 @@
+-- name: test_low_cardinality_with_lamda_function
+
+CREATE TABLE t1 (
+    c VARCHAR(65535) NULL COMMENT ""
+)
+ENGINE = OLAP
+DUPLICATE KEY(c)
+DISTRIBUTED BY RANDOM
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t1 VALUES ('A'), ('A');
+SELECT SLEEP(3);
+[UC] ANALYZE FULL TABLE t1;
+function: wait_global_dict_ready('c', 't1')
+
+set enable_scan_predicate_expr_reuse=false;
+WITH T2 AS (SELECT c IS NULL AS cn, [c] AS c FROM t1), T3 AS (SELECT array_length(ARRAY_MAP((arg_811) -> cn, c)) AS l FROM T2) SELECT * FROM T3;
+WITH T2 AS (SELECT c IS NULL AS cn, [c] AS c FROM t1), T3 AS (SELECT array_length(ARRAY_MAP((arg_811) -> cn, c)) AS l FROM T2) SELECT * FROM T3 WHERE l > 0;
+WITH T2 AS (SELECT c IS NULL AS cn, [c] AS c FROM t1), T3 AS (SELECT array_length(ARRAY_MAP((arg_811) -> cn, c)) AS l FROM T2) SELECT * FROM T3 WHERE l > 1;
+
+drop table t1;


### PR DESCRIPTION
## Why I'm doing:

This is a follow up of https://github.com/StarRocks/starrocks/pull/55861.

If the lambda function contains a dictmapping expr, we don't need to extract the outer common expression. because the dictmapping expr needs to be rewritten by DictOptimizeParser::rewrite_expr/DictMappingExpr::open function.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Skip outer common-expr extraction in lambdas containing `dictmapping`**: Introduces `Expr::is_contains_dictmapping_expr` and uses it in `LambdaFunction::extract_outer_common_exprs` to avoid extracting outer common expressions when a `dictmapping` exists, allowing proper rewrite by `DictOptimizeParser`.
> - **Improve diagnostics in `DictMappingExpr`**: Replaces generic internal errors with messages including `debug_string()` when `dict_func_expr` is unexpectedly null or children size is invalid.
> - **Add regression tests**: New SQL tests validate low-cardinality behavior with lambda functions and disabled predicate expr reuse.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3411017f28a6902cdbbd6287c7590c686e460411. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->