### PR TITLE
[BugFix] fix bundle file vacuum when Fe downgrade

### DIFF
--- a/be/src/storage/lake/async_file_deleter.h
+++ b/be/src/storage/lake/async_file_deleter.h
@@ -120,6 +120,11 @@ public:
 
     bool is_empty() const { return _pending_files.empty(); }
 
+    void clear() {
+        _pending_files.clear();
+        _delay_delete_files.clear();
+    }
+
 private:
     // file to shared count.
     std::unordered_map<std::string, uint32_t> _pending_files;

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -2966,8 +2966,6 @@ TEST_P(LakeVacuumTest, test_vacuum_shared_data_files) {
         vacuum(_tablet_mgr.get(), request, &response);
         ASSERT_TRUE(response.has_status());
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
-        EXPECT_EQ(0, response.vacuumed_files());
-        EXPECT_EQ(0, response.vacuumed_file_size());
 
         EXPECT_TRUE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"));
         EXPECT_TRUE(file_exist("00000000000259e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e1e.dat"));


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request improves the handling of bundle file deletion in the Lake storage vacuum process, especially when file bundling is disabled (such as during a downgrade or compatibility scenario). The changes ensure that bundle files are not deleted when the system doesn't have complete information, and also add a test to verify this behavior.

**Bundle file deletion logic:**

* Added a check in `vacuum_tablet_metadata` to clear the `bundle_file_deleter` if file bundling is disabled, preventing accidental deletion of bundle files when not all tablet information is available.
* Introduced a `clear()` method to the `AsyncBundleFileDeleter` class to reset its internal state, supporting the above logic.

**Testing:**

* Added a test case to `LakeVacuumTest` verifying that when `enable_file_bundling` is false, shared files are not deleted during vacuum, ensuring correct behavior in downgrade or compatibility scenarios.

https://github.com/StarRocks/StarRocksTest/issues/10842

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
