### PR TITLE
[Enhancement] Restore missing optimizations in DP statistics estimation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateUtils.java
@@ -67,21 +67,31 @@ public class StatisticsEstimateUtils {
     }
 
     public static Statistics adjustStatisticsByRowCount(Statistics statistics, double rowCount) {
-        // Do not compute predicate statistics if column statistics is unknown or table row count may inaccurate
-        if (statistics.getColumnStatistics().values().stream().anyMatch(ColumnStatistic::isUnknown) ||
-                statistics.isTableRowCountMayInaccurate()) {
+        if (statistics.isTableRowCountMayInaccurate()) {
             return statistics;
         }
-        double distinctValues = Math.max(1, rowCount);
-        boolean needAdjustDistinctValues = statistics.getColumnStatistics().values().stream()
-                .anyMatch(cs -> cs.getDistinctValuesCount() > distinctValues);
-        if (!needAdjustDistinctValues) {
-            return statistics.withOutputRowCount(rowCount);
+        for (ColumnStatistic cs : statistics.getColumnStatistics().values()) {
+            if (cs.isUnknown()) {
+                return statistics;
+            }
         }
 
-        Statistics.Builder builder = Statistics.buildFrom(statistics);
-        builder.setOutputRowCount(rowCount);
-        statistics.getColumnStatistics().forEach((column, columnStatistic) -> {
+        Statistics updated = statistics.withOutputRowCount(rowCount);
+        double distinctValues = Math.max(1, updated.getOutputRowCount());
+        boolean needAdjust = false;
+        for (ColumnStatistic cs : updated.getColumnStatistics().values()) {
+            if (cs.getDistinctValuesCount() > distinctValues) {
+                needAdjust = true;
+                break;
+            }
+        }
+        if (!needAdjust) {
+            return updated;
+        }
+
+        Statistics.Builder builder = Statistics.buildFrom(updated);
+        builder.setOutputRowCount(updated.getOutputRowCount());
+        updated.getColumnStatistics().forEach((column, columnStatistic) -> {
             if (columnStatistic.getDistinctValuesCount() > distinctValues) {
                 builder.addColumnStatistic(column,
                         ColumnStatistic.buildFrom(columnStatistic).setDistinctValuesCount(distinctValues).build());


### PR DESCRIPTION
## Why I'm doing:
Recent changes on `main` unintentionally dropped some performance optimizations in the DP statistics estimation hot path. Since DP join reorder calls `calculateStatistics()` thousands of times, the regression is amplified. This PR restores those missing optimizations to bring performance back while keeping cost/statistics semantics unchanged.

## What I'm doing:
- Restore the guard for `PredicateColumnsMgr.recordJoinPredicate(...)` under `skipPredicateColumnsCollectionScope()` to avoid repeated predicate-columns recording during DP stats estimation.
- Restore the rowcount-only fast path in correlated join estimation by using `withOutputRowCount(...)` instead of rebuilding `Statistics` via `buildFrom(...).build()`.
- Restore the optimized `adjustStatisticsByRowCount()` fast path:
  - update rowcount via `withOutputRowCount` first,
  - avoid stream/lambda overhead with loops and early breaks,
  - rebuild column stats only when NDV adjustment is actually needed.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores missing performance optimizations in DP stats estimation hot path without altering cost/statistics semantics.
> 
> - Guard `PredicateColumnsMgr.recordJoinPredicate(...)` with `shouldSkipPredicateColumnsCollection()` to avoid repeated recording during DP estimation
> - Use `withOutputRowCount(...)` in correlated inner-join estimation instead of rebuilding `Statistics`
> - Optimize `StatisticsEstimateUtils.adjustStatisticsByRowCount(...)`:
>   - update rowcount via `withOutputRowCount` first
>   - early-return if table row count is inaccurate or any column stats are unknown
>   - loop with early-break to decide NDV adjustment and rebuild only when needed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26596842ad6167e4013c56dfdb248a6e7bcdd38e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->