### PR TITLE
[BugFix] Improve identifier wrapping for JDBC table and column names

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
@@ -60,6 +60,11 @@ public class JDBCScanNode extends ScanNode {
         if (identifier.isEmpty()) {
             return name;
         }
+        // If name already have identifier wrapped, just return
+        if (name.length() > 2 && name.startsWith(identifier) && name.endsWith(identifier)) {
+            return name;
+        }
+
         String[] parts = name.split("\\.", -1);
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < parts.length; i++) {
@@ -67,7 +72,7 @@ public class JDBCScanNode extends ScanNode {
                 sb.append(".");
             }
             String part = parts[i];
-            if (part.startsWith(identifier) && part.endsWith(identifier)) {
+            if (part.length() > 2 && part.startsWith(identifier) && part.endsWith(identifier)) {
                 sb.append(part);
             } else {
                 sb.append(identifier).append(part).append(identifier);
@@ -129,8 +134,8 @@ public class JDBCScanNode extends ScanNode {
                 columns.add(objectIdentifier + colName + objectIdentifier);
             }
         }
-        // this happends when count(*)
-        if (0 == columns.size()) {
+        // this happens when count(*)
+        if (columns.isEmpty()) {
             columns.add("*");
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MySqlAndJDBCScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MySqlAndJDBCScanNodeTest.java
@@ -174,4 +174,221 @@ public class MySqlAndJDBCScanNodeTest {
         Assertions.assertTrue(nodeString.contains("TABLE: \"table\""), nodeString);
         Assertions.assertTrue(nodeString.contains("FROM \"table\""), nodeString);
     }
+
+    @Test
+    public void testWrapWithIdentifierForMySQL() throws DdlException {
+        // Test MySQL with backticks
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "root");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:mysql://localhost:3306");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "com.mysql.jdbc.Driver");
+        JDBCTable mysqlTable = new JDBCTable(1, "test_table",
+                Collections.singletonList(new Column("col1", VarcharType.VARCHAR)), properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(mysqlTable);
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, mysqlTable);
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        // Should wrap table name with backticks
+        Assertions.assertTrue(nodeString.contains("TABLE: `test_table`"), nodeString);
+        Assertions.assertTrue(nodeString.contains("FROM `test_table`"), nodeString);
+    }
+
+    @Test
+    public void testWrapWithIdentifierForSchemaQualifiedTable() throws DdlException {
+        // Test PostgreSQL with schema-qualified table name
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "postgres");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:postgresql://localhost:5432/testdb");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "org.postgresql.Driver");
+        JDBCTable pgTable = new JDBCTable(1, "public.users",
+                Collections.singletonList(new Column("id", VarcharType.VARCHAR)), properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(pgTable);
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, pgTable);
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        // Should wrap each part with double quotes
+        Assertions.assertTrue(nodeString.contains("TABLE: \"public\".\"users\""), nodeString);
+        Assertions.assertTrue(nodeString.contains("FROM \"public\".\"users\""), nodeString);
+    }
+
+    @Test
+    public void testWrapWithIdentifierForAlreadyWrappedTable() throws DdlException {
+        // Test that already wrapped identifiers are not double-wrapped
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "root");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:mysql://localhost:3306");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "com.mysql.jdbc.Driver");
+        JDBCTable mysqlTable = new JDBCTable(1, "`test_table`",
+                Collections.singletonList(new Column("col1", VarcharType.VARCHAR)), properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(mysqlTable);
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, mysqlTable);
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        // Should not double-wrap
+        Assertions.assertTrue(nodeString.contains("TABLE: `test_table`"), nodeString);
+        Assertions.assertFalse(nodeString.contains("``test_table``"), nodeString);
+    }
+
+    @Test
+    public void testWrapWithIdentifierForMariaDB() throws DdlException {
+        // Test MariaDB with backticks
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "root");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:mariadb://localhost:3306/testdb");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "org.mariadb.jdbc.Driver");
+        JDBCTable mariadbTable = new JDBCTable(1, "test_table",
+                Collections.singletonList(new Column("col1", VarcharType.VARCHAR)), properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(mariadbTable);
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, mariadbTable);
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains("TABLE: `test_table`"), nodeString);
+    }
+
+    @Test
+    public void testWrapWithIdentifierForClickHouse() throws DdlException {
+        // Test ClickHouse with backticks
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "default");
+        properties.put("password", "");
+        properties.put("jdbc_uri", "jdbc:clickhouse://localhost:8123/default");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "ru.yandex.clickhouse.ClickHouseDriver");
+        JDBCTable clickhouseTable = new JDBCTable(1, "events",
+                Collections.singletonList(new Column("event_id", VarcharType.VARCHAR)), properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(clickhouseTable);
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, clickhouseTable);
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        Assertions.assertTrue(nodeString.contains("TABLE: `events`"), nodeString);
+    }
+
+    @Test
+    public void testCreateJDBCTableColumnsWithMultipleColumns() throws DdlException {
+        // Test multiple columns are properly wrapped
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "postgres");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:postgresql://localhost:5432/testdb");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "org.postgresql.Driver");
+        List<Column> columns = Lists.newArrayList(
+                new Column("id", VarcharType.VARCHAR),
+                new Column("name", VarcharType.VARCHAR),
+                new Column("age", VarcharType.VARCHAR)
+        );
+        JDBCTable pgTable = new JDBCTable(1, "users", columns, properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(pgTable);
+        SlotDescriptor slot1 = new SlotDescriptor(new SlotId(1), "id", VarcharType.VARCHAR, true);
+        slot1.setColumn(columns.get(0));
+        slot1.setIsMaterialized(true);
+        tupleDesc.addSlot(slot1);
+        SlotDescriptor slot2 = new SlotDescriptor(new SlotId(2), "name", VarcharType.VARCHAR, true);
+        slot2.setColumn(columns.get(1));
+        slot2.setIsMaterialized(true);
+        tupleDesc.addSlot(slot2);
+        SlotDescriptor slot3 = new SlotDescriptor(new SlotId(3), "age", VarcharType.VARCHAR, true);
+        slot3.setColumn(columns.get(2));
+        slot3.setIsMaterialized(true);
+        tupleDesc.addSlot(slot3);
+
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, pgTable);
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        // Should have all columns wrapped with double quotes
+        Assertions.assertTrue(nodeString.contains("\"id\", \"name\", \"age\""), nodeString);
+    }
+
+    @Test
+    public void testCreateJDBCTableColumnsWithAlreadyWrappedColumnName() throws DdlException {
+        // Test column that already has identifier symbols
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "root");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:mysql://localhost:3306");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "com.mysql.jdbc.Driver");
+        List<Column> columns = Lists.newArrayList(
+                new Column("`select`", VarcharType.VARCHAR)
+        );
+        JDBCTable mysqlTable = new JDBCTable(1, "test_table", columns, properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(mysqlTable);
+        SlotDescriptor slot = new SlotDescriptor(new SlotId(1), "`select`", VarcharType.VARCHAR, true);
+        slot.setColumn(columns.get(0));
+        slot.setIsMaterialized(true);
+        tupleDesc.addSlot(slot);
+
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, mysqlTable);
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        // Should not double-wrap the column name
+        Assertions.assertTrue(nodeString.contains("SELECT `select`"), nodeString);
+        Assertions.assertFalse(nodeString.contains("``select``"), nodeString);
+    }
+
+    @Test
+    public void testCreateJDBCTableColumnsForCountStar() throws DdlException {
+        // Test count(*) scenario where no columns are materialized
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "root");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:mysql://localhost:3306");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "com.mysql.jdbc.Driver");
+        JDBCTable mysqlTable = new JDBCTable(1, "test_table",
+                Collections.singletonList(new Column("col1", VarcharType.VARCHAR)), properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(mysqlTable);
+        // Don't add any materialized slots to simulate count(*)
+
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, mysqlTable);
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        // Should use SELECT *
+        Assertions.assertTrue(nodeString.contains("SELECT *"), nodeString);
+    }
+
+    @Test
+    public void testWrapWithIdentifierForComplexSchemaPath() throws DdlException {
+        // Test database.schema.table format
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("user", "postgres");
+        properties.put("password", "123456");
+        properties.put("jdbc_uri", "jdbc:postgresql://localhost:5432/testdb");
+        properties.put("driver_url", "driver_url");
+        properties.put("checksum", "checksum");
+        properties.put("driver_class", "org.postgresql.Driver");
+        JDBCTable pgTable = new JDBCTable(1, "mydb.public.users",
+                Collections.singletonList(new Column("id", VarcharType.VARCHAR)), properties);
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(1));
+        tupleDesc.setTable(pgTable);
+        JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, pgTable);
+        scanNode.computeColumnsAndFilters();
+        String nodeString = scanNode.getExplainString();
+        // Should wrap each part separately
+        Assertions.assertTrue(nodeString.contains("\"mydb\".\"public\".\"users\""), nodeString);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
Fix https://github.com/StarRocks/StarRocksTest/issues/10848
## What I'm doing:
This pull request refactors how JDBC table and column names are wrapped with identifier symbols in the `JDBCScanNode` class. The main goal is to ensure consistent and correct quoting of identifiers, especially when dealing with names that may already be quoted or contain special characters.

Improvements to identifier handling:

* Added a new `wrapWithIdentifier` method to handle quoting of JDBC table names, ensuring each part of a potentially multi-part name is individually wrapped only if not already quoted. (`JDBCScanNode.java`)
* Updated the constructor to use `wrapWithIdentifier` for table names instead of simple concatenation, preventing double quoting or missing quotes. (`JDBCScanNode.java`)

Improvements to column name handling:

* Modified the logic in `createJDBCTableColumns` to check if column names are already quoted before adding identifier symbols, avoiding redundant quoting. (`JDBCScanNode.java`)

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
