### PR TITLE
[BugFix] Fix NPE in Iceberg metadata table query due to missing Configuration propagation (backport #67151)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
@@ -105,7 +105,7 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
     public static final long DISK_CACHE_EXPIRATION_SECONDS = Config.iceberg_metadata_disk_cache_expiration_seconds;
 
     private transient ContentCache fileContentCache;
-    private FileIO wrappedIO;
+    private ResolvingFileIO wrappedIO;
     private SerializableSupplier<Configuration> conf;
     private static final Pattern HADOOP_CATALOG_METADATA_JSON_PATTERN =
             Pattern.compile("^v\\d+(\\.gz)?\\.metadata\\.json(\\.gz)?$");
@@ -113,7 +113,6 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
     @Override
     public void initialize(Map<String, String> properties) {
         ResolvingFileIO resolvingFileIO = new ResolvingFileIO();
-        resolvingFileIO.setConf(conf.get());
         wrappedIO = resolvingFileIO;
         wrappedIO.initialize(properties);
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
@@ -117,6 +117,10 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
         wrappedIO = resolvingFileIO;
         wrappedIO.initialize(properties);
 
+        if (conf != null) {
+            wrappedIO.setConf(conf.get());
+        }
+
         if (ENABLE_DISK_CACHE) {
             this.fileContentCache = TwoLevelCacheHolder.INSTANCE;
         } else {
@@ -146,6 +150,9 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
     @Override
     public void setConf(Configuration conf) {
         this.conf = new SerializableConfiguration(conf)::get;
+        if (wrappedIO != null) {
+            wrappedIO.setConf(conf);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
@@ -62,74 +62,6 @@ public class IcebergCachingFileIOTest {
         Assertions.assertEquals(cacheIOInputFileSize, 39);
         cachingFileIO.deleteFile(path);
     }
-<<<<<<< HEAD
-=======
-
-    @Test
-    public void testNewFileWithException() {
-        IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO();
-        cachingFileIO.setConf(new Configuration());
-        Map<String, String> icebergProperties = new HashMap<>();
-        String key = ADLS_SAS_TOKEN + "account." + BLOB_ENDPOINT;
-        icebergProperties.put(key, "sas_token");
-        cachingFileIO.initialize(icebergProperties);
-
-        String path = "file:/tmp/non_existent_file.json";
-        Assertions.assertThrows(StarRocksConnectorException.class, () -> {
-            cachingFileIO.newInputFile(path);
-        });
-
-        Assertions.assertThrows(StarRocksConnectorException.class, () -> {
-            cachingFileIO.newOutputFile(path);
-        });
-    }
-
-    @Test
-    public void testBuildAzureConfFromProperties() throws StarRocksException {
-        Map<String, String> properties = new HashMap<>();
-        String key = ADLS_SAS_TOKEN + "account." + ADLS_ENDPOINT;
-        String sasToken = "sas_token";
-        properties.put(key, sasToken);
-        String path = "abfss://container@account.dfs.core.windows.net/path/1/2";
-
-        IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO();
-        cachingFileIO.setConf(new Configuration());
-        Configuration configuration = cachingFileIO.buildConfFromProperties(properties, path);
-
-        String authType = configuration.get("fs.azure.account.auth.type.account." + ADLS_ENDPOINT);
-        Assertions.assertEquals("SAS", authType);
-        String token = configuration.get("fs.azure.sas.fixed.token.account." + ADLS_ENDPOINT);
-        Assertions.assertEquals(sasToken, token);
-
-        properties = new HashMap<>();
-        key = ADLS_SAS_TOKEN + "account." + BLOB_ENDPOINT;
-        sasToken = "blob_sas_token";
-        properties.put(key, sasToken);
-        path = "wasbs://container@account.blob.core.windows.net/path/1/2";
-
-        cachingFileIO = new IcebergCachingFileIO();
-        cachingFileIO.setConf(new Configuration());
-        configuration = cachingFileIO.buildConfFromProperties(properties, path);
-
-        token = configuration.get("fs.azure.sas.container.account." + BLOB_ENDPOINT);
-        Assertions.assertEquals(sasToken, token);
-    }
-
-    @Test
-    public void testBuildGCSConfFromProperties() throws StarRocksException {
-        Map<String, String> properties = new HashMap<>();
-        String accessToken = "access_token";
-        properties.put(GCS_ACCESS_TOKEN, accessToken);
-        String path = "gs://iceberg_gcp/iceberg_catalog/path/1/2";
-
-        IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO();
-        cachingFileIO.setConf(new Configuration());
-        Configuration configuration = cachingFileIO.buildConfFromProperties(properties, path);
-        String token = configuration.get("fs.gs.temporary.access.token");
-        Assertions.assertEquals(accessToken, token);
-        Assertions.assertEquals(ACCESS_TOKEN_PROVIDER_IMPL,
-                configuration.get("fs.gs.auth.access.token.provider.impl"));
-    }
 
     @Test
     void testWrappedIOConfigurationPropagation() {
@@ -153,6 +85,4 @@ public class IcebergCachingFileIOTest {
             });
         });
     }
-
->>>>>>> b6e4cfa62b ([BugFix] Fix NPE in Iceberg metadata table query due to missing Configuration propagation (#67151))
 }


### PR DESCRIPTION
## Why I'm doing:

This is a manual backport of #67151 to branch-3.5, replacing #67807 which had a merge conflict issue.

When querying Iceberg metadata tables (history, snapshots, refs, etc.), NPE occurs with message: "Cannot invoke Configuration.size() because conf is null".

This happens because:
1. `IcebergCachingFileIO.getWrappedIO()` returns `ResolvingFileIO` without Configuration set
2. When `SerializableTable` serializes the FileIO, it calls `serializeConfWith()`
3. `SerializableConfSupplier` constructor calls `conf.size()` on null Configuration

## What I'm doing:

Fix `getWrappedIO()` to propagate Configuration to wrappedIO before returning.
- If `conf` is set via `setConf()`, use it
- If `conf` is null (e.g., REST catalog), use default `new Configuration()`

Also fixed the merge conflict in #67807 where duplicate `setConf()` call caused NPE during `initialize()`.

Fixes #67807

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

