### PR TITLE
[BugFix] change max string length to 1M when unknown (backport #67873)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.combinator.AggStateDesc;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.common.Pair;
 import com.starrocks.mysql.MysqlColType;
 import com.starrocks.proto.PScalarType;
@@ -1667,7 +1668,7 @@ public abstract class Type implements Cloneable {
                 ScalarType charType = ((ScalarType) this);
                 int charLength = charType.getLength();
                 if (charLength == -1) {
-                    charLength = 64;
+                    charLength = (this.getPrimitiveType() == PrimitiveType.CHAR) ? 255 : 1048576;
                 }
                 // utf8 charset
                 return charLength * 3;


### PR DESCRIPTION
## Why I'ms doing:
Currently, SR can't infer a correct max length for a complex expression, such as with a function.
For some BI tools (such as Qlik) and using ODBC, they rely on the returned max string length in metadata of each query. Then, when a query contains some string functions, the BI tools may get empty string value.

(But, according to my test, Excel, pyodbc, PowerBI return right values)

## What I'm doing:
So, we set the max string length to 1048576 when it's -1 (can't  be infered by SR correctly).

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

