### PR TITLE
[Enhancement] support pipeline execution for memtable flush and merge

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -272,6 +272,8 @@ set(STORAGE_FILES
     rows_mapper.cpp
     primary_key_compaction_conflict_resolver.cpp
     local_primary_key_compaction_conflict_resolver.cpp
+    load_spill_pipeline_merge_iterator.cpp
+    load_spill_pipeline_merge_context.cpp
     index/inverted/inverted_index_iterator.cpp
     index/inverted/inverted_index_option.cpp
     index/inverted/inverted_plugin_factory.cpp

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -42,6 +42,7 @@
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/update_manager.h"
 #include "storage/load_spill_block_manager.h"
+#include "storage/load_spill_pipeline_merge_context.h"
 #include "storage/memtable.h"
 #include "storage/memtable_sink.h"
 #include "storage/primary_key_encoder.h"

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -24,6 +24,8 @@
 #include "storage/lake/tablet_internal_parallel_merge_task.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/load_spill_block_manager.h"
+#include "storage/load_spill_pipeline_merge_context.h"
+#include "storage/load_spill_pipeline_merge_iterator.h"
 #include "storage/merge_iterator.h"
 #include "storage/storage_engine.h"
 #include "util/runtime_profile.h"
@@ -38,6 +40,7 @@ SpillMemTableSink::SpillMemTableSink(LoadSpillBlockManager* block_manager, Table
             "LoadSpillMerge-" + std::to_string(writer->tablet_id()) + "-" + std::to_string(writer->txn_id());
     _merge_mem_tracker = std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1, std::move(tracker_label),
                                                       GlobalEnv::GetInstance()->compaction_mem_tracker());
+    _pipeline_merge_context = std::make_unique<LoadSpillPipelineMergeContext>(_writer);
 }
 
 Status SpillMemTableSink::flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment, bool eos,
@@ -55,6 +58,48 @@ Status SpillMemTableSink::flush_chunk(const Chunk& chunk, starrocks::SegmentPB* 
     // record append bytes to `flush_data_size`
     if (flush_data_size != nullptr) {
         *flush_data_size = res.value();
+    }
+
+    // EAGER MERGE OPTIMIZATION: When spilled data accumulates to a threshold, proactively
+    // start merging blocks in the background BEFORE all flushes complete. This provides:
+    // 1. Better parallelism - merge tasks run concurrently with ongoing memtable flushes
+    // 2. Reduced final merge time - much of the merge work completes during the load phase
+    // 3. Lower memory pressure - blocks get merged and reclaimed earlier
+    //
+    // WHY THIS THRESHOLD: pk_index_eager_build_threshold_bytes indicates bulk load scenario
+    // where parallel merge benefits outweigh task coordination overhead.
+    if (_load_chunk_spiller->total_bytes() >= config::pk_index_eager_build_threshold_bytes &&
+        config::enable_load_spill_parallel_merge) {
+        // Disable auto-flush to manually control segment finalization timing
+        _writer->set_auto_flush(false);
+
+        // For PK tables in bulk load, eagerly build primary key index during merge
+        // instead of waiting until commit. This parallelizes expensive index construction.
+        _writer->try_enable_pk_index_eager_build();
+
+        // Lazy initialization: create thread pool token only when first needed
+        if (_token == nullptr) {
+            _token = StorageEngine::instance()
+                             ->load_spill_block_merge_executor()
+                             ->create_tablet_internal_parallel_merge_token();
+        }
+
+        // Generate ONE merge task eagerly (not all tasks). This allows pipeline execution
+        // where merge tasks are generated and submitted incrementally as resources allow,
+        // rather than all upfront which would consume excessive memory.
+        // final_round=false means this merges to intermediate blocks, not final tablet.
+        LoadSpillPipelineMergeIterator task_iterator(_load_chunk_spiller.get(), _writer,
+                                                     _pipeline_merge_context->quit_flag(), false /* final_round */);
+        task_iterator.init();
+        if (task_iterator.has_more()) {
+            auto current_task = task_iterator.current_task();
+            _pipeline_merge_context->add_merge_task(current_task);
+            auto submit_st = _token->submit(current_task);
+            if (!submit_st.ok()) {
+                // Submit failure doesn't fail the flush - task will report error when checked later
+                current_task->update_status(submit_st);
+            }
+        }
     }
     return Status::OK();
 }
@@ -75,102 +120,73 @@ Status SpillMemTableSink::flush_chunk_with_deletes(const Chunk& upserts, const C
     return Status::OK();
 }
 
-Status SpillMemTableSink::merge_blocks_to_segments_parallel(bool do_agg, const SchemaPtr& schema) {
-    auto token =
-            StorageEngine::instance()->load_spill_block_merge_executor()->create_tablet_internal_parallel_merge_token();
-    // 1. Get all spill block iterators
-    ASSIGN_OR_RETURN(auto spill_block_iterator_tasks,
-                     _load_chunk_spiller->generate_spill_block_input_tasks(config::load_spill_max_merge_bytes,
-                                                                           config::load_spill_memory_usage_per_merge,
-                                                                           true /* do_sort */, do_agg));
-    // 2. Prepare all tablet writers
-    std::vector<std::unique_ptr<TabletWriter>> writers;
-    for (size_t i = 0; i < spill_block_iterator_tasks.iterators.size(); ++i) {
-        ASSIGN_OR_RETURN(auto writer, _writer->clone());
-        writers.push_back(std::move(writer));
-    }
-    // 3. Prepare all parallel merge tasks
-    QuitFlag quit_flag;
-    std::vector<std::shared_ptr<TabletInternalParallelMergeTask>> tasks;
-    for (size_t i = 0; i < spill_block_iterator_tasks.iterators.size(); ++i) {
-        tasks.push_back(std::make_shared<TabletInternalParallelMergeTask>(
-                writers[i].get(), spill_block_iterator_tasks.iterators[i].get(), schema.get(), i, &quit_flag,
-                get_spiller()->metrics().write_io_timer));
-    }
-    // 4. Submit all tasks to thread pool
-    for (size_t i = 0; i < spill_block_iterator_tasks.iterators.size(); ++i) {
-        auto submit_st = token->submit(tasks[i]);
-        if (!submit_st.ok()) {
-            tasks[i]->update_status(submit_st);
-            break;
-        }
-    }
-    token->wait();
-    // 5. check all task status
-    for (const auto& task : tasks) {
-        RETURN_IF_ERROR(task->status());
-    }
-    // 6. merge all writers' result
-    RETURN_IF_ERROR(_writer->merge_other_writers(writers));
-
-    COUNTER_UPDATE(ADD_COUNTER(_load_chunk_spiller->profile(), "SpillMergeInputGroups", TUnit::UNIT),
-                   spill_block_iterator_tasks.group_count);
-    COUNTER_UPDATE(ADD_COUNTER(_load_chunk_spiller->profile(), "SpillMergeInputBytes", TUnit::BYTES),
-                   spill_block_iterator_tasks.total_block_bytes);
-    COUNTER_UPDATE(ADD_COUNTER(_load_chunk_spiller->profile(), "SpillMergeCount", TUnit::UNIT),
-                   spill_block_iterator_tasks.iterators.size());
-    return Status::OK();
-}
-
-Status SpillMemTableSink::merge_blocks_to_segments_serial(bool do_agg, const SchemaPtr& schema) {
-    auto char_field_indexes = ChunkHelper::get_char_field_indexes(*schema);
-    auto* spiller = get_spiller();
-    auto write_func = [&char_field_indexes, schema, spiller, this](Chunk* chunk) {
-        SCOPED_TIMER(spiller->metrics().write_io_timer);
-        ChunkHelper::padding_char_columns(char_field_indexes, *schema, _writer->tablet_schema(), chunk);
-        return _writer->write(*chunk, nullptr);
-    };
-    auto flush_func = [spiller, this]() {
-        SCOPED_TIMER(spiller->metrics().write_io_timer);
-        return _writer->flush();
-    };
-
-    Status st = _load_chunk_spiller->merge_write(config::load_spill_max_merge_bytes,
-                                                 config::load_spill_memory_usage_per_merge, true /* do_sort */, do_agg,
-                                                 write_func, flush_func);
-    LOG_IF(WARNING, !st.ok()) << fmt::format(
-            "SpillMemTableSink merge blocks to segment failed, txn:{} tablet:{} msg:{}", _writer->txn_id(),
-            _writer->tablet_id(), st.message());
-    return st;
-}
-
 Status SpillMemTableSink::merge_blocks_to_segments() {
     TEST_SYNC_POINT_CALLBACK("SpillMemTableSink::merge_blocks_to_segments", this);
     SCOPED_THREAD_LOCAL_MEM_SETTER(_merge_mem_tracker.get(), false);
     RETURN_IF(_load_chunk_spiller->empty(), Status::OK());
-    // merge process needs to control _writer's flush behavior manually
-    _writer->set_auto_flush(false);
 
-    SchemaPtr schema = _load_chunk_spiller->schema();
-    bool do_agg = schema->keys_type() == KeysType::AGG_KEYS || schema->keys_type() == KeysType::UNIQUE_KEYS;
+    // Manual flush control needed because we're coordinating multiple parallel writers
+    _writer->set_auto_flush(false);
 
     if (_load_chunk_spiller->total_bytes() >= config::pk_index_eager_build_threshold_bytes) {
         // When bulk load happens, try to enable eager PK index build
         _writer->try_enable_pk_index_eager_build();
-        // When eager PK index build is enabled, it will generate sst files when data loading,
-        // so we need to make sure no duplicate keys exist in segment files and sst files.
-        // That means we need to do aggregation when spill merge.
-        if (_writer->enable_pk_index_eager_build()) {
-            do_agg = true;
-        }
     }
 
     SCOPED_TIMER(ADD_TIMER(_load_chunk_spiller->profile(), "SpillMergeTime"));
-    if (config::enable_load_spill_parallel_merge) {
-        return merge_blocks_to_segments_parallel(do_agg, schema);
-    } else {
-        return merge_blocks_to_segments_serial(do_agg, schema);
+
+    // Lazy token creation: may already exist from eager merge in flush_chunk()
+    if (config::enable_load_spill_parallel_merge && _token == nullptr) {
+        _token = StorageEngine::instance()
+                         ->load_spill_block_merge_executor()
+                         ->create_tablet_internal_parallel_merge_token();
     }
+
+    // FINAL MERGE PHASE: Merge all remaining spilled blocks to final tablet segments.
+    // final_round=true ensures ALL remaining blocks are consumed (no partial batches left).
+    // This iterator generates tasks lazily - one at a time as we iterate, enabling
+    // dynamic load balancing and memory control.
+    LoadSpillPipelineMergeIterator task_iterator(_load_chunk_spiller.get(), _writer,
+                                                 _pipeline_merge_context->quit_flag(), true /* final_round */);
+
+    // PIPELINE EXECUTION MODEL: Generate tasks on-demand and submit for parallel execution.
+    // Each task processes a batch of block groups (up to load_spill_max_merge_bytes).
+    // This approach balances parallelism (multiple tasks running concurrently) with
+    // memory efficiency (not creating all tasks upfront).
+    for (task_iterator.init(); task_iterator.has_more(); task_iterator.next()) {
+        auto current_task = task_iterator.current_task();
+        _pipeline_merge_context->add_merge_task(current_task);
+
+        if (_token) {
+            // PARALLEL PATH: Submit to thread pool for async execution
+            auto submit_st = _token->submit(current_task);
+            if (!submit_st.ok()) {
+                current_task->update_status(submit_st);
+                break; // Stop submitting new tasks if thread pool is unavailable
+            }
+        } else {
+            // SERIAL PATH: Fallback when parallel merge is disabled or token unavailable.
+            // Executes task synchronously in current thread. This ensures correctness
+            // even if thread pool is exhausted or config disables parallelism.
+            current_task->run();
+            if (!current_task->status().ok()) {
+                break; // Stop on first error
+            }
+        }
+    }
+
+    // Wait for all submitted tasks to complete (no-op if serial path was used)
+    if (_token) {
+        _token->wait();
+    }
+
+    // RESULT CONSOLIDATION: Check all task statuses and merge their tablet writer results
+    // into the parent writer. This is the critical phase that combines all parallel work.
+    // Any task failure here will cause the entire load to fail.
+    RETURN_IF_ERROR(_pipeline_merge_context->merge_task_results());
+
+    // Return iterator status to catch any errors during task generation
+    return task_iterator.status();
 }
 
 int64_t SpillMemTableSink::txn_id() {

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -35,7 +35,7 @@ class TabletWriter;
 class SpillMemTableSink : public MemTableSink {
 public:
     SpillMemTableSink(LoadSpillBlockManager* block_manager, TabletWriter* writer, RuntimeProfile* profile);
-    ~SpillMemTableSink() override = default;
+    ~SpillMemTableSink() override;
 
     // Spill chunk to temporary storage or write directly if eos and no prior spills
     // @param slot_idx: slot index for tracking flush order in parallel flush mode

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -66,12 +66,6 @@ private:
     // Manages spilling chunks to disk and provides merge capabilities
     std::unique_ptr<LoadChunkSpiller> _load_chunk_spiller = nullptr;
 
-    // Thread pool token for submitting parallel merge tasks.
-    // WHY LAZILY CREATED: Only allocated when parallel merge is enabled AND spill size
-    // reaches threshold (pk_index_eager_build_threshold_bytes). This avoids unnecessary
-    // thread pool overhead for small loads that don't need parallel merge.
-    std::unique_ptr<ThreadPoolToken> _token = nullptr;
-
     // Coordinates parallel merge tasks and consolidates their results.
     // Collects tasks from both eager merge (in flush_chunk) and final merge phases,
     // ensuring all task results are properly merged into the tablet writer.

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -63,13 +63,13 @@ private:
     // to prevent OOM. Parent is compaction tracker since merge is similar to compaction.
     std::unique_ptr<MemTracker> _merge_mem_tracker = nullptr;
 
-    // Manages spilling chunks to disk and provides merge capabilities
-    std::unique_ptr<LoadChunkSpiller> _load_chunk_spiller = nullptr;
-
     // Coordinates parallel merge tasks and consolidates their results.
     // Collects tasks from both eager merge (in flush_chunk) and final merge phases,
     // ensuring all task results are properly merged into the tablet writer.
     std::unique_ptr<LoadSpillPipelineMergeContext> _pipeline_merge_context = nullptr;
+
+    // Manages spilling chunks to disk and provides merge capabilities
+    std::unique_ptr<LoadChunkSpiller> _load_chunk_spiller = nullptr;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
@@ -61,11 +61,11 @@ void TabletInternalParallelMergeTask::run() {
     auto chunk = chunk_shared_ptr.get();
     auto st = Status::OK();
 
-    // CANCELLATION CHECK: Loop while quit flag is not set. The condition "_quit_flag &&"
+    // CANCELLATION CHECK: Loop while quit flag is not set. The condition "_quit_flag == nullptr ||"
     // handles the case where quit_flag is nullptr (cancellation not supported). When nullptr,
     // we skip the quit check entirely and run to completion. When non-null, we check the
     // atomic flag on each iteration to support early termination on error or user cancellation.
-    while (!_quit_flag || !_quit_flag->load()) {
+    while (_quit_flag == nullptr || !_quit_flag->load()) {
         chunk->reset();
         auto itr_st = _task->merge_itr->get_next(chunk);
         if (itr_st.is_end_of_file()) {

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
@@ -22,32 +22,33 @@
 #include "storage/aggregate_iterator.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/tablet_writer.h"
+#include "storage/load_chunk_spiller.h"
 #include "storage/load_spill_block_manager.h"
+#include "storage/load_spill_pipeline_merge_iterator.h"
 #include "storage/merge_iterator.h"
 #include "storage/storage_engine.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks::lake {
 
-TabletInternalParallelMergeTask::TabletInternalParallelMergeTask(TabletWriter* writer, ChunkIterator* block_iterator,
-                                                                 Schema* schema, int32_t task_index,
-                                                                 QuitFlag* quit_flag,
+TabletInternalParallelMergeTask::TabletInternalParallelMergeTask(std::unique_ptr<TabletWriter> writer,
+                                                                 std::unique_ptr<LoadSpillPipelineMergeTask> task,
+                                                                 const Schema* schema, std::atomic<bool>* quit_flag,
                                                                  RuntimeProfile::Counter* write_io_timer)
-        : _writer(writer),
-          _block_iterator(block_iterator),
+        : _writer(std::move(writer)),
+          _task(std::move(task)),
           _schema(schema),
-          _task_index(task_index),
           _quit_flag(quit_flag),
           _write_io_timer(write_io_timer) {
-    std::string tracker_label = "LoadSpillMerge-" + std::to_string(writer->tablet_id()) + "-" +
-                                std::to_string(writer->txn_id()) + "-" + std::to_string(task_index);
+    std::string tracker_label =
+            "LoadSpillMerge-" + std::to_string(_writer->tablet_id()) + "-" + std::to_string(_writer->txn_id());
     _merge_mem_tracker = std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1, std::move(tracker_label),
                                                       GlobalEnv::GetInstance()->compaction_mem_tracker());
 }
 
 TabletInternalParallelMergeTask::~TabletInternalParallelMergeTask() {
-    if (_block_iterator != nullptr) {
-        _block_iterator->close();
+    if (_task->merge_itr != nullptr) {
+        _task->merge_itr->close();
     }
 }
 
@@ -59,9 +60,14 @@ void TabletInternalParallelMergeTask::run() {
     auto chunk_shared_ptr = ChunkHelper::new_chunk(*_schema, config::vector_chunk_size);
     auto chunk = chunk_shared_ptr.get();
     auto st = Status::OK();
-    while (!_quit_flag->quit.load()) {
+
+    // CANCELLATION CHECK: Loop while quit flag is not set. The condition "_quit_flag &&"
+    // handles the case where quit_flag is nullptr (cancellation not supported). When nullptr,
+    // we skip the quit check entirely and run to completion. When non-null, we check the
+    // atomic flag on each iteration to support early termination on error or user cancellation.
+    while (_quit_flag && !_quit_flag->load()) {
         chunk->reset();
-        auto itr_st = _block_iterator->get_next(chunk);
+        auto itr_st = _task->merge_itr->get_next(chunk);
         if (itr_st.is_end_of_file()) {
             break;
         } else if (itr_st.ok()) {
@@ -87,8 +93,9 @@ void TabletInternalParallelMergeTask::run() {
     timer.stop();
     LOG(INFO) << fmt::format(
             "SpillMemTableSink parallel merge blocks to segment finished, txn:{} tablet:{} "
-            "task_index:{}, cost {} ms",
-            _writer->txn_id(), _writer->tablet_id(), _task_index, timer.elapsed_time() / 1000000);
+            "total_block_groups: {}, total_block_bytes: {}, cost {} ms",
+            _writer->txn_id(), _writer->tablet_id(), _task->total_block_groups, _task->total_block_bytes,
+            timer.elapsed_time() / 1000000);
     update_status(st);
 }
 
@@ -97,10 +104,15 @@ void TabletInternalParallelMergeTask::cancel() {
 }
 
 void TabletInternalParallelMergeTask::update_status(const Status& st) {
+    // Update task's status (Status::update is idempotent - first error wins)
     _status.update(st);
+
+    // COOPERATIVE CANCELLATION: When one task fails, signal all other tasks to abort.
+    // WHY: No point continuing other merges if one failed - the entire load will fail anyway.
+    // This saves CPU/IO resources and provides faster failure detection. All tasks check
+    // this flag in their run() loop and exit early when set.
     if (!st.ok() && _quit_flag != nullptr) {
-        // Notify other tasks to quit
-        _quit_flag->quit.store(true);
+        _quit_flag->store(true);
     }
 }
 

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
@@ -65,7 +65,7 @@ void TabletInternalParallelMergeTask::run() {
     // handles the case where quit_flag is nullptr (cancellation not supported). When nullptr,
     // we skip the quit check entirely and run to completion. When non-null, we check the
     // atomic flag on each iteration to support early termination on error or user cancellation.
-    while (_quit_flag && !_quit_flag->load()) {
+    while (!_quit_flag || !_quit_flag->load()) {
         chunk->reset();
         auto itr_st = _task->merge_itr->get_next(chunk);
         if (itr_st.is_end_of_file()) {

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
@@ -90,6 +90,8 @@ void TabletInternalParallelMergeTask::run() {
         SCOPED_TIMER(_write_io_timer);
         st = _writer->finish();
     }
+    // Release block groups to free up spill disk space
+    _task->release_block_groups();
     timer.stop();
     LOG(INFO) << fmt::format(
             "SpillMemTableSink parallel merge blocks to segment finished, txn:{} tablet:{} "

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.h
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.h
@@ -23,38 +23,85 @@ namespace starrocks {
 class ChunkIterator;
 class MemTracker;
 class Schema;
+class LoadSpillPipelineMergeTask;
 
 namespace lake {
 
 class TabletWriter;
 
-struct QuitFlag {
-    std::atomic<bool> quit{false};
-};
-
+/**
+ * Runnable task that executes a single merge operation in parallel.
+ *
+ * OWNERSHIP MODEL CHANGE (for pipeline execution):
+ * - Takes unique_ptr ownership of both writer and task (previously raw pointers)
+ * - WHY: Enables true parallel execution where each task owns its resources independently
+ * - LIFETIME: Task holds all resources until completion, then transfers writer back via
+ *   writer() accessor for result merging in LoadSpillPipelineMergeContext
+ *
+ * THREAD SAFETY:
+ * - Each task operates on independent writer clone and task data (no shared state)
+ * - Only _quit_flag is shared (atomic for safe concurrent access)
+ * - Status updates are thread-safe via atomic operations in Status class
+ */
 class TabletInternalParallelMergeTask : public Runnable {
 public:
-    TabletInternalParallelMergeTask(TabletWriter* writer, ChunkIterator* block_iterator, Schema* schema,
-                                    int32_t task_index, QuitFlag* quit_flag, RuntimeProfile::Counter* write_io_timer);
+    /**
+     * @param writer - Cloned writer for this task (takes ownership)
+     * @param task - Merge task containing iterator and block groups (takes ownership)
+     * @param schema - Table schema (borrowed, outlives task)
+     * @param quit_flag - Shared cancellation flag (nullptr or points to context's atomic)
+     * @param write_io_timer - Shared I/O metrics counter (borrowed)
+     */
+    TabletInternalParallelMergeTask(std::unique_ptr<TabletWriter> writer,
+                                    std::unique_ptr<LoadSpillPipelineMergeTask> task, const Schema* schema,
+                                    std::atomic<bool>* quit_flag, RuntimeProfile::Counter* write_io_timer);
 
     ~TabletInternalParallelMergeTask();
 
+    /**
+     * Executes merge: reads from task's iterator, writes to writer.
+     * Checks quit_flag periodically for early termination.
+     */
     void run() override;
 
     void cancel() override;
 
+    /**
+     * Update task status and notify other tasks to quit if error occurred.
+     * Thread-safe: can be called from any thread.
+     */
     void update_status(const Status& st);
 
     const Status& status() const { return _status; }
 
+    /**
+     * Returns writer ownership for result consolidation.
+     * Called after task completes to merge results into parent writer.
+     */
+    const std::unique_ptr<TabletWriter>& writer() const { return _writer; }
+
 private:
-    TabletWriter* _writer = nullptr;
-    ChunkIterator* _block_iterator = nullptr;
+    // Owned writer clone for independent parallel writes
+    std::unique_ptr<TabletWriter> _writer;
+
+    // Owned merge task containing iterator and block groups.
+    // Ownership ensures block groups aren't destroyed before iterator finishes reading.
+    std::unique_ptr<LoadSpillPipelineMergeTask> _task;
+
+    // Memory tracker for this merge operation
     std::unique_ptr<MemTracker> _merge_mem_tracker;
-    Schema* _schema = nullptr;
-    int32_t _task_index = 0;
+
+    // Borrowed schema pointer (valid for task lifetime)
+    const Schema* _schema = nullptr;
+
+    // Task execution result
     Status _status;
-    QuitFlag* _quit_flag = nullptr;
+
+    // Shared quit flag for cancellation (may be nullptr if cancellation not supported).
+    // When set to true by any task, all tasks abort early.
+    std::atomic<bool>* _quit_flag = nullptr;
+
+    // Shared I/O metrics counter (borrowed)
     RuntimeProfile::Counter* _write_io_timer = nullptr;
 };
 

--- a/be/src/storage/lake/tablet_writer.cpp
+++ b/be/src/storage/lake/tablet_writer.cpp
@@ -20,6 +20,8 @@
 namespace starrocks::lake {
 
 void TabletWriter::try_enable_pk_index_eager_build() {
+    // Guard against multiple calls when writers are reused or merged in different pipeline phases
+    // (e.g., eager merge and final merge); this method is intentionally idempotent.
     if (_enable_pk_index_eager_build) {
         return;
     }

--- a/be/src/storage/lake/tablet_writer.cpp
+++ b/be/src/storage/lake/tablet_writer.cpp
@@ -20,6 +20,9 @@
 namespace starrocks::lake {
 
 void TabletWriter::try_enable_pk_index_eager_build() {
+    if (_enable_pk_index_eager_build) {
+        return;
+    }
     if (!config::enable_pk_index_eager_build || _schema->keys_type() != KeysType::PRIMARY_KEYS ||
         _schema->has_separate_sort_key()) {
         return;
@@ -61,19 +64,25 @@ void TabletWriter::check_global_dict(SegmentWriter* segment_writer) {
 Status TabletWriter::merge_other_writers(const std::vector<std::unique_ptr<TabletWriter>>& other_writers) {
     // merge other writers' files into current writer
     for (const auto& writer : other_writers) {
-        _segments.insert(_segments.end(), writer->_segments.begin(), writer->_segments.end());
-        _dels.insert(_dels.end(), writer->_dels.begin(), writer->_dels.end());
-        _ssts.insert(_ssts.end(), writer->_ssts.begin(), writer->_ssts.end());
-        _sst_ranges.insert(_sst_ranges.end(), writer->_sst_ranges.begin(), writer->_sst_ranges.end());
-        _num_rows += writer->_num_rows;
-        _data_size += writer->_data_size;
-        // _global_dict_columns_valid_info
-        for (const auto& [col, valid] : writer->_global_dict_columns_valid_info) {
-            if (!valid) {
-                _global_dict_columns_valid_info[col] = false;
-            } else if (_global_dict_columns_valid_info.find(col) == _global_dict_columns_valid_info.end()) {
-                _global_dict_columns_valid_info[col] = true;
-            }
+        RETURN_IF_ERROR(merge_other_writer(writer.get()));
+    }
+    return Status::OK();
+}
+
+Status TabletWriter::merge_other_writer(const TabletWriter* other_writer) {
+    // merge other writer's files into current writer
+    _segments.insert(_segments.end(), other_writer->_segments.begin(), other_writer->_segments.end());
+    _dels.insert(_dels.end(), other_writer->_dels.begin(), other_writer->_dels.end());
+    _ssts.insert(_ssts.end(), other_writer->_ssts.begin(), other_writer->_ssts.end());
+    _sst_ranges.insert(_sst_ranges.end(), other_writer->_sst_ranges.begin(), other_writer->_sst_ranges.end());
+    _num_rows += other_writer->_num_rows;
+    _data_size += other_writer->_data_size;
+    // _global_dict_columns_valid_info
+    for (const auto& [col, valid] : other_writer->_global_dict_columns_valid_info) {
+        if (!valid) {
+            _global_dict_columns_valid_info[col] = false;
+        } else if (_global_dict_columns_valid_info.find(col) == _global_dict_columns_valid_info.end()) {
+            _global_dict_columns_valid_info[col] = true;
         }
     }
     return Status::OK();

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -148,6 +148,7 @@ public:
     //      }
     //      main_writer->merge_other_writers(cloned_writers)
     Status merge_other_writers(const std::vector<std::unique_ptr<TabletWriter>>& other_writers);
+    Status merge_other_writer(const TabletWriter* other_writer);
 
     // allow to set custom tablet schema for writer, used in partial update
     void set_tablet_schema(TabletSchemaCSPtr schema) { _schema = std::move(schema); }

--- a/be/src/storage/load_chunk_spiller.cpp
+++ b/be/src/storage/load_chunk_spiller.cpp
@@ -395,6 +395,7 @@ StatusOr<LoadSpillPipelineMergeTaskPtr> LoadChunkSpiller::generate_pipeline_merg
     int64_t stop_idx = -1;
 
     // Check previous slot id for continuity
+    // Initialize to one less than the first slot to validate the first group in the continuity check.
     int64_t last_slot_idx = groups[0].slot_idx - 1;
 
     // BATCHING LOGIC: Accumulate continuous block groups until hitting size/memory limits
@@ -450,7 +451,7 @@ StatusOr<LoadSpillPipelineMergeTaskPtr> LoadChunkSpiller::generate_pipeline_merg
     // OWNERSHIP TRANSFER: Move block groups into task to prevent premature destruction.
     // The merge iterator (created above) needs these blocks to remain valid during async
     // task execution. By holding shared_ptr in result_task, we ensure blocks outlive iterator.
-    for (int i = 0; i <= stop_idx; i++) {
+    for (int64_t i = 0; i <= stop_idx; i++) {
         result_task->block_groups.push_back(groups[i].block_group);
     }
 

--- a/be/src/storage/load_chunk_spiller.cpp
+++ b/be/src/storage/load_chunk_spiller.cpp
@@ -395,19 +395,17 @@ StatusOr<LoadSpillPipelineMergeTaskPtr> LoadChunkSpiller::generate_pipeline_merg
     int64_t stop_idx = -1;
 
     // Check previous slot id for continuity
-    if (!final_round && groups[0].slot_idx > 0 && !_pipeline_merge_context->is_slot_ready(groups[0].slot_idx - 1)) {
-        // No continuous blocks available yet
-        return result_task;
-    }
+    int64_t last_slot_idx = groups[0].slot_idx - 1;
 
     // BATCHING LOGIC: Accumulate continuous block groups until hitting size/memory limits
     for (size_t i = 0; i < groups.size(); i++) {
         auto& group = groups[i];
 
         // CONTINUITY CHECK: Ensure we only merge consecutive slot_idx ranges
-        if (!final_round && !_pipeline_merge_context->is_slot_ready(group.slot_idx)) {
+        if (!final_round && !_pipeline_merge_context->is_slot_ready(last_slot_idx, group.slot_idx)) {
             break;
         }
+        last_slot_idx = group.slot_idx;
 
         // Create iterator for this block group's data
         merge_inputs.push_back(

--- a/be/src/storage/load_chunk_spiller.cpp
+++ b/be/src/storage/load_chunk_spiller.cpp
@@ -21,7 +21,10 @@
 #include "runtime/runtime_state.h"
 #include "storage/aggregate_iterator.h"
 #include "storage/chunk_helper.h"
+#include "storage/lake/tablet_internal_parallel_merge_task.h"
+#include "storage/lake/tablet_writer.h"
 #include "storage/load_spill_block_manager.h"
+#include "storage/load_spill_pipeline_merge_iterator.h"
 #include "storage/merge_iterator.h"
 #include "storage/union_iterator.h"
 
@@ -327,6 +330,138 @@ Status LoadChunkSpiller::merge_write(size_t target_size, size_t memory_usage_per
 
 bool LoadChunkSpiller::empty() {
     return _block_manager->block_container()->empty();
+}
+
+/**
+ * Generates a single merge task for pipeline execution by pulling a batch of block groups.
+ *
+ * WHY THIS METHOD EXISTS: Unlike generate_spill_block_input_tasks() which creates ALL tasks
+ * upfront (high memory overhead), this method generates ONE task at a time for lazy, on-demand
+ * task creation. This enables the pipeline execution model where tasks are generated as
+ * resources become available, providing better memory control and load balancing.
+ *
+ * KEY DIFFERENCES FROM BATCH GENERATION:
+ * - Memory: Creates one task at a time vs all tasks upfront
+ * - Ownership: Transfers block_group ownership to task (prevents premature destruction)
+ * - Continuity: Ensures continuous slot_idx ranges (critical for correctness)
+ * - Rounds: Supports both intermediate merges (final_round=false) and final merges (final_round=true)
+ *
+ * @param target_size - Max bytes per task (prevents oversized segment files)
+ * @param memory_usage_per_merge - Memory budget per task (prevents OOM)
+ * @param do_sort - Whether to use merge iterator (true) vs union iterator (false)
+ * @param do_agg - Whether to apply aggregation (for AGG_KEYS/UNIQUE_KEYS tables)
+ * @param final_round - If true, must consume ALL remaining blocks; if false, can stop at gaps
+ * @return Task with merge iterator, or task with nullptr iterator if no blocks available
+ */
+StatusOr<LoadSpillPipelineMergeTaskPtr> LoadChunkSpiller::generate_pipeline_merge_task(size_t target_size,
+                                                                                       size_t memory_usage_per_merge,
+                                                                                       bool do_sort, bool do_agg,
+                                                                                       bool final_round) {
+    LoadSpillPipelineMergeTaskPtr result_task = std::make_unique<LoadSpillPipelineMergeTask>();
+
+    // THREAD SAFETY: Lock held for entire operation because we're both reading and modifying
+    // the block groups vector (sorting + erasing). Must be atomic to prevent race conditions
+    // with concurrent flush operations adding new block groups.
+    std::lock_guard<std::mutex> lg(*_block_manager->block_container()->block_groups_mutex());
+    auto& groups = _block_manager->block_container()->block_groups();
+
+    // Empty result signals iteration complete (iterator checks merge_itr == nullptr)
+    RETURN_IF(groups.empty(), result_task);
+
+    std::vector<ChunkIteratorPtr> merge_inputs;
+    size_t current_input_bytes = 0;
+
+    // CONTINUITY ENFORCEMENT: Track last slot_idx to ensure we only merge continuous ranges.
+    // WHY: Gaps in slot_idx indicate pending flushes from parallel memtables. Merging across
+    // gaps would violate data ordering. In non-final rounds we stop at gaps; in final round
+    // gaps are errors (all flushes should be complete).
+    int64_t last_slot_idx = -1;
+    // Sort groups by slot_idx to restore original memtable flush order
+    // CORRECTNESS: When parallel flush is enabled, block groups are created out of order.
+    // Sorting by slot_idx ensures we merge blocks in the same order as they were originally
+    // flushed from memtables, which is critical for maintaining data consistency and version order.
+    std::sort(groups.begin(), groups.end(),
+              [](const BlockGroupPtrWithSlot& a, const BlockGroupPtrWithSlot& b) { return a.slot_idx < b.slot_idx; });
+
+    // Tracks the last group index included in this task (used for cleanup at end)
+    int64_t stop_idx = -1;
+
+    // BATCHING LOGIC: Accumulate continuous block groups until hitting size/memory limits
+    for (size_t i = 0; i < groups.size(); i++) {
+        auto& group = groups[i];
+
+        // CONTINUITY CHECK: Ensure we only merge consecutive slot_idx ranges
+        if (last_slot_idx != -1 && group.slot_idx != last_slot_idx + 1) {
+            if (final_round) {
+                // CRITICAL ERROR: In final round, gaps indicate a bug (missing flush or race condition).
+                // This should never happen if all memtable flushes completed properly.
+                LOG(ERROR) << fmt::format(
+                        "LoadChunkSpiller final round merge found non-continuous slot idx, load_id:{} "
+                        "fragment_instance_id:{} last_slot_idx:{} current_slot_idx:{}",
+                        (std::ostringstream() << _block_manager->load_id()).str(),
+                        (std::ostringstream() << _block_manager->fragment_instance_id()).str(), last_slot_idx,
+                        group.slot_idx);
+                return Status::InternalError("Non-continuous slot idx found in final round merge");
+            }
+            // Non-final round: Stop at gap and wait for pending flushes to fill the gap.
+            // The iterator will be called again later to process remaining groups.
+            break;
+        }
+
+        last_slot_idx = group.slot_idx;
+
+        // Create iterator for this block group's data
+        merge_inputs.push_back(
+                std::make_shared<BlockGroupIterator>(*_schema, *_spiller->serde(), group.block_group->blocks()));
+        current_input_bytes += group.block_group->data_size();
+        result_task->total_block_bytes += group.block_group->data_size();
+        result_task->total_block_groups++;
+
+        // STOPPING CRITERIA: Balance between task size and parallelism.
+        // Stop accumulating blocks when either:
+        // 1. Data size limit reached (target_size) - prevents creating oversized segment files
+        //    which can cause memory pressure and slow I/O during tablet writes
+        // 2. Memory limit reached (memory_usage_per_merge) - prevents OOM from holding too
+        //    many chunks in memory simultaneously during merge operation
+        //
+        // This batching strategy enables dynamic load balancing: many small tasks for high
+        // parallelism vs fewer large tasks for better merge efficiency.
+        if (merge_inputs.size() > 0 &&
+            (current_input_bytes >= target_size ||
+             merge_inputs.size() * config::load_spill_max_chunk_bytes >= memory_usage_per_merge)) {
+            // Build the merge iterator chain based on table type requirements
+            auto tmp_itr = do_sort ? new_heap_merge_iterator(merge_inputs) : new_union_iterator(merge_inputs);
+            result_task->merge_itr = do_agg ? new_aggregate_iterator(tmp_itr) : tmp_itr;
+            RETURN_IF_ERROR(result_task->merge_itr->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
+            merge_inputs.clear();
+            stop_idx = i;
+            break;
+        }
+    }
+
+    // FINAL ROUND SPECIAL HANDLING: In final merge, consume ALL remaining groups even if
+    // they don't reach target_size. This ensures no orphaned blocks are left behind.
+    // Non-final rounds can leave partial batches for next iteration.
+    if (final_round && merge_inputs.size() > 0) {
+        auto tmp_itr = do_sort ? new_heap_merge_iterator(merge_inputs) : new_union_iterator(merge_inputs);
+        result_task->merge_itr = do_agg ? new_aggregate_iterator(tmp_itr) : tmp_itr;
+        RETURN_IF_ERROR(result_task->merge_itr->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
+        merge_inputs.clear();
+        stop_idx = groups.size() - 1;
+    }
+
+    // OWNERSHIP TRANSFER: Move block groups into task to prevent premature destruction.
+    // The merge iterator (created above) needs these blocks to remain valid during async
+    // task execution. By holding shared_ptr in result_task, we ensure blocks outlive iterator.
+    for (int i = 0; i <= stop_idx; i++) {
+        result_task->block_groups.push_back(groups[i].block_group);
+    }
+
+    // CLEANUP: Remove processed groups from container so they won't be included in future
+    // tasks. This is why we need the lock - concurrent access during erase would corrupt vector.
+    groups.erase(groups.begin(), groups.begin() + stop_idx + 1);
+
+    return result_task;
 }
 
 } // namespace starrocks

--- a/be/src/storage/load_chunk_spiller.h
+++ b/be/src/storage/load_chunk_spiller.h
@@ -26,6 +26,7 @@ class LoadSpillBlockManager;
 class ChunkIterator;
 class LoadChunkSpiller;
 class LoadSpillPipelineMergeTask;
+class LoadSpillPipelineMergeContext;
 
 using ChunkIteratorPtr = std::shared_ptr<ChunkIterator>;
 using LoadSpillPipelineMergeTaskPtr = std::unique_ptr<LoadSpillPipelineMergeTask>;
@@ -85,7 +86,8 @@ struct SpillBlockInputTasks {
 class LoadChunkSpiller {
 public:
     friend class LoadSpillPipelineMergeIterator;
-    LoadChunkSpiller(LoadSpillBlockManager* block_manager, RuntimeProfile* profile);
+    LoadChunkSpiller(LoadSpillBlockManager* block_manager, RuntimeProfile* profile,
+                     LoadSpillPipelineMergeContext* pipeline_merge_context = nullptr);
     ~LoadChunkSpiller() = default;
 
     StatusOr<size_t> spill(const Chunk& chunk, int64_t slot_idx = -1);
@@ -121,6 +123,8 @@ private:
     LoadSpillBlockManager* _block_manager = nullptr;
     // destroy spiller before runtime_state
     std::shared_ptr<RuntimeState> _runtime_state;
+    // pipeline merge context for managing merge tasks
+    LoadSpillPipelineMergeContext* _pipeline_merge_context = nullptr;
     // used when input profile is nullptr
     std::unique_ptr<RuntimeProfile> _dummy_profile;
     RuntimeProfile* _profile = nullptr;

--- a/be/src/storage/load_chunk_spiller.h
+++ b/be/src/storage/load_chunk_spiller.h
@@ -121,13 +121,13 @@ private:
 
 private:
     LoadSpillBlockManager* _block_manager = nullptr;
+    RuntimeProfile* _profile = nullptr;
     // destroy spiller before runtime_state
     std::shared_ptr<RuntimeState> _runtime_state;
     // pipeline merge context for managing merge tasks
     LoadSpillPipelineMergeContext* _pipeline_merge_context = nullptr;
     // used when input profile is nullptr
     std::unique_ptr<RuntimeProfile> _dummy_profile;
-    RuntimeProfile* _profile = nullptr;
     spill::SpillerFactoryPtr _spiller_factory;
     std::shared_ptr<spill::Spiller> _spiller;
     SchemaPtr _schema;

--- a/be/src/storage/load_spill_block_manager.h
+++ b/be/src/storage/load_spill_block_manager.h
@@ -70,6 +70,7 @@ public:
     // No thread safe, UT only
     spill::BlockPtr get_block(size_t gid, size_t bid);
     std::vector<BlockGroupPtrWithSlot>& block_groups() { return _block_groups; }
+    std::mutex* block_groups_mutex() { return &_mutex; }
     size_t total_bytes() const { return _total_bytes; }
 
 private:

--- a/be/src/storage/load_spill_pipeline_merge_context.cpp
+++ b/be/src/storage/load_spill_pipeline_merge_context.cpp
@@ -1,0 +1,53 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/load_spill_pipeline_merge_context.h"
+
+#include "storage/lake/tablet_internal_parallel_merge_task.h"
+#include "storage/lake/tablet_writer.h"
+
+namespace starrocks {
+
+void LoadSpillPipelineMergeContext::add_merge_task(const std::shared_ptr<lake::TabletInternalParallelMergeTask>& task) {
+    // THREAD SAFETY: Lock required because multiple pipeline operators may concurrently
+    // register tasks. std::vector is not thread-safe for concurrent push_back operations.
+    // Lock scope is minimal (only protects vector modification, not task creation/execution)
+    // to avoid serialization bottleneck during parallel task generation.
+    std::lock_guard<std::mutex> lg(_merge_tasks_mutex);
+    _merge_tasks.push_back(task);
+}
+
+Status LoadSpillPipelineMergeContext::merge_task_results() {
+    // Hold lock during entire merge operation to prevent concurrent add_merge_task() calls
+    // while iterating. This is safe because merge_task_results() is only called after
+    // all tasks complete, so no new tasks should be added anyway.
+    std::lock_guard<std::mutex> lg(_merge_tasks_mutex);
+
+    for (const auto& task : _merge_tasks) {
+        // IMPORTANT: Check task status first to fail fast if any parallel merge task failed.
+        // This prevents wasting time merging partial results from failed operations.
+        // Task failures could include: OOM during merge, disk I/O errors, user cancellation.
+        RETURN_IF_ERROR(task->status());
+
+        // Merge task's writer results into parent writer. Each task wrote to a cloned
+        // writer instance during parallel execution. Now we consolidate all results.
+        // NOTE: This merge is sequential (not parallel) to maintain data ordering and
+        // consistency. The performance impact is acceptable because the heavy lifting
+        // (sorting, aggregation, I/O) already happened in parallel during task execution.
+        RETURN_IF_ERROR(_writer->merge_other_writer(task->writer().get()));
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/storage/load_spill_pipeline_merge_context.cpp
+++ b/be/src/storage/load_spill_pipeline_merge_context.cpp
@@ -16,6 +16,7 @@
 
 #include "storage/lake/tablet_internal_parallel_merge_task.h"
 #include "storage/lake/tablet_writer.h"
+#include "storage/load_spill_block_manager.h"
 #include "storage/storage_engine.h"
 
 namespace starrocks {

--- a/be/src/storage/load_spill_pipeline_merge_context.h
+++ b/be/src/storage/load_spill_pipeline_merge_context.h
@@ -1,0 +1,100 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "common/status.h"
+
+namespace starrocks {
+
+namespace lake {
+class TabletInternalParallelMergeTask;
+class TabletWriter;
+} // namespace lake
+
+/**
+ * Context for managing parallel merge tasks in pipeline execution during load spill operations.
+ *
+ * WHY THIS EXISTS: During large data loads, memory pressure causes data to spill to disk.
+ * The merge phase (reading spilled data and writing to final tablet) needs to support pipeline
+ * execution for better parallelism and resource utilization. This context collects merge tasks
+ * from multiple pipeline operators and coordinates their final merge into the tablet writer.
+ *
+ * DESIGN RATIONALE:
+ * - Each merge task operates on a subset of spilled block groups using a cloned writer
+ * - Tasks can execute in parallel without lock contention during the merge phase
+ * - Final merge_task_results() sequentially merges all task results into the parent writer
+ * - This two-phase approach (parallel execution + serial merge) maximizes throughput while
+ *   maintaining data correctness
+ *
+ * THREAD SAFETY: add_merge_task() is thread-safe and can be called from multiple pipeline
+ * operators concurrently. The mutex only protects vector modification, not task execution.
+ */
+class LoadSpillPipelineMergeContext {
+public:
+    LoadSpillPipelineMergeContext(lake::TabletWriter* writer) : _writer(writer) {}
+    ~LoadSpillPipelineMergeContext() = default;
+
+    /**
+     * Register a merge task for later result collection.
+     *
+     * THREAD SAFETY: Can be called concurrently from multiple pipeline operators.
+     * The mutex ensures safe vector modification without data races.
+     */
+    void add_merge_task(const std::shared_ptr<lake::TabletInternalParallelMergeTask>& task);
+
+    /**
+     * Merge results from all registered tasks into the parent writer.
+     *
+     * IMPORTANT: Must be called after all tasks have completed execution. This performs
+     * sequential merge to maintain data ordering and consistency. The serial merge here
+     * is acceptable because actual data processing (sorting, aggregation) already happened
+     * in parallel during task execution.
+     *
+     * @return Error if any task failed or if merging fails
+     */
+    Status merge_task_results();
+
+    /**
+     * Provides quit flag for early termination of merge tasks.
+     *
+     * WHY ATOMIC: Tasks check this flag during expensive merge operations to support
+     * cancellation (e.g., user abort, query timeout). Atomic ensures visibility across
+     * threads without mutex overhead on the hot read path.
+     */
+    std::atomic<bool>* quit_flag() { return &_quit_flag; }
+
+private:
+    // Parent writer that owns the final tablet data. All task results merge into this.
+    lake::TabletWriter* _writer;
+
+    // Collection of parallel merge tasks. Each task processes a subset of spilled data
+    // using a cloned writer. Vector grows as pipeline operators generate tasks.
+    std::vector<std::shared_ptr<lake::TabletInternalParallelMergeTask>> _merge_tasks;
+
+    // Protects concurrent modifications to _merge_tasks vector only. Does NOT protect
+    // task execution itself, allowing true parallelism during the merge phase.
+    std::mutex _merge_tasks_mutex;
+
+    // Shared quit flag checked by all merge tasks for cancellation support.
+    // Set to true when load operation is cancelled/aborted.
+    std::atomic<bool> _quit_flag{false};
+};
+
+}; // namespace starrocks

--- a/be/src/storage/load_spill_pipeline_merge_context.h
+++ b/be/src/storage/load_spill_pipeline_merge_context.h
@@ -97,9 +97,15 @@ public:
         _ready_slots.insert(slot_idx);
     }
 
-    bool is_slot_ready(int64_t slot_idx) {
+    bool is_slot_ready(int64_t from_slot_idx, int64_t to_slot_idx) {
         std::lock_guard<std::mutex> lg(_merge_tasks_mutex);
-        return _ready_slots.find(slot_idx) != _ready_slots.end();
+        for (int64_t i = from_slot_idx; i <= to_slot_idx; ++i) {
+            if (i >= 0 && _ready_slots.find(i) == _ready_slots.end()) {
+                // negative slot idx will be treated as ready
+                return false;
+            }
+        }
+        return true;
     }
 
 private:

--- a/be/src/storage/load_spill_pipeline_merge_context.h
+++ b/be/src/storage/load_spill_pipeline_merge_context.h
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <unordered_set>
 #include <vector>
 
 #include "common/status.h"

--- a/be/src/storage/load_spill_pipeline_merge_iterator.cpp
+++ b/be/src/storage/load_spill_pipeline_merge_iterator.cpp
@@ -1,0 +1,94 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/load_spill_pipeline_merge_iterator.h"
+
+#include "exec/spill/spiller.h"
+#include "exec/spill/spiller_factory.h"
+#include "runtime/runtime_state.h"
+#include "storage/lake/tablet_internal_parallel_merge_task.h"
+#include "storage/lake/tablet_writer.h"
+#include "storage/load_chunk_spiller.h"
+#include "storage/load_spill_block_manager.h"
+#include "storage/merge_iterator.h"
+#include "storage/union_iterator.h"
+
+namespace starrocks {
+
+LoadSpillPipelineMergeIterator::LoadSpillPipelineMergeIterator(LoadChunkSpiller* spiller,
+                                                               lake::TabletWriter* parent_writer,
+                                                               std::atomic<bool>* quit_flag, bool final_round)
+        : _spiller(spiller), _parent_writer(parent_writer), _quit_flag(quit_flag), _final_round(final_round) {
+    SchemaPtr schema = _spiller->schema();
+
+    // PERFORMANCE OPTIMIZATION: DUP_KEYS tables don't require sorting or aggregation
+    // during merge, so we can use a simpler union iterator instead of merge iterator.
+    // This saves significant CPU time (no comparisons) and memory (no aggregation state).
+    // For AGG_KEYS/UNIQUE_KEYS tables, we must perform sorted merge with aggregation
+    // to maintain correctness (combine duplicate keys, apply aggregate functions).
+    if (schema->keys_type() == KeysType::DUP_KEYS) {
+        _do_agg = false;
+    } else {
+        _do_agg = true;
+    }
+}
+
+void LoadSpillPipelineMergeIterator::_next() {
+    // Simple forwarding wrapper to allow public API (init/next) to remain clean
+    // while keeping actual generation logic in a separate Status-returning method
+    _status = _generate_next_task();
+}
+
+Status LoadSpillPipelineMergeIterator::_generate_next_task() {
+    // Pull next batch of block groups from spiller and create merge task.
+    // PARAMETERS EXPLAINED:
+    // - config::load_spill_max_merge_bytes: Max total bytes per task (load balancing)
+    // - config::load_spill_memory_usage_per_merge: Memory budget for merge operation
+    // - true (sort): Whether to sort during merge (always true for correctness)
+    // - _do_agg: Whether to perform aggregation (depends on table keys type)
+    // - _final_round: Whether this merges to final tablet vs intermediate blocks
+    ASSIGN_OR_RETURN(auto task, _spiller->generate_pipeline_merge_task(config::load_spill_max_merge_bytes,
+                                                                       config::load_spill_memory_usage_per_merge,
+                                                                       true /*sort*/, _do_agg, _final_round));
+
+    // nullptr merge_itr indicates no more block groups available - iteration complete
+    if (task->merge_itr != nullptr) {
+        // Update metrics for monitoring merge workload and performance analysis.
+        // These counters help identify bottlenecks (too many small merges vs few large ones)
+        // and validate that workload is being distributed evenly across pipeline tasks.
+        COUNTER_UPDATE(ADD_COUNTER(_spiller->profile(), "SpillMergeInputGroups", TUnit::UNIT),
+                       task->total_block_groups);
+        COUNTER_UPDATE(ADD_COUNTER(_spiller->profile(), "SpillMergeInputBytes", TUnit::BYTES), task->total_block_bytes);
+        COUNTER_UPDATE(ADD_COUNTER(_spiller->profile(), "SpillMergeCount", TUnit::UNIT), 1);
+
+        // WHY CLONE WRITER: Each parallel merge task needs its own writer instance to
+        // avoid lock contention and enable true parallel writes. The cloned writers
+        // maintain independent file handles and buffers. Results are merged back to
+        // parent writer later via merge_other_writer() in the merge context.
+        ASSIGN_OR_RETURN(auto writer, _parent_writer->clone());
+
+        // Create the parallel merge task with all necessary context: writer clone,
+        // merge iterator, schema, quit flag for cancellation, and I/O metrics timer.
+        _current_task = std::make_shared<lake::TabletInternalParallelMergeTask>(
+                std::move(writer), std::move(task), _spiller->_schema.get(), _quit_flag,
+                _spiller->spiller()->metrics().write_io_timer);
+    } else {
+        // No more data to merge - signal iteration completion by returning nullptr.
+        // Pipeline operators check has_more() which tests for nullptr to know when to stop.
+        _current_task = nullptr;
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/storage/load_spill_pipeline_merge_iterator.h
+++ b/be/src/storage/load_spill_pipeline_merge_iterator.h
@@ -55,6 +55,9 @@ struct LoadSpillPipelineMergeTask {
     // Used to ensure roughly equal work distribution and for performance analysis.
     size_t total_block_groups = 0;
     size_t total_block_bytes = 0;
+
+    // Release block group in advance to free load spill disk space
+    void release_block_groups() { block_groups.clear(); }
 };
 
 /**

--- a/be/src/storage/load_spill_pipeline_merge_iterator.h
+++ b/be/src/storage/load_spill_pipeline_merge_iterator.h
@@ -1,0 +1,137 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/spill/block_manager.h"
+#include "exec/spill/data_stream.h"
+#include "exec/spill/spiller_factory.h"
+#include "util/runtime_profile.h"
+
+namespace starrocks {
+
+class LoadChunkSpiller;
+class ChunkIterator;
+using ChunkIteratorPtr = std::shared_ptr<ChunkIterator>;
+
+namespace spill {
+class BlockGroup;
+} // namespace spill
+
+namespace lake {
+class TabletInternalParallelMergeTask;
+class TabletWriter;
+} // namespace lake
+
+/**
+ * Encapsulates a single merge task unit for pipeline execution.
+ *
+ * WHY THIS STRUCT: Groups all resources needed for one merge task to be executed
+ * independently in a pipeline operator. The block_groups ownership is critical.
+ */
+struct LoadSpillPipelineMergeTask {
+    // LIFETIME MANAGEMENT: Holds shared ownership of block groups to prevent premature
+    // destruction. The merge_itr reads from these block groups asynchronously during
+    // pipeline execution, so block groups must outlive the iterator. Without this,
+    // we'd have use-after-free bugs when blocks are reclaimed before iterator finishes.
+    std::vector<std::shared_ptr<spill::BlockGroup>> block_groups;
+
+    // Iterator that performs the actual merge of spilled data chunks. Supports both
+    // sorted merge (for aggregation/ordering) and union (for DUP_KEYS tables).
+    ChunkIteratorPtr merge_itr;
+
+    // Metrics for monitoring merge workload distribution across pipeline tasks.
+    // Used to ensure roughly equal work distribution and for performance analysis.
+    size_t total_block_groups = 0;
+    size_t total_block_bytes = 0;
+};
+
+/**
+ * Iterator that generates parallel merge tasks from spilled block groups.
+ *
+ * WHY ITERATOR PATTERN: Enables lazy task generation and natural integration with
+ * pipeline execution model. Instead of creating all merge tasks upfront (high memory),
+ * we generate tasks on-demand as pipeline operators become available. This provides
+ * better memory control and load balancing.
+ *
+ * MERGE ROUNDS EXPLAINED:
+ * - Non-final round: Merges spilled blocks back to fewer, larger blocks (reduce fanout)
+ * - Final round: Merges spilled blocks directly to tablet writer (final destination)
+ *
+ * This multi-round strategy prevents exceeding max file descriptor limits and reduces
+ * merge complexity when dealing with huge datasets split across thousands of blocks.
+ */
+class LoadSpillPipelineMergeIterator {
+public:
+    /**
+     * @param spiller - Source of spilled block groups to merge
+     * @param parent_writer - Tablet writer to clone for each parallel task
+     * @param quit_flag - Shared cancellation flag for all generated tasks
+     * @param final_round - If true, merge directly to tablet; if false, merge to intermediate blocks
+     */
+    LoadSpillPipelineMergeIterator(LoadChunkSpiller* spiller, lake::TabletWriter* parent_writer,
+                                   std::atomic<bool>* quit_flag, bool final_round);
+    ~LoadSpillPipelineMergeIterator() = default;
+
+    // Returns current merge task, or nullptr if iteration exhausted
+    std::shared_ptr<lake::TabletInternalParallelMergeTask> current_task() { return _current_task; }
+
+    // Initialize iterator by generating first task
+    void init() { _next(); }
+
+    // Advance to next task (generates new task on-demand)
+    void next() { _next(); }
+
+    // Check if more tasks are available. Pipeline operators use this for work scheduling.
+    bool has_more() const { return _current_task != nullptr; }
+
+    // Returns error status if task generation failed (e.g., OOM, I/O error)
+    const Status& status() const { return _status; }
+
+private:
+    void _next();
+
+    /**
+     * Generates next merge task by pulling block groups from spiller.
+     *
+     * BATCHING STRATEGY: Groups multiple block groups into single task based on
+     * config::load_spill_max_merge_bytes to balance parallelism vs merge efficiency.
+     * Too small = excessive overhead; too large = poor load balancing.
+     */
+    Status _generate_next_task();
+
+    LoadChunkSpiller* _spiller = nullptr;
+    lake::TabletWriter* _parent_writer = nullptr;
+
+    // Shared quit flag for cancellation support across all tasks
+    std::atomic<bool>* _quit_flag = nullptr;
+
+    // If true, this is the final merge round writing to tablet. If false, intermediate
+    // round writing back to spill blocks for next iteration.
+    bool _final_round = false;
+
+    // WHY NEEDED: Determines merge iterator type. DUP_KEYS tables use union iterator
+    // (simple concatenation), while AGG/UNIQUE keys use merge iterator (sorted merge
+    // with aggregation). This optimization saves CPU cycles for duplicate key tables
+    // that don't need ordering/deduplication.
+    bool _do_agg = false;
+
+    // Currently available task for pipeline operator to consume
+    std::shared_ptr<lake::TabletInternalParallelMergeTask> _current_task;
+
+    // Tracks errors during task generation (sticky - once failed, stays failed)
+    Status _status;
+};
+
+} // namespace starrocks

--- a/be/src/storage/load_spill_pipeline_merge_iterator.h
+++ b/be/src/storage/load_spill_pipeline_merge_iterator.h
@@ -97,7 +97,7 @@ public:
     void next() { _next(); }
 
     // Check if more tasks are available. Pipeline operators use this for work scheduling.
-    bool has_more() const { return _current_task != nullptr; }
+    bool has_more() const { return _current_task != nullptr && _status.ok(); }
 
     // Returns error status if task generation failed (e.g., OOM, I/O error)
     const Status& status() const { return _status; }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -554,6 +554,7 @@ SET(DW_TEST_FILES
     ./storage/lake/lake_persistent_index_size_tiered_compaction_strategy_test.cpp
     ./storage/lake/tablet_write_log_manager_test.cpp
     ./storage/load_spill_block_manager_test.cpp
+    ./storage/load_spill_pipeline_merge_test.cpp
     ./storage/memtable_flush_executor_test.cpp
     ./storage/memtable_test.cpp
     ./storage/merge_iterator_test.cpp

--- a/be/test/storage/lake/spill_mem_table_sink_test.cpp
+++ b/be/test/storage/lake/spill_mem_table_sink_test.cpp
@@ -368,29 +368,25 @@ TEST_P(SpillMemTableSinkTest, test_slot_idx_ordering_after_merge) {
     auto chunk3 = gen_data(kChunkSize, 3);
 
     starrocks::SegmentPB segment;
-    ASSERT_OK(sink.flush_chunk(*chunk0, &segment, false, nullptr, 5));
-    ASSERT_OK(sink.flush_chunk(*chunk1, &segment, false, nullptr, 2));
-    ASSERT_OK(sink.flush_chunk(*chunk2, &segment, false, nullptr, 8));
-    ASSERT_OK(sink.flush_chunk(*chunk3, &segment, false, nullptr, 1));
+    ASSERT_OK(sink.flush_chunk(*chunk0, &segment, false, nullptr, 2));
+    ASSERT_OK(sink.flush_chunk(*chunk1, &segment, false, nullptr, 1));
+    ASSERT_OK(sink.flush_chunk(*chunk2, &segment, false, nullptr, 3));
+    ASSERT_OK(sink.flush_chunk(*chunk3, &segment, false, nullptr, 0));
 
     // Before merge, groups are in insertion order
     auto& groups = block_manager->block_container()->block_groups();
     ASSERT_EQ(4, groups.size());
-    ASSERT_EQ(5, groups[0].slot_idx);
-    ASSERT_EQ(2, groups[1].slot_idx);
-    ASSERT_EQ(8, groups[2].slot_idx);
-    ASSERT_EQ(1, groups[3].slot_idx);
+    ASSERT_EQ(2, groups[0].slot_idx);
+    ASSERT_EQ(1, groups[1].slot_idx);
+    ASSERT_EQ(3, groups[2].slot_idx);
+    ASSERT_EQ(0, groups[3].slot_idx);
 
     // Merge blocks to segments - this should sort by slot_idx
     ASSERT_OK(sink.merge_blocks_to_segments());
 
-    // After merge, groups should be sorted by slot_idx
-    ASSERT_EQ(1, groups[0].slot_idx);
-    ASSERT_EQ(2, groups[1].slot_idx);
-    ASSERT_EQ(5, groups[2].slot_idx);
-    ASSERT_EQ(8, groups[3].slot_idx);
+    ASSERT_EQ(0, groups.size()); // Original groups cleared after merge
 
-    ASSERT_EQ(config::enable_load_spill_parallel_merge ? 4 : 1, tablet_writer->segments().size());
+    ASSERT_TRUE(tablet_writer->segments().size() > 0);
 }
 
 TEST_P(SpillMemTableSinkTest, test_flush_data_size_with_slot_idx) {

--- a/be/test/storage/lake/spill_mem_table_sink_test.cpp
+++ b/be/test/storage/lake/spill_mem_table_sink_test.cpp
@@ -32,6 +32,7 @@
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/test_util.h"
 #include "storage/load_spill_block_manager.h"
+#include "storage/load_spill_pipeline_merge_context.h"
 #include "storage/tablet_schema.h"
 #include "testutil/assert.h"
 #include "util/raw_container.h"

--- a/be/test/storage/load_spill_pipeline_merge_test.cpp
+++ b/be/test/storage/load_spill_pipeline_merge_test.cpp
@@ -1,0 +1,368 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/chunk.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "column/vectorized_fwd.h"
+#include "fs/fs.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/tablet_metadata.h"
+#include "storage/lake/tablet_writer.h"
+#include "storage/lake/test_util.h"
+#include "storage/load_chunk_spiller.h"
+#include "storage/load_spill_block_manager.h"
+#include "storage/load_spill_pipeline_merge_context.h"
+#include "storage/load_spill_pipeline_merge_iterator.h"
+#include "testutil/assert.h"
+#include "util/raw_container.h"
+#include "util/runtime_profile.h"
+
+namespace starrocks {
+
+class LoadSpillPipelineMergeTest : public ::testing::Test {
+public:
+    LoadSpillPipelineMergeTest() {
+        _tablet_metadata = lake::generate_simple_tablet_metadata(PRIMARY_KEYS);
+
+        _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+    }
+    void SetUp() override {
+        (void)FileSystem::Default()->create_dir_recursive(kTestDir);
+        _block_manager = std::make_unique<LoadSpillBlockManager>(TUniqueId(), TUniqueId(), kTestDir, nullptr);
+        ASSERT_OK(_block_manager->init());
+        _profile = std::make_unique<RuntimeProfile>("test");
+        _spiller = std::make_unique<LoadChunkSpiller>(_block_manager.get(), _profile.get());
+    }
+
+    void TearDown() override {
+        _spiller.reset();
+        _block_manager.reset();
+        (void)FileSystem::Default()->delete_dir_recursive(kTestDir);
+    }
+
+protected:
+    ChunkPtr gen_data(int64_t chunk_size, int start_value) {
+        std::vector<int> v0(chunk_size);
+        std::vector<int> v1(chunk_size);
+        for (int i = 0; i < chunk_size; i++) {
+            v0[i] = i + start_value;
+        }
+        for (int i = 0; i < chunk_size; i++) {
+            v1[i] = v0[i] * 3;
+        }
+
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        return std::make_shared<Chunk>(Columns{std::move(c0), std::move(c1)}, _schema);
+    }
+
+    size_t spill_chunks_with_slot_idx(const std::vector<std::pair<int32_t, int64_t>>& chunks_with_slots) {
+        size_t total_bytes = 0;
+        for (const auto& [start_value, slot_idx] : chunks_with_slots) {
+            auto chunk = gen_data(100, start_value);
+            ASSIGN_OR_ABORT(auto bytes, _spiller->spill(*chunk, slot_idx));
+            total_bytes += bytes;
+        }
+        return total_bytes;
+    }
+
+    constexpr static const char* const kTestDir = "./load_spill_pipeline_merge_test";
+    std::unique_ptr<LoadSpillBlockManager> _block_manager;
+    std::unique_ptr<RuntimeProfile> _profile;
+    std::unique_ptr<LoadChunkSpiller> _spiller;
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+};
+
+// Test basic pipeline merge task generation
+TEST_F(LoadSpillPipelineMergeTest, test_generate_pipeline_merge_task_basic) {
+    // Spill chunks with continuous slot indices
+    auto bytes = spill_chunks_with_slot_idx({{0, 0}, {100, 1}, {200, 2}});
+
+    // Generate a pipeline merge task
+    ASSIGN_OR_ABORT(auto task, _spiller->generate_pipeline_merge_task(
+                                       bytes - 1,                               // target_size
+                                       config::load_spill_max_chunk_bytes * 10, // memory_usage_per_merge
+                                       true,                                    // do_sort
+                                       false,                                   // do_agg
+                                       true));                                  // final_round
+
+    ASSERT_NE(task, nullptr);
+    ASSERT_NE(task->merge_itr, nullptr);
+    ASSERT_GT(task->total_block_groups, 0);
+    ASSERT_GT(task->total_block_bytes, 0);
+    ASSERT_EQ(task->block_groups.size(), task->total_block_groups);
+
+    // Verify block groups were removed from spiller
+    auto& remaining_groups = _block_manager->block_container()->block_groups();
+    ASSERT_EQ(remaining_groups.size(), 0);
+}
+
+// Test pipeline merge task generation with non-continuous slot indices
+TEST_F(LoadSpillPipelineMergeTest, test_generate_pipeline_merge_task_non_continuous) {
+    // Spill chunks with non-continuous slot indices (0, 1, 3)
+    auto bytes = spill_chunks_with_slot_idx({{0, 0}, {100, 1}, {200, 3}});
+
+    // Try to generate another task - should get empty task since slot_idx 2 is missing
+    auto task_or =
+            _spiller->generate_pipeline_merge_task(bytes,                                   // target_size
+                                                   config::load_spill_max_chunk_bytes * 10, // memory_usage_per_merge
+                                                   true,                                    // do_sort
+                                                   false,                                   // do_agg
+                                                   true);                                   // final_round
+
+    ASSERT_TRUE(!task_or.ok());
+}
+
+// Test final round merge with non-continuous slot indices should fail
+TEST_F(LoadSpillPipelineMergeTest, test_generate_pipeline_merge_task_final_round_non_continuous) {
+    // Spill chunks with non-continuous slot indices (0, 2, 3)
+    auto bytes = spill_chunks_with_slot_idx({{0, 0}, {100, 2}, {200, 3}});
+
+    // Final round merge should fail with non-continuous slot indices
+    auto result =
+            _spiller->generate_pipeline_merge_task(bytes,                                   // target_size
+                                                   config::load_spill_max_chunk_bytes * 10, // memory_usage_per_merge
+                                                   true,                                    // do_sort
+                                                   false,                                   // do_agg
+                                                   true);                                   // final_round
+
+    ASSERT_FALSE(result.ok());
+}
+
+// Test final round merge with continuous slot indices
+TEST_F(LoadSpillPipelineMergeTest, test_generate_pipeline_merge_task_final_round_continuous) {
+    // Spill chunks with continuous slot indices
+    auto bytes = spill_chunks_with_slot_idx({{0, 0}, {100, 1}, {200, 2}});
+
+    // Final round merge should succeed and merge all groups
+    ASSIGN_OR_ABORT(auto task, _spiller->generate_pipeline_merge_task(
+                                       bytes,                                   // target_size
+                                       config::load_spill_max_chunk_bytes * 10, // memory_usage_per_merge
+                                       true,                                    // do_sort
+                                       false,                                   // do_agg
+                                       true));                                  // final_round
+
+    ASSERT_NE(task, nullptr);
+    ASSERT_NE(task->merge_itr, nullptr);
+    ASSERT_EQ(task->total_block_groups, 3);
+
+    // All groups should be consumed
+    auto& remaining_groups = _block_manager->block_container()->block_groups();
+    ASSERT_EQ(remaining_groups.size(), 0);
+}
+
+// Test target size limitation
+TEST_F(LoadSpillPipelineMergeTest, test_generate_pipeline_merge_task_target_size_limit) {
+    // Spill multiple chunks with continuous slot indices
+    for (int i = 0; i < 10; i++) {
+        spill_chunks_with_slot_idx({{i * 100, i}});
+    }
+
+    // Set a small target_size to limit how many groups are merged
+    size_t small_target_size = 100; // Very small, should only merge 1-2 groups
+    ASSIGN_OR_ABORT(auto task, _spiller->generate_pipeline_merge_task(small_target_size, // target_size
+                                                                      1024 * 1024,       // memory_usage_per_merge
+                                                                      true,              // do_sort
+                                                                      false,             // do_agg
+                                                                      false));           // final_round
+
+    ASSERT_NE(task, nullptr);
+    ASSERT_NE(task->merge_itr, nullptr);
+    // Should only merge a subset of groups
+    ASSERT_LT(task->total_block_groups, 10);
+    ASSERT_GT(task->total_block_groups, 0);
+
+    // Remaining groups should exist
+    auto& remaining_groups = _block_manager->block_container()->block_groups();
+    ASSERT_GT(remaining_groups.size(), 0);
+}
+
+// Test slot_idx ordering is preserved
+TEST_F(LoadSpillPipelineMergeTest, test_generate_pipeline_merge_task_ordering) {
+    // Spill chunks in random order but with sequential slot indices
+    auto bytes = spill_chunks_with_slot_idx({{200, 2}, {0, 0}, {300, 3}, {100, 1}});
+
+    // Generate pipeline merge task
+    ASSIGN_OR_ABORT(auto task, _spiller->generate_pipeline_merge_task(
+                                       bytes,                                   // target_size
+                                       config::load_spill_max_chunk_bytes * 10, // memory_usage_per_merge
+                                       true,                                    // do_sort
+                                       false,                                   // do_agg
+                                       true));                                  // final_round
+
+    ASSERT_NE(task, nullptr);
+    ASSERT_NE(task->merge_itr, nullptr);
+    ASSERT_EQ(task->total_block_groups, 4);
+
+    // Verify all block groups are included
+    ASSERT_EQ(task->block_groups.size(), 4);
+}
+
+// Test empty spiller
+TEST_F(LoadSpillPipelineMergeTest, test_generate_pipeline_merge_task_empty) {
+    // Don't spill anything
+    ASSERT_TRUE(_spiller->empty());
+
+    // Generate pipeline merge task on empty spiller
+    ASSIGN_OR_ABORT(auto task, _spiller->generate_pipeline_merge_task(1024 * 1024, // target_size
+                                                                      1024 * 1024, // memory_usage_per_merge
+                                                                      true,        // do_sort
+                                                                      false,       // do_agg
+                                                                      false));     // final_round
+
+    ASSERT_NE(task, nullptr);
+    ASSERT_EQ(task->merge_itr, nullptr); // Empty task
+    ASSERT_EQ(task->total_block_groups, 0);
+    ASSERT_EQ(task->total_block_bytes, 0);
+}
+
+// Test LoadSpillPipelineMergeContext basic functionality
+TEST_F(LoadSpillPipelineMergeTest, test_pipeline_merge_context_basic) {
+    // Create a mock writer (nullptr for this basic test)
+    LoadSpillPipelineMergeContext context(nullptr);
+
+    // Test quit flag
+    auto* quit_flag = context.quit_flag();
+    ASSERT_NE(quit_flag, nullptr);
+    ASSERT_FALSE(quit_flag->load());
+
+    // Set quit flag
+    quit_flag->store(true);
+    ASSERT_TRUE(quit_flag->load());
+}
+
+// Test LoadSpillPipelineMergeContext add_merge_task
+TEST_F(LoadSpillPipelineMergeTest, test_pipeline_merge_context_add_tasks) {
+    LoadSpillPipelineMergeContext context(nullptr);
+
+    // Add multiple tasks (nullptr for this test)
+    for (int i = 0; i < 5; i++) {
+        context.add_merge_task(nullptr);
+    }
+
+    // The context should have added the tasks (verified internally via thread safety)
+    // In a real scenario, we would verify by calling merge_task_results()
+}
+
+// Test memory usage per merge limitation
+TEST_F(LoadSpillPipelineMergeTest, test_generate_pipeline_merge_task_memory_limit) {
+    // Spill multiple chunks
+    for (int i = 0; i < 10; i++) {
+        spill_chunks_with_slot_idx({{i * 100, i}});
+    }
+
+    // Set memory usage per merge to a value that limits number of groups
+    // Assuming config::load_spill_max_chunk_bytes is around 64KB
+    size_t memory_limit = 200 * 1024; // 200KB - should limit to ~3 groups
+    ASSIGN_OR_ABORT(auto task, _spiller->generate_pipeline_merge_task(10 * 1024 * 1024, // large target_size
+                                                                      memory_limit,     // memory_usage_per_merge
+                                                                      true,             // do_sort
+                                                                      false,            // do_agg
+                                                                      false));          // final_round
+
+    ASSERT_NE(task, nullptr);
+    ASSERT_NE(task->merge_itr, nullptr);
+    // Should be limited by memory, not target size
+    ASSERT_LT(task->total_block_groups, 10);
+
+    auto& remaining_groups = _block_manager->block_container()->block_groups();
+    ASSERT_GT(remaining_groups.size(), 0);
+}
+
+// Test incremental pipeline merge generation
+TEST_F(LoadSpillPipelineMergeTest, test_incremental_pipeline_merge) {
+    // Spill 6 chunks with continuous slot indices
+    for (int i = 0; i < 6; i++) {
+        spill_chunks_with_slot_idx({{i * 100, i}});
+    }
+
+    size_t small_target = 100; // Force small merges
+
+    // Generate first task
+    ASSIGN_OR_ABORT(auto task1, _spiller->generate_pipeline_merge_task(small_target, 1024 * 1024, true, false, false));
+    ASSERT_NE(task1, nullptr);
+    ASSERT_NE(task1->merge_itr, nullptr);
+    size_t first_batch_size = task1->total_block_groups;
+    ASSERT_GT(first_batch_size, 0);
+    ASSERT_LT(first_batch_size, 6);
+
+    // Generate second task
+    ASSIGN_OR_ABORT(auto task2, _spiller->generate_pipeline_merge_task(small_target, 1024 * 1024, true, false, false));
+    ASSERT_NE(task2, nullptr);
+
+    if (task2->merge_itr != nullptr) {
+        size_t second_batch_size = task2->total_block_groups;
+        ASSERT_GT(second_batch_size, 0);
+
+        // Total consumed should not exceed original
+        ASSERT_LE(first_batch_size + second_batch_size, 6);
+    }
+}
+
+// Test concurrent access to block groups during pipeline merge generation
+TEST_F(LoadSpillPipelineMergeTest, test_thread_safe_pipeline_merge_generation) {
+    // Spill chunks
+    for (int i = 0; i < 20; i++) {
+        spill_chunks_with_slot_idx({{i * 100, i}});
+    }
+
+    // The generate_pipeline_merge_task method should be thread-safe
+    // due to the mutex lock in the implementation
+    ASSIGN_OR_ABORT(auto task, _spiller->generate_pipeline_merge_task(1024 * 1024, 1024 * 1024, true, false, false));
+
+    ASSERT_NE(task, nullptr);
+    ASSERT_NE(task->merge_itr, nullptr);
+    ASSERT_GT(task->total_block_groups, 0);
+}
+
+// Test slot_idx sorting correctness
+TEST_F(LoadSpillPipelineMergeTest, test_slot_idx_sorting) {
+    // Create block groups with out-of-order slot indices
+    std::vector<std::pair<int32_t, int64_t>> out_of_order = {{500, 5}, {100, 1}, {400, 4}, {200, 2}, {0, 0}, {300, 3}};
+
+    auto bytes = spill_chunks_with_slot_idx(out_of_order);
+
+    // Generate task - should automatically sort by slot_idx
+    ASSIGN_OR_ABORT(auto task, _spiller->generate_pipeline_merge_task(bytes, config::load_spill_max_chunk_bytes * 10,
+                                                                      true, false, true));
+
+    ASSERT_NE(task, nullptr);
+    ASSERT_NE(task->merge_itr, nullptr);
+    // All 6 groups should be merged in order
+    ASSERT_EQ(task->total_block_groups, 6);
+}
+
+// Test duplicate slot_idx handling (should still work, just not continuous)
+TEST_F(LoadSpillPipelineMergeTest, test_duplicate_slot_idx) {
+    // Spill chunks with duplicate slot indices (0, 1, 1, 2)
+    spill_chunks_with_slot_idx({{0, 0}, {100, 1}, {150, 1}, {200, 2}});
+
+    // Should merge first chunk (slot 0), then stop at duplicate
+    ASSIGN_OR_ABORT(auto task, _spiller->generate_pipeline_merge_task(1024 * 1024, 1024 * 1024, true, false, false));
+
+    ASSERT_NE(task, nullptr);
+    ASSERT_NE(task->merge_itr, nullptr);
+    // Should only merge first continuous sequence
+    ASSERT_GE(task->total_block_groups, 1);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
By introducing pipelined execution for memtable flush and merge operations, bulk load performance has been significantly enhanced. In test environments, ingestion performance improved by 50% to 60%.

## What I'm doing:
This pull request introduces a new pipeline-based parallel merge mechanism for spill-to-disk block merging in the Lake storage engine. The changes improve performance and memory efficiency during large data loads by enabling eager and incremental merging of spilled blocks, leveraging a new context and iterator to coordinate parallel tasks. The legacy serial and parallel merge code paths are removed in favor of this new, unified approach.

**Key changes include:**

### Pipeline-based Parallel Merge Implementation

* Introduced `LoadSpillPipelineMergeContext` and `LoadSpillPipelineMergeIterator` to coordinate and generate merge tasks incrementally, allowing for more dynamic and memory-efficient parallel execution. These are now included in the build and relevant source files. [[1]](diffhunk://#diff-9d627bf4eacc9f0eb9f64ff0d63f80f7e94cb520306d93479ce2bd2264fdff6aR274-R275) [[2]](diffhunk://#diff-24e44403f5e4c75144f9645f2fcff77dcdd9269836bafd5b79d5b2d6589e49fdR45) [[3]](diffhunk://#diff-efa88e3aceab1fcfcdddb6ffc3114a8eaad0c2f687010b0099c408fe879c7121R27-R28) [[4]](diffhunk://#diff-9d2f24f0dc662172a1098c3f5e767399a0299e0d23ddf03ce0c01ffc4d966e17R25-R26)

* `SpillMemTableSink` now manages a pipeline merge context and thread pool token, enabling both eager background merging during flushes and a final merge phase, with all tasks coordinated and their results consolidated through the new context. [[1]](diffhunk://#diff-efa88e3aceab1fcfcdddb6ffc3114a8eaad0c2f687010b0099c408fe879c7121R43) [[2]](diffhunk://#diff-efa88e3aceab1fcfcdddb6ffc3114a8eaad0c2f687010b0099c408fe879c7121R62-R103) [[3]](diffhunk://#diff-9d2f24f0dc662172a1098c3f5e767399a0299e0d23ddf03ce0c01ffc4d966e17L51-R78)

### Eager and Incremental Merge Optimization

* Added logic to `flush_chunk` to trigger background merge tasks when spilled data exceeds a threshold, improving parallelism and reducing peak memory usage during bulk loads. Only one merge task is generated at a time to avoid excessive memory consumption.

* The final merge phase now uses the pipeline iterator to generate and submit tasks on demand, balancing parallelism and memory efficiency. Serial fallback is supported if parallelism is disabled or resources are unavailable.

### Removal of Legacy Merge Code

* Removed the previous `merge_blocks_to_segments_parallel` and `merge_blocks_to_segments_serial` methods, consolidating all merge logic into the new pipeline model for simplicity and maintainability. [[1]](diffhunk://#diff-efa88e3aceab1fcfcdddb6ffc3114a8eaad0c2f687010b0099c408fe879c7121L78-R189) [[2]](diffhunk://#diff-9d2f24f0dc662172a1098c3f5e767399a0299e0d23ddf03ce0c01ffc4d966e17L51-R78)

### Improvements to Task Coordination and Error Handling

* Updated `TabletInternalParallelMergeTask` to use the new pipeline task structure, support cooperative cancellation via a shared atomic flag, and improve logging and status updates for better observability and reliability. [[1]](diffhunk://#diff-de19c5c9ee355400914a4704ed011f845946f465b50e7794cc6dd5bb76d45555R25-R51) [[2]](diffhunk://#diff-de19c5c9ee355400914a4704ed011f845946f465b50e7794cc6dd5bb76d45555L62-R70) [[3]](diffhunk://#diff-de19c5c9ee355400914a4704ed011f845946f465b50e7794cc6dd5bb76d45555L90-R98) [[4]](diffhunk://#diff-de19c5c9ee355400914a4704ed011f845946f465b50e7794cc6dd5bb76d45555R107-R115)

---

**References:**  
[[1]](diffhunk://#diff-9d627bf4eacc9f0eb9f64ff0d63f80f7e94cb520306d93479ce2bd2264fdff6aR274-R275) [[2]](diffhunk://#diff-24e44403f5e4c75144f9645f2fcff77dcdd9269836bafd5b79d5b2d6589e49fdR45) [[3]](diffhunk://#diff-efa88e3aceab1fcfcdddb6ffc3114a8eaad0c2f687010b0099c408fe879c7121R27-R28) [[4]](diffhunk://#diff-efa88e3aceab1fcfcdddb6ffc3114a8eaad0c2f687010b0099c408fe879c7121R43) [[5]](diffhunk://#diff-efa88e3aceab1fcfcdddb6ffc3114a8eaad0c2f687010b0099c408fe879c7121R62-R103) [[6]](diffhunk://#diff-efa88e3aceab1fcfcdddb6ffc3114a8eaad0c2f687010b0099c408fe879c7121L78-R189) [[7]](diffhunk://#diff-9d2f24f0dc662172a1098c3f5e767399a0299e0d23ddf03ce0c01ffc4d966e17R25-R26) [[8]](diffhunk://#diff-9d2f24f0dc662172a1098c3f5e767399a0299e0d23ddf03ce0c01ffc4d966e17L51-R78) [[9]](diffhunk://#diff-de19c5c9ee355400914a4704ed011f845946f465b50e7794cc6dd5bb76d45555R25-R51) [[10]](diffhunk://#diff-de19c5c9ee355400914a4704ed011f845946f465b50e7794cc6dd5bb76d45555L62-R70) [[11]](diffhunk://#diff-de19c5c9ee355400914a4704ed011f845946f465b50e7794cc6dd5bb76d45555L90-R98) [[12]](diffhunk://#diff-de19c5c9ee355400914a4704ed011f845946f465b50e7794cc6dd5bb76d45555R107-R115)

Fix #66457

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a unified pipeline-based parallel merge for load spill, enabling eager background merging during flush and on-demand task generation in final merge for better parallelism and memory control.
> 
> - Add `LoadSpillPipelineMergeContext` and `LoadSpillPipelineMergeIterator` to generate/coordinate merge tasks and consolidate results into the parent `TabletWriter`
> - Update `SpillMemTableSink` to trigger eager pipeline merges on threshold, manage thread-pool token, and perform final pipeline merge with serial fallback
> - Refactor `TabletInternalParallelMergeTask` to own writer/task, support cooperative cancellation, and release spill resources
> - Enhance `LoadChunkSpiller` with per-task generation, slot readiness tracking, and thread-safe block-group batching; wire into spill flow
> - Add `TabletWriter::merge_other_writer` for result consolidation; minor eager PK index guard
> - Remove legacy serial/parallel merge paths; wire-up in CMake; add unit tests for pipeline merge and sink behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 276c77f0d80ed221f40dca854ca36ff57183b88e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->