### PR TITLE
[BugFix] Fix the unittests which use the non-exist functions for iceberg partition chunk writer.

### DIFF
--- a/be/test/connector_sink/partition_chunk_writer_test.cpp
+++ b/be/test/connector_sink/partition_chunk_writer_test.cpp
@@ -1114,10 +1114,9 @@ TEST_F(PartitionChunkWriterTest, test_connector_sink_profile_metrics) {
         // Write some chunks
         for (size_t i = 0; i < 3; ++i) {
             ChunkPtr chunk = ChunkHelper::new_chunk(*tuple_desc, 3);
-            chunk->get_column_raw_ptr_by_index(0)->append_datum(Slice("ccc" + std::to_string(i)));
-            chunk->get_column_raw_ptr_by_index(0)->append_datum(Slice("bbb" + std::to_string(i)));
-            chunk->get_column_raw_ptr_by_index(0)->append_datum(Slice("aaa" + std::to_string(i)));
-
+            chunk->get_column_by_index(0)->append_datum(Slice("ccc" + std::to_string(i)));
+            chunk->get_column_by_index(0)->append_datum(Slice("bbb" + std::to_string(i)));
+            chunk->get_column_by_index(0)->append_datum(Slice("aaa" + std::to_string(i)));
             auto ret = partition_writer->write(chunk);
             EXPECT_OK(ret);
         }
@@ -1211,10 +1210,9 @@ TEST_F(PartitionChunkWriterTest, test_buffer_partition_writer_profile_metrics) {
         // Write some chunks
         for (size_t i = 0; i < 2; ++i) {
             ChunkPtr chunk = ChunkHelper::new_chunk(*tuple_desc, 3);
-            chunk->get_column_raw_ptr_by_index(0)->append_datum(Slice("data" + std::to_string(i)));
-            chunk->get_column_raw_ptr_by_index(0)->append_datum(Slice("data" + std::to_string(i)));
-            chunk->get_column_raw_ptr_by_index(0)->append_datum(Slice("data" + std::to_string(i)));
-
+            chunk->get_column_by_index(0)->append_datum(Slice("data" + std::to_string(i)));
+            chunk->get_column_by_index(0)->append_datum(Slice("data" + std::to_string(i)));
+            chunk->get_column_by_index(0)->append_datum(Slice("data" + std::to_string(i)));
             auto ret = partition_writer->write(chunk);
             EXPECT_OK(ret);
         }


### PR DESCRIPTION
## What I'm doing:

Fix the unittests which use the non-exist functions for iceberg partition chunk writer, that cause the build failed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
