### PR TITLE
[BugFix] fix code conflict resolve issue

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -613,12 +613,12 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .build(&_put_aggregate_metadata_thread_pool));
     _parallel_compact_mgr = std::make_unique<lake::LakePersistentIndexParallelCompactMgr>(_lake_tablet_manager);
     RETURN_IF_ERROR_WITH_WARN(_parallel_compact_mgr->init(), "init ParallelCompactMgr failed");
-    RETURN_IF_ERROR(ThreadPoolBuilder("pk_index_get")
+    RETURN_IF_ERROR(ThreadPoolBuilder("cloud_native_pk_index_execution")
                             .set_min_threads(1)
                             .set_max_threads(1)
                             .set_max_queue_size(std::numeric_limits<int>::max())
                             .build(&_pk_index_execution_thread_pool));
-    RETURN_IF_ERROR(ThreadPoolBuilder("pk_index_flush")
+    RETURN_IF_ERROR(ThreadPoolBuilder("cloud_native_pk_index_memtable_flush")
                             .set_min_threads(1)
                             .set_max_threads(1)
                             .set_max_queue_size(std::numeric_limits<int>::max())

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -964,8 +964,9 @@ Status UpdateManager::_do_update_with_condition_parallel(const RowsetUpdateState
 
     // Obtain thread pool token for parallel execution if enabled
     std::unique_ptr<ThreadPoolToken> token;
-    if (config::enable_pk_index_parallel_get) {
-        token = ExecEnv::GetInstance()->pk_index_get_thread_pool()->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+    if (config::enable_pk_index_parallel_execution) {
+        token = ExecEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
+                ThreadPool::ExecutionMode::CONCURRENT);
     }
 
     // Setup shared state protected by mutex

--- a/be/test/storage/lake/condition_update_test.cpp
+++ b/be/test/storage/lake/condition_update_test.cpp
@@ -325,9 +325,9 @@ TEST_P(ConditionUpdateTest, test_condition_update_in_memtable) {
 // 3. Verify final state matches expected merge results based on max(c1) logic
 TEST_P(ConditionUpdateTest, test_condition_update_parallel) {
     // Configure test environment for parallel execution
-    ConfigResetGuard<bool> guard(&config::enable_pk_index_parallel_get, true);
+    ConfigResetGuard<bool> guard(&config::enable_pk_index_parallel_execution, true);
     ConfigResetGuard<bool> guard2(&config::enable_pk_index_parallel_compaction, true);
-    ConfigResetGuard<int64_t> guard3(&config::pk_index_parallel_get_min_rows, 4096);
+    ConfigResetGuard<int64_t> guard3(&config::pk_index_parallel_execution_min_rows, 4096);
     ConfigResetGuard<int64_t> guard4(&config::pk_parallel_execution_threshold_bytes, 1);
     ConfigResetGuard<bool> guard5(&config::ignore_merge_condition_inside_same_transaction, true);
     ConfigResetGuard<int64_t> guard6(&config::lake_publish_version_slow_log_ms, 0);

--- a/be/test/storage/lake/condition_update_test.cpp
+++ b/be/test/storage/lake/condition_update_test.cpp
@@ -328,7 +328,7 @@ TEST_P(ConditionUpdateTest, test_condition_update_parallel) {
     ConfigResetGuard<bool> guard(&config::enable_pk_index_parallel_execution, true);
     ConfigResetGuard<bool> guard2(&config::enable_pk_index_parallel_compaction, true);
     ConfigResetGuard<int64_t> guard3(&config::pk_index_parallel_execution_min_rows, 4096);
-    ConfigResetGuard<int64_t> guard4(&config::pk_parallel_execution_threshold_bytes, 1);
+    ConfigResetGuard<int64_t> guard4(&config::pk_index_eager_build_threshold_bytes, 1);
     ConfigResetGuard<bool> guard5(&config::ignore_merge_condition_inside_same_transaction, true);
     ConfigResetGuard<int64_t> guard6(&config::lake_publish_version_slow_log_ms, 0);
     // Force small write buffer to ensure SST files are generated (required for parallel path)


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request updates the naming and configuration for the parallel execution of primary key (PK) index operations in the codebase, moving from "parallel get" terminology to a more general "parallel execution." The changes also update related thread pool names and configuration flags to improve clarity and maintain consistency.

Configuration and naming updates for PK index parallel execution:

* Renamed the thread pool for PK index operations from `pk_index_get` and `pk_index_flush` to `cloud_native_pk_index_execution` and `cloud_native_pk_index_memtable_flush` in `ExecEnv::init`, ensuring thread pool names better reflect their purpose.
* Updated the configuration flag from `enable_pk_index_parallel_get` to `enable_pk_index_parallel_execution` and adjusted related code in `UpdateManager::_do_update_with_condition_parallel` to use the new flag and thread pool getter.
* Changed test configuration in `ConditionUpdateTest` to use the new flag `enable_pk_index_parallel_execution` and updated the related minimum rows config from `pk_index_parallel_get_min_rows` to `pk_index_parallel_execution_min_rows`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
