### PR TITLE
[Tool] add changed-files clang-format helpers

### DIFF
--- a/build-support/README.md
+++ b/build-support/README.md
@@ -1,0 +1,15 @@
+# build-support
+
+Brief notes on helper scripts in this directory.
+
+- `build-support/check-format.sh`: Check clang-format across `be/src` and `be/test` without modifying files. Usage: `bash build-support/check-format.sh`
+- `build-support/clang-format-changed-check.sh`: Check clang-format only on C++ files changed since `origin/main` (falls back to full check if missing). Usage: `bash build-support/clang-format-changed-check.sh`
+- `build-support/clang-format-changed.sh`: Apply clang-format to C++ files changed since `origin/main` (falls back to full format if missing). Usage: `bash build-support/clang-format-changed.sh`
+- `build-support/clang-format.sh`: Apply clang-format across `be/src` and `be/test`. Usage: `bash build-support/clang-format.sh`
+- `build-support/compile_time.sh`: Collect and report compile-time statistics (clang). Usage: `bash build-support/compile_time.sh`
+- `build-support/format_changed_files.py`: Filter a list of changed files to C++ sources within target dirs. Usage: `python3 build-support/format_changed_files.py --help`
+- `build-support/gen_build_version.py`: Generate build version metadata. Usage: `python3 build-support/gen_build_version.py --help`
+- `build-support/gen_notice.py`: Generate NOTICE file content from bundled licenses. Usage: `python3 build-support/gen_notice.py --help`
+- `build-support/lintutils.py`: Shared helpers for lint/format scripts. Imported by other scripts.
+- `build-support/run_clang_format.py`: Run clang-format in check or fix mode for given dirs. Usage: `python3 build-support/run_clang_format.py --help`
+- `build-support/sync_pom_to_gradle.py`: Sync Maven POM settings into Gradle config. Usage: `python3 build-support/sync_pom_to_gradle.py --help`

--- a/build-support/check-format.sh
+++ b/build-support/check-format.sh
@@ -30,8 +30,7 @@ export STARROCKS_HOME=`cd "${ROOT}/.."; pwd`
 
 CLANG_FORMAT=${CLANG_FORMAT_BINARY:=$(which clang-format)}
 
-python3 ${STARROCKS_HOME}/build-support/run_clang_format.py --clang_format_binary="${CLANG_FORMAT}" \
+python3 "${STARROCKS_HOME}/build-support/run_clang_format.py" --clang_format_binary="${CLANG_FORMAT}" \
 	--source_dirs="${STARROCKS_HOME}/be/src","${STARROCKS_HOME}/be/test" \
         --exclude_globs="${STARROCKS_HOME}/build-support/excludes" --quiet
-
 

--- a/build-support/clang-format-changed-check.sh
+++ b/build-support/clang-format-changed-check.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##############################################################
+# This script checks clang-format only on C++ files changed
+# since origin/main. If origin/main is unavailable, it checks
+# all C++ files in be/src and be/test.
+##############################################################
+
+set -eo pipefail
+
+ROOT=`dirname "$0"`
+ROOT=`cd "$ROOT"; pwd`
+
+export STARROCKS_HOME=`cd "${ROOT}/.."; pwd`
+
+CLANG_FORMAT=${CLANG_FORMAT_BINARY:=$(which clang-format)}
+EXCLUDES_FILE="${STARROCKS_HOME}/build-support/excludes"
+SOURCE_DIRS=("${STARROCKS_HOME}/be/src" "${STARROCKS_HOME}/be/test")
+
+if ! git -C "${STARROCKS_HOME}" rev-parse --verify origin/main >/dev/null 2>&1; then
+    echo "origin/main not found; checking all C++ files."
+    python3 "${STARROCKS_HOME}/build-support/run_clang_format.py" --clang_format_binary="${CLANG_FORMAT}" \
+        --source_dirs="${SOURCE_DIRS[0]}","${SOURCE_DIRS[1]}" \
+        --exclude_globs="${EXCLUDES_FILE}" --quiet
+    exit 0
+fi
+
+changed_files=$(
+    {
+        git -C "${STARROCKS_HOME}" diff --name-only --diff-filter=ACMR origin/main...HEAD
+        git -C "${STARROCKS_HOME}" diff --name-only --diff-filter=ACMR --cached -- be
+        git -C "${STARROCKS_HOME}" diff --name-only --diff-filter=ACMR -- be
+    } | sort -u
+)
+if [[ -z "${changed_files}" ]]; then
+    echo "No files changed since origin/main."
+    exit 0
+fi
+
+tmpfile=$(mktemp)
+trap 'rm -f "${tmpfile}"' EXIT
+
+python3 "${STARROCKS_HOME}/build-support/format_changed_files.py" \
+    --repo_root "${STARROCKS_HOME}" \
+    --exclude_globs "${EXCLUDES_FILE}" \
+    --source_dirs "${SOURCE_DIRS[0]}","${SOURCE_DIRS[1]}" \
+    --null < <(printf '%s\n' "${changed_files}") > "${tmpfile}"
+
+if [[ ! -s "${tmpfile}" ]]; then
+    echo "No changed C++ files to check since origin/main."
+    exit 0
+fi
+
+echo "C++ files to check:"
+while IFS= read -r -d '' filename; do
+    echo "${filename}"
+done < "${tmpfile}"
+
+error=0
+while IFS= read -r -d '' filename; do
+    formatted_tmp=$(mktemp)
+    trap 'rm -f "${tmpfile}" "${formatted_tmp}"' EXIT
+    "${CLANG_FORMAT}" -style=file "${filename}" > "${formatted_tmp}"
+    if ! diff -u "${filename}" "${formatted_tmp}" >/dev/null; then
+        echo "${filename} had clang-format style issues"
+        echo >&2
+        diff -u "${filename}" "${formatted_tmp}" >&2 || true
+        error=1
+    fi
+    rm -f "${formatted_tmp}"
+done < "${tmpfile}"
+
+if [[ "${error}" -ne 0 ]]; then
+    exit 1
+fi

--- a/build-support/clang-format-changed.sh
+++ b/build-support/clang-format-changed.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##############################################################
+# This script runs clang-format only on C++ files changed
+# since origin/main. If origin/main is unavailable, it formats
+# all C++ files in be/src and be/test.
+##############################################################
+
+set -eo pipefail
+
+ROOT=`dirname "$0"`
+ROOT=`cd "$ROOT"; pwd`
+
+export STARROCKS_HOME=`cd "${ROOT}/.."; pwd`
+
+CLANG_FORMAT=${CLANG_FORMAT_BINARY:=$(which clang-format)}
+EXCLUDES_FILE="${STARROCKS_HOME}/build-support/excludes"
+SOURCE_DIRS=("${STARROCKS_HOME}/be/src" "${STARROCKS_HOME}/be/test")
+
+if ! git -C "${STARROCKS_HOME}" rev-parse --verify origin/main >/dev/null 2>&1; then
+    echo "origin/main not found; formatting all C++ files."
+    python3 "${STARROCKS_HOME}/build-support/run_clang_format.py" --clang_format_binary="${CLANG_FORMAT}" --fix \
+        --source_dirs="${SOURCE_DIRS[0]}","${SOURCE_DIRS[1]}" \
+        --exclude_globs="${EXCLUDES_FILE}"
+    exit 0
+fi
+
+changed_files=$(
+    {
+        git -C "${STARROCKS_HOME}" diff --name-only --diff-filter=ACMR origin/main...HEAD
+        git -C "${STARROCKS_HOME}" diff --name-only --diff-filter=ACMR --cached -- be
+        git -C "${STARROCKS_HOME}" diff --name-only --diff-filter=ACMR -- be
+    } | sort -u
+)
+if [[ -z "${changed_files}" ]]; then
+    echo "No files changed since origin/main."
+    exit 0
+fi
+
+tmpfile=$(mktemp)
+trap 'rm -f "${tmpfile}"' EXIT
+
+python3 "${STARROCKS_HOME}/build-support/format_changed_files.py" \
+    --repo_root "${STARROCKS_HOME}" \
+    --exclude_globs "${EXCLUDES_FILE}" \
+    --source_dirs "${SOURCE_DIRS[0]}","${SOURCE_DIRS[1]}" \
+    --null < <(printf '%s\n' "${changed_files}") > "${tmpfile}"
+
+if [[ ! -s "${tmpfile}" ]]; then
+    echo "No changed C++ files to format since origin/main."
+    exit 0
+fi
+
+echo "C++ files to format:"
+while IFS= read -r -d '' filename; do
+    echo "${filename}"
+done < "${tmpfile}"
+
+xargs -0 -n 16 "${CLANG_FORMAT}" -style=file -i < "${tmpfile}"

--- a/build-support/clang-format.sh
+++ b/build-support/clang-format.sh
@@ -30,8 +30,7 @@ export STARROCKS_HOME=`cd "${ROOT}/.."; pwd`
 
 CLANG_FORMAT=${CLANG_FORMAT_BINARY:=$(which clang-format)}
 
-python3 ${STARROCKS_HOME}/build-support/run_clang_format.py --clang_format_binary="${CLANG_FORMAT}" --fix \
+python3 "${STARROCKS_HOME}/build-support/run_clang_format.py" --clang_format_binary="${CLANG_FORMAT}" --fix \
 	--source_dirs="${STARROCKS_HOME}/be/src","${STARROCKS_HOME}/be/test" \
         --exclude_globs="${STARROCKS_HOME}/build-support/excludes"
-
 

--- a/build-support/format_changed_files.py
+++ b/build-support/format_changed_files.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+import os
+import sys
+from fnmatch import fnmatch
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Filter changed files to C++ sources within target dirs.")
+    parser.add_argument(
+        "--repo_root",
+        required=True,
+        help="Absolute path to the repository root.")
+    parser.add_argument(
+        "--exclude_globs",
+        help="Filename containing globs for files that should be excluded.")
+    parser.add_argument(
+        "--source_dirs",
+        required=True,
+        help="Comma-separated root directories of the source code.")
+    parser.add_argument(
+        "--null",
+        action="store_true",
+        help="Use NUL as output delimiter for paths.")
+    return parser.parse_args()
+
+
+def _load_excludes(exclude_file):
+    if not exclude_file or not os.path.exists(exclude_file):
+        return []
+    with open(exclude_file) as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def main():
+    args = _parse_args()
+    repo_root = os.path.abspath(args.repo_root)
+    source_dirs = [os.path.abspath(p) for p in args.source_dirs.split(",") if p]
+    exclude_globs = _load_excludes(args.exclude_globs)
+
+    extensions = {".h", ".cc", ".cpp", ".tpp", ".hh", ".hpp"}
+    changed = [line.strip() for line in sys.stdin.read().splitlines() if line.strip()]
+    delimiter = "\0" if args.null else "\n"
+
+    for relpath in changed:
+        path = os.path.abspath(os.path.join(repo_root, relpath))
+        if os.path.splitext(path)[1] not in extensions:
+            continue
+        if not any(path == d or path.startswith(d + os.sep) for d in source_dirs):
+            continue
+        if any(fnmatch(path, glob) for glob in exclude_globs):
+            continue
+        if os.path.exists(path):
+            sys.stdout.write(path + delimiter)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tooling to run clang-format selectively on changed C++ files and minor improvements to existing scripts.
> 
> - New `clang-format-changed.sh` and `clang-format-changed-check.sh` to format/check only files changed since `origin/main` (fallback to full run)
> - New `format_changed_files.py` to filter changed paths to C++ sources within `be/src` and `be/test`, honoring `build-support/excludes`
> - Update `check-format.sh` and `clang-format.sh` to quote script paths for robustness
> - New `build-support/README.md` documenting the helper scripts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42e0a87e44403c1c964d41b329e40b37c1ffd240. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->