### PR TITLE
[Doc] Add hive truncate doc

### DIFF
--- a/docs/en/data_source/catalog/hive_catalog.md
+++ b/docs/en/data_source/catalog/hive_catalog.md
@@ -1157,6 +1157,56 @@ The following DMLs use the default file format Parquet as an example.
    INSERT OVERWRITE partition_tbl_1 partition(dt='2023-09-01',id=1) SELECT 'close';
    ```
 
+## Truncate a Hive table
+
+You can use the [TRUNCATE TABLE](../../sql-reference/sql-statements/table_bucket_part_index/TRUNCATE_TABLE.md) statement to quickly delete all data from Hive managed tables. This operation supports:
+
+- Truncating all data in non-partitioned tables
+- Truncating all partitions in a partitioned table
+- Truncating specific partitions in a partitioned table
+
+### Syntax
+
+```SQL
+TRUNCATE TABLE <table_name>
+
+TRUNCATE TABLE <table_name> PARTITION (partition_name = partition_value [, ...])
+```
+
+### Parameters
+
+- `table_name`: The name of the Hive table that you want to truncate data from. You need to [Switch to a Hive catalog and a database in it](#switch-to-a-hive-catalog-and-a-database-in-it) before you truncate the table in that database.
+- `partition_name = partition_value`: The name and value of the partition column(s) to identify which partition(s) to truncate.
+
+### Examples
+
+Switch to a Hive catalog and a database in it, and then use the following statements to truncate a Hive table in that database.
+
+1. Truncate a non-partitioned table:
+
+   ```SQL
+   TRUNCATE TABLE my_table;
+   ```
+
+2. Truncate all partitions of a partitioned table:
+
+   ```SQL
+   TRUNCATE TABLE my_partitioned_table;
+   ```
+
+3. Truncate a single-partition partitioned table:
+
+   ```SQL
+   TRUNCATE TABLE my_partitioned_table PARTITION (dt='2023-09-01');
+   ```
+
+4. Truncate specific partitions of a multi-partition partitioned table:
+
+   ```SQL
+   TRUNCATE TABLE my_partitioned_table PARTITION (dt='2023-09-01', id=1);
+   TRUNCATE TABLE my_multi_part_table PARTITION (k2='2020-01-02', k3='b');
+   ```
+
 ## Drop a Hive table
 
 Similar to the internal tables of StarRocks, if you have the [DROP](../../administration/user_privs/authorization/privilege_item.md#table) privilege on a Hive table, you can use the [DROP TABLE](../../sql-reference/sql-statements/table_bucket_part_index/DROP_TABLE.md) statement to drop that Hive table. This feature is supported from v3.1 onwards. Note that currently StarRocks supports dropping only managed tables of Hive.

--- a/docs/ja/data_source/catalog/hive_catalog.md
+++ b/docs/ja/data_source/catalog/hive_catalog.md
@@ -1157,6 +1157,56 @@ PARTITION (par_col1=<value> [, par_col2=<value>...])
    INSERT OVERWRITE partition_tbl_1 partition(dt='2023-09-01',id=1) SELECT 'close';
    ```
 
+## Hive テーブルの Truncate
+
+[TRUNCATE TABLE](../../sql-reference/sql-statements/table_bucket_part_index/TRUNCATE_TABLE.md) ステートメントを使用して、Hive マネージドテーブルからすべてのデータを迅速に削除できます。この操作は以下をサポートしています：
+
+- 非パーティションテーブルのすべてのデータを削除
+- パーティションテーブルのすべてのパーティションを削除
+- パーティションテーブルの特定のパーティションを削除
+
+### 構文
+
+```SQL
+TRUNCATE TABLE <table_name>
+
+TRUNCATE TABLE <table_name> PARTITION (partition_name = partition_value [, ...])
+```
+
+### パラメータ
+
+- `table_name`: データを削除する Hive テーブルの名前。データベース内のテーブルを削除する前に、[Hive カタログとデータベースに切り替える](#hive-catalog-とデータベースに切り替える)必要があります。
+- `partition_name = partition_value`: どのパーティションを削除するかを識別するための、パーティション列の名前と値。
+
+### 使用例
+
+Hive カタログとデータベースに切り替えた後、データベース内の Hive テーブルを以下のステートメントで truncate できます。
+
+1. 非パーティションテーブルを truncate:
+
+   ```SQL
+   TRUNCATE TABLE my_table;
+   ```
+
+2. パーティションテーブルのすべてのパーティションを truncate:
+
+   ```SQL
+   TRUNCATE TABLE my_partitioned_table;
+   ```
+
+3. 単一パーティションテーブルの特定パーティションを truncate:
+
+   ```SQL
+   TRUNCATE TABLE my_partitioned_table PARTITION (dt='2023-09-01');
+   ```
+
+4. 複数パーティションテーブルの特定パーティションを truncate:
+
+   ```SQL
+   TRUNCATE TABLE my_partitioned_table PARTITION (dt='2023-09-01', id=1);
+   TRUNCATE TABLE my_multi_part_table PARTITION (k2='2020-01-02', k3='b');
+   ```
+
 ## Hive テーブルの削除
 
 StarRocks の内部テーブルと同様に、Hive テーブルに対する [DROP](../../administration/user_privs/authorization/privilege_item.md#table) 権限を持っている場合、[DROP TABLE](../../sql-reference/sql-statements/table_bucket_part_index/DROP_TABLE.md) ステートメントを使用してその Hive テーブルを削除できます。この機能は v3.1 以降でサポートされています。現在、StarRocks は Hive の管理テーブルのみを削除することをサポートしています。

--- a/docs/zh/data_source/catalog/hive_catalog.md
+++ b/docs/zh/data_source/catalog/hive_catalog.md
@@ -1166,6 +1166,56 @@ PARTITION (par_col1=<value> [, par_col2=<value>...])
    INSERT OVERWRITE partition_tbl_1 partition(dt='2023-09-01',id=1) SELECT 'close';
    ```
 
+## 清空 Hive 表
+
+您可以使用 [TRUNCATE TABLE](../../sql-reference/sql-statements/table_bucket_part_index/TRUNCATE_TABLE.md) 语句快速删除 Hive 托管表中的所有数据。该操作支持：
+
+- 清空非分区表中的所有数据
+- 清空分区表中的所有分区
+- 清空分区表中的指定分区
+
+### 语法
+
+```SQL
+TRUNCATE TABLE <table_name>
+
+TRUNCATE TABLE <table_name> PARTITION (partition_name = partition_value [, ...])
+```
+
+### 参数
+
+- `table_name`: 要清空数据的 Hive 表名称。清空表数据前，需要[切换至目标 Hive Catalog 和 Database](#切换-hive-catalog-和数据库)。
+- `partition_name = partition_value`: 分区列的名称和值，用于识别要清空的分区。
+
+### 示例
+
+以下示例的前提是已切换至目标 Hive Catalog 和 Database。
+
+1. 清空非分区表：
+
+   ```SQL
+   TRUNCATE TABLE my_table;
+   ```
+
+2. 清空分区表所有分区：
+
+   ```SQL
+   TRUNCATE TABLE my_partitioned_table;
+   ```
+
+3. 清空单分区表的指定分区：
+
+   ```SQL
+   TRUNCATE TABLE my_partitioned_table PARTITION (dt='2023-09-01');
+   ```
+
+4. 清空多分区表的指定分区：
+
+   ```SQL
+   TRUNCATE TABLE my_partitioned_table PARTITION (dt='2023-09-01', id=1);
+   TRUNCATE TABLE my_multi_part_table PARTITION (k2='2020-01-02', k3='b');
+   ```
+
 ## 删除 Hive 表
 
 同 StarRocks 内表一致，如果您拥有 Hive 表的 [DROP](../../administration/user_privs/authorization/privilege_item.md#表权限-table) 权限，那么您可以使用 [DROP TABLE](../../sql-reference/sql-statements/table_bucket_part_index/DROP_TABLE.md) 来删除该 Hive 表。本功能自 3.2 版本起开始支持。注意当前只支持删除 Hive 的 Managed Table。


### PR DESCRIPTION
## Why I'm doing:
#65016
## What I'm doing:
This pull request adds documentation for the `TRUNCATE TABLE` statement for Hive managed tables to the Hive catalog documentation in English, Japanese, and Chinese. The new sections explain how to quickly delete all data from Hive tables, including syntax, parameters, and usage examples for both partitioned and non-partitioned tables.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4