### PR TITLE
[BugFix] Fix incorrect HMS.PARTITIONS.LIST_FS_PARTITIONS in case of union

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
@@ -106,7 +106,7 @@ public class RemoteFileOperations {
             pathKeyToPartition.put(key, partition);
         }
 
-        int cacheMissSize = partitions.size();
+        int cacheMissSize = pathKeyToPartition.size();
         if (enableCatalogLevelCache && params.isUseCache()) {
             cacheMissSize = cacheMissSize - remoteFileIO.getPresentRemoteFiles(
                     Lists.newArrayList(pathKeyToPartition.keySet())).size();


### PR DESCRIPTION
## Why I'm doing:
found in 3.3, in hive scan with union all could produce duplicate `referencedPartitionsPerTable` in `DescriptorTable`. Causing incorrect HMS.PARTITIONS.LIST_FS_PARTITIONS display in profile. Fix it to avoid user confusion.

stack
```
Affect(class count: 1 , method count: 2) cost in 242 ms, listenerId: 38
ts=2026-01-14 17:25:25;thread_name=starrocks-mysql-nio-pool-11654;id=1c74f;is_daemon=true;priority=5;TCCL=jdk.internal.loader.ClassLoaders$AppClassLoader@7aec35a
    @com.starrocks.connector.hive.HiveMetadata.getRemoteFileInfos()
        at com.starrocks.connector.CatalogConnectorMetadata.getRemoteFileInfos(CatalogConnectorMetadata.java:153)
        at com.starrocks.server.MetadataMgr.getRemoteFileInfos(MetadataMgr.java:786)
        at com.starrocks.server.MetadataMgr.getRemoteFileInfos(MetadataMgr.java:776)
        at com.starrocks.catalog.HiveTable.toThrift(HiveTable.java:351)
        at com.starrocks.analysis.DescriptorTable.toThrift(DescriptorTable.java:178)
        at com.starrocks.qe.StmtExecutor.handleQueryStmt(StmtExecutor.java:1268)
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:649)
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:363)
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:572)
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:910)
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.lang.Thread.run(Thread.java:834)
```

duplicate partition key result
```
method=com.starrocks.connector.hive.HiveMetadata.getRemoteFileInfos location=AtExit
ts=2026-01-14 17:08:02; [cost=0.456622ms] result=@ArrayList[
    @ArrayList[
        @HivePartitionKey[types: [VARCHAR]; keys: [20260112]; ],
        @HivePartitionKey[types: [VARCHAR]; keys: [20260112]; ],
        @HivePartitionKey[types: [VARCHAR]; keys: [20260112]; ],
    ],
]
```

## What I'm doing:

fix duplicate calculation result

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4