### PR TITLE
[BugFix] Fix ScopedTimer cause Concurrency Exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/RawScopedTimer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/RawScopedTimer.java
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.common.profile;
+
+import com.google.common.base.Stopwatch;
+
+import java.util.concurrent.TimeUnit;
+
+public class RawScopedTimer {
+
+    private final Stopwatch stopWatch = Stopwatch.createUnstarted();
+
+    public class Guard implements AutoCloseable {
+
+        public Guard() {
+            stopWatch.start();
+        }
+
+        @Override
+        public void close() {
+            stopWatch.stop();
+        }
+    }
+
+    public Guard start() {
+        return new Guard();
+    }
+
+    public long getTotalTime() {
+        return stopWatch.elapsed(TimeUnit.MILLISECONDS);
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -35,7 +35,6 @@
 package com.starrocks.qe;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -72,7 +71,6 @@ import com.starrocks.common.Status;
 import com.starrocks.common.TimeoutException;
 import com.starrocks.common.Version;
 import com.starrocks.common.profile.RawScopedTimer;
-import com.starrocks.common.profile.TimeWatcher;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.CompressionUtils;


### PR DESCRIPTION
## Why I'm doing:

```
2026-01-13 08:29:59.360+08:00 WARN (starrocks-mysql-nio-pool-2|128) [StmtExecutor.execute():1041] execute Exception, sql: {}, select * from db_0.table_2
 java.util.ConcurrentModificationException
        at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1013)
        at java.base/java.util.ArrayList$Itr.next(ArrayList.java:967)
        at java.base/java.lang.String.join(String.java:3327)
        at com.starrocks.common.profile.TimeWatcher.scope(TimeWatcher.java:37)
        at com.starrocks.common.profile.TracerImpl.watchScope(TracerImpl.java:55)
        at com.starrocks.common.profile.Tracers.watchScope(Tracers.java:193)
        at com.starrocks.qe.StmtExecutor.responseFields(StmtExecutor.java:1689)
        at com.starrocks.qe.StmtExecutor.handleQueryStmt(StmtExecutor.java:1667)
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:856)
        at com.starrocks.qe.ConnectProcessor.executeQueryAttempt(ConnectProcessor.java:555)
        at com.starrocks.qe.ConnectProcessor.runWithParserStageRetry(ConnectProcessor.java:449)
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:386)
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:766)
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:1144)
        at com.starrocks.mysql.nio.MySQLReadListener.handleRequest(MySQLReadListener.java:120)
        at com.starrocks.mysql.nio.MySQLReadListener.lambda$handleEvent$0(MySQLReadListener.java:88)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
