### PR TITLE
[Feature] Fast Schema Evolution for Materialized Views

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterOpType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterOpType.java
@@ -37,6 +37,7 @@ package com.starrocks.alter;
 import com.starrocks.sql.ast.AddColumnClause;
 import com.starrocks.sql.ast.AddColumnsClause;
 import com.starrocks.sql.ast.AddFieldClause;
+import com.starrocks.sql.ast.AddMVColumnClause;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.AddRollupClause;
 import com.starrocks.sql.ast.AlterClause;
@@ -45,6 +46,7 @@ import com.starrocks.sql.ast.CreateIndexClause;
 import com.starrocks.sql.ast.DropColumnClause;
 import com.starrocks.sql.ast.DropFieldClause;
 import com.starrocks.sql.ast.DropIndexClause;
+import com.starrocks.sql.ast.DropMVColumnClause;
 import com.starrocks.sql.ast.DropRollupClause;
 import com.starrocks.sql.ast.ModifyColumnClause;
 import com.starrocks.sql.ast.ModifyColumnCommentClause;
@@ -97,8 +99,10 @@ public enum AlterOpType {
         if (alterClause instanceof AddColumnClause ||
                 alterClause instanceof AddColumnsClause ||
                 alterClause instanceof AddFieldClause ||
+                alterClause instanceof AddMVColumnClause ||
                 alterClause instanceof CreateIndexClause ||
                 alterClause instanceof DropColumnClause ||
+                alterClause instanceof DropMVColumnClause ||
                 alterClause instanceof DropFieldClause ||
                 alterClause instanceof DropIndexClause ||
                 alterClause instanceof ModifyColumnClause ||

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -167,6 +167,11 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     // Virtual columns are not persisted and only exist during query analysis and planning.
     private transient boolean isVirtual = false;
 
+    // The timestamp when this column is created, the unit should be the same as
+    // PhysicalPartition#visibleVersionTime, which is milliseconds by default.
+    @SerializedName(value = "createdTime")
+    private long createdTime = -1;
+
     // Only for persist
     public Column() {
         this.name = "";
@@ -273,6 +278,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         this.generatedColumnExpr = null;
         this.uniqueId = columnUniqId;
         this.physicalName = physicalName;
+        this.createdTime = System.currentTimeMillis();
     }
 
     public Column(Column column) {
@@ -294,6 +300,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         this.uniqueId = column.getUniqueId();
         this.generatedColumnExpr = column.generatedColumnExpr;
         this.isHidden = column.isHidden;
+        this.createdTime = column.createdTime;
     }
 
     public Column deepCopy() {
@@ -464,6 +471,10 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
 
     public boolean isShadowColumn() {
         return this.name.startsWith(SchemaChangeHandler.SHADOW_NAME_PREFIX);
+    }
+
+    public long getCreatedTime() {
+        return createdTime;
     }
 
     public int getOlapColumnIndexSize() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -29,8 +29,6 @@ import com.starrocks.authorization.PrivilegeBuiltinConstants;
 import com.starrocks.backup.Status;
 import com.starrocks.backup.mv.MvBaseTableBackupInfo;
 import com.starrocks.backup.mv.MvRestoreContext;
-import com.starrocks.catalog.LightWeightDeltaLakeTable;
-import com.starrocks.catalog.LightWeightIcebergTable;
 import com.starrocks.catalog.constraint.ForeignKeyConstraint;
 import com.starrocks.catalog.constraint.GlobalConstraintManager;
 import com.starrocks.catalog.mv.MVPlanValidationResult;
@@ -243,7 +241,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
     @Override
     public boolean getUseFastSchemaEvolution() {
-        return false;
+        return true;
     }
 
     @Override
@@ -681,6 +679,9 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         this.dbId = dbId;
         this.refreshScheme = refreshScheme;
         this.active = true;
+
+        // Assign unique ids for columns
+        initUniqueId();
     }
 
     // Used for sync mv
@@ -2558,11 +2559,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
         // write edit log
         if (isWriteBaseTableInfoChangeEditLog) {
-            Map<Long, Map<String, BasePartitionInfo>> baseTableVisibleVersionMap =
-                    this.refreshScheme.asyncRefreshContext.baseTableVisibleVersionMap;
             AlterMaterializedViewBaseTableInfosLog alterMaterializedViewBaseTableInfos =
-                    new AlterMaterializedViewBaseTableInfosLog(dbId, getId(), oldMvId, baseTableInfos,
-                            baseTableVisibleVersionMap);
+                    new AlterMaterializedViewBaseTableInfosLog(oldMvId, this);
             GlobalStateMgr.getCurrentState().getEditLog().logAlterMvBaseTableInfos(alterMaterializedViewBaseTableInfos);
         }
 
@@ -2581,31 +2579,117 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * Replay AlterMaterializedViewBaseTableInfosLog and update associated variables.
      */
     public void replayAlterMaterializedViewBaseTableInfos(AlterMaterializedViewBaseTableInfosLog log) {
-        this.setBaseTableInfos(log.getBaseTableInfos());
-        Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
-                this.refreshScheme.asyncRefreshContext.baseTableVisibleVersionMap;
-        for (Map.Entry<Long, Map<String, MaterializedView.BasePartitionInfo>> e :
-                log.getBaseTableVisibleVersionMap().entrySet()) {
-            if (!baseTableVisibleVersionMap.containsKey(e.getKey())) {
-                baseTableVisibleVersionMap.put(e.getKey(), e.getValue());
-            } else {
-                Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = baseTableVisibleVersionMap.get(e.getKey());
-                partitionInfoMap.putAll(e.getValue());
-            }
-        }
-        for (BaseTableInfo baseTableInfo : baseTableInfos) {
-            Optional<Table> baseTableOpt = MvUtils.getTableWithIdentifier(baseTableInfo);
-            if (baseTableOpt.isEmpty()) {
-                continue;
-            }
-            Table baseTable = baseTableOpt.get();
-            baseTable.getRelatedMaterializedViews().remove(log.getMvId());
-            baseTable.getRelatedMaterializedViews().add(getMvId());
-        }
-        setActive();
+        int mvAlterType = log.getAlterType();
+        LOG.info("Replay alter materialized view base table infos log for mv {}, alter type is {}",
+                this.getName(), mvAlterType);
+        AlterMaterializedViewBaseTableInfosLog.AlterType alterType =
+                AlterMaterializedViewBaseTableInfosLog.AlterType.valueOf(mvAlterType);
+        switch (alterType) {
+            case ADD_COLUMN: {
+                // add column
+                this.viewDefineSql = log.getViewDefineSql();
+                this.simpleDefineSql = log.getSimpleDefineSql();
+                this.originalViewDefineSql = log.getOriginalViewDefineSql();
+                if (log.getQueryOutputIndices() != null) {
+                    this.queryOutputIndices = log.getQueryOutputIndices();
+                }
+                // reset cached query parse node
+                resetDefinedQueryParseNode();
+                // init unique id
+                initUniqueId();
 
-        // recheck again
-        fixRelationship();
+                // update version map if needed
+                Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
+                        this.refreshScheme.asyncRefreshContext.baseTableVisibleVersionMap;
+                // overwrite existing version info
+                for (Map.Entry<Long, Map<String, MaterializedView.BasePartitionInfo>> e :
+                        log.getBaseTableVisibleVersionMap().entrySet()) {
+                    baseTableVisibleVersionMap.computeIfAbsent(e.getKey(), k -> new HashMap<>())
+                            .putAll(e.getValue());
+                }
+                Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> baseTableInfoVisibleVersionMap =
+                        this.refreshScheme.asyncRefreshContext.baseTableInfoVisibleVersionMap;
+                for (Map.Entry<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> e :
+                        log.getBaseTableInfoVisibleVersionMap().entrySet()) {
+                    baseTableInfoVisibleVersionMap.computeIfAbsent(e.getKey(), k -> new HashMap<>())
+                            .putAll(e.getValue());
+                }
+                break;
+            }
+            case DROP_COLUMN:
+                // drop column
+                this.viewDefineSql = log.getViewDefineSql();
+                this.simpleDefineSql = log.getSimpleDefineSql();
+                this.originalViewDefineSql = log.getOriginalViewDefineSql();
+                if (log.getQueryOutputIndices() != null) {
+                    this.queryOutputIndices = log.getQueryOutputIndices();
+                }
+                // reset cached query parse node
+                resetDefinedQueryParseNode();
+                // init unique id
+                initUniqueId();
+                break;
+            default: {
+                this.setBaseTableInfos(log.getBaseTableInfos());
+                Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
+                        this.refreshScheme.asyncRefreshContext.baseTableVisibleVersionMap;
+                for (Map.Entry<Long, Map<String, MaterializedView.BasePartitionInfo>> e :
+                        log.getBaseTableVisibleVersionMap().entrySet()) {
+                    baseTableVisibleVersionMap.computeIfAbsent(e.getKey(), k -> new HashMap<>())
+                            .putAll(e.getValue());
+                }
+                for (BaseTableInfo baseTableInfo : baseTableInfos) {
+                    Optional<Table> baseTableOpt = MvUtils.getTableWithIdentifier(baseTableInfo);
+                    if (baseTableOpt.isEmpty()) {
+                        continue;
+                    }
+                    Table baseTable = baseTableOpt.get();
+                    baseTable.getRelatedMaterializedViews().remove(log.getMvId());
+                    baseTable.getRelatedMaterializedViews().add(getMvId());
+                }
+                setActive();
+
+                // recheck again
+                fixRelationship();
+            }
+        }
+    }
+
+    public synchronized void resetDefinedQueryParseNode() {
+        this.defineQueryParseNode = null;
+    }
+
+    public synchronized ParseNode initDefineQueryParseNode() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+        if (db == null) {
+            return null;
+        }
+        ParseNode defineQueryParseNode = null;
+        ConnectContext connectContext = ConnectContext.buildInner();
+        if (!Strings.isNullOrEmpty(originalViewDefineSql)) {
+            try {
+                String currentDBName = Strings.isNullOrEmpty(originalDBName) ? db.getOriginName() : originalDBName;
+                connectContext.setDatabase(currentDBName);
+                defineQueryParseNode = MvUtils.getQueryAst(originalViewDefineSql, connectContext);
+                clearHeavyObjectFromParseNode(defineQueryParseNode);
+            } catch (Exception e) {
+                // ignore
+                LOG.warn("parse original view define sql failed:", e);
+            }
+        }
+        if (defineQueryParseNode == null) {
+            if (!Strings.isNullOrEmpty(viewDefineSql)) {
+                try {
+                    connectContext.setDatabase(db.getOriginName());
+                    defineQueryParseNode = MvUtils.getQueryAst(viewDefineSql, connectContext);
+                    clearHeavyObjectFromParseNode(defineQueryParseNode);
+                } catch (Exception e) {
+                    // ignore
+                    LOG.warn("parse view define sql failed:", e);
+                }
+            }
+        }
+        return defineQueryParseNode;
     }
 
     /**
@@ -2613,34 +2697,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      */
     public synchronized ParseNode getDefineQueryParseNode() {
         if (this.defineQueryParseNode == null) {
-            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
-            if (db == null) {
-                return null;
-            }
-            ConnectContext connectContext = ConnectContext.buildInner();
-            if (!Strings.isNullOrEmpty(originalViewDefineSql)) {
-                try {
-                    String currentDBName = Strings.isNullOrEmpty(originalDBName) ? db.getOriginName() : originalDBName;
-                    connectContext.setDatabase(currentDBName);
-                    this.defineQueryParseNode = MvUtils.getQueryAst(originalViewDefineSql, connectContext);
-                    clearHeavyObjectFromParseNode(this.defineQueryParseNode);
-                } catch (Exception e) {
-                    // ignore
-                    LOG.warn("parse original view define sql failed:", e);
-                }
-            }
-            if (this.defineQueryParseNode == null) {
-                if (!Strings.isNullOrEmpty(viewDefineSql)) {
-                    try {
-                        connectContext.setDatabase(db.getOriginName());
-                        this.defineQueryParseNode = MvUtils.getQueryAst(viewDefineSql, connectContext);
-                        clearHeavyObjectFromParseNode(this.defineQueryParseNode);
-                    } catch (Exception e) {
-                        // ignore
-                        LOG.warn("parse view define sql failed:", e);
-                    }
-                }
-            }
+            this.defineQueryParseNode = initDefineQueryParseNode();
         }
         return this.defineQueryParseNode;
     }
@@ -2691,5 +2748,37 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                     .filter(col -> isWithInvisible || !col.isHidden())
                     .collect(Collectors.toList());
         }
+    }
+
+    /**
+     * To support fast schema evolution, we need to init unique id for each column in base schema.
+     */
+    public void initUniqueId() {
+        List<Column> baseSchema = getBaseSchema();
+        if (baseSchema != null && !baseSchema.isEmpty()
+                && baseSchema.get(0).getUniqueId() == Column.COLUMN_UNIQUE_ID_INIT_VALUE) {
+            for (Column column : baseSchema) {
+                column.setUniqueId(incAndGetMaxColUniqueId());
+            }
+        }
+    }
+
+    /**
+     * TODO(fixme): Since MV FSE will not trigger to refresh MV, so it may cause data
+     * inconsistent with mv's defined query. Only support MV FSE when:
+     * - `query_rewrite_consistency` is set to `force_mv` which can accept some data inconsistent.
+     * - disabled for refresh which is not used for mv rewrite.
+     */
+    public boolean isSupportFastSchemaEvolutionInDanger() {
+        if (tableProperty == null || !isActive()) {
+            return false;
+        }
+        TableProperty.QueryRewriteConsistencyMode queryRewriteConsistencyMode =
+                tableProperty.getQueryRewriteConsistencyMode();
+        if (queryRewriteConsistencyMode == TableProperty.QueryRewriteConsistencyMode.FORCE_MV ||
+                queryRewriteConsistencyMode == TableProperty.QueryRewriteConsistencyMode.DISABLE) {
+            return true;
+        }
+        return !tableProperty.getMvQueryRewriteSwitch().isEnable();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
@@ -102,4 +102,11 @@ public class MaterializedViewExceptions {
     public static String inactiveReasonForConsecutiveFailures(String mvName) {
         return INACTIVE_REASON_FOR_CONSECUTIVE_FAILURES + mvName;
     }
+
+    public static String unSupportedReasonForMVFSE(String reason) {
+        return String.format("fast schema evolution failed: %s. Please use 1) 'CREATE a new MV " +
+                "and use `SWAP MV` to replace the current', or 2) `ALTER MATERIALIZED VIEW <NAME> SET " +
+                "('query_rewrite_consistency'='force_mv')` to force query rewrite. or 3) `ALTER MATERIALIZED VIEW " +
+                "<NAME> set ('enable_query_rewrite'='false')` to disable query rewrite.", reason);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -141,7 +141,7 @@ import java.util.stream.Collectors;
 import static com.starrocks.sql.parser.ErrorMsgProxy.PARSER_ERROR_MSG;
 
 public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void, ConnectContext> {
-    private final Table table;
+    protected final Table table;
 
     public AlterTableClauseAnalyzer(Table table) {
         this.table = table;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -58,6 +58,7 @@ import com.starrocks.sql.ast.AddComputeNodeBlackListStmt;
 import com.starrocks.sql.ast.AddComputeNodeClause;
 import com.starrocks.sql.ast.AddFieldClause;
 import com.starrocks.sql.ast.AddFollowerClause;
+import com.starrocks.sql.ast.AddMVColumnClause;
 import com.starrocks.sql.ast.AddObserverClause;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.AddPartitionColumnClause;
@@ -189,6 +190,7 @@ import com.starrocks.sql.ast.DropFollowerClause;
 import com.starrocks.sql.ast.DropFunctionStmt;
 import com.starrocks.sql.ast.DropHistogramStmt;
 import com.starrocks.sql.ast.DropIndexClause;
+import com.starrocks.sql.ast.DropMVColumnClause;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.DropObserverClause;
 import com.starrocks.sql.ast.DropPartitionClause;
@@ -1124,6 +1126,35 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         return columnDesc.stream().map(context -> getColumnDef(context)).collect(toList());
     }
 
+    private ColumnDef.DefaultValueDef getDefaultValueDef(
+            com.starrocks.sql.parser.StarRocksParser.DefaultDescContext defaultDescContext) {
+        ColumnDef.DefaultValueDef defaultValueDef = ColumnDef.DefaultValueDef.NOT_SET;
+        if (defaultDescContext != null) {
+            if (defaultDescContext.string() != null) {
+                String value = ((StringLiteral) visit(defaultDescContext.string())).getStringValue();
+                defaultValueDef = new ColumnDef.DefaultValueDef(true, new StringLiteral(value));
+            } else if (defaultDescContext.NULL() != null) {
+                defaultValueDef = ColumnDef.DefaultValueDef.NULL_DEFAULT_VALUE;
+            } else if (defaultDescContext.CURRENT_TIMESTAMP() != null) {
+                List<Expr> expr = Lists.newArrayList();
+                if (defaultDescContext.INTEGER_VALUE() != null) {
+                    expr.add(new IntLiteral(Long.parseLong(defaultDescContext.INTEGER_VALUE().getText()),
+                            IntegerType.INT));
+                }
+                defaultValueDef = new ColumnDef.DefaultValueDef(true, (expr.size() == 1),
+                        new FunctionCallExpr("current_timestamp", expr));
+            } else if (defaultDescContext.qualifiedName() != null) {
+                String functionName = defaultDescContext.qualifiedName().getText().toLowerCase();
+                defaultValueDef = new ColumnDef.DefaultValueDef(true,
+                        new FunctionCallExpr(functionName, new ArrayList<>()));
+            } else if (defaultDescContext.expression() != null) {
+                Expr defaultExpr = (Expr) visit(defaultDescContext.expression());
+                defaultValueDef = new ColumnDef.DefaultValueDef(true, defaultExpr);
+            }
+        }
+        return defaultValueDef;
+    }
+
     private ColumnDef getColumnDef(com.starrocks.sql.parser.StarRocksParser.ColumnDescContext context) {
         Identifier colIdentifier = (Identifier) visit(context.identifier());
         String columnName = colIdentifier.getValue();
@@ -1192,30 +1223,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         if (isAutoIncrement != null) {
             isAllowNull = false;
         }
-        ColumnDef.DefaultValueDef defaultValueDef = ColumnDef.DefaultValueDef.NOT_SET;
         final com.starrocks.sql.parser.StarRocksParser.DefaultDescContext defaultDescContext = context.defaultDesc();
-        if (defaultDescContext != null) {
-            if (defaultDescContext.string() != null) {
-                String value = ((StringLiteral) visit(defaultDescContext.string())).getStringValue();
-                defaultValueDef = new ColumnDef.DefaultValueDef(true, new StringLiteral(value));
-            } else if (defaultDescContext.NULL() != null) {
-                defaultValueDef = ColumnDef.DefaultValueDef.NULL_DEFAULT_VALUE;
-            } else if (defaultDescContext.CURRENT_TIMESTAMP() != null) {
-                List<Expr> expr = Lists.newArrayList();
-                if (defaultDescContext.INTEGER_VALUE() != null) {
-                    expr.add(new IntLiteral(Long.parseLong(defaultDescContext.INTEGER_VALUE().getText()), IntegerType.INT));
-                }
-                defaultValueDef = new ColumnDef.DefaultValueDef(true, (expr.size() == 1),
-                        new FunctionCallExpr("current_timestamp", expr));
-            } else if (defaultDescContext.qualifiedName() != null) {
-                String functionName = defaultDescContext.qualifiedName().getText().toLowerCase();
-                defaultValueDef = new ColumnDef.DefaultValueDef(true,
-                        new FunctionCallExpr(functionName, new ArrayList<>()));
-            } else if (defaultDescContext.expression() != null) {
-                Expr defaultExpr = (Expr) visit(defaultDescContext.expression());
-                defaultValueDef = new ColumnDef.DefaultValueDef(true, defaultExpr);
-            }
-        }
+        final ColumnDef.DefaultValueDef defaultValueDef = getDefaultValueDef(defaultDescContext);
         final com.starrocks.sql.parser.StarRocksParser.GeneratedColumnDescContext generatedColumnDescContext =
                 context.generatedColumnDesc();
         Expr expr = null;
@@ -2368,6 +2377,17 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         if (context.swapTableClause() != null) {
             alterTableClause = (SwapTableClause) visit(context.swapTableClause());
         }
+        
+        // add column to materialized view
+        if (context.addMVColumnClause() != null) {
+            alterTableClause = (AddMVColumnClause) visit(context.addMVColumnClause());
+        }
+
+        // drop column from materialized view
+        if (context.dropMVColumnClause() != null) {
+            alterTableClause = (DropMVColumnClause) visit(context.dropMVColumnClause());
+        }
+        
         return new AlterMaterializedViewStmt(mvTableRef, alterTableClause, createPos(context));
     }
 
@@ -5001,6 +5021,24 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     public ParseNode visitSwapTableClause(com.starrocks.sql.parser.StarRocksParser.SwapTableClauseContext context) {
         Identifier identifier = (Identifier) visit(context.identifier());
         return new SwapTableClause(normalizeName(identifier.getValue()), createPos(context));
+    }
+
+    @Override
+    public ParseNode visitAddMVColumnClause(com.starrocks.sql.parser.StarRocksParser.AddMVColumnClauseContext context) {
+        String columnName = getIdentifierName(context.identifier());
+        Expr aggregateExpression = (Expr) visit(context.expression());
+        ColumnDef.DefaultValueDef defaultValueDef = getDefaultValueDef(context.defaultDesc());
+        String comment = null;
+        if (context.string() != null) {
+            comment = ((StringLiteral) visit(context.string())).getStringValue();
+        }
+        return new AddMVColumnClause(columnName, aggregateExpression, defaultValueDef, comment, createPos(context));
+    }
+
+    @Override
+    public ParseNode visitDropMVColumnClause(com.starrocks.sql.parser.StarRocksParser.DropMVColumnClauseContext context) {
+        String columnName = getIdentifierName(context.identifier());
+        return new DropMVColumnClause(columnName, createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -36,10 +36,13 @@ import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.AddMVColumnClause;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
+import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.RefreshSchemeClause;
 import com.starrocks.sql.ast.SyncRefreshSchemeDesc;
+import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.utframe.UtFrameUtils;
@@ -175,6 +178,19 @@ public class AlterMaterializedViewTest extends MVTestBase  {
                     (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
             Assertions.assertThrows(SemanticException.class, () -> currentState.getLocalMetastore().alterMaterializedView(stmt));
         }
+    }
+
+    @Test
+    public void testAlterMVAddColumnWithDefaultValue() throws Exception {
+        String alterMvSql = "alter materialized view mv1 add column v1_default as v1 default 10";
+        AlterMaterializedViewStmt stmt =
+                (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
+        AddMVColumnClause clause = (AddMVColumnClause) stmt.getAlterTableClause();
+        ColumnDef.DefaultValueDef defaultValueDef = clause.getDefaultValueDef();
+        Assertions.assertTrue(defaultValueDef.isSet);
+        Assertions.assertTrue(defaultValueDef.expr.isConstant());
+        IntLiteral intLiteral = (IntLiteral) defaultValueDef.expr;
+        Assertions.assertEquals(10, intLiteral.getValue());
     }
 
     // TODO: consider to support alterjob for mv

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -377,8 +377,7 @@ public class MaterializedViewTest extends StarRocksTestBase {
         Assertions.assertNotNull(db);
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "mv_replay");
         MaterializedView mv = (MaterializedView) table;
-        AlterMaterializedViewBaseTableInfosLog log = new AlterMaterializedViewBaseTableInfosLog(db.getId(), mv.getId(), null,
-                mv.getBaseTableInfos(), mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap());
+        AlterMaterializedViewBaseTableInfosLog log = new AlterMaterializedViewBaseTableInfosLog(null, mv);
         mv.replayAlterMaterializedViewBaseTableInfos(log);
 
         starRocksAssert.dropMaterializedView("mv_replay");

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -744,8 +744,18 @@ alterMaterializedViewStatement
         refreshSchemeDesc |
         tableRenameClause |
         modifyPropertiesClause |
-        swapTableClause )
+        swapTableClause |
+        addMVColumnClause |
+        dropMVColumnClause )
     | ALTER MATERIALIZED VIEW mvName=qualifiedName statusDesc
+    ;
+
+addMVColumnClause
+    : ADD COLUMN columnName=identifier AS aggregateExpression=expression defaultDesc? (COMMENT string)?
+    ;
+
+dropMVColumnClause
+    : DROP COLUMN columnName=identifier
     ;
 
 refreshMaterializedViewStatement

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AddMVColumnClause.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AddMVColumnClause.java
@@ -1,0 +1,91 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.TypeDef;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.type.Type;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Clause which is used to add a column with aggregate expression to a materialized view.
+ * Syntax: ALTER MATERIALIZED VIEW mv_name ADD COLUMN column_name AS aggregate_expr [DEFAULT default_value]
+ *         [COMMENT 'comment']
+ * 
+ * Example:
+ * ALTER MATERIALIZED VIEW mv1 ADD COLUMN new_metric_sum AS SUM(new_metric_sum)
+ */
+public class AddMVColumnClause extends AlterTableColumnClause {
+    private final String columnName;
+    private final Expr aggregateExpression;
+    private final ColumnDef.DefaultValueDef defaultValueDef;
+    private final String comment;
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public Expr getAggregateExpression() {
+        return aggregateExpression;
+    }
+
+    public ColumnDef.DefaultValueDef getDefaultValueDef() {
+        return defaultValueDef;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public AddMVColumnClause(String columnName, Expr aggregateExpression, String comment) {
+        this(columnName, aggregateExpression, ColumnDef.DefaultValueDef.NULL_DEFAULT_VALUE, comment, NodePosition.ZERO);
+    }
+
+    public AddMVColumnClause(String columnName, Expr aggregateExpression,
+                             ColumnDef.DefaultValueDef defaultValueDef, String comment) {
+        this(columnName, aggregateExpression, defaultValueDef, comment, NodePosition.ZERO);
+    }
+
+    public AddMVColumnClause(String columnName, Expr aggregateExpression, String comment, NodePosition pos) {
+        this(columnName, aggregateExpression, ColumnDef.DefaultValueDef.NULL_DEFAULT_VALUE, comment, pos);
+    }
+
+    public AddMVColumnClause(String columnName, Expr aggregateExpression,
+                             ColumnDef.DefaultValueDef defaultValueDef, String comment, NodePosition pos) {
+        super(null, pos);
+        this.columnName = columnName;
+        this.aggregateExpression = aggregateExpression;
+        this.defaultValueDef = defaultValueDef == null
+                ? ColumnDef.DefaultValueDef.NULL_DEFAULT_VALUE
+                : defaultValueDef;
+        this.comment = comment;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitAddMVColumnClause(this, context);
+    }
+
+    public AddColumnsClause toAddColumnsClause(Type columnType) {
+        ColumnDef columnDef = new ColumnDef(columnName, new TypeDef(columnType, getPos()), null,
+                false, null, null, true,
+                defaultValueDef,
+                null, null, comment, getPos());
+        return new AddColumnsClause(List.of(columnDef), null, Collections.emptyMap(), getPos());
+    }
+}

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -875,6 +875,14 @@ public interface AstVisitor<R, C> {
         return visitAlterTableColumnClause(clause, context);
     }
 
+    default R visitAddMVColumnClause(AddMVColumnClause clause, C context) {
+        return visitAlterTableColumnClause(clause, context);
+    }
+
+    default R visitDropMVColumnClause(DropMVColumnClause clause, C context) {
+        return visitAlterTableColumnClause(clause, context);
+    }
+
     default R visitAddFieldClause(AddFieldClause clause, C context) {
         return visitAlterTableColumnClause(clause, context);
     }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/DropMVColumnClause.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/DropMVColumnClause.java
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.sql.parser.NodePosition;
+
+import java.util.Collections;
+
+/**
+ * Clause which is used to drop a column from a materialized view.
+ * Syntax: ALTER MATERIALIZED VIEW mv_name DROP COLUMN column_name
+ */
+public class DropMVColumnClause extends AlterTableColumnClause {
+    private final String columnName;
+
+    public DropMVColumnClause(String columnName) {
+        this(columnName, NodePosition.ZERO);
+    }
+
+    public DropMVColumnClause(String columnName, NodePosition pos) {
+        super(null, pos);
+        this.columnName = columnName;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitDropMVColumnClause(this, context);
+    }
+
+    public DropColumnClause toDropColumnClause() {
+        return new DropColumnClause(columnName, null, Collections.emptyMap(), getPos());
+    }
+}

--- a/test/sql/test_mv/R/test_mv_fast_schema_change
+++ b/test/sql/test_mv/R/test_mv_fast_schema_change
@@ -1,0 +1,603 @@
+-- name: test_mv_fast_schema_change
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+-- result:
+-- !result
+drop table if exists t1;
+-- result:
+-- !result
+drop materialized view if exists test_mv1;
+-- result:
+-- !result
+CREATE TABLE t1 (
+  dt datetime,
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`, `c0`, `c1`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+  "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 SELECT '2026-01-01', generate_series % 10, generate_series, generate_series, generate_series FROM TABLE(generate_series(1, 100));
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY hash(c0) 
+PROPERTIES (
+  "replication_num" = "1",
+  "query_rewrite_consistency" = "force_mv"
+)
+AS 
+SELECT dt, c0, count(c1) as cnt_c1 from t1 group by dt, c0;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+019c2d99-e28d-7a24-a292-c8b7523a20ab
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1 from t1 group by dt, c0", "test_mv1")
+-- result:
+True
+-- !result
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01 00:00:00	0	10
+2026-01-01 00:00:00	1	10
+2026-01-01 00:00:00	2	10
+-- !result
+SELECT dt, c0, count(c1) as cnt_c1 from t1 group by dt, c0 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	10
+2026-01-01 00:00:00	1	10
+2026-01-01 00:00:00	2	10
+-- !result
+ALTER MATERIALIZED VIEW test_mv1 ADD COLUMN cnt_c2 AS count(c2);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv1;
+-- result:
+dt	datetime	YES	true	None	
+c0	int	YES	true	None	
+cnt_c1	bigint	NO	true	None	
+cnt_c2	bigint	YES	false	None	NONE
+-- !result
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2 from t1 group by dt, c0", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2 from t1 group by dt, c0 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	10	10
+2026-01-01 00:00:00	1	10	10
+2026-01-01 00:00:00	2	10	10
+-- !result
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01 00:00:00	0	10	None
+2026-01-01 00:00:00	1	10	None
+2026-01-01 00:00:00	2	10	None
+-- !result
+ALTER MATERIALIZED VIEW test_mv1 ADD COLUMN cnt_c3 AS count(c3) DEFAULT "0";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv1;
+-- result:
+dt	datetime	YES	true	None	
+c0	int	YES	true	None	
+cnt_c1	bigint	NO	true	None	
+cnt_c2	bigint	YES	false	None	NONE
+cnt_c3	bigint	YES	false	0	NONE
+-- !result
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, count(c3) as cnt_c3 from t1 group by dt, c0", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, count(c3) as cnt_c3 from t1 group by dt, c0 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	10	10	10
+2026-01-01 00:00:00	1	10	10	10
+2026-01-01 00:00:00	2	10	10	10
+-- !result
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01 00:00:00	0	10	None	0
+2026-01-01 00:00:00	1	10	None	0
+2026-01-01 00:00:00	2	10	None	0
+-- !result
+INSERT INTO t1 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+019c2d9a-138c-7a0e-9459-478545393304
+-- !result
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2 from t1 group by dt, c0", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2 from t1 group by dt, c0 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	11	11
+2026-01-01 00:00:00	1	10	10
+2026-01-01 00:00:00	2	10	10
+-- !result
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01 00:00:00	0	11	11	11
+2026-01-01 00:00:00	1	10	10	10
+2026-01-01 00:00:00	2	10	10	10
+-- !result
+ALTER TABLE t1 ADD COLUMN c4 int;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC t1;
+-- result:
+dt	datetime	YES	true	None	
+c0	int	YES	true	None	
+c1	varchar(20)	YES	true	None	
+c2	varchar(200)	YES	false	None	
+c3	int	YES	false	None	
+c4	int	YES	false	None	
+-- !result
+INSERT INTO t1 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0, 0);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+019c2d9a-2b23-74a0-81e1-feda2a22fbf9
+-- !result
+ALTER MATERIALIZED VIEW test_mv1 ADD COLUMN sum_c4 AS sum(c4);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv1;
+-- result:
+dt	datetime	YES	true	None	
+c0	int	YES	true	None	
+cnt_c1	bigint	NO	true	None	
+cnt_c2	bigint	YES	false	None	NONE
+cnt_c3	bigint	YES	false	0	NONE
+sum_c4	bigint	YES	false	None	NONE
+-- !result
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4 from t1 group by dt, c0", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4 from t1 group by dt, c0 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	12	12	0
+2026-01-01 00:00:00	1	10	10	None
+2026-01-01 00:00:00	2	10	10	None
+-- !result
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01 00:00:00	0	12	12	12	None
+2026-01-01 00:00:00	1	10	10	10	None
+2026-01-01 00:00:00	2	10	10	10	None
+-- !result
+INSERT INTO t1 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0, 0);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+019c2d9a-41d2-71b3-a6ae-6df4d979c893
+-- !result
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4 from t1 group by dt, c0", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4 from t1 group by dt, c0 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	13	13	0
+2026-01-01 00:00:00	1	10	10	None
+2026-01-01 00:00:00	2	10	10	None
+-- !result
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01 00:00:00	0	13	13	13	0
+2026-01-01 00:00:00	1	10	10	10	None
+2026-01-01 00:00:00	2	10	10	10	None
+-- !result
+ALTER MATERIALIZED VIEW test_mv1 ADD COLUMN c4 AS c4;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv1;
+-- result:
+dt	datetime	YES	true	None	
+c0	int	YES	true	None	
+cnt_c1	bigint	NO	true	None	
+cnt_c2	bigint	YES	false	None	NONE
+cnt_c3	bigint	YES	false	0	NONE
+sum_c4	bigint	YES	false	None	NONE
+c4	int	YES	false	None	NONE
+-- !result
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4, c4 from t1 group by dt, c0, c4", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4, c4 from t1 group by dt, c0, c4 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	2	2	0	0
+2026-01-01 00:00:00	0	11	11	None	None
+2026-01-01 00:00:00	1	10	10	None	None
+-- !result
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01 00:00:00	0	13	13	13	0	None
+2026-01-01 00:00:00	1	10	10	10	None	None
+2026-01-01 00:00:00	2	10	10	10	None	None
+-- !result
+INSERT INTO t1 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0, 0);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+019c2d9a-5c24-7374-bc49-dfcd5a98c216
+-- !result
+function: print_hit_materialized_view("select dt, c0, c4, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4 from t1 group by dt, c0, c4", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4, c4 from t1 group by dt, c0, c4 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	3	3	0	0
+2026-01-01 00:00:00	0	11	11	None	None
+2026-01-01 00:00:00	1	10	10	None	None
+-- !result
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01 00:00:00	0	3	3	3	0	0
+2026-01-01 00:00:00	0	11	11	11	None	None
+2026-01-01 00:00:00	1	10	10	10	None	None
+-- !result
+ALTER MATERIALIZED VIEW test_mv1 DROP COLUMN cnt_c2;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv1;
+-- result:
+dt	datetime	YES	true	None	
+c0	int	YES	true	None	
+cnt_c1	bigint	NO	true	None	
+cnt_c3	bigint	YES	false	0	NONE
+sum_c4	bigint	YES	false	None	NONE
+c4	int	YES	false	None	NONE
+-- !result
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, sum(c4) as sum_c4, c4 from t1 group by dt, c0, c4", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, c0, count(c1) as cnt_c1, sum(c4) as sum_c4, c4 from t1 group by dt, c0, c4 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	3	0	0
+2026-01-01 00:00:00	0	11	None	None
+2026-01-01 00:00:00	1	10	None	None
+-- !result
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01 00:00:00	0	3	3	0	0
+2026-01-01 00:00:00	0	11	11	None	None
+2026-01-01 00:00:00	1	10	10	None	None
+-- !result
+INSERT INTO t1 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0, 0);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+019c2d9a-7aad-765c-8411-847fcf8ddaad
+-- !result
+function: print_hit_materialized_view("select dt, c0, c4, count(c1) as cnt_c1, sum(c4) as sum_c4 from t1 group by dt, c0, c4", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, c0, count(c1) as cnt_c1, sum(c4) as sum_c4, c4 from t1 group by dt, c0, c4 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	4	0	0
+2026-01-01 00:00:00	0	11	None	None
+2026-01-01 00:00:00	1	10	None	None
+-- !result
+SELECT * FROM test_mv1 ORDER BY ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	4	4	0	0
+2026-01-01 00:00:00	0	11	11	None	None
+2026-01-01 00:00:00	1	10	10	None	None
+-- !result
+ALTER MATERIALIZED VIEW test_mv1 DROP COLUMN sum_c4;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv1;
+-- result:
+dt	datetime	YES	true	None	
+c0	int	YES	true	None	
+cnt_c1	bigint	NO	true	None	
+cnt_c3	bigint	YES	false	0	NONE
+c4	int	YES	false	None	NONE
+-- !result
+function: print_hit_materialized_view("select dt, c0, c4, count(c1) as cnt_c1 from t1 group by dt, c0, c4", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, c0, count(c1) as cnt_c1, c4 from t1 group by dt, c0, c4 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	4	0
+2026-01-01 00:00:00	0	11	None
+2026-01-01 00:00:00	1	10	None
+-- !result
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01 00:00:00	0	4	4	0
+2026-01-01 00:00:00	0	11	11	None
+2026-01-01 00:00:00	1	10	10	None
+-- !result
+INSERT INTO t1 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0, 0);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+019c2d9a-8eea-70ee-9b5d-f7e1869247ee
+-- !result
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, c4 from t1 group by dt, c0, c4", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, c0, count(c1) as cnt_c1, c4 from t1 group by dt, c0, c4 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	5	0
+2026-01-01 00:00:00	0	11	None
+2026-01-01 00:00:00	1	10	None
+-- !result
+SELECT * FROM test_mv1 ORDER BY ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	5	5	0
+2026-01-01 00:00:00	0	11	11	None
+2026-01-01 00:00:00	1	10	10	None
+-- !result
+[UC]ALTER MATERIALIZED VIEW test_mv1 DROP COLUMN c4;
+-- result:
+[REGEX]E:.*
+-- !result
+INSERT INTO t1 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0, 0);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+-- result:
+019c2d9a-981a-707a-a87b-ea6b3e31347f
+-- !result
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1 from t1 group by dt, c0", "test_mv1")
+-- result:
+True
+-- !result
+SELECT dt, c0, count(c1) as cnt_c1 from t1 group by dt, c0 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	17
+2026-01-01 00:00:00	1	10
+2026-01-01 00:00:00	2	10
+-- !result
+SELECT * FROM test_mv1 ORDER BY ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	6	6	0
+2026-01-01 00:00:00	0	11	11	None
+2026-01-01 00:00:00	1	10	10	None
+-- !result
+DROP MATERIALIZED VIEW test_mv1;
+-- result:
+-- !result
+DROP TABLE t1;
+-- result:
+-- !result
+CREATE TABLE t2 (
+  dt datetime,
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`, `c0`, `c1`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`c0`, `c1`) 
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t2 SELECT '2026-01-01', generate_series % 5, generate_series, generate_series, generate_series FROM TABLE(generate_series(1, 100));
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv2 
+PARTITION BY date_trunc('day', dt)  
+DISTRIBUTED BY HASH(`c0`, `c1`) 
+AS 
+SELECT dt, c0, c1 from t2;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+-- result:
+019c2d9a-a57b-7efd-b3d4-7394b8c8a5fa
+-- !result
+function: print_hit_materialized_view("select dt, c0, c1 from t2", "test_mv2")
+-- result:
+True
+-- !result
+SELECT dt, c0, c1 FROM test_mv2 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01 00:00:00	0	10
+2026-01-01 00:00:00	0	100
+2026-01-01 00:00:00	0	15
+-- !result
+SELECT dt, c0, c1 from t2 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	10
+2026-01-01 00:00:00	0	100
+2026-01-01 00:00:00	0	15
+-- !result
+ALTER MATERIALIZED VIEW test_mv2 ADD COLUMN c3 AS c3 + 1;
+-- result:
+[REGEX]E:.*
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv2;
+-- result:
+dt	datetime	YES	true	None	
+c0	int	YES	true	None	
+c1	varchar(1048576)	YES	true	None	
+-- !result
+SELECT dt, c0, c1, c3 FROM test_mv2 ORDER BY ALL LIMIT 3;
+-- result:
+[REGEX]E:.*
+-- !result
+SELECT dt, c0, c1, c3 + 1 from t2 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	10	11
+2026-01-01 00:00:00	0	100	101
+2026-01-01 00:00:00	0	15	16
+-- !result
+ALTER MATERIALIZED VIEW test_mv2 ADD COLUMN c3_default AS c3 + 1 DEFAULT "0";
+-- result:
+[REGEX]E:.*
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv2;
+-- result:
+dt	datetime	YES	true	None	
+c0	int	YES	true	None	
+c1	varchar(1048576)	YES	true	None	
+-- !result
+SELECT dt, c0, c1, c3, c3_default FROM test_mv2 ORDER BY ALL LIMIT 3;
+-- result:
+[REGEX]E:.*
+-- !result
+SELECT dt, c0, c1, c3 + 1, c3 + 1 from t2 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	10	11	11
+2026-01-01 00:00:00	0	100	101	101
+2026-01-01 00:00:00	0	15	16	16
+-- !result
+ALTER TABLE t2 ADD COLUMN c4 int;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC t2;
+-- result:
+dt	datetime	YES	true	None	
+c0	int	YES	true	None	
+c1	varchar(20)	YES	true	None	
+c2	varchar(200)	YES	false	None	
+c3	int	YES	false	None	
+c4	int	YES	false	None	
+-- !result
+ALTER MATERIALIZED VIEW test_mv2 ADD COLUMN c4 AS c4 + 1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv2;
+-- result:
+dt	datetime	YES	true	None	
+c0	int	YES	true	None	
+c1	varchar(1048576)	YES	true	None	
+c4	bigint	YES	false	None	NONE
+-- !result
+function: print_hit_materialized_view("select dt, c0, c1, c4 + 1 from t2", "test_mv2")
+-- result:
+True
+-- !result
+SELECT dt, c0, c1, c4 FROM test_mv2 ORDER BY dt, c0, c1, c4 LIMIT 3;
+-- result:
+2026-01-01 00:00:00	0	10	None
+2026-01-01 00:00:00	0	100	None
+2026-01-01 00:00:00	0	15	None
+-- !result
+SELECT dt, c0, c1, c4 + 1 from t2 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	10	None
+2026-01-01 00:00:00	0	100	None
+2026-01-01 00:00:00	0	15	None
+-- !result
+INSERT INTO t2 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0, 0);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+-- result:
+019c2d9a-c5e3-7a00-9617-238601ee35d9
+-- !result
+function: print_hit_materialized_view("select dt, c0, c1, c4 + 1 from t2", "test_mv2")
+-- result:
+True
+-- !result
+SELECT dt, c0, c1, c4  FROM test_mv2 ORDER BY dt, c0, c1, c4 LIMIT 3;
+-- result:
+2026-01-01 00:00:00	0	10	None
+2026-01-01 00:00:00	0	100	None
+2026-01-01 00:00:00	0	15	None
+-- !result
+SELECT dt, c0, c1, c4 + 1 from t2 order by ALL limit 3;
+-- result:
+2026-01-01 00:00:00	0	10	None
+2026-01-01 00:00:00	0	100	None
+2026-01-01 00:00:00	0	15	None
+-- !result
+ALTER MATERIALIZED VIEW test_mv2 DROP COLUMN c4;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv2;
+-- result:
+dt	datetime	YES	true	None	
+c0	int	YES	true	None	
+c1	varchar(1048576)	YES	true	None	
+-- !result
+DROP MATERIALIZED VIEW test_mv2;
+-- result:
+-- !result
+DROP TABLE t2;
+-- result:
+-- !result

--- a/test/sql/test_mv/R/test_mv_fast_schema_change_with_aggregate
+++ b/test/sql/test_mv/R/test_mv_fast_schema_change_with_aggregate
@@ -1,0 +1,959 @@
+-- name: test_mv_fast_schema_change_with_aggregate @slow
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+-- result:
+-- !result
+drop table if exists t1_agg;
+-- result:
+-- !result
+drop materialized view if exists test_mv_agg1;
+-- result:
+-- !result
+CREATE TABLE t1_agg (
+    dt DATE,
+    c0 INT,
+    c1 VARCHAR(20),
+    c2 VARCHAR(200),
+    c3 INT SUM,
+    c4 INT SUM
+) ENGINE=OLAP
+AGGREGATE KEY(dt, c0, c1, c2)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(c0) BUCKETS 48
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t1_agg
+SELECT '2026-01-01', generate_series % 10, 'val_' || CAST(generate_series AS VARCHAR),
+       'desc_' || CAST(generate_series AS VARCHAR), generate_series, generate_series * 2
+FROM TABLE(generate_series(1, 100));
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv_agg1
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY hash(c0)
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "force_mv"
+)
+AS
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1
+FROM t1_agg
+GROUP BY dt, c0;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+-- result:
+019c2d99-e2ac-7e9f-933c-aa96e623c3b9
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+-- result:
+True
+-- !result
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	550	1
+2026-01-01	1	460	1
+2026-01-01	2	470	1
+-- !result
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	550	1
+2026-01-01	1	460	1
+2026-01-01	2	470	1
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN cnt_c2 AS COUNT(c2);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg1;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+sum_c3	bigint	YES	true	None	
+cnt_c1	bigint	NO	true	None	
+cnt_c2	bigint	YES	false	None	NONE
+-- !result
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+-- result:
+True
+-- !result
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	550	1	1
+2026-01-01	1	460	1	1
+2026-01-01	2	470	1	1
+-- !result
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	550	1	None
+2026-01-01	1	460	1	None
+2026-01-01	2	470	1	None
+-- !result
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_0', 'desc_0', 10, 20);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+-- result:
+019c2d9a-0932-70e7-986e-9980c98ba35c
+-- !result
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+-- result:
+True
+-- !result
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	560	2	2
+2026-01-01	1	460	1	1
+2026-01-01	2	470	1	1
+-- !result
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	560	2	2
+2026-01-01	1	460	1	1
+2026-01-01	2	470	1	1
+-- !result
+ALTER TABLE t1_agg ADD COLUMN c5 VARCHAR(100);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC t1_agg;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+c1	varchar(20)	YES	true	None	
+c2	varchar(200)	YES	true	None	
+c5	varchar(100)	YES	true	None	
+c3	int	YES	false	None	
+c4	int	YES	false	None	
+-- !result
+ALTER TABLE t1_agg ADD COLUMN c6 INT SUM;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC t1_agg;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+c1	varchar(20)	YES	true	None	
+c2	varchar(200)	YES	true	None	
+c5	varchar(100)	YES	true	None	
+c3	int	YES	false	None	
+c4	int	YES	false	None	
+c6	int	YES	false	None	
+-- !result
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_1', 'desc_1', 'desc_2', 15, 30, 25);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+-- result:
+019c2d9a-2603-7b4a-906a-dbce58e72224
+-- !result
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+-- result:
+True
+-- !result
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	575	3	3
+2026-01-01	1	460	1	1
+2026-01-01	2	470	1	1
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN sum_c6 AS SUM(c6);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg1;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+sum_c3	bigint	YES	true	None	
+cnt_c1	bigint	NO	true	None	
+cnt_c2	bigint	YES	false	None	NONE
+sum_c6	bigint	YES	false	None	NONE
+-- !result
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+-- result:
+True
+-- !result
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	575	3	3	25
+2026-01-01	1	460	1	1	None
+2026-01-01	2	470	1	1	None
+-- !result
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	575	3	3	None
+2026-01-01	1	460	1	1	None
+2026-01-01	2	470	1	1	None
+-- !result
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_2', 'desc_2', 'desc_3', 20, 40, 35);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+-- result:
+019c2d9a-3e97-71d3-a0c0-a4fa7accdea6
+-- !result
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+-- result:
+True
+-- !result
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	595	4	4	60
+2026-01-01	1	460	1	1	None
+2026-01-01	2	470	1	1	None
+-- !result
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	595	4	4	60
+2026-01-01	1	460	1	1	None
+2026-01-01	2	470	1	1	None
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN c5 AS c5;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg1;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+sum_c3	bigint	YES	true	None	
+cnt_c1	bigint	NO	true	None	
+cnt_c2	bigint	YES	false	None	NONE
+sum_c6	bigint	YES	false	None	NONE
+c5	varchar(1048576)	YES	false	None	NONE
+-- !result
+function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+-- result:
+True
+-- !result
+SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	None	560	2	2	None
+2026-01-01	0	desc_2	15	1	1	25
+2026-01-01	0	desc_3	20	1	1	35
+-- !result
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	595	4	4	60	None
+2026-01-01	1	460	1	1	None	None
+2026-01-01	2	470	1	1	None	None
+-- !result
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_3', 'desc_3', 'desc_4', 25, 50, 45);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+-- result:
+019c2d9a-5b06-79e2-a705-4ebbf6be15bd
+-- !result
+function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+-- result:
+True
+-- !result
+SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	None	560	2	2	None
+2026-01-01	0	desc_2	15	1	1	25
+2026-01-01	0	desc_3	20	1	1	35
+-- !result
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	15	1	1	25	desc_2
+2026-01-01	0	20	1	1	35	desc_3
+2026-01-01	0	25	1	1	45	desc_4
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN cnt_c2;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg1;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+sum_c3	bigint	YES	true	None	
+cnt_c1	bigint	NO	true	None	
+sum_c6	bigint	YES	false	None	NONE
+c5	varchar(1048576)	YES	false	None	NONE
+-- !result
+function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+-- result:
+True
+-- !result
+SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	None	560	2	None
+2026-01-01	0	desc_2	15	1	25
+2026-01-01	0	desc_3	20	1	35
+-- !result
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	15	1	25	desc_2
+2026-01-01	0	20	1	35	desc_3
+2026-01-01	0	25	1	45	desc_4
+-- !result
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_4', 'desc_4', 'desc_5', 30, 60, 55);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+-- result:
+019c2d9a-7ab3-7891-a68d-cfd9340c853a
+-- !result
+function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+-- result:
+True
+-- !result
+SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	None	560	2	None
+2026-01-01	0	desc_2	15	1	25
+2026-01-01	0	desc_3	20	1	35
+-- !result
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	15	1	25	desc_2
+2026-01-01	0	20	1	35	desc_3
+2026-01-01	0	25	1	45	desc_4
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN sum_c6;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg1;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+sum_c3	bigint	YES	true	None	
+cnt_c1	bigint	NO	true	None	
+c5	varchar(1048576)	YES	false	None	NONE
+-- !result
+function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+-- result:
+True
+-- !result
+SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	None	560	2
+2026-01-01	0	desc_2	15	1
+2026-01-01	0	desc_3	20	1
+-- !result
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	15	1	desc_2
+2026-01-01	0	20	1	desc_3
+2026-01-01	0	25	1	desc_4
+-- !result
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_5', 'desc_5', 'desc_6', 35, 70, 65);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+-- result:
+019c2d9a-8f6a-7634-b935-2b0f8bcf9cf6
+-- !result
+function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+-- result:
+True
+-- !result
+SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	None	560	2
+2026-01-01	0	desc_2	15	1
+2026-01-01	0	desc_3	20	1
+-- !result
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	15	1	desc_2
+2026-01-01	0	20	1	desc_3
+2026-01-01	0	25	1	desc_4
+-- !result
+[UC]ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN c5;
+-- result:
+[REGEX]E:.*
+-- !result
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_6', 'desc_6', 'desc_7', 40, 80, 75);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+-- result:
+019c2d9a-9791-703b-9cb8-f3b8678a1fc0
+-- !result
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+-- result:
+True
+-- !result
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	725	8
+2026-01-01	1	460	1
+2026-01-01	2	470	1
+-- !result
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	15	1	desc_2
+2026-01-01	0	20	1	desc_3
+2026-01-01	0	25	1	desc_4
+-- !result
+DROP MATERIALIZED VIEW test_mv_agg1;
+-- result:
+-- !result
+DROP TABLE t1_agg;
+-- result:
+-- !result
+drop table if exists t2_agg;
+-- result:
+-- !result
+drop materialized view if exists test_mv_agg2;
+-- result:
+-- !result
+CREATE TABLE t2_agg (
+    dt DATE,
+    c0 INT,
+    c1 VARCHAR(20),
+    c2 INT SUM,
+    c3 BIGINT SUM,
+    c4 VARCHAR(100) REPLACE,
+    c5 DOUBLE SUM
+) ENGINE=OLAP
+AGGREGATE KEY(dt, c0, c1)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(c0)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t2_agg
+SELECT '2026-01-01', generate_series % 5, 'val_' || CAST(generate_series AS VARCHAR),
+       generate_series, generate_series * 100, 'replace_' || CAST(generate_series AS VARCHAR), generate_series * 0.5
+FROM TABLE(generate_series(1, 50));
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv_agg2
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(c0)
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "force_mv"
+)
+AS
+SELECT dt, c0, SUM(c2) as sum_c2, MAX(c3) as max_c3, MIN(c3) as min_c3, AVG(c5) as avg_c5
+FROM t2_agg
+GROUP BY dt, c0;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg2 WITH SYNC MODE;
+-- result:
+019c2d9a-a177-7c42-ada1-8457a8d4227c
+-- !result
+SELECT * FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	275	27500	27500	137.5
+2026-01-01	1	235	23500	23500	117.5
+2026-01-01	2	245	24500	24500	122.5
+-- !result
+SELECT dt, c0, SUM(c2) as sum_c2, MAX(c3) as max_c3, MIN(c3) as min_c3, AVG(c5) as avg_c5
+FROM t2_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	275	27500	27500	137.5
+2026-01-01	1	235	23500	23500	117.5
+2026-01-01	2	245	24500	24500	122.5
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg2 ADD COLUMN cnt_c1 AS COUNT(c1);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg2;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+sum_c2	bigint	YES	true	None	
+max_c3	bigint	YES	true	None	
+min_c3	bigint	YES	true	None	
+avg_c5	double	YES	false	None	NONE
+cnt_c1	bigint	YES	false	None	NONE
+-- !result
+SELECT dt, c0, sum_c2, max_c3, min_c3, avg_c5, cnt_c1 FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	275	27500	27500	137.5	None
+2026-01-01	1	235	23500	23500	117.5	None
+2026-01-01	2	245	24500	24500	122.5	None
+-- !result
+SELECT dt, c0, SUM(c2) as sum_c2, MAX(c3) as max_c3, MIN(c3) as min_c3, AVG(c5) as avg_c5, COUNT(c1) as cnt_c1
+FROM t2_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	275	27500	27500	137.5	1
+2026-01-01	1	235	23500	23500	117.5	1
+2026-01-01	2	245	24500	24500	122.5	1
+-- !result
+ALTER TABLE t2_agg ADD COLUMN c6 INT MAX;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC t2_agg;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+c1	varchar(20)	YES	true	None	
+c2	int	YES	false	None	
+c3	bigint	YES	false	None	
+c4	varchar(100)	YES	false	None	
+c5	double	YES	false	None	
+c6	int	YES	false	None	
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg2 ADD COLUMN max_c6 AS MAX(c6);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg2;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+sum_c2	bigint	YES	true	None	
+max_c3	bigint	YES	true	None	
+min_c3	bigint	YES	true	None	
+avg_c5	double	YES	false	None	NONE
+cnt_c1	bigint	YES	false	None	NONE
+max_c6	int	YES	false	None	NONE
+-- !result
+INSERT INTO t2_agg VALUES ('2026-01-01', 0, 'new_val', 100, 1000, 'replace_new', 10.5, 50);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg2 WITH SYNC MODE;
+-- result:
+019c2d9a-b6c8-70e2-bf2e-45a3873e85d9
+-- !result
+SELECT dt, c0, sum_c2, max_c3, min_c3, avg_c5, cnt_c1, max_c6 FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	375	27500	1000	74.0	2	50
+2026-01-01	1	235	23500	23500	117.5	1	None
+2026-01-01	2	245	24500	24500	122.5	1	None
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg2 DROP COLUMN cnt_c1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg2;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+sum_c2	bigint	YES	true	None	
+max_c3	bigint	YES	true	None	
+min_c3	bigint	YES	true	None	
+avg_c5	double	YES	false	None	NONE
+max_c6	int	YES	false	None	NONE
+-- !result
+DROP MATERIALIZED VIEW test_mv_agg2;
+-- result:
+-- !result
+DROP TABLE t2_agg;
+-- result:
+-- !result
+drop table if exists t3_agg;
+-- result:
+-- !result
+drop materialized view if exists test_mv_agg3;
+-- result:
+-- !result
+CREATE TABLE t3_agg (
+    dt DATE,
+    c0 INT,
+    c1 VARCHAR(20),
+    c2 INT SUM,
+    c3 VARCHAR(200) REPLACE
+) ENGINE=OLAP
+AGGREGATE KEY(dt, c0, c1)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(c0)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t3_agg
+SELECT '2026-01-01', generate_series % 5, 'val_' || CAST(generate_series AS VARCHAR),
+       generate_series, 'desc_' || CAST(generate_series AS VARCHAR)
+FROM TABLE(generate_series(1, 50));
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv_agg3
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(c0)
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "force_mv"
+)
+AS
+SELECT dt, c0, c1, SUM(c2) as total_c2
+FROM t3_agg
+GROUP BY dt, c0, c1;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
+-- result:
+019c2d9a-bf2f-741a-bda8-61783afb7549
+-- !result
+SELECT * FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	1	275
+2026-01-01	1	1	235
+2026-01-01	2	1	245
+-- !result
+SELECT dt, c0, c1, SUM(c2) as total_c2 FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	1	275
+2026-01-01	1	1	235
+2026-01-01	2	1	245
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg3 ADD COLUMN c3_expr AS approx_count_distinct(c3) DEFAULT "0";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg3;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+c1	varchar(1048576)	YES	true	None	
+total_c2	bigint	YES	false	None	NONE
+c3_expr	bigint	YES	false	0	NONE
+-- !result
+SELECT dt, c0, c1, total_c2, c3_expr FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	1	275	0
+2026-01-01	1	1	235	0
+2026-01-01	2	1	245	0
+-- !result
+SELECT dt, c0, c1, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	1	275	1
+2026-01-01	1	1	235	1
+2026-01-01	2	1	245	1
+-- !result
+ALTER TABLE t3_agg ADD COLUMN c4 INT SUM;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC t3_agg;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+c1	varchar(20)	YES	true	None	
+c2	int	YES	false	None	
+c3	varchar(200)	YES	false	None	
+c4	int	YES	false	None	
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg3 ADD COLUMN sum_c4 AS SUM(c4);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg3;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+c1	varchar(1048576)	YES	true	None	
+total_c2	bigint	YES	false	None	NONE
+c3_expr	bigint	YES	false	0	NONE
+sum_c4	bigint	YES	false	None	NONE
+-- !result
+INSERT INTO t3_agg VALUES ('2026-01-01', 0, 'new_val', 200, 'new_desc', 50);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
+-- result:
+019c2d9a-d622-7903-a3c7-5e5d80c27a30
+-- !result
+function: print_hit_materialized_view("SELECT dt, c0, c1, SUM(c2), SUM(c4) FROM t3_agg GROUP BY dt, c0, c1", "test_mv_agg3")
+-- result:
+True
+-- !result
+SELECT dt, c0, c1, total_c2, c3_expr, sum_c4 FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	1	275	1	None
+2026-01-01	0	new_val	200	1	50
+2026-01-01	1	1	235	1	None
+-- !result
+SELECT dt, c0, c1, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr, SUM(c4) as sum_c4 FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+-- result:
+2026-01-01	0	1	275	1	None
+2026-01-01	0	new_val	200	1	50
+2026-01-01	1	1	235	1	None
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg3 DROP COLUMN c3_expr;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg3;
+-- result:
+dt	date	YES	true	None	
+c0	int	YES	true	None	
+c1	varchar(1048576)	YES	true	None	
+total_c2	bigint	YES	false	None	NONE
+sum_c4	bigint	YES	false	None	NONE
+-- !result
+DROP MATERIALIZED VIEW test_mv_agg3;
+-- result:
+-- !result
+DROP TABLE t3_agg;
+-- result:
+-- !result
+drop table if exists t4_agg;
+-- result:
+-- !result
+drop materialized view if exists test_mv_agg4;
+-- result:
+-- !result
+CREATE TABLE t4_agg (
+    dt DATE,
+    category_id INT,
+    product_id INT,
+    sales_amount DECIMAL(20, 2) SUM,
+    quantity INT SUM,
+    discount_amount DECIMAL(20, 2) SUM,
+    product_name VARCHAR(100) REPLACE
+) ENGINE=OLAP
+AGGREGATE KEY(dt, category_id, product_id)
+PARTITION BY date_trunc('month', dt)
+DISTRIBUTED BY HASH(product_id) BUCKETS 16
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t4_agg
+SELECT '2026-01-01', 1, 100, 1500.50, 10, 100.25, 'Product A'
+UNION ALL
+SELECT '2026-01-01', 1, 101, 2500.75, 15, 200.50, 'Product A'
+UNION ALL
+SELECT '2026-01-01', 2, 200, 3000.00, 20, 300.00, 'Product B'
+UNION ALL
+SELECT '2026-01-02', 1, 100, 1800.25, 12, 150.00, 'Product A';
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv_agg4
+PARTITION BY date_trunc('month', dt)
+DISTRIBUTED BY HASH(category_id)
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "force_mv"
+)
+AS
+SELECT dt, category_id,
+       SUM(sales_amount) as total_sales,
+       SUM(quantity) as total_quantity,
+       SUM(discount_amount) as total_discount
+FROM t4_agg
+GROUP BY dt, category_id;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
+-- result:
+019c2d9a-e20c-7cb9-afe1-66d0af724132
+-- !result
+SELECT * FROM test_mv_agg4 ORDER BY ALL;
+-- result:
+2026-01-01	1	4001.25	25	300.75
+2026-01-01	2	3000.00	20	300.00
+2026-01-02	1	1800.25	12	150.00
+-- !result
+SELECT dt, category_id,
+       SUM(sales_amount) as total_sales,
+       SUM(quantity) as total_quantity,
+       SUM(discount_amount) as total_discount
+FROM t4_agg GROUP BY dt, category_id ORDER BY dt, category_id;
+-- result:
+2026-01-01	1	4001.25	25	300.75
+2026-01-01	2	3000.00	20	300.00
+2026-01-02	1	1800.25	12	150.00
+-- !result
+ALTER TABLE t4_agg ADD COLUMN profit DECIMAL(20, 2) SUM;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC t4_agg;
+-- result:
+dt	date	YES	true	None	
+category_id	int	YES	true	None	
+product_id	int	YES	true	None	
+sales_amount	decimal(38,2)	YES	false	None	
+quantity	int	YES	false	None	
+discount_amount	decimal(38,2)	YES	false	None	
+product_name	varchar(100)	YES	false	None	
+profit	decimal(38,2)	YES	false	None	
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg4 ADD COLUMN total_profit AS SUM(profit);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg4;
+-- result:
+dt	date	YES	true	None	
+category_id	int	YES	true	None	
+total_sales	decimal(38,2)	YES	true	None	
+total_quantity	bigint	YES	true	None	
+total_discount	decimal(38,2)	YES	false	None	NONE
+total_profit	decimal(38,2)	YES	false	None	NONE
+-- !result
+INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 5000.00, 30, 500.00, 1200.00, 1.00);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
+-- result:
+019c2d9a-f111-7add-9661-aced453a5624
+-- !result
+SELECT dt, category_id, total_sales, total_quantity, total_discount, total_profit FROM test_mv_agg4 ORDER BY dt, category_id;
+-- result:
+2026-01-01	1	4001.25	25	300.75	None
+2026-01-01	2	3000.00	20	300.00	None
+2026-01-02	1	1800.25	12	150.00	None
+2026-01-03	3	5000.00	30	500.00	1.00
+-- !result
+ALTER TABLE t4_agg ADD COLUMN region VARCHAR(50);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC t4_agg;
+-- result:
+dt	date	YES	true	None	
+category_id	int	YES	true	None	
+product_id	int	YES	true	None	
+region	varchar(50)	YES	true	None	
+sales_amount	decimal(38,2)	YES	false	None	
+quantity	int	YES	false	None	
+discount_amount	decimal(38,2)	YES	false	None	
+product_name	varchar(100)	YES	false	None	
+profit	decimal(38,2)	YES	false	None	
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg4 ADD COLUMN region AS region;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg4;
+-- result:
+dt	date	YES	true	None	
+category_id	int	YES	true	None	
+total_sales	decimal(38,2)	YES	true	None	
+total_quantity	bigint	YES	true	None	
+total_discount	decimal(38,2)	YES	false	None	NONE
+total_profit	decimal(38,2)	YES	false	None	NONE
+region	varchar(1048576)	YES	false	None	NONE
+-- !result
+INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, "Product C", 5000.00, 30, 500.00, 1200.00, 1.00);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
+-- result:
+019c2d9a-fe97-72a7-83c7-29b6c5ef0744
+-- !result
+function: print_hit_materialized_view("SELECT dt, category_id, region, SUM(sales_amount), SUM(quantity), SUM(profit) FROM t4_agg GROUP BY dt, category_id, region", "test_mv_agg4")
+-- result:
+True
+-- !result
+SELECT dt, category_id, region, total_sales, total_quantity, total_discount, total_profit
+FROM test_mv_agg4 ORDER BY dt, category_id, region;
+-- result:
+2026-01-01	1	None	4001.25	25	300.75	None
+2026-01-01	2	None	3000.00	20	300.00	None
+2026-01-02	1	None	1800.25	12	150.00	None
+2026-01-03	3	None	5000.00	30	500.00	1.00
+2026-01-03	3	Product C	5000.00	30	500.00	1.00
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg4 DROP COLUMN total_discount;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg4;
+-- result:
+dt	date	YES	true	None	
+category_id	int	YES	true	None	
+total_sales	decimal(38,2)	YES	true	None	
+total_quantity	bigint	YES	true	None	
+total_profit	decimal(38,2)	YES	false	None	NONE
+region	varchar(1048576)	YES	false	None	NONE
+-- !result
+ALTER MATERIALIZED VIEW test_mv_agg4 DROP COLUMN region;
+-- result:
+[REGEX]E:.*
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DESC test_mv_agg4;
+-- result:
+dt	date	YES	true	None	
+category_id	int	YES	true	None	
+total_sales	decimal(38,2)	YES	true	None	
+total_quantity	bigint	YES	true	None	
+total_profit	decimal(38,2)	YES	false	None	NONE
+region	varchar(1048576)	YES	false	None	NONE
+-- !result
+DROP MATERIALIZED VIEW test_mv_agg4;
+-- result:
+-- !result
+DROP TABLE t4_agg;
+-- result:
+-- !result

--- a/test/sql/test_mv/T/test_mv_fast_schema_change
+++ b/test/sql/test_mv/T/test_mv_fast_schema_change
@@ -1,0 +1,199 @@
+-- name: test_mv_fast_schema_change
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+
+drop table if exists t1;
+drop materialized view if exists test_mv1;
+CREATE TABLE t1 (
+  dt datetime,
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`, `c0`, `c1`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+  "replication_num" = "1"
+);
+insert into t1 SELECT '2026-01-01', generate_series % 10, generate_series, generate_series, generate_series FROM TABLE(generate_series(1, 100));
+
+CREATE MATERIALIZED VIEW test_mv1 
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY hash(c0) 
+PROPERTIES (
+  "replication_num" = "1",
+  "query_rewrite_consistency" = "force_mv"
+)
+AS 
+SELECT dt, c0, count(c1) as cnt_c1 from t1 group by dt, c0;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+set enable_materialized_view_rewrite = false;
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1 from t1 group by dt, c0", "test_mv1")
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, count(c1) as cnt_c1 from t1 group by dt, c0 order by ALL limit 3;
+
+-- test mv add column cnt_c2
+ALTER MATERIALIZED VIEW test_mv1 ADD COLUMN cnt_c2 AS count(c2);
+function: wait_alter_table_finish()
+DESC test_mv1;
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2 from t1 group by dt, c0", "test_mv1")
+SELECT dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2 from t1 group by dt, c0 order by ALL limit 3;
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- test mv add column with default value
+ALTER MATERIALIZED VIEW test_mv1 ADD COLUMN cnt_c3 AS count(c3) DEFAULT "0";
+function: wait_alter_table_finish()
+DESC test_mv1;
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, count(c3) as cnt_c3 from t1 group by dt, c0", "test_mv1")
+SELECT dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, count(c3) as cnt_c3 from t1 group by dt, c0 order by ALL limit 3;
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- refresh mv after add column
+INSERT INTO t1 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0);
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2 from t1 group by dt, c0", "test_mv1")
+SELECT dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2 from t1 group by dt, c0 order by ALL limit 3;
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+
+-- t1 add column c4
+ALTER TABLE t1 ADD COLUMN c4 int;
+function: wait_alter_table_finish()
+DESC t1;
+-- refresh mv after add column
+INSERT INTO t1 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0, 0);
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+-- add sum aggregation column
+ALTER MATERIALIZED VIEW test_mv1 ADD COLUMN sum_c4 AS sum(c4);
+function: wait_alter_table_finish()
+DESC test_mv1;
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4 from t1 group by dt, c0", "test_mv1")
+SELECT dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4 from t1 group by dt, c0 order by ALL limit 3;
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- refresh mv after insert
+INSERT INTO t1 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0, 0);
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4 from t1 group by dt, c0", "test_mv1")
+SELECT dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4 from t1 group by dt, c0 order by ALL limit 3;
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+
+-- add group by key column
+ALTER MATERIALIZED VIEW test_mv1 ADD COLUMN c4 AS c4;
+function: wait_alter_table_finish()
+DESC test_mv1;
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4, c4 from t1 group by dt, c0, c4", "test_mv1")
+SELECT dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4, c4 from t1 group by dt, c0, c4 order by ALL limit 3;
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- refresh mv after insert
+INSERT INTO t1 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0, 0);
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("select dt, c0, c4, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4 from t1 group by dt, c0, c4", "test_mv1")
+SELECT dt, c0, count(c1) as cnt_c1, count(c2) as cnt_c2, sum(c4) as sum_c4, c4 from t1 group by dt, c0, c4 order by ALL limit 3;
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+
+-- test mv drop column
+ALTER MATERIALIZED VIEW test_mv1 DROP COLUMN cnt_c2;
+function: wait_alter_table_finish()
+DESC test_mv1;
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, sum(c4) as sum_c4, c4 from t1 group by dt, c0, c4", "test_mv1")
+SELECT dt, c0, count(c1) as cnt_c1, sum(c4) as sum_c4, c4 from t1 group by dt, c0, c4 order by ALL limit 3;
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- refresh mv after drop
+INSERT INTO t1 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0, 0);
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("select dt, c0, c4, count(c1) as cnt_c1, sum(c4) as sum_c4 from t1 group by dt, c0, c4", "test_mv1")
+SELECT dt, c0, count(c1) as cnt_c1, sum(c4) as sum_c4, c4 from t1 group by dt, c0, c4 order by ALL limit 3;
+SELECT * FROM test_mv1 ORDER BY ALL limit 3;
+
+-- test mv drop aggregation column
+ALTER MATERIALIZED VIEW test_mv1 DROP COLUMN sum_c4;
+function: wait_alter_table_finish()
+DESC test_mv1;
+function: print_hit_materialized_view("select dt, c0, c4, count(c1) as cnt_c1 from t1 group by dt, c0, c4", "test_mv1")
+SELECT dt, c0, count(c1) as cnt_c1, c4 from t1 group by dt, c0, c4 order by ALL limit 3;
+SELECT * FROM test_mv1 ORDER BY ALL LIMIT 3;
+-- refresh mv after drop
+INSERT INTO t1 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0, 0);
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1, c4 from t1 group by dt, c0, c4", "test_mv1")
+SELECT dt, c0, count(c1) as cnt_c1, c4 from t1 group by dt, c0, c4 order by ALL limit 3;
+SELECT * FROM test_mv1 ORDER BY ALL limit 3;
+
+-- test mv drop group by key column
+[UC]ALTER MATERIALIZED VIEW test_mv1 DROP COLUMN c4;
+-- refresh mv after drop
+INSERT INTO t1 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0, 0);
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: print_hit_materialized_view("select dt, c0, count(c1) as cnt_c1 from t1 group by dt, c0", "test_mv1")
+SELECT dt, c0, count(c1) as cnt_c1 from t1 group by dt, c0 order by ALL limit 3;
+SELECT * FROM test_mv1 ORDER BY ALL limit 3;
+
+DROP MATERIALIZED VIEW test_mv1;
+DROP TABLE t1;
+
+-- test mv without group by key column
+CREATE TABLE t2 (
+  dt datetime,
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`dt`, `c0`, `c1`)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(`c0`, `c1`) 
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into t2 SELECT '2026-01-01', generate_series % 5, generate_series, generate_series, generate_series FROM TABLE(generate_series(1, 100));
+
+CREATE MATERIALIZED VIEW test_mv2 
+PARTITION BY date_trunc('day', dt)  
+DISTRIBUTED BY HASH(`c0`, `c1`) 
+AS 
+SELECT dt, c0, c1 from t2;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+function: print_hit_materialized_view("select dt, c0, c1 from t2", "test_mv2")
+SELECT dt, c0, c1 FROM test_mv2 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, c1 from t2 order by ALL limit 3;
+
+-- test mv add column
+ALTER MATERIALIZED VIEW test_mv2 ADD COLUMN c3 AS c3 + 1;
+function: wait_alter_table_finish()
+DESC test_mv2;
+SELECT dt, c0, c1, c3 FROM test_mv2 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, c1, c3 + 1 from t2 order by ALL limit 3;
+
+-- test mv add column with default value
+ALTER MATERIALIZED VIEW test_mv2 ADD COLUMN c3_default AS c3 + 1 DEFAULT "0";
+function: wait_alter_table_finish()
+DESC test_mv2;
+SELECT dt, c0, c1, c3, c3_default FROM test_mv2 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, c1, c3 + 1, c3 + 1 from t2 order by ALL limit 3;
+
+-- base table add column
+ALTER TABLE t2 ADD COLUMN c4 int;
+function: wait_alter_table_finish()
+DESC t2;
+ALTER MATERIALIZED VIEW test_mv2 ADD COLUMN c4 AS c4 + 1;
+function: wait_alter_table_finish()
+DESC test_mv2;
+function: print_hit_materialized_view("select dt, c0, c1, c4 + 1 from t2", "test_mv2")
+SELECT dt, c0, c1, c4 FROM test_mv2 ORDER BY dt, c0, c1, c4 LIMIT 3;
+SELECT dt, c0, c1, c4 + 1 from t2 order by ALL limit 3;
+
+INSERT INTO t2 VALUES ('2026-01-01', 0, "c1_0", "c2_0", 0, 0);
+[UC]REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+function: print_hit_materialized_view("select dt, c0, c1, c4 + 1 from t2", "test_mv2")
+SELECT dt, c0, c1, c4  FROM test_mv2 ORDER BY dt, c0, c1, c4 LIMIT 3;
+SELECT dt, c0, c1, c4 + 1 from t2 order by ALL limit 3;
+
+-- test mv drop column
+ALTER MATERIALIZED VIEW test_mv2 DROP COLUMN c4;
+function: wait_alter_table_finish()
+DESC test_mv2;
+
+DROP MATERIALIZED VIEW test_mv2;
+DROP TABLE t2;

--- a/test/sql/test_mv/T/test_mv_fast_schema_change_with_aggregate
+++ b/test/sql/test_mv/T/test_mv_fast_schema_change_with_aggregate
@@ -1,0 +1,398 @@
+-- name: test_mv_fast_schema_change_with_aggregate @slow
+
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+
+-- Test 1: Aggregate table with SUM aggregation - MV schema change tests
+drop table if exists t1_agg;
+drop materialized view if exists test_mv_agg1;
+
+CREATE TABLE t1_agg (
+    dt DATE,
+    c0 INT,
+    c1 VARCHAR(20),
+    c2 VARCHAR(200),
+    c3 INT SUM,
+    c4 INT SUM
+) ENGINE=OLAP
+AGGREGATE KEY(dt, c0, c1, c2)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(c0) BUCKETS 48
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t1_agg
+SELECT '2026-01-01', generate_series % 10, 'val_' || CAST(generate_series AS VARCHAR),
+       'desc_' || CAST(generate_series AS VARCHAR), generate_series, generate_series * 2
+FROM TABLE(generate_series(1, 100));
+
+-- Create MV on aggregate base table
+CREATE MATERIALIZED VIEW test_mv_agg1
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY hash(c0)
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "force_mv"
+)
+AS
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1
+FROM t1_agg
+GROUP BY dt, c0;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+
+set enable_materialized_view_rewrite = false;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+
+-- Test MV add aggregation column (count)
+ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN cnt_c2 AS COUNT(c2);
+function: wait_alter_table_finish()
+DESC test_mv_agg1;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+
+-- Refresh MV after add column
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_0', 'desc_0', 10, 20);
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+
+-- Test base table add column (non-aggregation column)
+ALTER TABLE t1_agg ADD COLUMN c5 VARCHAR(100);
+function: wait_alter_table_finish()
+DESC t1_agg;
+
+-- Test base table add aggregation column
+ALTER TABLE t1_agg ADD COLUMN c6 INT SUM;
+function: wait_alter_table_finish()
+DESC t1_agg;
+
+-- Refresh MV and verify existing columns still work
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_1', 'desc_1', 'desc_2', 15, 30, 25);
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+
+-- Test MV add column that references new aggregation column
+ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN sum_c6 AS SUM(c6);
+function: wait_alter_table_finish()
+DESC test_mv_agg1;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+
+-- Refresh MV after add column
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_2', 'desc_2', 'desc_3', 20, 40, 35);
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+
+-- Test MV add group by key column
+ALTER MATERIALIZED VIEW test_mv_agg1 ADD COLUMN c5 AS c5;
+function: wait_alter_table_finish()
+DESC test_mv_agg1;
+function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+
+-- Refresh MV after insert
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_3', 'desc_3', 'desc_4', 25, 50, 45);
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), COUNT(c2), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, COUNT(c2) as cnt_c2, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+
+-- Test MV drop column (drop aggregation column cnt_c2)
+ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN cnt_c2;
+function: wait_alter_table_finish()
+DESC test_mv_agg1;
+function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+
+-- Refresh MV after drop
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_4', 'desc_4', 'desc_5', 30, 60, 55);
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1), SUM(c6) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1, SUM(c6) as sum_c6 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+
+-- Test MV drop aggregation column (drop sum_c6)
+ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN sum_c6;
+function: wait_alter_table_finish()
+DESC test_mv_agg1;
+function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+
+-- Refresh MV after drop
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_5', 'desc_5', 'desc_6', 35, 70, 65);
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, c0, c5, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0, c5", "test_mv_agg1")
+SELECT dt, c0, c5, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0, c5 ORDER BY ALL LIMIT 3;
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+
+-- Test MV drop group by key column (drop c5)
+[UC]ALTER MATERIALIZED VIEW test_mv_agg1 DROP COLUMN c5;
+-- Refresh MV after drop
+INSERT INTO t1_agg VALUES ('2026-01-01', 0, 'val_6', 'desc_6', 'desc_7', 40, 80, 75);
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg1 WITH SYNC MODE;
+function: print_hit_materialized_view("SELECT dt, c0, SUM(c3), COUNT(c1) FROM t1_agg GROUP BY dt, c0", "test_mv_agg1")
+SELECT dt, c0, SUM(c3) as sum_c3, COUNT(c1) as cnt_c1 FROM t1_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+SELECT * FROM test_mv_agg1 ORDER BY ALL LIMIT 3;
+
+DROP MATERIALIZED VIEW test_mv_agg1;
+DROP TABLE t1_agg;
+
+-- Test 2: Aggregate table with multiple aggregation types - MV schema change
+drop table if exists t2_agg;
+drop materialized view if exists test_mv_agg2;
+
+CREATE TABLE t2_agg (
+    dt DATE,
+    c0 INT,
+    c1 VARCHAR(20),
+    c2 INT SUM,
+    c3 BIGINT SUM,
+    c4 VARCHAR(100) REPLACE,
+    c5 DOUBLE SUM
+) ENGINE=OLAP
+AGGREGATE KEY(dt, c0, c1)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(c0)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t2_agg
+SELECT '2026-01-01', generate_series % 5, 'val_' || CAST(generate_series AS VARCHAR),
+       generate_series, generate_series * 100, 'replace_' || CAST(generate_series AS VARCHAR), generate_series * 0.5
+FROM TABLE(generate_series(1, 50));
+
+-- Create MV on aggregate base table with multiple aggregation functions
+CREATE MATERIALIZED VIEW test_mv_agg2
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(c0)
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "force_mv"
+)
+AS
+SELECT dt, c0, SUM(c2) as sum_c2, MAX(c3) as max_c3, MIN(c3) as min_c3, AVG(c5) as avg_c5
+FROM t2_agg
+GROUP BY dt, c0;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg2 WITH SYNC MODE;
+
+SELECT * FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c2) as sum_c2, MAX(c3) as max_c3, MIN(c3) as min_c3, AVG(c5) as avg_c5
+FROM t2_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+
+-- Test MV add column with new aggregation
+ALTER MATERIALIZED VIEW test_mv_agg2 ADD COLUMN cnt_c1 AS COUNT(c1);
+function: wait_alter_table_finish()
+DESC test_mv_agg2;
+SELECT dt, c0, sum_c2, max_c3, min_c3, avg_c5, cnt_c1 FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, SUM(c2) as sum_c2, MAX(c3) as max_c3, MIN(c3) as min_c3, AVG(c5) as avg_c5, COUNT(c1) as cnt_c1
+FROM t2_agg GROUP BY dt, c0 ORDER BY ALL LIMIT 3;
+
+-- Base table add aggregation column
+ALTER TABLE t2_agg ADD COLUMN c6 INT MAX;
+function: wait_alter_table_finish()
+DESC t2_agg;
+
+-- MV add column referencing new MAX aggregation
+ALTER MATERIALIZED VIEW test_mv_agg2 ADD COLUMN max_c6 AS MAX(c6);
+function: wait_alter_table_finish()
+DESC test_mv_agg2;
+
+INSERT INTO t2_agg VALUES ('2026-01-01', 0, 'new_val', 100, 1000, 'replace_new', 10.5, 50);
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg2 WITH SYNC MODE;
+
+SELECT dt, c0, sum_c2, max_c3, min_c3, avg_c5, cnt_c1, max_c6 FROM test_mv_agg2 ORDER BY ALL LIMIT 3;
+
+-- Test MV drop column
+ALTER MATERIALIZED VIEW test_mv_agg2 DROP COLUMN cnt_c1;
+function: wait_alter_table_finish()
+DESC test_mv_agg2;
+
+DROP MATERIALIZED VIEW test_mv_agg2;
+DROP TABLE t2_agg;
+
+-- Test 3: Aggregate table - MV without group by key column (similar to test_mv_schema_change1 t2)
+drop table if exists t3_agg;
+drop materialized view if exists test_mv_agg3;
+
+CREATE TABLE t3_agg (
+    dt DATE,
+    c0 INT,
+    c1 VARCHAR(20),
+    c2 INT SUM,
+    c3 VARCHAR(200) REPLACE
+) ENGINE=OLAP
+AGGREGATE KEY(dt, c0, c1)
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(c0)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t3_agg
+SELECT '2026-01-01', generate_series % 5, 'val_' || CAST(generate_series AS VARCHAR),
+       generate_series, 'desc_' || CAST(generate_series AS VARCHAR)
+FROM TABLE(generate_series(1, 50));
+
+-- MV without group by key column (similar to test_mv_schema_change1 t2)
+CREATE MATERIALIZED VIEW test_mv_agg3
+PARTITION BY date_trunc('day', dt)
+DISTRIBUTED BY HASH(c0)
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "force_mv"
+)
+AS
+SELECT dt, c0, c1, SUM(c2) as total_c2
+FROM t3_agg
+GROUP BY dt, c0, c1;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
+
+SELECT * FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, c1, SUM(c2) as total_c2 FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+
+-- Test MV add column (expression column)
+ALTER MATERIALIZED VIEW test_mv_agg3 ADD COLUMN c3_expr AS approx_count_distinct(c3) DEFAULT "0";
+function: wait_alter_table_finish()
+DESC test_mv_agg3;
+SELECT dt, c0, c1, total_c2, c3_expr FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, c1, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+
+-- Base table add column
+ALTER TABLE t3_agg ADD COLUMN c4 INT SUM;
+function: wait_alter_table_finish()
+DESC t3_agg;
+
+-- MV add column referencing new aggregation
+ALTER MATERIALIZED VIEW test_mv_agg3 ADD COLUMN sum_c4 AS SUM(c4);
+function: wait_alter_table_finish()
+DESC test_mv_agg3;
+
+INSERT INTO t3_agg VALUES ('2026-01-01', 0, 'new_val', 200, 'new_desc', 50);
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg3 WITH SYNC MODE;
+
+function: print_hit_materialized_view("SELECT dt, c0, c1, SUM(c2), SUM(c4) FROM t3_agg GROUP BY dt, c0, c1", "test_mv_agg3")
+SELECT dt, c0, c1, total_c2, c3_expr, sum_c4 FROM test_mv_agg3 ORDER BY ALL LIMIT 3;
+SELECT dt, c0, c1, SUM(c2) as total_c2, approx_count_distinct(c3) as c3_expr, SUM(c4) as sum_c4 FROM t3_agg GROUP BY dt, c0, c1 ORDER BY ALL LIMIT 3;
+
+-- Test MV drop column
+ALTER MATERIALIZED VIEW test_mv_agg3 DROP COLUMN c3_expr;
+function: wait_alter_table_finish()
+DESC test_mv_agg3;
+
+DROP MATERIALIZED VIEW test_mv_agg3;
+DROP TABLE t3_agg;
+
+-- Test 4: Aggregate table - Multiple aggregations and schema evolution
+drop table if exists t4_agg;
+drop materialized view if exists test_mv_agg4;
+
+CREATE TABLE t4_agg (
+    dt DATE,
+    category_id INT,
+    product_id INT,
+    sales_amount DECIMAL(20, 2) SUM,
+    quantity INT SUM,
+    discount_amount DECIMAL(20, 2) SUM,
+    product_name VARCHAR(100) REPLACE
+) ENGINE=OLAP
+AGGREGATE KEY(dt, category_id, product_id)
+PARTITION BY date_trunc('month', dt)
+DISTRIBUTED BY HASH(product_id) BUCKETS 16
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t4_agg
+SELECT '2026-01-01', 1, 100, 1500.50, 10, 100.25, 'Product A'
+UNION ALL
+SELECT '2026-01-01', 1, 101, 2500.75, 15, 200.50, 'Product A'
+UNION ALL
+SELECT '2026-01-01', 2, 200, 3000.00, 20, 300.00, 'Product B'
+UNION ALL
+SELECT '2026-01-02', 1, 100, 1800.25, 12, 150.00, 'Product A';
+
+-- Create MV with multiple aggregations
+CREATE MATERIALIZED VIEW test_mv_agg4
+PARTITION BY date_trunc('month', dt)
+DISTRIBUTED BY HASH(category_id)
+PROPERTIES (
+    "replication_num" = "1",
+    "query_rewrite_consistency" = "force_mv"
+)
+AS
+SELECT dt, category_id,
+       SUM(sales_amount) as total_sales,
+       SUM(quantity) as total_quantity,
+       SUM(discount_amount) as total_discount
+FROM t4_agg
+GROUP BY dt, category_id;
+
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
+
+SELECT * FROM test_mv_agg4 ORDER BY ALL;
+SELECT dt, category_id,
+       SUM(sales_amount) as total_sales,
+       SUM(quantity) as total_quantity,
+       SUM(discount_amount) as total_discount
+FROM t4_agg GROUP BY dt, category_id ORDER BY dt, category_id;
+
+-- Test: Base table add aggregation column
+ALTER TABLE t4_agg ADD COLUMN profit DECIMAL(20, 2) SUM;
+function: wait_alter_table_finish()
+DESC t4_agg;
+
+-- MV add column referencing new aggregation
+ALTER MATERIALIZED VIEW test_mv_agg4 ADD COLUMN total_profit AS SUM(profit);
+function: wait_alter_table_finish()
+DESC test_mv_agg4;
+
+INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, 5000.00, 30, 500.00, 1200.00, 1.00);
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
+
+SELECT dt, category_id, total_sales, total_quantity, total_discount, total_profit FROM test_mv_agg4 ORDER BY dt, category_id;
+
+-- Test: Base table add non-aggregation column
+ALTER TABLE t4_agg ADD COLUMN region VARCHAR(50);
+function: wait_alter_table_finish()
+DESC t4_agg;
+
+-- MV add group by column
+ALTER MATERIALIZED VIEW test_mv_agg4 ADD COLUMN region AS region;
+function: wait_alter_table_finish()
+DESC test_mv_agg4;
+
+-- Insert with new column
+INSERT INTO t4_agg VALUES ('2026-01-03', 3, 300, "Product C", 5000.00, 30, 500.00, 1200.00, 1.00);
+[UC]REFRESH MATERIALIZED VIEW test_mv_agg4 WITH SYNC MODE;
+
+function: print_hit_materialized_view("SELECT dt, category_id, region, SUM(sales_amount), SUM(quantity), SUM(profit) FROM t4_agg GROUP BY dt, category_id, region", "test_mv_agg4")
+SELECT dt, category_id, region, total_sales, total_quantity, total_discount, total_profit
+FROM test_mv_agg4 ORDER BY dt, category_id, region;
+
+-- Test drop MV columns
+ALTER MATERIALIZED VIEW test_mv_agg4 DROP COLUMN total_discount;
+function: wait_alter_table_finish()
+DESC test_mv_agg4;
+
+ALTER MATERIALIZED VIEW test_mv_agg4 DROP COLUMN region;
+function: wait_alter_table_finish()
+DESC test_mv_agg4;
+
+DROP MATERIALIZED VIEW test_mv_agg4;
+DROP TABLE t4_agg;
+


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/issues/67914


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.1
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables lightweight schema changes on materialized views and wires them through parser, analyzer, executors, persistence, and replay.
> 
> - Introduces `TableProperty.MVFastSchemaEvolutionMode` (`DISABLED`, `CHECKED`, `LOOSE`, `FORCE`) controllable via `fast_schema_evolution_mode` property; executor applies it during property alters
> - Supports `ALTER MATERIALIZED VIEW ... ADD COLUMN <name> AS <expr> [COMMENT ...]` and `ALTER MATERIALIZED VIEW ... DROP COLUMN <name>`
>   - Grammar (`StarRocks.g4`), AST (`AddMVColumnClause`, `DropMVColumnClause`), AstBuilder wiring, and clause analyzers added
>   - `AlterMVJobExecutor` modifies MV query AST, validates aggregates/group-by usage, resolves base column, infers type, triggers schema change, updates MV define SQL, evicts caches, and adjusts refresh visibility per mode
>   - Prevents dropping columns used in `GROUP BY`; deactivates related MVs on drop
> - Persists/replays MV changes with extended `AlterMaterializedViewBaseTableInfosLog` (new `alterType`, view SQL, and visible-version maps); `MaterializedView` replay updated and parse-node init/reset helpers added
> - Adds `Column.createdTime` to assist refresh impact checks
> - Classifies new clauses as `SCHEMA_CHANGE` in `AlterOpType`
> - Property plumbing for `fast_schema_evolution_mode` in `TableProperty` and `PropertyAnalyzer`
> - Comprehensive UTs and SQL tests covering add/drop flows, modes, and rewrite behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a437ebe83fb320f437cf594005732d6458c17c10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->