### PR TITLE
[UT] Disable flaky PseudoCluster related tests

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoClusterTest.java
@@ -39,6 +39,7 @@ import mockit.MockUp;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
@@ -50,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+@Disabled("skip in CI: flaky pseudocluster tests")
 public class PseudoClusterTest {
     @BeforeAll
     public static void setUp() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InformationSchemaBeFeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InformationSchemaBeFeTableTest.java
@@ -24,11 +24,13 @@ import com.starrocks.pseudocluster.PseudoCluster;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.sql.Statement;
 
+@Disabled("skip in CI: flaky pseudocluster tests")
 public class InformationSchemaBeFeTableTest {
     @BeforeAll
     public static void setUp() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ConcurrentTxnNewPublishTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ConcurrentTxnNewPublishTest.java
@@ -16,9 +16,11 @@
 package com.starrocks.transaction;
 
 import com.starrocks.common.Config;
+import org.junit.jupiter.api.Disabled;
 
 import java.sql.SQLException;
 
+@Disabled("skip in CI: flaky pseudocluster tests")
 public class ConcurrentTxnNewPublishTest extends ConcurrentTxnTest {
     @Override
     void setup() throws SQLException {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ConcurrentTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ConcurrentTxnTest.java
@@ -21,12 +21,14 @@ import com.starrocks.pseudocluster.Tablet;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@Disabled("skip in CI: flaky pseudocluster tests")
 public class ConcurrentTxnTest {
     @BeforeAll
     public static void setUp() throws Exception {
@@ -37,6 +39,9 @@ public class ConcurrentTxnTest {
     @AfterAll
     public static void tearDown() throws Exception {
         Config.enable_statistic_collect_on_first_load = true;
+        if (PseudoCluster.getInstance() != null) {
+            PseudoCluster.getInstance().shutdown(true);
+        }
     }
 
     int runTime = 2;
@@ -48,7 +53,6 @@ public class ConcurrentTxnTest {
     int runSeconds = 3;
     boolean withRead = true;
     boolean withUpdateDelete = true;
-    boolean deleteRunDir = true;
 
     void setup() throws SQLException {
         Config.enable_new_publish_mechanism = false;
@@ -80,6 +84,5 @@ public class ConcurrentTxnTest {
             Assertions.assertEquals(DBLoad.TableLoad.totalTabletRead.get(), Tablet.getTotalReadSucceed());
             Tablet.clearStats();
         }
-        PseudoCluster.getInstance().shutdown(deleteRunDir);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ConcurrentTxnWithFailureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ConcurrentTxnWithFailureTest.java
@@ -16,9 +16,11 @@ package com.starrocks.transaction;
 
 import com.starrocks.common.Config;
 import com.starrocks.pseudocluster.PseudoCluster;
+import org.junit.jupiter.api.Disabled;
 
 import java.sql.SQLException;
 
+@Disabled("skip in CI: flaky pseudocluster tests")
 public class ConcurrentTxnWithFailureTest extends ConcurrentTxnTest {
     @Override
     void setup() throws SQLException {


### PR DESCRIPTION
## Why I'm doing:

Some PseudoCluster related UT became flaky for the last 1-2 month, likely some FE side changes caused this. Disable them for now. 

## What I'm doing:

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.1
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4