### PR TITLE
[BugFix] Prevent NormalizePredicateRule oscillation on non-deterministic expressions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/NormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/NormalizePredicateRule.java
@@ -74,9 +74,13 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
             return predicate;
         }
 
+        if (!predicate.getChild(1).isVariable()) {
+            return predicate;
+        }
+
         ScalarOperator result = predicate.commutative();
         Preconditions.checkState(!(result.getChild(0).isConstant() && result.getChild(1).isVariable()),
-                "Normalized predicate error: " + result);
+                "Normalized predicate error: %s", result);
         return result;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriterTest.java
@@ -229,4 +229,16 @@ public class ScalarOperatorRewriterTest {
         Assertions.assertEquals(predicate, result);
 
     }
+
+    @Test
+    public void testUuidBothSidesNoInfiniteLoop() {
+        CallOperator uuid1 = new CallOperator(FunctionSet.UUID, VarcharType.VARCHAR, Lists.newArrayList());
+        CallOperator uuid2 = new CallOperator(FunctionSet.UUID, VarcharType.VARCHAR, Lists.newArrayList());
+        BinaryPredicateOperator predicate = new BinaryPredicateOperator(BinaryType.NE, uuid1, uuid2);
+
+        ScalarOperatorRewriter operatorRewriter = new ScalarOperatorRewriter();
+        ScalarOperator result = operatorRewriter.rewrite(predicate,
+                ScalarOperatorRewriter.DEFAULT_REWRITE_SCAN_PREDICATE_RULES);
+        Assertions.assertEquals(predicate, result);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
The planner can hang on predicates where both sides are neither column-references nor foldable constants, which is common with **non-deterministic functions**. In particular, `CallOperator` overrides `isConstant()` so that any function in `FunctionSet.nonDeterministicFunctions` (e.g. `uuid()`) is **not treated as constant** even if it has no children:
- it returns `false` immediately for non-deterministic functions
- otherwise it is constant only if all children are constant

This means expressions like `uuid() != uuid()` are **not variable** (no `ColumnRefOperator` in the tree) and also **not constant**, and `NormalizePredicateRule` may swap operands repeatedly, causing scalar rewrite to never converge.

reproduce case:
explain select uuid() != uuid();

## What I'm doing:
- Prevent `NormalizePredicateRule` from swapping binary predicates unless the rewrite will converge (only swap when the right side contains column refs).

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.1
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4