### PR TITLE
[UT] fix test_merge_commit_cancel

### DIFF
--- a/test/sql/test_stream_load/R/test_merge_commit_cancel
+++ b/test/sql/test_stream_load/R/test_merge_commit_cancel
@@ -44,32 +44,7 @@ function: get_running_transaction_count("db_${uuid0}")
 -- result:
 0
 -- !result
-shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_async:true" -H "merge_commit_interval_ms:600000" -H "merge_commit_parallel:1" -d '{"id":2,"name":"n2","score":2}' ${url}/api/db_${uuid0}/t0/_stream_load
--- result:
-0
-{
-    "Status": "Success",
-    "Message": "OK"
-}
--- !result
-function: get_running_transaction_count("db_${uuid0}")
--- result:
-1
--- !result
-[UC]function: label2=get_single_running_transaction_label("db_${uuid0}")
--- result:
-merge_commit_019b7ea8-2daa-7e32-8798-18fb4088bce4
--- !result
-shell: curl --location-trusted -u "root:" -X POST "${url}/api/db_${uuid0}/t0/_cancel?label=${label2}"
--- result:
-0
-{"status":"OK","code":"0","msg":"Success","message":"OK"}
--- !result
-function: get_running_transaction_count("db_${uuid0}")
--- result:
-0
--- !result
-select count(*) from t0 where id in (1, 2);
+select count(*) from t0;
 -- result:
 0
 -- !result

--- a/test/sql/test_stream_load/T/test_merge_commit_cancel
+++ b/test/sql/test_stream_load/T/test_merge_commit_cancel
@@ -29,15 +29,7 @@ shell: curl --location-trusted -u "root:" -X POST "${url}/api/db_${uuid0}/t0/_ca
 -- 4) Verify no running transactions
 function: get_running_transaction_count("db_${uuid0}")
 
--- 5) Start another merge-commit stream load, repeat cancel
-shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_async:true" -H "merge_commit_interval_ms:600000" -H "merge_commit_parallel:1" -d '{"id":2,"name":"n2","score":2}' ${url}/api/db_${uuid0}/t0/_stream_load
-
-function: get_running_transaction_count("db_${uuid0}")
-
-[UC]function: label2=get_single_running_transaction_label("db_${uuid0}")
-shell: curl --location-trusted -u "root:" -X POST "${url}/api/db_${uuid0}/t0/_cancel?label=${label2}"
-
-function: get_running_transaction_count("db_${uuid0}")
+-- 5) TODO verify merge commit task state is CANCELLED after supporting information_schema.loads later
 
 -- 6) Verify data not loaded
-select count(*) from t0 where id in (1, 2);
+select count(*) from t0;


### PR DESCRIPTION
## Why I'm doing:
Currently, the case want to verify the merge commit task is cancelled by checking whether a new request triggers a new task creation. But the task on BE side is cancelled asynchronously, so it's not stable. 

```
[Stacktrace]: 
Traceback (most recent call last):
  File "/root/.pyenv/versions/3.9.19/lib/python3.9/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/root/.pyenv/versions/3.9.19/lib/python3.9/unittest/case.py", line 592, in run
    self._callTestMethod(testMethod)
  File "/root/.pyenv/versions/3.9.19/lib/python3.9/unittest/case.py", line 550, in _callTestMethod
    method()
  File "/root/.pyenv/versions/3.9.19/lib/python3.9/site-packages/nose/case.py", line 170, in runTest
    self.test(*self.arg)
  File "/root/.pyenv/versions/3.9.19/lib/python3.9/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/home/runner/_work/starrocks/starrocks/test/lib/sql_annotation.py", line 53, in wrapper
    raise e
  File "/home/runner/_work/starrocks/starrocks/test/lib/sql_annotation.py", line 44, in wrapper
    res = func(*args, **kwargs)
  File "/home/runner/_work/starrocks/starrocks/test/test_sql_cases.py", line 460, in test_sql_basic
    self.check(sql_id, sql, expect_res, actual_res, order, ori_sql)
  File "/home/runner/_work/starrocks/starrocks/test/lib/sr_sql_lib.py", line 1404, in check
    tools.assert_equal(str(exp), str(act))
  File "/root/.pyenv/versions/3.9.19/lib/python3.9/unittest/case.py", line 837, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/root/.pyenv/versions/3.9.19/lib/python3.9/unittest/case.py", line 1217, in assertMultiLineEqual
    self.fail(self._formatMessage(msg, standardMsg))
  File "/root/.pyenv/versions/3.9.19/lib/python3.9/unittest/case.py", line 676, in fail
    raise self.failureException(msg)
AssertionError: '1' != '0'
- 1
+ 0


[Standard Output]: 
?[1;32m------------------------------------------------------------ ?[0m
?[1;32m[case name]: test_merge_commit_cancel ?[0m
?[1;32m[case file]: sql/test_stream_load/R/test_merge_commit_cancel ?[0m
?[1;32m------------------------------------------------------------ ?[0m
	 → case db: ['db_6e83e1362c90479e8db658555c9c11bb']
	 → case resource: []
create database db_6e83e1362c90479e8db658555c9c11bb;
use db_6e83e1362c90479e8db658555c9c11bb;
CREATE TABLE `t0`
(
    `id` int(11) NOT NULL COMMENT "user id",
    `name` varchar(65533) NULL COMMENT "user name",
    `score` int(11) NOT NULL COMMENT "user score"
)
ENGINE=OLAP
PRIMARY KEY(`id`)
DISTRIBUTED BY HASH(`id`)
PROPERTIES (
 "replication_num" = "1"
);
[SHELL]: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_async:true" -H "merge_commit_interval_ms:600000" -H "merge_commit_parallel:1" -d '{"id":1,"name":"n1","score":1}' http://172.21.250.198:8034/api/db_6e83e1362c90479e8db658555c9c11bb/t0/_stream_load
[FUNCTION]: get_running_transaction_count("db_6e83e1362c90479e8db658555c9c11bb")
[FUNCTION]: get_single_running_transaction_label("db_6e83e1362c90479e8db658555c9c11bb")
[SHELL]: curl --location-trusted -u "root:" -X POST "http://172.21.250.198:8034/api/db_6e83e1362c90479e8db658555c9c11bb/t0/_cancel?label=merge_commit_019bbb6f-a986-7648-abfc-e5307304f9cd"
[FUNCTION]: get_running_transaction_count("db_6e83e1362c90479e8db658555c9c11bb")
[SHELL]: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_async:true" -H "merge_commit_interval_ms:600000" -H "merge_commit_parallel:1" -d '{"id":2,"name":"n2","score":2}' http://172.21.250.198:8034/api/db_6e83e1362c90479e8db658555c9c11bb/t0/_stream_load
[FUNCTION]: get_running_transaction_count("db_6e83e1362c90479e8db658555c9c11bb")
?[1;32m******************** [FINISH] test_merge_commit_cancel ******************** ?[0m
```

## What I'm doing:
There is not a better way to check the task is cancelled because merge commit lacks of observibility. I will check it in #67879 after supporting `information_schema.loads` so that we can get the state of the merge commit task

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [X] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4