### PR TITLE
[BugFix] Fix variadic functions returning wrong dates

### DIFF
--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -145,6 +145,7 @@ vectorized_functions = [
     [102721, "negative", True, False, "DECIMAL64", ["DECIMAL64"], "MathFunctions::negative<TYPE_DECIMAL64>"],
     [102722, "negative", True, False, "DECIMAL128", ["DECIMAL128"], "MathFunctions::negative<TYPE_DECIMAL128>"],
 
+    [10288, "least", True, False, "DATETIME", ["DATETIME", "..."], "MathFunctions::least<TYPE_DATETIME>"],
     [10280, "least", True, False, "TINYINT", ["TINYINT", "..."], "MathFunctions::least<TYPE_TINYINT>"],
     [10281, "least", True, False, "SMALLINT", ["SMALLINT", "..."], "MathFunctions::least<TYPE_SMALLINT>"],
     [10282, "least", True, False, "INT", ["INT", "..."], "MathFunctions::least<TYPE_INT>"],
@@ -156,9 +157,9 @@ vectorized_functions = [
     [102870, "least", True, False, "DECIMAL32", ["DECIMAL32", "..."], "MathFunctions::least<TYPE_DECIMAL32>"],
     [102871, "least", True, False, "DECIMAL64", ["DECIMAL64", "..."], "MathFunctions::least<TYPE_DECIMAL64>"],
     [102872, "least", True, False, "DECIMAL128", ["DECIMAL128", "..."], "MathFunctions::least<TYPE_DECIMAL128>"],
-    [10288, "least", True, False, "DATETIME", ["DATETIME", "..."], "MathFunctions::least<TYPE_DATETIME>"],
     [10289, "least", True, False, "VARCHAR", ["VARCHAR", "..."], "MathFunctions::least<TYPE_VARCHAR>"],
 
+    [10298, "greatest", True, False, "DATETIME", ["DATETIME", "..."], "MathFunctions::greatest<TYPE_DATETIME>"],
     [10290, "greatest", True, False, "TINYINT", ["TINYINT", "..."], "MathFunctions::greatest<TYPE_TINYINT>"],
     [10291, "greatest", True, False, "SMALLINT", ["SMALLINT", "..."], "MathFunctions::greatest<TYPE_SMALLINT>"],
     [10292, "greatest", True, False, "INT", ["INT", "..."], "MathFunctions::greatest<TYPE_INT>"],
@@ -170,7 +171,6 @@ vectorized_functions = [
     [102970, "greatest", True, False, "DECIMAL32", ["DECIMAL32", "..."], "MathFunctions::greatest<TYPE_DECIMAL32>"],
     [102971, "greatest", True, False, "DECIMAL64", ["DECIMAL64", "..."], "MathFunctions::greatest<TYPE_DECIMAL64>"],
     [102972, "greatest", True, False, "DECIMAL128", ["DECIMAL128", "..."], "MathFunctions::greatest<TYPE_DECIMAL128>"],
-    [10298, "greatest", True, False, "DATETIME", ["DATETIME", "..."], "MathFunctions::greatest<TYPE_DATETIME>"],
     [10299, "greatest", True, False, "VARCHAR", ["VARCHAR", "..."], "MathFunctions::greatest<TYPE_VARCHAR>"],
 
     [10300, "rand", True, False, "DOUBLE", [], "MathFunctions::rand", "MathFunctions::rand_prepare",
@@ -745,6 +745,8 @@ vectorized_functions = [
     [70319, 'nullif', True, False, 'JSON', ['JSON', 'JSON'], 'nullptr'],
 
     [70400, 'coalesce', True, False, 'BOOLEAN', ['BOOLEAN', '...'], 'nullptr'],
+    [70409, 'coalesce', True, False, 'DATE', ['DATE', '...'], 'nullptr'],
+    [70408, 'coalesce', True, False, 'DATETIME', ['DATETIME', '...'], 'nullptr'],
     [70401, 'coalesce', True, False, 'TINYINT', ['TINYINT', '...'], 'nullptr'],
     [70402, 'coalesce', True, False, 'SMALLINT', ['SMALLINT', '...'], 'nullptr'],
     [70403, 'coalesce', True, False, 'INT', ['INT', '...'], 'nullptr'],
@@ -752,8 +754,6 @@ vectorized_functions = [
     [70405, 'coalesce', True, False, 'LARGEINT', ['LARGEINT', '...'], 'nullptr'],
     [70406, 'coalesce', True, False, 'FLOAT', ['FLOAT', '...'], 'nullptr'],
     [70407, 'coalesce', True, False, 'DOUBLE', ['DOUBLE', '...'], 'nullptr'],
-    [70408, 'coalesce', True, False, 'DATETIME', ['DATETIME', '...'], 'nullptr'],
-    [70409, 'coalesce', True, False, 'DATE', ['DATE', '...'], 'nullptr'],
     [70410, 'coalesce', True, False, 'DECIMALV2', ['DECIMALV2', '...'], 'nullptr'],
     [704100, 'coalesce', True, False, 'DECIMAL32', ['DECIMAL32', '...'], 'nullptr'],
     [704101, 'coalesce', True, False, 'DECIMAL64', ['DECIMAL64', '...'], 'nullptr'],

--- a/test/sql/test_function/R/test_greatest_least_coalesce_datetime
+++ b/test/sql/test_function/R/test_greatest_least_coalesce_datetime
@@ -1,0 +1,68 @@
+-- name: test_greatest_date_datetime_wrong_result @system
+-- result:
+2026-01-14
+-- !result
+select date(greatest(date('2026-01-14'), timestamp('2026-01-11 00:00:00')));
+-- result:
+2026-01-14
+-- !result
+-- name: test_greatest_date_datetime_returns_datetime @system
+-- result:
+2026-01-14 00:00:00
+-- !result
+select greatest(date('2026-01-11'), timestamp('2026-01-14 00:00:00'));
+-- result:
+datetime
+-- !result
+select typeof(greatest(date('2026-01-11'), timestamp('2026-01-14 00:00:00')));
+-- result:
+datetime
+-- !result
+-- name: test_least_date_datetime_returns_datetime @system
+-- result:
+2026-01-11 00:00:00
+-- !result
+select least(date('2026-01-14'), timestamp('2026-01-11 00:00:00'));
+-- result:
+datetime
+-- !result
+select typeof(least(date('2026-01-14'), timestamp('2026-01-11 00:00:00')));
+-- result:
+datetime
+-- !result
+-- name: test_coalesce_date_datetime_returns_datetime @system
+-- result:
+2026-01-11 00:00:00
+-- !result
+select coalesce(null, date('2026-01-11'), timestamp('2026-01-14 00:00:00'));
+-- result:
+datetime
+-- !result
+select typeof(coalesce(null, date('2026-01-11'), timestamp('2026-01-14 00:00:00')));
+-- result:
+datetime
+-- !result
+-- name: test_greatest_pure_dates_returns_datetime @system
+-- result:
+2026-01-14 00:00:00
+-- !result
+select greatest(date('2026-01-11'), date('2026-01-14'), date('2026-01-09'));
+-- result:
+datetime
+-- !result
+select typeof(greatest(date('2026-01-11'), date('2026-01-14'), date('2026-01-09')));
+-- result:
+datetime
+-- !result
+-- name: test_numeric_types_unchanged @system
+-- result:
+bigint
+-- !result
+select typeof(greatest(cast(100 as int), cast(200 as bigint)));
+-- result:
+int
+-- !result
+select typeof(greatest(20260114, 20260115));
+-- result:
+int
+-- !result

--- a/test/sql/test_function/R/test_greatest_least_coalesce_datetime
+++ b/test/sql/test_function/R/test_greatest_least_coalesce_datetime
@@ -1,66 +1,48 @@
--- name: test_greatest_date_datetime_wrong_result @system
--- result:
-2026-01-14
--- !result
+-- name: test_greatest_date_datetime_wrong_result
 select date(greatest(date('2026-01-14'), timestamp('2026-01-11 00:00:00')));
 -- result:
 2026-01-14
 -- !result
--- name: test_greatest_date_datetime_returns_datetime @system
--- result:
-2026-01-14 00:00:00
--- !result
+-- name: test_greatest_date_datetime_returns_datetime
 select greatest(date('2026-01-11'), timestamp('2026-01-14 00:00:00'));
 -- result:
-datetime
+2026-01-14 00:00:00
 -- !result
 select typeof(greatest(date('2026-01-11'), timestamp('2026-01-14 00:00:00')));
 -- result:
 datetime
 -- !result
--- name: test_least_date_datetime_returns_datetime @system
--- result:
-2026-01-11 00:00:00
--- !result
+-- name: test_least_date_datetime_returns_datetime
 select least(date('2026-01-14'), timestamp('2026-01-11 00:00:00'));
 -- result:
-datetime
+2026-01-11 00:00:00
 -- !result
 select typeof(least(date('2026-01-14'), timestamp('2026-01-11 00:00:00')));
 -- result:
 datetime
 -- !result
--- name: test_coalesce_date_datetime_returns_datetime @system
--- result:
-2026-01-11 00:00:00
--- !result
+-- name: test_coalesce_date_datetime_returns_datetime
 select coalesce(null, date('2026-01-11'), timestamp('2026-01-14 00:00:00'));
 -- result:
-datetime
+2026-01-11 00:00:00
 -- !result
 select typeof(coalesce(null, date('2026-01-11'), timestamp('2026-01-14 00:00:00')));
 -- result:
 datetime
 -- !result
--- name: test_greatest_pure_dates_returns_datetime @system
--- result:
-2026-01-14 00:00:00
--- !result
+-- name: test_greatest_pure_dates_returns_datetime
 select greatest(date('2026-01-11'), date('2026-01-14'), date('2026-01-09'));
 -- result:
-datetime
+2026-01-14 00:00:00
 -- !result
 select typeof(greatest(date('2026-01-11'), date('2026-01-14'), date('2026-01-09')));
 -- result:
 datetime
 -- !result
--- name: test_numeric_types_unchanged @system
--- result:
-bigint
--- !result
+-- name: test_numeric_types_unchanged
 select typeof(greatest(cast(100 as int), cast(200 as bigint)));
 -- result:
-int
+bigint
 -- !result
 select typeof(greatest(20260114, 20260115));
 -- result:

--- a/test/sql/test_function/T/test_greatest_least_coalesce_datetime
+++ b/test/sql/test_function/T/test_greatest_least_coalesce_datetime
@@ -1,0 +1,26 @@
+-- name: test_greatest_date_datetime_wrong_result @system
+-- The actual user-visible bug: wrapping result in date() returns wrong date
+select date(greatest(date('2026-01-14'), timestamp('2026-01-11 00:00:00')));
+
+-- name: test_greatest_date_datetime_returns_datetime @system
+-- Root cause: greatest(DATE, DATETIME) should return DATETIME, not BIGINT
+select greatest(date('2026-01-11'), timestamp('2026-01-14 00:00:00'));
+select typeof(greatest(date('2026-01-11'), timestamp('2026-01-14 00:00:00')));
+
+-- name: test_least_date_datetime_returns_datetime @system
+select least(date('2026-01-14'), timestamp('2026-01-11 00:00:00'));
+select typeof(least(date('2026-01-14'), timestamp('2026-01-11 00:00:00')));
+
+-- name: test_coalesce_date_datetime_returns_datetime @system
+select coalesce(null, date('2026-01-11'), timestamp('2026-01-14 00:00:00'));
+select typeof(coalesce(null, date('2026-01-11'), timestamp('2026-01-14 00:00:00')));
+
+-- name: test_greatest_pure_dates_returns_datetime @system
+-- greatest/least only have DATETIME signatures, so pure DATE inputs return DATETIME (not INT)
+select greatest(date('2026-01-11'), date('2026-01-14'), date('2026-01-09'));
+select typeof(greatest(date('2026-01-11'), date('2026-01-14'), date('2026-01-09')));
+
+-- name: test_numeric_types_unchanged @system
+-- Verify no regression: numeric types should still work correctly
+select typeof(greatest(cast(100 as int), cast(200 as bigint)));
+select typeof(greatest(20260114, 20260115));

--- a/test/sql/test_function/T/test_greatest_least_coalesce_datetime
+++ b/test/sql/test_function/T/test_greatest_least_coalesce_datetime
@@ -1,26 +1,26 @@
--- name: test_greatest_date_datetime_wrong_result @system
+-- name: test_greatest_date_datetime_wrong_result
 -- The actual user-visible bug: wrapping result in date() returns wrong date
 select date(greatest(date('2026-01-14'), timestamp('2026-01-11 00:00:00')));
 
--- name: test_greatest_date_datetime_returns_datetime @system
+-- name: test_greatest_date_datetime_returns_datetime
 -- Root cause: greatest(DATE, DATETIME) should return DATETIME, not BIGINT
 select greatest(date('2026-01-11'), timestamp('2026-01-14 00:00:00'));
 select typeof(greatest(date('2026-01-11'), timestamp('2026-01-14 00:00:00')));
 
--- name: test_least_date_datetime_returns_datetime @system
+-- name: test_least_date_datetime_returns_datetime
 select least(date('2026-01-14'), timestamp('2026-01-11 00:00:00'));
 select typeof(least(date('2026-01-14'), timestamp('2026-01-11 00:00:00')));
 
--- name: test_coalesce_date_datetime_returns_datetime @system
+-- name: test_coalesce_date_datetime_returns_datetime
 select coalesce(null, date('2026-01-11'), timestamp('2026-01-14 00:00:00'));
 select typeof(coalesce(null, date('2026-01-11'), timestamp('2026-01-14 00:00:00')));
 
--- name: test_greatest_pure_dates_returns_datetime @system
+-- name: test_greatest_pure_dates_returns_datetime
 -- greatest/least only have DATETIME signatures, so pure DATE inputs return DATETIME (not INT)
 select greatest(date('2026-01-11'), date('2026-01-14'), date('2026-01-09'));
 select typeof(greatest(date('2026-01-11'), date('2026-01-14'), date('2026-01-09')));
 
--- name: test_numeric_types_unchanged @system
+-- name: test_numeric_types_unchanged
 -- Verify no regression: numeric types should still work correctly
 select typeof(greatest(cast(100 as int), cast(200 as bigint)));
 select typeof(greatest(20260114, 20260115));


### PR DESCRIPTION
  ## Why I'm doing:

  Variadic functions (greatest, least, coalesce) return wrong dates when mixing DATE and DATETIME types.
 
 Root Cause:
Function resolution in `fe/fe-core/src/main/java/com/starrocks/catalog/Function.java` uses "first match wins" strategy.  The `getFunction()` method (lines 778-817) tries each signature in order and returns the first one where all arguments can implicitly cast to the signature's types via `IS_NONSTRICT_SUPERTYPE_OF` mode.

The Bug:
  Before this fix, BIGINT signatures were registered before DATETIME signatures:
  greatest(BIGINT, ...) <- tried first
  greatest(DATETIME, ...) <- never reached

  For variadic functions, `Function.java` lines 584-593 check if trailing arguments can cast to the vararg type using `TypeManager.isImplicitlyCastable()`. Since both DATE and DATETIME can cast to BIGINT (for internal storage), the BIGINT signature matched first, causing temporal values to be compared as numbers instead of dates.

  ## What I'm doing:

  Reorder signatures of variadic functions working with date/datetimes in `functions.py` to prioritize DATETIME before numeric types:
  greatest(DATETIME, ...) <- tried first, matches DATE+DATETIME 
  greatest(BIGINT, ...) <- only tried if DATETIME fails

  **Why No Regressions:**
  The type casting check in  `Function.java:561-597` prevents false positives:
  - DATE/DATETIME can cast to DATETIME (temporal semantics preserved)
  - INT/BIGINT cannot cast to DATETIME (pure numbers skip to numeric signatures)

  Closes #67946

  ## What type of PR is this:

  - [x] BugFix
  - [ ] Feature
  - [ ] Enhancement
  - [ ] Refactor
  - [ ] UT
  - [ ] Doc
  - [ ] Tool

  Does this PR entail a change in behavior?

  - [x] Yes, this PR will result in a change in behavior.
  - [ ] No, this PR will not result in a change in behavior.

  If yes, please specify the type of change:

  - [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
  - [ ] Parameter changes: default values, similar parameters but with different default values
  - [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
  - [ ] Feature removed
  - [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

  ## Checklist:

  - [x] I have added test cases for my bug fix or my new feature
  - [ ] This pr needs user documentation (for new or modified features or behaviors)
    - [ ] I have added documentation for my new feature or new function
    - [ ] This pr needs auto generate documentation
  - [ ] This is a backport pr

  ## Bugfix cherry-pick branch check:
  - [x] I have checked the version labels which the pr will be auto-backported to the target branch
    - [x] 4.1
    - [x] 4.0
    - [x] 3.5
    - [x] 3.4