### PR TITLE
[Enhancement] Add a cleaner for BrpcStubCache to cleanup unused connections (backport #61417)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -52,6 +52,9 @@ CONF_Int32(brpc_num_threads, "-1");
 // The max number of single connections maintained by the brpc client and each server.
 // Theses connections are created during the first few access and will be used thereafter
 CONF_Int32(brpc_max_connections_per_server, "1");
+// BRPC stub cache expire configurations
+// The expire time of BRPC stub cache, default 60 minutes.
+CONF_mInt32(brpc_stub_expire_s, "3600"); // 60 minutes
 
 // Declare a selection strategy for those servers have many ips.
 // Note that there should at most one ip match this list.

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -747,7 +747,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
 #endif
     _load_channel_mgr = new LoadChannelMgr();
     _load_stream_mgr = new LoadStreamMgr();
-    _brpc_stub_cache = new BrpcStubCache();
+    _brpc_stub_cache = new BrpcStubCache(this);
     _stream_load_executor = new StreamLoadExecutor(this);
     _stream_context_mgr = new StreamContextMgr();
     _transaction_mgr = new TransactionMgr(this);

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -110,6 +110,7 @@ set(UTIL_FILES
   hash_util.cpp
   debug_action.cpp
   internal_service_recoverable_stub.cpp
+  brpc_stub_cache.cpp
   byte_buffer.cpp
 )
 

--- a/be/src/util/brpc_stub_cache.cpp
+++ b/be/src/util/brpc_stub_cache.cpp
@@ -1,0 +1,208 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/brpc_stub_cache.h"
+
+#include "common/config.h"
+#include "gen_cpp/internal_service.pb.h"
+#include "gen_cpp/lake_service.pb.h"
+#include "runtime/exec_env.h"
+#include "util/failpoint/fail_point.h"
+#include "util/starrocks_metrics.h"
+
+namespace starrocks {
+
+BrpcStubCache::BrpcStubCache(ExecEnv* exec_env) : _pipeline_timer(exec_env->pipeline_timer()) {
+    _stub_map.init(239);
+    REGISTER_GAUGE_STARROCKS_METRIC(brpc_endpoint_stub_count, [this]() {
+        std::lock_guard<SpinLock> l(_lock);
+        return _stub_map.size();
+    });
+}
+
+BrpcStubCache::~BrpcStubCache() {
+    std::vector<std::shared_ptr<StubPool>> pools_to_cleanup;
+    {
+        std::lock_guard<SpinLock> l(_lock);
+
+        for (auto& stub : _stub_map) {
+            pools_to_cleanup.push_back(stub.second);
+        }
+    }
+
+    for (auto& pool : pools_to_cleanup) {
+        pool->_cleanup_task->unschedule(_pipeline_timer);
+    }
+
+    _stub_map.clear();
+}
+
+std::shared_ptr<PInternalService_RecoverableStub> BrpcStubCache::get_stub(const butil::EndPoint& endpoint) {
+    std::lock_guard<SpinLock> l(_lock);
+
+    auto stub_pool = _stub_map.seek(endpoint);
+    if (stub_pool == nullptr) {
+        auto new_pool = std::make_shared<StubPool>();
+        new_pool->_cleanup_task = new EndpointCleanupTask<BrpcStubCache>(this, endpoint);
+        _stub_map.insert(endpoint, new_pool);
+        stub_pool = _stub_map.seek(endpoint);
+    }
+
+    if (_pipeline_timer->unschedule((*stub_pool)->_cleanup_task) != TIMER_TASK_RUNNING) {
+        timespec tm = butil::seconds_from_now(config::brpc_stub_expire_s);
+        auto status = _pipeline_timer->schedule((*stub_pool)->_cleanup_task, tm);
+        if (!status.ok()) {
+            LOG(WARNING) << "Failed to schedule brpc cleanup task: " << endpoint;
+        }
+    }
+
+    return (*stub_pool)->get_or_create(endpoint);
+}
+
+std::shared_ptr<PInternalService_RecoverableStub> BrpcStubCache::get_stub(const TNetworkAddress& taddr) {
+    return get_stub(taddr.hostname, taddr.port);
+}
+
+std::shared_ptr<PInternalService_RecoverableStub> BrpcStubCache::get_stub(const std::string& host, int port) {
+    butil::EndPoint endpoint;
+    std::string realhost;
+    std::string brpc_url;
+    realhost = host;
+    if (!is_valid_ip(host)) {
+        Status status = hostname_to_ip(host, realhost);
+        if (!status.ok()) {
+            LOG(WARNING) << "failed to get ip from host:" << status.to_string();
+            return nullptr;
+        }
+    }
+    brpc_url = get_host_port(realhost, port);
+    if (str2endpoint(brpc_url.c_str(), &endpoint)) {
+        LOG(WARNING) << "unknown endpoint, host=" << host;
+        return nullptr;
+    }
+    return get_stub(endpoint);
+}
+
+void BrpcStubCache::cleanup_expired(const butil::EndPoint& endpoint) {
+    std::lock_guard<SpinLock> l(_lock);
+
+    LOG(INFO) << "cleanup brpc stub, endpoint:" << endpoint;
+    _stub_map.erase(endpoint);
+}
+
+BrpcStubCache::StubPool::StubPool() : _idx(-1) {
+    _stubs.reserve(config::brpc_max_connections_per_server);
+}
+
+BrpcStubCache::StubPool::~StubPool() {
+    _stubs.clear();
+    SAFE_DELETE(_cleanup_task);
+}
+
+std::shared_ptr<PInternalService_RecoverableStub> BrpcStubCache::StubPool::get_or_create(
+        const butil::EndPoint& endpoint) {
+    if (UNLIKELY(_stubs.size() < config::brpc_max_connections_per_server)) {
+        auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint, "");
+        if (!stub->reset_channel().ok()) {
+            return nullptr;
+        }
+        _stubs.push_back(stub);
+        return stub;
+    }
+    if (++_idx >= config::brpc_max_connections_per_server) {
+        _idx = 0;
+    }
+    return _stubs[_idx];
+}
+
+HttpBrpcStubCache* HttpBrpcStubCache::getInstance() {
+    static HttpBrpcStubCache cache;
+    return &cache;
+}
+
+HttpBrpcStubCache::HttpBrpcStubCache() {
+    _stub_map.init(500);
+    _pipeline_timer = ExecEnv::GetInstance()->pipeline_timer();
+}
+
+HttpBrpcStubCache::~HttpBrpcStubCache() {
+    std::vector<std::shared_ptr<EndpointCleanupTask<HttpBrpcStubCache>>> task_to_cleanup;
+
+    {
+        std::lock_guard<SpinLock> l(_lock);
+        for (auto& stub : _stub_map) {
+            task_to_cleanup.push_back(stub.second.second);
+        }
+    }
+
+    for (auto& task : task_to_cleanup) {
+        task->unschedule(_pipeline_timer);
+    }
+
+    _stub_map.clear();
+}
+
+StatusOr<std::shared_ptr<PInternalService_RecoverableStub>> HttpBrpcStubCache::get_http_stub(
+        const TNetworkAddress& taddr) {
+    butil::EndPoint endpoint;
+    std::string realhost;
+    std::string brpc_url;
+    realhost = taddr.hostname;
+    if (!is_valid_ip(taddr.hostname)) {
+        Status status = hostname_to_ip(taddr.hostname, realhost);
+        if (!status.ok()) {
+            LOG(WARNING) << "failed to get ip from host:" << status.to_string();
+            return nullptr;
+        }
+    }
+    brpc_url = get_host_port(realhost, taddr.port);
+    if (str2endpoint(brpc_url.c_str(), &endpoint)) {
+        return Status::RuntimeError("unknown endpoint, host = " + taddr.hostname);
+    }
+    // get is exist
+    std::lock_guard<SpinLock> l(_lock);
+
+    auto stub_pair_ptr = _stub_map.seek(endpoint);
+    if (stub_pair_ptr == nullptr) {
+        // create
+        auto new_task = std::make_shared<EndpointCleanupTask<HttpBrpcStubCache>>(this, endpoint);
+        auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint, "http");
+        if (!stub->reset_channel().ok()) {
+            return Status::RuntimeError("init http brpc channel error on " + taddr.hostname + ":" +
+                                        std::to_string(taddr.port));
+        }
+        _stub_map.insert(endpoint, std::make_pair(stub, new_task));
+        stub_pair_ptr = _stub_map.seek(endpoint);
+    }
+
+    // schedule clean up task
+    if (_pipeline_timer->unschedule((*stub_pair_ptr).second.get()) != TIMER_TASK_RUNNING) {
+        timespec tm = butil::seconds_from_now(config::brpc_stub_expire_s);
+        auto status = _pipeline_timer->schedule((*stub_pair_ptr).second.get(), tm);
+        if (!status.ok()) {
+            LOG(WARNING) << "Failed to schedule http brpc cleanup task: " << endpoint;
+        }
+    }
+
+    return (*stub_pair_ptr).first;
+}
+
+void HttpBrpcStubCache::cleanup_expired(const butil::EndPoint& endpoint) {
+    std::lock_guard<SpinLock> l(_lock);
+
+    LOG(INFO) << "cleanup http brpc stub, endpoint:" << endpoint;
+    _stub_map.erase(endpoint);
+}
+
+} // namespace starrocks

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -40,6 +40,7 @@
 
 #include "common/config.h"
 #include "common/statusor.h"
+#include "exec/pipeline/schedule/pipeline_timer.h"
 #include "gen_cpp/Types_types.h" // TNetworkAddress
 #include "gen_cpp/internal_service.pb.h"
 #include "service/brpc.h"
@@ -50,133 +51,64 @@
 
 namespace starrocks {
 
-// map used
+constexpr int TIMER_TASK_RUNNING = 1;
+
+class ExecEnv;
+
+template <typename StubCacheT>
+class EndpointCleanupTask : public starrocks::pipeline::PipelineTimerTask {
+public:
+    EndpointCleanupTask(StubCacheT* cache, const butil::EndPoint& endpoint) : _cache(cache), _endpoint(endpoint){};
+    void Run() override { _cache->cleanup_expired(_endpoint); }
+
+private:
+    StubCacheT* _cache;
+    butil::EndPoint _endpoint;
+};
 class BrpcStubCache {
 public:
-    BrpcStubCache() {
-        _stub_map.init(239);
-        REGISTER_GAUGE_STARROCKS_METRIC(brpc_endpoint_stub_count, [this]() {
-            std::lock_guard<SpinLock> l(_lock);
-            return _stub_map.size();
-        });
-    }
-    ~BrpcStubCache() {
-        for (auto& stub : _stub_map) {
-            delete stub.second;
-        }
-    }
+    BrpcStubCache(ExecEnv* exec_env);
+    ~BrpcStubCache();
 
-    std::shared_ptr<PInternalService_RecoverableStub> get_stub(const butil::EndPoint& endpoint) {
-        std::lock_guard<SpinLock> l(_lock);
-        auto stub_pool = _stub_map.seek(endpoint);
-        if (stub_pool == nullptr) {
-            StubPool* pool = new StubPool();
-            _stub_map.insert(endpoint, pool);
-            return pool->get_or_create(endpoint);
-        }
-        return (*stub_pool)->get_or_create(endpoint);
-    }
-
-    std::shared_ptr<PInternalService_RecoverableStub> get_stub(const TNetworkAddress& taddr) {
-        return get_stub(taddr.hostname, taddr.port);
-    }
-
-    std::shared_ptr<PInternalService_RecoverableStub> get_stub(const std::string& host, int port) {
-        butil::EndPoint endpoint;
-        std::string realhost;
-        std::string brpc_url;
-        realhost = host;
-        if (!is_valid_ip(host)) {
-            Status status = hostname_to_ip(host, realhost);
-            if (!status.ok()) {
-                LOG(WARNING) << "failed to get ip from host:" << status.to_string();
-                return nullptr;
-            }
-        }
-        brpc_url = get_host_port(realhost, port);
-        if (str2endpoint(brpc_url.c_str(), &endpoint)) {
-            LOG(WARNING) << "unknown endpoint, host=" << host;
-            return nullptr;
-        }
-        return get_stub(endpoint);
-    }
+    std::shared_ptr<PInternalService_RecoverableStub> get_stub(const butil::EndPoint& endpoint);
+    std::shared_ptr<PInternalService_RecoverableStub> get_stub(const TNetworkAddress& taddr);
+    std::shared_ptr<PInternalService_RecoverableStub> get_stub(const std::string& host, int port);
+    void cleanup_expired(const butil::EndPoint& endpoint);
 
 private:
     // StubPool is used to store all stubs with a single endpoint, and the client in the same BE process maintains up to
     // brpc_max_connections_per_server single connections with each server.
     // These connections will be created during the first few accesses and will be reused later.
     struct StubPool {
-        StubPool() { _stubs.reserve(config::brpc_max_connections_per_server); }
-
-        std::shared_ptr<PInternalService_RecoverableStub> get_or_create(const butil::EndPoint& endpoint) {
-            if (UNLIKELY(_stubs.size() < config::brpc_max_connections_per_server)) {
-                auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint, "");
-                if (!stub->reset_channel().ok()) {
-                    return nullptr;
-                }
-                _stubs.push_back(stub);
-                return stub;
-            }
-            if (++_idx >= config::brpc_max_connections_per_server) {
-                _idx = 0;
-            }
-            return _stubs[_idx];
-        }
+        StubPool();
+        ~StubPool();
+        std::shared_ptr<PInternalService_RecoverableStub> get_or_create(const butil::EndPoint& endpoint);
 
         std::vector<std::shared_ptr<PInternalService_RecoverableStub>> _stubs;
+        EndpointCleanupTask<BrpcStubCache>* _cleanup_task = nullptr;
         int64_t _idx = -1;
     };
 
     SpinLock _lock;
-    butil::FlatMap<butil::EndPoint, StubPool*> _stub_map;
+    butil::FlatMap<butil::EndPoint, std::shared_ptr<StubPool>> _stub_map;
+    pipeline::PipelineTimer* _pipeline_timer;
 };
 
 class HttpBrpcStubCache {
 public:
-    static HttpBrpcStubCache* getInstance() {
-        static HttpBrpcStubCache cache;
-        return &cache;
-    }
-
-    StatusOr<std::shared_ptr<PInternalService_RecoverableStub>> get_http_stub(const TNetworkAddress& taddr) {
-        butil::EndPoint endpoint;
-        std::string realhost;
-        std::string brpc_url;
-        realhost = taddr.hostname;
-        if (!is_valid_ip(taddr.hostname)) {
-            Status status = hostname_to_ip(taddr.hostname, realhost);
-            if (!status.ok()) {
-                LOG(WARNING) << "failed to get ip from host:" << status.to_string();
-                return nullptr;
-            }
-        }
-        brpc_url = get_host_port(realhost, taddr.port);
-        if (str2endpoint(brpc_url.c_str(), &endpoint)) {
-            return Status::RuntimeError("unknown endpoint, host = " + taddr.hostname);
-        }
-        // get is exist
-        std::lock_guard<SpinLock> l(_lock);
-        auto stub_ptr = _stub_map.seek(endpoint);
-        if (stub_ptr != nullptr) {
-            return *stub_ptr;
-        }
-        // create
-        auto stub = std::make_shared<PInternalService_RecoverableStub>(endpoint, "http");
-        if (!stub->reset_channel().ok()) {
-            return Status::RuntimeError("init brpc http channel error on " + taddr.hostname + ":" +
-                                        std::to_string(taddr.port));
-        }
-        _stub_map.insert(endpoint, stub);
-        return stub;
-    }
+    static HttpBrpcStubCache* getInstance();
+    StatusOr<std::shared_ptr<PInternalService_RecoverableStub>> get_http_stub(const TNetworkAddress& taddr);
 
 private:
-    HttpBrpcStubCache() { _stub_map.init(500); }
-    HttpBrpcStubCache(const HttpBrpcStubCache& cache) = delete;
-    HttpBrpcStubCache& operator=(const HttpBrpcStubCache& cache) = delete;
+    HttpBrpcStubCache();
+    HttpBrpcStubCache(const HttpBrpcStubCache&) = delete;
+    HttpBrpcStubCache& operator=(const HttpBrpcStubCache&) = delete;
 
     SpinLock _lock;
-    butil::FlatMap<butil::EndPoint, std::shared_ptr<PInternalService_RecoverableStub>> _stub_map;
+    butil::FlatMap<butil::EndPoint, std::pair<std::shared_ptr<PInternalService_RecoverableStub>,
+                                              std::shared_ptr<EndpointCleanupTask<HttpBrpcStubCache>>>>
+            _stub_map;
+    pipeline::PipelineTimer* _pipeline_timer;
 };
 
 } // namespace starrocks

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -98,11 +98,13 @@ class HttpBrpcStubCache {
 public:
     static HttpBrpcStubCache* getInstance();
     StatusOr<std::shared_ptr<PInternalService_RecoverableStub>> get_http_stub(const TNetworkAddress& taddr);
+    void cleanup_expired(const butil::EndPoint& endpoint);
 
 private:
     HttpBrpcStubCache();
     HttpBrpcStubCache(const HttpBrpcStubCache&) = delete;
     HttpBrpcStubCache& operator=(const HttpBrpcStubCache&) = delete;
+    ~HttpBrpcStubCache();
 
     SpinLock _lock;
     butil::FlatMap<butil::EndPoint, std::pair<std::shared_ptr<PInternalService_RecoverableStub>,

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -91,7 +91,7 @@ public:
         config::streaming_load_max_mb = 1;
 
         _env._load_stream_mgr = new LoadStreamMgr();
-        _env._brpc_stub_cache = new BrpcStubCache();
+        _env._brpc_stub_cache = new BrpcStubCache(&_env);
         _env._stream_load_executor = new StreamLoadExecutor(&_env);
 
         _evhttp_req = evhttp_request_new(nullptr, nullptr);

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -68,7 +68,7 @@ public:
         config::streaming_load_max_mb = 1;
 
         _env._load_stream_mgr = new LoadStreamMgr();
-        _env._brpc_stub_cache = new BrpcStubCache();
+        _env._brpc_stub_cache = new BrpcStubCache(&_env);
         _env._stream_load_executor = new StreamLoadExecutor(&_env);
         _env._stream_context_mgr = new StreamContextMgr();
         _env._transaction_mgr = new TransactionMgr(&_env);

--- a/be/test/util/brpc_stub_cache_test.cpp
+++ b/be/test/util/brpc_stub_cache_test.cpp
@@ -18,6 +18,10 @@
 #include "util/brpc_stub_cache.h"
 
 #include <gtest/gtest.h>
+#include <testutil/assert.h>
+
+#include "runtime/exec_env.h"
+#include "util/failpoint/fail_point.h"
 
 namespace starrocks {
 
@@ -25,10 +29,22 @@ class BrpcStubCacheTest : public testing::Test {
 public:
     BrpcStubCacheTest() = default;
     ~BrpcStubCacheTest() override = default;
+    void SetUp() override {
+        _env._pipeline_timer = new pipeline::PipelineTimer();
+        ASSERT_OK(_env._pipeline_timer->start());
+    }
+    void TearDown() override {
+        delete _env._pipeline_timer;
+        _env._pipeline_timer = nullptr;
+        config::brpc_stub_expire_s = 3600;
+    }
+
+private:
+    ExecEnv _env;
 };
 
 TEST_F(BrpcStubCacheTest, normal) {
-    BrpcStubCache cache;
+    BrpcStubCache cache(&_env);
     TNetworkAddress address;
     address.hostname = "127.0.0.1";
     address.port = 123;
@@ -44,7 +60,7 @@ TEST_F(BrpcStubCacheTest, normal) {
 }
 
 TEST_F(BrpcStubCacheTest, invalid) {
-    BrpcStubCache cache;
+    BrpcStubCache cache(&_env);
     TNetworkAddress address;
     address.hostname = "invalid.cm.invalid";
     address.port = 123;
@@ -53,7 +69,7 @@ TEST_F(BrpcStubCacheTest, invalid) {
 }
 
 TEST_F(BrpcStubCacheTest, reset) {
-    BrpcStubCache cache;
+    BrpcStubCache cache(&_env);
     TNetworkAddress address;
     address.hostname = "127.0.0.1";
     address.port = 123;
@@ -65,6 +81,94 @@ TEST_F(BrpcStubCacheTest, reset) {
     auto istub2 = stub1->stub();
 
     ASSERT_NE(istub1, istub2);
+}
+
+TEST_F(BrpcStubCacheTest, lake_service_stub_normal) {
+    LakeServiceBrpcStubCache cache;
+    TNetworkAddress address;
+    std::string hostname = "127.0.0.1";
+    int32_t port1 = 123;
+    auto stub1 = cache.get_stub(hostname, port1);
+    ASSERT_TRUE(stub1.ok());
+    int32_t port2 = 124;
+    auto stub2 = cache.get_stub(hostname, port2);
+    ASSERT_TRUE(stub2.ok());
+    ASSERT_NE(*stub1, *stub2);
+    auto stub3 = cache.get_stub(hostname, port1);
+    ASSERT_TRUE(stub3.ok());
+    ASSERT_EQ(*stub1, *stub3);
+    auto stub4 = cache.get_stub("invalid.cm.invalid", 123);
+    ASSERT_FALSE(stub4.ok());
+}
+
+TEST_F(BrpcStubCacheTest, test_http_stub) {
+    HttpBrpcStubCache cache;
+    TNetworkAddress address;
+    address.hostname = "127.0.0.1";
+    address.port = 123;
+    auto stub1 = cache.get_http_stub(address);
+    ASSERT_NE(nullptr, *stub1);
+    address.port = 124;
+    auto stub2 = cache.get_http_stub(address);
+    ASSERT_NE(nullptr, *stub2);
+    ASSERT_NE(*stub1, *stub2);
+    address.port = 123;
+    auto stub3 = cache.get_http_stub(address);
+    ASSERT_NE(nullptr, *stub3);
+    ASSERT_EQ(*stub1, *stub3);
+
+    address.hostname = "invalid.cm.invalid";
+    auto stub4 = cache.get_http_stub(address);
+    ASSERT_EQ(nullptr, *stub4);
+}
+
+TEST_F(BrpcStubCacheTest, test_cleanup) {
+    config::brpc_stub_expire_s = 1;
+    BrpcStubCache cache(&_env);
+    TNetworkAddress address;
+    address.hostname = "127.0.0.1";
+    address.port = 123;
+    auto stub1 = cache.get_stub(address);
+    ASSERT_NE(nullptr, stub1);
+    auto stub2 = cache.get_stub(address);
+    ASSERT_EQ(stub2, stub1);
+
+    sleep(2);
+    auto stub3 = cache.get_stub(address);
+    ASSERT_NE(stub3, stub1);
+}
+
+TEST_F(BrpcStubCacheTest, test_lake_cleanup) {
+    config::brpc_stub_expire_s = 1;
+    LakeServiceBrpcStubCache cache;
+    std::string hostname = "127.0.0.1";
+    int32_t port = 123;
+    auto stub1 = cache.get_stub(hostname, port);
+    ASSERT_TRUE(stub1.ok());
+    ASSERT_NE(nullptr, *stub1);
+    auto stub2 = cache.get_stub(hostname, port);
+    ASSERT_TRUE(stub1.ok());
+    ASSERT_EQ(*stub2, *stub1);
+
+    sleep(2);
+    auto stub3 = cache.get_stub(hostname, port);
+    ASSERT_NE(*stub3, *stub1);
+}
+
+TEST_F(BrpcStubCacheTest, test_http_cleanup) {
+    config::brpc_stub_expire_s = 1;
+    HttpBrpcStubCache cache;
+    TNetworkAddress address;
+    address.hostname = "127.0.0.1";
+    address.port = 123;
+    auto stub1 = cache.get_http_stub(address);
+    ASSERT_NE(nullptr, *stub1);
+    auto stub2 = cache.get_http_stub(address);
+    ASSERT_EQ(*stub2, *stub1);
+
+    sleep(2);
+    auto stub3 = cache.get_http_stub(address);
+    ASSERT_NE(*stub3, *stub1);
 }
 
 } // namespace starrocks

--- a/be/test/util/brpc_stub_cache_test.cpp
+++ b/be/test/util/brpc_stub_cache_test.cpp
@@ -83,24 +83,6 @@ TEST_F(BrpcStubCacheTest, reset) {
     ASSERT_NE(istub1, istub2);
 }
 
-TEST_F(BrpcStubCacheTest, lake_service_stub_normal) {
-    LakeServiceBrpcStubCache cache;
-    TNetworkAddress address;
-    std::string hostname = "127.0.0.1";
-    int32_t port1 = 123;
-    auto stub1 = cache.get_stub(hostname, port1);
-    ASSERT_TRUE(stub1.ok());
-    int32_t port2 = 124;
-    auto stub2 = cache.get_stub(hostname, port2);
-    ASSERT_TRUE(stub2.ok());
-    ASSERT_NE(*stub1, *stub2);
-    auto stub3 = cache.get_stub(hostname, port1);
-    ASSERT_TRUE(stub3.ok());
-    ASSERT_EQ(*stub1, *stub3);
-    auto stub4 = cache.get_stub("invalid.cm.invalid", 123);
-    ASSERT_FALSE(stub4.ok());
-}
-
 TEST_F(BrpcStubCacheTest, test_http_stub) {
     HttpBrpcStubCache cache;
     TNetworkAddress address;
@@ -136,23 +118,6 @@ TEST_F(BrpcStubCacheTest, test_cleanup) {
     sleep(2);
     auto stub3 = cache.get_stub(address);
     ASSERT_NE(stub3, stub1);
-}
-
-TEST_F(BrpcStubCacheTest, test_lake_cleanup) {
-    config::brpc_stub_expire_s = 1;
-    LakeServiceBrpcStubCache cache;
-    std::string hostname = "127.0.0.1";
-    int32_t port = 123;
-    auto stub1 = cache.get_stub(hostname, port);
-    ASSERT_TRUE(stub1.ok());
-    ASSERT_NE(nullptr, *stub1);
-    auto stub2 = cache.get_stub(hostname, port);
-    ASSERT_TRUE(stub1.ok());
-    ASSERT_EQ(*stub2, *stub1);
-
-    sleep(2);
-    auto stub3 = cache.get_stub(hostname, port);
-    ASSERT_NE(*stub3, *stub1);
 }
 
 TEST_F(BrpcStubCacheTest, test_http_cleanup) {

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -256,6 +256,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Description: The maximum body size of a bRPC.
 - Introduced in: -
 
+##### brpc_stub_expire_s
+
+- Default: 3600
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: The expire time of BRPC stub cache, default 60 minutes.
+- Introduced in: -
+
 <!--
 ##### brpc_socket_max_unwritten_bytes
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4