### PR TITLE
[Enhancement] Ignore information schema for warehouse idle check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -377,12 +377,14 @@ public abstract class AlterJobV2 implements Writable {
     }
 
     private void finishHook() {
-        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId);
+        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId,
+                "AlterJob: jobId[" + jobId + "], jobType[" + type + "]");
     }
 
     protected void cancelHook(boolean cancelled) {
         if (cancelled) {
-            WarehouseIdleChecker.updateJobLastFinishTime(warehouseId);
+            WarehouseIdleChecker.updateJobLastFinishTime(warehouseId,
+                    "AlterJob: jobId[" + jobId + "], jobType[" + type + "]");
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -801,7 +801,7 @@ public class BackupJob extends AbstractJob {
 
         MetricRepo.COUNTER_UNFINISHED_BACKUP_JOB.increase(-1L);
         WarehouseIdleChecker.updateJobLastFinishTime(WarehouseManager.DEFAULT_WAREHOUSE_ID,
-                "BackupJob: jobId[" + jobInfo + "]" + " label[" + label + "]");
+                "BackupJob: jobId[" + jobId + "]" + " label[" + label + "]");
     }
 
     private boolean uploadFile(String localFilePath, String remoteFilePath) {
@@ -890,7 +890,7 @@ public class BackupJob extends AbstractJob {
         // log
         globalStateMgr.getEditLog().logBackupJob(this);
         WarehouseIdleChecker.updateJobLastFinishTime(WarehouseManager.DEFAULT_WAREHOUSE_ID,
-                "BackupJob: jobId[" + jobInfo + "]" + " label[" + label + "]");
+                "BackupJob: jobId[" + jobId + "]" + " label[" + label + "]");
         LOG.info("finished to cancel backup job. current state: {}. {}", curState.name(), this);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -800,7 +800,8 @@ public class BackupJob extends AbstractJob {
         LOG.info("job is finished. {}", this);
 
         MetricRepo.COUNTER_UNFINISHED_BACKUP_JOB.increase(-1L);
-        WarehouseIdleChecker.updateJobLastFinishTime(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        WarehouseIdleChecker.updateJobLastFinishTime(WarehouseManager.DEFAULT_WAREHOUSE_ID,
+                "BackupJob: jobId[" + jobInfo + "]" + " label[" + label + "]");
     }
 
     private boolean uploadFile(String localFilePath, String remoteFilePath) {
@@ -888,7 +889,8 @@ public class BackupJob extends AbstractJob {
 
         // log
         globalStateMgr.getEditLog().logBackupJob(this);
-        WarehouseIdleChecker.updateJobLastFinishTime(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        WarehouseIdleChecker.updateJobLastFinishTime(WarehouseManager.DEFAULT_WAREHOUSE_ID,
+                "BackupJob: jobId[" + jobInfo + "]" + " label[" + label + "]");
         LOG.info("finished to cancel backup job. current state: {}. {}", curState.name(), this);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1804,7 +1804,8 @@ public class RestoreJob extends AbstractJob {
                 status = st;
             }
             MetricRepo.COUNTER_UNFINISHED_RESTORE_JOB.increase(-1L);
-            WarehouseIdleChecker.updateJobLastFinishTime(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+            WarehouseIdleChecker.updateJobLastFinishTime(WarehouseManager.DEFAULT_WAREHOUSE_ID,
+                    "RestoreJob: jobId[" + jobId + "] label[" + label + "]");
             return;
         }
         LOG.info("waiting {} tablets to commit. {}", unfinishedSignatureToId.size(), this);
@@ -2163,7 +2164,8 @@ public class RestoreJob extends AbstractJob {
             return;
         }
 
-        WarehouseIdleChecker.updateJobLastFinishTime(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        WarehouseIdleChecker.updateJobLastFinishTime(WarehouseManager.DEFAULT_WAREHOUSE_ID,
+                "RestoreJob: jobId[" + jobId + "] label[" + label + "]");
         LOG.info("finished to cancel restore job. is replay: {}. {}", isReplay, this);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/SqlUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/SqlUtils.java
@@ -18,6 +18,7 @@
 package com.starrocks.common.util;
 
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.TableName;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.SetNamesVar;
@@ -25,9 +26,11 @@ import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.SetTransaction;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SystemVariable;
+import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.InformationFunction;
 import com.starrocks.sql.ast.expression.VariableExpr;
+import com.starrocks.statistic.StatsConstants;
 import org.apache.commons.lang3.StringUtils;
 
 public class SqlUtils {
@@ -96,6 +99,23 @@ public class SqlUtils {
                             || item instanceof SystemVariable));
         }
 
+        return false;
+    }
+
+    /**
+     * Return true if the SQL queries any table under information_schema.
+     */
+    public static boolean isInformationQuery(StatementBase parsedStmt) {
+        if (parsedStmt instanceof QueryStatement queryStatement) {
+            if (queryStatement.getQueryRelation() != null &&
+                    queryStatement.getQueryRelation() instanceof SelectRelation selectRelation) {
+                if (selectRelation.getRelation() instanceof TableRelation tableRelation) {
+                    TableName tableName = tableRelation.getName();
+                    return tableName != null
+                            && StatsConstants.INFORMATION_SCHEMA.equalsIgnoreCase(tableName.getDb());
+                }
+            }
+        }
         return false;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -365,7 +365,8 @@ public class BrokerLoadJob extends BulkLoadJob {
                         .add("state", state)
                         .add("error_msg", "this task will be ignored when job is: " + state)
                         .build());
-                WarehouseIdleChecker.updateJobLastFinishTime(warehouseId, System.currentTimeMillis());
+                WarehouseIdleChecker.updateJobLastFinishTime(warehouseId,
+                        "BrokerLoad: jobId[" + id + "] label[" + label + "]");
                 return;
             }
 
@@ -398,7 +399,7 @@ public class BrokerLoadJob extends BulkLoadJob {
     @Override
     public void afterVisible(TransactionState txnState, boolean txnOperated) {
         super.afterVisible(txnState, txnOperated);
-        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId);
+        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId, "BrokerLoad: jobId[" + id + "] label[" + label + "]");
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -857,13 +857,13 @@ public class SparkLoadJob extends BulkLoadJob {
             }
         });
         clearJob();
-        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId);
+        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId, "SparkLoad: id[" + id + "] label[" + label + "]");
     }
 
     @Override
     public void afterAborted(TransactionState txnState, boolean txnOperated, String txnStatusChangeReason) {
         super.afterAborted(txnState, txnOperated, txnStatusChangeReason);
-        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId);
+        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId, "SparkLoad: id[" + id + "] label[" + label + "]");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -1484,7 +1484,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         state = JobState.STOPPED;
         clearTasks();
         endTimestamp = System.currentTimeMillis();
-        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId);
+        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId, "RoutineLoad: name: " + name);
     }
 
     private void executeCancel(ErrorReason reason) {
@@ -1492,7 +1492,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         state = JobState.CANCELLED;
         clearTasks();
         endTimestamp = System.currentTimeMillis();
-        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId);
+        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId, "RoutineLoad: name: " + name);
     }
 
     private void clearTasks() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1320,7 +1320,7 @@ public class StreamLoadTask extends AbstractStreamLoadTask {
             // sync stream load related query info should unregister here
             QeProcessorImpl.INSTANCE.unregisterQuery(loadId);
         }
-        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId);
+        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId, "StreamLoad: label[" + label + "]");
     }
 
     @Override
@@ -1358,7 +1358,7 @@ public class StreamLoadTask extends AbstractStreamLoadTask {
         } finally {
             writeUnlock();
         }
-        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId);
+        WarehouseIdleChecker.updateJobLastFinishTime(warehouseId, "StreamLoad: label[" + label + "]");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1057,7 +1057,8 @@ public class StmtExecutor {
             }
 
             if (shouldMarkIdleCheck && originWarehouseId != null) {
-                WarehouseIdleChecker.decreaseRunningSQL(originWarehouseId, originStmt.originStmt);
+                WarehouseIdleChecker.decreaseRunningSQL(originWarehouseId,
+                        originStmt == null ? "" : originStmt.originStmt);
             }
 
             recordExecStatsIntoContext();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1057,7 +1057,7 @@ public class StmtExecutor {
             }
 
             if (shouldMarkIdleCheck && originWarehouseId != null) {
-                WarehouseIdleChecker.decreaseRunningSQL(originWarehouseId);
+                WarehouseIdleChecker.decreaseRunningSQL(originWarehouseId, originStmt.originStmt);
             }
 
             recordExecStatsIntoContext();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -3484,13 +3484,17 @@ public class StmtExecutor {
 
     protected boolean shouldMarkIdleCheck(StatementBase parsedStmt) {
         boolean isPreQuerySQL = false;
+        boolean isInformationQuery = false;
         try {
             isPreQuerySQL = SqlUtils.isPreQuerySQL(parsedStmt);
+            isInformationQuery = StatsConstants.INFORMATION_SCHEMA.equalsIgnoreCase(context.currentDb)
+                    || SqlUtils.isInformationQuery(parsedStmt);
         } catch (Exception e) {
             LOG.warn("check isPreQuerySQL failed", e);
         }
         return !isInternalStmt
                 && !isPreQuerySQL
+                && !isInformationQuery
                 && !(parsedStmt instanceof ShowStmt)
                 && !(parsedStmt instanceof AdminSetConfigStmt);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
@@ -74,7 +74,8 @@ public class TaskRunExecutor {
                 // NOTE: Ensure this thread local is removed after this method to avoid memory leak in JVM.
                 ConnectContext.remove();
                 status.setFinishTime(System.currentTimeMillis());
-                WarehouseIdleChecker.updateJobLastFinishTime(taskRun.getRunCtx().getCurrentWarehouseId());
+                WarehouseIdleChecker.updateJobLastFinishTime(taskRun.getRunCtx().getCurrentWarehouseId(),
+                        "TaskRun: name[" + status.getTaskName() + "]");
             }
             return status.getState();
         }, taskRunPool);

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/IdleStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/IdleStatus.java
@@ -60,6 +60,8 @@ public class IdleStatus {
         Long runningTaskCnt;
         @SerializedName("lastFinishedJobTime")
         Long lastFinishedJobTime;
+        @SerializedName("lastFinishedJobInfo")
+        String lastFinishedJobInfo;
 
         public WarehouseStatus(long id, String name, boolean isIdle, long idleTime) {
             this.id = id;

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/WarehouseIdleChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/WarehouseIdleChecker.java
@@ -108,7 +108,7 @@ public class WarehouseIdleChecker extends FrontendDaemon {
     public static void decreaseRunningSQL(long wId, String sql) {
         AtomicLong runningSQL = getRunningSQLCount(wId);
         runningSQL.decrementAndGet();
-        String smallSql = sql != null ? sql.substring(0, Math.min(10, sql.length())) : "";
+        String smallSql = sql.substring(0, Math.min(20, sql.length()));
         updateJobLastFinishTime(wId, "Query: " + smallSql);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/WarehouseIdleChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/WarehouseIdleChecker.java
@@ -113,6 +113,9 @@ public class WarehouseIdleChecker extends FrontendDaemon {
     }
 
     public static void updateJobLastFinishTime(long wId, String info) {
+        if (GlobalStateMgr.isCheckpointThread()) {
+            return;
+        }
         LAST_FINISHED_JOB_TIME.put(wId, System.currentTimeMillis());
         LAST_FINISHED_JOB_INFO.put(wId, info);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SqlUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SqlUtilsTest.java
@@ -54,4 +54,15 @@ public class SqlUtilsTest {
         Assertions.assertTrue(SqlUtils.isPreQuerySQL(
                 SqlParser.parseSingleStatement("select session_id()", SqlModeHelper.MODE_DEFAULT)));
     }
+
+    @Test
+    public void testIsInformationQuery() {
+        Assertions.assertTrue(SqlUtils.isInformationQuery(
+                SqlParser.parseSingleStatement("select * from information_schema.tables",
+                        SqlModeHelper.MODE_DEFAULT)));
+
+        Assertions.assertFalse(SqlUtils.isInformationQuery(
+                SqlParser.parseSingleStatement("select * from test_db.test_tbl",
+                        SqlModeHelper.MODE_DEFAULT)));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorSimpleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorSimpleTest.java
@@ -1020,7 +1020,8 @@ public class ShowExecutorSimpleTest {
 
     @Test
     public void testShouldMarkIdleCheck() {
-        StmtExecutor stmtExecutor = new StmtExecutor(new ConnectContext(),
+        ConnectContext connectContext = new ConnectContext();
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext,
                 SqlParser.parseSingleStatement("select @@query_timeout", SqlModeHelper.MODE_DEFAULT));
 
         Assertions.assertFalse(stmtExecutor.shouldMarkIdleCheck(
@@ -1041,5 +1042,17 @@ public class ShowExecutorSimpleTest {
         Assertions.assertFalse(stmtExecutor.shouldMarkIdleCheck(
                 SqlParser.parseSingleStatement("admin set frontend config('proc_profile_cpu_enable' = 'true')",
                         SqlModeHelper.MODE_DEFAULT)));
+
+        Assertions.assertFalse(stmtExecutor.shouldMarkIdleCheck(
+                SqlParser.parseSingleStatement("select * from information_schema.tables",
+                        SqlModeHelper.MODE_DEFAULT)));
+
+        connectContext.setDatabase("information_schema");
+        Assertions.assertFalse(stmtExecutor.shouldMarkIdleCheck(
+                SqlParser.parseSingleStatement("select * from tables", SqlModeHelper.MODE_DEFAULT)));
+
+        connectContext.setDatabase("test");
+        Assertions.assertTrue(stmtExecutor.shouldMarkIdleCheck(
+                SqlParser.parseSingleStatement("select * from tables", SqlModeHelper.MODE_DEFAULT)));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances warehouse idle detection and observability.
> 
> - Excludes `information_schema` queries from idle accounting via `SqlUtils.isInformationQuery` and `StmtExecutor.shouldMarkIdleCheck`
> - Extends `WarehouseIdleChecker` API: `decreaseRunningSQL(wId, sql)`, `updateJobLastFinishTime(wId, info)`; tracks `LAST_FINISHED_JOB_TIME` and `LAST_FINISHED_JOB_INFO` (skips checkpoint thread)
> - Surfaces `lastFinishedJobInfo` in idle status response (`IdleStatus.WarehouseStatus`)
> - Adds contextual info to all update call sites (Alter/Backup/Restore/Load/StreamLoad/RoutineLoad/TaskRun) and includes short SQL preview for queries
> - Adds unit tests for information schema detection and idle check behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ce668579466a7871461ccc506c6b45bcea7818f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->