### PR TITLE
[BugFix] Fix low cardinality with data distribution bug.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -618,8 +618,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         }
 
         // Didn't find PhysicalDistributionOperator in the single-child path
-        // This should not happen for shuffle join
-        throw new IllegalStateException("PhysicalDistributionOperator not found in shuffle join child tree");
+        // Although it's logically a shuffle join, there's no actual data redistribution in the physical plan
+        // (e.g., single BE node scenario), so data distribution won't be changed
+        return false;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -586,76 +586,22 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         root.getUsedColumns().getStream().forEach(disableRewriteStringColumns::union);
     }
 
-    /**
-     * Check if the first PhysicalDistributionOperator in the child tree will change data distribution
-     * due to low-cardinality optimization.
-     *
-     * @param child the child OptExpression to check
-     * @param onColumns the join ON condition columns
-     * @return true if data distribution will be changed, false otherwise
-     */
-    private boolean checkDistributionWillBeChanged(OptExpression child, ColumnRefSet onColumns) {
-        // Find the first PhysicalDistributionOperator by traversing from parent to child
-        // For shuffle join, there must be a PhysicalDistributionOperator in the child tree
-        OptExpression current = child;
-        while (current.arity() == 1) {
-            Operator op = current.getOp();
-
-            // Found the first PhysicalDistributionOperator
-            if (op.getOpType() == OperatorType.PHYSICAL_DISTRIBUTION) {
-                DecodeInfo distDecodeInfo = allOperatorDecodeInfo.get(op);
-                if (distDecodeInfo == null) {
-                    return false;
-                }
-
-                // Check if outputStringColumns contains any join ON columns
-                // If yes, it means the distribution will use dictionary columns, which changes data distribution
-                return distDecodeInfo.outputStringColumns.containsAny(onColumns);
-            }
-
-            // Continue to traverse to the first child
-            current = current.inputAt(0);
-        }
-
-        // Didn't find PhysicalDistributionOperator in the single-child path
-        // Although it's logically a shuffle join, there's no actual data redistribution in the physical plan
-        // (e.g., single BE node scenario), so data distribution won't be changed
-        return false;
-    }
-
     @Override
     public DecodeInfo visitPhysicalJoin(OptExpression optExpression, DecodeInfo context) {
         PhysicalJoinOperator join = optExpression.getOp().cast();
         DecodeInfo result = context.createOutputInfo();
-
         if (join.getOnPredicate() == null) {
-            return context.outputStringColumns.isEmpty() ? DecodeInfo.EMPTY : result;
-        }
-
-        ColumnRefSet onColumns = join.getOnPredicate().getUsedColumns();
-
-        DistributionProperty leftDistribution = optExpression.getRequiredProperties().get(0).getDistributionProperty();
-        DistributionProperty rightDistribution = optExpression.getRequiredProperties().get(1).getDistributionProperty();
-
-        if (context.outputStringColumns.isEmpty()) {
-            // For shuffle join, check if the first PhysicalDistributionOperator in left or right child tree
-            // has outputStringColumns containing join ON columns.
-            // If yes, it means the distribution will use dictionary columns, which changes data distribution.
-            if (leftDistribution.isShuffle() && rightDistribution.isShuffle()) {
-                boolean leftWillChangeDistribution = checkDistributionWillBeChanged(optExpression.inputAt(0), onColumns);
-                boolean rightWillChangeDistribution = checkDistributionWillBeChanged(optExpression.inputAt(1), onColumns);
-                if (leftWillChangeDistribution || rightWillChangeDistribution) {
-                    onColumns.getStream().forEach(disableRewriteStringColumns::union);
-                }
-            }
-
-            return DecodeInfo.EMPTY;
-        }
-
-        if (!result.inputStringColumns.containsAny(onColumns)) {
             return result;
         }
 
+        ColumnRefSet onColumns = join.getOnPredicate().getUsedColumns();
+        if (context.outputStringColumns.isEmpty() || !result.inputStringColumns.containsAny(onColumns)) {
+            onColumns.getStream().forEach(disableRewriteStringColumns::union);
+            return result;
+        }
+
+        DistributionProperty leftDistribution = optExpression.getRequiredProperties().get(0).getDistributionProperty();
+        DistributionProperty rightDistribution = optExpression.getRequiredProperties().get(1).getDistributionProperty();
         // Currently only supports broadcast join.
         if (!sessionVariable.isEnableLowCardinalityOptimizeForJoin() ||
                 (leftDistribution.isShuffle() && rightDistribution.isShuffle())) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -165,6 +165,30 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "\"compression\" = \"LZ4\"\n" +
                 ");");
 
+        starRocksAssert.withTable("CREATE TABLE `low_card_t3` (\n" +
+                "  `d_date` date ,\n" +
+                "  `c_user` varchar(50) ,\n" +
+                "  `c_dept` varchar(50) ,\n" +
+                "  `c_par` varchar(50) ,\n" +
+                "  `c_nodevalue` varchar(50) ,\n" +
+                "  `c_brokername` varchar(50) ,\n" +
+                "  `f_asset` decimal128(20, 5) ,\n" +
+                "  `f_asset_zb` decimal128(20, 5) ,\n" +
+                "  `f_managerfee` decimal128(20, 5) ,\n" +
+                "  `fee_zb` decimal128(20, 5) ,\n" +
+                "  `cpc` int(11) \n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`d_date`, `c_user`, `c_dept`, `c_par`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`d_date`, `c_user`, `c_dept`, `c_par`) BUCKETS 16 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"DEFAULT\",\n" +
+                "\"enable_persistent_index\" = \"true\",\n" +
+                "\"compression\" = \"LZ4\"\n" +
+                ");");
+
         FeConstants.USE_MOCK_DICT_MANAGER = true;
         connectContext.getSessionVariable().setSqlMode(2);
         connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
@@ -2445,6 +2469,145 @@ public class LowCardinalityTest2 extends PlanTestBase {
                     "  |  join op: INNER JOIN (BROADCAST)\n" +
                     "  |  equal join conjunct: [2: c_user, VARCHAR, true] = [13: c_user, VARCHAR, true]\n" +
                     "  |  equal join conjunct: [2: c_user, VARCHAR, true] = [25: cast, VARCHAR(65533), true]");
+        } finally {
+            FeConstants.runningUnitTest = false;
+        }
+    }
+
+    @Test
+    public void testShuffleJoinWithDistributionCheck() throws Exception {
+        FeConstants.runningUnitTest = true;
+        try {
+            String sql;
+            String plan;
+
+            // Test case 1: Shuffle join where the join column appears in parent node's output
+            sql = "SELECT max(t1.c_user) FROM low_card_t1 t1 " +
+                    "JOIN [shuffle] low_card_t1 t2 ON t1.c_user = t2.c_user";
+            plan = getVerboseExplain(sql);
+            // The join should use original VARCHAR columns, not dictionary-encoded INT columns
+            assertContains(plan, "equal join conjunct: [2: c_user, VARCHAR, true] = [13: c_user, VARCHAR, true]");
+            // No Global Dict Exprs because c_user is disabled for shuffle join
+            assertNotContains(plan, "Global Dict Exprs:");
+
+            // Test case 2: Shuffle join with multiple join columns in parent node's output
+            sql = "SELECT COUNT(1) FROM low_card_t1 t1 " +
+                    "JOIN [shuffle] low_card_t1 t2 ON t1.c_user = t2.c_user AND t1.c_dept = t2.c_dept";
+            plan = getVerboseExplain(sql);
+            assertContains(plan, "equal join conjunct: [2: c_user, VARCHAR, true] = [13: c_user, VARCHAR, true]");
+            assertContains(plan, "equal join conjunct: [3: c_dept, VARCHAR, true] = [14: c_dept, VARCHAR, true]");
+            assertNotContains(plan, "Global Dict Exprs:");
+
+            // Test case 3: Mixed scenario - shuffle join on c_user, but aggregate on c_dept
+            // c_user should NOT use dictionary (shuffle join column)
+            // c_dept SHOULD use dictionary (not involved in shuffle join)
+            sql = "SELECT MIN(t1.c_dept), MAX(t2.c_dept) FROM low_card_t1 t1 " +
+                    "JOIN [shuffle] low_card_t1 t2 ON t1.c_user = t2.c_user";
+            plan = getVerboseExplain(sql);
+            // c_user should use VARCHAR (shuffle join column)
+            assertContains(plan, "equal join conjunct: [2: c_user, VARCHAR, true] = [13: c_user, VARCHAR, true]");
+            assertContains(plan, "  9:Decode\n" +
+                    "  |  <dict id 27> : <string id 23>\n" +
+                    "  |  <dict id 28> : <string id 24>\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  8:AGGREGATE (merge finalize)\n" +
+                    "  |  aggregate: min[([27: min, INT, true]); args: INT; result: INT; " +
+                    "args nullable: true; result nullable: true], max[([28: max, INT, true]); " +
+                    "args: INT; result: INT; args nullable: true; result nullable: true]\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  7:EXCHANGE\n" +
+                    "     distribution type: GATHER\n" +
+                    "     cardinality: 1");
+
+            //Test case 4: context.outputStringColumns.isEmpty() is true for visitPhysicalJoin
+            sql = "SELECT t2.c_user, t4.c_dept FROM (select * from (select c_dept, c_user, first_value(c_user) " +
+                    "over(partition by c_user,c_dept order by c_dept) as rz from low_card_t3) t1 " +
+                    "where rz = '1') t2" +
+                    " JOIN [shuffle] (select * from (select c_dept, c_user, " +
+                    "first_value(c_user) over(partition by c_user,c_dept order by c_dept) as rnz " +
+                    "from low_card_t1) t3 where rnz = '1') t4 ON t2.c_user = t4.c_user and t2.c_dept = t4.c_dept;";
+            plan = getVerboseExplain(sql);
+            // Verify the execution plan don't contains Global Dict Exprs
+            assertNotContains(plan, "Global Dict Exprs:");
+            assertContains(plan, "  13:Project\n" +
+                    "  |  output columns:\n" +
+                    "  |  2 <-> [2: c_user, VARCHAR, true]\n" +
+                    "  |  15 <-> [15: c_dept, VARCHAR, true]\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  12:HASH JOIN\n" +
+                    "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                    "  |  equal join conjunct: [2: c_user, VARCHAR, true] = [14: c_user, VARCHAR, true]\n" +
+                    "  |  equal join conjunct: [3: c_dept, VARCHAR, true] = [15: c_dept, VARCHAR, true]\n" +
+                    "  |  build runtime filters:\n" +
+                    "  |  - filter_id = 0, build_expr = (14: c_user), remote = false\n" +
+                    "  |  - filter_id = 1, build_expr = (15: c_dept), remote = false\n" +
+                    "  |  output columns: 2, 15\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  |----11:Project\n" +
+                    "  |    |  output columns:\n" +
+                    "  |    |  14 <-> [14: c_user, VARCHAR, true]\n" +
+                    "  |    |  15 <-> [15: c_dept, VARCHAR, true]\n" +
+                    "  |    |  cardinality: 1\n" +
+                    "  |    |  \n" +
+                    "  |    10:SELECT\n" +
+                    "  |    |  predicates: 24: first_value(14: c_user) = '1'\n" +
+                    "  |    |  cardinality: 1\n" +
+                    "  |    |  \n" +
+                    "  |    9:ANALYTIC\n" +
+                    "  |    |  functions: [, first_value[([14: c_user, VARCHAR, true]); args: VARCHAR; " +
+                    "result: VARCHAR; args nullable: true; result nullable: true], ]\n" +
+                    "  |    |  partition by: [14: c_user, VARCHAR, true], [15: c_dept, VARCHAR, true]\n" +
+                    "  |    |  order by: [15: c_dept, VARCHAR, true] ASC\n" +
+                    "  |    |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |    |  cardinality: 1\n" +
+                    "  |    |  \n" +
+                    "  |    8:SORT\n" +
+                    "  |    |  order by: [14, VARCHAR, true] ASC, [15, VARCHAR, true] ASC\n" +
+                    "  |    |  analytic partition by: [14: c_user, VARCHAR, true], [15: c_dept, VARCHAR, true]\n" +
+                    "  |    |  offset: 0\n" +
+                    "  |    |  cardinality: 1\n" +
+                    "  |    |  \n" +
+                    "  |    7:EXCHANGE\n" +
+                    "  |       distribution type: SHUFFLE\n" +
+                    "  |       partition exprs: [14: c_user, VARCHAR, true], [15: c_dept, VARCHAR, true]\n" +
+                    "  |       cardinality: 1\n" +
+                    "  |    \n" +
+                    "  5:Project\n" +
+                    "  |  output columns:\n" +
+                    "  |  2 <-> [2: c_user, VARCHAR, true]\n" +
+                    "  |  3 <-> [3: c_dept, VARCHAR, true]\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  4:SELECT\n" +
+                    "  |  predicates: 12: first_value(2: c_user) = '1'\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  3:ANALYTIC\n" +
+                    "  |  functions: [, first_value[([2: c_user, VARCHAR, true]); args: VARCHAR; " +
+                    "result: VARCHAR; args nullable: true; result nullable: true], ]\n" +
+                    "  |  partition by: [2: c_user, VARCHAR, true], [3: c_dept, VARCHAR, true]\n" +
+                    "  |  order by: [3: c_dept, VARCHAR, true] ASC\n" +
+                    "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  2:SORT\n" +
+                    "  |  order by: [2, VARCHAR, true] ASC, [3, VARCHAR, true] ASC\n" +
+                    "  |  analytic partition by: [2: c_user, VARCHAR, true], [3: c_dept, VARCHAR, true]\n" +
+                    "  |  offset: 0\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  probe runtime filters:\n" +
+                    "  |  - filter_id = 0, probe_expr = (2: c_user)\n" +
+                    "  |  - filter_id = 1, probe_expr = (3: c_dept)\n" +
+                    "  |  \n" +
+                    "  1:EXCHANGE\n" +
+                    "     distribution type: SHUFFLE\n" +
+                    "     partition exprs: [2: c_user, VARCHAR, true], [3: c_dept, VARCHAR, true]\n" +
+                    "     cardinality: 1");
+            
         } finally {
             FeConstants.runningUnitTest = false;
         }


### PR DESCRIPTION
## Why I'm doing:
```
19ms|    after extract best plan:
PhysicalHashJoinOperator{joinType=INNER JOIN, joinPredicate=70: account = 113: account AND 103: uname = 114: uname, limit=-1, predicate=null}

->  PhysicalHashAggregate {type=GLOBAL, groupBy=[70: account, 103: uname], partitionBy=[70: account, 103: uname] ,aggregations={}}

    ->  PhysicalDistributionOperator {distributionSpec=SHUFFLE_AGG[70(true), 103(true)] ,globalDict=[]}

        ->  PhysicalHashAggregate {type=LOCAL, groupBy=[70: account, 103: uname], partitionBy=[70: account, 103: uname] ,aggregations={}}

            ->  PhysicalHashJoinOperator{joinType=INNER JOIN, joinPredicate=7: account = 70: account, limit=-1, predicate=null}

                ->  PhysicalHashAggregate {type=GLOBAL, groupBy=[7: account, 1: dt], partitionBy=[7: account, 1: dt] ,aggregations={}}

                    ->  PhysicalDistributionOperator {distributionSpec=SHUFFLE_AGG[7(true), 1(true)] ,globalDict=[]}

                        ->  PhysicalHashAggregate {type=LOCAL, groupBy=[7: account, 1: dt], partitionBy=[7: account, 1: dt] ,aggregations={}}

                            ->  PhysicalOlapScanOperator {table=2957681, selectedPartitionId=[3643822, 3643883, 3643944, 3644005, 3644066, 3644127, 3644188, 3644249, 3644310, 3644371, 3644432, 3644493, 3644554, 3644615, 3644676, 3644737, 3644798, 3644859, 3644920, 3644981, 3645042, 3645103, 3645164, 3645225, 3645286, 3645347, 3645408, 3645469, 3645530, 3645591, 3645652, 3645713, 3645774, 3645835, 3645896, 3645957, 3646018, 3646079, 3646140, 3646201, 3646262, 3646323, 3646384, 3968036, 5516637, 17136435, 20452438, 39845030, 55605205], selectedIndexId=75456507, outputColumns=[1: dt, 7: account], projection=[1: dt, 7: account], predicate=7: account IS NOT NULL AND cast(7: account as DECIMAL128(38,9)) = 1834791220779017.000000000 AND 19: cost > 0 AND 2: dt_hour = -1, prunedPartitionPredicates=[], limit=-1}
                ->  PhysicalDistributionOperator {distributionSpec=BROADCAST ,globalDict=[]}

                    ->  PhysicalHashJoinOperator{joinType=INNER JOIN, joinPredicate=61: id = 102: aid, limit=-1, predicate=null}

                        ->  PHYSICAL_FILTER

                            ->  PHYSICAL_WINDOW

                                ->  PhysicalTopNOperator {phase=FINAL, orderBy=[102: aid ASC NULLS FIRST, 101: id DESC NULLS LAST], limit=-1, offset=0}

                                    ->  PhysicalDistributionOperator {distributionSpec=SHUFFLE_AGG[102(true)] ,globalDict=[]}

                                        ->  PhysicalTopNOperator {phase=PARTIAL, orderBy=[102: aid ASC NULLS FIRST, 101: id DESC NULLS LAST], limit=-1, offset=0}

                                            ->  PhysicalOlapScanOperator {table=864224, selectedPartitionId=[864223], selectedIndexId=864225, outputColumns=[101: id, 102: aid, 103: uname], projection=[101: id, 102: aid, 103: uname], predicate=102: aid IS NOT NULL AND 105: sys_del_s = 0, prunedPartitionPredicates=[], limit=-1}
                        ->  PhysicalDistributionOperator {distributionSpec=SHUFFLE_ENFORCE[61(true)] ,globalDict=[]}

                            ->  PhysicalHashAggregate {type=GLOBAL, groupBy=[61: id, 70: account], partitionBy=[61: id, 70: account] ,aggregations={}}

                                ->  PhysicalOlapScanOperator {table=910706, selectedPartitionId=[132969850], selectedIndexId=910707, outputColumns=[70: account, 61: id], projection=[70: account, 61: id], predicate=70: account IS NOT NULL AND cast(70: account as DECIMAL128(38,9)) = 1834791220779017.000000000 AND 61: id IS NOT NULL AND 78: deleted = 0 AND 83: is_app = 1, prunedPartitionPredicates=[], limit=-1}
->  PHYSICAL_FILTER

    ->  PHYSICAL_WINDOW

        ->  PhysicalTopNOperator {phase=FINAL, orderBy=[113: account ASC NULLS FIRST, 114: uname ASC NULLS FIRST, 115: start_dt DESC NULLS LAST], limit=-1, offset=0}

            ->  PhysicalDistributionOperator {distributionSpec=SHUFFLE_AGG[113(true), 114(true)] ,globalDict=[]}

                ->  PhysicalTopNOperator {phase=PARTIAL, orderBy=[113: account ASC NULLS FIRST, 114: uname ASC NULLS FIRST, 115: start_dt DESC NULLS LAST], limit=-1, offset=0}

                    ->  PhysicalOlapScanOperator {table=17208956, selectedPartitionId=[156842904], selectedIndexId=17208957, outputColumns=[113: account, 114: uname, 115: start_dt], projection=null, predicate=113: account IS NOT NULL AND 114: uname IS NOT NULL AND cast(113: account as DECIMAL128(38,9)) = 1834791220779017.000000000, prunedPartitionPredicates=[], limit=-1}
20ms|    final plan after physical rewrite:
PhysicalHashJoinOperator{joinType=INNER JOIN, joinPredicate=70: account = 113: account AND 103: uname = 114: uname, limit=-1, predicate=null}

->  PhysicalHashAggregate {type=GLOBAL, groupBy=[70: account, 103: uname], partitionBy=[70: account, 103: uname] ,aggregations={}}

    ->  PhysicalDistributionOperator {distributionSpec=SHUFFLE_AGG[70(true), 103(true)] ,globalDict=[]}

        ->  PhysicalHashAggregate {type=LOCAL, groupBy=[70: account, 103: uname], partitionBy=[70: account, 103: uname] ,aggregations={}}

            ->  PhysicalHashJoinOperator{joinType=INNER JOIN, joinPredicate=7: account = 70: account, limit=-1, predicate=null}

                ->  PhysicalHashAggregate {type=GLOBAL, groupBy=[7: account, 1: dt], partitionBy=[7: account, 1: dt] ,aggregations={}}

                    ->  PhysicalDistributionOperator {distributionSpec=SHUFFLE_AGG[7(true), 1(true)] ,globalDict=[]}

                        ->  PhysicalHashAggregate {type=LOCAL, groupBy=[7: account, 1: dt], partitionBy=[7: account, 1: dt] ,aggregations={}}

                            ->  PhysicalOlapScanOperator {table=2957681, selectedPartitionId=[3643822, 3643883, 3643944, 3644005, 3644066, 3644127, 3644188, 3644249, 3644310, 3644371, 3644432, 3644493, 3644554, 3644615, 3644676, 3644737, 3644798, 3644859, 3644920, 3644981, 3645042, 3645103, 3645164, 3645225, 3645286, 3645347, 3645408, 3645469, 3645530, 3645591, 3645652, 3645713, 3645774, 3645835, 3645896, 3645957, 3646018, 3646079, 3646140, 3646201, 3646262, 3646323, 3646384, 3968036, 5516637, 17136435, 20452438, 39845030, 55605205], selectedIndexId=75456507, outputColumns=[1: dt, 7: account], projection=[1: dt, 7: account], predicate=7: account IS NOT NULL AND cast(7: account as DECIMAL128(38,9)) = 1834791220779017.000000000 AND 19: cost > 0 AND 2: dt_hour = -1, prunedPartitionPredicates=[], limit=-1}
                ->  PhysicalDistributionOperator {distributionSpec=BROADCAST ,globalDict=[]}

                    ->  PhysicalHashJoinOperator{joinType=INNER JOIN, joinPredicate=61: id = 102: aid, limit=-1, predicate=null}

                        ->  PHYSICAL_FILTER

                            ->  PHYSICAL_WINDOW

                                ->  PhysicalTopNOperator {phase=FINAL, orderBy=[102: aid ASC NULLS FIRST, 101: id DESC NULLS LAST], limit=-1, offset=0}

                                    ->  PhysicalDistributionOperator {distributionSpec=SHUFFLE_AGG[102(true)] ,globalDict=[]}

                                        ->  PhysicalTopNOperator {phase=PARTIAL, orderBy=[102: aid ASC NULLS FIRST, 101: id DESC NULLS LAST], limit=-1, offset=0}

                                            ->  PhysicalOlapScanOperator {table=864224, selectedPartitionId=[864223], selectedIndexId=864225, outputColumns=[101: id, 102: aid, 103: uname], projection=[101: id, 102: aid, 103: uname], predicate=102: aid IS NOT NULL AND 105: sys_del_s = 0, prunedPartitionPredicates=[], limit=-1}
                        ->  PhysicalDistributionOperator {distributionSpec=SHUFFLE_ENFORCE[61(true)] ,globalDict=[]}

                            ->  PhysicalHashAggregate {type=GLOBAL, groupBy=[61: id, 70: account], partitionBy=[61: id, 70: account] ,aggregations={}}

                                ->  PhysicalOlapScanOperator {table=910706, selectedPartitionId=[132969850], selectedIndexId=910707, outputColumns=[70: account, 61: id], projection=[70: account, 61: id], predicate=70: account IS NOT NULL AND cast(70: account as DECIMAL128(38,9)) = 1834791220779017.000000000 AND 61: id IS NOT NULL AND 78: deleted = 0 AND 83: is_app = 1, prunedPartitionPredicates=[], limit=-1}
->  PHYSICAL_FILTER

    ->  PHYSICAL_WINDOW

        ->  PHYSICAL_DECODE

            ->  PhysicalTopNOperator {phase=FINAL, orderBy=[113: account ASC NULLS FIRST, 119: uname ASC NULLS FIRST, 115: start_dt DESC NULLS LAST], limit=-1, offset=0}

                ->  PhysicalDistributionOperator {distributionSpec=SHUFFLE_AGG[113(true), 119(true)] ,globalDict=[119:com.starrocks.sql.optimizer.statistics.ColumnDict@19ee23d6]}

                    ->  PhysicalTopNOperator {phase=PARTIAL, orderBy=[113: account ASC NULLS FIRST, 119: uname ASC NULLS FIRST, 115: start_dt DESC NULLS LAST], limit=-1, offset=0}

                        ->  PhysicalOlapScanOperator {table=17208956, selectedPartitionId=[156842904], selectedIndexId=17208957, outputColumns=[113: account, 115: start_dt, 119: uname], projection=null, predicate=113: account IS NOT NULL AND DictMapping(119: uname, 114: uname IS NOT NULL) AND cast(113: account as DECIMAL128(38,9)) = 1834791220779017.000000000, prunedPartitionPredicates=[], limit=-1}
Tracer Cost: 12236us

```
## What I'm doing:

Fixes #

**Approach 1**: Dictionary optimization must not change data distribution characteristics
 Safe case: If the first PhysicalDistributionOperator's outputStringColumns does NOT contain join columns → The columns will be decoded before distribution, preserving the original data distribution.

 Unsafe case: If the first PhysicalDistributionOperator's outputStringColumns contains join columns → The columns will be shuffled in dictionary form, which changes the data distribution (because hash(string) ≠ hash(dict_id)). Dictionary optimization must be disabled for these columns.

**Approach 2(approve)**: Directly disable the use of dictionary columns in the join keys (onColumns)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
