### PR TITLE
[BugFix] Reject table function on the left side of join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -918,6 +918,11 @@ public class QueryAnalyzer {
 
         @Override
         public Scope visitJoin(JoinRelation join, Scope parentScope) {
+            if (join.getLeft() instanceof TableFunctionRelation) {
+                throw unsupportedException("Table function cannot appear on the left side of a join. " +
+                        "Place it on the right side (optionally with LATERAL) or wrap it with TABLE(...).");
+            }
+
             Scope leftScope = process(join.getLeft(), parentScope);
             Scope rightScope;
             if (join.getRight() instanceof TableFunctionRelation || join.isLateral()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeLateralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeLateralTest.java
@@ -53,6 +53,8 @@ public class AnalyzeLateralTest {
         analyzeFail("select  unnest(split('1,2,3',','))", "Table function cannot be used in expression");
         analyzeFail("select a.* from unnest(split('1,2,3',',')) a",
                 "Table function must be used with lateral join");
+        analyzeFail("select * from unnest(split('1,2,3',',')) a, t0",
+                "Table function cannot appear on the left side of a join");
 
         analyzeFail("select * from t0,unnest(bitmap_to_array(bitmap_union(to_bitmap(v1))))",
                 "Table Function clause cannot contain aggregations");


### PR DESCRIPTION
## Why I'm doing:
```
MySQL td> select * from  generate_series(0, 1, 10), t1
(1064, 'Cannot invoke "com.starrocks.sql.optimizer.transformer.ExpressionMapping.get(com.starrocks.sql.ast.expression.Expr)" because "expressionMapping" is null')
```
This is confusing for users and should be rejected in the analyzer with a clear, actionable message.

## What I'm doing:
- Add an analyzer check to reject **table functions on the left side of a join**, and return a clearer error message suggesting the supported rewrites (move it to the right side / use `LATERAL` / wrap with `TABLE(...)`).
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
