### PR TITLE
[BugFix] Fix sql server and oracle identifier symbol

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
@@ -158,9 +158,7 @@ public class JDBCScanNode extends ScanNode {
             return "`";
         }
         if (jdbcUri.startsWith("jdbc:postgresql") ||
-                jdbcUri.startsWith("jdbc:postgres") ||
-                jdbcUri.startsWith("jdbc:oracle") ||
-                jdbcUri.startsWith("jdbc:sqlserver")) {
+                jdbcUri.startsWith("jdbc:postgres")) {
             return "\"";
         }
         return "";

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MySqlAndJDBCScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MySqlAndJDBCScanNodeTest.java
@@ -151,8 +151,8 @@ public class MySqlAndJDBCScanNodeTest {
         JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, oracleTable);
         scanNode.computeColumnsAndFilters();
         String nodeString = scanNode.getExplainString();
-        Assertions.assertTrue(nodeString.contains("TABLE: \"select\""), nodeString);
-        Assertions.assertTrue(nodeString.contains("FROM \"select\""), nodeString);
+        Assertions.assertTrue(nodeString.contains("TABLE: select"), nodeString);
+        Assertions.assertTrue(nodeString.contains("FROM select"), nodeString);
     }
 
     @Test
@@ -171,8 +171,8 @@ public class MySqlAndJDBCScanNodeTest {
         JDBCScanNode scanNode = new JDBCScanNode(new PlanNodeId(1), tupleDesc, sqlServerTable);
         scanNode.computeColumnsAndFilters();
         String nodeString = scanNode.getExplainString();
-        Assertions.assertTrue(nodeString.contains("TABLE: \"table\""), nodeString);
-        Assertions.assertTrue(nodeString.contains("FROM \"table\""), nodeString);
+        Assertions.assertTrue(nodeString.contains("TABLE: table"), nodeString);
+        Assertions.assertTrue(nodeString.contains("FROM table"), nodeString);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
Fix https://github.com/StarRocks/StarRocksTest/issues/10865, this issue is introduced by https://github.com/StarRocks/starrocks/pull/67690

SQL Server Issues with Double Quotes:
**Setting Dependency**: Double quotes only work when the QUOTED_IDENTIFIER session setting is ON (enabled). If this setting is OFF, double quotes will cause syntax errors.
**Non-Standard Convention**: SQL Server primarily uses square brackets [] as its native identifier quoting mechanism. Double quotes are supported for SQL standard compliance but are not the preferred syntax.

Oracle Issues with Double Quotes:
**Case Sensitivity Trap**: Double-quoted identifiers are case-sensitive, while unquoted identifiers are automatically converted to uppercase. This creates a common pitfall where developers expect case-insensitive behavior but get case-sensitive matching instead.
**Mandatory Consistent Usage**: If an object (table, column, etc.) is created with double quotes, every subsequent reference to that object must use double quotes with the exact same case. This creates maintenance overhead and breaks standard querying patterns.
**Storage Mismatch:** Most Oracle objects are created without double quotes (stored as uppercase in data dictionaries). Attempting to query them with double quotes and lowercase names will fail because Oracle looks for exact case matches.

## What I'm doing:
This pull request updates how identifier symbols are handled for Oracle and SQL Server JDBC sources. Previously, table names were wrapped in double quotes for these databases; now, they are left unquoted. Corresponding unit tests have been updated to reflect this change.

JDBC identifier symbol handling:

* Modified `JDBCScanNode.getIdentifierSymbol()` to stop returning double quotes for Oracle and SQL Server JDBC URIs, so these databases now use unquoted identifiers.

Test updates:

* Updated `testFiltersInOracleJDBCScanNode` and `testFiltersInSqlServerJDBCScanNode` in `MySqlAndJDBCScanNodeTest.java` to expect unquoted table names in the explain output.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
