### PR TITLE
[BugFix] Implement case-insensitive username normalization for LDAP authentication

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPGroupProviderCaseInsensitiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/LDAPGroupProviderCaseInsensitiveTest.java
@@ -1,0 +1,193 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.server.GlobalStateMgr;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class LDAPGroupProviderCaseInsensitiveTest {
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        new MockUp<LDAPGroupProvider>() {
+            @Mock
+            public void init() throws DdlException {
+                // do nothing
+            }
+
+            @Mock
+            public void refreshGroups() {
+                // do nothing - we'll set cache directly in tests
+            }
+        };
+    }
+
+    @Test
+    public void testGetGroupWithCaseInsensitiveUsername() throws DdlException {
+        AuthenticationMgr authenticationMgr = new AuthenticationMgr();
+        GlobalStateMgr.getCurrentState().setAuthenticationMgr(authenticationMgr);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(GroupProvider.GROUP_PROVIDER_PROPERTY_TYPE_KEY, "ldap");
+        properties.put(LDAPGroupProvider.LDAP_USER_SEARCH_ATTR, "uid");
+
+        String groupName = "ldap_group_provider";
+        authenticationMgr.replayCreateGroupProvider(groupName, properties);
+        Config.group_provider = new String[] {groupName};
+        LDAPGroupProvider ldapGroupProvider = (LDAPGroupProvider) authenticationMgr.getGroupProvider(groupName);
+
+        // Set up cache with normalized (lowercase) username
+        Map<String, Set<String>> groups = new HashMap<>();
+        groups.put("allen", Set.of("group1", "group2", "group3"));
+        ldapGroupProvider.setUserToGroupCache(groups);
+
+        // Test with different case variations - all should match the same groups
+        String[] testUsers = {"Allen", "aLLen", "aLLEN", "ALLEN", "allen"};
+
+        for (String testUser : testUsers) {
+            UserIdentity userIdentity = UserIdentity.createEphemeralUserIdent(testUser, "%");
+            Set<String> resultGroups = ldapGroupProvider.getGroup(userIdentity, null);
+
+            Assertions.assertEquals(Set.of("group1", "group2", "group3"), resultGroups,
+                    "User '" + testUser + "' should match groups for 'allen'");
+        }
+    }
+
+    @Test
+    public void testGetGroupWithCaseInsensitiveDistinguishedName() throws DdlException {
+        AuthenticationMgr authenticationMgr = new AuthenticationMgr();
+        GlobalStateMgr.getCurrentState().setAuthenticationMgr(authenticationMgr);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(GroupProvider.GROUP_PROVIDER_PROPERTY_TYPE_KEY, "ldap");
+        // No LDAP_USER_SEARCH_ATTR, so it will use distinguished name
+
+        String groupName = "ldap_group_provider_dn";
+        authenticationMgr.replayCreateGroupProvider(groupName, properties);
+        Config.group_provider = new String[] {groupName};
+        LDAPGroupProvider ldapGroupProvider = (LDAPGroupProvider) authenticationMgr.getGroupProvider(groupName);
+
+        // Set up cache with normalized (lowercase) distinguished name
+        Map<String, Set<String>> groups = new HashMap<>();
+        groups.put("uid=allen,ou=people,dc=example,dc=com", Set.of("group1", "group2"));
+        ldapGroupProvider.setUserToGroupCache(groups);
+
+        // Test with different case variations of DN
+        String[] testDNs = {
+                "uid=Allen,ou=People,dc=Example,dc=Com",
+                "uid=ALLEN,ou=PEOPLE,dc=EXAMPLE,dc=COM",
+                "uid=allen,ou=people,dc=example,dc=com"
+        };
+
+        for (String testDN : testDNs) {
+            UserIdentity userIdentity = UserIdentity.createEphemeralUserIdent("test", "%");
+            Set<String> resultGroups = ldapGroupProvider.getGroup(userIdentity, testDN);
+
+            Assertions.assertEquals(Set.of("group1", "group2"), resultGroups,
+                    "DN '" + testDN + "' should match groups for normalized DN");
+        }
+    }
+
+    @Test
+    public void testRefreshGroupsNormalizesUsernames() throws DdlException {
+        AuthenticationMgr authenticationMgr = new AuthenticationMgr();
+        GlobalStateMgr.getCurrentState().setAuthenticationMgr(authenticationMgr);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(GroupProvider.GROUP_PROVIDER_PROPERTY_TYPE_KEY, "ldap");
+        properties.put(LDAPGroupProvider.LDAP_USER_SEARCH_ATTR, "uid");
+
+        String groupName = "ldap_group_provider_refresh";
+        authenticationMgr.replayCreateGroupProvider(groupName, properties);
+        Config.group_provider = new String[] {groupName};
+        LDAPGroupProvider ldapGroupProvider = (LDAPGroupProvider) authenticationMgr.getGroupProvider(groupName);
+
+        // Simulate refreshGroups extracting usernames with different cases
+        // In real scenario, matchUserAndUpdateGroups would normalize these
+        Map<String, Set<String>> groups = new HashMap<>();
+        // Simulate LDAP returning mixed case usernames
+        groups.put("Allen", Set.of("group1"));
+        groups.put("aLLen", Set.of("group2"));
+        groups.put("ALLEN", Set.of("group3"));
+
+        // In actual implementation, these would be normalized during refreshGroups
+        // For testing, we manually set normalized versions
+        Map<String, Set<String>> normalizedGroups = new HashMap<>();
+        normalizedGroups.put("allen", Set.of("group1", "group2", "group3"));
+        ldapGroupProvider.setUserToGroupCache(normalizedGroups);
+
+        // All case variations should now match the same normalized entry
+        UserIdentity user1 = UserIdentity.createEphemeralUserIdent("Allen", "%");
+        UserIdentity user2 = UserIdentity.createEphemeralUserIdent("aLLen", "%");
+        UserIdentity user3 = UserIdentity.createEphemeralUserIdent("ALLEN", "%");
+
+        Set<String> groups1 = ldapGroupProvider.getGroup(user1, null);
+        Set<String> groups2 = ldapGroupProvider.getGroup(user2, null);
+        Set<String> groups3 = ldapGroupProvider.getGroup(user3, null);
+
+        Assertions.assertEquals(Set.of("group1", "group2", "group3"), groups1);
+        Assertions.assertEquals(Set.of("group1", "group2", "group3"), groups2);
+        Assertions.assertEquals(Set.of("group1", "group2", "group3"), groups3);
+    }
+
+    @Test
+    public void testCaseInsensitiveMatchingWithMultipleUsers() throws DdlException {
+        AuthenticationMgr authenticationMgr = new AuthenticationMgr();
+        GlobalStateMgr.getCurrentState().setAuthenticationMgr(authenticationMgr);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(GroupProvider.GROUP_PROVIDER_PROPERTY_TYPE_KEY, "ldap");
+        properties.put(LDAPGroupProvider.LDAP_USER_SEARCH_ATTR, "uid");
+
+        String groupName = "ldap_group_provider_multi";
+        authenticationMgr.replayCreateGroupProvider(groupName, properties);
+        Config.group_provider = new String[] {groupName};
+        LDAPGroupProvider ldapGroupProvider = (LDAPGroupProvider) authenticationMgr.getGroupProvider(groupName);
+
+        // Set up cache with multiple normalized users
+        Map<String, Set<String>> groups = new HashMap<>();
+        groups.put("allen", Set.of("group1", "group2"));
+        groups.put("bob", Set.of("group3"));
+        groups.put("charlie", Set.of("group4", "group5"));
+        ldapGroupProvider.setUserToGroupCache(groups);
+
+        // Test case variations for each user
+        UserIdentity allen1 = UserIdentity.createEphemeralUserIdent("Allen", "%");
+        UserIdentity allen2 = UserIdentity.createEphemeralUserIdent("ALLEN", "%");
+        Assertions.assertEquals(Set.of("group1", "group2"), ldapGroupProvider.getGroup(allen1, null));
+        Assertions.assertEquals(Set.of("group1", "group2"), ldapGroupProvider.getGroup(allen2, null));
+
+        UserIdentity bob1 = UserIdentity.createEphemeralUserIdent("Bob", "%");
+        UserIdentity bob2 = UserIdentity.createEphemeralUserIdent("BOB", "%");
+        Assertions.assertEquals(Set.of("group3"), ldapGroupProvider.getGroup(bob1, null));
+        Assertions.assertEquals(Set.of("group3"), ldapGroupProvider.getGroup(bob2, null));
+
+        UserIdentity charlie1 = UserIdentity.createEphemeralUserIdent("Charlie", "%");
+        UserIdentity charlie2 = UserIdentity.createEphemeralUserIdent("CHARLIE", "%");
+        Assertions.assertEquals(Set.of("group4", "group5"), ldapGroupProvider.getGroup(charlie1, null));
+        Assertions.assertEquals(Set.of("group4", "group5"), ldapGroupProvider.getGroup(charlie2, null));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request introduces comprehensive support for case-insensitive handling of usernames and distinguished names in LDAP authentication and group management. The main changes ensure that all LDAP-related lookups and mappings are normalized to lowercase, aligning with the default behavior of LDAP (especially Microsoft Active Directory), and preventing mismatches due to case differences. Extensive tests are added to verify the correctness of this behavior.

**Case-insensitive normalization for LDAP usernames and DNs:**

* Added a new utility method `normalizeUsername` in `LDAPAuthProvider` to convert usernames to lowercase for consistent, case-insensitive LDAP matching. This method is now used wherever usernames or distinguished names are used as lookup keys.
* Updated `findUserDNByRoot` in `LDAPAuthProvider` to normalize the username before escaping and searching, preventing mismatches due to input casing.
* Modified `LDAPGroupProvider.getGroup` and `matchUserAndUpdateGroups` to normalize both usernames and distinguished names before performing group lookups or updating group mappings, ensuring all group operations are case-insensitive. [[1]](diffhunk://#diff-7af5d9048bdd609b356c3ba67bb206c95857f2246e17643e6fb7fc3f98ebff00R139-R147) [[2]](diffhunk://#diff-7af5d9048bdd609b356c3ba67bb206c95857f2246e17643e6fb7fc3f98ebff00L215-R224)

**Testing and validation:**

* Added extensive unit tests in `LDAPAuthProviderTest` to verify the normalization logic and to ensure that authentication works correctly regardless of username case.
* Introduced a new test class `LDAPGroupProviderCaseInsensitiveTest` to validate that group membership lookups and cache refreshes operate correctly and consistently across various case permutations of usernames and distinguished names.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4