### PR TITLE
[BugFix] [FollowUp] Fix low cardinality bug with more lamda function

### DIFF
--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -444,4 +444,13 @@ int ArrayMapExpr::get_slot_ids(std::vector<SlotId>* slot_ids) const {
     return num;
 }
 
+Status ArrayMapExpr::do_for_each_child(const std::function<Status(Expr*)>& callback) {
+    RETURN_IF_ERROR(Expr::do_for_each_child(callback));
+
+    for (const auto& [slot_id, expr] : _outer_common_exprs) {
+        RETURN_IF_ERROR(callback(expr));
+    }
+    return Status::OK();
+}
+
 } // namespace starrocks

--- a/be/src/exprs/array_map_expr.h
+++ b/be/src/exprs/array_map_expr.h
@@ -45,6 +45,8 @@ public:
     std::string debug_string() const override;
     int get_slot_ids(std::vector<SlotId>* slot_ids) const override;
 
+    Status do_for_each_child(const std::function<Status(Expr*)>& callback) override;
+
 private:
     template <bool all_const_input, bool independent_lambda_expr>
     StatusOr<ColumnPtr> evaluate_lambda_expr(ExprContext* context, Chunk* chunk, const Columns& arguments,

--- a/be/src/exprs/array_sort_lambda_expr.cpp
+++ b/be/src/exprs/array_sort_lambda_expr.cpp
@@ -91,6 +91,15 @@ void ArraySortLambdaExpr::close(RuntimeState* state, ExprContext* context, Funct
     Expr::close(state, context, scope);
 }
 
+Status ArraySortLambdaExpr::do_for_each_child(const std::function<Status(Expr*)>& callback) {
+    RETURN_IF_ERROR(Expr::do_for_each_child(callback));
+
+    for (const auto& [slot_id, expr] : _outer_common_exprs) {
+        RETURN_IF_ERROR(callback(expr));
+    }
+    return Status::OK();
+}
+
 // Helper class to manage comparisons during sorting
 
 class SortComparator {

--- a/be/src/exprs/array_sort_lambda_expr.h
+++ b/be/src/exprs/array_sort_lambda_expr.h
@@ -46,6 +46,8 @@ public:
 
     int get_slot_ids(std::vector<SlotId>* slot_ids) const override;
 
+    Status do_for_each_child(const std::function<Status(Expr*)>& callback) override;
+
 private:
     StatusOr<ColumnPtr> evaluate_lambda_expr(ExprContext* context, Chunk* chunk, const Column* data_column);
 

--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -68,16 +68,14 @@ Status LambdaFunction::extract_outer_common_exprs(RuntimeState* state, ExprConte
     for (int i = 0; i < child_num; i++) {
         auto child = expr->get_child(i);
 
-        // ignore dictmapping expr & its children, because it will be rewritten by DictOptimizeParser::rewrite_expr function.
-        if (child->is_dictmapping_expr()) {
-            continue;
+        // ignore dictmapping expr's children, because dictmapping expr will be rewritten by DictOptimizeParser::rewrite_expr function
+        // as a unified column ref expr.
+        if (!child->is_dictmapping_expr()) {
+            RETURN_IF_ERROR(extract_outer_common_exprs(state, expr_ctx, child, ctx));
         }
 
-        RETURN_IF_ERROR(extract_outer_common_exprs(state, expr_ctx, child, ctx));
-
         // if child is a slotref or a lambda function or a literal, we can't replace it.
-        if (child->is_slotref() || child->is_lambda_function() || child->is_literal() || child->is_constant() ||
-            child->is_dictmapping_expr()) {
+        if (child->is_slotref() || child->is_lambda_function() || child->is_literal() || child->is_constant()) {
             continue;
         }
 

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_with_lamda_function
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_with_lamda_function
@@ -19,7 +19,7 @@ SELECT SLEEP(3);
 -- !result
 [UC] ANALYZE FULL TABLE t1;
 -- result:
-test_db_bf1e812a1ddf43f49bddea55b1ae64eb.t1	analyze	status	OK
+test_db_e70dbc89852c4b2a9ab87cb70dced610.t1	analyze	status	OK
 -- !result
 function: wait_global_dict_ready('c', 't1')
 -- result:
@@ -39,6 +39,15 @@ WITH T2 AS (SELECT c IS NULL AS cn, [c] AS c FROM t1), T3 AS (SELECT array_lengt
 1
 -- !result
 WITH T2 AS (SELECT c IS NULL AS cn, [c] AS c FROM t1), T3 AS (SELECT array_length(ARRAY_MAP((arg_811) -> cn, c)) AS l FROM T2) SELECT * FROM T3 WHERE l > 1;
+-- result:
+-- !result
+WITH T2 AS (SELECT c IS NULL AS dict, ["A"] AS arr1, ["a"] AS arr2 FROM t1), T3 AS (SELECT ARRAY_LENGTH(ARRAY_MAP((arg1)->ARRAY_SUM(ARRAY_MAP((arg2)->dict, arr2)), arr1)) AS l FROM T2) SELECT * FROM T3 WHERE l > 1;
+-- result:
+-- !result
+WITH T2 AS (SELECT c IS NULL AS dict, ["A"] AS arr1, ["a"] AS arr2 FROM t1), T3 AS (SELECT ARRAY_LENGTH(ARRAY_SORTBY((arg1)->ARRAY_SUM(ARRAY_MAP((arg2)->dict, arr2)), arr1)) AS l FROM T2) SELECT * FROM T3 WHERE l > 1;
+-- result:
+-- !result
+WITH T2 AS (SELECT c IS NULL AS dict, ["A"] AS arr1, ["a"] AS arr2 FROM t1), T3 AS (SELECT ARRAY_LENGTH(ARRAY_SORTBY((arg1)->ARRAY_SUM(ARRAY_MAP((arg2)->dict, arr2)), arr1)) AS l FROM T2) SELECT * FROM T3 WHERE l > 1;
 -- result:
 -- !result
 drop table t1;

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_with_lamda_function
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_with_lamda_function
@@ -19,5 +19,10 @@ set enable_scan_predicate_expr_reuse=false;
 WITH T2 AS (SELECT c IS NULL AS cn, [c] AS c FROM t1), T3 AS (SELECT array_length(ARRAY_MAP((arg_811) -> cn, c)) AS l FROM T2) SELECT * FROM T3;
 WITH T2 AS (SELECT c IS NULL AS cn, [c] AS c FROM t1), T3 AS (SELECT array_length(ARRAY_MAP((arg_811) -> cn, c)) AS l FROM T2) SELECT * FROM T3 WHERE l > 0;
 WITH T2 AS (SELECT c IS NULL AS cn, [c] AS c FROM t1), T3 AS (SELECT array_length(ARRAY_MAP((arg_811) -> cn, c)) AS l FROM T2) SELECT * FROM T3 WHERE l > 1;
-
+-- array map
+WITH T2 AS (SELECT c IS NULL AS dict, ["A"] AS arr1, ["a"] AS arr2 FROM t1), T3 AS (SELECT ARRAY_LENGTH(ARRAY_MAP((arg1)->ARRAY_SUM(ARRAY_MAP((arg2)->dict, arr2)), arr1)) AS l FROM T2) SELECT * FROM T3 WHERE l > 1;
+-- array sortby (can use outer variables like dict)
+WITH T2 AS (SELECT c IS NULL AS dict, ["A"] AS arr1, ["a"] AS arr2 FROM t1), T3 AS (SELECT ARRAY_LENGTH(ARRAY_SORTBY((arg1)->ARRAY_SUM(ARRAY_MAP((arg2)->dict, arr2)), arr1)) AS l FROM T2) SELECT * FROM T3 WHERE l > 1;
+-- array sortby (can use outer variables like dict)
+WITH T2 AS (SELECT c IS NULL AS dict, ["A"] AS arr1, ["a"] AS arr2 FROM t1), T3 AS (SELECT ARRAY_LENGTH(ARRAY_SORTBY((arg1)->ARRAY_SUM(ARRAY_MAP((arg2)->dict, arr2)), arr1)) AS l FROM T2) SELECT * FROM T3 WHERE l > 1;
 drop table t1;


### PR DESCRIPTION
## Why I'm doing:
This is a follow up of https://github.com/StarRocks/starrocks/issues/67843.

The last pr missed array_map_expr / array_sort_lamda_expr, fix them again.

## What I'm doing:
- Add `_outer_common_exprs` as its child for array_map_expr / array_sort_lamda_expr to avoid ignoring dict rewrite.
- Support dict expr as common expr reuse but cannot split its child.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
