### PR TITLE
[BugFix] fix the patch for poco HTTPClientSession::readDataToResponseIOStream

### DIFF
--- a/thirdparty/patches/poco-1.12.5-zero-copy.patch
+++ b/thirdparty/patches/poco-1.12.5-zero-copy.patch
@@ -75,31 +75,41 @@ diff --git a/Net/src/HTTPClientSession.cpp b/Net/src/HTTPClientSession.cpp
  #else
  		_pResponseStream = new HTTPFixedLengthInputStream(*this, response.getContentLength());
  #endif
-@@ -388,6 +396,24 @@ std::istream& HTTPClientSession::receiveResponse(HTTPResponse& response)
+@@ -388,8 +396,34 @@ std::istream& HTTPClientSession::receiveResponse(HTTPResponse& response)
  		_pResponseStream = new HTTPInputStream(*this);
  
  	return *_pResponseStream;
 +
-+}
-+
-+void HTTPClientSession::readDataToResponseIOStream(HTTPResponse& response) {
-+	auto ioStream = response.getResponseIOStream();
-+	auto length = response.getContentLength64();
-+	char* buffer = reinterpret_cast<char *>(response.getPreAllocatedBuffer());
-+	auto n = read(buffer, length);
-+	auto current = n;
-+	while (n > 0 && current < length) {
-+		n = read(buffer + current, length - current);
-+		current += n;
-+	}
-+	if (n <= 0) {
-+		throw IllegalStateException("Poco socket read operation failed");
-+	}
-+	response.setBodyFilled(true);
-+	return;
  }
  
++void HTTPClientSession::readDataToResponseIOStream(HTTPResponse& response) {
++    constexpr int MAX_READ_LENGTH = 67108864;  // 64MB
++    char* buffer = reinterpret_cast<char*>(response.getPreAllocatedBuffer());
++
++    ssize_t length = response.getContentLength64();
++    ssize_t current = 0;
++    ssize_t remain = length;
++    while (remain > 0) {
++        int next_read = MAX_READ_LENGTH;
++        if (remain < next_read) {
++            next_read = static_cast<int>(remain);
++        }
++        int n = read(buffer + current, next_read);
++        if (n <= 0) {
++            break;
++        }
++        current += n;
++        remain -= n;
++    }
++    if (remain > 0) {
++        throw IllegalStateException("Poco socket read operation failed");
++    }
++    response.setBodyFilled(true);
++    return;
++}
  
+ bool HTTPClientSession::peekResponse(HTTPResponse& response)
+ {
 diff --git a/Net/src/HTTPResponse.cpp b/Net/src/HTTPResponse.cpp
 --- a/Net/src/HTTPResponse.cpp
 +++ b/Net/src/HTTPResponse.cpp


### PR DESCRIPTION
* properly handle integer overflow reading files larger than 2GB

## Why I'm doing:

```
	auto n = read(buffer, length);
	auto current = n;
```

The `n` and `current` will be auto deducted to `int` type, it should be explicitly set to int64 for file size.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
