### PR TITLE
[BugFix] return value of the case when expression is incorrect

### DIFF
--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -174,8 +174,13 @@ size_t ColumnHelper::count_true_with_notnull(const starrocks::ColumnPtr& col) {
         } else if (null_count == 0) {
             return true_count;
         } else {
-            // In fact, the null_count maybe is different with true_count, but it's no impact
-            return null_count;
+            size_t count = 0;
+            for (size_t i = 0; i < col->size(); i++) {
+                if (!null_data[i] && bool_data[i]) {
+                    count++;
+                }
+            }
+            return count;
         }
     } else {
         const Buffer<uint8_t>& bool_data = ColumnHelper::cast_to_raw<TYPE_BOOLEAN>(col)->get_data();
@@ -206,8 +211,13 @@ size_t ColumnHelper::count_false_with_notnull(const starrocks::ColumnPtr& col) {
         } else if (null_count == 0) {
             return false_count;
         } else {
-            // In fact, the null_count maybe is different with false_count, but it's no impact
-            return null_count;
+            size_t count = 0;
+            for (size_t i = 0; i < col->size(); i++) {
+                if (!null_data[i] && !bool_data[i]) {
+                    count++;
+                }
+            }
+            return count;
         }
     } else {
         const Buffer<uint8_t>& bool_data = ColumnHelper::cast_to_raw<TYPE_BOOLEAN>(col)->get_data();


### PR DESCRIPTION
## Why I'm doing:
The return value of the case when expression is incorrect

## What I'm doing:

<img width="953" height="525" alt="image" src="https://github.com/user-attachments/assets/203ef121-65b9-4be2-916c-36b6b652e6b3" />


Fixes #67790 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

