### PR TITLE
[Enhancement] Optimize memory usage by sharing adjacent tablet range bounds

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -246,6 +246,8 @@ public class SplitTabletJob extends TabletReshardJob {
                                 }
                             }
                         }
+                        // Share adjacent tablet range bounds to reduce memory usage
+                        newIndex.shareAdjacentTabletRangeBounds();
                     }
                 } else {
                     LOG.error("Unknown publish state {} in {}", publishResult.publishState(), this);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/BoolVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/BoolVariant.java
@@ -15,10 +15,7 @@
 package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.thrift.TVariant;
-import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.BooleanType;
-import com.starrocks.type.TypeSerializer;
 
 import java.util.Objects;
 
@@ -54,15 +51,6 @@ public class BoolVariant extends Variant {
     @Override
     public String getStringValue() {
         return value ? "TRUE" : "FALSE";
-    }
-
-    @Override
-    public TVariant toThrift() {
-        TVariant variant = new TVariant();
-        variant.setType(TypeSerializer.toThrift(type));
-        variant.setValue(getStringValue());
-        variant.setVariant_type(TVariantType.NORMAL_VALUE);
-        return variant;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DateVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DateVariant.java
@@ -17,10 +17,7 @@ package com.starrocks.catalog;
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.util.DateUtils;
-import com.starrocks.thrift.TVariant;
-import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.Type;
-import com.starrocks.type.TypeSerializer;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -56,15 +53,6 @@ public class DateVariant extends Variant {
     @Override
     public String getStringValue() {
         return Instant.ofEpochSecond(seconds, nanos).toString();
-    }
-
-    @Override
-    public TVariant toThrift() {
-        TVariant variant = new TVariant();
-        variant.setType(TypeSerializer.toThrift(type));
-        variant.setValue(getStringValue());
-        variant.setVariant_type(TVariantType.NORMAL_VALUE);
-        return variant;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IntVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IntVariant.java
@@ -16,10 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.thrift.TVariant;
-import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.Type;
-import com.starrocks.type.TypeSerializer;
 
 import java.util.Objects;
 
@@ -57,15 +54,6 @@ public class IntVariant extends Variant {
     @Override
     public String getStringValue() {
         return String.valueOf(value);
-    }
-
-    @Override
-    public TVariant toThrift() {
-        TVariant variant = new TVariant();
-        variant.setType(TypeSerializer.toThrift(type));
-        variant.setValue(getStringValue());
-        variant.setVariant_type(TVariantType.NORMAL_VALUE);
-        return variant;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LargeIntVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LargeIntVariant.java
@@ -16,10 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Int128;
-import com.starrocks.thrift.TVariant;
-import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.IntegerType;
-import com.starrocks.type.TypeSerializer;
 
 import java.math.BigInteger;
 
@@ -56,15 +53,6 @@ public class LargeIntVariant extends Variant {
     @Override
     public String getStringValue() {
         return value.toString();
-    }
-
-    @Override
-    public TVariant toThrift() {
-        TVariant variant = new TVariant();
-        variant.setType(TypeSerializer.toThrift(type));
-        variant.setValue(getStringValue());
-        variant.setVariant_type(TVariantType.NORMAL_VALUE);
-        return variant;
     }
 
     public BigInteger toBigInteger() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.clone.BalanceStat;
 import com.starrocks.clone.BalanceStat.BalanceType;
+import com.starrocks.common.Range;
 import com.starrocks.common.io.Writable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.persist.gson.GsonPostProcessable;
@@ -380,6 +381,71 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         }
         if (metaId == 0L) {
             metaId = id;
+        }
+        // Share adjacent tablet range bounds to reduce memory usage
+        shareAdjacentTabletRangeBounds();
+    }
+
+    /**
+     * Shares adjacent tablet range bounds to reduce memory usage.
+     * For adjacent tablets where upperBound[i-1] equals lowerBound[i],
+     * makes them share the same Tuple object instance.
+     *
+     * <p>This method validates that adjacent tablet ranges are continuous:
+     * the previous tablet's upper bound must equal the current tablet's lower bound,
+     * and neither bound can be null.
+     *
+     * <p>For non-range distribution tables, TabletRange may be null, in which case
+     * this method skips processing for those tablets.
+     *
+     * <p>This method should be called after deserialization or tablet split
+     * operations to optimize memory usage.
+     *
+     * @throws IllegalStateException if adjacent tablet ranges are not continuous
+     *         or if any bound is null (when both TabletRanges are non-null)
+     */
+    public void shareAdjacentTabletRangeBounds() {
+        for (int i = 1; i < tablets.size(); i++) {
+            Tablet prevTablet = tablets.get(i - 1);
+            Tablet currTablet = tablets.get(i);
+
+            TabletRange prevTabletRange = prevTablet.getRange();
+            TabletRange currTabletRange = currTablet.getRange();
+            // Skip if either TabletRange is null (non-range distribution tables)
+            if (prevTabletRange == null || currTabletRange == null) {
+                break;
+            }
+
+            Range<Tuple> prevRange = prevTabletRange.getRange();
+            Range<Tuple> currRange = currTabletRange.getRange();
+
+            Tuple prevUpperBound = prevRange.getUpperBound();
+            Tuple currLowerBound = currRange.getLowerBound();
+
+            // Validate that bounds are not null
+            if (prevUpperBound == null || currLowerBound == null) {
+                throw new IllegalStateException(
+                        "Range bound is null: tablet " + prevTablet.getId() + " upper bound is "
+                                + (prevUpperBound == null ? "null" : prevUpperBound)
+                                + ", tablet " + currTablet.getId() + " lower bound is "
+                                + (currLowerBound == null ? "null" : currLowerBound));
+            }
+
+            // Validate range continuity
+            if (!prevUpperBound.equals(currLowerBound)) {
+                throw new IllegalStateException(
+                        "Adjacent tablet ranges are not continuous: tablet " + prevTablet.getId()
+                                + " upper bound " + prevUpperBound + " != tablet " + currTablet.getId()
+                                + " lower bound " + currLowerBound);
+            }
+
+            // Share the same Tuple object: use prevUpperBound as the shared bound
+            Range<Tuple> newRange = Range.of(
+                    prevUpperBound,  // Share the same Tuple object
+                    currRange.getUpperBound(),
+                    currRange.isLowerBoundIncluded(),
+                    currRange.isUpperBoundIncluded());
+            currTablet.setRange(new TabletRange(newRange));
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaxVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaxVariant.java
@@ -14,8 +14,6 @@
 
 package com.starrocks.catalog;
 
-import com.starrocks.thrift.TVariant;
-import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.Type;
 
 import java.util.Objects;
@@ -33,14 +31,6 @@ public class MaxVariant extends Variant {
     @Override
     public long getLongValue() {
         return Long.MAX_VALUE;
-    }
-
-    @Override
-    public TVariant toThrift() {
-        TVariant variant = new TVariant();
-        variant.setType(com.starrocks.type.TypeSerializer.toThrift(type));
-        variant.setVariant_type(TVariantType.MAXIMUM);
-        return variant;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MinVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MinVariant.java
@@ -14,8 +14,6 @@
 
 package com.starrocks.catalog;
 
-import com.starrocks.thrift.TVariant;
-import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.Type;
 
 import java.util.Objects;
@@ -33,14 +31,6 @@ public class MinVariant extends Variant {
     @Override
     public long getLongValue() {
         return Long.MIN_VALUE;
-    }
-
-    @Override
-    public TVariant toThrift() {
-        TVariant variant = new TVariant();
-        variant.setType(com.starrocks.type.TypeSerializer.toThrift(type));
-        variant.setVariant_type(TVariantType.MINIMUM);
-        return variant;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/NullVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/NullVariant.java
@@ -14,10 +14,7 @@
 
 package com.starrocks.catalog;
 
-import com.starrocks.thrift.TVariant;
-import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.Type;
-import com.starrocks.type.TypeSerializer;
 
 import java.util.Objects;
 
@@ -34,14 +31,6 @@ public class NullVariant extends Variant {
     @Override
     public long getLongValue() {
         throw new IllegalStateException("NullVariant has no numeric value");
-    }
-
-    @Override
-    public TVariant toThrift() {
-        TVariant variant = new TVariant();
-        variant.setType(TypeSerializer.toThrift(type));
-        variant.setVariant_type(TVariantType.NULL_VALUE);
-        return variant;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StringVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StringVariant.java
@@ -16,10 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.util.StringUtils;
-import com.starrocks.thrift.TVariant;
-import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.Type;
-import com.starrocks.type.TypeSerializer;
 
 /*
  * StringVariant is for type CHAR, VARCHAR, BINARY, VARBINARY and HLL
@@ -42,15 +39,6 @@ public class StringVariant extends Variant {
     @Override
     public String getStringValue() {
         return value;
-    }
-
-    @Override
-    public TVariant toThrift() {
-        TVariant variant = new TVariant();
-        variant.setType(TypeSerializer.toThrift(type));
-        variant.setValue(getStringValue());
-        variant.setVariant_type(TVariantType.NORMAL_VALUE);
-        return variant;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletRange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletRange.java
@@ -41,6 +41,34 @@ public class TabletRange {
         return range.toString();
     }
 
+    public TTabletRange toThrift() {
+        TTabletRange tRange = new TTabletRange();
+        tRange.setLower_bound_included(range.isLowerBoundIncluded());
+        tRange.setUpper_bound_included(range.isUpperBoundIncluded());
+
+        if (!range.isMinimum()) {
+            tRange.setLower_bound(range.getLowerBound().toThrift());
+        }
+        if (!range.isMaximum()) {
+            tRange.setUpper_bound(range.getUpperBound().toThrift());
+        }
+        return tRange;
+    }
+
+    public TabletRangePB toProto() {
+        TabletRangePB rangePB = new TabletRangePB();
+        rangePB.lowerBoundIncluded = range.isLowerBoundIncluded();
+        rangePB.upperBoundIncluded = range.isUpperBoundIncluded();
+
+        if (!range.isMinimum()) {
+            rangePB.lowerBound = range.getLowerBound().toProto();
+        }
+        if (!range.isMaximum()) {
+            rangePB.upperBound = range.getUpperBound().toProto();
+        }
+        return rangePB;
+    }
+
     public static TabletRange fromThrift(TTabletRange tTabletRange) {
         return new TabletRange(
                 Range.of(Tuple.fromThrift(tTabletRange.lower_bound), Tuple.fromThrift(tTabletRange.upper_bound),
@@ -55,17 +83,4 @@ public class TabletRange {
         return new TabletRange(Range.of(lowerBound, upperBound, lowerIncluded, upperIncluded));
     }
 
-    public TTabletRange toThrift() {
-        TTabletRange tRange = new TTabletRange();
-        tRange.setLower_bound_included(range.isLowerBoundIncluded());
-        tRange.setUpper_bound_included(range.isUpperBoundIncluded());
-
-        if (!range.isMinimum()) {
-            tRange.setLower_bound(range.getLowerBound().toThrift());
-        }
-        if (!range.isMaximum()) {
-            tRange.setUpper_bound(range.getUpperBound().toThrift());
-        }
-        return tRange;
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tuple.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tuple.java
@@ -61,17 +61,23 @@ public class Tuple implements Comparable<Tuple> {
         return values.toString();
     }
 
+    public TTuple toThrift() {
+        TTuple tuple = new TTuple();
+        tuple.setValues(values.stream().map(Variant::toThrift).collect(Collectors.toList()));
+        return tuple;
+    }
+
+    public TuplePB toProto() {
+        TuplePB tuple = new TuplePB();
+        tuple.values = values.stream().map(Variant::toProto).collect(Collectors.toList());
+        return tuple;
+    }
+
     public static Tuple fromThrift(TTuple tTuple) {
         return new Tuple(tTuple.values.stream().map(v -> Variant.fromThrift(v)).collect(Collectors.toList()));
     }
 
     public static Tuple fromProto(TuplePB tuplePB) {
         return new Tuple(tuplePB.values.stream().map(v -> Variant.fromProto(v)).collect(Collectors.toList()));
-    }
-
-    public TTuple toThrift() {
-        TTuple tuple = new TTuple();
-        tuple.setValues(values.stream().map(Variant::toThrift).collect(Collectors.toList()));
-        return tuple;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
@@ -23,6 +23,7 @@ import com.starrocks.thrift.TVariant;
 import com.starrocks.thrift.TVariantType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeDeserializer;
+import com.starrocks.type.TypeSerializer;
 
 import java.util.List;
 
@@ -53,9 +54,37 @@ public abstract class Variant implements Comparable<Variant> {
 
     public abstract long getLongValue();
 
-    public abstract TVariant toThrift();
+    public TVariant toThrift() {
+        TVariant variant = new TVariant();
+        variant.setType(TypeSerializer.toThrift(type));
+        if (this instanceof NullVariant) {
+            variant.setVariant_type(TVariantType.NULL_VALUE);
+        } else if (this instanceof MinVariant) {
+            variant.setVariant_type(TVariantType.MINIMUM);
+        } else if (this instanceof MaxVariant) {
+            variant.setVariant_type(TVariantType.MAXIMUM);
+        } else {
+            variant.setVariant_type(TVariantType.NORMAL_VALUE);
+            variant.setValue(getStringValue());
+        }
+        return variant;
+    }
 
-    // public abstract VariantPB toProto();
+    public VariantPB toProto() {
+        VariantPB variant = new VariantPB();
+        variant.type = TypeSerializer.toProtobuf(type);
+        if (this instanceof NullVariant) {
+            variant.variantType = VariantTypePB.NULL_VALUE;
+        } else if (this instanceof MinVariant) {
+            variant.variantType = VariantTypePB.MINIMUM;
+        } else if (this instanceof MaxVariant) {
+            variant.variantType = VariantTypePB.MAXIMUM;
+        } else {
+            variant.variantType = VariantTypePB.NORMAL_VALUE;
+            variant.value = getStringValue();
+        }
+        return variant;
+    }
 
     protected abstract int compareToImpl(Variant other);
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexTest.java
@@ -36,6 +36,7 @@ package com.starrocks.catalog;
 
 import com.starrocks.catalog.MaterializedIndex.IndexState;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.Range;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
@@ -46,6 +47,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -114,5 +116,303 @@ public class MaterializedIndexTest {
         MaterializedIndex newIndex = GsonUtils.GSON.fromJson(json, MaterializedIndex.class);
 
         Assertions.assertEquals(1L, newIndex.getMetaId());
+    }
+
+    // ==================== Share Adjacent Tablet Range Bounds Tests ====================
+
+    private Tuple createTuple(int value) throws Exception {
+        return new Tuple(Arrays.asList(Variant.of(IntegerType.INT, String.valueOf(value))));
+    }
+
+    private LocalTablet createTabletWithRange(long tabletId, Tuple lower, Tuple upper,
+                                              boolean lowerIncluded, boolean upperIncluded) {
+        LocalTablet tablet = new LocalTablet(tabletId);
+        Range<Tuple> range = Range.of(lower, upper, lowerIncluded, upperIncluded);
+        tablet.setRange(new TabletRange(range));
+        return tablet;
+    }
+
+    @Test
+    public void testShareAdjacentTabletRangeBounds() throws Exception {
+        // Test that adjacent tablet range bounds are shared (same object reference)
+        MaterializedIndex index = new MaterializedIndex(1, IndexState.NORMAL);
+
+        Tuple t10 = createTuple(10);
+        Tuple t20 = createTuple(20);
+        Tuple t20Copy = createTuple(20);  // Different object, same value
+        Tuple t30 = createTuple(30);
+
+        // Create tablets with different Tuple objects for the shared bound
+        LocalTablet tablet1 = createTabletWithRange(1001, t10, t20, true, false);
+        LocalTablet tablet2 = createTabletWithRange(1002, t20Copy, t30, true, false);
+
+        index.addTablet(tablet1, null, false);
+        index.addTablet(tablet2, null, false);
+
+        // Before sharing: bounds are equal but different objects
+        Assertions.assertEquals(t20, tablet2.getRange().getRange().getLowerBound());
+        Assertions.assertNotSame(t20, tablet2.getRange().getRange().getLowerBound());
+
+        // Share adjacent bounds
+        index.shareAdjacentTabletRangeBounds();
+
+        // After sharing: tablet2's lower bound should be the same object as tablet1's upper bound
+        Assertions.assertSame(
+                tablet1.getRange().getRange().getUpperBound(),
+                tablet2.getRange().getRange().getLowerBound());
+    }
+
+    @Test
+    public void testShareAdjacentTabletRangeBoundsWithMultipleTablets() throws Exception {
+        // Test sharing with multiple consecutive tablets
+        MaterializedIndex index = new MaterializedIndex(1, IndexState.NORMAL);
+
+        int numTablets = 5;
+        Tuple[] bounds = new Tuple[numTablets + 1];
+        for (int i = 0; i <= numTablets; i++) {
+            bounds[i] = createTuple(i * 10);
+        }
+
+        // Create tablets with separate Tuple objects for each bound
+        for (int i = 0; i < numTablets; i++) {
+            Tuple lower = createTuple(i * 10);  // New Tuple object
+            Tuple upper = createTuple((i + 1) * 10);  // New Tuple object
+            LocalTablet tablet = createTabletWithRange(1000 + i, lower, upper, true, false);
+            index.addTablet(tablet, null, false);
+        }
+
+        // Share adjacent bounds
+        index.shareAdjacentTabletRangeBounds();
+
+        // Verify all adjacent bounds are shared
+        List<Tablet> tablets = index.getTablets();
+        for (int i = 1; i < tablets.size(); i++) {
+            Tablet prevTablet = tablets.get(i - 1);
+            Tablet currTablet = tablets.get(i);
+
+            Assertions.assertSame(
+                    prevTablet.getRange().getRange().getUpperBound(),
+                    currTablet.getRange().getRange().getLowerBound(),
+                    "Tablets " + (i - 1) + " and " + i + " should share bound");
+        }
+    }
+
+    @Test
+    public void testShareAdjacentTabletRangeBoundsThrowsOnDiscontinuity() throws Exception {
+        // Test that non-continuous ranges throw exception
+        MaterializedIndex index = new MaterializedIndex(1, IndexState.NORMAL);
+
+        Tuple t10 = createTuple(10);
+        Tuple t20 = createTuple(20);
+        Tuple t25 = createTuple(25);  // Gap: 20 != 25
+        Tuple t30 = createTuple(30);
+
+        LocalTablet tablet1 = createTabletWithRange(1001, t10, t20, true, false);
+        LocalTablet tablet2 = createTabletWithRange(1002, t25, t30, true, false);
+
+        index.addTablet(tablet1, null, false);
+        index.addTablet(tablet2, null, false);
+
+        // Should throw exception due to discontinuous ranges
+        IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, () -> {
+            index.shareAdjacentTabletRangeBounds();
+        });
+
+        // Verify error message contains relevant information
+        Assertions.assertTrue(exception.getMessage().contains("not continuous"));
+        Assertions.assertTrue(exception.getMessage().contains("1001"));
+        Assertions.assertTrue(exception.getMessage().contains("1002"));
+    }
+
+    @Test
+    public void testShareAdjacentTabletRangeBoundsThrowsOnNullBounds() throws Exception {
+        // Test that null bounds throw exception
+        MaterializedIndex index = new MaterializedIndex(1, IndexState.NORMAL);
+
+        Tuple t10 = createTuple(10);
+        Tuple t20 = createTuple(20);
+
+        // First tablet with null upper bound (positive infinity)
+        LocalTablet tablet1 = new LocalTablet(1001);
+        Range<Tuple> range1 = Range.of(t10, null, true, false);  // [10, +∞)
+        tablet1.setRange(new TabletRange(range1));
+
+        // Second tablet with normal bounds
+        LocalTablet tablet2 = createTabletWithRange(1002, t10, t20, true, false);
+
+        index.addTablet(tablet1, null, false);
+        index.addTablet(tablet2, null, false);
+
+        // Should throw exception due to null bound
+        IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, () -> {
+            index.shareAdjacentTabletRangeBounds();
+        });
+
+        // Verify error message contains relevant information
+        Assertions.assertTrue(exception.getMessage().contains("null"));
+    }
+
+    @Test
+    public void testShareAdjacentTabletRangeBoundsSkipsNullTabletRange() throws Exception {
+        // Test that null TabletRange is skipped (for non-range distribution tables)
+        MaterializedIndex index = new MaterializedIndex(1, IndexState.NORMAL);
+
+        Tuple t10 = createTuple(10);
+        Tuple t20 = createTuple(20);
+        Tuple t30 = createTuple(30);
+
+        LocalTablet tablet1 = createTabletWithRange(1001, t10, t20, true, false);
+        // tablet2 has null TabletRange (non-range distribution table)
+        LocalTablet tablet2 = new LocalTablet(1002);
+        tablet2.setRange(null);
+        LocalTablet tablet3 = createTabletWithRange(1003, t20, t30, true, false);
+
+        index.addTablet(tablet1, null, false);
+        index.addTablet(tablet2, null, false);
+        index.addTablet(tablet3, null, false);
+
+        // Should not throw exception - null TabletRange is skipped
+        index.shareAdjacentTabletRangeBounds();
+
+        // Verify tablet1 and tablet3 ranges are unchanged (no sharing because tablet2 is in between)
+        Assertions.assertNotNull(tablet1.getRange());
+        Assertions.assertNull(tablet2.getRange());
+        Assertions.assertNotNull(tablet3.getRange());
+    }
+
+    @Test
+    public void testShareAdjacentTabletRangeBoundsWithEmptyList() throws Exception {
+        // Test that empty tablets list doesn't cause issues
+        MaterializedIndex index = new MaterializedIndex(1, IndexState.NORMAL);
+
+        // Should not throw
+        index.shareAdjacentTabletRangeBounds();
+
+        Assertions.assertTrue(index.getTablets().isEmpty());
+    }
+
+    @Test
+    public void testShareAdjacentTabletRangeBoundsWithSingleTablet() throws Exception {
+        // Test that single tablet doesn't cause issues
+        MaterializedIndex index = new MaterializedIndex(1, IndexState.NORMAL);
+
+        Tuple t10 = createTuple(10);
+        Tuple t20 = createTuple(20);
+
+        LocalTablet tablet = createTabletWithRange(1001, t10, t20, true, false);
+        index.addTablet(tablet, null, false);
+
+        // Should not throw
+        index.shareAdjacentTabletRangeBounds();
+
+        // Verify tablet is unchanged
+        Assertions.assertEquals(t10, tablet.getRange().getRange().getLowerBound());
+        Assertions.assertEquals(t20, tablet.getRange().getRange().getUpperBound());
+    }
+
+    @Test
+    public void testShareAdjacentTabletRangeBoundsPreservesInclusionFlags() throws Exception {
+        // Test that inclusion flags are preserved during sharing
+        MaterializedIndex index = new MaterializedIndex(1, IndexState.NORMAL);
+
+        Tuple t10 = createTuple(10);
+        Tuple t20 = createTuple(20);
+        Tuple t20Copy = createTuple(20);
+        Tuple t30 = createTuple(30);
+
+        // tablet1: [10, 20] (closed interval)
+        LocalTablet tablet1 = createTabletWithRange(1001, t10, t20, true, true);
+        // tablet2: (20, 30) (open interval) - note: same bound value but different inclusion
+        LocalTablet tablet2 = createTabletWithRange(1002, t20Copy, t30, false, false);
+
+        index.addTablet(tablet1, null, false);
+        index.addTablet(tablet2, null, false);
+
+        // Share adjacent bounds
+        index.shareAdjacentTabletRangeBounds();
+
+        // Verify inclusion flags are preserved
+        Range<Tuple> range1 = tablet1.getRange().getRange();
+        Assertions.assertTrue(range1.isLowerBoundIncluded());
+        Assertions.assertTrue(range1.isUpperBoundIncluded());
+
+        Range<Tuple> range2 = tablet2.getRange().getRange();
+        Assertions.assertFalse(range2.isLowerBoundIncluded());
+        Assertions.assertFalse(range2.isUpperBoundIncluded());
+
+        // Verify bounds are shared
+        Assertions.assertSame(range1.getUpperBound(), range2.getLowerBound());
+    }
+
+    @Test
+    public void testGsonPostProcessSharesAdjacentBounds() throws Exception {
+        // Test that gsonPostProcess shares adjacent bounds after deserialization
+        MaterializedIndex index = new MaterializedIndex(1, IndexState.NORMAL);
+
+        Tuple t10 = createTuple(10);
+        Tuple t20 = createTuple(20);
+        Tuple t30 = createTuple(30);
+
+        LocalTablet tablet1 = createTabletWithRange(1001, t10, t20, true, false);
+        LocalTablet tablet2 = createTabletWithRange(1002, t20, t30, true, false);
+
+        index.addTablet(tablet1, null, false);
+        index.addTablet(tablet2, null, false);
+
+        // Serialize and deserialize
+        String json = GsonUtils.GSON.toJson(index);
+        MaterializedIndex deserializedIndex = GsonUtils.GSON.fromJson(json, MaterializedIndex.class);
+
+        // After deserialization, adjacent bounds should be shared
+        List<Tablet> tablets = deserializedIndex.getTablets();
+        Assertions.assertSame(
+                tablets.get(0).getRange().getRange().getUpperBound(),
+                tablets.get(1).getRange().getRange().getLowerBound());
+    }
+
+    @Test
+    public void testSerializationRoundTripPreservesRanges() throws Exception {
+        // Test complete serialization/deserialization round trip
+        MaterializedIndex index = new MaterializedIndex(1, IndexState.NORMAL);
+
+        Tuple t10 = createTuple(10);
+        Tuple t20 = createTuple(20);
+        Tuple t30 = createTuple(30);
+        Tuple t40 = createTuple(40);
+
+        // Create tablets: [10, 20), [20, 30), [30, 40)
+        LocalTablet tablet1 = createTabletWithRange(1001, t10, t20, true, false);
+        LocalTablet tablet2 = createTabletWithRange(1002, t20, t30, true, false);
+        LocalTablet tablet3 = createTabletWithRange(1003, t30, t40, true, false);
+
+        index.addTablet(tablet1, null, false);
+        index.addTablet(tablet2, null, false);
+        index.addTablet(tablet3, null, false);
+
+        // Save original ranges for verification
+        Range<Tuple> originalRange1 = tablet1.getRange().getRange();
+        Range<Tuple> originalRange2 = tablet2.getRange().getRange();
+        Range<Tuple> originalRange3 = tablet3.getRange().getRange();
+
+        // Serialize and deserialize
+        String json = GsonUtils.GSON.toJson(index);
+        MaterializedIndex deserializedIndex = GsonUtils.GSON.fromJson(json, MaterializedIndex.class);
+
+        // Verify all tablets have correct ranges after deserialization
+        List<Tablet> tablets = deserializedIndex.getTablets();
+        Assertions.assertEquals(3, tablets.size());
+
+        // Verify ranges are equal
+        Range<Tuple> range1 = tablets.get(0).getRange().getRange();
+        Assertions.assertEquals(originalRange1.getLowerBound(), range1.getLowerBound());
+        Assertions.assertEquals(originalRange1.getUpperBound(), range1.getUpperBound());
+
+        Range<Tuple> range2 = tablets.get(1).getRange().getRange();
+        Assertions.assertEquals(originalRange2.getLowerBound(), range2.getLowerBound());
+        Assertions.assertEquals(originalRange2.getUpperBound(), range2.getUpperBound());
+
+        Range<Tuple> range3 = tablets.get(2).getRange().getRange();
+        Assertions.assertEquals(originalRange3.getLowerBound(), range3.getLowerBound());
+        Assertions.assertEquals(originalRange3.getUpperBound(), range3.getUpperBound());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -66,6 +66,7 @@ import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeDeserializer;
 import com.starrocks.type.TypeFactory;
+import com.starrocks.type.TypeSerializer;
 import com.starrocks.type.VarbinaryType;
 import com.starrocks.type.VarcharType;
 import com.starrocks.type.VariantType;
@@ -415,6 +416,34 @@ public class TypeTest {
         pTypeDesc = buildStructType(fieldNames, fieldTypes);
         tp = TypeDeserializer.fromProtobuf(pTypeDesc);
         Assertions.assertTrue(tp.isStructType());
+    }
+
+    @Test
+    public void testTypeSerializerToProtobufScalar() {
+        ScalarType varchar = new VarcharType(10);
+        Type restoredVarchar = TypeDeserializer.fromProtobuf(TypeSerializer.toProtobuf(varchar));
+        Assertions.assertEquals(varchar, restoredVarchar);
+
+        ScalarType decimal = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 12, 3);
+        Type restoredDecimal = TypeDeserializer.fromProtobuf(TypeSerializer.toProtobuf(decimal));
+        Assertions.assertEquals(decimal, restoredDecimal);
+    }
+
+    @Test
+    public void testTypeSerializerToProtobufComplex() {
+        Type arrayType = new ArrayType(IntegerType.INT);
+        Type restoredArray = TypeDeserializer.fromProtobuf(TypeSerializer.toProtobuf(arrayType));
+        Assertions.assertEquals(arrayType, restoredArray);
+
+        Type mapType = new MapType(IntegerType.INT, new VarcharType(20));
+        Type restoredMap = TypeDeserializer.fromProtobuf(TypeSerializer.toProtobuf(mapType));
+        Assertions.assertEquals(mapType, restoredMap);
+
+        StructType structType = new StructType(Lists.newArrayList(
+                new StructField("f1", IntegerType.INT),
+                new StructField("f2", new VarcharType(5))));
+        Type restoredStruct = TypeDeserializer.fromProtobuf(TypeSerializer.toProtobuf(structType));
+        Assertions.assertEquals(structType, restoredStruct);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
This change optimizes memory usage for TabletRange in MaterializedIndex by
sharing Tuple objects between adjacent tablets' range bounds.

## What I'm doing:
Two optimization scenarios are addressed:

1. Deserialization optimization:
   - After deserialization (gsonPostProcess), call shareAdjacentTabletRangeBounds() to
     make adjacent tablets share the same Tuple object for their common bound.

2. Tablet split optimization:
   - After tablet split operations, call shareAdjacentTabletRangeBounds() to
     make adjacent tablets share the same Tuple object for their common bound.
   - This method also validates range continuity and throws IllegalStateException
     if adjacent ranges are not continuous.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
