### PR TITLE
[BugFix] Fix JSON path rewrite pruning partition predicate columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -346,6 +346,16 @@ public class JsonPathRewriteRule extends TransformationRule {
             if (builder.getPredicate() != null) {
                 requiredColumnSet.union(builder.getPredicate().getUsedColumns());
             }
+            
+            if (scanOperator instanceof LogicalOlapScanOperator olapScanOperator &&
+                    MapUtils.isNotEmpty(olapScanOperator.getColRefToColumnMetaMap())) {
+                for (ScalarOperator p : olapScanOperator.getPrunedPartitionPredicates()) {
+                    if (p != null) {
+                        requiredColumnSet.union(p.getUsedColumns());
+                    }
+                }
+            }
+
             if (scanOperator.getProjection() != null) {
                 Map<ColumnRefOperator, ScalarOperator> mapping = Maps.newHashMap();
                 for (var entry : scanOperator.getProjection().getColumnRefMap().entrySet()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
@@ -409,5 +409,6 @@ public class JsonPathRewriteTest extends PlanTestBase {
             starRocksAssert.dropTable("json_rename");
         }
     }
+
 }
 

--- a/test/sql/test_json/R/test_json_path_rewrite_pruned_partition_predicates.sql
+++ b/test/sql/test_json/R/test_json_path_rewrite_pruned_partition_predicates.sql
@@ -1,0 +1,37 @@
+-- name: test_json_path_rewrite_pruned_partition_predicates
+drop database if exists test_json_path_rewrite_pruned_partition_predicates;
+-- result:
+-- !result
+CREATE DATABASE test_json_path_rewrite_pruned_partition_predicates;
+-- result:
+-- !result
+USE test_json_path_rewrite_pruned_partition_predicates;
+-- result:
+-- !result
+CREATE TABLE json_partition_prune (
+  `company_id` varchar(256) NULL,
+  `ts` datetime NULL,
+  `company_metadata` json NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`company_id`)
+PARTITION BY RANGE(`ts`)
+(PARTITION p20260108 VALUES [('2026-01-08 00:00:00'), ('2026-01-09 00:00:00')))
+DISTRIBUTED BY HASH(`company_id`) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO json_partition_prune VALUES
+('a', '2026-01-08 12:00:00', parse_json('{"path":"/profile"}')),
+('b', '2026-01-08 13:00:00', parse_json('{"path":"/products"}')),
+('c', '2026-01-08 14:00:00', parse_json('{"path":"/products"}'));
+-- result:
+-- !result
+SELECT COALESCE(COALESCE(json_query(company_metadata, '$.path'), ''), '') AS k, COUNT(*) AS c
+FROM json_partition_prune
+WHERE ts >= TIMESTAMP('2026-01-08 00:00:00') AND ts < TIMESTAMP('2026-01-09 00:00:00')
+GROUP BY 1
+ORDER BY 1;
+-- result:
+/products	2
+/profile	1
+-- !result

--- a/test/sql/test_json/T/test_json_path_rewrite_pruned_partition_predicates.sql
+++ b/test/sql/test_json/T/test_json_path_rewrite_pruned_partition_predicates.sql
@@ -1,0 +1,27 @@
+-- name: test_json_path_rewrite_pruned_partition_predicates
+drop database if exists test_json_path_rewrite_pruned_partition_predicates;
+CREATE DATABASE test_json_path_rewrite_pruned_partition_predicates;
+USE test_json_path_rewrite_pruned_partition_predicates;
+
+CREATE TABLE json_partition_prune (
+  `company_id` varchar(256) NULL,
+  `ts` datetime NULL,
+  `company_metadata` json NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`company_id`)
+PARTITION BY RANGE(`ts`)
+(PARTITION p20260108 VALUES [('2026-01-08 00:00:00'), ('2026-01-09 00:00:00')))
+DISTRIBUTED BY HASH(`company_id`) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO json_partition_prune VALUES
+('a', '2026-01-08 12:00:00', parse_json('{"path":"/profile"}')),
+('b', '2026-01-08 13:00:00', parse_json('{"path":"/products"}')),
+('c', '2026-01-08 14:00:00', parse_json('{"path":"/products"}'));
+
+SELECT COALESCE(COALESCE(json_query(company_metadata, '$.path'), ''), '') AS k, COUNT(*) AS c
+FROM json_partition_prune
+WHERE ts >= TIMESTAMP('2026-01-08 00:00:00') AND ts < TIMESTAMP('2026-01-09 00:00:00')
+GROUP BY 1
+ORDER BY 1;
+


### PR DESCRIPTION
## Why I'm doing:
With `cbo_json_v2_rewrite` enabled, applying `TF_JSON_PATH_REWRITE` can prune away partition columns when partition pruning moves partition predicates from `scan.predicate` into `prunedPartitionPredicates`. This may cause plan validation to fail with `Input dependency cols check failed` (issue #67665).

## What I'm doing:
- Include columns referenced by `prunedPartitionPredicates` in the scan’s `requiredColumnSet` during `JsonPathRewriteRule` so partition columns are not dropped from `colRefToColumnMetaMap`.

Fixes #67665

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
