### PR TITLE
[Enhancement] Add ErrorMessage information to audit logs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
@@ -55,7 +55,8 @@ public class LogUtil {
                 .setFeIp(FrontendOptions.getLocalHostAddress())
                 .setDb(authPacket == null ? "null" : authPacket.getDb())
                 .setState(ctx.getState().toString())
-                .setErrorCode(ctx.getState().getErrorMessage());
+                .setErrorCode(ctx.getState().getErrorMessage())
+                .setErrorMsg(ctx.getState().getErrorMessage());
         GlobalStateMgr.getCurrentState().getAuditEventProcessor().handleAuditEvent(builder.build());
 
         QueryDetail queryDetail = new QueryDetail();

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -183,6 +183,9 @@ public class AuditEvent {
     @AuditField(value = "CacheHitRatio", ignore_empty = true)
     public String cacheHitRatio = "";
 
+    @AuditField(value = "ErrorMessage")
+    public String errorMessage = "";
+
     public void calculateCacheHitRatio() {
         if (!isQuery || RunMode.isSharedNothingMode()) {
             return;
@@ -499,6 +502,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setPreparedStmtId(String preparedStmtId) {
             auditEvent.preparedStmtId = preparedStmtId;
+            return this;
+        }
+
+        public AuditEventBuilder setErrorMsg(String errorMsg) {
+            auditEvent.errorMessage = errorMsg;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -242,7 +242,8 @@ public class ConnectProcessor {
                 .setCNGroup(ctx.getCurrentComputeResourceName())
                 .setQuerySource(ctx.getQuerySource().toString())
                 .setCommand(ctx.getCommandStr())
-                .setPreparedStmtId(executor == null ? null : executor.getPreparedStmtId());
+                .setPreparedStmtId(executor == null ? null : executor.getPreparedStmtId())
+                .setErrorMsg(ctx.getState().getErrorMessage());
 
         if (ctx.getState().isQuery()) {
             if (ctx.getState().getErrType() != QueryState.ErrType.BLACKLISTED) {

--- a/fe/fe-core/src/test/java/com/starrocks/plugin/AuditEventTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/plugin/AuditEventTest.java
@@ -46,7 +46,8 @@ public class AuditEventTest {
                 .setCustomSessionName("customSessionName")
                 .setCNGroup("test_cngroup")
                 .addReadLocalCnt(100)
-                .addReadRemoteCnt(100);
+                .addReadRemoteCnt(100)
+                .setErrorMsg("errorMsg");
 
         new MockUp<RunMode>() {
             @Mock
@@ -79,5 +80,6 @@ public class AuditEventTest {
         Assertions.assertEquals("50.0%", event.cacheHitRatio);
         Assertions.assertEquals(100, event.writeClientTimeMs);
         Assertions.assertEquals((float) 50, event.getCacheMissRatio());
+        Assertions.assertEquals("errorMsg", event.errorMessage);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Currently, the audit logs only record the error code without the corresponding detailed error message.
During troubleshooting, engineers have to search for the exact error information in the system logs, which is inefficient.
To improve usability and troubleshooting efficiency, detailed error messages should be added to the audit logs

## What I'm doing:
Add ErrorMessage information to audit logs

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances audit visibility by recording detailed error text alongside error codes.
> 
> - Introduces `ErrorMessage` field to `AuditEvent` (annotated `@AuditField`) and builder method `setErrorMsg`
> - Populates error message in `LogUtil` (connection audit) and `ConnectProcessor` (after exec)
> - Updates `AuditEventTest` to cover `errorMessage` population
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03dbd1878e72960977cbeb2f6a92a1281d990bd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->