### PR TITLE
[BugFix] Fixed bad path regex to work with legal simple json paths

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -80,7 +80,7 @@ public class JsonPathRewriteRule extends TransformationRule {
 
     private static final Logger LOG = LogManager.getLogger(JsonPathRewriteRule.class);
     private static final java.util.regex.Pattern JSON_PATH_VALID_PATTERN =
-            java.util.regex.Pattern.compile("^[a-zA-Z0-9\-_]+$");
+            java.util.regex.Pattern.compile("^[a-zA-Z0-9_-]+$");
     public static final String COLUMN_REF_HINT = "JsonPathExtended";
 
     private static final Set<String> SUPPORTED_JSON_FUNCTIONS = Set.of(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -80,7 +80,7 @@ public class JsonPathRewriteRule extends TransformationRule {
 
     private static final Logger LOG = LogManager.getLogger(JsonPathRewriteRule.class);
     private static final java.util.regex.Pattern JSON_PATH_VALID_PATTERN =
-            java.util.regex.Pattern.compile("^[a-zA-Z0-9_]+$");
+            java.util.regex.Pattern.compile("^[a-zA-Z0-9\-_]+$");
     public static final String COLUMN_REF_HINT = "JsonPathExtended";
 
     private static final Set<String> SUPPORTED_JSON_FUNCTIONS = Set.of(


### PR DESCRIPTION
## Why I'm doing:
I have JSON keys that contain the characters `-`. While looking at profiles, I noticed that queries for those keys aren't properly pushing down their filter predicates. This regex prevents the FE from considering this a valid column access expression, which then causes the significantly less performant jsonMerge to run, causing a pretty significant performance regression to all queries accessing these keys.

## What I'm doing:
Added the `-` character I use on a regular basis to the regex.

I noticed in the `be` code paths, this is the regex that is used, plus one that was commented out? It is unclear to me if there is a better option, but this is what I saw: [link to code](https://github.com/StarRocks/starrocks/blob/fecbb3edcb0f75609276ac693dea852e29480926/be/src/exprs/json_functions.cpp#L61-L63)

```
// static const re2::RE2 JSON_PATTERN("^([a-zA-Z0-9_\\-\\:\\s#\\|\\.]*)(?:\\[([0-9]+)\\])?");
// json path cannot contains: ", [, ]
const re2::RE2 SIMPLE_JSONPATH_PATTERN(R"(^([^\"\[\]]*)(?:\[([0-9]+|\*)\])?)", re2::RE2::Quiet);
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `JsonPathRewriteRule` to broaden simple JSON path validation from `^[a-zA-Z0-9_]+$` to `^[a-zA-Z0-9\-_]+$`.
> 
> - Enables rewrite of JSON functions when field names include hyphens, improving predicate/projection pushdown on JSON columns
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1e60845956653d820df0ba95f66cfd6d4ece568. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->