### PR TITLE
[UT] fix variant metadata DCHECK failed

### DIFF
--- a/be/test/serde/column_array_serde_test.cpp
+++ b/be/test/serde/column_array_serde_test.cpp
@@ -152,6 +152,10 @@ PARALLEL_TEST(ColumnArraySerdeTest, variant_column) {
     }
 }
 
+#if !DCHECK_IS_ON()
+// we have DCHECK inside VariantColumn deserialize to check version,
+// so this test case is only enabled when DCHECK is off
+
 // NOLINTNEXTLINE
 PARALLEL_TEST(ColumnArraySerdeTest, variant_column_failed_deserialize) {
     auto c1 = VariantColumn::create();
@@ -172,6 +176,7 @@ PARALLEL_TEST(ColumnArraySerdeTest, variant_column_failed_deserialize) {
     ASSERT_ERROR(ColumnArraySerde::deserialize(buffer.data(), c2.get()));
     ASSERT_EQ(0, c2->size()); // Deserialization should fail, resulting in an empty column
 }
+#endif
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ColumnArraySerdeTest, hll_column_failed_deserialize) {


### PR DESCRIPTION
## Why I'm doing:

In ctor of `VarianMetadata` we have DCHECK if version is supported or not

```
        const uint8_t version = header() & kVersionMask;
        DCHECK(version == kSupportedVersion) << "Unsupported variant version: " << std::to_string(version);
```

and in UT we try to cover this case. however we can not catch DCHECK failure right now.

## What I'm doing:

So right now the only way is to disable this test case when we use DEBUG version.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
