### PR TITLE
[Enhancement] add more metrics for load spill read and write

### DIFF
--- a/be/src/storage/load_chunk_spiller.cpp
+++ b/be/src/storage/load_chunk_spiller.cpp
@@ -24,6 +24,7 @@
 #include "storage/load_spill_block_manager.h"
 #include "storage/merge_iterator.h"
 #include "storage/union_iterator.h"
+#include "util/starrocks_metrics.h"
 
 namespace starrocks {
 
@@ -78,6 +79,15 @@ Status LoadSpillOutputDataStream::_freeze_current_block() {
         return Status::OK();
     }
     RETURN_IF_ERROR(_block->flush());
+    if (_block->is_remote()) {
+        // Update remote block write metric
+        StarRocksMetrics::instance()->load_spill_remote_blocks_write_total.increment(1);
+        StarRocksMetrics::instance()->load_spill_remote_bytes_write_total.increment(_block->size());
+    } else {
+        // Update local block write metric
+        StarRocksMetrics::instance()->load_spill_local_blocks_write_total.increment(1);
+        StarRocksMetrics::instance()->load_spill_local_bytes_write_total.increment(_block->size());
+    }
     RETURN_IF_ERROR(_block_manager->release_block(_block));
     // Save this block into the block group, which is tagged with slot_idx for ordering
     _block_manager->block_container()->append_block(_block_group, _block);
@@ -185,8 +195,14 @@ public:
                 COUNTER_UPDATE(metrics.block_count, 1);
                 if (_blocks[_block_idx]->is_remote()) {
                     COUNTER_UPDATE(metrics.remote_block_count, 1);
+                    StarRocksMetrics::instance()->load_spill_remote_blocks_read_total.increment(1);
+                    StarRocksMetrics::instance()->load_spill_remote_bytes_read_total.increment(
+                            _blocks[_block_idx]->size());
                 } else {
                     COUNTER_UPDATE(metrics.local_block_count, 1);
+                    StarRocksMetrics::instance()->load_spill_local_blocks_read_total.increment(1);
+                    StarRocksMetrics::instance()->load_spill_local_bytes_read_total.increment(
+                            _blocks[_block_idx]->size());
                 }
             }
             auto st = _serde.deserialize(_ctx, _reader.get());

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -67,6 +67,15 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name) {
     REGISTER_STARROCKS_METRIC(async_delta_writer_task_execute_duration_us);
     REGISTER_STARROCKS_METRIC(async_delta_writer_task_pending_duration_us);
 
+    REGISTER_STARROCKS_METRIC(load_spill_local_blocks_read_total);
+    REGISTER_STARROCKS_METRIC(load_spill_local_blocks_write_total);
+    REGISTER_STARROCKS_METRIC(load_spill_remote_blocks_read_total);
+    REGISTER_STARROCKS_METRIC(load_spill_remote_blocks_write_total);
+    REGISTER_STARROCKS_METRIC(load_spill_local_bytes_read_total);
+    REGISTER_STARROCKS_METRIC(load_spill_local_bytes_write_total);
+    REGISTER_STARROCKS_METRIC(load_spill_remote_bytes_read_total);
+    REGISTER_STARROCKS_METRIC(load_spill_remote_bytes_write_total);
+
     REGISTER_STARROCKS_METRIC(delta_writer_commit_task_total);
     REGISTER_STARROCKS_METRIC(delta_writer_wait_flush_task_total);
     REGISTER_STARROCKS_METRIC(delta_writer_wait_flush_duration_us);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -227,6 +227,15 @@ public:
     METRIC_DEFINE_INT_COUNTER(async_delta_writer_task_pending_duration_us, MetricUnit::MICROSECONDS);
     // Metrics for metadata lru cache
     METRIC_DEFINE_INT_GAUGE(metadata_cache_bytes_total, MetricUnit::BYTES);
+    // Metrics for load spill blocks read & write
+    METRIC_DEFINE_INT_COUNTER(load_spill_local_blocks_read_total, MetricUnit::OPERATIONS);
+    METRIC_DEFINE_INT_COUNTER(load_spill_local_blocks_write_total, MetricUnit::OPERATIONS);
+    METRIC_DEFINE_INT_COUNTER(load_spill_remote_blocks_read_total, MetricUnit::OPERATIONS);
+    METRIC_DEFINE_INT_COUNTER(load_spill_remote_blocks_write_total, MetricUnit::OPERATIONS);
+    METRIC_DEFINE_INT_COUNTER(load_spill_local_bytes_read_total, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_COUNTER(load_spill_local_bytes_write_total, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_COUNTER(load_spill_remote_bytes_read_total, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_COUNTER(load_spill_remote_bytes_write_total, MetricUnit::BYTES);
 
     // Metrics for delta writer
     // The number of eos task that executed


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request adds detailed metrics tracking for load spill block read and write operations, distinguishing between local and remote blocks. These changes help monitor the number and size of blocks read from and written to both local and remote storage during load spilling, improving observability and debugging capabilities.

**Metrics instrumentation:**

* Added new counters in `StarRocksMetrics` for tracking the total number and bytes of local and remote load spill blocks read and written (`be/src/util/starrocks_metrics.h`).
* Updated `LoadSpillOutputDataStream::_freeze_current_block()` to increment the appropriate metrics after flushing a block, based on whether the block is local or remote (`be/src/storage/load_chunk_spiller.cpp`).
* Updated `BlockGroupIterator` to increment the correct metrics when reading blocks, again distinguishing between local and remote blocks (`be/src/storage/load_chunk_spiller.cpp`).

**Codebase maintenance:**

* Included the `starrocks_metrics.h` header in `load_chunk_spiller.cpp` to support the new metrics functionality (`be/src/storage/load_chunk_spiller.cpp`).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
