### PR TITLE
[BugFix] Fix MaterializedIndex metaId initialization when upgrading from old version (backport #67967)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -98,7 +98,7 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     @SerializedName(value = "id")
     private long id;
     @SerializedName(value = "metaId")
-    private long metaId = -1L;
+    private long metaId = 0L;
     @SerializedName(value = "state")
     private IndexState state;
     @SerializedName(value = "rowCount")
@@ -240,9 +240,9 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         return tablet;
     }
 
-    public void setIdForRestore(long idxId) {
-        this.id = idxId;
-        this.metaId = idxId;
+    public void setIdForRestore(long idxMetaId) {
+        this.id = idxMetaId;
+        this.metaId = idxMetaId;
     }
 
     public long getId() {
@@ -378,7 +378,7 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         for (Tablet tablet : tablets) {
             idToTablets.put(tablet.getId(), tablet);
         }
-        if (metaId == -1L) {
+        if (metaId == 0L) {
             metaId = id;
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexTest.java
@@ -36,6 +36,7 @@ package com.starrocks.catalog;
 
 import com.starrocks.catalog.MaterializedIndex.IndexState;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.type.IntegerType;
@@ -79,7 +80,7 @@ public class MaterializedIndexTest {
     }
 
     @Test
-    public void testVisibleForTransaction() throws Exception {
+    public void testVisibleForTransaction() {
         index = new MaterializedIndex(10);
         Assertions.assertEquals(IndexState.NORMAL, index.getState());
         Assertions.assertTrue(index.visibleForTransaction(0));
@@ -98,5 +99,15 @@ public class MaterializedIndexTest {
         Assertions.assertFalse(index.visibleForTransaction(9));
         Assertions.assertTrue(index.visibleForTransaction(10));
         Assertions.assertTrue(index.visibleForTransaction(11));
+    }
+
+    @Test
+    public void testGsonPostProcess() {
+        MaterializedIndex index = new MaterializedIndex();
+        Deencapsulation.setField(index, "id", 1L);
+        Assertions.assertEquals(1L, index.getId());
+        Assertions.assertEquals(0L, index.getMetaId());
+        index.gsonPostProcess();
+        Assertions.assertEquals(1L, index.getMetaId());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

#67967

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

