### PR TITLE
[BugFix] dead lock accurs when the hms connection pool is full

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -67,6 +67,7 @@ public class HiveMetaClient {
 
     private final LinkedList<RecyclableClient> clientPool = new LinkedList<>();
     private final Object clientPoolLock = new Object();
+    private final Object clientCreationLock = new Object();
 
     private final HiveConf conf;
 
@@ -112,14 +113,18 @@ public class HiveMetaClient {
         // When the number of currently used clients is less than maxPoolSize,
         // the client will be recycled and reused. If it does, we close the client.
         public void finish() {
+            boolean shouldClose = false;
             synchronized (clientPoolLock) {
                 if (clientPool.size() >= maxPoolSize) {
-                    LOG.warn("There are more than {} connections currently accessing the metastore",
-                            maxPoolSize);
-                    close();
+                    shouldClose = true;
                 } else {
                     clientPool.offer(this);
                 }
+            }
+            if (shouldClose) {
+                LOG.warn("There are more than {} connections currently accessing the metastore",
+                        maxPoolSize);
+                close();
             }
         }
 
@@ -146,16 +151,26 @@ public class HiveMetaClient {
             Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader());
         }
 
+        RecyclableClient client = null;
         synchronized (clientPoolLock) {
-            RecyclableClient client = clientPool.poll();
+            client = clientPool.poll();
+        }
+
+        if (client != null) {
+            return client;
+        }
+
+        synchronized (clientCreationLock) {
             // The pool was empty so create a new client and return that.
             // Serialize client creation to defend against possible race conditions accessing
             // local Kerberos state
-            if (client == null) {
-                return new RecyclableClient(conf);
-            } else {
-                return client;
+            synchronized (clientPoolLock) {
+                client = clientPool.poll();
+                if (client != null) {
+                    return client;
+                }
             }
+            return new RecyclableClient(conf);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
Under high concurrency, when the HMS (Hive Metastore) client pool in HiveMetaClient is exhausted, the current implementation can cause threads to hold the lock for a long time. In extreme cases, this may lead to deadlocks or stalls, especially when client creation or closure blocks. This directly impacts the stability and throughput of Hive metadata access.

## What I'm doing:
This pull request refactors the client pool management logic in `HiveMetaClient.java` to improve thread safety and code clarity. The main changes focus on how clients are acquired from and returned to the pool, ensuring that client creation and closure are handled outside of synchronized blocks to reduce lock contention and potential performance bottlenecks.

**Improvements to client pool management:**

* Refactored the `finish()` method in the `RecyclableClient` class to defer client closure (`close()`) and logging outside of the synchronized block, reducing the time spent holding the lock and improving thread safety.
* Updated the `getClient()` method to poll the client pool inside a synchronized block and create a new client outside the lock if the pool is empty, minimizing lock scope and avoiding potential race conditions.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
