### PR TITLE
[BugFix] Stop StarMgr journal writer before BDB environment close during leader transfer

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFEServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFEServer.java
@@ -276,6 +276,12 @@ public class StarRocksFEServer {
             journalWriter.stopAndWait();
             Journal journal = GlobalStateMgr.getCurrentState().getJournal();
 
+            // stop star mgr journal writer before bdb env close, to avoid "Unclosed Database: starmgr_*" errors
+            if (RunMode.isSharedDataMode()) {
+                JournalWriter starMgrJournalWriter = StarMgrServer.getCurrentState().getJournalSystem().getJournalWriter();
+                starMgrJournalWriter.stopAndWait();
+            }
+
             // transfer leader
             if (journal instanceof BDBJEJournal) {
                 BDBEnvironment bdbEnvironment = ((BDBJEJournal) journal).getBdbEnvironment();

--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFEServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFEServer.java
@@ -287,7 +287,8 @@ public class StarRocksFEServer {
                         LOG.warn("skip stopping StarMgr journal writer because getJournalWriter() returned null");
                     }
                 } else {
-                    LOG.warn("skip stopping StarMgr journal writer because StarMgrServer or its journal system is not initialized");
+                    LOG.warn("skip stopping StarMgr journal writer because StarMgrServer or its journal system " +
+                            "is not initialized");
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
@@ -312,4 +312,10 @@ public class StarMgrServer {
     public void triggerNewImage() {
         journalSystem.getJournalWriter().setForceRollJournal();
     }
+
+    public void markLeaderTransferred() {
+        if (journalSystem != null) {
+            journalSystem.markLeaderTransferred();
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/staros/StarOSBDBJEJournalSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/StarOSBDBJEJournalSystem.java
@@ -235,5 +235,11 @@ public class StarOSBDBJEJournalSystem implements JournalSystem {
     public JournalWriter getJournalWriter() {
         return journalWriter;
     }
+
+    public void markLeaderTransferred() {
+        if (journalWriter != null) {
+            journalWriter.setLeaderTransferred();
+        }
+    }
 }
 


### PR DESCRIPTION
## Why I'm doing:

During FE leader transfer in shared-data mode, the BDB environment is closed while the StarMgr journal writer still has open database handles. This causes "Unclosed Database: starmgr_*" warning messages in the FE logs.

## What I'm doing:

Stop the StarMgr journal writer before closing the BDB environment during graceful shutdown. This ensures all database handles are properly closed before the BDB environment cleanup.

The fix adds a call to stop the StarMgr journal writer right after stopping the main journal writer, but before the BDB environment is closed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:

N/A

## Related issues:

Fixes "Unclosed Database: starmgr_*" warning messages during FE leader transfer in shared-data mode.

## Checklist:

- [ ] I have added test cases for my code.
- [ ] This PR needs documentation.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [x] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4