### PR TITLE
[BugFix] Delete shard group meta from StarManager when dropping cloud-native table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeListPartitionInfo.java
@@ -37,9 +37,8 @@ public class RecycleLakeListPartitionInfo extends RecycleListPartitionInfo {
         try {
             ComputeResource computeResource =
                     GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource(tableId);
-            if (LakeTableHelper.removePartitionDirectory(partition, computeResource)) {
+            if (LakeTableHelper.cleanSharedDataPartitionAndDeleteShardGroupMeta(partition, computeResource, true)) {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().onErasePartition(partition);
-                LakeTableHelper.deleteShardGroupMeta(partition);
                 return true;
             } else {
                 return false;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeRangePartitionInfo.java
@@ -40,9 +40,8 @@ public class RecycleLakeRangePartitionInfo extends RecycleRangePartitionInfo  {
         try {
             ComputeResource computeResource =
                     GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource(tableId);
-            if (LakeTableHelper.removePartitionDirectory(partition, computeResource)) {
+            if (LakeTableHelper.cleanSharedDataPartitionAndDeleteShardGroupMeta(partition, computeResource, true)) {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().onErasePartition(partition);
-                LakeTableHelper.deleteShardGroupMeta(partition);
                 return true;
             } else {
                 return false;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeUnPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeUnPartitionInfo.java
@@ -39,9 +39,8 @@ public class RecycleLakeUnPartitionInfo extends RecycleUnPartitionInfo {
         try {
             ComputeResource computeResource =
                     GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource(tableId);
-            if (LakeTableHelper.removePartitionDirectory(partition, computeResource)) {
+            if (LakeTableHelper.cleanSharedDataPartitionAndDeleteShardGroupMeta(partition, computeResource, true)) {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().onErasePartition(partition);
-                LakeTableHelper.deleteShardGroupMeta(partition);
                 return true;
             } else {
                 return false;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ReplaceLakePartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ReplaceLakePartitionTest.java
@@ -219,7 +219,7 @@ public class ReplaceLakePartitionTest {
             LakeTable tbl = buildLakeTableWithTempPartition(PartitionType.RANGE);
             new MockUp<LakeTable>() {
                 @Mock
-                public Collection<PhysicalPartition> getAllPhysicalPartitions() {
+                public Collection<PhysicalPartition> getAllPartitions() {
                     return Lists.newArrayList();
                 }
             };
@@ -233,7 +233,7 @@ public class ReplaceLakePartitionTest {
             LakeTable tbl = buildLakeTableWithTempPartition(PartitionType.LIST);
             new MockUp<LakeTable>() {
                 @Mock
-                public Collection<PhysicalPartition> getAllPhysicalPartitions() {
+                public Collection<PhysicalPartition> getAllPartitions() {
                     return Lists.newArrayList();
                 }
             };
@@ -247,7 +247,7 @@ public class ReplaceLakePartitionTest {
             LakeTable tbl = buildLakeTableWithTempPartition(PartitionType.UNPARTITIONED);
             new MockUp<LakeTable>() {
                 @Mock
-                public Collection<PhysicalPartition> getAllPhysicalPartitions() {
+                public Collection<PhysicalPartition> getAllPartitions() {
                     return Lists.newArrayList();
                 }
             };

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableCleanerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableCleanerTest.java
@@ -19,9 +19,9 @@ import com.staros.proto.FilePathInfo;
 import com.staros.proto.ShardInfo;
 import com.staros.proto.StatusCode;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.proto.DropTableRequest;
-import com.starrocks.proto.DropTableResponse;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.server.GlobalStateMgr;
@@ -36,8 +36,6 @@ import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.CompletableFuture;
 
 public class LakeTableCleanerTest {
     private final ShardInfo shardInfo;
@@ -70,7 +68,8 @@ public class LakeTableCleanerTest {
 
     @Test
     public void test(@Mocked LakeTable table,
-                     @Mocked PhysicalPartition partition,
+                     @Mocked Partition partition,
+                     @Mocked PhysicalPartition physicalPartition,
                      @Mocked MaterializedIndex index,
                      @Mocked LakeTablet tablet,
                      @Mocked LakeService lakeService) throws StarClientException {
@@ -92,25 +91,21 @@ public class LakeTableCleanerTest {
 
         new Expectations() {
             {
-                table.getAllPhysicalPartitions();
+                table.getAllPartitions();
                 result = Lists.newArrayList(partition);
                 minTimes = 1;
-                maxTimes = 1;
 
-                partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
+                partition.getSubPartitions();
+                result = Lists.newArrayList(physicalPartition);
+                minTimes = 1;
+
+                physicalPartition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
                 result = Lists.newArrayList(index);
                 minTimes = 1;
-                maxTimes = 1;
 
                 index.getTablets();
                 result = Lists.newArrayList(tablet);
                 minTimes = 1;
-                maxTimes = 1;
-
-                lakeService.dropTable((DropTableRequest) any);
-                result = CompletableFuture.completedFuture(new DropTableResponse());
-                minTimes = 1;
-                maxTimes = 1;
             }
         };
 
@@ -119,7 +114,8 @@ public class LakeTableCleanerTest {
 
     @Test
     public void testNoTablet(@Mocked LakeTable table,
-                             @Mocked PhysicalPartition partition,
+                             @Mocked Partition partition,
+                             @Mocked PhysicalPartition physicalPartition,
                              @Mocked MaterializedIndex index,
                              @Mocked LakeTablet tablet,
                              @Mocked LakeService lakeService) {
@@ -127,20 +123,21 @@ public class LakeTableCleanerTest {
 
         new Expectations() {
             {
-                table.getAllPhysicalPartitions();
+                table.getAllPartitions();
                 result = Lists.newArrayList(partition);
                 minTimes = 1;
-                maxTimes = 1;
 
-                partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
+                partition.getSubPartitions();
+                result = Lists.newArrayList(physicalPartition);
+                minTimes = 1;
+
+                physicalPartition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
                 result = Lists.newArrayList(index);
                 minTimes = 1;
-                maxTimes = 1;
 
                 index.getTablets();
                 result = Lists.emptyList();
                 minTimes = 1;
-                maxTimes = 1;
             }
         };
 
@@ -149,7 +146,8 @@ public class LakeTableCleanerTest {
 
     @Test
     public void testNoAliveNode(@Mocked LakeTable table,
-                                @Mocked PhysicalPartition partition,
+                                @Mocked Partition partition,
+                                @Mocked PhysicalPartition physicalPartition,
                                 @Mocked MaterializedIndex index,
                                 @Mocked LakeTablet tablet,
                                 @Mocked LakeService lakeService) throws StarClientException {
@@ -164,20 +162,21 @@ public class LakeTableCleanerTest {
 
         new Expectations() {
             {
-                table.getAllPhysicalPartitions();
+                table.getAllPartitions();
                 result = Lists.newArrayList(partition);
                 minTimes = 1;
-                maxTimes = 1;
 
-                partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
+                partition.getSubPartitions();
+                result = Lists.newArrayList(physicalPartition);
+                minTimes = 1;
+
+                physicalPartition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
                 result = Lists.newArrayList(index);
                 minTimes = 1;
-                maxTimes = 1;
 
                 index.getTablets();
                 result = Lists.newArrayList(tablet);
                 minTimes = 1;
-                maxTimes = 1;
             }
         };
 
@@ -186,7 +185,8 @@ public class LakeTableCleanerTest {
 
     @Test
     public void testGetShardInfoFailed(@Mocked LakeTable table,
-                                       @Mocked PhysicalPartition partition,
+                                       @Mocked Partition partition,
+                                       @Mocked PhysicalPartition physicalPartition,
                                        @Mocked MaterializedIndex index,
                                        @Mocked LakeTablet tablet,
                                        @Mocked LakeService lakeService) throws StarClientException {
@@ -194,20 +194,21 @@ public class LakeTableCleanerTest {
 
         new Expectations() {
             {
-                table.getAllPhysicalPartitions();
+                table.getAllPartitions();
                 result = Lists.newArrayList(partition);
                 minTimes = 1;
-                maxTimes = 1;
 
-                partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
+                partition.getSubPartitions();
+                result = Lists.newArrayList(physicalPartition);
+                minTimes = 1;
+
+                physicalPartition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
                 result = Lists.newArrayList(index);
                 minTimes = 1;
-                maxTimes = 1;
 
                 index.getTablets();
                 result = Lists.newArrayList(tablet);
                 minTimes = 1;
-                maxTimes = 1;
             }
         };
 
@@ -216,7 +217,8 @@ public class LakeTableCleanerTest {
 
     @Test
     public void testRPCFailed(@Mocked LakeTable table,
-                              @Mocked PhysicalPartition partition,
+                              @Mocked Partition partition,
+                              @Mocked PhysicalPartition physicalPartition,
                               @Mocked MaterializedIndex index,
                               @Mocked LakeTablet tablet,
                               @Mocked LakeService lakeService) throws StarClientException {
@@ -238,25 +240,25 @@ public class LakeTableCleanerTest {
 
         new Expectations() {
             {
-                table.getAllPhysicalPartitions();
+                table.getAllPartitions();
                 result = Lists.newArrayList(partition);
                 minTimes = 1;
-                maxTimes = 1;
 
-                partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
+                partition.getSubPartitions();
+                result = Lists.newArrayList(physicalPartition);
+                minTimes = 1;
+
+                physicalPartition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
                 result = Lists.newArrayList(index);
                 minTimes = 1;
-                maxTimes = 1;
 
                 index.getTablets();
                 result = Lists.newArrayList(tablet);
                 minTimes = 1;
-                maxTimes = 1;
 
                 lakeService.dropTable((DropTableRequest) any);
                 result = new RuntimeException("Injected RPC error");
                 minTimes = 1;
-                maxTimes = 1;
             }
         };
 
@@ -265,7 +267,8 @@ public class LakeTableCleanerTest {
 
     @Test
     public void testShardNotFound(@Mocked LakeTable table,
-                                  @Mocked PhysicalPartition partition,
+                                  @Mocked Partition partition,
+                                  @Mocked PhysicalPartition physicalPartition,
                                   @Mocked MaterializedIndex index,
                                   @Mocked LakeTablet tablet,
                                   @Mocked LakeService lakeService) throws StarClientException {
@@ -273,20 +276,21 @@ public class LakeTableCleanerTest {
 
         new Expectations() {
             {
-                table.getAllPhysicalPartitions();
+                table.getAllPartitions();
                 result = Lists.newArrayList(partition);
                 minTimes = 1;
-                maxTimes = 1;
 
-                partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
+                partition.getSubPartitions();
+                result = Lists.newArrayList(physicalPartition);
+                minTimes = 1;
+
+                physicalPartition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
                 result = Lists.newArrayList(index);
                 minTimes = 1;
-                maxTimes = 1;
 
                 index.getTablets();
                 result = Lists.newArrayList(tablet);
                 minTimes = 1;
-                maxTimes = 1;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/RecycleLakePartitionInfoEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/RecycleLakePartitionInfoEditLogTest.java
@@ -21,7 +21,6 @@ import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.HashDistributionInfo;
-import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionKey;
@@ -85,12 +84,11 @@ public class RecycleLakePartitionInfoEditLogTest {
         DistributionInfo distributionInfo = new HashDistributionInfo(3, List.of(col1));
 
         MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
-        LocalTablet tablet = new LocalTablet(TABLET_ID);
+        LakeTablet tablet = new LakeTablet(TABLET_ID);
         TabletMeta tabletMeta = new TabletMeta(DB_ID, TABLE_ID, partitionId, INDEX_ID, TStorageMedium.HDD);
         baseIndex.addTablet(tablet, tabletMeta);
 
-        Partition partition = new Partition(partitionId, physicalPartitionId, partitionName, baseIndex, distributionInfo);
-        return partition;
+        return new Partition(partitionId, physicalPartitionId, partitionName, baseIndex, distributionInfo);
     }
 
     @Test
@@ -107,17 +105,14 @@ public class RecycleLakePartitionInfoEditLogTest {
         // Verify initial state
         Assertions.assertTrue(partitionInfo.isRecoverable());
 
-        // 3. Mock LakeTableHelper.removePartitionDirectory to return true
+        // 3. Mock LakeTableHelper.cleanSharedDataPartitionAndDeleteShardGroupMeta to return true
         // Mock LakeTableHelper using MockUp
         new MockUp<LakeTableHelper>() {
             @Mock
-            public boolean removePartitionDirectory(Partition partition, ComputeResource computeResource) {
+            public boolean cleanSharedDataPartitionAndDeleteShardGroupMeta(Partition partition,
+                                                                           ComputeResource computeResource,
+                                                                           boolean keepSharedDirectory) {
                 return true;
-            }
-            
-            @Mock
-            public void deleteShardGroupMeta(Partition partition) {
-                // Do nothing
             }
         };
 
@@ -162,16 +157,13 @@ public class RecycleLakePartitionInfoEditLogTest {
         // Verify initial state
         Assertions.assertTrue(partitionInfo.isRecoverable());
 
-        // 3. Mock LakeTableHelper.removePartitionDirectory to return true
+        // 3. Mock LakeTableHelper.cleanSharedDataPartitionAndDeleteShardGroupMeta to return true
         new MockUp<LakeTableHelper>() {
             @Mock
-            public boolean removePartitionDirectory(Partition partition, ComputeResource computeResource) {
+            public boolean cleanSharedDataPartitionAndDeleteShardGroupMeta(Partition partition,
+                                                                           ComputeResource computeResource,
+                                                                           boolean keepSharedDirectory) {
                 return true;
-            }
-            
-            @Mock
-            public void deleteShardGroupMeta(Partition partition) {
-                // Do nothing
             }
         };
 
@@ -215,16 +207,13 @@ public class RecycleLakePartitionInfoEditLogTest {
         // Verify initial state
         Assertions.assertTrue(partitionInfo.isRecoverable());
 
-        // 3. Mock LakeTableHelper.removePartitionDirectory to return true
+        // 3. Mock LakeTableHelper.cleanSharedDataPartitionAndDeleteShardGroupMeta to return true
         new MockUp<LakeTableHelper>() {
             @Mock
-            public boolean removePartitionDirectory(Partition partition, ComputeResource computeResource) {
+            public boolean cleanSharedDataPartitionAndDeleteShardGroupMeta(Partition partition,
+                                                                           ComputeResource computeResource,
+                                                                           boolean keepSharedDirectory) {
                 return true;
-            }
-            
-            @Mock
-            public void deleteShardGroupMeta(Partition partition) {
-                // Do nothing
             }
         };
 


### PR DESCRIPTION
## Why I'm doing:
When executing DROP TABLE FORCE on a cloud-native (shared_data) table, the table's shard group metadata in StarManager was not being deleted immediately. This leads to orphan shard groups accumulating in `StarManager`.

The reason is that `LakeTableHelper.deleteTableFromRecycleBin()` only calls `LakeTableCleaner.cleanTable()` to delete remote storage data. It doesn't call `deleteShardGroup()` to clean up shard group metadata in `StarManager`. The orphan shard groups are only cleaned up by the background `StarMgrMetaSyncer` thread.

For clusters with frequent table creation/deletion operations, this results in a large number of orphan shard/shardGroup entries accumulating in `StarManager`, consuming memory and potentially affecting FE's performance.

## What I'm doing:

This PR is a supplement to #56691. In that PR, we proactively deleted the metadata in `StarManager` at the end of the drop partition operation.

Similarly,  in this PR I add `deleteTableShardGroupMeta()` method to `LakeTableHelper` and call it in `deleteTableFromRecycleBin()` after successfully cleaning table data. This ensures shard group metadata is deleted immediately when a table is dropped, consistent with the behavior of partition deletion (which already calls `deleteShardGroupMeta`).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
