### PR TITLE
[Enhancement] Support show create view with original comments inside

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -940,7 +940,9 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
         AlterViewInfo alterViewInfo = new AlterViewInfo(db.getId(), table.getId(),
                 alterViewClause.getInlineViewDef(),
                 alterViewClause.getColumns(),
-                ctx.getSessionVariable().getSqlMode(), alterViewClause.getComment());
+                ctx.getSessionVariable().getSqlMode(),
+                alterViewClause.getComment(),
+                alterViewClause.getOriginalViewDefineSql());
 
         GlobalStateMgr.getCurrentState().getAlterJobMgr().alterView(alterViewInfo);
         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -579,6 +579,7 @@ public class AlterJobMgr {
                 .getLocalMetastore().getTable(db.getId(), alterViewInfo.getTableId());
         String inlineViewDef = alterViewInfo.getInlineViewDef();
         long sqlMode = alterViewInfo.getSqlMode();
+        String originalViewDef = alterViewInfo.getOriginalViewDef();
 
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(view.getId()), LockType.WRITE);
@@ -590,6 +591,7 @@ public class AlterJobMgr {
             }
             GlobalStateMgr.getCurrentState().getEditLog().logModifyViewDef(alterViewInfo, wal -> {
                 view.setInlineViewDefWithSqlMode(inlineViewDef, sqlMode);
+                view.setOriginalViewDef(originalViewDef);
                 view.setNewFullSchema(alterViewInfo.getNewFullSchema());
                 view.setComment(alterViewInfo.getComment());
             });
@@ -610,6 +612,7 @@ public class AlterJobMgr {
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(view.getId()), LockType.WRITE);
         try {
             view.setInlineViewDefWithSqlMode(alterViewInfo.getInlineViewDef(), alterViewInfo.getSqlMode());
+            view.setOriginalViewDef(alterViewInfo.getOriginalViewDef());
             view.setNewFullSchema(alterViewInfo.getNewFullSchema());
             view.setComment(alterViewInfo.getComment());
             AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(view,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -42,6 +42,7 @@ import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.common.util.SqlCredentialRedactor;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.ConnectorTableInfo;
@@ -790,7 +791,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     public void setOriginalViewDefineSql(String originalViewDefineSql) {
-        this.originalViewDefineSql = originalViewDefineSql;
+        // redact credentials in the original view define sql to avoid persisting sensitive information
+        this.originalViewDefineSql = SqlCredentialRedactor.redact(originalViewDefineSql);
     }
 
     public String setIvmDefineSql(String ivmDefineSql) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/View.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/View.java
@@ -64,7 +64,7 @@ public class View extends Table {
 
     // The original SQL-string given as view definition. Set during analysis.
     // Corresponds to Hive's viewOriginalText.
-    @Deprecated
+    @SerializedName(value = "o")
     private String originalViewDef = "";
 
     // Query statement (as SQL string) that defines the View for view substitution.
@@ -135,9 +135,25 @@ public class View extends Table {
         return inlineViewDef;
     }
 
+    public void setOriginalViewDef(String originalViewDef) {
+        this.originalViewDef = originalViewDef;
+    }
+
+    public String getDDLViewDef() {
+        if (originalViewDef != null && !originalViewDef.isEmpty()) {
+            return originalViewDef;
+        } else {
+            return inlineViewDef;
+        }
+    }
+
     // show create view that from files() need remove the credential
     public String getInlineViewDefWithoutCredential() {
-        return AstToSQLBuilder.toSQL(getQueryStatement());
+        if (originalViewDef != null && !originalViewDef.isEmpty()) {
+            return originalViewDef;
+        } else {
+            return AstToSQLBuilder.toSQL(getQueryStatement());
+        }
     }
 
     public long getSqlMode() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/View.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/View.java
@@ -38,6 +38,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.SqlCredentialRedactor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
@@ -136,7 +137,9 @@ public class View extends Table {
     }
 
     public void setOriginalViewDef(String originalViewDef) {
-        this.originalViewDef = originalViewDef;
+        // Ensure that credentials are redacted before storing the original view definition to
+        // avoid persisting sensitive information
+        this.originalViewDef = SqlCredentialRedactor.redact(originalViewDef);
     }
 
     public String getDDLViewDef() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
@@ -312,7 +312,7 @@ public class ViewsSystemTable extends SystemTable {
                 status.setLast_check_time(table.getLastCheckTime());
                 if (listingViews) {
                     View view = (View) table;
-                    String ddlSql = view.getInlineViewDef();
+                    String ddlSql = view.getDDLViewDef();
 
                     ConnectContext connectContext = ConnectContext.buildInner();
                     connectContext.setQualifiedUser(AuthenticationMgr.ROOT_USER);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/AlterViewInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/AlterViewInfo.java
@@ -40,6 +40,8 @@ public class AlterViewInfo implements Writable {
     private String comment;
     @SerializedName(value = "security")
     private boolean security;
+    @SerializedName(value = "originalViewDef")
+    private String originalViewDef;
 
     public AlterViewInfo() {
         // for persist
@@ -47,13 +49,15 @@ public class AlterViewInfo implements Writable {
     }
 
     public AlterViewInfo(long dbId, long tableId, String inlineViewDef, List<Column> newFullSchema, long sqlMode,
-                         String comment) {
+                         String comment,
+                         String originalViewDef) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.inlineViewDef = inlineViewDef;
         this.newFullSchema = newFullSchema;
         this.sqlMode = sqlMode;
         this.comment = comment;
+        this.originalViewDef = originalViewDef;
     }
 
     public AlterViewInfo(long dbId, long tableId, boolean security) {
@@ -88,6 +92,10 @@ public class AlterViewInfo implements Writable {
 
     public boolean getSecurity() {
         return security;
+    }
+
+    public String getOriginalViewDef() {
+        return originalViewDef;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4455,6 +4455,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             view.setComment(stmt.getComment());
             view.setInlineViewDefWithSqlMode(stmt.getInlineViewDef(),
                     ConnectContext.get().getSessionVariable().getSqlMode());
+            view.setOriginalViewDef(stmt.getOriginalViewDefineSql());
 
             if (stmt.isSecurity()) {
                 view.setSecurity(stmt.isSecurity());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
@@ -79,8 +80,17 @@ public class ViewAnalyzer {
             }
             List<Column> viewColumns = analyzeViewColumns(stmt.getQueryStatement().getQueryRelation(), stmt.getColWithComments());
             stmt.setColumns(viewColumns);
+
+            // reserve the original view sql
+
             String viewSql = AstToSQLBuilder.toSQLWithCredential(stmt.getQueryStatement());
             stmt.setInlineViewDef(viewSql);
+            Preconditions.checkArgument(stmt.getOrigStmt() != null, "View's original statement is null");
+            String originalViewDef = stmt.getOrigStmt().originStmt;
+            Preconditions.checkArgument(originalViewDef != null, "View's original view definition is null");
+            Preconditions.checkArgument(stmt.getQueryStartIndex() >= 0 && stmt.getQueryStopIndex() >= stmt.getQueryStartIndex(),
+                    "View's query start or stop index is invalid");
+            stmt.setOriginalViewDefineSql(originalViewDef.substring(stmt.getQueryStartIndex(), stmt.getQueryStopIndex()));
             return null;
         }
 
@@ -126,6 +136,14 @@ public class ViewAnalyzer {
             alterViewClause.setColumns(viewColumns);
             String viewSql = AstToSQLBuilder.toSQL(alterViewClause.getQueryStatement());
             alterViewClause.setInlineViewDef(viewSql);
+            Preconditions.checkArgument(stmt.getOrigStmt() != null, "View's original statement is null");
+            String originalViewDef = stmt.getOrigStmt().originStmt;
+            Preconditions.checkArgument(originalViewDef != null, "View's original view definition is null");
+            Preconditions.checkArgument(alterViewClause.getQueryStartIndex() >= 0 &&
+                            alterViewClause.getQueryStopIndex() >= alterViewClause.getQueryStartIndex(),
+                    "View's query start or stop index is invalid");
+            alterViewClause.setOriginalViewDefineSql(
+                    originalViewDef.substring(alterViewClause.getQueryStartIndex(), alterViewClause.getQueryStopIndex()));
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
@@ -20,7 +20,6 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
-import com.starrocks.common.util.SqlCredentialRedactor;
 import com.starrocks.connector.ConnectorType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.util.SqlCredentialRedactor;
 import com.starrocks.connector.ConnectorType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterViewClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterViewClause.java
@@ -25,7 +25,11 @@ public class AlterViewClause extends AlterClause {
 
     protected List<Column> columns;
     protected String inlineViewDef;
+    protected String originalViewDefineSql;
     protected String comment;
+    protected int queryStartIndex = -1;
+    protected int queryStopIndex = -1;
+
     public AlterViewClause(List<ColWithComment> colWithComments, QueryStatement queryStatement, NodePosition nodePosition) {
         super(nodePosition);
         this.colWithComments = colWithComments;
@@ -62,6 +66,30 @@ public class AlterViewClause extends AlterClause {
 
     public void setInlineViewDef(String inlineViewDef) {
         this.inlineViewDef = inlineViewDef;
+    }
+
+    public String getOriginalViewDefineSql() {
+        return originalViewDefineSql;
+    }
+
+    public void setOriginalViewDefineSql(String originalViewDefineSql) {
+        this.originalViewDefineSql = originalViewDefineSql;
+    }
+
+    public int getQueryStartIndex() {
+        return queryStartIndex;
+    }
+
+    public void setQueryStartIndex(int queryStartIndex) {
+        this.queryStartIndex = queryStartIndex;
+    }
+
+    public int getQueryStopIndex() {
+        return queryStopIndex;
+    }
+
+    public void setQueryStopIndex(int queryStopIndex) {
+        this.queryStopIndex = queryStopIndex;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterViewStmt.java
@@ -47,6 +47,7 @@ public class AlterViewStmt extends DdlStmt {
         AlterViewClause alterViewClause = new AlterViewClause(
                 stmt.getColWithComments(), stmt.getQueryStatement(), NodePosition.ZERO);
         alterViewClause.setInlineViewDef(stmt.getInlineViewDef());
+        alterViewClause.setOriginalViewDefineSql(stmt.getOriginalViewDefineSql());
         alterViewClause.setColumns(stmt.getColumns());
         alterViewClause.setComment(stmt.getComment());
         return new AlterViewStmt(stmt.getTableRef(), stmt.isSecurity(), AlterDialectType.NONE, Maps.newHashMap(),
@@ -91,6 +92,16 @@ public class AlterViewStmt extends DdlStmt {
 
     public AlterViewClause getAlterClause() {
         return alterClause;
+    }
+
+    public String getOriginalViewDefineSql() {
+        return alterClause == null ? null : alterClause.getOriginalViewDefineSql();
+    }
+
+    public void setOriginalViewDefineSql(String originalViewDefineSql) {
+        if (alterClause != null) {
+            alterClause.setOriginalViewDefineSql(originalViewDefineSql);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateViewStmt.java
@@ -34,6 +34,9 @@ public class CreateViewStmt extends DdlStmt {
     //Resolved by Analyzer
     protected List<Column> columns;
     private String inlineViewDef;
+    private String originalViewDefineSql;
+    private int queryStartIndex = -1;
+    private int queryStopIndex = -1;
     private Map<String, String> properties;
 
     public CreateViewStmt(boolean ifNotExists,
@@ -133,6 +136,30 @@ public class CreateViewStmt extends DdlStmt {
 
     public void setInlineViewDef(String inlineViewDef) {
         this.inlineViewDef = inlineViewDef;
+    }
+
+    public String getOriginalViewDefineSql() {
+        return originalViewDefineSql;
+    }
+
+    public void setOriginalViewDefineSql(String originalViewDefineSql) {
+        this.originalViewDefineSql = originalViewDefineSql;
+    }
+
+    public int getQueryStartIndex() {
+        return queryStartIndex;
+    }
+
+    public void setQueryStartIndex(int queryStartIndex) {
+        this.queryStartIndex = queryStartIndex;
+    }
+
+    public int getQueryStopIndex() {
+        return queryStopIndex;
+    }
+
+    public void setQueryStopIndex(int queryStopIndex) {
+        this.queryStopIndex = queryStopIndex;
     }
 
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1814,7 +1814,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             }
         }
 
-        return new CreateViewStmt(
+        CreateViewStmt stmt = new CreateViewStmt(
                 context.IF() != null,
                 context.REPLACE() != null,
                 targetTableRef,
@@ -1825,6 +1825,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                 createPos(context),
                 getCaseInsensitiveProperties(context.properties())
                 );
+        stmt.setQueryStartIndex(context.queryStatement().start.getStartIndex());
+        stmt.setQueryStopIndex(context.queryStatement().stop.getStopIndex() + 1);
+        return stmt;
     }
 
     @Override
@@ -1857,6 +1860,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                     context.MODIFY() != null ? AlterViewStmt.AlterDialectType.MODIFY : AlterViewStmt.AlterDialectType.NONE;
             QueryStatement queryStatement = (QueryStatement) visit(context.queryStatement());
             AlterViewClause alterClause = new AlterViewClause(colWithComments, queryStatement, createPos(context));
+            alterClause.setQueryStartIndex(context.queryStatement().start.getStartIndex());
+            alterClause.setQueryStopIndex(context.queryStatement().stop.getStopIndex() + 1);
             return new AlterViewStmt(targetTableRef, isSecurity, alterDialectType, properties, alterClause, createPos(context));
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobMgrEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobMgrEditLogTest.java
@@ -180,7 +180,8 @@ public class AlterJobMgrEditLogTest {
         List<Column> newColumns = new ArrayList<>();
         Column newCol1 = new Column("c1", com.starrocks.type.IntegerType.INT);
         newColumns.add(newCol1);
-        AlterViewInfo alterViewInfo = new AlterViewInfo(db.getId(), view.getId(), newViewDef, newColumns, 0L, "test comment");
+        AlterViewInfo alterViewInfo = new AlterViewInfo(db.getId(), view.getId(), newViewDef, newColumns, 0L, "test comment",
+                newViewDef);
 
         // 3. Execute alterView operation (master side)
         alterJobMgr.alterView(alterViewInfo);
@@ -262,7 +263,8 @@ public class AlterJobMgrEditLogTest {
         List<Column> newColumns = new ArrayList<>();
         Column newCol1 = new Column("c1", com.starrocks.type.IntegerType.INT);
         newColumns.add(newCol1);
-        AlterViewInfo alterViewInfo = new AlterViewInfo(db.getId(), view.getId(), newViewDef, newColumns, 0L, "test comment");
+        AlterViewInfo alterViewInfo = new AlterViewInfo(db.getId(), view.getId(), newViewDef, newColumns, 0L, "test comment",
+                newViewDef);
 
         // 3. Mock EditLog.logModifyViewDef to throw exception
         EditLog spyEditLog = spy(GlobalStateMgr.getCurrentState().getEditLog());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateViewStmtTest.java
@@ -152,39 +152,38 @@ public class ShowCreateViewStmtTest {
         testCases.add(new String[]{"test_view_0",
                 "create view test_view_0 AS SELECT " +
                         " *, concat('', null) FROM `test`.`tbl1`",
-                "CREATE VIEW `test_view_0` (`k1`, `k2`, `v1`, `concat('', NULL)`) SECURITY NONE AS SELECT `test`.`tbl1`.`k1`, `test`.`tbl1`.`k2`, `test`.`tbl1`.`v1`, concat('', NULL) AS `concat('', NULL)`\n" +
-                        "FROM `test`.`tbl1`;"
+                "CREATE VIEW `test_view_0` (`k1`, `k2`, `v1`, `concat('', NULL)`) SECURITY NONE " +
+                        "AS SELECT  *, concat('', null) FROM `test`.`tbl1`;"
         });
         testCases.add(new String[]{"test_view_1",
                 "create view test_view_1 AS SELECT " +
                         "concat(`test`.`tbl1`.`k1`, `test`.`tbl1`.`k2`) FROM `test`.`tbl1`",
-                "CREATE VIEW `test_view_1` (`concat(test.tbl1.k1, test.tbl1.k2)`) SECURITY NONE AS SELECT concat(`test`.`tbl1`.`k1`, `test`.`tbl1`.`k2`) AS `concat(test.tbl1.k1, test.tbl1.k2)`\n" +
-                        "FROM `test`.`tbl1`;"
+                "CREATE VIEW `test_view_1` (`concat(test.tbl1.k1, test.tbl1.k2)`) SECURITY NONE " +
+                        "AS SELECT concat(`test`.`tbl1`.`k1`, `test`.`tbl1`.`k2`) FROM `test`.`tbl1`;"
         });
         testCases.add(new String[]{"test_view_2",
                 "create view test_view_2 AS SELECT " +
                         "`test`.`tbl1`.`k1`, `test`.`tbl1`.`k2` FROM `test`.`tbl1`",
-                "CREATE VIEW `test_view_2` (`k1`, `k2`) SECURITY NONE AS SELECT `test`.`tbl1`.`k1`, `test`.`tbl1`.`k2`\n" +
-                        "FROM `test`.`tbl1`;"
+                "CREATE VIEW `test_view_2` (`k1`, `k2`) SECURITY NONE AS " +
+                        "SELECT `test`.`tbl1`.`k1`, `test`.`tbl1`.`k2` FROM `test`.`tbl1`;"
         });
         testCases.add(new String[]{"test_view_3",
                 "create view test_view_3 AS SELECT " +
                         "*, `test`.`tbl1`.`k2` as k3 FROM `test`.`tbl1`",
-                "CREATE VIEW `test_view_3` (`k1`, `k2`, `v1`, `k3`) SECURITY NONE AS " +
-                        "SELECT `test`.`tbl1`.`k1`, `test`.`tbl1`.`k2`, `test`.`tbl1`.`v1`, `test`.`tbl1`.`k2` AS `k3`\n" +
+                "CREATE VIEW `test_view_3` (`k1`, `k2`, `v1`, `k3`) SECURITY NONE AS SELECT *, `test`.`tbl1`.`k2` as k3 " +
                         "FROM `test`.`tbl1`;"
         });
         testCases.add(new String[]{"test_view_4",
                 "create view test_view_4 AS " +
                         "SELECT  `test`.`tbl1`.`k1` as c1, `test`.`tbl1`.`k2` as c2 FROM `test`.`tbl1`",
-                "CREATE VIEW `test_view_4` (`c1`, `c2`) SECURITY NONE AS SELECT `test`.`tbl1`.`k1` AS `c1`, `test`.`tbl1`.`k2` AS `c2`\n" +
-                        "FROM `test`.`tbl1`;"
+                "CREATE VIEW `test_view_4` (`c1`, `c2`) SECURITY NONE AS SELECT  `test`.`tbl1`.`k1` as c1, " +
+                        "`test`.`tbl1`.`k2` as c2 FROM `test`.`tbl1`;"
         });
         testCases.add(new String[]{"test_view_5",
                 "create view test_view_5 SECURITY INVOKER AS " +
                         "SELECT  `test`.`tbl1`.`k1` as c1, `test`.`tbl1`.`k2` as c2 FROM `test`.`tbl1`",
-                "CREATE VIEW `test_view_5` (`c1`, `c2`) SECURITY INVOKER AS SELECT `test`.`tbl1`.`k1` AS `c1`, `test`.`tbl1`.`k2` AS `c2`\n" +
-                        "FROM `test`.`tbl1`;"
+                "CREATE VIEW `test_view_5` (`c1`, `c2`) SECURITY INVOKER AS SELECT  `test`.`tbl1`.`k1` as c1, " +
+                        "`test`.`tbl1`.`k2` as c2 FROM `test`.`tbl1`;"
         });
 
         ConnectContext ctx = starRocksAssert.getCtx();
@@ -219,8 +218,7 @@ public class ShowCreateViewStmtTest {
         AstToStringBuilder.getDdlStmt(createViewStmt.getDbName(), views.get(0), res,
                 null, null, false, false, false);
         Assertions.assertEquals("CREATE VIEW `test_view` (`k1` COMMENT \"dt\", `k2`, `v1`)\n" +
-                "COMMENT \"view comment\" SECURITY NONE AS SELECT `test`.`tbl1`.`k1`, `test`.`tbl1`.`k2`, `test`.`tbl1`.`v1`\n" +
-                "FROM `test`.`tbl1`;", res.get(0));
+                "COMMENT \"view comment\" SECURITY NONE AS select * from tbl1;", res.get(0));
     }
 
     @Test

--- a/test/sql/test_view/R/test_files_view
+++ b/test/sql/test_view/R/test_files_view
@@ -1,18 +1,21 @@
 -- name: test_files_view
-
 create database db_${uuid0};
+-- result:
+-- !result
 use db_${uuid0};
-
+-- result:
+-- !result
 shell: ossutil64 mkdir oss://${oss_bucket}/test_files/parquet_format/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
 
+-- !result
 shell: ossutil64 cp --force ./sql/test_files/parquet_format/basic_type.parquet oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ | grep -Pv "(average|elapsed)"
 -- result:
 0
 
 Succeed: Total num: 1, size: 2,281. OK num: 1(upload 1 files).
 -- !result
-
-
 select * from files(
     "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
     "format" = "parquet",
@@ -23,7 +26,6 @@ select * from files(
 0	1	2	3.20	2024-10-01	2024-10-01 12:12:12	a	4.3
 1	11	12	13.20	2024-10-02	2024-10-02 13:13:13	b	14.3
 -- !result
-
 create view files_view as select * from files(
     "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
     "format" = "parquet",
@@ -32,17 +34,17 @@ create view files_view as select * from files(
     "aws.s3.endpoint" = "${oss_endpoint}");
 -- result:
 -- !result
-
 select * from files_view;
 -- result:
 0	1	2	3.20	2024-10-01	2024-10-01 12:12:12	a	4.3
 1	11	12	13.20	2024-10-02	2024-10-02 13:13:13	b	14.3
 -- !result
-
 show create view files_view;
 -- result:
-[REGEX].*"aws.s3.access_key" = "\*\*\*".*"aws.s3.secret_key" = "\*\*\*".*
+[REGEX].*"aws.s3.access_key" = \*\*\*[\s\S]*"aws.s3.secret_key" = \*\*\*[\s\S]*
 -- !result
-
-
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/parquet_format/${uuid0}/ > /dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_view/R/test_show_create_view
+++ b/test/sql/test_view/R/test_show_create_view
@@ -1,0 +1,43 @@
+-- name: test_show_create_view
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create or replace view test_view comment 'test comment 1' as ( select 
+"test" as test_column  -- this is a comment
+);
+-- result:
+-- !result
+select TABLE_NAME, TABLE_COMMENT from information_schema.tables WHERE TABLE_NAME = 'test_view' and TABLE_SCHEMA = 'db_${uuid0}';
+-- result:
+test_view	test comment 1
+-- !result
+show create view test_view;
+-- result:
+test_view	CREATE VIEW `test_view` (`test_column`)
+COMMENT "test comment 1" SECURITY NONE AS ( select 
+"test" as test_column  -- this is a comment
+);	utf8	utf8_general_ci
+-- !result
+create table t1(c1 bigint, c2 bigint);
+-- result:
+-- !result
+create or replace view test_view as select 
+c1, -- this is a comment
+c2 -- this is a comment
+from t1;
+-- result:
+-- !result
+select TABLE_NAME, TABLE_COMMENT from information_schema.tables WHERE TABLE_NAME = 'test_view' and TABLE_SCHEMA = 'db_${uuid0}';
+-- result:
+test_view	
+-- !result
+show create view test_view;
+-- result:
+test_view	CREATE VIEW `test_view` (`c1`, `c2`) SECURITY NONE AS select 
+c1, -- this is a comment
+c2 -- this is a comment
+from t1;	utf8	utf8_general_ci
+-- !result

--- a/test/sql/test_view/T/test_show_create_view
+++ b/test/sql/test_view/T/test_show_create_view
@@ -1,0 +1,19 @@
+-- name: test_show_create_view
+create database db_${uuid0};
+use db_${uuid0};
+create or replace view test_view comment 'test comment 1' as ( select 
+"test" as test_column  -- this is a comment
+);
+select TABLE_NAME, TABLE_COMMENT from information_schema.tables WHERE TABLE_NAME = 'test_view' and TABLE_SCHEMA = 'db_${uuid0}';
+show create view test_view;
+
+
+create table t1(c1 bigint, c2 bigint);
+
+create or replace view test_view as select 
+c1, -- this is a comment
+c2 -- this is a comment
+from t1;
+
+select TABLE_NAME, TABLE_COMMENT from information_schema.tables WHERE TABLE_NAME = 'test_view' and TABLE_SCHEMA = 'db_${uuid0}';
+show create view test_view;


### PR DESCRIPTION
## Why I'm doing:

When `show create view xxx`, we may want to show the originally defined view query, which may contain comments about column and view names.

## What I'm doing:
- Display user's defined query when execute `show create view xxx`;

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables SHOW CREATE VIEW to return the user’s original SQL (including inline comments) instead of the rewritten/expanded SQL.
> 
> - Persist original view SQL via `View.originalViewDef` (serialized) and plumb through `CreateViewStmt`/`AlterViewStmt` → `AlterViewClause` → `AlterViewInfo`
> - Capture original SQL substring in `ViewAnalyzer` using parser token indices; add validations
> - Set/read original SQL on create/alter/replay paths (`LocalMetastore`, `AlterJobExecutor`, `AlterJobMgr`)
> - Prefer original SQL in `View.getDDLViewDef()` and `getInlineViewDefWithoutCredential()`; `ViewsSystemTable` now uses `getDDLViewDef()`
> - Update/add tests (`ShowCreateViewStmtTest`, SQL tests, edit log tests, `CreateViewTest`) to assert comments are preserved in output
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5392ffe8e82c934dee6f871117e39b8d07014371. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->