### PR TITLE
[Enhancement] Improve error message clarity for INJECTED columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/projection/PartitionProjectionService.java
@@ -267,7 +267,7 @@ public class PartitionProjectionService {
             throw new IllegalArgumentException(
                     "Cannot enumerate all partitions for table with INJECTED projection columns: " +
                     injectedColumns + ". INJECTED columns require explicit filter values in the WHERE clause. " +
-                    "Use getProjectedPartitions() with specific filter values instead.");
+                    "Add a filter like 'WHERE " + injectedColumns.get(0) + " = <value>' to query this table.");
         }
 
         PartitionProjection projection = createProjection(table);


### PR DESCRIPTION
## Why I'm doing

Following up on my previous PR(#67601), I noticed the error message could be more helpful to users.

## What I'm doing

Improving the error message from:
```
Use getProjectedPartitions() with specific filter values instead.
```

To a more descriptive message that:
- Shows which INJECTED columns are causing the issue  
- Explains the requirement clearly
- Provides a concrete example

## Does this PR entail a change in behavior?

- [x] No, only improves user experience with better error messages

`mysql> SELECT * FROM `glue_catalog`.partition_projection_test.injected_test;
ERROR 1064 (HY000): Cannot enumerate all partitions for table with INJECTED projection columns: [customer_id]. INJECTED columns require explicit filter values in the WHERE clause. Add a filter like 'WHERE customer_id = <value>' to query this table.`

<img width="944" height="309" alt="image" src="https://github.com/user-attachments/assets/a9ab23ee-eac7-4a93-a747-95395ad2eb5b" />

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement (Error message improvement)
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4