### PR TITLE
[Enhancement] add DeltaLakeCacheSizeEstimator to estimate delta lake metadata cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeCacheSizeEstimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeCacheSizeEstimator.java
@@ -147,28 +147,6 @@ public class DeltaLakeCacheSizeEstimator {
         return size;
     }
 
-    private static long estimateRowBasedBatchSize(int batchSize, StructType schema) {
-        long size = 0;
-
-        // ArrayList overhead for storing rows
-        size += 48; // ArrayList object
-        size += batchSize * 8L; // References array
-
-        // Estimate per-row overhead
-        int fieldCount = schema.length();
-        long perRowOverhead = 48; // Row object + field array
-        perRowOverhead += fieldCount * 24L; // Field references and metadata
-
-        // Add data size based on field types
-        for (StructField field : schema.fields()) {
-            perRowOverhead += estimateFieldDataSize(field.getDataType());
-        }
-
-        size += perRowOverhead * batchSize;
-
-        return size;
-    }
-
     private static long estimateFieldDataSize(DataType dataType) {
         if (dataType == null) {
             return 8; // Reference size

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeCacheSizeEstimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeCacheSizeEstimator.java
@@ -19,22 +19,10 @@ import com.starrocks.common.Pair;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.types.ArrayType;
-import io.delta.kernel.types.BinaryType;
-import io.delta.kernel.types.BooleanType;
-import io.delta.kernel.types.ByteType;
 import io.delta.kernel.types.DataType;
-import io.delta.kernel.types.DateType;
-import io.delta.kernel.types.DecimalType;
-import io.delta.kernel.types.DoubleType;
-import io.delta.kernel.types.FloatType;
-import io.delta.kernel.types.IntegerType;
-import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.MapType;
-import io.delta.kernel.types.ShortType;
-import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
-import io.delta.kernel.types.TimestampType;
 
 import java.util.List;
 
@@ -145,48 +133,6 @@ public class DeltaLakeCacheSizeEstimator {
         }
 
         return size;
-    }
-
-    private static long estimateFieldDataSize(DataType dataType) {
-        if (dataType == null) {
-            return 8; // Reference size
-        }
-
-        // Conservative estimates based on data type
-        // Conservative estimates based on data type
-        if (dataType instanceof BooleanType) {
-            return 2;
-        } else if (dataType instanceof ByteType) {
-            return 2;
-        } else if (dataType instanceof ShortType) {
-            return 4;
-        } else if (dataType instanceof IntegerType) {
-            return 8;
-        } else if (dataType instanceof LongType) {
-            return 16;
-        } else if (dataType instanceof FloatType) {
-            return 16;
-        } else if (dataType instanceof DoubleType) {
-            return 24;
-        } else if (dataType instanceof StringType) {
-            return 64;
-        } else if (dataType instanceof DecimalType) {
-            return 32;
-        } else if (dataType instanceof DateType) {
-            return 16;
-        } else if (dataType instanceof TimestampType) {
-            return 24;
-        } else if (dataType instanceof BinaryType) {
-            return 128;
-        } else if (dataType instanceof ArrayType) {
-            return 128;
-        } else if (dataType instanceof MapType) {
-            return 256;
-        } else if (dataType instanceof StructType) {
-            return 256;
-        } else {
-            return 64;
-        }
     }
 
     private static long estimateColumnarBatchSize(ColumnarBatch batch, int batchSize) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeCacheSizeEstimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeCacheSizeEstimator.java
@@ -1,0 +1,320 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.starrocks.common.Pair;
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.types.ArrayType;
+import io.delta.kernel.types.BinaryType;
+import io.delta.kernel.types.BooleanType;
+import io.delta.kernel.types.ByteType;
+import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.DateType;
+import io.delta.kernel.types.DecimalType;
+import io.delta.kernel.types.DoubleType;
+import io.delta.kernel.types.FloatType;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.MapType;
+import io.delta.kernel.types.ShortType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructField;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.types.TimestampType;
+
+import java.util.List;
+
+public class DeltaLakeCacheSizeEstimator {
+    // Checkpoint cache size estimation
+    public static long estimateCheckpointByStructure(
+            Pair<DeltaLakeFileStatus, StructType> key,
+            List<ColumnarBatch> value) {
+        long size = 0;
+
+        // Estimate key size
+        if (key != null) {
+            // DeltaLakeFileStatus size
+            size += 48; // Object overhead
+            if (key.first != null && key.first.getPath() != null) {
+                size += key.first.getPath().length() * 2L; // String characters (UTF-16)
+                size += 40; // String object overhead
+            }
+
+            // StructType size
+            size += 64; // Base object overhead
+            if (key.second != null) {
+                size += 48; // StructType fields
+            }
+        }
+
+        // Estimate value size (List<ColumnarBatch>)
+        if (value != null) {
+            size += 40; // ArrayList overhead
+            int batchCount = value.size();
+            size += batchCount * 8L; // ArrayList references
+
+            for (ColumnarBatch batch : value) {
+                size += estimateColumnarBatchStructure(batch);
+            }
+        }
+
+        return size;
+    }
+
+    private static long estimateColumnarBatchStructure(ColumnarBatch batch) {
+        if (batch == null) {
+            return 0;
+        }
+
+        long size = 64; // Base ColumnarBatch overhead
+
+        // Basic info we can get from any ColumnarBatch
+        int batchSize = batch.getSize();
+        StructType schema = batch.getSchema();
+
+        // Estimate schema size
+        if (schema != null) {
+            size += estimateSchemaSize(schema);
+        }
+
+        // Estimate based on batch type and characteristics
+        if (batch instanceof io.delta.kernel.defaults.internal.data.DefaultRowBasedColumnarBatch) {
+            // Row-based batches typically store data as List<Row>
+            size += estimateRowBasedBatchSize(batchSize, schema);
+        } else if (batch instanceof io.delta.kernel.defaults.internal.data.DefaultColumnarBatch) {
+            // True columnar batch - estimate column vectors
+            size += estimateTrueColumnarBatchSize(batch, batchSize);
+        } else {
+            // Unknown implementation - use conservative estimate
+            size += batchSize * 384L; // 384 bytes per row (conservative)
+        }
+
+        return size;
+    }
+
+    private static long estimateSchemaSize(StructType schema) {
+        long size = 64; // Base StructType overhead
+
+        // Estimate field sizes
+        List<StructField> fields = schema.fields();
+        size += fields.size() * 96L; // Each field overhead
+
+        // Add string sizes for field names
+        for (StructField field : fields) {
+            if (field.getName() != null) {
+                size += field.getName().length() * 2L + 40; // UTF-16 string
+            }
+            // Estimate data type size
+            size += estimateDataTypeSize(field.getDataType());
+        }
+
+        return size;
+    }
+
+    private static long estimateDataTypeSize(DataType dataType) {
+        if (dataType == null) {
+            return 0;
+        }
+
+        long size = 32; // Base DataType overhead
+
+        // Add size based on type complexity
+        if (dataType instanceof StructType) {
+            // Nested struct
+            size += estimateSchemaSize((StructType) dataType);
+        } else if (dataType instanceof ArrayType) {
+            // Array type
+            size += 24; // ArrayType overhead
+            size += estimateDataTypeSize(((ArrayType) dataType).getElementType());
+        } else if (dataType instanceof MapType) {
+            // Map type
+            size += 32; // MapType overhead
+            size += estimateDataTypeSize(((MapType) dataType).getKeyType());
+            size += estimateDataTypeSize(((MapType) dataType).getValueType());
+        }
+
+        return size;
+    }
+
+    private static long estimateRowBasedBatchSize(int batchSize, StructType schema) {
+        long size = 0;
+
+        // ArrayList overhead for storing rows
+        size += 48; // ArrayList object
+        size += batchSize * 8L; // References array
+
+        // Estimate per-row overhead
+        int fieldCount = schema.length();
+        long perRowOverhead = 48; // Row object + field array
+        perRowOverhead += fieldCount * 24L; // Field references and metadata
+
+        // Add data size based on field types
+        for (StructField field : schema.fields()) {
+            perRowOverhead += estimateFieldDataSize(field.getDataType());
+        }
+
+        size += perRowOverhead * batchSize;
+
+        return size;
+    }
+
+    private static long estimateFieldDataSize(DataType dataType) {
+        if (dataType == null) {
+            return 8; // Reference size
+        }
+
+        // Conservative estimates based on data type
+        // Conservative estimates based on data type
+        if (dataType instanceof BooleanType) {
+            return 2;
+        } else if (dataType instanceof ByteType) {
+            return 2;
+        } else if (dataType instanceof ShortType) {
+            return 4;
+        } else if (dataType instanceof IntegerType) {
+            return 8;
+        } else if (dataType instanceof LongType) {
+            return 16;
+        } else if (dataType instanceof FloatType) {
+            return 16;
+        } else if (dataType instanceof DoubleType) {
+            return 24;
+        } else if (dataType instanceof StringType) {
+            return 64;
+        } else if (dataType instanceof DecimalType) {
+            return 32;
+        } else if (dataType instanceof DateType) {
+            return 16;
+        } else if (dataType instanceof TimestampType) {
+            return 24;
+        } else if (dataType instanceof BinaryType) {
+            return 128;
+        } else if (dataType instanceof ArrayType) {
+            return 128;
+        } else if (dataType instanceof MapType) {
+            return 256;
+        } else if (dataType instanceof StructType) {
+            return 256;
+        } else {
+            return 64;
+        }
+    }
+
+    private static long estimateTrueColumnarBatchSize(ColumnarBatch batch, int batchSize) {
+        long size = 0;
+
+        // Estimate each column vector
+        StructType schema = batch.getSchema();
+        int columnCount = schema.length();
+
+        for (int i = 0; i < columnCount; i++) {
+            try {
+                ColumnVector vector = batch.getColumnVector(i);
+                if (vector != null) {
+                    size += estimateColumnVectorSize(vector, batchSize);
+                }
+            } catch (Exception e) {
+                // If we can't access the vector, estimate conservatively
+                size += batchSize * 1024L * 3; // 3K bytes per cell
+            }
+        }
+
+        return size;
+    }
+
+    private static long estimateColumnVectorSize(ColumnVector vector, int size) {
+        if (vector == null) {
+            return 0;
+        }
+
+        long vectorSize = 64; // Base ColumnVector overhead
+
+        // Estimate based on common vector types
+        if (vector instanceof io.delta.kernel.defaults.internal.data.vector.DefaultStructVector) {
+            // Conservative estimate for structs
+            vectorSize += size * 1024L * 5; // Assume 5K bytes average per struct
+        } else {
+            // Generic estimation
+            vectorSize += size * 512L;
+        }
+
+        return vectorSize;
+    }
+
+    // JSON cache size estimation
+    public static long estimateJsonByStructure(
+            DeltaLakeFileStatus key,
+            List<JsonNode> value) {
+        long size = 0;
+
+        // Estimate key size
+        if (key != null) {
+            size += 32; // Object overhead
+            if (key.getPath() != null) {
+                size += key.getPath().length() * 2L; // String
+                size += 40; // String overhead
+            }
+        }
+
+        // Estimate value size (List<JsonNode>)
+        if (value != null) {
+            size += 40; // ArrayList overhead
+            int nodeCount = value.size();
+            size += nodeCount * 8L; // References
+
+            // Sample to estimate average JsonNode size
+            if (!value.isEmpty()) {
+                long sampleSize = 0;
+                int sampleCount = Math.min(10, nodeCount);
+                for (int i = 0; i < sampleCount; i++) {
+                    sampleSize += estimateJsonNodeStructure(value.get(i));
+                }
+                size += (sampleSize / sampleCount) * nodeCount;
+            }
+        }
+
+        return size;
+    }
+
+    private static long estimateJsonNodeStructure(JsonNode node) {
+        if (node == null) {
+            return 0;
+        }
+
+        long size = 40; // Base JsonNode overhead
+
+        if (node.isObject() || node.isArray()) {
+            size += 160; // Container overhead
+            int childCount = node.size();
+            size += childCount * 1024L; // Average child overhead
+        } else if (node.isTextual()) {
+            String text = node.asText();
+            size += text.length() * 2L; // UTF-16 characters
+            size += 40; // String overhead
+        } else if (node.isBinary()) {
+            try {
+                size += node.binaryValue().length; // Binary data
+            } catch (Exception e) {
+                size += 64; // Conservative estimate
+            }
+        } else {
+            size += 32; // Primitive value
+        }
+
+        return size;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeCacheSizeEstimatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeCacheSizeEstimatorTest.java
@@ -238,7 +238,8 @@ public class DeltaLakeCacheSizeEstimatorTest {
         DeltaLakeFileStatus deltaStatus = DeltaLakeFileStatus.of(fileStatus);
 
         try {
-            String complexJson = "{\"id\": 1, \"user\": {\"name\": \"John\", \"age\": 30}, \"items\": [1, 2, 3], \"active\": true}";
+            String complexJson =
+                    "{\"id\": 1, \"user\": {\"name\": \"John\", \"age\": 30}, \"items\": [1, 2, 3], \"active\": true}";
             JsonNode node = mapper.readTree(complexJson);
             List<JsonNode> jsonNodes = new ArrayList<>();
             jsonNodes.add(node);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeCacheSizeEstimatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeCacheSizeEstimatorTest.java
@@ -1,0 +1,252 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.starrocks.common.Pair;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.types.ArrayType;
+import io.delta.kernel.types.BinaryType;
+import io.delta.kernel.types.BooleanType;
+import io.delta.kernel.types.ByteType;
+import io.delta.kernel.types.DateType;
+import io.delta.kernel.types.DecimalType;
+import io.delta.kernel.types.DoubleType;
+import io.delta.kernel.types.FloatType;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.ShortType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.types.TimestampType;
+import io.delta.kernel.utils.FileStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Fail.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class DeltaLakeCacheSizeEstimatorTest {
+
+    @Test
+    public void testEstimateCheckpointByStructure() {
+        // Create sample key
+        FileStatus fileStatus = FileStatus.of("s3://bucket/test.parquet", 1024, 123);
+        DeltaLakeFileStatus deltaStatus = DeltaLakeFileStatus.of(fileStatus);
+        StructType schema = new StructType()
+                .add("col1", IntegerType.INTEGER)
+                .add("col2", StringType.STRING)
+                .add("col3", LongType.LONG);
+        Pair<DeltaLakeFileStatus, StructType> key = Pair.create(deltaStatus, schema);
+
+        // Create empty value
+        List<ColumnarBatch> value = new ArrayList<>();
+
+        // Estimate size
+        long size = DeltaLakeCacheSizeEstimator.estimateCheckpointByStructure(key, value);
+
+        // Verify size is positive
+        assertTrue(size > 0);
+    }
+
+    @Test
+    public void testEstimateCheckpointWithBatches() {
+        // Create sample key
+        FileStatus fileStatus = FileStatus.of("s3://bucket/test.parquet", 1024, 123);
+        DeltaLakeFileStatus deltaStatus = DeltaLakeFileStatus.of(fileStatus);
+        StructType schema = new StructType()
+                .add("col1", IntegerType.INTEGER)
+                .add("col2", StringType.STRING);
+        Pair<DeltaLakeFileStatus, StructType> key = Pair.create(deltaStatus, schema);
+
+        // Create sample ColumnarBatch value
+        List<ColumnarBatch> value = new ArrayList<>();
+
+        // Add some batches (this is a simplified test)
+        // In practice, these would be real ColumnarBatch objects created by DeltaKernel
+
+        // Estimate size
+        long size = DeltaLakeCacheSizeEstimator.estimateCheckpointByStructure(key, value);
+        assertTrue(size > 0);
+    }
+
+    @Test
+    public void testEstimateCheckpointByStructureNullKey() {
+        // Test with null key
+        List<ColumnarBatch> value = new ArrayList<>();
+        long size = DeltaLakeCacheSizeEstimator.estimateCheckpointByStructure(null, value);
+        assertTrue(size >= 0);
+    }
+
+    @Test
+    public void testEstimateCheckpointByStructureNullValue() {
+        // Create sample key
+        FileStatus fileStatus = FileStatus.of("s3://bucket/test.parquet", 1024, 123);
+        DeltaLakeFileStatus deltaStatus = DeltaLakeFileStatus.of(fileStatus);
+        StructType schema = new StructType().add("col1", IntegerType.INTEGER);
+        Pair<DeltaLakeFileStatus, StructType> key = Pair.create(deltaStatus, schema);
+
+        // Test with null value
+        long size = DeltaLakeCacheSizeEstimator.estimateCheckpointByStructure(key, null);
+        assertTrue(size > 0);
+    }
+
+    @Test
+    public void testEstimateJsonByStructure() {
+        // Create sample key
+        FileStatus fileStatus = FileStatus.of("s3://bucket/test.json", 512, 456);
+        DeltaLakeFileStatus deltaStatus = DeltaLakeFileStatus.of(fileStatus);
+
+        // Create sample JSON values
+        List<JsonNode> jsonNodes = new ArrayList<>();
+        ObjectMapper mapper = new ObjectMapper();
+
+        try {
+            // Create sample JSON objects
+            JsonNode node1 = mapper.readTree("{\"id\": 1, \"name\": \"test\", \"value\": 123}");
+            JsonNode node2 = mapper.readTree("{\"id\": 2, \"name\": \"test2\", \"value\": 456}");
+            jsonNodes.add(node1);
+            jsonNodes.add(node2);
+        } catch (Exception e) {
+            fail("Failed to create JSON nodes: " + e.getMessage());
+        }
+
+        // Estimate size
+        long size = DeltaLakeCacheSizeEstimator.estimateJsonByStructure(deltaStatus, jsonNodes);
+
+        assertTrue(size > 0);
+    }
+
+    @Test
+    public void testEstimateJsonByStructureNullKey() {
+        // Create sample JSON values
+        List<JsonNode> jsonNodes = new ArrayList<>();
+        ObjectMapper mapper = new ObjectMapper();
+
+        try {
+            jsonNodes.add(mapper.readTree("{\"id\": 1}"));
+        } catch (Exception e) {
+            fail("Failed to create JSON nodes: " + e.getMessage());
+        }
+
+        // Test with null key
+        long size = DeltaLakeCacheSizeEstimator.estimateJsonByStructure(null, jsonNodes);
+        assertTrue(size > 0);
+    }
+
+    @Test
+    public void testEstimateJsonWithEmptyArray() {
+        // Create sample key
+        FileStatus fileStatus = FileStatus.of("s3://bucket/test.json", 512, 456);
+        DeltaLakeFileStatus deltaStatus = DeltaLakeFileStatus.of(fileStatus);
+
+        // Test with empty JSON list
+        List<JsonNode> emptyNodes = new ArrayList<>();
+        long size = DeltaLakeCacheSizeEstimator.estimateJsonByStructure(deltaStatus, emptyNodes);
+        assertTrue(size > 0);
+    }
+
+    @Test
+    public void testEstimateComplexSchema() {
+        // Create complex schema
+        StructType complexSchema = new StructType()
+                .add("id", IntegerType.INTEGER)
+                .add("name", StringType.STRING)
+                .add("price", DecimalType.USER_DEFAULT)
+                .add("created_at", TimestampType.TIMESTAMP)
+                .add("metadata", new StructType()
+                        .add("author", StringType.STRING)
+                        .add("version", IntegerType.INTEGER))
+                .add("tags", new ArrayType(StringType.STRING, true));
+
+        FileStatus fileStatus = FileStatus.of("s3://bucket/test.parquet", 1024, 123);
+        DeltaLakeFileStatus deltaStatus = DeltaLakeFileStatus.of(fileStatus);
+        Pair<DeltaLakeFileStatus, StructType> key = Pair.create(deltaStatus, complexSchema);
+
+        List<ColumnarBatch> value = new ArrayList<>();
+
+        long size = DeltaLakeCacheSizeEstimator.estimateCheckpointByStructure(key, value);
+        assertTrue(size > 0);
+    }
+
+    @Test
+    public void testEstimatePrimitiveTypes() {
+        // Test all primitive types
+        StructType primitiveSchema = new StructType()
+                .add("bool_col", BooleanType.BOOLEAN)
+                .add("byte_col", ByteType.BYTE)
+                .add("short_col", ShortType.SHORT)
+                .add("int_col", IntegerType.INTEGER)
+                .add("long_col", LongType.LONG)
+                .add("float_col", FloatType.FLOAT)
+                .add("double_col", DoubleType.DOUBLE)
+                .add("string_col", StringType.STRING)
+                .add("binary_col", BinaryType.BINARY)
+                .add("date_col", DateType.DATE)
+                .add("timestamp_col", TimestampType.TIMESTAMP);
+
+        FileStatus fileStatus = FileStatus.of("s3://bucket/test.parquet", 1024, 123);
+        DeltaLakeFileStatus deltaStatus = DeltaLakeFileStatus.of(fileStatus);
+        Pair<DeltaLakeFileStatus, StructType> key = Pair.create(deltaStatus, primitiveSchema);
+
+        List<ColumnarBatch> value = new ArrayList<>();
+
+        long size = DeltaLakeCacheSizeEstimator.estimateCheckpointByStructure(key, value);
+        assertTrue(size > 0);
+    }
+
+    @Test
+    public void testEstimateNestedStructures() {
+        // Test deeply nested structures
+        StructType deeplyNested = new StructType()
+                .add("level1", new StructType()
+                        .add("level2", new StructType()
+                                .add("level3", new StructType()
+                                        .add("value", StringType.STRING))));
+
+        FileStatus fileStatus = FileStatus.of("s3://bucket/test.parquet", 1024, 123);
+        DeltaLakeFileStatus deltaStatus = DeltaLakeFileStatus.of(fileStatus);
+        Pair<DeltaLakeFileStatus, StructType> key = Pair.create(deltaStatus, deeplyNested);
+
+        List<ColumnarBatch> value = new ArrayList<>();
+
+        long size = DeltaLakeCacheSizeEstimator.estimateCheckpointByStructure(key, value);
+        assertTrue(size > 0);
+    }
+
+    @Test
+    public void testJsonComplexStructure() {
+        // Create complex JSON structure
+        ObjectMapper mapper = new ObjectMapper();
+        FileStatus fileStatus = FileStatus.of("s3://bucket/test.json", 512, 456);
+        DeltaLakeFileStatus deltaStatus = DeltaLakeFileStatus.of(fileStatus);
+
+        try {
+            String complexJson = "{\"id\": 1, \"user\": {\"name\": \"John\", \"age\": 30}, \"items\": [1, 2, 3], \"active\": true}";
+            JsonNode node = mapper.readTree(complexJson);
+            List<JsonNode> jsonNodes = new ArrayList<>();
+            jsonNodes.add(node);
+
+            long size = DeltaLakeCacheSizeEstimator.estimateJsonByStructure(deltaStatus, jsonNodes);
+            assertTrue(size > 0);
+        } catch (Exception e) {
+            fail("Failed to parse complex JSON: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
The memory usage of the Delta Lake checkpoint/json cache differs significantly from the actual value.
## What I'm doing:
This pull request introduces a new structure-based cache size estimation for Delta Lake metadata caching, replacing the previous reliance on Spark's `SizeEstimator`. The new approach improves accuracy and removes a dependency on Spark internals. It includes a new utility class for cache size estimation and corresponding unit tests to ensure correctness and robustness.

**Cache Size Estimation Improvements:**

* Added the new utility class `DeltaLakeCacheSizeEstimator` to estimate cache entry sizes for both checkpoint and JSON metadata using object structure rather than Spark's `SizeEstimator`.
* Updated `DeltaLakeMetastore` to use the new structure-based estimation methods for both checkpoint and JSON caches, removing the Spark dependency and improving cache weight calculation. [[1]](diffhunk://#diff-b6752a3c7152a92de2a44a6a4b4f8da10987e00233d7b784e7514432a14edc00L46) [[2]](diffhunk://#diff-b6752a3c7152a92de2a44a6a4b4f8da10987e00233d7b784e7514432a14edc00L83-R87) [[3]](diffhunk://#diff-b6752a3c7152a92de2a44a6a4b4f8da10987e00233d7b784e7514432a14edc00L98-R106)

**Testing and Validation:**

* Added comprehensive unit tests in `DeltaLakeCacheSizeEstimatorTest.java` to verify the accuracy and reliability of the new estimation logic for various schema and JSON structures.
Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
