### PR TITLE
[Enhancement] Support multiple compression formats (GZIP/SNAPPY/ZSTD/LZ4/LZ4_FRAME/DEFLATE/ZLIB/BZIP2) for CSV file exports

### DIFF
--- a/be/src/connector/file_chunk_sink.cpp
+++ b/be/src/connector/file_chunk_sink.cpp
@@ -52,9 +52,35 @@ StatusOr<std::unique_ptr<ConnectorChunkSink>> FileChunkSinkProvider::create_chun
     auto runtime_state = ctx->fragment_context->runtime_state();
     std::shared_ptr<FileSystem> fs = FileSystem::CreateUniqueFromString(ctx->path, FSOptions(&ctx->cloud_conf)).value();
     auto column_evaluators = ColumnEvaluator::clone(ctx->column_evaluators);
+
+    // Add compression extension for compressed CSV files.
+    // Note: Parquet and ORC are self-contained formats with compression info in metadata,
+    // so they don't need compression extensions. CSV is plain text and needs extensions
+    // (e.g., .csv.gz) to indicate the content is compressed.
+    std::string file_suffix = boost::to_lower_copy(ctx->format);
+    if (boost::iequals(ctx->format, formats::CSV)) {
+        switch (ctx->compression_type) {
+        case TCompressionType::GZIP:
+            file_suffix += ".gz";
+            break;
+        case TCompressionType::SNAPPY:
+            file_suffix += ".snappy";
+            break;
+        case TCompressionType::ZSTD:
+            file_suffix += ".zst";
+            break;
+        case TCompressionType::LZ4:
+        case TCompressionType::LZ4_FRAME:
+            file_suffix += ".lz4";
+            break;
+        default:
+            // No extension for uncompressed or unsupported types
+            break;
+        }
+    }
+
     auto location_provider = std::make_shared<connector::LocationProvider>(
-            ctx->path, print_id(ctx->fragment_context->query_id()), runtime_state->be_number(), driver_id,
-            boost::to_lower_copy(ctx->format));
+            ctx->path, print_id(ctx->fragment_context->query_id()), runtime_state->be_number(), driver_id, file_suffix);
 
     std::shared_ptr<formats::FileWriterFactory> file_writer_factory;
     if (boost::iequals(ctx->format, formats::PARQUET)) {

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -21,6 +21,7 @@ ADD_BE_LIB(Formats
         csv/converter.cpp
         csv/csv_reader.cpp
         csv/csv_file_writer.cpp
+        csv/output_stream_file.cpp
         csv/date_converter.cpp
         csv/datetime_converter.cpp
         csv/decimalv2_converter.cpp

--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -24,30 +24,26 @@
 #include "formats/utils.h"
 #include "output_stream_file.h"
 #include "runtime/current_thread.h"
+#include "util/compression/compression_utils.h"
+#include "util/defer_op.h"
 
 namespace starrocks::formats {
 
 CSVFileWriter::CSVFileWriter(std::string location, std::shared_ptr<csv::OutputStream> output_stream,
                              std::vector<std::string> column_names, std::vector<TypeDescriptor> types,
                              std::vector<std::unique_ptr<ColumnEvaluator>>&& column_evaluators,
-                             TCompressionType::type compression_type, std::shared_ptr<CSVWriterOptions> writer_options,
-                             std::function<void()> rollback_action)
+                             std::shared_ptr<CSVWriterOptions> writer_options, std::function<void()> rollback_action)
         : _location(std::move(location)),
           _output_stream(std::move(output_stream)),
           _column_names(std::move(column_names)),
           _types(std::move(types)),
           _column_evaluators(std::move(column_evaluators)),
-          _compression_type(compression_type),
           _writer_options(std::move(writer_options)),
           _rollback_action(std::move(rollback_action)) {}
 
 CSVFileWriter::~CSVFileWriter() = default;
 
 Status CSVFileWriter::init() {
-    if (_compression_type != TCompressionType::NO_COMPRESSION) {
-        return Status::NotSupported(fmt::format("not supported compression type {}", to_string(_compression_type)));
-    }
-
     RETURN_IF_ERROR(ColumnEvaluator::init(_column_evaluators));
     _column_converters.reserve(_types.size());
     for (auto& type : _types) {
@@ -215,14 +211,38 @@ StatusOr<WriterAndStream> CSVFileWriterFactory::create(const std::string& path) 
     auto rollback_action = [fs = _fs, path = path]() {
         WARN_IF_ERROR(ignore_not_found(fs->delete_file(path)), "fail to delete file");
     };
+    // Use DeferOp to ensure cleanup on any failure after file creation
+    bool success = false;
+    DeferOp cleanup_on_failure([&success, &rollback_action]() {
+        if (!success) {
+            rollback_action();
+        }
+    });
+
     auto column_evaluators = ColumnEvaluator::clone(_column_evaluators);
     auto types = ColumnEvaluator::types(_column_evaluators);
     auto async_output_stream =
             std::make_unique<io::AsyncFlushOutputStream>(std::move(file), _executors, _runtime_state);
-    auto csv_output_stream = std::make_shared<csv::AsyncOutputStreamFile>(async_output_stream.get(), 1024 * 1024);
-    auto writer =
-            std::make_unique<CSVFileWriter>(path, csv_output_stream, _column_names, types, std::move(column_evaluators),
-                                            _compression_type, _parsed_options, rollback_action);
+
+    // Create base async output stream
+    auto base_stream = std::make_shared<csv::AsyncOutputStreamFile>(async_output_stream.get(), 1024 * 1024);
+
+    // Wrap with compression if enabled (decorator pattern)
+    std::shared_ptr<csv::OutputStream> csv_output_stream;
+    CompressionTypePB compression_pb = CompressionUtils::to_compression_pb(_compression_type);
+    // Only use compression if it's a valid, recognized compression type
+    // (not UNKNOWN_COMPRESSION which is returned for AUTO, DEFAULT_COMPRESSION, etc.)
+    if (compression_pb != CompressionTypePB::NO_COMPRESSION &&
+        compression_pb != CompressionTypePB::UNKNOWN_COMPRESSION) {
+        ASSIGN_OR_RETURN(csv_output_stream,
+                         csv::CompressedOutputStream::create(base_stream, compression_pb, 1024 * 1024));
+    } else {
+        csv_output_stream = base_stream;
+    }
+
+    auto writer = std::make_unique<CSVFileWriter>(path, csv_output_stream, _column_names, types,
+                                                  std::move(column_evaluators), _parsed_options, rollback_action);
+    success = true; // Mark success to prevent cleanup
     return WriterAndStream{
             .writer = std::move(writer),
             .stream = std::move(async_output_stream),

--- a/be/src/formats/csv/csv_file_writer.h
+++ b/be/src/formats/csv/csv_file_writer.h
@@ -50,8 +50,7 @@ public:
     CSVFileWriter(std::string location, std::shared_ptr<csv::OutputStream> output_stream,
                   std::vector<std::string> column_names, std::vector<TypeDescriptor> types,
                   std::vector<std::unique_ptr<ColumnEvaluator>>&& column_evaluators,
-                  TCompressionType::type compression_type, std::shared_ptr<CSVWriterOptions> writer_options,
-                  std::function<void()> rollback_action);
+                  std::shared_ptr<CSVWriterOptions> writer_options, std::function<void()> rollback_action);
 
     ~CSVFileWriter() override;
 
@@ -73,7 +72,6 @@ private:
     const std::vector<std::string> _column_names;
     const std::vector<TypeDescriptor> _types;
     std::vector<std::unique_ptr<ColumnEvaluator>> _column_evaluators;
-    TCompressionType::type _compression_type = TCompressionType::UNKNOWN_COMPRESSION;
     std::shared_ptr<CSVWriterOptions> _writer_options;
     const std::function<void()> _rollback_action;
     std::shared_ptr<csv::Converter::Options> _converter_options;

--- a/be/src/formats/csv/output_stream.h
+++ b/be/src/formats/csv/output_stream.h
@@ -114,6 +114,10 @@ public:
 protected:
     virtual Status _sync(const char* data, size_t size) = 0;
 
+    // Returns the number of bytes currently in the base class buffer
+    // that haven't been synced yet.
+    std::size_t _pending_buffer_size() const { return _pos - _buff; }
+
 private:
     size_t _free_space() const { return _end - _pos; }
 

--- a/be/src/formats/csv/output_stream_file.cpp
+++ b/be/src/formats/csv/output_stream_file.cpp
@@ -1,0 +1,143 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/csv/output_stream_file.h"
+
+namespace starrocks::csv {
+
+// Check if compression type supports incremental compression via frame concatenation.
+// Only these formats can have multiple independent frames concatenated together.
+static bool supports_incremental_compression(CompressionTypePB compression_type) {
+    switch (compression_type) {
+    case CompressionTypePB::GZIP:
+        // Multiple GZIP streams can be concatenated; gunzip handles this correctly.
+        return true;
+    case CompressionTypePB::LZ4_FRAME:
+        // LZ4 frame format supports concatenation of multiple frames.
+        return true;
+    case CompressionTypePB::ZSTD:
+        // ZSTD supports concatenation of multiple frames.
+        return true;
+    default:
+        // SNAPPY, LZ4 (raw block), and others don't support frame concatenation.
+        return false;
+    }
+}
+
+StatusOr<std::shared_ptr<CompressedOutputStream>> CompressedOutputStream::create(
+        std::shared_ptr<OutputStream> underlying_stream, CompressionTypePB compression_type, size_t buff_size) {
+    // Check if compression type supports incremental compression
+    if (!supports_incremental_compression(compression_type)) {
+        return Status::InvalidArgument(
+                fmt::format("Compression type {} does not support incremental compression for CSV export. "
+                            "Supported types: GZIP, LZ4_FRAME, ZSTD",
+                            CompressionTypePB_Name(compression_type)));
+    }
+
+    const BlockCompressionCodec* codec = nullptr;
+    RETURN_IF_ERROR(get_block_compression_codec(compression_type, &codec));
+    if (codec == nullptr) {
+        return Status::InvalidArgument(
+                fmt::format("Failed to get compression codec for type: {}", CompressionTypePB_Name(compression_type)));
+    }
+    return std::shared_ptr<CompressedOutputStream>(
+            new CompressedOutputStream(std::move(underlying_stream), codec, compression_type, buff_size));
+}
+
+CompressedOutputStream::CompressedOutputStream(std::shared_ptr<OutputStream> underlying_stream,
+                                               const BlockCompressionCodec* codec, CompressionTypePB compression_type,
+                                               size_t buff_size)
+        : OutputStream(buff_size),
+          _underlying_stream(std::move(underlying_stream)),
+          _codec(codec),
+          _compression_type(compression_type) {}
+
+bool CompressedOutputStream::_supports_incremental_compression() const {
+    return supports_incremental_compression(_compression_type);
+}
+
+Status CompressedOutputStream::_flush_compressed_chunk() {
+    if (_uncompressed_buffer.empty()) {
+        return Status::OK();
+    }
+
+    Slice input(reinterpret_cast<const char*>(_uncompressed_buffer.data()), _uncompressed_buffer.size());
+    size_t max_compressed_size = _codec->max_compressed_len(_uncompressed_buffer.size());
+    _compress_buffer.resize(max_compressed_size);
+    Slice output(reinterpret_cast<char*>(_compress_buffer.data()), max_compressed_size);
+
+    RETURN_IF_ERROR(_codec->compress(input, &output));
+
+    // Write compressed data to underlying stream
+    RETURN_IF_ERROR(_underlying_stream->write(Slice(output.data, output.size)));
+
+    // Track compressed bytes written
+    _compressed_bytes_written += output.size;
+
+    // Clear the uncompressed buffer
+    _uncompressed_buffer.clear();
+
+    return Status::OK();
+}
+
+Status CompressedOutputStream::_sync(const char* data, size_t size) {
+    if (size == 0) {
+        return Status::OK();
+    }
+
+    // Buffer uncompressed data
+    size_t old_size = _uncompressed_buffer.size();
+    _uncompressed_buffer.resize(old_size + size);
+    memcpy(_uncompressed_buffer.data() + old_size, data, size);
+
+    // Flush when buffer reaches chunk size to limit memory usage.
+    // Each flush creates an independent compressed frame that can be
+    // concatenated with other frames.
+    if (_uncompressed_buffer.size() >= kDefaultChunkSize) {
+        RETURN_IF_ERROR(_flush_compressed_chunk());
+    }
+
+    return Status::OK();
+}
+
+Status CompressedOutputStream::finalize() {
+    // First flush any remaining data in the base OutputStream buffer
+    RETURN_IF_ERROR(OutputStream::finalize());
+
+    // Compress and write any remaining buffered data
+    RETURN_IF_ERROR(_flush_compressed_chunk());
+
+    // Shrink buffer to free memory
+    _uncompressed_buffer.shrink_to_fit();
+
+    // Finalize the underlying stream
+    return _underlying_stream->finalize();
+}
+
+std::size_t CompressedOutputStream::size() {
+    // Return the total compressed bytes written so far, plus an estimate for pending
+    // uncompressed data in the buffer. This provides a reasonable approximation of
+    // the final file size for file rotation decisions.
+    //
+    // For pending data, we use the max_compressed_len as a conservative estimate.
+    // This may slightly overestimate, but ensures file rotation triggers before
+    // files get too large.
+    size_t pending_estimate = 0;
+    if (!_uncompressed_buffer.empty()) {
+        pending_estimate = _codec->max_compressed_len(_uncompressed_buffer.size());
+    }
+    return _compressed_bytes_written + pending_estimate;
+}
+
+} // namespace starrocks::csv

--- a/be/src/formats/csv/output_stream_file.cpp
+++ b/be/src/formats/csv/output_stream_file.cpp
@@ -63,10 +63,6 @@ CompressedOutputStream::CompressedOutputStream(std::shared_ptr<OutputStream> und
           _codec(codec),
           _compression_type(compression_type) {}
 
-bool CompressedOutputStream::_supports_incremental_compression() const {
-    return supports_incremental_compression(_compression_type);
-}
-
 Status CompressedOutputStream::_flush_compressed_chunk() {
     if (_uncompressed_buffer.empty()) {
         return Status::OK();

--- a/be/src/formats/csv/output_stream_file.cpp
+++ b/be/src/formats/csv/output_stream_file.cpp
@@ -14,72 +14,131 @@
 
 #include "formats/csv/output_stream_file.h"
 
+#include <algorithm>
+#include <cstring>
+
+#include "fmt/format.h"
+#include "util/coding.h"
+#include "util/compression/compression_headers.h"
+
 namespace starrocks::csv {
 
-// Check if compression type supports incremental compression via frame concatenation.
-// Only these formats can have multiple independent frames concatenated together.
-static bool supports_incremental_compression(CompressionTypePB compression_type) {
-    switch (compression_type) {
-    case CompressionTypePB::GZIP:
-        // Multiple GZIP streams can be concatenated; gunzip handles this correctly.
-        return true;
-    case CompressionTypePB::LZ4_FRAME:
-        // LZ4 frame format supports concatenation of multiple frames.
-        return true;
-    case CompressionTypePB::ZSTD:
-        // ZSTD supports concatenation of multiple frames.
-        return true;
-    default:
-        // SNAPPY, LZ4 (raw block), and others don't support frame concatenation.
-        return false;
-    }
+static bool is_block_compression(CompressionTypePB compression_type) {
+    return compression_type == CompressionTypePB::SNAPPY || compression_type == CompressionTypePB::LZ4;
 }
 
 StatusOr<std::shared_ptr<CompressedOutputStream>> CompressedOutputStream::create(
         std::shared_ptr<OutputStream> underlying_stream, CompressionTypePB compression_type, size_t buff_size) {
-    // Check if compression type supports incremental compression
-    if (!supports_incremental_compression(compression_type)) {
+    if (compression_type == CompressionTypePB::NO_COMPRESSION ||
+        compression_type == CompressionTypePB::UNKNOWN_COMPRESSION) {
         return Status::InvalidArgument(
-                fmt::format("Compression type {} does not support incremental compression for CSV export. "
-                            "Supported types: GZIP, LZ4_FRAME, ZSTD",
-                            CompressionTypePB_Name(compression_type)));
+                fmt::format("Invalid compression type: {}", CompressionTypePB_Name(compression_type)));
     }
 
-    const BlockCompressionCodec* codec = nullptr;
-    RETURN_IF_ERROR(get_block_compression_codec(compression_type, &codec));
-    if (codec == nullptr) {
-        return Status::InvalidArgument(
-                fmt::format("Failed to get compression codec for type: {}", CompressionTypePB_Name(compression_type)));
+    std::unique_ptr<StreamCompressor> compressor;
+    if (!is_block_compression(compression_type)) {
+        RETURN_IF_ERROR(StreamCompressor::create_compressor(compression_type, &compressor));
     }
-    return std::shared_ptr<CompressedOutputStream>(
-            new CompressedOutputStream(std::move(underlying_stream), codec, buff_size));
+    return std::shared_ptr<CompressedOutputStream>(new CompressedOutputStream(
+            std::move(underlying_stream), compression_type, std::move(compressor), buff_size));
 }
 
 CompressedOutputStream::CompressedOutputStream(std::shared_ptr<OutputStream> underlying_stream,
-                                               const BlockCompressionCodec* codec, size_t buff_size)
-        : OutputStream(buff_size), _underlying_stream(std::move(underlying_stream)), _codec(codec) {}
+                                               CompressionTypePB compression_type,
+                                               std::unique_ptr<StreamCompressor> compressor, size_t buff_size)
+        : OutputStream(buff_size),
+          _underlying_stream(std::move(underlying_stream)),
+          _compression_type(compression_type),
+          _compressor(std::move(compressor)) {
+    _compress_buffer.resize(64 * 1024);
+    if (is_block_compression(_compression_type)) {
+        _block_buffer.reserve(kBlockBufferSize);
+    }
+}
 
-Status CompressedOutputStream::_flush_compressed_chunk() {
-    if (_uncompressed_buffer.empty()) {
+Status CompressedOutputStream::_compress_and_write(const uint8_t* data, size_t size) {
+    size_t remaining = size;
+    while (remaining > 0) {
+        size_t needed = _compressor->max_compressed_len(remaining);
+        if (needed > _compress_buffer.size()) {
+            _compress_buffer.resize(needed);
+        }
+        size_t input_read = 0;
+        size_t output_written = 0;
+        RETURN_IF_ERROR(_compressor->compress(data, remaining, &input_read, _compress_buffer.data(),
+                                              _compress_buffer.size(), &output_written));
+        if (output_written > 0) {
+            RETURN_IF_ERROR(_underlying_stream->write(
+                    Slice(reinterpret_cast<const char*>(_compress_buffer.data()), output_written)));
+            _compressed_bytes_written += output_written;
+        }
+        if (input_read == 0 && output_written == 0) {
+            return Status::InternalError("Stream compression made no progress");
+        }
+        data += input_read;
+        remaining -= input_read;
+    }
+    return Status::OK();
+}
+
+Status CompressedOutputStream::_flush_block() {
+    if (_block_buffer.empty()) {
         return Status::OK();
     }
 
-    Slice input(reinterpret_cast<const char*>(_uncompressed_buffer.data()), _uncompressed_buffer.size());
-    size_t max_compressed_size = _codec->max_compressed_len(_uncompressed_buffer.size());
-    _compress_buffer.resize(max_compressed_size);
-    Slice output(reinterpret_cast<char*>(_compress_buffer.data()), max_compressed_size);
+    uint32_t block_size = _block_buffer.size();
+    if (_compression_type == CompressionTypePB::SNAPPY) {
+        size_t max_compressed = snappy::MaxCompressedLength(block_size);
+        _compress_buffer.resize(max_compressed);
+        size_t compressed_len = 0;
+        snappy::RawCompress(reinterpret_cast<const char*>(_block_buffer.data()), block_size,
+                            reinterpret_cast<char*>(_compress_buffer.data()), &compressed_len);
+        RETURN_IF_ERROR(_write_block(block_size, _compress_buffer.data(), static_cast<uint32_t>(compressed_len)));
+    } else if (_compression_type == CompressionTypePB::LZ4) {
+        size_t max_compressed = LZ4_compressBound(block_size);
+        _compress_buffer.resize(max_compressed);
+        int compressed_len =
+                LZ4_compress_default(reinterpret_cast<const char*>(_block_buffer.data()),
+                                     reinterpret_cast<char*>(_compress_buffer.data()), block_size, max_compressed);
+        if (compressed_len <= 0) {
+            return Status::InternalError("LZ4 compress failed");
+        }
+        RETURN_IF_ERROR(_write_block(block_size, _compress_buffer.data(), static_cast<uint32_t>(compressed_len)));
+    } else {
+        return Status::InvalidArgument(
+                fmt::format("Unsupported block compression type: {}", CompressionTypePB_Name(_compression_type)));
+    }
 
-    RETURN_IF_ERROR(_codec->compress(input, &output));
+    _block_buffer.clear();
+    return Status::OK();
+}
 
-    // Write compressed data to underlying stream
-    RETURN_IF_ERROR(_underlying_stream->write(Slice(output.data, output.size)));
+Status CompressedOutputStream::_write_block(uint32_t block_size, const uint8_t* compressed_data,
+                                            uint32_t compressed_len) {
+    // Block stream format (big-endian):
+    //   [uncompressed_block_len][compressed_len][compressed_payload]
+    uint8_t header[kBlockHeaderSize];
+    encode_fixed32_be(header, block_size);
+    encode_fixed32_be(header + 4, compressed_len);
+    RETURN_IF_ERROR(_underlying_stream->write(Slice(reinterpret_cast<const char*>(header), sizeof(header))));
+    RETURN_IF_ERROR(_underlying_stream->write(Slice(reinterpret_cast<const char*>(compressed_data), compressed_len)));
+    _compressed_bytes_written += sizeof(header) + compressed_len;
+    return Status::OK();
+}
 
-    // Track compressed bytes written
-    _compressed_bytes_written += output.size;
+size_t CompressedOutputStream::_estimate_block_compressed_len(CompressionTypePB compression_type, size_t input_size) {
+    if (compression_type == CompressionTypePB::SNAPPY) {
+        return snappy::MaxCompressedLength(input_size);
+    }
+    return LZ4_compressBound(input_size);
+}
 
-    // Clear the uncompressed buffer
-    _uncompressed_buffer.clear();
-
+Status CompressedOutputStream::_write_block_end() {
+    // Block stream terminator: block_len = 0
+    uint8_t header[kBlockEndSize];
+    encode_fixed32_be(header, 0);
+    RETURN_IF_ERROR(_underlying_stream->write(Slice(reinterpret_cast<const char*>(header), sizeof(header))));
+    _compressed_bytes_written += sizeof(header);
     return Status::OK();
 }
 
@@ -88,51 +147,74 @@ Status CompressedOutputStream::_sync(const char* data, size_t size) {
         return Status::OK();
     }
 
-    // Buffer uncompressed data
-    size_t old_size = _uncompressed_buffer.size();
-    _uncompressed_buffer.resize(old_size + size);
-    memcpy(_uncompressed_buffer.data() + old_size, data, size);
-
-    // Flush when buffer reaches chunk size to limit memory usage.
-    // Each flush creates an independent compressed frame that can be
-    // concatenated with other frames.
-    if (_uncompressed_buffer.size() >= kDefaultChunkSize) {
-        RETURN_IF_ERROR(_flush_compressed_chunk());
+    if (is_block_compression(_compression_type)) {
+        size_t remaining = size;
+        const uint8_t* input = reinterpret_cast<const uint8_t*>(data);
+        while (remaining > 0) {
+            size_t to_copy = std::min(remaining, kBlockBufferSize - _block_buffer.size());
+            size_t old_size = _block_buffer.size();
+            _block_buffer.resize(old_size + to_copy);
+            memcpy(_block_buffer.data() + old_size, input, to_copy);
+            input += to_copy;
+            remaining -= to_copy;
+            if (_block_buffer.size() >= kBlockBufferSize) {
+                RETURN_IF_ERROR(_flush_block());
+            }
+        }
+        return Status::OK();
     }
 
-    return Status::OK();
+    return _compress_and_write(reinterpret_cast<const uint8_t*>(data), size);
 }
 
 Status CompressedOutputStream::finalize() {
     // First flush any remaining data in the base OutputStream buffer
     RETURN_IF_ERROR(OutputStream::finalize());
 
-    // Compress and write any remaining buffered data
-    RETURN_IF_ERROR(_flush_compressed_chunk());
+    if (is_block_compression(_compression_type)) {
+        RETURN_IF_ERROR(_flush_block());
+        RETURN_IF_ERROR(_write_block_end());
+    } else {
+        bool stream_end = false;
+        while (!stream_end) {
+            size_t needed = _compressor->max_compressed_len(0);
+            if (needed > _compress_buffer.size()) {
+                _compress_buffer.resize(needed);
+            }
+            size_t output_written = 0;
+            RETURN_IF_ERROR(_compressor->finish(_compress_buffer.data(), _compress_buffer.size(), &output_written,
+                                                &stream_end));
+            if (output_written > 0) {
+                RETURN_IF_ERROR(_underlying_stream->write(
+                        Slice(reinterpret_cast<const char*>(_compress_buffer.data()), output_written)));
+                _compressed_bytes_written += output_written;
+            }
+            if (!stream_end && output_written == 0) {
+                return Status::InternalError("Stream compression finish made no progress");
+            }
+        }
+    }
 
     // Shrink buffer to free memory
-    _uncompressed_buffer.shrink_to_fit();
+    _block_buffer.shrink_to_fit();
+    _compress_buffer.shrink_to_fit();
 
     // Finalize the underlying stream
     return _underlying_stream->finalize();
 }
 
 std::size_t CompressedOutputStream::size() {
-    // Return the total compressed bytes written so far, plus an estimate for pending
-    // uncompressed data. This provides a reasonable approximation of the final file
-    // size for file rotation decisions.
-    //
-    // Pending data includes:
-    // 1. Data in the base class OutputStream buffer (not yet synced)
-    // 2. Data in _uncompressed_buffer (synced but not yet compressed)
-    //
-    // For pending data, we use the max_compressed_len as a conservative estimate.
-    // This may slightly overestimate, but ensures file rotation triggers before
-    // files get too large.
-    size_t total_pending = _pending_buffer_size() + _uncompressed_buffer.size();
+    size_t total_pending = _pending_buffer_size() + _block_buffer.size();
     size_t pending_estimate = 0;
     if (total_pending > 0) {
-        pending_estimate = _codec->max_compressed_len(total_pending);
+        if (is_block_compression(_compression_type)) {
+            // Estimate block framing overhead per block plus a final terminator.
+            size_t num_blocks = (total_pending + kBlockBufferSize - 1) / kBlockBufferSize;
+            size_t per_block_overhead = kBlockHeaderSize * num_blocks + kBlockEndSize;
+            pending_estimate = _estimate_block_compressed_len(_compression_type, total_pending) + per_block_overhead;
+        } else {
+            pending_estimate = _compressor->max_compressed_len(total_pending);
+        }
     }
     return _compressed_bytes_written + pending_estimate;
 }

--- a/be/src/formats/csv/output_stream_file.h
+++ b/be/src/formats/csv/output_stream_file.h
@@ -105,14 +105,13 @@ protected:
 private:
     // Private constructor - use create() factory method instead
     CompressedOutputStream(std::shared_ptr<OutputStream> underlying_stream, const BlockCompressionCodec* codec,
-                           CompressionTypePB compression_type, size_t buff_size);
+                           size_t buff_size);
 
     // Compress and write the current buffer to underlying stream
     Status _flush_compressed_chunk();
 
     std::shared_ptr<OutputStream> _underlying_stream;
     const BlockCompressionCodec* _codec;
-    CompressionTypePB _compression_type;
     // Buffer to accumulate uncompressed data before compression
     raw::RawVector<uint8_t> _uncompressed_buffer;
     raw::RawVector<uint8_t> _compress_buffer;

--- a/be/src/formats/csv/output_stream_file.h
+++ b/be/src/formats/csv/output_stream_file.h
@@ -110,10 +110,6 @@ private:
     // Compress and write the current buffer to underlying stream
     Status _flush_compressed_chunk();
 
-    // Check if the compression type supports incremental compression via frame concatenation.
-    // GZIP, LZ4_FRAME, and ZSTD support this because multiple frames can be concatenated.
-    bool _supports_incremental_compression() const;
-
     std::shared_ptr<OutputStream> _underlying_stream;
     const BlockCompressionCodec* _codec;
     CompressionTypePB _compression_type;

--- a/be/src/formats/csv/output_stream_file.h
+++ b/be/src/formats/csv/output_stream_file.h
@@ -121,6 +121,7 @@ private:
 
     std::shared_ptr<OutputStream> _underlying_stream;
     CompressionTypePB _compression_type;
+    bool _is_block_compression; // Cached result of is_block_compression(_compression_type)
     std::unique_ptr<StreamCompressor> _compressor;
     raw::RawVector<uint8_t> _compress_buffer;
     raw::RawVector<uint8_t> _block_buffer;

--- a/be/src/util/coding.h
+++ b/be/src/util/coding.h
@@ -43,6 +43,15 @@ inline void encode_fixed32_le(uint8_t* buf, uint32_t val) {
 #endif
 }
 
+inline void encode_fixed32_be(uint8_t* buf, uint32_t val) {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    uint32_t res = bswap_32(val);
+    memcpy(buf, &res, sizeof(res));
+#else
+    memcpy(buf, &val, sizeof(val));
+#endif
+}
+
 inline void encode_fixed64_le(uint8_t* buf, uint64_t val) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     memcpy(buf, &val, sizeof(val));

--- a/be/src/util/compression/compression_utils.h
+++ b/be/src/util/compression/compression_utils.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <string>
+
+#include "common/statusor.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/types.pb.h"
 
@@ -54,6 +57,8 @@ public:
             return CompressionTypePB::GZIP;
         } else if (ext == "bz2") {
             return CompressionTypePB::BZIP2;
+        } else if (ext == "zlib") {
+            return CompressionTypePB::ZLIB;
         } else if (ext == "deflate") {
             return CompressionTypePB::DEFLATE;
         } else if (ext == "lz4") {
@@ -66,6 +71,35 @@ public:
             return CompressionTypePB::ZSTD;
         } else {
             return CompressionTypePB::UNKNOWN_COMPRESSION;
+        }
+    }
+
+    static StatusOr<std::string> to_compression_ext(TCompressionType::type compression_type) {
+        switch (compression_type) {
+        case TCompressionType::NO_COMPRESSION:
+            return std::string();
+        case TCompressionType::GZIP:
+            return ".gz";
+        case TCompressionType::ZSTD:
+            return ".zst";
+        case TCompressionType::LZ4:
+            return ".lz4";
+        case TCompressionType::LZ4_FRAME:
+            // LZ4_FRAME and LZ4 share the same extension; read path auto-detects the format.
+            return ".lz4";
+        case TCompressionType::SNAPPY:
+            return ".snappy";
+        case TCompressionType::DEFLATE:
+            return ".deflate";
+        case TCompressionType::ZLIB:
+            return ".zlib";
+        case TCompressionType::BZIP2:
+            return ".bz2";
+        case TCompressionType::DEFAULT_COMPRESSION:
+            return std::string();
+        default:
+            return Status::InvalidArgument("Unsupported compression type: " +
+                                           std::to_string(static_cast<int>(compression_type)));
         }
     }
 };

--- a/be/src/util/compression/stream_compression.h
+++ b/be/src/util/compression/stream_compression.h
@@ -91,7 +91,7 @@ public:
     // input(in):               buf where compress begin
     // input_len(in):           max length of input buf
     // input_bytes_read(out):   bytes which is consumed by compressor
-    // output(out):             buf where to save compressed data
+    // output(in):              buf where to save compressed data
     // output_len(in):          max length of output buf
     // output_bytes_written(out): compressed data size in output buf
     virtual Status compress(const uint8_t* input, size_t input_len, size_t* input_bytes_read, uint8_t* output,

--- a/be/src/util/compression/stream_compression.h
+++ b/be/src/util/compression/stream_compression.h
@@ -84,4 +84,37 @@ protected:
     size_t _compressed_block_size = 0;
 };
 
+class StreamCompressor {
+public:
+    virtual ~StreamCompressor() = default;
+
+    // input(in):               buf where compress begin
+    // input_len(in):           max length of input buf
+    // input_bytes_read(out):   bytes which is consumed by compressor
+    // output(out):             buf where to save compressed data
+    // output_len(in):          max length of output buf
+    // output_bytes_written(out): compressed data size in output buf
+    virtual Status compress(const uint8_t* input, size_t input_len, size_t* input_bytes_read, uint8_t* output,
+                            size_t output_len, size_t* output_bytes_written) = 0;
+
+    // Finish the compression stream and write any final bytes.
+    // stream_end(out): true if the stream is fully finished.
+    virtual Status finish(uint8_t* output, size_t output_len, size_t* output_bytes_written, bool* stream_end) = 0;
+
+    // Returns an upper bound on the max compressed length for input length.
+    virtual size_t max_compressed_len(size_t len) const = 0;
+
+public:
+    static Status create_compressor(CompressionTypePB type, std::unique_ptr<StreamCompressor>* compressor);
+
+    virtual std::string debug_info() { return "StreamCompressor"; }
+
+protected:
+    virtual Status init() { return Status::OK(); }
+
+    explicit StreamCompressor(CompressionTypePB ctype) : _ctype(ctype) {}
+
+    CompressionTypePB _ctype;
+};
+
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -213,6 +213,7 @@ set(EXEC_FILES
         ./formats/csv/array_converter_test.cpp
         ./formats/csv/boolean_converter_test.cpp
         ./formats/csv/csv_file_writer_test.cpp
+        ./formats/csv/output_stream_file_test.cpp
         ./formats/csv/date_converter_test.cpp
         ./formats/csv/datetime_converter_test.cpp
         ./formats/csv/decimalv2_converter_test.cpp

--- a/be/test/formats/csv/compression_test_utils.h
+++ b/be/test/formats/csv/compression_test_utils.h
@@ -78,6 +78,11 @@ inline std::string decompress_data(const std::string& compressed_data, Compressi
 }
 
 inline std::string decompress_stream_data(const std::string& compressed_data, CompressionTypePB compression_type) {
+    // Handle GZIP using the specialized decompress_gzip() function
+    if (compression_type == CompressionTypePB::GZIP) {
+        return decompress_gzip(compressed_data);
+    }
+
     std::unique_ptr<StreamCompression> decompressor;
     Status st = StreamCompression::create_decompressor(compression_type, &decompressor);
     EXPECT_TRUE(st.ok());

--- a/be/test/formats/csv/compression_test_utils.h
+++ b/be/test/formats/csv/compression_test_utils.h
@@ -1,0 +1,78 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <zlib.h>
+
+#include <string>
+
+#include "gen_cpp/segment.pb.h"
+#include "util/compression/block_compression.h"
+#include "util/slice.h"
+
+namespace starrocks::test {
+
+// Helper function to decompress gzip data using zlib directly
+inline std::string decompress_gzip(const std::string& compressed_data) {
+    z_stream z_strm = {nullptr};
+    z_strm.zalloc = Z_NULL;
+    z_strm.zfree = Z_NULL;
+    z_strm.opaque = Z_NULL;
+
+    // MAX_WBITS + 16 for gzip format
+    int ret = inflateInit2(&z_strm, MAX_WBITS + 16);
+    EXPECT_EQ(ret, Z_OK);
+
+    z_strm.next_in = reinterpret_cast<Bytef*>(const_cast<char*>(compressed_data.data()));
+    z_strm.avail_in = compressed_data.size();
+
+    size_t max_uncompressed_size = compressed_data.size() * 100; // Conservative estimate
+    std::string uncompressed_data;
+    uncompressed_data.resize(max_uncompressed_size);
+
+    z_strm.next_out = reinterpret_cast<Bytef*>(uncompressed_data.data());
+    z_strm.avail_out = max_uncompressed_size;
+
+    ret = inflate(&z_strm, Z_FINISH);
+    EXPECT_TRUE(ret == Z_OK || ret == Z_STREAM_END);
+
+    size_t actual_size = z_strm.total_out;
+    inflateEnd(&z_strm);
+
+    uncompressed_data.resize(actual_size);
+    return uncompressed_data;
+}
+
+// Helper function to decompress data with specified compression type (non-GZIP)
+inline std::string decompress_data(const std::string& compressed_data, CompressionTypePB compression_type) {
+    const BlockCompressionCodec* codec;
+    Status st = get_block_compression_codec(compression_type, &codec);
+    EXPECT_TRUE(st.ok());
+
+    Slice input(compressed_data.data(), compressed_data.size());
+    size_t max_uncompressed_size = compressed_data.size() * 100; // Conservative estimate
+    std::string uncompressed_data;
+    uncompressed_data.resize(max_uncompressed_size);
+    Slice output(uncompressed_data.data(), max_uncompressed_size);
+
+    st = codec->decompress(input, &output);
+    EXPECT_TRUE(st.ok());
+
+    uncompressed_data.resize(output.size);
+    return uncompressed_data;
+}
+
+} // namespace starrocks::test

--- a/be/test/formats/csv/csv_file_writer_test.cpp
+++ b/be/test/formats/csv/csv_file_writer_test.cpp
@@ -26,6 +26,7 @@
 #include "column/map_column.h"
 #include "column/struct_column.h"
 #include "common/object_pool.h"
+#include "compression_test_utils.h"
 #include "formats/column_evaluator.h"
 #include "formats/csv/output_stream_file.h"
 #include "fs/fs_memory.h"
@@ -73,9 +74,9 @@ TEST_F(CSVFileWriterTest, TestWriteIntergers) {
     auto output_stream = std::make_unique<csv::OutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -129,9 +130,9 @@ TEST_F(CSVFileWriterTest, TestWriteBoolean) {
     auto output_stream = std::make_unique<csv::OutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -169,9 +170,9 @@ TEST_F(CSVFileWriterTest, TestWriteFloat) {
     auto output_stream = std::make_unique<csv::OutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -210,9 +211,9 @@ TEST_F(CSVFileWriterTest, TestWriteDouble) {
     auto output_stream = std::make_unique<csv::OutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -251,9 +252,9 @@ TEST_F(CSVFileWriterTest, TestWriteDate) {
     auto output_stream = std::make_unique<csv::OutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -301,9 +302,9 @@ TEST_F(CSVFileWriterTest, TestWriteDatetime) {
     auto output_stream = std::make_unique<csv::OutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -350,9 +351,9 @@ TEST_F(CSVFileWriterTest, TestWriteVarchar) {
     auto output_stream = std::make_unique<csv::OutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -399,9 +400,9 @@ TEST_F(CSVFileWriterTest, TestWriteArrayInt) {
     auto output_stream = std::make_unique<csv::OutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -465,9 +466,9 @@ TEST_F(CSVFileWriterTest, TestWriteArrayBigInt) {
     auto output_stream = std::make_unique<csv::OutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -522,9 +523,9 @@ TEST_F(CSVFileWriterTest, TestWriteArrayWithNull) {
     auto output_stream = std::make_unique<csv::OutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -586,9 +587,9 @@ TEST_F(CSVFileWriterTest, TestWriteHiveArray) {
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     writer_options->is_hive = true;
     writer_options->collection_delim = '\002';
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -654,9 +655,9 @@ TEST_F(CSVFileWriterTest, TestWriteMap) {
     auto output_stream = std::make_unique<csv::OutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_ERROR(writer->init());
 }
 
@@ -677,9 +678,9 @@ TEST_F(CSVFileWriterTest, TestWriteNestedArray) {
     auto output_stream = std::make_unique<csv::OutputStreamFile>(std::move(output_file), 1024);
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -737,13 +738,13 @@ TEST_F(CSVFileWriterTest, TestUnknownCompression) {
 
     auto column_names = _make_type_names(type_descs);
     auto output_file = _fs.new_writable_file(_file_path).value();
-    auto output_stream = std::make_unique<csv::OutputStreamFile>(std::move(output_file), 1024);
-    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
-    auto writer_options = std::make_shared<formats::CSVWriterOptions>();
-    auto writer = std::make_unique<formats::CSVFileWriter>(
-            _file_path, std::move(output_stream), column_names, type_descs, std::move(column_evaluators),
-            TCompressionType::UNKNOWN_COMPRESSION, writer_options, []() {});
-    ASSERT_ERROR(writer->init());
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(output_file), nullptr, nullptr);
+
+    // UNKNOWN_COMPRESSION should fail when creating CompressedOutputStream
+    // We expect this to return an error status
+    auto base_stream = std::make_shared<csv::AsyncOutputStreamFile>(async_stream.get(), 1024);
+    auto result = csv::CompressedOutputStream::create(base_stream, CompressionTypePB::UNKNOWN_COMPRESSION, 1024);
+    ASSERT_FALSE(result.ok());
 }
 
 TEST_F(CSVFileWriterTest, TestFactory) {
@@ -782,6 +783,8 @@ TEST_F(CSVFileWriterTest, TestFactoryWithOptions) {
     ASSERT_OK(maybe_writer.status());
 }
 
+// ==================== Header Tests ====================
+
 // Test header row output with include_header option
 TEST_F(CSVFileWriterTest, TestWriteWithHeader) {
     std::vector<TypeDescriptor> type_descs{
@@ -796,9 +799,9 @@ TEST_F(CSVFileWriterTest, TestWriteWithHeader) {
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     writer_options->include_header = true;
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -841,9 +844,9 @@ TEST_F(CSVFileWriterTest, TestWriteHeaderOnly) {
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     writer_options->include_header = true;
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     // Commit without writing any data
@@ -872,9 +875,9 @@ TEST_F(CSVFileWriterTest, TestWriteHeaderWithSpecialChars) {
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     writer_options->include_header = true;
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto result = writer->commit();
@@ -903,9 +906,9 @@ TEST_F(CSVFileWriterTest, TestWriteHeaderWithCustomDelimiter) {
     writer_options->include_header = true;
     writer_options->column_terminated_by = "\t";
     writer_options->line_terminated_by = "\r\n";
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto result = writer->commit();
@@ -933,9 +936,9 @@ TEST_F(CSVFileWriterTest, TestWriteHeaderEscapeCustomDelimiter) {
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     writer_options->include_header = true;
     writer_options->column_terminated_by = "\t";
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto result = writer->commit();
@@ -959,9 +962,9 @@ TEST_F(CSVFileWriterTest, TestWriteWithoutHeader) {
     auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
     auto writer_options = std::make_shared<formats::CSVWriterOptions>();
     writer_options->include_header = false; // explicitly false
-    auto writer = std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names,
-                                                           type_descs, std::move(column_evaluators),
-                                                           TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
     ASSERT_OK(writer->init());
 
     auto chunk = std::make_shared<Chunk>();
@@ -981,6 +984,349 @@ TEST_F(CSVFileWriterTest, TestWriteWithoutHeader) {
     // No header row, only data
     std::string expect = "1\n2\n";
     ASSERT_EQ(content, expect);
+}
+
+// ==================== Compression Tests ====================
+
+TEST_F(CSVFileWriterTest, TestWriteIntegersWithGzipCompression) {
+    std::vector<TypeDescriptor> type_descs{
+            TypeDescriptor::from_logical_type(TYPE_TINYINT),
+            TypeDescriptor::from_logical_type(TYPE_SMALLINT),
+            TypeDescriptor::from_logical_type(TYPE_INT),
+            TypeDescriptor::from_logical_type(TYPE_BIGINT),
+    };
+    auto column_names = _make_type_names(type_descs);
+    auto maybe_output_file = _fs.new_writable_file(_file_path);
+    EXPECT_OK(maybe_output_file.status());
+    auto output_file = std::move(maybe_output_file.value());
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<csv::AsyncOutputStreamFile>(async_stream.get(), 1024 * 1024);
+    auto csv_output_stream_result =
+            csv::CompressedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
+    ASSERT_OK(csv_output_stream_result.status());
+    auto csv_output_stream = std::move(csv_output_stream_result.value());
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::CSVWriterOptions>();
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(csv_output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    {
+        auto col0 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_TINYINT), true);
+        std::vector<int8_t> int8_nums{INT8_MIN, INT8_MAX, 0, 1};
+        auto count = col0->append_numbers(int8_nums.data(), size(int8_nums) * sizeof(int8_t));
+        ASSERT_EQ(4, count);
+        chunk->append_column(std::move(col0), chunk->num_columns());
+
+        auto col1 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_SMALLINT), true);
+        std::vector<int16_t> int16_nums{INT16_MIN, INT16_MAX, 0, 1};
+        count = col1->append_numbers(int16_nums.data(), size(int16_nums) * sizeof(int16_t));
+        ASSERT_EQ(4, count);
+        chunk->append_column(std::move(col1), chunk->num_columns());
+
+        auto col2 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), true);
+        std::vector<int32_t> int32_nums{INT32_MIN, INT32_MAX, 0, 1};
+        count = col2->append_numbers(int32_nums.data(), size(int32_nums) * sizeof(int32_t));
+        ASSERT_EQ(4, count);
+        chunk->append_column(std::move(col2), chunk->num_columns());
+
+        auto col3 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_BIGINT), true);
+        std::vector<int64_t> int64_nums{INT64_MIN, INT64_MAX, 0, 1};
+        count = col3->append_numbers(int64_nums.data(), size(int64_nums) * sizeof(int64_t));
+        ASSERT_EQ(4, count);
+        chunk->append_column(std::move(col3), chunk->num_columns());
+    }
+
+    // write chunk
+    ASSERT_OK(writer->write(chunk.get()));
+    auto result = writer->commit();
+    ASSERT_OK(result.io_status);
+    ASSERT_EQ(result.file_statistics.record_count, 4);
+
+    // Note: writer->commit() already calls finalize() on CompressedOutputStream
+    // which internally closes the async stream, so we don't call async_stream->close() here
+
+    // verify correctness - read compressed data and decompress
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(_file_path, &compressed_content));
+
+    std::string content = test::decompress_gzip(compressed_content);
+    std::string expect =
+            "-128,-32768,-2147483648,-9223372036854775808\n127,32767,2147483647,9223372036854775807\n0,0,0,0\n1,1,1,"
+            "1\n";
+    ASSERT_EQ(content, expect);
+}
+
+TEST_F(CSVFileWriterTest, TestWriteVarcharWithGzipCompression) {
+    std::vector<TypeDescriptor> type_descs{TypeDescriptor::from_logical_type(TYPE_VARCHAR)};
+    auto column_names = _make_type_names(type_descs);
+    auto maybe_output_file = _fs.new_writable_file(_file_path);
+    EXPECT_OK(maybe_output_file.status());
+    auto output_file = std::move(maybe_output_file.value());
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<csv::AsyncOutputStreamFile>(async_stream.get(), 1024 * 1024);
+    auto csv_output_stream_result =
+            csv::CompressedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
+    ASSERT_OK(csv_output_stream_result.status());
+    auto csv_output_stream = std::move(csv_output_stream_result.value());
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::CSVWriterOptions>();
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(csv_output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    {
+        auto data_column = BinaryColumn::create();
+        data_column->append("hello");
+        data_column->append("world");
+        data_column->append("starrocks");
+        data_column->append("lakehouse");
+
+        auto null_column = UInt8Column::create();
+        std::vector<uint8_t> nulls = {0, 0, 0, 0};
+        null_column->append_numbers(nulls.data(), nulls.size());
+        auto nullable_column = NullableColumn::create(std::move(data_column), std::move(null_column));
+        chunk->append_column(std::move(nullable_column), chunk->num_columns());
+    }
+
+    // write chunk
+    ASSERT_OK(writer->write(chunk.get()));
+    auto result = writer->commit();
+    ASSERT_OK(result.io_status);
+    ASSERT_EQ(result.file_statistics.record_count, 4);
+
+    // Note: writer->commit() already calls finalize() which closes the async stream
+
+    // verify correctness
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(_file_path, &compressed_content));
+
+    std::string content = test::decompress_gzip(compressed_content);
+    std::string expect = "hello\nworld\nstarrocks\nlakehouse\n";
+    ASSERT_EQ(content, expect);
+}
+
+TEST_F(CSVFileWriterTest, TestWriteLargeDataWithGzipCompression) {
+    std::vector<TypeDescriptor> type_descs{TypeDescriptor::from_logical_type(TYPE_INT),
+                                           TypeDescriptor::from_logical_type(TYPE_VARCHAR)};
+    auto column_names = _make_type_names(type_descs);
+    auto maybe_output_file = _fs.new_writable_file(_file_path);
+    EXPECT_OK(maybe_output_file.status());
+    auto output_file = std::move(maybe_output_file.value());
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<csv::AsyncOutputStreamFile>(async_stream.get(), 1024 * 1024);
+    auto csv_output_stream_result =
+            csv::CompressedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
+    ASSERT_OK(csv_output_stream_result.status());
+    auto csv_output_stream = std::move(csv_output_stream_result.value());
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::CSVWriterOptions>();
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(csv_output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
+    ASSERT_OK(writer->init());
+
+    // Write multiple chunks
+    const int num_chunks = 10;
+    const int rows_per_chunk = 1000;
+    int total_rows = 0;
+
+    for (int c = 0; c < num_chunks; c++) {
+        auto chunk = std::make_shared<Chunk>();
+
+        auto int_column = Int32Column::create();
+        auto str_column = BinaryColumn::create();
+
+        for (int i = 0; i < rows_per_chunk; i++) {
+            int_column->append(c * rows_per_chunk + i);
+            str_column->append("row_" + std::to_string(c * rows_per_chunk + i));
+        }
+
+        chunk->append_column(std::move(int_column), chunk->num_columns());
+        chunk->append_column(std::move(str_column), chunk->num_columns());
+
+        ASSERT_OK(writer->write(chunk.get()));
+        total_rows += rows_per_chunk;
+    }
+
+    auto result = writer->commit();
+    ASSERT_OK(result.io_status);
+    ASSERT_EQ(result.file_statistics.record_count, total_rows);
+
+    // Note: writer->commit() already calls finalize() which closes the async stream
+
+    // Verify compressed file size is smaller than expected uncompressed size
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(_file_path, &compressed_content));
+
+    // Decompress and verify first and last few lines
+    std::string content = test::decompress_gzip(compressed_content);
+    EXPECT_TRUE(content.find("0,row_0\n") != std::string::npos);
+    EXPECT_TRUE(content.find(std::to_string(total_rows - 1) + ",row_" + std::to_string(total_rows - 1) + "\n") !=
+                std::string::npos);
+
+    // Count lines
+    int line_count = std::count(content.begin(), content.end(), '\n');
+    EXPECT_EQ(line_count, total_rows);
+}
+
+TEST_F(CSVFileWriterTest, TestCompressionRatio) {
+    std::vector<TypeDescriptor> type_descs{TypeDescriptor::from_logical_type(TYPE_VARCHAR)};
+    auto column_names = _make_type_names(type_descs);
+
+    // Expected uncompressed content (calculate manually)
+    std::string expected_line = "This is a repetitive line that should compress very well\n";
+    const int num_lines = 100; // Use fewer lines to avoid edge cases
+    std::string expected_content;
+    for (int i = 0; i < num_lines; i++) {
+        expected_content += expected_line;
+    }
+    size_t expected_uncompressed_size = expected_content.size();
+
+    // Create compressed file
+    std::string compressed_path = "/data_compressed.csv.gz";
+    {
+        auto maybe_output_file = _fs.new_writable_file(compressed_path);
+        EXPECT_OK(maybe_output_file.status());
+        auto output_file = std::move(maybe_output_file.value());
+        auto async_stream =
+                std::make_unique<io::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
+        auto base_stream = std::make_shared<csv::AsyncOutputStreamFile>(async_stream.get(), 1024 * 1024);
+        auto csv_output_stream_result =
+                csv::CompressedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
+        ASSERT_OK(csv_output_stream_result.status());
+        auto csv_output_stream = std::move(csv_output_stream_result.value());
+        auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+        auto writer_options = std::make_shared<formats::CSVWriterOptions>();
+        auto writer = std::make_unique<formats::CSVFileWriter>(compressed_path, std::move(csv_output_stream),
+                                                               column_names, type_descs, std::move(column_evaluators),
+                                                               writer_options, []() {});
+        ASSERT_OK(writer->init());
+
+        auto chunk = std::make_shared<Chunk>();
+        auto data_column = BinaryColumn::create();
+
+        // Add repetitive data
+        for (int i = 0; i < num_lines; i++) {
+            data_column->append("This is a repetitive line that should compress very well");
+        }
+        chunk->append_column(std::move(data_column), chunk->num_columns());
+
+        ASSERT_OK(writer->write(chunk.get()));
+        ASSERT_OK(writer->commit().io_status);
+    }
+
+    // Read and verify compressed file
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(compressed_path, &compressed_content));
+
+    // Compressed should be significantly smaller than uncompressed
+    EXPECT_LT(compressed_content.size(), expected_uncompressed_size / 2);
+
+    // Verify decompressed content matches expected
+    std::string decompressed = test::decompress_gzip(compressed_content);
+    EXPECT_EQ(decompressed.size(), expected_uncompressed_size);
+    EXPECT_EQ(decompressed, expected_content);
+}
+
+TEST_F(CSVFileWriterTest, TestFactoryWithGzipCompression) {
+    auto type_int = TypeDescriptor::from_logical_type(TYPE_INT);
+    auto type_varchar = TypeDescriptor::from_logical_type(TYPE_VARCHAR);
+    std::vector<TypeDescriptor> type_descs{type_int, type_varchar};
+
+    auto column_names = _make_type_names(type_descs);
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto fs = std::make_shared<MemoryFileSystem>();
+    auto factory = formats::CSVFileWriterFactory(fs, TCompressionType::GZIP, {}, column_names,
+                                                 std::move(column_evaluators), nullptr, _runtime_state);
+    ASSERT_OK(factory.init());
+
+    auto maybe_writer_and_stream = factory.create("/test_compressed.csv.gz");
+    ASSERT_OK(maybe_writer_and_stream.status());
+
+    auto& writer_and_stream = maybe_writer_and_stream.value();
+    ASSERT_NE(writer_and_stream.writer, nullptr);
+    ASSERT_NE(writer_and_stream.stream, nullptr);
+
+    // Write some data
+    auto chunk = std::make_shared<Chunk>();
+    auto int_col = Int32Column::create();
+    auto str_col = BinaryColumn::create();
+    int_col->append(1);
+    int_col->append(2);
+    str_col->append("test1");
+    str_col->append("test2");
+    chunk->append_column(std::move(int_col), chunk->num_columns());
+    chunk->append_column(std::move(str_col), chunk->num_columns());
+
+    ASSERT_OK(writer_and_stream.writer->init());
+    ASSERT_OK(writer_and_stream.writer->write(chunk.get()));
+    auto result = writer_and_stream.writer->commit();
+    ASSERT_OK(result.io_status);
+    ASSERT_EQ(result.file_statistics.record_count, 2);
+
+    // Note: writer->commit() already calls finalize() which closes the stream
+
+    // Verify compressed output
+    std::string compressed_content;
+    ASSERT_OK(fs->read_file("/test_compressed.csv.gz", &compressed_content));
+
+    std::string content = test::decompress_gzip(compressed_content);
+    EXPECT_TRUE(content.find("1,test1\n") != std::string::npos);
+    EXPECT_TRUE(content.find("2,test2\n") != std::string::npos);
+}
+
+TEST_F(CSVFileWriterTest, TestCompressionWithCustomDelimiters) {
+    std::vector<TypeDescriptor> type_descs{TypeDescriptor::from_logical_type(TYPE_INT),
+                                           TypeDescriptor::from_logical_type(TYPE_VARCHAR)};
+    auto column_names = _make_type_names(type_descs);
+    auto maybe_output_file = _fs.new_writable_file(_file_path);
+    EXPECT_OK(maybe_output_file.status());
+    auto output_file = std::move(maybe_output_file.value());
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(output_file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<csv::AsyncOutputStreamFile>(async_stream.get(), 1024 * 1024);
+    auto csv_output_stream_result =
+            csv::CompressedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024 * 1024);
+    ASSERT_OK(csv_output_stream_result.status());
+    auto csv_output_stream = std::move(csv_output_stream_result.value());
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::CSVWriterOptions>();
+    writer_options->column_terminated_by = "|";
+    writer_options->line_terminated_by = ";\n";
+    auto writer =
+            std::make_unique<formats::CSVFileWriter>(_file_path, std::move(csv_output_stream), column_names, type_descs,
+                                                     std::move(column_evaluators), writer_options, []() {});
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    {
+        auto int_col = Int32Column::create();
+        auto str_col = BinaryColumn::create();
+        int_col->append(100);
+        int_col->append(200);
+        str_col->append("value1");
+        str_col->append("value2");
+        chunk->append_column(std::move(int_col), chunk->num_columns());
+        chunk->append_column(std::move(str_col), chunk->num_columns());
+    }
+
+    ASSERT_OK(writer->write(chunk.get()));
+    auto result = writer->commit();
+    ASSERT_OK(result.io_status);
+    ASSERT_EQ(result.file_statistics.record_count, 2);
+
+    // Note: writer->commit() already calls finalize() which closes the async stream
+
+    // Verify custom delimiters are preserved after compression
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(_file_path, &compressed_content));
+
+    std::string content = test::decompress_gzip(compressed_content);
+    EXPECT_EQ(content, "100|value1;\n200|value2;\n");
 }
 
 } // namespace starrocks::formats

--- a/be/test/formats/csv/csv_file_writer_test.cpp
+++ b/be/test/formats/csv/csv_file_writer_test.cpp
@@ -808,7 +808,8 @@ TEST_F(CSVFileWriterTest, TestWriteWithHeader) {
     {
         auto col0 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), true);
         std::vector<int32_t> int_nums{1, 2};
-        col0->append_numbers(int_nums.data(), size(int_nums) * sizeof(int32_t));
+        size_t appended = col0->append_numbers(int_nums.data(), size(int_nums) * sizeof(int32_t));
+        ASSERT_EQ(appended, size(int_nums));
         chunk->append_column(std::move(col0), chunk->num_columns());
 
         auto data_column = BinaryColumn::create();
@@ -971,7 +972,8 @@ TEST_F(CSVFileWriterTest, TestWriteWithoutHeader) {
     {
         auto col0 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), true);
         std::vector<int32_t> int_nums{1, 2};
-        col0->append_numbers(int_nums.data(), size(int_nums) * sizeof(int32_t));
+        size_t appended = col0->append_numbers(int_nums.data(), size(int_nums) * sizeof(int32_t));
+        ASSERT_EQ(appended, size(int_nums));
         chunk->append_column(std::move(col0), chunk->num_columns());
     }
 

--- a/be/test/formats/csv/output_stream_file_test.cpp
+++ b/be/test/formats/csv/output_stream_file_test.cpp
@@ -1,0 +1,498 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/csv/output_stream_file.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "common/object_pool.h"
+#include "compression_test_utils.h"
+#include "exec/pipeline/fragment_context.h"
+#include "fs/fs_memory.h"
+#include "io/async_flush_output_stream.h"
+#include "testutil/assert.h"
+
+namespace starrocks::csv {
+
+class OutputStreamFileTest : public testing::Test {
+public:
+    void SetUp() override {
+        _fragment_context = std::make_shared<pipeline::FragmentContext>();
+        _fragment_context->set_runtime_state(std::make_shared<RuntimeState>());
+        _runtime_state = _fragment_context->runtime_state();
+    }
+
+    void TearDown() override {}
+
+protected:
+    std::shared_ptr<pipeline::FragmentContext> _fragment_context;
+    RuntimeState* _runtime_state;
+    MemoryFileSystem _fs;
+};
+
+// Test basic compression functionality
+TEST_F(OutputStreamFileTest, TestBasicCompression) {
+    std::string file_path = "/test_basic_compression.csv.gz";
+    auto maybe_file = _fs.new_writable_file(file_path);
+    ASSERT_OK(maybe_file.status());
+    auto file = std::move(maybe_file.value());
+
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<AsyncOutputStreamFile>(async_stream.get(), 1024);
+    auto compressed_stream_result = CompressedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024);
+    ASSERT_OK(compressed_stream_result.status());
+    auto compressed_stream = std::move(compressed_stream_result.value());
+
+    // Write some test data
+    std::string test_data = "Hello, World!\nThis is a test.\n";
+    ASSERT_OK(compressed_stream->write(Slice(test_data)));
+    ASSERT_OK(compressed_stream->finalize());
+    // Note: finalize() already closes the async stream internally
+
+    // Read back the compressed data
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(file_path, &compressed_content));
+
+    // Verify the content is actually compressed (should be smaller or different)
+    EXPECT_NE(compressed_content, test_data);
+
+    // Decompress and verify
+    std::string decompressed = starrocks::test::decompress_gzip(compressed_content);
+    EXPECT_EQ(decompressed, test_data);
+}
+
+// Test compression with empty data
+TEST_F(OutputStreamFileTest, TestEmptyDataCompression) {
+    std::string file_path = "/test_empty_compression.csv.gz";
+    auto maybe_file = _fs.new_writable_file(file_path);
+    ASSERT_OK(maybe_file.status());
+    auto file = std::move(maybe_file.value());
+
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<AsyncOutputStreamFile>(async_stream.get(), 1024);
+    auto compressed_stream_result = CompressedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024);
+    ASSERT_OK(compressed_stream_result.status());
+    auto compressed_stream = std::move(compressed_stream_result.value());
+
+    // Finalize without writing any data
+    ASSERT_OK(compressed_stream->finalize());
+    // Note: finalize() already closes the async stream internally
+
+    // Read back the file
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(file_path, &compressed_content));
+
+    // For empty data, there should be minimal or no compressed content
+    // The exact behavior depends on the compression implementation
+    EXPECT_GE(compressed_content.size(), 0);
+}
+
+// Test compression with large data
+TEST_F(OutputStreamFileTest, TestLargeDataCompression) {
+    std::string file_path = "/test_large_compression.csv.gz";
+    auto maybe_file = _fs.new_writable_file(file_path);
+    ASSERT_OK(maybe_file.status());
+    auto file = std::move(maybe_file.value());
+
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<AsyncOutputStreamFile>(async_stream.get(), 1024);
+    auto compressed_stream_result = CompressedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024);
+    ASSERT_OK(compressed_stream_result.status());
+    auto compressed_stream = std::move(compressed_stream_result.value());
+
+    // Generate large test data (10KB of repetitive data - highly compressible)
+    std::string test_data;
+    for (int i = 0; i < 1000; i++) {
+        test_data += "This is line " + std::to_string(i) + "\n";
+    }
+
+    ASSERT_OK(compressed_stream->write(Slice(test_data)));
+    ASSERT_OK(compressed_stream->finalize());
+    // Note: finalize() already closes the async stream internally
+
+    // Read back the compressed data
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(file_path, &compressed_content));
+
+    // Verify compression is effective (compressed should be smaller)
+    EXPECT_LT(compressed_content.size(), test_data.size());
+
+    // Decompress and verify
+    std::string decompressed = starrocks::test::decompress_gzip(compressed_content);
+    EXPECT_EQ(decompressed, test_data);
+}
+
+// Test multiple writes before finalize
+TEST_F(OutputStreamFileTest, TestMultipleWrites) {
+    std::string file_path = "/test_multiple_writes.csv.gz";
+    auto maybe_file = _fs.new_writable_file(file_path);
+    ASSERT_OK(maybe_file.status());
+    auto file = std::move(maybe_file.value());
+
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<AsyncOutputStreamFile>(async_stream.get(), 1024);
+    auto compressed_stream_result = CompressedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024);
+    ASSERT_OK(compressed_stream_result.status());
+    auto compressed_stream = std::move(compressed_stream_result.value());
+
+    // Write data in multiple chunks
+    std::string chunk1 = "First chunk\n";
+    std::string chunk2 = "Second chunk\n";
+    std::string chunk3 = "Third chunk\n";
+
+    ASSERT_OK(compressed_stream->write(Slice(chunk1)));
+    ASSERT_OK(compressed_stream->write(Slice(chunk2)));
+    ASSERT_OK(compressed_stream->write(Slice(chunk3)));
+    ASSERT_OK(compressed_stream->finalize());
+    // Note: finalize() already closes the async stream internally
+
+    // Read back and decompress
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(file_path, &compressed_content));
+
+    std::string decompressed = starrocks::test::decompress_gzip(compressed_content);
+    std::string expected = chunk1 + chunk2 + chunk3;
+    EXPECT_EQ(decompressed, expected);
+}
+
+// Test compression with data larger than buffer
+TEST_F(OutputStreamFileTest, TestDataLargerThanBuffer) {
+    std::string file_path = "/test_larger_than_buffer.csv.gz";
+    auto maybe_file = _fs.new_writable_file(file_path);
+    ASSERT_OK(maybe_file.status());
+    auto file = std::move(maybe_file.value());
+
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<AsyncOutputStreamFile>(async_stream.get(), 1024);
+    // Use a small buffer size to test buffer overflow handling
+    auto compressed_stream_result = CompressedOutputStream::create(base_stream, CompressionTypePB::GZIP, 64);
+    ASSERT_OK(compressed_stream_result.status());
+    auto compressed_stream = std::move(compressed_stream_result.value());
+
+    // Write data larger than buffer
+    std::string test_data;
+    for (int i = 0; i < 100; i++) {
+        test_data += "Line " + std::to_string(i) + "\n";
+    }
+
+    ASSERT_OK(compressed_stream->write(Slice(test_data)));
+    ASSERT_OK(compressed_stream->finalize());
+    // Note: finalize() already closes the async stream internally
+
+    // Read back and decompress
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(file_path, &compressed_content));
+
+    std::string decompressed = starrocks::test::decompress_gzip(compressed_content);
+    EXPECT_EQ(decompressed, test_data);
+}
+
+// Test size() method
+TEST_F(OutputStreamFileTest, TestSizeMethod) {
+    std::string file_path = "/test_size.csv.gz";
+    auto maybe_file = _fs.new_writable_file(file_path);
+    ASSERT_OK(maybe_file.status());
+    auto file = std::move(maybe_file.value());
+
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<AsyncOutputStreamFile>(async_stream.get(), 1024);
+    auto compressed_stream_result = CompressedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024);
+    ASSERT_OK(compressed_stream_result.status());
+    auto compressed_stream = std::move(compressed_stream_result.value());
+
+    std::string test_data = "Test data\n";
+    ASSERT_OK(compressed_stream->write(Slice(test_data)));
+    ASSERT_OK(compressed_stream->finalize());
+
+    // size() should return the position in the underlying stream
+    size_t size = compressed_stream->size();
+    EXPECT_GT(size, 0);
+
+    // Note: finalize() already closes the async stream internally
+}
+
+// Test compression with special characters
+TEST_F(OutputStreamFileTest, TestSpecialCharacters) {
+    std::string file_path = "/test_special_chars.csv.gz";
+    auto maybe_file = _fs.new_writable_file(file_path);
+    ASSERT_OK(maybe_file.status());
+    auto file = std::move(maybe_file.value());
+
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<AsyncOutputStreamFile>(async_stream.get(), 1024);
+    auto compressed_stream_result = CompressedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024);
+    ASSERT_OK(compressed_stream_result.status());
+    auto compressed_stream = std::move(compressed_stream_result.value());
+
+    // Test data with special characters
+    std::string test_data = "Hello,世界\n\"quoted,value\"\n\ttab\tseparated\n\\N\n";
+
+    ASSERT_OK(compressed_stream->write(Slice(test_data)));
+    ASSERT_OK(compressed_stream->finalize());
+    // Note: finalize() already closes the async stream internally
+
+    // Read back and decompress
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(file_path, &compressed_content));
+
+    std::string decompressed = starrocks::test::decompress_gzip(compressed_content);
+    EXPECT_EQ(decompressed, test_data);
+}
+
+// Test compression with binary data
+TEST_F(OutputStreamFileTest, TestBinaryData) {
+    std::string file_path = "/test_binary.csv.gz";
+    auto maybe_file = _fs.new_writable_file(file_path);
+    ASSERT_OK(maybe_file.status());
+    auto file = std::move(maybe_file.value());
+
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<AsyncOutputStreamFile>(async_stream.get(), 1024);
+    auto compressed_stream_result = CompressedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024);
+    ASSERT_OK(compressed_stream_result.status());
+    auto compressed_stream = std::move(compressed_stream_result.value());
+
+    // Test data with binary content (all byte values)
+    std::string test_data;
+    for (int i = 0; i < 256; i++) {
+        test_data += static_cast<char>(i);
+    }
+
+    ASSERT_OK(compressed_stream->write(Slice(test_data)));
+    ASSERT_OK(compressed_stream->finalize());
+    // Note: finalize() already closes the async stream internally
+
+    // Read back and decompress
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(file_path, &compressed_content));
+
+    std::string decompressed = starrocks::test::decompress_gzip(compressed_content);
+    EXPECT_EQ(decompressed, test_data);
+}
+
+// Test that uncompressed stream still works (regression test)
+TEST_F(OutputStreamFileTest, TestUncompressedStream) {
+    std::string file_path = "/test_uncompressed.csv";
+    auto maybe_file = _fs.new_writable_file(file_path);
+    ASSERT_OK(maybe_file.status());
+    auto file = std::move(maybe_file.value());
+
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+    auto output_stream = std::make_unique<AsyncOutputStreamFile>(async_stream.get(), 1024);
+
+    std::string test_data = "Uncompressed data\n";
+    ASSERT_OK(output_stream->write(Slice(test_data)));
+    ASSERT_OK(output_stream->finalize());
+    // Note: finalize() already closes the async stream internally
+
+    // Read back the data (should be uncompressed)
+    std::string content;
+    ASSERT_OK(_fs.read_file(file_path, &content));
+    EXPECT_EQ(content, test_data);
+}
+
+// Note: TestWriteAfterFinalize was removed because OutputStream::write() only writes to
+// internal buffer and doesn't check finalize state. The write would succeed to buffer,
+// but any subsequent flush would fail since the underlying stream is closed.
+
+// Test very small writes
+TEST_F(OutputStreamFileTest, TestVerySmallWrites) {
+    std::string file_path = "/test_small_writes.csv.gz";
+    auto maybe_file = _fs.new_writable_file(file_path);
+    ASSERT_OK(maybe_file.status());
+    auto file = std::move(maybe_file.value());
+
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<AsyncOutputStreamFile>(async_stream.get(), 1024);
+    auto compressed_stream_result = CompressedOutputStream::create(base_stream, CompressionTypePB::GZIP, 1024);
+    ASSERT_OK(compressed_stream_result.status());
+    auto compressed_stream = std::move(compressed_stream_result.value());
+
+    // Write one byte at a time
+    std::string test_data = "ABCDEFGH";
+    for (char c : test_data) {
+        ASSERT_OK(compressed_stream->write(c));
+    }
+
+    ASSERT_OK(compressed_stream->finalize());
+    // Note: finalize() already closes the async stream internally
+
+    // Read back and decompress
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(file_path, &compressed_content));
+
+    std::string decompressed = starrocks::test::decompress_gzip(compressed_content);
+    EXPECT_EQ(decompressed, test_data);
+}
+
+// Test SNAPPY compression is rejected (does not support incremental compression)
+TEST_F(OutputStreamFileTest, TestSnappyCompressionRejected) {
+    std::string file_path = "/test_snappy.csv.snappy";
+    auto maybe_file = _fs.new_writable_file(file_path);
+    ASSERT_OK(maybe_file.status());
+    auto file = std::move(maybe_file.value());
+
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<AsyncOutputStreamFile>(async_stream.get(), 1024);
+
+    // SNAPPY does not support incremental compression, so creation should fail
+    auto compressed_stream_result = CompressedOutputStream::create(base_stream, CompressionTypePB::SNAPPY, 1024);
+    ASSERT_FALSE(compressed_stream_result.ok());
+    EXPECT_TRUE(compressed_stream_result.status().is_invalid_argument());
+}
+
+// Test ZSTD compression
+TEST_F(OutputStreamFileTest, TestZstdCompression) {
+    std::string file_path = "/test_zstd.csv.zst";
+    auto maybe_file = _fs.new_writable_file(file_path);
+    ASSERT_OK(maybe_file.status());
+    auto file = std::move(maybe_file.value());
+
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<AsyncOutputStreamFile>(async_stream.get(), 1024);
+    auto compressed_stream_result = CompressedOutputStream::create(base_stream, CompressionTypePB::ZSTD, 1024);
+    ASSERT_OK(compressed_stream_result.status());
+    auto compressed_stream = std::move(compressed_stream_result.value());
+
+    // Generate test data
+    std::string test_data;
+    for (int i = 0; i < 100; i++) {
+        test_data += "Row " + std::to_string(i) + ",data,value\n";
+    }
+
+    ASSERT_OK(compressed_stream->write(Slice(test_data)));
+    ASSERT_OK(compressed_stream->finalize());
+    // Note: finalize() already closes the async stream internally
+
+    // Read back the compressed data
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(file_path, &compressed_content));
+
+    // Verify compression is effective
+    EXPECT_LT(compressed_content.size(), test_data.size());
+
+    // Decompress and verify
+    std::string decompressed = starrocks::test::decompress_data(compressed_content, CompressionTypePB::ZSTD);
+    EXPECT_EQ(decompressed, test_data);
+}
+
+// Test LZ4 (raw block) compression is rejected (does not support incremental compression)
+TEST_F(OutputStreamFileTest, TestLz4CompressionRejected) {
+    std::string file_path = "/test_lz4.csv.lz4";
+    auto maybe_file = _fs.new_writable_file(file_path);
+    ASSERT_OK(maybe_file.status());
+    auto file = std::move(maybe_file.value());
+
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<AsyncOutputStreamFile>(async_stream.get(), 1024);
+
+    // LZ4 (raw block) does not support incremental compression, so creation should fail
+    // Use LZ4_FRAME instead for incremental compression support
+    auto compressed_stream_result = CompressedOutputStream::create(base_stream, CompressionTypePB::LZ4, 1024);
+    ASSERT_FALSE(compressed_stream_result.ok());
+    EXPECT_TRUE(compressed_stream_result.status().is_invalid_argument());
+}
+
+// Test LZ4_FRAME compression
+TEST_F(OutputStreamFileTest, TestLz4FrameCompression) {
+    std::string file_path = "/test_lz4_frame.csv.lz4";
+    auto maybe_file = _fs.new_writable_file(file_path);
+    ASSERT_OK(maybe_file.status());
+    auto file = std::move(maybe_file.value());
+
+    auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+    auto base_stream = std::make_shared<AsyncOutputStreamFile>(async_stream.get(), 1024);
+    auto compressed_stream_result = CompressedOutputStream::create(base_stream, CompressionTypePB::LZ4_FRAME, 1024);
+    ASSERT_OK(compressed_stream_result.status());
+    auto compressed_stream = std::move(compressed_stream_result.value());
+
+    // Generate test data
+    std::string test_data;
+    for (int i = 0; i < 100; i++) {
+        test_data += "Row " + std::to_string(i) + ",data,value\n";
+    }
+
+    ASSERT_OK(compressed_stream->write(Slice(test_data)));
+    ASSERT_OK(compressed_stream->finalize());
+    // Note: finalize() already closes the async stream internally
+
+    // Read back the compressed data
+    std::string compressed_content;
+    ASSERT_OK(_fs.read_file(file_path, &compressed_content));
+
+    // Verify compression is effective
+    EXPECT_LT(compressed_content.size(), test_data.size());
+
+    // Decompress and verify
+    std::string decompressed = starrocks::test::decompress_data(compressed_content, CompressionTypePB::LZ4_FRAME);
+    EXPECT_EQ(decompressed, test_data);
+}
+
+// Test all supported compression types with large data
+// Only GZIP, LZ4_FRAME, and ZSTD support incremental compression via frame concatenation
+TEST_F(OutputStreamFileTest, TestAllCompressionTypesLargeData) {
+    std::vector<std::pair<CompressionTypePB, std::string>> compression_types = {
+            {CompressionTypePB::GZIP, ".gz"},
+            {CompressionTypePB::ZSTD, ".zst"},
+            {CompressionTypePB::LZ4_FRAME, ".lz4"},
+    };
+
+    // Generate large test data (highly compressible)
+    std::string test_data;
+    for (int i = 0; i < 1000; i++) {
+        test_data += "Line " + std::to_string(i) + ",repeated,data,for,compression,test\n";
+    }
+
+    for (const auto& [compression_type, extension] : compression_types) {
+        std::string file_path =
+                "/test_all_compression_" + std::to_string(static_cast<int>(compression_type)) + ".csv" + extension;
+        auto maybe_file = _fs.new_writable_file(file_path);
+        ASSERT_OK(maybe_file.status());
+        auto file = std::move(maybe_file.value());
+
+        auto async_stream = std::make_unique<io::AsyncFlushOutputStream>(std::move(file), nullptr, _runtime_state);
+        auto base_stream = std::make_shared<AsyncOutputStreamFile>(async_stream.get(), 1024);
+        auto compressed_stream_result = CompressedOutputStream::create(base_stream, compression_type, 1024);
+        ASSERT_OK(compressed_stream_result.status());
+        auto compressed_stream = std::move(compressed_stream_result.value());
+
+        ASSERT_OK(compressed_stream->write(Slice(test_data)));
+        ASSERT_OK(compressed_stream->finalize());
+        // Note: finalize() already closes the async stream internally
+
+        // Read back the compressed data
+        std::string compressed_content;
+        ASSERT_OK(_fs.read_file(file_path, &compressed_content));
+
+        // Verify compression is effective
+        EXPECT_LT(compressed_content.size(), test_data.size())
+                << "Compression type " << static_cast<int>(compression_type) << " should compress data";
+
+        // Decompress and verify - use different function for GZIP since BlockCompressionCodec
+        // doesn't properly handle GZIP decompression output size
+        std::string decompressed;
+        if (compression_type == CompressionTypePB::GZIP) {
+            decompressed = starrocks::test::decompress_gzip(compressed_content);
+        } else {
+            decompressed = starrocks::test::decompress_data(compressed_content, compression_type);
+        }
+        EXPECT_EQ(decompressed, test_data)
+                << "Compression type " << static_cast<int>(compression_type) << " should decompress correctly";
+    }
+}
+
+} // namespace starrocks::csv

--- a/be/test/formats/csv/output_stream_file_test.cpp
+++ b/be/test/formats/csv/output_stream_file_test.cpp
@@ -410,7 +410,7 @@ TEST_F(OutputStreamFileTest, TestZstdCompression) {
 
 // Test LZ4 (raw block) compression
 TEST_F(OutputStreamFileTest, TestLz4RawCompression) {
-    std::string file_path = "/test_lz4raw.csv.lz4raw";
+    std::string file_path = "/test_lz4raw.csv.lz4";
     auto maybe_file = _fs.new_writable_file(file_path);
     ASSERT_OK(maybe_file.status());
     auto file = std::move(maybe_file.value());


### PR DESCRIPTION
## Why I'm doing:
Add GZIP/SNAPPY/ZSTD/LZ4/LZ4_FRAME/DEFLATE/ZLIB/BZIP2 compression support to CSV exports via INSERT INTO FILES. 

**Usage example**

```
INSERT INTO FILES(
    'path' = 'file:///tmp/export/',
    'format' = 'csv',
    'compression' = 'gzip'
)
```

## What I'm doing:

  - Switched CSV export compression to streaming codecs and added block‑framed SNAPPY/LZ4 output in be/src/formats/csv/output_stream_file.h and be/src/formats/csv/output_stream_file.cpp.
  - Added/extended stream compression support (GZIP/DEFLATE/BZIP2/ZSTD/LZ4_FRAME) and LZ4 auto‑detect on read (frame vs block) in be/src/util/compression/stream_compression.h and be/src/util/compression/
    stream_compression.cpp.
  - Updated compression utilities and suffix mapping (generic to_compression_ext, .lz4 → LZ4 auto‑detect) in be/src/util/compression/compression_utils.h, and wired suffix use in be/src/connector/
    file_chunk_sink.cpp.
  - Expanded/adjusted tests for CSV compression formats and LZ4 auto‑detect in be/test/formats/csv/output_stream_file_test.cpp and helper updates in be/test/formats/csv/compression_test_utils.h; fixed
    append_numbers warning assertions in be/test/formats/csv/csv_file_writer_test.cpp.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces end-to-end CSV compression via streaming codecs and block-framed SNAPPY/LZ4, plus extension handling and broad test coverage.
> 
> - Add `csv::CompressedOutputStream` (decorator) supporting `GZIP/ZSTD/LZ4_FRAME/DEFLATE/ZLIB/BZIP2` via streaming and `SNAPPY/LZ4` via block stream; implement finalize/size estimation and block framing in `csv/output_stream_file.{h,cpp}`
> - Wire compression into `CSVFileWriterFactory::create` to wrap the base async stream; simplify `CSVFileWriter` ctor by removing compression arg; ensure rollback via `DeferOp`
> - Append compression-based suffix for CSV paths in `connector/file_chunk_sink.cpp` using `CompressionUtils::to_compression_ext`
> - Extend compression infra: new `StreamCompressor` API and implementations (gzip/zlib/deflate, bzip2, zstd, lz4_frame), LZ4 auto-detect (frame vs block), and BE encoding helpers (`encode_fixed32_be`) in `util/*`
> - Update build and add extensive tests for CSV writer headers/delimiters and all codecs, including size checks and LZ4 auto-detection (`output_stream_file_test.cpp`, `compression_test_utils.h`, `csv_file_writer_test.cpp`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82d35442b71af5a78a62da78c00ff262da1b7fae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->