### PR TITLE
[Enhancement] Introduce a commit queue for Iceberg table sink to avoid concurrent commit conflicts.

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -3793,6 +3793,33 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: When this item is set to `true`, the system allows Lake tables to use the combined transaction log path for relevant transactions. Available for shared-data clusters only.
 - Introduced in: v3.3.7, v3.4.0, v3.5.0
 
+##### enable_iceberg_commit_queue
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to enable commit queue for Iceberg tables to avoid concurrent commit conflicts. Iceberg uses optimistic concurrency control (OCC) for metadata commits. When multiple threads concurrently commit to the same table, conflicts can occur with errors like: "Cannot commit: Base metadata location is not same as the current table metadata location". When enabled, each Iceberg table has its own single-threaded executor for commit operations, ensuring that commits to the same table are serialized and preventing OCC conflicts. Different tables can commit concurrently, maintaining overall throughput. This is a system-level optimization to improve reliability and should be enabled by default. If disabled, concurrent commits may fail due to optimistic locking conflicts.
+- Introduced in: v4.1.0
+
+##### iceberg_commit_queue_timeout_seconds
+
+- Default: 300
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: The timeout in seconds for waiting for an Iceberg commit operation to complete. When using the commit queue (`enable_iceberg_commit_queue=true`), each commit operation must complete within this timeout. If a commit takes longer than this timeout, it will be cancelled and an error will be raised. Factors that affect commit time include: number of data files being committed, metadata size of the table, performance of the underlying storage (e.g., S3, HDFS).
+- Introduced in: v4.1.0
+
+##### iceberg_commit_queue_max_size
+
+- Default: 1000
+- Type: Int
+- Unit: Count
+- Is mutable: No
+- Description: The maximum number of pending commit operations per Iceberg table. When using the commit queue (`enable_iceberg_commit_queue=true`), this limits the number of commit operations that can be queued for a single table. When the limit is reached, additional commit operations will execute in the caller thread (blocking until capacity available). This configuration is read at FE startup and applies to newly created table executors. Requires FE restart to take effect. Increase this value if you expect many concurrent commits to the same table. If this value is too low, commits may block in the caller thread during high concurrency.
+- Introduced in: v4.1.0
+
 ### Other
 
 ##### agent_task_resend_wait_time_ms

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCommitQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCommitQueueManager.java
@@ -1,0 +1,515 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+/**
+ * Manages serialized commit operations for Iceberg tables to avoid concurrent commit conflicts.
+ *
+ * <p>Iceberg uses optimistic concurrency control (OCC) for metadata commits. When multiple threads
+ * concurrently commit to the same table, conflicts can occur:
+ *
+ * <pre>
+ * Thread A reads metadata V1 -&gt; writes data -&gt; attempts to commit
+ * Thread B reads metadata V1 -&gt; writes data -&gt; commits successfully (metadata now V2)
+ * Thread A attempts to commit -&gt; FAILS because current metadata is V2, not V1
+ * </pre>
+ *
+ * <p>This manager creates a single-threaded executor per table to serialize commits, ensuring
+ * that only one commit operation per table proceeds at a time. Different tables can commit
+ * concurrently, maintaining overall throughput.
+ *
+ * <p>Table executors are automatically evicted after a period of inactivity (default: 1 hour)
+ * to prevent unbounded memory growth.
+ *
+ * <p>Thread safety: This class is thread-safe and can be used concurrently from multiple threads.
+ */
+public class IcebergCommitQueueManager {
+
+    private static final Logger LOG = LogManager.getLogger(IcebergCommitQueueManager.class);
+
+    /**
+     * Configuration for the commit queue manager.
+     */
+    public static class Config {
+        private final boolean enabled;
+        private final long timeoutSeconds;
+        private final int maxQueueSize;
+
+        // Minimum valid values for configuration
+        private static final long MIN_TIMEOUT_SECONDS = 120L;
+        private static final int MIN_QUEUE_SIZE = 10;
+
+        public Config(boolean enabled, long timeoutSeconds, int maxQueueSize) {
+            this.enabled = enabled;
+
+            // Use minimum value with warning if timeout is less than minimum
+            if (timeoutSeconds < MIN_TIMEOUT_SECONDS) {
+                LOG.warn("Invalid iceberg_commit_queue_timeout_seconds: {}, using minimum value: {}",
+                         timeoutSeconds, MIN_TIMEOUT_SECONDS);
+                this.timeoutSeconds = MIN_TIMEOUT_SECONDS;
+            } else {
+                this.timeoutSeconds = timeoutSeconds;
+            }
+
+            // Use minimum value with warning if queue size is less than minimum
+            if (maxQueueSize < MIN_QUEUE_SIZE) {
+                LOG.warn("Invalid iceberg_commit_queue_max_size: {}, using minimum value: {}",
+                         maxQueueSize, MIN_QUEUE_SIZE);
+                this.maxQueueSize = MIN_QUEUE_SIZE;
+            } else {
+                this.maxQueueSize = maxQueueSize;
+            }
+        }
+
+        /**
+         * Get the minimum valid timeout value in seconds.
+         * Used when invalid timeout is configured.
+         */
+        public static long getMinTimeoutSeconds() {
+            return MIN_TIMEOUT_SECONDS;
+        }
+
+        /**
+         * Get the minimum valid queue size.
+         * Used when invalid queue size is configured.
+         */
+        public static int getMinQueueSize() {
+            return MIN_QUEUE_SIZE;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public long getTimeoutSeconds() {
+            return timeoutSeconds;
+        }
+
+        public int getMaxQueueSize() {
+            return maxQueueSize;
+        }
+    }
+
+    /**
+     * Represents a commit task to be executed.
+     */
+    @FunctionalInterface
+    public interface CommitTask {
+        /**
+         * Execute the commit operation. May throw any exception.
+         */
+        void execute() throws Exception;
+    }
+
+    /**
+     * Result of a commit operation.
+     */
+    public static class CommitResult {
+        private final boolean success;
+        private final Throwable error;
+
+        private CommitResult(boolean success, Throwable error) {
+            this.success = success;
+            this.error = error;
+        }
+
+        public static CommitResult success() {
+            return new CommitResult(true, null);
+        }
+
+        public static CommitResult failure(Throwable error) {
+            return new CommitResult(false, error);
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public Throwable getError() {
+            return error;
+        }
+
+        /**
+         * Rethrows the exception if the commit failed, preserving the original exception type.
+         *
+         * <p>This method preserves exception types to maintain backwards compatibility:
+         * <ul>
+         *   <li>{@link Error} types are rethrown as-is (e.g., {@link InternalError})</li>
+         *   <li>{@link RuntimeException} types are rethrown as-is</li>
+         *   <li>Checked exceptions are wrapped in {@link RuntimeException}</li>
+         * </ul>
+         *
+         * @throws Error if the original error was an {@link Error}
+         * @throws RuntimeException if the original exception was a {@link RuntimeException} or checked exception
+         */
+        public void rethrowIfFailed() {
+            if (!success && error != null) {
+                // Preserve Error types - they should never be wrapped
+                if (error instanceof Error) {
+                    throw (Error) error;
+                }
+                // Preserve RuntimeException types
+                if (error instanceof RuntimeException) {
+                    throw (RuntimeException) error;
+                }
+                // Wrap checked exceptions
+                throw new RuntimeException(error);
+            }
+        }
+    }
+
+    /**
+     * Holds the executor service for a specific table.
+     */
+    private static class TableCommitExecutor {
+        private final ExecutorService executor;
+
+        TableCommitExecutor(ExecutorService executor) {
+            this.executor = executor;
+        }
+
+        ExecutorService getExecutor() {
+            return executor;
+        }
+    }
+
+    /**
+     * Rejected execution handler that blocks until the queue has capacity.
+     * This preserves serialized execution without running tasks in the caller thread.
+     * Has a maximum wait time to prevent indefinite blocking.
+     */
+    private static class BlockWhenQueueFullPolicy implements RejectedExecutionHandler {
+        private static final long MAX_WAIT_SECONDS = 60;  // Maximum wait time: 60 seconds
+
+        @Override
+        public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+            if (executor.isShutdown()) {
+                throw new RejectedExecutionException("Executor is shutdown");
+            }
+            try {
+                // Block until queue has capacity, but with a maximum wait time
+                boolean enqueued = executor.getQueue().offer(r, MAX_WAIT_SECONDS, TimeUnit.SECONDS);
+                if (!enqueued) {
+                    throw new RejectedExecutionException("Commit queue full - waited " + MAX_WAIT_SECONDS +
+                            " seconds but queue still at capacity. Consider increasing iceberg_commit_queue_max_size.");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RejectedExecutionException("Interrupted while waiting for commit queue capacity", e);
+            }
+        }
+    }
+
+    private final Supplier<Config> configSupplier;
+    private final Cache<TableCommitKey, TableCommitExecutor> tableExecutors;
+
+    /**
+     * Creates a new commit queue manager with a config supplier.
+     * The supplier is called on each submit to get the latest configuration,
+     * allowing runtime config changes to take effect immediately.
+     *
+     * @param configSupplier the supplier that provides the current configuration
+     */
+    public IcebergCommitQueueManager(Supplier<Config> configSupplier) {
+        this.configSupplier = Preconditions.checkNotNull(configSupplier, "configSupplier cannot be null");
+        // Use Guava Cache with expireAfterAccess to automatically evict idle executors
+        // This prevents unbounded memory growth when many tables are written to over time
+        this.tableExecutors = CacheBuilder.newBuilder()
+                .expireAfterAccess(1, TimeUnit.HOURS)  // Evict after 1 hour of inactivity
+                .removalListener(new RemovalListener<TableCommitKey, TableCommitExecutor>() {
+                    @Override
+                    public void onRemoval(RemovalNotification<TableCommitKey, TableCommitExecutor> notification) {
+                        if (notification.getValue() != null) {
+                            shutdownExecutor(notification.getValue().getExecutor(), notification.getKey());
+                        }
+                    }
+                })
+                .build();
+        LOG.info("IcebergCommitQueueManager initialized with 1 hour idle timeout for table executors");
+    }
+
+    /**
+     * Creates a new commit queue manager with the given configuration.
+     *
+     * @param config the configuration for this manager
+     */
+    public IcebergCommitQueueManager(Config config) {
+        this(() -> config);
+    }
+
+    /**
+     * Creates a new commit queue manager with default configuration.
+     */
+    public IcebergCommitQueueManager() {
+        this(new Config(true, 120, 1000));
+    }
+
+    /**
+     * Submits a commit task for the specified table and waits for completion.
+     *
+     * <p>If the queue manager is disabled, the task is executed immediately in the calling thread.
+     * If enabled, the task is submitted to a single-threaded executor for the table, ensuring
+     * serialized execution.
+     *
+     * <p>Configuration is read fresh on each call, so runtime config changes take effect immediately.
+     *
+     * @param catalogName the catalog name
+     * @param dbName      the database name
+     * @param tableName   the table name
+     * @param task        the commit task to execute
+     * @return the result of the commit operation
+     * @throws RuntimeException if the task fails or times out
+     */
+    public CommitResult submitCommit(String catalogName, String dbName, String tableName, CommitTask task) {
+        if (Thread.currentThread().isInterrupted()) {
+            return CommitResult.failure(new InterruptedException("Commit interrupted"));
+        }
+        Config config = configSupplier.get();
+
+        if (!config.isEnabled()) {
+            // Queue is disabled, execute directly
+            try {
+                task.execute();
+                return CommitResult.success();
+            } catch (Exception e) {
+                return CommitResult.failure(e);
+            }
+        }
+
+        TableCommitKey key = new TableCommitKey(catalogName, dbName, tableName);
+        TableCommitExecutor tableExecutor = getOrCreateTableExecutor(key);
+
+        long timeoutSeconds = config.getTimeoutSeconds();
+        long startNanos = System.nanoTime();
+        Future<CommitResult> future;
+        try {
+            future = tableExecutor.getExecutor().submit(() -> {
+                try {
+                    task.execute();
+                    return CommitResult.success();
+                } catch (Exception e) {
+                    LOG.warn("Failed to execute commit task for {}.{}.{}: {}",
+                            catalogName, dbName, tableName, e.getMessage(), e);
+                    return CommitResult.failure(e);
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            LOG.error("Failed to submit commit task for {}.{}.{}",
+                    catalogName, dbName, tableName, e);
+            return CommitResult.failure(e);
+        }
+
+        long remainingNanos = TimeUnit.SECONDS.toNanos(timeoutSeconds) - (System.nanoTime() - startNanos);
+        if (remainingNanos <= 0) {
+            future.cancel(true);
+            return CommitResult.failure(new TimeoutException(
+                    "Commit timeout after " + timeoutSeconds + " seconds"));
+        }
+
+        try {
+            return future.get(remainingNanos, TimeUnit.NANOSECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted while waiting for commit to complete for {}.{}.{}",
+                    catalogName, dbName, tableName, e);
+            future.cancel(true);
+            return CommitResult.failure(new InterruptedException("Commit interrupted: " + e.getMessage()));
+        } catch (ExecutionException e) {
+            LOG.error("Exception during commit execution for {}.{}.{}",
+                    catalogName, dbName, tableName, e.getCause());
+            return CommitResult.failure(e.getCause() != null ? e.getCause() : e);
+        } catch (TimeoutException e) {
+            LOG.error("Timeout waiting for commit to complete for {}.{}.{} after {} seconds",
+                    catalogName, dbName, tableName, timeoutSeconds, e);
+            future.cancel(true);
+            return CommitResult.failure(new TimeoutException(
+                    "Commit timeout after " + timeoutSeconds + " seconds"));
+        }
+    }
+
+    /**
+     * Submits a commit task and rethrows any exception as a RuntimeException.
+     *
+     * @param catalogName the catalog name
+     * @param dbName      the database name
+     * @param tableName   the table name
+     * @param task        the commit task to execute
+     * @throws RuntimeException if the task fails or times out
+     */
+    public void submitCommitAndRethrow(String catalogName, String dbName, String tableName, CommitTask task) {
+        CommitResult result = submitCommit(catalogName, dbName, tableName, task);
+        result.rethrowIfFailed();
+    }
+
+    private TableCommitExecutor getOrCreateTableExecutor(TableCommitKey key) {
+        try {
+            return tableExecutors.get(key, () -> {
+                Config config = configSupplier.get();
+                ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                        .setDaemon(true)
+                        .setNameFormat("iceberg-commit-" + key.catalogName + "-" + key.dbName + "-" + key.tableName + "-%d")
+                        .build();
+                // Use bounded ThreadPoolExecutor with CallerRunsPolicy to enforce maxQueueSize
+                // When queue is full, tasks are executed in the caller thread (blocks until capacity available)
+                ExecutorService executor = new ThreadPoolExecutor(
+                        1,  // corePoolSize
+                        1,  // maximumPoolSize
+                        0L, TimeUnit.MILLISECONDS,  // idle thread timeout
+                        new LinkedBlockingQueue<>(config.getMaxQueueSize()),  // bounded queue
+                        threadFactory,
+                        new BlockWhenQueueFullPolicy());  // block until queue has capacity
+                LOG.info("Created commit queue executor for {}.{}.{}, max queue size: {}",
+                        key.catalogName, key.dbName, key.tableName, config.getMaxQueueSize());
+                return new TableCommitExecutor(executor);
+            });
+        } catch (ExecutionException e) {
+            throw new RuntimeException("Failed to create table executor", e);
+        }
+    }
+
+    /**
+     * Shuts down the executor for a specific table.
+     *
+     * <p>This method is idempotent - calling it multiple times for the same table is safe.
+     *
+     * @param catalogName the catalog name
+     * @param dbName      the database name
+     * @param tableName   the table name
+     */
+    public void shutdownTableExecutor(String catalogName, String dbName, String tableName) {
+        TableCommitKey key = new TableCommitKey(catalogName, dbName, tableName);
+        tableExecutors.invalidate(key);
+    }
+
+    /**
+     * Shuts down all executors for tables matching the given database name.
+     *
+     * @param catalogName the catalog name
+     * @param dbName      the database name
+     */
+    public void shutdownDatabaseExecutors(String catalogName, String dbName) {
+        // Invalidate all matching entries - the removal listener will handle shutdown
+        tableExecutors.asMap().entrySet().removeIf(entry -> {
+            TableCommitKey key = entry.getKey();
+            return key.catalogName.equals(catalogName) && key.dbName.equals(dbName);
+        });
+    }
+
+    /**
+     * Shuts down all executors in this manager.
+     */
+    public void shutdownAll() {
+        // Invalidate all entries - the removal listener will handle shutdown
+        tableExecutors.invalidateAll();
+    }
+
+    private void shutdownExecutor(ExecutorService executor, TableCommitKey key) {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                LOG.warn("Executor for {}.{}.{} did not terminate in time, forcing shutdown",
+                        key.catalogName, key.dbName, key.tableName);
+                executor.shutdownNow();
+                if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    LOG.error("Executor for {}.{}.{} did not terminate after forced shutdown",
+                            key.catalogName, key.dbName, key.tableName);
+                }
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Returns the number of tables with active executors.
+     */
+    @VisibleForTesting
+    public long getActiveTableCount() {
+        return tableExecutors.size();
+    }
+
+    /**
+     * Returns whether the manager is enabled.
+     */
+    public boolean isEnabled() {
+        return configSupplier.get().isEnabled();
+    }
+
+    /**
+     * Key for identifying a specific table.
+     */
+    @VisibleForTesting
+    static class TableCommitKey {
+        private final String catalogName;
+        private final String dbName;
+        private final String tableName;
+
+        TableCommitKey(String catalogName, String dbName, String tableName) {
+            this.catalogName = Preconditions.checkNotNull(catalogName, "catalogName cannot be null");
+            this.dbName = Preconditions.checkNotNull(dbName, "dbName cannot be null");
+            this.tableName = Preconditions.checkNotNull(tableName, "tableName cannot be null");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof TableCommitKey)) {
+                return false;
+            }
+            TableCommitKey that = (TableCommitKey) o;
+            return catalogName.equals(that.catalogName)
+                    && dbName.equals(that.dbName)
+                    && tableName.equals(that.tableName);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = catalogName.hashCode();
+            result = 31 * result + dbName.hashCode();
+            result = 31 * result + tableName.hashCode();
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return catalogName + "." + dbName + "." + tableName;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -27,6 +27,7 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.constraint.ForeignKeyConstraint;
 import com.starrocks.catalog.constraint.UniqueConstraint;
 import com.starrocks.common.AlreadyExistsException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -162,6 +163,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -219,17 +221,29 @@ public class IcebergMetadata implements ConnectorMetadata {
     private final ConnectorProperties properties;
     private final IcebergProcedureRegistry procedureRegistry;
 
+    // Commit queue manager for serializing Iceberg commits to avoid optimistic locking conflicts
+    private final IcebergCommitQueueManager commitQueueManager;
+
     public IcebergMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, IcebergCatalog icebergCatalog,
                            ExecutorService jobPlanningExecutor, ExecutorService refreshOtherFeExecutor,
                            IcebergCatalogProperties catalogProperties) {
         this(catalogName, hdfsEnvironment, icebergCatalog, jobPlanningExecutor, refreshOtherFeExecutor,
-                catalogProperties, new ConnectorProperties(ConnectorType.ICEBERG), new IcebergProcedureRegistry());
+                catalogProperties, new ConnectorProperties(ConnectorType.ICEBERG), new IcebergProcedureRegistry(),
+                null);
     }
 
     public IcebergMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, IcebergCatalog icebergCatalog,
                            ExecutorService jobPlanningExecutor, ExecutorService refreshOtherFeExecutor,
                            IcebergCatalogProperties catalogProperties, ConnectorProperties properties,
                            IcebergProcedureRegistry procedureRegistry) {
+        this(catalogName, hdfsEnvironment, icebergCatalog, jobPlanningExecutor, refreshOtherFeExecutor,
+                catalogProperties, properties, procedureRegistry, null);
+    }
+
+    public IcebergMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, IcebergCatalog icebergCatalog,
+                           ExecutorService jobPlanningExecutor, ExecutorService refreshOtherFeExecutor,
+                           IcebergCatalogProperties catalogProperties, ConnectorProperties properties,
+                           IcebergProcedureRegistry procedureRegistry, IcebergCommitQueueManager commitQueueManager) {
         this.catalogName = catalogName;
         this.hdfsEnvironment = hdfsEnvironment;
         this.icebergCatalog = icebergCatalog;
@@ -238,6 +252,28 @@ public class IcebergMetadata implements ConnectorMetadata {
         this.catalogProperties = catalogProperties;
         this.properties = properties;
         this.procedureRegistry = procedureRegistry;
+
+        // Use the shared commit queue manager from IcebergConnector if provided,
+        // otherwise create a new one (for backwards compatibility and testing)
+        if (commitQueueManager != null) {
+            this.commitQueueManager = commitQueueManager;
+            LOG.info("IcebergMetadata using shared commit queue manager for catalog {}", catalogName);
+        } else {
+            // Initialize commit queue manager with a supplier that reads the latest FE configuration
+            // This allows runtime config changes (enable_iceberg_commit_queue, iceberg_commit_queue_timeout_seconds)
+            // to take effect immediately without FE restart.
+            this.commitQueueManager = new IcebergCommitQueueManager(() -> {
+                IcebergCommitQueueManager.Config queueConfig = new IcebergCommitQueueManager.Config(
+                        Config.enable_iceberg_commit_queue,
+                        Config.iceberg_commit_queue_timeout_seconds,
+                        Config.iceberg_commit_queue_max_size
+                );
+                return queueConfig;
+            });
+            LOG.info("Iceberg commit queue initialized for catalog {}: enabled={}, timeoutSeconds={}, maxSize={}",
+                    catalogName, Config.enable_iceberg_commit_queue,
+                    Config.iceberg_commit_queue_timeout_seconds, Config.iceberg_commit_queue_max_size);
+        }
     }
 
     @Override
@@ -1305,33 +1341,56 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     @Override
     public void finishSink(String dbName, String tableName, List<TSinkCommitInfo> commitInfos, String branch, Object extra) {
-        boolean isOverwrite = false;
-        boolean isRewrite = false;
+        // Normalize db name and table name to lower case for commit queue key
+        // because some catalogs are case-insensitive (e.g., Hive, Glue)
+        //
+        // The normalizing for all catalogs is safe because:
+        // 1. The commit queue only serializes commits, it doesn't affect table identity
+        // 2. In the rare case where two tables differ only by case (e.g., "db.Table" vs "db.TABLE"),
+        //    sharing the same commit queue executor is harmless - commits are still serialized
+        // 3. It prevents bugs from inconsistent casing in user code (e.g., finishSink("DB") vs finishSink("db"))
+        String queueDbName = dbName.toLowerCase(Locale.ROOT);
+        String queueTableName = tableName.toLowerCase(Locale.ROOT);
+
+        final boolean isOverwrite;
+        final boolean isRewrite;
         if (!commitInfos.isEmpty()) {
             TSinkCommitInfo sinkCommitInfo = commitInfos.get(0);
             if (sinkCommitInfo.isSetIs_overwrite()) {
                 isOverwrite = sinkCommitInfo.is_overwrite;
+                isRewrite = false;
             } else if (sinkCommitInfo.isSetIs_rewrite()) {
+                isOverwrite = false;
                 isRewrite = sinkCommitInfo.is_rewrite;
+            } else {
+                isOverwrite = false;
+                isRewrite = false;
             }
+        } else {
+            isOverwrite = false;
+            isRewrite = false;
         }
 
-        List<TIcebergDataFile> dataFiles = commitInfos.stream()
+        final List<TIcebergDataFile> dataFiles = commitInfos.stream()
                 .map(TSinkCommitInfo::getIceberg_data_file).collect(Collectors.toList());
 
-        IcebergTable table = (IcebergTable) getTable(new ConnectContext(), dbName, tableName);
-        org.apache.iceberg.Table nativeTbl = table.getNativeTable();
-        Transaction transaction = nativeTbl.newTransaction();
+        // Use commit queue to serialize commits to the same table and avoid optimistic locking conflicts
+        commitQueueManager.submitCommitAndRethrow(catalogName, queueDbName, queueTableName, () -> {
+            IcebergTable table = (IcebergTable) getTable(new ConnectContext(), dbName, tableName);
+            org.apache.iceberg.Table nativeTbl = table.getNativeTable();
+            Transaction transaction = nativeTbl.newTransaction();
 
-        // Check if this is a delete operation (any file is marked as POSITION_DELETES)
-        boolean isDeleteOperation = dataFiles.stream().anyMatch(dataFile ->
-                dataFile.isSetFile_content() &&
-                        (dataFile.getFile_content() == TIcebergFileContent.POSITION_DELETES));
-        if (isDeleteOperation) {
-            commitDeleteOperation(transaction, nativeTbl, dataFiles, branch, dbName, tableName, extra);
-        } else {
-            commitDataOperation(transaction, nativeTbl, dataFiles, branch, isOverwrite, isRewrite, extra, dbName, tableName);
-        }
+            // Check if this is a delete operation (any file is marked as POSITION_DELETES)
+            boolean isDeleteOperation = dataFiles.stream().anyMatch(dataFile ->
+                    dataFile.isSetFile_content() &&
+                            (dataFile.getFile_content() == TIcebergFileContent.POSITION_DELETES));
+            if (isDeleteOperation) {
+                commitDeleteOperation(transaction, nativeTbl, dataFiles, branch, dbName, tableName, extra);
+            } else {
+                commitDataOperation(transaction, nativeTbl, dataFiles, branch, isOverwrite, isRewrite, extra,
+                        dbName, tableName);
+            }
+        });
     }
 
     private void commitWithCleanup(Runnable commitAction, Runnable cleanupAction,
@@ -1754,4 +1813,3 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
     }
 }
-

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergCommitQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergCommitQueueManagerTest.java
@@ -1,0 +1,1281 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for IcebergCommitQueueManager.
+ */
+public class IcebergCommitQueueManagerTest {
+
+    private IcebergCommitQueueManager manager;
+    private IcebergCommitQueueManager.Config config;
+
+    @BeforeEach
+    public void setUp() {
+        config = new IcebergCommitQueueManager.Config(
+                true,   // enabled
+                120,    // 120 seconds timeout (minimum valid value)
+                100     // max queue size
+        );
+        manager = new IcebergCommitQueueManager(config);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (manager != null) {
+            manager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testConstructor() {
+        assertNotNull(manager);
+        assertTrue(manager.isEnabled());
+        assertEquals(0, manager.getActiveTableCount());
+    }
+
+    @Test
+    public void testInvalidConfigParametersUseDefaultValues() {
+        // Test timeout less than minimum - should use minimum value
+        IcebergCommitQueueManager.Config smallTimeoutConfig =
+                new IcebergCommitQueueManager.Config(true, 60, 100);
+        assertEquals(IcebergCommitQueueManager.Config.getMinTimeoutSeconds(),
+                     smallTimeoutConfig.getTimeoutSeconds());
+        assertEquals(100, smallTimeoutConfig.getMaxQueueSize());
+
+        // Test negative timeout - should use minimum value
+        IcebergCommitQueueManager.Config negativeTimeoutConfig =
+                new IcebergCommitQueueManager.Config(true, -1, 100);
+        assertEquals(IcebergCommitQueueManager.Config.getMinTimeoutSeconds(),
+                     negativeTimeoutConfig.getTimeoutSeconds());
+        assertEquals(100, negativeTimeoutConfig.getMaxQueueSize());
+
+        // Test zero timeout - should use minimum value
+        IcebergCommitQueueManager.Config zeroTimeoutConfig =
+                new IcebergCommitQueueManager.Config(true, 0, 100);
+        assertEquals(IcebergCommitQueueManager.Config.getMinTimeoutSeconds(),
+                     zeroTimeoutConfig.getTimeoutSeconds());
+
+        // Test queue size less than minimum - should use minimum value
+        IcebergCommitQueueManager.Config smallQueueConfig =
+                new IcebergCommitQueueManager.Config(true, 120, 5);
+        assertEquals(120, smallQueueConfig.getTimeoutSeconds());
+        assertEquals(IcebergCommitQueueManager.Config.getMinQueueSize(),
+                     smallQueueConfig.getMaxQueueSize());
+
+        // Test negative queue size - should use minimum value
+        IcebergCommitQueueManager.Config negativeQueueConfig =
+                new IcebergCommitQueueManager.Config(true, 120, -1);
+        assertEquals(120, negativeQueueConfig.getTimeoutSeconds());
+        assertEquals(IcebergCommitQueueManager.Config.getMinQueueSize(),
+                     negativeQueueConfig.getMaxQueueSize());
+
+        // Test both invalid - should use minimum values for both
+        IcebergCommitQueueManager.Config bothInvalidConfig =
+                new IcebergCommitQueueManager.Config(true, 30, 5);
+        assertEquals(IcebergCommitQueueManager.Config.getMinTimeoutSeconds(),
+                     bothInvalidConfig.getTimeoutSeconds());
+        assertEquals(IcebergCommitQueueManager.Config.getMinQueueSize(),
+                     bothInvalidConfig.getMaxQueueSize());
+    }
+
+    @Test
+    public void testConstructorWithDefaultConfig() {
+        IcebergCommitQueueManager defaultManager = new IcebergCommitQueueManager();
+        assertNotNull(defaultManager);
+        defaultManager.shutdownAll();
+    }
+
+    @Test
+    public void testSuccessfulCommit() {
+        IcebergCommitQueueManager.CommitResult result =
+                manager.submitCommit("catalog", "db", "table", () -> {
+                    // Simulate a successful commit
+                });
+
+        assertTrue(result.isSuccess());
+        assertFalse(result.isSuccess() && result.getError() != null);
+    }
+
+    @Test
+    public void testSuccessfulCommitWithReturnValue() {
+        AtomicInteger counter = new AtomicInteger(0);
+
+        IcebergCommitQueueManager.CommitResult result =
+                manager.submitCommit("catalog", "db", "table", () -> {
+                    counter.incrementAndGet();
+                });
+
+        assertTrue(result.isSuccess());
+        assertEquals(1, counter.get());
+    }
+
+    @Test
+    public void testFailedCommit() {
+        IcebergCommitQueueManager.CommitResult result =
+                manager.submitCommit("catalog", "db", "table", () -> {
+                    throw new RuntimeException("Commit failed");
+                });
+
+        assertFalse(result.isSuccess());
+        assertNotNull(result.getError());
+        assertTrue(result.getError() instanceof RuntimeException);
+        assertEquals("Commit failed", result.getError().getMessage());
+    }
+
+    @Test
+    public void testSubmitCommitAndRethrow() {
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            manager.submitCommitAndRethrow("catalog", "db", "table", () -> {
+                throw new RuntimeException("Commit failed");
+            });
+        });
+
+        assertEquals("Commit failed", exception.getMessage());
+    }
+
+    @Test
+    public void testSubmitCommitAndRethrowSuccess() {
+        // Should not throw any exception
+        manager.submitCommitAndRethrow("catalog", "db", "table", () -> {
+            // Successful commit
+        });
+    }
+
+    @Test
+    public void testConcurrentCommitsToSameTable() throws Exception {
+        int numThreads = 10;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(numThreads);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger counter = new AtomicInteger(0);
+        List<Exception> exceptions = new ArrayList<>();
+
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+
+        for (int i = 0; i < numThreads; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await(); // Wait for all threads to be ready
+
+                    manager.submitCommitAndRethrow("catalog", "db", "table", () -> {
+                        // Simulate some work
+                        Thread.sleep(50);
+                        counter.incrementAndGet();
+                    });
+
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    exceptions.add(e);
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        // Start all threads at once
+        startLatch.countDown();
+
+        // Wait for all threads to complete
+        assertTrue(endLatch.await(30, TimeUnit.SECONDS));
+        executor.shutdown();
+
+        // All commits should succeed
+        assertEquals(numThreads, successCount.get());
+        assertEquals(numThreads, counter.get());
+        assertTrue(exceptions.isEmpty(), "There should be no exceptions: " + exceptions);
+    }
+
+    @Test
+    public void testConcurrentCommitsToDifferentTables() throws Exception {
+        int numTables = 5;
+        int commitsPerTable = 4;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(numTables * commitsPerTable);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger counter = new AtomicInteger(0);
+        List<Exception> exceptions = new ArrayList<>();
+
+        ExecutorService executor = Executors.newFixedThreadPool(numTables * commitsPerTable);
+
+        for (int table = 0; table < numTables; table++) {
+            final String tableName = "table_" + table;
+
+            for (int i = 0; i < commitsPerTable; i++) {
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+
+                        manager.submitCommitAndRethrow("catalog", "db", tableName, () -> {
+                            // Simulate some work
+                            Thread.sleep(50);
+                            counter.incrementAndGet();
+                        });
+
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    } finally {
+                        endLatch.countDown();
+                    }
+                });
+            }
+        }
+
+        startLatch.countDown();
+        assertTrue(endLatch.await(30, TimeUnit.SECONDS));
+        executor.shutdown();
+
+        assertEquals(numTables * commitsPerTable, successCount.get());
+        assertEquals(numTables * commitsPerTable, counter.get());
+        assertTrue(exceptions.isEmpty(), "There should be no exceptions: " + exceptions);
+    }
+
+    @Test
+    public void testDisableCommitQueue() throws Exception {
+        IcebergCommitQueueManager.Config disabledConfig =
+                new IcebergCommitQueueManager.Config(false, 120, 100);
+        IcebergCommitQueueManager disabledManager =
+                new IcebergCommitQueueManager(disabledConfig);
+
+        ExecutorService executor = null;
+        try {
+            assertFalse(disabledManager.isEnabled());
+
+            AtomicInteger executionOrder = new AtomicInteger(0);
+            List<Integer> order = new ArrayList<>();
+            CountDownLatch tasksExecuted = new CountDownLatch(3);
+            CountDownLatch allSubmitted = new CountDownLatch(3);
+
+            // Submit multiple concurrent commits
+            executor = Executors.newFixedThreadPool(3);
+
+            for (int i = 0; i < 3; i++) {
+                final int index = i;
+                executor.submit(() -> {
+                    try {
+                        allSubmitted.countDown();
+                        disabledManager.submitCommit("catalog", "db", "table", () -> {
+                            order.add(index);
+                            executionOrder.incrementAndGet();
+                            tasksExecuted.countDown();
+                        });
+                    } catch (Throwable e) {
+                        // Log exception if any
+                        System.err.println("Task " + index + " failed: " + e.getMessage());
+                        e.printStackTrace();
+                    }
+                });
+            }
+
+            // Wait for all tasks to be submitted first
+            assertTrue(allSubmitted.await(5, TimeUnit.SECONDS));
+
+            // Now wait for all commits to execute
+            assertTrue(tasksExecuted.await(10, TimeUnit.SECONDS));
+
+            // Shutdown executor
+            executor.shutdown();
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+
+            // When disabled, commits execute immediately (not serialized)
+            assertEquals(3, executionOrder.get(), "All 3 tasks should execute");
+            assertEquals(3, order.size(), "All 3 tasks should complete");
+        } finally {
+            if (executor != null && !executor.isShutdown()) {
+                executor.shutdownNow();
+            }
+            disabledManager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testShutdownTableExecutor() {
+        // Create a table executor by submitting a commit
+        manager.submitCommit("catalog", "db", "table", () -> {});
+
+        assertEquals(1, manager.getActiveTableCount());
+
+        // Shutdown the executor for the table
+        manager.shutdownTableExecutor("catalog", "db", "table");
+
+        assertEquals(0, manager.getActiveTableCount());
+
+        // Shutdown should be idempotent
+        manager.shutdownTableExecutor("catalog", "db", "table");
+        assertEquals(0, manager.getActiveTableCount());
+    }
+
+    @Test
+    public void testShutdownDatabaseExecutors() {
+        // Create executors for multiple tables
+        manager.submitCommit("catalog", "db", "table1", () -> {});
+        manager.submitCommit("catalog", "db", "table2", () -> {});
+        manager.submitCommit("catalog", "db", "table3", () -> {});
+
+        assertEquals(3, manager.getActiveTableCount());
+
+        // Shutdown all executors for the database
+        manager.shutdownDatabaseExecutors("catalog", "db");
+
+        assertEquals(0, manager.getActiveTableCount());
+    }
+
+    @Test
+    public void testShutdownAll() {
+        // Create executors for multiple databases
+        manager.submitCommit("catalog", "db1", "table1", () -> {});
+        manager.submitCommit("catalog", "db1", "table2", () -> {});
+        manager.submitCommit("catalog", "db2", "table3", () -> {});
+
+        assertEquals(3, manager.getActiveTableCount());
+
+        manager.shutdownAll();
+
+        assertEquals(0, manager.getActiveTableCount());
+    }
+
+    @Test
+    public void testSerializationOfCommits() throws Exception {
+        // Test that commits to the same table are serialized
+        CountDownLatch firstCommitStarted = new CountDownLatch(1);
+        CountDownLatch firstCommitBlocking = new CountDownLatch(1);
+        CountDownLatch secondCommitStarted = new CountDownLatch(1);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        // First commit that will block
+        executor.submit(() -> {
+            manager.submitCommit("catalog", "db", "table", () -> {
+                firstCommitStarted.countDown();
+                try {
+                    // Block for a while
+                    firstCommitBlocking.await(2, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        });
+
+        // Wait for first commit to start
+        assertTrue(firstCommitStarted.await(5, TimeUnit.SECONDS));
+
+        // Second commit should wait for first to complete
+        executor.submit(() -> {
+            secondCommitStarted.countDown();
+            manager.submitCommit("catalog", "db", "table", () -> {
+                // This should execute after first commit completes
+            });
+        });
+
+        // Second commit should start quickly (after first is done)
+        assertTrue(secondCommitStarted.await(5, TimeUnit.SECONDS));
+
+        // Release first commit
+        firstCommitBlocking.countDown();
+
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testDifferentTablesExecuteInParallel() throws Exception {
+        // Test that commits to different tables can execute in parallel
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(1);
+        CountDownLatch bothStarted = new CountDownLatch(2);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        // Commit to table1
+        executor.submit(() -> {
+            manager.submitCommit("catalog", "db", "table1", () -> {
+                bothStarted.countDown();
+                try {
+                    latch1.await(2, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        });
+
+        // Commit to table2
+        executor.submit(() -> {
+            manager.submitCommit("catalog", "db", "table2", () -> {
+                bothStarted.countDown();
+                try {
+                    latch2.await(2, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        });
+
+        // Both commits should start (executing in parallel)
+        assertTrue(bothStarted.await(5, TimeUnit.SECONDS));
+
+        // Release both commits
+        latch1.countDown();
+        latch2.countDown();
+
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testBoundedQueueDoesNotLoseTasks() throws Exception {
+        // Create a manager with minimum queue size to test that no tasks are lost
+        IcebergCommitQueueManager.Config smallQueueConfig =
+                new IcebergCommitQueueManager.Config(true, 120, 10);  // max queue size = 10 (minimum valid)
+        IcebergCommitQueueManager smallQueueManager =
+                new IcebergCommitQueueManager(smallQueueConfig);
+
+        try {
+            CountDownLatch firstTaskStarted = new CountDownLatch(1);
+            CountDownLatch proceedWithFirst = new CountDownLatch(1);
+            AtomicInteger tasksExecuted = new AtomicInteger(0);
+
+            // Submit first task that will block and occupy the worker thread
+            Thread firstThread = new Thread(() -> {
+                smallQueueManager.submitCommit("catalog", "db", "table", () -> {
+                    tasksExecuted.incrementAndGet();
+                    firstTaskStarted.countDown();
+                    try {
+                        proceedWithFirst.await(10, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+            });
+            firstThread.start();
+
+            // Wait for first task to start running
+            assertTrue(firstTaskStarted.await(5, TimeUnit.SECONDS));
+            // Add delay to ensure the task is actually blocked on await()
+            Thread.sleep(200);
+
+            // Submit tasks to fill the queue (size = 10)
+            CountDownLatch queueFillLatch = new CountDownLatch(10);
+            for (int i = 0; i < 10; i++) {
+                smallQueueManager.submitCommit("catalog", "db", "table", () -> {
+                    tasksExecuted.incrementAndGet();
+                    queueFillLatch.countDown();
+                });
+            }
+
+            // Give some time for queue to be filled
+            Thread.sleep(100);
+
+            // Submit one more task - with BlockWhenQueueFullPolicy, this will wait
+            // for queue capacity via offer() with timeout
+            smallQueueManager.submitCommit("catalog", "db", "table", () -> {
+                tasksExecuted.incrementAndGet();
+            });
+
+            // Release the first blocking task, which allows all tasks to complete
+            proceedWithFirst.countDown();
+
+            // Wait for all tasks to complete
+            assertTrue(queueFillLatch.await(5, TimeUnit.SECONDS),
+                    "Queue tasks should complete after first task is released");
+
+            firstThread.join(5000);
+
+            // All 12 tasks should have executed (no tasks lost despite queue being full)
+            assertEquals(12, tasksExecuted.get(),
+                    "All tasks should execute despite queue being full");
+        } finally {
+            smallQueueManager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testSubmitInterruptedReturnsFailure() throws Exception {
+        IcebergCommitQueueManager.Config smallQueueConfig =
+                new IcebergCommitQueueManager.Config(true, 120, 10);
+        IcebergCommitQueueManager smallQueueManager =
+                new IcebergCommitQueueManager(smallQueueConfig);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            CountDownLatch taskRunning = new CountDownLatch(1);
+            CountDownLatch proceed = new CountDownLatch(1);
+
+            // Occupy the single worker so queue fills
+            executor.submit(() -> smallQueueManager.submitCommit("catalog", "db", "table", () -> {
+                taskRunning.countDown();
+                try {
+                    proceed.await(10, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }));
+            assertTrue(taskRunning.await(5, TimeUnit.SECONDS));
+
+            AtomicInteger counter = new AtomicInteger(0);
+            AtomicInteger failures = new AtomicInteger(0);
+            Thread submitThread = new Thread(() -> {
+                try {
+                    Thread.currentThread().interrupt();
+                    IcebergCommitQueueManager.CommitResult result =
+                            smallQueueManager.submitCommit("catalog", "db", "table", () -> counter.incrementAndGet());
+                    if (result.isSuccess() || !(result.getError() instanceof InterruptedException)) {
+                        failures.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    failures.incrementAndGet();
+                }
+            });
+            submitThread.start();
+            submitThread.join(5000);
+            assertEquals(0, counter.get());
+            assertEquals(0, failures.get());
+            proceed.countDown();
+        } finally {
+            executor.shutdownNow();
+            smallQueueManager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testDynamicConfigRefresh() throws Exception {
+        // Test that runtime config changes take effect immediately
+        AtomicInteger enabledFlag = new AtomicInteger(1);  // 1 = enabled, 0 = disabled
+        AtomicInteger timeoutFlag = new AtomicInteger(120);  // timeout in seconds (minimum valid value)
+
+        IcebergCommitQueueManager dynamicManager =
+                new IcebergCommitQueueManager(() -> new IcebergCommitQueueManager.Config(
+                        enabledFlag.get() == 1,
+                        timeoutFlag.get(),
+                        100  // max queue size
+                ));
+
+        try {
+            // Initially enabled - commit should go through queue
+            CountDownLatch commitStarted = new CountDownLatch(1);
+            CountDownLatch proceedCommit = new CountDownLatch(1);
+
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            executor.submit(() -> {
+                dynamicManager.submitCommit("catalog", "db", "table", () -> {
+                    commitStarted.countDown();
+                    try {
+                        proceedCommit.await(5, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+            });
+
+            // Wait for commit to start
+            assertTrue(commitStarted.await(5, TimeUnit.SECONDS));
+            assertTrue(dynamicManager.isEnabled());
+
+            // Now disable the queue
+            enabledFlag.set(0);
+
+            // Commit should execute directly (not queued) since queue is disabled
+            AtomicInteger counter = new AtomicInteger(0);
+            dynamicManager.submitCommit("catalog", "db", "table2", () -> {
+                counter.incrementAndGet();
+            });
+
+            // This commit should complete immediately since queue is disabled
+            assertEquals(1, counter.get());
+            assertFalse(dynamicManager.isEnabled());
+
+            // Re-enable the queue
+            enabledFlag.set(1);
+            assertTrue(dynamicManager.isEnabled());
+
+            proceedCommit.countDown();
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+        } finally {
+            dynamicManager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testSharedCommitQueueManagerAcrossMetadataInstances() throws Exception {
+        // Test that multiple IcebergMetadata instances sharing the same commitQueueManager
+        // properly serialize commits to the same table (simulating multiple queries)
+        IcebergCommitQueueManager sharedManager = new IcebergCommitQueueManager(
+                new IcebergCommitQueueManager.Config(true, 120, 100));
+
+        try {
+            AtomicInteger commitOrder = new AtomicInteger(0);
+            List<String> executionOrder = new ArrayList<>();
+            CountDownLatch firstCommitStarted = new CountDownLatch(1);
+            CountDownLatch firstCommitBlocking = new CountDownLatch(1);
+            CountDownLatch secondCommitStarted = new CountDownLatch(1);
+            CountDownLatch thirdCommitStarted = new CountDownLatch(1);
+
+            ExecutorService executor = Executors.newFixedThreadPool(3);
+
+            // Simulate Query 1: First commit that will block
+            executor.submit(() -> {
+                // Simulate creating an IcebergMetadata instance with the shared manager
+                sharedManager.submitCommit("catalog", "db", "table", () -> {
+                    executionOrder.add("query1-commit1");
+                    firstCommitStarted.countDown();
+                    try {
+                        firstCommitBlocking.await(3, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    commitOrder.incrementAndGet();
+                });
+            });
+
+            // Wait for first commit to start
+            assertTrue(firstCommitStarted.await(5, TimeUnit.SECONDS));
+
+            // Simulate Query 2: Submit a commit while first is blocking
+            executor.submit(() -> {
+                secondCommitStarted.countDown();
+                sharedManager.submitCommit("catalog", "db", "table", () -> {
+                    executionOrder.add("query2-commit1");
+                    commitOrder.incrementAndGet();
+                });
+            });
+
+            // Simulate Query 3: Another commit to the same table
+            executor.submit(() -> {
+                thirdCommitStarted.countDown();
+                sharedManager.submitCommit("catalog", "db", "table", () -> {
+                    executionOrder.add("query3-commit1");
+                    commitOrder.incrementAndGet();
+                });
+            });
+
+            // Verify second and third commits are queued (not started yet)
+            assertTrue(secondCommitStarted.await(1, TimeUnit.SECONDS));
+            assertTrue(thirdCommitStarted.await(1, TimeUnit.SECONDS));
+            assertEquals(1, executionOrder.size()); // Only first commit executed
+
+            // Release first commit
+            firstCommitBlocking.countDown();
+
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+
+            // All commits should complete in order
+            assertEquals(3, commitOrder.get());
+            assertEquals(3, executionOrder.size());
+            assertEquals("query1-commit1", executionOrder.get(0));
+            assertEquals("query2-commit1", executionOrder.get(1));
+            assertEquals("query3-commit1", executionOrder.get(2));
+        } finally {
+            sharedManager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testConcurrentQueriesWithSharedManager() throws Exception {
+        // Test that multiple "queries" (threads) using the same shared manager
+        // properly serialize commits to the same table
+        IcebergCommitQueueManager sharedManager = new IcebergCommitQueueManager(
+                new IcebergCommitQueueManager.Config(true, 120, 100));
+
+        try {
+            int numQueries = 10;
+            int commitsPerQuery = 5;
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch endLatch = new CountDownLatch(numQueries * commitsPerQuery);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger counter = new AtomicInteger(0);
+            List<Exception> exceptions = new ArrayList<>();
+
+            ExecutorService executor = Executors.newFixedThreadPool(numQueries);
+
+            for (int query = 0; query < numQueries; query++) {
+                final int queryId = query;
+
+                for (int commit = 0; commit < commitsPerQuery; commit++) {
+                    executor.submit(() -> {
+                        try {
+                            startLatch.await(); // Wait for all threads to be ready
+
+                            // Simulate a query submitting commits
+                            sharedManager.submitCommit("catalog", "db", "shared_table", () -> {
+                                // Simulate some work
+                                Thread.sleep(20);
+                                counter.incrementAndGet();
+                            });
+
+                            successCount.incrementAndGet();
+                        } catch (Exception e) {
+                            exceptions.add(e);
+                        } finally {
+                            endLatch.countDown();
+                        }
+                    });
+                }
+            }
+
+            // Start all threads at once
+            startLatch.countDown();
+
+            // Wait for all threads to complete
+            assertTrue(endLatch.await(60, TimeUnit.SECONDS));
+            executor.shutdown();
+
+            // All commits should succeed and execute in order
+            assertEquals(numQueries * commitsPerQuery, successCount.get());
+            assertEquals(numQueries * commitsPerQuery, counter.get());
+            assertTrue(exceptions.isEmpty(), "There should be no exceptions: " + exceptions);
+        } finally {
+            sharedManager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testIdleExecutorCleanup() throws Exception {
+        // Test that idle executors are automatically evicted from the cache
+        // Note: This test uses a very short idle timeout for testing purposes
+        // In production, the timeout is 1 hour
+        IcebergCommitQueueManager.Config shortIdleConfig =
+                new IcebergCommitQueueManager.Config(true, 120, 100);
+        IcebergCommitQueueManager shortIdleManager =
+                new IcebergCommitQueueManager(shortIdleConfig);
+
+        try {
+            // Create executors for multiple tables
+            shortIdleManager.submitCommit("catalog", "db", "table1", () -> {});
+            shortIdleManager.submitCommit("catalog", "db", "table2", () -> {});
+            shortIdleManager.submitCommit("catalog", "db", "table3", () -> {});
+
+            // All three executors should be active
+            assertEquals(3, shortIdleManager.getActiveTableCount());
+
+            // Note: Guava Cache's expireAfterAccess cleanup is done during:
+            // 1. Manual cache operations (get, put)
+            // 2. Periodic maintenance (not guaranteed to be immediate)
+            //
+            // In this test, we verify the structure is in place. The actual eviction
+            // happens asynchronously by Guava Cache based on the expireAfterAccess setting.
+
+            // To trigger cleanup, we can perform a cache operation
+            // The cache size will be updated during the next maintenance cycle
+
+            // Verify the structure exists and can be used
+            shortIdleManager.submitCommit("catalog", "db", "table1", () -> {});
+
+            // The cache structure is working correctly
+            assertTrue(shortIdleManager.getActiveTableCount() >= 1);
+        } finally {
+            shortIdleManager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testMultipleCatalogsWithSharedManagers() throws Exception {
+        // Test that different catalogs can have independent commit queues
+        IcebergCommitQueueManager catalogA = new IcebergCommitQueueManager(
+                new IcebergCommitQueueManager.Config(true, 120, 100));
+        IcebergCommitQueueManager catalogB = new IcebergCommitQueueManager(
+                new IcebergCommitQueueManager.Config(true, 120, 100));
+
+        try {
+            CountDownLatch catalogALatch = new CountDownLatch(1);
+            CountDownLatch catalogBLatch = new CountDownLatch(1);
+            CountDownLatch bothStarted = new CountDownLatch(2);
+
+            ExecutorService executor = Executors.newFixedThreadPool(2);
+
+            // Commit to catalog A
+            executor.submit(() -> {
+                catalogA.submitCommit("catalogA", "db", "table", () -> {
+                    bothStarted.countDown();
+                    try {
+                        catalogALatch.await(2, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+            });
+
+            // Commit to catalog B
+            executor.submit(() -> {
+                catalogB.submitCommit("catalogB", "db", "table", () -> {
+                    bothStarted.countDown();
+                    try {
+                        catalogBLatch.await(2, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+            });
+
+            // Both commits should execute in parallel (different catalogs)
+            assertTrue(bothStarted.await(5, TimeUnit.SECONDS));
+
+            catalogALatch.countDown();
+            catalogBLatch.countDown();
+
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        } finally {
+            catalogA.shutdownAll();
+            catalogB.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testCommitQueueManagerWithSupplier() throws Exception {
+        // Test that commitQueueManager correctly uses a supplier for dynamic config
+        AtomicInteger enabledFlag = new AtomicInteger(1);
+
+        IcebergCommitQueueManager supplierManager = new IcebergCommitQueueManager(
+                () -> new IcebergCommitQueueManager.Config(
+                        enabledFlag.get() == 1,
+                        10,  // timeout
+                        100   // max queue size
+                ));
+
+        try {
+            assertTrue(supplierManager.isEnabled());
+
+            // Disable the queue
+            enabledFlag.set(0);
+            assertFalse(supplierManager.isEnabled());
+
+            // Commits should execute directly when disabled
+            AtomicInteger counter = new AtomicInteger(0);
+            supplierManager.submitCommit("catalog", "db", "table", () -> {
+                counter.incrementAndGet();
+            });
+
+            assertEquals(1, counter.get());
+        } finally {
+            supplierManager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testBlockPolicyWithMaxWaitTime() throws Exception {
+        // Test that BlockWhenQueueFullPolicy has a maximum wait time
+        // Create a manager with minimum queue size
+        IcebergCommitQueueManager.Config smallQueueConfig =
+                new IcebergCommitQueueManager.Config(true, 120, 10);  // minimum valid queue size
+        IcebergCommitQueueManager smallQueueManager =
+                new IcebergCommitQueueManager(smallQueueConfig);
+
+        try {
+            CountDownLatch taskRunning = new CountDownLatch(1);
+            CountDownLatch proceedWithFirst = new CountDownLatch(1);
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+
+            // Submit first task that will occupy the worker thread
+            Future<IcebergCommitQueueManager.CommitResult> firstFuture = executor.submit(() ->
+                    smallQueueManager.submitCommit("catalog", "db", "table", () -> {
+                        taskRunning.countDown();
+                        try {
+                            // Block for longer than MAX_WAIT_SECONDS (60s)
+                            proceedWithFirst.await(120, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }));
+
+            // Wait for first task to start running
+            assertTrue(taskRunning.await(5, TimeUnit.SECONDS));
+
+            // Submit second task - worker is occupied, this task will be queued
+            // With BlockWhenQueueFullPolicy, it waits for queue capacity
+            CountDownLatch secondTaskStarted = new CountDownLatch(1);
+            Thread secondThread = new Thread(() -> {
+                secondTaskStarted.countDown();
+                IcebergCommitQueueManager.CommitResult result =
+                        smallQueueManager.submitCommit("catalog", "db", "table", () -> {
+                            // This should execute after first task completes
+                        });
+                // Should succeed after waiting (not exceed max wait time in this test)
+                assertTrue(result.isSuccess(), "Second task should succeed");
+            });
+            secondThread.start();
+
+            assertTrue(secondTaskStarted.await(5, TimeUnit.SECONDS));
+
+            // Wait a short time to ensure second task is waiting for queue capacity
+            Thread.sleep(1000);
+
+            // Release the first task - second task should proceed
+            proceedWithFirst.countDown();
+
+            // Wait for both tasks to complete
+            firstFuture.get(10, TimeUnit.SECONDS);
+            secondThread.join(10000);
+            executor.shutdown();
+
+        } finally {
+            smallQueueManager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testCommitWithExceptionInTask() {
+        // Test that exceptions during commit execution are properly captured
+        IcebergCommitQueueManager.Config config =
+                new IcebergCommitQueueManager.Config(true, 120, 10);
+        IcebergCommitQueueManager queueManager =
+                new IcebergCommitQueueManager(config);
+
+        try {
+            RuntimeException expectedException = new RuntimeException("Expected test exception");
+
+            IcebergCommitQueueManager.CommitResult result =
+                    queueManager.submitCommit("catalog", "db", "table", () -> {
+                        throw expectedException;
+                    });
+
+            assertFalse(result.isSuccess());
+            assertTrue(result.getError() instanceof RuntimeException);
+            assertEquals("Expected test exception", result.getError().getMessage());
+        } finally {
+            queueManager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testCommitResultRethrowIfFailed() {
+        // Test successful commit rethrow
+        IcebergCommitQueueManager.CommitResult successResult =
+                IcebergCommitQueueManager.CommitResult.success();
+        assertDoesNotThrow(successResult::rethrowIfFailed);
+
+        // Test failed commit rethrow with RuntimeException
+        RuntimeException runtimeException = new RuntimeException("Test error");
+        IcebergCommitQueueManager.CommitResult runtimeFailureResult =
+                IcebergCommitQueueManager.CommitResult.failure(runtimeException);
+        Exception exception = assertThrows(RuntimeException.class, runtimeFailureResult::rethrowIfFailed);
+        assertEquals("Test error", exception.getMessage());
+        assertSame(runtimeException, exception, "Should rethrow same RuntimeException instance");
+
+        // Test failed commit rethrow with Error type (should be rethrown as-is, not wrapped)
+        InternalError internalError = new InternalError("Test internal error");
+        IcebergCommitQueueManager.CommitResult errorFailureResult =
+                IcebergCommitQueueManager.CommitResult.failure(internalError);
+        Error thrownError = assertThrows(Error.class, errorFailureResult::rethrowIfFailed);
+        assertEquals("Test internal error", thrownError.getMessage());
+        assertSame(internalError, thrownError, "Should rethrow same Error instance");
+
+        // Test failed commit rethrow with checked exception
+        InterruptedException checkedException = new InterruptedException("Test interrupt");
+        IcebergCommitQueueManager.CommitResult checkedFailureResult =
+                IcebergCommitQueueManager.CommitResult.failure(checkedException);
+        Exception wrappedException = assertThrows(RuntimeException.class, checkedFailureResult::rethrowIfFailed);
+        assertEquals(checkedException, wrappedException.getCause());
+
+        // Test failed commit with null error should not throw
+        IcebergCommitQueueManager.CommitResult nullErrorResult =
+                IcebergCommitQueueManager.CommitResult.failure(null);
+        assertDoesNotThrow(nullErrorResult::rethrowIfFailed);
+    }
+
+    @Test
+    public void testSubmitCommitWithThreadInterrupted() {
+        // Test that interrupted thread returns failure
+        IcebergCommitQueueManager.Config config =
+                new IcebergCommitQueueManager.Config(true, 120, 10);
+        IcebergCommitQueueManager queueManager =
+                new IcebergCommitQueueManager(config);
+
+        try {
+            // Interrupt the current thread
+            Thread.currentThread().interrupt();
+
+            IcebergCommitQueueManager.CommitResult result =
+                    queueManager.submitCommit("catalog", "db", "table", () -> {});
+
+            assertFalse(result.isSuccess());
+            assertTrue(result.getError() instanceof InterruptedException);
+
+            // Clear interrupt status
+            assertTrue(Thread.interrupted());
+        } finally {
+            queueManager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testSubmitCommitWithExecutionException() {
+        // Test that exceptions during commit execution are properly wrapped
+        IcebergCommitQueueManager.Config config =
+                new IcebergCommitQueueManager.Config(true, 120, 10);
+        IcebergCommitQueueManager queueManager =
+                new IcebergCommitQueueManager(config);
+
+        try {
+            RuntimeException expectedException = new RuntimeException("Expected test exception");
+
+            IcebergCommitQueueManager.CommitResult result =
+                    queueManager.submitCommit("catalog", "db", "table", () -> {
+                        throw expectedException;
+                    });
+
+            assertFalse(result.isSuccess());
+            assertTrue(result.getError() instanceof RuntimeException);
+            assertEquals("Expected test exception", result.getError().getMessage());
+        } finally {
+            queueManager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testTableCommitKeyEqualsAndHashCode() {
+        // Test equals method
+        IcebergCommitQueueManager.TableCommitKey key1 =
+                new IcebergCommitQueueManager.TableCommitKey("catalog", "db", "table");
+        IcebergCommitQueueManager.TableCommitKey key2 =
+                new IcebergCommitQueueManager.TableCommitKey("catalog", "db", "table");
+        IcebergCommitQueueManager.TableCommitKey key3 =
+                new IcebergCommitQueueManager.TableCommitKey("catalog", "db", "table2");
+        IcebergCommitQueueManager.TableCommitKey key4 =
+                new IcebergCommitQueueManager.TableCommitKey("catalog", "db2", "table");
+        IcebergCommitQueueManager.TableCommitKey key5 =
+                new IcebergCommitQueueManager.TableCommitKey("catalog2", "db", "table");
+
+        // Reflexive
+        assertEquals(key1, key1);
+
+        // Symmetric
+        assertEquals(key1, key2);
+        assertEquals(key2, key1);
+
+        // Transitive
+        assertEquals(key1, key2);
+        assertEquals(key2, key1);
+
+        // Consistent
+        assertEquals(key1, key2);
+        assertEquals(key1.hashCode(), key2.hashCode());
+
+        // Not equal
+        assertNotEquals(key1, key3);
+        assertNotEquals(key1, key4);
+        assertNotEquals(key1, key5);
+
+        // Equal objects have equal hash codes
+        assertEquals(key1.hashCode(), key2.hashCode());
+        assertNotEquals(key1.hashCode(), key3.hashCode());
+    }
+
+    @Test
+    public void testTableCommitKeyToString() {
+        IcebergCommitQueueManager.TableCommitKey key =
+                new IcebergCommitQueueManager.TableCommitKey("my_catalog", "my_db", "my_table");
+        String result = key.toString();
+        assertEquals("my_catalog.my_db.my_table", result);
+    }
+
+    @Test
+    public void testTableCommitKeyNullChecks() {
+        assertThrows(NullPointerException.class, () ->
+                new IcebergCommitQueueManager.TableCommitKey(null, "db", "table"));
+        assertThrows(NullPointerException.class, () ->
+                new IcebergCommitQueueManager.TableCommitKey("catalog", null, "table"));
+        assertThrows(NullPointerException.class, () ->
+                new IcebergCommitQueueManager.TableCommitKey("catalog", "db", null));
+    }
+
+    @Test
+    public void testConfigGetterMethods() {
+        IcebergCommitQueueManager.Config config =
+                new IcebergCommitQueueManager.Config(true, 150, 50);
+
+        assertTrue(config.isEnabled());
+        assertEquals(150, config.getTimeoutSeconds());
+        assertEquals(50, config.getMaxQueueSize());
+    }
+
+    @Test
+    public void testCommitResultErrorAccessors() {
+        // Test success result
+        IcebergCommitQueueManager.CommitResult successResult =
+                IcebergCommitQueueManager.CommitResult.success();
+        assertTrue(successResult.isSuccess());
+        assertNull(successResult.getError());
+
+        // Test failure result
+        Exception testException = new Exception("Test");
+        IcebergCommitQueueManager.CommitResult failureResult =
+                IcebergCommitQueueManager.CommitResult.failure(testException);
+        assertFalse(failureResult.isSuccess());
+        assertEquals(testException, failureResult.getError());
+    }
+
+    @Test
+    public void testShutdownTableExecutorIdempotent() {
+        // Test that shutdownTableExecutor is idempotent
+        IcebergCommitQueueManager.Config config =
+                new IcebergCommitQueueManager.Config(true, 120, 10);
+        IcebergCommitQueueManager queueManager =
+                new IcebergCommitQueueManager(config);
+
+        try {
+            // Submit a task to create the executor
+            queueManager.submitCommit("catalog", "db", "table", () -> {});
+
+            // Shutdown multiple times - should not throw
+            queueManager.shutdownTableExecutor("catalog", "db", "table");
+            queueManager.shutdownTableExecutor("catalog", "db", "table");
+            queueManager.shutdownTableExecutor("catalog", "db", "table");
+
+            // Should be able to submit again (new executor created)
+            IcebergCommitQueueManager.CommitResult result =
+                    queueManager.submitCommit("catalog", "db", "table", () -> {});
+            assertTrue(result.isSuccess());
+        } finally {
+            queueManager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testShutdownDatabaseExecutorsWithMultipleTables() {
+        // Test shutdownDatabaseExecutors shuts down all tables in a database
+        IcebergCommitQueueManager.Config config =
+                new IcebergCommitQueueManager.Config(true, 120, 10);
+        IcebergCommitQueueManager queueManager =
+                new IcebergCommitQueueManager(config);
+
+        try {
+            // Create executors for multiple tables in the same database
+            queueManager.submitCommit("catalog", "db", "table1", () -> {});
+            queueManager.submitCommit("catalog", "db", "table2", () -> {});
+            queueManager.submitCommit("catalog", "db", "table3", () -> {});
+
+            // Create executor for different database
+            queueManager.submitCommit("catalog", "db2", "table1", () -> {});
+
+            assertEquals(4, queueManager.getActiveTableCount());
+
+            // Shutdown all executors for 'db' database
+            queueManager.shutdownDatabaseExecutors("catalog", "db");
+
+            // Only db2.table1 should remain
+            assertEquals(1, queueManager.getActiveTableCount());
+
+            // Verify we can still submit to db2
+            IcebergCommitQueueManager.CommitResult result =
+                    queueManager.submitCommit("catalog", "db2", "table1", () -> {});
+            assertTrue(result.isSuccess());
+        } finally {
+            queueManager.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testConfigWithMinimumValues() {
+        // Test with minimum queue size
+        IcebergCommitQueueManager.Config config =
+                new IcebergCommitQueueManager.Config(true, 120, 9);
+
+        assertEquals(IcebergCommitQueueManager.Config.getMinQueueSize(),
+                     config.getMaxQueueSize());
+    }
+
+    @Test
+    public void testBlockWhenQueueFullPolicyInterrupted() throws Exception {
+        // Test that BlockWhenQueueFullPolicy handles interruption correctly
+        IcebergCommitQueueManager.Config smallQueueConfig =
+                new IcebergCommitQueueManager.Config(true, 120, 10);
+        IcebergCommitQueueManager queueManager =
+                new IcebergCommitQueueManager(smallQueueConfig);
+
+        try {
+            CountDownLatch taskRunning = new CountDownLatch(1);
+            CountDownLatch proceedWithFirst = new CountDownLatch(1);
+            Thread submitThread = Thread.currentThread();
+
+            // Submit first task that blocks and occupies the worker thread
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            executor.submit(() -> {
+                queueManager.submitCommit("catalog", "db", "table", () -> {
+                    taskRunning.countDown();
+                    try {
+                        proceedWithFirst.await(10, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+            });
+
+            // Wait for first task to start
+            assertTrue(taskRunning.await(5, TimeUnit.SECONDS));
+
+            // Fill the queue with tasks
+            for (int i = 0; i < 10; i++) {
+                queueManager.submitCommit("catalog", "db", "table", () -> {});
+            }
+
+            // Now interrupt the thread that will try to submit (in a separate thread)
+            CountDownLatch submissionStarted = new CountDownLatch(1);
+            CountDownLatch submissionComplete = new CountDownLatch(1);
+            AtomicBoolean succeeded = new AtomicBoolean(false);
+
+            Thread interruptingThread = new Thread(() -> {
+                submissionStarted.countDown();
+                try {
+                    // This should block in offer(), then be interrupted
+                    queueManager.submitCommit("catalog", "db", "table", () -> {});
+                    succeeded.set(true);
+                } finally {
+                    submissionComplete.countDown();
+                }
+            });
+
+            interruptingThread.start();
+            assertTrue(submissionStarted.await(5, TimeUnit.SECONDS));
+
+            // Interrupt the thread while it's waiting in offer()
+            interruptingThread.interrupt();
+
+            // The submission should complete (with failure)
+            assertTrue(submissionComplete.await(5, TimeUnit.SECONDS));
+
+            proceedWithFirst.countDown();
+            executor.shutdown();
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+        } finally {
+            queueManager.shutdownAll();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -51,6 +51,7 @@ import com.starrocks.connector.RemoteMetaSplit;
 import com.starrocks.connector.SerializedMetaSpec;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
+import com.starrocks.connector.iceberg.procedure.IcebergProcedureRegistry;
 import com.starrocks.connector.iceberg.procedure.RemoveOrphanFilesProcedure;
 import com.starrocks.connector.metadata.MetadataCollectJob;
 import com.starrocks.connector.metadata.MetadataTableType;
@@ -162,7 +163,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.starrocks.catalog.Table.TableType.ICEBERG;
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ENABLE_DISTRIBUTED_PLAN_LOAD_DATA_FILE_COLUMN_STATISTICS_WITH_EQ_DELETE;
@@ -178,7 +183,9 @@ import static com.starrocks.type.IntegerType.INT;
 import static com.starrocks.type.StringType.STRING;
 import static com.starrocks.type.VarcharType.VARCHAR;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IcebergMetadataTest extends TableTestBase {
     private static final String CATALOG_NAME = "iceberg_catalog";
@@ -939,9 +946,10 @@ public class IcebergMetadataTest extends TableTestBase {
         tSinkCommitInfo.setIs_overwrite(false);
         tSinkCommitInfo.setIceberg_data_file(tIcebergDataFile);
 
-        ExceptionChecker.expectThrowsWithMsg(InternalError.class,
-                "Invalid partition and fingerprint size",
+        // Error types are preserved and rethrown directly (not wrapped) by commit queue
+        Error error = Assertions.assertThrows(InternalError.class,
                 () -> metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(tSinkCommitInfo), null));
+        Assertions.assertTrue(error.getMessage().contains("Invalid partition and fingerprint size"));
 
     }
 
@@ -2382,5 +2390,195 @@ public class IcebergMetadataTest extends TableTestBase {
         mockedNativeTableA.refresh();
         List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTableA.newScan().planFiles());
         Assertions.assertFalse(fileScanTasks.isEmpty());
+    }
+
+    @Test
+    public void testConcurrentFinishSinkWithCommitQueue() throws Exception {
+        // Test that concurrent commits to the same table are serialized by the commit queue
+        // This test verifies that the commit queue integration in IcebergMetadata is working correctly
+
+        // Save original config values
+        boolean originalEnableQueue = Config.enable_iceberg_commit_queue;
+        int originalTimeout = Config.iceberg_commit_queue_timeout_seconds;
+
+        try {
+            // Enable commit queue with short timeout for testing
+            Config.enable_iceberg_commit_queue = true;
+            Config.iceberg_commit_queue_timeout_seconds = 30;
+
+            IcebergHiveCatalog icebergHiveCatalog =
+                    new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+            IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                    Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+            IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                    "iceberg_table", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+
+            new Expectations(metadata) {
+                {
+                    metadata.getTable((ConnectContext) any, anyString, anyString);
+                    result = icebergTable;
+                    minTimes = 0;
+                }
+            };
+
+            // Prepare test data - append file to table
+            mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+            mockedNativeTableA.refresh();
+
+            int numThreads = 5;
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch endLatch = new CountDownLatch(numThreads);
+            AtomicInteger successCount = new AtomicInteger(0);
+            List<Exception> exceptions = new ArrayList<>();
+
+            ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+
+            // Submit multiple concurrent commits to the same table
+            for (int i = 0; i < numThreads; i++) {
+                final int threadId = i;
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+
+                        // Create commit info for this thread
+                        TIcebergDataFile dataFile = new TIcebergDataFile();
+                        dataFile.setPath(FILE_A.path().toString() + "_thread_" + threadId);
+                        dataFile.setFormat("parquet");
+                        dataFile.setRecord_count(10);
+                        dataFile.setFile_size_in_bytes(1024);
+                        dataFile.setPartition_path(mockedNativeTableA.location() + "/data/data_bucket=0/");
+
+                        TSinkCommitInfo commitInfo = new TSinkCommitInfo();
+                        commitInfo.setIceberg_data_file(dataFile);
+
+                        // This should be serialized by the commit queue
+                        metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(commitInfo), null);
+
+                        successCount.incrementAndGet();
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    } finally {
+                        endLatch.countDown();
+                    }
+                });
+            }
+
+            // Start all threads
+            startLatch.countDown();
+
+            // Wait for all commits to complete
+            assertTrue(endLatch.await(60, TimeUnit.SECONDS),
+                    "All commits should complete within timeout");
+            executor.shutdown();
+
+            // Verify all commits succeeded
+            assertEquals(numThreads, successCount.get(),
+                    "All commits should succeed when using commit queue");
+            assertTrue(exceptions.isEmpty(),
+                    "There should be no exceptions: " + exceptions);
+
+        } finally {
+            // Restore original config values
+            Config.enable_iceberg_commit_queue = originalEnableQueue;
+            Config.iceberg_commit_queue_timeout_seconds = originalTimeout;
+        }
+    }
+
+    @Test
+    public void testFinishSinkWithCommitQueueDisabled() throws Exception {
+        // Test that commits work when commit queue is disabled
+
+        // Save original config values
+        boolean originalEnableQueue = Config.enable_iceberg_commit_queue;
+
+        try {
+            // Disable commit queue
+            Config.enable_iceberg_commit_queue = false;
+
+            IcebergHiveCatalog icebergHiveCatalog =
+                    new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+            IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                    Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+            IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                    "iceberg_table", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+
+            new Expectations(metadata) {
+                {
+                    metadata.getTable((ConnectContext) any, anyString, anyString);
+                    result = icebergTable;
+                    minTimes = 0;
+                }
+            };
+
+            // Prepare test data
+            mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+
+            // Create commit info
+            TIcebergDataFile dataFile = new TIcebergDataFile();
+            dataFile.setPath(FILE_A.path().toString());
+            dataFile.setFormat("parquet");
+            dataFile.setRecord_count(10);
+            dataFile.setFile_size_in_bytes(1024);
+            dataFile.setPartition_path(mockedNativeTableA.location() + "/data/data_bucket=0/");
+
+            TSinkCommitInfo commitInfo = new TSinkCommitInfo();
+            commitInfo.setIceberg_data_file(dataFile);
+
+            // Commit should succeed even when queue is disabled
+            metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(commitInfo), null);
+
+            // Verify commit succeeded
+            mockedNativeTableA.refresh();
+            List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTableA.newScan().planFiles());
+            Assertions.assertFalse(fileScanTasks.isEmpty());
+
+        } finally {
+            // Restore original config values
+            Config.enable_iceberg_commit_queue = originalEnableQueue;
+        }
+    }
+
+    @Test
+    public void testFinishSinkNormalizesCaseForHiveCatalogCommitQueue() throws Exception {
+        IcebergCommitQueueManager.Config config = new IcebergCommitQueueManager.Config(true, 30, 100);
+        IcebergCommitQueueManager manager = new IcebergCommitQueueManager(config);
+        try {
+            IcebergHiveCatalog icebergHiveCatalog =
+                    new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+            IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                    Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null,
+                    new ConnectorProperties(ConnectorType.ICEBERG), new IcebergProcedureRegistry(), manager);
+            IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                    "iceberg_table", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+
+            new Expectations(metadata) {
+                {
+                    metadata.getTable((ConnectContext) any, anyString, anyString);
+                    result = icebergTable;
+                    minTimes = 0;
+                }
+            };
+
+            // Prepare test data
+            mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+
+            TIcebergDataFile dataFile = new TIcebergDataFile();
+            dataFile.setPath(FILE_A.path().toString());
+            dataFile.setFormat("parquet");
+            dataFile.setRecord_count(10);
+            dataFile.setFile_size_in_bytes(1024);
+            dataFile.setPartition_path(mockedNativeTableA.location() + "/data/data_bucket=0/");
+
+            TSinkCommitInfo commitInfo = new TSinkCommitInfo();
+            commitInfo.setIceberg_data_file(dataFile);
+
+            metadata.finishSink("Iceberg_DB", "Iceberg_Table", Lists.newArrayList(commitInfo), null);
+            metadata.finishSink("ICEBERG_DB", "ICEBERG_TABLE", Lists.newArrayList(commitInfo), null);
+
+            assertEquals(1, manager.getActiveTableCount(),
+                    "Commit queue key should be normalized for Hive catalog");
+        } finally {
+            manager.shutdownAll();
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Apache Iceberg uses optimistic concurrency control (OCC) for metadata commits. When multiple threads attempt to commit to the same table concurrently, conflicts occur:

  Thread A: read metadata V1 → write data → attempt to commit with V1
  Thread B: read metadata V1 → write data → commit successfully (metadata now V2)
  Thread A: attempt to commit with V1 → FAILS (current metadata is V2, not V1)

  In StarRocks, high-concurrency workloads (e.g., multiple INSERT INTO jobs writing to the same Iceberg table) frequently encounter this scenario, leading to:
  - Commit failures requiring retry
  - Wasted CPU and I/O resources
  - Unpredictable job completion times
  - Potential data ingestion pipeline stalls

## What I'm doing:

This pull request introduces a commit queue mechanism for Iceberg tables to address optimistic concurrency control (OCC) commit conflicts. It adds new system-level configuration options, implements a thread-safe manager to serialize commit operations per table, and updates the `IcebergMetadata` logic to utilize the commit queue. Additionally, it includes supporting changes in unit tests and configuration. These changes collectively improve the reliability of concurrent Iceberg table commits in StarRocks.

**Iceberg Commit Queue Implementation and Integration**

*Commit Queue Core Logic:*
- Introduced the new `IcebergCommitQueueManager` class, which manages a single-threaded executor per Iceberg table to serialize commits and prevent OCC conflicts. The manager supports configurable enablement, commit timeout, and queue size. It provides methods for submitting commit tasks and shutting down executors.

*Configuration Enhancements:*
- Added three new configuration options to `Config.java`:
  - `enable_iceberg_commit_queue` (default: true) to enable/disable the commit queue,
  - `iceberg_commit_queue_timeout_seconds` (default: 300) to set commit operation timeout,
  - `iceberg_commit_queue_max_size` (default: 1000) to limit pending commits per table.

*Integration with Iceberg Metadata:*
- Updated `IcebergMetadata` to instantiate and use `IcebergCommitQueueManager` with the configured options. All commit operations in `finishSink` are now routed through the commit queue to guarantee serialization per table and avoid OCC errors. 

*Document:*
- Added related documents for the new configurations.

*Testing Support:*
- Added new imports and utilities in `IcebergMetadataTest.java` to facilitate concurrent commit testing and assertion of commit queue behavior.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4