### PR TITLE
[BugFix] Fix duplicate key error when rebuilding primary index during lake replication (backport #67737)

### DIFF
--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -295,6 +295,10 @@ public:
     }
 
     Status finish() override {
+        if (_is_lake_replication) {
+            return finalize_lake_replication();
+        }
+
         SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(true);
         SCOPED_THREAD_LOCAL_SINGLETON_CHECK_MEM_TRACKER_SETTER(
                 config::enable_pk_strict_memcheck ? _tablet.update_mgr()->mem_tracker() : nullptr);
@@ -366,6 +370,20 @@ private:
             ASSIGN_OR_RETURN(_index_entry, _tablet.update_mgr()->prepare_primary_index(
                                                    _metadata, &_builder, _base_version, _new_version, _guard));
         }
+        return Status::OK();
+    }
+
+    Status finalize_lake_replication() {
+        // For lake pk replication transactions, we don't need to handle primary index or delvec operations.
+        // This is because the tablet metadata is directly copied from the source cluster's table
+        _metadata->GetReflection()->MutableUnknownFields(_metadata.get())->Clear();
+        _metadata->set_version(_new_version);
+        if (_skip_write_tablet_metadata) {
+            return ExecEnv::GetInstance()->lake_tablet_manager()->cache_tablet_metadata(_metadata);
+        }
+        // Persist the tablet metadata
+        RETURN_IF_ERROR(_tablet.put_metadata(_metadata));
+        _has_finalized = true;
         return Status::OK();
     }
 
@@ -575,6 +593,9 @@ private:
 
                 _tablet.update_mgr()->unload_primary_index(_tablet.id());
 
+                // Mark this as a lake replication transaction
+                _is_lake_replication = true;
+
                 VLOG(3) << "Apply pk replication log with tablet metadata provided. tablet_id: " << _tablet.id()
                         << ", base_version: " << _base_version << ", new_version: " << _new_version
                         << ", txn_id: " << txn_meta.txn_id() << ", metadata id: " << _metadata->id()
@@ -631,6 +652,8 @@ private:
     // True when finalize meta file success.
     bool _has_finalized = false;
     bool _rebuild_pindex = false;
+    // True when the transaction is a lake replication type (has tablet_metadata in op_replication).
+    bool _is_lake_replication = false;
 };
 
 class NonPrimaryKeyTxnLogApplier : public TxnLogApplier {

--- a/be/test/storage/lake/txn_log_applier_test.cpp
+++ b/be/test/storage/lake/txn_log_applier_test.cpp
@@ -46,6 +46,24 @@ MutableTabletMetadataPtr build_pk_metadata(int64_t id) {
     return meta;
 }
 
+// Helper to build primary key metadata with LOCAL persistent index enabled.
+// This simulates the scenario where the source cluster has local persistent index enabled,
+// which would trigger prepare_primary_index() in finish() for non-replication transactions.
+MutableTabletMetadataPtr build_pk_metadata_with_local_persistent_index(int64_t id) {
+    auto meta = std::make_shared<TabletMetadata>();
+    meta->set_id(id);
+    meta->set_version(1);
+    meta->set_next_rowset_id(0);
+    auto* schema = meta->mutable_schema();
+    schema->set_id(200);
+    schema->set_keys_type(PRIMARY_KEYS);
+    // Enable local persistent index - this is the key configuration that would
+    // trigger prepare_primary_index() call in finish() method
+    meta->set_enable_persistent_index(true);
+    meta->set_persistent_index_type(PersistentIndexTypePB::LOCAL);
+    return meta;
+}
+
 // Create an op_write txn log
 std::shared_ptr<TxnLogPB> make_op_write_log(int64_t txn_id, int64_t num_rows, int64_t data_size,
                                             const std::vector<std::string>& segments) {
@@ -160,6 +178,121 @@ TEST(TxnLogApplierBatchTest, PrimaryKeyBatchRejectsLogWithoutWrite) {
     Status st = applier->apply(logs);
     EXPECT_TRUE(st.is_not_supported()) << st.to_string();
     EXPECT_EQ(0, meta->rowsets_size());
+}
+
+// Create a lake replication txn log with tablet_metadata for PK table
+// This simulates a lake-to-lake replication scenario
+std::shared_ptr<TxnLogPB> make_lake_replication_log_with_tablet_metadata(int64_t txn_id, int64_t num_rows,
+                                                                         int64_t data_size, int64_t next_rowset_id) {
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_txn_id(txn_id);
+    auto* op_replication = log->mutable_op_replication();
+
+    // Set txn_meta with TXN_REPLICATED state
+    auto* txn_meta = op_replication->mutable_txn_meta();
+    txn_meta->set_txn_id(txn_id);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_snapshot_version(2);
+    txn_meta->set_data_version(0); // data_version=0 means full snapshot
+
+    // Set tablet_metadata - this is the key field that distinguishes lake replication
+    auto* tablet_metadata = op_replication->mutable_tablet_metadata();
+    tablet_metadata->set_next_rowset_id(next_rowset_id);
+    auto* rowset = tablet_metadata->add_rowsets();
+    rowset->set_id(0);
+    rowset->set_num_rows(num_rows);
+    rowset->set_data_size(data_size);
+    rowset->add_segments("replicated_seg1");
+    rowset->add_segment_size(data_size);
+
+    return log;
+}
+
+// Test that PK table with lake replication log (has tablet_metadata) skips prepare_primary_index in finish().
+// Background: When replicating primary key tables from a source cluster with local persistent index enabled,
+// all pk index need rebuilding on the target. Before the fix, during finish() phase, if LOCAL type persistent
+// index is used, prepare_primary_index() would be called, which uses base_version to fetch delvecs from old
+// metadata. But the old metadata doesn't contain delvec info for rowsets replicated from source cluster,
+// causing duplicate key errors like:
+// "Already exist: FixedMutableIndex<20> insert found duplicate key, new(rssid=X rowid=0), old(rssid=Y rowid=Z)"
+// The fix: For lake pk table replication txns, finish() should just put or cache metadata, skipping pk index rebuild.
+TEST(TxnLogApplierBatchTest, PrimaryKeyLakeReplicationFinishSkipsPrepareIndex) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 30001);
+    // Use metadata with LOCAL persistent index enabled - this is the scenario that would
+    // trigger prepare_primary_index() in finish() for normal transactions
+    auto meta = build_pk_metadata_with_local_persistent_index(30001);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    // Create a lake replication log with tablet_metadata
+    // This sets _is_lake_replication = true in apply_replication_log()
+    auto log = make_lake_replication_log_with_tablet_metadata(50, 100, 2048, 10);
+
+    // Apply the replication log - this marks the transaction as lake replication
+    Status apply_st = applier->apply(*log);
+    EXPECT_TRUE(apply_st.ok()) << apply_st.to_string();
+
+    // Verify that the metadata was updated with the replicated rowsets
+    EXPECT_EQ(1, meta->rowsets_size());
+    EXPECT_EQ(100, meta->rowsets(0).num_rows());
+    EXPECT_EQ(2048, meta->rowsets(0).data_size());
+    EXPECT_EQ(10u, meta->next_rowset_id());
+
+    // Call finish() - this is the critical code path being tested.
+    // Before the fix, finish() would call prepare_primary_index() for LOCAL persistent index,
+    // which would fail with duplicate key error because delvec info is missing.
+    // After the fix, finish() should detect _is_lake_replication and skip prepare_primary_index(),
+    // directly writing metadata instead.
+    Status finish_st = applier->finish();
+    EXPECT_TRUE(finish_st.ok()) << finish_st.to_string();
+
+    // Verify the version was correctly updated in finish()
+    EXPECT_EQ(2, meta->version());
+}
+
+// Create a lake replication txn log WITHOUT tablet_metadata (shared-nothing cluster migration)
+std::shared_ptr<TxnLogPB> make_replication_log_without_tablet_metadata(int64_t txn_id, int64_t num_rows,
+                                                                       int64_t data_size) {
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_txn_id(txn_id);
+    auto* op_replication = log->mutable_op_replication();
+
+    // Set txn_meta with TXN_REPLICATED state
+    auto* txn_meta = op_replication->mutable_txn_meta();
+    txn_meta->set_txn_id(txn_id);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_snapshot_version(2);
+    txn_meta->set_data_version(0);
+
+    // Add op_writes instead of tablet_metadata - traditional replication path
+    auto* op_write = op_replication->add_op_writes();
+    auto* rowset = op_write->mutable_rowset();
+    rowset->set_id(0);
+    rowset->set_num_rows(num_rows);
+    rowset->set_data_size(data_size);
+    rowset->add_segments("trad_replicated_seg1");
+    rowset->add_segment_size(data_size);
+
+    return log;
+}
+
+// Test that non-PK table with lake replication log (has tablet_metadata) works correctly
+TEST(TxnLogApplierBatchTest, NonPrimaryKeyLakeReplicationApply) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 30002);
+    auto meta = build_non_pk_metadata(30002);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    // Create a lake replication log with tablet_metadata
+    auto log = make_lake_replication_log_with_tablet_metadata(60, 200, 4096, 15);
+
+    // Apply the replication log
+    Status st = applier->apply(*log);
+    EXPECT_TRUE(st.ok()) << st.to_string();
+
+    // Verify that the metadata was updated with the replicated rowsets
+    EXPECT_EQ(1, meta->rowsets_size());
+    EXPECT_EQ(200, meta->rowsets(0).num_rows());
+    EXPECT_EQ(4096, meta->rowsets(0).data_size());
+    EXPECT_EQ(15u, meta->next_rowset_id());
 }
 
 } // namespace lake


### PR DESCRIPTION
## Why I'm doing:

This is an fix for https://github.com/StarRocks/starrocks/pull/60587. While replcating primary key tables from source cluster who has local persistent index eabled, all pk index need rebuilding on the target, and an error might occure

E20251228 20:36:03.444674 139904780482304 persistent_index.cpp:3418] load index failed: tablet=1360815 rowset:78421 segment:0 reason: Already exist: FixedMutableIndex<20> insert found duplicate key, new(rssid=78421 rowid=0), old(rssid=78271 rowid=763)
The reason is that in previous implementation, at the finish phase of txn log applier, while LOCAL type persistent index is used, prepare_primary_index is called, which uses base_version to fetch delvecs from old metadata, but the old metadata doesn't contain delvec info for rowsets replicated from source cluster.

## What I'm doing:

Go back to the source, for lake pk table replication txns, the finish phase should just put or cache metadata, no need to rebuild pk index here.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

