### PR TITLE
[Enhancement] Prevent predicate columns daemon from repeatedly checking dropped db/table/column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ColumnUsage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ColumnUsage.java
@@ -140,6 +140,14 @@ public class ColumnUsage implements GsonPostProcessable {
         return this.lastUsed.isAfter(lastPersist);
     }
 
+    /**
+     * Check if the column usage record is still valid.
+     * A record becomes invalid when its corresponding database, table, or column has been dropped.
+     */
+    public boolean isValid() {
+        return getColumnFullId().toNames().isPresent();
+    }
+
     public ColumnUsage merge(ColumnUsage other) {
         Preconditions.checkArgument(other.equals(this));
         ColumnUsage merged = new ColumnUsage(this.columnId, this.tableName, EnumSet.copyOf(this.useCase));


### PR DESCRIPTION
## Why I'm doing:

When a table or database is dropped, PredicateColumnsDaemonThread would continuously emit WARN logs like:
'unable to find column: ColumnFullId{dbId=..., tableId=..., columnUniqueId=...}'

The vacuum() method only cleaned up records based on TTL, but did not remove records for dropped db/table/column. These invalid records remained in persistent storage and were repeatedly loaded during restore(), causing WARN log spam.

## What I'm doing:

Fixes #67650

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
