### PR TITLE
[Enhancement] Support user-level default warehouse for Stream Load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -68,9 +68,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
@@ -222,15 +220,6 @@ public class LoadAction extends RestBaseAction {
             BaseRequest request, BaseResponse response, String dbName, String tableName) throws DdlException {
         TableId tableId = new TableId(dbName, tableName);
         StreamLoadKvParams params = StreamLoadKvParams.fromHttpHeaders(request.getRequest().headers());
-        if (!params.getWarehouse().isPresent()) {
-            String userWarehouseName = getUserDefaultWarehouse(request);
-            if (GlobalStateMgr.getCurrentState().getWarehouseMgr().warehouseExists(userWarehouseName)) {
-                Map<String, String> newParams = new HashMap<>(params.toMap());
-                newParams.put(StreamLoadHttpHeader.HTTP_WAREHOUSE, userWarehouseName);
-                params = new StreamLoadKvParams(newParams);
-            }
-        }
-
         RequestCoordinatorBackendResult result = GlobalStateMgr.getCurrentState()
                 .getBatchWriteMgr().requestCoordinatorBackends(tableId, params);
         if (!result.isOk()) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -194,9 +194,9 @@ public class LoadAction extends RestBaseAction {
         if (request.getRequest().headers().contains(WAREHOUSE_KEY)) {
             warehouseName = request.getRequest().headers().get(WAREHOUSE_KEY);
         } else {
-            String userWarehouseName = getUserDefaultWarehouse(request);
-            if (warehouseManager.warehouseExists(userWarehouseName)) {
-                warehouseName = userWarehouseName;
+            Optional<String> userWarehouseName = getUserDefaultWarehouse(request);
+            if (userWarehouseName.isPresent() && warehouseManager.warehouseExists(userWarehouseName.get())) {
+                warehouseName = userWarehouseName.get();
             }
         }
         final CRAcquireContext acquireContext = CRAcquireContext.of(warehouseName);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -39,6 +39,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.starrocks.authentication.UserProperty;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.AuthorizationMgr;
 import com.starrocks.catalog.UserIdentity;
@@ -58,8 +59,11 @@ import com.starrocks.http.WebUtils;
 import com.starrocks.http.rest.v2.RestBaseResultV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectScheduler;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.ExecuteEnv;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TNetworkAddress;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -409,5 +413,26 @@ public class RestBaseAction extends BaseAction {
                 response,
                 status,
                 new RestBaseResultV2<>(status.code(), message));
+    }
+
+    public static String getUserDefaultWarehouse(BaseRequest request) {
+        ConnectContext ctx = request.getConnectContext();
+        if (ctx != null && ctx.getCurrentUserIdentity() != null) {
+            UserIdentity userIdentity = ctx.getCurrentUserIdentity();
+            if (!userIdentity.isEphemeral()) {
+                try {
+                    UserProperty userProperty = GlobalStateMgr.getCurrentState().getAuthenticationMgr()
+                            .getUserProperty(userIdentity.getUser());
+                    String userWarehouse = userProperty.getSessionVariables().get(SessionVariable.WAREHOUSE_NAME);
+                    if (!Strings.isNullOrEmpty(userWarehouse)) {
+                        return userWarehouse;
+                    }
+                } catch (SemanticException e) {
+                    // user does not exist, use default warehouse
+                    LOG.warn("Failed to get user property. user: {}", userIdentity.getUser(), e);
+                }
+            }
+        }
+        return WarehouseManager.DEFAULT_WAREHOUSE_NAME;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -61,7 +61,6 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectScheduler;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.system.Frontend;
@@ -415,7 +414,7 @@ public class RestBaseAction extends BaseAction {
                 new RestBaseResultV2<>(status.code(), message));
     }
 
-    public static String getUserDefaultWarehouse(BaseRequest request) {
+    public static Optional<String> getUserDefaultWarehouse(BaseRequest request) {
         ConnectContext ctx = request.getConnectContext();
         if (ctx != null && ctx.getCurrentUserIdentity() != null) {
             UserIdentity userIdentity = ctx.getCurrentUserIdentity();
@@ -425,7 +424,7 @@ public class RestBaseAction extends BaseAction {
                             .getUserProperty(userIdentity.getUser());
                     String userWarehouse = userProperty.getSessionVariables().get(SessionVariable.WAREHOUSE_NAME);
                     if (!Strings.isNullOrEmpty(userWarehouse)) {
-                        return userWarehouse;
+                        return Optional.of(userWarehouse);
                     }
                 } catch (SemanticException e) {
                     // user does not exist, use default warehouse
@@ -433,6 +432,6 @@ public class RestBaseAction extends BaseAction {
                 }
             }
         }
-        return WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+        return Optional.empty();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -333,6 +333,11 @@ public class TransactionLoadAction extends RestBaseAction {
         String warehouseName = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
         if (request.getRequest().headers().contains(WAREHOUSE_KEY)) {
             warehouseName = request.getRequest().headers().get(WAREHOUSE_KEY);
+        } else {
+            String userWarehouseName = getUserDefaultWarehouse(request);
+            if (GlobalStateMgr.getCurrentState().getWarehouseMgr().warehouseExists(userWarehouseName)) {
+                warehouseName = userWarehouseName;
+            }
         }
 
         String label = request.getRequest().headers().get(LABEL_KEY);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -334,9 +334,10 @@ public class TransactionLoadAction extends RestBaseAction {
         if (request.getRequest().headers().contains(WAREHOUSE_KEY)) {
             warehouseName = request.getRequest().headers().get(WAREHOUSE_KEY);
         } else {
-            String userWarehouseName = getUserDefaultWarehouse(request);
-            if (GlobalStateMgr.getCurrentState().getWarehouseMgr().warehouseExists(userWarehouseName)) {
-                warehouseName = userWarehouseName;
+            Optional<String> userWarehouseName = getUserDefaultWarehouse(request);
+            if (userWarehouseName.isPresent() &&
+                    GlobalStateMgr.getCurrentState().getWarehouseMgr().warehouseExists(userWarehouseName.get())) {
+                warehouseName = userWarehouseName.get();
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadKvParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadKvParams.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import static com.starrocks.http.rest.RestBaseAction.WAREHOUSE_KEY;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_ASYNC;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_INTERVAL_MS;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_PARALLEL;
@@ -59,6 +58,7 @@ import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_TIMEOUT;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_TIMEZONE;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_TRANSMISSION_COMPRESSION_TYPE;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_TRIM_SPACE;
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_WAREHOUSE;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_WHERE;
 
 /**
@@ -241,7 +241,7 @@ public class StreamLoadKvParams implements StreamLoadParams {
 
     @Override
     public Optional<String> getWarehouse() {
-        return Optional.ofNullable(params.get(WAREHOUSE_KEY));
+        return Optional.ofNullable(params.get(HTTP_WAREHOUSE));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
@@ -68,6 +68,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE;
@@ -566,8 +567,8 @@ public class LoadActionTest extends StarRocksHttpTestCase {
 
         new MockUp<LoadAction>() {
             @Mock
-            public String getUserDefaultWarehouse(BaseRequest request) {
-                return "user_wh";
+            public Optional<String> getUserDefaultWarehouse(BaseRequest request) {
+                return Optional.of("user_wh");
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
@@ -584,43 +584,4 @@ public class LoadActionTest extends StarRocksHttpTestCase {
             assertEquals(307, response.code());
         }
     }
-
-    @Test
-    public void testBatchWriteStreamLoadWarehouseSelection() throws Exception {
-        Map<String, String> map = new HashMap<>();
-        map.put(HTTP_ENABLE_BATCH_WRITE, "true");
-        // No warehouse header
-        Request request = buildRequest(map);
-        List<ComputeNode> computeNodes = new ArrayList<>();
-        computeNodes.add(new ComputeNode(1, "192.0.0.1", 9050));
-        computeNodes.get(0).setHttpPort(8040);
-
-        new MockUp<WarehouseManager>() {
-            @Mock
-            public boolean warehouseExists(String warehouseName) {
-                return "user_wh".equals(warehouseName);
-            }
-        };
-
-        new MockUp<LoadAction>() {
-            @Mock
-            public String getUserDefaultWarehouse(BaseRequest request) {
-                return "user_wh";
-            }
-        };
-
-        new MockUp<BatchWriteMgr>() {
-            @Mock
-            public RequestCoordinatorBackendResult requestCoordinatorBackends(TableId tableId, StreamLoadKvParams params) {
-                // Verify that warehouse is set in params
-                Assertions.assertTrue(params.getWarehouse().isPresent());
-                Assertions.assertEquals("user_wh", params.getWarehouse().get());
-                return new RequestCoordinatorBackendResult(new TStatus(TStatusCode.OK), computeNodes);
-            }
-        };
-
-        try (Response response = noRedirectClient.newCall(request).execute()) {
-            assertEquals(307, response.code());
-        }
-    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
@@ -15,6 +15,11 @@
 package com.starrocks.http;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.Lists;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.proc.ProcResult;
+import com.starrocks.http.rest.LoadAction;
 import com.starrocks.load.batchwrite.BatchWriteMgr;
 import com.starrocks.load.batchwrite.RequestCoordinatorBackendResult;
 import com.starrocks.load.batchwrite.TableId;
@@ -22,11 +27,18 @@ import com.starrocks.load.streamload.StreamLoadKvParams;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.warehouse.cngroup.AlterCnGroupStmt;
+import com.starrocks.sql.ast.warehouse.cngroup.CreateCnGroupStmt;
+import com.starrocks.sql.ast.warehouse.cngroup.DropCnGroupStmt;
+import com.starrocks.sql.ast.warehouse.cngroup.EnableDisableCnGroupStmt;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
+import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.cngroup.CRAcquireContext;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
@@ -417,6 +429,198 @@ public class LoadActionTest extends StarRocksHttpTestCase {
             SimpleScheduler.removeFromBlocklist(1L);
             SimpleScheduler.removeFromBlocklist(2L);
             SimpleScheduler.removeFromBlocklist(3L);
+        }
+    }
+
+    @Test
+    public void testStreamLoadWarehouseSelection() throws Exception {
+        String host = "192.0.0.1";
+        int httpPort = 8040;
+        ComputeNode node = new ComputeNode(1, host, 9050);
+        node.setHttpPort(httpPort);
+        node.setAlive(true);
+        Deencapsulation.setField(node, "status", ComputeNode.Status.OK);
+
+        ComputeResource computeResource = new ComputeResource() {
+            @Override
+            public long getWarehouseId() {
+                return 1L;
+            }
+
+            @Override
+            public long getWorkerGroupId() {
+                return 1L;
+            }
+        };
+
+        new MockUp<RunMode>() {
+            @Mock
+            boolean isSharedDataMode() {
+                return true;
+            }
+        };
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public boolean warehouseExists(String warehouseName) {
+                return true;
+            }
+
+            @Mock
+            public ComputeResource acquireComputeResource(CRAcquireContext context) {
+                return computeResource;
+            }
+
+            @Mock
+            public List<Long> getAllComputeNodeIds(ComputeResource resource) {
+                return Lists.newArrayList(1L);
+            }
+
+            @Mock
+            public Warehouse getWarehouse(String warehouseName) {
+                return new Warehouse(1L, "user_wh", "root") {
+                    @Override
+                    public long getResumeTime() {
+                        return 0L;
+                    }
+
+                    @Override
+                    public Long getAnyWorkerGroupId() {
+                        return 0L;
+                    }
+
+                    @Override
+                    public void addNodeToCNGroup(ComputeNode node, String cnGroupName) throws DdlException {
+
+                    }
+
+                    @Override
+                    public void validateRemoveNodeFromCNGroup(ComputeNode node, String cnGroupName) throws DdlException {
+
+                    }
+
+                    @Override
+                    public List<Long> getWorkerGroupIds() {
+                        return List.of();
+                    }
+
+                    @Override
+                    public List<String> getWarehouseInfo() {
+                        return List.of();
+                    }
+
+                    @Override
+                    public List<List<String>> getWarehouseNodesInfo() {
+                        return List.of();
+                    }
+
+                    @Override
+                    public ProcResult fetchResult() {
+                        return null;
+                    }
+
+                    @Override
+                    public void createCNGroup(CreateCnGroupStmt stmt) throws DdlException {
+
+                    }
+
+                    @Override
+                    public void dropCNGroup(DropCnGroupStmt stmt) throws DdlException {
+
+                    }
+
+                    @Override
+                    public void enableCNGroup(EnableDisableCnGroupStmt stmt) throws DdlException {
+
+                    }
+
+                    @Override
+                    public void disableCNGroup(EnableDisableCnGroupStmt stmt) throws DdlException {
+
+                    }
+
+                    @Override
+                    public void alterCNGroup(AlterCnGroupStmt stmt) throws DdlException {
+
+                    }
+
+                    @Override
+                    public void replayInternalOpLog(String payload) {
+
+                    }
+
+                    @Override
+                    public boolean isAvailable() {
+                        return false;
+                    }
+                };
+            }
+        };
+
+        new MockUp<CRAcquireContext>() {
+            @Mock
+            public String getWarehouseName() {
+                return "user_wh";
+            }
+        };
+
+        new MockUp<LoadAction>() {
+            @Mock
+            public String getUserDefaultWarehouse(BaseRequest request) {
+                return "user_wh";
+            }
+        };
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public ComputeNode getBackendOrComputeNode(long nodeId) {
+                return node;
+            }
+        };
+
+        Map<String, String> headers = new HashMap<>();
+        Request request = buildRequest(headers);
+        try (Response response = noRedirectClient.newCall(request).execute()) {
+            assertEquals(307, response.code());
+        }
+    }
+
+    @Test
+    public void testBatchWriteStreamLoadWarehouseSelection() throws Exception {
+        Map<String, String> map = new HashMap<>();
+        map.put(HTTP_ENABLE_BATCH_WRITE, "true");
+        // No warehouse header
+        Request request = buildRequest(map);
+        List<ComputeNode> computeNodes = new ArrayList<>();
+        computeNodes.add(new ComputeNode(1, "192.0.0.1", 9050));
+        computeNodes.get(0).setHttpPort(8040);
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public boolean warehouseExists(String warehouseName) {
+                return "user_wh".equals(warehouseName);
+            }
+        };
+
+        new MockUp<LoadAction>() {
+            @Mock
+            public String getUserDefaultWarehouse(BaseRequest request) {
+                return "user_wh";
+            }
+        };
+
+        new MockUp<BatchWriteMgr>() {
+            @Mock
+            public RequestCoordinatorBackendResult requestCoordinatorBackends(TableId tableId, StreamLoadKvParams params) {
+                // Verify that warehouse is set in params
+                Assertions.assertTrue(params.getWarehouse().isPresent());
+                Assertions.assertEquals("user_wh", params.getWarehouse().get());
+                return new RequestCoordinatorBackendResult(new TStatus(TStatusCode.OK), computeNodes);
+            }
+        };
+
+        try (Response response = noRedirectClient.newCall(request).execute()) {
+            assertEquals(307, response.code());
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -237,5 +237,4 @@ public class RestBaseActionTest {
         warehouse = restBaseAction.getUserDefaultWarehouse(mockRequest);
         Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_NAME, warehouse);
     }
-
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -24,7 +24,6 @@ import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.http.rest.RestBaseAction;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TNetworkAddress;
@@ -46,6 +45,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -207,8 +207,8 @@ public class RestBaseActionTest {
             }
         };
 
-        String warehouse = restBaseAction.getUserDefaultWarehouse(mockRequest);
-        Assertions.assertEquals("test_warehouse", warehouse);
+        Optional<String> warehouse = restBaseAction.getUserDefaultWarehouse(mockRequest);
+        Assertions.assertEquals("test_warehouse", warehouse.get());
 
         new MockUp<AuthenticationMgr>() {
             @Mock
@@ -222,7 +222,7 @@ public class RestBaseActionTest {
             }
         };
         warehouse = restBaseAction.getUserDefaultWarehouse(mockRequest);
-        Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_NAME, warehouse);
+        Assertions.assertFalse(warehouse.isPresent());
 
         new MockUp<AuthenticationMgr>() {
             @Mock
@@ -231,10 +231,10 @@ public class RestBaseActionTest {
             }
         };
         warehouse = restBaseAction.getUserDefaultWarehouse(mockRequest);
-        Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_NAME, warehouse);
+        Assertions.assertFalse(warehouse.isPresent());
 
         when(mockRequest.getConnectContext()).thenReturn(null);
         warehouse = restBaseAction.getUserDefaultWarehouse(mockRequest);
-        Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_NAME, warehouse);
+        Assertions.assertFalse(warehouse.isPresent());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -82,6 +82,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import static com.starrocks.common.jmockit.Deencapsulation.setField;
@@ -575,8 +576,8 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
 
             new MockUp<RestBaseAction>() {
                 @Mock
-                public String getUserDefaultWarehouse(BaseRequest request) {
-                    return "user_wh";
+                public Optional<String> getUserDefaultWarehouse(BaseRequest request) {
+                    return Optional.of("user_wh");
                 }
             };
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -555,7 +555,6 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                             anyLong, anyInt, anyInt, (TransactionResult) any, (ComputeResource) any);
                     times = 1;
                     result = new Delegate<Void>() {
-
                         public void beginLoadTaskFromFrontend(String dbName,
                                                               String tableName,
                                                               String label,
@@ -570,7 +569,6 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                             // Validate that the correct warehouse is passed
                             assertEquals(expectedWarehouseId, computeResource.getWarehouseId());
                         }
-
                     };
                 }
             };

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -20,7 +20,9 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.proc.ProcResult;
 import com.starrocks.http.rest.ActionStatus;
+import com.starrocks.http.rest.RestBaseAction;
 import com.starrocks.http.rest.TransactionLoadAction;
 import com.starrocks.http.rest.TransactionLoadCoordinatorMgr;
 import com.starrocks.http.rest.TransactionResult;
@@ -29,6 +31,11 @@ import com.starrocks.load.streamload.StreamLoadMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.warehouse.cngroup.AlterCnGroupStmt;
+import com.starrocks.sql.ast.warehouse.cngroup.CreateCnGroupStmt;
+import com.starrocks.sql.ast.warehouse.cngroup.DropCnGroupStmt;
+import com.starrocks.sql.ast.warehouse.cngroup.EnableDisableCnGroupStmt;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TNetworkAddress;
@@ -42,6 +49,7 @@ import com.starrocks.transaction.TransactionState.TxnCoordinator;
 import com.starrocks.transaction.TransactionState.TxnSourceType;
 import com.starrocks.transaction.TransactionStatus;
 import com.starrocks.transaction.TxnCommitAttachment;
+import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
@@ -532,6 +540,166 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
                 assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY))
                         .contains("Warehouse name: non_exist_warehouse not exist"));
+            }
+        }
+    }
+
+    @Test
+    public void beginTransactionWithUserDefaultWarehouseTest() throws Exception {
+        long expectedWarehouseId = 12345L;
+        {
+            new Expectations() {
+                {
+                    streamLoadMgr.beginLoadTaskFromFrontend(
+                            anyString, anyString, anyString, anyString, anyString,
+                            anyLong, anyInt, anyInt, (TransactionResult) any, (ComputeResource) any);
+                    times = 1;
+                    result = new Delegate<Void>() {
+
+                        public void beginLoadTaskFromFrontend(String dbName,
+                                                              String tableName,
+                                                              String label,
+                                                              String user,
+                                                              String clientIp,
+                                                              long timeoutMillis,
+                                                              int channelNum,
+                                                              int channelId,
+                                                              TransactionResult resp,
+                                                              ComputeResource computeResource) {
+                            resp.addResultEntry(TransactionResult.LABEL_KEY, label);
+                            // Validate that the correct warehouse is passed
+                            assertEquals(expectedWarehouseId, computeResource.getWarehouseId());
+                        }
+
+                    };
+                }
+            };
+
+            new MockUp<RestBaseAction>() {
+                @Mock
+                public String getUserDefaultWarehouse(BaseRequest request) {
+                    return "user_wh";
+                }
+            };
+
+            new MockUp<WarehouseManager>() {
+                @Mock
+                public boolean warehouseExists(String warehouseName) {
+                    return "user_wh".equals(warehouseName);
+                }
+
+                @Mock
+                public Warehouse getWarehouse(String warehouseName) {
+                    if ("user_wh".equals(warehouseName)) {
+                        return new Warehouse(expectedWarehouseId, "user_wh", "root")  {
+                            @Override
+                            public long getResumeTime() {
+                                return 0L;
+                            }
+
+                            @Override
+                            public Long getAnyWorkerGroupId() {
+                                return 0L;
+                            }
+
+                            @Override
+                            public void addNodeToCNGroup(ComputeNode node, String cnGroupName) throws DdlException {
+
+                            }
+
+                            @Override
+                            public void validateRemoveNodeFromCNGroup(ComputeNode node, String cnGroupName) throws DdlException {
+
+                            }
+
+                            @Override
+                            public List<Long> getWorkerGroupIds() {
+                                return List.of();
+                            }
+
+                            @Override
+                            public List<String> getWarehouseInfo() {
+                                return List.of();
+                            }
+
+                            @Override
+                            public List<List<String>> getWarehouseNodesInfo() {
+                                return List.of();
+                            }
+
+                            @Override
+                            public ProcResult fetchResult() {
+                                return null;
+                            }
+
+                            @Override
+                            public void createCNGroup(CreateCnGroupStmt stmt) throws DdlException {
+
+                            }
+
+                            @Override
+                            public void dropCNGroup(DropCnGroupStmt stmt) throws DdlException {
+
+                            }
+
+                            @Override
+                            public void enableCNGroup(EnableDisableCnGroupStmt stmt) throws DdlException {
+
+                            }
+
+                            @Override
+                            public void disableCNGroup(EnableDisableCnGroupStmt stmt) throws DdlException {
+
+                            }
+
+                            @Override
+                            public void alterCNGroup(AlterCnGroupStmt stmt) throws DdlException {
+
+                            }
+
+                            @Override
+                            public void replayInternalOpLog(String payload) {
+
+                            }
+
+                            @Override
+                            public boolean isAvailable() {
+                                return false;
+                            }
+                        };
+                    }
+                    return null;
+                }
+
+                @Mock
+                public ComputeResource acquireComputeResource(long warehouseId) {
+                    return new ComputeResource() {
+                        @Override
+                        public long getWarehouseId() {
+                            return warehouseId;
+                        }
+
+                        @Override
+                        public long getWorkerGroupId() {
+                            return 0;
+                        }
+                    };
+                }
+            };
+
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(TABLE_KEY, TABLE_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+                reqBuilder.addHeader(CHANNEL_ID_STR, "0");
+                reqBuilder.addHeader(CHANNEL_NUM_STR, "2");
+                // no warehouse set here
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertEquals(label, Objects.toString(body.get(TransactionResult.LABEL_KEY)));
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadKvParamsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadKvParamsTest.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.starrocks.http.rest.RestBaseAction.WAREHOUSE_KEY;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_ASYNC;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_INTERVAL_MS;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_PARALLEL;
@@ -55,6 +54,7 @@ import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_TIMEOUT;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_TIMEZONE;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_TRANSMISSION_COMPRESSION_TYPE;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_TRIM_SPACE;
+import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_WAREHOUSE;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_WHERE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -249,7 +249,7 @@ public class StreamLoadKvParamsTest extends StreamLoadParamsTestBase {
 
     @Override
     protected StreamLoadParams buildWarehouse(String expected) {
-        return buildParams(WAREHOUSE_KEY, expected);
+        return buildParams(HTTP_WAREHOUSE, expected);
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Previously, Stream Load defaulted to the system-wide 'default_warehouse' if no header was provided.

This PR improves the selection logic to prioritize the user's configured `session.warehouse` before falling back to the system default.

Support stream load, transaction stream load.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
