### PR TITLE
[Enhancement] Make tablet range optional and null-safe for non-range distribution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
@@ -100,6 +100,9 @@ public class LakeTableAlterJobV2Builder extends AlterJobV2Builder {
                 for (int i = 0; i < originTablets.size(); i++) {
                     Tablet originTablet = originTablets.get(i);
                     Tablet shadowTablet = new LakeTablet(shadowTabletIds.get(i));
+                    if (table.isRangeDistribution()) {
+                        shadowTablet.setRange(originTablet.getRange());
+                    }
                     shadowIndex.addTablet(shadowTablet, shadowTabletMeta);
                     schemaChangeJob
                             .addTabletIdMap(physicalPartitionId, shadowIndexMetaId, shadowTablet.getId(), originTablet.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
@@ -109,6 +109,9 @@ public class LakeTableRollupBuilder extends AlterJobV2Builder {
                 for (int i = 0; i < originTablets.size(); i++) {
                     Tablet originTablet = originTablets.get(i);
                     Tablet shadowTablet = new LakeTablet(shadowTabletIds.get(i));
+                    if (olapTable.isRangeDistribution()) {
+                        shadowTablet.setRange(originTablet.getRange());
+                    }
                     mvIndex.addTablet(shadowTablet, shadowTabletMeta);
                     mvJob.addTabletIdMap(physicalPartitionId, shadowTablet.getId(), originTablet.getId());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
@@ -101,6 +101,9 @@ public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
                     long shadowTabletId = globalStateMgr.getNextId();
 
                     LocalTablet shadowTablet = new LocalTablet(shadowTabletId);
+                    if (table.isRangeDistribution()) {
+                        shadowTablet.setRange(originTablet.getRange());
+                    }
                     shadowIndex.addTablet(shadowTablet, shadowTabletMeta);
                     addedTablets.add(shadowTablet);
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableRollupJobBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableRollupJobBuilder.java
@@ -75,6 +75,9 @@ public class OlapTableRollupJobBuilder extends AlterJobV2Builder {
                     long mvTabletId = globalStateMgr.getNextId();
 
                     Tablet newTablet = new LocalTablet(mvTabletId);
+                    if (olapTable.isRangeDistribution()) {
+                        newTablet.setRange(baseTablet.getRange());
+                    }
 
                     mvIndex.addTablet(newTablet, mvTabletMeta);
                     addedTablets.add(newTablet);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
@@ -16,7 +16,6 @@ package com.starrocks.alter.reshard;
 
 import com.google.common.base.Preconditions;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.DistributionInfo.DistributionInfoType;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
@@ -72,7 +71,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                     + " in table " + db.getFullName() + '.' + table.getName());
         }
 
-        if (table.getDefaultDistributionInfo().getType() != DistributionInfoType.RANGE) {
+        if (!table.isRangeDistribution()) {
             throw new StarRocksException("Unsupported distribution type " + table.getDefaultDistributionInfo().getType()
                     + " in table " + db.getFullName() + '.' + table.getName());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -84,6 +84,7 @@ import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.TabletRange;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MaterializedViewExceptions;
@@ -1058,6 +1059,11 @@ public class RestoreJob extends AbstractJob {
             for (int i = 0; i < tabletNum; ++i) {
                 long newTabletId = globalStateMgr.getNextId();
                 LocalTablet newTablet = new LocalTablet(newTabletId);
+                if (remoteOlapTbl.isRangeDistribution()) {
+                    // In shared-nothing mode, ranges do not support splitting.
+                    // There will only be one default range.
+                    newTablet.setRange(new TabletRange());
+                }
                 index.addTablet(newTablet, null /* tablet meta */, false/* update inverted index */);
 
                 // replicas
@@ -1097,6 +1103,11 @@ public class RestoreJob extends AbstractJob {
             for (int i = 0; i < tabletNum; i++) {
                 long newTabletId = globalStateMgr.getNextId();
                 LocalTablet newTablet = new LocalTablet(newTabletId);
+                if (remoteOlapTbl.isRangeDistribution()) {
+                    // In shared-nothing mode, ranges do not support splitting.
+                    // There will only be one default range.
+                    newTablet.setRange(new TabletRange());
+                }
                 index.addTablet(newTablet, null /* tablet meta */, false/* update inverted index */);
 
                 // replicas

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
@@ -32,7 +32,7 @@ public abstract class Tablet extends MetaObject implements Writable {
     protected long id;
 
     @SerializedName(value = "range")
-    protected TabletRange range = new TabletRange();
+    protected TabletRange range;
 
     public Tablet() {
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -38,7 +38,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.alter.reshard.TabletReshardUtils;
-import com.starrocks.catalog.DistributionInfo.DistributionInfoType;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorReportException;
@@ -199,8 +198,7 @@ public class TabletStatMgr extends FrontendDaemon {
     }
 
     private static void triggerTabletReshard(Database db, OlapTable table, long maxTabletSize) {
-        if (table.isCloudNativeTableOrMaterializedView()
-                && table.getDefaultDistributionInfo().getType() == DistributionInfoType.RANGE
+        if (table.isCloudNativeTableOrMaterializedView() && table.isRangeDistribution()
                 && TabletReshardUtils.needSplit(maxTabletSize)) {
             try {
                 GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().createTabletReshardJob(

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
@@ -86,7 +86,7 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                 tabletInfo.add(new ByteSizeValue(lakeTablet.getDataSize(true)));
                 tabletInfo.add(lakeTablet.getRowCount(0L));
                 tabletInfo.add(lakeTablet.getMinVersion());
-                tabletInfo.add(lakeTablet.getRange().toString());
+                tabletInfo.add(String.valueOf(lakeTablet.getRange()));
                 tabletInfos.add(tabletInfo);
             }
         } finally {
@@ -171,7 +171,7 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                     new ByteSizeValue(tablet.getDataSize(true)).toString(),
                     String.valueOf(tablet.getRowCount(0L)),
                     String.valueOf(tablet.getMinVersion()),
-                    tablet.getRange().toString()
+                    String.valueOf(tablet.getRange())
             );
             result.addRow(row);
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -822,7 +822,9 @@ public class OlapTableSink extends DataSink {
             tIndex.setTablets(index.getTablets().stream().map(tablet -> {
                 TOlapTableTablet tTablet = new TOlapTableTablet();
                 tTablet.setId(tablet.getId());
-                tTablet.setRange(tablet.getRange().toThrift());
+                if (tablet.getRange() != null) {
+                    tTablet.setRange(tablet.getRange().toThrift());
+                }
                 return tTablet;
             }).collect(Collectors.toList()));
             tPartition.addToIndexes(tIndex);
@@ -1026,9 +1028,9 @@ public class OlapTableSink extends DataSink {
     }
 
     private static boolean canUseColocateMVIndex(OlapTable table) {
+        // disable colocate mv index for range distribution for now
         return Config.enable_colocate_mv_index && table.isEnableColocateMVIndex() &&
-               // disable colocate mv index for range distribution for now
-               table.getDefaultDistributionInfo().getType() != DistributionInfo.DistributionInfoType.RANGE;
+                !table.isRangeDistribution();
     }
 
     public boolean canUsePipeLine() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -92,6 +92,7 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.View;
 import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.catalog.system.sys.SysDb;
@@ -2157,6 +2158,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 null, properties, computeResource);
         for (long shardId : shardIds) {
             Tablet tablet = new LakeTablet(shardId);
+            if (distributionInfoType == DistributionInfo.DistributionInfoType.RANGE) {
+                tablet.setRange(new TabletRange());
+            }
             index.addTablet(tablet, tabletMeta);
             tabletIdSet.add(tablet.getId());
         }
@@ -2239,6 +2243,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             for (int i = 0; i < distributionInfo.getBucketNum(); ++i) {
                 // create a new tablet with random chosen backends
                 LocalTablet tablet = new LocalTablet(getNextId());
+                if (distributionInfoType == DistributionInfo.DistributionInfoType.RANGE) {
+                    tablet.setRange(new TabletRange());
+                }
 
                 // add tablet to inverted index first
                 index.addTablet(tablet, tabletMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -2064,7 +2064,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             tIndex.setTablets(index.getTablets().stream().map(tablet -> {
                 TOlapTableTablet tTablet = new TOlapTableTablet();
                 tTablet.setId(tablet.getId());
-                tTablet.setRange(tablet.getRange().toThrift());
+                if (tablet.getRange() != null) {
+                    tTablet.setRange(tablet.getRange().toThrift());
+                }
                 return tTablet;
             }).collect(Collectors.toList()));
             tPartition.addToIndexes(tIndex);
@@ -2505,7 +2507,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             tIndex.setTablets(index.getTablets().stream().map(tablet -> {
                 TOlapTableTablet tTablet = new TOlapTableTablet();
                 tTablet.setId(tablet.getId());
-                tTablet.setRange(tablet.getRange().toThrift());
+                if (tablet.getRange() != null) {
+                    tTablet.setRange(tablet.getRange().toThrift());
+                }
                 return tTablet;
             }).collect(Collectors.toList()));
             tPartition.addToIndexes(tIndex);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/LocalTabletTest.java
@@ -127,6 +127,7 @@ public class LocalTabletTest {
         Assertions.assertEquals(replica2, tablet.getReplicaByBackendId(replica2.getBackendId()));
         Assertions.assertEquals(replica3, tablet.getReplicaByBackendId(replica3.getBackendId()));
 
+        Assertions.assertNull(tablet.getRange());
         Assertions.assertEquals(600003L, tablet.getDataSize(false));
         Assertions.assertEquals(200002L, tablet.getDataSize(true));
         Assertions.assertEquals(3002L, tablet.getRowCount(100));

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/LakeTabletsProcNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/LakeTabletsProcNodeTest.java
@@ -122,11 +122,13 @@ public class LakeTabletsProcNodeTest {
             Assertions.assertEquals((long) result.get(0).get(0), tablet1Id);
             String backendIds = (String) result.get(0).get(1);
             Assertions.assertTrue(backendIds.contains("10000") && backendIds.contains("10001"));
+            Assertions.assertEquals("null", result.get(0).get(5));
         }
         {
             Assertions.assertEquals((long) result.get(1).get(0), tablet2Id);
             String backendIds = (String) result.get(1).get(1);
             Assertions.assertTrue(backendIds.contains("10001") && backendIds.contains("10002"));
+            Assertions.assertEquals("null", result.get(1).get(5));
         }
 
         { // check show single tablet with tablet id
@@ -139,6 +141,7 @@ public class LakeTabletsProcNodeTest {
             Assertions.assertEquals(new Gson().toJson(tablet1.getBackendIds()), row.get(1));
             Assertions.assertEquals(new ByteSizeValue(tablet1.getDataSize(true)).toString(), row.get(2));
             Assertions.assertEquals(String.valueOf(tablet1.getRowCount(0L)), row.get(3));
+            Assertions.assertEquals("null", row.get(5));
         }
 
         { // error case

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTabletTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.lake;
 
+import com.starrocks.catalog.TabletRange;
 import com.starrocks.persist.gson.GsonUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -32,13 +33,20 @@ public class LakeTabletTest {
         Assertions.assertEquals(tablet.getId(), deserializedTablet.getId());
         Assertions.assertEquals(tablet.getDataSize(true), deserializedTablet.getDataSize(true));
         Assertions.assertEquals(tablet.getRowCount(0), deserializedTablet.getRowCount(0));
-        Assertions.assertNotNull(deserializedTablet.getRange());
+        Assertions.assertNull(deserializedTablet.getRange());
     }
 
     @Test
     public void testDefaultConstructor() {
         LakeTablet tablet = new LakeTablet();
-        Assertions.assertNotNull(tablet.getRange());
+        Assertions.assertNull(tablet.getRange());
+    }
+
+    @Test
+    public void testRangeSerialization() {
+        LakeTablet tablet = new LakeTablet(10002L, new TabletRange());
+        String json = GsonUtils.GSON.toJson(tablet);
+        LakeTablet deserializedTablet = GsonUtils.GSON.fromJson(json, LakeTablet.class);
+        Assertions.assertNotNull(deserializedTablet.getRange());
     }
 }
-


### PR DESCRIPTION
## Why I'm doing:
Non-range distribution do not need tablet range. This PR make tablet range optional and null-safe for non-range distribution.

## What I'm doing:
- Remove default TabletRange initialization so non-range tablets keep null range
- Create range only for range-distribution tablets in LocalMetastore
- Copy range for range-distribution shadow tablets in alter/rollup builders
- Guard range serialization in FrontendServiceImpl and OlapTableSink
- Output null range safely in LakeTabletsProcDir and update tests accordingly

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
