### PR TITLE
[BugFix] Fix in runtime filter prepare race condition in event scheduler

### DIFF
--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -153,6 +153,7 @@ Status HashJoinBuildOperator::set_finishing(RuntimeState* state) {
             }
         }
         RuntimeMembershipFilterList bloom_filters(partial_bloom_filters.begin(), partial_bloom_filters.end());
+        RETURN_IF_ERROR(RuntimeFilterCollector::prepare_runtime_in_filters(state, in_filter_lists));
         runtime_filter_hub()->set_collector(_plan_node_id, _driver_sequence,
                                             std::make_unique<RuntimeFilterCollector>(in_filter_lists));
         state->runtime_filter_port()->publish_local_colocate_filters(bloom_filters);
@@ -195,6 +196,7 @@ Status HashJoinBuildOperator::set_finishing(RuntimeState* state) {
                 state->runtime_filter_port()->publish_runtime_filters(bloom_filters);
             }
 
+            RETURN_IF_ERROR(RuntimeFilterCollector::prepare_runtime_in_filters(state, in_filters));
             // move runtime filters into RuntimeFilterHub.
             runtime_filter_hub()->set_collector(_plan_node_id,
                                                 std::make_unique<RuntimeFilterCollector>(std::move(in_filters)));

--- a/be/src/exec/pipeline/nljoin/nljoin_context.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.cpp
@@ -173,6 +173,7 @@ Status NLJoinContext::_init_runtime_filter(RuntimeState* state) {
         auto* pool = state->obj_pool();
         ASSIGN_OR_RETURN(auto rfs, CrossJoinNode::rewrite_runtime_filter(pool, _rf_descs, one_row_chunk.get(),
                                                                          _rf_conjuncts_ctx));
+        RETURN_IF_ERROR(RuntimeFilterCollector::prepare_runtime_in_filters(state, rfs));
         _rf_hub->set_collector(_plan_node_id,
                                std::make_unique<RuntimeFilterCollector>(std::move(rfs), RuntimeMembershipFilterList{}));
     } else {

--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -370,8 +370,7 @@ void OperatorFactory::_prepare_runtime_holders(const std::vector<RuntimeFilterHo
 
         auto&& in_filters = collector->get_in_filters_bounded_by_tuple_ids(_tuple_ids);
         for (auto* filter : in_filters) {
-            WARN_IF_ERROR(filter->prepare(runtime_state()), "prepare filter expression failed");
-            WARN_IF_ERROR(filter->open(runtime_state()), "open filter expression failed");
+            DCHECK(filter->opened());
             runtime_in_filters->push_back(filter);
         }
     }

--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <utility>
 
+#include "common/object_pool.h"
 #include "common/statusor.h"
 #include "exec/pipeline/schedule/observer.h"
 #include "exprs/expr_context.h"
@@ -71,10 +72,27 @@ struct RuntimeMembershipFilterBuildParam {
 // and every HashJoinBuildOperatorFactory has its corresponding RuntimeFilterCollector.
 struct RuntimeFilterCollector {
     RuntimeFilterCollector(RuntimeInFilterList&& in_filters, RuntimeMembershipFilterList&& bloom_filters)
-            : _in_filters(std::move(in_filters)), _bloom_filters(std::move(bloom_filters)) {}
-    RuntimeFilterCollector(RuntimeInFilterList in_filters) : _in_filters(std::move(in_filters)) {}
+            : _in_filters(std::move(in_filters)), _bloom_filters(std::move(bloom_filters)) {
+        for (auto filter : _in_filters) {
+            DCHECK(filter->opened());
+        }
+    }
+
+    RuntimeFilterCollector(RuntimeInFilterList in_filters) : _in_filters(std::move(in_filters)) {
+        for (auto filter : _in_filters) {
+            DCHECK(filter->opened());
+        }
+    }
 
     RuntimeInFilterList& get_in_filters() { return _in_filters; }
+
+    static Status prepare_runtime_in_filters(RuntimeState* state, RuntimeInFilterList& in_filters) {
+        for (auto& in_filter : in_filters) {
+            RETURN_IF_ERROR(in_filter->prepare(state));
+            RETURN_IF_ERROR(in_filter->open(state));
+        }
+        return Status::OK();
+    }
 
     // In-filters are constructed by a node and may be pushed down to its descendant node.
     // Different tuple id and slot id between descendant and ancestor nodes may be referenced to the same column,


### PR DESCRIPTION
## Why I'm doing:

OLAP_SCAN and OLAP_SCAN_PREPARE will have the same plan_node_id. so they will gather the same runtime filter and cause race condition.

This issue only occurs when the event scheduler is enabled. Since the poller is single-threaded, executing prepare multiple times is safe.

```
PC: @          0xb30bd1c starrocks::MemPool::~MemPool()
*** SIGSEGV (@0x312e303128303c) received by PID 2789 (TID 0xe76521c6fe80) LWP(3694) from PID 824717372; stack trace: ***
    @     0xe7660a5d53dc (/usr/lib/aarch64-linux-gnu/libc.so.6+0x853db)
    @          0xee09df8 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0xe7660b6246e4 PosixSignals::chained_handler(int, siginfo_t*, void*) [clone .part.0]
    @     0xe7660b62509c JVM_handle_linux_signal
    @     0xe7660bc908f8 ([vdso]+0x8f7)
    @          0xb30bd1c starrocks::MemPool::~MemPool()
    @          0x82585e4 starrocks::ExprContext::prepare(starrocks::RuntimeState*)
    @          0x82a0224 starrocks::pipeline::OperatorFactory::_prepare_runtime_holders(std::vector<starrocks::pipeline::RuntimeFilterHolder*, std::allocator<starrocks::pipeline::RuntimeFilterHolder*> > const&, std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprCon
    @          0x82a0894 starrocks::pipeline::OperatorFactory::_prepare_runtime_in_filters(starrocks::RuntimeState*)
    @     0xe7660a5d53dc (/usr/lib/aarch64-linux-gnu/libc.so.6+0x853db)
    @          0x82a1794 starrocks::pipeline::Operator::set_precondition_ready(starrocks::RuntimeState*)
    @          0x8046b9c starrocks::pipeline::PipelineDriver::mark_precondition_ready()
    @          0x83af210 starrocks::pipeline::PipelineDriver::check_is_ready()
    @          0x83ad84c starrocks::pipeline::EventScheduler::try_schedule(starrocks::pipeline::PipelineDriver*)
    @          0x83ac204 starrocks::pipeline::PipelineObserver::_do_update(int)
    @          0x84db290 starrocks::pipeline::PipelineObserver::source_trigger()
    @          0xa41d620 starrocks::pipeline::HashJoinBuildOperator::set_finishing(starrocks::RuntimeState*)
    @          0x8044bec starrocks::pipeline::PipelineDriver::_mark_operator_finishing(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)
    @          0x8047c2c starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0xb25def4 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xb6bfd54 starrocks::ThreadPool::dispatch_thread()
    @          0xb6b633c starrocks::Thread::supervise_thread(void*)
    @     0xe7660a5d0398 (/usr/lib/aarch64-linux-gnu/libc.so.6+0x80397)
    @     0xe7660a639e9c (/usr/lib/aarch64-linux-gnu/libc.so.6+0xe9e9b)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
