### PR TITLE
[BugFix] Fix string type length analyze

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -631,6 +631,9 @@ public class TypeManager {
         }
 
         if (t1.isStringType() || t2.isStringType()) {
+            if (t1.getLength() <= 0 || t2.getLength() <= 0) {
+                return VarcharType.VARCHAR;
+            }
             return TypeFactory.createVarcharType(Math.max(t1.getLength(), t2.getLength()));
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -90,8 +90,8 @@ public class ArrayTypeTest extends PlanTestBase {
 
         sql = "select concat(i_1, s_1, d_1) from adec";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "array_concat(CAST(2: i_1 AS ARRAY<VARCHAR(65533)>), 3: s_1, " +
-                "CAST(4: d_1 AS ARRAY<VARCHAR(65533)>))");
+        assertContains(plan, "array_concat(CAST(2: i_1 AS ARRAY<VARCHAR>), 3: s_1, " +
+                "CAST(4: d_1 AS ARRAY<VARCHAR>))");
 
         sql = "select concat(d_1, d_2) from adec";
         plan = getFragmentPlan(sql);
@@ -106,10 +106,10 @@ public class ArrayTypeTest extends PlanTestBase {
 
         sql = "select concat(i_1, s_1, d_1, d_2, d_3, d_4, d_5, d_6) from adec";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "array_concat(CAST(2: i_1 AS ARRAY<VARCHAR(65533)>), 3: s_1, " +
-                "CAST(4: d_1 AS ARRAY<VARCHAR(65533)>), CAST(5: d_2 AS ARRAY<VARCHAR(65533)>), " +
-                "CAST(6: d_3 AS ARRAY<VARCHAR(65533)>), CAST(7: d_4 AS ARRAY<VARCHAR(65533)>), " +
-                "CAST(8: d_5 AS ARRAY<VARCHAR(65533)>), CAST(9: d_6 AS ARRAY<VARCHAR(65533)>))");
+        assertContains(plan, "array_concat(CAST(2: i_1 AS ARRAY<VARCHAR>), 3: s_1, " +
+                "CAST(4: d_1 AS ARRAY<VARCHAR>), CAST(5: d_2 AS ARRAY<VARCHAR>), " +
+                "CAST(6: d_3 AS ARRAY<VARCHAR>), CAST(7: d_4 AS ARRAY<VARCHAR>), " +
+                "CAST(8: d_5 AS ARRAY<VARCHAR>), CAST(9: d_6 AS ARRAY<VARCHAR>))");
 
         sql = "select concat(v1, [1,2,3], s_1) from adec";
         plan = getFragmentPlan(sql);
@@ -478,8 +478,8 @@ public class ArrayTypeTest extends PlanTestBase {
         sql = "select array_intersect(d_3, s_1) from adec;";
         plan = getVerboseExplain(sql);
         assertCContains(plan, "array_intersect[(cast([6: d_3, ARRAY<DECIMAL128(25,19)>, false] " +
-                "as ARRAY<VARCHAR(65533)>), [3: s_1, ARRAY<VARCHAR(65533)>, true]); args: INVALID_TYPE; " +
-                "result: ARRAY<VARCHAR(65533)>;");
+                "as ARRAY<VARCHAR>), [3: s_1, ARRAY<VARCHAR(65533)>, true]); args: INVALID_TYPE; " +
+                "result: ARRAY<VARCHAR>;");
     }
 
     @Test
@@ -622,7 +622,7 @@ public class ArrayTypeTest extends PlanTestBase {
         plan = getVerboseExplain(sql);
         assertContains(plan, "arrays_overlap[(" +
                 "[3: s_1, ARRAY<VARCHAR(65533)>, true], " +
-                "cast([4: d_1, ARRAY<DECIMAL128(26,2)>, false] as ARRAY<VARCHAR(65533)>));");
+                "cast([4: d_1, ARRAY<DECIMAL128(26,2)>, false] as ARRAY<VARCHAR>));");
     }
 
     @Test
@@ -655,8 +655,8 @@ public class ArrayTypeTest extends PlanTestBase {
 
         sql = "select array_append(s_1, 1.0) from adec;";
         plan = getVerboseExplain(sql);
-        assertCContains(plan, "array_append[([3: s_1, ARRAY<VARCHAR(65533)>, true], '1.0');" +
-                " args: INVALID_TYPE,VARCHAR; result: ARRAY<VARCHAR(65533)>;");
+        assertCContains(plan, "array_append[([3: s_1, ARRAY<VARCHAR(65533)>, true], '1.0');"
+                + " args: INVALID_TYPE,VARCHAR; result: ARRAY<VARCHAR>;");
 
         sql = "select array_contains(i_1, 'a') from adec;";
         plan = getVerboseExplain(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
@@ -70,7 +70,7 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
                 "  2:EXCHANGE");
         sql = "select c2 from test1 union all select c2_0 from test1";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "CAST(3: c2 AS struct<a int(11), b varchar(10)>)");
+        assertContains(plan, "CAST(3: c2 AS struct<a int(11), b varchar>)");
 
         sql = "select index_struct[1].`index` from index_struct_nest";
         plan = getFragmentPlan(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1503,7 +1503,7 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         assertContains(plan, "39:Project\n" +
                 "  |  <slot 2> : 2: N_NAME\n" +
                 "  |  <slot 64> : if(CAST(42: C_NATIONKEY AS DOUBLE) > 44: C_ACCTBAL, 31: O_ORDERPRIORITY, " +
-                "CAST(33: O_SHIPPRIORITY AS VARCHAR(15)))\n" +
+                "CAST(33: O_SHIPPRIORITY AS VARCHAR))\n" +
                 "  |  \n" +
                 "  38:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1040,12 +1040,7 @@ public class LowCardinalityTest extends PlanTestBase {
         assertContains(plan, "  4:TOP-N\n"
                 + "  |  order by: <slot 17> 17: S_ADDRESS ASC\n"
                 + "  |  offset: 0\n"
-                + "  |  limit: 10\n"
-                + "  |  \n"
-                + "  3:HASH JOIN\n"
-                + "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n"
-                + "  |  colocate: false, reason: \n"
-                + "  |  equal join conjunct: 1: S_SUPPKEY = 9: S_SUPPKEY");
+                + "  |  limit: 10\n");
 
         // Decode
         sql = "select max(S_ADDRESS), max(S_COMMENT) from " +
@@ -1053,17 +1048,9 @@ public class LowCardinalityTest extends PlanTestBase {
                 "join supplier_nullable r " +
                 " on l.S_SUPPKEY = r.S_SUPPKEY ) tb group by S_SUPPKEY";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  7:Decode\n"
-                + "  |  <dict id 21> : <string id 17>\n"
-                + "  |  <dict id 22> : <string id 18>\n"
-                + "  |  \n"
-                + "  6:Project\n"
-                + "  |  <slot 21> : 21: S_ADDRESS\n"
-                + "  |  <slot 22> : 22: S_COMMENT\n"
-                + "  |  \n"
-                + "  5:AGGREGATE (update finalize)\n"
-                + "  |  output: max(19: S_ADDRESS), max(20: S_COMMENT)\n"
-                + "  |  group by: 1: S_SUPPKEY");
+        assertContains(plan, "Decode\n"
+                + "  |  <dict id 23> : <string id 17>\n"
+                + "  |  <dict id 24> : <string id 18>");
         // the fragment on the top don't have to send global dicts
         sql = "select upper(ST_S_ADDRESS),\n" +
                 "    upper(ST_S_COMMENT)\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1007,7 +1007,7 @@ public class LowCardinalityTest extends PlanTestBase {
 
         sql = "select * from test.join1 right join test.join2 on join1.id = join2.id where round(2.0, 0) > 3.0";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  5:Decode\n" +
+        assertContains(plan, "Decode\n" +
                 "  |  <dict id 7> : <string id 3>\n" +
                 "  |  <dict id 8> : <string id 6>");
 
@@ -1037,15 +1037,15 @@ public class LowCardinalityTest extends PlanTestBase {
         sql = "select * from supplier l join supplier_nullable r where l.S_SUPPKEY = r.S_SUPPKEY " +
                 "order by l.S_ADDRESS limit 10";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  4:TOP-N\n" +
-                "  |  order by: <slot 17> 17: S_ADDRESS ASC\n" +
-                "  |  offset: 0\n" +
-                "  |  limit: 10\n" +
-                "  |  \n" +
-                "  3:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (BROADCAST)\n" +
-                "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 1: S_SUPPKEY = 9: S_SUPPKEY");
+        assertContains(plan, "  4:TOP-N\n"
+                + "  |  order by: <slot 17> 17: S_ADDRESS ASC\n"
+                + "  |  offset: 0\n"
+                + "  |  limit: 10\n"
+                + "  |  \n"
+                + "  3:HASH JOIN\n"
+                + "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n"
+                + "  |  colocate: false, reason: \n"
+                + "  |  equal join conjunct: 1: S_SUPPKEY = 9: S_SUPPKEY");
 
         // Decode
         sql = "select max(S_ADDRESS), max(S_COMMENT) from " +
@@ -1053,26 +1053,17 @@ public class LowCardinalityTest extends PlanTestBase {
                 "join supplier_nullable r " +
                 " on l.S_SUPPKEY = r.S_SUPPKEY ) tb group by S_SUPPKEY";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "9:Decode\n" +
-                "  |  <dict id 23> : <string id 17>\n" +
-                "  |  <dict id 24> : <string id 18>\n" +
-                "  |  \n" +
-                "  8:Project\n" +
-                "  |  <slot 23> : 23: S_ADDRESS\n" +
-                "  |  <slot 24> : 24: S_COMMENT\n" +
-                "  |  \n" +
-                "  7:AGGREGATE (merge finalize)\n" +
-                "  |  output: max(21: S_ADDRESS), max(22: S_COMMENT)\n" +
-                "  |  group by: 1: S_SUPPKEY");
-        plan = getThriftPlan(sql);
-        Assertions.assertEquals(plan.split("\n").length, 3);
-        assertContains(plan.split("\n")[0], "query_global_dicts:" +
-                "[TGlobalDict(columnId:19, strings:[6D 6F 63 6B], ids:[1], version:1), " +
-                "TGlobalDict(columnId:20, strings:[6D 6F 63 6B], ids:[1], version:1), " +
-                "TGlobalDict(columnId:21, strings:[6D 6F 63 6B], ids:[1], version:1), " +
-                "TGlobalDict(columnId:22, strings:[6D 6F 63 6B], ids:[1], version:1), " +
-                "TGlobalDict(columnId:23, strings:[6D 6F 63 6B], ids:[1], version:1), " +
-                "TGlobalDict(columnId:24, strings:[6D 6F 63 6B], ids:[1], version:1)])");
+        assertContains(plan, "  7:Decode\n"
+                + "  |  <dict id 21> : <string id 17>\n"
+                + "  |  <dict id 22> : <string id 18>\n"
+                + "  |  \n"
+                + "  6:Project\n"
+                + "  |  <slot 21> : 21: S_ADDRESS\n"
+                + "  |  <slot 22> : 22: S_COMMENT\n"
+                + "  |  \n"
+                + "  5:AGGREGATE (update finalize)\n"
+                + "  |  output: max(19: S_ADDRESS), max(20: S_COMMENT)\n"
+                + "  |  group by: 1: S_SUPPKEY");
         // the fragment on the top don't have to send global dicts
         sql = "select upper(ST_S_ADDRESS),\n" +
                 "    upper(ST_S_COMMENT)\n" +
@@ -1093,7 +1084,7 @@ public class LowCardinalityTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "  20:AGGREGATE (update serialize)\n" +
                 "  |  STREAMING\n" +
-                "  |  group by: 30: S_ADDRESS, 31: S_COMMENT\n" +
+                "  |  group by: 32: cast, 33: cast\n" +
                 "  |  \n" +
                 "  0:UNION\n" +
                 "  |  \n" +
@@ -1475,44 +1466,44 @@ public class LowCardinalityTest extends PlanTestBase {
         String plan;
         sql = "select t1a from test_all_type group by t1a union all select v4 from t1 where false";
         plan = getFragmentPlan(sql);
-        Assertions.assertTrue(plan.contains("  3:Decode\n" +
-                "  |  <dict id 16> : <string id 15>"));
-        Assertions.assertTrue(plan.contains("  2:Project\n" +
-                "  |  <slot 16> : 16: t1a"));
+        assertContains(plan, "Decode\n"
+                + "  |  <dict id 17> : <string id 16>");
+        Assertions.assertTrue(plan.contains("2:Project\n"
+                + "  |  <slot 17> : 17: t1a"));
 
         // COW Case
         sql = "SELECT 'all', 'allx' where 1 = 2 union all select distinct S_ADDRESS, S_ADDRESS from supplier;";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  3:Project\n" +
-                "  |  <slot 14> : clone(8: S_ADDRESS)\n" +
-                "  |  <slot 15> : 8: S_ADDRESS\n" +
-                "  |  \n" +
-                "  2:Decode\n" +
-                "  |  <dict id 16> : <string id 8>\n" +
-                "  |  \n" +
-                "  1:AGGREGATE (update finalize)\n" +
-                "  |  group by: 16: S_ADDRESS");
+        assertContains(plan, "  3:Project\n"
+                + "  |  <slot 14> : clone(6: S_ADDRESS)\n"
+                + "  |  <slot 15> : 6: S_ADDRESS\n"
+                + "  |  \n"
+                + "  2:Decode\n"
+                + "  |  <dict id 16> : <string id 6>\n"
+                + "  |  \n"
+                + "  1:AGGREGATE (update finalize)\n"
+                + "  |  group by: 16: S_ADDRESS");
 
         sql = "SELECT 'all', 'all', 'all', 'all' where 1 = 2 union all " +
                 "select distinct S_ADDRESS, S_SUPPKEY + 1, S_SUPPKEY + 1, S_ADDRESS + 1 from supplier;";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  4:Project\n" +
-                "  |  <slot 20> : 9: S_ADDRESS\n" +
-                "  |  <slot 21> : 25: cast\n" +
-                "  |  <slot 22> : CAST(15: expr AS VARCHAR)\n" +
-                "  |  <slot 23> : CAST(CAST(9: S_ADDRESS AS DOUBLE) + 1.0 AS VARCHAR)\n" +
-                "  |  common expressions:\n" +
-                "  |  <slot 25> : CAST(15: expr AS VARCHAR)\n" +
-                "  |  \n" +
-                "  3:Decode\n" +
-                "  |  <dict id 24> : <string id 9>\n" +
-                "  |  \n" +
-                "  2:AGGREGATE (update finalize)\n" +
-                "  |  group by: 24: S_ADDRESS, 15: expr\n" +
-                "  |  \n" +
-                "  1:Project\n" +
-                "  |  <slot 15> : CAST(7: S_SUPPKEY AS BIGINT) + 1\n" +
-                "  |  <slot 24> : 24: S_ADDRESS");
+        assertContains(plan, "  4:Project\n"
+                + "  |  <slot 20> : 8: S_ADDRESS\n"
+                + "  |  <slot 21> : 25: cast\n"
+                + "  |  <slot 22> : CAST(14: expr AS VARCHAR)\n"
+                + "  |  <slot 23> : CAST(CAST(8: S_ADDRESS AS DOUBLE) + 1.0 AS VARCHAR)\n"
+                + "  |  common expressions:\n"
+                + "  |  <slot 25> : CAST(14: expr AS VARCHAR)\n"
+                + "  |  \n"
+                + "  3:Decode\n"
+                + "  |  <dict id 24> : <string id 8>\n"
+                + "  |  \n"
+                + "  2:AGGREGATE (update finalize)\n"
+                + "  |  group by: 24: S_ADDRESS, 14: expr\n"
+                + "  |  \n"
+                + "  1:Project\n"
+                + "  |  <slot 14> : CAST(6: S_SUPPKEY AS BIGINT) + 1\n"
+                + "  |  <slot 24> : 24: S_ADDRESS");
 
     }
 
@@ -2043,21 +2034,21 @@ public class LowCardinalityTest extends PlanTestBase {
                 "   w1 t1 \n" +
                 "   JOIN [broadcast] part_v2 t2 ON t1.P_NAME2 = t2.P_NAME AND t1.P_NAME = t2.P_NAME;";
         String plan = getCostExplain(sql);
-        assertContains(plan, "  4:Decode\n" +
-                "  |  <dict id 38> : <string id 2>\n" +
-                "  |  cardinality: 1\n" +
-                "  |  probe runtime filters:\n" +
-                "  |  - filter_id = 1, probe_expr = (2: P_NAME)\n" +
-                "  |  column statistics: \n" +
-                "  |  * P_NAME-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
-                "  |  * P_BRAND-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
-                "  |  * cast-->[-Infinity, Infinity, 0.0, 16.0, 3.0] ESTIMATE\n" +
-                "  |  \n" +
-                "  3:EXCHANGE\n" +
-                "     distribution type: ROUND_ROBIN\n" +
-                "     cardinality: 1\n" +
-                "     probe runtime filters:\n" +
-                "     - filter_id = 0, probe_expr = (<slot 12>)");
+        assertContains(plan, "  4:Decode\n"
+                + "  |  <dict id 38> : <string id 2>\n"
+                + "  |  cardinality: 1\n"
+                + "  |  probe runtime filters:\n"
+                + "  |  - filter_id = 1, probe_expr = (2: P_NAME)\n"
+                + "  |  column statistics: \n"
+                + "  |  * P_NAME-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n"
+                + "  |  * P_BRAND-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n"
+                + "  |  * case-->[-Infinity, Infinity, 0.0, 16.0, 3.0] ESTIMATE\n"
+                + "  |  \n"
+                + "  3:EXCHANGE\n"
+                + "     distribution type: ROUND_ROBIN\n"
+                + "     cardinality: 1\n"
+                + "     probe runtime filters:\n"
+                + "     - filter_id = 0, probe_expr = (<slot 11>)");
         System.out.println(plan);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -1159,15 +1159,15 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "        union select 1,2\n" +
                 "    ) sys";
         plan = getFragmentPlan(sql);
-        assertContains(plan, plan, "  20:AGGREGATE (update serialize)\n" +
-                "  |  STREAMING\n" +
-                "  |  group by: 30: S_ADDRESS, 31: S_COMMENT\n" +
-                "  |  \n" +
-                "  0:UNION\n" +
-                "  |  \n" +
-                "  |----19:EXCHANGE\n" +
-                "  |    \n" +
-                "  16:EXCHANGE");
+        assertContains(plan, plan, "  20:AGGREGATE (update serialize)\n"
+                + "  |  STREAMING\n"
+                + "  |  group by: 32: cast, 33: cast\n"
+                + "  |  \n"
+                + "  0:UNION\n"
+                + "  |  \n"
+                + "  |----19:EXCHANGE\n"
+                + "  |    \n"
+                + "  16:EXCHANGE");
         assertContains(plan, plan, "Decode");
         plan = getThriftPlan(sql);
         assertNotContains(plan.split("\n")[1], "query_global_dicts");
@@ -1624,8 +1624,8 @@ public class LowCardinalityTest2 extends PlanTestBase {
         String plan;
         sql = "select t1a from test_all_type group by t1a union all select v4 from t1 where false";
         plan = getFragmentPlan(sql);
-        Assertions.assertTrue(plan.contains("  2:Project\n" +
-                "  |  <slot 15> : DictDecode(16: t1a, [<place-holder>])"), plan);
+        Assertions.assertTrue(plan.contains("  2:Project\n"
+                + "  |  <slot 16> : DictDecode(17: t1a, [<place-holder>])"), plan);
 
         // COW Case
         sql = "SELECT 'all', 'allx' where 1 = 2 union all select distinct S_ADDRESS, S_ADDRESS from supplier;";
@@ -1639,20 +1639,20 @@ public class LowCardinalityTest2 extends PlanTestBase {
         sql = "SELECT 'all', 'all', 'all', 'all' where 1 = 2 union all " +
                 "select distinct S_ADDRESS, S_SUPPKEY + 1, S_SUPPKEY + 1, S_ADDRESS + 1 from supplier;";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  3:Project\n" +
-                "  |  <slot 20> : DictDecode(24: S_ADDRESS, [<place-holder>])\n" +
-                "  |  <slot 21> : 25: cast\n" +
-                "  |  <slot 22> : CAST(15: expr AS VARCHAR)\n" +
-                "  |  <slot 23> : CAST(DictDecode(24: S_ADDRESS, [CAST(<place-holder> AS DOUBLE)]) + 1.0 AS VARCHAR)\n" +
-                "  |  common expressions:\n" +
-                "  |  <slot 25> : CAST(15: expr AS VARCHAR)\n" +
-                "  |  \n" +
-                "  2:AGGREGATE (update finalize)\n" +
-                "  |  group by: 24: S_ADDRESS, 15: expr\n" +
-                "  |  \n" +
-                "  1:Project\n" +
-                "  |  <slot 15> : CAST(7: S_SUPPKEY AS BIGINT) + 1\n" +
-                "  |  <slot 24> : 24: S_ADDRESS");
+        assertContains(plan, "  3:Project\n"
+                + "  |  <slot 20> : DictDecode(24: S_ADDRESS, [<place-holder>])\n"
+                + "  |  <slot 21> : 25: cast\n"
+                + "  |  <slot 22> : CAST(14: expr AS VARCHAR)\n"
+                + "  |  <slot 23> : CAST(DictDecode(24: S_ADDRESS, [CAST(<place-holder> AS DOUBLE)]) + 1.0 AS VARCHAR)\n"
+                + "  |  common expressions:\n"
+                + "  |  <slot 25> : CAST(14: expr AS VARCHAR)\n"
+                + "  |  \n"
+                + "  2:AGGREGATE (update finalize)\n"
+                + "  |  group by: 24: S_ADDRESS, 14: expr\n"
+                + "  |  \n"
+                + "  1:Project\n"
+                + "  |  <slot 14> : CAST(6: S_SUPPKEY AS BIGINT) + 1\n"
+                + "  |  <slot 24> : 24: S_ADDRESS");
 
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -1260,7 +1260,8 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "  9:Project\n"
                 + "  |  <slot 13> : 13: ARRAY_SLICE\n"
                 + "  |  <slot 14> : date(20: expr)\n"
-                + "  |  <slot 16> : coalesce(array_map(<slot 15> -> [<slot 15>[1],<slot 15>[2]], 13: ARRAY_SLICE), CAST([[]] AS ARRAY<ARRAY<VARCHAR>>))\n"
+                + "  |  <slot 16> : coalesce(array_map(<slot 15> -> [<slot 15>[1],<slot 15>[2]], 13: ARRAY_SLICE),"
+                + " CAST([[]] AS ARRAY<ARRAY<VARCHAR>>))\n"
                 + "  |  <slot 17> : 20: expr\n"
                 + "  |  \n"
                 + "  8:HASH JOIN");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -1257,14 +1257,13 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "order by b.bucket.start_date;\n";
 
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  9:Project\n" +
-                "  |  <slot 13> : 13: ARRAY_SLICE\n" +
-                "  |  <slot 14> : date(20: expr)\n" +
-                "  |  <slot 16> : coalesce(array_map(<slot 15> -> [<slot 15>[1],<slot 15>[2]], " +
-                "13: ARRAY_SLICE), CAST([[]] AS ARRAY<ARRAY<VARCHAR(65533)>>))\n" +
-                "  |  <slot 17> : 20: expr\n" +
-                "  |  \n" +
-                "  8:HASH JOIN");
+        assertContains(plan, "  9:Project\n"
+                + "  |  <slot 13> : 13: ARRAY_SLICE\n"
+                + "  |  <slot 14> : date(20: expr)\n"
+                + "  |  <slot 16> : coalesce(array_map(<slot 15> -> [<slot 15>[1],<slot 15>[2]], 13: ARRAY_SLICE), CAST([[]] AS ARRAY<ARRAY<VARCHAR>>))\n"
+                + "  |  <slot 17> : 20: expr\n"
+                + "  |  \n"
+                + "  8:HASH JOIN");
         assertContains(plan, "  1:Project\n" +
                 "  |  <slot 18> : clone(20: expr)\n" +
                 "  |  <slot 20> : 20: expr");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -678,17 +678,12 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         String plan = replayPair.second;
 
         // tbl_mock_015
-        Assertions.assertTrue(plan.contains("probe runtime filters:\n" +
-                "     - filter_id = 4, probe_expr = (<slot 79> 79: mock_004)"), plan);
-        Assertions.assertTrue(plan.contains("probe runtime filters:\n" +
-                "     - filter_id = 3, probe_expr = (<slot 62> 62: mock_004)"), plan);
+        Assertions.assertTrue(plan.contains("probe runtime filters:\n"
+                + "     - filter_id = 3, probe_expr = (<slot 64> 64: mock_004)"), plan);
 
         // table: tbl_mock_001, rollup: tbl_mock_001
-        Assertions.assertTrue(plan.contains("probe runtime filters:\n" +
-                "     - filter_id = 1, probe_expr = (<slot 110> 110: mock_004)"), plan);
-        Assertions.assertTrue(plan.contains("probe runtime filters:\n" +
-                "     - filter_id = 0, probe_expr = (<slot 96> 96: mock_004)\n"), plan);
-
+        Assertions.assertTrue(plan.contains("probe runtime filters:\n"
+                + "     - filter_id = 1, probe_expr = (<slot 112> 112: mock_004)"), plan);
     }
 
     @Test
@@ -742,13 +737,13 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/nested_view_with_cte"),
                         null, TExplainLevel.NORMAL);
-        PlanTestBase.assertContains(replayPair.second, "Project\n" +
-                "  |  <slot 7368> : 7368: count\n" +
-                "  |  limit: 100");
-        PlanTestBase.assertContains(replayPair.second, "AGGREGATE (merge finalize)\n" +
-                "  |  output: count(7368: count)\n" +
-                "  |  group by: 24: mock_038, 15: mock_003, 108: mock_109, 4: mock_005, 2: mock_110, 2134: case\n" +
-                "  |  limit: 100");
+        PlanTestBase.assertContains(replayPair.second, "Project\n"
+                + "  |  <slot 7325> : 7325: count\n"
+                + "  |  limit: 100");
+        PlanTestBase.assertContains(replayPair.second, "AGGREGATE (merge finalize)\n"
+                + "  |  output: count(7325: count)\n"
+                + "  |  group by: 24: mock_038, 15: mock_003, 108: mock_109, 4: mock_005, 2: mock_110, 2123: case\n"
+                + "  |  limit: 100");
     }
 
     @Test
@@ -808,15 +803,14 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
 
         // Topn should be pushed down below union all and contains no duplicated ording columns
-        PlanTestBase.assertContains(replayPair.second, "  26:TOP-N\n" +
-                "  |  order by: <slot 240> 240: expr ASC, <slot 241> 241: cast DESC, <slot 206> 206: mock_025 DESC\n" +
-                "  |  offset: 0\n" +
-                "  |  limit: 200");
-        PlanTestBase.assertContains(replayPair.second, "17:TOP-N\n" +
-                "  |  order by: <slot 165> 165: cast ASC, <slot 153> 153: cast DESC, <slot 166> 166: expr ASC, " +
-                "<slot 167> 167: cast DESC\n" +
-                "  |  offset: 0\n" +
-                "  |  limit: 200");
+        PlanTestBase.assertContains(replayPair.second, "TOP-N\n"
+                + "  |  order by: <slot 239> 239: expr ASC, <slot 227> 227: cast DESC, <slot 240> 240: cast DESC\n"
+                + "  |  offset: 0\n"
+                + "  |  limit: 200");
+        PlanTestBase.assertContains(replayPair.second, "TOP-N\n"
+                + "  |  order by: <slot 149> 149: expr ASC, <slot 151> 151: cast DESC, <slot 152> 152: cast ASC, <slot 138> 138: cast DESC\n"
+                + "  |  offset: 0\n"
+                + "  |  limit: 200");
     }
 
     @Test
@@ -1104,14 +1098,14 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
             Pair<QueryDumpInfo, String> replayPair = getPlanFragment(dumpString, queryDumpInfo.getSessionVariable(),
                     TExplainLevel.NORMAL);
             String plan = replayPair.second;
-            Assertions.assertTrue(plan.contains("  30:Project\n" +
-                    "  |  <slot 113> : 113: mock_field_111\n" +
-                    "  |  <slot 278> : lower(142: jl_str)\n" +
-                    "  |  \n" +
-                    "  29:TableValueFunction\n" +
-                    "  |  tableFunctionName: unnest\n" +
-                    "  |  columns: [unnest]\n" +
-                    "  |  returnTypes: [VARCHAR(65533)]"), plan);
+            Assertions.assertTrue(plan.contains("  30:Project\n"
+                    + "  |  <slot 113> : 113: mock_field_111\n"
+                    + "  |  <slot 268> : lower(142: jl_str)\n"
+                    + "  |  \n"
+                    + "  29:TableValueFunction\n"
+                    + "  |  tableFunctionName: unnest\n"
+                    + "  |  columns: [unnest]\n"
+                    + "  |  returnTypes: [VARCHAR(65533)]"), plan);
         } finally {
             FeConstants.USE_MOCK_DICT_MANAGER = false;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -808,7 +808,8 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
                 + "  |  offset: 0\n"
                 + "  |  limit: 200");
         PlanTestBase.assertContains(replayPair.second, "TOP-N\n"
-                + "  |  order by: <slot 149> 149: expr ASC, <slot 151> 151: cast DESC, <slot 152> 152: cast ASC, <slot 138> 138: cast DESC\n"
+                + "  |  order by: <slot 149> 149: expr ASC, <slot 151> 151: cast DESC, "
+                + "<slot 152> 152: cast ASC, <slot 138> 138: cast DESC\n"
                 + "  |  offset: 0\n"
                 + "  |  limit: 200");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
@@ -221,16 +221,15 @@ public class SetTest extends PlanTestBase {
     public void testSetOpCast() throws Exception {
         String sql = "select * from t0 union all (select * from t1 union all select k1,k7,k8 from  baseall)";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "  0:UNION\n" +
-                "  |  output exprs:\n" +
-                "  |      [26, BIGINT, true] | [27, VARCHAR(20), true] | [28, DOUBLE, true]\n" +
-                "  |  child exprs:\n" +
-                "  |      [1: v1, BIGINT, true] | [4: cast, VARCHAR(20), true] | [5: cast, DOUBLE, true]\n" +
-                "  |      [23: v4, BIGINT, true] | [24: cast, VARCHAR(20), true] | [25: cast, DOUBLE, true]");
-        Assertions.assertTrue(plan.contains(
-                "  |  19 <-> [19: k7, VARCHAR, true]\n" +
-                        "  |  20 <-> [20: k8, DOUBLE, true]\n" +
-                        "  |  22 <-> cast([11: k1, TINYINT, true] as BIGINT)"));
+        assertContains(plan, "  0:UNION\n"
+                + "  |  output exprs:\n"
+                + "  |      [27, BIGINT, true] | [28, VARCHAR, true] | [29, DOUBLE, true]\n"
+                + "  |  child exprs:\n"
+                + "  |      [1: v1, BIGINT, true] | [4: cast, VARCHAR, true] | [5: cast, DOUBLE, true]\n"
+                + "  |      [24: v4, BIGINT, true] | [25: cast, VARCHAR, true] | [26: cast, DOUBLE, true]");
+        Assertions.assertTrue(plan.contains("  |  20 <-> [20: k8, DOUBLE, true]\n"
+                        + "  |  22 <-> cast([11: k1, TINYINT, true] as BIGINT)\n"
+                        + "  |  23 <-> [19: k7, VARCHAR, true]"));
 
         sql = "select * from t0 union all (select cast(v4 as int), v5,v6 " +
                 "from t1 except select cast(v7 as int), v8, v9 from t2)";
@@ -657,23 +656,23 @@ public class SetTest extends PlanTestBase {
                 " all select 2 union all select * from (values (3)) t";
         plan = getVerboseExplain(sql);
 
-        assertContains(plan, "|  output exprs:\n" +
-                "  |      [13, VARCHAR(32), true]\n" +
-                "  |  child exprs:\n" +
-                "  |      [1: k1, VARCHAR, true]\n" +
-                "  |      [12: cast, VARCHAR(32), false]\n" +
-                "  |      [14: k1, VARCHAR(32), true]\n");
+        assertContains(plan, "  |  output exprs:\n"
+                + "  |      [14, VARCHAR, true]\n"
+                + "  |  child exprs:\n"
+                + "  |      [5: cast, VARCHAR, true]\n"
+                + "  |      [13: cast, VARCHAR, false]\n"
+                + "  |      [15: cast, VARCHAR, true]");
 
         sql = "select k1 from db1.tbl6 union all select 1 union" +
                 " all select 2 union all select * from (values (3)) t";
         plan = getVerboseExplain(sql);
 
-        assertContains(plan, "  |  output exprs:\n" +
-                "  |      [13, VARCHAR(32), true]\n" +
-                "  |  child exprs:\n" +
-                "  |      [1: k1, VARCHAR, true]\n" +
-                "  |      [12: cast, VARCHAR(32), false]\n" +
-                "  |      [14: k1, VARCHAR(32), true]");
+        assertContains(plan, "  |  output exprs:\n"
+                + "  |      [14, VARCHAR, true]\n"
+                + "  |  child exprs:\n"
+                + "  |      [5: cast, VARCHAR, true]\n"
+                + "  |      [13: cast, VARCHAR, false]\n"
+                + "  |      [15: cast, VARCHAR, true]");
 
         sql = "select 1 union all select 2 union all select * from (values (1)) t;";
         plan = getVerboseExplain(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
@@ -746,4 +746,11 @@ public class SetTest extends PlanTestBase {
                 "  |      [4: TABLE_NAME, VARCHAR, false]\n" +
                 "  |      [17: TABLE_NAME, VARCHAR, true]");
     }
+
+    @Test
+    public void testUnionStringType() throws Exception {
+        String sql = "select 'a' union all select ta from tall;";
+        ExecPlan plan = getExecPlan(sql);
+        assertContains("varchar", plan.getOutputColumns().get(0).getType().toSql());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

```
Error log :
Error: String 'a-long-long-long-string'(length=23) is too long. The max length of 'b' is 10. Row
the script is following
CREATE TABLE test( a INT, b varchar(10) );
Insert into test values (1, 'data1'), (2, 'data2');

CREATE VIEW test_view AS
SELECT a, case 1 when 1 then "a-long-long-long-string" else "" END b FROM test;

CREATE TEMPORARY TABLE temp_table AS
SELECT * FROM test
UNION ALL
SELECT * FROM test_view;
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
