### PR TITLE
[Refactor] Remove an outdated TODO in function_context.h

### DIFF
--- a/be/src/exprs/function_context.h
+++ b/be/src/exprs/function_context.h
@@ -57,7 +57,6 @@ public:
         /// concurrently on a single host if the UDF will be evaluated in multiple plan
         /// fragments on that host. In general, read-only state that doesn't need to be
         /// recomputed for every UDF call should be fragment-local.
-        /// TODO: not yet implemented
         FRAGMENT_LOCAL,
 
         /// Indicates that the function state is local to the execution thread. This state


### PR DESCRIPTION
## Why I'm doing:

This TODO is outdated. FRAGMENT_LOCAL is implemented and actively used in many function implementations.

## What I'm doing:

Remove this TODO in the comment.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
