### PR TITLE
[Enhancement] Introduce a host-level sorting for iceberg table sink to improve data organization and later reading performance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -25,6 +25,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.Util;
 import com.starrocks.connector.BucketProperty;
+import com.starrocks.connector.ConnectorSinkSortScope;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergApiConverter;
 import com.starrocks.connector.iceberg.IcebergCatalogType;
@@ -234,15 +235,25 @@ public class IcebergTable extends Table {
     public List<Integer> getSortKeyIndexes() {
         List<Integer> indexes = new ArrayList<>();
         org.apache.iceberg.Table nativeTable = getNativeTable();
-        List<Types.NestedField> fields = nativeTable.schema().asStruct().fields();
-        List<Integer> sortFieldSourceIds = nativeTable.sortOrder().fields().stream()
-                .map(SortField::sourceId)
-                .collect(Collectors.toList());
+        SortOrder sortOrder = nativeTable.sortOrder();
+        if (sortOrder == null || sortOrder.fields().isEmpty()) {
+            return indexes;
+        }
 
+        List<Types.NestedField> fields = nativeTable.schema().asStruct().fields();
+        // The Iceberg table's sort order may differs from schema column order, e.g., sorting by [B, A] when
+        // schema is [A, B]), So we need to build a mapping from fieldId to schema index first, and then get
+        // the correct index according to sort order.
+        Map<Integer, Integer> fieldIdToIndex = Maps.newHashMap();
         for (int i = 0; i < fields.size(); i++) {
-            Types.NestedField field = fields.get(i);
-            if (sortFieldSourceIds.contains(field.fieldId())) {
-                indexes.add(i);
+            fieldIdToIndex.put(fields.get(i).fieldId(), i);
+        }
+
+        // Keep the returned indexes aligned with sortOrder.fields() order.
+        for (SortField sortField : sortOrder.fields()) {
+            Integer idx = fieldIdToIndex.get(sortField.sourceId());
+            if (idx != null) {
+                indexes.add(idx);
             }
         }
 
@@ -508,19 +519,34 @@ public class IcebergTable extends Table {
 
         SortOrder sortOrder = nativeTable.sortOrder();
         if (sortOrder != null && sortOrder.isSorted()) {
-            TSortOrder tSortOrder = new TSortOrder();
-            List<Integer> sortKeyIndexes = getSortKeyIndexes();
-            for (int idx = 0; idx < sortKeyIndexes.size(); ++idx) {
-                int sortKeyIndex = sortKeyIndexes.get(idx);
-                SortField sortField = sortOrder.fields().get(idx);
-                if (!sortField.transform().isIdentity()) {
-                    continue;
+            // Check if we should skip sort_order for host-level sorting
+            boolean shouldSkipSortOrder = false;
+            ConnectContext context = ConnectContext.get();
+            if (context != null) {
+                ConnectorSinkSortScope sortScope = ConnectorSinkSortScope.fromName(
+                        context.getSessionVariable().getConnectorSinkSortScope());
+                // When using host-level sorting, FE ensures data is sorted before reaching BE,
+                // so we don't need to pass sort_order to BE to avoid duplicate sorting
+                if (sortScope == ConnectorSinkSortScope.NONE || sortScope == ConnectorSinkSortScope.HOST) {
+                    shouldSkipSortOrder = true;
                 }
-                tSortOrder.addToSort_key_idxes(sortKeyIndex);
-                tSortOrder.addToIs_ascs(sortField.direction() == SortDirection.ASC);
-                tSortOrder.addToIs_null_firsts(sortField.nullOrder() == NullOrder.NULLS_FIRST);
             }
-            tIcebergTable.setSort_order(tSortOrder);
+
+            if (!shouldSkipSortOrder) {
+                TSortOrder tSortOrder = new TSortOrder();
+                List<Integer> sortKeyIndexes = getSortKeyIndexes();
+                for (int idx = 0; idx < sortKeyIndexes.size(); ++idx) {
+                    int sortKeyIndex = sortKeyIndexes.get(idx);
+                    SortField sortField = sortOrder.fields().get(idx);
+                    if (!sortField.transform().isIdentity()) {
+                        continue;
+                    }
+                    tSortOrder.addToSort_key_idxes(sortKeyIndex);
+                    tSortOrder.addToIs_ascs(sortField.direction() == SortDirection.ASC);
+                    tSortOrder.addToIs_null_firsts(sortField.nullOrder() == NullOrder.NULLS_FIRST);
+                }
+                tIcebergTable.setSort_order(tSortOrder);
+            }
         }
 
         TTableDescriptor tTableDescriptor = new TTableDescriptor(id, TTableType.ICEBERG_TABLE,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorSinkSortScope.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorSinkSortScope.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Controls the sorting scope for connector sink operations.
+ * Now we support three scopes: NONE, FILE and HOST.
+ * And more sorting scope can be supported in the future, such as WAREHOUSE, CLUSTER, etc.
+ */
+public enum ConnectorSinkSortScope {
+    /**
+     * No sorting is performed.
+     */
+    NONE("none"),
+
+    /**
+     * Sort within each file (current default behavior).
+     * Each file written by the connector will have sorted data internally.
+     */
+    FILE("file"),
+
+    /**
+     * Sort at host level.
+     * Data sent to each host is sorted, ensuring all files on the same host
+     * contain globally sorted data. In this mode, BE should not perform
+     * additional file-level sorting since the data is already sorted.
+     */
+    HOST("host");
+
+    private final String scopeName;
+
+    ConnectorSinkSortScope(String scopeName) {
+        this.scopeName = scopeName;
+    }
+
+    public static ConnectorSinkSortScope fromName(String scopeName) {
+        checkArgument(scopeName != null, "Connector sink sort scope name is null");
+
+        if (NONE.scopeName().equalsIgnoreCase(scopeName)) {
+            return NONE;
+        } else if (FILE.scopeName().equalsIgnoreCase(scopeName)) {
+            return FILE;
+        } else if (HOST.scopeName().equalsIgnoreCase(scopeName)) {
+            return HOST;
+        } else {
+            throw new IllegalArgumentException(
+                    "Unknown connector sink sort scope: " + scopeName +
+                    ", only support none, file, and host");
+        }
+    }
+
+    public String scopeName() {
+        return scopeName;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -54,6 +54,7 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.ConnectorSinkShuffleMode;
+import com.starrocks.connector.ConnectorSinkSortScope;
 import com.starrocks.connector.PlanMode;
 import com.starrocks.datacache.DataCachePopulateMode;
 import com.starrocks.monitor.unit.TimeValue;
@@ -578,6 +579,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_CONNECTOR_SINK_SPILL = "enable_connector_sink_spill";
     public static final String CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD = "connector_sink_spill_mem_limit_threshold";
+    public static final String CONNECTOR_SINK_SORT_SCOPE = "connector_sink_sort_scope";
     public static final String PIPELINE_SINK_DOP = "pipeline_sink_dop";
     public static final String ENABLE_ADAPTIVE_SINK_DOP = "enable_adaptive_sink_dop";
     public static final String RUNTIME_FILTER_SCAN_WAIT_TIME = "runtime_filter_scan_wait_time";
@@ -1468,6 +1470,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD, flag = VariableMgr.INVISIBLE)
     private double connectorSinkSpillMemLimitThreshold = 0.5;
+
+    @VariableMgr.VarAttr(name = CONNECTOR_SINK_SORT_SCOPE)
+    private String connectorSinkSortScope = ConnectorSinkSortScope.FILE.scopeName();
 
     // execute sql don't return result, for performance test
     @VarAttr(name = ENABLE_EXECUTION_ONLY, flag = VariableMgr.INVISIBLE)
@@ -2519,6 +2524,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public long getConnectorSinkTargetMaxFileSize() {
         return connectorSinkTargetMaxFileSize;
+    }
+
+    public String getConnectorSinkSortScope() {
+        return connectorSinkSortScope;
+    }
+
+    public void setConnectorSinkSortScope(String connectorSinkSortScope) {
+        this.connectorSinkSortScope = connectorSinkSortScope;
     }
 
     @VariableMgr.VarAttr(name = ENABLE_FILE_METACACHE)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -39,6 +39,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ConnectorSinkShuffleMode;
+import com.starrocks.connector.ConnectorSinkSortScope;
 import com.starrocks.load.Load;
 import com.starrocks.planner.BlackHoleTableSink;
 import com.starrocks.planner.DataSink;
@@ -89,10 +90,13 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.DistributionProperty;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.base.EmptyDistributionProperty;
 import com.starrocks.sql.optimizer.base.GatherDistributionSpec;
 import com.starrocks.sql.optimizer.base.HashDistributionDesc;
+import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.base.RoundRobinDistributionSpec;
+import com.starrocks.sql.optimizer.base.SortProperty;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -116,7 +120,11 @@ import com.starrocks.thrift.TResultSinkType;
 import com.starrocks.type.NullType;
 import com.starrocks.type.Type;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortField;
+import org.apache.iceberg.SortOrder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -922,30 +930,56 @@ public class InsertPlanner {
         Table targetTable = insertStmt.getTargetTable();
         if (targetTable instanceof IcebergTable) {
             IcebergTable icebergTable = (IcebergTable) targetTable;
+
+            // Create distribution property if global shuffle is enabled
+            DistributionProperty distributionProperty = EmptyDistributionProperty.INSTANCE;
             ConnectorSinkShuffleMode shuffleMode = session.getConnectorSinkShuffleMode();
 
             // For shuffle mode except NEVER, only apply shuffle to partitioned tables
             if (shuffleMode != ConnectorSinkShuffleMode.NEVER && !icebergTable.getPartitionColumns().isEmpty()) {
 
-                // Handle FORCE mode - always enable global shuffle
-                // We also handle the old session variable `enable_iceberg_sink_global_shuffle` for compatibility.
-                if (shuffleMode == ConnectorSinkShuffleMode.FORCE) {
+                // For FORCE mode - always enable global shuffle, we also handle the old session variable
+                // `enable_iceberg_sink_global_shuffle` for compatibility.
+                // For AUTO mode - use adaptive logic based on partition count and backend count
+                if (shuffleMode == ConnectorSinkShuffleMode.FORCE || (shuffleMode == ConnectorSinkShuffleMode.AUTO &&
+                        shouldEnableAdaptiveGlobalShuffle(insertStmt, icebergTable, session))) {
                     List<Integer> partitionColumnIDs = icebergTable.partitionColumnIndexes().stream()
                             .map(x -> outputColumns.get(x).getId()).collect(Collectors.toList());
-                    return createShufflePropertyFromPartitions(partitionColumnIDs);
+                    distributionProperty = createDistributionPropertyFromPartitions(partitionColumnIDs);
                 }
+            }
 
-                // Handle AUTO mode - use adaptive logic based on partition count and backend count
-                if (shuffleMode == ConnectorSinkShuffleMode.AUTO) {
-                    boolean shouldEnableGlobalShuffle = shouldEnableAdaptiveGlobalShuffle(
-                            insertStmt, icebergTable, session);
-                    if (shouldEnableGlobalShuffle) {
-                        List<Integer> partitionColumnIDs = icebergTable.partitionColumnIndexes().stream()
-                                .map(x -> outputColumns.get(x).getId()).collect(Collectors.toList());
-                        return createShufflePropertyFromPartitions(partitionColumnIDs);
+            // Check if we should use host-level sorting for connector sink
+            ConnectorSinkSortScope sortScope = ConnectorSinkSortScope.fromName(session.getConnectorSinkSortScope());
+            boolean useHostLevelSort = (sortScope == ConnectorSinkSortScope.HOST);
+
+            // Get sort order info from Iceberg table
+            List<Ordering> sortOrderings = new ArrayList<>();
+            if (useHostLevelSort) {
+                org.apache.iceberg.Table nativeTable = icebergTable.getNativeTable();
+                SortOrder sortOrder = nativeTable.sortOrder();
+                if (sortOrder != null && sortOrder.isSorted()) {
+                    List<Integer> sortKeyIndexes = icebergTable.getSortKeyIndexes();
+                    for (int idx = 0; idx < sortKeyIndexes.size(); ++idx) {
+                        int sortKeyIndex = sortKeyIndexes.get(idx);
+                        SortField sortField = sortOrder.fields().get(idx);
+                        // Skip non-identity transforms
+                        if (!sortField.transform().isIdentity()) {
+                            continue;
+                        }
+                        boolean isAsc = sortField.direction() == SortDirection.ASC;
+                        boolean isNullFirst = sortField.nullOrder() == NullOrder.NULLS_FIRST;
+                        sortOrderings.add(new Ordering(outputColumns.get(sortKeyIndex), isAsc, isNullFirst));
                     }
                 }
             }
+
+            // Create sort property if host-level sorting is enabled and sort order exists
+            SortProperty sortProperty = SortProperty.createProperty(sortOrderings);
+
+            // Return property set with both distribution and sort properties
+            // These properties also can be empty.
+            return new PhysicalPropertySet(distributionProperty, sortProperty);
         }
 
         if (targetTable instanceof TableFunctionTable) {
@@ -963,7 +997,7 @@ public class InsertPlanner {
                 } else { // use hash shuffle for partitioned table
                     List<Integer> partitionColumnIDs = table.getPartitionColumnIDs().stream()
                             .map(x -> outputColumns.get(x).getId()).collect(Collectors.toList());
-                    return createShufflePropertyFromPartitions(partitionColumnIDs);
+                    return new PhysicalPropertySet(createDistributionPropertyFromPartitions(partitionColumnIDs));
                 }
             }
 
@@ -1017,11 +1051,10 @@ public class InsertPlanner {
         return new PhysicalPropertySet(property);
     }
 
-    private PhysicalPropertySet createShufflePropertyFromPartitions(List<Integer> partitionColumnIDs) {
+    private DistributionProperty createDistributionPropertyFromPartitions(List<Integer> partitionColumnIDs) {
         HashDistributionDesc desc = new HashDistributionDesc(partitionColumnIDs, HashDistributionDesc.SourceType.SHUFFLE_AGG);
         DistributionSpec spec = DistributionSpec.createHashDistributionSpec(desc);
-        DistributionProperty property = DistributionProperty.createProperty(spec);
-        return new PhysicalPropertySet(property);
+        return DistributionProperty.createProperty(spec);
     }
 
     private OptExprBuilder fillKeyPartitionsColumn(ColumnRefFactory columnRefFactory,
@@ -1133,19 +1166,19 @@ public class InsertPlanner {
 
     /**
      * Judge whether adaptive global shuffle should be enabled based on partition count and backend count.
-     *
+     * <p>
      * Decision criteria (configurable via session variables):
      * 1. Enable when estimated partition count >= backend count * ratio
      * 2. OR when estimated partition count >= absolute threshold
      *
-     * @param insertStmt INSERT statement
+     * @param insertStmt   INSERT statement
      * @param icebergTable target Iceberg table
-     * @param session Session variable
+     * @param session      Session variable
      * @return whether to enable global shuffle
      */
     private boolean shouldEnableAdaptiveGlobalShuffle(InsertStmt insertStmt,
-                                                       IcebergTable icebergTable,
-                                                       SessionVariable session) {
+                                                      IcebergTable icebergTable,
+                                                      SessionVariable session) {
         // Get the number of alive BE nodes and CN nodes in the cluster
         SystemInfoService clusterInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
         int aliveBackendNum = clusterInfo.getAliveBackendNumber();
@@ -1204,7 +1237,7 @@ public class InsertPlanner {
     /**
      * Estimate the number of partitions that may be involved in this INSERT operation.
      *
-     * @param insertStmt INSERT statement
+     * @param insertStmt   INSERT statement
      * @param icebergTable target Iceberg table
      * @return estimated partition count
      */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -343,6 +343,16 @@ public class SetStmtAnalyzer {
             PlanMode.fromName(resolvedExpression.getStringValue());
         }
 
+        // check connector_sink_sort_scope
+        if (variable.equalsIgnoreCase(SessionVariable.CONNECTOR_SINK_SORT_SCOPE)) {
+            try {
+                com.starrocks.connector.ConnectorSinkSortScope.fromName(resolvedExpression.getStringValue());
+            } catch (Exception e) {
+                throw new SemanticException(String.format("Unsupported connector_sink_sort_scope: %s, " +
+                        "valid values are: none, file, host", resolvedExpression.getStringValue()));
+            }
+        }
+
         // check populate datacache mode
         if (variable.equalsIgnoreCase(SessionVariable.POPULATE_DATACACHE_MODE)) {
             DataCachePopulateMode.fromName(resolvedExpression.getStringValue());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorSinkSortScopeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorSinkSortScopeTest.java
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ConnectorSinkSortScopeTest {
+
+    @Test
+    public void testFromName() {
+        Assertions.assertEquals(ConnectorSinkSortScope.NONE, ConnectorSinkSortScope.fromName("none"));
+        Assertions.assertEquals(ConnectorSinkSortScope.NONE, ConnectorSinkSortScope.fromName("NONE"));
+        Assertions.assertEquals(ConnectorSinkSortScope.NONE, ConnectorSinkSortScope.fromName("None"));
+
+        Assertions.assertEquals(ConnectorSinkSortScope.FILE, ConnectorSinkSortScope.fromName("file"));
+        Assertions.assertEquals(ConnectorSinkSortScope.FILE, ConnectorSinkSortScope.fromName("FILE"));
+        Assertions.assertEquals(ConnectorSinkSortScope.FILE, ConnectorSinkSortScope.fromName("File"));
+
+        Assertions.assertEquals(ConnectorSinkSortScope.HOST, ConnectorSinkSortScope.fromName("host"));
+        Assertions.assertEquals(ConnectorSinkSortScope.HOST, ConnectorSinkSortScope.fromName("HOST"));
+        Assertions.assertEquals(ConnectorSinkSortScope.HOST, ConnectorSinkSortScope.fromName("Host"));
+    }
+
+    @Test
+    public void testFromNameNull() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            ConnectorSinkSortScope.fromName(null);
+        });
+    }
+
+    @Test
+    public void testFromNameInvalid() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            ConnectorSinkSortScope.fromName("invalid");
+        });
+    }
+
+    @Test
+    public void testScopeName() {
+        Assertions.assertEquals("none", ConnectorSinkSortScope.NONE.scopeName());
+        Assertions.assertEquals("file", ConnectorSinkSortScope.FILE.scopeName());
+        Assertions.assertEquals("host", ConnectorSinkSortScope.HOST.scopeName());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/InsertPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/InsertPlannerTest.java
@@ -15,21 +15,33 @@
 package com.starrocks.planner;
 
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
+import com.starrocks.connector.ConnectorSinkSortScope;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.InsertPlanner;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.optimizer.base.EmptyDistributionProperty;
+import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
+import com.starrocks.sql.optimizer.base.SortProperty;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.ScalarType;
 import mockit.Delegate;
 import mockit.Expectations;
 import mockit.Mocked;
 import mockit.Verifications;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -128,4 +140,129 @@ public class InsertPlannerTest {
             metadataMgr.refreshTable(anyString, anyString, (Table) any, (List<String>) any, anyBoolean); times = 0;
         }};
     }
+
+    @Test
+    public void testCreatePhysicalPropertySetWithFileMode(@Mocked InsertStmt insertStmt,
+                                                        @Mocked SessionVariable session,
+                                                        @Mocked IcebergTable icebergTable,
+                                                        @Mocked QueryStatement queryStatement) throws Exception {
+        // Create output columns
+        List<ColumnRefOperator> outputColumns = new ArrayList<>();
+        outputColumns.add(new ColumnRefOperator(1, new ScalarType(PrimitiveType.INT), "col1", true));
+        outputColumns.add(new ColumnRefOperator(2, new ScalarType(PrimitiveType.BIGINT), "col2", true));
+
+        new Expectations() {{
+            insertStmt.getTargetTable(); result = icebergTable;
+            insertStmt.getQueryStatement(); result = queryStatement;
+            queryStatement.getQueryRelation(); result = null;
+            session.getConnectorSinkSortScope(); result = ConnectorSinkSortScope.FILE.scopeName();
+            icebergTable.getPartitionColumns().isEmpty(); result = true; minTimes = 0;
+        }};
+
+        // Use reflection to call the private method
+        Method method = InsertPlanner.class.getDeclaredMethod(
+                "createPhysicalPropertySet", InsertStmt.class, List.class, SessionVariable.class);
+        method.setAccessible(true);
+        PhysicalPropertySet result = (PhysicalPropertySet) method.invoke(new InsertPlanner(), insertStmt, outputColumns, session);
+
+        // FILE mode should not create SortProperty
+        // PhysicalPropertySet should be empty (no distribution, no sort)
+        assert result != null;
+        assert result.getSortProperty().isEmpty();
+    }
+
+    @Test
+    public void testCreatePhysicalPropertySetWithHostModeNoSortOrder(@Mocked InsertStmt insertStmt,
+                                                                     @Mocked SessionVariable session,
+                                                                     @Mocked IcebergTable icebergTable,
+                                                                     @Mocked QueryStatement queryStatement,
+                                                                     @Mocked org.apache.iceberg.Table nativeTable,
+                                                                     @Mocked org.apache.iceberg.SortOrder sortOrder) throws Exception {
+        // Create output columns
+        List<ColumnRefOperator> outputColumns = new ArrayList<>();
+        outputColumns.add(new ColumnRefOperator(1, new ScalarType(PrimitiveType.INT), "col1", true));
+        outputColumns.add(new ColumnRefOperator(2, new ScalarType(PrimitiveType.BIGINT), "col2", true));
+
+        new Expectations() {{
+            insertStmt.getTargetTable(); result = icebergTable;
+            insertStmt.getQueryStatement(); result = queryStatement;
+            queryStatement.getQueryRelation(); result = null;
+            session.getConnectorSinkSortScope(); result = ConnectorSinkSortScope.HOST.scopeName();
+            icebergTable.getNativeTable(); result = nativeTable;
+            nativeTable.sortOrder(); result = sortOrder;
+            sortOrder.isSorted(); result = false;
+            icebergTable.getPartitionColumns().isEmpty(); result = true; minTimes = 0;
+        }};
+
+        // Use reflection to call the private method
+        Method method = InsertPlanner.class.getDeclaredMethod(
+                "createPhysicalPropertySet", InsertStmt.class, List.class, SessionVariable.class);
+        method.setAccessible(true);
+        PhysicalPropertySet result = (PhysicalPropertySet) method.invoke(new InsertPlanner(), insertStmt, outputColumns, session);
+
+        // HOST mode with no sort order should not create SortProperty
+        assert result != null;
+        assert result.getSortProperty().isEmpty();
+        assert result.getDistributionProperty() == EmptyDistributionProperty.INSTANCE;
+    }
+
+    @Test
+    public void testCreatePhysicalPropertySetWithHostModeWithSortOrder(@Mocked InsertStmt insertStmt,
+                                                                       @Mocked SessionVariable session,
+                                                                       @Mocked IcebergTable icebergTable,
+                                                                       @Mocked QueryStatement queryStatement,
+                                                                       @Mocked org.apache.iceberg.Table nativeTable,
+                                                                       @Mocked org.apache.iceberg.SortOrder sortOrder,
+                                                                       @Mocked org.apache.iceberg.SortField sortField1,
+                                                                       @Mocked org.apache.iceberg.SortField sortField2,
+                                                                       @Mocked org.apache.iceberg.transforms.Transform transform1,
+                                                                       @Mocked org.apache.iceberg.transforms.Transform transform2) throws Exception {
+        // sortKeyIndexes contains array positions in schema (0, 1, etc.)
+        final List<Integer> sortKeyIndexes = new ArrayList<>();
+        sortKeyIndexes.add(0);
+        sortKeyIndexes.add(1);
+
+        final List<org.apache.iceberg.SortField> sortFields = new ArrayList<>();
+        sortFields.add(sortField1);
+        sortFields.add(sortField2);
+
+        // Create output columns (matching schema order)
+        List<ColumnRefOperator> outputColumns = new ArrayList<>();
+        outputColumns.add(new ColumnRefOperator(0, new ScalarType(PrimitiveType.INT), "col1", true));
+        outputColumns.add(new ColumnRefOperator(1, new ScalarType(PrimitiveType.BIGINT), "col2", true));
+
+        new Expectations() {{
+            insertStmt.getTargetTable(); result = icebergTable;
+            insertStmt.getQueryStatement(); result = queryStatement;
+            queryStatement.getQueryRelation(); result = null;
+            session.getConnectorSinkSortScope(); result = ConnectorSinkSortScope.HOST.scopeName();
+            icebergTable.getNativeTable(); result = nativeTable;
+            nativeTable.sortOrder(); result = sortOrder;
+            sortOrder.isSorted(); result = true;
+            icebergTable.getSortKeyIndexes(); result = sortKeyIndexes;
+            sortOrder.fields(); result = sortFields;
+            sortField1.transform(); result = transform1;
+            transform1.isIdentity(); result = true;
+            sortField1.direction(); result = org.apache.iceberg.SortDirection.ASC;
+            sortField1.nullOrder(); result = org.apache.iceberg.NullOrder.NULLS_FIRST;
+            sortField2.transform(); result = transform2;
+            transform2.isIdentity(); result = true;
+            sortField2.direction(); result = org.apache.iceberg.SortDirection.DESC;
+            sortField2.nullOrder(); result = org.apache.iceberg.NullOrder.NULLS_LAST;
+            icebergTable.getPartitionColumns().isEmpty(); result = true; minTimes = 0;
+        }};
+
+        // Use reflection to call the private method
+        Method method = InsertPlanner.class.getDeclaredMethod(
+                "createPhysicalPropertySet", InsertStmt.class, List.class, SessionVariable.class);
+        method.setAccessible(true);
+        PhysicalPropertySet result = (PhysicalPropertySet) method.invoke(new InsertPlanner(), insertStmt, outputColumns, session);
+
+        // Verify the result - HOST mode with sort order should create SortProperty
+        assert result != null;
+        SortProperty sortProperty = result.getSortProperty();
+        // The sort property should not be empty when host-level sorting is enabled with sort order
+        assert sortProperty != null;
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/SetStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/SetStmtTest.java
@@ -512,5 +512,77 @@ public class SetStmtTest {
         }
     }
 
-    
+    @Test
+    public void testConnectorSinkSortScope() {
+        // Test valid values
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CONNECTOR_SINK_SORT_SCOPE,
+                    new StringLiteral("none"));
+            SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+            Assertions.assertEquals("none", setVar.getResolvedExpression().getStringValue());
+        }
+
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CONNECTOR_SINK_SORT_SCOPE,
+                    new StringLiteral("file"));
+            SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+            Assertions.assertEquals("file", setVar.getResolvedExpression().getStringValue());
+        }
+
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CONNECTOR_SINK_SORT_SCOPE,
+                    new StringLiteral("host"));
+            SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+            Assertions.assertEquals("host", setVar.getResolvedExpression().getStringValue());
+        }
+
+        // Test case insensitivity
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CONNECTOR_SINK_SORT_SCOPE,
+                    new StringLiteral("NONE"));
+            SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+            Assertions.assertEquals("NONE", setVar.getResolvedExpression().getStringValue());
+        }
+
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CONNECTOR_SINK_SORT_SCOPE,
+                    new StringLiteral("FILE"));
+            SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+            Assertions.assertEquals("FILE", setVar.getResolvedExpression().getStringValue());
+        }
+
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CONNECTOR_SINK_SORT_SCOPE,
+                    new StringLiteral("HOST"));
+            SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+            Assertions.assertEquals("HOST", setVar.getResolvedExpression().getStringValue());
+        }
+
+        // Test invalid value "hos" (typo)
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CONNECTOR_SINK_SORT_SCOPE,
+                    new StringLiteral("hos"));
+            try {
+                SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                Assertions.fail("should fail for invalid value 'hos'");
+            } catch (SemanticException e) {
+                assertThat(e.getMessage(), containsString("Unsupported connector_sink_sort_scope: hos"));
+                assertThat(e.getMessage(), containsString("valid values are: none, file, host"));
+            }
+        }
+
+        // Test invalid value "invalid"
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CONNECTOR_SINK_SORT_SCOPE,
+                    new StringLiteral("invalid"));
+            try {
+                SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                Assertions.fail("should fail for invalid value 'invalid'");
+            } catch (SemanticException e) {
+                assertThat(e.getMessage(), containsString("Unsupported connector_sink_sort_scope: invalid"));
+            }
+        }
+    }
+
+
 }


### PR DESCRIPTION
## Why I'm doing:
Currently, StarRocks performs file-level sorting when writing to Iceberg tables with a defined sort order.
This can reduce the impact of sorting on the overall write time, but only ensure the order of the records in each file. Compared to write performance, users may sometimes be more concerned about the order of data after it has been written, so as to provide better performance for subsequent queries.

## What I'm doing:
This enhancement introduces host-level sorting to improve data organization and reading performance.
For the host-level sorting, the data files in a same BE node are sorted, but with higher write latency.

Specifically, this PR finish these things:
-  Add a new session variable `connector_sink_sort_scope` with three supported values: `NONE`, `FILE` (default), and `HOST`
- When set to `HOST`, `InsertPlanner` creates a `SortProperty` based on the Iceberg table's sort order,
    ensuring data is globally sorted at the host level before distribution
- Modify `IcebergTable.toThrift()` to skip sending sort order to BE when host-level sorting is active,
    preventing duplicate sorting operations
- Add `ConnectorSinkSortScope` enum and corresponding unit tests
- Fix the `getSortKeyIndexes` to handle the case that the Iceberg table's sort order differs from schema column order.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
