### PR TITLE
[Enhancement] Support segment-level splitting for parallel compaction

### DIFF
--- a/be/src/storage/lake/compaction_policy.cpp
+++ b/be/src/storage/lake/compaction_policy.cpp
@@ -42,6 +42,13 @@ inline int64_t calc_effective_segment_count(const RowsetMetadataPB& rowset) {
         return 1;
     }
     int segments_size = rowset.segments_size();
+    // Only skip rowsets produced by large-rowset-split compaction.
+    // Use a narrow condition to avoid affecting other overlapped rowsets whose
+    // next_compaction_offset may also reach segments_size for different reasons.
+    if (rowset.next_compaction_offset() >= static_cast<uint32_t>(segments_size) &&
+        rowset.data_size() >= config::lake_compaction_max_rowset_size) {
+        return 0;
+    }
     if (segments_size == 0) {
         return 1;
     }

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -126,7 +126,7 @@ void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&
     compact_stat->set_write_segment_bytes(context->stats->write_segment_bytes);
     compact_stat->set_write_time_remote(context->stats->io_ns_write_remote);
     compact_stat->set_in_queue_time_sec(context->stats->in_queue_time_sec);
-    compact_stat->set_sub_task_count(1); // each tablet will have 1 task
+    compact_stat->set_sub_task_count(context->subtask_count);
     compact_stat->set_total_compact_input_file_size(context->stats->input_file_size);
     if (context->skip_write_txnlog && context->txn_log != nullptr) {
         // context->txn_log could be nullptr if the task is failed before writing txn log.
@@ -359,8 +359,8 @@ void CompactionScheduler::process_parallel_compaction(const CompactRequest* requ
             // 1. create_parallel_tasks failed (result.status() is not OK)
             // 2. create_parallel_tasks returned 0 (indicates fallback, e.g., data size too small)
             if (!result.ok()) {
-                LOG(WARNING) << "Failed to create parallel tasks for tablet " << tablet_id << ": " << result.status()
-                             << ", falling back to normal compaction";
+                VLOG(1) << "Failed to create parallel tasks for tablet " << tablet_id << ": " << result.status()
+                        << ", falling back to normal compaction";
             } else {
                 VLOG(1) << "Parallel compaction not applicable for tablet " << tablet_id
                         << ", falling back to normal compaction";

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -116,6 +116,8 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     int64_t table_id;
     int64_t partition_id;
     int32_t subtask_id = -1; // -1 means not a parallel compaction subtask
+    // Number of subtasks in this compaction (1 for normal compaction, >1 for parallel compaction)
+    int32_t subtask_count = 1;
     // Flag to indicate this is a merged context from parallel compaction.
     // When true, cleanup_tablet should be called in remove_states after RPC response is sent.
     bool is_parallel_merged = false;

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -52,6 +52,17 @@ public:
     explicit Rowset(TabletManager* tablet_mgr, TabletMetadataPtr tablet_metadata, int rowset_index,
                     size_t compaction_segment_limit);
 
+    // Create a Rowset with a specific segment range [segment_start, segment_end).
+    // Used for large rowset split compaction where a single rowset is split into multiple subtasks.
+    // Each subtask processes a subset of segments.
+    //
+    // Requires:
+    //  - segment_start >= 0
+    //  - segment_end > segment_start
+    //  - segment_end <= metadata.segments_size()
+    explicit Rowset(TabletManager* tablet_mgr, TabletMetadataPtr tablet_metadata, int rowset_index,
+                    int32_t segment_start, int32_t segment_end);
+
     virtual ~Rowset();
 
     DISALLOW_COPY_AND_MOVE(Rowset);
@@ -87,12 +98,23 @@ public:
     [[nodiscard]] bool is_overlapped() const override { return metadata().overlapped(); }
 
     // if _compaction_segment_limit is set > 0, it means only partial segments will be used
+    // if _segment_range_end > 0, it means segment range mode is used
     [[nodiscard]] int64_t num_segments() const {
+        if (_segment_range_end > 0) {
+            return _segment_range_end - _segment_range_start;
+        }
         return _compaction_segment_limit > 0 ? _compaction_segment_limit : metadata().segments_size();
     }
 
     // only used in compaction
     [[nodiscard]] bool partial_segments_compaction() const { return _compaction_segment_limit > 0; }
+
+    // Check if this rowset uses segment range mode (for large rowset split compaction)
+    [[nodiscard]] bool is_segment_range_mode() const { return _segment_range_end > 0; }
+
+    // Get segment range [start, end), only valid when is_segment_range_mode() returns true
+    [[nodiscard]] int32_t segment_range_start() const { return _segment_range_start; }
+    [[nodiscard]] int32_t segment_range_end() const { return _segment_range_end; }
     // only used in compaction
     [[nodiscard]] Status add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_compaction,
                                                               TabletWriter* writer, uint64_t& uncompacted_num_rows,
@@ -152,6 +174,11 @@ private:
     // default is 0 means every segment will be used.
     // only used for compaction
     size_t _compaction_segment_limit;
+    // Segment range for large rowset split compaction.
+    // When _segment_range_end > 0, only segments in [_segment_range_start, _segment_range_end) are used.
+    // Default is 0, meaning all segments are used.
+    int32_t _segment_range_start = 0;
+    int32_t _segment_range_end = 0;
 };
 
 inline std::vector<RowsetPtr> Rowset::get_rowsets(TabletManager* tablet_mgr, const TabletMetadataPtr& tablet_metadata) {

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <set>
+#include <sstream>
 
 #include "base/utility/defer_op.h"
 #include "common/config.h"
@@ -27,36 +28,16 @@
 #include "storage/lake/compaction_policy.h"
 #include "storage/lake/compaction_scheduler.h"
 #include "storage/lake/compaction_task.h"
+#include "storage/lake/filenames.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/update_manager.h"
 #include "storage/lake/versioned_tablet.h"
 #include "storage/memtable_flush_executor.h"
+#include "storage/rows_mapper.h"
 #include "storage/storage_engine.h"
 
 namespace starrocks::lake {
-
-namespace {
-
-// Collect successful subtask IDs (unified logic for both PK and non-PK tables)
-// All successful subtasks are included regardless of whether they are consecutive.
-// Each successful subtask's output rowset will replace its corresponding input rowsets.
-std::vector<int32_t> collect_success_subtask_ids(
-        const std::vector<std::unique_ptr<CompactionTaskContext>>& completed_subtasks, int64_t tablet_id,
-        int64_t txn_id) {
-    std::vector<int32_t> success_subtask_ids;
-    for (const auto& ctx : completed_subtasks) {
-        if (!ctx->status.ok()) {
-            LOG(WARNING) << "Parallel compaction: skipping failed subtask " << ctx->subtask_id << " for tablet "
-                         << tablet_id << ", txn_id=" << txn_id << ", status=" << ctx->status;
-            continue;
-        }
-        success_subtask_ids.push_back(ctx->subtask_id);
-    }
-    return success_subtask_ids;
-}
-
-} // namespace
 
 // ================================================================================
 // Helper functions for split_rowsets_into_groups
@@ -691,33 +672,29 @@ StatusOr<int> TabletParallelCompactionManager::create_parallel_tasks(
     ASSIGN_OR_RETURN(auto all_rowsets, pick_rowsets_for_compaction(tablet_id, txn_id, version, force_base_compaction));
     size_t total_rowsets_count = all_rowsets.size();
 
-    // Step 2: Split rowsets into groups
-    auto valid_groups =
-            split_rowsets_into_groups(tablet_id, std::move(all_rowsets), max_parallel, max_bytes, is_pk_table);
+    // Use the unified grouping algorithm that supports both large rowset splitting
+    // and small rowset grouping. _split_large_rowset and execute_subtask_segment_range
+    // are segment-based and do not depend on primary index, so this works for all table
+    // types (PK, duplicate key, unique key, aggregate key).
+    // Step 2: Create subtask groups (handles both large rowset split and small rowset grouping)
+    auto subtask_groups = _create_subtask_groups(tablet_id, std::move(all_rowsets), max_parallel, max_bytes);
 
-    if (valid_groups.empty()) {
-        // Empty groups means we should fallback to normal compaction flow.
-        // This happens when:
-        // 1. Total data size is less than max_bytes_per_subtask (no parallelism benefit)
-        // 2. Not enough rowsets for parallel compaction
-        // 3. Has delete predicate
-        // 4. max_parallel <= 1
-        // Return 0 to indicate fallback to normal compaction (not an error).
+    if (subtask_groups.empty()) {
         VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " txn=" << txn_id
                 << " fallback to normal compaction, total_rowsets=" << total_rowsets_count;
         return 0;
     }
 
-    VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " created " << valid_groups.size() << " groups from "
-            << total_rowsets_count << " rowsets";
+    VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " created " << subtask_groups.size()
+            << " subtask groups from " << total_rowsets_count << " rowsets";
 
     // Step 3: Create and register tablet state
     ASSIGN_OR_RETURN(auto state_ptr, create_and_register_tablet_state(tablet_id, txn_id, version, max_parallel,
                                                                       max_bytes, std::move(callback), release_token));
 
     // Step 4: Submit subtasks
-    return submit_subtasks(std::move(state_ptr), std::move(valid_groups), force_base_compaction, thread_pool,
-                           acquire_token, release_token);
+    return submit_subtasks_from_groups(std::move(state_ptr), std::move(subtask_groups), force_base_compaction,
+                                       thread_pool, acquire_token, release_token);
 }
 
 std::shared_ptr<TabletParallelCompactionState> TabletParallelCompactionManager::get_tablet_state(int64_t tablet_id,
@@ -866,6 +843,12 @@ void TabletParallelCompactionManager::on_subtask_complete(int64_t tablet_id, int
         // until all tablets complete, consistent with normal compaction behavior.
         merged_context->is_parallel_merged = true;
 
+        // Set subtask_count to the actual number of subtasks
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            merged_context->subtask_count = static_cast<int32_t>(state->completed_subtasks.size());
+        }
+
         callback->finish_task(std::move(merged_context));
         // Note: Do NOT call cleanup_tablet here. The cleanup will be done by
         // CompactionScheduler::remove_states when RPC response is sent.
@@ -925,6 +908,13 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
     int64_t version = 0;
     std::vector<int32_t> success_subtask_ids;
 
+    struct LcrmMergeTask {
+        int merged_compaction_idx;
+        std::vector<FileMetaPB> lcrm_files;
+        std::vector<int64_t> num_rows_per_subtask;
+    };
+    std::vector<LcrmMergeTask> lcrm_merge_tasks;
+
     {
         std::lock_guard<std::mutex> lock(state->mutex);
 
@@ -939,9 +929,82 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
                       return a->subtask_id < b->subtask_id;
                   });
 
-        // Collect successful subtask IDs (unified logic for both PK and non-PK tables)
-        // All successful subtasks are included regardless of whether they are consecutive.
-        success_subtask_ids = collect_success_subtask_ids(state->completed_subtasks, tablet_id, txn_id);
+        // Build a map from subtask_id to status for quick lookup
+        std::unordered_map<int32_t, bool> subtask_success_map;
+        for (const auto& ctx : state->completed_subtasks) {
+            subtask_success_map[ctx->subtask_id] = ctx->status.ok();
+        }
+
+        // For large rowset split groups, check if ALL subtasks in the group succeeded
+        // AND the actual count matches the expected count.
+        // If any subtask in a group failed, or if the group is incomplete (some subtasks
+        // were not created due to acquire_token() failure), the entire group is considered failed.
+        // This ensures data consistency - we either replace the entire large rowset or keep it unchanged.
+        std::unordered_set<uint32_t> failed_large_rowset_ids;
+        for (const auto& [large_rowset_id, subtask_ids] : state->large_rowset_split_groups) {
+            // Check if the split is complete by comparing actual vs expected subtask count
+            auto expected_it = state->expected_large_rowset_split_counts.find(large_rowset_id);
+            int32_t expected_count = (expected_it != state->expected_large_rowset_split_counts.end())
+                                             ? expected_it->second
+                                             : static_cast<int32_t>(subtask_ids.size());
+            bool is_complete = (static_cast<int32_t>(subtask_ids.size()) == expected_count);
+
+            if (!is_complete) {
+                failed_large_rowset_ids.insert(large_rowset_id);
+                LOG(WARNING) << "Large rowset split group incomplete: tablet=" << tablet_id << ", txn_id=" << txn_id
+                             << ", large_rowset_id=" << large_rowset_id << ", actual_subtasks=" << subtask_ids.size()
+                             << ", expected_subtasks=" << expected_count << ", created_subtask_ids=["
+                             << JoinInts(subtask_ids, ",") << "]"
+                             << ". All subtasks in this group will be skipped to prevent data loss.";
+                continue;
+            }
+
+            // Check if all subtasks in the group succeeded
+            bool all_success = true;
+            for (int32_t sid : subtask_ids) {
+                auto it = subtask_success_map.find(sid);
+                if (it == subtask_success_map.end() || !it->second) {
+                    all_success = false;
+                    break;
+                }
+            }
+            if (!all_success) {
+                failed_large_rowset_ids.insert(large_rowset_id);
+                LOG(WARNING) << "Large rowset split group failed: tablet=" << tablet_id << ", txn_id=" << txn_id
+                             << ", large_rowset_id=" << large_rowset_id << ", subtask_ids=["
+                             << JoinInts(subtask_ids, ",") << "]"
+                             << ". All subtasks in this group will be skipped.";
+            }
+        }
+
+        // Build a map from subtask_id to its large_rowset_id (if it's a LARGE_ROWSET_PART type)
+        std::unordered_map<int32_t, uint32_t> subtask_to_large_rowset;
+        for (const auto& [large_rowset_id, subtask_ids] : state->large_rowset_split_groups) {
+            for (int32_t sid : subtask_ids) {
+                subtask_to_large_rowset[sid] = large_rowset_id;
+            }
+        }
+
+        // Collect successful subtask IDs, excluding subtasks from failed large rowset groups
+        for (const auto& ctx : state->completed_subtasks) {
+            if (!ctx->status.ok()) {
+                LOG(WARNING) << "Parallel compaction: skipping failed subtask " << ctx->subtask_id << " for tablet "
+                             << tablet_id << ", txn_id=" << txn_id << ", status=" << ctx->status;
+                continue;
+            }
+
+            // Check if this subtask belongs to a failed large rowset group
+            auto it = subtask_to_large_rowset.find(ctx->subtask_id);
+            if (it != subtask_to_large_rowset.end()) {
+                if (failed_large_rowset_ids.count(it->second) > 0) {
+                    LOG(WARNING) << "Parallel compaction: skipping subtask " << ctx->subtask_id
+                                 << " because its large rowset group " << it->second << " failed";
+                    continue;
+                }
+            }
+
+            success_subtask_ids.push_back(ctx->subtask_id);
+        }
 
         // If no successful subtasks, return error
         if (success_subtask_ids.empty()) {
@@ -952,21 +1015,181 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
 
         std::unordered_set<int32_t> success_subtask_id_set(success_subtask_ids.begin(), success_subtask_ids.end());
 
-        // Fill subtask_compactions: each successful subtask's OpCompaction is copied directly
-        // This allows reusing publish_primary_compaction for each subtask during apply
+        // Build a set of successful large rowset IDs for merging
+        std::unordered_set<uint32_t> successful_large_rowset_ids;
+        for (const auto& [large_rowset_id, subtask_ids] : state->large_rowset_split_groups) {
+            if (failed_large_rowset_ids.count(large_rowset_id) == 0) {
+                successful_large_rowset_ids.insert(large_rowset_id);
+            }
+        }
+
+        // Track which subtasks have been processed (for large rowset split merging)
+        std::unordered_set<int32_t> processed_subtask_ids;
+
+        // Process large rowset split groups: merge all subtasks into a single OpCompaction
+        for (const auto& [large_rowset_id, subtask_ids] : state->large_rowset_split_groups) {
+            if (failed_large_rowset_ids.count(large_rowset_id) > 0) {
+                continue; // Skip failed groups
+            }
+
+            // Create merged OpCompaction for this large rowset split
+            int merged_compaction_idx = op_parallel->subtask_compactions_size();
+            auto* merged_compaction = op_parallel->add_subtask_compactions();
+
+            // Use the first subtask's input_rowsets (all subtasks share the same input)
+            bool first_subtask = true;
+            int64_t total_num_rows = 0;
+            int64_t total_data_size = 0;
+            LcrmMergeTask lcrm_task;
+            lcrm_task.merged_compaction_idx = merged_compaction_idx;
+
+            // Sort subtask_ids to ensure consistent segment ordering
+            std::vector<int32_t> sorted_subtask_ids(subtask_ids.begin(), subtask_ids.end());
+            std::sort(sorted_subtask_ids.begin(), sorted_subtask_ids.end());
+
+            for (int32_t sid : sorted_subtask_ids) {
+                // Find the context for this subtask
+                const CompactionTaskContext* ctx = nullptr;
+                for (const auto& c : state->completed_subtasks) {
+                    if (c->subtask_id == sid) {
+                        ctx = c.get();
+                        break;
+                    }
+                }
+                if (ctx == nullptr || ctx->txn_log == nullptr || !ctx->txn_log->has_op_compaction()) {
+                    continue;
+                }
+
+                const auto& subtask_op = ctx->txn_log->op_compaction();
+
+                if (first_subtask) {
+                    // Copy input_rowsets from first subtask
+                    for (int i = 0; i < subtask_op.input_rowsets_size(); i++) {
+                        merged_compaction->add_input_rowsets(subtask_op.input_rowsets(i));
+                    }
+                    // Set subtask_id to the first subtask's id for tracking
+                    merged_compaction->set_subtask_id(sid);
+                    // Copy compact_version from the first subtask for conflict detection
+                    if (subtask_op.has_compact_version()) {
+                        merged_compaction->set_compact_version(subtask_op.compact_version());
+                    }
+                    first_subtask = false;
+                }
+
+                // Merge output_rowset segments
+                if (subtask_op.has_output_rowset()) {
+                    const auto& output = subtask_op.output_rowset();
+                    auto* merged_output = merged_compaction->mutable_output_rowset();
+
+                    // Add segments
+                    for (int i = 0; i < output.segments_size(); i++) {
+                        merged_output->add_segments(output.segments(i));
+                    }
+                    // Add segment_size
+                    for (int i = 0; i < output.segment_size_size(); i++) {
+                        merged_output->add_segment_size(output.segment_size(i));
+                    }
+                    // Add segment_encryption_metas
+                    for (int i = 0; i < output.segment_encryption_metas_size(); i++) {
+                        merged_output->add_segment_encryption_metas(output.segment_encryption_metas(i));
+                    }
+                    // Add segment_metas
+                    for (int i = 0; i < output.segment_metas_size(); i++) {
+                        merged_output->add_segment_metas()->CopyFrom(output.segment_metas(i));
+                    }
+
+                    total_num_rows += output.num_rows();
+                    total_data_size += output.data_size();
+                }
+
+                // Merge ssts and sst_ranges (they are generated together in compaction)
+                for (int i = 0; i < subtask_op.ssts_size(); i++) {
+                    merged_compaction->add_ssts()->CopyFrom(subtask_op.ssts(i));
+                }
+                for (int i = 0; i < subtask_op.sst_ranges_size(); i++) {
+                    merged_compaction->add_sst_ranges()->CopyFrom(subtask_op.sst_ranges(i));
+                }
+
+                // Collect subtask LCRM files for merging into a single LCRM
+                if (subtask_op.has_lcrm_file()) {
+                    lcrm_task.lcrm_files.push_back(subtask_op.lcrm_file());
+                    lcrm_task.num_rows_per_subtask.push_back(
+                            subtask_op.has_output_rowset() ? subtask_op.output_rowset().num_rows() : 0);
+                    op_parallel->add_orphan_lcrm_files()->CopyFrom(subtask_op.lcrm_file());
+                }
+
+                // Mark this subtask as processed
+                processed_subtask_ids.insert(sid);
+            }
+
+            // Collect LCRM merge task if subtask LCRMs are available
+            if (!lcrm_task.lcrm_files.empty()) {
+                lcrm_merge_tasks.push_back(std::move(lcrm_task));
+            }
+
+            // If no valid subtask was processed, remove the empty merged_compaction
+            // to avoid undefined behavior when dereferencing empty input_rowsets
+            if (first_subtask) {
+                op_parallel->mutable_subtask_compactions()->RemoveLast();
+                if (!lcrm_merge_tasks.empty() &&
+                    lcrm_merge_tasks.back().merged_compaction_idx == merged_compaction_idx) {
+                    lcrm_merge_tasks.pop_back();
+                }
+                LOG(WARNING) << "Large rowset split group has no valid subtasks, removing empty compaction"
+                             << ", tablet=" << tablet_id << ", large_rowset_id=" << large_rowset_id;
+                continue;
+            }
+
+            // Set merged output rowset properties
+            if (merged_compaction->has_output_rowset()) {
+                auto* merged_output = merged_compaction->mutable_output_rowset();
+                merged_output->set_num_rows(total_num_rows);
+                merged_output->set_data_size(total_data_size);
+                merged_output->set_overlapped(true);
+                merged_output->set_next_compaction_offset(merged_output->segments_size());
+            }
+
+            // Log segment file names for debugging data consistency
+            std::stringstream seg_names;
+            const auto& merged_output_rowset = merged_compaction->output_rowset();
+            for (int i = 0; i < merged_output_rowset.segments_size(); i++) {
+                if (i > 0) seg_names << ",";
+                seg_names << merged_output_rowset.segments(i);
+            }
+            VLOG(1) << "Merged large rowset split result: tablet=" << tablet_id << ", txn_id=" << txn_id
+                    << ", large_rowset_id=" << large_rowset_id << ", subtask_count=" << sorted_subtask_ids.size()
+                    << ", total_segments=" << merged_output_rowset.segments_size() << ", total_rows=" << total_num_rows
+                    << ", total_data_size=" << total_data_size << ", merged_ssts=" << merged_compaction->ssts_size()
+                    << ", merged_sst_ranges=" << merged_compaction->sst_ranges_size()
+                    << ", compact_version=" << merged_compaction->compact_version() << ", input_rowsets=["
+                    << JoinInts(std::vector<uint32_t>(merged_compaction->input_rowsets().begin(),
+                                                      merged_compaction->input_rowsets().end()),
+                                ",")
+                    << "]"
+                    << ", orphan_lcrm_count=" << op_parallel->orphan_lcrm_files_size() << ", segment_files=["
+                    << seg_names.str() << "]";
+        }
+
+        // Process normal subtasks (not part of large rowset split)
         for (const auto& ctx : state->completed_subtasks) {
             if (success_subtask_id_set.count(ctx->subtask_id) == 0) {
+                continue;
+            }
+            // Skip if already processed as part of large rowset split
+            if (processed_subtask_ids.count(ctx->subtask_id) > 0) {
                 continue;
             }
             if (ctx->txn_log == nullptr || !ctx->txn_log->has_op_compaction()) {
                 continue;
             }
 
-            // Copy the entire OpCompaction from this subtask
-            // Note: SST compaction fields (input_sstables/output_sstable) should be empty in subtask
+            // Copy the entire OpCompaction from this normal subtask
             auto* subtask_compaction = op_parallel->add_subtask_compactions();
             subtask_compaction->CopyFrom(ctx->txn_log->op_compaction());
             subtask_compaction->set_subtask_id(ctx->subtask_id);
+            // Clear segment_range fields for normal subtasks (not needed)
+            subtask_compaction->clear_segment_range_start();
+            subtask_compaction->clear_segment_range_end();
         }
 
         // Record success_subtask_ids for tracking
@@ -988,6 +1211,19 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
     }
     // Lock released here
 
+    // Merge subtask LCRM files into a single LCRM for each large rowset split group.
+    // This enables the light publish path (SST ingestion) instead of the full publish
+    // path (try_replace), which is more robust and performant.
+    for (auto& task : lcrm_merge_tasks) {
+        auto st = _merge_subtask_lcrm_files(tablet_id, txn_id, task.lcrm_files, task.num_rows_per_subtask,
+                                            op_parallel->mutable_subtask_compactions(task.merged_compaction_idx));
+        if (!st.ok()) {
+            LOG(WARNING) << "Failed to merge LCRM files for large rowset split, tablet=" << tablet_id
+                         << ", txn_id=" << txn_id << ", status=" << st;
+            return st;
+        }
+    }
+
     // Execute SST compaction once after all subtasks complete.
     // Store results in OpParallelCompaction (not in individual subtask OpCompactions).
     RETURN_IF_ERROR(execute_sst_compaction_for_parallel(tablet_id, version, op_parallel));
@@ -998,16 +1234,28 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
 void TabletParallelCompactionManager::mark_rowsets_compacting(TabletParallelCompactionState* state,
                                                               const std::vector<uint32_t>& rowset_ids) {
     // Assumes state->mutex is already held
+    // Use reference counting: increment count for each rowset_id.
+    // For large rowset split, multiple subtasks share the same rowset_id,
+    // so we increment the count each time instead of just inserting.
     for (uint32_t rid : rowset_ids) {
-        state->compacting_rowsets.insert(rid);
+        state->compacting_rowsets[rid]++;
     }
 }
 
 void TabletParallelCompactionManager::unmark_rowsets_compacting(TabletParallelCompactionState* state,
                                                                 const std::vector<uint32_t>& rowset_ids) {
     // Assumes state->mutex is already held
+    // Use reference counting: decrement count for each rowset_id.
+    // Only remove the entry when count reaches zero.
+    // This ensures that for large rowset split, the rowset is only unmarked
+    // when ALL subtasks using it have completed.
     for (uint32_t rid : rowset_ids) {
-        state->compacting_rowsets.erase(rid);
+        auto it = state->compacting_rowsets.find(rid);
+        if (it != state->compacting_rowsets.end()) {
+            if (--it->second <= 0) {
+                state->compacting_rowsets.erase(it);
+            }
+        }
     }
 }
 
@@ -1259,6 +1507,670 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
             }
         }
     }
+}
+
+// ================================================================================
+// Large rowset split related functions (all table types)
+// ================================================================================
+
+bool TabletParallelCompactionManager::_is_large_rowset_for_split(const RowsetPtr& rowset,
+                                                                 int64_t max_bytes_per_subtask) {
+    int64_t data_size = rowset->data_size();
+    int64_t min_size = 2 * config::lake_compaction_max_rowset_size;
+    const auto& meta = rowset->metadata();
+
+    // Skip rowsets where all segments have already been processed by a previous
+    // split compaction. Re-splitting would just produce the same overlapped output
+    // and cause an infinite compaction loop.
+    if (meta.next_compaction_offset() >= static_cast<uint32_t>(meta.segments_size())) {
+        return false;
+    }
+
+    // A rowset is considered "large" and should be split if:
+    // 1. data_size >= 2 * lake_compaction_max_rowset_size (at least twice the max rowset size)
+    // 2. data_size > max_bytes_per_subtask (larger than what a single subtask should handle)
+    // 3. segments_size >= 4 (enough segments to split into at least 2 subtasks with 2 segments each)
+    // 4. is_overlapped (non-overlapped rowsets don't need segment-level compaction)
+    return data_size >= min_size && data_size > max_bytes_per_subtask && meta.segments_size() >= 4 &&
+           rowset->is_overlapped();
+}
+
+std::vector<SubtaskGroup> TabletParallelCompactionManager::_split_large_rowset(const RowsetPtr& rowset,
+                                                                               int64_t target_bytes_per_subtask,
+                                                                               int32_t max_subtasks) {
+    std::vector<SubtaskGroup> groups;
+
+    const auto& meta = rowset->metadata();
+    int32_t total_segments = meta.segments_size();
+    int64_t total_data_size = rowset->data_size();
+
+    if (total_segments < 2 || total_data_size <= 0) {
+        return groups;
+    }
+
+    // Estimate average bytes per segment
+    int64_t avg_bytes_per_segment = total_data_size / total_segments;
+
+    // Calculate how many subtasks we would need based on target_bytes_per_subtask
+    int32_t ideal_num_subtasks = 1;
+    if (target_bytes_per_subtask > 0) {
+        ideal_num_subtasks =
+                static_cast<int32_t>((total_data_size + target_bytes_per_subtask - 1) / target_bytes_per_subtask);
+    }
+
+    // Limit to max_subtasks if specified (> 0)
+    // When max_subtasks is specified and less than ideal_num_subtasks, we allow each subtask
+    // to process more data than target_bytes_per_subtask to ensure completeness
+    int32_t actual_num_subtasks = ideal_num_subtasks;
+    if (max_subtasks > 0 && actual_num_subtasks > max_subtasks) {
+        actual_num_subtasks = max_subtasks;
+        VLOG(1) << "Large rowset " << rowset->id() << " capped from " << ideal_num_subtasks << " to "
+                << actual_num_subtasks << " subtasks (exceeding size limit to ensure completeness)";
+    }
+
+    // Ensure at least 1 subtask
+    actual_num_subtasks = std::max(1, actual_num_subtasks);
+
+    // Calculate segments per subtask for even distribution
+    int32_t segments_per_subtask = (total_segments + actual_num_subtasks - 1) / actual_num_subtasks;
+
+    // Ensure we have at least 2 segments per subtask for meaningful compaction
+    segments_per_subtask = std::max(2, segments_per_subtask);
+
+    // Recalculate actual number of subtasks based on segments_per_subtask
+    actual_num_subtasks = (total_segments + segments_per_subtask - 1) / segments_per_subtask;
+
+    // Split segments into groups
+    int32_t segment_start = 0;
+    while (segment_start < total_segments) {
+        int32_t segment_end = std::min(segment_start + segments_per_subtask, total_segments);
+
+        // Ensure we have at least 2 segments in the group (except for the last group)
+        if (segment_end - segment_start < 2 && segment_start > 0) {
+            // Merge with previous group
+            if (!groups.empty()) {
+                groups.back().segment_end = total_segments;
+                groups.back().total_bytes = total_data_size - (groups.back().segment_start * avg_bytes_per_segment);
+            }
+            break;
+        }
+
+        SubtaskGroup group;
+        group.type = SubtaskType::LARGE_ROWSET_PART;
+        group.large_rowset = rowset;
+        group.large_rowset_id = rowset->id();
+        group.segment_start = segment_start;
+        group.segment_end = segment_end;
+        group.total_bytes = (segment_end - segment_start) * avg_bytes_per_segment;
+
+        groups.push_back(std::move(group));
+        segment_start = segment_end;
+    }
+
+    VLOG(1) << "Split large rowset " << rowset->id() << " into " << groups.size() << " subtasks"
+            << ", total_segments=" << total_segments << ", total_bytes=" << total_data_size
+            << ", segments_per_subtask=" << segments_per_subtask << ", ideal_num_subtasks=" << ideal_num_subtasks
+            << ", max_subtasks=" << max_subtasks;
+
+    return groups;
+}
+
+std::vector<SubtaskGroup> TabletParallelCompactionManager::_group_small_rowsets(std::vector<RowsetPtr> rowsets,
+                                                                                int64_t target_bytes_per_subtask) {
+    std::vector<SubtaskGroup> groups;
+
+    if (rowsets.empty()) {
+        return groups;
+    }
+
+    SubtaskGroup current_group;
+    current_group.type = SubtaskType::NORMAL;
+    current_group.total_bytes = 0;
+
+    for (auto& rowset : rowsets) {
+        int64_t rowset_bytes = rowset->data_size();
+
+        // If adding this rowset would exceed the target and current group has content,
+        // start a new group
+        if (!current_group.rowsets.empty() && current_group.total_bytes + rowset_bytes > target_bytes_per_subtask) {
+            // Only add groups with at least 1 rowset that needs compaction
+            if (!current_group.rowsets.empty()) {
+                groups.push_back(std::move(current_group));
+                current_group = SubtaskGroup();
+                current_group.type = SubtaskType::NORMAL;
+                current_group.total_bytes = 0;
+            }
+        }
+
+        current_group.rowsets.push_back(std::move(rowset));
+        current_group.total_bytes += rowset_bytes;
+    }
+
+    // Add the last group
+    if (!current_group.rowsets.empty()) {
+        groups.push_back(std::move(current_group));
+    }
+
+    return groups;
+}
+
+std::vector<SubtaskGroup> TabletParallelCompactionManager::_create_subtask_groups(int64_t tablet_id,
+                                                                                  std::vector<RowsetPtr> rowsets,
+                                                                                  int32_t max_parallel,
+                                                                                  int64_t max_bytes_per_subtask) {
+    // Perform validation checks similar to split_rowsets_into_groups
+    RowsetStats stats = _calculate_rowset_stats(rowsets);
+
+    // Check early return conditions for falling back to normal compaction.
+    constexpr int64_t kMinSegmentsForParallel = 4; // 2 subtasks * 2 segments each
+    bool not_enough_segments = stats.total_segments < kMinSegmentsForParallel;
+
+    if (stats.total_bytes <= max_bytes_per_subtask || max_parallel <= 1 || stats.has_delete_predicate ||
+        not_enough_segments) {
+        std::string reason = stats.has_delete_predicate
+                                     ? "has_delete_predicate"
+                                     : (max_parallel <= 1)
+                                               ? "max_parallel<=1"
+                                               : not_enough_segments ? "not_enough_segments" : "data_size_small";
+        VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " fallback to normal compaction (" << reason
+                << "): " << rowsets.size() << " rowsets, " << stats.total_segments << " segments, " << stats.total_bytes
+                << " bytes";
+        return {};
+    }
+
+    std::vector<SubtaskGroup> all_groups;
+
+    // Separate large rowsets (to be split) from small rowsets (to be grouped)
+    std::vector<RowsetPtr> large_rowsets;
+    std::vector<RowsetPtr> small_rowsets;
+
+    for (auto& rowset : rowsets) {
+        if (_is_large_rowset_for_split(rowset, max_bytes_per_subtask)) {
+            large_rowsets.push_back(std::move(rowset));
+        } else {
+            small_rowsets.push_back(std::move(rowset));
+        }
+    }
+
+    VLOG(1) << "Create subtask groups: tablet=" << tablet_id << ", large_rowsets=" << large_rowsets.size()
+            << ", small_rowsets=" << small_rowsets.size() << ", max_parallel=" << max_parallel
+            << ", max_bytes_per_subtask=" << max_bytes_per_subtask;
+
+    // Track remaining parallel slots
+    int32_t remaining_parallel = max_parallel;
+
+    // Process large rowsets first, ensuring each large rowset's split is complete.
+    // Strategy:
+    // 1. If a large rowset can be split within remaining_parallel slots, split it normally
+    // 2. If a large rowset needs more slots than remaining_parallel AND remaining_parallel >= 2,
+    //    cap it to remaining_parallel (allowing it to exceed max_bytes_per_subtask to ensure completeness)
+    // 3. If remaining_parallel < 2, skip this large rowset (splitting with only 1 slot is meaningless)
+    // 4. If no slots remain, skip this large rowset entirely (it won't participate in this compaction)
+    for (auto& large_rowset : large_rowsets) {
+        if (remaining_parallel <= 0) {
+            VLOG(1) << "Skipping large rowset " << large_rowset->id()
+                    << " - no remaining parallel slots (max_parallel=" << max_parallel << ")";
+            continue;
+        }
+
+        // Calculate how many subtasks this rowset would need based on target_bytes_per_subtask
+        int64_t total_data_size = large_rowset->data_size();
+        int32_t ideal_subtasks = 1;
+        if (max_bytes_per_subtask > 0) {
+            ideal_subtasks =
+                    static_cast<int32_t>((total_data_size + max_bytes_per_subtask - 1) / max_bytes_per_subtask);
+        }
+
+        // If ideal_subtasks > remaining_parallel, we need to cap it.
+        // But capping only makes sense if remaining_parallel >= 2 (splitting with 1 slot is meaningless)
+        if (ideal_subtasks > remaining_parallel && remaining_parallel < 2) {
+            VLOG(1) << "Skipping large rowset " << large_rowset->id() << " - needs " << ideal_subtasks
+                    << " subtasks but only " << remaining_parallel << " slots remaining (need at least 2 to split)";
+            continue;
+        }
+
+        // Cap to remaining_parallel if needed (this may exceed max_bytes_per_subtask per group)
+        int32_t actual_max_subtasks = std::min(ideal_subtasks, remaining_parallel);
+
+        auto split_groups = _split_large_rowset(large_rowset, max_bytes_per_subtask, actual_max_subtasks);
+
+        if (!split_groups.empty()) {
+            remaining_parallel -= static_cast<int32_t>(split_groups.size());
+            for (auto& g : split_groups) {
+                all_groups.push_back(std::move(g));
+            }
+        }
+    }
+
+    // Group small rowsets into the remaining parallel slots
+    if (remaining_parallel > 0 && !small_rowsets.empty()) {
+        auto small_groups = _group_small_rowsets(std::move(small_rowsets), max_bytes_per_subtask);
+        for (auto& g : small_groups) {
+            if (remaining_parallel <= 0) {
+                VLOG(1) << "Skipping remaining small rowset groups - no remaining parallel slots";
+                break;
+            }
+            // Only add groups that are valid for compaction (>= 2 rowsets or 1 overlapped rowset)
+            if (g.rowsets.size() >= 2 || (g.rowsets.size() == 1 && g.rowsets[0]->is_overlapped() &&
+                                          g.rowsets[0]->metadata().segments_size() >= 2)) {
+                all_groups.push_back(std::move(g));
+                remaining_parallel--;
+            } else {
+                VLOG(1) << "Skipping small group with " << g.rowsets.size() << " rowsets (not enough for compaction)";
+            }
+        }
+    }
+
+    VLOG(1) << "Created " << all_groups.size() << " subtask groups for tablet " << tablet_id
+            << " (max_parallel=" << max_parallel << ", used=" << (max_parallel - remaining_parallel) << ")";
+
+    return all_groups;
+}
+
+StatusOr<int> TabletParallelCompactionManager::submit_subtasks_from_groups(
+        const std::shared_ptr<TabletParallelCompactionState>& state_ptr, std::vector<SubtaskGroup> groups,
+        bool force_base_compaction, ThreadPool* thread_pool, const AcquireTokenFunc& acquire_token,
+        const ReleaseTokenFunc& release_token) {
+    int64_t tablet_id = state_ptr->tablet_id;
+    int64_t txn_id = state_ptr->txn_id;
+    int64_t version = state_ptr->version;
+    int32_t max_parallel = state_ptr->max_parallel;
+
+    if (groups.empty()) {
+        cleanup_tablet(tablet_id, txn_id);
+        return Status::NotFound(strings::Substitute("No groups to submit: tablet_id=$0, txn_id=$1", tablet_id, txn_id));
+    }
+
+    // Acquire all tokens upfront to ensure atomic submission of all subtasks.
+    // This prevents partial large-rowset splits which would cause data loss:
+    // if only some subtasks of a large rowset split are created, get_merged_txn_log()
+    // would treat the partial split as complete and the first subtask would delete
+    // the original rowset, dropping segments that never got a subtask.
+    int32_t total_groups = static_cast<int32_t>(groups.size());
+    int32_t tokens_acquired = 0;
+
+    for (int32_t i = 0; i < total_groups; i++) {
+        if (!acquire_token()) {
+            LOG(WARNING) << "Parallel compaction: failed to acquire limiter token " << i << "/" << total_groups
+                         << " for tablet " << tablet_id << ", txn_id=" << txn_id << ". Releasing " << tokens_acquired
+                         << " acquired tokens.";
+            // Release all acquired tokens
+            for (int32_t j = 0; j < tokens_acquired; j++) {
+                release_token(false);
+            }
+            cleanup_tablet(tablet_id, txn_id);
+            return Status::ResourceBusy(strings::Substitute(
+                    "Failed to acquire all limiter tokens: tablet_id=$0, txn_id=$1, acquired=$2, total=$3", tablet_id,
+                    txn_id, tokens_acquired, total_groups));
+        }
+        tokens_acquired++;
+    }
+
+    VLOG(1) << "Parallel compaction: acquired all " << tokens_acquired << " tokens for tablet " << tablet_id
+            << ", txn_id=" << txn_id;
+
+    // Record expected split counts for each large rowset as a safety net.
+    // Even though we've acquired all tokens, thread pool submission can still fail.
+    // This allows get_merged_txn_log() to detect incomplete splits.
+    {
+        std::unordered_map<uint32_t, int32_t> expected_counts;
+        for (const auto& group : groups) {
+            if (group.type == SubtaskType::LARGE_ROWSET_PART) {
+                expected_counts[group.large_rowset_id]++;
+            }
+        }
+        if (!expected_counts.empty()) {
+            std::lock_guard<std::mutex> lock(state_ptr->mutex);
+            state_ptr->expected_large_rowset_split_counts = std::move(expected_counts);
+        }
+    }
+
+    // Now create and submit all subtasks. Since we've acquired all tokens,
+    // we won't have partial large-rowset splits due to token exhaustion.
+    // Thread pool submission failures are still possible but rare.
+    int subtasks_created = 0;
+    int64_t submitted_bytes = 0;
+
+    for (size_t group_idx = 0; group_idx < groups.size(); group_idx++) {
+        auto& group = groups[group_idx];
+        int32_t subtask_id = static_cast<int32_t>(group_idx);
+
+        // Collect rowset IDs
+        std::vector<uint32_t> rowset_ids;
+        int64_t input_bytes = group.total_bytes;
+
+        if (group.type == SubtaskType::NORMAL) {
+            for (const auto& rowset : group.rowsets) {
+                rowset_ids.push_back(rowset->id());
+            }
+        } else {
+            // LARGE_ROWSET_PART: only one rowset
+            rowset_ids.push_back(group.large_rowset_id);
+        }
+        submitted_bytes += input_bytes;
+
+        // Mark rowsets as compacting and create subtask info
+        {
+            std::lock_guard<std::mutex> lock(state_ptr->mutex);
+            mark_rowsets_compacting(state_ptr.get(), rowset_ids);
+
+            SubtaskInfo info;
+            info.subtask_id = subtask_id;
+            info.input_rowset_ids = rowset_ids;
+            info.input_bytes = input_bytes;
+            info.start_time = ::time(nullptr);
+            info.type = group.type;
+            if (group.type == SubtaskType::LARGE_ROWSET_PART) {
+                info.large_rowset_id = group.large_rowset_id;
+                info.segment_start = group.segment_start;
+                info.segment_end = group.segment_end;
+
+                // Record in large_rowset_split_groups for tracking
+                state_ptr->large_rowset_split_groups[group.large_rowset_id].push_back(subtask_id);
+            }
+            state_ptr->running_subtasks[subtask_id] = std::move(info);
+            state_ptr->total_subtasks_created++;
+        }
+
+        _running_subtasks++;
+
+        // Submit task to thread pool (token already acquired)
+        Status submit_st;
+        if (group.type == SubtaskType::NORMAL) {
+            auto rowsets = std::move(group.rowsets);
+            submit_st = thread_pool->submit_func([this, tablet_id, txn_id, subtask_id, rowsets = std::move(rowsets),
+                                                  version, force_base_compaction, release_token]() mutable {
+                execute_subtask(tablet_id, txn_id, subtask_id, std::move(rowsets), version, force_base_compaction,
+                                release_token);
+            });
+        } else {
+            // LARGE_ROWSET_PART: create a segment-range rowset
+            auto large_rowset = group.large_rowset;
+            auto large_rowset_id = group.large_rowset_id;
+            auto segment_start = group.segment_start;
+            auto segment_end = group.segment_end;
+            submit_st = thread_pool->submit_func([this, tablet_id, txn_id, subtask_id, large_rowset, large_rowset_id,
+                                                  segment_start, segment_end, version, force_base_compaction,
+                                                  release_token]() mutable {
+                execute_subtask_segment_range(tablet_id, txn_id, subtask_id, large_rowset, large_rowset_id,
+                                              segment_start, segment_end, version, force_base_compaction,
+                                              release_token);
+            });
+        }
+
+        if (!submit_st.ok()) {
+            LOG(WARNING) << "Parallel compaction: failed to submit subtask " << subtask_id << " for tablet "
+                         << tablet_id << ": " << submit_st;
+            // Revert state changes
+            {
+                std::lock_guard<std::mutex> lock(state_ptr->mutex);
+                unmark_rowsets_compacting(state_ptr.get(), rowset_ids);
+                state_ptr->running_subtasks.erase(subtask_id);
+                state_ptr->total_subtasks_created--;
+                if (group.type == SubtaskType::LARGE_ROWSET_PART) {
+                    auto& split_ids = state_ptr->large_rowset_split_groups[group.large_rowset_id];
+                    split_ids.erase(std::remove(split_ids.begin(), split_ids.end(), subtask_id), split_ids.end());
+                }
+            }
+            _running_subtasks--;
+
+            // Release token for this failed subtask
+            release_token(false);
+
+            // Release remaining tokens that haven't been used yet
+            int32_t remaining_tokens = total_groups - static_cast<int32_t>(group_idx) - 1;
+            for (int32_t j = 0; j < remaining_tokens; j++) {
+                release_token(false);
+            }
+
+            if (subtasks_created == 0) {
+                cleanup_tablet(tablet_id, txn_id);
+                return submit_st;
+            }
+            // Note: If some subtasks were already submitted, we break and let them run.
+            // This is a thread pool submission failure, not a token acquisition failure,
+            // so partial execution is acceptable for NORMAL type groups.
+            // For LARGE_ROWSET_PART groups, the incomplete split detection in
+            // get_merged_txn_log will handle this case.
+            break;
+        }
+
+        subtasks_created++;
+
+        if (group.type == SubtaskType::NORMAL) {
+            VLOG(1) << "Parallel compaction: created NORMAL subtask " << subtask_id << " for tablet " << tablet_id
+                    << ", txn_id=" << txn_id << ", rowsets=" << rowset_ids.size() << ", input_bytes=" << input_bytes;
+        } else {
+            VLOG(1) << "Parallel compaction: created LARGE_ROWSET_PART subtask " << subtask_id << " for tablet "
+                    << tablet_id << ", txn_id=" << txn_id << ", large_rowset_id=" << group.large_rowset_id
+                    << ", segment_range=[" << group.segment_start << "," << group.segment_end << ")"
+                    << ", input_bytes=" << input_bytes;
+        }
+    }
+
+    if (subtasks_created == 0) {
+        cleanup_tablet(tablet_id, txn_id);
+        return Status::NotFound(strings::Substitute(
+                "Failed to create any subtask: tablet_id=$0, txn_id=$1, total_groups=$2, max_parallel=$3", tablet_id,
+                txn_id, groups.size(), max_parallel));
+    }
+
+    VLOG(1) << "Parallel compaction: successfully created " << subtasks_created << " subtasks for tablet " << tablet_id
+            << ", txn_id=" << txn_id << ", total_bytes=" << submitted_bytes;
+
+    return subtasks_created;
+}
+
+void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tablet_id, int64_t txn_id,
+                                                                    int32_t subtask_id, const RowsetPtr& input_rowset,
+                                                                    uint32_t large_rowset_id, int32_t segment_start,
+                                                                    int32_t segment_end, int64_t version,
+                                                                    bool force_base_compaction,
+                                                                    const ReleaseTokenFunc& release_token) {
+    VLOG(1) << "Executing parallel compaction segment-range subtask " << subtask_id << " for tablet " << tablet_id
+            << ", txn_id=" << txn_id << ", large_rowset_id=" << large_rowset_id << ", segment_range=[" << segment_start
+            << "," << segment_end << ")";
+
+    // Get tablet state
+    auto state = get_tablet_state(tablet_id, txn_id);
+    if (state == nullptr) {
+        _running_subtasks--;
+        if (release_token) {
+            release_token(false);
+        }
+        LOG(WARNING) << "Tablet state not found during segment-range subtask execution, tablet=" << tablet_id
+                     << ", txn_id=" << txn_id << ", subtask_id=" << subtask_id;
+        return;
+    }
+
+    // Create compaction context
+    auto context = CompactionTaskContext::create_for_subtask(txn_id, tablet_id, version, force_base_compaction,
+                                                             true /* skip_write_txnlog */, state->callback, subtask_id);
+
+    auto start_time = ::time(nullptr);
+    context->start_time.store(start_time, std::memory_order_relaxed);
+
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        auto it = state->running_subtasks.find(subtask_id);
+        if (it != state->running_subtasks.end()) {
+            int64_t enqueue_time = it->second.start_time;
+            int64_t in_queue_time_sec = start_time > enqueue_time ? (start_time - enqueue_time) : 0;
+            context->stats->in_queue_time_sec += in_queue_time_sec;
+            it->second.context = context.get();
+        }
+    }
+
+    // Get tablet metadata to create segment-range rowset
+    auto tablet_or = _tablet_mgr->get_tablet(tablet_id, version);
+    if (!tablet_or.ok()) {
+        LOG(WARNING) << "Failed to get tablet for segment-range subtask " << subtask_id << ": " << tablet_or.status();
+        context->status = tablet_or.status();
+        on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
+        if (release_token) {
+            release_token(false);
+        }
+        return;
+    }
+
+    auto& tablet = tablet_or.value();
+    const auto& metadata = tablet.metadata();
+
+    // Find the rowset index in metadata
+    int rowset_index = -1;
+    for (int i = 0; i < metadata->rowsets_size(); i++) {
+        if (metadata->rowsets(i).id() == large_rowset_id) {
+            rowset_index = i;
+            break;
+        }
+    }
+
+    if (rowset_index < 0) {
+        LOG(WARNING) << "Rowset " << large_rowset_id << " not found in metadata for tablet " << tablet_id;
+        context->status = Status::NotFound(strings::Substitute("Rowset $0 not found in metadata", large_rowset_id));
+        on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
+        if (release_token) {
+            release_token(false);
+        }
+        return;
+    }
+
+    // Create segment-range rowset
+    auto segment_range_rowset =
+            std::make_shared<Rowset>(_tablet_mgr, metadata, rowset_index, segment_start, segment_end);
+
+    // Create compaction task using segment-range rowset
+    std::vector<RowsetPtr> input_rowsets;
+    input_rowsets.push_back(std::move(segment_range_rowset));
+
+    auto compaction_task_or = _tablet_mgr->compact(context.get(), std::move(input_rowsets));
+    if (!compaction_task_or.ok()) {
+        LOG(WARNING) << "Failed to create compaction task for segment-range subtask " << subtask_id << ": "
+                     << compaction_task_or.status();
+        context->status = compaction_task_or.status();
+        on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
+        if (release_token) {
+            release_token(compaction_task_or.status().is_mem_limit_exceeded());
+        }
+        return;
+    }
+
+    auto compaction_task = compaction_task_or.value();
+    context->runs.fetch_add(1, std::memory_order_relaxed);
+
+    // Execute compaction
+    auto cancel_func = [this, tablet_id, txn_id, subtask_id, version]() {
+        if (get_tablet_state(tablet_id, txn_id) == nullptr) {
+            return Status::Cancelled(strings::Substitute(
+                    "Tablet parallel compaction state has been cleaned up: tablet_id=$0, txn_id=$1, "
+                    "version=$2, subtask_id=$3",
+                    tablet_id, txn_id, version, subtask_id));
+        }
+        return Status::OK();
+    };
+
+    ThreadPool* flush_pool = nullptr;
+    if (config::lake_enable_compaction_async_write) {
+        flush_pool = StorageEngine::instance()->lake_memtable_flush_executor()->get_thread_pool();
+    }
+
+    auto exec_st = compaction_task->execute(cancel_func, flush_pool);
+
+    auto finish_time = std::max<int64_t>(::time(nullptr), start_time);
+    auto cost = finish_time - start_time;
+
+    if (!exec_st.ok()) {
+        LOG(WARNING) << "Segment-range compaction subtask " << subtask_id << " failed for tablet " << tablet_id << ": "
+                     << exec_st << ", cost=" << cost << "s";
+        context->status = exec_st;
+    } else {
+        VLOG(1) << "Segment-range compaction subtask " << subtask_id << " completed for tablet " << tablet_id
+                << ", cost=" << cost << "s";
+
+        // For segment-range subtask, we need to set segment_range in OpCompaction
+        if (context->txn_log != nullptr && context->txn_log->has_op_compaction()) {
+            auto* op_compaction = context->txn_log->mutable_op_compaction();
+            op_compaction->set_segment_range_start(segment_start);
+            op_compaction->set_segment_range_end(segment_end);
+        }
+    }
+
+    context->finish_time.store(finish_time, std::memory_order_release);
+
+    bool mem_limit_exceeded = exec_st.is_mem_limit_exceeded();
+    on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
+
+    if (release_token) {
+        release_token(mem_limit_exceeded);
+    }
+}
+
+Status TabletParallelCompactionManager::_merge_subtask_lcrm_files(int64_t tablet_id, int64_t txn_id,
+                                                                  const std::vector<FileMetaPB>& lcrm_files,
+                                                                  const std::vector<int64_t>& num_rows_per_subtask,
+                                                                  TxnLogPB_OpCompaction* merged_compaction) {
+    if (lcrm_files.empty()) {
+        return Status::OK();
+    }
+    DCHECK(lcrm_files.size() == num_rows_per_subtask.size());
+
+    ASSIGN_OR_RETURN(auto output_path, new_lake_rows_mapper_filename(_tablet_mgr, tablet_id, txn_id));
+
+    auto merge_impl = [&]() -> Status {
+        RowsMapperBuilder builder(output_path);
+
+        static constexpr size_t kBatchSize = 65536;
+        int64_t total_rows = 0;
+
+        for (size_t i = 0; i < lcrm_files.size(); i++) {
+            const auto& lcrm_file = lcrm_files[i];
+            int64_t num_rows = num_rows_per_subtask[i];
+            if (num_rows <= 0) {
+                continue;
+            }
+
+            RowsMapperIterator iter;
+            FileInfo info;
+            ASSIGN_OR_RETURN(info.path, lake_rows_mapper_filename(_tablet_mgr, tablet_id, lcrm_file.name()));
+            if (lcrm_file.size() > 0) {
+                info.size = lcrm_file.size();
+            }
+            RETURN_IF_ERROR(iter.open(info));
+
+            int64_t remaining = num_rows;
+            while (remaining > 0) {
+                size_t fetch = std::min(remaining, (int64_t)kBatchSize);
+                std::vector<uint64_t> batch;
+                RETURN_IF_ERROR(iter.next_values(fetch, &batch));
+                RETURN_IF_ERROR(builder.append(batch));
+                remaining -= fetch;
+            }
+            RETURN_IF_ERROR(iter.status());
+            total_rows += num_rows;
+        }
+
+        RETURN_IF_ERROR(builder.finalize());
+
+        auto file_info = builder.file_info();
+        if (!file_info.path.empty()) {
+            auto* file_meta = merged_compaction->mutable_lcrm_file();
+            file_meta->set_name(file_info.path);
+            if (file_info.size.has_value()) {
+                file_meta->set_size(file_info.size.value());
+            }
+            VLOG(1) << "Merged " << lcrm_files.size() << " subtask LCRM files into " << file_info.path
+                    << ", tablet=" << tablet_id << ", txn_id=" << txn_id << ", total_rows=" << total_rows
+                    << ", size=" << (file_info.size.has_value() ? file_info.size.value() : -1);
+        }
+
+        return Status::OK();
+    };
+
+    auto st = merge_impl();
+    if (!st.ok()) {
+        (void)fs::delete_file(output_path);
+    }
+    return st;
 }
 
 } // namespace starrocks::lake

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -288,6 +288,12 @@ message TxnLogPB {
         // Subtask ID for parallel compaction. Only set when this OpCompaction is part of
         // OpParallelCompaction. For normal compaction, this field is not set.
         optional int32 subtask_id = 12;
+        // Segment range for large rowset split compaction.
+        // When a large rowset is split into multiple subtasks, each subtask processes
+        // a range of segments [segment_range_start, segment_range_end).
+        // Only set for LARGE_ROWSET_PART type subtasks.
+        optional int32 segment_range_start = 13;
+        optional int32 segment_range_end = 14;
     }
 
     // Parallel compaction operation: contains multiple subtask compaction results.
@@ -305,6 +311,10 @@ message TxnLogPB {
         optional PersistentIndexSstablePB output_sstable = 4;
         // Pk index compaction may generate multi sstables in latest impl.
         repeated PersistentIndexSstablePB output_sstables = 5;
+        // Orphan lcrm files to be cleaned up during publish.
+        // When large rowset split subtasks are merged, their individual lcrm_files
+        // are no longer valid (segment IDs change after merge) and must be cleaned.
+        repeated FileMetaPB orphan_lcrm_files = 6;
     }
 
     message OpSchemaChange {

--- a/test/sql/test_parallel_compaction/R/test_pk_large_rowset_split
+++ b/test/sql/test_parallel_compaction/R/test_pk_large_rowset_split
@@ -1,0 +1,156 @@
+-- name: test_pk_large_rowset_split_basic @cloud @sequential
+create database test_pk_large_rowset_split_${uuid0};
+-- result:
+-- !result
+use test_pk_large_rowset_split_${uuid0};
+-- result:
+-- !result
+[UC]orig_max_rowset_size=SELECT VALUE from information_schema.be_configs where name='lake_compaction_max_rowset_size' limit 1;
+-- result:
+4294967296
+-- !result
+[UC]orig_max_bytes_per_subtask=SELECT VALUE from information_schema.be_configs where name='lake_compaction_max_bytes_per_subtask' limit 1;
+-- result:
+5368709120
+-- !result
+[UC]orig_write_buffer_size=SELECT VALUE from information_schema.be_configs where name='write_buffer_size' limit 1;
+-- result:
+104857600
+-- !result
+[UC]orig_enable_load_spill=SELECT VALUE from information_schema.be_configs where name='enable_load_spill' limit 1;
+-- result:
+true
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_max_tasks" = "0");
+-- result:
+-- !result
+UPDATE information_schema.be_configs SET VALUE = 'false' WHERE name = 'enable_load_spill';
+-- result:
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '1048576' WHERE name = 'write_buffer_size';
+-- result:
+-- !result
+SELECT sleep(2);
+-- result:
+1
+-- !result
+CREATE TABLE `pk_large_split` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(500),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "4"
+);
+-- result:
+-- !result
+INSERT INTO pk_large_split SELECT generate_series, generate_series, CONCAT(MD5(CAST(generate_series AS STRING)), MD5(CAST(generate_series*2 AS STRING)), MD5(CAST(generate_series*3 AS STRING)), MD5(CAST(generate_series*4 AS STRING)), MD5(CAST(generate_series*5 AS STRING)), MD5(CAST(generate_series*6 AS STRING)), MD5(CAST(generate_series*7 AS STRING)), MD5(CAST(generate_series*8 AS STRING)), MD5(CAST(generate_series*9 AS STRING)), MD5(CAST(generate_series*10 AS STRING))), generate_series * 10 FROM TABLE(generate_series(1, 50000));
+-- result:
+-- !result
+SELECT sleep(1);
+-- result:
+1
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+-- result:
+1
+-- !result
+SELECT NUM_SEGMENT >= 4 as has_enough_segments FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+-- result:
+1
+-- !result
+[UC]seg_before=SELECT NUM_SEGMENT FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+-- result:
+13
+-- !result
+[UC]version_before=SELECT MAX_VERSION FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+-- result:
+2
+-- !result
+[UC]data_size=SELECT DATA_SIZE FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+-- result:
+16226630
+-- !result
+SELECT COUNT(*) FROM pk_large_split;
+-- result:
+50000
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '2097152' WHERE name = 'lake_compaction_max_rowset_size';
+-- result:
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '3145728' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+SELECT sleep(2);
+-- result:
+1
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_max_tasks" = "-1");
+-- result:
+-- !result
+[UC]ALTER TABLE pk_large_split COMPACT;
+-- result:
+-- !result
+SELECT sleep(30);
+-- result:
+1
+-- !result
+[UC]SHOW PROC '/compactions';
+-- result:
+test_pk_large_rowset_split_ab7262b655c84f36a231faf57b4ce2fe.pk_large_split.22046	11020	2026-01-27 01:02:48	2026-01-27 01:02:49	2026-01-27 01:02:49	None	{"sub_task_count":3,"read_local_sec":0,"read_local_mb":15,"read_remote_sec":0,"read_remote_mb":0,"read_segment_count":13,"write_segment_count":3,"write_segment_mb":0,"write_remote_sec":0,"in_queue_sec":0}
+-- !result
+[UC]version_after=SELECT MAX_VERSION FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+-- result:
+3
+-- !result
+SELECT ${version_after} > ${version_before} as compaction_happened;
+-- result:
+1
+-- !result
+[UC]rowset_after=SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+-- result:
+3
+-- !result
+SELECT ${rowset_after} > 1 as parallel_compaction_triggered;
+-- result:
+1
+-- !result
+[UC]seg_after=SELECT NUM_SEGMENT FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+-- result:
+3
+-- !result
+SELECT ${seg_after} < ${seg_before} as segments_reduced;
+-- result:
+1
+-- !result
+SELECT COUNT(*) FROM pk_large_split;
+-- result:
+50000
+-- !result
+SELECT k1, k2, LENGTH(v1), v2 FROM pk_large_split WHERE k1 IN (1, 10000, 20000, 30000, 40000, 50000) ORDER BY k1;
+-- result:
+1	1	320	10
+10000	10000	320	100000
+20000	20000	320	200000
+30000	30000	320	300000
+40000	40000	320	400000
+50000	50000	320	500000
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '${orig_max_rowset_size}' WHERE name = 'lake_compaction_max_rowset_size';
+-- result:
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '${orig_max_bytes_per_subtask}' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '${orig_write_buffer_size}' WHERE name = 'write_buffer_size';
+-- result:
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '${orig_enable_load_spill}' WHERE name = 'enable_load_spill';
+-- result:
+-- !result
+DROP DATABASE test_pk_large_rowset_split_${uuid0} FORCE;
+-- result:
+-- !result

--- a/test/sql/test_parallel_compaction/T/test_pk_large_rowset_split
+++ b/test/sql/test_parallel_compaction/T/test_pk_large_rowset_split
@@ -1,0 +1,89 @@
+-- name: test_pk_large_rowset_split_basic @cloud @sequential
+-- Test PK table large rowset split feature
+
+create database test_pk_large_rowset_split_${uuid0};
+use test_pk_large_rowset_split_${uuid0};
+
+-- Save original configs
+[UC]orig_max_rowset_size=SELECT VALUE from information_schema.be_configs where name='lake_compaction_max_rowset_size' limit 1;
+[UC]orig_max_bytes_per_subtask=SELECT VALUE from information_schema.be_configs where name='lake_compaction_max_bytes_per_subtask' limit 1;
+[UC]orig_write_buffer_size=SELECT VALUE from information_schema.be_configs where name='write_buffer_size' limit 1;
+[UC]orig_enable_load_spill=SELECT VALUE from information_schema.be_configs where name='enable_load_spill' limit 1;
+
+-- Disable global compaction FIRST to prevent background compaction
+ADMIN SET FRONTEND CONFIG ("lake_compaction_max_tasks" = "0");
+
+-- Set write config for multiple segments
+UPDATE information_schema.be_configs SET VALUE = 'false' WHERE name = 'enable_load_spill';
+UPDATE information_schema.be_configs SET VALUE = '1048576' WHERE name = 'write_buffer_size';
+
+SELECT sleep(2);
+
+-- Create PK table with VARCHAR column (harder to compress) and parallel compaction enabled
+CREATE TABLE `pk_large_split` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(500),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "4"
+);
+
+-- Single INSERT with random string data (harder to compress)
+INSERT INTO pk_large_split SELECT generate_series, generate_series, CONCAT(MD5(CAST(generate_series AS STRING)), MD5(CAST(generate_series*2 AS STRING)), MD5(CAST(generate_series*3 AS STRING)), MD5(CAST(generate_series*4 AS STRING)), MD5(CAST(generate_series*5 AS STRING)), MD5(CAST(generate_series*6 AS STRING)), MD5(CAST(generate_series*7 AS STRING)), MD5(CAST(generate_series*8 AS STRING)), MD5(CAST(generate_series*9 AS STRING)), MD5(CAST(generate_series*10 AS STRING))), generate_series * 10 FROM TABLE(generate_series(1, 50000));
+
+SELECT sleep(1);
+
+-- Check before compaction: should have 1 rowset with multiple segments
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+SELECT NUM_SEGMENT >= 4 as has_enough_segments FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+[UC]seg_before=SELECT NUM_SEGMENT FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+[UC]version_before=SELECT MAX_VERSION FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+[UC]data_size=SELECT DATA_SIZE FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+
+SELECT COUNT(*) FROM pk_large_split;
+
+-- Set compaction thresholds for large rowset split:
+-- data_size ~= 15MB, 13 segments, each segment ~= 1.15MB
+-- lake_compaction_max_rowset_size = 2MB so each segment < 2MB (passes min_input_segment_check)
+-- min_size = 2 * 2MB = 4MB, data_size 15MB >= 4MB (passes _is_large_rowset_for_split)
+-- lake_compaction_max_bytes_per_subtask = 3MB so data_size > 3MB (passes _is_large_rowset_for_split)
+UPDATE information_schema.be_configs SET VALUE = '2097152' WHERE name = 'lake_compaction_max_rowset_size';
+UPDATE information_schema.be_configs SET VALUE = '3145728' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+SELECT sleep(2);
+
+-- Re-enable compaction and trigger
+ADMIN SET FRONTEND CONFIG ("lake_compaction_max_tasks" = "-1");
+[UC]ALTER TABLE pk_large_split COMPACT;
+
+SELECT sleep(30);
+
+-- Show compaction status
+[UC]SHOW PROC '/compactions';
+
+-- Check after compaction
+[UC]version_after=SELECT MAX_VERSION FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+SELECT ${version_after} > ${version_before} as compaction_happened;
+
+-- Parallel compaction produces multiple rowsets (one per subtask)
+-- Check NUM_ROWSET > 1 indicates parallel compaction was triggered
+[UC]rowset_after=SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+SELECT ${rowset_after} > 1 as parallel_compaction_triggered;
+
+[UC]seg_after=SELECT NUM_SEGMENT FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_split' AND c.TABLE_SCHEMA = 'test_pk_large_rowset_split_${uuid0}';
+SELECT ${seg_after} < ${seg_before} as segments_reduced;
+
+SELECT COUNT(*) FROM pk_large_split;
+SELECT k1, k2, LENGTH(v1), v2 FROM pk_large_split WHERE k1 IN (1, 10000, 20000, 30000, 40000, 50000) ORDER BY k1;
+
+-- Restore configs
+UPDATE information_schema.be_configs SET VALUE = '${orig_max_rowset_size}' WHERE name = 'lake_compaction_max_rowset_size';
+UPDATE information_schema.be_configs SET VALUE = '${orig_max_bytes_per_subtask}' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+UPDATE information_schema.be_configs SET VALUE = '${orig_write_buffer_size}' WHERE name = 'write_buffer_size';
+UPDATE information_schema.be_configs SET VALUE = '${orig_enable_load_spill}' WHERE name = 'enable_load_spill';
+
+DROP DATABASE test_pk_large_rowset_split_${uuid0} FORCE;


### PR DESCRIPTION
## Why I'm doing:

The current parallel compaction can only group rowsets at the rowset level. For large rowsets with many segments (e.g., 8GB+ with 8+ segments), a single subtask must process all segments sequentially, limiting parallelism and increasing memory pressure.

## What I'm doing:

- Add segment range mode to Rowset class for partial segment loading
- Add SubtaskType (NORMAL/LARGE_ROWSET_PART) to distinguish subtask types
- Implement large rowset split with "all-or-nothing" semantics:
  * Split criteria: size >= 2x max_rowset_size, segments >= 4, overlapped
  * All subtasks from same split must succeed for apply
- Add unit tests for new functionality

Fixes #66457

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
