### PR TITLE
[Enhancement] Add segment metadata filter for lake tables to skip segments based on sort key range

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -631,6 +631,10 @@ CONF_Bool(enable_load_segment_parallel, "false");
 CONF_Int32(load_segment_thread_pool_num_max, "128");
 CONF_Int32(load_segment_thread_pool_queue_size, "10240");
 
+// Enable segment metadata filter for lake tables.
+// When enabled, segments whose sort key range does not intersect with query predicates will be skipped.
+CONF_mBool(enable_lake_segment_metadata_filter, "true");
+
 // Fragment thread pool
 CONF_Int32(fragment_pool_thread_num_min, "64");
 CONF_Int32(fragment_pool_thread_num_max, "4096");

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -758,6 +758,10 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _bf_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BloomFilterFilterRows", TUnit::UNIT, segment_init_name);
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, segment_init_name);
+    _seg_metadata_filtered_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "SegmentMetadataFilterRows", TUnit::UNIT, segment_init_name);
+    _segs_metadata_filtered_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "SegmentsMetadataFiltered", TUnit::UNIT, segment_init_name);
     _seg_rt_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentRuntimeZoneMapFilterRows", TUnit::UNIT, segment_init_name);
     _zm_filtered_counter =
@@ -903,6 +907,8 @@ void LakeDataSource::update_counter(RuntimeState* state) {
     COUNTER_UPDATE(_record_predicate_filter_counter, _reader->stats().rows_record_predicate_filtered);
 
     COUNTER_UPDATE(_seg_zm_filtered_counter, _reader->stats().segment_stats_filtered);
+    COUNTER_UPDATE(_seg_metadata_filtered_counter, _reader->stats().segment_metadata_filtered);
+    COUNTER_UPDATE(_segs_metadata_filtered_counter, _reader->stats().segments_metadata_filtered);
     COUNTER_UPDATE(_seg_rt_filtered_counter, _reader->stats().runtime_stats_filtered);
     COUNTER_UPDATE(_zm_filtered_counter, _reader->stats().rows_stats_filtered);
     COUNTER_UPDATE(_bf_filtered_counter, _reader->stats().rows_bf_filtered);

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -152,6 +152,8 @@ private:
     RuntimeProfile::Counter* _zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bf_filtered_counter = nullptr;
     RuntimeProfile::Counter* _seg_zm_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _seg_metadata_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _segs_metadata_filtered_counter = nullptr;
     RuntimeProfile::Counter* _seg_rt_filtered_counter = nullptr;
     RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
     RuntimeProfile::Counter* _rows_after_sk_filtered_counter = nullptr;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -184,6 +184,10 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER_SKIP_MIN_MAX(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT,
                                            _get_counter_min_max_type("SegmentZoneMapFilterRows"), segment_init_name);
+    _seg_metadata_filtered_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "SegmentMetadataFilterRows", TUnit::UNIT, segment_init_name);
+    _segs_metadata_filtered_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "SegmentsMetadataFiltered", TUnit::UNIT, segment_init_name);
     _seg_rt_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentRuntimeZoneMapFilterRows", TUnit::UNIT, segment_init_name);
     _zm_filtered_counter =
@@ -895,6 +899,8 @@ void OlapChunkSource::_update_counter() {
     COUNTER_UPDATE(_del_vec_filter_counter, _reader->stats().rows_del_vec_filtered);
 
     COUNTER_UPDATE(_seg_zm_filtered_counter, _reader->stats().segment_stats_filtered);
+    COUNTER_UPDATE(_seg_metadata_filtered_counter, _reader->stats().segment_metadata_filtered);
+    COUNTER_UPDATE(_segs_metadata_filtered_counter, _reader->stats().segments_metadata_filtered);
     COUNTER_UPDATE(_seg_rt_filtered_counter, _reader->stats().runtime_stats_filtered);
     COUNTER_UPDATE(_zm_filtered_counter, _reader->stats().rows_stats_filtered);
     COUNTER_UPDATE(_vector_index_filtered_counter, _reader->stats().rows_vector_index_filtered);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -142,6 +142,10 @@ private:
     RuntimeProfile::Counter* _zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _seg_zm_filtered_counter = nullptr;
 
+    // Segment metadata filter (sort key range filtering for lake tables)
+    RuntimeProfile::Counter* _seg_metadata_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _segs_metadata_filtered_counter = nullptr;
+
     // Bloom filter
     RuntimeProfile::Counter* _bf_filter_timer = nullptr;
     RuntimeProfile::Counter* _bf_filtered_counter = nullptr;

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -201,6 +201,7 @@ set(STORAGE_FILES
     lake/replication_txn_manager.cpp
     lake/lake_replication_txn_manager.cpp
     lake/rowset.cpp
+    lake/segment_metadata_filter.cpp
     lake/schema_change.cpp
     lake/starlet_location_provider.cpp
     lake/tablet.cpp

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <unordered_set>
+
 #include "common/statusor.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "storage/lake/tablet.h"
@@ -120,7 +122,8 @@ public:
     Status load_segments(std::vector<SegmentPtr>* segments, bool fill_cache, int64_t buffer_size = -1);
 
     [[nodiscard]] Status load_segments(std::vector<SegmentPtr>* segments, SegmentReadOptions& seg_options,
-                                       std::pair<std::vector<SegmentPtr>, std::vector<SegmentPtr>>* not_used_segments);
+                                       std::pair<std::vector<SegmentPtr>, std::vector<SegmentPtr>>* not_used_segments,
+                                       const std::unordered_set<int>* skip_segment_idxs = nullptr);
 
     int64_t tablet_id() const { return _tablet_id; }
 

--- a/be/src/storage/lake/segment_metadata_filter.cpp
+++ b/be/src/storage/lake/segment_metadata_filter.cpp
@@ -1,0 +1,139 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/segment_metadata_filter.h"
+
+#include "storage/column_predicate.h"
+#include "storage/datum_variant.h"
+#include "storage/zone_map_detail.h"
+
+namespace starrocks::lake {
+
+namespace {
+
+// Build ZoneMapDetail from TuplePB for a specific column.
+// Returns error if column_idx is out of range.
+StatusOr<ZoneMapDetail> build_zone_map_detail(const TuplePB& min_tuple, const TuplePB& max_tuple, int column_idx) {
+    if (column_idx >= min_tuple.values_size() || column_idx >= max_tuple.values_size()) {
+        return Status::InvalidArgument(fmt::format("column_idx {} out of range, min size: {}, max size: {}", column_idx,
+                                                   min_tuple.values_size(), max_tuple.values_size()));
+    }
+
+    DatumVariant min_variant;
+    RETURN_IF_ERROR(min_variant.from_proto(min_tuple.values(column_idx)));
+
+    DatumVariant max_variant;
+    RETURN_IF_ERROR(max_variant.from_proto(max_tuple.values(column_idx)));
+
+    // Data is sorted by sort key, nulls are placed first.
+    // If min is null, the segment contains null values (has_null = true).
+    // If min is not null, the segment does not contain null values.
+    // ZoneMapDetail(min_or_null_value, max_value) constructor handles this automatically.
+    ZoneMapDetail detail(min_variant.value(), max_variant.value());
+    return detail;
+}
+
+// Predicate tree visitor that determines if a segment can be pruned.
+struct MetadataPruner {
+    // Handle single column predicate.
+    bool operator()(const PredicateColumnNode& node) const {
+        const auto* col_pred = node.col_pred();
+        if (col_pred == nullptr) {
+            return false;
+        }
+
+        // IS NULL / IS NOT NULL predicates are not supported.
+        if (col_pred->type() == PredicateType::kIsNull || col_pred->type() == PredicateType::kNotNull) {
+            return false;
+        }
+
+        const ColumnId column_id = col_pred->column_id();
+
+        // Find the position of column_id in sort_key_idxes.
+        // The tuple values are stored in sort_key_idxes order, not column ID order.
+        // For example, if sort_key_idxes = [2, 0, 1], then:
+        //   tuple[0] = value of column 2 (first sort key)
+        //   tuple[1] = value of column 0 (second sort key)
+        //   tuple[2] = value of column 1 (third sort key)
+        int sort_key_pos = -1;
+        for (size_t i = 0; i < sort_key_idxes.size(); i++) {
+            if (sort_key_idxes[i] == column_id) {
+                sort_key_pos = static_cast<int>(i);
+                break;
+            }
+        }
+
+        // If column is not in sort key, cannot filter using this metadata.
+        if (sort_key_pos < 0) {
+            return false;
+        }
+
+        // Build ZoneMapDetail for this column using its position in the sort key tuple.
+        auto detail_or = build_zone_map_detail(min_tuple, max_tuple, sort_key_pos);
+        if (!detail_or.ok()) {
+            return false;
+        }
+
+        // Reuse ColumnPredicate::zone_map_filter.
+        // zone_map_filter returns false if segment definitely does not contain matching data.
+        return !col_pred->zone_map_filter(detail_or.value());
+    }
+
+    // AND node: if any child can prune, the whole AND can prune.
+    bool operator()(const PredicateAndNode& node) const {
+        return std::any_of(node.children().begin(), node.children().end(),
+                           [this](const auto& child) { return child.visit(*this); });
+    }
+
+    // OR node: all children must be able to prune for the whole OR to prune.
+    bool operator()(const PredicateOrNode& node) const {
+        return !node.empty() && std::all_of(node.children().begin(), node.children().end(),
+                                            [this](const auto& child) { return child.visit(*this); });
+    }
+
+    const TuplePB& min_tuple;
+    const TuplePB& max_tuple;
+    const std::vector<ColumnId>& sort_key_idxes;
+};
+
+} // namespace
+
+bool SegmentMetadataFilter::may_contain(const SegmentMetadataPB& segment_meta,
+                                        const PredicateTree& pred_tree_for_zone_map,
+                                        const TabletSchema& tablet_schema) {
+    // No metadata available, conservatively return true.
+    if (!segment_meta.has_sort_key_min() || !segment_meta.has_sort_key_max()) {
+        return true;
+    }
+
+    const auto& min_tuple = segment_meta.sort_key_min();
+    const auto& max_tuple = segment_meta.sort_key_max();
+
+    if (min_tuple.values_size() == 0 || max_tuple.values_size() == 0) {
+        return true;
+    }
+
+    // Get sort key column indices. The tuple values are stored in this order.
+    const auto& sort_key_idxes = tablet_schema.sort_key_idxes();
+    if (sort_key_idxes.empty()) {
+        return true;
+    }
+
+    MetadataPruner pruner{min_tuple, max_tuple, sort_key_idxes};
+    bool can_prune = pred_tree_for_zone_map.visit(pruner);
+
+    return !can_prune;
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/segment_metadata_filter.h
+++ b/be/src/storage/lake/segment_metadata_filter.h
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "gen_cpp/lake_types.pb.h"
+#include "storage/predicate_tree/predicate_tree.hpp"
+#include "storage/tablet_schema.h"
+
+namespace starrocks::lake {
+
+// Segment metadata filter for Lake tables.
+// Uses sort_key_min/max from SegmentMetadataPB to filter segments
+// that cannot possibly contain data matching the query predicates.
+class SegmentMetadataFilter {
+public:
+    // Check if a segment may contain data matching the predicates.
+    // Returns true if the segment may contain matching data (need to read).
+    // Returns false if the segment definitely does not contain matching data (can skip).
+    static bool may_contain(const SegmentMetadataPB& segment_meta, const PredicateTree& pred_tree_for_zone_map,
+                            const TabletSchema& tablet_schema);
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -296,6 +296,11 @@ struct OlapReaderStatistics {
     int64_t read_pk_index_ns = 0;
 
     // ------ for lake tablet ------
+    // Rows skipped by segment metadata filter (sort key range filtering).
+    int64_t segment_metadata_filtered = 0;
+    // Number of segments skipped by segment metadata filter.
+    int64_t segments_metadata_filtered = 0;
+
     int64_t pages_from_local_disk = 0;
 
     int64_t compressed_bytes_read_local_disk = 0;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -539,6 +539,7 @@ SET(DW_TEST_FILES
     ./storage/lake/tablet_reshard_test.cpp
     ./storage/lake/replication_txn_manager_test.cpp
     ./storage/lake/rowset_test.cpp
+    ./storage/lake/segment_metadata_filter_test.cpp
     ./storage/lake/schema_change_test.cpp
     ./storage/lake/lake_replication_txn_manager_test.cpp
     ./storage/lake/spill_mem_table_sink_test.cpp

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -15,21 +15,25 @@
 #include <gtest/gtest.h>
 
 #include <optional>
+#include <unordered_set>
 
 #include "column/binary_column.h"
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
 #include "column/schema.h"
 #include "column/vectorized_fwd.h"
+#include "common/config.h"
 #include "common/logging.h"
 #include "runtime/types.h"
 #include "storage/chunk_helper.h"
+#include "storage/column_predicate.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/transactions.h"
 #include "storage/lake/versioned_tablet.h"
 #include "storage/lake/vertical_compaction_task.h"
+#include "storage/predicate_tree/predicate_tree.hpp"
 #include "storage/rowset/rowset_options.h"
 #include "storage/tablet_schema.h"
 #include "test_util.h"
@@ -753,6 +757,303 @@ TEST_F(LakeRowsetTest, test_get_each_segment_iterator_with_delvec_respects_table
     ASSIGN_OR_ABORT(auto seg_iters, rowset->get_each_segment_iterator_with_delvec(input_schema, 1, nullptr, &stats));
 
     ASSERT_EQ(count_rows_from_iters(seg_iters), 3 * 2);
+}
+
+// Test class for segment metadata filter and parallel load with skip_segment_idxs
+class LakeRowsetSegmentMetadataFilterTest : public TestBase {
+public:
+    LakeRowsetSegmentMetadataFilterTest() : TestBase(kTestDirectory) {
+        // Create a tablet schema with one INT sort key column
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(DUP_KEYS);
+        schema_pb.set_num_short_key_columns(1);
+        schema_pb.set_id(next_id());
+
+        auto* c0 = schema_pb.add_column();
+        c0->set_unique_id(next_id());
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+
+        auto* c1 = schema_pb.add_column();
+        c1->set_unique_id(next_id());
+        c1->set_name("c1");
+        c1->set_type("INT");
+        c1->set_is_key(false);
+        c1->set_is_nullable(false);
+        c1->set_aggregation("NONE");
+
+        // Set sort key column index
+        schema_pb.add_sort_key_idxes(0);
+
+        _tablet_metadata = std::make_shared<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+        _tablet_metadata->set_cumulative_point(0);
+        _tablet_metadata->set_next_rowset_id(1);
+        *_tablet_metadata->mutable_schema() = schema_pb;
+
+        _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+    }
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+    // Create rowsets with segment_metas for testing
+    // Creates 3 segments with sort key ranges: [0,10], [20,30], [40,50]
+    void create_rowsets_with_segment_metas() {
+        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        ASSERT_OK(writer->open());
+
+        // Segment 0: keys [0, 10]
+        {
+            auto c0 = Int32Column::create();
+            auto c1 = Int32Column::create();
+            for (int i = 0; i <= 10; i++) {
+                c0->append(i);
+                c1->append(i * 2);
+            }
+            Chunk chunk({c0, c1}, _schema);
+            ASSERT_OK(writer->write(chunk));
+            ASSERT_OK(writer->finish());
+        }
+
+        // Segment 1: keys [20, 30]
+        {
+            auto c0 = Int32Column::create();
+            auto c1 = Int32Column::create();
+            for (int i = 20; i <= 30; i++) {
+                c0->append(i);
+                c1->append(i * 2);
+            }
+            Chunk chunk({c0, c1}, _schema);
+            ASSERT_OK(writer->write(chunk));
+            ASSERT_OK(writer->finish());
+        }
+
+        // Segment 2: keys [40, 50]
+        {
+            auto c0 = Int32Column::create();
+            auto c1 = Int32Column::create();
+            for (int i = 40; i <= 50; i++) {
+                c0->append(i);
+                c1->append(i * 2);
+            }
+            Chunk chunk({c0, c1}, _schema);
+            ASSERT_OK(writer->write(chunk));
+            ASSERT_OK(writer->finish());
+        }
+
+        const auto& files = writer->segments();
+        ASSERT_EQ(3, files.size());
+
+        // Build rowset metadata with segment_metas
+        auto* rowset = _tablet_metadata->add_rowsets();
+        rowset->set_overlapped(false);
+        rowset->set_id(1);
+        rowset->set_num_rows(33); // 11 + 11 + 11
+
+        for (const auto& file : files) {
+            rowset->add_segments(file.path);
+        }
+
+        // Add segment_metas with sort_key_min/max
+        // Segment 0: [0, 10]
+        {
+            auto* seg_meta = rowset->add_segment_metas();
+            auto* min_tuple = seg_meta->mutable_sort_key_min();
+            auto* min_var = min_tuple->add_values();
+            TypeDescriptor td(TYPE_INT);
+            *min_var->mutable_type() = td.to_protobuf();
+            min_var->set_value("0");
+
+            auto* max_tuple = seg_meta->mutable_sort_key_max();
+            auto* max_var = max_tuple->add_values();
+            *max_var->mutable_type() = td.to_protobuf();
+            max_var->set_value("10");
+
+            seg_meta->set_num_rows(11);
+        }
+
+        // Segment 1: [20, 30]
+        {
+            auto* seg_meta = rowset->add_segment_metas();
+            auto* min_tuple = seg_meta->mutable_sort_key_min();
+            auto* min_var = min_tuple->add_values();
+            TypeDescriptor td(TYPE_INT);
+            *min_var->mutable_type() = td.to_protobuf();
+            min_var->set_value("20");
+
+            auto* max_tuple = seg_meta->mutable_sort_key_max();
+            auto* max_var = max_tuple->add_values();
+            *max_var->mutable_type() = td.to_protobuf();
+            max_var->set_value("30");
+
+            seg_meta->set_num_rows(11);
+        }
+
+        // Segment 2: [40, 50]
+        {
+            auto* seg_meta = rowset->add_segment_metas();
+            auto* min_tuple = seg_meta->mutable_sort_key_min();
+            auto* min_var = min_tuple->add_values();
+            TypeDescriptor td(TYPE_INT);
+            *min_var->mutable_type() = td.to_protobuf();
+            min_var->set_value("40");
+
+            auto* max_tuple = seg_meta->mutable_sort_key_max();
+            auto* max_var = max_tuple->add_values();
+            *max_var->mutable_type() = td.to_protobuf();
+            max_var->set_value("50");
+
+            seg_meta->set_num_rows(11);
+        }
+
+        writer->close();
+
+        _tablet_metadata->set_version(2);
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+protected:
+    constexpr static const char* const kTestDirectory = "test_lake_rowset_segment_metadata_filter";
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+};
+
+// Test: Segment metadata filter skips segments based on predicate
+TEST_F(LakeRowsetSegmentMetadataFilterTest, test_segment_metadata_filter_skips_segments) {
+    create_rowsets_with_segment_metas();
+
+    // Ensure metadata filter is enabled
+    ConfigResetGuard<bool> guard(&config::enable_lake_segment_metadata_filter, true);
+
+    auto rowset =
+            std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 0 /* compaction_segment_limit */);
+
+    RowsetReadOptions rs_opts;
+    OlapReaderStatistics stats;
+    rs_opts.stats = &stats;
+    rs_opts.tablet_schema = _tablet_schema;
+
+    // Create predicate: c0 = 25 (only matches segment 1 with range [20, 30])
+    std::unique_ptr<ColumnPredicate> pred(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "25"));
+    PredicateAndNode root;
+    root.add_child(PredicateColumnNode(pred.get()));
+    rs_opts.pred_tree_for_zone_map = PredicateTree::create(std::move(root));
+
+    auto input_schema = ChunkHelper::convert_schema(_tablet_schema, std::vector<ColumnId>{0});
+    ASSIGN_OR_ABORT(auto iters, rowset->read(input_schema, rs_opts));
+
+    // Verify stats: 2 segments should be filtered (segment 0 and segment 2)
+    ASSERT_EQ(stats.segments_metadata_filtered, 2);
+    // Filtered rows = 11 (segment 0) + 11 (segment 2) = 22
+    ASSERT_EQ(stats.segment_metadata_filtered, 22);
+    // Only 1 segment should be read
+    ASSERT_EQ(stats.segments_read_count, 1);
+}
+
+// Test: Segment metadata filter disabled by config
+TEST_F(LakeRowsetSegmentMetadataFilterTest, test_segment_metadata_filter_disabled) {
+    create_rowsets_with_segment_metas();
+
+    // Disable metadata filter
+    ConfigResetGuard<bool> guard(&config::enable_lake_segment_metadata_filter, false);
+
+    auto rowset =
+            std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 0 /* compaction_segment_limit */);
+
+    RowsetReadOptions rs_opts;
+    OlapReaderStatistics stats;
+    rs_opts.stats = &stats;
+    rs_opts.tablet_schema = _tablet_schema;
+
+    // Create predicate: c0 = 25
+    std::unique_ptr<ColumnPredicate> pred(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "25"));
+    PredicateAndNode root;
+    root.add_child(PredicateColumnNode(pred.get()));
+    rs_opts.pred_tree_for_zone_map = PredicateTree::create(std::move(root));
+
+    auto input_schema = ChunkHelper::convert_schema(_tablet_schema, std::vector<ColumnId>{0});
+    ASSIGN_OR_ABORT(auto iters, rowset->read(input_schema, rs_opts));
+
+    // No segments should be filtered when config is disabled
+    ASSERT_EQ(stats.segments_metadata_filtered, 0);
+    ASSERT_EQ(stats.segment_metadata_filtered, 0);
+    // All 3 segments should be read
+    ASSERT_EQ(stats.segments_read_count, 3);
+}
+
+// Test: load_segments with skip_segment_idxs in serial mode
+TEST_F(LakeRowsetSegmentMetadataFilterTest, test_load_segments_with_skip_segment_idxs) {
+    create_rowsets_with_segment_metas();
+
+    // Disable parallel load to test serial mode
+    ConfigResetGuard<bool> guard(&config::enable_load_segment_parallel, false);
+
+    auto rowset =
+            std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 0 /* compaction_segment_limit */);
+
+    std::vector<SegmentPtr> segments;
+    SegmentReadOptions seg_options;
+    seg_options.lake_io_opts.fill_data_cache = false;
+    seg_options.lake_io_opts.fill_metadata_cache = false;
+
+    // Skip segment 1
+    std::unordered_set<int> skip_segment_idxs = {1};
+
+    ASSERT_OK(rowset->load_segments(&segments, seg_options, nullptr, &skip_segment_idxs));
+
+    // Should have 3 entries (including nullptr placeholder)
+    ASSERT_EQ(segments.size(), 3);
+
+    // Segment 0 should be loaded
+    ASSERT_NE(segments[0], nullptr);
+    // Segment 1 should be skipped (nullptr)
+    ASSERT_EQ(segments[1], nullptr);
+    // Segment 2 should be loaded
+    ASSERT_NE(segments[2], nullptr);
+}
+
+// Test: load_segments with skip_segment_idxs in parallel mode with index mapping
+TEST_F(LakeRowsetSegmentMetadataFilterTest, test_load_segments_parallel_with_skip_segment_idxs) {
+    create_rowsets_with_segment_metas();
+
+    // Enable parallel load to test parallel mode with index mapping
+    ConfigResetGuard<bool> guard(&config::enable_load_segment_parallel, true);
+
+    auto rowset =
+            std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 0 /* compaction_segment_limit */);
+
+    std::vector<SegmentPtr> segments;
+    SegmentReadOptions seg_options;
+    seg_options.lake_io_opts.fill_data_cache = false;
+    seg_options.lake_io_opts.fill_metadata_cache = false;
+
+    // Skip segment 1
+    std::unordered_set<int> skip_segment_idxs = {1};
+
+    ASSERT_OK(rowset->load_segments(&segments, seg_options, nullptr, &skip_segment_idxs));
+
+    // Should have 3 entries with correct index mapping
+    ASSERT_EQ(segments.size(), 3);
+
+    // Segment 0 should be loaded at index 0
+    ASSERT_NE(segments[0], nullptr);
+    // Segment 1 should be skipped (nullptr) at index 1
+    ASSERT_EQ(segments[1], nullptr);
+    // Segment 2 should be loaded at index 2
+    ASSERT_NE(segments[2], nullptr);
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/segment_metadata_filter_test.cpp
+++ b/be/test/storage/lake/segment_metadata_filter_test.cpp
@@ -1,0 +1,509 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/segment_metadata_filter.h"
+
+#include <gtest/gtest.h>
+
+#include "runtime/types.h"
+#include "storage/column_predicate.h"
+#include "storage/predicate_tree/predicate_tree.hpp"
+#include "storage/tablet_schema.h"
+
+namespace starrocks::lake {
+
+class SegmentMetadataFilterTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        // Create a simple tablet schema with two INT columns as sort keys.
+        // Column 0 (c0): INT, sort key
+        // Column 1 (c1): INT, sort key
+        // Column 2 (c2): INT, not a sort key
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(DUP_KEYS);
+        schema_pb.set_num_short_key_columns(2);
+
+        auto* c0 = schema_pb.add_column();
+        c0->set_unique_id(0);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+
+        auto* c1 = schema_pb.add_column();
+        c1->set_unique_id(1);
+        c1->set_name("c1");
+        c1->set_type("INT");
+        c1->set_is_key(true);
+        c1->set_is_nullable(false);
+
+        auto* c2 = schema_pb.add_column();
+        c2->set_unique_id(2);
+        c2->set_name("c2");
+        c2->set_type("INT");
+        c2->set_is_key(false);
+        c2->set_is_nullable(false);
+        c2->set_aggregation("NONE");
+
+        // Set sort key column indices: [0, 1]
+        schema_pb.add_sort_key_idxes(0);
+        schema_pb.add_sort_key_idxes(1);
+
+        _tablet_schema = TabletSchema::create(schema_pb);
+    }
+
+protected:
+    // Helper function to create a VariantPB for an INT value.
+    static VariantPB make_int_variant(int32_t value) {
+        VariantPB var;
+        TypeDescriptor td(TYPE_INT);
+        *var.mutable_type() = td.to_protobuf();
+        var.set_value(std::to_string(value));
+        return var;
+    }
+
+    // Helper function to create a VariantPB for a null INT value.
+    static VariantPB make_null_int_variant() {
+        VariantPB var;
+        TypeDescriptor td(TYPE_INT);
+        *var.mutable_type() = td.to_protobuf();
+        // No value set means null
+        return var;
+    }
+
+    // Helper function to create segment metadata with sort key min/max.
+    static SegmentMetadataPB create_segment_meta(const std::vector<int32_t>& min_values,
+                                                 const std::vector<int32_t>& max_values) {
+        SegmentMetadataPB meta;
+        auto* min_tuple = meta.mutable_sort_key_min();
+        for (int32_t v : min_values) {
+            *min_tuple->add_values() = make_int_variant(v);
+        }
+        auto* max_tuple = meta.mutable_sort_key_max();
+        for (int32_t v : max_values) {
+            *max_tuple->add_values() = make_int_variant(v);
+        }
+        meta.set_num_rows(100);
+        return meta;
+    }
+
+    // Helper function to create a predicate tree with a single column predicate.
+    static PredicateTree create_pred_tree_with_column_pred(const ColumnPredicate* pred) {
+        PredicateAndNode root;
+        root.add_child(PredicateColumnNode(pred));
+        return PredicateTree::create(std::move(root));
+    }
+
+    std::shared_ptr<TabletSchema> _tablet_schema;
+};
+
+// Test: No sort_key_min/max metadata, should return true (may contain).
+TEST_F(SegmentMetadataFilterTest, test_no_metadata) {
+    SegmentMetadataPB meta;
+    // No sort_key_min or sort_key_max set
+
+    std::unique_ptr<ColumnPredicate> pred(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "50"));
+    PredicateTree pred_tree = create_pred_tree_with_column_pred(pred.get());
+
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: Empty min_tuple values, should return true.
+TEST_F(SegmentMetadataFilterTest, test_empty_tuple_values) {
+    SegmentMetadataPB meta;
+    meta.mutable_sort_key_min(); // Empty tuple
+    auto* max_tuple = meta.mutable_sort_key_max();
+    *max_tuple->add_values() = make_int_variant(100);
+
+    std::unique_ptr<ColumnPredicate> pred(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "50"));
+    PredicateTree pred_tree = create_pred_tree_with_column_pred(pred.get());
+
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: EQ predicate - value within range, should return true.
+TEST_F(SegmentMetadataFilterTest, test_eq_within_range) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // Predicate: c0 = 50 (within range)
+    std::unique_ptr<ColumnPredicate> pred(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "50"));
+    PredicateTree pred_tree = create_pred_tree_with_column_pred(pred.get());
+
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: EQ predicate - value outside range, should return false.
+TEST_F(SegmentMetadataFilterTest, test_eq_outside_range) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // Predicate: c0 = 5 (below range)
+    std::unique_ptr<ColumnPredicate> pred1(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "5"));
+    PredicateTree pred_tree1 = create_pred_tree_with_column_pred(pred1.get());
+    ASSERT_FALSE(SegmentMetadataFilter::may_contain(meta, pred_tree1, *_tablet_schema));
+
+    // Predicate: c0 = 200 (above range)
+    std::unique_ptr<ColumnPredicate> pred2(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "200"));
+    PredicateTree pred_tree2 = create_pred_tree_with_column_pred(pred2.get());
+    ASSERT_FALSE(SegmentMetadataFilter::may_contain(meta, pred_tree2, *_tablet_schema));
+}
+
+// Test: GE predicate - range overlaps, should return true.
+TEST_F(SegmentMetadataFilterTest, test_ge_overlaps) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // Predicate: c0 >= 50 (overlaps with [50, 100])
+    std::unique_ptr<ColumnPredicate> pred(new_column_ge_predicate(get_type_info(TYPE_INT), 0, "50"));
+    PredicateTree pred_tree = create_pred_tree_with_column_pred(pred.get());
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: GE predicate - no overlap, should return false.
+TEST_F(SegmentMetadataFilterTest, test_ge_no_overlap) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // Predicate: c0 >= 200 (no overlap, segment max is 100)
+    std::unique_ptr<ColumnPredicate> pred(new_column_ge_predicate(get_type_info(TYPE_INT), 0, "200"));
+    PredicateTree pred_tree = create_pred_tree_with_column_pred(pred.get());
+    ASSERT_FALSE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: LE predicate - range overlaps, should return true.
+TEST_F(SegmentMetadataFilterTest, test_le_overlaps) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // Predicate: c0 <= 50 (overlaps with [10, 50])
+    std::unique_ptr<ColumnPredicate> pred(new_column_le_predicate(get_type_info(TYPE_INT), 0, "50"));
+    PredicateTree pred_tree = create_pred_tree_with_column_pred(pred.get());
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: LE predicate - no overlap, should return false.
+TEST_F(SegmentMetadataFilterTest, test_le_no_overlap) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // Predicate: c0 <= 5 (no overlap, segment min is 10)
+    std::unique_ptr<ColumnPredicate> pred(new_column_le_predicate(get_type_info(TYPE_INT), 0, "5"));
+    PredicateTree pred_tree = create_pred_tree_with_column_pred(pred.get());
+    ASSERT_FALSE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: Second sort key column predicate.
+TEST_F(SegmentMetadataFilterTest, test_second_sort_key_column) {
+    // Segment has c0 range [10, 100], c1 range [20, 200]
+    SegmentMetadataPB meta = create_segment_meta({10, 20}, {100, 200});
+
+    // Predicate: c1 = 50 (within range)
+    std::unique_ptr<ColumnPredicate> pred1(new_column_eq_predicate(get_type_info(TYPE_INT), 1, "50"));
+    PredicateTree pred_tree1 = create_pred_tree_with_column_pred(pred1.get());
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree1, *_tablet_schema));
+
+    // Predicate: c1 = 5 (outside range)
+    std::unique_ptr<ColumnPredicate> pred2(new_column_eq_predicate(get_type_info(TYPE_INT), 1, "5"));
+    PredicateTree pred_tree2 = create_pred_tree_with_column_pred(pred2.get());
+    ASSERT_FALSE(SegmentMetadataFilter::may_contain(meta, pred_tree2, *_tablet_schema));
+}
+
+// Test: Non-sort-key column predicate - cannot filter.
+TEST_F(SegmentMetadataFilterTest, test_non_sort_key_column) {
+    // Segment has c0 range [10, 100], c1 range [20, 200]
+    SegmentMetadataPB meta = create_segment_meta({10, 20}, {100, 200});
+
+    // Predicate: c2 = 5 (c2 is not a sort key, cannot filter)
+    std::unique_ptr<ColumnPredicate> pred(new_column_eq_predicate(get_type_info(TYPE_INT), 2, "5"));
+    PredicateTree pred_tree = create_pred_tree_with_column_pred(pred.get());
+
+    // Should return true because we cannot use non-sort-key columns for filtering.
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: AND predicate tree - any child can prune.
+TEST_F(SegmentMetadataFilterTest, test_and_predicate_any_can_prune) {
+    // Segment has c0 range [10, 100], c1 range [20, 200]
+    SegmentMetadataPB meta = create_segment_meta({10, 20}, {100, 200});
+
+    // Predicate: c0 = 50 AND c1 = 5
+    // c0 = 50 is within range, c1 = 5 is outside range.
+    // For AND, if any child can prune, the whole AND can prune.
+    std::unique_ptr<ColumnPredicate> pred1(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "50"));
+    std::unique_ptr<ColumnPredicate> pred2(new_column_eq_predicate(get_type_info(TYPE_INT), 1, "5"));
+
+    PredicateAndNode root;
+    root.add_child(PredicateColumnNode(pred1.get()));
+    root.add_child(PredicateColumnNode(pred2.get()));
+    PredicateTree pred_tree = PredicateTree::create(std::move(root));
+
+    // c1 = 5 can prune, so should return false
+    ASSERT_FALSE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: AND predicate tree - none can prune.
+TEST_F(SegmentMetadataFilterTest, test_and_predicate_none_can_prune) {
+    // Segment has c0 range [10, 100], c1 range [20, 200]
+    SegmentMetadataPB meta = create_segment_meta({10, 20}, {100, 200});
+
+    // Predicate: c0 = 50 AND c1 = 50
+    // Both within range.
+    std::unique_ptr<ColumnPredicate> pred1(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "50"));
+    std::unique_ptr<ColumnPredicate> pred2(new_column_eq_predicate(get_type_info(TYPE_INT), 1, "50"));
+
+    PredicateAndNode root;
+    root.add_child(PredicateColumnNode(pred1.get()));
+    root.add_child(PredicateColumnNode(pred2.get()));
+    PredicateTree pred_tree = PredicateTree::create(std::move(root));
+
+    // Neither can prune, should return true
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: OR predicate tree - all children must prune for the whole OR to prune.
+TEST_F(SegmentMetadataFilterTest, test_or_predicate_all_prune) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // Predicate: c0 = 5 OR c0 = 200
+    // Both outside range.
+    std::unique_ptr<ColumnPredicate> pred1(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "5"));
+    std::unique_ptr<ColumnPredicate> pred2(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "200"));
+
+    PredicateOrNode or_node;
+    or_node.add_child(PredicateColumnNode(pred1.get()));
+    or_node.add_child(PredicateColumnNode(pred2.get()));
+
+    PredicateAndNode root;
+    root.add_child(std::move(or_node));
+    PredicateTree pred_tree = PredicateTree::create(std::move(root));
+
+    // Both can prune, so should return false
+    ASSERT_FALSE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: OR predicate tree - not all can prune.
+TEST_F(SegmentMetadataFilterTest, test_or_predicate_partial_prune) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // Predicate: c0 = 50 OR c0 = 200
+    // c0 = 50 is within range, c0 = 200 is outside range.
+    std::unique_ptr<ColumnPredicate> pred1(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "50"));
+    std::unique_ptr<ColumnPredicate> pred2(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "200"));
+
+    PredicateOrNode or_node;
+    or_node.add_child(PredicateColumnNode(pred1.get()));
+    or_node.add_child(PredicateColumnNode(pred2.get()));
+
+    PredicateAndNode root;
+    root.add_child(std::move(or_node));
+    PredicateTree pred_tree = PredicateTree::create(std::move(root));
+
+    // c0 = 50 cannot prune, so should return true
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: IS NULL predicate - not supported, cannot filter.
+TEST_F(SegmentMetadataFilterTest, test_is_null_predicate) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // IS NULL predicates are not supported for metadata filtering.
+    std::unique_ptr<ColumnPredicate> pred(new_column_null_predicate(get_type_info(TYPE_INT), 0, true));
+    PredicateTree pred_tree = create_pred_tree_with_column_pred(pred.get());
+
+    // Should return true (cannot filter with IS NULL)
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: IS NOT NULL predicate - not supported, cannot filter.
+TEST_F(SegmentMetadataFilterTest, test_is_not_null_predicate) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // IS NOT NULL predicates are not supported for metadata filtering.
+    std::unique_ptr<ColumnPredicate> pred(new_column_null_predicate(get_type_info(TYPE_INT), 0, false));
+    PredicateTree pred_tree = create_pred_tree_with_column_pred(pred.get());
+
+    // Should return true (cannot filter with IS NOT NULL)
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: Empty predicate tree, should return true.
+TEST_F(SegmentMetadataFilterTest, test_empty_predicate_tree) {
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    PredicateTree pred_tree;
+    ASSERT_TRUE(pred_tree.empty());
+
+    // Empty predicate tree should be handled by the caller.
+    // But our function should still work correctly.
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: LT predicate.
+TEST_F(SegmentMetadataFilterTest, test_lt_predicate) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // Predicate: c0 < 5 (no overlap)
+    std::unique_ptr<ColumnPredicate> pred1(new_column_lt_predicate(get_type_info(TYPE_INT), 0, "5"));
+    PredicateTree pred_tree1 = create_pred_tree_with_column_pred(pred1.get());
+    ASSERT_FALSE(SegmentMetadataFilter::may_contain(meta, pred_tree1, *_tablet_schema));
+
+    // Predicate: c0 < 50 (overlap)
+    std::unique_ptr<ColumnPredicate> pred2(new_column_lt_predicate(get_type_info(TYPE_INT), 0, "50"));
+    PredicateTree pred_tree2 = create_pred_tree_with_column_pred(pred2.get());
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree2, *_tablet_schema));
+}
+
+// Test: GT predicate.
+TEST_F(SegmentMetadataFilterTest, test_gt_predicate) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // Predicate: c0 > 200 (no overlap)
+    std::unique_ptr<ColumnPredicate> pred1(new_column_gt_predicate(get_type_info(TYPE_INT), 0, "200"));
+    PredicateTree pred_tree1 = create_pred_tree_with_column_pred(pred1.get());
+    ASSERT_FALSE(SegmentMetadataFilter::may_contain(meta, pred_tree1, *_tablet_schema));
+
+    // Predicate: c0 > 50 (overlap)
+    std::unique_ptr<ColumnPredicate> pred2(new_column_gt_predicate(get_type_info(TYPE_INT), 0, "50"));
+    PredicateTree pred_tree2 = create_pred_tree_with_column_pred(pred2.get());
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree2, *_tablet_schema));
+}
+
+// Test: NE predicate - generally cannot be used for zone map filtering effectively.
+TEST_F(SegmentMetadataFilterTest, test_ne_predicate) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // Predicate: c0 != 50
+    // NE predicates typically cannot prune unless all values equal the NE value.
+    std::unique_ptr<ColumnPredicate> pred(new_column_ne_predicate(get_type_info(TYPE_INT), 0, "50"));
+    PredicateTree pred_tree = create_pred_tree_with_column_pred(pred.get());
+
+    // Should return true (NE with a value in range cannot prune)
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: Range where min == max (single value segment).
+TEST_F(SegmentMetadataFilterTest, test_single_value_range) {
+    // Segment has c0 = 50 (min == max)
+    SegmentMetadataPB meta = create_segment_meta({50, 0}, {50, 100});
+
+    // Predicate: c0 = 50 (match)
+    std::unique_ptr<ColumnPredicate> pred1(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "50"));
+    PredicateTree pred_tree1 = create_pred_tree_with_column_pred(pred1.get());
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree1, *_tablet_schema));
+
+    // Predicate: c0 = 60 (no match)
+    std::unique_ptr<ColumnPredicate> pred2(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "60"));
+    PredicateTree pred_tree2 = create_pred_tree_with_column_pred(pred2.get());
+    ASSERT_FALSE(SegmentMetadataFilter::may_contain(meta, pred_tree2, *_tablet_schema));
+}
+
+// Test: Empty sort_key_idxes in tablet schema.
+TEST_F(SegmentMetadataFilterTest, test_empty_sort_key_idxes) {
+    // Create a tablet schema without sort keys.
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_num_short_key_columns(0);
+
+    auto* c0 = schema_pb.add_column();
+    c0->set_unique_id(0);
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(false);
+    c0->set_is_nullable(false);
+    c0->set_aggregation("NONE");
+
+    auto schema_no_sort_key = TabletSchema::create(schema_pb);
+
+    SegmentMetadataPB meta = create_segment_meta({10}, {100});
+
+    std::unique_ptr<ColumnPredicate> pred(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "5"));
+    PredicateTree pred_tree = create_pred_tree_with_column_pred(pred.get());
+
+    // Should return true because no sort keys.
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree, *schema_no_sort_key));
+}
+
+// Test: Boundary cases - predicate value equals min or max.
+TEST_F(SegmentMetadataFilterTest, test_boundary_values) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // Predicate: c0 = 10 (equals min, should match)
+    std::unique_ptr<ColumnPredicate> pred1(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "10"));
+    PredicateTree pred_tree1 = create_pred_tree_with_column_pred(pred1.get());
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree1, *_tablet_schema));
+
+    // Predicate: c0 = 100 (equals max, should match)
+    std::unique_ptr<ColumnPredicate> pred2(new_column_eq_predicate(get_type_info(TYPE_INT), 0, "100"));
+    PredicateTree pred_tree2 = create_pred_tree_with_column_pred(pred2.get());
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree2, *_tablet_schema));
+
+    // Predicate: c0 >= 100 (boundary, should match)
+    std::unique_ptr<ColumnPredicate> pred3(new_column_ge_predicate(get_type_info(TYPE_INT), 0, "100"));
+    PredicateTree pred_tree3 = create_pred_tree_with_column_pred(pred3.get());
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree3, *_tablet_schema));
+
+    // Predicate: c0 <= 10 (boundary, should match)
+    std::unique_ptr<ColumnPredicate> pred4(new_column_le_predicate(get_type_info(TYPE_INT), 0, "10"));
+    PredicateTree pred_tree4 = create_pred_tree_with_column_pred(pred4.get());
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree4, *_tablet_schema));
+
+    // Predicate: c0 > 100 (just beyond max, should not match)
+    std::unique_ptr<ColumnPredicate> pred5(new_column_gt_predicate(get_type_info(TYPE_INT), 0, "100"));
+    PredicateTree pred_tree5 = create_pred_tree_with_column_pred(pred5.get());
+    ASSERT_FALSE(SegmentMetadataFilter::may_contain(meta, pred_tree5, *_tablet_schema));
+
+    // Predicate: c0 < 10 (just below min, should not match)
+    std::unique_ptr<ColumnPredicate> pred6(new_column_lt_predicate(get_type_info(TYPE_INT), 0, "10"));
+    PredicateTree pred_tree6 = create_pred_tree_with_column_pred(pred6.get());
+    ASSERT_FALSE(SegmentMetadataFilter::may_contain(meta, pred_tree6, *_tablet_schema));
+}
+
+// Test: IN predicate - all values outside range.
+TEST_F(SegmentMetadataFilterTest, test_in_predicate_all_outside) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // Predicate: c0 IN (1, 2, 3) - all values below min
+    std::vector<std::string> values = {"1", "2", "3"};
+    std::unique_ptr<ColumnPredicate> pred(new_column_in_predicate(get_type_info(TYPE_INT), 0, values));
+    PredicateTree pred_tree = create_pred_tree_with_column_pred(pred.get());
+
+    // All IN values are outside range, should not match
+    ASSERT_FALSE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+// Test: IN predicate - some values inside range.
+TEST_F(SegmentMetadataFilterTest, test_in_predicate_partial_inside) {
+    // Segment has c0 range [10, 100]
+    SegmentMetadataPB meta = create_segment_meta({10, 0}, {100, 100});
+
+    // Predicate: c0 IN (5, 50, 200) - 50 is within range
+    std::vector<std::string> values = {"5", "50", "200"};
+    std::unique_ptr<ColumnPredicate> pred(new_column_in_predicate(get_type_info(TYPE_INT), 0, values));
+    PredicateTree pred_tree = create_pred_tree_with_column_pred(pred.get());
+
+    // 50 is within range, should match
+    ASSERT_TRUE(SegmentMetadataFilter::may_contain(meta, pred_tree, *_tablet_schema));
+}
+
+} // namespace starrocks::lake

--- a/be/test/storage/rowset/flat_json_column_compact_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_compact_test.cpp
@@ -197,7 +197,7 @@ protected:
             auto st = iter->seek_to_first();
             ASSERT_TRUE(st.ok()) << st.to_string();
 
-            size_t rows_read;
+            size_t rows_read = 0;
             std::for_each(jsons.begin(), jsons.end(), [&](MutableColumnPtr& json) { rows_read += json->size(); });
             st = iter->next_batch(&rows_read, read_col.get());
             ASSERT_TRUE(st.ok());


### PR DESCRIPTION
## Why I'm doing:

In customer-facing scenarios, there are many queries that filter by tenant_id or similar prefix columns of the primary key (e.g., WHERE tenant_id=123 on a table with primary key (tenant_id, order_id)). Currently, lake tables have to scan all segments in a rowset even when the query only involves sort key prefix columns, causing unnecessary I/O and computation overhead.

## What I'm doing:

Lake tables already record sort_key_min/max in SegmentMetadataPB during write, but these metadata are not utilized during query. This commit leverages the existing sort_key_min/max metadata to filter segments before reading. By reusing the zone map filter mechanism from ColumnPredicate, it supports various predicate types including =, !=, <, <=, >, >=, IN, and NOT IN on sort key columns. A new config option enable_lake_segment_metadata_filter (default true) is added to control this feature, and a profile counter SegmentMetadataFilterRows is added for monitoring the filter effectiveness.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
