### PR TITLE
[BugFix] Fix resource group classifier matching for sync MV queries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -127,6 +127,7 @@ public class PlannerMetaLocker implements AutoCloseable {
     public void close() {
         unlock();
     }
+
     /**
      * Collect tables that need to be protected by the PlannerMetaLock
      */
@@ -181,8 +182,8 @@ public class PlannerMetaLocker implements AutoCloseable {
             // This ensures the database is registered in currentSqlDbIds for
             // resource group classifier matching.
             Pair<Table, MaterializedIndexMeta> mvIndex =
-                GlobalStateMgr.getCurrentState().getLocalMetastore()
-                    .getMaterializedViewIndex(dbName, tbName);
+                    GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getMaterializedViewIndex(dbName, tbName);
             if (mvIndex != null) {
                 table = mvIndex.first;
             }
@@ -236,7 +237,7 @@ public class PlannerMetaLocker implements AutoCloseable {
 
         @Override
         public Void visitAlterTableStatement(AlterTableStmt statement, Void context) {
-            Pair<Database, Table> dbAndTable = resolveTable(session, 
+            Pair<Database, Table> dbAndTable = resolveTable(session,
                     com.starrocks.catalog.TableName.fromTableRef(statement.getTableRef()));
             put(dbAndTable);
             return super.visitAlterTableStatement(statement, context);
@@ -244,7 +245,7 @@ public class PlannerMetaLocker implements AutoCloseable {
 
         @Override
         public Void visitAlterViewStatement(AlterViewStmt statement, Void context) {
-            Pair<Database, Table> dbAndTable = resolveTable(session, 
+            Pair<Database, Table> dbAndTable = resolveTable(session,
                     com.starrocks.catalog.TableName.fromTableRef(statement.getTableRef()));
             put(dbAndTable);
             return super.visitAlterViewStatement(statement, context);
@@ -252,7 +253,7 @@ public class PlannerMetaLocker implements AutoCloseable {
 
         @Override
         public Void visitAlterMaterializedViewStatement(AlterMaterializedViewStmt statement, Void context) {
-            Pair<Database, Table> dbAndTable = resolveTable(session, 
+            Pair<Database, Table> dbAndTable = resolveTable(session,
                     com.starrocks.catalog.TableName.fromTableRef(statement.getMvTableRef()));
             put(dbAndTable);
             return super.visitAlterMaterializedViewStatement(statement, context);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -176,24 +176,36 @@ public class PlannerMetaLocker implements AutoCloseable {
 
         Table table = metadataMgr.getTable(session, catalogName, dbName, tbName);
         if (table == null) {
-            // Fallback: Sync MV names are index names, not table names.
-            // When querying via [_SYNC_MV_] hint, we need to resolve through the
-            // materialized index to find the base table and its database.
-            // This ensures the database is registered in currentSqlDbIds for
-            // resource group classifier matching.
-            Pair<Table, MaterializedIndexMeta> mvIndex =
-                    GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .getMaterializedViewIndex(dbName, tbName);
-            if (mvIndex != null) {
-                table = mvIndex.first;
-            }
-        }
-
-        if (table == null) {
             return null;
         }
 
         return new Pair<>(db, table);
+    }
+
+    private static Pair<Database, Table> resolveSyncMV(ConnectContext session, TableName tableName) {
+        String dbName = tableName.getDb();
+        String tbName = tableName.getTbl();
+
+        if (Strings.isNullOrEmpty(dbName)) {
+            dbName = session.getDatabase();
+        }
+        if (Strings.isNullOrEmpty(dbName) || Strings.isNullOrEmpty(tbName)) {
+            return null;
+        }
+
+        Pair<Table, MaterializedIndexMeta> mvIndex =
+                GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getMaterializedViewIndex(dbName, tbName);
+        if (mvIndex == null) {
+            return null;
+        }
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+        if (db == null) {
+            return null;
+        }
+
+        return new Pair<>(db, mvIndex.first);
     }
 
     private static class TableCollector extends AstTraverser<Void, Void> {
@@ -262,6 +274,9 @@ public class PlannerMetaLocker implements AutoCloseable {
         @Override
         public Void visitTable(TableRelation node, Void context) {
             Pair<Database, Table> dbAndTable = resolveTable(session, node.getName());
+            if (dbAndTable == null && node.isSyncMVQuery()) {
+                dbAndTable = resolveSyncMV(session, node.getName());
+            }
             put(dbAndTable);
             return null;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerTest.java
@@ -1,0 +1,132 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.catalog.ResourceGroup;
+import com.starrocks.catalog.ResourceGroupClassifier;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.system.BackendResourceStat;
+import com.starrocks.thrift.TWorkGroup;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static com.starrocks.server.WarehouseManager.DEFAULT_WAREHOUSE_ID;
+import static com.starrocks.sql.optimizer.MVTestUtils.waitingRollupJobV2Finish;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlannerMetaLockerTest {
+    private static StarRocksAssert starRocksAssert;
+    private static ConnectContext connectContext;
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test_db").useDatabase("test_db");
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        BackendResourceStat.getInstance().reset();
+        BackendResourceStat.getInstance().setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, 1, 32);
+    }
+
+    @AfterEach
+    public void afterEach() throws Exception {
+        try {
+            starRocksAssert.dropMaterializedView("test_mv");
+        } catch (Exception ignored) {
+        }
+        try {
+            DDLStmtExecutor.execute(
+                UtFrameUtils.parseStmtWithNewParser("drop resource group test_rg", connectContext),
+                connectContext);
+        } catch (Exception ignored) {
+        }
+    }
+
+    @Test
+    public void testResourceGroupClassifierWithSyncMV() throws Exception {
+        // 1. Create base table
+        starRocksAssert.withTable("CREATE TABLE test_table (" +
+            "k1 int NOT NULL, " +
+            "k2 int NOT NULL, " +
+            "v1 int SUM) " +
+            "AGGREGATE KEY(k1, k2) " +
+            "DISTRIBUTED BY HASH(k1) BUCKETS 3 " +
+            "PROPERTIES('replication_num' = '1')");
+
+        // 2. Create sync materialized view
+        String createMvSql = "create materialized view test_mv as " +
+            "select k1, sum(v1) from test_table group by k1;";
+        CreateMaterializedViewStmt createMvStmt = (CreateMaterializedViewStmt)
+            UtFrameUtils.parseStmtWithNewParser(createMvSql, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore()
+            .createMaterializedView(createMvStmt);
+        waitingRollupJobV2Finish();
+
+        // 3. Create resource group with database classifier
+        String createRgSql = "create resource group test_rg " +
+            "to (`db`='test_db') " +
+            "with (" +
+            "    'cpu_core_limit' = '10'," +
+            "    'mem_limit' = '50%'," +
+            "    'concurrency_limit' = '5'," +
+            "    'type' = 'normal'" +
+            ");";
+        DDLStmtExecutor.execute(
+            UtFrameUtils.parseStmtWithNewParser(createRgSql, connectContext),
+            connectContext);
+
+        // 4. Execute query with [_SYNC_MV_] hint
+        // This triggers PlannerMetaLocker.resolveTable() with the sync MV fallback
+        String querySql = "select * from test_mv [_SYNC_MV_];";
+        UtFrameUtils.getPlanAndFragment(connectContext, querySql);
+
+        // 5. Verify database ID was captured in currentSqlDbIds
+        Set<Long> dbIds = connectContext.getCurrentSqlDbIds();
+        long testDbId = GlobalStateMgr.getCurrentState().getLocalMetastore()
+            .getDb("test_db").getId();
+        assertThat(dbIds)
+            .as("Database ID should be registered in currentSqlDbIds after sync MV query")
+            .contains(testDbId);
+
+        // 6. Verify resource group classifier matches
+        TWorkGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr()
+            .chooseResourceGroup(
+                connectContext,
+                ResourceGroupClassifier.QueryType.SELECT,
+                dbIds);
+
+        assertThat(wg)
+            .as("Resource group should not be null")
+            .isNotNull();
+        assertThat(wg.getName())
+            .as("Sync MV query should match database classifier")
+            .isEqualTo("test_rg");
+        assertThat(wg.getName())
+            .as("Should not fall back to default resource group")
+            .isNotEqualTo(ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PlannerMetaLockerTest.java
@@ -59,6 +59,10 @@ public class PlannerMetaLockerTest {
         } catch (Exception ignored) {
         }
         try {
+            starRocksAssert.dropTable("test_table");
+        } catch (Exception ignored) {
+        }
+        try {
             DDLStmtExecutor.execute(
                     UtFrameUtils.parseStmtWithNewParser("drop resource group test_rg", connectContext),
                     connectContext);


### PR DESCRIPTION
## Why I'm doing:

Resource group classifiers with `db` parameter fail to match queries using the `[_SYNC_MV_]` hint because `PlannerMetaLocker.resolveTable()` cannot resolve sync materialized view names. Sync MVs use index names (not table names), causing `metadataMgr.getTable()` to return null, so the database never gets registered in `currentSqlDbIds`.

## What I'm doing:

Add fallback in `PlannerMetaLocker.resolveTable()` to resolve sync MV names via `getMaterializedViewIndex()` when regular table lookup fails. If sync MV is found, use its base table (which has the correct database).

Fixes #68130

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4