### PR TITLE
[BugFix] Prevent aggregate pushdown when group keys involve JSON type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateCollector.java
@@ -701,6 +701,13 @@ public class PushDownAggregateCollector extends OptExpressionVisitor<Void, Aggre
         ColumnRefSet allGroupByColumns = new ColumnRefSet();
         context.groupBys.values().forEach(c -> allGroupByColumns.union(c.getUsedColumns()));
 
+        for (int colId : allGroupByColumns.getColumnIds()) {
+            ColumnRefOperator colRef = factory.getColumnRef(colId);
+            if (colRef.getType() != null && !colRef.getType().canGroupBy()) {
+                return false;
+            }
+        }
+
         ColumnRefSet allAggregateColumns = new ColumnRefSet();
         context.aggregations.values().forEach(c -> allAggregateColumns.union(c.getUsedColumns()));
 


### PR DESCRIPTION
## Why I'm doing:

Aggregate pushdown may rewrite DISTINCT/group-by expressions to their used columns when pushing below Project/Join.  
For expressions that depend on a JSON column, this can end up pushing down an aggregate that **groups by a JSON column**, which is not supported in BE and fails at runtime with:
`group by type JSON is not supported backend`.

## What I'm doing:

- Add a safety check in `PushDownAggregateCollector` to block aggregate pushdown when any group-key used column type cannot be grouped in BE (e.g. JSON).

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
