### PR TITLE
[Enhancement] Add metrics for FileScanNode in Backend

### DIFF
--- a/be/src/connector/file_connector.cpp
+++ b/be/src/connector/file_connector.cpp
@@ -23,6 +23,7 @@
 #include "exec/file_scanner/parquet_scanner.h"
 #include "exprs/expr.h"
 #include "file_chunk_sink.h"
+#include "util/starrocks_metrics.h"
 
 namespace starrocks::connector {
 
@@ -202,6 +203,11 @@ void FileDataSource::_init_counter() {
 void FileDataSource::_update_counter() {
     _runtime_state->update_num_rows_load_filtered(_counter.num_rows_filtered);
     _runtime_state->update_num_rows_load_unselected(_counter.num_rows_unselected);
+    // update the file scan metrics all together
+    auto* metric_repo = StarRocksMetrics::instance()->file_scan_metrics();
+    if (metric_repo != nullptr) {
+        metric_repo->update(_scanner->file_format(), _scanner->scan_type(), _counter);
+    }
 
     COUNTER_UPDATE(_scanner_total_timer, _counter.total_ns);
     COUNTER_UPDATE(_scanner_fill_timer, _counter.fill_ns);

--- a/be/src/exec/file_scanner/avro_cpp_scanner.cpp
+++ b/be/src/exec/file_scanner/avro_cpp_scanner.cpp
@@ -32,7 +32,9 @@ AvroCppScanner::AvroCppScanner(RuntimeState* state, RuntimeProfile* profile, con
                                ScannerCounter* counter, bool schema_only)
         : FileScanner(state, profile, scan_range.params, counter, schema_only),
           _scan_range(scan_range),
-          _max_chunk_size(state->chunk_size()) {}
+          _max_chunk_size(state->chunk_size()) {
+    _file_format_str = "avro";
+}
 
 Status AvroCppScanner::open() {
     RETURN_IF_ERROR(FileScanner::open());
@@ -195,6 +197,7 @@ StatusOr<AvroReaderUniquePtr> AvroCppScanner::open_avro_reader(const TBrokerRang
         return Status::EndOfFile("Empty file");
     }
 
+    ++_counter->num_files_read;
     auto col_not_found_as_null =
             _scan_range.params.__isset.flexible_column_mapping && _scan_range.params.flexible_column_mapping;
     auto avro_reader = std::make_unique<AvroReader>();

--- a/be/src/exec/file_scanner/avro_scanner.cpp
+++ b/be/src/exec/file_scanner/avro_scanner.cpp
@@ -63,14 +63,18 @@ AvroScanner::AvroScanner(RuntimeState* state, RuntimeProfile* profile, const TBr
         : FileScanner(state, profile, scan_range.params, counter),
           _scan_range(scan_range),
           _serdes(nullptr),
-          _closed(false) {}
+          _closed(false) {
+    _file_format_str = "avro_stream";
+}
 
 AvroScanner::AvroScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
                          ScannerCounter* counter, std::string schema_text)
         : FileScanner(state, profile, scan_range.params, counter),
           _scan_range(scan_range),
           _schema_text(std::move(schema_text)),
-          _closed(false) {}
+          _closed(false) {
+    _file_format_str = "avro_stream";
+}
 
 AvroScanner::~AvroScanner() {
 #if BE_TEST
@@ -154,6 +158,7 @@ Status AvroScanner::open() {
         LOG(WARNING) << "Failed to create sequential files: " << st.to_string();
         return st;
     }
+    ++_counter->num_files_read;
 
     for (const auto& desc : _src_slot_descriptors) {
         if (desc == nullptr) {

--- a/be/src/exec/file_scanner/csv_scanner.cpp
+++ b/be/src/exec/file_scanner/csv_scanner.cpp
@@ -132,6 +132,7 @@ char* CSVScanner::ScannerCSVReader::_find_line_delimiter(CSVBuffer& buffer, size
 CSVScanner::CSVScanner(RuntimeState* state, RuntimeProfile* profile, const TBrokerScanRange& scan_range,
                        ScannerCounter* counter, bool schema_only)
         : FileScanner(state, profile, scan_range.params, counter, schema_only), _scan_range(scan_range) {
+    _file_format_str = "csv";
     if (scan_range.params.__isset.multi_column_separator) {
         _parse_options.column_delimiter = scan_range.params.multi_column_separator;
     } else {
@@ -267,6 +268,9 @@ Status CSVScanner::_init_reader() {
             }
             CSVReader::Record dummy;
             RETURN_IF_ERROR(_curr_reader->next_record(&dummy));
+        } else {
+            // NOTE: if the file is split into multiple ranges, the first range is responsible to increase the counter.
+            ++_counter->num_files_read;
         }
 
         // only the first range needs to skip header

--- a/be/src/exec/file_scanner/file_scanner.cpp
+++ b/be/src/exec/file_scanner/file_scanner.cpp
@@ -47,7 +47,12 @@ FileScanner::FileScanner(starrocks::RuntimeState* state, starrocks::RuntimeProfi
           _strict_mode(false),
           _error_counter(0),
           _file_scan_type(TFileScanType::LOAD),
-          _schema_only(schema_only) {}
+          _file_format_str("UNKNOWN"),
+          _schema_only(schema_only) {
+    if (_params.__isset.file_scan_type) {
+        _file_scan_type = _params.file_scan_type;
+    }
+}
 
 FileScanner::~FileScanner() = default;
 

--- a/be/src/exec/file_scanner/json_scanner.cpp
+++ b/be/src/exec/file_scanner/json_scanner.cpp
@@ -49,7 +49,9 @@ JsonScanner::JsonScanner(RuntimeState* state, RuntimeProfile* profile, const TBr
           _next_range(0),
           _max_chunk_size(state->chunk_size()),
           _cur_file_reader(nullptr),
-          _cur_file_eof(true) {}
+          _cur_file_eof(true) {
+    _file_format_str = "json";
+}
 
 JsonScanner::~JsonScanner() = default;
 
@@ -250,6 +252,7 @@ Status JsonScanner::_open_next_reader() {
         return st;
     }
     _next_range++;
+    ++_counter->num_files_read;
     return Status::OK();
 }
 

--- a/be/src/exec/file_scanner/parquet_scanner.cpp
+++ b/be/src/exec/file_scanner/parquet_scanner.cpp
@@ -40,6 +40,7 @@ ParquetScanner::ParquetScanner(RuntimeState* state, RuntimeProfile* profile, con
           _max_chunk_size(state->chunk_size() ? state->chunk_size() : 4096),
           _batch_start_idx(0),
           _chunk_start_idx(0) {
+    _file_format_str = "parquet";
     _chunk_filter.reserve(_max_chunk_size);
     _conv_ctx.state = state;
 }
@@ -475,6 +476,10 @@ Status ParquetScanner::open_next_reader() {
             parquet_reader->set_invalid_as_null(true);
         }
         _next_file++;
+        if (range_desc.start_offset == 0) {
+            // NOTE: if the file is split into multiple ranges, the first range is responsible to increase the counter.
+            ++_counter->num_files_read;
+        }
         int64_t file_size;
         RETURN_IF_ERROR(parquet_reader->size(&file_size));
         _last_file_size = file_size;

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -50,6 +50,7 @@ set(UTIL_FILES
   starrocks_metrics.cpp
   mem_info.cpp
   metrics.cpp
+  metrics/file_scan_metrics.cpp
   misc.cpp
   murmur_hash3.cpp
   ndv_estimator.cpp

--- a/be/src/util/metrics/file_scan_metrics.cpp
+++ b/be/src/util/metrics/file_scan_metrics.cpp
@@ -1,0 +1,81 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/metrics/file_scan_metrics.h"
+
+#include "exec/file_scanner/file_scanner.h"
+
+namespace starrocks {
+
+// NOTE:
+// * avro_stream -> AvroScanner for routine load, purposely ignored here.
+// * avro -> AvroCppScanner, Avro Files Scanner
+static const std::vector<std::string> FILE_FORMATS = {"avro", "csv", "json", "orc", "parquet"};
+static const std::vector<std::string> SCAN_TYPES = {"insert", "query", "load"};
+
+FileScanMetrics::FileScanMetrics(MetricRegistry* registry) {
+    for (const auto& file_format : FILE_FORMATS) {
+        for (const auto& scan_type : SCAN_TYPES) {
+            _register_metrics(registry, file_format, scan_type);
+        }
+    }
+}
+
+void FileScanMetrics::_register_metrics(MetricRegistry* registry, const std::string& file_format,
+                                        const std::string& scan_type) {
+    auto metrics = std::make_unique<SingleFileScanMetrics>();
+
+    MetricLabels labels;
+    labels.add("file_format", file_format);
+    labels.add("scan_type", scan_type);
+
+    metrics->file_read = std::make_unique<IntCounter>(MetricUnit::NOUNIT);
+    registry->register_metric("files_scan_num_files_read", labels, metrics->file_read.get());
+
+    metrics->bytes_read = std::make_unique<IntCounter>(MetricUnit::BYTES);
+    registry->register_metric("files_scan_num_bytes_read", labels, metrics->bytes_read.get());
+
+    metrics->raw_rows_read = std::make_unique<IntCounter>(MetricUnit::ROWS);
+    registry->register_metric("files_scan_num_raw_rows_read", labels, metrics->raw_rows_read.get());
+
+    metrics->valid_rows_read = std::make_unique<IntCounter>(MetricUnit::ROWS);
+    registry->register_metric("files_scan_num_valid_rows_read", labels, metrics->valid_rows_read.get());
+
+    metrics->rows_return = std::make_unique<IntCounter>(MetricUnit::ROWS);
+    registry->register_metric("files_scan_num_rows_return", labels, metrics->rows_return.get());
+
+    _metrics_map.emplace(std::make_pair(file_format, scan_type), std::move(metrics));
+}
+
+void FileScanMetrics::update(const std::string& file_format, const std::string& scan_type,
+                             const ScannerCounter& counter) {
+    auto it = _metrics_map.find({file_format, scan_type});
+    if (it != _metrics_map.end()) {
+        auto* metrics = it->second.get();
+        metrics->file_read->increment(counter.num_files_read);
+        metrics->bytes_read->increment(counter.num_bytes_read);
+
+        // raw_rows = filtered_rows_read + num_rows_filtered
+        int64_t raw_rows = counter.filtered_rows_read + counter.num_rows_filtered;
+        metrics->raw_rows_read->increment(raw_rows);
+
+        // valid_rows = unselected + returned
+        int64_t valid_rows = counter.num_rows_unselected + counter.num_rows_read;
+        metrics->valid_rows_read->increment(valid_rows);
+
+        metrics->rows_return->increment(counter.num_rows_read);
+    }
+}
+
+} // namespace starrocks

--- a/be/src/util/metrics/file_scan_metrics.h
+++ b/be/src/util/metrics/file_scan_metrics.h
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "util/metrics.h"
+
+namespace starrocks {
+
+struct ScannerCounter;
+
+class FileScanMetrics {
+public:
+    FileScanMetrics(MetricRegistry* registry);
+    ~FileScanMetrics() = default;
+
+    void update(const std::string& file_format, const std::string& scan_type, const ScannerCounter& counter);
+
+private:
+    struct SingleFileScanMetrics {
+        std::unique_ptr<IntCounter> file_read;
+        std::unique_ptr<IntCounter> bytes_read;
+        std::unique_ptr<IntCounter> raw_rows_read;
+        std::unique_ptr<IntCounter> valid_rows_read;
+        std::unique_ptr<IntCounter> rows_return;
+    };
+
+    void _register_metrics(MetricRegistry* registry, const std::string& file_format, const std::string& scan_type);
+
+    // Key is <file_format, scan_type>
+    std::map<std::pair<std::string, std::string>, std::unique_ptr<SingleFileScanMetrics>> _metrics_map;
+};
+
+} // namespace starrocks

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -291,6 +291,8 @@ void StarRocksMetrics::initialize(const std::vector<std::string>& paths, bool in
         _system_metrics.install(&_metrics, disk_devices, network_interfaces);
     }
 
+    _file_scan_metrics = std::make_unique<FileScanMetrics>(&_metrics);
+
 #ifndef __APPLE__
     if (init_jvm_metrics) {
         auto status = _jvm_metrics.init();

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -44,6 +44,7 @@
 #include "util/jvm_metrics.h"
 #endif
 #include "util/metrics.h"
+#include "util/metrics/file_scan_metrics.h"
 #include "util/system_metrics.h"
 #include "util/table_metrics.h"
 
@@ -433,6 +434,7 @@ public:
     TableMetricsManager* table_metrics_mgr() { return &_table_metrics_mgr; }
     TableMetricsPtr table_metrics(uint64_t table_id) { return _table_metrics_mgr.get_table_metrics(table_id); }
     pipeline::PipelineExecutorMetrics* get_pipeline_executor_metrics() { return &pipeline_executor_metrics; }
+    FileScanMetrics* file_scan_metrics() { return _file_scan_metrics.get(); }
 
 private:
     // Don't allow constructor
@@ -452,6 +454,8 @@ private:
     JVMMetrics _jvm_metrics;
 #endif
     TableMetricsManager _table_metrics_mgr;
+
+    std::unique_ptr<FileScanMetrics> _file_scan_metrics;
 };
 
 }; // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -385,6 +385,7 @@ set(EXEC_FILES
         ./util/json_flattener_test.cpp
         ./util/md5_test.cpp
         ./util/memcmp_test.cpp
+        ./util/metrics/file_scan_metrics_test.cpp
         ./util/monotime_test.cpp
         ./util/mysql_row_buffer_test.cpp
         ./util/new_metrics_test.cpp

--- a/be/test/exec/file_scanner/avro_cpp_scanner_test.cpp
+++ b/be/test/exec/file_scanner/avro_cpp_scanner_test.cpp
@@ -109,7 +109,11 @@ public:
         broker_scan_range->params = *params;
         broker_scan_range->ranges = ranges;
 
-        return std::make_unique<AvroCppScanner>(_state.get(), _profile, *broker_scan_range, _counter);
+        auto scanner = std::make_unique<AvroCppScanner>(_state.get(), _profile, *broker_scan_range, _counter);
+        EXPECT_EQ("avro", scanner->file_format());
+        // scan_type is not set in TBrokerScanRangeParams, default to LOAD
+        EXPECT_EQ("load", scanner->scan_type());
+        return scanner;
     }
 
 private:
@@ -173,7 +177,7 @@ TEST_F(AvroCppScannerTest, test_read_primitive_types) {
 
     chunk_or = scanner->get_next();
     ASSERT_TRUE(chunk_or.status().is_end_of_file());
-
+    ASSERT_EQ(ranges.size(), scanner->TEST_scanner_counter()->num_files_read);
     scanner->close();
 }
 

--- a/be/test/util/metrics/file_scan_metrics_test.cpp
+++ b/be/test/util/metrics/file_scan_metrics_test.cpp
@@ -1,0 +1,113 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/metrics/file_scan_metrics.h"
+
+#include <gtest/gtest.h>
+
+#include "exec/file_scanner/file_scanner.h"
+
+namespace starrocks {
+
+class FileScanMetricsTest : public testing::Test {
+public:
+    FileScanMetricsTest() = default;
+    ~FileScanMetricsTest() override = default;
+};
+
+TEST_F(FileScanMetricsTest, TestUpdate) {
+    MetricRegistry registry("test_registry");
+    FileScanMetrics metrics(&registry);
+
+    ScannerCounter counter;
+    counter.filtered_rows_read = 50;
+    counter.num_rows_filtered = 10;
+    counter.num_rows_unselected = 20;
+    counter.num_rows_read = 30;
+    counter.num_bytes_read = 1000;
+    counter.num_files_read = 2;
+
+    metrics.update("parquet", "query", counter);
+
+    // Verify metrics
+    MetricLabels labels;
+    labels.add("file_format", "parquet");
+    labels.add("scan_type", "query");
+
+    auto* file_read = registry.get_metric("files_scan_num_files_read", labels);
+    ASSERT_NE(nullptr, file_read);
+    ASSERT_EQ("2", file_read->to_string());
+
+    auto* bytes_read = registry.get_metric("files_scan_num_bytes_read", labels);
+    ASSERT_NE(nullptr, bytes_read);
+    ASSERT_EQ("1000", bytes_read->to_string());
+
+    // raw_rows = 10 + 50
+    auto* raw_rows = registry.get_metric("files_scan_num_raw_rows_read", labels);
+    ASSERT_NE(nullptr, raw_rows);
+    ASSERT_EQ("60", raw_rows->to_string());
+
+    // valid_rows = 20 + 30 = 50 (filtered_rows_read)
+    auto* valid_rows = registry.get_metric("files_scan_num_valid_rows_read", labels);
+    ASSERT_NE(nullptr, valid_rows);
+    ASSERT_EQ("50", valid_rows->to_string());
+
+    auto* rows_return = registry.get_metric("files_scan_num_rows_return", labels);
+    ASSERT_NE(nullptr, rows_return);
+    ASSERT_EQ("30", rows_return->to_string());
+}
+
+TEST_F(FileScanMetricsTest, TestMixedUpdate) {
+    MetricRegistry registry("test_registry");
+    FileScanMetrics metrics(&registry);
+
+    ScannerCounter counter1;
+    counter1.num_rows_read = 100;
+    counter1.filtered_rows_read = 100;
+    metrics.update("orc", "insert", counter1);
+
+    ScannerCounter counter2;
+    counter2.num_rows_read = 50;
+    counter2.filtered_rows_read = 50;
+    metrics.update("orc", "insert", counter2);
+
+    MetricLabels labels;
+    labels.add("file_format", "orc");
+    labels.add("scan_type", "insert");
+
+    auto* rows_return = registry.get_metric("files_scan_num_rows_return", labels);
+    ASSERT_NE(nullptr, rows_return);
+    ASSERT_EQ("150", rows_return->to_string());
+}
+
+TEST_F(FileScanMetricsTest, TestAvroStreamIgnored) {
+    MetricRegistry registry("test_registry");
+    FileScanMetrics metrics(&registry);
+
+    ScannerCounter counter;
+    counter.num_rows_read = 10;
+
+    // update with avro_stream, should be ignored
+    metrics.update("avro_stream", "query", counter);
+
+    MetricLabels labels;
+    labels.add("file_format", "avro_stream");
+    labels.add("scan_type", "query");
+
+    // Metric should not exist
+    auto* rows_return = registry.get_metric("files_scan_num_rows_return", labels);
+    ASSERT_EQ(nullptr, rows_return);
+}
+
+} // namespace starrocks

--- a/docs/en/administration/management/monitoring/metrics.md
+++ b/docs/en/administration/management/monitoring/metrics.md
@@ -704,6 +704,31 @@ For more information on how to build a monitoring service for your StarRocks clu
 - Unit: Bytes
 - Description: Total number of scanned bytes.
 
+### starrocks_be_files_scan_num_files_read
+
+- Unit: Count
+- Description: Number of files read from external storage (CSV, Parquet, ORC, JSON, Avro). Labels: `file_format`, `scan_type`.
+
+### starrocks_be_files_scan_num_bytes_read
+
+- Unit: Bytes
+- Description: Total bytes read from external storage. Labels: `file_format`, `scan_type`.
+
+### starrocks_be_files_scan_num_raw_rows_read
+
+- Unit: Count
+- Description: Total raw rows read from external storage before format validation and predicate filtering. Labels: `file_format`, `scan_type`.
+
+### starrocks_be_files_scan_num_valid_rows_read
+
+- Unit: Count
+- Description: Number of valid rows read (excluding rows with invalid format). Labels: `file_format`, `scan_type`.
+
+### starrocks_be_files_scan_num_rows_return
+
+- Unit: Count
+- Description: Number of rows returned after predicate filtering. Labels: `file_format`, `scan_type`.
+
 ### disk_reads_completed
 
 - Unit: Count

--- a/docs/ja/administration/management/monitoring/metrics.md
+++ b/docs/ja/administration/management/monitoring/metrics.md
@@ -704,6 +704,31 @@ StarRocks クラスタのモニタリングサービスの構築方法につい�
 - 単位: Bytes
 - 説明: スキャンされたバイトの総数。
 
+### starrocks_be_files_scan_num_files_read
+
+- 単位: Count
+- 説明: 外部ストレージ（CSV, Parquet, ORC, JSON, Avro）から読み取られたファイルの数。ラベル: `file_format`, `scan_type`。
+
+### starrocks_be_files_scan_num_bytes_read
+
+- 単位: Bytes
+- 説明: 外部ストレージから読み取られた総バイト数。ラベル: `file_format`, `scan_type`。
+
+### starrocks_be_files_scan_num_raw_rows_read
+
+- 単位: Count
+- 説明: フィルタリング前に外部ストレージから読み取られた生の総行数。ラベル: `file_format`, `scan_type`。
+
+### starrocks_be_files_scan_num_valid_rows_read
+
+- 単位: Count
+- 説明: 読み取られた有効な行数（フォーマットが無効な行を除く）。ラベル: `file_format`, `scan_type`。
+
+### starrocks_be_files_scan_num_rows_return
+
+- 単位: Count
+- 説明: 述語フィルタリング後に返された行数。ラベル: `file_format`, `scan_type`。
+
 ### disk_reads_completed
 
 - 単位: Count

--- a/docs/zh/administration/management/monitoring/metrics.md
+++ b/docs/zh/administration/management/monitoring/metrics.md
@@ -704,6 +704,31 @@ displayed_sidebar: docs
 - 单位：Byte
 - 描述：扫描的总字节数。
 
+### starrocks_be_files_scan_num_files_read
+
+- 单位：个
+- 描述：从外部存储（CSV, Parquet, ORC, JSON, Avro）读取的文件数量。标签：`file_format`, `scan_type`。
+
+### starrocks_be_files_scan_num_bytes_read
+
+- 单位：Byte
+- 描述：从外部存储读取的总字节数。标签：`file_format`, `scan_type`。
+
+### starrocks_be_files_scan_num_raw_rows_read
+
+- 单位：个
+- 描述：从外部存储读取的原始行总数（包括格式错误的行，过滤和谓词过滤之前）。标签：`file_format`, `scan_type`。
+
+### starrocks_be_files_scan_num_valid_rows_read
+
+- 单位：个
+- 描述：读取的有效行数（排除格式错误的行）。标签：`file_format`, `scan_type`。
+
+### starrocks_be_files_scan_num_rows_return
+
+- 单位：个
+- 描述：谓词过滤后返回的行数。标签：`file_format`, `scan_type`。
+
 ### disk_reads_completed
 
 - 单位：个


### PR DESCRIPTION
Overview:
Introduces a comprehensive set of metrics for FILES in the Backend to improve observability of data loading

Backend Changes:
- Added `FileScanMetrics` to track data loading across different formats (Parquet, ORC, JSON, CSV, Avro).
- New metrics (labels: `file_format`, `scan_type`):
  - `files_table_num_files_read`
  - `files_table_num_bytes_read`
  - `files_table_num_raw_rows_read`
  - `files_table_num_valid_rows_read`
  - `files_table_num_rows_return`
- Integrated metrics collection into `FileConnector` and `FileScanner` subclasses.
- Added logic to exclude internal `avro_stream` (AvroScanner) scans from public metrics to avoid pollution.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4