### PR TITLE
[BugFix] Clear sstable_meta during full replication for PK table with cloud native persistent index (backport #67954)

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -100,12 +100,6 @@ void MetaFileBuilder::append_dcg(uint32_t rssid,
             // Put this `.cols` files into orphan files
             FileMetaPB file_meta;
             file_meta.set_name(dcg_ver.column_files(i));
-<<<<<<< HEAD
-=======
-            if (dcg_ver.shared_files_size() > 0 && i < dcg_ver.shared_files_size()) {
-                file_meta.set_shared(dcg_ver.shared_files(i));
-            }
->>>>>>> b61f3b8745 ([BugFix] Clear sstable_meta during full replication for PK table with cloud native persistent index (#67954))
             _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
         }
     }

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -375,7 +375,6 @@ private:
 
             // Clear delvec_meta and add to orphan files.
             for (const auto& [version, file] : old_delvec_meta.version_to_file()) {
-                if (new_referenced_files.count(file.name()) > 0) continue;
                 FileMetaPB file_meta;
                 file_meta.set_name(file.name());
                 file_meta.set_size(file.size());
@@ -383,7 +382,6 @@ private:
             }
             // Clear sstable_meta and add to orphan files.
             for (const auto& sstable : old_sstable_meta.sstables()) {
-                if (new_referenced_files.count(sstable.filename()) > 0) continue;
                 FileMetaPB file_meta;
                 file_meta.set_name(sstable.filename());
                 file_meta.set_size(sstable.filesize());
@@ -392,7 +390,6 @@ private:
             // Clear dcg_meta and add to orphan files.
             for (const auto& [_, dcg_ver] : old_dcg_meta.dcgs()) {
                 for (int i = 0; i < dcg_ver.column_files_size(); ++i) {
-                    if (new_referenced_files.count(dcg_ver.column_files(i)) > 0) continue;
                     FileMetaPB file_meta;
                     file_meta.set_name(dcg_ver.column_files(i));
                     _metadata->mutable_orphan_files()->Add(std::move(file_meta));

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -346,9 +346,13 @@ private:
                       << ", txn_id: " << txn_id;
         } else {
             auto old_rowsets = std::move(*_metadata->mutable_rowsets());
-<<<<<<< HEAD
+            auto old_delvec_meta = std::move(*_metadata->mutable_delvec_meta());
+            auto old_sstable_meta = std::move(*_metadata->mutable_sstable_meta());
+            auto old_dcg_meta = std::move(*_metadata->mutable_dcg_meta());
             _metadata->mutable_rowsets()->Clear();
             _metadata->mutable_delvec_meta()->Clear();
+            _metadata->mutable_sstable_meta()->Clear();
+            _metadata->mutable_dcg_meta()->Clear();
 
             auto new_next_rowset_id = _metadata->next_rowset_id();
             for (const auto& op_write : op_replication.op_writes()) {
@@ -359,97 +363,15 @@ private:
                 new_next_rowset_id =
                         std::max<uint32_t>(new_next_rowset_id, new_rowset_id + std::max(1, rowset->segments_size()));
             }
-
             for (const auto& [segment_id, delvec_data] : op_replication.delvecs()) {
                 auto delvec = std::make_shared<DelVector>();
                 RETURN_IF_ERROR(delvec->load(_new_version, delvec_data.data().data(), delvec_data.data().size()));
                 _builder.append_delvec(delvec, segment_id + _metadata->next_rowset_id());
             }
-
             _metadata->set_next_rowset_id(new_next_rowset_id);
-            _metadata->set_cumulative_point(0);
             old_rowsets.Swap(_metadata->mutable_compaction_inputs());
 
-            _tablet.update_mgr()->unload_primary_index(_tablet.id());
-
-=======
-            auto old_delvec_meta = std::move(*_metadata->mutable_delvec_meta());
-            auto old_sstable_meta = std::move(*_metadata->mutable_sstable_meta());
-            auto old_dcg_meta = std::move(*_metadata->mutable_dcg_meta());
-            _metadata->mutable_rowsets()->Clear();
-            _metadata->mutable_delvec_meta()->Clear();
-            _metadata->mutable_sstable_meta()->Clear();
-            _metadata->mutable_dcg_meta()->Clear();
-
-            if (op_replication.has_tablet_metadata()) {
-                // Lake replication (replication from shared-data cluster) with tablet metadata provided.
-                // Mark this as a lake replication transaction
-                _is_lake_replication = true;
-
-                const auto& copied_tablet_meta = op_replication.tablet_metadata();
-                _metadata->mutable_rowsets()->CopyFrom(copied_tablet_meta.rowsets());
-                _metadata->mutable_dcg_meta()->CopyFrom(copied_tablet_meta.dcg_meta());
-                _metadata->mutable_sstable_meta()->CopyFrom(copied_tablet_meta.sstable_meta());
-                _metadata->mutable_delvec_meta()->CopyFrom(copied_tablet_meta.delvec_meta());
-
-                _metadata->set_next_rowset_id(copied_tablet_meta.next_rowset_id());
-                // In lake replication scenario, we need to carefully handle compaction_inputs.
-                // The new rowsets may still reference the same rowset id as old rowsets (incremental sync).
-                // Only add rowsets whose id is NOT present in new rowsets to compaction_inputs.
-                // This ensures that files still referenced by new rowsets won't be deleted by vacuum.
-                std::unordered_set<uint32_t> new_rowset_ids;
-                for (const auto& rowset : _metadata->rowsets()) {
-                    new_rowset_ids.insert(rowset.id());
-                }
-                for (auto&& old_rowset : old_rowsets) {
-                    if (new_rowset_ids.count(old_rowset.id()) == 0) {
-                        _metadata->mutable_compaction_inputs()->Add(std::move(old_rowset));
-                    }
-                }
-
-                VLOG(3) << "Apply pk replication log with tablet metadata provided. tablet_id: " << _tablet.id()
-                        << ", base_version: " << _base_version << ", new_version: " << _new_version
-                        << ", txn_id: " << txn_meta.txn_id() << ", metadata id: " << _metadata->id()
-                        << ", next_rowset_id: " << _metadata->next_rowset_id()
-                        << ", rowsets size: " << _metadata->rowsets_size();
-            } else {
-                // Non-Lake replication (replication from shared-nothing cluster).
-                auto new_next_rowset_id = _metadata->next_rowset_id();
-                for (const auto& op_write : op_replication.op_writes()) {
-                    auto rowset = _metadata->add_rowsets();
-                    rowset->CopyFrom(op_write.rowset());
-                    const auto new_rowset_id = rowset->id() + _metadata->next_rowset_id();
-                    rowset->set_id(new_rowset_id);
-                    new_next_rowset_id = std::max<uint32_t>(new_next_rowset_id,
-                                                            new_rowset_id + std::max(1, rowset->segments_size()));
-                }
-                for (const auto& [segment_id, delvec_data] : op_replication.delvecs()) {
-                    auto delvec = std::make_shared<DelVector>();
-                    RETURN_IF_ERROR(delvec->load(_new_version, delvec_data.data().data(), delvec_data.data().size()));
-                    _builder.append_delvec(delvec, segment_id + _metadata->next_rowset_id());
-                }
-                _metadata->set_next_rowset_id(new_next_rowset_id);
-                old_rowsets.Swap(_metadata->mutable_compaction_inputs());
-            }
-
             _metadata->set_cumulative_point(0);
-
-            // In lake replication scenario, build set of files still referenced by new metadata.
-            // These files should not be added to orphan_files to avoid being deleted by vacuum.
-            std::unordered_set<std::string> new_referenced_files;
-            if (_is_lake_replication) {
-                for (const auto& [ver, f] : _metadata->delvec_meta().version_to_file()) {
-                    new_referenced_files.insert(f.name());
-                }
-                for (const auto& sst : _metadata->sstable_meta().sstables()) {
-                    new_referenced_files.insert(sst.filename());
-                }
-                for (const auto& [sid, dcg] : _metadata->dcg_meta().dcgs()) {
-                    for (const auto& cf : dcg.column_files()) {
-                        new_referenced_files.insert(cf);
-                    }
-                }
-            }
 
             // Clear delvec_meta and add to orphan files.
             for (const auto& [version, file] : old_delvec_meta.version_to_file()) {
@@ -457,7 +379,6 @@ private:
                 FileMetaPB file_meta;
                 file_meta.set_name(file.name());
                 file_meta.set_size(file.size());
-                file_meta.set_shared(file.shared());
                 _metadata->mutable_orphan_files()->Add(std::move(file_meta));
             }
             // Clear sstable_meta and add to orphan files.
@@ -466,7 +387,6 @@ private:
                 FileMetaPB file_meta;
                 file_meta.set_name(sstable.filename());
                 file_meta.set_size(sstable.filesize());
-                file_meta.set_shared(sstable.shared());
                 _metadata->mutable_orphan_files()->Add(std::move(file_meta));
             }
             // Clear dcg_meta and add to orphan files.
@@ -475,15 +395,11 @@ private:
                     if (new_referenced_files.count(dcg_ver.column_files(i)) > 0) continue;
                     FileMetaPB file_meta;
                     file_meta.set_name(dcg_ver.column_files(i));
-                    if (dcg_ver.shared_files_size() > 0 && i < dcg_ver.shared_files_size()) {
-                        file_meta.set_shared(dcg_ver.shared_files(i));
-                    }
                     _metadata->mutable_orphan_files()->Add(std::move(file_meta));
                 }
             }
 
             _tablet.update_mgr()->unload_primary_index(_tablet.id());
->>>>>>> b61f3b8745 ([BugFix] Clear sstable_meta during full replication for PK table with cloud native persistent index (#67954))
             LOG(INFO) << "Apply pk full replication log finish. tablet_id: " << _tablet.id()
                       << ", base_version: " << _base_version << ", new_version: " << _new_version
                       << ", txn_id: " << txn_id;
@@ -740,7 +656,6 @@ private:
         } else {
             auto old_rowsets = std::move(*_metadata->mutable_rowsets());
             _metadata->mutable_rowsets()->Clear();
-<<<<<<< HEAD
 
             for (const auto& op_write : op_replication.op_writes()) {
                 RETURN_IF_ERROR(apply_write_log(op_write));
@@ -749,35 +664,6 @@ private:
             _metadata->set_cumulative_point(0);
             old_rowsets.Swap(_metadata->mutable_compaction_inputs());
 
-=======
-            if (op_replication.has_tablet_metadata()) {
-                // Lake replication (replication from shared-data cluster) with tablet metadata provided.
-                const auto& copied_tablet_meta = op_replication.tablet_metadata();
-                _metadata->mutable_rowsets()->CopyFrom(copied_tablet_meta.rowsets());
-
-                _metadata->set_next_rowset_id(copied_tablet_meta.next_rowset_id());
-                // In lake replication scenario, we need to carefully handle compaction_inputs.
-                // The new rowsets may still reference the same rowset id as old rowsets (incremental sync).
-                // Only add rowsets whose id is NOT present in new rowsets to compaction_inputs.
-                // This ensures that files still referenced by new rowsets won't be deleted by vacuum.
-                std::unordered_set<uint32_t> new_rowset_ids;
-                for (const auto& rowset : _metadata->rowsets()) {
-                    new_rowset_ids.insert(rowset.id());
-                }
-                for (auto&& old_rowset : old_rowsets) {
-                    if (new_rowset_ids.count(old_rowset.id()) == 0) {
-                        _metadata->mutable_compaction_inputs()->Add(std::move(old_rowset));
-                    }
-                }
-            } else {
-                // Non-Lake replication (replication from shared-nothing cluster).
-                for (const auto& op_write : op_replication.op_writes()) {
-                    RETURN_IF_ERROR(apply_write_log(op_write, txn_meta.txn_id()));
-                }
-                old_rowsets.Swap(_metadata->mutable_compaction_inputs());
-            }
-            _metadata->set_cumulative_point(0);
->>>>>>> b61f3b8745 ([BugFix] Clear sstable_meta during full replication for PK table with cloud native persistent index (#67954))
             LOG(INFO) << "Apply full replication log finish. tablet_id: " << _tablet.id()
                       << ", base_version: " << _metadata->version() << ", new_version: " << _new_version
                       << ", txn_id: " << txn_meta.txn_id();

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -2198,15 +2198,12 @@ TEST_P(LakePrimaryKeyPublishTest, test_full_replication_clears_delvec_and_dcg_me
     auto& delvec_file = (*delvec_meta->mutable_version_to_file())[100];
     delvec_file.set_name("test_delvec_file.delvec");
     delvec_file.set_size(1024);
-    delvec_file.set_shared(false);
 
     // Add mock dcg_meta entry
     auto* dcg_meta = modified_metadata->mutable_dcg_meta();
     auto& dcg_ver = (*dcg_meta->mutable_dcgs())[0];
     dcg_ver.add_column_files("test_dcg_file1.cols");
     dcg_ver.add_column_files("test_dcg_file2.cols");
-    dcg_ver.add_shared_files(false);
-    dcg_ver.add_shared_files(true);
 
     // Save modified metadata
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(modified_metadata));
@@ -2280,15 +2277,12 @@ TEST_P(LakePrimaryKeyPublishTest, test_full_replication_clears_delvec_and_dcg_me
         if (orphan_file.name() == "test_delvec_file.delvec") {
             found_delvec_file = true;
             EXPECT_EQ(orphan_file.size(), 1024);
-            EXPECT_FALSE(orphan_file.shared());
         }
         if (orphan_file.name() == "test_dcg_file1.cols") {
             found_dcg_file1 = true;
-            EXPECT_FALSE(orphan_file.shared());
         }
         if (orphan_file.name() == "test_dcg_file2.cols") {
             found_dcg_file2 = true;
-            EXPECT_TRUE(orphan_file.shared());
         }
     }
     EXPECT_TRUE(found_delvec_file) << "Expected delvec file to be in orphan_files";


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
