### PR TITLE
[Enhancement] Remove old materialized index after tablet splitting finished

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -536,11 +536,11 @@ public class SplitTabletJob extends TabletReshardJob {
 
                 physicalPartition.setVisibleVersion(commitVersion, stateStartedTimeMs);
 
-                // Temporary code, ignore, will be replaced later
                 for (ReshardingMaterializedIndex reshardingIndex : reshardingPhysicalPartition
                         .getReshardingIndexes().values()) {
                     MaterializedIndex newIndex = reshardingIndex.getMaterializedIndex();
-                    physicalPartition.addMaterializedIndex(newIndex, newIndex.getMetaId() == olapTable.getBaseIndexMetaId());
+                    physicalPartition.addMaterializedIndex(newIndex,
+                            newIndex.getMetaId() == olapTable.getBaseIndexMetaId());
                 }
             }
         }
@@ -559,17 +559,15 @@ public class SplitTabletJob extends TabletReshardJob {
 
                 for (ReshardingMaterializedIndex reshardingIndex : reshardingPhysicalPartition
                         .getReshardingIndexes().values()) {
-                    MaterializedIndex oldIndex = physicalPartition.getIndex(reshardingIndex.getMaterializedIndexId());
+                    MaterializedIndex oldIndex = physicalPartition
+                            .deleteMaterializedIndexByIndexId(reshardingIndex.getMaterializedIndexId());
                     if (oldIndex == null) {
                         continue;
                     }
-
-                    /*
-                     * To do later
-                     * for (Tablet tablet : oldIndex.getTablets()) {
-                     * invertedIndex.deleteTablet(tablet.getId());
-                     * }
-                     */
+                    // Remove old tablets from inverted index
+                    for (Tablet tablet : oldIndex.getTablets()) {
+                        invertedIndex.deleteTablet(tablet.getId());
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -401,6 +401,21 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
         idToVisibleIndex.put(mIndex.getId(), mIndex);
     }
 
+    public MaterializedIndex deleteMaterializedIndexByIndexId(long indexId) {
+        MaterializedIndex index = idToVisibleIndex.remove(indexId);
+        if (index == null) {
+            index = idToShadowIndex.remove(indexId);
+        }
+
+        if (index != null) {
+            List<Long> indexIds = indexMetaIdToIndexIds.get(index.getMetaId());
+            Preconditions.checkState(indexIds != null && indexIds.remove(indexId),
+                    String.format("index id %d not found in indexMetaIdToIndexIds", indexId));
+        }
+
+        return index;
+    }
+
     public List<MaterializedIndex> deleteMaterializedIndexByMetaId(long indexMetaId) {
         List<MaterializedIndex> indices = Lists.newArrayList();
         List<Long> indexIds = indexMetaIdToIndexIds.remove(indexMetaId);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Remove old materialized index after tablet splitting finished

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
