### PR TITLE
[BugFix] Fix the bug of json parse in get fe metrics

### DIFF
--- a/be/src/exec/schema_scanner/schema_fe_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_fe_metrics_scanner.cpp
@@ -56,17 +56,21 @@ Status SchemaFeMetricsScanner::_get_fe_metrics(RuntimeState* state) {
 
         simdjson::ondemand::parser parser;
         simdjson::padded_string json_metrics(metrics);
-        for (auto json_metric : parser.iterate(json_metrics)) {
-            auto& info = _infos.emplace_back();
-            info.id = frontend.id;
-            info.value = static_cast<int64_t>(double(json_metric["value"]));
-            auto n = std::string_view(json_metric["tags"]["metric"]);
-            info.name = std::string(n.begin(), n.end());
-            std::ostringstream oss;
-            oss << simdjson::to_json_string(json_metric["tags"]);
-            info.labels = oss.str();
-            VLOG(2) << "id: " << info.id << "name: " << info.name << ", labels: " << info.labels
-                    << ", value: " << info.value;
+        try {
+            for (auto json_metric : parser.iterate(json_metrics)) {
+                auto& info = _infos.emplace_back();
+                info.id = frontend.id;
+                info.value = static_cast<int64_t>(double(json_metric["value"]));
+                auto n = std::string_view(json_metric["tags"]["metric"]);
+                info.name = std::string(n.begin(), n.end());
+                std::ostringstream oss;
+                oss << simdjson::to_json_string(json_metric["tags"]);
+                info.labels = oss.str();
+                VLOG(2) << "id: " << info.id << "name: " << info.name << ", labels: " << info.labels
+                        << ", value: " << info.value;
+            }
+        } catch (const simdjson::simdjson_error& e) {
+            return Status::InternalError("Parse the result of fe metrics failed: " + std::string(e.what()));
         }
     }
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -92,6 +92,7 @@ set(EXEC_FILES
         ./exec/schema_task_runs_scanner_test.cpp
         ./exec/schema_scanner/schema_be_tablet_write_log_scanner_test.cpp
         ./exec/schema_scanner/schema_scanner_test.cpp
+        ./exec/schema_scanner/schema_fe_metrics_scanner_test.cpp
         ./exec/sink/connector_sink_operator_test.cpp
         ./exec/sink/sink_io_buffer_test.cpp
         ./exec/stream/mem_state_table_test.cpp

--- a/be/test/exec/schema_scanner/schema_fe_metrics_scanner_test.cpp
+++ b/be/test/exec/schema_scanner/schema_fe_metrics_scanner_test.cpp
@@ -1,0 +1,81 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner/schema_fe_metrics_scanner.h"
+
+#include <gtest/gtest.h>
+
+#include "http/ev_http_server.h"
+#include "http/http_channel.h"
+#include "http/http_client.h"
+#include "http/http_handler.h"
+#include "http/http_request.h"
+#include "runtime/runtime_state.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class HttpClientTestSimpleGetHandler : public HttpHandler {
+public:
+    HttpClientTestSimpleGetHandler() = default;
+    void handle(HttpRequest* req) override {
+        std::string resp = R"([{"tags":{"metric":"jvm_young_gc","type":"count"},"unit":"nounit","value:741}])";
+        HttpChannel::send_reply(req, resp);
+    }
+};
+
+class SchemaFeMetricsScannerTest : public testing::Test {
+public:
+    SchemaFeMetricsScannerTest() {}
+    ~SchemaFeMetricsScannerTest() override = default;
+
+    void SetUp() override {
+        _server = std::make_unique<EvHttpServer>(0);
+        _server->register_handler(GET, "/metrics", &_handler);
+        ASSERT_OK(_server->start());
+        _port = _server->get_real_port();
+        ASSERT_NE(0, _port);
+        _hostname = "http://127.0.0.1:" + std::to_string(_port);
+    }
+
+    void TearDown() override {
+        _server->stop();
+        _server->join();
+    }
+
+protected:
+    HttpClientTestSimpleGetHandler _handler;
+    std::unique_ptr<EvHttpServer> _server = nullptr;
+    int _port = 0;
+    std::string _hostname = "";
+    ObjectPool _pool;
+};
+
+TEST_F(SchemaFeMetricsScannerTest, test_patial_json) {
+    RuntimeState state;
+    TFrontend frontend;
+    frontend.__set_ip("127.0.0.1");
+    frontend.__set_id("1");
+    frontend.__set_http_port(_port);
+
+    SchemaScannerParam param;
+    param.frontends.push_back(std::move(frontend));
+
+    SchemaFeMetricsScanner scanner;
+    ASSERT_OK(scanner.init(&param, &_pool));
+    auto st = scanner.start(&state);
+    ASSERT_ERROR(st);
+    ASSERT_TRUE(st.message().find("A string is opened") != std::string::npos);
+}
+} // namespace starrocks

--- a/be/test/exec/schema_scanner/schema_fe_metrics_scanner_test.cpp
+++ b/be/test/exec/schema_scanner/schema_fe_metrics_scanner_test.cpp
@@ -26,9 +26,9 @@
 
 namespace starrocks {
 
-class HttpClientTestSimpleGetHandler : public HttpHandler {
+class SchemaFeMetricsScannerGetHandler : public HttpHandler {
 public:
-    HttpClientTestSimpleGetHandler() = default;
+    SchemaFeMetricsScannerGetHandler() = default;
     void handle(HttpRequest* req) override {
         std::string resp = R"([{"tags":{"metric":"jvm_young_gc","type":"count"},"unit":"nounit","value:741}])";
         HttpChannel::send_reply(req, resp);
@@ -55,7 +55,7 @@ public:
     }
 
 protected:
-    HttpClientTestSimpleGetHandler _handler;
+    SchemaFeMetricsScannerGetHandler _handler;
     std::unique_ptr<EvHttpServer> _server = nullptr;
     int _port = 0;
     std::string _hostname = "";

--- a/be/test/exec/schema_scanner/schema_fe_metrics_scanner_test.cpp
+++ b/be/test/exec/schema_scanner/schema_fe_metrics_scanner_test.cpp
@@ -62,7 +62,7 @@ protected:
     ObjectPool _pool;
 };
 
-TEST_F(SchemaFeMetricsScannerTest, test_patial_json) {
+TEST_F(SchemaFeMetricsScannerTest, test_partial_json) {
     RuntimeState state;
     TFrontend frontend;
     frontend.__set_ip("127.0.0.1");

--- a/be/test/http/http_client_test.cpp
+++ b/be/test/http/http_client_test.cpp
@@ -26,6 +26,7 @@
 #include "http/http_channel.h"
 #include "http/http_handler.h"
 #include "http/http_request.h"
+#include "testutil/assert.h"
 
 namespace starrocks {
 
@@ -117,7 +118,7 @@ public:
         s_server->register_handler(POST, "/simple_post", &s_simple_post_handler);
         s_server->register_handler(GET, "/header_test", &s_header_handler);
         s_server->register_handler(GET, "/multi_header_test", &s_multi_header_handler);
-        s_server->start();
+        ASSERT_OK(s_server->start());
         real_port = s_server->get_real_port();
         ASSERT_NE(0, real_port);
         hostname = "http://127.0.0.1:" + std::to_string(real_port);


### PR DESCRIPTION
## Why I'm doing:

If the result returned by `getFeMetrics()` is not a complete JSON string, the JSON parser will throw an exception. If this exception is not caught, the program will crash.

```
terminate called after throwing an instance of 'simdjson::simdjson_error'
  what():  UNCLOSED_STRING: A string is opened, but never closed.

*** Aborted at 1768557257 (unix time) try "date -d @1768557257" if you are using GNU date ***
PC: @     0x1498c0c8ba6c __pthread_kill_implementation
*** SIGABRT (@0x1f20001129f) received by PID 70303 (TID 0x148d3ff87640) LWP(76947) from PID 70303; stack trace: ***
    @     0x1498c0c8ef38 __pthread_once_slow
    @          0xbed4e94 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x1498c0c3e730 (/usr/lib64/libc.so.6+0x3e72f)
    @     0x1498c0c8ba6c __pthread_kill_implementation
    @     0x1498c0c3e686 __GI_raise
    @     0x1498c0c28833 __GI_abort
    @          0x3f76f21 __gnu_cxx::__verbose_terminate_handler() [clone .cold]
    @          0xfb1d096 __cxxabiv1::__terminate(void (*)())
    @          0x3f76db9 std::terminate()
    @          0xfb1d233 __cxa_throw
    @          0x45d8de8 __wrap___cxa_throw
    @          0x5860ba1 starrocks::SchemaFeMetricsScanner::_get_fe_metrics(starrocks::RuntimeState*)
    @          0x5864713 starrocks::SchemaFeMetricsScanner::start(starrocks::RuntimeState*)
    @          0x58b8fea std::once_flag::_Prepare_execution::_Prepare_execution<std::call_once<starrocks::pipeline::SchemaChunkSource::start(starrocks::RuntimeState*)::{lambda()#1}>(std::once_flag&, starrocks::pipeline::SchemaChunkSo
urce::start(starrocks::RuntimeState*)::{lambda()@
    @     0x1498c0c8ef38 __pthread_once_slow
    @          0x58b90d4 starrocks::pipeline::SchemaChunkSource::start(starrocks::RuntimeState*)
    @          0x53914d6 auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const [clone
 .isra.0]
    @          0x54d7a29 starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x45fee3f starrocks::ThreadPool::dispatch_thread()
    @          0x45f5c30 starrocks::Thread::supervise_thread(void*)
    @     0x1498c0c89d22 start_thread
    @     0x1498c0d0ed40 __clone3
```

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
