### PR TITLE
[Enhancement] prevent mv holding large external tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakeTable.java
@@ -197,6 +197,10 @@ public class DeltaLakeTable extends Table {
         return Joiner.on(":").join(tableName, uuid == null ? "" : uuid);
     }
 
+    public MetastoreTable getMetastoreTable() {
+        return metastoreTable;
+    }
+
     @Override
     public int hashCode() {
         return com.google.common.base.Objects.hashCode(getCatalogName(), dbName, getTableIdentifier());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -275,6 +275,7 @@ public class IcebergTable extends Table {
     public int getFormatVersion() {
         return ((BaseTable) getNativeTable()).operations().current().formatVersion();
     }
+
     /**
      * <p>
      * In the Iceberg Partition Evolution scenario, 'org.apache.iceberg.PartitionField#name' only represents the
@@ -335,6 +336,10 @@ public class IcebergTable extends Table {
 
     public IcebergCatalogType getCatalogType() {
         return IcebergCatalogType.valueOf(icebergProperties.get(ICEBERG_CATALOG_TYPE));
+    }
+
+    public Map<String, String> getIcebergProperties() {
+        return icebergProperties;
     }
 
     public String getTableLocation() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LightWeightDeltaLakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LightWeightDeltaLakeTable.java
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+package com.starrocks.catalog;
+
+import com.starrocks.catalog.DeltaLakeTable;
+import io.delta.kernel.Snapshot;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.actions.Metadata;
+
+/**
+ * Lightweight Iceberg table now is used inside mv plan cache to avoid hold large memory usage.
+ *
+ * When we serialize logical plans of materialized views into the MV plan cache, keeping the full
+ * snapshots would retain large snapshot metadata,
+ * quickly blowing up cache size and heap. 
+ * 
+ * LightWeightDeltaLakeTable drops the snapshots and keeps only
+ * lightweight identifiers. It can be used to compare whether two tables are the same,
+ * but no more metadata related operations are supported.
+ */
+
+public class LightWeightDeltaLakeTable extends DeltaLakeTable {
+
+    //used for comparasion
+    private String tableIdentifier;
+
+    public LightWeightDeltaLakeTable(DeltaLakeTable table) {
+        super(table.getId(), table.getCatalogName(), table.getCatalogDBName(), table.getCatalogTableName(),
+                table.getBaseSchema(), table.getPartitionColumnNames(), null, null, table.getMetastoreTable());
+        this.tableIdentifier = table.getTableIdentifier();
+    }
+
+    @Override
+    public Snapshot getDeltaSnapshot() {
+        throw new UnsupportedOperationException("LightWeightDeltaLakeTable does not support getDeltaSnapshot");
+    }
+
+    @Override
+    public Engine getDeltaEngine() {
+        throw new UnsupportedOperationException("LightWeightDeltaLakeTable does not support getDeltaEngine");
+    }
+
+    @Override
+    public Metadata getDeltaMetadata() {
+        throw new UnsupportedOperationException("LightWeightDeltaLakeTable does not support getDeltaMetadata");
+    }
+
+    @Override
+    public String getTableIdentifier() {
+        return tableIdentifier;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LightWeightIcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LightWeightIcebergTable.java
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+package com.starrocks.catalog;
+
+import com.starrocks.catalog.IcebergTable;
+
+import java.util.List;
+
+/**
+ * Lightweight Iceberg table now is used inside mv plan cache to avoid hold large memory usage.
+ *
+ * When we serialize logical plans of materialized views into the MV plan cache, keeping the full
+ * org.apache.iceberg.Table would retain large snapshot metadata,
+ * quickly blowing up cache size and heap. 
+ * 
+ * LightIcebergTable drops the nativeTable and keeps only
+ * lightweight identifiers. It can be used to compare whether two Iceberg tables are the same,
+ * but no more metadata related operations are supported.
+ */
+
+public class LightWeightIcebergTable extends IcebergTable {
+
+    //used for comparasion
+    private String tableIdentifier;
+
+    public LightWeightIcebergTable(IcebergTable table) {
+        super(table.getId(), table.getName(), table.getCatalogName(), table.getResourceName(),
+                table.getCatalogDBName(), table.getCatalogTableName(), table.getComment(),
+                table.getBaseSchema(), null, table.getIcebergProperties());
+        this.tableIdentifier = table.getTableIdentifier();
+    }
+
+    @Override
+    public org.apache.iceberg.Table getNativeTable() {
+        throw new UnsupportedOperationException("LightWeightIcebergTable does not support getNativeTable");
+    }
+
+    @Override
+    public String getTableIdentifier() {
+        return tableIdentifier;
+    }
+
+    @Override
+    public List<Column> getPartitionColumns() {
+        throw new UnsupportedOperationException("LightWeightIcebergTable does not support getPartitionColumns");
+    }
+
+    @Override
+    public String getUUID() {
+        throw new UnsupportedOperationException("LightWeightIcebergTable does not support getUUID");
+    }
+
+    @Override
+    public boolean isUnPartitioned() {
+        throw new UnsupportedOperationException("LightWeightIcebergTable does not support isUnPartitioned");
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -29,6 +29,8 @@ import com.starrocks.authorization.PrivilegeBuiltinConstants;
 import com.starrocks.backup.Status;
 import com.starrocks.backup.mv.MvBaseTableBackupInfo;
 import com.starrocks.backup.mv.MvRestoreContext;
+import com.starrocks.catalog.LightWeightDeltaLakeTable;
+import com.starrocks.catalog.LightWeightIcebergTable;
 import com.starrocks.catalog.constraint.ForeignKeyConstraint;
 import com.starrocks.catalog.constraint.GlobalConstraintManager;
 import com.starrocks.catalog.mv.MVPlanValidationResult;
@@ -74,8 +76,10 @@ import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SelectAnalyzer;
+import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.ParseNode;
+import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprToSql;
 import com.starrocks.sql.ast.expression.ExprUtils;
@@ -2615,6 +2619,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                     String currentDBName = Strings.isNullOrEmpty(originalDBName) ? db.getOriginName() : originalDBName;
                     connectContext.setDatabase(currentDBName);
                     this.defineQueryParseNode = MvUtils.getQueryAst(originalViewDefineSql, connectContext);
+                    clearHeavyObjectFromParseNode(this.defineQueryParseNode);
                 } catch (Exception e) {
                     // ignore
                     LOG.warn("parse original view define sql failed:", e);
@@ -2625,6 +2630,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                     try {
                         connectContext.setDatabase(db.getOriginName());
                         this.defineQueryParseNode = MvUtils.getQueryAst(viewDefineSql, connectContext);
+                        clearHeavyObjectFromParseNode(this.defineQueryParseNode);
                     } catch (Exception e) {
                         // ignore
                         LOG.warn("parse view define sql failed:", e);
@@ -2633,6 +2639,27 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             }
         }
         return this.defineQueryParseNode;
+    }
+
+    //To avoid mv hold the heavy object.
+    private void clearHeavyObjectFromParseNode(ParseNode parseNode) {
+        if (parseNode == null) {
+            return;
+        }
+        new AstTraverser<Void, Void>() {
+            @Override
+            public Void visitTable(TableRelation node, Void context) {
+                Table table = node.getTable();
+                if (table instanceof IcebergTable) {
+                    Table light = new LightWeightIcebergTable((IcebergTable) table);
+                    node.setTable(light);
+                } else if (table instanceof DeltaLakeTable) {
+                    Table light = new LightWeightDeltaLakeTable((DeltaLakeTable) table);
+                    node.setTable(light);
+                }
+                return super.visitTable(node, context);
+            }
+        }.visit(parseNode, null);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalScanOperator.java
@@ -111,6 +111,10 @@ public abstract class LogicalScanOperator extends LogicalOperator {
         return table;
     }
 
+    public void setTable(Table table) {
+        this.table = table;
+    }
+
     public Map<ColumnRefOperator, Column> getColRefToColumnMetaMap() {
         return colRefToColumnMetaMap;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -20,6 +20,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.LightWeightDeltaLakeTable;
+import com.starrocks.catalog.LightWeightIcebergTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
@@ -189,10 +191,10 @@ public class OptExpressionDuplicator {
             Operator.Builder opBuilder = OperatorBuilderFactory.build(optExpression.getOp());
             LogicalScanOperator scanOperator = (LogicalScanOperator) optExpression.getOp();
             opBuilder.withOperator(scanOperator);
-            // Use scan operator's table instead of columnRefFactory's table
-            // This fixes the issue where transparent MV rewrite rewrites MV scan to base table scan,
-            // but columnRefFactory still maps column refs to MV table
-            Table scanTable = scanOperator.getTable();
+            // Use scan operator's table instead of columnRefFactory's table.
+            // If a lightweight external table sneaks in (from mv plan cache), restore full table here
+            // to avoid leaking LightWeight* into physical planning (e.g. Iceberg native table access execpetion).
+            Table scanTable = refreshLightWeightExternalTable(scanOperator.getTable());
             Map<ColumnRefOperator, Column> columnRefOperatorColumnMap = scanOperator.getColRefToColumnMetaMap();
             ImmutableMap.Builder<ColumnRefOperator, Column> columnRefColumnMapBuilder = new ImmutableMap.Builder<>();
             Map<Integer, Integer> relationIdMapping = Maps.newHashMap();
@@ -255,18 +257,14 @@ public class OptExpressionDuplicator {
             } else {
                 if (isRefreshExternalTable && scanOperator.getOpType() == OperatorType.LOGICAL_ICEBERG_SCAN) {
                     // refresh iceberg table's metadata
-                    Table refBaseTable = scanOperator.getTable();
-                    IcebergTable cachedIcebergTable = (IcebergTable) refBaseTable;
-                    String catalogName = cachedIcebergTable.getCatalogName();
-                    String dbName = cachedIcebergTable.getCatalogDBName();
-                    TableName tableName = new TableName(catalogName, dbName, cachedIcebergTable.getName());
-                    Table currentTable =
-                            GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(new ConnectContext(), tableName)
-                                    .orElse(null);
+                    Table refBaseTable = scanTable;
+                    //the table is already load in refreshLightWeightExternalTable
+                    IcebergTable currentTable = (IcebergTable) refBaseTable;
+
                     if (currentTable == null) {
                         return null;
                     }
-                    scanBuilder.setTable(currentTable);
+
                     TvrVersionRange versionRange = TvrTableSnapshot.of(
                             Optional.ofNullable(((IcebergTable) currentTable).getNativeTable().currentSnapshot())
                                     .map(Snapshot::snapshotId));
@@ -296,6 +294,7 @@ public class OptExpressionDuplicator {
             }
             ImmutableMap<ColumnRefOperator, Column> newColumnRefColumnMap = columnRefColumnMapBuilder.build();
             scanBuilder.setColRefToColumnMetaMap(newColumnRefColumnMap);
+            scanBuilder.setTable(scanTable);
 
             // process external table scan operator's predicates
             LogicalScanOperator newScanOperator = (LogicalScanOperator) opBuilder.build();
@@ -303,6 +302,25 @@ public class OptExpressionDuplicator {
                 processExternalTableScanOperator(newScanOperator);
             }
             return OptExpression.create(newScanOperator);
+        }
+
+        private Table refreshLightWeightExternalTable(Table table) {
+            if (!(table instanceof LightWeightIcebergTable || table instanceof LightWeightDeltaLakeTable)) {
+                return table;
+            }
+            ConnectContext connectContext = ConnectContext.get() == null ? new ConnectContext() : ConnectContext.get();
+            String catalogName = table.getCatalogName();
+            String dbName = table.getCatalogDBName();
+            TableName tableName = new TableName(catalogName, dbName, table.getName());
+            try {
+                // lookup the latest full table from global state manager
+                Table currentTable =
+                        GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(connectContext, tableName)
+                                .orElse(null);
+                return currentTable;
+            } catch (Exception e) {
+                return null;
+            }
         }
 
         private void processExternalTableScanOperator(LogicalScanOperator newScanOperator) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -16,6 +16,7 @@ package com.starrocks.analysis;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.ColocateTableIndex;
@@ -23,7 +24,9 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.LightWeightIcebergTable;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MaterializedViewRefreshType;
@@ -39,6 +42,7 @@ import com.starrocks.catalog.mv.MVPlanValidationResult;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.ThreadUtil;
@@ -73,8 +77,13 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.MvRewritePreprocessor;
+import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
@@ -97,6 +106,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.mockito.Mockito;
 
 import java.lang.reflect.Method;
 import java.time.LocalDateTime;
@@ -6032,5 +6042,51 @@ public class CreateMaterializedViewTest extends MVTestBase {
                     "AS SELECT 'This is a test' AS `'This is a test'`, 123 AS `123`, `iceberg0`.`partitioned_db`.`v1`.`date`, `iceberg0`.`partitioned_db`.`v1`.`id`\n" +
                     "FROM `iceberg0`.`partitioned_db`.`t2` AS `v1`;", ddl);
         }
+    }
+
+    @Test
+    public void testRemoveHeavyObjectsFromTableClearsNativeIcebergTable() throws Exception {
+        Column column = new Column("c1", com.starrocks.type.IntegerType.INT);
+        ColumnRefOperator colRef = new ColumnRefOperator(1, com.starrocks.type.IntegerType.INT, "c1", true);
+
+        org.apache.iceberg.BaseTable nativeTable = Mockito.mock(org.apache.iceberg.BaseTable.class);
+        org.apache.iceberg.Schema schema =
+                new org.apache.iceberg.Schema(org.apache.iceberg.types.Types.NestedField.required(
+                        1, "c1", org.apache.iceberg.types.Types.IntegerType.get()));
+        org.apache.iceberg.PartitionSpec spec =
+                org.apache.iceberg.PartitionSpec.builderFor(schema).identity("c1").build();
+        org.apache.iceberg.TableMetadata meta = Mockito.mock(org.apache.iceberg.TableMetadata.class);
+        org.apache.iceberg.TableOperations ops = Mockito.mock(org.apache.iceberg.TableOperations.class);
+        Mockito.when(nativeTable.schema()).thenReturn(schema);
+        Mockito.when(nativeTable.spec()).thenReturn(spec);
+        Mockito.when(nativeTable.operations()).thenReturn(ops);
+        Mockito.when(ops.current()).thenReturn(meta);
+        Mockito.when(meta.uuid()).thenReturn("uuid-1234");
+
+        IcebergTable icebergTable = IcebergTable.builder()
+                .setId(1)
+                .setSrTableName("t")
+                .setCatalogName("iceberg")
+                .setCatalogDBName("db")
+                .setCatalogTableName("t")
+                .setNativeTable(nativeTable)
+                .setFullSchema(java.util.List.of(column))
+                .build();
+
+        LogicalIcebergScanOperator scan = new LogicalIcebergScanOperator(
+                icebergTable,
+                ImmutableMap.of(colRef, column),
+                ImmutableMap.of(column, colRef),
+                Operator.DEFAULT_LIMIT,
+                null,
+                TvrTableSnapshot.empty());
+        OptExpression opt = OptExpression.create(scan);
+
+        Method remover = CachingMvPlanContextBuilder.class
+                .getDeclaredMethod("removeHeavyObjectsFromTable", OptExpression.class);
+        remover.setAccessible(true);
+        remover.invoke(null, opt);
+
+        Assertions.assertTrue(scan.getTable() instanceof LightWeightIcebergTable);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.connector.iceberg;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -31,8 +30,10 @@ import com.starrocks.common.tvr.TvrVersion;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.ConnectorTableInfo;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -57,7 +58,6 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
@@ -179,11 +179,9 @@ public class MockIcebergMetadata implements ConnectorMetadata {
                         MOCKED_UNPARTITIONED_TABLE_NAME0), MOCKED_UNPARTITIONED_TABLE_NAME0,
                 schema, spec, 3);
 
-        String tableIdentifier = Joiner.on(":").join(MOCKED_UNPARTITIONED_TABLE_NAME0, UUID.randomUUID());
         MockIcebergTable mockIcebergTable = new MockIcebergTable(1, MOCKED_UNPARTITIONED_TABLE_NAME0,
                 MOCKED_ICEBERG_CATALOG_NAME, null, MOCKED_UNPARTITIONED_DB_NAME,
-                MOCKED_UNPARTITIONED_TABLE_NAME0, schemas, baseTable, null,
-                tableIdentifier, "");
+                MOCKED_UNPARTITIONED_TABLE_NAME0, schemas, baseTable, null, "");
 
         Map<String, ColumnStatistic> columnStatisticMap;
         List<String> colNames = schemas.stream().map(Column::getName).collect(Collectors.toList());
@@ -476,10 +474,8 @@ public class MockIcebergMetadata implements ConnectorMetadata {
         Schema schema = getIcebergPartitionSchema(tblName);
         TestTables.TestTable baseTable = getPartitionIdentityTable(tblName, schema);
 
-        String tableIdentifier = Joiner.on(":").join(tblName, UUID.randomUUID());
         return new MockIcebergTable(tblName.hashCode(), tblName, MOCKED_ICEBERG_CATALOG_NAME,
-                null, MOCKED_PARTITIONED_DB_NAME, tblName, schemas, baseTable, null,
-                tableIdentifier, "");
+                null, MOCKED_PARTITIONED_DB_NAME, tblName, schemas, baseTable, null, "");
     }
 
     public static MockIcebergTable getPartitionTransformIcebergTable(String tblName, List<Column> schemas)
@@ -487,10 +483,8 @@ public class MockIcebergMetadata implements ConnectorMetadata {
         Schema schema = getIcebergPartitionTransformSchema(tblName);
         TestTables.TestTable baseTable = getPartitionTransformTable(tblName, schema);
 
-        String tableIdentifier = Joiner.on(":").join(tblName, UUID.randomUUID());
         return new MockIcebergTable(tblName.hashCode(), tblName, MOCKED_ICEBERG_CATALOG_NAME,
-                null, MOCKED_PARTITIONED_TRANSFORMS_DB_NAME, tblName, schemas, baseTable, null,
-                tableIdentifier, "");
+                null, MOCKED_PARTITIONED_TRANSFORMS_DB_NAME, tblName, schemas, baseTable, null, "");
     }
 
     @Override
@@ -507,7 +501,18 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     public com.starrocks.catalog.Table getTable(ConnectContext context, String dbName, String tblName) {
         readLock();
         try {
-            return MOCK_TABLE_MAP.get(dbName).get(tblName).icebergTable;
+            MockIcebergTable t = MOCK_TABLE_MAP.get(dbName).get(tblName).icebergTable;
+            MockIcebergTable t1 = new MockIcebergTable(t.getId(), t.getName(), t.getCatalogName(), t.getResourceName(),
+                        t.getCatalogDBName(), t.getCatalogTableName(),
+                        t.getBaseSchema(), t.getNativeTable(), t.getIcebergProperties(),
+                        t.getComment());
+            ConnectorTableInfo info = GlobalStateMgr.getCurrentState()
+                    .getConnectorTblMetaInfoMgr()
+                    .getConnectorTableInfo(t.getCatalogName(), t.getCatalogDBName(), t.getTableIdentifier());
+            if (info != null && info.getRelatedMaterializedViews() != null) {
+                t1.getRelatedMaterializedViews().addAll(info.getRelatedMaterializedViews());
+            }
+            return t1;
         } finally {
             readUnlock();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergTable.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergTable.java
@@ -21,18 +21,11 @@ import java.util.List;
 import java.util.Map;
 
 public class MockIcebergTable extends IcebergTable {
-    private final String tableIdentifier;
 
     public MockIcebergTable(long id, String srTableName, String catalogName, String resourceName, String remoteDbName,
                         String remoteTableName, List<Column> schema, org.apache.iceberg.Table nativeTable,
-                        Map<String, String> icebergProperties, String tableIdentifier, String comment) {
+                        Map<String, String> icebergProperties, String comment) {
         super(id, srTableName, catalogName, resourceName, remoteDbName, remoteTableName, comment, schema,
                 nativeTable, icebergProperties);
-        this.tableIdentifier = tableIdentifier;
-    }
-
-    @Override
-    public String getTableIdentifier() {
-        return this.tableIdentifier;
     }
 }


### PR DESCRIPTION
## Why I'm doing:
MaterializeView will use MVPlanCacheBuilder to cache logical plan, the logical plan may hold the lake table with large amounts metadata. The logical plan is used to do mv rewrite, and holding the large memory of metadata are useless most of the time.

So does the ast defined query node kept in MaterializedView, it may be cached when the MaterializedView is cache key in mv cache. The lake table hold in ast tree is aslo useless.
## What I'm doing:
Remove these heavy memory node to lower the cache memory usage under mv on lake.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
