### PR TITLE
[Feature] Support EXECUTE AS chaining via original user privilege check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
@@ -208,6 +208,11 @@ public class AuthenticationHandler {
         // Set current role IDs based on the authenticated user and groups
         context.setCurrentRoleIds(authenticationResult.authenticatedUser, groups);
 
+        // Snapshot original(login) user context once for later authorization checks (e.g. EXECUTE AS chain).
+        // It should remain unchanged even if currentUserIdentity is modified by EXECUTE AS.
+        context.getAccessControlContext().initOriginalUserContext(
+                authenticationResult.authenticatedUser, groups, context.getCurrentRoleIds());
+
         // Step 5: Validate group access permissions
         // If authentication result specifies allowed groups, verify user belongs to at least one
         // This ensures users can only access groups they are authorized for

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationMgr.java
@@ -914,22 +914,17 @@ public class AuthorizationMgr {
                 checkUser = current;
                 checkGroups = context.getGroups();
                 checkRoleIds = context.getCurrentRoleIds();
-            } else if (current == null) {
-                // No current identity: use original
-                checkUser = original;
-                checkGroups = acc.getOriginalGroups();
-                checkRoleIds = acc.getOriginalRoleIds();
-            } else if (current.equals(original)) {
-                // Not impersonating (current == original): use current* to respect SET ROLE
-                checkUser = current;
-                checkGroups = context.getGroups();
-                checkRoleIds = context.getCurrentRoleIds();
-            } else {
-                // Impersonating: use original(login) user context for IMPERSONATE checks.
+            } else if (current == null || !current.equals(original)) {
+                // No current identity OR impersonating: use original(login) user context
                 // This allows chaining EXECUTE AS on the same session based on the original user's privileges.
                 checkUser = original;
                 checkGroups = acc.getOriginalGroups();
                 checkRoleIds = acc.getOriginalRoleIds();
+            } else {
+                // Not impersonating (current == original): use current* to respect SET ROLE
+                checkUser = current;
+                checkGroups = context.getGroups();
+                checkRoleIds = context.getCurrentRoleIds();
             }
 
             PrivilegeCollectionV2 collection = mergePrivilegeCollection(checkUser, checkGroups, checkRoleIds);

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationMgr.java
@@ -927,6 +927,12 @@ public class AuthorizationMgr {
                 checkRoleIds = context.getCurrentRoleIds();
             }
 
+            // Defensive check: if somehow both original and current are null, deny access
+            if (checkUser == null) {
+                LOG.warn("canExecuteAs: checkUser is null, denying access to impersonate {}", impersonateUser);
+                return false;
+            }
+
             PrivilegeCollectionV2 collection = mergePrivilegeCollection(checkUser, checkGroups, checkRoleIds);
             PEntryObject object = provider.generateUserObject(ObjectType.USER, impersonateUser);
             return provider.check(ObjectType.USER, PrivilegeType.IMPERSONATE, object, collection);

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlProto.java
@@ -239,6 +239,12 @@ public class MysqlProto {
         if (prevOriginalUserIdentity != null) {
             context.getAccessControlContext().setOriginalUserContext(
                     prevOriginalUserIdentity, prevOriginalGroups, prevOriginalRoleIds);
+        } else {
+            // Reset original context to null if previous session had none.
+            // This prevents the new user's original context (set by authenticate() before failure)
+            // from remaining after restore, which would allow the previous user to exploit
+            // the new user's IMPERSONATE privileges.
+            context.getAccessControlContext().resetOriginalUserContext();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteAsExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteAsExecutor.java
@@ -55,6 +55,12 @@ public class ExecuteAsExecutor {
         } else {
             userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
         }
+
+        // Snapshot current role IDs into originalRoleIds if this is the first EXECUTE AS.
+        // This ensures SET ROLE executed before EXECUTE AS is honored when chaining.
+        ctx.getAccessControlContext().snapshotRoleIdsIfNotImpersonating(
+                ctx.getCurrentUserIdentity(), ctx.getCurrentRoleIds());
+
         ctx.setCurrentUserIdentity(userIdentity);
 
         // Refresh groups and roles for all users based on security integration

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/ExecuteAsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/ExecuteAsExecutorTest.java
@@ -131,7 +131,7 @@ public class ExecuteAsExecutorTest {
     }
 
     @Test
-    public void testExecuteAsChainUsesOriginalLoginUserForImpersonateCheck() throws Exception {
+    void testExecuteAsChainUsesOriginalLoginUserForImpersonateCheck() throws Exception {
         // Create users
         authenticationMgr.createUser(
                 new CreateUserStmt(new UserRef("admin_user", "%"), true, null, List.of(), Map.of(), NodePosition.ZERO));

--- a/fe/fe-spi/src/main/java/com/starrocks/authentication/AccessControlContext.java
+++ b/fe/fe-spi/src/main/java/com/starrocks/authentication/AccessControlContext.java
@@ -101,13 +101,12 @@ public class AccessControlContext {
     }
 
     /**
-     * Initialize the original(login) user context once.
-     * This method is idempotent and will only set the original context if it has not been set before.
+     * Initialize or update the original(login) user context from the result of a successful
+     * authentication. Called once per login and again on re-authentication of the same
+     * connection (e.g. to refresh roles after grant/revoke). For CHANGE USER, the caller
+     * must invoke {@link #resetOriginalUserContext()} before re-auth so this sets the new user.
      */
     public void initOriginalUserContext(UserIdentity userIdentity, Set<String> groups, Set<Long> roleIds) {
-        if (this.originalUserIdentity != null) {
-            return;
-        }
         this.originalUserIdentity = userIdentity;
         this.originalGroups = groups == null ? new HashSet<>() : new HashSet<>(groups);
         this.originalRoleIds = roleIds == null ? new HashSet<>() : new HashSet<>(roleIds);

--- a/fe/fe-spi/src/main/java/com/starrocks/authentication/AccessControlContext.java
+++ b/fe/fe-spi/src/main/java/com/starrocks/authentication/AccessControlContext.java
@@ -40,8 +40,9 @@ public class AccessControlContext {
     private UserIdentity currentUserIdentity;
 
     // Original (login) user context snapshot.
-    // This is initialized once right after authentication succeeds and should not change even after EXECUTE AS.
-    // It is used for cases where permission checks (e.g. IMPERSONATE) need to be based on the original login user
+    // Set/updated after each successful authentication; reset before re-authentication (e.g. CHANGE USER).
+    // Unchanged by EXECUTE AS. Restored from backup when CHANGE USER fails.
+    // Used for permission checks (e.g. IMPERSONATE) that must be based on the original login user
     // instead of the current impersonated user.
     private UserIdentity originalUserIdentity = null;
     private Set<String> originalGroups = null;

--- a/fe/fe-spi/src/main/java/com/starrocks/authentication/AccessControlContext.java
+++ b/fe/fe-spi/src/main/java/com/starrocks/authentication/AccessControlContext.java
@@ -148,6 +148,22 @@ public class AccessControlContext {
         return originalRoleIds == null ? Collections.emptySet() : originalRoleIds;
     }
 
+    /**
+     * Update originalRoleIds to match current session's role IDs if not yet impersonating.
+     * This ensures SET ROLE executed BEFORE the first EXECUTE AS is honored when chaining.
+     * Should be called right before the first EXECUTE AS changes currentUserIdentity.
+     *
+     * @param currentUser the current user identity before EXECUTE AS
+     * @param currentRoleIds the current role IDs (reflecting any SET ROLE changes)
+     */
+    public void snapshotRoleIdsIfNotImpersonating(UserIdentity currentUser, Set<Long> currentRoleIds) {
+        // Only update if we haven't started impersonating yet (current == original)
+        if (this.originalUserIdentity != null && currentUser != null
+                && currentUser.equals(this.originalUserIdentity)) {
+            this.originalRoleIds = currentRoleIds == null ? new HashSet<>() : new HashSet<>(currentRoleIds);
+        }
+    }
+
     public void setDistinguishedName(String distinguishedName) {
         this.distinguishedName = distinguishedName;
     }


### PR DESCRIPTION
Enable multiple sequential EXECUTE AS statements on the same connection by checking IMPERSONATE privileges based on the original login user instead of the current impersonated user.

- Store original user context (identity, groups, roles) in AccessControlContext
- Initialize original context during authentication
- Use original context for IMPERSONATE checks in AuthorizationMgr.canExecuteAs()
- Add test case for EXECUTE AS chaining scenario
- Fix security issue: reset original context on re-authentication to prevent
  new user from inheriting IMPERSONATE privileges from previous login user

Maintains backward compatibility with fallback to current user behavior.

## Why I'm doing:

Currently, when using `EXECUTE AS user WITH NO REVERT`, the system checks IMPERSONATE privileges based on the **current impersonated user** (`currentUserIdentity`), not the **original login user** (`qualifiedUser`). This creates a limitation where:

1. After executing `EXECUTE AS user1 WITH NO REVERT`, the connection context switches to `user1`
2. When attempting to execute `EXECUTE AS user2 WITH NO REVERT` on the same connection, the system checks if `user1` has IMPERSONATE privilege on `user2`
3. If `user1` doesn't have IMPERSONATE privilege on `user2`, the operation fails, even though the original login user (e.g., `admin_user`) might have IMPERSONATE privileges on both `user1` and `user2`

This limitation prevents applications using connection pooling from chaining multiple `EXECUTE AS` statements on the same connection, forcing them to either:
- Grant IMPERSONATE privileges to intermediate users (not always feasible)
- Use separate connections for each user (defeats connection pooling)

## What I'm doing:

This PR enables `EXECUTE AS` to check IMPERSONATE privileges based on the **original login user** instead of the current impersonated user, allowing multiple sequential `EXECUTE AS` statements on the same connection.

**Implementation details:**

1. **Store original user context** in `AccessControlContext`:
   - Added `originalUserIdentity`, `originalGroups`, and `originalRoleIds` fields to store the original login user context snapshot
   - These fields are initialized once during authentication and remain unchanged during the session

2. **Initialize original context** in `AuthenticationHandler`:
   - Call `initOriginalUserContext()` after setting groups and roles during authentication
   - This ensures the original user context is captured at login time

3. **Modify privilege checking** in `AuthorizationMgr.canExecuteAs()`:
   - Use original user context (identity, groups, roles) for IMPERSONATE privilege checks when available
   - Fallback to current user behavior if original context is not available (for backward compatibility)

4. **Add test case** to verify the feature:
   - Test case `testExecuteAsChainUsesOriginalLoginUserForImpersonateCheck()` verifies that chaining `EXECUTE AS` statements works correctly based on original user privileges

**Example usage:**
-- Login as admin_user (has IMPERSONATE on user1 and user2)
`EXECUTE AS user1 WITH NO REVERT;`  -- Checks: admin_user has IMPERSONATE on user1 ✓
-- ... execute queries with user1 permissions ...
`EXECUTE AS user2 WITH NO REVERT; ` -- Checks: admin_user has IMPERSONATE on user2 ✓ (now works!)

Fixes #68149

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables chaining of `EXECUTE AS` by basing `IMPERSONATE` checks on the original(login) user, not the currently impersonated user.
> 
> - Add original user snapshot (`originalUserIdentity`, `originalGroups`, `originalRoleIds`) to `AccessControlContext`; initialize in `AuthenticationHandler`
> - Update `AuthorizationMgr.canExecuteAs()` to prefer original context (with fallbacks) when checking `IMPERSONATE`
> - Strengthen MySQL `CHANGE USER`: snapshot full session (incl. original context), reset original context before re-auth, and restore previous session on failure to prevent privilege leakage
> - Add targeted unit tests for chaining behavior, null-current edge case, and `CHANGE USER` failure restore paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f07e5e053a5427413700f25c095c65f402bd0506. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->