### PR TITLE
[Enhancement] Support Big-endian encoding for primary key in range-distribution table in share data mode.

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -440,7 +440,12 @@ inline Status DeltaWriterImpl::reset_memtable() {
         _mem_table = std::make_unique<MemTable>(_tablet_id, &_write_schema_for_mem_table, _mem_table_sink.get(),
                                                 _max_buffer_size, _mem_tracker);
     }
-    RETURN_IF_ERROR(_mem_table->prepare());
+
+    PrimaryKeyEncodingType pk_encoding_type = PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE;
+    if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
+        ASSIGN_OR_RETURN(pk_encoding_type, _tablet_schema->primary_key_encoding_type_or_error());
+    }
+    RETURN_IF_ERROR(_mem_table->prepare(pk_encoding_type));
     _mem_table->set_write_buffer_row(_max_buffer_rows);
     return Status::OK();
 }
@@ -880,7 +885,6 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
 
 Status DeltaWriterImpl::fill_auto_increment_id(Chunk& chunk) {
     ASSIGN_OR_RETURN(auto tablet, _tablet_manager->get_tablet(_tablet_id));
-
     // 1. get pk column from chunk
     vector<uint32_t> pk_columns;
     for (size_t i = 0; i < _write_schema->num_key_columns(); i++) {
@@ -888,12 +892,13 @@ Status DeltaWriterImpl::fill_auto_increment_id(Chunk& chunk) {
     }
     Schema pkey_schema = ChunkHelper::convert_schema(_write_schema, pk_columns);
     MutableColumnPtr pk_column;
-    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
+    ASSIGN_OR_RETURN(auto pk_encoding_type, _tablet_schema->primary_key_encoding_type_or_error());
+    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, pk_encoding_type).ok()) {
         CHECK(false) << "create column for primary key encoder failed";
     }
     auto col = pk_column->clone();
 
-    PrimaryKeyEncoder::encode(pkey_schema, chunk, 0, chunk.num_rows(), col.get());
+    PrimaryKeyEncoder::encode(pkey_schema, chunk, 0, chunk.num_rows(), col.get(), pk_encoding_type);
     MutableColumns upserts;
     upserts.resize(1);
     upserts[0] = std::move(col);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -804,8 +804,9 @@ Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
 Status LakePersistentIndex::load_dels(const RowsetPtr& rowset, const Schema& pkey_schema, int64_t rowset_version) {
     TRACE_COUNTER_SCOPE_LATENCY_US("rebuild_index_del_cost_us");
     // Build pk column struct from schema
+    ASSIGN_OR_RETURN(auto pk_encoding_type, rowset->tablet_schema()->primary_key_encoding_type_or_error());
     MutableColumnPtr pk_column;
-    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, pk_encoding_type));
     // Iterate all del files and insert into index.
     for (int del_idx = 0; del_idx < rowset->metadata().del_files_size(); ++del_idx) {
         TRACE_COUNTER_INCREMENT("rebuild_index_del_cnt", 1);
@@ -922,9 +923,10 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     auto pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
 
     _need_rebuild_file_cnt = need_rebuild_file_cnt(*metadata, metadata->sstable_meta());
+    ASSIGN_OR_RETURN(auto pk_encoding_type, tablet_schema->primary_key_encoding_type_or_error());
 
     // Init PersistentIndex
-    _key_size = PrimaryKeyEncoder::get_encoded_fixed_size(pkey_schema);
+    _key_size = PrimaryKeyEncoder::get_encoded_fixed_size(pkey_schema, pk_encoding_type);
 
     const auto& sstables = metadata->sstable_meta().sstables();
     // Rebuild persistent index from `rebuild_rss_rowid_point`
@@ -932,9 +934,9 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
     const uint32_t rebuild_rss_id = rebuild_rss_rowid_point >> 32;
     OlapReaderStatistics stats;
     MutableColumnPtr pk_column;
-    if (pk_columns.size() > 1) {
-        // more than one key column
-        if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
+    if (pk_columns.size() > 1 || pk_encoding_type == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2) {
+        // more than one key column or big endian encoding
+        if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, pk_encoding_type).ok()) {
             CHECK(false) << "create column for primary key encoder failed";
         }
     }
@@ -983,7 +985,8 @@ Status LakePersistentIndex::load_from_lake_tablet(TabletManager* tablet_mgr, con
                     Column* pkc = nullptr;
                     if (pk_column) {
                         pk_column->reset_column();
-                        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get());
+                        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get(),
+                                                  pk_encoding_type);
                         pkc = pk_column.get();
                     } else {
                         pkc = const_cast<Column*>(chunk->columns()[0].get());

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -50,13 +50,15 @@ Status LakePrimaryIndex::lake_load(TabletManager* tablet_mgr, const TabletMetada
     if (need_rebuild()) {
         unload_without_lock();
     }
+    // _do_lake_load may need tablet id to fetch tablet schema/encoding type.
+    // Set it before loading to avoid using the default value (0).
+    _tablet_id = metadata->id();
     _status = _do_lake_load(tablet_mgr, metadata, base_version, builder);
     TEST_SYNC_POINT_CALLBACK("lake_index_load.1", &_status);
     if (_status.ok()) {
         // update data version when memory index or persistent index load finish.
         _data_version = base_version;
     }
-    _tablet_id = metadata->id();
     _loaded = true;
     TRACE("end load pk index");
     if (!_status.ok()) {
@@ -127,9 +129,10 @@ Status LakePrimaryIndex::_do_lake_load(TabletManager* tablet_mgr, const TabletMe
 
     OlapReaderStatistics stats;
     MutableColumnPtr pk_column;
-    if (pk_columns.size() > 1) {
-        // more than one key column
-        RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
+    ASSIGN_OR_RETURN(auto pk_encoding_type, tablet_schema->primary_key_encoding_type_or_error());
+    if (pk_columns.size() > 1 || pk_encoding_type == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2) {
+        // more than one key column or V2 encoding
+        RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, pk_encoding_type));
     }
     vector<uint32_t> rowids;
     rowids.reserve(4096);
@@ -163,7 +166,8 @@ Status LakePrimaryIndex::_do_lake_load(TabletManager* tablet_mgr, const TabletMe
                     const Column* pkc = nullptr;
                     if (pk_column) {
                         pk_column->reset_column();
-                        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get());
+                        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get(),
+                                                  pk_encoding_type);
                         pkc = pk_column.get();
                     } else {
                         pkc = chunk->columns()[0].get();

--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
@@ -61,6 +61,10 @@ Schema LakePrimaryKeyCompactionConflictResolver::generate_pkey_schema() {
     return ChunkHelper::convert_schema(tablet_schema, pk_columns);
 }
 
+StatusOr<PrimaryKeyEncodingType> LakePrimaryKeyCompactionConflictResolver::primary_key_encoding_type() const {
+    return _rowset->tablet_schema()->primary_key_encoding_type_or_error();
+}
+
 Status LakePrimaryKeyCompactionConflictResolver::segment_iterator(
         const std::function<Status(const CompactConflictResolveParams&, const std::vector<ChunkIteratorPtr>&,
                                    const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>& handler) {

--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.h
@@ -52,6 +52,7 @@ public:
 
     StatusOr<FileInfo> filename() const override;
     Schema generate_pkey_schema() override;
+    StatusOr<PrimaryKeyEncodingType> primary_key_encoding_type() const override;
     Status segment_iterator(
             const std::function<Status(const CompactConflictResolveParams&, const std::vector<ChunkIteratorPtr>&,
                                        const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>& handler)

--- a/be/src/storage/lake/lake_primary_key_recover.cpp
+++ b/be/src/storage/lake/lake_primary_key_recover.cpp
@@ -131,4 +131,9 @@ int64_t LakePrimaryKeyRecover::tablet_id() {
     return _tablet->id();
 }
 
+StatusOr<PrimaryKeyEncodingType> LakePrimaryKeyRecover::primary_key_encoding_type() const {
+    auto tablet_schema = std::make_unique<TabletSchema>(_metadata->schema());
+    return tablet_schema->primary_key_encoding_type_or_error();
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/lake_primary_key_recover.h
+++ b/be/src/storage/lake/lake_primary_key_recover.h
@@ -55,6 +55,8 @@ public:
 
     int64_t tablet_id() override;
 
+    StatusOr<PrimaryKeyEncodingType> primary_key_encoding_type() const override;
+
     // Sorrt rowset by rowsetid
     // also consider sorting in data loading and compact concurrency scenarios
     static Status sort_rowsets(std::vector<RowsetPtr>* rowsets);

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -129,6 +129,8 @@ public:
 
     [[nodiscard]] int64_t version() const { return metadata().version(); }
 
+    TabletSchemaPtr tablet_schema() const { return _tablet_schema; }
+
     bool has_data_files() const override { return num_segments() > 0 || num_dels() > 0; }
 
     // no practical significance, just compatible interface

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -21,6 +21,7 @@
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_metadata.h"
+#include "storage/primary_key_encoding_types.h"
 #include "storage/tablet_schema.h"
 
 namespace starrocks::lake {
@@ -86,7 +87,8 @@ class SegmentPKIterator {
 public:
     SegmentPKIterator() = default;
     ~SegmentPKIterator() { close(); }
-    Status init(const ChunkIteratorPtr& iter, const Schema& pkey_schema, bool load_whole);
+    Status init(const ChunkIteratorPtr& iter, const Schema& pkey_schema, bool lazy_load,
+                PrimaryKeyEncodingType encoding_type);
     void next();
     bool done();
     Status status();
@@ -128,6 +130,8 @@ private:
     ChunkUniquePtr _pk_column_chunk;
     // For no lazy load, we can load whole pk column and encode at once.
     MutableColumnPtr _standalone_pk_column;
+    // The encoding type of primary key.
+    PrimaryKeyEncodingType _encoding_type = PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE;
 };
 
 using SegmentPKIteratorPtr = std::unique_ptr<SegmentPKIterator>;

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -610,6 +610,7 @@ Status UpdateManager::_handle_column_upsert_mode(const TxnLogPB_OpWrite& op_writ
 
     DCHECK_EQ(insert_rowids_by_segment.size(), op_write.rowset().segments_size());
 
+    ASSIGN_OR_RETURN(auto pk_encoding_type, tschema->primary_key_encoding_type_or_error());
     for (uint32_t seg = 0; seg < op_write.rowset().segments_size(); ++seg) {
         // Reuse insert_rowids computed by ColumnModePartialUpdateHandler
         const auto& insert_rowids = insert_rowids_by_segment[seg];
@@ -647,7 +648,7 @@ Status UpdateManager::_handle_column_upsert_mode(const TxnLogPB_OpWrite& op_writ
         });
 
         MutableColumnPtr pk_column_for_upsert;
-        RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column_for_upsert));
+        RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column_for_upsert, pk_encoding_type));
 
         for (size_t batch_start = 0; batch_start < insert_rowids.size(); batch_start += batch_size) {
             size_t batch_end = std::min(batch_start + batch_size, insert_rowids.size());
@@ -660,7 +661,8 @@ Status UpdateManager::_handle_column_upsert_mode(const TxnLogPB_OpWrite& op_writ
             RETURN_IF_ERROR(writer.append_chunk(*full_chunk));
             total_rows += full_chunk->num_rows();
 
-            PrimaryKeyEncoder::encode(pkey_schema, *full_chunk, 0, full_chunk->num_rows(), pk_column_for_upsert.get());
+            PrimaryKeyEncoder::encode(pkey_schema, *full_chunk, 0, full_chunk->num_rows(), pk_column_for_upsert.get(),
+                                      pk_encoding_type);
         }
 
         uint64_t seg_file_size = 0, idx_size = 0, footer_pos = 0;

--- a/be/src/storage/local_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/local_primary_key_compaction_conflict_resolver.cpp
@@ -44,6 +44,10 @@ Schema LocalPrimaryKeyCompactionConflictResolver::generate_pkey_schema() {
     return ChunkHelper::convert_schema(schema, pk_columns);
 }
 
+StatusOr<PrimaryKeyEncodingType> LocalPrimaryKeyCompactionConflictResolver::primary_key_encoding_type() const {
+    return PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1;
+}
+
 Status LocalPrimaryKeyCompactionConflictResolver::segment_iterator(
         const std::function<Status(const CompactConflictResolveParams&, const std::vector<ChunkIteratorPtr>&,
                                    const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>& handler) {

--- a/be/src/storage/local_primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/local_primary_key_compaction_conflict_resolver.h
@@ -39,6 +39,7 @@ public:
 
     StatusOr<FileInfo> filename() const override;
     Schema generate_pkey_schema() override;
+    StatusOr<PrimaryKeyEncodingType> primary_key_encoding_type() const override;
     Status segment_iterator(
             const std::function<Status(const CompactConflictResolveParams&, const std::vector<ChunkIteratorPtr>&,
                                        const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>& handler)

--- a/be/src/storage/local_primary_key_recover.cpp
+++ b/be/src/storage/local_primary_key_recover.cpp
@@ -144,4 +144,8 @@ int64_t LocalPrimaryKeyRecover::tablet_id() {
     return _tablet->tablet_id();
 }
 
+StatusOr<PrimaryKeyEncodingType> LocalPrimaryKeyRecover::primary_key_encoding_type() const {
+    return PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1;
+}
+
 } // namespace starrocks

--- a/be/src/storage/local_primary_key_recover.h
+++ b/be/src/storage/local_primary_key_recover.h
@@ -42,6 +42,8 @@ public:
     // also consider sorting in data loading and compact concurrency scenarios
     static Status sort_rowsets(std::vector<RowsetSharedPtr>* rowsets);
 
+    StatusOr<PrimaryKeyEncodingType> primary_key_encoding_type() const override;
+
 private:
     Tablet* _tablet;
     UpdateManager* _update_mgr;

--- a/be/src/storage/local_tablet_reader.cpp
+++ b/be/src/storage/local_tablet_reader.cpp
@@ -116,8 +116,10 @@ Status LocalTabletReader::multi_get(const Chunk& keys, const std::vector<uint32_
         pk_columns.push_back((uint32_t)i);
     }
     MutableColumnPtr pk_column;
-    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(*tablet_schema->schema(), &pk_column));
-    PrimaryKeyEncoder::encode(*tablet_schema->schema(), keys, 0, keys.num_rows(), pk_column.get());
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(*tablet_schema->schema(), &pk_column,
+                                                     PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
+    PrimaryKeyEncoder::encode(*tablet_schema->schema(), keys, 0, keys.num_rows(), pk_column.get(),
+                              PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
 
     // search pks in pk index to get rowids
     EditVersion edit_version;

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -23,6 +23,7 @@
 #include "gen_cpp/olap_file.pb.h"
 #include "storage/chunk_aggregator.h"
 #include "storage/olap_define.h"
+#include "storage/primary_key_encoding_types.h"
 
 namespace starrocks {
 
@@ -84,8 +85,7 @@ public:
 
     ~MemTable();
 
-    // prepare the memtable for writing which must be called before writing any data
-    Status prepare();
+    Status prepare(PrimaryKeyEncodingType pk_encoding_type);
 
     int64_t tablet_id() const { return _tablet_id; }
 
@@ -171,6 +171,7 @@ private:
     size_t _aggregator_bytes_usage = 0;
 
     MemtableStats _stats;
+    PrimaryKeyEncodingType _pk_encoding_type = PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const MemTable& table) {

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -27,9 +27,10 @@ namespace starrocks {
 
 Status PrimaryKeyCompactionConflictResolver::execute() {
     Schema pkey_schema = generate_pkey_schema();
+    ASSIGN_OR_RETURN(auto encoding_type, primary_key_encoding_type());
 
     MutableColumnPtr pk_column;
-    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true));
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, encoding_type, true));
 
     // init rows mapper iter
     ASSIGN_OR_RETURN(auto filename, filename());
@@ -98,8 +99,9 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                                 }
                                 // 6. replace pk index
                                 TRACE_COUNTER_SCOPE_LATENCY_US("compaction_replace_index_latency_us");
-                                TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(),
-                                                                              col.get()));
+                                TRY_CATCH_BAD_ALLOC(
+                                        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get(),
+                                                                  encoding_type));
                                 RETURN_IF_ERROR(params.index->replace(params.rowset_id + segment_id, current_rowid,
                                                                       replace_indexes, *col));
                                 current_rowid += chunk->num_rows();

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -99,9 +99,8 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                                 }
                                 // 6. replace pk index
                                 TRACE_COUNTER_SCOPE_LATENCY_US("compaction_replace_index_latency_us");
-                                TRY_CATCH_BAD_ALLOC(
-                                        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get(),
-                                                                  encoding_type));
+                                TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(),
+                                                                              col.get(), encoding_type));
                                 RETURN_IF_ERROR(params.index->replace(params.rowset_id + segment_id, current_rowid,
                                                                       replace_indexes, *col));
                                 current_rowid += chunk->num_rows();

--- a/be/src/storage/primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.h
@@ -20,6 +20,7 @@
 #include "fs/fs.h"
 #include "storage/chunk_iterator.h"
 #include "storage/del_vector.h"
+#include "storage/primary_key_encoding_types.h"
 
 namespace starrocks {
 
@@ -46,6 +47,7 @@ public:
     // get_size() metadata calls (~10-50ms each), significantly improving performance
     // during parallel pk index execution where hundreds of mapper files are accessed.
     virtual StatusOr<FileInfo> filename() const = 0;
+    virtual StatusOr<PrimaryKeyEncodingType> primary_key_encoding_type() const = 0;
     virtual Schema generate_pkey_schema() = 0;
     virtual Status breakpoint_check() { return Status::OK(); }
     virtual Status segment_iterator(

--- a/be/src/storage/primary_key_encoding_types.h
+++ b/be/src/storage/primary_key_encoding_types.h
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace starrocks {
+
+/*
+ * PrimaryKeyEncodingType is used to specify the encoding type of primary key.
+ * V1: encode the primary key as original way.
+ * V2: always encode the primary key as big endian.
+ *
+ * We introduce this enum class to support compatibility with existing code.
+ * In general, we should encode the primary key using V2 which can
+ * preserve the key order after encoding. But for the historical reasons,
+ * if the there is only one pk column and it is not string type, it will
+ * not be encoded as big endian. For compatibility, we need to support the
+ * V1 encoding type to keep the original way.
+ *
+ * Currently, we only support V2 encoding type for range-distribution table
+ * in share data mode.
+ *
+ * PK_ENCODING_TYPE_NONE is not a valid encoding type, it is used to indicate for
+ * the non-primary key tablet for the compatibility issue and should not be used
+ * in any primary key encode context.
+*/
+enum class PrimaryKeyEncodingType {
+    PK_ENCODING_TYPE_NONE = 0,
+    PK_ENCODING_TYPE_V1 = 1,
+    PK_ENCODING_TYPE_V2 = 2,
+};
+
+} // namespace starrocks

--- a/be/src/storage/primary_key_recover.h
+++ b/be/src/storage/primary_key_recover.h
@@ -62,6 +62,8 @@ public:
 
     // delete pk index and delvec, then rebuild them
     Status recover();
+
+    virtual StatusOr<PrimaryKeyEncodingType> primary_key_encoding_type() const = 0;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -336,7 +336,9 @@ private:
                                   std::vector<std::unique_ptr<RowSourceMaskBuffer>>* rowsets_mask_buffer = nullptr) {
         MutableColumnPtr sort_column;
         if (schema.sort_key_idxes().size() > 1) {
-            if (!PrimaryKeyEncoder::create_column(schema, &sort_column, schema.sort_key_idxes()).ok()) {
+            if (!PrimaryKeyEncoder::create_column(schema, &sort_column, schema.sort_key_idxes(),
+                                                  PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1)
+                         .ok()) {
                 LOG(FATAL) << "create column for primary key encoder failed";
             }
         } else if (schema.sort_key_idxes().size() == 1 && schema.field(schema.sort_key_idxes()[0])->is_nullable()) {
@@ -638,7 +640,8 @@ Status compaction_merge_rowsets(Tablet& tablet, int64_t version, const vector<Ro
         }
     }();
     std::unique_ptr<RowsetMerger> merger;
-    auto key_type = PrimaryKeyEncoder::encoded_primary_key_type(schema, schema.sort_key_idxes());
+    auto key_type = PrimaryKeyEncoder::encoded_primary_key_type(schema, schema.sort_key_idxes(),
+                                                                PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
     switch (key_type) {
     case TYPE_BOOLEAN:
         merger = std::make_unique<RowsetMergerImpl<uint8_t>>();

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -136,7 +136,8 @@ Status RowsetUpdateState::_load_upserts(Rowset* rowset, uint32_t idx, Column* pk
             } else if (!st.ok()) {
                 return st;
             } else {
-                TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get()));
+                TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get(),
+                                                              PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
             }
         }
         RETURN_ERROR_IF_FALSE(col->size() == num_rows, "read segment: iter rows != num rows");
@@ -167,7 +168,8 @@ Status RowsetUpdateState::_do_load(Tablet* tablet, Rowset* rowset) {
     }
     Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
     MutableColumnPtr pk_column;
-    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
+    RETURN_IF_ERROR(
+            PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
     // if rowset is partial rowset, we need to load rowset totally because we don't support load multiple load
     // for partial update so far
     bool ignore_mem_limit =
@@ -200,7 +202,8 @@ Status RowsetUpdateState::load_deletes(Rowset* rowset, uint32_t idx) {
     }
     Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
     MutableColumnPtr pk_column;
-    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
+    RETURN_IF_ERROR(
+            PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
     return _load_deletes(rowset, idx, pk_column.get());
 }
 
@@ -212,7 +215,8 @@ Status RowsetUpdateState::load_upserts(Rowset* rowset, uint32_t upsert_id) {
     }
     Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
     MutableColumnPtr pk_column;
-    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true));
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column,
+                                                     PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1, true));
     return _load_upserts(rowset, upsert_id, pk_column.get());
 }
 

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -514,13 +514,18 @@ Status SchemaChangeWithSorting::process(TabletReader* reader, RowsetWriter* new_
     Schema new_schema = ChunkHelper::convert_schema(new_tablet->tablet_schema(), cids);
     auto char_field_indexes = ChunkHelper::get_char_field_indexes(new_schema);
 
+    PrimaryKeyEncodingType pk_encoding_type = PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE;
+    if (new_tschema->keys_type() == KeysType::PRIMARY_KEYS) {
+        ASSIGN_OR_RETURN(pk_encoding_type, new_tschema->primary_key_encoding_type_or_error());
+    }
+
     // memtable max buffer size set default 80% of memory limit so that it will do _merge() if reach limit
     // set max memtable size to 4G since some column has limit size, it will make invalid data
     size_t max_buffer_size = std::min<size_t>(
             4294967296, static_cast<size_t>(_memory_limitation * config::memory_ratio_for_sorting_schema_change));
     auto mem_table = std::make_unique<MemTable>(new_tablet->tablet_id(), &new_schema, &mem_table_sink, max_buffer_size,
                                                 CurrentThread::mem_tracker());
-    RETURN_IF_ERROR_WITH_WARN(mem_table->prepare(), alter_msg_header() + "failed to prepare mem table");
+    RETURN_IF_ERROR_WITH_WARN(mem_table->prepare(pk_encoding_type), alter_msg_header() + "failed to prepare mem table");
 
     auto selective = std::make_unique<std::vector<uint32_t>>();
     selective->resize(config::vector_chunk_size);
@@ -548,7 +553,8 @@ Status SchemaChangeWithSorting::process(TabletReader* reader, RowsetWriter* new_
             RETURN_IF_ERROR_WITH_WARN(mem_table->flush(), alter_msg_header() + "failed to flush mem table");
             mem_table = std::make_unique<MemTable>(new_tablet->tablet_id(), &new_schema, &mem_table_sink,
                                                    max_buffer_size, CurrentThread::mem_tracker());
-            RETURN_IF_ERROR_WITH_WARN(mem_table->prepare(), alter_msg_header() + "failed to prepare mem table");
+            RETURN_IF_ERROR_WITH_WARN(mem_table->prepare(pk_encoding_type),
+                                      alter_msg_header() + "failed to prepare mem table");
             VLOG(2) << alter_msg_header() << "SortSchemaChange memory usage: " << cur_usage << " after mem table flush "
                     << CurrentThread::mem_tracker()->consumption();
         }
@@ -593,7 +599,8 @@ Status SchemaChangeWithSorting::process(TabletReader* reader, RowsetWriter* new_
             RETURN_IF_ERROR_WITH_WARN(mem_table->flush(), alter_msg_header() + "failed to flush mem table");
             mem_table = std::make_unique<MemTable>(new_tablet->tablet_id(), &new_schema, &mem_table_sink,
                                                    max_buffer_size, CurrentThread::mem_tracker());
-            RETURN_IF_ERROR_WITH_WARN(mem_table->prepare(), alter_msg_header() + "failed to prepare mem table");
+            RETURN_IF_ERROR_WITH_WARN(mem_table->prepare(pk_encoding_type),
+                                      alter_msg_header() + "failed to prepare mem table");
         }
 
         mem_pool->clear();

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -245,8 +245,10 @@ Status TabletReader::_init_collector_for_pk_index_read() {
                                                         num_pk_eq_predicates, tablet_schema->num_key_columns()));
     }
     MutableColumnPtr pk_column;
-    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(*tablet_schema->schema(), &pk_column));
-    PrimaryKeyEncoder::encode(*tablet_schema->schema(), *keys, 0, keys->num_rows(), pk_column.get());
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(*tablet_schema->schema(), &pk_column,
+                                                     PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
+    PrimaryKeyEncoder::encode(*tablet_schema->schema(), *keys, 0, keys->num_rows(), pk_column.get(),
+                              PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
 
     // get rowid using pk index
     std::vector<uint64_t> rowids(1);

--- a/be/src/storage/update_compaction_state.cpp
+++ b/be/src/storage/update_compaction_state.cpp
@@ -77,7 +77,8 @@ Status CompactionState::_load_segments(Rowset* rowset, uint32_t segment_id) {
     Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
 
     MutableColumnPtr pk_column;
-    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true));
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column,
+                                                     PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1, true));
 
     RowsetReleaseGuard guard(rowset->shared_from_this());
     OlapReaderStatistics stats;
@@ -114,7 +115,8 @@ Status CompactionState::_load_segments(Rowset* rowset, uint32_t segment_id) {
             } else if (!st.ok()) {
                 return st;
             } else {
-                TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get()));
+                TRY_CATCH_BAD_ALLOC(PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get(),
+                                                              PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
             }
         }
         itr->close();

--- a/be/test/storage/lake/lake_persistent_index_parallel_compact_mgr_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_parallel_compact_mgr_test.cpp
@@ -167,8 +167,10 @@ protected:
             chunk->append_column(std::move(col), (SlotId)0);
 
             MutableColumnPtr pk_column;
-            RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
-            PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get());
+            const auto encoding_type = _tablet_metadata->has_range() ? PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2
+                                                                     : PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1;
+            RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, encoding_type));
+            PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get(), encoding_type);
             std::string key;
             if (pk_column->is_binary()) {
                 key = ColumnHelper::get_binary_column(pk_column.get())->get_slice(0).to_string();
@@ -1327,8 +1329,10 @@ TEST_F(LakePersistentIndexParallelCompactMgrTest, test_compact_with_tablet_range
         col->append_datum(Datum(v));
         chunk->append_column(std::move(col), (SlotId)0);
         MutableColumnPtr pk_column;
-        EXPECT_OK(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
-        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get());
+        EXPECT_OK(
+                PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2));
+        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get(),
+                                  PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
         if (pk_column->is_binary()) {
             return ColumnHelper::get_binary_column(pk_column.get())->get_slice(0).to_string();
         } else {
@@ -1414,8 +1418,10 @@ TEST_F(LakePersistentIndexParallelCompactMgrTest, test_compact_with_multi_column
         chunk->append_column(std::move(col2), (SlotId)1);
 
         MutableColumnPtr pk_column;
-        EXPECT_OK(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
-        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get());
+        EXPECT_OK(
+                PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2));
+        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get(),
+                                  PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
         return ColumnHelper::get_binary_column(pk_column.get())->get_slice(0).to_string();
     };
 

--- a/be/test/storage/lake/lake_persistent_index_parallel_compact_mgr_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_parallel_compact_mgr_test.cpp
@@ -1289,6 +1289,7 @@ TEST_F(LakePersistentIndexParallelCompactMgrTest, test_compact_with_tablet_range
     ASSERT_OK(mgr->init());
 
     // 1. Setup Tablet Metadata with a specific range [100, 200)
+    _tablet_metadata->mutable_schema()->set_primary_key_encoding_type(PK_ENCODING_TYPE_V2);
     auto* range = _tablet_metadata->mutable_range();
     auto* lower = range->mutable_lower_bound();
     auto* v_lower = lower->add_values();
@@ -1374,6 +1375,7 @@ TEST_F(LakePersistentIndexParallelCompactMgrTest, test_compact_with_multi_column
     c2->set_type("INT");
     c2->set_is_key(false);
     c2->set_is_nullable(false);
+    schema->set_primary_key_encoding_type(PK_ENCODING_TYPE_V2);
 
     auto mgr = std::make_unique<LakePersistentIndexParallelCompactMgr>(_tablet_mgr.get());
     ASSERT_OK(mgr->init());

--- a/be/test/storage/lake/tablet_range_helper_test.cpp
+++ b/be/test/storage/lake/tablet_range_helper_test.cpp
@@ -27,6 +27,7 @@ namespace starrocks::lake {
 TEST(TabletRangeHelperTest, test_create_sst_seek_range_from) {
     TabletSchemaPB schema_pb;
     schema_pb.set_keys_type(PRIMARY_KEYS);
+    schema_pb.set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
 
     // c0, c1 are keys
     auto c0 = schema_pb.add_column();
@@ -83,6 +84,7 @@ TEST(TabletRangeHelperTest, test_create_sst_seek_range_from) {
 TEST(TabletRangeHelperTest, test_non_nullable_key_rejects_null_range) {
     TabletSchemaPB schema_pb;
     schema_pb.set_keys_type(PRIMARY_KEYS);
+    schema_pb.set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
 
     auto c0 = schema_pb.add_column();
     c0->set_name("c0");
@@ -106,6 +108,36 @@ TEST(TabletRangeHelperTest, test_non_nullable_key_rejects_null_range) {
     ASSERT_FALSE(res.ok());
     ASSERT_TRUE(res.status().is_invalid_argument());
     ASSERT_EQ("Non-nullable primary key contains NULL in tablet range", res.status().message());
+}
+
+TEST(TabletRangeHelperTest, test_create_sst_seek_range_requires_v2_encoding) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(PRIMARY_KEYS);
+    schema_pb.set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1);
+
+    auto c0 = schema_pb.add_column();
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+
+    schema_pb.clear_sort_key_idxes();
+    schema_pb.add_sort_key_idxes(0);
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    TabletRangePB range_pb;
+    auto lower = range_pb.mutable_lower_bound();
+    auto v0 = lower->add_values();
+    TypeDescriptor type_int(TYPE_INT);
+    v0->mutable_type()->CopyFrom(type_int.to_protobuf());
+    v0->set_value("1");
+    range_pb.set_lower_bound_included(true);
+
+    auto res = TabletRangeHelper::create_sst_seek_range_from(range_pb, tablet_schema);
+    ASSERT_FALSE(res.ok());
+    ASSERT_TRUE(res.status().is_invalid_argument());
+    ASSERT_THAT(res.status().to_string(),
+                testing::HasSubstr("Big-endian encoding is required for range-distribution table in share data mode"));
 }
 
 TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_full_range) {

--- a/be/test/storage/memtable_flush_executor_test.cpp
+++ b/be/test/storage/memtable_flush_executor_test.cpp
@@ -274,7 +274,7 @@ TEST_F(MemTableFlushExecutorTest, testMemtableFlush) {
     const string path = "./MemTableFlushExecutorTest_testDupKeysInsertFlushRead";
     MySetUp("pk int,name varchar,pv int", "pk int,name varchar,pv int", 1, KeysType::DUP_KEYS, path);
     auto mem_table = make_unique<MemTable>(1, &_vectorized_schema, _slots, _mem_table_sink.get(), _mem_tracker.get());
-    ASSERT_TRUE(mem_table->prepare().ok());
+    ASSERT_TRUE(mem_table->prepare(PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1).ok());
     auto mem_table_flush_executor = make_unique<MemTableFlushExecutor>();
 
     std::vector<DataDir*> data_dirs = {nullptr, nullptr};
@@ -305,7 +305,7 @@ TEST_F(MemTableFlushExecutorTest, testMemtableFlushWithSeg) {
     const string path = "./MemTableFlushExecutorTest_testMemtableFlushWithSeg";
     MySetUp("pk int,name varchar,pv int", "pk int,name varchar,pv int", 1, KeysType::DUP_KEYS, path);
     auto mem_table = make_unique<MemTable>(1, &_vectorized_schema, _slots, _mem_table_sink.get(), _mem_tracker.get());
-    ASSERT_TRUE(mem_table->prepare().ok());
+    ASSERT_TRUE(mem_table->prepare(PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1).ok());
     auto mem_table_flush_executor = make_unique<MemTableFlushExecutor>();
 
     std::vector<DataDir*> data_dirs = {nullptr, nullptr};
@@ -419,7 +419,7 @@ TEST_F(MemTableFlushExecutorTest, testMemtableFlushWithSlotIdx) {
     for (int i = 0; i < 3; i++) {
         auto mem_table =
                 make_unique<MemTable>(1, &_vectorized_schema, _slots, _mem_table_sink.get(), _mem_tracker.get());
-        ASSERT_TRUE(mem_table->prepare().ok());
+        ASSERT_TRUE(mem_table->prepare(PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1).ok());
 
         auto pchunk = gen_chunk(*_slots, n);
         vector<uint32_t> indexes;
@@ -466,7 +466,7 @@ TEST_F(MemTableFlushExecutorTest, testWaitForTimeout) {
 
     const size_t n = 2000;
     auto mem_table = make_unique<MemTable>(1, &_vectorized_schema, _slots, _mem_table_sink.get(), _mem_tracker.get());
-    ASSERT_TRUE(mem_table->prepare().ok());
+    ASSERT_TRUE(mem_table->prepare(PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1).ok());
 
     auto pchunk = gen_chunk(*_slots, n);
     vector<uint32_t> indexes;
@@ -522,7 +522,7 @@ TEST_F(MemTableFlushExecutorTest, testParallelMemtableFinalize) {
 
     const size_t n = 2000;
     auto mem_table = make_unique<MemTable>(1, &_vectorized_schema, _slots, _mem_table_sink.get(), _mem_tracker.get());
-    ASSERT_TRUE(mem_table->prepare().ok());
+    ASSERT_TRUE(mem_table->prepare(PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1).ok());
 
     auto pchunk = gen_chunk(*_slots, n);
     vector<uint32_t> indexes;
@@ -559,7 +559,7 @@ TEST_F(MemTableFlushExecutorTest, testFinalizeIdempotent) {
 
     const size_t n = 1000;
     auto mem_table = make_unique<MemTable>(1, &_vectorized_schema, _slots, _mem_table_sink.get(), _mem_tracker.get());
-    ASSERT_TRUE(mem_table->prepare().ok());
+    ASSERT_TRUE(mem_table->prepare(PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1).ok());
 
     auto pchunk = gen_chunk(*_slots, n);
     vector<uint32_t> indexes;

--- a/be/test/storage/memtable_test.cpp
+++ b/be/test/storage/memtable_test.cpp
@@ -229,7 +229,7 @@ public:
         _vectorized_schema = MemTable::convert_schema(_schema, _slots);
         _mem_table =
                 std::make_unique<MemTable>(1, &_vectorized_schema, _slots, _mem_table_sink.get(), _mem_tracker.get());
-        ASSERT_TRUE(_mem_table->prepare().ok());
+        ASSERT_TRUE(_mem_table->prepare(PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1).ok());
     }
 
     void TearDown() override {

--- a/be/test/storage/primary_index_test.cpp
+++ b/be/test/storage/primary_index_test.cpp
@@ -376,8 +376,9 @@ PARALLEL_TEST(PrimaryIndexTest, test_composite_key) {
     }
 
     MutableColumnPtr pk_column;
-    PrimaryKeyEncoder::create_column(*schema, &pk_column);
-    PrimaryKeyEncoder::encode(*schema, *chunk, 0, chunk->num_rows(), pk_column.get());
+    PrimaryKeyEncoder::create_column(*schema, &pk_column, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
+    PrimaryKeyEncoder::encode(*schema, *chunk, 0, chunk->num_rows(), pk_column.get(),
+                              PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
 
     ASSERT_TRUE(pk_index->insert(0, 0, *pk_column).ok());
     LOG(INFO) << "pk_index memory:" << pk_index->memory_usage();

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -369,7 +369,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForBoolean) {
 TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForTinyint) {
     auto sc = create_key_schema({TYPE_TINYINT});
     std::vector<int8_t> sorted_values = {std::numeric_limits<int8_t>::min(), -1, 0, 1,
-                                          std::numeric_limits<int8_t>::max()};
+                                         std::numeric_limits<int8_t>::max()};
     auto pchunk = ChunkHelper::new_chunk(*sc, sorted_values.size());
     for (int8_t v : sorted_values) {
         Datum d;
@@ -383,7 +383,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForTinyint) {
 TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForSmallint) {
     auto sc = create_key_schema({TYPE_SMALLINT});
     std::vector<int16_t> sorted_values = {std::numeric_limits<int16_t>::min(), -1, 0, 1,
-                                           std::numeric_limits<int16_t>::max()};
+                                          std::numeric_limits<int16_t>::max()};
     auto pchunk = ChunkHelper::new_chunk(*sc, sorted_values.size());
     for (int16_t v : sorted_values) {
         Datum d;
@@ -396,11 +396,9 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForSmallint) {
 
 TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForLargeint) {
     auto sc = create_key_schema({TYPE_LARGEINT});
-    std::vector<int128_t> sorted_values = {std::numeric_limits<int128_t>::min(),
-                                            static_cast<int128_t>(-1),
-                                            static_cast<int128_t>(0),
-                                            static_cast<int128_t>(1),
-                                            std::numeric_limits<int128_t>::max()};
+    std::vector<int128_t> sorted_values = {std::numeric_limits<int128_t>::min(), static_cast<int128_t>(-1),
+                                           static_cast<int128_t>(0), static_cast<int128_t>(1),
+                                           std::numeric_limits<int128_t>::max()};
     auto pchunk = ChunkHelper::new_chunk(*sc, sorted_values.size());
     for (int128_t v : sorted_values) {
         Datum d;
@@ -494,8 +492,7 @@ TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForCompositeIntInt) 
     auto sc = create_key_schema({TYPE_INT, TYPE_BIGINT});
     // Pairs in ascending order: (int, bigint)
     auto pchunk = ChunkHelper::new_chunk(*sc, 5);
-    std::vector<std::pair<int32_t, int64_t>> sorted_pairs = {
-            {-100, -1000}, {-100, 0}, {0, -1}, {0, 0}, {100, 999}};
+    std::vector<std::pair<int32_t, int64_t>> sorted_pairs = {{-100, -1000}, {-100, 0}, {0, -1}, {0, 0}, {100, 999}};
     for (const auto& [v1, v2] : sorted_pairs) {
         Datum d1, d2;
         d1.set_int32(v1);
@@ -602,9 +599,9 @@ TEST(PrimaryKeyEncoderTest, testV2EncodeExceedLimitForComposite) {
 
     // 4 (int) + 100 (varchar) + 1 (escape for \0) + 2 (separator) + 2 (smallint) = 109
     EXPECT_FALSE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
-                                                         PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2));
-    EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 10,
                                                         PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2));
+    EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 10,
+                                                       PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2));
 }
 
 } // namespace starrocks

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -16,12 +16,15 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <memory>
 
+#include "column/binary_column.h"
 #include "column/chunk.h"
 #include "column/schema.h"
 #include "gutil/stringprintf.h"
 #include "storage/chunk_helper.h"
+#include "types/date_value.h"
 #include "types/datum.h"
 
 using namespace std;
@@ -46,7 +49,7 @@ static unique_ptr<Schema> create_key_schema(const vector<LogicalType>& types) {
 TEST(PrimaryKeyEncoderTest, testEncodeInt32) {
     auto sc = create_key_schema({TYPE_INT});
     MutableColumnPtr dest;
-    PrimaryKeyEncoder::create_column(*sc, &dest);
+    PrimaryKeyEncoder::create_column(*sc, &dest, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
     const int n = 1000;
     auto pchunk = ChunkHelper::new_chunk(*sc, n);
     for (int i = 0; i < n; i++) {
@@ -54,9 +57,9 @@ TEST(PrimaryKeyEncoderTest, testEncodeInt32) {
         tmp.set_int32(i * 2343);
         pchunk->mutable_columns()[0]->append_datum(tmp);
     }
-    PrimaryKeyEncoder::encode(*sc, *pchunk, 0, n, dest.get());
+    PrimaryKeyEncoder::encode(*sc, *pchunk, 0, n, dest.get(), PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
     auto dchunk = pchunk->clone_empty_with_schema();
-    PrimaryKeyEncoder::decode(*sc, *dest, 0, n, dchunk.get());
+    PrimaryKeyEncoder::decode(*sc, *dest, 0, n, dchunk.get(), PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
     ASSERT_EQ(pchunk->num_rows(), dchunk->num_rows());
     for (int i = 0; i < n; i++) {
         ASSERT_EQ(pchunk->get_column_by_index(0)->get(i).get_int32(),
@@ -67,7 +70,7 @@ TEST(PrimaryKeyEncoderTest, testEncodeInt32) {
 TEST(PrimaryKeyEncoderTest, testEncodeInt128) {
     auto sc = create_key_schema({TYPE_LARGEINT});
     MutableColumnPtr dest;
-    PrimaryKeyEncoder::create_column(*sc, &dest);
+    PrimaryKeyEncoder::create_column(*sc, &dest, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
     const int n = 1000;
     auto pchunk = ChunkHelper::new_chunk(*sc, n);
     for (int i = 0; i < n; i++) {
@@ -79,9 +82,10 @@ TEST(PrimaryKeyEncoderTest, testEncodeInt128) {
     for (int i = 0; i < n; i++) {
         indexes.emplace_back(i);
     }
-    PrimaryKeyEncoder::encode_selective(*sc, *pchunk, indexes.data(), n, dest.get());
+    PrimaryKeyEncoder::encode_selective(*sc, *pchunk, indexes.data(), n, dest.get(),
+                                        PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
     auto dchunk = pchunk->clone_empty_with_schema();
-    PrimaryKeyEncoder::decode(*sc, *dest, 0, n, dchunk.get());
+    PrimaryKeyEncoder::decode(*sc, *dest, 0, n, dchunk.get(), PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
     ASSERT_EQ(pchunk->num_rows(), dchunk->num_rows());
     for (int i = 0; i < n; i++) {
         ASSERT_EQ(pchunk->get_column_by_index(0)->get(i).get_int128(),
@@ -92,7 +96,7 @@ TEST(PrimaryKeyEncoderTest, testEncodeInt128) {
 TEST(PrimaryKeyEncoderTest, testEncodeComposite) {
     auto sc = create_key_schema({TYPE_INT, TYPE_VARCHAR, TYPE_SMALLINT, TYPE_BOOLEAN});
     MutableColumnPtr dest;
-    PrimaryKeyEncoder::create_column(*sc, &dest);
+    PrimaryKeyEncoder::create_column(*sc, &dest, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
     const int n = 1;
     auto pchunk = ChunkHelper::new_chunk(*sc, n);
     for (int i = 0; i < n; i++) {
@@ -115,9 +119,10 @@ TEST(PrimaryKeyEncoderTest, testEncodeComposite) {
     for (int i = 0; i < n; i++) {
         indexes.emplace_back(i);
     }
-    PrimaryKeyEncoder::encode_selective(*sc, *pchunk, indexes.data(), n, dest.get());
+    PrimaryKeyEncoder::encode_selective(*sc, *pchunk, indexes.data(), n, dest.get(),
+                                        PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
     auto dchunk = pchunk->clone_empty_with_schema();
-    PrimaryKeyEncoder::decode(*sc, *dest, 0, n, dchunk.get());
+    PrimaryKeyEncoder::decode(*sc, *dest, 0, n, dchunk.get(), PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
     ASSERT_EQ(pchunk->num_rows(), dchunk->num_rows());
     for (int i = 0; i < n; i++) {
         ASSERT_EQ(pchunk->get_column_by_index(0)->get(i).get_int32(),
@@ -147,8 +152,10 @@ TEST(PrimaryKeyEncoderTest, testEncodeCompositeLimit) {
         pchunk->mutable_columns()[2]->append_datum(tmp);
         tmp.set_uint8(1);
         pchunk->mutable_columns()[3]->append_datum(tmp);
-        EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 10));
-        EXPECT_FALSE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128));
+        EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 10,
+                                                           PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
+        EXPECT_FALSE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
+                                                            PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
     }
 
     {
@@ -166,7 +173,8 @@ TEST(PrimaryKeyEncoderTest, testEncodeCompositeLimit) {
         pchunk->mutable_columns()[2]->append_datum(tmp);
         tmp.set_uint8(1);
         pchunk->mutable_columns()[3]->append_datum(tmp);
-        EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128));
+        EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
+                                                           PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
     }
 }
 
@@ -184,7 +192,8 @@ TEST(PrimaryKeyEncoderTest, testEncodeVarcharLimit) {
                  "00000000000000000000000000000000000";
         tmp.set_slice(tmpstr);
         pchunk->mutable_columns()[0]->append_datum(tmp);
-        EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128));
+        EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
+                                                           PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
     }
     {
         auto pchunk = ChunkHelper::new_chunk(*sc, n);
@@ -195,8 +204,407 @@ TEST(PrimaryKeyEncoderTest, testEncodeVarcharLimit) {
         tmpstr = "slice00000000000000000000000000000000000";
         tmp.set_slice(tmpstr);
         pchunk->mutable_columns()[0]->append_datum(tmp);
-        EXPECT_FALSE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128));
+        EXPECT_FALSE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
+                                                            PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1));
     }
+}
+
+TEST(PrimaryKeyEncoderTest, testSingleIntV2EncodingRoundTripAndColumnType) {
+    auto sc = create_key_schema({TYPE_INT});
+    MutableColumnPtr v1_dest;
+    MutableColumnPtr v2_dest;
+
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(*sc, &v1_dest, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1).ok());
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(*sc, &v2_dest, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2).ok());
+    ASSERT_FALSE(v1_dest->is_binary());
+    ASSERT_TRUE(v2_dest->is_binary());
+
+    auto pchunk = ChunkHelper::new_chunk(*sc, 5);
+    std::vector<int32_t> values = {std::numeric_limits<int32_t>::min(), -1, 0, 1, std::numeric_limits<int32_t>::max()};
+    for (int32_t v : values) {
+        Datum d;
+        d.set_int32(v);
+        pchunk->mutable_columns()[0]->append_datum(d);
+    }
+
+    PrimaryKeyEncoder::encode(*sc, *pchunk, 0, pchunk->num_rows(), v2_dest.get(),
+                              PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
+    auto decoded = pchunk->clone_empty_with_schema();
+    ASSERT_TRUE(PrimaryKeyEncoder::decode(*sc, *v2_dest, 0, v2_dest->size(), decoded.get(),
+                                          PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2)
+                        .ok());
+    ASSERT_EQ(pchunk->num_rows(), decoded->num_rows());
+    for (int i = 0; i < pchunk->num_rows(); i++) {
+        ASSERT_EQ(pchunk->get_column_by_index(0)->get(i).get_int32(),
+                  decoded->get_column_by_index(0)->get(i).get_int32());
+    }
+}
+
+TEST(PrimaryKeyEncoderTest, testEncodedTypeAndFixedSizeByEncodingType) {
+    auto single_sc = create_key_schema({TYPE_INT});
+    std::vector<ColumnId> key_idxes = {0};
+
+    ASSERT_EQ(PrimaryKeyEncoder::encoded_primary_key_type(*single_sc, key_idxes,
+                                                          PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1),
+              TYPE_INT);
+    ASSERT_EQ(PrimaryKeyEncoder::encoded_primary_key_type(*single_sc, key_idxes,
+                                                          PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2),
+              TYPE_VARCHAR);
+    ASSERT_EQ(PrimaryKeyEncoder::get_encoded_fixed_size(*single_sc, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1), 4);
+    ASSERT_EQ(PrimaryKeyEncoder::get_encoded_fixed_size(*single_sc, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2), 0);
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForInt) {
+    auto sc = create_key_schema({TYPE_INT});
+    // Values spanning negative, zero, and positive range, including INT32 boundaries
+    std::vector<int32_t> sorted_values = {std::numeric_limits<int32_t>::min(), -1000, -1, 0, 1, 1000,
+                                          std::numeric_limits<int32_t>::max()};
+
+    MutableColumnPtr dest;
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(*sc, &dest, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2).ok());
+
+    auto pchunk = ChunkHelper::new_chunk(*sc, sorted_values.size());
+    for (int32_t v : sorted_values) {
+        Datum d;
+        d.set_int32(v);
+        pchunk->mutable_columns()[0]->append_datum(d);
+    }
+    PrimaryKeyEncoder::encode(*sc, *pchunk, 0, pchunk->num_rows(), dest.get(),
+                              PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
+
+    // Verify that encoded keys preserve the same order as original values
+    auto& bcol = down_cast<BinaryColumn&>(*dest);
+    for (size_t i = 1; i < bcol.size(); i++) {
+        Slice prev = bcol.get_slice(i - 1);
+        Slice curr = bcol.get_slice(i);
+        ASSERT_LT(prev.compare(curr), 0) << "Encoded key order violated at index " << i << ": value["
+                                         << sorted_values[i - 1] << "] should be < value[" << sorted_values[i] << "]";
+    }
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForBigint) {
+    auto sc = create_key_schema({TYPE_BIGINT});
+    std::vector<int64_t> sorted_values = {std::numeric_limits<int64_t>::min(), -1, 0, 1,
+                                          std::numeric_limits<int64_t>::max()};
+
+    MutableColumnPtr dest;
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(*sc, &dest, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2).ok());
+
+    auto pchunk = ChunkHelper::new_chunk(*sc, sorted_values.size());
+    for (int64_t v : sorted_values) {
+        Datum d;
+        d.set_int64(v);
+        pchunk->mutable_columns()[0]->append_datum(d);
+    }
+    PrimaryKeyEncoder::encode(*sc, *pchunk, 0, pchunk->num_rows(), dest.get(),
+                              PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
+
+    auto& bcol = down_cast<BinaryColumn&>(*dest);
+    for (size_t i = 1; i < bcol.size(); i++) {
+        Slice prev = bcol.get_slice(i - 1);
+        Slice curr = bcol.get_slice(i);
+        ASSERT_LT(prev.compare(curr), 0) << "Encoded key order violated at index " << i << ": value["
+                                         << sorted_values[i - 1] << "] should be < value[" << sorted_values[i] << "]";
+    }
+}
+
+TEST(PrimaryKeyEncoderTest, testEncodingTypeMappingFallback) {
+    auto invalid_pb = static_cast<PrimaryKeyEncodingTypePB>(9999);
+    auto invalid_internal = static_cast<PrimaryKeyEncodingType>(9999);
+
+    ASSERT_EQ(PrimaryKeyEncoder::encoding_type_from_pb(invalid_pb), PrimaryKeyEncodingType::PK_ENCODING_TYPE_NONE);
+    ASSERT_EQ(PrimaryKeyEncoder::pb_from_encoding_type(invalid_internal),
+              PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_NONE);
+}
+
+// ======================== V2 encoding tests ========================
+
+// Helper: encode with V2, then verify encoded keys preserve sort order via byte comparison
+static void verify_v2_sort_order_preserved(const Schema& schema, const Chunk& chunk, size_t n) {
+    MutableColumnPtr dest;
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &dest, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2).ok());
+    PrimaryKeyEncoder::encode(schema, chunk, 0, n, dest.get(), PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
+    ASSERT_TRUE(dest->is_binary());
+    auto& bcol = down_cast<BinaryColumn&>(*dest);
+    ASSERT_EQ(bcol.size(), n);
+    for (size_t i = 1; i < bcol.size(); i++) {
+        Slice prev = bcol.get_slice(i - 1);
+        Slice curr = bcol.get_slice(i);
+        ASSERT_LT(prev.compare(curr), 0) << "Encoded key order violated at index " << i;
+    }
+}
+
+// Helper: encode with V2, decode, and verify round-trip correctness
+static void verify_v2_round_trip(const Schema& schema, const Chunk& original) {
+    size_t n = original.num_rows();
+    MutableColumnPtr dest;
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &dest, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2).ok());
+    PrimaryKeyEncoder::encode(schema, original, 0, n, dest.get(), PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
+    auto decoded = original.clone_empty_with_schema();
+    ASSERT_TRUE(
+            PrimaryKeyEncoder::decode(schema, *dest, 0, n, decoded.get(), PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2)
+                    .ok());
+    ASSERT_EQ(n, decoded->num_rows());
+    for (size_t col = 0; col < schema.num_key_fields(); col++) {
+        for (size_t row = 0; row < n; row++) {
+            ASSERT_EQ(original.get_column_by_index(col)->get(row), decoded->get_column_by_index(col)->get(row))
+                    << "Mismatch at col=" << col << " row=" << row;
+        }
+    }
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForBoolean) {
+    auto sc = create_key_schema({TYPE_BOOLEAN});
+    auto pchunk = ChunkHelper::new_chunk(*sc, 2);
+    // false(0) < true(1)
+    for (uint8_t v : {(uint8_t)0, (uint8_t)1}) {
+        Datum d;
+        d.set_uint8(v);
+        pchunk->mutable_columns()[0]->append_datum(d);
+    }
+    verify_v2_sort_order_preserved(*sc, *pchunk, 2);
+    verify_v2_round_trip(*sc, *pchunk);
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForTinyint) {
+    auto sc = create_key_schema({TYPE_TINYINT});
+    std::vector<int8_t> sorted_values = {std::numeric_limits<int8_t>::min(), -1, 0, 1,
+                                          std::numeric_limits<int8_t>::max()};
+    auto pchunk = ChunkHelper::new_chunk(*sc, sorted_values.size());
+    for (int8_t v : sorted_values) {
+        Datum d;
+        d.set_int8(v);
+        pchunk->mutable_columns()[0]->append_datum(d);
+    }
+    verify_v2_sort_order_preserved(*sc, *pchunk, sorted_values.size());
+    verify_v2_round_trip(*sc, *pchunk);
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForSmallint) {
+    auto sc = create_key_schema({TYPE_SMALLINT});
+    std::vector<int16_t> sorted_values = {std::numeric_limits<int16_t>::min(), -1, 0, 1,
+                                           std::numeric_limits<int16_t>::max()};
+    auto pchunk = ChunkHelper::new_chunk(*sc, sorted_values.size());
+    for (int16_t v : sorted_values) {
+        Datum d;
+        d.set_int16(v);
+        pchunk->mutable_columns()[0]->append_datum(d);
+    }
+    verify_v2_sort_order_preserved(*sc, *pchunk, sorted_values.size());
+    verify_v2_round_trip(*sc, *pchunk);
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForLargeint) {
+    auto sc = create_key_schema({TYPE_LARGEINT});
+    std::vector<int128_t> sorted_values = {std::numeric_limits<int128_t>::min(),
+                                            static_cast<int128_t>(-1),
+                                            static_cast<int128_t>(0),
+                                            static_cast<int128_t>(1),
+                                            std::numeric_limits<int128_t>::max()};
+    auto pchunk = ChunkHelper::new_chunk(*sc, sorted_values.size());
+    for (int128_t v : sorted_values) {
+        Datum d;
+        d.set_int128(v);
+        pchunk->mutable_columns()[0]->append_datum(d);
+    }
+    verify_v2_sort_order_preserved(*sc, *pchunk, sorted_values.size());
+    verify_v2_round_trip(*sc, *pchunk);
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForDate) {
+    auto sc = create_key_schema({TYPE_DATE});
+    // DateValue stores julian day as int32_t internally
+    auto pchunk = ChunkHelper::new_chunk(*sc, 3);
+    // 2000-01-01, 2020-06-15, 2025-12-31
+    std::vector<std::string> date_strings = {"2000-01-01", "2020-06-15", "2025-12-31"};
+    for (const auto& s : date_strings) {
+        DateValue dv;
+        dv.from_string(s.c_str(), s.size());
+        Datum d;
+        d.set_date(dv);
+        pchunk->mutable_columns()[0]->append_datum(d);
+    }
+    verify_v2_sort_order_preserved(*sc, *pchunk, 3);
+    verify_v2_round_trip(*sc, *pchunk);
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForDatetime) {
+    auto sc = create_key_schema({TYPE_DATETIME});
+    auto pchunk = ChunkHelper::new_chunk(*sc, 3);
+    // TimestampValue stores microseconds as int64_t internally
+    std::vector<std::string> datetime_strings = {"2000-01-01 00:00:00", "2020-06-15 12:30:45", "2025-12-31 23:59:59"};
+    for (const auto& s : datetime_strings) {
+        TimestampValue tv;
+        tv.from_string(s.c_str(), s.size());
+        Datum d;
+        d.set_timestamp(tv);
+        pchunk->mutable_columns()[0]->append_datum(d);
+    }
+    verify_v2_sort_order_preserved(*sc, *pchunk, 3);
+    verify_v2_round_trip(*sc, *pchunk);
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodingRoundTripForSingleVarchar) {
+    auto sc = create_key_schema({TYPE_VARCHAR});
+    auto pchunk = ChunkHelper::new_chunk(*sc, 4);
+    std::vector<std::string> values = {"", "abc", "hello world", std::string("with\0null", 9)};
+    for (const auto& s : values) {
+        Datum d;
+        d.set_slice(Slice(s));
+        pchunk->mutable_columns()[0]->append_datum(d);
+    }
+    verify_v2_round_trip(*sc, *pchunk);
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForSingleVarchar) {
+    auto sc = create_key_schema({TYPE_VARCHAR});
+    auto pchunk = ChunkHelper::new_chunk(*sc, 4);
+    // Lexicographic order: "" < "aaa" < "aab" < "b"
+    std::vector<std::string> sorted_values = {"", "aaa", "aab", "b"};
+    for (const auto& s : sorted_values) {
+        Datum d;
+        d.set_slice(Slice(s));
+        pchunk->mutable_columns()[0]->append_datum(d);
+    }
+    verify_v2_sort_order_preserved(*sc, *pchunk, sorted_values.size());
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodingRoundTripForCompositeIntVarchar) {
+    auto sc = create_key_schema({TYPE_INT, TYPE_VARCHAR});
+    const int n = 10;
+    auto pchunk = ChunkHelper::new_chunk(*sc, n);
+    for (int i = 0; i < n; i++) {
+        Datum d_int;
+        d_int.set_int32(i * 100 - 500);
+        pchunk->mutable_columns()[0]->append_datum(d_int);
+
+        Datum d_str;
+        std::string s = StringPrintf("key_%04d", i);
+        if (i % 3 == 0) {
+            // inject \0 byte to test escape handling
+            s[2] = '\0';
+        }
+        d_str.set_slice(Slice(s));
+        pchunk->mutable_columns()[1]->append_datum(d_str);
+    }
+    verify_v2_round_trip(*sc, *pchunk);
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForCompositeIntInt) {
+    auto sc = create_key_schema({TYPE_INT, TYPE_BIGINT});
+    // Pairs in ascending order: (int, bigint)
+    auto pchunk = ChunkHelper::new_chunk(*sc, 5);
+    std::vector<std::pair<int32_t, int64_t>> sorted_pairs = {
+            {-100, -1000}, {-100, 0}, {0, -1}, {0, 0}, {100, 999}};
+    for (const auto& [v1, v2] : sorted_pairs) {
+        Datum d1, d2;
+        d1.set_int32(v1);
+        d2.set_int64(v2);
+        pchunk->mutable_columns()[0]->append_datum(d1);
+        pchunk->mutable_columns()[1]->append_datum(d2);
+    }
+    verify_v2_sort_order_preserved(*sc, *pchunk, sorted_pairs.size());
+    verify_v2_round_trip(*sc, *pchunk);
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodingPreservesSortOrderForCompositeVarcharInt) {
+    auto sc = create_key_schema({TYPE_VARCHAR, TYPE_INT});
+    auto pchunk = ChunkHelper::new_chunk(*sc, 4);
+    // Composite order: ("aaa", 1) < ("aaa", 2) < ("aab", -1) < ("b", 0)
+    std::vector<std::pair<std::string, int32_t>> sorted_pairs = {{"aaa", 1}, {"aaa", 2}, {"aab", -1}, {"b", 0}};
+    for (const auto& [s, v] : sorted_pairs) {
+        Datum d_str, d_int;
+        d_str.set_slice(Slice(s));
+        d_int.set_int32(v);
+        pchunk->mutable_columns()[0]->append_datum(d_str);
+        pchunk->mutable_columns()[1]->append_datum(d_int);
+    }
+    verify_v2_sort_order_preserved(*sc, *pchunk, sorted_pairs.size());
+    verify_v2_round_trip(*sc, *pchunk);
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodingRoundTripForCompositeAllTypes) {
+    auto sc = create_key_schema({TYPE_BOOLEAN, TYPE_TINYINT, TYPE_SMALLINT, TYPE_INT, TYPE_BIGINT, TYPE_VARCHAR});
+    const int n = 5;
+    auto pchunk = ChunkHelper::new_chunk(*sc, n);
+    for (int i = 0; i < n; i++) {
+        Datum d;
+        d.set_uint8(i % 2);
+        pchunk->mutable_columns()[0]->append_datum(d);
+
+        d.set_int8(static_cast<int8_t>(i * 10 - 20));
+        pchunk->mutable_columns()[1]->append_datum(d);
+
+        d.set_int16(static_cast<int16_t>(i * 100 - 200));
+        pchunk->mutable_columns()[2]->append_datum(d);
+
+        d.set_int32(i * 1000 - 2000);
+        pchunk->mutable_columns()[3]->append_datum(d);
+
+        d.set_int64(static_cast<int64_t>(i) * 10000 - 20000);
+        pchunk->mutable_columns()[4]->append_datum(d);
+
+        std::string s = StringPrintf("val_%d", i);
+        d.set_slice(Slice(s));
+        pchunk->mutable_columns()[5]->append_datum(d);
+    }
+    verify_v2_round_trip(*sc, *pchunk);
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodeSelectiveRoundTrip) {
+    auto sc = create_key_schema({TYPE_INT, TYPE_VARCHAR});
+    const int n = 6;
+    auto pchunk = ChunkHelper::new_chunk(*sc, n);
+    for (int i = 0; i < n; i++) {
+        Datum d_int;
+        d_int.set_int32(i * 111);
+        pchunk->mutable_columns()[0]->append_datum(d_int);
+        Datum d_str;
+        std::string s = StringPrintf("s%d", i);
+        d_str.set_slice(Slice(s));
+        pchunk->mutable_columns()[1]->append_datum(d_str);
+    }
+
+    // Select only even indices: 0, 2, 4
+    std::vector<uint32_t> indexes = {0, 2, 4};
+    MutableColumnPtr dest;
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(*sc, &dest, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2).ok());
+    PrimaryKeyEncoder::encode_selective(*sc, *pchunk, indexes.data(), indexes.size(), dest.get(),
+                                        PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2);
+    ASSERT_EQ(dest->size(), 3);
+
+    auto decoded = pchunk->clone_empty_with_schema();
+    ASSERT_TRUE(PrimaryKeyEncoder::decode(*sc, *dest, 0, 3, decoded.get(), PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2)
+                        .ok());
+    for (int i = 0; i < 3; i++) {
+        int orig_idx = indexes[i];
+        ASSERT_EQ(pchunk->get_column_by_index(0)->get(orig_idx).get_int32(),
+                  decoded->get_column_by_index(0)->get(i).get_int32());
+        ASSERT_EQ(pchunk->get_column_by_index(1)->get(orig_idx).get_slice(),
+                  decoded->get_column_by_index(1)->get(i).get_slice());
+    }
+}
+
+TEST(PrimaryKeyEncoderTest, testV2EncodeExceedLimitForComposite) {
+    auto sc = create_key_schema({TYPE_INT, TYPE_VARCHAR, TYPE_SMALLINT});
+    const int n = 1;
+    auto pchunk = ChunkHelper::new_chunk(*sc, n);
+    Datum d;
+    d.set_int32(42);
+    pchunk->mutable_columns()[0]->append_datum(d);
+    // VARCHAR with \0 byte to test escape overhead calculation
+    std::string s(100, 'x');
+    s[50] = '\0';
+    d.set_slice(Slice(s));
+    pchunk->mutable_columns()[1]->append_datum(d);
+    d.set_int16(10);
+    pchunk->mutable_columns()[2]->append_datum(d);
+
+    // 4 (int) + 100 (varchar) + 1 (escape for \0) + 2 (separator) + 2 (smallint) = 109
+    EXPECT_FALSE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128,
+                                                         PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2));
+    EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 10,
+                                                        PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2));
 }
 
 } // namespace starrocks

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -265,7 +265,8 @@ TEST_F(RowsetMergerTest, horizontal_merge) {
     EXPECT_EQ(pks.size(), read_tablet(_tablet, version));
     TestRowsetWriter writer;
     Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
-    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks).ok());
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1)
+                        .ok());
     ASSERT_TRUE(compaction_merge_rowsets(*_tablet, version, rowsets, &writer, cfg).ok());
     ASSERT_EQ(pks.size(), writer.all_pks->size());
     const auto* raw_pk_array = reinterpret_cast<const int64_t*>(writer.all_pks->raw_data());
@@ -313,7 +314,8 @@ TEST_F(RowsetMergerTest, vertical_merge) {
     EXPECT_EQ(pks.size(), read_tablet(_tablet, version));
     TestRowsetWriter writer;
     Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
-    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks).ok());
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1)
+                        .ok());
     writer.non_key_columns.emplace_back(Int16Column::create());
     writer.non_key_columns.emplace_back(Int32Column::create());
     ASSERT_TRUE(compaction_merge_rowsets(*_tablet, version, rowsets, &writer, cfg).ok());
@@ -374,7 +376,8 @@ TEST_F(RowsetMergerTest, horizontal_merge_seq) {
     EXPECT_EQ(pks.size(), read_tablet(_tablet, version));
     TestRowsetWriter writer;
     Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
-    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks).ok());
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1)
+                        .ok());
     ASSERT_TRUE(compaction_merge_rowsets(*_tablet, version, rowsets, &writer, cfg).ok());
     ASSERT_EQ(pks.size(), writer.all_pks->size());
     const auto* raw_pk_array = reinterpret_cast<const int64_t*>(writer.all_pks->raw_data());
@@ -421,7 +424,8 @@ TEST_F(RowsetMergerTest, vertical_merge_seq) {
     EXPECT_EQ(pks.size(), read_tablet(_tablet, version));
     TestRowsetWriter writer;
     Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
-    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks).ok());
+    ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1)
+                        .ok());
     writer.non_key_columns.emplace_back(Int16Column::create());
     writer.non_key_columns.emplace_back(Int32Column::create());
     ASSERT_TRUE(compaction_merge_rowsets(*_tablet, version, rowsets, &writer, cfg).ok());


### PR DESCRIPTION
## Why I'm doing:
In current implementation, we always encode the primary key without BIG_ENDIAN transformation if the there is only one pk column and it is not string type. Such encoding method can not perserve the key order after encoding which is bad for range-distribution table in share data mode.

## What I'm doing:
We use PrimaryKeyEncodingType in tabletschema to store the encoding type.
NONE: for non-primary key tablet for the compatibility issue and should not be used in any primary key encode context.
V1: encoding as the previous way.
v2: always encoding as big-endian way,
Currently, we only support V2 encoding type for range-distribution table in share data mode.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
