### PR TITLE
[Enhancement] Adapt load process for multi-version materialized indexes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -332,16 +332,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                 // use newLoadingTasks to save new created loading tasks and submit them later.
                 newLoadingTasks.add(task);
                 // load id will be added to loadStatistic when executing this task
-
-                // save all related tables and rollups in transaction state
-                TransactionState txnState =
-                        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionState(dbId, transactionId);
-                if (txnState == null) {
-                    throw new StarRocksException("txn does not exist: " + transactionId);
-                }
-                txnState.addTableIndexes(table);
             }
-
         } finally {
             locker.unLockDatabase(db.getId(), LockType.READ);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
@@ -90,7 +90,6 @@ import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.common.MetaUtils;
-import com.starrocks.transaction.TransactionState;
 import com.starrocks.type.PrimitiveType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -190,14 +189,6 @@ public class SparkLoadPendingTask extends LoadTask {
                             tableIdToPartitionIds.get(tableId));
                     etlTable = new EtlTable(etlIndexes, etlPartitionInfo);
                     tables.put(tableId, etlTable);
-
-                    // add table indexes to transaction state
-                    TransactionState txnState = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                            .getTransactionState(dbId, transactionId);
-                    if (txnState == null) {
-                        throw new LoadException("txn does not exist. id: " + transactionId);
-                    }
-                    txnState.addTableIndexes(table);
                 }
 
                 // file group

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -944,13 +944,11 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
                     add("label", label).
                     add("streamLoadTaskId", streamLoadTask.getId()));
 
-            // add table indexes to transaction state
             TransactionState txnState =
                     GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionState(db.getId(), txnId);
             if (txnState == null) {
                 throw new StarRocksException("txn does not exist: " + txnId);
             }
-            txnState.addTableIndexes(planner.getDestTable());
 
             planParams.setImport_label(txnState.getLabel());
             planParams.setDb_name(db.getFullName());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -815,7 +815,9 @@ public class OlapTableSink extends DataSink {
 
     private static void setMaterializedIndexes(TOlapTablePartition tPartition, List<MaterializedIndex> indexes) {
         for (MaterializedIndex index : indexes) {
-            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIdsInOrder());
+            // Because multiple versions of a materialized index cannot be loaded simultaneously,
+            // the `TOlapTableIndexTablets.index_id` is set to the `index meta id`.
+            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getMetaId(), index.getTabletIdsInOrder());
             tIndex.setTablets(index.getTablets().stream().map(tablet -> {
                 TOlapTableTablet tTablet = new TOlapTableTablet();
                 tTablet.setId(tablet.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -626,12 +626,6 @@ public class StatementPlanner {
                     sourceType,
                     session.getExecTimeout(),
                     session.getCurrentComputeResource());
-
-            // add table indexes to transaction state
-            if (targetTable instanceof OlapTable) {
-                TransactionState txnState = transactionMgr.getTransactionState(dbId, txnId);
-                txnState.addTableIndexes((OlapTable) targetTable);
-            }
         }
 
         stmt.setTxnId(txnId);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1021,7 +1021,7 @@ public class DatabaseTransactionMgr {
                         return false;
                     }
 
-                    List<MaterializedIndex> allIndices = txn.getPartitionLoadedTblIndexes(tableId, partition);
+                    List<MaterializedIndex> allIndices = txn.getPartitionLoadedIndexes(tableId, partition);
                     int quorumNum = partitionInfo.getQuorumNum(partition.getParentId(), table.writeQuorum());
                     int replicaNum = partitionInfo.getReplicationNum(partition.getParentId());
                     for (MaterializedIndex index : allIndices) {
@@ -1201,7 +1201,7 @@ public class DatabaseTransactionMgr {
                                 partitionInfo.getQuorumNum(physicalPartition.getParentId(), table.writeQuorum());
 
                         List<MaterializedIndex> allIndices =
-                                transactionState.getPartitionLoadedTblIndexes(tableId, physicalPartition);
+                                transactionState.getPartitionLoadedIndexesWithoutLock(tableId, physicalPartition);
                         for (MaterializedIndex index : allIndices) {
                             for (Tablet tablet : index.getTablets()) {
                                 int healthReplicaNum = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -148,7 +148,7 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
         List<Long> unfinishedTablets = null;
         for (Long partitionId : dirtyPartitionSet) {
             PhysicalPartition partition = table.getPhysicalPartition(partitionId);
-            List<MaterializedIndex> allIndices = txnState.getPartitionLoadedTblIndexes(table.getId(), partition);
+            List<MaterializedIndex> allIndices = txnState.getPartitionLoadedIndexesWithoutLock(table.getId(), partition);
             for (MaterializedIndex index : allIndices) {
                 Optional<Tablet> unfinishedTablet =
                         index.getTablets().stream().filter(t -> !finishedTabletsOfThisTable.contains(t.getId()))

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
@@ -53,7 +53,7 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
                 continue;
             }
             List<MaterializedIndex> allIndices =
-                    partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
+                    txnState.getPartitionLoadedIndexesWithoutLock(table.getId(), partition);
             for (MaterializedIndex index : allIndices) {
                 for (Tablet tablet : index.getTablets()) {
                     for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
@@ -109,7 +109,7 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
             short replicationNum = table.getPartitionInfo().getReplicationNum(partitionId);
             long version = partitionCommitInfo.getVersion();
             List<MaterializedIndex> allIndices =
-                    partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
+                    txnState.getPartitionLoadedIndexesWithoutLock(table.getId(), partition);
             List<String> skipUpdateReplicas = Lists.newArrayList();
             for (MaterializedIndex index : allIndices) {
                 for (Tablet tablet : index.getTablets()) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
@@ -177,7 +177,7 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
                 continue;
             }
 
-            List<MaterializedIndex> allIndices = txnState.getPartitionLoadedTblIndexes(table.getId(), partition);
+            List<MaterializedIndex> allIndices = txnState.getPartitionLoadedIndexesWithoutLock(table.getId(), partition);
             int quorumReplicaNum = table.getPartitionInfo().getQuorumNum(partition.getParentId(), table.writeQuorum());
             for (MaterializedIndex index : allIndices) {
                 for (Tablet tablet : index.getTablets()) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -591,7 +591,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
             for (int i = 0; i < transactionStates.size(); i++) {
                 TransactionState txnState = transactionStates.get(i);
                 computeResource = txnState.getComputeResource();
-                List<MaterializedIndex> indexes = txnState.getPartitionLoadedTblIndexes(table.getId(), partition);
+                List<MaterializedIndex> indexes = txnState.getPartitionLoadedIndexes(table.getId(), partition);
                 for (MaterializedIndex index : indexes) {
                     if (index.getState() == MaterializedIndex.IndexState.SHADOW) {
                         // sanity check. should not happen
@@ -914,7 +914,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
                 return false;
             }
             baseVersion = partition.getVisibleVersion();
-            List<MaterializedIndex> indexes = txnState.getPartitionLoadedTblIndexes(table.getId(), partition);
+            List<MaterializedIndex> indexes = txnState.getPartitionLoadedIndexes(table.getId(), partition);
             for (MaterializedIndex index : indexes) {
                 if (!index.visibleForTransaction(txnId)) {
                     LOG.info("Ignored index {} for transaction {}", table.getIndexNameByMetaId(index.getMetaId()), txnId);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionChecker.java
@@ -117,7 +117,7 @@ public class TransactionChecker {
                     PartitionChecker partitionChecker = new PartitionChecker(partitionId, partitionCommitInfo.getVersion(),
                             table.getPartitionInfo().getQuorumNum(partitionId, table.writeQuorum()));
                     List<MaterializedIndex> allIndices =
-                            txn.getPartitionLoadedTblIndexes(tableCommitInfo.getTableId(), partition);
+                            txn.getPartitionLoadedIndexes(tableCommitInfo.getTableId(), partition);
                     for (MaterializedIndex index : allIndices) {
                         for (Tablet tablet : index.getTablets()) {
                             partitionChecker.tablets.add((LocalTablet) tablet);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -35,6 +35,7 @@
 package com.starrocks.transaction;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -42,7 +43,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
-import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
@@ -338,9 +339,10 @@ public class TransactionState implements Writable, GsonPreProcessable {
     private ComputeResource computeResource = WarehouseManager.DEFAULT_RESOURCE;
 
     // this map should be set when load execution begin, so that when the txn commit, it will know
-    // which tables and rollups it loaded.
-    // tbl id -> (index ids)
-    private final Map<Long, Set<Long>> loadedTblIndexes = Maps.newHashMap();
+    // which tables, physical partitions and materialized indexes it loaded.
+    // tbl id -> (physical partition id -> (index ids))
+    @SerializedName("ltpi")
+    private final Map<Long, Map<Long, List<Long>>> loadedTblPartitionIndexes;
 
     // record some error msgs during the transaction operation.
     // this msg will be shown in show proc "/transactions/dbId/";
@@ -375,6 +377,14 @@ public class TransactionState implements Writable, GsonPreProcessable {
         txnLock.writeLock().unlock();
     }
 
+    public void readLock() {
+        txnLock.readLock().lock();
+    }
+
+    public void readUnlock() {
+        txnLock.readLock().unlock();
+    }
+
     public TransactionState() {
         this.dbId = -1;
         this.tableIdList = Lists.newArrayList();
@@ -393,6 +403,7 @@ public class TransactionState implements Writable, GsonPreProcessable {
         this.publishVersionTasks = Maps.newHashMap();
         this.hasSendTask = false;
         this.latch = new CountDownLatch(1);
+        this.loadedTblPartitionIndexes = Maps.newHashMap();
         this.txnSpan = TraceManager.startNoopSpan();
         this.traceParent = TraceManager.toTraceParent(txnSpan.getSpanContext());
 
@@ -420,6 +431,7 @@ public class TransactionState implements Writable, GsonPreProcessable {
         this.publishVersionTasks = Maps.newHashMap();
         this.hasSendTask = false;
         this.latch = new CountDownLatch(1);
+        this.loadedTblPartitionIndexes = Maps.newHashMap();
         this.callbackIdList = Lists.newArrayList(callbackId);
 
         this.timeoutMs = timeoutMs;
@@ -452,6 +464,7 @@ public class TransactionState implements Writable, GsonPreProcessable {
         this.publishVersionTasks = Maps.newHashMap();
         this.hasSendTask = false;
         this.latch = new CountDownLatch(1);
+        this.loadedTblPartitionIndexes = Maps.newHashMap();
         this.callbackIdList = Lists.newArrayList();
 
         this.timeoutMs = timeoutMs;
@@ -865,33 +878,65 @@ public class TransactionState implements Writable, GsonPreProcessable {
         return false;
     }
 
-    /*
-     * Add related table indexes to the transaction.
-     * If function should always be called before adding this transaction state to transaction manager,
-     * No other thread will access this state. So no need to lock
+    /**
+     * Add materialized index ids related to the loaded table and physical partition in the transaction.
      */
-    public void addTableIndexes(OlapTable table) {
-        Set<Long> indexIds = loadedTblIndexes.computeIfAbsent(table.getId(), k -> Sets.newHashSet());
-        // always equal the index ids
-        indexIds.clear();
-        // TODO(wyb): fix indexIds with partition
-        indexIds.addAll(table.getIndexMetaIdToMeta().keySet());
+    public void addPartitionLoadedIndexesWithoutLock(long tableId, long physicalPartitionId, List<Long> indexIds) {
+        Preconditions.checkState(!indexIds.isEmpty());
+        Map<Long, List<Long>> loadedPartitionIndexes = loadedTblPartitionIndexes.computeIfAbsent(
+                tableId, k -> Maps.newHashMap());
+        loadedPartitionIndexes.put(physicalPartitionId, indexIds);
     }
 
-    public List<MaterializedIndex> getPartitionLoadedTblIndexes(long tableId, PhysicalPartition partition) {
-        List<MaterializedIndex> loadedIndex;
-        if (loadedTblIndexes.isEmpty()) {
-            loadedIndex = partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
-        } else {
-            loadedIndex = Lists.newArrayList();
-            for (long indexId : loadedTblIndexes.get(tableId)) {
-                MaterializedIndex index = partition.getLatestIndex(indexId);
-                if (index != null) {
-                    loadedIndex.add(index);
+    public void addPartitionLoadedIndexes(long tableId, long physicalPartitionId, List<Long> indexIds) {
+        writeLock();
+        try {
+            addPartitionLoadedIndexesWithoutLock(tableId, physicalPartitionId, indexIds);
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    /**
+     * Get materialized indexes by table and physical partition from the transaction.
+     */
+    public List<MaterializedIndex> getPartitionLoadedIndexesWithoutLock(long tableId, PhysicalPartition physicalPartition) {
+        Map<Long, List<Long>> loadedPartitionIndexes = loadedTblPartitionIndexes.get(tableId);
+        if (loadedPartitionIndexes != null) {
+            List<Long> loadedIndexIds = loadedPartitionIndexes.get(physicalPartition.getId());
+            if (loadedIndexIds != null) {
+                List<MaterializedIndex> loadedIndexes = Lists.newArrayList();
+                List<Long> missingIndexIds = new ArrayList<>();
+
+                for (Long indexId : loadedIndexIds) {
+                    MaterializedIndex index = physicalPartition.getIndex(indexId);
+                    if (index != null) {
+                        loadedIndexes.add(index);
+                    } else {
+                        missingIndexIds.add(indexId);
+                    }
                 }
+
+                if (!missingIndexIds.isEmpty()) {
+                    LOG.warn("transaction {} has loaded materialized indexes {} which do not exist" +
+                                    " in table {} physical partition {}",
+                            getTransactionId(), missingIndexIds, tableId, physicalPartition.getId());
+                }
+
+                return loadedIndexes;
             }
         }
-        return loadedIndex;
+
+        return physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL);
+    }
+
+    public List<MaterializedIndex> getPartitionLoadedIndexes(long tableId, PhysicalPartition physicalPartition) {
+        readLock();
+        try {
+            return getPartitionLoadedIndexesWithoutLock(tableId, physicalPartition);
+        } finally {
+            readUnlock();
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -18,7 +18,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.Config;
@@ -442,7 +441,6 @@ public class TransactionStmtExecutor {
             }
             if (!txnState.getTableIdList().contains(targetTable.getId())) {
                 txnState.getTableIdList().add(targetTable.getId());
-                txnState.addTableIndexes((OlapTable) targetTable);
             }
 
             String label = txnState.getLabel();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -66,6 +66,8 @@ import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletLocation;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWriteQuorumType;
+import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.TransactionState;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.StringType;
 import com.starrocks.type.TypeFactory;
@@ -127,7 +129,8 @@ public class OlapTableSinkTest {
     }
 
     @Test
-    public void testSinglePartition() throws StarRocksException {
+    public void testSinglePartition(@Mocked GlobalStateMgr globalStateMgr,
+                                    @Mocked GlobalTransactionMgr globalTransactionMgr) throws StarRocksException {
         TupleDescriptor tuple = getTuple();
         SinglePartitionInfo partInfo = new SinglePartitionInfo();
         partInfo.setReplicationNum(2, (short) 3);
@@ -138,6 +141,14 @@ public class OlapTableSinkTest {
 
         new Expectations() {
             {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                globalTransactionMgr.getTransactionState(anyLong, anyLong);
+                result = new TransactionState();
+                globalStateMgr.getNodeMgr().getClusterInfo();
+                result = new SystemInfoService();
                 dstTable.getId();
                 result = 1;
                 dstTable.getPartitionInfo();
@@ -160,9 +171,10 @@ public class OlapTableSinkTest {
     }
 
     @Test
-    public void testRangePartition(
-            @Injectable RangePartitionInfo partInfo,
-            @Injectable MaterializedIndex index) throws StarRocksException {
+    public void testRangePartition(@Injectable RangePartitionInfo partInfo,
+                                   @Injectable MaterializedIndex index,
+                                   @Mocked GlobalStateMgr globalStateMgr,
+                                   @Mocked GlobalTransactionMgr globalTransactionMgr) throws StarRocksException {
         TupleDescriptor tuple = getTuple();
 
         HashDistributionInfo distInfo = new HashDistributionInfo(
@@ -176,6 +188,14 @@ public class OlapTableSinkTest {
 
         new Expectations() {
             {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                globalTransactionMgr.getTransactionState(anyLong, anyLong);
+                result = new TransactionState();
+                globalStateMgr.getNodeMgr().getClusterInfo();
+                result = new SystemInfoService();
                 dstTable.getId();
                 result = 1;
                 dstTable.getPartitionInfo();
@@ -299,7 +319,7 @@ public class OlapTableSinkTest {
         tPartition.setId(physicalPartitionId);
         partitionParam.addToPartitions(tPartition);
         TOlapTableLocationParam param = OlapTableSink.createLocation(
-                table, partitionParam, false);
+                table, partitionParam, false, null);
         System.out.println(param);
 
         // Check
@@ -404,7 +424,7 @@ public class OlapTableSinkTest {
         tPartition.setId(physicalPartitionId);
         partitionParam.addToPartitions(tPartition);
         TOlapTableLocationParam param = OlapTableSink.createLocation(
-                table, partitionParam, true);
+                table, partitionParam, true, null);
         System.out.println(param);
 
         // Check
@@ -425,7 +445,8 @@ public class OlapTableSinkTest {
     }
 
     @Test
-    public void testSingleListPartition() throws StarRocksException {
+    public void testSingleListPartition(@Mocked GlobalStateMgr globalStateMgr,
+                                        @Mocked GlobalTransactionMgr globalTransactionMgr) throws StarRocksException {
         TupleDescriptor tuple = getTuple();
         ListPartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST,
                 Lists.newArrayList(new Column("province", StringType.STRING)));
@@ -441,6 +462,14 @@ public class OlapTableSinkTest {
 
         new Expectations() {
             {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                globalTransactionMgr.getTransactionState(anyLong, anyLong);
+                result = new TransactionState();
+                globalStateMgr.getNodeMgr().getClusterInfo();
+                result = new SystemInfoService();
                 dstTable.getId();
                 result = 1;
                 dstTable.getPartitions();
@@ -465,7 +494,8 @@ public class OlapTableSinkTest {
     }
 
     @Test
-    public void testImmutablePartition() throws StarRocksException {
+    public void testImmutablePartition(@Mocked GlobalStateMgr globalStateMgr,
+                                       @Mocked GlobalTransactionMgr globalTransactionMgr) throws StarRocksException {
         TupleDescriptor tuple = getTuple();
         SinglePartitionInfo partInfo = new SinglePartitionInfo();
         partInfo.setReplicationNum(2, (short) 3);
@@ -484,6 +514,14 @@ public class OlapTableSinkTest {
 
         new Expectations() {
             {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                globalTransactionMgr.getTransactionState(anyLong, anyLong);
+                result = new TransactionState();
+                globalStateMgr.getNodeMgr().getClusterInfo();
+                result = new SystemInfoService();
                 dstTable.getId();
                 result = 1;
                 dstTable.getPartitionInfo();
@@ -507,7 +545,8 @@ public class OlapTableSinkTest {
     }
 
     @Test
-    public void testInitialOpenPartition() throws StarRocksException {
+    public void testInitialOpenPartition(@Mocked GlobalStateMgr globalStateMgr,
+                                         @Mocked GlobalTransactionMgr globalTransactionMgr) throws StarRocksException {
         TupleDescriptor tuple = getTuple();
         SinglePartitionInfo partInfo = new SinglePartitionInfo();
         partInfo.setReplicationNum(2, (short) 3);
@@ -526,6 +565,14 @@ public class OlapTableSinkTest {
 
         new Expectations() {
             {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                globalTransactionMgr.getTransactionState(anyLong, anyLong);
+                result = new TransactionState();
+                globalStateMgr.getNodeMgr().getClusterInfo();
+                result = new SystemInfoService();
                 dstTable.getId();
                 result = 1;
                 dstTable.getPartitionInfo();
@@ -553,7 +600,8 @@ public class OlapTableSinkTest {
     }
 
     @Test
-    public void testSchemaChangeOpenPartition() throws StarRocksException {
+    public void testSchemaChangeOpenPartition(@Mocked GlobalStateMgr globalStateMgr,
+                                              @Mocked GlobalTransactionMgr globalTransactionMgr) throws StarRocksException {
         TupleDescriptor tuple = getTuple();
         SinglePartitionInfo partInfo = new SinglePartitionInfo();
         partInfo.setReplicationNum(2, (short) 3);
@@ -570,6 +618,14 @@ public class OlapTableSinkTest {
 
         new Expectations() {
             {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                globalTransactionMgr.getTransactionState(anyLong, anyLong);
+                result = new TransactionState();
+                globalStateMgr.getNodeMgr().getClusterInfo();
+                result = new SystemInfoService();
                 dstTable.getId();
                 result = 1;
                 dstTable.getPartitionInfo();
@@ -737,7 +793,7 @@ public class OlapTableSinkTest {
         TOlapTablePartition tPartition = new TOlapTablePartition();
         tPartition.setId(physicalPartitionId);
         partitionParam.addToPartitions(tPartition);
-        TOlapTableLocationParam param = OlapTableSink.createLocation(table, partitionParam, false);
+        TOlapTableLocationParam param = OlapTableSink.createLocation(table, partitionParam, false, null);
         LOG.warn("TableLocationParam: {}", param);
         // Check
         List<TTabletLocation> locations = param.getTablets();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest2.java
@@ -71,7 +71,7 @@ public class OlapTableSinkTest2 {
         }
 
         try {
-            OlapTableSink.createLocation(olapTable, partitionParam, false);
+            OlapTableSink.createLocation(olapTable, partitionParam, false, null);
         } catch (StarRocksException e) {
             System.out.println(e.getMessage());
             Assertions.assertTrue(e.getMessage().contains("replicas: 10001:1/-1/1/0:NORMAL:ALIVE"));

--- a/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorMockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorMockTest.java
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.pseudocluster.PseudoCluster;
+import com.starrocks.rpc.ThriftRPCRequestExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.thrift.TMasterOpResult;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class LeaderOpExecutorMockTest {
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+    private static PseudoCluster cluster;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        Config.bdbje_heartbeat_timeout_second = 60;
+        Config.bdbje_replica_ack_timeout_second = 60;
+        Config.bdbje_lock_timeout_second = 60;
+        // set some parameters to speedup test
+        Config.tablet_sched_checker_interval_seconds = 1;
+        Config.tablet_sched_repair_delay_factor_second = 1;
+        Config.enable_new_publish_mechanism = true;
+        PseudoCluster.getOrCreateWithRandomPort(true, 1);
+        GlobalStateMgr.getCurrentState().getTabletChecker().setInterval(1000);
+        cluster = PseudoCluster.getInstance();
+
+        FeConstants.runningUnitTest = true;
+        Config.alter_scheduler_interval_millisecond = 100;
+        Config.dynamic_partition_enable = true;
+        Config.dynamic_partition_check_interval_seconds = 1;
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+        starRocksAssert.withDatabase("d1").useDatabase("d1")
+                .withTable(
+                        "CREATE TABLE d1.t1(k1 int, k2 int, k3 int)" +
+                                " distributed by hash(k1) buckets 3 properties('replication_num' = '1');")
+                .withTable(
+                        "CREATE TABLE d1.t2(k1 int, k2 int, k3 int)" +
+                                " distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
+    }
+
+    @Test
+    public void testTxnForward() throws Exception {
+        String sql = "begin";
+        StatementBase stmtBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+
+        TMasterOpResult tMasterOpResult = new TMasterOpResult();
+        tMasterOpResult.setTxn_id(1);
+
+        try (MockedStatic<ThriftRPCRequestExecutor> thriftConnectionPoolMockedStatic =
+                Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
+            thriftConnectionPoolMockedStatic.when(()
+                            -> ThriftRPCRequestExecutor.call(Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
+                    .thenReturn(tMasterOpResult);
+            LeaderOpExecutor executor =
+                    new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(), connectContext, RedirectStatus.FORWARD_NO_SYNC, false,
+                            null);
+            executor.execute();
+
+            Assertions.assertEquals(1, connectContext.getTxnId());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorTest.java
@@ -22,7 +22,6 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.rpc.ThriftConnectionPool;
-import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendServiceImpl;
 import com.starrocks.sql.ast.OriginStatement;
@@ -38,8 +37,6 @@ import org.apache.thrift.TException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 public class LeaderOpExecutorTest {
     private static ConnectContext connectContext;
@@ -78,7 +75,6 @@ public class LeaderOpExecutorTest {
 
     @Test
     public void testResourceGroupNameInAuditLog() throws Exception {
-
         String createGroup = "create resource group rg1\n" +
                 "to\n" +
                 "    (db='d1')\n" +
@@ -159,27 +155,5 @@ public class LeaderOpExecutorTest {
         TMasterOpRequest request = executor.createTMasterOpRequest(connectContext, 1);
         Assertions.assertEquals(catalog, request.getCatalog());
         Assertions.assertEquals(database, request.getDb());
-    }
-
-    @Test
-    public void testTxnForward() throws Exception {
-        String sql = "begin";
-        StatementBase stmtBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-
-        TMasterOpResult tMasterOpResult = new TMasterOpResult();
-        tMasterOpResult.setTxn_id(1);
-
-        try (MockedStatic<ThriftRPCRequestExecutor> thriftConnectionPoolMockedStatic =
-                Mockito.mockStatic(ThriftRPCRequestExecutor.class)) {
-            thriftConnectionPoolMockedStatic.when(()
-                            -> ThriftRPCRequestExecutor.call(Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
-                    .thenReturn(tMasterOpResult);
-            LeaderOpExecutor executor =
-                    new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(), connectContext, RedirectStatus.FORWARD_NO_SYNC, false,
-                            null);
-            executor.execute();
-
-            Assertions.assertEquals(1, connectContext.getTxnId());
-        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -21,7 +21,6 @@ import com.starrocks.alter.LakeTableSchemaChangeJob;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.GlobalStateMgrTestUtil;
 import com.starrocks.catalog.MaterializedIndex;
-import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
@@ -631,7 +630,7 @@ public class LakePublishBatchTest {
                         "txn1" + "_" + UUIDUtil.genUUID().toString(), transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         TransactionState txnState1 = globalTransactionMgr.getTransactionState(db.getId(), txn1);
-        txnState1.addTableIndexes((OlapTable) table);
+        txnState1.addPartitionLoadedIndexes(table.getId(), physicalPartition.getId(), Lists.newArrayList(normalIndex.getId()));
         List<TabletCommitInfo> commitInfo1 = commitAllTablets(List.of(normalTablet));
 
         // do a schema change, which will create a shadow index
@@ -658,7 +657,8 @@ public class LakePublishBatchTest {
                         "txn2" + "_" + UUIDUtil.genUUID().toString(), transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         TransactionState txnState2 = globalTransactionMgr.getTransactionState(db.getId(), txn2);
-        txnState2.addTableIndexes((OlapTable) table);
+        txnState2.addPartitionLoadedIndexes(table.getId(), physicalPartition.getId(),
+                Lists.newArrayList(normalIndex.getId(), shadowIndex.getId()));
         List<TabletCommitInfo> commitInfo2 = commitAllTablets(List.of(normalTablet, shadowTablet));
 
         // txn3 includes tablets of both base index and shadow index
@@ -666,7 +666,8 @@ public class LakePublishBatchTest {
                 "txn3" + "_" + UUIDUtil.genUUID().toString(), transactionSource,
                 TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         TransactionState txnState3 = globalTransactionMgr.getTransactionState(db.getId(), txn3);
-        txnState3.addTableIndexes((OlapTable) table);
+        txnState3.addPartitionLoadedIndexes(table.getId(), physicalPartition.getId(),
+                Lists.newArrayList(normalIndex.getId(), shadowIndex.getId()));
         List<TabletCommitInfo> commitInfo3 = commitAllTablets(List.of(normalTablet, shadowTablet));
 
         // commit in the order of txn2, tnx1, and txn3

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -70,6 +70,8 @@ message POlapTableColumnParam {
 };
 
 message POlapTableIndexSchema {
+    // Because multiple versions of a materialized index cannot be loaded simultaneously,
+    // the `id` is set to the `index meta id`.
     required int64 id = 1;
     repeated string columns = 2;
     required int32 schema_hash = 3;

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -287,6 +287,8 @@ struct TOlapTableTablet {
 }
 
 struct TOlapTableIndexTablets {
+    // Because multiple versions of a materialized index cannot be loaded simultaneously,
+    // the `index id` is set to the `index meta id`.
     1: required i64 index_id
     2: required list<i64> tablet_ids
     3: optional list<TOlapTableTablet> tablets
@@ -342,7 +344,9 @@ struct TOlapTableColumnParam {
 }
 
 struct TOlapTableIndexSchema {
-    1: required i64 id // index id
+    // Because multiple versions of a materialized index cannot be loaded simultaneously,
+    // the `id` is set to the `index meta id`.
+    1: required i64 id
     2: required list<string> columns
     3: required i32 schema_hash
     4: optional TOlapTableColumnParam column_param


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. Refactor `TransactionState`: Replace the table-level `loadedTblIndexes` with `loadedTblPartitionIndexes`. This allows the transaction to record exactly which materialized indexes are being written to for each specific physical partition.
2. Update `OlapTableSink`: Modified to register the loaded indexes into `TransactionState` during the partition creation phase. This ensures that location creation and subsequent commit/publish phases use the correct set of indexes.
3. Update Load/Delete Jobs: Updated `LakeDeleteJob`, `OlapDeleteJob`, and `FrontendServiceImpl` (Stream Load) to calculate and register the affected materialized indexes per physical partition.
4. Compatibility: Updated `TransactionState.getPartitionLoadedIndexes` to return the specific loaded indexes if recorded; otherwise, it falls back to returning all visible indexes (IndexExtState.ALL) for the physical partition.
5. Spark load does not support range distribution table.


https://github.com/StarRocks/starrocks/issues/64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
