### PR TITLE
[Enhancement] Support enable global shuffle in iceberg table sink dynamically (backport #67442)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorSinkShuffleMode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorSinkShuffleMode.java
@@ -1,0 +1,48 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public enum ConnectorSinkShuffleMode {
+    FORCE("force"),
+    AUTO("auto"),
+    NEVER("never");
+
+    private final String modeName;
+
+    ConnectorSinkShuffleMode(String modeName) {
+        this.modeName = modeName;
+    }
+
+    public static ConnectorSinkShuffleMode fromName(String modeName) {
+        checkArgument(modeName != null, "Connector sink shuffle mode name is null");
+
+        if (FORCE.modeName().equalsIgnoreCase(modeName)) {
+            return FORCE;
+        } else if (AUTO.modeName().equalsIgnoreCase(modeName)) {
+            return AUTO;
+        } else if (NEVER.modeName().equalsIgnoreCase(modeName)) {
+            return NEVER;
+        } else {
+            throw new IllegalArgumentException(
+                    "Unknown connector sink shuffle mode: " + modeName + ", only support force, auto, and never");
+        }
+    }
+
+    public String modeName() {
+        return modeName;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -53,6 +53,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.connector.ConnectorSinkShuffleMode;
 import com.starrocks.connector.PlanMode;
 import com.starrocks.datacache.DataCachePopulateMode;
 import com.starrocks.monitor.unit.TimeValue;
@@ -554,7 +555,26 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // when writing to fewer partitions. Therefore, we introduce a new invisible session variable with a default
     // false value temporarily. Once we can handle the shuffle behavior automatically to avoid some bad cases,
     // We will make it be controlled by the common connector session.
+    // Deprecated: Use connector_sink_shuffle_mode instead
     public static final String ENABLE_ICEBERG_SINK_GLOBAL_SHUFFLE = "enable_iceberg_sink_global_shuffle";
+
+    // Control global shuffle mode for connector table sink (Iceberg, Hive, File, etc.)
+    // Supports three modes:
+    // - force: Always enable global shuffle
+    // - auto: Automatically decide based on partition count and backend count (adaptive)
+    // - never: Never enable global shuffle
+    // Default is "auto" for adaptive optimization.
+    public static final String CONNECTOR_SINK_SHUFFLE_MODE = "connector_sink_shuffle_mode";
+
+    // The absolute threshold of partition count to enable adaptive global shuffle.
+    // When the estimated partition count is >= this value, adaptive shuffle will be enabled.
+    // Default is 500 partitions.
+    public static final String CONNECTOR_SINK_SHUFFLE_PARTITION_THRESHOLD = "connector_sink_shuffle_partition_threshold";
+
+    // The ratio of partition count to backend count to enable adaptive global shuffle.
+    // When estimated partition count >= backend count * this ratio, adaptive shuffle will be enabled.
+    // Default is 2.0 (i.e., enable shuffle when partitions >= backends * 2).
+    public static final String CONNECTOR_SINK_SHUFFLE_PARTITION_NODE_RATIO = "connector_sink_shuffle_partition_node_ratio";
 
     public static final String ENABLE_CONNECTOR_SINK_SPILL = "enable_connector_sink_spill";
     public static final String CONNECTOR_SINK_SPILL_MEM_LIMIT_THRESHOLD = "connector_sink_spill_mem_limit_threshold";
@@ -1430,8 +1450,19 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkGlobalShuffle = true;
 
+    // Deprecated: Use connector_sink_shuffle_mode instead
     @VariableMgr.VarAttr(name = ENABLE_ICEBERG_SINK_GLOBAL_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean enableIcebergSinkGlobalShuffle = false;
+
+    @VariableMgr.VarAttr(name = CONNECTOR_SINK_SHUFFLE_MODE)
+    private String connectorSinkShuffleMode = ConnectorSinkShuffleMode.AUTO.modeName();
+
+    @VariableMgr.VarAttr(name = CONNECTOR_SINK_SHUFFLE_PARTITION_THRESHOLD, flag = VariableMgr.INVISIBLE)
+    private long connectorSinkShufflePartitionThreshold = 500;
+
+    @VariableMgr.VarAttr(name = CONNECTOR_SINK_SHUFFLE_PARTITION_NODE_RATIO, flag = VariableMgr.INVISIBLE)
+    private double connectorSinkShufflePartitionNodeRatio = 2.0;
+
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_SINK_SPILL, flag = VariableMgr.INVISIBLE)
     private boolean enableConnectorSinkSpill = true;
 
@@ -4280,8 +4311,25 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableConnectorSinkGlobalShuffle;
     }
 
+    public ConnectorSinkShuffleMode getConnectorSinkShuffleMode() {
+        ConnectorSinkShuffleMode mode = ConnectorSinkShuffleMode.fromName(this.connectorSinkShuffleMode);
+        // Backward compatibility: legacy iceberg-only boolean implies FORCE when new mode stays at default AUTO.
+        if (mode == ConnectorSinkShuffleMode.AUTO && enableIcebergSinkGlobalShuffle) {
+            return ConnectorSinkShuffleMode.FORCE;
+        }
+        return mode;
+    }
+
     public boolean isEnableIcebergSinkGlobalShuffle() {
         return enableIcebergSinkGlobalShuffle;
+    }
+
+    public long getConnectorSinkShufflePartitionThreshold() {
+        return connectorSinkShufflePartitionThreshold;
+    }
+
+    public double getConnectorSinkShufflePartitionNodeRatio() {
+        return connectorSinkShufflePartitionNodeRatio;
     }
 
     public boolean isEnableConnectorSinkSpill() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPartitionEstimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPartitionEstimator.java
@@ -1,0 +1,890 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Field;
+import com.starrocks.sql.analyzer.RelationFields;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.Relation;
+import com.starrocks.sql.ast.SelectList;
+import com.starrocks.sql.ast.SelectListItem;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.ast.expression.CastExpr;
+import com.starrocks.sql.ast.expression.CompoundPredicate;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.InPredicate;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Estimator for partition count based on query predicates.
+ *
+ * This class provides static utility methods for estimating partition count
+ * using multiple strategies:
+ *
+ * 1. Predicate-based estimation (WHERE clause analysis) - uses inner class PredicateEstimator
+ * 2. Statistics-based estimation (NDV)
+ * 3. Existing partition count from metadata
+ *
+ * The estimator supports column mapping from SELECT output columns to target
+ * table partition columns, allowing proper estimation even when source and target
+ * tables have different partition column names.
+ *
+ * Estimation logic:
+ * 1. Equality predicates (col = value): typically selects 1 value per column
+ * 2. OR predicates (col = 'x' OR col = 'y'): count the number of distinct values
+ * 3. IN predicates (col IN (...)): count the number of values in the list
+ * 4. Range predicates (col > value): estimate using NDV statistics (10% selectivity)
+ *
+ * Examples:
+ * - dt = '2024-01-01' AND country = 'US'  -> 1 partition
+ * - dt = '2024-01-01' AND (country = 'US' OR country = 'CA')  -> 2 partitions
+ * - dt IN ('2024-01-01', '2024-01-02') AND country = 'US'  -> 2 partitions
+ * - dt > '2024-01-01'  -> estimated based on NDV (e.g., 10% of total partitions)
+ */
+public class InsertPartitionEstimator {
+    private static final Logger LOG = LogManager.getLogger(InsertPartitionEstimator.class);
+
+    // Private constructor to prevent instantiation - this is a utility class
+    private InsertPartitionEstimator() {
+    }
+
+    /**
+     * Estimate partition count for an INSERT operation.
+     * This is the main entry point that fetches all necessary metadata and estimates partition count.
+     *
+     * @param insertStmt the INSERT statement
+     * @param table the target table (can be any Table implementation: Iceberg, Hive, etc.)
+     * @return estimated partition count, -1 means unable to estimate
+     */
+    public static long estimatePartitionCountForInsert(InsertStmt insertStmt, Table table) {
+        long existingPartitionCount = 0;
+        boolean metadataAvailable = false;
+        try {
+            // Try to get current partition count from table metadata
+            List<String> partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                    .listPartitionNames(table.getCatalogName(),
+                            table.getCatalogDBName(),
+                            table.getCatalogTableName(),
+                            new ConnectorMetadatRequestContext());
+            existingPartitionCount = partitionNames.size();
+            metadataAvailable = true;
+
+            // Check if there's a WHERE predicate
+            QueryRelation queryRelation = insertStmt.getQueryStatement().getQueryRelation();
+            boolean hasWherePredicate = false;
+            if (queryRelation instanceof SelectRelation) {
+                SelectRelation selectRelation = (SelectRelation) queryRelation;
+                hasWherePredicate = selectRelation.hasWhereClause() && selectRelation.getPredicate() != null;
+            }
+
+            // Get NDV statistics for partition columns
+            Map<String, Double> partitionNdv = getPartitionColumnNdv(table);
+
+            // Use estimatePartitionCount for the actual estimation
+            return estimatePartitionCount(insertStmt, table, existingPartitionCount,
+                    hasWherePredicate, partitionNdv);
+        } catch (Exception e) {
+            LOG.warn("Failed to get partition count for table {}.{}: {}",
+                    table.getCatalogDBName(), table.getName(), e.getMessage());
+        }
+
+        // When metadata was unavailable (exception), return -1 to indicate unable to estimate
+        return metadataAvailable ? existingPartitionCount : -1;
+    }
+
+    /**
+     * Estimate partition count for an INSERT operation.
+     * This is the main strategy selector that combines multiple estimation strategies.
+     *
+     * Estimation strategy (in order of priority):
+     * 1. Static partition insert: returns 1
+     * 2. Predicate-based estimation (WHERE clause analysis)
+     * 3. Statistics-based estimation (NDV)
+     * 4. Existing partition count
+     *
+     * @param insertStmt the INSERT statement
+     * @param table the target table
+     * @param existingPartitionCount current partition count from metadata
+     * @param hasWherePredicate whether the INSERT has a WHERE clause
+     * @param partitionNdv optional NDV statistics for partition columns (can be null/empty)
+     * @return estimated partition count, -1 means unable to estimate
+     */
+    public static long estimatePartitionCount(InsertStmt insertStmt,
+                                               Table table,
+                                               long existingPartitionCount,
+                                               boolean hasWherePredicate,
+                                               Map<String, Double> partitionNdv) {
+        // 1. For static partition INSERT, only writes to one partition
+        if (insertStmt.isStaticKeyPartitionInsert()) {
+            return 1;
+        }
+
+        // Use provided NDV or empty map if null
+        Map<String, Double> ndv = (partitionNdv != null) ? partitionNdv : new HashMap<>();
+
+        // 2. Try predicate-based estimation (only if there's a WHERE clause)
+        if (hasWherePredicate) {
+            return estimateFromPredicates(insertStmt, table, existingPartitionCount, ndv);
+        }
+
+        // 3. No WHERE clause, try statistics-based estimation for empty tables
+        if (existingPartitionCount == 0 && ndv != null && !ndv.isEmpty()) {
+            long statsEstimate = estimateFromStatistics(ndv);
+            if (statsEstimate > 0) {
+                return statsEstimate;
+            }
+        }
+
+        // 4. Default to existing partition count
+        return existingPartitionCount;
+    }
+
+    /**
+     * Estimate partition count for an INSERT operation (without NDV).
+     * This is a convenience method that calls the main method with null NDV.
+     *
+     * @param insertStmt the INSERT statement
+     * @param table the target table
+     * @param existingPartitionCount current partition count from metadata
+     * @param hasWherePredicate whether the INSERT has a WHERE clause
+     * @return estimated partition count, -1 means unable to estimate
+     */
+    public static long estimatePartitionCount(InsertStmt insertStmt,
+                                               Table table,
+                                               long existingPartitionCount,
+                                               boolean hasWherePredicate) {
+        return estimatePartitionCount(insertStmt, table, existingPartitionCount, hasWherePredicate, null);
+    }
+
+    /**
+     * Estimate partition count using NDV statistics.
+     * This is used as a fallback when partition metadata is unavailable.
+     *
+     * @param partitionNdv map from partition column name to NDV statistics
+     * @return estimated partition count, -1 if unable to estimate
+     */
+    public static long estimateFromStatistics(Map<String, Double> partitionNdv) {
+        if (partitionNdv == null || partitionNdv.isEmpty()) {
+            return -1;
+        }
+        long estimate = 1;
+        boolean hasValidNdv = false;
+        for (double ndv : partitionNdv.values()) {
+            if (Double.isNaN(ndv) || ndv <= 0) {
+                return -1;  // Any invalid NDV makes the entire estimate unreliable
+            }
+            hasValidNdv = true;
+            long result = multiplyWithOverflowCheck(estimate, (long) Math.ceil(ndv));
+            if (result == -1) {
+                // Overflow detected
+                return -1;
+            }
+            estimate = result;
+        }
+        return hasValidNdv ? estimate : -1;
+    }
+
+    /**
+     * Estimate partition count from WHERE clause predicates.
+     *
+     * @param insertStmt the INSERT statement
+     * @param table the target table
+     * @param existingPartitionCount current partition count from metadata
+     * @param partitionNdv map from partition column name to NDV statistics
+     * @return estimated partition count, -1 if unable to estimate
+     */
+    private static long estimateFromPredicates(InsertStmt insertStmt,
+                                                Table table,
+                                                long existingPartitionCount,
+                                                Map<String, Double> partitionNdv) {
+        QueryRelation queryRelation = insertStmt.getQueryStatement().getQueryRelation();
+
+        // Only support SelectRelation with WHERE clause
+        if (!(queryRelation instanceof SelectRelation)) {
+            return -1;
+        }
+
+        SelectRelation selectRelation = (SelectRelation) queryRelation;
+        if (!selectRelation.hasWhereClause()) {
+            // No WHERE clause, return existing partition count
+            return existingPartitionCount;
+        }
+
+        Expr predicate = selectRelation.getPredicate();
+        if (predicate == null) {
+            return existingPartitionCount;
+        }
+
+        if (table.getPartitionColumns().isEmpty()) {
+            return -1;
+        }
+
+        // Build column mapping
+        Map<String, String> selectColToTargetPartitionCol =
+                buildSelectToTargetPartitionMapping(insertStmt, table, selectRelation);
+
+        // Create PredicateEstimator to handle predicate-based estimation
+        Set<String> partitionColNames = table.getPartitionColumns().stream()
+                .map(col -> col.getName().toLowerCase())
+                .collect(Collectors.toSet());
+
+        PredicateEstimator estimator = new PredicateEstimator(
+                partitionColNames, selectColToTargetPartitionCol, partitionNdv);
+        Long estimatedCount = estimator.estimate(predicate);
+        // If predicate estimation returns null (unable to estimate), return -1
+        return estimatedCount != null ? estimatedCount : -1;
+    }
+
+    /**
+     * Get NDV statistics for partition columns.
+     *
+     * @param table the target table
+     * @return map from partition column name to NDV statistics
+     */
+    private static Map<String, Double> getPartitionColumnNdv(Table table) {
+        Map<String, Double> partitionNdv = new HashMap<>();
+        if (table == null || table.getPartitionColumns().isEmpty()) {
+            return partitionNdv;
+        }
+
+        try {
+            if (GlobalStateMgr.getCurrentState().getStatisticStorage() == null) {
+                return partitionNdv;
+            }
+            for (Column partitionCol : table.getPartitionColumns()) {
+                ColumnStatistic statistic = GlobalStateMgr.getCurrentState().getStatisticStorage()
+                        .getColumnStatistic(table, partitionCol.getName());
+                if (statistic == null || statistic.isUnknown()) {
+                    continue;
+                }
+                double ndv = statistic.getDistinctValuesCount();
+                if (!Double.isNaN(ndv) && ndv > 0) {
+                    partitionNdv.put(partitionCol.getName().toLowerCase(), ndv);
+                }
+            }
+        } catch (Exception e) {
+            LOG.debug("Failed to fetch partition column NDV for table {}.{}: {}",
+                    table.getCatalogDBName(), table.getName(), e.getMessage());
+        }
+        return partitionNdv;
+    }
+
+    /**
+     * Build mapping from SELECT output column names to target partition column names.
+     * This handles SELECT *, column aliases, and different column names between source and target tables.
+     *
+     * For example:
+     * - INSERT INTO target (id, dt) SELECT id, src_dt FROM src WHERE src_dt = '...'
+     *   Creates mapping: {"src_dt" -> "dt"}
+     * - INSERT INTO target (id, dt) SELECT * FROM src WHERE src_dt = '...'
+     *   Creates mapping: {"src_dt" -> "dt"} (extracts src_dt from source relation fields)
+     * - INSERT INTO target (id, dt) SELECT *, 123 FROM src WHERE src_dt = '...'
+     *   Creates mapping: {"src_dt" -> "dt"} (handles mixed SELECT * with literals)
+     *
+     * @param insertStmt the INSERT statement
+     * @param table the target table (can be any Table implementation: Iceberg, Hive, etc.)
+     * @param selectRelation the SELECT relation
+     * @return mapping from SELECT column names to target partition column names
+     */
+    private static Map<String, String> buildSelectToTargetPartitionMapping(InsertStmt insertStmt,
+                                                                           Table table,
+                                                                           SelectRelation selectRelation) {
+        Map<String, String> mapping = new HashMap<>();
+        Map<String, String> targetPartitionColMap = table.getPartitionColumns().stream()
+                .collect(Collectors.toMap(
+                        col -> col.getName().toLowerCase(),
+                        Column::getName,
+                        (a, b) -> a));
+        if (targetPartitionColMap.isEmpty()) {
+            return mapping;
+        }
+
+        // Get SELECT list items to extract source column names
+        SelectList selectList = selectRelation.getSelectList();
+        if (selectList == null) {
+            return mapping;
+        }
+
+        List<SelectListItem> selectItems = selectList.getItems();
+        if (selectItems == null || selectItems.isEmpty()) {
+            return mapping;
+        }
+
+        List<String> targetColNames = insertStmt.getTargetColumnNames();
+
+        // Check if SELECT list contains any star items
+        boolean hasStar = selectItems.stream().anyMatch(item -> item != null && item.isStar());
+
+        // Determine loop limit: for SELECT *, use target schema size; otherwise use select items size
+        int loopLimit = hasStar ? table.getFullSchema().size()
+                                : Math.min(selectItems.size(), table.getFullSchema().size());
+
+        for (int i = 0; i < loopLimit; i++) {
+            // Determine which target column this position maps to
+            String targetColName;
+            if (targetColNames != null && i < targetColNames.size()) {
+                targetColName = targetColNames.get(i);
+            } else {
+                Column targetCol = table.getFullSchema().get(i);
+                if (targetCol == null) {
+                    continue;
+                }
+                targetColName = targetCol.getName();
+            }
+
+            // Check if this target column is a partition column using O(1) map lookup
+            String targetPartColName = targetPartitionColMap.get(targetColName.toLowerCase());
+            if (targetPartColName == null) {
+                continue;  // Not a partition column, skip
+            }
+
+            // Extract source column name
+            String sourceColName;
+            if (hasStar) {
+                // For SELECT *, source column at position i comes from source relation fields
+                sourceColName = getSourceColumnNameForStarSelect(selectRelation, i);
+            } else {
+                // For explicit column list, extract from the SELECT expression
+                SelectListItem selectItem = selectItems.get(i);
+                if (selectItem == null) {
+                    continue;
+                }
+                sourceColName = extractSourceColumnName(selectItem, selectRelation, i);
+            }
+
+            if (sourceColName != null) {
+                // Map source column name -> target partition column name
+                mapping.put(sourceColName.toLowerCase(), targetPartColName.toLowerCase());
+            }
+        }
+
+        return mapping;
+    }
+
+    /**
+     * Extract the source column name from a SelectListItem.
+     *
+     * For "SELECT *", extracts the column name from the source relation's fields.
+     * For "src_dt AS dt", returns "src_dt" (the source column).
+     * For "dt" (no alias), returns "dt".
+     * For "col1 + col2", returns null (not a simple column reference).
+     *
+     * @param selectItem the SELECT list item
+     * @param selectRelation the SELECT relation (for SELECT * support)
+     * @param position the position in the SELECT list (for SELECT * support)
+     * @return the source column name, or null if not a simple column reference
+     */
+    private static String extractSourceColumnName(SelectListItem selectItem,
+                                                   SelectRelation selectRelation,
+                                                   int position) {
+        if (selectItem.isStar()) {
+            // For SELECT *, get the source column name from the relation fields
+            return getSourceColumnNameForStarSelect(selectRelation, position);
+        }
+
+        Expr expr = selectItem.getExpr();
+        if (expr == null) {
+            return null;
+        }
+
+        // If the expression is a SlotRef (direct column reference), use it
+        if (expr instanceof SlotRef) {
+            return ((SlotRef) expr).getColumnName();
+        }
+
+        // Try to extract SlotRef from implicit cast
+        if (expr instanceof CastExpr) {
+            CastExpr cast = (CastExpr) expr;
+            if (cast.isImplicit() && cast.getChild(0) instanceof SlotRef) {
+                return ((SlotRef) cast.getChild(0)).getColumnName();
+            }
+        }
+
+        // For more complex expressions, return null
+        // We only handle simple column references for partition pruning
+        return null;
+    }
+
+    /**
+     * Get the source column name for SELECT * at a given position.
+     *
+     * For "INSERT INTO target_table (id, dt) SELECT * FROM src_table WHERE ...",
+     * where src_table has columns (id, src_dt):
+     * - Position 0: maps to source column "id"
+     * - Position 1: maps to source column "src_dt"
+     *
+     * @param selectRelation the SELECT relation
+     * @param position the position in the SELECT list
+     * @return the source column name, or null if unable to determine
+     */
+    private static String getSourceColumnNameForStarSelect(SelectRelation selectRelation, int position) {
+        try {
+            // Get the source relation's fields to find the column name at this position
+            Relation relation = selectRelation.getRelation();
+            if (relation == null) {
+                return null;
+            }
+
+            // Check if the analyzer has resolved the relation fields
+            // This should be available after analysis phase
+            if (relation.getScope() != null) {
+                RelationFields relationFields = relation.getRelationFields();
+                if (relationFields != null) {
+                    List<Field> allFields = relationFields.getAllFields();
+                    if (position >= 0 && position < allFields.size()) {
+                        Field field = allFields.get(position);
+                        if (field != null) {
+                            return field.getName();
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.debug("Failed to get source column name for SELECT * at position {}: {}",
+                    position, e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Multiply two long values with overflow check.
+     * Returns the product, or -1 if overflow would occur.
+     */
+    public static long multiplyWithOverflowCheck(long base, long factor) {
+        if (base == 0 || factor == 0) {
+            return 0;
+        }
+        // Check for potential overflow before multiplying
+        if (base > Long.MAX_VALUE / factor) {
+            // Overflow risk too high, return -1 to indicate unable to estimate reliably
+            return -1;
+        }
+        return base * factor;
+    }
+
+    /**
+     * Inner class for predicate-based partition count estimation.
+     * This class is only instantiated when predicate-based estimation is needed.
+     */
+    private static class PredicateEstimator {
+        private final Set<String> partitionColNames;
+        private final Map<String, String> selectColToTargetPartitionCol;
+        private final Map<String, Long> columnDistinctValues;
+        private final Map<String, Double> partitionNdv;
+
+        /**
+         * Create a new predicate estimator.
+         *
+         * @param partitionColNames set of target table partition column names (lowercase)
+         * @param selectColToTargetPartitionCol mapping from SELECT output column names to target partition column names
+         * @param partitionNdv map from partition column name to NDV statistics
+         */
+        PredicateEstimator(Set<String> partitionColNames,
+                          Map<String, String> selectColToTargetPartitionCol,
+                          Map<String, Double> partitionNdv) {
+            this.partitionColNames = partitionColNames;
+            this.selectColToTargetPartitionCol = selectColToTargetPartitionCol;
+            this.columnDistinctValues = new HashMap<>();
+            this.partitionNdv = partitionNdv;
+        }
+
+        /**
+         * Estimate partition count based on the given predicate.
+         *
+         * @param predicate the WHERE clause predicate
+         * @return estimated partition count, or null if unable to estimate
+         */
+        Long estimate(Expr predicate) {
+            // Split compound predicate into conjuncts (AND-connected)
+            List<Expr> conjuncts = extractConjuncts(predicate);
+
+            for (Expr conjunct : conjuncts) {
+                if (!processPredicate(conjunct)) {
+                    // If we encounter a predicate we can't handle, return null to indicate
+                    // we cannot reliably estimate
+                    return null;
+                }
+            }
+
+            // If we have equality predicates for all partition columns, return product
+            if (columnDistinctValues.size() == partitionColNames.size()) {
+                long totalPartitions = 1;
+                for (long count : columnDistinctValues.values()) {
+                    totalPartitions = InsertPartitionEstimator.multiplyWithOverflowCheck(totalPartitions, count);
+                    if (totalPartitions == -1) {
+                        return null;
+                    }
+                }
+                return totalPartitions;
+            }
+
+            // Partial match - if we have at least one equality predicate on partition column
+            // we can provide some estimate, but be conservative
+            if (!columnDistinctValues.isEmpty()) {
+                long estimate = columnDistinctValues.values().stream()
+                        .reduce(1L, InsertPartitionEstimator::multiplyWithOverflowCheck);
+                return estimate;
+            }
+
+            // No predicate-derived estimate; fall back to NDV from statistics if available
+            if (partitionNdv != null && !partitionNdv.isEmpty()) {
+                long estimate = 1;
+                boolean hasNdv = false;
+                for (double ndv : partitionNdv.values()) {
+                    if (Double.isNaN(ndv) || ndv <= 0) {
+                        continue;
+                    }
+                    hasNdv = true;
+                    estimate = InsertPartitionEstimator.multiplyWithOverflowCheck(estimate, (long) Math.ceil(ndv));
+                }
+                if (hasNdv) {
+                    return estimate;
+                }
+            }
+
+            return null;
+        }
+
+        /**
+         * Recursively extract AND-connected predicates.
+         * For OR predicates, try to extract values if they're on the same partition column.
+         */
+        private List<Expr> extractConjuncts(Expr expr) {
+            List<Expr> result = new ArrayList<>();
+            extractConjunctsRecursive(expr, result);
+            return result;
+        }
+
+        private void extractConjunctsRecursive(Expr expr, List<Expr> result) {
+            if (expr instanceof CompoundPredicate) {
+                CompoundPredicate compound = (CompoundPredicate) expr;
+                if (compound.getOp() == CompoundPredicate.Operator.AND) {
+                    extractConjunctsRecursive(expr.getChild(0), result);
+                    extractConjunctsRecursive(expr.getChild(1), result);
+                    return;
+                }
+                // For OR predicates, keep them as is - will be processed in processPredicate
+            }
+            result.add(expr);
+        }
+
+        private boolean processPredicate(Expr predicate) {
+            // Handle CompoundPredicate (OR) - extract values for same column
+            if (predicate instanceof CompoundPredicate) {
+                return processCompoundPredicate((CompoundPredicate) predicate);
+            }
+
+            // Handle BinaryPredicate (equality, range comparisons)
+            if (predicate instanceof BinaryPredicate) {
+                return processBinaryPredicate((BinaryPredicate) predicate);
+            }
+
+            // Handle InPredicate
+            if (predicate instanceof InPredicate) {
+                return processInPredicate((InPredicate) predicate);
+            }
+
+            // For other predicate types we can't analyze (like LIKE), return true to skip
+            return true;
+        }
+
+        /**
+         * Process compound predicates (OR).
+         * Extract partition column values from OR predicates like:
+         * - col = 'x' OR col = 'y'  (2 values)
+         * - col IN ('x', 'y', 'z')  (handled by processInPredicate)
+         *
+         * Only handles OR predicates on the same partition column.
+         * Returns false for complex OR predicates that can't be analyzed.
+         */
+        private boolean processCompoundPredicate(CompoundPredicate compound) {
+            // Only handle OR predicates
+            if (compound.getOp() != CompoundPredicate.Operator.OR) {
+                return true; // Not an OR predicate, skip
+            }
+
+            // Try to extract partition column value counts from OR expression
+            Map<String, Long> orValueCounts = new HashMap<>();
+
+            // Recursively extract OR value counts
+            if (!extractOrValueCounts(compound, orValueCounts)) {
+                // Failed to extract, can't estimate
+                return false;
+            }
+
+            // If we found partition columns with OR-ed values, use them for estimation
+            for (Map.Entry<String, Long> entry : orValueCounts.entrySet()) {
+                String targetPartColName = entry.getKey();
+                long valueCount = entry.getValue();
+                // Use the count of distinct OR values as the estimate
+                columnDistinctValues.put(targetPartColName, valueCount);
+            }
+
+            return true;
+        }
+
+        /**
+         * Recursively extract OR value counts from a predicate tree.
+         * Returns false if the predicate is too complex to analyze.
+         *
+         * @param expr the expression to analyze
+         * @param orValueCounts map from target partition column name to value count
+         * @return true if successful, false if too complex
+         */
+        private boolean extractOrValueCounts(Expr expr, Map<String, Long> orValueCounts) {
+            if (expr instanceof CompoundPredicate) {
+                CompoundPredicate compound = (CompoundPredicate) expr;
+
+                if (compound.getOp() == CompoundPredicate.Operator.OR) {
+                    // Continue recursively
+                    boolean leftOk = extractOrValueCounts(compound.getChild(0), orValueCounts);
+                    boolean rightOk = extractOrValueCounts(compound.getChild(1), orValueCounts);
+
+                    // Merge results from both sides
+                    // If both sides have the same column, add the counts
+                    // If different columns, we can't handle (too complex)
+                    // Check if OR involves multiple different partition columns
+                    if (orValueCounts.size() > 1) {
+                        // Multiple partition columns in OR - too complex to estimate accurately
+                        // For example: dt = '2024-01-01' OR country = 'US'
+                        // could match many more partitions than just the value counts
+                        return false;
+                    }
+                    return leftOk && rightOk;
+                } else if (compound.getOp() == CompoundPredicate.Operator.AND) {
+                    // AND inside OR - too complex for our simple analysis
+                    // For example: (a = 1 AND b = 2) OR (a = 3 AND b = 4)
+                    return false;
+                }
+            }
+
+            // Try to extract equality predicate info
+            EqualityPredInfo equalityInfo = extractEqualityPredicateInfo(expr);
+            if (equalityInfo != null) {
+                // Check if it's a partition column
+                String selectColName = equalityInfo.columnName;
+                if (isPartitionColumn(selectColName)) {
+                    String targetPartColName = getTargetPartitionColumnName(selectColName);
+
+                    // Increment the count for this partition column
+                    orValueCounts.merge(targetPartColName, 1L, Long::sum);
+                }
+                return true;
+            }
+
+            // For IN predicate inside OR, handle it
+            if (expr instanceof InPredicate) {
+                InPredicate inPred = (InPredicate) expr;
+                if (!inPred.isNotIn() && inPred.isConstantValues()) {
+                    SlotRef slotRef = extractSlotRef(inPred.getChild(0));
+                    if (slotRef != null) {
+                        String colName = slotRef.getColumnName().toLowerCase();
+                        if (isPartitionColumn(colName)) {
+                            String targetPartColName = getTargetPartitionColumnName(colName);
+                            // Add the IN predicate value count
+                            long count = inPred.getInElementNum();
+                            orValueCounts.merge(targetPartColName, count, Long::sum);
+                        }
+                    }
+                }
+                return true;
+            }
+
+            // Unknown predicate type in OR - can't reliably estimate
+            return false;
+        }
+
+        /**
+         * Check if a SELECT column name maps to a target table partition column.
+         * First tries the mapping, then falls back to direct name match.
+         */
+        private boolean isPartitionColumn(String selectColName) {
+            // First check if we have a mapping for this SELECT column
+            if (selectColToTargetPartitionCol != null) {
+                String targetPartCol = selectColToTargetPartitionCol.get(selectColName);
+                if (targetPartCol != null && partitionColNames.contains(targetPartCol)) {
+                    return true;
+                }
+            }
+            // Fallback to direct name match (for backward compatibility)
+            return partitionColNames.contains(selectColName);
+        }
+
+        /**
+         * Get the target partition column name for a SELECT column name.
+         * Returns the mapped partition column name, or the original name if no mapping exists.
+         */
+        private String getTargetPartitionColumnName(String selectColName) {
+            if (selectColToTargetPartitionCol != null) {
+                String targetPartCol = selectColToTargetPartitionCol.get(selectColName);
+                if (targetPartCol != null) {
+                    return targetPartCol;
+                }
+            }
+            return selectColName;
+        }
+
+        /**
+         * Helper class to hold equality predicate information
+         */
+        private static class EqualityPredInfo {
+            final String columnName;
+
+            EqualityPredInfo(String columnName) {
+                this.columnName = columnName;
+            }
+        }
+
+        /**
+         * Extract column name from an equality predicate (col = value).
+         * Returns EqualityPredInfo if this is a simple equality predicate, null otherwise.
+         */
+        private EqualityPredInfo extractEqualityPredicateInfo(Expr expr) {
+            if (!(expr instanceof BinaryPredicate)) {
+                return null;
+            }
+
+            BinaryPredicate binary = (BinaryPredicate) expr;
+            if (binary.getOp() != BinaryType.EQ) {
+                return null;
+            }
+
+            // Check if one side is a column reference
+            SlotRef slotRef = extractSlotRef(binary.getChild(0));
+            if (slotRef == null) {
+                slotRef = extractSlotRef(binary.getChild(1));
+            }
+
+            if (slotRef == null) {
+                return null;
+            }
+
+            return new EqualityPredInfo(slotRef.getColumnName().toLowerCase());
+        }
+
+        private boolean processBinaryPredicate(BinaryPredicate binary) {
+            // Check if this is an equality predicate
+            boolean isEquality = binary.getOp() == BinaryType.EQ;
+            boolean isRange = !isEquality && (
+                    binary.getOp() == BinaryType.LT ||
+                    binary.getOp() == BinaryType.LE ||
+                    binary.getOp() == BinaryType.GT ||
+                    binary.getOp() == BinaryType.GE);
+
+            // Check if one side is a partition column reference
+            SlotRef slotRef = extractSlotRef(binary.getChild(0));
+            if (slotRef == null) {
+                slotRef = extractSlotRef(binary.getChild(1));
+            }
+
+            if (slotRef == null) {
+                return true; // Neither side is a simple column reference
+            }
+
+            String selectColName = slotRef.getColumnName().toLowerCase();
+            // Check if this SELECT column maps to a target table partition column
+            if (!isPartitionColumn(selectColName)) {
+                return true; // Not a partition column
+            }
+
+            // Get the target partition column name for NDV lookup and storing results
+            String targetPartColName = getTargetPartitionColumnName(selectColName);
+
+            if (isEquality) {
+                // Equality predicate: typically selects 1 value per column
+                columnDistinctValues.put(targetPartColName, 1L);
+            } else if (isRange) {
+                // Range predicate: use NDV statistics to estimate selectivity
+                double ndv = partitionNdv != null && partitionNdv.containsKey(targetPartColName)
+                        ? partitionNdv.get(targetPartColName) : -1;
+                if (ndv > 0) {
+                    // Estimate using fixed selectivity (10% of partitions)
+                    // Assumes 10% of partitions are selected by range predicates (e.g., dt > '2024-01-01').
+                    // This is conservative; actual selectivity depends on range bounds
+                    long estimated = (long) Math.ceil(ndv * 0.1);
+                    // Ensure at least 1 partition is estimated
+                    columnDistinctValues.put(targetPartColName, Math.max(1L, estimated));
+                }
+                // If no NDV statistics available, we can't estimate - leave empty to trigger fallback
+            }
+            return true;
+        }
+
+        private boolean processInPredicate(InPredicate inPred) {
+            // Only handle IN (not NOT IN) with constant values
+            if (inPred.isNotIn()) {
+                return true; // NOT IN doesn't help estimate partition count
+            }
+
+            if (!inPred.isConstantValues()) {
+                return true; // Non-constant values, can't estimate
+            }
+
+            // Check if the left side is a partition column reference
+            SlotRef slotRef = extractSlotRef(inPred.getChild(0));
+            if (slotRef == null) {
+                return true;
+            }
+
+            String selectColName = slotRef.getColumnName().toLowerCase();
+            // Check if this SELECT column maps to a target table partition column
+            if (!isPartitionColumn(selectColName)) {
+                return true; // Not a partition column
+            }
+
+            // Get the target partition column name for storing results
+            String targetPartColName = getTargetPartitionColumnName(selectColName);
+
+            // Count distinct values in IN list
+            long distinctCount = inPred.getInElementNum();
+            columnDistinctValues.put(targetPartColName, distinctCount);
+            return true;
+        }
+
+        private SlotRef extractSlotRef(Expr expr) {
+            // Direct SlotRef
+            if (expr instanceof SlotRef) {
+                return (SlotRef) expr;
+            }
+
+            // Unwrap implicit cast
+            if (expr instanceof CastExpr) {
+                CastExpr cast = (CastExpr) expr;
+                if (cast.isImplicit() && cast.getChild(0) instanceof SlotRef) {
+                    return (SlotRef) cast.getChild(0);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -38,6 +38,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.connector.ConnectorSinkShuffleMode;
 import com.starrocks.load.Load;
 import com.starrocks.planner.BlackHoleTableSink;
 import com.starrocks.planner.DataSink;
@@ -109,6 +110,7 @@ import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
+import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TResultSinkType;
 import com.starrocks.type.NullType;
@@ -920,13 +922,29 @@ public class InsertPlanner {
         Table targetTable = insertStmt.getTargetTable();
         if (targetTable instanceof IcebergTable) {
             IcebergTable icebergTable = (IcebergTable) targetTable;
-            if (session.isEnableIcebergSinkGlobalShuffle() && (!icebergTable.getPartitionColumns().isEmpty())) {
-                List<Integer> partitionColumnIDs = icebergTable.partitionColumnIndexes().stream()
-                        .map(x -> outputColumns.get(x).getId()).collect(Collectors.toList());
-                HashDistributionDesc desc = new HashDistributionDesc(partitionColumnIDs,
-                        HashDistributionDesc.SourceType.SHUFFLE_AGG);
-                return new PhysicalPropertySet(DistributionProperty
-                        .createProperty(DistributionSpec.createHashDistributionSpec(desc)));
+            ConnectorSinkShuffleMode shuffleMode = session.getConnectorSinkShuffleMode();
+
+            // For shuffle mode except NEVER, only apply shuffle to partitioned tables
+            if (shuffleMode != ConnectorSinkShuffleMode.NEVER && !icebergTable.getPartitionColumns().isEmpty()) {
+
+                // Handle FORCE mode - always enable global shuffle
+                // We also handle the old session variable `enable_iceberg_sink_global_shuffle` for compatibility.
+                if (shuffleMode == ConnectorSinkShuffleMode.FORCE) {
+                    List<Integer> partitionColumnIDs = icebergTable.partitionColumnIndexes().stream()
+                            .map(x -> outputColumns.get(x).getId()).collect(Collectors.toList());
+                    return createShufflePropertyFromPartitions(partitionColumnIDs);
+                }
+
+                // Handle AUTO mode - use adaptive logic based on partition count and backend count
+                if (shuffleMode == ConnectorSinkShuffleMode.AUTO) {
+                    boolean shouldEnableGlobalShuffle = shouldEnableAdaptiveGlobalShuffle(
+                            insertStmt, icebergTable, session);
+                    if (shouldEnableGlobalShuffle) {
+                        List<Integer> partitionColumnIDs = icebergTable.partitionColumnIndexes().stream()
+                                .map(x -> outputColumns.get(x).getId()).collect(Collectors.toList());
+                        return createShufflePropertyFromPartitions(partitionColumnIDs);
+                    }
+                }
             }
         }
 
@@ -945,10 +963,7 @@ public class InsertPlanner {
                 } else { // use hash shuffle for partitioned table
                     List<Integer> partitionColumnIDs = table.getPartitionColumnIDs().stream()
                             .map(x -> outputColumns.get(x).getId()).collect(Collectors.toList());
-                    HashDistributionDesc desc = new HashDistributionDesc(partitionColumnIDs,
-                            HashDistributionDesc.SourceType.SHUFFLE_AGG);
-                    return new PhysicalPropertySet(DistributionProperty
-                            .createProperty(DistributionSpec.createHashDistributionSpec(desc)));
+                    return createShufflePropertyFromPartitions(partitionColumnIDs);
                 }
             }
 
@@ -999,6 +1014,13 @@ public class InsertPlanner {
 
         shuffleServiceEnable = true;
 
+        return new PhysicalPropertySet(property);
+    }
+
+    private PhysicalPropertySet createShufflePropertyFromPartitions(List<Integer> partitionColumnIDs) {
+        HashDistributionDesc desc = new HashDistributionDesc(partitionColumnIDs, HashDistributionDesc.SourceType.SHUFFLE_AGG);
+        DistributionSpec spec = DistributionSpec.createHashDistributionSpec(desc);
+        DistributionProperty property = DistributionProperty.createProperty(spec);
         return new PhysicalPropertySet(property);
     }
 
@@ -1107,5 +1129,86 @@ public class InsertPlanner {
         }
         checkPartitionInsertValid(targetTable);
         return true;
+    }
+
+    /**
+     * Judge whether adaptive global shuffle should be enabled based on partition count and backend count.
+     *
+     * Decision criteria (configurable via session variables):
+     * 1. Enable when estimated partition count >= backend count * ratio
+     * 2. OR when estimated partition count >= absolute threshold
+     *
+     * @param insertStmt INSERT statement
+     * @param icebergTable target Iceberg table
+     * @param session Session variable
+     * @return whether to enable global shuffle
+     */
+    private boolean shouldEnableAdaptiveGlobalShuffle(InsertStmt insertStmt,
+                                                       IcebergTable icebergTable,
+                                                       SessionVariable session) {
+        // Get the number of alive BE nodes and CN nodes in the cluster
+        SystemInfoService clusterInfo = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        int aliveBackendNum = clusterInfo.getAliveBackendNumber();
+        int totalComputeNodeNum = clusterInfo.getTotalComputeNodeNumber();
+        int totalWorkerNum = aliveBackendNum + totalComputeNodeNum;
+
+        // Don't enable global shuffle if we have only 1 or 0 worker nodes
+        if (totalWorkerNum <= 1) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Disable adaptive global shuffle for connector table {}.{}: " +
+                                "total worker nodes ({}) <= 1",
+                        icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(),
+                        totalWorkerNum);
+            }
+            return false;
+        }
+
+        // Estimate the number of partitions that may be involved in this insert
+        long estimatedPartitionCount = estimatePartitionCountForInsert(insertStmt, icebergTable);
+
+        // Don't enable global shuffle if unable to estimate partition count or only writing to 1 partition
+        // estimatedPartitionCount <= 1 covers:
+        // - -1: unable to estimate (users typically write to only the latest partition)
+        // - 0 or 1: only writing to one partition
+        if (estimatedPartitionCount <= 1) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Disable adaptive global shuffle for connector table {}.{}: " +
+                                "estimated partition count ({}) <= 1",
+                        icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(),
+                        estimatedPartitionCount);
+            }
+            return false;
+        }
+
+        // Get configured thresholds from connector variables
+        long partitionCountThreshold = session.getConnectorSinkShufflePartitionThreshold();
+        double partitionCountNodeRatio = session.getConnectorSinkShufflePartitionNodeRatio();
+
+        // Decision logic:
+        // 1. estimated partitions >= total worker count * ratio coefficient
+        // 2. OR estimated partitions >= absolute threshold
+        boolean shouldEnable = estimatedPartitionCount >= (long) (totalWorkerNum * partitionCountNodeRatio)
+                || estimatedPartitionCount >= partitionCountThreshold;
+
+        if (shouldEnable && LOG.isDebugEnabled()) {
+            LOG.debug("Enable adaptive global shuffle for connector table {}.{}: " +
+                            "estimated partitions={}, total workers={}, threshold={}, ratio={}",
+                    icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(),
+                    estimatedPartitionCount, totalWorkerNum,
+                    partitionCountThreshold, partitionCountNodeRatio);
+        }
+
+        return shouldEnable;
+    }
+
+    /**
+     * Estimate the number of partitions that may be involved in this INSERT operation.
+     *
+     * @param insertStmt INSERT statement
+     * @param icebergTable target Iceberg table
+     * @return estimated partition count
+     */
+    private long estimatePartitionCountForInsert(InsertStmt insertStmt, IcebergTable icebergTable) {
+        return InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -28,6 +28,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.ParseUtil;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.connector.ConnectorSinkShuffleMode;
 import com.starrocks.connector.PlanMode;
 import com.starrocks.datacache.DataCachePopulateMode;
 import com.starrocks.monitor.unit.TimeValue;
@@ -345,6 +346,30 @@ public class SetStmtAnalyzer {
         // check populate datacache mode
         if (variable.equalsIgnoreCase(SessionVariable.POPULATE_DATACACHE_MODE)) {
             DataCachePopulateMode.fromName(resolvedExpression.getStringValue());
+        }
+
+        // check connector sink shuffle mode
+        if (variable.equalsIgnoreCase(SessionVariable.CONNECTOR_SINK_SHUFFLE_MODE)) {
+            ConnectorSinkShuffleMode.fromName(resolvedExpression.getStringValue());
+        }
+
+        if (variable.equalsIgnoreCase(SessionVariable.CONNECTOR_SINK_SHUFFLE_PARTITION_THRESHOLD)) {
+            checkRangeLongVariable(resolvedExpression, SessionVariable.CONNECTOR_SINK_SHUFFLE_PARTITION_THRESHOLD, 1L, null);
+        }
+
+        if (variable.equalsIgnoreCase(SessionVariable.CONNECTOR_SINK_SHUFFLE_PARTITION_NODE_RATIO)) {
+            String val = resolvedExpression.getStringValue();
+            double ratio;
+            try {
+                ratio = Double.parseDouble(val);
+            } catch (NumberFormatException e) {
+                throw new SemanticException(String.format("failed to parse %s value %s",
+                        SessionVariable.CONNECTOR_SINK_SHUFFLE_PARTITION_NODE_RATIO, val));
+            }
+            if (Double.isNaN(ratio) || Double.isInfinite(ratio) || ratio <= 0) {
+                throw new SemanticException(String.format("%s should be a positive finite number, got %s",
+                        SessionVariable.CONNECTOR_SINK_SHUFFLE_PARTITION_NODE_RATIO, val));
+            }
         }
 
         // count_distinct_implementation

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorSinkShuffleModeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorSinkShuffleModeTest.java
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ConnectorSinkShuffleModeTest {
+
+    @Test
+    public void testFromName() {
+        Assertions.assertEquals(ConnectorSinkShuffleMode.AUTO, ConnectorSinkShuffleMode.fromName("auto"));
+        Assertions.assertEquals(ConnectorSinkShuffleMode.AUTO, ConnectorSinkShuffleMode.fromName("AUTO"));
+        Assertions.assertEquals(ConnectorSinkShuffleMode.FORCE, ConnectorSinkShuffleMode.fromName("force"));
+        Assertions.assertEquals(ConnectorSinkShuffleMode.NEVER, ConnectorSinkShuffleMode.fromName("never"));
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ConnectorSinkShuffleMode.fromName("unknown"));
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> ConnectorSinkShuffleMode.fromName(null));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -93,4 +93,23 @@ public class SessionVariableTest {
         sessionVariable.setEnableInsertPartialUpdate(false);
         Assertions.assertFalse(sessionVariable.isEnableInsertPartialUpdate());
     }
+
+    @Test
+    public void testConnectorSinkShuffleModeBackwardCompatibility() {
+        SessionVariable sessionVariable = new SessionVariable();
+
+        // Default mode is AUTO
+        Assertions.assertEquals(com.starrocks.connector.ConnectorSinkShuffleMode.AUTO,
+                sessionVariable.getConnectorSinkShuffleMode());
+
+        // Backward compatibility: enableIcebergSinkGlobalShuffle implies FORCE when mode stays at default AUTO.
+        com.starrocks.common.jmockit.Deencapsulation.setField(sessionVariable, "enableIcebergSinkGlobalShuffle", true);
+        Assertions.assertEquals(com.starrocks.connector.ConnectorSinkShuffleMode.FORCE,
+                sessionVariable.getConnectorSinkShuffleMode());
+
+        // Explicitly set mode to NEVER should not be affected by legacy boolean.
+        com.starrocks.common.jmockit.Deencapsulation.setField(sessionVariable, "connectorSinkShuffleMode", "never");
+        Assertions.assertEquals(com.starrocks.connector.ConnectorSinkShuffleMode.NEVER,
+                sessionVariable.getConnectorSinkShuffleMode());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/InsertPartitionEstimatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/InsertPartitionEstimatorTest.java
@@ -1,0 +1,511 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectList;
+import com.starrocks.sql.ast.SelectListItem;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.ast.expression.CompoundPredicate;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.sql.optimizer.statistics.StatisticStorage;
+import com.starrocks.type.DateType;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for InsertPartitionEstimator
+ */
+public class InsertPartitionEstimatorTest {
+
+    @Test
+    public void testEstimatePartitionCountFromPredicates_OrSamePartitionColumn(@Mocked InsertStmt insertStmt,
+                                                                               @Mocked IcebergTable table,
+                                                                               @Mocked QueryStatement queryStatement,
+                                                                               @Mocked SelectRelation selectRelation,
+                                                                               @Mocked SelectList selectList) {
+        // WHERE dt='2024-01-01' OR dt='2024-01-02' -> 2
+        Expr dtEq1 = new BinaryPredicate(BinaryType.EQ, new SlotRef(null, "dt"), new StringLiteral("2024-01-01"));
+        Expr dtEq2 = new BinaryPredicate(BinaryType.EQ, new SlotRef(null, "dt"), new StringLiteral("2024-01-02"));
+        Expr predicate = new CompoundPredicate(CompoundPredicate.Operator.OR, dtEq1, dtEq2);
+
+        new Expectations() {
+            {
+                insertStmt.getQueryStatement();
+                result = queryStatement;
+                minTimes = 0;
+
+                queryStatement.getQueryRelation();
+                result = selectRelation;
+                minTimes = 0;
+
+                selectRelation.hasWhereClause();
+                result = true;
+                minTimes = 0;
+
+                selectRelation.getPredicate();
+                result = predicate;
+                minTimes = 0;
+
+                table.getPartitionColumns();
+                result = Lists.newArrayList(new Column("dt", DateType.DATE));
+                minTimes = 0;
+
+                // Ensure mapping build doesn't early-exit
+                selectRelation.getSelectList();
+                result = selectList;
+                minTimes = 0;
+
+                selectList.getItems();
+                result = Lists.newArrayList(new SelectListItem(new SlotRef(null, "dt"), null));
+                minTimes = 0;
+
+                insertStmt.getTargetColumnNames();
+                result = Lists.newArrayList("dt");
+                minTimes = 0;
+
+                table.getFullSchema();
+                result = Lists.newArrayList(new Column("dt", DateType.DATE));
+                minTimes = 0;
+            }
+        };
+
+        long result = Deencapsulation.invoke(
+                InsertPartitionEstimator.class,
+                "estimateFromPredicates",
+                insertStmt, table, 100L, new HashMap<String, Double>());
+        assertEquals(2L, result);
+    }
+
+    // ==================== estimatePartitionCountForInsert Tests ====================
+
+    @Test
+    public void testEstimatePartitionCountForInsert_MetadataUnavailable(@Mocked InsertStmt insertStmt,
+                                                                         @Mocked IcebergTable table) {
+        new Expectations() {
+            {
+                table.getCatalogName();
+                result = new RuntimeException("Connection failed");
+                minTimes = 0;
+            }
+        };
+
+        long result = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, table);
+        assertEquals(-1L, result);
+    }
+
+    @Test
+    public void testEstimatePartitionCountForInsert_EmptyPartitionList(@Mocked InsertStmt insertStmt,
+                                                                        @Mocked IcebergTable table,
+                                                                        @Mocked com.starrocks.server.GlobalStateMgr gsm,
+                                                                        @Mocked com.starrocks.server.MetadataMgr metadataMgr,
+                                                                        @Mocked QueryStatement queryStatement,
+                                                                        @Mocked QueryRelation queryRelation,
+                                                                        @Mocked SelectRelation selectRelation) {
+        new Expectations() {
+            {
+                com.starrocks.server.GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                result = Lists.newArrayList();  // Empty partition list
+                minTimes = 0;
+
+                table.getCatalogName();
+                result = "test_catalog";
+                minTimes = 0;
+
+                table.getCatalogDBName();
+                result = "test_db";
+                minTimes = 0;
+
+                table.getCatalogTableName();
+                result = "test_table";
+                minTimes = 0;
+
+                table.getPartitionColumns();
+                result = Lists.newArrayList(new Column("dt", DateType.DATE));
+                minTimes = 0;
+
+                insertStmt.getQueryStatement();
+                result = queryStatement;
+                minTimes = 0;
+
+                queryStatement.getQueryRelation();
+                result = selectRelation;
+                minTimes = 0;
+
+                selectRelation.hasWhereClause();
+                result = false;
+                minTimes = 0;
+
+                gsm.getStatisticStorage();
+                result = null;
+                minTimes = 0;
+            }
+        };
+
+        long result = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, table);
+        assertTrue(result <= 0);
+    }
+
+    // ==================== estimatePartitionCount Tests ====================
+
+    @Test
+    public void testEstimatePartitionCount_StaticPartitionInsert(@Mocked InsertStmt insertStmt) {
+        new Expectations() {
+            {
+                insertStmt.isStaticKeyPartitionInsert();
+                result = true;
+                minTimes = 0;
+            }
+        };
+
+        long result = InsertPartitionEstimator.estimatePartitionCount(
+                insertStmt, null, 100L, false, null);
+        assertEquals(1L, result);
+    }
+
+    @Test
+    public void testEstimatePartitionCount_NoWhereClauseWithNdv(@Mocked InsertStmt insertStmt) {
+        new Expectations() {
+            {
+                insertStmt.isStaticKeyPartitionInsert();
+                result = false;
+                minTimes = 0;
+            }
+        };
+
+        Map<String, Double> ndv = new HashMap<>();
+        ndv.put("dt", 10.0);
+        ndv.put("country", 5.0);
+
+        long result = InsertPartitionEstimator.estimatePartitionCount(
+                insertStmt, null, 0L, false, ndv);
+        assertEquals(50L, result);
+    }
+
+    @Test
+    public void testEstimatePartitionCount_NoWhereClauseExistingPartitions(@Mocked InsertStmt insertStmt) {
+        new Expectations() {
+            {
+                insertStmt.isStaticKeyPartitionInsert();
+                result = false;
+                minTimes = 0;
+            }
+        };
+
+        long result = InsertPartitionEstimator.estimatePartitionCount(
+                insertStmt, null, 100L, false, null);
+        assertEquals(100L, result);
+    }
+
+    // ==================== estimateFromStatistics Tests ====================
+
+    @Test
+    public void testEstimateFromStatistics_NullMap() {
+        long result = InsertPartitionEstimator.estimateFromStatistics(null);
+        assertEquals(-1L, result);
+    }
+
+    @Test
+    public void testEstimateFromStatistics_EmptyMap() {
+        long result = InsertPartitionEstimator.estimateFromStatistics(new HashMap<>());
+        assertEquals(-1L, result);
+    }
+
+    @Test
+    public void testEstimateFromStatistics_InvalidNdv() {
+        Map<String, Double> ndv = new HashMap<>();
+        ndv.put("dt", Double.NaN);
+
+        long result = InsertPartitionEstimator.estimateFromStatistics(ndv);
+        assertEquals(-1L, result);
+    }
+
+    @Test
+    public void testEstimateFromStatistics_NegativeNdv() {
+        Map<String, Double> ndv = new HashMap<>();
+        ndv.put("dt", -1.0);
+
+        long result = InsertPartitionEstimator.estimateFromStatistics(ndv);
+        assertEquals(-1L, result);
+    }
+
+    @Test
+    public void testEstimateFromStatistics_ZeroNdv() {
+        Map<String, Double> ndv = new HashMap<>();
+        ndv.put("dt", 0.0);
+
+        long result = InsertPartitionEstimator.estimateFromStatistics(ndv);
+        assertEquals(-1L, result);
+    }
+
+    @Test
+    public void testEstimateFromStatistics_Overflow() {
+        Map<String, Double> ndv = new HashMap<>();
+        ndv.put("col1", (double) Long.MAX_VALUE);
+        ndv.put("col2", 2.0);
+
+        long result = InsertPartitionEstimator.estimateFromStatistics(ndv);
+        assertEquals(-1L, result);
+    }
+
+    @Test
+    public void testEstimateFromStatistics_Success() {
+        Map<String, Double> ndv = new HashMap<>();
+        ndv.put("dt", 10.0);
+        ndv.put("country", 5.0);
+
+        long result = InsertPartitionEstimator.estimateFromStatistics(ndv);
+        assertEquals(50L, result);
+    }
+
+    // ==================== multiplyWithOverflowCheck Tests ====================
+
+    @Test
+    public void testMultiplyWithOverflowCheck_ZeroBase() {
+        long result = InsertPartitionEstimator.multiplyWithOverflowCheck(0, 100);
+        assertEquals(0L, result);
+    }
+
+    @Test
+    public void testMultiplyWithOverflowCheck_ZeroFactor() {
+        long result = InsertPartitionEstimator.multiplyWithOverflowCheck(100, 0);
+        assertEquals(0L, result);
+    }
+
+    @Test
+    public void testMultiplyWithOverflowCheck_Overflow() {
+        long result = InsertPartitionEstimator.multiplyWithOverflowCheck(Long.MAX_VALUE, 2);
+        assertEquals(-1L, result);
+    }
+
+    @Test
+    public void testMultiplyWithOverflowCheck_Success() {
+        long result = InsertPartitionEstimator.multiplyWithOverflowCheck(10, 5);
+        assertEquals(50L, result);
+    }
+
+    // ==================== buildSelectToTargetPartitionMapping Tests ====================
+
+    @Test
+    public void testBuildSelectToTargetPartitionMapping_NoPartitionColumns(@Mocked InsertStmt insertStmt,
+                                                                            @Mocked IcebergTable table,
+                                                                            @Mocked SelectRelation selectRelation) {
+        new Expectations() {
+            {
+                table.getPartitionColumns();
+                result = Lists.newArrayList();
+                minTimes = 0;
+            }
+        };
+
+        Map<String, String> result = Deencapsulation.invoke(
+                InsertPartitionEstimator.class,
+                "buildSelectToTargetPartitionMapping",
+                insertStmt, table, selectRelation);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testBuildSelectToTargetPartitionMapping_NullSelectList(@Mocked InsertStmt insertStmt,
+                                                                        @Mocked IcebergTable table,
+                                                                        @Mocked SelectRelation selectRelation) {
+        Column partCol = new Column("dt", DateType.DATE);
+        new Expectations() {
+            {
+                table.getPartitionColumns();
+                result = Lists.newArrayList(partCol);
+                minTimes = 0;
+
+                selectRelation.getSelectList();
+                result = null;
+                minTimes = 0;
+            }
+        };
+
+        Map<String, String> result = Deencapsulation.invoke(
+                InsertPartitionEstimator.class,
+                "buildSelectToTargetPartitionMapping",
+                insertStmt, table, selectRelation);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testBuildSelectToTargetPartitionMapping_EmptySelectItems(@Mocked InsertStmt insertStmt,
+                                                                          @Mocked IcebergTable table,
+                                                                          @Mocked SelectRelation selectRelation,
+                                                                          @Mocked SelectList selectList) {
+        Column partCol = new Column("dt", DateType.DATE);
+        new Expectations() {
+            {
+                table.getPartitionColumns();
+                result = Lists.newArrayList(partCol);
+                minTimes = 0;
+
+                selectRelation.getSelectList();
+                result = selectList;
+                minTimes = 0;
+
+                selectList.getItems();
+                result = Lists.newArrayList();
+                minTimes = 0;
+            }
+        };
+
+        Map<String, String> result = Deencapsulation.invoke(
+                InsertPartitionEstimator.class,
+                "buildSelectToTargetPartitionMapping",
+                insertStmt, table, selectRelation);
+
+        assertTrue(result.isEmpty());
+    }
+
+    // ==================== extractSourceColumnName Tests ====================
+
+    @Test
+    public void testExtractSourceColumnName_NullExpr(@Mocked SelectListItem selectItem,
+                                                      @Mocked SelectRelation selectRelation) {
+        new Expectations() {
+            {
+                selectItem.getExpr();
+                result = null;
+                minTimes = 0;
+            }
+        };
+
+        String result = Deencapsulation.invoke(
+                InsertPartitionEstimator.class,
+                "extractSourceColumnName",
+                selectItem, selectRelation, 0);
+
+        assertNull(result);
+    }
+
+    // ==================== getSourceColumnNameForStarSelect Tests ====================
+
+    @Test
+    public void testGetSourceColumnNameForStarSelect_NullRelation(@Mocked SelectRelation selectRelation) {
+        new Expectations() {
+            {
+                selectRelation.getRelation();
+                result = null;
+                minTimes = 0;
+            }
+        };
+
+        String result = Deencapsulation.invoke(
+                InsertPartitionEstimator.class,
+                "getSourceColumnNameForStarSelect",
+                selectRelation, 0);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testEstimatePartitionCountForInsert_ExceptionInGetNdv(@Mocked InsertStmt insertStmt,
+                                                                       @Mocked IcebergTable table,
+                                                                       @Mocked com.starrocks.server.GlobalStateMgr gsm,
+                                                                       @Mocked com.starrocks.server.MetadataMgr metadataMgr,
+                                                                       @Mocked QueryStatement queryStatement,
+                                                                       @Mocked QueryRelation queryRelation,
+                                                                       @Mocked SelectRelation selectRelation,
+                                                                       @Mocked StatisticStorage statisticStorage) {
+        new Expectations() {
+            {
+                com.starrocks.server.GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                result = Lists.newArrayList("p1", "p2");
+                minTimes = 0;
+
+                table.getCatalogName();
+                result = "catalog";
+                minTimes = 0;
+
+                table.getCatalogDBName();
+                result = "db";
+                minTimes = 0;
+
+                table.getCatalogTableName();
+                result = "table";
+                minTimes = 0;
+
+                table.getPartitionColumns();
+                result = Lists.newArrayList(new Column("dt", DateType.DATE));
+                minTimes = 0;
+
+                gsm.getStatisticStorage();
+                result = statisticStorage;
+                minTimes = 0;
+
+                statisticStorage.getColumnStatistic(table, "dt");
+                result = new RuntimeException("Statistics error");
+                minTimes = 0;
+
+                insertStmt.getQueryStatement();
+                result = queryStatement;
+                minTimes = 0;
+
+                queryStatement.getQueryRelation();
+                result = selectRelation;
+                minTimes = 0;
+
+                selectRelation.hasWhereClause();
+                result = false;
+                minTimes = 0;
+            }
+        };
+
+        long result = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, table);
+        // Should return existing partition count when statistics fetch fails
+        assertEquals(2L, result);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/InsertPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/InsertPlannerTest.java
@@ -1,0 +1,1556 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.connector.ConnectorMetadatRequestContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
+import com.starrocks.server.NodeMgr;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.PartitionRef;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.ast.expression.CompoundPredicate;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.InPredicate;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.StatisticStorage;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.type.DateType;
+import com.starrocks.type.VarcharType;
+import mockit.Delegate;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for InsertPlanner
+ */
+public class InsertPlannerTest {
+
+    private InsertPlanner insertPlanner;
+
+    private static void setInsertPlannerLoggerLevel(Level level) {
+        Configurator.setLevel(InsertPlanner.class.getName(), level);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        insertPlanner = new InsertPlanner();
+    }
+
+    /**
+     * Test adaptive shuffle is enabled when partition count exceeds backend count * ratio
+     */
+    @Test
+    public void testAdaptiveShuffleEnabledByPartitionRatio(@Mocked GlobalStateMgr gsm,
+                                                           @Mocked MetadataMgr metadataMgr,
+                                                           @Mocked IcebergTable icebergTable,
+                                                           @Mocked InsertStmt insertStmt,
+                                                           @Mocked SessionVariable sessionVariable,
+                                                           @Mocked QueryStatement queryStatement,
+                                                           @Mocked SelectRelation selectRelation,
+                                                           @Mocked NodeMgr nodeMgr,
+                                                           @Mocked SystemInfoService clusterInfo) {
+        // Setup: 10 backends, 0 CN, total workers = 10, 50 partitions, ratio = 2.0
+        // Expected: 50 >= 10 * 2.0 = 20, so should enable shuffle
+        setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 10, 0, 50, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
+
+        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                insertStmt, icebergTable, sessionVariable);
+        assertTrue(enabled);
+    }
+
+    @Test
+    public void testAdaptiveShuffleEnabledByPartitionRatio_DebugLogCovered(@Mocked GlobalStateMgr gsm,
+                                                                           @Mocked MetadataMgr metadataMgr,
+                                                                           @Mocked IcebergTable icebergTable,
+                                                                           @Mocked InsertStmt insertStmt,
+                                                                           @Mocked SessionVariable sessionVariable,
+                                                                           @Mocked QueryStatement queryStatement,
+                                                                           @Mocked SelectRelation selectRelation,
+                                                                           @Mocked NodeMgr nodeMgr,
+                                                                           @Mocked SystemInfoService clusterInfo) {
+        setInsertPlannerLoggerLevel(Level.DEBUG);
+        try {
+            setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                    queryStatement, selectRelation, 10, 0, 50, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
+
+            boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                    insertStmt, icebergTable, sessionVariable);
+            assertTrue(enabled);
+        } finally {
+            setInsertPlannerLoggerLevel(Level.INFO);
+        }
+    }
+
+    /**
+     * Test adaptive shuffle is enabled when partition count exceeds absolute threshold
+     */
+    @Test
+    public void testAdaptiveShuffleEnabledByAbsoluteThreshold(@Mocked GlobalStateMgr gsm,
+                                                              @Mocked MetadataMgr metadataMgr,
+                                                              @Mocked IcebergTable icebergTable,
+                                                              @Mocked InsertStmt insertStmt,
+                                                              @Mocked SessionVariable sessionVariable,
+                                                              @Mocked QueryStatement queryStatement,
+                                                              @Mocked SelectRelation selectRelation,
+                                                              @Mocked NodeMgr nodeMgr,
+                                                              @Mocked SystemInfoService clusterInfo) {
+        // Setup: 10 backends, 0 CN, total workers = 10, 1500 partitions, threshold = 100, ratio = 2.0
+        // Expected: 1500 >= 100, so should enable shuffle
+        setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 10, 0, 1500, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
+
+        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                insertStmt, icebergTable, sessionVariable);
+        assertTrue(enabled);
+    }
+
+    /**
+     * Test adaptive shuffle is disabled when partition count is below both thresholds
+     */
+    @Test
+    public void testAdaptiveShuffleDisabledWhenPartitionsLow(@Mocked GlobalStateMgr gsm,
+                                                             @Mocked MetadataMgr metadataMgr,
+                                                             @Mocked IcebergTable icebergTable,
+                                                             @Mocked InsertStmt insertStmt,
+                                                             @Mocked SessionVariable sessionVariable,
+                                                             @Mocked QueryStatement queryStatement,
+                                                             @Mocked SelectRelation selectRelation,
+                                                             @Mocked NodeMgr nodeMgr,
+                                                             @Mocked SystemInfoService clusterInfo) {
+        // Setup: 10 backends, 0 CN, total workers = 10, 5 partitions, threshold = 100, ratio = 2.0
+        // Expected: 5 < 100 and 5 < 10 * 2.0 = 20, so should NOT enable shuffle
+        setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 10, 0, 5, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
+
+        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                insertStmt, icebergTable, sessionVariable);
+        assertFalse(enabled);
+    }
+
+    /**
+     * Test static partition insert returns partition count of 1
+     */
+    @Test
+    public void testStaticPartitionInsert(@Mocked GlobalStateMgr gsm,
+                                          @Mocked MetadataMgr metadataMgr,
+                                          @Mocked IcebergTable icebergTable,
+                                          @Mocked InsertStmt insertStmt,
+                                          @Mocked SessionVariable sessionVariable,
+                                          @Mocked PartitionRef partitionRef,
+                                          @Mocked QueryStatement queryStatement,
+                                          @Mocked SelectRelation selectRelation,
+                                          @Mocked NodeMgr nodeMgr,
+                                          @Mocked SystemInfoService clusterInfo) {
+        // Setup: static partition insert, 10 backends, 0 CN
+        setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 10, 0, 100, 100L, 2.0, true, partitionRef, null, false, nodeMgr, clusterInfo);
+
+        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
+                insertStmt, icebergTable);
+        assertEquals(1L, partitionCount);
+    }
+
+    /**
+     * Test adaptive shuffle is disabled when no backends available
+     */
+    @Test
+    public void testAdaptiveShuffleDisabledWhenNoBackends(@Mocked GlobalStateMgr gsm,
+                                                          @Mocked MetadataMgr metadataMgr,
+                                                          @Mocked IcebergTable icebergTable,
+                                                          @Mocked InsertStmt insertStmt,
+                                                          @Mocked SessionVariable sessionVariable,
+                                                          @Mocked QueryStatement queryStatement,
+                                                          @Mocked SelectRelation selectRelation,
+                                                          @Mocked NodeMgr nodeMgr,
+                                                          @Mocked SystemInfoService clusterInfo) {
+        // Setup: 0 backends, 0 CN, total workers = 0
+        setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 0, 0, 50, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
+
+        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                insertStmt, icebergTable, sessionVariable);
+        assertFalse(enabled);
+    }
+
+    /**
+     * Test adaptive shuffle is disabled when total worker count is 1 (1 BE + 0 CN)
+     */
+    @Test
+    public void testAdaptiveShuffleDisabledWhenSingleWorker(@Mocked GlobalStateMgr gsm,
+                                                             @Mocked MetadataMgr metadataMgr,
+                                                             @Mocked IcebergTable icebergTable,
+                                                             @Mocked InsertStmt insertStmt,
+                                                             @Mocked SessionVariable sessionVariable,
+                                                             @Mocked QueryStatement queryStatement,
+                                                             @Mocked SelectRelation selectRelation,
+                                                             @Mocked NodeMgr nodeMgr,
+                                                             @Mocked SystemInfoService clusterInfo) {
+        // Setup: 1 backend, 0 CN, total workers = 1, should NOT enable shuffle even with many partitions
+        setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 1, 0, 1000, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
+
+        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                insertStmt, icebergTable, sessionVariable);
+        assertFalse(enabled);
+    }
+
+    @Test
+    public void testAdaptiveShuffleDisabledWhenSingleWorker_DebugLogCovered(@Mocked GlobalStateMgr gsm,
+                                                                            @Mocked MetadataMgr metadataMgr,
+                                                                            @Mocked IcebergTable icebergTable,
+                                                                            @Mocked InsertStmt insertStmt,
+                                                                            @Mocked SessionVariable sessionVariable,
+                                                                            @Mocked QueryStatement queryStatement,
+                                                                            @Mocked SelectRelation selectRelation,
+                                                                            @Mocked NodeMgr nodeMgr,
+                                                                            @Mocked SystemInfoService clusterInfo) {
+        setInsertPlannerLoggerLevel(Level.DEBUG);
+        try {
+            setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                    queryStatement, selectRelation, 1, 0, 1000, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
+
+            boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                    insertStmt, icebergTable, sessionVariable);
+            assertFalse(enabled);
+        } finally {
+            setInsertPlannerLoggerLevel(Level.INFO);
+        }
+    }
+
+    /**
+     * Test adaptive shuffle is disabled when partition count is 1
+     */
+    @Test
+    public void testAdaptiveShuffleDisabledWhenSinglePartition(@Mocked GlobalStateMgr gsm,
+                                                                @Mocked MetadataMgr metadataMgr,
+                                                                @Mocked IcebergTable icebergTable,
+                                                                @Mocked InsertStmt insertStmt,
+                                                                @Mocked SessionVariable sessionVariable,
+                                                                @Mocked QueryStatement queryStatement,
+                                                                @Mocked SelectRelation selectRelation,
+                                                                @Mocked NodeMgr nodeMgr,
+                                                                @Mocked SystemInfoService clusterInfo) {
+        // Setup: 10 backends, 0 CN, 1 partition, should NOT enable shuffle
+        setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 10, 0, 1, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
+
+        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                insertStmt, icebergTable, sessionVariable);
+        assertFalse(enabled);
+    }
+
+    @Test
+    public void testAdaptiveShuffleDisabledWhenSinglePartition_DebugLogCovered(@Mocked GlobalStateMgr gsm,
+                                                                               @Mocked MetadataMgr metadataMgr,
+                                                                               @Mocked IcebergTable icebergTable,
+                                                                               @Mocked InsertStmt insertStmt,
+                                                                               @Mocked SessionVariable sessionVariable,
+                                                                               @Mocked QueryStatement queryStatement,
+                                                                               @Mocked SelectRelation selectRelation,
+                                                                               @Mocked NodeMgr nodeMgr,
+                                                                               @Mocked SystemInfoService clusterInfo) {
+        setInsertPlannerLoggerLevel(Level.DEBUG);
+        try {
+            setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                    queryStatement, selectRelation, 10, 0, 1, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
+
+            boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                    insertStmt, icebergTable, sessionVariable);
+            assertFalse(enabled);
+        } finally {
+            setInsertPlannerLoggerLevel(Level.INFO);
+        }
+    }
+
+    /**
+     * Test adaptive shuffle is disabled when partition count is 0 (new table with no partitions)
+     */
+    @Test
+    public void testAdaptiveShuffleDisabledWhenUnableToEstimate(@Mocked GlobalStateMgr gsm,
+                                                                 @Mocked MetadataMgr metadataMgr,
+                                                                 @Mocked IcebergTable icebergTable,
+                                                                 @Mocked InsertStmt insertStmt,
+                                                                 @Mocked SessionVariable sessionVariable,
+                                                                 @Mocked QueryStatement queryStatement,
+                                                                 @Mocked SelectRelation selectRelation,
+                                                                 @Mocked NodeMgr nodeMgr,
+                                                                 @Mocked SystemInfoService clusterInfo) {
+        // Setup: return empty partition list (new table with no partitions yet)
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                gsm.getNodeMgr();
+                result = nodeMgr;
+                minTimes = 0;
+
+                nodeMgr.getClusterInfo();
+                result = clusterInfo;
+                minTimes = 0;
+
+                clusterInfo.getAliveBackendNumber();
+                result = 10;
+                minTimes = 0;
+
+                clusterInfo.getTotalComputeNodeNumber();
+                result = 0;
+                minTimes = 0;
+
+                // Return empty partition list
+                metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                result = new ArrayList<String>();
+                minTimes = 0;
+
+                icebergTable.getCatalogName();
+                result = "test_catalog";
+                minTimes = 0;
+
+                icebergTable.getCatalogDBName();
+                result = "test_db";
+                minTimes = 0;
+
+                icebergTable.getCatalogTableName();
+                result = "test_table";
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = Lists.newArrayList(new Column("dt", DateType.DATE));
+                minTimes = 0;
+
+                sessionVariable.getConnectorSinkShufflePartitionThreshold();
+                result = 100L;
+                minTimes = 0;
+
+                sessionVariable.getConnectorSinkShufflePartitionNodeRatio();
+                result = 2.0;
+                minTimes = 0;
+            }
+        };
+
+        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
+                insertStmt, icebergTable);
+        // Empty partition list returns 0 (new table with no partitions yet)
+        // This correctly disables shuffle since estimatedPartitionCount (0) <= 1
+        assertEquals(0L, partitionCount);
+
+        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                insertStmt, icebergTable, sessionVariable);
+        assertFalse(enabled);
+    }
+
+    /**
+     * Test adaptive shuffle with BE + CN combination
+     */
+    @Test
+    public void testAdaptiveShuffleWithBEAndCN(@Mocked GlobalStateMgr gsm,
+                                               @Mocked MetadataMgr metadataMgr,
+                                               @Mocked IcebergTable icebergTable,
+                                               @Mocked InsertStmt insertStmt,
+                                               @Mocked SessionVariable sessionVariable,
+                                               @Mocked QueryStatement queryStatement,
+                                               @Mocked SelectRelation selectRelation,
+                                               @Mocked NodeMgr nodeMgr,
+                                               @Mocked SystemInfoService clusterInfo) {
+        // Setup: 5 backends + 5 CN = 10 workers, 50 partitions, ratio = 2.0
+        // Expected: 50 >= 10 * 2.0 = 20, so should enable shuffle
+        setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 5, 5, 50, 100L, 2.0, false, null, null, false, nodeMgr, clusterInfo);
+
+        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                insertStmt, icebergTable, sessionVariable);
+        assertTrue(enabled);
+    }
+
+    /**
+     * Test behavior when partition list is empty (returns 0, disables shuffle)
+     */
+    @Test
+    public void testEmptyPartitionList(@Mocked GlobalStateMgr gsm,
+                                       @Mocked MetadataMgr metadataMgr,
+                                       @Mocked IcebergTable icebergTable,
+                                       @Mocked InsertStmt insertStmt,
+                                       @Mocked SessionVariable sessionVariable) {
+        // Setup: empty partition list (new table with no partitions yet)
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                result = new ArrayList<String>(); // Empty partition list
+                minTimes = 0;
+
+                icebergTable.getCatalogName();
+                result = "test_catalog";
+                minTimes = 0;
+
+                icebergTable.getCatalogDBName();
+                result = "test_db";
+                minTimes = 0;
+
+                icebergTable.getCatalogTableName();
+                result = "test_table";
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = Lists.newArrayList(new Column("dt", DateType.DATE));
+                minTimes = 0;
+
+                GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+            }
+        };
+
+        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
+                insertStmt, icebergTable);
+        // Empty partition list returns 0 (new table with no partitions yet)
+        assertEquals(0L, partitionCount);
+    }
+
+    /**
+     * Test behavior when partition list retrieval throws exception (returns -1, disables shuffle)
+     */
+    @Test
+    public void testPartitionListException(@Mocked GlobalStateMgr gsm,
+                                           @Mocked MetadataMgr metadataMgr,
+                                           @Mocked IcebergTable icebergTable,
+                                           @Mocked InsertStmt insertStmt,
+                                           @Mocked SessionVariable sessionVariable) {
+        // Setup: exception when getting partition list
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                result = new Exception("Failed to get partitions");
+                minTimes = 0;
+
+                icebergTable.getCatalogName();
+                result = "test_catalog";
+                minTimes = 0;
+
+                icebergTable.getCatalogDBName();
+                result = "test_db";
+                minTimes = 0;
+
+                icebergTable.getCatalogTableName();
+                result = "test_table";
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = Lists.newArrayList(new Column("dt", DateType.DATE));
+                minTimes = 0;
+            }
+        };
+
+        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
+                insertStmt, icebergTable);
+        assertEquals(-1L, partitionCount);
+    }
+
+    /**
+     * Test partition estimation falls back to column statistics when partition names are unavailable.
+     */
+
+    @Test
+    public void testPartitionCountFromStatistics(@Mocked GlobalStateMgr gsm,
+                                                 @Mocked MetadataMgr metadataMgr,
+                                                 @Mocked IcebergTable icebergTable,
+                                                 @Mocked InsertStmt insertStmt,
+                                                 @Mocked SessionVariable sessionVariable,
+                                                 @Mocked QueryStatement queryStatement,
+                                                 @Mocked SelectRelation selectRelation,
+                                                 @Mocked StatisticStorage statisticStorage,
+                                                 @Mocked NodeMgr nodeMgr,
+                                                 @Mocked SystemInfoService clusterInfo) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                result = new ArrayList<String>();
+                minTimes = 0;
+
+                gsm.getStatisticStorage();
+                result = statisticStorage;
+                minTimes = 0;
+
+                statisticStorage.getColumnStatistic(icebergTable, "dt");
+                result = ColumnStatistic.buildFrom(ColumnStatistic.unknown()).setDistinctValuesCount(10).setType(
+                        ColumnStatistic.StatisticType.ESTIMATE).build();
+                minTimes = 0;
+
+                statisticStorage.getColumnStatistic(icebergTable, "country");
+                result = ColumnStatistic.buildFrom(ColumnStatistic.unknown()).setDistinctValuesCount(5).setType(
+                        ColumnStatistic.StatisticType.ESTIMATE).build();
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = Lists.newArrayList(
+                        new Column("dt", DateType.DATE),
+                        new Column("country", VarcharType.VARCHAR)
+                );
+                minTimes = 0;
+
+                icebergTable.getCatalogName();
+                result = "test_catalog";
+                minTimes = 0;
+
+                icebergTable.getCatalogDBName();
+                result = "test_db";
+                minTimes = 0;
+
+                icebergTable.getCatalogTableName();
+                result = "test_table";
+                minTimes = 0;
+
+                insertStmt.isStaticKeyPartitionInsert();
+                result = false;
+                minTimes = 0;
+
+                insertStmt.getQueryStatement();
+                result = queryStatement;
+                minTimes = 0;
+
+                queryStatement.getQueryRelation();
+                result = selectRelation;
+                minTimes = 0;
+
+                selectRelation.hasWhereClause();
+                result = false;
+                minTimes = 0;
+
+                sessionVariable.getConnectorSinkShufflePartitionThreshold();
+                result = 100L;
+                minTimes = 0;
+
+                sessionVariable.getConnectorSinkShufflePartitionNodeRatio();
+                result = 2.0;
+                minTimes = 0;
+
+                gsm.getNodeMgr();
+                result = nodeMgr;
+                minTimes = 0;
+
+                nodeMgr.getClusterInfo();
+                result = clusterInfo;
+                minTimes = 0;
+
+                clusterInfo.getAliveBackendNumber();
+                result = 5;
+                minTimes = 0;
+
+                clusterInfo.getTotalComputeNodeNumber();
+                result = 0;
+                minTimes = 0;
+            }
+        };
+
+        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
+                insertStmt, icebergTable);
+        assertEquals(50L, partitionCount);
+    }
+
+    /**
+     * Test partition predicate estimation reduces partition count.
+     */
+    @Test
+    public void testPartitionPredicateEstimation(@Mocked GlobalStateMgr gsm,
+                                                 @Mocked MetadataMgr metadataMgr,
+                                                 @Mocked IcebergTable icebergTable,
+                                                 @Mocked InsertStmt insertStmt,
+                                                 @Mocked SessionVariable sessionVariable,
+                                                 @Mocked QueryStatement queryStatement,
+                                                 @Mocked SelectRelation selectRelation,
+                                                 @Mocked NodeMgr nodeMgr,
+                                                 @Mocked SystemInfoService clusterInfo) {
+        Expr dtPredicate = new BinaryPredicate(BinaryType.EQ, new SlotRef(null, "dt"),
+                new StringLiteral("2024-01-01"));
+        Expr countryPredicate = new InPredicate(new SlotRef(null, "country"),
+                Lists.newArrayList(new StringLiteral("US"), new StringLiteral("CA")), false);
+        Expr predicate = new CompoundPredicate(CompoundPredicate.Operator.AND, dtPredicate, countryPredicate);
+
+        setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 10, 0, 100, 200L, 10.0, false, null, predicate, true, nodeMgr, clusterInfo);
+
+        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
+                insertStmt, icebergTable);
+        assertEquals(2L, partitionCount);
+    }
+
+    /**
+     * Test: when WHERE exists but predicate is too complex to estimate, return unknown (-1) instead of
+     * falling back to existing partition count.
+     */
+    @Test
+    public void testPartitionPredicateUnestimatableReturnsUnknown(@Mocked GlobalStateMgr gsm,
+                                                                  @Mocked MetadataMgr metadataMgr,
+                                                                  @Mocked IcebergTable icebergTable,
+                                                                  @Mocked InsertStmt insertStmt,
+                                                                  @Mocked SessionVariable sessionVariable,
+                                                                  @Mocked QueryStatement queryStatement,
+                                                                  @Mocked SelectRelation selectRelation,
+                                                                  @Mocked NodeMgr nodeMgr,
+                                                                  @Mocked SystemInfoService clusterInfo) {
+        Expr dtEq1 = new BinaryPredicate(BinaryType.EQ, new SlotRef(null, "dt"), new StringLiteral("2024-01-01"));
+        Expr dtEq2 = new BinaryPredicate(BinaryType.EQ, new SlotRef(null, "dt"), new StringLiteral("2024-01-02"));
+        Expr countryEq1 = new BinaryPredicate(BinaryType.EQ, new SlotRef(null, "country"), new StringLiteral("US"));
+        Expr countryEq2 = new BinaryPredicate(BinaryType.EQ, new SlotRef(null, "country"), new StringLiteral("CA"));
+
+        // (dt='2024-01-01' AND country='US') OR (dt='2024-01-02' AND country='CA')
+        // This OR-of-AND is intentionally too complex for InsertPartitionEstimator.
+        Expr left = new CompoundPredicate(CompoundPredicate.Operator.AND, dtEq1, countryEq1);
+        Expr right = new CompoundPredicate(CompoundPredicate.Operator.AND, dtEq2, countryEq2);
+        Expr predicate = new CompoundPredicate(CompoundPredicate.Operator.OR, left, right);
+
+        setupMockExpectationsForAdaptiveShuffle(gsm, metadataMgr, icebergTable, insertStmt, sessionVariable,
+                queryStatement, selectRelation, 10, 0, 200, 100L, 2.0, false, null, predicate, true, nodeMgr, clusterInfo);
+
+        long partitionCount = Deencapsulation.invoke(insertPlanner, "estimatePartitionCountForInsert",
+                insertStmt, icebergTable);
+        assertEquals(-1L, partitionCount);
+
+        boolean enabled = Deencapsulation.invoke(insertPlanner, "shouldEnableAdaptiveGlobalShuffle",
+                insertStmt, icebergTable, sessionVariable);
+        assertFalse(enabled);
+    }
+
+    // Helper method to setup common mock expectations
+    private void setupMockExpectationsForAdaptiveShuffle(GlobalStateMgr gsm,
+                                                         MetadataMgr metadataMgr,
+                                                         IcebergTable icebergTable,
+                                                         InsertStmt insertStmt,
+                                                         SessionVariable sessionVariable,
+                                                         QueryStatement queryStatement,
+                                                         SelectRelation selectRelation,
+                                                         int backendCount,
+                                                         int computeNodeCount,
+                                                         int partitionCount,
+                                                         long threshold,
+                                                         double ratio,
+                                                         boolean isStaticPartitionInsert,
+                                                         PartitionRef partitionRef,
+                                                         Expr predicate,
+                                                         boolean hasWhereClause,
+                                                         NodeMgr nodeMgr,
+                                                         SystemInfoService clusterInfo) {
+        new Expectations() {
+            {
+                // GlobalStateMgr setup
+                GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                gsm.getNodeMgr();
+                result = nodeMgr;
+                minTimes = 0;
+
+                nodeMgr.getClusterInfo();
+                result = clusterInfo;
+                minTimes = 0;
+
+                clusterInfo.getAliveBackendNumber();
+                result = backendCount;
+                minTimes = 0;
+
+                clusterInfo.getTotalComputeNodeNumber();
+                result = computeNodeCount;
+                minTimes = 0;
+
+                // MetadataMgr setup for partition names
+                metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                result = new Delegate<List<String>>() {
+                    @SuppressWarnings("unused")
+                    List<String> delegate(String catalog, String db, String table,
+                                          ConnectorMetadatRequestContext context) {
+                        List<String> partitions = new ArrayList<>();
+                        for (int i = 0; i < partitionCount; i++) {
+                            partitions.add("p" + i);
+                        }
+                        return partitions;
+                    }
+                };
+                minTimes = 0;
+
+                // IcebergTable setup
+                icebergTable.getCatalogName();
+                result = "test_catalog";
+                minTimes = 0;
+
+                icebergTable.getCatalogDBName();
+                result = "test_db";
+                minTimes = 0;
+
+                icebergTable.getCatalogTableName();
+                result = "test_table";
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = Lists.newArrayList(
+                        new Column("dt", DateType.DATE),
+                        new Column("country", VarcharType.VARCHAR)
+                );
+                minTimes = 0;
+
+                // InsertStmt setup
+                insertStmt.isStaticKeyPartitionInsert();
+                result = isStaticPartitionInsert;
+                minTimes = 0;
+
+                insertStmt.getTargetPartitionNames();
+                result = partitionRef;
+                minTimes = 0;
+
+                if (partitionRef != null) {
+                    partitionRef.getPartitionColNames();
+                    result = Lists.newArrayList("p1");
+                    minTimes = 0;
+                }
+
+                insertStmt.getQueryStatement();
+                result = queryStatement;
+                minTimes = 0;
+
+                queryStatement.getQueryRelation();
+                result = selectRelation;
+                minTimes = 0;
+
+                selectRelation.hasWhereClause();
+                result = hasWhereClause;
+                minTimes = 0;
+
+                selectRelation.getPredicate();
+                result = predicate;
+                minTimes = 0;
+
+                // SessionVariable setup
+                sessionVariable.getConnectorSinkShufflePartitionThreshold();
+                result = threshold;
+                minTimes = 0;
+
+                sessionVariable.getConnectorSinkShufflePartitionNodeRatio();
+                result = ratio;
+                minTimes = 0;
+            }
+        };
+    }
+
+    // ==================== PredicateEstimator Coverage Tests ====================
+    // These tests are designed to improve coverage of InsertPartitionEstimator.PredicateEstimator
+    // by testing various predicate scenarios and verifying the estimated partition count
+
+    /**
+     * Test partition estimation with equality predicate on single partition column
+     * Expected: estimate = 1 (single value from equality predicate)
+     */
+    @Test
+    public void testEstimatePartitionWithEqualityPredicate(@Mocked GlobalStateMgr gsm,
+                                                           @Mocked MetadataMgr metadataMgr,
+                                                           @Mocked IcebergTable icebergTable,
+                                                           @Mocked InsertStmt insertStmt,
+                                                           @Mocked QueryStatement queryStatement,
+                                                           @Mocked SelectRelation selectRelation,
+                                                           @Mocked SlotRef slotRef,
+                                                           @Mocked StringLiteral literal) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                // 100 existing partitions
+                metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                result = createPartitionList(100);
+                minTimes = 0;
+
+                icebergTable.getCatalogName();
+                result = "test_catalog";
+                minTimes = 0;
+
+                icebergTable.getCatalogDBName();
+                result = "test_db";
+                minTimes = 0;
+
+                icebergTable.getCatalogTableName();
+                result = "test_table";
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = Lists.newArrayList(new Column("dt", DateType.DATE));
+                minTimes = 0;
+
+                insertStmt.getQueryStatement();
+                result = queryStatement;
+                minTimes = 0;
+
+                queryStatement.getQueryRelation();
+                result = selectRelation;
+                minTimes = 0;
+
+                selectRelation.hasWhereClause();
+                result = true;
+                minTimes = 0;
+
+                // WHERE dt = '2024-01-01'
+                selectRelation.getPredicate();
+                result = createBinaryPredicate(BinaryType.EQ, slotRef, literal);
+                minTimes = 0;
+
+                slotRef.getColumnName();
+                result = "dt";
+                minTimes = 0;
+
+                literal.getStringValue();
+                result = "2024-01-01";
+                minTimes = 0;
+
+                insertStmt.isStaticKeyPartitionInsert();
+                result = false;
+                minTimes = 0;
+            }
+        };
+
+        long estimatedCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
+        // Equality predicate on single partition column should estimate 1 partition
+        assertEquals(1L, estimatedCount);
+    }
+
+    /**
+     * Test partition estimation with IN predicate
+     * Expected: estimate = 3 (number of values in IN list)
+     */
+    @Test
+    public void testEstimatePartitionWithInPredicate(@Mocked GlobalStateMgr gsm,
+                                                      @Mocked MetadataMgr metadataMgr,
+                                                      @Mocked IcebergTable icebergTable,
+                                                      @Mocked InsertStmt insertStmt,
+                                                      @Mocked QueryStatement queryStatement,
+                                                      @Mocked SelectRelation selectRelation,
+                                                      @Mocked SlotRef slotRef,
+                                                      @Mocked InPredicate inPredicate,
+                                                      @Mocked StringLiteral literal1,
+                                                      @Mocked StringLiteral literal2,
+                                                      @Mocked StringLiteral literal3) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                result = createPartitionList(100);
+                minTimes = 0;
+
+                icebergTable.getCatalogName();
+                result = "test_catalog";
+                minTimes = 0;
+
+                icebergTable.getCatalogDBName();
+                result = "test_db";
+                minTimes = 0;
+
+                icebergTable.getCatalogTableName();
+                result = "test_table";
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = Lists.newArrayList(new Column("dt", DateType.DATE));
+                minTimes = 0;
+
+                insertStmt.getQueryStatement();
+                result = queryStatement;
+                minTimes = 0;
+
+                queryStatement.getQueryRelation();
+                result = selectRelation;
+                minTimes = 0;
+
+                selectRelation.hasWhereClause();
+                result = true;
+                minTimes = 0;
+
+                // WHERE dt IN ('2024-01-01', '2024-01-02', '2024-01-03')
+                selectRelation.getPredicate();
+                result = inPredicate;
+                minTimes = 0;
+
+                inPredicate.isNotIn();
+                result = false;
+                minTimes = 0;
+
+                inPredicate.isConstantValues();
+                result = true;
+                minTimes = 0;
+
+                inPredicate.getChild(0);
+                result = slotRef;
+                minTimes = 0;
+
+                inPredicate.getInElementNum();
+                result = 3;
+                minTimes = 0;
+
+                inPredicate.getChildren();
+                result = Lists.newArrayList(slotRef, literal1, literal2, literal3);
+                minTimes = 0;
+
+                slotRef.getColumnName();
+                result = "dt";
+                minTimes = 0;
+
+                literal1.getStringValue();
+                result = "2024-01-01";
+                minTimes = 0;
+
+                literal2.getStringValue();
+                result = "2024-01-02";
+                minTimes = 0;
+
+                literal3.getStringValue();
+                result = "2024-01-03";
+                minTimes = 0;
+
+                insertStmt.isStaticKeyPartitionInsert();
+                result = false;
+                minTimes = 0;
+            }
+        };
+
+        long estimatedCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
+        // IN predicate should estimate 3 partitions
+        assertEquals(3L, estimatedCount);
+    }
+
+    /**
+     * Test partition estimation with OR predicate on same column
+     * Expected: estimate = 2 (sum of OR values)
+     */
+    @Test
+    public void testEstimatePartitionWithOrSameColumn(@Mocked GlobalStateMgr gsm,
+                                                       @Mocked MetadataMgr metadataMgr,
+                                                       @Mocked IcebergTable icebergTable,
+                                                       @Mocked InsertStmt insertStmt,
+                                                       @Mocked QueryStatement queryStatement,
+                                                       @Mocked SelectRelation selectRelation,
+                                                       @Mocked SlotRef slotRef1,
+                                                       @Mocked SlotRef slotRef2,
+                                                       @Mocked StringLiteral literal1,
+                                                       @Mocked StringLiteral literal2,
+                                                       @Mocked BinaryPredicate leftPred,
+                                                       @Mocked BinaryPredicate rightPred,
+                                                       @Mocked CompoundPredicate orPredicate) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                result = createPartitionList(100);
+                minTimes = 0;
+
+                icebergTable.getCatalogName();
+                result = "test_catalog";
+                minTimes = 0;
+
+                icebergTable.getCatalogDBName();
+                result = "test_db";
+                minTimes = 0;
+
+                icebergTable.getCatalogTableName();
+                result = "test_table";
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = Lists.newArrayList(new Column("dt", DateType.DATE));
+                minTimes = 0;
+
+                insertStmt.getQueryStatement();
+                result = queryStatement;
+                minTimes = 0;
+
+                queryStatement.getQueryRelation();
+                result = selectRelation;
+                minTimes = 0;
+
+                selectRelation.hasWhereClause();
+                result = true;
+                minTimes = 0;
+
+                // WHERE dt = '2024-01-01' OR dt = '2024-01-02'
+                selectRelation.getPredicate();
+                result = orPredicate;
+                minTimes = 0;
+
+                orPredicate.getOp();
+                result = CompoundPredicate.Operator.OR;
+                minTimes = 0;
+
+                orPredicate.getChild(0);
+                result = leftPred;
+                minTimes = 0;
+
+                orPredicate.getChild(1);
+                result = rightPred;
+                minTimes = 0;
+
+                setupBinaryPredicateExpectations(leftPred, slotRef1, literal1, "dt", "2024-01-01", BinaryType.EQ);
+                setupBinaryPredicateExpectations(rightPred, slotRef2, literal2, "dt", "2024-01-02", BinaryType.EQ);
+
+                insertStmt.isStaticKeyPartitionInsert();
+                result = false;
+                minTimes = 0;
+            }
+        };
+
+        long estimatedCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
+        // OR on same column should estimate 2 partitions
+        assertEquals(2L, estimatedCount);
+    }
+
+    /**
+     * Test partition estimation with OR predicate on different columns
+     * Expected: estimate = -1 (return -1 due to complexity)
+     */
+    @Test
+    public void testEstimatePartitionWithOrDifferentColumns(@Mocked GlobalStateMgr gsm,
+                                                            @Mocked MetadataMgr metadataMgr,
+                                                            @Mocked IcebergTable icebergTable,
+                                                            @Mocked InsertStmt insertStmt,
+                                                            @Mocked QueryStatement queryStatement,
+                                                            @Mocked SelectRelation selectRelation,
+                                                            @Mocked SlotRef slotRef1,
+                                                            @Mocked SlotRef slotRef2,
+                                                            @Mocked StringLiteral literal1,
+                                                            @Mocked StringLiteral literal2,
+                                                            @Mocked BinaryPredicate leftPred,
+                                                            @Mocked BinaryPredicate rightPred,
+                                                            @Mocked CompoundPredicate orPredicate) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                result = createPartitionList(100);
+                minTimes = 0;
+
+                icebergTable.getCatalogName();
+                result = "test_catalog";
+                minTimes = 0;
+
+                icebergTable.getCatalogDBName();
+                result = "test_db";
+                minTimes = 0;
+
+                icebergTable.getCatalogTableName();
+                result = "test_table";
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = Lists.newArrayList(
+                        new Column("dt", DateType.DATE),
+                        new Column("country", VarcharType.VARCHAR)
+                );
+                minTimes = 0;
+
+                insertStmt.getQueryStatement();
+                result = queryStatement;
+                minTimes = 0;
+
+                queryStatement.getQueryRelation();
+                result = selectRelation;
+                minTimes = 0;
+
+                selectRelation.hasWhereClause();
+                result = true;
+                minTimes = 0;
+
+                // WHERE dt = '2024-01-01' OR country = 'US'
+                selectRelation.getPredicate();
+                result = orPredicate;
+                minTimes = 0;
+
+                orPredicate.getOp();
+                result = CompoundPredicate.Operator.OR;
+                minTimes = 0;
+
+                orPredicate.getChild(0);
+                result = leftPred;
+                minTimes = 0;
+
+                orPredicate.getChild(1);
+                result = rightPred;
+                minTimes = 0;
+
+                setupBinaryPredicateExpectations(leftPred, slotRef1, literal1, "dt", "2024-01-01", BinaryType.EQ);
+                setupBinaryPredicateExpectations(rightPred, slotRef2, literal2, "country", "US", BinaryType.EQ);
+
+                insertStmt.isStaticKeyPartitionInsert();
+                result = false;
+                minTimes = 0;
+            }
+        };
+
+        long estimatedCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
+        // OR on different columns should fall back to -1
+        assertEquals(-1, estimatedCount);
+    }
+
+    /**
+     * Test partition estimation with AND predicate on multiple partition columns
+     * Expected: estimate = 1 (product of equality predicates: 1 * 1 = 1)
+     */
+    @Test
+    public void testEstimatePartitionWithAndPredicate(@Mocked GlobalStateMgr gsm,
+                                                      @Mocked MetadataMgr metadataMgr,
+                                                      @Mocked IcebergTable icebergTable,
+                                                      @Mocked InsertStmt insertStmt,
+                                                      @Mocked QueryStatement queryStatement,
+                                                      @Mocked SelectRelation selectRelation,
+                                                      @Mocked SlotRef slotRef1,
+                                                      @Mocked SlotRef slotRef2,
+                                                      @Mocked StringLiteral literal1,
+                                                      @Mocked StringLiteral literal2,
+                                                      @Mocked BinaryPredicate leftPred,
+                                                      @Mocked BinaryPredicate rightPred,
+                                                      @Mocked CompoundPredicate andPredicate) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                result = createPartitionList(100);
+                minTimes = 0;
+
+                icebergTable.getCatalogName();
+                result = "test_catalog";
+                minTimes = 0;
+
+                icebergTable.getCatalogDBName();
+                result = "test_db";
+                minTimes = 0;
+
+                icebergTable.getCatalogTableName();
+                result = "test_table";
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = Lists.newArrayList(
+                        new Column("dt", DateType.DATE),
+                        new Column("country", VarcharType.VARCHAR)
+                );
+                minTimes = 0;
+
+                insertStmt.getQueryStatement();
+                result = queryStatement;
+                minTimes = 0;
+
+                queryStatement.getQueryRelation();
+                result = selectRelation;
+                minTimes = 0;
+
+                selectRelation.hasWhereClause();
+                result = true;
+                minTimes = 0;
+
+                // WHERE dt = '2024-01-01' AND country = 'US'
+                selectRelation.getPredicate();
+                result = andPredicate;
+                minTimes = 0;
+
+                andPredicate.getOp();
+                result = CompoundPredicate.Operator.AND;
+                minTimes = 0;
+
+                andPredicate.getChild(0);
+                result = leftPred;
+                minTimes = 0;
+
+                andPredicate.getChild(1);
+                result = rightPred;
+                minTimes = 0;
+
+                setupBinaryPredicateExpectations(leftPred, slotRef1, literal1, "dt", "2024-01-01", BinaryType.EQ);
+                setupBinaryPredicateExpectations(rightPred, slotRef2, literal2, "country", "US", BinaryType.EQ);
+
+                insertStmt.isStaticKeyPartitionInsert();
+                result = false;
+                minTimes = 0;
+            }
+        };
+
+        long estimatedCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
+        // AND on multiple partition columns should estimate 1 partition (1 * 1 = 1)
+        assertEquals(1L, estimatedCount);
+    }
+
+    /**
+     * Test partition estimation with range predicate (>)
+     * Expected: estimate = 10 (10% of 100 existing partitions)
+     */
+    @Test
+    public void testEstimatePartitionWithRangePredicate(@Mocked GlobalStateMgr gsm,
+                                                        @Mocked MetadataMgr metadataMgr,
+                                                        @Mocked StatisticStorage statisticStorage,
+                                                        @Mocked IcebergTable icebergTable,
+                                                        @Mocked InsertStmt insertStmt,
+                                                        @Mocked QueryStatement queryStatement,
+                                                        @Mocked SelectRelation selectRelation,
+                                                        @Mocked NodeMgr nodeMgr,
+                                                        @Mocked SystemInfoService clusterInfo,
+                                                        @Mocked SlotRef slotRef,
+                                                        @Mocked StringLiteral literal) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                gsm.getNodeMgr();
+                result = nodeMgr;
+                minTimes = 0;
+
+                nodeMgr.getClusterInfo();
+                result = clusterInfo;
+                minTimes = 0;
+
+                clusterInfo.getAliveBackendNumber();
+                result = 10;
+                minTimes = 0;
+
+                clusterInfo.getTotalComputeNodeNumber();
+                result = 0;
+                minTimes = 0;
+
+                metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                result = createPartitionList(100);
+                minTimes = 0;
+
+                icebergTable.getCatalogName();
+                result = "test_catalog";
+                minTimes = 0;
+
+                icebergTable.getCatalogDBName();
+                result = "test_db";
+                minTimes = 0;
+
+                icebergTable.getCatalogTableName();
+                result = "test_table";
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = Lists.newArrayList(new Column("dt", DateType.DATE));
+                minTimes = 0;
+
+                gsm.getStatisticStorage();
+                result = statisticStorage;
+                minTimes = 0;
+
+                // NDV = 100
+                ColumnStatistic columnStatistic = new ColumnStatistic(
+                        Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 0, 1, 100);
+                statisticStorage.getColumnStatistic(icebergTable, "dt");
+                result = columnStatistic;
+                minTimes = 0;
+
+                insertStmt.getQueryStatement();
+                result = queryStatement;
+                minTimes = 0;
+
+                queryStatement.getQueryRelation();
+                result = selectRelation;
+                minTimes = 0;
+
+                selectRelation.hasWhereClause();
+                result = true;
+                minTimes = 0;
+
+                // WHERE dt > '2024-01-01'
+                selectRelation.getPredicate();
+                result = createBinaryPredicate(BinaryType.GT, slotRef, literal);
+                minTimes = 0;
+
+                slotRef.getColumnName();
+                result = "dt";
+                minTimes = 0;
+
+                literal.getStringValue();
+                result = "2024-01-01";
+                minTimes = 0;
+
+                insertStmt.isStaticKeyPartitionInsert();
+                result = false;
+                minTimes = 0;
+            }
+        };
+
+        long estimatedCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
+        // Range predicate should estimate 10% of NDV
+        assertEquals(10L, estimatedCount);
+    }
+
+    /**
+     * Test partition estimation with NOT IN predicate
+     * Expected: estimate = 100 (falls back to existing partition count)
+     */
+    @Test
+    public void testEstimatePartitionWithNotInPredicate(@Mocked GlobalStateMgr gsm,
+                                                         @Mocked MetadataMgr metadataMgr,
+                                                         @Mocked StatisticStorage statisticStorage,
+                                                         @Mocked IcebergTable icebergTable,
+                                                         @Mocked InsertStmt insertStmt,
+                                                         @Mocked QueryStatement queryStatement,
+                                                         @Mocked SelectRelation selectRelation,
+                                                         @Mocked NodeMgr nodeMgr,
+                                                         @Mocked SystemInfoService clusterInfo,
+                                                         @Mocked SlotRef slotRef,
+                                                         @Mocked InPredicate notInPredicate) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = gsm;
+                minTimes = 0;
+
+                gsm.getMetadataMgr();
+                result = metadataMgr;
+                minTimes = 0;
+
+                gsm.getNodeMgr();
+                result = nodeMgr;
+                minTimes = 0;
+
+                nodeMgr.getClusterInfo();
+                result = clusterInfo;
+                minTimes = 0;
+
+                clusterInfo.getAliveBackendNumber();
+                result = 10;
+                minTimes = 0;
+
+                clusterInfo.getTotalComputeNodeNumber();
+                result = 0;
+                minTimes = 0;
+
+                metadataMgr.listPartitionNames(anyString, anyString, anyString,
+                        withInstanceOf(ConnectorMetadatRequestContext.class));
+                result = createPartitionList(100);
+                minTimes = 0;
+
+                icebergTable.getCatalogName();
+                result = "test_catalog";
+                minTimes = 0;
+
+                icebergTable.getCatalogDBName();
+                result = "test_db";
+                minTimes = 0;
+
+                icebergTable.getCatalogTableName();
+                result = "test_table";
+                minTimes = 0;
+
+                icebergTable.getPartitionColumns();
+                result = Lists.newArrayList(new Column("dt", DateType.DATE));
+                minTimes = 0;
+
+                gsm.getStatisticStorage();
+                result = statisticStorage;
+                minTimes = 0;
+
+                ColumnStatistic columnStatistic = new ColumnStatistic(
+                        Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 0, 1, 100);
+                statisticStorage.getColumnStatistic(icebergTable, "dt");
+                result = columnStatistic;
+                minTimes = 0;
+
+                insertStmt.getQueryStatement();
+                result = queryStatement;
+                minTimes = 0;
+
+                queryStatement.getQueryRelation();
+                result = selectRelation;
+                minTimes = 0;
+
+                selectRelation.hasWhereClause();
+                result = true;
+                minTimes = 0;
+
+                // WHERE dt NOT IN ('2024-01-01', '2024-01-02')
+                selectRelation.getPredicate();
+                result = notInPredicate;
+                minTimes = 0;
+
+                notInPredicate.isNotIn();
+                result = true;
+                minTimes = 0;
+
+                notInPredicate.getChild(0);
+                result = slotRef;
+                minTimes = 0;
+
+                slotRef.getColumnName();
+                result = "dt";
+                minTimes = 0;
+
+                insertStmt.isStaticKeyPartitionInsert();
+                result = false;
+                minTimes = 0;
+            }
+        };
+
+        long estimatedCount = InsertPartitionEstimator.estimatePartitionCountForInsert(insertStmt, icebergTable);
+        // NOT IN should fall back to existing partition count
+        assertEquals(100L, estimatedCount);
+    }
+
+    // ==================== Helper Methods ====================
+
+    private List<String> createPartitionList(int count) {
+        List<String> partitions = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            partitions.add("p" + i);
+        }
+        return partitions;
+    }
+
+    private void setupBinaryPredicateExpectations(@Mocked BinaryPredicate predicate,
+                                                   @Mocked SlotRef slotRef,
+                                                   @Mocked StringLiteral literal,
+                                                   String columnName,
+                                                   String literalValue,
+                                                   BinaryType binaryType) {
+        new Expectations() {
+            {
+                predicate.getOp();
+                result = binaryType;
+                minTimes = 0;
+
+                predicate.getChild(0);
+                result = slotRef;
+                minTimes = 0;
+
+                predicate.getChild(1);
+                result = literal;
+                minTimes = 0;
+
+                slotRef.getColumnName();
+                result = columnName;
+                minTimes = 0;
+
+                literal.getStringValue();
+                result = literalValue;
+                minTimes = 0;
+            }
+        };
+    }
+
+    private BinaryPredicate createBinaryPredicate(BinaryType type, SlotRef slotRef, StringLiteral literal) {
+        BinaryPredicate pred = new BinaryPredicate(type, slotRef, literal);
+        return pred;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
@@ -170,6 +170,32 @@ public class AnalyzeSetVariableTest {
     }
 
     @Test
+    public void testConnectorSinkShuffleModeVariables() {
+        analyzeSuccess("set connector_sink_shuffle_mode = 'auto'");
+        analyzeSuccess("set connector_sink_shuffle_mode = 'force'");
+        analyzeSuccess("set connector_sink_shuffle_mode = 'never'");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            com.starrocks.sql.ast.StatementBase stmt = AnalyzeTestUtil.parseSql(
+                    "set connector_sink_shuffle_mode = 'unknown'");
+            Analyzer.analyze(stmt, connectContext);
+        });
+
+        analyzeSuccess("set connector_sink_shuffle_partition_threshold = 1");
+        analyzeFail("set connector_sink_shuffle_partition_threshold = 0",
+                "connector_sink_shuffle_partition_threshold must be equal or greater than 1");
+
+        analyzeSuccess("set connector_sink_shuffle_partition_node_ratio = 0.1");
+        analyzeFail("set connector_sink_shuffle_partition_node_ratio = 0",
+                "connector_sink_shuffle_partition_node_ratio should be a positive finite number");
+        analyzeFail("set connector_sink_shuffle_partition_node_ratio = 'NaN'",
+                "connector_sink_shuffle_partition_node_ratio should be a positive finite number");
+        analyzeFail("set connector_sink_shuffle_partition_node_ratio = 'Infinity'",
+                "connector_sink_shuffle_partition_node_ratio should be a positive finite number");
+        analyzeFail("set connector_sink_shuffle_partition_node_ratio = 'abc'",
+                "failed to parse connector_sink_shuffle_partition_node_ratio");
+    }
+
+    @Test
     public void testSetNames() {
         String sql = "SET NAMES 'utf8mb4' COLLATE 'bogus'";
         analyzeSuccess(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.connector.ConnectorSinkShuffleMode;
 import com.starrocks.planner.DataSink;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
@@ -852,6 +853,9 @@ public class InsertPlanTest extends PlanTestBase {
 
                 icebergTable.getPartitionColumnNames();
                 result = new ArrayList<>();
+
+                icebergTable.getPartitionColumns();
+                result = new ArrayList<>();
             }
         };
 
@@ -998,8 +1002,8 @@ public class InsertPlanTest extends PlanTestBase {
 
         new MockUp<SessionVariable>() {
             @Mock
-            public boolean isEnableIcebergSinkGlobalShuffle() {
-                return true;
+            public ConnectorSinkShuffleMode getConnectorSinkShuffleMode() {
+                return ConnectorSinkShuffleMode.FORCE;
             }
         };
 


### PR DESCRIPTION
## Why I'm doing:
Now we support global shuffle in iceberg table sink, but disable it by default to avoid the performance degradation. So, users can only benefit from performance by manually enabling global shuffle in specific scenarios. So, it is not flexible enough for users.

## What I'm doing:
* Introduce a new, more flexible session variable to control global shuffle behavior for connector table sinks (such as Iceberg, Hive, and File tables). The new variable, `connector_sink_shuffle_mode`, supports three modes—`force`, `auto`, and `never`
* Implements `InsertPartitionEstimator` utility class for intelligent partition count estimation using predicates, statistics, and metadata
* When connector_sink_shuffle_mode is `auto`, we judge whether adaptive global shuffle should be enabled based on related partition count and backend count, and enable it dynamically.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

