### PR TITLE
[Doc] Update ADMIN SHOW CONFIG return parameters and examples

### DIFF
--- a/docs/en/sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SHOW_CONFIG.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SHOW_CONFIG.md
@@ -26,11 +26,11 @@ Description of the return parameters:
 
 ```plain text
 1. Key:        Configuration item name
-2. Value:      Configuration item value
-3. Type:       Configuration item type 
-4. IsMutable:  Whether it can be set through the ADMIN SET CONFIG command
-5. MasterOnly: Whether it only applies to leader FE
-6. Comment:    Configuration item description 
+2. AliasNames: Aliases of the configuration item
+3. Value:      Configuration item value
+4. Type:       Configuration item type
+5. IsMutable:  Whether it can be set through the ADMIN SET CONFIG command
+6. Comment:    Configuration item description
 ```
 
 ## Examples
@@ -44,11 +44,11 @@ Description of the return parameters:
 2. Search for the configuration of the current FE node by using the `like` predicate.  
 
     ```plain text
-    mysql> ADMIN SHOW FRONTEND CONFIG LIKE '%check_java_version%';
-    +--------------------+-------+---------+-----------+------------+---------+
-    | Key                | Value | Type    | IsMutable | MasterOnly | Comment |
-    +--------------------+-------+---------+-----------+------------+---------+
-    | check_java_version | true  | boolean | false     | false      |         |
-    +--------------------+-------+---------+-----------+------------+---------+
+    mysql> ADMIN SHOW FRONTEND CONFIG LIKE '%vectorized_load_enable%';
+    +------------------------+------------+-------+---------+-----------+---------+
+    | Key                    | AliasNames | Value | Type    | IsMutable | Comment |
+    +------------------------+------------+-------+---------+-----------+---------+
+    | vectorized_load_enable | []         | true  | boolean | true      |         |
+    +------------------------+------------+-------+---------+-----------+---------+
     1 row in set (0.00 sec)
     ```

--- a/docs/ja/sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SHOW_CONFIG.md
+++ b/docs/ja/sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SHOW_CONFIG.md
@@ -28,10 +28,10 @@ ADMIN SHOW FRONTEND CONFIG [LIKE "pattern"]
 
 ```plain text
 1. Key:        設定項目名
-2. Value:      設定項目の値
-3. Type:       設定項目のタイプ
-4. IsMutable:  ADMIN SET CONFIG コマンドで設定可能かどうか
-5. MasterOnly: leader FE のみに適用されるかどうか
+2. AliasNames: 設定項目のエイリアス
+3. Value:      設定項目の値
+4. Type:       設定項目のタイプ
+5. IsMutable:  ADMIN SET CONFIG コマンドで設定可能かどうか
 6. Comment:    設定項目の説明
 ```
 
@@ -46,11 +46,11 @@ ADMIN SHOW FRONTEND CONFIG [LIKE "pattern"]
 2. `like` 述語を使用して、現在の FE ノードの設定を検索します。
 
     ```plain text
-    mysql> ADMIN SHOW FRONTEND CONFIG LIKE '%check_java_version%';
-    +--------------------+-------+---------+-----------+------------+---------+
-    | Key                | Value | Type    | IsMutable | MasterOnly | Comment |
-    +--------------------+-------+---------+-----------+------------+---------+
-    | check_java_version | true  | boolean | false     | false      |         |
-    +--------------------+-------+---------+-----------+------------+---------+
+    mysql> ADMIN SHOW FRONTEND CONFIG LIKE '%vectorized_load_enable%';
+    +------------------------+------------+-------+---------+-----------+---------+
+    | Key                    | AliasNames | Value | Type    | IsMutable | Comment |
+    +------------------------+------------+-------+---------+-----------+---------+
+    | vectorized_load_enable | []         | true  | boolean | true      |         |
+    +------------------------+------------+-------+---------+-----------+---------+
     1 row in set (0.00 sec)
     ```

--- a/docs/zh/sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SHOW_CONFIG.md
+++ b/docs/zh/sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SHOW_CONFIG.md
@@ -31,10 +31,10 @@ ADMIN SHOW FRONTEND CONFIG [LIKE "pattern"]
 ```plain text
 1. Key         配置项名称
 2. AliasNames  配置项别名
-2. Value       配置项取值
-3. Type        配置项数据类型
-4. IsMutable   是否可以通过 ADMIN SET CONFIG 命令动态设置
-5. Comment     配置项说明
+3. Value       配置项取值
+4. Type        配置项数据类型
+5. IsMutable   是否可以通过 ADMIN SET CONFIG 命令动态设置
+6. Comment     配置项说明
 ```
 
 ## 示例
@@ -48,12 +48,11 @@ ADMIN SHOW FRONTEND CONFIG [LIKE "pattern"]
 2. 使用 like 谓词搜索当前 FE 节点的配置。
 
     ```plain text
-    mysql> ADMIN SHOW FRONTEND CONFIG LIKE '%check_java_version%';
-    +--------------------+------------+-------+---------+-----------+---------+
-    | Key                | AliasNames | Value | Type    | IsMutable | Comment |
-    +--------------------+------------+-------+---------+-----------+---------+
-    | check_java_version | []         | true  | boolean | false     |         |
-    +--------------------+------------+-------+---------+-----------+---------+
+    mysql> ADMIN SHOW FRONTEND CONFIG LIKE '%vectorized_load_enable%';
+    +------------------------+------------+-------+---------+-----------+---------+
+    | Key                    | AliasNames | Value | Type    | IsMutable | Comment |
+    +------------------------+------------+-------+---------+-----------+---------+
+    | vectorized_load_enable | []         | true  | boolean | true      |         |
+    +------------------------+------------+-------+---------+-----------+---------+
     1 row in set (0.00 sec)
-
     ```


### PR DESCRIPTION
## Why I'm doing:

The current documentation for `ADMIN SHOW CONFIG` is outdated regarding the return parameters and examples.
1. The return parameter `MasterOnly` has been removed and `AliasNames` has been added in recent versions (e.g., v4.0.2), but the docs still reflect the old structure.
2. The example query using `check_java_version` returns an Empty Set in newer versions, which confuses users.
3. The Chinese documentation had incorrect numbering in the parameter description list.

## What I'm doing:

Updated the `ADMIN SHOW CONFIG` documentation for English, Japanese, and Chinese:
- **Updated Return Parameters:** Removed `MasterOnly`, added `AliasNames`, and fixed the numbering in the Chinese docs.
- **Updated Example:** Replaced the outdated `check_java_version` example with `vectorized_load_enable`, which returns a valid result.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4