### PR TITLE
[BugFix] Fix a bug that some kind of partitions can not be written

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -45,14 +45,12 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_CONNECTION_POOL_SIZE;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TIMEOUT;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TYPE;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
-import static org.apache.hadoop.hive.common.FileUtils.unescapePathName;
 
 public class HiveMetaClient {
     private static final Logger LOG = LogManager.getLogger(HiveMetaClient.class);
@@ -317,10 +315,8 @@ public class HiveMetaClient {
             RecyclableClient client = null;
             StarRocksConnectorException connectionException = null;
             try {
-                List<String> decodedPartitionNames = partitionNames.stream().
-                        map(name -> unescapePathName(name)).collect(Collectors.toList());
                 client = getClient();
-                partitions = client.hiveClient.getPartitionsByNames(dbName, tblName, decodedPartitionNames);
+                partitions = client.hiveClient.getPartitionsByNames(dbName, tblName, partitionNames);
                 if (partitions.size() != partitionNames.size()) {
                     LOG.warn("Expect to fetch {} partition on [{}.{}], but actually fetched {} partition",
                             partitionNames.size(), dbName, tblName, partitions.size());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -455,12 +455,13 @@ public class HiveMetadata implements ConnectorMetadata {
             return;
         }
         HiveTable table = (HiveTable) getTable(new ConnectContext(), dbName, tableName);
+        List<String> partitionColumnNames = table.getPartitionColumnNames();
         String stagingDir = commitInfos.get(0).getStaging_dir();
         boolean isOverwrite = commitInfos.get(0).isIs_overwrite();
 
         List<PartitionUpdate> partitionUpdates = commitInfos.stream()
                 .map(TSinkCommitInfo::getHive_file_info)
-                .map(fileInfo -> PartitionUpdate.get(fileInfo, stagingDir, table.getTableLocation()))
+                .map(fileInfo -> PartitionUpdate.get(fileInfo, stagingDir, table.getTableLocation(), partitionColumnNames))
                 .collect(Collectors.collectingAndThen(Collectors.toList(), PartitionUpdate::merge));
 
         List<String> partitionColNames = table.getPartitionColumnNames();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/PartitionUpdate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/PartitionUpdate.java
@@ -97,17 +97,20 @@ public class PartitionUpdate {
         OVERWRITE,
     }
 
-    public static PartitionUpdate get(THiveFileInfo fileInfo, String stagingDir, String tableLocation) {
+    public static PartitionUpdate get(THiveFileInfo fileInfo, String stagingDir,
+                                      String tableLocation, List<String> partitionColNames) {
         Preconditions.checkState(fileInfo.isSetPartition_path() && !Strings.isNullOrEmpty(fileInfo.getPartition_path()),
                 "Missing partition path");
 
-        String partitionName = PartitionUtil.getPartitionName(stagingDir, fileInfo.getPartition_path());
+        String partitionNameFromPath = PartitionUtil.getPartitionName(stagingDir, fileInfo.getPartition_path());
+        List<String> partitionValues = PartitionUtil.toPartitionValues(partitionNameFromPath);
+        String partitionName = PartitionUtil.toHivePartitionName(partitionColNames, partitionValues);
 
         String tableLocationWithSlash = getPathWithSlash(tableLocation);
         String stagingDirWithSlash = getPathWithSlash(stagingDir);
 
-        String writePath = stagingDirWithSlash + partitionName + "/";
-        String targetPath = tableLocationWithSlash + partitionName + "/";
+        String writePath = stagingDirWithSlash + partitionNameFromPath + "/";
+        String targetPath = tableLocationWithSlash + partitionNameFromPath + "/";
 
         return new PartitionUpdate(partitionName, new Path(writePath), new Path(targetPath),
                 Lists.newArrayList(fileInfo.getFile_name()), fileInfo.getRecord_count(), fileInfo.getFile_size_in_bytes());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/PartitionUpdateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/PartitionUpdateTest.java
@@ -34,7 +34,9 @@ public class PartitionUpdateTest {
         fileInfo.setPartition_path("hdfs://hadoop01:9000/tmp/starrocks/queryid/k2=2");
         fileInfo.setRecord_count(10);
         fileInfo.setFile_size_in_bytes(100);
-        PartitionUpdate pu = PartitionUpdate.get(fileInfo, stagingDir, tableLocation);
+        List<String> partitionColNames = Lists.newArrayList();
+        partitionColNames.add("k2");
+        PartitionUpdate pu = PartitionUpdate.get(fileInfo, stagingDir, tableLocation, partitionColNames);
         pu.setUpdateMode(PartitionUpdate.UpdateMode.NEW);
         Assertions.assertEquals("k2=2", pu.getName());
         Assertions.assertEquals(Lists.newArrayList("myfile.parquet"), pu.getFileNames());
@@ -49,7 +51,7 @@ public class PartitionUpdateTest {
         ExceptionChecker.expectThrowsWithMsg(
                 IllegalStateException.class,
                 "Missing partition path",
-                () -> PartitionUpdate.get(fileInfo1, stagingDir, tableLocation));
+                () -> PartitionUpdate.get(fileInfo1, stagingDir, tableLocation, partitionColNames));
     }
 
     @Test

--- a/test/sql/test_dml/R/test_escape
+++ b/test/sql/test_dml/R/test_escape
@@ -23,6 +23,12 @@ insert into hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par values(1, 
 insert into hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par values(2, "4-NOT SPECI");
 -- result:
 -- !result
+insert into hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par values(1, "4-NOT SPECI:123");
+-- result:
+-- !result
+insert into hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par values(2, "4-NOT SPECI:123");
+-- result:
+-- !result
 drop table hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par force;
 -- result:
 -- !result

--- a/test/sql/test_dml/T/test_escape
+++ b/test/sql/test_dml/T/test_escape
@@ -18,6 +18,10 @@ insert into hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par values(1, 
 
 insert into hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par values(2, "4-NOT SPECI");
 
+insert into hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par values(1, "4-NOT SPECI:123");
+
+insert into hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par values(2, "4-NOT SPECI:123");
+
 drop table hive_catalog_${uuid0}.hive_db_${uuid0}.hive_lineorder_par force;
 
 drop database hive_catalog_${uuid0}.hive_db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
Fix the bug that mentioned in https://github.com/StarRocks/starrocks/issues/64340

When write the partition with ':' twice will have the following issue.
<img width="2774" height="1166" alt="image" src="https://github.com/user-attachments/assets/8f420c74-7cd2-40ef-bc55-73293428f263" />
The partition name we used to get the partition from HMS was unescaped to 'lo_orderpriority=4-NOT SPECI:13123'
But we do not register it into HMS we will only register 'lo_orderpriority=4-NOT SPECI%3A213123' in HMS.
## What I'm doing:
Remove the unescape in HiveMetaClient and regenerate partitionName in PartitionUpdate.java
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
