### PR TITLE
[Enhancement] Support shared file cleanup for range distribution vacuum and tablet deletion

### DIFF
--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -343,6 +343,9 @@ message VacuumRequest {
     // All tablet metadata and their data files of these verisons should be retained and can not be
     // vaccummed.
     repeated int64 retain_versions = 9;
+    // Whether enable shared file cleanup in vacuum.
+    // This flag is used for both file-bundling tables and range-distribution tables.
+    optional bool enable_shared_file_cleanup = 10;
 }
 
 message VacuumResponse {
@@ -467,4 +470,3 @@ service LakeService {
     rpc get_tablet_metadatas(GetTabletMetadatasRequest) returns (GetTabletMetadatasResponse);
     rpc repair_tablet_metadata(RepairTabletMetadataRequest) returns (RepairTabletMetadataResponse);
 }
-


### PR DESCRIPTION
## Why I'm doing:
  Range distribution tablet split/merge introduces shared data files across tablets.
  The previous vacuum/delete_tablets flow mainly handled bundle-file sharing, which could lead to incorrect or incomplete shared-file cleanup in range distribution scenarios.

## What I'm doing:
  - Added `enable_shared_file_cleanup` in `VacuumRequest` (kept `enable_file_bundling` for compatibility).
  - FE autovacuum:
    - Computes `enableSharedFileCleanup = fileBundling || table.isRangeDistribution()`.
    - Uses single-node (aggregator) scheduling when shared cleanup is enabled.
    - Sends both flags to BE (`enableFileBundling` + `enableSharedFileCleanup`).
  - BE vacuum:
    - Introduced shared-segment detection helper (`bundle_file_offsets` or `shared_segments`).
    - Reused delayed-delete model by renaming/extending to `AsyncSharedFileDeleter`.
    - Extended shared candidate collection and alive-reference scan for rowset/delvec/dcg/sstable shared files.
    - Decoupled behavior:
      - `enable_file_bundling`: controls bundle metadata vacuum path.
      - `enable_shared_file_cleanup`: controls shared data file cleanup.
  - BE `delete_tablets`:
    - Fixed txnlog cleanup for `op_compaction` and `op_schema_change` to avoid unconditional deletion of shared/bundle segments.
    - Applied the same shared-safe gate used by `op_write`.
  - Added/updated BE unit tests to cover shared cleanup and txnlog shared-segment safety.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
