### PR TITLE
[UT] fix UT core due to WorkGroupManager not initialized

### DIFF
--- a/be/test/agent/resource_group_usage_recorder_test.cpp
+++ b/be/test/agent/resource_group_usage_recorder_test.cpp
@@ -17,6 +17,7 @@
 #include "exec/workgroup/work_group.h"
 #include "gtest/gtest.h"
 #include "runtime/exec_env.h"
+#include "testutil/assert.h"
 
 namespace starrocks {
 
@@ -28,6 +29,7 @@ TEST(ResourceGroupUsageRecorderTest, test_get_resource_group_usages) {
             CpuInfo::num_cores(), num_cores, num_cores, num_cores, CpuInfo::get_core_ids(), true,
             config::enable_resource_group_cpu_borrowing, StarRocksMetrics::instance()->get_pipeline_executor_metrics());
     exec_env._workgroup_manager = std::make_unique<workgroup::WorkGroupManager>(std::move(executors_manager_opts));
+    ASSERT_OK(exec_env._workgroup_manager->start());
 
     workgroup::DefaultWorkGroupInitialization default_workgroup_init;
     auto default_wg = exec_env.workgroup_manager()->get_default_workgroup();


### PR DESCRIPTION
## Why I'm doing:
found in 3.5.11, when run be ut script by default parameters would core due to WorkGroupManager not initialized

stack
```cpp
[----------] 5 tests from TestPipelineControlFlow
[ RUN      ] TestPipelineControlFlow.test_two_operatories
UNKNOWN ASAN (build UNKNOWN distro ubuntu arch x86_64)
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000, plan_node_id:-1
*** Aborted at 1768900621 (unix time) try "date -d @1768900621" if you are using GNU date ***
PC: @         0x1b7d312e starrocks::pipeline::PipelineTestBase::_execute()::{lambda(std::shared_ptr<starrocks::pipeline::PipelineDriver> const&)#2}::operator()(std::shared_ptr<starrocks::pipeline::PipelineDriver> const&) const
*** SIGSEGV (@0x0) received by PID 18297 (TID 0x7f9959dc9ac0) LWP(18297) from PID 0; stack trace: ***
    @         0x3494ab36 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f9959e87ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x3494a379 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f995b17c3be PosixSignals::chained_handler(int, siginfo_t*, void*) [clone .part.0]
    @     0x7f995b17cf0e JVM_handle_linux_signal
    @     0x7f9959e30520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @         0x1b7d312e starrocks::pipeline::PipelineTestBase::_execute()::{lambda(std::shared_ptr<starrocks::pipeline::PipelineDriver> const&)#2}::operator()(std::shared_ptr<starrocks::pipeline::PipelineDriver> const&) const
    @         0x1b7d667d starrocks::pipeline::FragmentContext::iterate_drivers<starrocks::pipeline::PipelineTestBase::_execute()::{lambda(std::shared_ptr<starrocks::pipeline::PipelineDriver> const&)#2}>(starrocks::pipeline::PipelineTestBase::_execute()::{lambda(std::shared_ptr<sta�
    @         0x1b7d7880 void std::__invoke_impl<void, starrocks::pipeline::FragmentContext::iterate_drivers<starrocks::pipeline::PipelineTestBase::_execute()::{lambda(std::shared_ptr<starrocks::pipeline::PipelineDriver> const&)#2}>(starrocks::pipeline::PipelineTestBase::_execute(�
    @         0x1b7d7542 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::FragmentContext::iterate_drivers<starrocks::pipeline::PipelineTestBase::_execute()::{lambda(std::shared_ptr<starrocks::pipeline::PipelineDriver> const&)#2}>(starrocks::pipeline::PipelineTestBase::_�
    @         0x1b7d70af std::_Function_handler<void (starrocks::pipeline::Pipeline*), starrocks::pipeline::FragmentContext::iterate_drivers<starrocks::pipeline::PipelineTestBase::_execute()::{lambda(std::shared_ptr<starrocks::pipeline::PipelineDriver> const&)#2}>(starrocks::pipel�
    @         0x2543f174 std::function<void (starrocks::pipeline::Pipeline*)>::operator()(starrocks::pipeline::Pipeline*) const
    @         0x2543d435 auto starrocks::pipeline::ExecutionGroup::for_each_pipeline<std::function<void (starrocks::pipeline::Pipeline*)> const&>(std::function<void (starrocks::pipeline::Pipeline*)> const&)
    @         0x2543149b starrocks::pipeline::FragmentContext::iterate_pipeline(std::function<void (starrocks::pipeline::Pipeline*)> const&)
    @         0x1b7d6811 void starrocks::pipeline::FragmentContext::iterate_drivers<starrocks::pipeline::PipelineTestBase::_execute()::{lambda(std::shared_ptr<starrocks::pipeline::PipelineDriver> const&)#2}>(starrocks::pipeline::PipelineTestBase::_execute()::{lambda(std::shared_pt�
    @         0x1b7d3355 starrocks::pipeline::PipelineTestBase::_execute()
    @         0x1b7cfd56 starrocks::pipeline::PipelineTestBase::start_test()
    @         0x1b7292e7 starrocks::pipeline::TestPipelineControlFlow_test_two_operatories_Test::TestBody()
    @         0x374db094 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)
    @         0x374cc67e testing::Test::Run()
    @         0x374cc7e5 testing::TestInfo::Run()
    @         0x374cc8d5 testing::TestSuite::Run()
    @         0x374cce96 testing::internal::UnitTestImpl::RunAllTests()
    @         0x374cd0d1 testing::UnitTest::Run()
    @         0x1acc427e RUN_ALL_TESTS()
    @         0x1acadaea starrocks::init_test_env(int, char**)
    @         0x1acae57f main
    @     0x7f9959e17d90 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
    @     0x7f9959e17e40 __libc_start_main
    @         0x1abd6025 _start
```

rc
[starrocks/be/test/agent/resource_group_usage_recorder_test.cpp at branch-3.5.11 · StarRocks/starrock](https://github.com/StarRocks/starrocks/blob/branch-3.5.11/be/test/agent/resource_group_usage_recorder_test.cpp#L30)
![img_v3_02u5_3b0ec0c1-85eb-4f4e-acef-be694fb5d3hu](https://github.com/user-attachments/assets/66eb865e-7743-4eb5-82b2-e1845c63fb98)


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
