### PR TITLE
[BugFix] fix range partition overlap

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -224,6 +224,10 @@ public class RangePartitionInfo extends PartitionInfo {
         }
         newRange = Range.closedOpen(lowKey, newRangeUpper);
 
+        if (lastRange != null) {
+            RangeUtils.checkRangeIntersect(newRange, lastRange);
+        }
+        
         if (currentRange != null) {
             // check if range intersected
             RangeUtils.checkRangeIntersect(newRange, currentRange);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/RangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/RangePartitionInfoTest.java
@@ -376,6 +376,46 @@ public class RangePartitionInfoTest {
         });
     }
 
+    /**
+     * Regression test: when adding a fixed range partition with an explicitly specified lower bound, we must validate
+     * intersection against both the predecessor and successor partitions. Only checking the successor can miss overlaps
+     * with earlier partitions when the lower bound is much smaller than expected.
+     */
+    @Test
+    public void testFixedRangeOverlapShouldCheckPreviousRange() {
+        assertThrows(DdlException.class, () -> {
+            // Single-column INT range partitioning.
+            int columns = 1;
+            Column partDt = new Column("part_dt", new ScalarType(PrimitiveType.INT), true, null, "", "");
+            partitionColumns.add(partDt);
+            partitionInfo = new RangePartitionInfo(partitionColumns);
+
+            // Existing partitions are non-overlapping.
+            PartitionKeyDesc p1 = new PartitionKeyDesc(
+                    Lists.newArrayList(new PartitionValue("20220901")),
+                    Lists.newArrayList(new PartitionValue("20220902")));
+            SingleRangePartitionDesc d1 = new SingleRangePartitionDesc(false, "p1", p1, null);
+            PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(d1, columns, null);
+            partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(partitionColumns), d1, 1L, false);
+
+            PartitionKeyDesc p2 = new PartitionKeyDesc(
+                    Lists.newArrayList(new PartitionValue("20260110")),
+                    Lists.newArrayList(new PartitionValue("20260111")));
+            SingleRangePartitionDesc d2 = new SingleRangePartitionDesc(false, "p2", p2, null);
+            PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(d2, columns, null);
+            partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(partitionColumns), d2, 2L, false);
+
+            // Buggy fixed-range: upper bound equals successor's lower bound (so it doesn't intersect the successor),
+            // but its lower bound is far smaller and intersects earlier partitions.
+            PartitionKeyDesc bad = new PartitionKeyDesc(
+                    Lists.newArrayList(new PartitionValue("2020109")),
+                    Lists.newArrayList(new PartitionValue("20260110")));
+            SingleRangePartitionDesc dBad = new SingleRangePartitionDesc(false, "p_bad", bad, null);
+            PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(dBad, columns, null);
+            partitionInfo.handleNewSinglePartitionDesc(MetaUtils.buildIdToColumn(partitionColumns), dBad, 3L, false);
+        });
+    }
+
     @Test
     public void testCopyPartitionInfo() throws Exception {
         Column k1 = new Column("k1", new ScalarType(PrimitiveType.INT), true, null, "", "");


### PR DESCRIPTION
## Why I'm doing:
Prevent creating overlapping fixed-range partitions when an explicit lower bound is provided

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
