### PR TITLE
[Enhancement] Add a database meta cache for jdbc catalog to reduce remote RPC overhead and the impact of external system failure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetaCache.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetaCache.java
@@ -84,6 +84,19 @@ public class JDBCMetaCache<K, V> {
         }
     }
 
+    public V getIfPresent(@NonNull K key) {
+        if (this.metaCache != null && this.enableCache) {
+            return this.metaCache.getIfPresent(key);
+        }
+        return null;
+    }
+
+    public void put(@NonNull K key, V value) {
+        if (this.metaCache != null && this.enableCache) {
+            this.metaCache.put(key, value);
+        }
+    }
+
     public boolean isEnableCache() {
         return enableCache;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -58,6 +58,7 @@ public class JDBCMetadata implements ConnectorMetadata {
     JDBCSchemaResolver schemaResolver;
     private String catalogName;
 
+    private JDBCMetaCache<String, Database> dbCache;
     private JDBCMetaCache<JDBCTableName, List<String>> partitionNamesCache;
     private JDBCMetaCache<JDBCTableName, Integer> tableIdCache;
     private JDBCMetaCache<JDBCTableName, Table> tableInstanceCache;
@@ -124,6 +125,7 @@ public class JDBCMetadata implements ConnectorMetadata {
     }
 
     private void createMetaAsyncCacheInstances(Map<String, String> properties) {
+        dbCache = new JDBCMetaCache<>(properties, false);
         partitionNamesCache = new JDBCMetaCache<>(properties, false);
         tableIdCache = new JDBCMetaCache<>(properties, true);
         tableInstanceCache = new JDBCMetaCache<>(properties, false);
@@ -183,13 +185,39 @@ public class JDBCMetadata implements ConnectorMetadata {
 
     @Override
     public Database getDb(ConnectContext context, String name) {
-        try {
-            if (listDbNames(context).contains(name)) {
-                return new Database(0, name);
-            } else {
-                return null;
+        // NOTE: We use manual cache control (getIfPresent + put) instead of the lambda-based approach
+        // for the following reason:
+        //
+        // The lambda in getTable() can return null when the table doesn't exist, but JDBCMetaCache.get()
+        // uses Objects.requireNonNull() which throws NullPointerException when the lambda returns null.
+        //
+        // For getDb(), we need to return null for non-existent databases (a valid result, not an error),
+        // so we manually control the cache to avoid the NPE issue:
+        // 1. Use getIfPresent() to check cache without triggering the lambda
+        // 2. On cache miss, query directly and only cache successful (non-null) results
+        // 3. Return null for non-existent databases or SQLException without caching
+
+        // Check cache first
+        Database cached = dbCache.getIfPresent(name);
+        if (cached != null) {
+            return cached;
+        }
+
+        // Cache miss - query directly
+        try (Connection connection = getConnection()) {
+            if (schemaResolver.databaseExists(connection, name)) {
+                Database db = new Database(0, name);
+                // Only cache on success to avoid caching null values
+                dbCache.put(name, db);
+                return db;
             }
-        } catch (StarRocksConnectorException e) {
+            // Database doesn't exist - don't cache null
+            return null;
+        } catch (SQLException e) {
+            // From getConnection() or databaseExists()
+            LOG.warn("Failed to check database existence for {}.{}: {}",
+                    catalogName, name, e.getMessage());
+            // Exception occurred - don't cache null
             return null;
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -255,6 +255,105 @@ public class JDBCMetadataTest {
     }
 
     @Test
+    public void testDbCacheHit() {
+        // Test that second getDb call uses cache (getCatalogs only called once)
+        try {
+            // Enable cache for this test and create new JDBCMetadata instance
+            Map<String, String> cachedProperties = new HashMap<>(properties);
+            cachedProperties.put("jdbc_meta_cache_enable", "true");
+
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(cachedProperties, "catalog", dataSource);
+
+            new Expectations() {
+                {
+                    dataSource.getConnection();
+                    result = connection;
+                    minTimes = 0;
+
+                    // getCatalogs should only be called ONCE due to caching
+                    connection.getMetaData().getCatalogs();
+                    result = dbResult;
+                    minTimes = 1;
+                    maxTimes = 1;
+
+                    connection.getMetaData().getTables("test", null, null,
+                            new String[] {"TABLE", "VIEW"});
+                    result = tableResult;
+                    minTimes = 0;
+
+                    connection.getMetaData().getColumns("test", null, "tbl1", "%");
+                    result = columnResult;
+                    minTimes = 0;
+                }
+            };
+
+            dbResult.beforeFirst();
+            Database db1 = jdbcMetadata.getDb(new ConnectContext(), "test");
+            Assertions.assertNotNull(db1);
+            Assertions.assertEquals("test", db1.getOriginName());
+
+            // Second call should use cache, getCatalogs won't be called again
+            Database db2 = jdbcMetadata.getDb(new ConnectContext(), "test");
+            Assertions.assertNotNull(db2);
+            Assertions.assertEquals("test", db2.getOriginName());
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    public void testDbCacheMissForNonExistentDb() {
+        // Test getDb returns null for non-existent database
+        try {
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog", dataSource);
+            dbResult.beforeFirst();
+            Database db = jdbcMetadata.getDb(new ConnectContext(), "nonexistent");
+            Assertions.assertNull(db);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            Assertions.fail();
+        }
+    }
+
+    @Test
+    public void testDbCacheEnabledReturnsNullForNonExistentDb() throws SQLException {
+        // Test that getDb returns null (not NPE) for non-existent database when cache is enabled
+        // This is the bug fix test - previously it would throw NullPointerException due to
+        // Objects.requireNonNull() in JDBCMetaCache.get() when the lambda returned null
+
+        MockResultSet emptySchemaResult = new MockResultSet("schemas");
+        emptySchemaResult.addColumn("TABLE_SCHEM", Arrays.asList("information_schema"));
+
+        new Expectations() {
+            {
+                dataSource.getConnection();
+                result = connection;
+                minTimes = 0;
+
+                // Mock getSchemas to return empty result (simulating non-existent database)
+                connection.getMetaData().getSchemas();
+                result = emptySchemaResult;
+                minTimes = 0;
+            }
+        };
+
+        // Enable cache
+        Map<String, String> cachedProperties = new HashMap<>(properties);
+        cachedProperties.put("jdbc_meta_cache_enable", "true");
+
+        JDBCMetadata jdbcMetadata = new JDBCMetadata(cachedProperties, "catalog", dataSource);
+
+        // First call - should return null without throwing NPE
+        Database db1 = jdbcMetadata.getDb(new ConnectContext(), "nonexistent_db");
+        Assertions.assertNull(db1, "First call should return null for non-existent database");
+
+        // Second call - should also return null (not cached, and no NPE)
+        Database db2 = jdbcMetadata.getDb(new ConnectContext(), "nonexistent_db");
+        Assertions.assertNull(db2, "Second call should also return null for non-existent database");
+    }
+
+    @Test
     public void testGetJdbcUrl() {
         properties.put(JDBCResource.URI, "jdbc:mysql://127.0.0.1:3306");
         JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");


### PR DESCRIPTION

## Why I'm doing:
Now StarRocks supports some JDBC meta caches, such as `partitionNamesCache`, `tableIdCache`, `tableInstanceCache` and `partitionInfoCache`. However, we also need remote RPC for each query to get database. So, it is necessary to add a database meta cache for jdbc catalog to reduce remote RPC overhead and the impact of external system failure.

## What I'm doing:


This pull request introduces a database-level cache to the JDBC connector metadata layer, improving performance and consistency for database existence checks. It implements a new caching mechanism for the `getDb` method, adds database existence checks in schema resolvers, and enhances test coverage for the new behavior.

**Caching and Metadata Improvements:**

* Added a new `JDBCMetaCache<String, Database>` named `dbCache` to `JDBCMetadata`, and initialized it in `createMetaAsyncCacheInstances` to cache database objects and avoid repeated existence checks. 
* Refactored the `getDb` method in `JDBCMetadata` to use `dbCache`, ensuring database existence is verified only on cache miss, and improved error handling and logging for failed checks.

**Schema Resolver Enhancements:**

* Added a `databaseExists` method to `JDBCSchemaResolver` to check for a database/schema's existence via JDBC metadata, and implemented the method in `MysqlSchemaResolver` to use catalog names for MySQL.

**Testing Improvements:**

* Added tests in `JDBCMetadataTest` to verify correct cache behavior for existing and non-existent databases, ensuring cache hits return consistent results and cache misses return `null`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
