### PR TITLE
[BugFix] fix scan result error when dict page is too large

### DIFF
--- a/be/src/storage/rowset/binary_plain_page.cpp
+++ b/be/src/storage/rowset/binary_plain_page.cpp
@@ -20,7 +20,9 @@
 #include <emmintrin.h>
 #endif
 
+#include <algorithm>
 #include <cstring>
+#include <limits>
 
 #include "column/append_with_mask.h"
 #include "column/binary_column.h"
@@ -28,10 +30,74 @@
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 #include "gutil/casts.h"
+#include "simd/simd.h"
 #include "storage/column_predicate.h"
 #include "types/logical_type.h"
+#include "util/raw_container.h"
 
 namespace starrocks {
+
+template <LogicalType Type>
+Status BinaryPlainPageDecoder<Type>::get_dict_filter_selection(const std::vector<const ColumnPredicate*>& predicates,
+                                                               const uint8_t** selection, uint32_t* dict_size,
+                                                               uint32_t* selected_count) const {
+    DCHECK(_parsed);
+    DCHECK(selection != nullptr);
+    DCHECK(dict_size != nullptr);
+    DCHECK(selected_count != nullptr);
+
+    *dict_size = _num_elems;
+    if (UNLIKELY(_num_elems == 0)) {
+        *selection = nullptr;
+        *selected_count = 0;
+        return Status::OK();
+    }
+
+    if (!_dict_filter_cache_valid) {
+        raw::stl_vector_resize_uninitialized(&_dict_filter_cache_selection, _num_elems);
+
+        // NOTE:
+        // compound_and_predicates_evaluate() (and ColumnPredicate::evaluate*) uses uint16_t [from,to) bounds, so we must
+        // evaluate the dictionary in chunks when dict_size > 65535. This is correctness critical: otherwise the
+        // truncated range would leave part of dict_selection as 0, causing over-filtering.
+
+        constexpr uint32_t kMaxRowsPerEval = std::numeric_limits<uint16_t>::max(); // 65535
+        uint32_t begin = 0;
+        while (begin < _num_elems) {
+            const uint32_t end = std::min(_num_elems, begin + kMaxRowsPerEval);
+            const uint32_t chunk_elems = end - begin;
+
+            BinaryColumn::Offsets offsets;
+            offsets.resize(chunk_elems + 1);
+            offsets[0] = 0;
+
+            const uint32_t base_abs_off = offset_uncheck(static_cast<int>(begin));
+            // Intermediate offsets: i in (begin, end)
+            for (uint32_t i = begin + 1; i < end; ++i) {
+                offsets[i - begin] = offset_uncheck(static_cast<int>(i)) - base_abs_off;
+            }
+            const uint32_t chunk_bytes = offset(static_cast<int>(end)) - base_abs_off;
+            offsets[chunk_elems] = chunk_bytes;
+
+            ContainerResource container(_page_handle, &_data[base_abs_off], chunk_bytes);
+            auto dict_chunk_column = BinaryColumn::create(std::move(container), std::move(offsets));
+
+            std::vector<uint16_t> selected_idx(chunk_elems);
+            RETURN_IF_ERROR(compound_and_predicates_evaluate(
+                    predicates, dict_chunk_column.get(), _dict_filter_cache_selection.data() + begin,
+                    selected_idx.data(), 0, static_cast<uint16_t>(chunk_elems)));
+
+            begin = end;
+        }
+
+        _dict_filter_cache_selected_count = SIMD::count_nonzero(_dict_filter_cache_selection.data(), _num_elems);
+        _dict_filter_cache_valid = true;
+    }
+
+    *selection = _dict_filter_cache_selection.data();
+    *selected_count = _dict_filter_cache_selected_count;
+    return Status::OK();
+}
 
 template <LogicalType Type>
 Status BinaryPlainPageDecoder<Type>::next_batch(size_t* count, Column* dst) {

--- a/be/src/storage/rowset/binary_plain_page.cpp
+++ b/be/src/storage/rowset/binary_plain_page.cpp
@@ -62,6 +62,7 @@ Status BinaryPlainPageDecoder<Type>::get_dict_filter_selection(const std::vector
         // truncated range would leave part of dict_selection as 0, causing over-filtering.
 
         constexpr uint32_t kMaxRowsPerEval = std::numeric_limits<uint16_t>::max(); // 65535
+        std::vector<uint16_t> selected_idx(std::min(_num_elems, kMaxRowsPerEval));
         uint32_t begin = 0;
         while (begin < _num_elems) {
             const uint32_t end = std::min(_num_elems, begin + kMaxRowsPerEval);
@@ -82,7 +83,6 @@ Status BinaryPlainPageDecoder<Type>::get_dict_filter_selection(const std::vector
             ContainerResource container(_page_handle, &_data[base_abs_off], chunk_bytes);
             auto dict_chunk_column = BinaryColumn::create(std::move(container), std::move(offsets));
 
-            std::vector<uint16_t> selected_idx(chunk_elems);
             RETURN_IF_ERROR(compound_and_predicates_evaluate(
                     predicates, dict_chunk_column.get(), _dict_filter_cache_selection.data() + begin,
                     selected_idx.data(), 0, static_cast<uint16_t>(chunk_elems)));

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -178,6 +178,9 @@ private:
         std::string to_string() const;
 
         OlapReaderStatistics* stats = nullptr;
+        // Non-null when runtime filter pushdown is enabled. Points to SegmentIterator::_column_to_runtime_filters_map.
+        // Used by predicate-column late materialization to include runtime filters in page-level predicate pushdown.
+        std::unordered_map<ColumnId, RuntimeFilterPredicates>* runtime_filters_by_column = nullptr;
 
         Schema _read_schema;
         Schema _dict_decode_schema;
@@ -609,8 +612,13 @@ Status SegmentIterator::ScanContext::PredicateLateMaterializationScanStrategy::r
     DCHECK(!_ctx->_predicate_order.empty());
 
     auto& column_iterators = _ctx->_column_iterators_for_predicate_late_materialize;
+    const ColumnId first_column_id = _ctx->_predicate_order[0];
+    const bool first_col_has_runtime_filter =
+            _ctx->runtime_filters_by_column != nullptr && _ctx->runtime_filters_by_column->contains(first_column_id);
+    // TODO:support runtime bloom filter push down to page level
     bool first_col_supports_pushdown =
-            column_iterators[0]->support_push_down_predicate(_ctx->_column_predicate_map[_ctx->_predicate_order[0]]);
+            !first_col_has_runtime_filter &&
+            column_iterators[0]->support_push_down_predicate(_ctx->_column_predicate_map[first_column_id]);
 
     // reset _is_filtered every time
     _ctx->_is_filtered = false;
@@ -644,7 +652,7 @@ Status SegmentIterator::ScanContext::PredicateLateMaterializationScanStrategy::r
                 // and selection is record for filter rowId column
                 // and only append filtered data in col
                 RETURN_IF_ERROR(column_iterators[i]->next_batch_with_filter(
-                        range, col, _ctx->_column_predicate_map[_ctx->_predicate_order[0]], selection, selected_idx,
+                        range, col, _ctx->_column_predicate_map[first_column_id], selection, selected_idx,
                         &processed_rows));
                 size_t appended_rows = col->size() - original_row_num;
                 if (processed_rows >= appended_rows && _ctx->stats != nullptr) {
@@ -2811,7 +2819,8 @@ void SegmentIterator::_build_context_for_predicate(ScanContext* ctx) {
     // but we still can push down predicate into page level
     ctx->_only_output_one_predicate_col_with_filter_push_down =
             !has_or_predicates && (_predicate_columns == 1 && _schema.num_fields() == 1) &&
-            ctx->_column_iterators[0]->support_push_down_predicate(column_predicate_map.begin()->second);
+            ctx->_column_iterators[0]->support_push_down_predicate(column_predicate_map.begin()->second) &&
+            _opts.enable_predicate_col_late_materialize;
 
     if (!ctx->_enable_predicate_col_late_materialize && !ctx->_only_output_one_predicate_col_with_filter_push_down) {
         return;
@@ -2898,6 +2907,13 @@ void SegmentIterator::_build_column_oriented_rf(ScanContext* ctx) {
             }
         }
     }
+
+    // Expose runtime filter presence to ScanContext so PredicateLateMaterializationScanStrategy can decide
+    // whether it's safe to push down predicates to the page level for the first predicate column.
+    ctx->runtime_filters_by_column =
+            (_opts.enable_join_runtime_filter_pushdown && !_column_to_runtime_filters_map.empty())
+                    ? &_column_to_runtime_filters_map
+                    : nullptr;
 }
 
 Status SegmentIterator::_init_global_dict_decoder() {


### PR DESCRIPTION
## Why I'm doing:
when writing string column in one segment, sr will try to use dict encoding first, if ndv of string is too large to store in one page, then use plain decoding.
1. when https://github.com/StarRocks/starrocks/pull/64600 push down predicate into string page, it calculate predicates on the single dict page every time, if the dict page is super large(dictionary_page_size=1048576), it will make performance downgrade
2. if the dict page of string column is too large for uint16, then using column predicate's “Status evaluate(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const = 0” directly on dict page will cause selection is truncated, which cause wrong data filtering
3. when push down filter into page level, it lost runtime bloom filter

## What I'm doing:
1. reuse dict page's predicate evaluation result 
2. when calculate dict page's predicate, if dict page size exceed uint16, calculate predicate every 65536 rows to avoid truncation
3. disable predicate push down to page when column has runtime bloom filter. Todo: support push down runtime bloom filter into page level
4. make enable_predicate_col_late_materialize control the whole optimization

Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/10847)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
