### PR TITLE
[BugFix] Fix duplicate column unique_id conflict for flat JSON extended columns

### DIFF
--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -134,4 +134,19 @@ inline std::ostream& operator<<(std::ostream& out, const ColumnAccessPath& val) 
     return out;
 }
 
+// Use next_column_unique_id instead of num_columns to avoid unique_id conflicts.
+// num_columns() returns the current column count, but unique_ids may have gaps
+// after ADD/DROP COLUMN operations. Using num_columns() can cause extended columns
+// (flat JSON subfields) to get unique_ids that conflict with existing columns.
+
+// Returns the next unique ID. only used in flat json column access path.
+template <class ScanNodeType>
+size_t next_uniq_id(const ScanNodeType& tnode) {
+    if (tnode.__isset.next_uniq_id) {
+        return tnode.next_uniq_id;
+    }
+    // provide a large number to avoid conflict
+    return std::numeric_limits<int32_t>::max() - 1000000;
+}
+
 } // namespace starrocks

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -560,7 +560,7 @@ Status LakeDataSource::_extend_schema_by_access_paths() {
     }
 
     TabletSchemaSPtr tmp_schema = TabletSchema::copy(*_tablet_schema);
-    int field_number = tmp_schema->num_columns();
+    int field_number = _provider->next_uniq_id();
     for (auto& path : access_paths) {
         if (!path->is_extended()) {
             continue;

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -242,6 +242,9 @@ public:
     bool output_chunk_by_bucket() const override {
         return _t_lake_scan_node.__isset.output_chunk_by_bucket && _t_lake_scan_node.output_chunk_by_bucket;
     }
+
+    size_t next_uniq_id() const { return starrocks::next_uniq_id(_t_lake_scan_node); }
+
     bool is_asc_hint() const override {
         if (!sorted_by_keys_per_tablet() && _t_lake_scan_node.__isset.output_asc_hint) {
             return _t_lake_scan_node.output_asc_hint;

--- a/be/src/exec/lake_meta_scanner.cpp
+++ b/be/src/exec/lake_meta_scanner.cpp
@@ -57,6 +57,7 @@ Status LakeMetaScanner::_real_init() {
     // Pass column access paths and extend schema similar to OLAP path
     if (_parent->_meta_scan_node.__isset.column_access_paths && !_parent->_column_access_paths.empty()) {
         reader_params.column_access_paths = &_parent->_column_access_paths;
+        reader_params.next_uniq_id = starrocks::next_uniq_id(_parent->_meta_scan_node);
     }
 
     _reader = std::make_unique<LakeMetaReader>();

--- a/be/src/exec/olap_meta_scanner.cpp
+++ b/be/src/exec/olap_meta_scanner.cpp
@@ -82,7 +82,7 @@ Status OlapMetaScanner::_init_meta_reader_params() {
     // add the extended column access paths into tablet_schema
     {
         TabletSchemaSPtr tmp_schema = TabletSchema::copy(*_reader_params.tablet_schema);
-        int field_number = tmp_schema->num_columns();
+        int field_number = starrocks::next_uniq_id(_parent->_meta_scan_node);
         for (auto& path : _parent->_column_access_paths) {
             int root_column_index = tmp_schema->field_index(path->path());
             RETURN_IF(root_column_index < 0, Status::RuntimeError("unknown access path: " + path->path()));

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -616,7 +616,7 @@ Status OlapChunkSource::_extend_schema_by_access_paths() {
     }
 
     TabletSchemaSPtr tmp_schema = TabletSchema::copy(*_tablet_schema);
-    int field_number = tmp_schema->num_columns();
+    int field_number = _scan_ctx->next_unique_id();
     for (auto& path : *access_paths) {
         if (!path->is_extended()) {
             continue;

--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -15,6 +15,7 @@
 #include "exec/pipeline/scan/olap_scan_context.h"
 
 #include "exec/olap_scan_node.h"
+#include "exec/olap_scan_prepare.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exprs/runtime_filter_bank.h"
 #include "storage/tablet.h"
@@ -46,6 +47,10 @@ Status ConcurrentJitRewriter::rewrite(std::vector<ExprContext*>& expr_ctxs, Obje
 
 const std::vector<ColumnAccessPathPtr>* OlapScanContext::column_access_paths() const {
     return &_scan_node->column_access_paths();
+}
+
+size_t OlapScanContext::next_unique_id() const {
+    return starrocks::next_uniq_id(_scan_node->thrift_olap_scan_node());
 }
 
 void OlapScanContext::attach_shared_input(int32_t operator_seq, int32_t source_index) {

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -102,6 +102,9 @@ public:
                            RuntimeFilterProbeCollector* runtime_bloom_filters, int32_t driver_sequence);
 
     OlapScanNode* scan_node() const { return _scan_node; }
+    // Returns the next unique ID. only used in flat json column access path.
+    size_t next_unique_id() const;
+
     ScanConjunctsManager& conjuncts_manager() { return *_conjuncts_manager; }
     const std::vector<ExprContext*>& not_push_down_conjuncts() const { return _not_push_down_conjuncts; }
     const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges() const { return _key_ranges; }

--- a/be/src/storage/lake_meta_reader.cpp
+++ b/be/src/storage/lake_meta_reader.cpp
@@ -56,11 +56,7 @@ Status LakeMetaReader::init(const LakeMetaReaderParams& read_params) {
     TabletSchemaCSPtr tablet_schema = base_schema;
     if (read_params.column_access_paths != nullptr && !read_params.column_access_paths->empty()) {
         TabletSchemaSPtr tmp_schema = TabletSchema::copy(*base_schema);
-        // Use next_column_unique_id instead of num_columns to avoid unique_id conflicts.
-        // num_columns() returns the current column count, but unique_ids may have gaps
-        // after ADD/DROP COLUMN operations. Using num_columns() can cause extended columns
-        // (flat JSON subfields) to get unique_ids that conflict with existing columns.
-        int field_number = tmp_schema->next_column_unique_id();
+        int field_number = read_params.next_uniq_id;
         for (auto& path : *read_params.column_access_paths) {
             int root_column_index = tmp_schema->field_index(path->path());
             RETURN_IF(root_column_index < 0, Status::RuntimeError("unknown access path: " + path->path()));

--- a/be/src/storage/lake_meta_reader.h
+++ b/be/src/storage/lake_meta_reader.h
@@ -28,6 +28,7 @@ struct LakeMetaReaderParams : MetaReaderParams {
     // The key of the schema used for reading. no value for legacy compatibility.
     std::optional<TableSchemaKeyPB> schema_key;
     std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
+    size_t next_uniq_id;
 };
 
 namespace lake {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
@@ -226,6 +226,7 @@ public class MetaScanNode extends AbstractOlapTableScanNode {
 
         if (CollectionUtils.isNotEmpty(columnAccessPaths)) {
             msg.meta_scan_node.setColumn_access_paths(columnAccessPathToThrift());
+            msg.meta_scan_node.setNext_uniq_id(olapTable.getMaxColUniqueId());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1111,6 +1111,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
 
             if (CollectionUtils.isNotEmpty(columnAccessPaths)) {
                 msg.lake_scan_node.setColumn_access_paths(columnAccessPathToThrift());
+                msg.lake_scan_node.setNext_uniq_id(olapTable.getMaxColUniqueId());
             }
 
             if (!scanTabletIds.isEmpty()) {
@@ -1170,6 +1171,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
 
             if (CollectionUtils.isNotEmpty(columnAccessPaths)) {
                 msg.olap_scan_node.setColumn_access_paths(columnAccessPathToThrift());
+                msg.olap_scan_node.setNext_uniq_id(olapTable.getMaxColUniqueId());
             }
 
             if (vectorSearchOptions != null && vectorSearchOptions.isEnableUseANN()) {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -642,6 +642,9 @@ struct TOlapScanNode {
   52: optional i64 back_pressure_throttle_time
   53: optional i64 back_pressure_throttle_time_upper_bound
   54: optional i64 back_pressure_num_rows
+
+  // This field is only used for flat json to provide a uniq id
+  55: optional i32 next_uniq_id
 }
 
 struct TJDBCScanNode {
@@ -688,6 +691,8 @@ struct TLakeScanNode {
   // inverted index
   44: optional bool enable_prune_column_after_index_filter
   45: optional bool enable_gin_filter
+
+  46: optional i32 next_uniq_id
 }
 
 struct TEqJoinCondition {
@@ -1292,6 +1297,7 @@ struct TMetaScanNode {
     // deprecated. use schema key instead
     5: optional i64 schema_id
     6: optional Descriptors.TTableSchemaKey schema_key
+    7: optional i32 next_uniq_id
 }
 
 struct TDecodeNode {

--- a/test/sql/test_semi/R/test_flat_json_schema_change
+++ b/test/sql/test_semi/R/test_flat_json_schema_change
@@ -1,0 +1,119 @@
+-- name: test_flat_json_after_schema_change @system
+CREATE DATABASE IF NOT EXISTS test_flat_json_schema_change;
+-- result:
+-- !result
+USE test_flat_json_schema_change;
+-- result:
+-- !result
+CREATE TABLE `t_json_schema_change` (
+  `id` bigint(20) NOT NULL,
+  `data` json NULL,
+  `col1` int NULL,
+  `col2` int NULL,
+  `col3` int NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+INSERT INTO t_json_schema_change VALUES
+(1, parse_json('{"name": "alice", "age": 30, "city": "seattle"}'), 1, 2, 3),
+(2, parse_json('{"name": "bob", "age": 25, "city": "boston"}'), 4, 5, 6),
+(3, parse_json('{"name": "charlie", "age": 35, "city": "chicago"}'), 7, 8, 9);
+-- result:
+-- !result
+ALTER TABLE t_json_schema_change ADD COLUMN col4 int;
+-- result:
+-- !result
+ALTER TABLE t_json_schema_change ADD COLUMN col5 int;
+-- result:
+-- !result
+ALTER TABLE t_json_schema_change ADD COLUMN col6 int;
+-- result:
+-- !result
+ALTER TABLE t_json_schema_change DROP COLUMN col1;
+-- result:
+-- !result
+ALTER TABLE t_json_schema_change DROP COLUMN col2;
+-- result:
+-- !result
+ALTER TABLE t_json_schema_change DROP COLUMN col3;
+-- result:
+-- !result
+ALTER TABLE t_json_schema_change ADD COLUMN col7 int;
+-- result:
+-- !result
+ALTER TABLE t_json_schema_change ADD COLUMN col8 int;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+-- !result
+INSERT INTO t_json_schema_change (id, data, col4, col5, col6, col7, col8) VALUES
+(4, parse_json('{"name": "david", "age": 40, "city": "denver"}'), 10, 11, 12, 13, 14),
+(5, parse_json('{"name": "eve", "age": 28, "city": "detroit"}'), 15, 16, 17, 18, 19);
+-- result:
+-- !result
+SELECT id, get_json_string(data, '$.name') as name FROM t_json_schema_change ORDER BY id;
+-- result:
+1	alice
+2	bob
+3	charlie
+4	david
+5	eve
+-- !result
+SELECT id, get_json_int(data, '$.age') as age FROM t_json_schema_change ORDER BY id;
+-- result:
+1	30
+2	25
+3	35
+4	40
+5	28
+-- !result
+SELECT id, get_json_string(data, '$.city') as city FROM t_json_schema_change ORDER BY id;
+-- result:
+1	seattle
+2	boston
+3	chicago
+4	denver
+5	detroit
+-- !result
+SELECT id, 
+       get_json_string(data, '$.name') as name,
+       get_json_int(data, '$.age') as age,
+       get_json_string(data, '$.city') as city
+FROM t_json_schema_change 
+ORDER BY id;
+-- result:
+1	alice	30	seattle
+2	bob	25	boston
+3	charlie	35	chicago
+4	david	40	denver
+5	eve	28	detroit
+-- !result
+SELECT id, json_query(data, '$.name') as name FROM t_json_schema_change ORDER BY id;
+-- result:
+1	"alice"
+2	"bob"
+3	"charlie"
+4	"david"
+5	"eve"
+-- !result
+SELECT id, data->'name' as name FROM t_json_schema_change ORDER BY id;
+-- result:
+1	"alice"
+2	"bob"
+3	"charlie"
+4	"david"
+5	"eve"
+-- !result
+DROP TABLE t_json_schema_change;
+-- result:
+-- !result
+DROP DATABASE test_flat_json_schema_change;
+-- result:
+-- !result

--- a/test/sql/test_semi/R/test_flat_json_schema_change
+++ b/test/sql/test_semi/R/test_flat_json_schema_change
@@ -1,10 +1,4 @@
--- name: test_flat_json_after_schema_change @system
-CREATE DATABASE IF NOT EXISTS test_flat_json_schema_change;
--- result:
--- !result
-USE test_flat_json_schema_change;
--- result:
--- !result
+-- name: test_flat_json_after_schema_change
 CREATE TABLE `t_json_schema_change` (
   `id` bigint(20) NOT NULL,
   `data` json NULL,
@@ -52,6 +46,7 @@ ALTER TABLE t_json_schema_change ADD COLUMN col8 int;
 -- !result
 function: wait_alter_table_finish()
 -- result:
+None
 -- !result
 INSERT INTO t_json_schema_change (id, data, col4, col5, col6, col7, col8) VALUES
 (4, parse_json('{"name": "david", "age": 40, "city": "denver"}'), 10, 11, 12, 13, 14),
@@ -110,10 +105,4 @@ SELECT id, data->'name' as name FROM t_json_schema_change ORDER BY id;
 3	"charlie"
 4	"david"
 5	"eve"
--- !result
-DROP TABLE t_json_schema_change;
--- result:
--- !result
-DROP DATABASE test_flat_json_schema_change;
--- result:
 -- !result

--- a/test/sql/test_semi/T/test_flat_json_schema_change
+++ b/test/sql/test_semi/T/test_flat_json_schema_change
@@ -1,4 +1,4 @@
--- name: test_flat_json_after_schema_change @cloud
+-- name: test_flat_json_after_schema_change
 -- Test flat JSON query after ADD/DROP COLUMN operations
 -- This tests the fix for duplicate column unique_id conflict
 -- where extended columns (flat JSON subfields) could get the same

--- a/test/sql/test_semi/T/test_flat_json_schema_change
+++ b/test/sql/test_semi/T/test_flat_json_schema_change
@@ -1,4 +1,4 @@
--- name: test_flat_json_after_schema_change @system
+-- name: test_flat_json_after_schema_change @cloud
 -- Test flat JSON query after ADD/DROP COLUMN operations
 -- This tests the fix for duplicate column unique_id conflict
 -- where extended columns (flat JSON subfields) could get the same

--- a/test/sql/test_semi/T/test_flat_json_schema_change
+++ b/test/sql/test_semi/T/test_flat_json_schema_change
@@ -1,0 +1,64 @@
+-- name: test_flat_json_after_schema_change @system
+-- Test flat JSON query after ADD/DROP COLUMN operations
+-- This tests the fix for duplicate column unique_id conflict
+-- where extended columns (flat JSON subfields) could get the same
+-- unique_id as existing columns after schema changes.
+
+CREATE DATABASE IF NOT EXISTS test_flat_json_schema_change;
+USE test_flat_json_schema_change;
+
+CREATE TABLE `t_json_schema_change` (
+  `id` bigint(20) NOT NULL,
+  `data` json NULL,
+  `col1` int NULL,
+  `col2` int NULL,
+  `col3` int NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"fast_schema_evolution" = "true"
+);
+
+INSERT INTO t_json_schema_change VALUES
+(1, parse_json('{"name": "alice", "age": 30, "city": "seattle"}'), 1, 2, 3),
+(2, parse_json('{"name": "bob", "age": 25, "city": "boston"}'), 4, 5, 6),
+(3, parse_json('{"name": "charlie", "age": 35, "city": "chicago"}'), 7, 8, 9);
+
+ALTER TABLE t_json_schema_change ADD COLUMN col4 int;
+ALTER TABLE t_json_schema_change ADD COLUMN col5 int;
+ALTER TABLE t_json_schema_change ADD COLUMN col6 int;
+
+ALTER TABLE t_json_schema_change DROP COLUMN col1;
+ALTER TABLE t_json_schema_change DROP COLUMN col2;
+ALTER TABLE t_json_schema_change DROP COLUMN col3;
+
+ALTER TABLE t_json_schema_change ADD COLUMN col7 int;
+ALTER TABLE t_json_schema_change ADD COLUMN col8 int;
+
+function: wait_alter_table_finish()
+
+INSERT INTO t_json_schema_change (id, data, col4, col5, col6, col7, col8) VALUES
+(4, parse_json('{"name": "david", "age": 40, "city": "denver"}'), 10, 11, 12, 13, 14),
+(5, parse_json('{"name": "eve", "age": 28, "city": "detroit"}'), 15, 16, 17, 18, 19);
+
+SELECT id, get_json_string(data, '$.name') as name FROM t_json_schema_change ORDER BY id;
+
+SELECT id, get_json_int(data, '$.age') as age FROM t_json_schema_change ORDER BY id;
+
+SELECT id, get_json_string(data, '$.city') as city FROM t_json_schema_change ORDER BY id;
+
+SELECT id, 
+       get_json_string(data, '$.name') as name,
+       get_json_int(data, '$.age') as age,
+       get_json_string(data, '$.city') as city
+FROM t_json_schema_change 
+ORDER BY id;
+
+SELECT id, json_query(data, '$.name') as name FROM t_json_schema_change ORDER BY id;
+
+SELECT id, data->'name' as name FROM t_json_schema_change ORDER BY id;
+
+DROP TABLE t_json_schema_change;
+DROP DATABASE test_flat_json_schema_change;

--- a/test/sql/test_semi/T/test_flat_json_schema_change
+++ b/test/sql/test_semi/T/test_flat_json_schema_change
@@ -4,7 +4,7 @@
 -- where extended columns (flat JSON subfields) could get the same
 -- unique_id as existing columns after schema changes.
 
-CREATE DATABASE IF NOT EXISTS test_flat_json_schema_change;
+CREATE DATABASE IF NOT EXISTS test_flat_json_${uuid0};
 USE test_flat_json_schema_change;
 
 CREATE TABLE `t_json_schema_change` (

--- a/test/sql/test_semi/T/test_flat_json_schema_change
+++ b/test/sql/test_semi/T/test_flat_json_schema_change
@@ -1,11 +1,9 @@
 -- name: test_flat_json_after_schema_change
+
 -- Test flat JSON query after ADD/DROP COLUMN operations
 -- This tests the fix for duplicate column unique_id conflict
 -- where extended columns (flat JSON subfields) could get the same
 -- unique_id as existing columns after schema changes.
-
-CREATE DATABASE IF NOT EXISTS test_flat_json_${uuid0};
-USE test_flat_json_schema_change;
 
 CREATE TABLE `t_json_schema_change` (
   `id` bigint(20) NOT NULL,
@@ -59,6 +57,3 @@ ORDER BY id;
 SELECT id, json_query(data, '$.name') as name FROM t_json_schema_change ORDER BY id;
 
 SELECT id, data->'name' as name FROM t_json_schema_change ORDER BY id;
-
-DROP TABLE t_json_schema_change;
-DROP DATABASE test_flat_json_schema_change;


### PR DESCRIPTION
## Summary

Fix a bug where flat JSON extended columns (subfields like `source.page`) can get duplicate `unique_id` values that conflict with existing regular columns, causing the error:

```
Duplicate column id=101 found between column 'tags_new' and column 'source.page' in tablet schema
```

## Root Cause

In `lake_meta_reader.cpp`, when querying with flat JSON subfields, extended columns are dynamically added to the tablet schema. These columns were assigned `unique_id` starting from `num_columns()`:

```cpp
int field_number = tmp_schema->num_columns();  // BUG
column.set_unique_id(++field_number);
```

However, `num_columns()` returns the current column count, while `unique_id` values can have gaps after ADD/DROP COLUMN operations (unique_ids are never reused). This causes extended columns to potentially receive the same `unique_id` as existing columns.

**Example scenario:**
| Operation | num_columns | next_column_unique_id | 
|-----------|-------------|----------------------|
| Create table (100 cols) | 100 | 100 |
| ADD COLUMN tags_new | 101 | 101 |
| DROP COLUMN old_col | 100 | 101 |
| Query flat JSON → extended col gets `unique_id = 101` | **CONFLICT** |

## Fix

close #68519, #68184

Use `next_column_unique_id()` instead of `num_columns()`, which correctly tracks the next available unique_id regardless of column count:

```cpp
int field_number = tmp_schema->next_column_unique_id();  // FIXED
```


## What type of PR is this?

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Test
- [ ] Doc
- [ ] Build

Does this PR entail a change in behavior?

 - [ ] Yes, this PR will result in a change in behavior.
 - [x] No, this PR will not result in a change in behavior.

## Testing

This fix addresses the duplicate column id error reported in production with StarRocks 4.0.x when using flat JSON feature with tables that have undergone schema changes (ADD/DROP COLUMN).

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4