### PR TITLE
[Enhancement] Introduce utils for FE memory estimation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -67,6 +67,7 @@ import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.TableRefPersist;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
@@ -102,7 +103,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -965,9 +965,9 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        List<Object> jobSamples = new ArrayList<>(dbIdToBackupOrRestoreJob.values());
-        return Lists.newArrayList(Pair.create(jobSamples, (long) dbIdToBackupOrRestoreJob.size()));
+    public long estimateSize() {
+        return Estimator.estimate(repoMgr)
+                + Estimator.estimate(dbIdToBackupOrRestoreJob, 5, 20);
     }
 
     public Map<Long, Long> getRunningBackupRestoreCount() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -53,6 +53,7 @@ import com.starrocks.common.util.concurrent.LockUtils.SlowLockLogStats;
 import com.starrocks.common.util.concurrent.QueryableReentrantReadWriteLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.memory.estimate.IgnoreMemoryTrack;
 import com.starrocks.persist.DropInfo;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -105,6 +106,7 @@ public class Database extends MetaObject implements Writable {
     @SerializedName(value = "r")
     private volatile long replicaQuotaSize;
 
+    @IgnoreMemoryTrack
     private final Map<String, Table> nameToTable;
     private final Map<Long, Table> idToTable;
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -81,6 +81,7 @@ import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.StorageInfo;
+import com.starrocks.memory.estimate.IgnoreMemoryTrack;
 import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.persist.OriginStatementInfo;
 import com.starrocks.planner.DescriptorTable.ReferencedPartitionInfo;
@@ -206,6 +207,7 @@ public class OlapTable extends Table {
     @SerializedName(value = "indexIdToMeta")
     protected Map<Long, MaterializedIndexMeta> indexMetaIdToMeta = Maps.newHashMap();
     // index name -> index meta id, not change the SerializedName for compatibility
+    @IgnoreMemoryTrack
     @SerializedName(value = "indexNameToId")
     protected Map<String, Long> indexNameToMetaId = Maps.newHashMap();
 
@@ -217,6 +219,7 @@ public class OlapTable extends Table {
 
     @SerializedName(value = "idToPartition")
     protected Map<Long, Partition> idToPartition = new HashMap<>();
+    @IgnoreMemoryTrack
     protected Map<String, Partition> nameToPartition = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
 
     protected Map<Long, Long> physicalPartitionIdToPartitionId = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -36,6 +36,7 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Writable;
+import com.starrocks.memory.estimate.ShallowMemory;
 import com.starrocks.sql.ast.ReplicaStatus;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
@@ -47,6 +48,7 @@ import java.util.Comparator;
 /**
  * This class represents the olap replica related metadata.
  */
+@ShallowMemory
 public class Replica implements Writable {
     private static final Logger LOG = LogManager.getLogger(Replica.class);
     public static final VersionComparator<Replica> VERSION_DESC_COMPARATOR = new VersionComparator<Replica>();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -48,6 +48,7 @@ import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.io.Writable;
+import com.starrocks.memory.estimate.IgnoreMemoryTrack;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.planner.DescriptorTable.ReferencedPartitionInfo;
 import com.starrocks.server.GlobalStateMgr;
@@ -202,6 +203,7 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
      * column names can change, but the column ID of a specific column will never change.
      * Use case-insensitive tree map, because the column name is case-insensitive in the system.
      */
+    @IgnoreMemoryTrack
     protected Map<String, Column> nameToColumn;
     protected Map<ColumnId, Column> idToColumn;
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
@@ -34,8 +34,10 @@
 
 package com.starrocks.catalog;
 
+import com.starrocks.memory.estimate.ShallowMemory;
 import com.starrocks.thrift.TStorageMedium;
 
+@ShallowMemory
 public class TabletMeta {
     private final long dbId;
     private final long tableId;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TempPartitions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TempPartitions.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.common.io.Writable;
+import com.starrocks.memory.estimate.IgnoreMemoryTrack;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.server.GlobalStateMgr;
 
@@ -55,6 +56,7 @@ import java.util.Set;
 public class TempPartitions implements Writable, GsonPostProcessable {
     @SerializedName(value = "idToPartition")
     private Map<Long, Partition> idToPartition = Maps.newHashMap();
+    @IgnoreMemoryTrack
     private Map<String, Partition> nameToPartition = Maps.newHashMap();
     @Deprecated
     // the range info of temp partitions has been moved to "partitionInfo" in OlapTable.

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -39,8 +39,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
-import com.starrocks.common.Pair;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.memory.estimate.Estimator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -53,7 +53,6 @@ import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
-import java.util.stream.Collectors;
 
 /*
  * if you want to visit the atrribute(such as queryID,defaultDb)
@@ -85,8 +84,6 @@ public class ProfileManager implements MemoryTrackable {
 
     public static final String LOAD_TYPE_STREAM_LOAD = "STREAM_LOAD";
     public static final String LOAD_TYPE_ROUTINE_LOAD = "ROUTINE_LOAD";
-
-    private static final int MEMORY_PROFILE_SAMPLES = 10;
 
     public static final ArrayList<String> PROFILE_HEADERS = new ArrayList<>(
             Arrays.asList(QUERY_ID, USER, DEFAULT_DB, SQL_STATEMENT, QUERY_TYPE,
@@ -282,19 +279,19 @@ public class ProfileManager implements MemoryTrackable {
 
     @Override
     public Map<String, Long> estimateCount() {
-        return ImmutableMap.of("QueryProfile", (long) profileMap.size());
+        readLock.lock();
+        try {
+            return ImmutableMap.of("QueryProfile", (long) profileMap.size());
+        } finally {
+            readLock.unlock();
+        }
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
+    public long estimateSize() {
         readLock.lock();
         try {
-            List<Object> profileSamples = profileMap.values()
-                    .stream()
-                    .limit(MEMORY_PROFILE_SAMPLES)
-                    .collect(Collectors.toList());
-
-            return Lists.newArrayList(Pair.create(profileSamples, (long) profileMap.size()));
+            return Estimator.estimate(profileMap, 10);
         } finally {
             readLock.unlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnector.java
@@ -14,11 +14,9 @@
 
 package com.starrocks.connector;
 
-import com.starrocks.common.Pair;
 import com.starrocks.connector.informationschema.InformationSchemaConnector;
 import com.starrocks.connector.metadata.TableMetaConnector;
 
-import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -63,8 +61,8 @@ public class CatalogConnector implements Connector {
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        return normalConnector.getSamples();
+    public long estimateSize() {
+        return normalConnector.estimateSize();
     }
 
     public String normalConnectorClassName() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/Connector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/Connector.java
@@ -14,13 +14,10 @@
 
 package com.starrocks.connector;
 
-import com.starrocks.common.Pair;
 import com.starrocks.connector.config.ConnectorConfig;
 import com.starrocks.memory.MemoryTrackable;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public interface Connector extends MemoryTrackable {
@@ -53,9 +50,5 @@ public interface Connector extends MemoryTrackable {
 
     default Map<String, Long> estimateCount() {
         return new HashMap<>();
-    }
-
-    default List<Pair<List<Object>, Long>> getSamples() {
-        return new ArrayList<>();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/LazyConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/LazyConnector.java
@@ -19,13 +19,11 @@ import com.starrocks.authorization.NativeAccessController;
 import com.starrocks.authorization.ranger.hive.RangerHiveAccessController;
 import com.starrocks.authorization.ranger.starrocks.RangerStarRocksAccessController;
 import com.starrocks.common.Config;
-import com.starrocks.common.Pair;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.sql.analyzer.Authorizer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.List;
 import java.util.Map;
 
 public class LazyConnector implements Connector {
@@ -100,9 +98,9 @@ public class LazyConnector implements Connector {
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
+    public long estimateSize() {
         initIfNeeded();
-        return delegate.getSamples();
+        return delegate.estimateSize();
     }
 
     public String getRealConnectorClassName() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeConnector.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.connector.delta;
 
-import com.starrocks.common.Pair;
 import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
@@ -26,7 +25,6 @@ import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -93,12 +91,12 @@ public class DeltaLakeConnector implements Connector {
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        return metastore.getSamples();
+    public Map<String, Long> estimateCount() {
+        return metastore.estimateCount();
     }
 
     @Override
-    public Map<String, Long> estimateCount() {
-        return metastore.estimateCount();
+    public long estimateSize() {
+        return metastore.estimateSize();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -22,12 +22,12 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
-import com.starrocks.common.Pair;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorViewDefinition;
 import com.starrocks.connector.PlanMode;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.rest.IcebergRESTCatalog;
+import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
@@ -42,6 +42,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StarRocksIcebergTableScan;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
@@ -55,6 +56,7 @@ import org.apache.spark.util.SizeEstimator;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -70,8 +72,6 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     private static final Logger LOG = LogManager.getLogger(CachingIcebergCatalog.class);
     public static final long NEVER_CACHE = 0;
     public static final long DEFAULT_CACHE_NUM = 100000;
-    private static final int MEMORY_META_SAMPLES = 10;
-    private static final int MEMORY_FILE_SAMPLES = 100;
     private static final int MEMORY_SNAPSHOT_SIZE = 2048; // approx memory size of one snapshot object without manifests
     private static final int MEMORY_MANIFEST_SIZE = 1024; // approx memory size of one manifest object in snapshot
     private static final int MEMORY_DATA_FILE_SIZE = 1536; // approx memory size of one data file in manifest
@@ -603,49 +603,6 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         return ans;
     }
 
-    @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        Pair<List<Object>, Long> dbSamples = Pair.create(databases.asMap().values()
-                        .stream()
-                        .limit(MEMORY_META_SAMPLES)
-                        .collect(Collectors.toList()),
-                databases.estimatedSize());
-
-        List<List<String>> partitionNames = getAllCachedPartitionNames();
-        List<Object> partitions = partitionNames
-                .stream()
-                .flatMap(List::stream)
-                .limit(MEMORY_FILE_SAMPLES)
-                .collect(Collectors.toList());
-        long partitionTotal = partitionNames
-                .stream()
-                .mapToLong(List::size)
-                .sum();
-        Pair<List<Object>, Long> partitionSamples = Pair.create(partitions, partitionTotal);
-
-        List<Object> dataFiles = dataFileCache.asMap().values()
-                .stream().flatMap(Set::stream)
-                .limit(MEMORY_FILE_SAMPLES)
-                .collect(Collectors.toList());
-        long dataFilesTotal = dataFileCache.asMap().values()
-                .stream()
-                .mapToLong(Set::size)
-                .sum();
-        Pair<List<Object>, Long> dataFileSamples = Pair.create(dataFiles, dataFilesTotal);
-
-        List<Object> deleteFiles = deleteFileCache.asMap().values()
-                .stream().flatMap(Set::stream)
-                .limit(MEMORY_FILE_SAMPLES)
-                .collect(Collectors.toList());
-        long deleteFilesTotal = deleteFileCache.asMap().values()
-                .stream()
-                .mapToLong(Set::size)
-                .sum();
-        Pair<List<Object>, Long> deleteFileSamples = Pair.create(deleteFiles, deleteFilesTotal);
-
-        return Lists.newArrayList(dbSamples, partitionSamples, dataFileSamples, deleteFileSamples);
-    }
-
     public static long estimatePartitionDataInBytes(PartitionData pd) {
         if (pd == null) {
             return 0L;
@@ -703,7 +660,6 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         return size;
     }
 
-    @Override
     public Map<String, Long> estimateCount() {
         Map<String, Long> counter = new HashMap<>();
         List<List<String>> partitionNames = getAllCachedPartitionNames();
@@ -726,6 +682,81 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                 .mapToLong(Set::size)
                 .sum());
         return counter;
+    }
+
+    @Override
+    public long estimateSize() {
+        return Estimator.estimate(tables.asMap(), 10) +
+                Estimator.estimate(databases.asMap(), 10) +
+                estimateDataFileCacheSize() +
+                estimateDeleteFileCacheSize() + Estimator.estimate(metaFileCacheMap, 10);
+    }
+
+    private long estimateDataFileCacheSize() {
+        int cnt = dataFileCache.asMap().size();
+        long size = Estimator.estimate(dataFileCache.asMap().keySet(), cnt);
+        for (Set<DataFile> files : dataFileCache.asMap().values()) {
+            if (files.isEmpty()) {
+                continue;
+            }
+            StructLike like = files.iterator().next().partition();
+            if (like instanceof PartitionData partitionData) {
+                // all files using the same PartitionData schema, so ignore it in estimation
+                org.apache.avro.Schema schema = partitionData.getSchema();
+                Set<Class<?>> ignoreClass = new HashSet<>();
+                ignoreClass.add(schema.getClass());
+                size += Estimator.estimate(files, 10, ignoreClass);
+                size += Estimator.estimate(schema, 10);
+            } else {
+                size += Estimator.estimate(files, 10);
+            }
+        }
+        return size;
+    }
+
+    private long estimateDeleteFileCacheSize() {
+        int cnt = deleteFileCache.asMap().size();
+        // Estimate size of keys
+        long size = Estimator.estimate(deleteFileCache.asMap().keySet(), cnt);
+
+        // Count total delete files across all cache entries
+        long totalDeleteFiles = deleteFileCache.asMap().values().stream()
+                .mapToLong(Set::size)
+                .sum();
+
+        if (totalDeleteFiles == 0) {
+            return size;
+        }
+
+        // Sample up to 100 DeleteFiles evenly distributed
+        int sampleTarget = (int) Math.min(100, totalDeleteFiles);
+        long step = totalDeleteFiles / sampleTarget;
+        List<DeleteFile> samples = new ArrayList<>(sampleTarget);
+        long index = 0;
+        long nextSampleIndex = 0;
+
+        outer:
+        for (Set<DeleteFile> files : deleteFileCache.asMap().values()) {
+            for (DeleteFile file : files) {
+                if (index == nextSampleIndex) {
+                    samples.add(file);
+                    nextSampleIndex += step;
+                    if (samples.size() >= sampleTarget) {
+                        break outer;
+                    }
+                }
+                index++;
+            }
+        }
+
+        // Estimate all samples at once, then calculate average and extrapolate
+        if (!samples.isEmpty()) {
+            long sampleTotalSize = Estimator.estimate(samples, samples.size());
+            long avgSize = sampleTotalSize / samples.size();
+            size += avgSize * totalDeleteFiles;
+        }
+
+        return size;
     }
 
     private long countSnapshotsSafe(Table table) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.MetaNotFoundException;
-import com.starrocks.common.Pair;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.ConnectorViewDefinition;
 import com.starrocks.connector.PartitionUtil;
@@ -266,10 +265,6 @@ public interface IcebergCatalog extends MemoryTrackable {
 
     default Map<String, Long> estimateCount() {
         return new HashMap<>();
-    }
-
-    default List<Pair<List<Object>, Long>> getSamples() {
-        return new ArrayList<>();
     }
 
     // --------------- partition APIs ---------------

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -15,7 +15,6 @@
 package com.starrocks.connector.iceberg;
 
 import com.starrocks.common.Config;
-import com.starrocks.common.Pair;
 import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
@@ -38,7 +37,6 @@ import org.apache.iceberg.util.ThreadPools;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
@@ -97,7 +95,8 @@ public class IcebergConnector implements Connector {
         if (Config.enable_iceberg_custom_worker_thread) {
             LOG.info("Default iceberg worker thread number changed " + Config.iceberg_worker_num_threads);
             Properties props = System.getProperties();
-            props.setProperty(ThreadPools.WORKER_THREAD_POOL_SIZE_PROP, String.valueOf(Config.iceberg_worker_num_threads));
+            props.setProperty(ThreadPools.WORKER_THREAD_POOL_SIZE_PROP,
+                    String.valueOf(Config.iceberg_worker_num_threads));
         }
 
         switch (nativeCatalogType) {
@@ -112,7 +111,8 @@ public class IcebergConnector implements Connector {
             case JDBC_CATALOG:
                 return new IcebergJdbcCatalog(catalogName, conf, properties);
             default:
-                throw new StarRocksConnectorException("Property %s is missing or not supported now.", ICEBERG_CATALOG_TYPE);
+                throw new StarRocksConnectorException("Property %s is missing or not supported now.",
+                        ICEBERG_CATALOG_TYPE);
         }
     }
 
@@ -168,7 +168,8 @@ public class IcebergConnector implements Connector {
 
     @Override
     public void shutdown() {
-        GlobalStateMgr.getCurrentState().getConnectorTableMetadataProcessor().unRegisterCachingIcebergCatalog(catalogName);
+        GlobalStateMgr.getCurrentState().getConnectorTableMetadataProcessor()
+                .unRegisterCachingIcebergCatalog(catalogName);
         if (icebergJobPlanningExecutor != null) {
             icebergJobPlanningExecutor.shutdown();
         }
@@ -192,7 +193,7 @@ public class IcebergConnector implements Connector {
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        return icebergNativeCatalog.getSamples();
+    public long estimateSize() {
+        return icebergNativeCatalog.estimateSize();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -78,6 +78,7 @@ import com.starrocks.http.rest.HealthAction;
 import com.starrocks.http.rest.HttpSSLContextLoader;
 import com.starrocks.http.rest.IdleAction;
 import com.starrocks.http.rest.LoadAction;
+import com.starrocks.http.rest.MemoryUsageAction;
 import com.starrocks.http.rest.MetaReplayerCheckAction;
 import com.starrocks.http.rest.MetricsAction;
 import com.starrocks.http.rest.MigrationAction;
@@ -217,6 +218,7 @@ public class HttpServer {
         ShowMetaInfoAction.registerAction(controller);
         ShowProcAction.registerAction(controller);
         ShowRuntimeInfoAction.registerAction(controller);
+        MemoryUsageAction.registerAction(controller);
         GetLogFileAction.registerAction(controller);
         TriggerAction.registerAction(controller);
         GetSmallFileAction.registerAction(controller);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MemoryUsageAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MemoryUsageAction.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest;
+
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import com.starrocks.memory.MemoryStat;
+import com.starrocks.memory.MemoryUsageTracker;
+import io.netty.handler.codec.http.HttpMethod;
+
+import java.util.Map;
+
+public class MemoryUsageAction extends RestBaseAction {
+
+    public MemoryUsageAction(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller) throws IllegalArgException {
+        controller.registerHandler(HttpMethod.GET, "/api/memory_usage",
+                new MemoryUsageAction(controller));
+    }
+
+    @Override
+    public void execute(BaseRequest request, BaseResponse response) {
+        Map<String, Object> result = Maps.newLinkedHashMap();
+
+        result.put("jvm", MemoryUsageTracker.getJVMMemoryMap());
+
+        Map<String, Map<String, MemoryStat>> memoryUsage = MemoryUsageTracker.collectMemoryUsage();
+
+        Map<String, Object> modules = Maps.newLinkedHashMap();
+        for (Map.Entry<String, Map<String, MemoryStat>> moduleEntry : memoryUsage.entrySet()) {
+            Map<String, Object> classMap = Maps.newLinkedHashMap();
+            for (Map.Entry<String, MemoryStat> classEntry : moduleEntry.getValue().entrySet()) {
+                MemoryStat stat = classEntry.getValue();
+                Map<String, Object> statMap = Maps.newLinkedHashMap();
+                statMap.put("current_consumption", stat.getCurrentConsumption());
+                statMap.put("peak_consumption", stat.getPeakConsumption());
+                statMap.put("counter", stat.getCounterMap());
+                classMap.put(classEntry.getKey(), statMap);
+            }
+            modules.put(moduleEntry.getKey(), classMap);
+        }
+        result.put("modules", modules);
+
+        Gson gson = new Gson();
+        response.setContentType("application/json");
+        response.getContent().append(gson.toJson(result));
+
+        sendResult(request, response);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MemoryUsageAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MemoryUsageAction.java
@@ -23,6 +23,7 @@ import com.starrocks.http.IllegalArgException;
 import com.starrocks.memory.MemoryStat;
 import com.starrocks.memory.MemoryUsageTracker;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.util.Map;
 
@@ -39,6 +40,12 @@ public class MemoryUsageAction extends RestBaseAction {
 
     @Override
     public void execute(BaseRequest request, BaseResponse response) {
+        if (!"127.0.0.1".equals(request.getHostString())) {
+            response.appendContent("only allow access from 127.0.0.1");
+            writeResponse(request, response, HttpResponseStatus.FORBIDDEN);
+            return;
+        }
+
         Map<String, Object> result = Maps.newLinkedHashMap();
 
         result.put("jvm", MemoryUsageTracker.getJVMMemoryMap());

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
@@ -16,11 +16,10 @@ package com.starrocks.lake.compaction;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Config;
-import com.starrocks.common.Pair;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -289,11 +288,7 @@ public class CompactionMgr implements MemoryTrackable {
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        List<Object> samples = partitionStatisticsHashMap.values()
-                .stream()
-                .limit(1)
-                .collect(Collectors.toList());
-        return Lists.newArrayList(Pair.create(samples, (long) partitionStatisticsHashMap.size()));
+    public long estimateSize() {
+        return Estimator.estimate(partitionStatisticsHashMap);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -80,6 +80,7 @@ import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.datacache.DataCacheMetrics;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.persist.BackendTabletsInfo;
 import com.starrocks.persist.BatchDeleteReplicaInfo;
 import com.starrocks.persist.ReplicaPersistInfo;
@@ -148,20 +149,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 public class ReportHandler extends Daemon implements MemoryTrackable {
-    @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        try (CloseableLock ignored = CloseableLock.lock(lock.readLock())) {
-            List<Pair<List<Object>, Long>> result = new ArrayList<>();
-            for (Map<Long, ReportTask> taskMap : pendingTaskMap.values()) {
-                result.add(Pair.create(taskMap.values()
-                        .stream()
-                        .limit(1)
-                        .collect(Collectors.toList()),
-                        (long) taskMap.size()));
-            }
-            return result;
-        }
-    }
 
     @Override
     public Map<String, Long> estimateCount() {
@@ -172,6 +159,17 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
             }
             long queueSize = (long) reportQueue.size() + (long) resourceReportQueue.size();
             return ImmutableMap.of("PendingTask", count, "ReportQueue", queueSize);
+        }
+    }
+
+    @Override
+    public long estimateSize() {
+        try (CloseableLock ignored = CloseableLock.lock(lock.readLock())) {
+            long size = 0;
+            for (Map<Long, ReportTask> taskMap : pendingTaskMap.values()) {
+                size += Estimator.estimate(taskMap, 20);
+            }
+            return size;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobMgr.java
@@ -18,9 +18,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.common.Pair;
 import com.starrocks.common.io.Writable;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.persist.CreateInsertOverwriteJobLog;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.InsertOverwriteStateChangeInfo;
@@ -44,11 +44,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
 
 public class InsertOverwriteJobMgr implements Writable, GsonPostProcessable, MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(InsertOverwriteJobMgr.class);
-    private static final int MEMORY_JOB_SAMPLES = 10;
 
     @SerializedName(value = "overwriteJobMap")
     private Map<Long, InsertOverwriteJob> overwriteJobMap;
@@ -261,11 +259,7 @@ public class InsertOverwriteJobMgr implements Writable, GsonPostProcessable, Mem
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        List<Object> samples = overwriteJobMap.values()
-                .stream()
-                .limit(MEMORY_JOB_SAMPLES)
-                .collect(Collectors.toList());
-        return Lists.newArrayList(Pair.create(samples, (long) overwriteJobMap.size()));
+    public long estimateSize() {
+        return Estimator.estimate(overwriteJobMap, 10);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -46,7 +46,6 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.LoadException;
 import com.starrocks.common.MetaNotFoundException;
-import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.TimeoutException;
 import com.starrocks.common.util.LogBuilder;
@@ -56,6 +55,7 @@ import com.starrocks.load.FailMsg;
 import com.starrocks.load.FailMsg.CancelType;
 import com.starrocks.load.Load;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.persist.AlterLoadJobOperationLog;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
@@ -106,7 +106,6 @@ import java.util.stream.Collectors;
  */
 public class LoadMgr implements MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(LoadMgr.class);
-    private static final int MEMORY_JOB_SAMPLES = 10;
 
     private final Map<Long, LoadJob> idToLoadJob = Maps.newConcurrentMap();
     private final Map<Long, Map<String, List<LoadJob>>> dbIdToLabelToLoadJobs = Maps.newConcurrentMap();
@@ -862,12 +861,8 @@ public class LoadMgr implements MemoryTrackable {
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        List<Object> samples = idToLoadJob.values()
-                .stream()
-                .limit(MEMORY_JOB_SAMPLES)
-                .collect(Collectors.toList());
-        return Lists.newArrayList(Pair.create(samples, (long) idToLoadJob.size()));
+    public long estimateSize() {
+        return Estimator.estimate(idToLoadJob, 20);
     }
 
     public Map<Long, Long> getRunningLoadCount() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
@@ -45,7 +45,6 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.InternalErrorCode;
 import com.starrocks.common.MetaNotFoundException;
-import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.DebugUtil;
@@ -53,6 +52,7 @@ import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
 import com.starrocks.load.RoutineLoadDesc;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.persist.AlterRoutineLoadJobOperationLog;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.OriginStatementInfo;
@@ -96,7 +96,6 @@ import java.util.stream.Collectors;
 
 public class RoutineLoadMgr implements Writable, MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(RoutineLoadMgr.class);
-    private static final int MEMORY_JOB_SAMPLES = 10;
 
     // warehouse ==> {be : running tasks num}
     private Map<Long, Map<Long, Integer>> warehouseNodeTasksNum = Maps.newHashMap();
@@ -793,13 +792,8 @@ public class RoutineLoadMgr implements Writable, MemoryTrackable {
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        List<Object> samples = idToRoutineLoadJob.values()
-                .stream()
-                .limit(MEMORY_JOB_SAMPLES)
-                .collect(Collectors.toList());
-
-        return Lists.newArrayList(Pair.create(samples, (long) idToRoutineLoadJob.size()));
+    public long estimateSize() {
+        return Estimator.estimate(idToRoutineLoadJob, 20);
     }
 
     public Map<Long, Long> getRunningRoutingLoadCount() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -26,12 +26,12 @@ import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.MetaNotFoundException;
-import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
 import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -65,7 +65,6 @@ import java.util.stream.Collectors;
 
 public class StreamLoadMgr implements MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(StreamLoadMgr.class);
-    private static final int MEMORY_JOB_SAMPLES = 10;
 
     // Task types that need to be persisted to the image file.
     // The order matters: it determines the serialization/deserialization order in save() and load().
@@ -733,12 +732,8 @@ public class StreamLoadMgr implements MemoryTrackable {
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        List<Object> samples = idToStreamLoadTask.values()
-                .stream()
-                .limit(MEMORY_JOB_SAMPLES)
-                .collect(Collectors.toList());
-        return Lists.newArrayList(Pair.create(samples, (long) idToStreamLoadTask.size()));
+    public long estimateSize() {
+        return Estimator.estimate(idToStreamLoadTask, 20);
     }
 
     public long getLatestFinishTime() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -45,6 +45,7 @@ import com.starrocks.load.LoadConstants;
 import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.load.loadv2.ManualLoadTxnCommitAttachment;
 import com.starrocks.load.routineload.RLTaskTxnCommitAttachment;
+import com.starrocks.memory.estimate.IgnoreMemoryTrack;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.QeProcessorImpl;
@@ -194,6 +195,7 @@ public class StreamLoadTask extends AbstractStreamLoadTask {
     private Coordinator coord;
     private Map<Integer, TNetworkAddress> channelIdToBEHTTPAddress;
     private Map<Integer, TNetworkAddress> channelIdToBEHTTPPort;
+    @IgnoreMemoryTrack
     private OlapTable table;
     private long taskDeadlineMs;
     private boolean isCommitting;

--- a/fe/fe-core/src/main/java/com/starrocks/memory/AgentTaskTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/AgentTaskTracker.java
@@ -15,11 +15,8 @@
 package com.starrocks.memory;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import com.starrocks.common.Pair;
 import com.starrocks.task.AgentTaskQueue;
 
-import java.util.List;
 import java.util.Map;
 
 public class AgentTaskTracker implements MemoryTrackable {
@@ -29,8 +26,7 @@ public class AgentTaskTracker implements MemoryTrackable {
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        return Lists.newArrayList(Pair.create(AgentTaskQueue.getSamplesForMemoryTracker(),
-                (long) AgentTaskQueue.getTaskNum()));
+    public long estimateSize() {
+        return AgentTaskQueue.estimateSize();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/memory/MemoryTrackable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/MemoryTrackable.java
@@ -14,47 +14,12 @@
 
 package com.starrocks.memory;
 
-import com.starrocks.common.Pair;
-import org.openjdk.jol.info.ClassLayout;
-
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 public interface MemoryTrackable {
-    // The default implementation of estimateSize only calculate the shadow size of the object.
-    // The shadow size is the same for all instances of the specified class,
-    // so using CLASS_SIZE to cache the class's instance shadow size.
-    // the key is class name, the value is size
-    Map<String, Long> CLASS_SIZE = new ConcurrentHashMap<>();
-
     default long estimateSize() {
-        List<Pair<List<Object>, Long>> samples = getSamples();
-        long totalBytes = 0;
-        for (Pair<List<Object>, Long> pair : samples) {
-            List<Object> sampleObjects = pair.first;
-            long size = pair.second;
-            if (!sampleObjects.isEmpty()) {
-                long sampleSize = sampleObjects.stream().mapToLong(this::getInstanceSize).sum();
-                totalBytes += (long) (((double) sampleSize) / sampleObjects.size() * size);
-            }
-        }
-
-        return totalBytes;
-    }
-
-    default long getInstanceSize(Object object) {
-        String className = object.getClass().getName();
-        return CLASS_SIZE.computeIfAbsent(className, s -> ClassLayout.parseInstance(object).instanceSize());
+        return 0;
     }
 
     Map<String, Long> estimateCount();
-
-    // Samples for estimateSize() to calculate memory size;
-    // Pair.fist is the sample objects, Pair.second is the total size of that module.
-    // For example:
-    // Manager has two list attributes: List<A>, List<B>, we get 10 objects for samples,
-    // this function should return:
-    // Pair<10 A objects, List<A>.size()>, Pair<10 B object, List<B>.size()>
-    List<Pair<List<Object>, Long>> getSamples();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/memory/QueryTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/QueryTracker.java
@@ -24,4 +24,9 @@ public class QueryTracker implements MemoryTrackable {
     public Map<String, Long> estimateCount() {
         return ImmutableMap.of("QueryDetail", QueryDetailQueue.getTotalQueriesCount());
     }
+
+    @Override
+    public long estimateSize() {
+        return QueryDetailQueue.estimateSize();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/memory/estimate/CustomEstimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/estimate/CustomEstimator.java
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.starrocks.memory;
+package com.starrocks.memory.estimate;
 
-import com.google.common.collect.ImmutableMap;
-import com.starrocks.qe.QueryDetailQueue;
-
-import java.util.Map;
-
-public class QueryTracker implements MemoryTrackable {
-    @Override
-    public Map<String, Long> estimateCount() {
-        return ImmutableMap.of("QueryDetail", QueryDetailQueue.getTotalQueriesCount());
-    }
+/**
+ * Interface for custom memory estimators.
+ * Implement this interface to provide specialized memory estimation
+ * for specific object types that require custom handling.
+ */
+@FunctionalInterface
+public interface CustomEstimator {
+    /**
+     * Estimate the memory size of the given object.
+     *
+     * @param obj the object to estimate
+     * @return the estimated memory size in bytes
+     */
+    long estimate(Object obj);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/memory/estimate/Estimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/estimate/Estimator.java
@@ -1,0 +1,589 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.memory.estimate;
+
+import org.jetbrains.annotations.NotNull;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.RandomAccess;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Utility class for estimating the memory size of Java objects.
+ * <p>
+ * Features:
+ * - Sampling-based estimation for arrays and collections
+ * - Recursive traversal of object fields with depth limit
+ * - Support for custom estimators for specific types
+ * - Caching of class shallow sizes for performance
+ * - Dynamic sample size calculation based on max depth to limit total computations
+ * <p>
+ * Important: This estimator will access all fields of an object,
+ * you should make sure the object is immutable or is protected by lock when calling estimate
+ */
+public class Estimator {
+
+    // Default maximum recursion depth
+    private static final int DEFAULT_MAX_DEPTH = 20;
+
+    private static final int DEFAULT_SAMPLE_SIZE = 5;
+
+    // Array header size: object header (12 bytes) + length field (4 bytes) = 16 bytes on 64-bit JVM
+    public static final int ARRAY_HEADER_SIZE = 16;
+
+    private static final long HIDDEN_CLASS_SHALLOW_SIZE = 16;
+
+    // Reference size on 64-bit JVM (with compressed oops, typically 4 bytes; without, 8 bytes)
+    private static final int REFERENCE_SIZE = 4;
+
+    // Shallow sizes of classes (bound to Class lifecycle, avoids ClassLoader leaks)
+    private static final ClassValue<Long> SHALLOW_SIZE = new ClassValue<>() {
+        @Override
+        protected Long computeValue(@NotNull Class<?> clazz) {
+            if (isHiddenClass(clazz)) {
+                return HIDDEN_CLASS_SHALLOW_SIZE;
+            }
+            try {
+                return ClassLayout.parseClass(clazz).instanceSize();
+            } catch (RuntimeException e) {
+                return HIDDEN_CLASS_SHALLOW_SIZE;
+            }
+        }
+    };
+
+    // Registry for custom estimators
+    protected static final Map<Class<?>, CustomEstimator> CUSTOM_ESTIMATORS = new HashMap<>();
+
+    // Registry for classes that should only calculate shallow memory
+    // Store class names instead of Class<?> to avoid pinning Class/ClassLoader.
+    protected static final Set<String> SHALLOW_MEMORY_CLASS_NAMES = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    // Cache for nested reference fields of classes (bound to Class lifecycle, avoids ClassLoader leaks)
+    // Also moves trySetAccessible into computeValue to avoid doing it in hot path.
+    protected static final ClassValue<Field[]> CLASS_NESTED_FIELDS = new ClassValue<>() {
+        @Override
+        protected Field[] computeValue(Class<?> clazz) {
+            ArrayList<Field> nested = new ArrayList<>();
+            for (Field field : clazz.getDeclaredFields()) {
+                // Skip static fields
+                if (Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
+
+                // Skip fields annotated with @IgnoreMemoryTrack
+                if (field.isAnnotationPresent(IgnoreMemoryTrack.class)) {
+                    continue;
+                }
+
+                // Skip primitive fields (already included in shallow size)
+                if (field.getType().isPrimitive()) {
+                    continue;
+                }
+
+                // Skip enum fields (enum instances are singletons, already allocated at class loading)
+                if (field.getType().isEnum()) {
+                    continue;
+                }
+
+                // Do accessibility attempt once during caching, not in hot path.
+                try {
+                    field.trySetAccessible();
+                } catch (Throwable ignore) {
+                    // ignore; access may still fail later, handled in estimateNestedField
+                }
+
+                nested.add(field);
+            }
+            return nested.toArray(new Field[0]);
+        }
+    };
+
+    // Primitive type sizes in bytes
+    private static final Map<Class<?>, Integer> PRIMITIVE_SIZES = Map.of(
+            boolean.class, 1,
+            byte.class, 1,
+            char.class, 2,
+            short.class, 2,
+            int.class, 4,
+            float.class, 4,
+            long.class, 8,
+            double.class, 8
+    );
+
+    // Set to track visited objects and avoid counting the same object twice
+    private final Set<Object> visited;
+
+    // Set of classes to ignore during estimation
+    private final Set<Class<?>> ignoreClasses;
+
+    public Estimator() {
+        this(Collections.emptySet());
+    }
+
+    public Estimator(Set<Class<?>> ignoreClasses) {
+        this.visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        this.ignoreClasses = ignoreClasses != null ? ignoreClasses : Collections.emptySet();
+    }
+
+    /**
+     * Register a custom estimator for a specific class.
+     *
+     * @param clazz     the class to register estimator for
+     * @param estimator the custom estimator
+     */
+    public static void registerCustomEstimator(Class<?> clazz, CustomEstimator estimator) {
+        CUSTOM_ESTIMATORS.put(clazz, estimator);
+    }
+
+    /**
+     * Get the custom estimator for a class, if registered.
+     *
+     * @param clazz the class to look up
+     * @return the custom estimator, or null if not registered
+     */
+    public static CustomEstimator getCustomEstimator(Class<?> clazz) {
+        return CUSTOM_ESTIMATORS.get(clazz);
+    }
+
+    /**
+     * Register a class as shallow memory class.
+     * Classes registered here will only calculate shallow memory size.
+     *
+     * @param clazz the class to register
+     */
+    public static void registerShallowMemoryClass(Class<?> clazz) {
+        if (clazz != null) {
+            SHALLOW_MEMORY_CLASS_NAMES.add(clazz.getName());
+        }
+    }
+
+    /**
+     * Check if a class is a shallow memory class (annotated with @ShallowMemory or registered).
+     *
+     * @param clazz the class to check
+     * @return true if the class should only calculate shallow memory
+     */
+    public static boolean isShallowMemoryClass(Class<?> clazz) {
+        return clazz.isAnnotationPresent(ShallowMemory.class) || SHALLOW_MEMORY_CLASS_NAMES.contains(clazz.getName());
+    }
+
+    /**
+     * Estimate the memory size of an object with default settings.
+     *
+     * @param obj the object to estimate
+     * @return the estimated memory size in bytes
+     */
+    public static long estimate(Object obj) {
+        return new Estimator().estimateInternal(obj, DEFAULT_MAX_DEPTH, DEFAULT_SAMPLE_SIZE);
+    }
+
+    /**
+     * Estimate the memory size of an object with specified sample size.
+     *
+     * @param obj        the object to estimate
+     * @param sampleSize the number of elements to sample for collections/arrays
+     * @return the estimated memory size in bytes
+     */
+    public static long estimate(Object obj, int sampleSize) {
+        return new Estimator().estimateInternal(obj, DEFAULT_MAX_DEPTH, sampleSize);
+    }
+
+    /**
+     * Estimate the memory size of an object with specified sample size and max depth.
+     *
+     * @param obj        the object to estimate
+     * @param sampleSize the number of elements to sample for collections/arrays
+     * @param maxDepth   the maximum recursion depth
+     * @return the estimated memory size in bytes
+     */
+    public static long estimate(Object obj, int sampleSize, int maxDepth) {
+        return new Estimator().estimateInternal(obj, maxDepth, sampleSize);
+    }
+
+    /**
+     * Estimate the memory size of an object with specified ignore classes.
+     * Objects of ignored classes will not be counted in the estimation.
+     * This is useful when multiple objects reference the same shared object,
+     * and you want to exclude that shared object from the calculation.
+     *
+     * @param obj           the object to estimate
+     * @param ignoreClasses set of classes to ignore during estimation
+     * @return the estimated memory size in bytes
+     */
+    public static long estimate(Object obj, Set<Class<?>> ignoreClasses) {
+        return new Estimator(ignoreClasses).estimateInternal(obj, DEFAULT_MAX_DEPTH, DEFAULT_SAMPLE_SIZE);
+    }
+
+    /**
+     * Estimate the memory size of an object with specified sample size and ignore classes.
+     *
+     * @param obj           the object to estimate
+     * @param sampleSize    the number of elements to sample for collections/arrays
+     * @param ignoreClasses set of classes to ignore during estimation
+     * @return the estimated memory size in bytes
+     */
+    public static long estimate(Object obj, int sampleSize, Set<Class<?>> ignoreClasses) {
+        return new Estimator(ignoreClasses).estimateInternal(obj, DEFAULT_MAX_DEPTH, sampleSize);
+    }
+
+    /**
+     * Estimate the memory size of an object with all options specified.
+     *
+     * @param obj           the object to estimate
+     * @param sampleSize    the number of elements to sample for collections/arrays
+     * @param maxDepth      the maximum recursion depth
+     * @param ignoreClasses set of classes to ignore during estimation
+     * @return the estimated memory size in bytes
+     */
+    public static long estimate(Object obj, int sampleSize, int maxDepth, Set<Class<?>> ignoreClasses) {
+        return new Estimator(ignoreClasses).estimateInternal(obj, maxDepth, sampleSize);
+    }
+
+    /**
+     * Internal estimation method with sampled set to track visited objects.
+     */
+    private long estimateInternal(Object obj, int maxDepth, int sampleSize) {
+        if (obj == null) {
+            return 0;
+        }
+
+        // Skip if already visited (avoid counting the same object twice)
+        if (!visited.add(obj)) {
+            return 0;
+        }
+
+        Class<?> clazz = obj.getClass();
+
+        // Skip classes in the ignore set
+        if (ignoreClasses.contains(clazz)) {
+            return 0;
+        }
+
+        // Skip classes annotated with @IgnoreMemoryTrack
+        if (clazz.isAnnotationPresent(IgnoreMemoryTrack.class)) {
+            return 0;
+        }
+
+        // Check for custom estimator
+        CustomEstimator customEstimator = getCustomEstimator(clazz);
+        if (customEstimator != null) {
+            return customEstimator.estimate(obj);
+        }
+
+        // Check for shallow memory class (annotated or registered)
+        if (isShallowMemoryClass(clazz)) {
+            return shallow(clazz);
+        }
+
+        // If max depth reached, return shallow size
+        if (maxDepth <= 0) {
+            return shallow(obj);
+        }
+
+        // Handle arrays
+        if (clazz.isArray()) {
+            return estimateArray(obj, maxDepth, sampleSize);
+        }
+
+        // Handle collections
+        if (obj instanceof Collection) {
+            return estimateCollection((Collection<?>) obj, maxDepth, sampleSize);
+        }
+
+        // Handle maps
+        if (obj instanceof Map<?, ?> map) {
+            return shallow(obj) +
+                    estimateCollection(map.keySet(), maxDepth, sampleSize) +
+                    estimateCollection(map.values(), maxDepth, sampleSize);
+        }
+
+        // Recursively calculate size for reference fields
+        return estimateObject(obj, maxDepth, sampleSize);
+    }
+
+    /**
+     * Calculate the shallow size of an object (instance size without references).
+     *
+     * @param obj the object
+     * @return the shallow size in bytes
+     */
+    public static long shallow(Object obj) {
+        if (obj == null) {
+            return 0;
+        }
+
+        Class<?> clazz = obj.getClass();
+
+        // for arrays, calculate size without caching,
+        // because the shallow size of arrays depends on their length
+        if (clazz.isArray()) {
+            int length = Array.getLength(obj);
+            Class<?> componentType = clazz.getComponentType();
+            if (componentType.isPrimitive()) {
+                return ARRAY_HEADER_SIZE + (long) length * PRIMITIVE_SIZES.get(componentType);
+            } else {
+                return ARRAY_HEADER_SIZE + (long) length * REFERENCE_SIZE;
+            }
+        }
+
+        // Non-array: shallow size depends only on the class, use ClassValue
+        return SHALLOW_SIZE.get(clazz);
+    }
+
+    public static long shallow(Class<?> clazz) {
+        if (clazz.isArray()) {
+            throw new IllegalArgumentException("Use shallow(Object obj) for array instances");
+        }
+        return SHALLOW_SIZE.get(clazz);
+    }
+
+    /**
+     * Estimate the size of a collection using sampling.
+     *
+     * @param collection the collection to estimate
+     * @param maxDepth   the maximum recursion depth for elements
+     * @param sampleSize the number of elements to sample
+     * @return the estimated memory size in bytes
+     */
+    private long estimateCollection(Collection<?> collection, int maxDepth, int sampleSize) {
+        if (collection == null || collection.isEmpty()) {
+            return collection == null ? 0 : shallow(collection);
+        }
+
+        long shallowSize = shallow(collection);
+
+        // Get first non-null element to determine element type
+        Object firstElement = null;
+        for (Object item : collection) {
+            if (item != null) {
+                firstElement = item;
+                break;
+            }
+        }
+
+        if (firstElement == null) {
+            return shallowSize;
+        }
+
+        // Check if element type is a shallow memory class
+        Class<?> elementClass = firstElement.getClass();
+        if (isShallowMemoryClass(elementClass)) {
+            long elementShallowSize = shallow(elementClass);
+            return shallowSize + elementShallowSize * collection.size();
+        }
+
+        List<Object> samples = getSamples(collection, sampleSize);
+
+        if (samples.isEmpty()) {
+            return shallowSize;
+        }
+
+        long sampleTotalSize = 0;
+        for (Object sample : samples) {
+            sampleTotalSize += estimateInternal(sample, maxDepth - 1, sampleSize);
+        }
+
+        double avgSize = (double) sampleTotalSize / samples.size();
+        return shallowSize + (long) (avgSize * collection.size());
+    }
+
+    /**
+     * Estimate the size of an array using sampling.
+     *
+     * @param array      the array to estimate
+     * @param maxDepth   the maximum recursion depth for elements
+     * @param sampleSize the number of elements to sample
+     * @return the estimated memory size in bytes
+     */
+    private long estimateArray(Object array, int maxDepth, int sampleSize) {
+        int length = Array.getLength(array);
+        Class<?> componentType = array.getClass().getComponentType();
+
+        if (componentType.isPrimitive()) {
+            return ARRAY_HEADER_SIZE + (long) length * PRIMITIVE_SIZES.get(componentType);
+        }
+
+        // For empty object arrays
+        if (length == 0) {
+            return ARRAY_HEADER_SIZE;
+        }
+
+        // For object arrays: header + references + element sizes
+        long shallowSize = ARRAY_HEADER_SIZE + (long) REFERENCE_SIZE * length;
+
+        // Check if component type is a shallow memory class
+        if (isShallowMemoryClass(componentType)) {
+            long elementShallowSize = shallow(componentType);
+            return shallowSize + elementShallowSize * length;
+        }
+
+        List<Object> samples = getSamplesFromArray(array, length, sampleSize);
+
+        if (samples.isEmpty()) {
+            return shallowSize;
+        }
+
+        long sampleTotalSize = 0;
+        for (Object sample : samples) {
+            sampleTotalSize += estimateInternal(sample, maxDepth - 1, sampleSize);
+        }
+
+        double avgSize = (double) sampleTotalSize / samples.size();
+        return shallowSize + (long) (avgSize * length);
+    }
+
+    /**
+     * Estimate the size of a regular object by traversing its fields.
+     *
+     * @param obj        the object to estimate
+     * @param maxDepth   the maximum recursion depth
+     * @param sampleSize the number of elements to sample for collections/arrays
+     * @return the estimated memory size in bytes
+     */
+    private long estimateObject(Object obj, int maxDepth, int sampleSize) {
+        if (isHiddenClass(obj.getClass())) {
+            return HIDDEN_CLASS_SHALLOW_SIZE;
+        }
+
+        long size = shallow(obj);
+
+        for (Class<?> c = obj.getClass(); c != null && c != Object.class; c = c.getSuperclass()) {
+            if (c.isAnnotationPresent(IgnoreMemoryTrack.class)) {
+                return 0;
+            }
+            Field[] nestedFields = CLASS_NESTED_FIELDS.get(c);
+            for (Field field : nestedFields) {
+                size += estimateNestedField(obj, field, maxDepth, sampleSize);
+            }
+        }
+
+        return size;
+    }
+
+    private long estimateNestedField(Object obj, Field field, int maxDepth, int sampleSize) {
+        try {
+            Object fieldValue = field.get(obj);
+            if (fieldValue == null) {
+                return 0;
+            }
+            return estimateInternal(fieldValue, maxDepth - 1, sampleSize);
+        } catch (IllegalAccessException | InaccessibleObjectException e) {
+            // Skip fields that cannot be accessed
+            return 0;
+        }
+    }
+
+    /**
+     * Get sample elements from a collection.
+     * Samples are evenly distributed across the collection using a fixed step size.
+     * For RandomAccess lists (ArrayList, etc.), uses index access for efficiency.
+     * For non-RandomAccess collections (LinkedList, etc.), iterates with step skipping.
+     *
+     * @param collection the collection to sample
+     * @param sampleSize the number of elements to sample
+     * @return a list of sample elements
+     */
+    private static List<Object> getSamples(Collection<?> collection, int sampleSize) {
+        int size = collection.size();
+        List<Object> samples = new ArrayList<>(Math.min(sampleSize, size));
+
+        if (size <= sampleSize) {
+            // If collection is small, use all elements
+            for (Object item : collection) {
+                if (item != null) {
+                    samples.add(item);
+                }
+            }
+        } else if (collection instanceof List<?> list && collection instanceof RandomAccess) {
+            // For RandomAccess lists, sample evenly distributed elements using index access
+            int step = size / sampleSize;
+            for (int i = 0; i < size && samples.size() < sampleSize; i += step) {
+                Object item = list.get(i);
+                if (item != null) {
+                    samples.add(item);
+                }
+            }
+        } else {
+            // For non-RandomAccess collections, iterate with step skipping
+            int step = size / sampleSize;
+            int index = 0;
+            int nextSampleIndex = 0;
+            for (Object item : collection) {
+                if (index == nextSampleIndex) {
+                    if (item != null) {
+                        samples.add(item);
+                    }
+                    nextSampleIndex += step;
+                    if (samples.size() >= sampleSize) {
+                        break;
+                    }
+                }
+                index++;
+            }
+        }
+
+        return samples;
+    }
+
+    /**
+     * Get sample elements from an array.
+     *
+     * @param array      the array to sample
+     * @param length     the length of the array
+     * @param sampleSize the number of elements to sample
+     * @return a list of sample elements
+     */
+    private static List<Object> getSamplesFromArray(Object array, int length, int sampleSize) {
+        List<Object> samples = new ArrayList<>(Math.min(sampleSize, length));
+
+        if (length <= sampleSize) {
+            // If array is small, use all elements
+            for (int i = 0; i < length; i++) {
+                Object item = Array.get(array, i);
+                if (item != null) {
+                    samples.add(item);
+                }
+            }
+        } else {
+            // Sample evenly distributed elements
+            int step = length / sampleSize;
+            for (int i = 0; i < length && samples.size() < sampleSize; i += step) {
+                Object item = Array.get(array, i);
+                if (item != null) {
+                    samples.add(item);
+                }
+            }
+        }
+
+        return samples;
+    }
+
+    private static boolean isHiddenClass(Class<?> c) {
+        return c.isHidden()
+                || c.isSynthetic() && c.getName().contains("$$Lambda$");
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/memory/estimate/IgnoreMemoryTrack.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/estimate/IgnoreMemoryTrack.java
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.starrocks.memory;
+package com.starrocks.memory.estimate;
 
-import com.google.common.collect.ImmutableMap;
-import com.starrocks.qe.QueryDetailQueue;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import java.util.Map;
-
-public class QueryTracker implements MemoryTrackable {
-    @Override
-    public Map<String, Long> estimateCount() {
-        return ImmutableMap.of("QueryDetail", QueryDetailQueue.getTotalQueriesCount());
-    }
+/**
+ * Annotation to mark fields or classes that should be excluded from memory tracking.
+ * - Fields annotated with @IgnoreMemoryTrack will be skipped during memory size estimation.
+ * - Classes annotated with @IgnoreMemoryTrack will return 0 for memory estimation.
+ */
+@Target({ElementType.FIELD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IgnoreMemoryTrack {
 }

--- a/fe/fe-core/src/main/java/com/starrocks/memory/estimate/README.md
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/estimate/README.md
@@ -1,0 +1,160 @@
+# Memory Estimation Module
+
+This module provides utilities for estimating the memory footprint of Java objects in StarRocks FE. It is designed for memory tracking and monitoring purposes, enabling accurate memory usage statistics without the overhead of deep object graph traversal.
+
+## Overview
+
+The memory estimation module offers:
+
+- **Sampling-based estimation** for arrays and collections to balance accuracy and performance
+- **Recursive field traversal** with configurable depth limits
+- **Custom estimator support** for specialized object types
+- **Annotation-based control** to exclude or simplify memory tracking for specific classes/fields
+- **Caching** of class shallow sizes for optimal performance
+
+## Components
+
+### Estimator
+
+The core utility class (`Estimator.java`) that estimates memory size of Java objects.
+
+**Key Features:**
+- Uses JOL (Java Object Layout) for accurate shallow size calculation
+- Samples elements from large collections/arrays instead of traversing all elements
+- Caches shallow sizes to avoid repeated reflection overhead
+- Automatically detects and caches classes with no nested reference fields
+
+### Annotations
+
+#### @IgnoreMemoryTrack
+
+Marks fields or classes to be excluded from memory tracking.
+
+```java
+// Exclude a field from memory estimation
+public class MyClass {
+    @IgnoreMemoryTrack
+    private SomeLargeObject cache;  // Will not be counted
+}
+
+// Exclude an entire class - returns 0 for memory estimation
+@IgnoreMemoryTrack
+public class IgnoredClass {
+    // ...
+}
+```
+
+#### @ShallowMemory
+
+Marks classes that should only calculate shallow memory size (no recursive field traversal).
+
+```java
+@ShallowMemory
+public class SimpleData {
+    private int id;
+    private String name;  // name's content won't be recursively calculated
+}
+```
+
+For collections containing `@ShallowMemory` elements, the estimation uses `shallow_size * element_count` instead of sampling.
+
+### CustomEstimator
+
+Interface for implementing specialized memory estimators for specific object types.
+
+```java
+@FunctionalInterface
+public interface CustomEstimator {
+    long estimate(Object obj);
+}
+```
+
+## Usage
+
+### Basic Estimation
+
+```java
+// Estimate with default settings (max depth = 8, sample size = 5)
+long size = Estimator.estimate(myObject);
+
+// Estimate with custom max depth
+long size = Estimator.estimate(myObject, 4);
+
+// Estimate with custom max depth and sample size
+long size = Estimator.estimate(myObject, 4, 10);
+```
+
+### Register Custom Estimators
+
+```java
+// Register a custom estimator for a specific class
+Estimator.registerCustomEstimator(String.class, new StringEstimator());
+
+// Register with a lambda
+Estimator.registerCustomEstimator(MyClass.class, obj -> {
+    MyClass mc = (MyClass) obj;
+    return 100 + mc.getData().length * 8;
+});
+```
+
+### Register Shallow Memory Classes Programmatically
+
+```java
+// Register a class to only calculate shallow memory
+Estimator.registerShallowMemoryClass(SomeExternalClass.class);
+```
+
+### Get Shallow Size Only
+
+```java
+// Get shallow size of an object instance
+long shallowSize = Estimator.shallow(myObject);
+
+// Get shallow size of a class (for non-array types)
+long shallowSize = Estimator.shallow(MyClass.class);
+```
+
+## Implementation Details
+
+### Estimation Algorithm
+
+1. **Null check**: Returns 0 for null objects
+2. **Annotation check**: Returns 0 for `@IgnoreMemoryTrack` classes
+3. **Custom estimator**: Uses registered custom estimator if available
+4. **Shallow memory check**: Returns shallow size for `@ShallowMemory` classes
+5. **Depth check**: Returns shallow size if max depth is reached
+6. **Type-specific handling**:
+   - **Arrays**: Calculates header + references + sampled element sizes
+   - **Collections**: Calculates shallow size + sampled element sizes
+   - **Maps**: Calculates shallow size + key set + value collection
+   - **Objects**: Recursively estimates all non-static, non-primitive reference fields
+
+### Sampling Strategy
+
+For large collections and arrays:
+- **RandomAccess lists** (e.g., ArrayList): Evenly distributed sampling using index access
+- **Non-RandomAccess collections** (e.g., LinkedList): Takes first N elements to avoid O(n) traversal
+- **Arrays**: Evenly distributed sampling
+
+### Caching
+
+- **Shallow size cache**: `ConcurrentHashMap<Class<?>, Long>` for class instance sizes
+- **Nested fields cache**: `ConcurrentHashMap<Class<?>, List<Field>>` for reference fields per class
+- **Shallow memory classes**: Auto-detected and cached when a class has no nested reference fields
+
+### Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `DEFAULT_MAX_DEPTH` | 8 | Default recursion depth limit |
+| `DEFAULT_SAMPLE_SIZE` | 5 | Default number of elements to sample |
+| `ARRAY_HEADER_SIZE` | 16 | Array header size on 64-bit JVM |
+| `REFERENCE_SIZE` | 4 | Reference size with compressed oops |
+
+## Best Practices
+
+1. **Use annotations** for classes with known memory patterns to avoid unnecessary recursion
+2. **Register custom estimators** for complex objects with predictable memory layouts
+3. **Adjust depth and sample size** based on your accuracy vs. performance requirements
+4. **Mark external library classes** as shallow memory if deep traversal is not needed
+5. **Use `@IgnoreMemoryTrack`** for cached or shared objects that shouldn't be counted multiple times

--- a/fe/fe-core/src/main/java/com/starrocks/memory/estimate/README.md
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/estimate/README.md
@@ -1,16 +1,20 @@
 # Memory Estimation Module
 
-This module provides utilities for estimating the memory footprint of Java objects in StarRocks FE. It is designed for memory tracking and monitoring purposes, enabling accurate memory usage statistics without the overhead of deep object graph traversal.
+This module provides utilities for estimating the memory footprint of Java objects in StarRocks FE. It is designed for
+memory tracking and monitoring, balancing accuracy and performance by combining shallow sizes, sampling, and bounded
+recursion instead of deep object graph traversal.
 
 ## Overview
 
 The memory estimation module offers:
 
-- **Sampling-based estimation** for arrays and collections to balance accuracy and performance
-- **Recursive field traversal** with configurable depth limits
-- **Custom estimator support** for specialized object types
-- **Annotation-based control** to exclude or simplify memory tracking for specific classes/fields
-- **Caching** of class shallow sizes for optimal performance
+- Sampling-based estimation for arrays and collections
+- Recursive field traversal with configurable depth limits
+- Custom estimator support for specialized object types
+- Annotation-based control to exclude or simplify memory tracking for specific classes or fields
+- Optional ignore-class sets for excluding shared objects from a single estimate
+- ClassValue-based caching of class shallow sizes and reference fields
+- Identity-based cycle detection to avoid double counting the same object
 
 ## Components
 
@@ -18,11 +22,13 @@ The memory estimation module offers:
 
 The core utility class (`Estimator.java`) that estimates memory size of Java objects.
 
-**Key Features:**
-- Uses JOL (Java Object Layout) for accurate shallow size calculation
+Key features:
+
+- Uses JOL (Java Object Layout) for accurate shallow size calculation when possible
 - Samples elements from large collections/arrays instead of traversing all elements
-- Caches shallow sizes to avoid repeated reflection overhead
-- Automatically detects and caches classes with no nested reference fields
+- Supports custom estimators and shallow-only classes
+- Provides overloads for max depth, sample size, and ignore-class sets
+- Caches shallow sizes and reference fields via `ClassValue`
 
 ### Annotations
 
@@ -56,7 +62,8 @@ public class SimpleData {
 }
 ```
 
-For collections containing `@ShallowMemory` elements, the estimation uses `shallow_size * element_count` instead of sampling.
+For collections containing `@ShallowMemory` elements, the estimation uses `shallow_size * element_count` instead of
+sampling.
 
 ### CustomEstimator
 
@@ -74,14 +81,24 @@ public interface CustomEstimator {
 ### Basic Estimation
 
 ```java
-// Estimate with default settings (max depth = 8, sample size = 5)
+// Estimate with default settings (max depth = 20, sample size = 5)
 long size = Estimator.estimate(myObject);
 
-// Estimate with custom max depth
-long size = Estimator.estimate(myObject, 4);
+// Estimate with custom sample size
+long size = Estimator.estimate(myObject, 10);
 
-// Estimate with custom max depth and sample size
-long size = Estimator.estimate(myObject, 4, 10);
+// Estimate with custom sample size and max depth
+long size = Estimator.estimate(myObject, 10, 4);
+```
+
+### Ignore Classes for Shared Objects
+
+```java
+Set<Class<?>> ignore = Set.of(SharedCache.class);
+long size = Estimator.estimate(myObject, ignore);
+
+// With custom sample size and max depth
+long size = Estimator.estimate(myObject, 10, 4, ignore);
 ```
 
 ### Register Custom Estimators
@@ -110,7 +127,7 @@ Estimator.registerShallowMemoryClass(SomeExternalClass.class);
 // Get shallow size of an object instance
 long shallowSize = Estimator.shallow(myObject);
 
-// Get shallow size of a class (for non-array types)
+// Get shallow size of a class (non-array types only)
 long shallowSize = Estimator.shallow(MyClass.class);
 ```
 
@@ -118,43 +135,53 @@ long shallowSize = Estimator.shallow(MyClass.class);
 
 ### Estimation Algorithm
 
-1. **Null check**: Returns 0 for null objects
-2. **Annotation check**: Returns 0 for `@IgnoreMemoryTrack` classes
-3. **Custom estimator**: Uses registered custom estimator if available
-4. **Shallow memory check**: Returns shallow size for `@ShallowMemory` classes
-5. **Depth check**: Returns shallow size if max depth is reached
-6. **Type-specific handling**:
-   - **Arrays**: Calculates header + references + sampled element sizes
-   - **Collections**: Calculates shallow size + sampled element sizes
-   - **Maps**: Calculates shallow size + key set + value collection
-   - **Objects**: Recursively estimates all non-static, non-primitive reference fields
+1. Null check: returns 0 for null objects
+2. Cycle check: returns 0 if the object was already visited
+3. Ignore-class check: returns 0 for classes in the ignore set
+4. Annotation check: returns 0 for `@IgnoreMemoryTrack` classes
+5. Custom estimator: uses registered custom estimator if available
+6. Shallow memory check: returns shallow size for `@ShallowMemory` classes
+7. Depth check: returns shallow size if max depth is reached
+8. Type-specific handling based on arrays, collections, maps, or regular objects
+
+Hidden or synthetic lambda classes are treated as a fixed shallow size (16 bytes) to avoid JOL failures.
+
+### Type-Specific Handling
+
+- Arrays: header + references + sampled element sizes
+- Collections: shallow size + sampled element sizes
+- Maps: shallow size + key set + value collection sizes
+- Objects: recursively estimates all non-static, non-primitive, non-enum reference fields
 
 ### Sampling Strategy
 
-For large collections and arrays:
-- **RandomAccess lists** (e.g., ArrayList): Evenly distributed sampling using index access
-- **Non-RandomAccess collections** (e.g., LinkedList): Takes first N elements to avoid O(n) traversal
-- **Arrays**: Evenly distributed sampling
+- If size <= sample size: uses all non-null elements
+- RandomAccess lists (e.g., ArrayList): evenly distributed sampling via index access
+- Non-RandomAccess collections (e.g., LinkedList): iterates and picks evenly spaced elements
+- Arrays: evenly distributed sampling
 
 ### Caching
 
-- **Shallow size cache**: `ConcurrentHashMap<Class<?>, Long>` for class instance sizes
-- **Nested fields cache**: `ConcurrentHashMap<Class<?>, List<Field>>` for reference fields per class
-- **Shallow memory classes**: Auto-detected and cached when a class has no nested reference fields
+- Shallow size cache: `ClassValue<Long>` to avoid repeated JOL reflection work
+- Nested reference fields cache: `ClassValue<Field[]>` with `trySetAccessible()` attempted once during caching
+- Shallow memory classes: stored by class name to avoid pinning ClassLoaders
 
 ### Constants
 
 | Constant | Value | Description |
 |----------|-------|-------------|
-| `DEFAULT_MAX_DEPTH` | 8 | Default recursion depth limit |
+| `DEFAULT_MAX_DEPTH` | 20 | Default recursion depth limit |
 | `DEFAULT_SAMPLE_SIZE` | 5 | Default number of elements to sample |
-| `ARRAY_HEADER_SIZE` | 16 | Array header size on 64-bit JVM |
+| `ARRAY_HEADER_SIZE` | 16 | Array header size on a 64-bit JVM |
 | `REFERENCE_SIZE` | 4 | Reference size with compressed oops |
+| `HIDDEN_CLASS_SHALLOW_SIZE` | 16 | Fallback size for hidden or synthetic lambda classes |
+
+Note: These constants assume a 64-bit JVM with compressed oops. Actual layouts may differ.
 
 ## Best Practices
 
-1. **Use annotations** for classes with known memory patterns to avoid unnecessary recursion
-2. **Register custom estimators** for complex objects with predictable memory layouts
-3. **Adjust depth and sample size** based on your accuracy vs. performance requirements
-4. **Mark external library classes** as shallow memory if deep traversal is not needed
-5. **Use `@IgnoreMemoryTrack`** for cached or shared objects that shouldn't be counted multiple times
+1. Ensure the target object is immutable or protected by a lock during estimation
+2. Use annotations for classes with known memory patterns to avoid unnecessary recursion
+3. Register custom estimators for complex objects with predictable memory layouts
+4. Adjust depth and sample size based on your accuracy vs. performance requirements
+5. Use `@IgnoreMemoryTrack` or ignore-class sets for shared objects that shouldn't be counted multiple times

--- a/fe/fe-core/src/main/java/com/starrocks/memory/estimate/ShallowMemory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/estimate/ShallowMemory.java
@@ -1,0 +1,32 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.memory.estimate;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to mark classes that should only calculate shallow memory size.
+ * - Classes annotated with @ShallowMemory will only return shallow size during memory estimation,
+ *   without recursively calculating the size of their fields.
+ * - For collections containing elements of @ShallowMemory classes, the estimation will use
+ *   shallow_size * element_count instead of sampling and recursive calculation.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ShallowMemory {
+}

--- a/fe/fe-core/src/main/java/com/starrocks/memory/estimate/StringEstimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/estimate/StringEstimator.java
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.starrocks.memory;
+package com.starrocks.memory.estimate;
 
-import com.google.common.collect.ImmutableMap;
-import com.starrocks.qe.QueryDetailQueue;
+import com.google.common.base.Preconditions;
 
-import java.util.Map;
-
-public class QueryTracker implements MemoryTrackable {
+public class StringEstimator implements CustomEstimator {
     @Override
-    public Map<String, Long> estimateCount() {
-        return ImmutableMap.of("QueryDetail", QueryDetailQueue.getTotalQueriesCount());
+    public long estimate(Object obj) {
+        Preconditions.checkArgument(obj instanceof String);
+        String str = (String) obj;
+        // String: shallow size + array header (16 bytes) + character data
+        // Java 9+ uses byte[] with compact strings (Latin-1: 1 byte per char, otherwise 2 bytes)
+        // Here we use a conservative estimate of 1 byte per character for most cases
+        return Estimator.shallow(str) + Estimator.ARRAY_HEADER_SIZE + str.length();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -35,16 +35,15 @@
 package com.starrocks.qe;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.MvId;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.Config;
-import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.qe.scheduler.slot.LogicalSlot;
 import com.starrocks.thrift.TBatchReportExecStatusParams;
@@ -75,7 +74,6 @@ import static com.starrocks.mysql.MysqlCommand.COM_STMT_EXECUTE;
 
 public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
     private static final Logger LOG = LogManager.getLogger(QeProcessorImpl.class);
-    private static final int MEMORY_QUERY_SAMPLES = 10;
     private final Map<TUniqueId, QueryInfo> coordinatorMap = Maps.newConcurrentMap();
     private final Map<TUniqueId, Long> monitorQueryMap = Maps.newConcurrentMap();
 
@@ -344,17 +342,13 @@ public final class QeProcessorImpl implements QeProcessor, MemoryTrackable {
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        List<Object> samples = coordinatorMap.values()
-                .stream()
-                .limit(MEMORY_QUERY_SAMPLES)
-                .collect(Collectors.toList());
-        return Lists.newArrayList(Pair.create(samples, (long) coordinatorMap.size()));
+    public Map<String, Long> estimateCount() {
+        return ImmutableMap.of("QueryCoordinator", (long) coordinatorMap.size());
     }
 
     @Override
-    public Map<String, Long> estimateCount() {
-        return ImmutableMap.of("QueryCoordinator", (long) coordinatorMap.size());
+    public long estimateSize() {
+        return Estimator.estimate(coordinatorMap, 20);
     }
 
     public static final class QueryInfo {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -27,12 +27,12 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.ResourceGroupClassifier;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
-import com.starrocks.common.Pair;
 import com.starrocks.common.util.LogUtil;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.QueryableReentrantLock;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.persist.AlterTaskInfo;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
@@ -79,7 +79,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static com.starrocks.scheduler.SubmitResult.SubmitStatus.SUBMITTED;
 
@@ -1165,12 +1164,8 @@ public class TaskManager implements MemoryTrackable {
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        List<Object> taskSamples = idToTaskMap.values()
-                .stream()
-                .limit(1)
-                .collect(Collectors.toList());
-        return Lists.newArrayList(Pair.create(taskSamples, (long) idToTaskMap.size()));
+    public long estimateSize() {
+        return Estimator.estimate(idToTaskMap, 20);
     }
 
     public boolean containTask(String taskName) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -16,9 +16,7 @@
 package com.starrocks.scheduler;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
-import com.starrocks.common.Pair;
 import com.starrocks.common.util.LogUtil;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.QueryableReentrantLock;
@@ -323,15 +321,6 @@ public class TaskRunManager implements MemoryTrackable {
         return ImmutableMap.of("PendingTaskRun", validPendingCount,
                 "RunningTaskRun", (long) taskRunScheduler.getRunningTaskCount(),
                 "HistoryTaskRun", taskRunHistory.getTaskRunCount());
-    }
-
-    @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        List<Object> taskRunSamples = taskRunHistory.getSamplesForMemoryTracker();
-        long size = taskRunScheduler.getPendingQueueCount()
-                + taskRunScheduler.getRunningTaskCount()
-                + taskRunHistory.getTaskRunCount();
-        return Lists.newArrayList(Pair.create(taskRunSamples, size));
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -39,7 +39,6 @@ import java.util.stream.Collectors;
 
 public class TaskRunHistory {
     private static final Logger LOG = LogManager.getLogger(TaskRunHistory.class);
-    private static final int MEMORY_TASK_RUN_SAMPLES = 10;
 
     // Thread-Safe history map:
     // QueryId -> TaskRunStatus
@@ -85,13 +84,6 @@ public class TaskRunHistory {
 
     public synchronized long getTaskRunCount() {
         return historyTaskRunMap.size();
-    }
-
-    public synchronized List<Object> getSamplesForMemoryTracker() {
-        return historyTaskRunMap.values()
-                .stream()
-                .limit(MEMORY_TASK_RUN_SAMPLES)
-                .collect(Collectors.toList());
     }
 
     public List<TaskRunStatus> lookupHistoryByTaskNames(String dbName, Set<String> taskNames) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVTimelinessMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVTimelinessMgr.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.scheduler.mv;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvRefreshArbiter;
@@ -22,12 +21,9 @@ import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.Config;
-import com.starrocks.common.Pair;
 import com.starrocks.memory.MemoryTrackable;
 
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Manage the timeliness of materialized view according to the MVChangeEvent across multiple queries.
@@ -41,8 +37,6 @@ import java.util.stream.Collectors;
  * TODO: we can track more mv/base table's changes to update the timeliness info in the future.
  */
 public class MVTimelinessMgr implements MemoryTrackable {
-    private static final int MEMORY_META_SAMPLES = 10;
-
     // materialized view -> MvUpdateInfo
     private final Map<MaterializedView, MvUpdateInfo> mvTimelinessMap = Maps.newConcurrentMap();
 
@@ -93,14 +87,5 @@ public class MVTimelinessMgr implements MemoryTrackable {
     @Override
     public Map<String, Long> estimateCount() {
         return Map.of("mvTimelinessMap", (long) mvTimelinessMap.size());
-    }
-
-    @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        List<Object> mvTimelinessMapSamples = mvTimelinessMap.values()
-                .stream()
-                .limit(MEMORY_META_SAMPLES)
-                .collect(Collectors.toList());
-        return Lists.newArrayList(Pair.create(mvTimelinessMapSamples, (long) mvTimelinessMap.size()));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -170,6 +170,7 @@ import com.starrocks.load.routineload.RoutineLoadTaskScheduler;
 import com.starrocks.load.streamload.StreamLoadMgr;
 import com.starrocks.memory.MemoryUsageTracker;
 import com.starrocks.memory.ProcProfileCollector;
+import com.starrocks.memory.estimate.IgnoreMemoryTrack;
 import com.starrocks.meta.SqlBlackList;
 import com.starrocks.meta.SqlDigestBlackList;
 import com.starrocks.metric.MetricRepo;
@@ -282,6 +283,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+@IgnoreMemoryTrack
 public class GlobalStateMgr {
     private static final Logger LOG = LogManager.getLogger(GlobalStateMgr.class);
     // 0 ~ 9999 used for qe

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -129,6 +129,7 @@ import com.starrocks.lake.StorageInfo;
 import com.starrocks.listener.LoadJobMVListener;
 import com.starrocks.load.pipe.PipeManager;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.mv.MVMetaVersionRepairer;
 import com.starrocks.mv.MVRepairHandler;
 import com.starrocks.mv.analyzer.MVPartitionExprResolver;
@@ -5444,33 +5445,6 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        long totalCount = idToDb.values()
-                .stream()
-                .mapToInt(database -> {
-                    Locker locker = new Locker();
-                    locker.lockDatabase(database.getId(), LockType.READ);
-                    try {
-                        return database.getOlapPartitionsCount();
-                    } finally {
-                        locker.unLockDatabase(database.getId(), LockType.READ);
-                    }
-                }).sum();
-        List<Object> samples = new ArrayList<>();
-        // get every olap table's first partition
-        for (Database database : idToDb.values()) {
-            Locker locker = new Locker();
-            locker.lockDatabase(database.getId(), LockType.READ);
-            try {
-                samples.addAll(database.getPartitionSamples());
-            } finally {
-                locker.unLockDatabase(database.getId(), LockType.READ);
-            }
-        }
-        return Lists.newArrayList(Pair.create(samples, totalCount));
-    }
-
-    @Override
     public Map<String, Long> estimateCount() {
         long totalCount = idToDb.values()
                 .stream()
@@ -5484,6 +5458,21 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                     }
                 }).sum();
         return ImmutableMap.of("Partition", totalCount);
+    }
+
+    @Override
+    public long estimateSize() {
+        long size = 0;
+        for (Database database : idToDb.values()) {
+            Locker locker = new Locker();
+            locker.lockDatabase(database.getId(), LockType.READ);
+            try {
+                size += Estimator.estimate(database.getTables());
+            } finally {
+                locker.unLockDatabase(database.getId(), LockType.READ);
+            }
+        }
+        return size;
     }
 
     public void alterTableAutoIncrement(String dbName, String tableName, long newAutoIncrementValue) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnMinMaxMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnMinMaxMgr.java
@@ -33,6 +33,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -121,8 +122,8 @@ public class ColumnMinMaxMgr implements IMinMaxStatsMgr, MemoryTrackable {
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        return List.of(Pair.create(List.of(new ColumnMinMax("1", "10000")), (long) cache.asMap().size()));
+    public long estimateSize() {
+        return Estimator.estimate(cache.asMap(), 20);
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IcebergColumnMinMaxMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IcebergColumnMinMaxMgr.java
@@ -21,10 +21,10 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.starrocks.common.Config;
-import com.starrocks.common.Pair;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -93,8 +93,8 @@ public class IcebergColumnMinMaxMgr implements IMinMaxStatsMgr, MemoryTrackable 
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        return List.of(Pair.create(List.of(new ColumnMinMax("1", "10000")), (long) cache.asMap().size()));
+    public long estimateSize() {
+        return Estimator.estimate(cache.asMap(), 20);
     }
 
     private static final class CacheLoader implements AsyncCacheLoader<CacheKey, Optional<ColumnMinMax>> {

--- a/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
@@ -41,6 +41,7 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.common.TraceManager;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.memory.estimate.IgnoreMemoryTrack;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TPartitionVersionInfo;
 import com.starrocks.thrift.TPublishVersionRequest;
@@ -65,6 +66,7 @@ public class PublishVersionTask extends AgentTask {
     private final List<Long> errorTablets;
     private Set<Long> errorReplicas;
     private final long commitTimestamp;
+    @IgnoreMemoryTrack
     private final TransactionState txnState;
     private Span span;
     private boolean enableSyncPublish;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -64,6 +64,7 @@ import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeTableHelper;
 import com.starrocks.load.loadv2.ManualLoadTxnCommitAttachment;
 import com.starrocks.load.routineload.RLTaskTxnCommitAttachment;
+import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.metric.TableMetricsEntity;
 import com.starrocks.metric.TableMetricsRegistry;
@@ -116,7 +117,6 @@ import static com.starrocks.common.ErrorCode.ERR_NO_ROWS_IMPORTED;
 public class DatabaseTransactionMgr {
     public static final String TXN_TIMEOUT_BY_MANAGER = "timeout by txn manager";
     private static final Logger LOG = LogManager.getLogger(DatabaseTransactionMgr.class);
-    private static final int MEMORY_TXN_SAMPLES = 10;
     private final TransactionStateListenerFactory stateListenerFactory = new TransactionStateListenerFactory();
     private final TransactionLogApplierFactory txnLogApplierFactory = new TransactionLogApplierFactory();
     private final GlobalStateMgr globalStateMgr;
@@ -2303,33 +2303,22 @@ public class DatabaseTransactionMgr {
         }
     }
 
-    public List<Object> getSamplesForMemoryTracker() {
-        readLock();
-        try {
-            if (idToRunningTransactionState.size() > 0) {
-                return idToRunningTransactionState.values()
-                        .stream()
-                        .limit(MEMORY_TXN_SAMPLES)
-                        .collect(Collectors.toList());
-            }
-            if (idToFinalStatusTransactionState.size() > 0) {
-                return idToFinalStatusTransactionState.values()
-                        .stream()
-                        .limit(MEMORY_TXN_SAMPLES)
-                        .collect(Collectors.toList());
-            }
-            return new ArrayList<>();
-        } finally {
-            readUnlock();
-        }
-    }
-
     public void resetTransactionStateTabletCommitInfos(TransactionState transactionState) {
         writeLock();
         try {
             transactionState.resetTabletCommitInfos();
         } finally {
             writeUnlock();
+        }
+    }
+
+    public long estimateSize() {
+        readLock();
+        try {
+            return Estimator.estimate(idToRunningTransactionState, 20) +
+                    Estimator.estimate(idToFinalStatusTransactionState, 20);
+        } finally {
+            readUnlock();
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -947,19 +947,11 @@ public class GlobalTransactionMgr implements MemoryTrackable {
     }
 
     @Override
-    public List<Pair<List<Object>, Long>> getSamples() {
-        List<Object> txnSamples = new ArrayList<>();
-        for (DatabaseTransactionMgr mgr : dbIdToDatabaseTransactionMgrs.values()) {
-            List<Object> samples = mgr.getSamplesForMemoryTracker();
-            if (samples.size() > 0) {
-                txnSamples.addAll(samples);
-                break;
-            }
+    public long estimateSize() {
+        long size = 0;
+        for (DatabaseTransactionMgr dbTxnMgr : dbIdToDatabaseTransactionMgrs.values()) {
+            size += dbTxnMgr.estimateSize();
         }
-
-        List<Object> callbackSamples = callbackFactory.getSamplesForMemoryTracker();
-
-        return Lists.newArrayList(Pair.create(txnSamples, (long) getTransactionNum()),
-                Pair.create(callbackSamples, callbackFactory.getCallBackCnt()));
+        return size;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TxnStateCallbackFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TxnStateCallbackFactory.java
@@ -21,14 +21,11 @@ import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 // saves all TxnStateChangeListeners
 public class TxnStateCallbackFactory {
     private static final Logger LOG = LogManager.getLogger(TxnStateCallbackFactory.class);
-    private static final int MEMORY_CALLBACK_SAMPLES = 30;
 
     private Map<Long, TxnStateChangeCallback> callbacks = Maps.newHashMap();
 
@@ -55,12 +52,5 @@ public class TxnStateCallbackFactory {
 
     public synchronized long getCallBackCnt() {
         return callbacks.size();
-    }
-
-    public synchronized List<Object> getSamplesForMemoryTracker() {
-        return callbacks.values()
-                .stream()
-                .limit(MEMORY_CALLBACK_SAMPLES)
-                .collect(Collectors.toList());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeConnectorTest.java
@@ -81,7 +81,7 @@ public class DeltaLakeConnectorTest {
         CatalogConnector catalogConnector = ConnectorFactory.createConnector(
                 new ConnectorContext("delta0", "deltalake", properties), false);
         Assertions.assertTrue(catalogConnector.supportMemoryTrack());
-        Assertions.assertEquals(0, catalogConnector.estimateSize());
+        Assertions.assertEquals(840, catalogConnector.estimateSize());
         Assertions.assertEquals(4, catalogConnector.estimateCount().size());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/memory/estimate/EstimatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/memory/estimate/EstimatorTest.java
@@ -1,0 +1,1403 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.memory.estimate;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EstimatorTest {
+
+    @BeforeEach
+    void setUp() {
+        // Clear registries before each test
+        // Note: SHALLOW_SIZE and CLASS_NESTED_FIELDS are ClassValue-based caches and cannot be cleared
+        Estimator.CUSTOM_ESTIMATORS.clear();
+        Estimator.SHALLOW_MEMORY_CLASS_NAMES.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Clear registries after each test
+        Estimator.CUSTOM_ESTIMATORS.clear();
+        Estimator.SHALLOW_MEMORY_CLASS_NAMES.clear();
+    }
+
+    // ==================== Null and Basic Tests ====================
+
+    @Test
+    void testEstimateNull() {
+        assertEquals(0, Estimator.estimate(null));
+    }
+
+    @Test
+    void testShallowNull() {
+        // Explicitly cast to Object to call shallow(Object) instead of shallow(Class<?>)
+        assertEquals(0, Estimator.shallow((Object) null));
+    }
+
+    // ==================== Primitive Array Tests ====================
+
+    @Test
+    void testEstimatePrimitiveIntArray() {
+        int[] array = new int[100];
+        long size = Estimator.estimate(array);
+        // Array header (16) + 100 * 4 bytes = 416
+        assertEquals(Estimator.ARRAY_HEADER_SIZE + 100 * 4, size);
+    }
+
+    @Test
+    void testEstimatePrimitiveLongArray() {
+        long[] array = new long[50];
+        long size = Estimator.estimate(array);
+        // Array header (16) + 50 * 8 bytes = 416
+        assertEquals(Estimator.ARRAY_HEADER_SIZE + 50 * 8, size);
+    }
+
+    @Test
+    void testEstimatePrimitiveByteArray() {
+        byte[] array = new byte[200];
+        long size = Estimator.estimate(array);
+        // Array header (16) + 200 * 1 byte = 216
+        assertEquals(Estimator.ARRAY_HEADER_SIZE + 200, size);
+    }
+
+    @Test
+    void testEstimatePrimitiveBooleanArray() {
+        boolean[] array = new boolean[100];
+        long size = Estimator.estimate(array);
+        // Array header (16) + 100 * 1 byte = 116
+        assertEquals(Estimator.ARRAY_HEADER_SIZE + 100, size);
+    }
+
+    @Test
+    void testEstimatePrimitiveCharArray() {
+        char[] array = new char[100];
+        long size = Estimator.estimate(array);
+        // Array header (16) + 100 * 2 bytes = 216
+        assertEquals(Estimator.ARRAY_HEADER_SIZE + 100 * 2, size);
+    }
+
+    @Test
+    void testEstimatePrimitiveShortArray() {
+        short[] array = new short[100];
+        long size = Estimator.estimate(array);
+        // Array header (16) + 100 * 2 bytes = 216
+        assertEquals(Estimator.ARRAY_HEADER_SIZE + 100 * 2, size);
+    }
+
+    @Test
+    void testEstimatePrimitiveFloatArray() {
+        float[] array = new float[100];
+        long size = Estimator.estimate(array);
+        // Array header (16) + 100 * 4 bytes = 416
+        assertEquals(Estimator.ARRAY_HEADER_SIZE + 100 * 4, size);
+    }
+
+    @Test
+    void testEstimatePrimitiveDoubleArray() {
+        double[] array = new double[100];
+        long size = Estimator.estimate(array);
+        // Array header (16) + 100 * 8 bytes = 816
+        assertEquals(Estimator.ARRAY_HEADER_SIZE + 100 * 8, size);
+    }
+
+    @Test
+    void testEstimateEmptyPrimitiveArray() {
+        int[] array = new int[0];
+        long size = Estimator.estimate(array);
+        assertEquals(Estimator.ARRAY_HEADER_SIZE, size);
+    }
+
+    // ==================== Object Array Tests ====================
+
+    @Test
+    void testEstimateEmptyObjectArray() {
+        Object[] array = new Object[0];
+        long size = Estimator.estimate(array);
+        assertEquals(Estimator.ARRAY_HEADER_SIZE, size);
+    }
+
+    @Test
+    void testEstimateObjectArrayWithNulls() {
+        Object[] array = new Object[10];
+        // All null elements
+        long size = Estimator.estimate(array);
+        // Array header (16) + 10 * reference size (4) = 56
+        assertEquals(Estimator.ARRAY_HEADER_SIZE + 10 * 4, size);
+    }
+
+    @Test
+    void testEstimateStringArray() {
+        String[] array = new String[] {"hello", "world", "test"};
+        long size = Estimator.estimate(array);
+        // Should be positive and include array overhead + string sizes
+        assertTrue(size > Estimator.ARRAY_HEADER_SIZE + 3 * 4);
+    }
+
+    // ==================== Collection Tests ====================
+
+    @Test
+    void testEstimateEmptyArrayList() {
+        List<String> list = new ArrayList<>();
+        long size = Estimator.estimate(list);
+        assertTrue(size > 0);
+    }
+
+    @Test
+    void testEstimateArrayListWithElements() {
+        List<String> list = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            list.add("element" + i);
+        }
+        long size = Estimator.estimate(list);
+        // Should be significantly larger than empty list
+        assertTrue(size > Estimator.estimate(new ArrayList<>()));
+    }
+
+    @Test
+    void testEstimateLinkedList() {
+        LinkedList<Integer> list = new LinkedList<>();
+        for (int i = 0; i < 100; i++) {
+            list.add(i);
+        }
+        long size = Estimator.estimate(list);
+        assertTrue(size > 0);
+    }
+
+    @Test
+    void testEstimateHashSet() {
+        Set<String> set = new HashSet<>();
+        for (int i = 0; i < 50; i++) {
+            set.add("item" + i);
+        }
+        long size = Estimator.estimate(set);
+        assertTrue(size > 0);
+    }
+
+    @Test
+    void testEstimateConcurrentHashMap() {
+        Map<String, Integer> map = new ConcurrentHashMap<>();
+        for (int i = 0; i < 50; i++) {
+            map.put("key" + i, i);
+        }
+        long size = Estimator.estimate(map);
+        assertTrue(size > 0);
+    }
+
+    // ==================== Map Tests ====================
+
+    @Test
+    void testEstimateEmptyHashMap() {
+        Map<String, String> map = new HashMap<>();
+        long size = Estimator.estimate(map);
+        assertTrue(size > 0);
+    }
+
+    @Test
+    void testEstimateHashMapWithElements() {
+        Map<String, String> map = new HashMap<>();
+        for (int i = 0; i < 100; i++) {
+            map.put("key" + i, "value" + i);
+        }
+        long size = Estimator.estimate(map);
+        assertTrue(size > Estimator.estimate(new HashMap<>()));
+    }
+
+    // ==================== Custom Object Tests ====================
+
+    @Test
+    void testEstimateSimpleObject() {
+        SimpleObject obj = new SimpleObject(42, "test");
+        long size = Estimator.estimate(obj);
+        assertTrue(size > 0);
+    }
+
+    @Test
+    void testEstimateNestedObject() {
+        NestedObject nested = new NestedObject();
+        nested.inner = new SimpleObject(1, "inner");
+        long size = Estimator.estimate(nested);
+        // Should include both outer and inner object
+        assertTrue(size > Estimator.shallow(nested));
+    }
+
+    @Test
+    void testEstimateObjectWithCollection() {
+        ObjectWithCollection obj = new ObjectWithCollection();
+        for (int i = 0; i < 50; i++) {
+            obj.items.add("item" + i);
+        }
+        long size = Estimator.estimate(obj);
+        assertTrue(size > Estimator.shallow(obj));
+    }
+
+    // ==================== Max Depth Tests ====================
+
+    @Test
+    void testEstimateWithDepthZero() {
+        NestedObject nested = new NestedObject();
+        nested.inner = new SimpleObject(1, "inner");
+
+        long shallowSize = Estimator.estimate(nested, 5, 0);
+        long deepSize = Estimator.estimate(nested, 5, 8);
+
+        // With depth 0, should only return shallow size
+        assertEquals(Estimator.shallow(nested), shallowSize);
+        assertTrue(deepSize > shallowSize);
+    }
+
+    @Test
+    void testEstimateWithCustomDepth() {
+        DeeplyNestedObject deep = createDeeplyNestedObject(10);
+
+        long depth2 = Estimator.estimate(deep, 5, 2);
+        long depth5 = Estimator.estimate(deep, 5, 5);
+        long depth10 = Estimator.estimate(deep, 5, 10);
+
+        // More depth should generally result in larger size estimation
+        assertTrue(depth5 >= depth2);
+        assertTrue(depth10 >= depth5);
+    }
+
+    // ==================== Sample Size Tests ====================
+
+    @Test
+    void testEstimateWithCustomSampleSize() {
+        List<String> list = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            list.add("element" + i);
+        }
+
+        long sample1 = Estimator.estimate(list, 1, 8);
+        long sample5 = Estimator.estimate(list, 5, 8);
+        long sample10 = Estimator.estimate(list, 10, 8);
+
+        // All should be positive
+        assertTrue(sample1 > 0);
+        assertTrue(sample5 > 0);
+        assertTrue(sample10 > 0);
+    }
+
+    // ==================== Annotation Tests ====================
+
+    @Test
+    void testIgnoreMemoryTrackOnClass() {
+        IgnoredClass obj = new IgnoredClass();
+        obj.data = new int[1000];
+        assertEquals(0, Estimator.estimate(obj));
+    }
+
+    @Test
+    void testIgnoreMemoryTrackOnField() {
+        ObjectWithIgnoredField obj = new ObjectWithIgnoredField();
+        obj.tracked = "tracked";
+        obj.ignored = new int[1000];
+
+        long size = Estimator.estimate(obj);
+        // Size should not include the ignored array
+        long arraySize = Estimator.ARRAY_HEADER_SIZE + 1000 * 4;
+        assertTrue(size < arraySize);
+    }
+
+    @Test
+    void testShallowMemoryAnnotation() {
+        ShallowOnlyClass obj = new ShallowOnlyClass();
+        obj.data = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            obj.data.add("item" + i);
+        }
+
+        long size = Estimator.estimate(obj);
+        long shallowSize = Estimator.shallow(obj);
+        // Should only return shallow size
+        assertEquals(shallowSize, size);
+    }
+
+    // ==================== Custom Estimator Tests ====================
+
+    @Test
+    void testRegisterAndUseCustomEstimator() {
+        Estimator.registerCustomEstimator(CustomEstimatedClass.class, obj -> 12345L);
+
+        CustomEstimatedClass obj = new CustomEstimatedClass();
+        assertEquals(12345L, Estimator.estimate(obj));
+    }
+
+    @Test
+    void testGetCustomEstimator() {
+        CustomEstimator estimator = obj -> 100L;
+        Estimator.registerCustomEstimator(CustomEstimatedClass.class, estimator);
+
+        assertEquals(estimator, Estimator.getCustomEstimator(CustomEstimatedClass.class));
+        assertNull(Estimator.getCustomEstimator(SimpleObject.class));
+    }
+
+    @Test
+    void testStringEstimator() {
+        Estimator.registerCustomEstimator(String.class, new StringEstimator());
+
+        String str = "Hello, World!";
+        long size = Estimator.estimate(str);
+
+        // Should be shallow size + array header + string length
+        long expected = Estimator.shallow(str) + Estimator.ARRAY_HEADER_SIZE + str.length();
+        assertEquals(expected, size);
+    }
+
+    // ==================== Shallow Memory Class Registration Tests ====================
+
+    @Test
+    void testRegisterShallowMemoryClass() {
+        assertFalse(Estimator.isShallowMemoryClass(SimpleObject.class));
+
+        Estimator.registerShallowMemoryClass(SimpleObject.class);
+
+        assertTrue(Estimator.isShallowMemoryClass(SimpleObject.class));
+    }
+
+    @Test
+    void testIsShallowMemoryClassWithAnnotation() {
+        assertTrue(Estimator.isShallowMemoryClass(ShallowOnlyClass.class));
+    }
+
+    @Test
+    void testCollectionWithShallowMemoryElements() {
+        Estimator.registerShallowMemoryClass(SimpleObject.class);
+
+        List<SimpleObject> list = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            list.add(new SimpleObject(i, "name" + i));
+        }
+
+        long size = Estimator.estimate(list);
+        // Size should be list shallow size + element shallow size * count
+        long listShallow = Estimator.shallow(list);
+        long elementShallow = Estimator.shallow(SimpleObject.class);
+        long expected = listShallow + elementShallow * 100;
+        assertEquals(expected, size);
+    }
+
+    // ==================== Shallow Size Tests ====================
+
+    @Test
+    void testShallowSizeObject() {
+        SimpleObject obj = new SimpleObject(1, "test");
+        long shallow = Estimator.shallow(obj);
+        assertTrue(shallow > 0);
+    }
+
+    @Test
+    void testShallowSizeClass() {
+        long shallow = Estimator.shallow(SimpleObject.class);
+        assertTrue(shallow > 0);
+    }
+
+    @Test
+    void testShallowSizeArrayThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Estimator.shallow(int[].class);
+        });
+    }
+
+    @Test
+    void testShallowSizeArrayInstance() {
+        int[] array = new int[100];
+        long shallow = Estimator.shallow(array);
+        assertEquals(Estimator.ARRAY_HEADER_SIZE + 100 * 4, shallow);
+    }
+
+    // ==================== Cache Tests ====================
+
+    @Test
+    void testShallowSizeIsConsistent() {
+        SimpleObject obj = new SimpleObject(1, "test");
+
+        // ClassValue-based cache should return consistent results
+        long size1 = Estimator.shallow(obj);
+        long size2 = Estimator.shallow(obj);
+        assertEquals(size1, size2);
+        assertTrue(size1 > 0);
+    }
+
+    @Test
+    void testPrimitiveArrayShallowSizeReturnsCorrectValues() {
+        int[] intArray = new int[100];
+        long[] longArray = new long[50];
+        byte[] byteArray = new byte[200];
+
+        // Calculate shallow size for primitive arrays
+        long intSize = Estimator.shallow(intArray);
+        long longSize = Estimator.shallow(longArray);
+        long byteSize = Estimator.shallow(byteArray);
+
+        // Verify correct sizes are returned
+        assertEquals(Estimator.ARRAY_HEADER_SIZE + 100 * 4, intSize);
+        assertEquals(Estimator.ARRAY_HEADER_SIZE + 50 * 8, longSize);
+        assertEquals(Estimator.ARRAY_HEADER_SIZE + 200, byteSize);
+    }
+
+    @Test
+    void testNestedFieldsAreCached() {
+        NestedObject obj = new NestedObject();
+        obj.inner = new SimpleObject(1, "test");
+
+        Estimator.estimate(obj);
+
+        // ClassValue-based cache returns computed value on get()
+        Field[] fields = Estimator.CLASS_NESTED_FIELDS.get(NestedObject.class);
+        assertNotNull(fields);
+        assertTrue(fields.length > 0);
+    }
+
+    @Test
+    void testNestedFieldsContainsCorrectFieldNames() {
+        // Test SimpleObject: should only contain "name" (id is primitive, skipped)
+        Field[] simpleFields = Estimator.CLASS_NESTED_FIELDS.get(SimpleObject.class);
+        assertNotNull(simpleFields);
+        assertEquals(1, simpleFields.length);
+        assertEquals("name", simpleFields[0].getName());
+    }
+
+    @Test
+    void testNestedFieldsForNestedObject() {
+        // Test NestedObject: should contain "inner"
+        Field[] nestedFields = Estimator.CLASS_NESTED_FIELDS.get(NestedObject.class);
+        assertNotNull(nestedFields);
+        assertEquals(1, nestedFields.length);
+        assertEquals("inner", nestedFields[0].getName());
+    }
+
+    @Test
+    void testNestedFieldsForObjectWithCollection() {
+        // Test ObjectWithCollection: should contain "items"
+        Field[] fields = Estimator.CLASS_NESTED_FIELDS.get(ObjectWithCollection.class);
+        assertNotNull(fields);
+        assertEquals(1, fields.length);
+        assertEquals("items", fields[0].getName());
+    }
+
+    @Test
+    void testNestedFieldsExcludesIgnoredFields() {
+        // Test ObjectWithIgnoredField: should only contain "tracked", not "ignored"
+        Field[] fields = Estimator.CLASS_NESTED_FIELDS.get(ObjectWithIgnoredField.class);
+        assertNotNull(fields);
+        assertEquals(1, fields.length);
+        assertEquals("tracked", fields[0].getName());
+    }
+
+    @Test
+    void testNestedFieldsExcludesEnumFields() {
+        // Test ObjectWithEnum: enum field should be excluded
+        Field[] fields = Estimator.CLASS_NESTED_FIELDS.get(ObjectWithEnum.class);
+        assertNotNull(fields);
+        // Enum field should be excluded, so the array should be empty
+        assertEquals(0, fields.length);
+    }
+
+    @Test
+    void testNestedFieldsExcludesStaticFields() {
+        // Test ObjectWithStaticField: static field should be excluded
+        Field[] fields = Estimator.CLASS_NESTED_FIELDS.get(ObjectWithStaticField.class);
+        assertNotNull(fields);
+        assertEquals(1, fields.length);
+        assertEquals("instanceData", fields[0].getName());
+    }
+
+    @Test
+    void testNestedFieldsForComplexObject() {
+        // Test a complex object with multiple field types
+        Field[] fields = Estimator.CLASS_NESTED_FIELDS.get(ComplexObject.class);
+        assertNotNull(fields);
+        // Should contain: stringField, listField, mapField, nestedField
+        // Should NOT contain: intField (primitive), enumField (enum)
+        assertEquals(4, fields.length);
+
+        Set<String> fieldNames = java.util.Arrays.stream(fields)
+                .map(Field::getName)
+                .collect(java.util.stream.Collectors.toSet());
+        assertTrue(fieldNames.contains("stringField"));
+        assertTrue(fieldNames.contains("listField"));
+        assertTrue(fieldNames.contains("mapField"));
+        assertTrue(fieldNames.contains("nestedField"));
+        assertFalse(fieldNames.contains("intField"));
+        assertFalse(fieldNames.contains("enumField"));
+    }
+
+    @Test
+    void testNestedFieldsForInheritedClass() {
+        // Test SubClass: fields are cached per class in hierarchy
+        SubClass obj = new SubClass();
+        obj.baseField = "base";
+        obj.subField = "sub";
+        Estimator.estimate(obj);
+
+        // SubClass's own fields
+        Field[] subFields = Estimator.CLASS_NESTED_FIELDS.get(SubClass.class);
+        assertNotNull(subFields);
+        assertEquals(1, subFields.length);
+        assertEquals("subField", subFields[0].getName());
+
+        // BaseClass's fields (cached separately)
+        Field[] baseFields = Estimator.CLASS_NESTED_FIELDS.get(BaseClass.class);
+        assertNotNull(baseFields);
+        assertEquals(1, baseFields.length);
+        assertEquals("baseField", baseFields[0].getName());
+    }
+
+    // ==================== Enum Field Tests ====================
+
+    @Test
+    void testEnumFieldsAreSkipped() {
+        ObjectWithEnum obj = new ObjectWithEnum();
+        obj.status = Status.ACTIVE;
+
+        long size = Estimator.estimate(obj);
+        // Enum fields should be skipped (they're singletons)
+        // Size should be shallow size of the object only
+        long shallow = Estimator.shallow(obj);
+        assertEquals(shallow, size);
+    }
+
+    // ==================== Static Field Tests ====================
+
+    @Test
+    void testStaticFieldsAreSkipped() {
+        ObjectWithStaticField.staticData = new int[1000];
+        ObjectWithStaticField obj = new ObjectWithStaticField();
+        obj.instanceData = "test";
+
+        long size = Estimator.estimate(obj);
+        // Static field should not be included
+        long staticArraySize = Estimator.ARRAY_HEADER_SIZE + 1000 * 4;
+        assertTrue(size < staticArraySize);
+    }
+
+    // ==================== Edge Case Tests ====================
+
+    @Test
+    void testEstimateCollectionWithAllNulls() {
+        List<String> list = new ArrayList<>();
+        list.add(null);
+        list.add(null);
+        list.add(null);
+
+        long size = Estimator.estimate(list);
+        assertEquals(Estimator.shallow(list), size);
+    }
+
+    @Test
+    void testEstimateArrayWithAllNulls() {
+        String[] array = new String[10];
+        // All elements are null
+
+        long size = Estimator.estimate(array);
+        // Should be header + references only
+        assertEquals(Estimator.ARRAY_HEADER_SIZE + 10 * 4, size);
+    }
+
+    @Test
+    void testEstimateSelfReferencingObject() {
+        // This tests that depth limit prevents infinite recursion
+        SelfReferencingClass obj = new SelfReferencingClass();
+        obj.self = obj;
+
+        // Should not hang or throw StackOverflowError
+        long size = Estimator.estimate(obj);
+        assertTrue(size > 0);
+    }
+
+    @Test
+    void testEstimateLargeCollection() {
+        List<Integer> list = new ArrayList<>();
+        for (int i = 0; i < 100000; i++) {
+            list.add(i);
+        }
+
+        long size = Estimator.estimate(list);
+        assertTrue(size > 0);
+    }
+
+    // ==================== Inheritance Tests ====================
+
+    @Test
+    void testEstimateSubclass() {
+        SubClass obj = new SubClass();
+        obj.baseField = "base";
+        obj.subField = "sub";
+
+        long size = Estimator.estimate(obj);
+        // Should include fields from both base and subclass
+        assertTrue(size > Estimator.shallow(obj));
+    }
+
+    @Test
+    void testIgnoreMemoryTrackOnSuperclass() {
+        SubClassOfIgnored obj = new SubClassOfIgnored();
+        obj.subData = "data";
+
+        // When any class in the hierarchy has @IgnoreMemoryTrack, the entire object returns 0
+        // This prevents partial memory tracking which could be misleading
+        long size = Estimator.estimate(obj);
+        assertEquals(0, size);
+    }
+
+    @Test
+    void testIgnoreMemoryTrackOnMiddleClass() {
+        // Test class hierarchy: SubSubClass -> IgnoredMiddleClass (@IgnoreMemoryTrack) -> BaseClass
+        SubSubClassOfIgnoredMiddle obj = new SubSubClassOfIgnoredMiddle();
+        obj.baseField = "base";
+        obj.subSubField = "subsub";
+
+        // Should return 0 because IgnoredMiddleClass in the hierarchy has @IgnoreMemoryTrack
+        long size = Estimator.estimate(obj);
+        assertEquals(0, size);
+    }
+
+    @Test
+    void testNoIgnoreMemoryTrackInHierarchy() {
+        // Test class hierarchy without @IgnoreMemoryTrack: SubClass -> BaseClass
+        SubClass obj = new SubClass();
+        obj.baseField = "base";
+        obj.subField = "sub";
+
+        // Should estimate normally since no class in hierarchy has @IgnoreMemoryTrack
+        long size = Estimator.estimate(obj);
+        assertTrue(size > 0);
+        assertTrue(size > Estimator.shallow(obj));
+    }
+
+    // ==================== Helper Classes ====================
+
+    static class SimpleObject {
+        int id;
+        String name;
+
+        SimpleObject(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
+    static class NestedObject {
+        SimpleObject inner;
+    }
+
+    static class ObjectWithCollection {
+        List<String> items = new ArrayList<>();
+    }
+
+    static class DeeplyNestedObject {
+        int level;
+        DeeplyNestedObject next;
+    }
+
+    private DeeplyNestedObject createDeeplyNestedObject(int depth) {
+        DeeplyNestedObject root = new DeeplyNestedObject();
+        root.level = 0;
+        DeeplyNestedObject current = root;
+        for (int i = 1; i < depth; i++) {
+            current.next = new DeeplyNestedObject();
+            current.next.level = i;
+            current = current.next;
+        }
+        return root;
+    }
+
+    @IgnoreMemoryTrack
+    static class IgnoredClass {
+        int[] data;
+    }
+
+    static class ObjectWithIgnoredField {
+        String tracked;
+        @IgnoreMemoryTrack
+        int[] ignored;
+    }
+
+    @ShallowMemory
+    static class ShallowOnlyClass {
+        List<String> data;
+    }
+
+    static class CustomEstimatedClass {
+        int data;
+    }
+
+    static class PrimitiveOnlyClass {
+        int intValue;
+        long longValue;
+        double doubleValue;
+        boolean boolValue;
+    }
+
+    enum Status {
+        ACTIVE, INACTIVE
+    }
+
+    static class ObjectWithEnum {
+        Status status;
+    }
+
+    static class ObjectWithStaticField {
+        static int[] staticData;
+        String instanceData;
+    }
+
+    static class SelfReferencingClass {
+        SelfReferencingClass self;
+    }
+
+    static class BaseClass {
+        String baseField;
+    }
+
+    static class SubClass extends BaseClass {
+        String subField;
+    }
+
+    @IgnoreMemoryTrack
+    static class IgnoredBaseClass {
+        String ignoredData;
+    }
+
+    static class SubClassOfIgnored extends IgnoredBaseClass {
+        String subData;
+    }
+
+    @IgnoreMemoryTrack
+    static class IgnoredMiddleClass extends BaseClass {
+        String middleData;
+    }
+
+    static class SubSubClassOfIgnoredMiddle extends IgnoredMiddleClass {
+        String subSubField;
+    }
+
+    static class ComplexObject {
+        int intField;
+        String stringField;
+        List<String> listField;
+        Map<String, Integer> mapField;
+        SimpleObject nestedField;
+        Status enumField;
+    }
+
+    // ==================== Hidden Class Tests ====================
+
+    @Test
+    void testShallowSizeLambdaExpression() {
+        // Lambda expressions generate hidden classes (or synthetic classes with $$Lambda$ in name)
+        Supplier<String> lambda = () -> "hello";
+
+        long size = Estimator.shallow(lambda);
+        // Hidden classes should return HIDDEN_CLASS_SHALLOW_SIZE (16)
+        assertEquals(16, size);
+    }
+
+    @Test
+    void testShallowSizeLambdaWithCapture() {
+        // Lambda that captures a variable
+        String captured = "captured value";
+        Function<String, String> lambda = (s) -> captured + s;
+
+        long size = Estimator.shallow(lambda);
+        // Hidden classes should return HIDDEN_CLASS_SHALLOW_SIZE (16)
+        assertEquals(16, size);
+    }
+
+    @Test
+    void testEstimateLambdaExpression() {
+        Supplier<Integer> lambda = () -> 42;
+
+        long size = Estimator.estimate(lambda);
+        assertEquals(16, size);
+    }
+
+    @Test
+    void testEstimateObjectContainingLambda() {
+        ObjectWithLambda obj = new ObjectWithLambda();
+        obj.name = "test";
+        obj.callback = () -> "callback result";
+
+        long size = Estimator.estimate(obj);
+        // Size should include object shallow size + string size + lambda size (16)
+        assertTrue(size > Estimator.shallow(obj));
+    }
+
+    @Test
+    void testEstimateCollectionOfLambdas() {
+        List<Supplier<String>> lambdas = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            final int index = i;
+            lambdas.add(() -> "value" + index);
+        }
+
+        long size = Estimator.estimate(lambdas);
+        // Size should be positive and include list overhead + lambda sizes
+        assertTrue(size > Estimator.shallow(lambdas));
+    }
+
+    @Test
+    void testShallowSizeMethodReference() {
+        // Method references also generate hidden/synthetic classes
+        Function<String, Integer> methodRef = String::length;
+
+        long size = Estimator.shallow(methodRef);
+        // Method references should also return HIDDEN_CLASS_SHALLOW_SIZE (16)
+        assertEquals(16, size);
+    }
+
+    @Test
+    void testLambdaClassIsCachedCorrectly() {
+        Supplier<String> lambda = () -> "test";
+
+        // ClassValue-based cache should return consistent results
+        long size1 = Estimator.shallow(lambda);
+        long size2 = Estimator.shallow(lambda);
+        assertEquals(size1, size2);
+        assertEquals(16, size1);
+    }
+
+    @Test
+    void testMultipleDifferentLambdasHaveSameShallowSize() {
+        Supplier<String> lambda1 = () -> "first";
+        Supplier<String> lambda2 = () -> "second";
+        Function<Integer, String> lambda3 = (i) -> "number: " + i;
+
+        long size1 = Estimator.shallow(lambda1);
+        long size2 = Estimator.shallow(lambda2);
+        long size3 = Estimator.shallow(lambda3);
+
+        // All hidden classes should have the same shallow size
+        assertEquals(16, size1);
+        assertEquals(16, size2);
+        assertEquals(16, size3);
+    }
+
+    // Helper class for hidden class tests
+    static class ObjectWithLambda {
+        String name;
+        Supplier<String> callback;
+    }
+
+    // ==================== Sampled Deduplication Tests ====================
+
+    @Test
+    void testSameObjectReferencedMultipleTimesCountedOnce() {
+        // Create a shared object that will be referenced multiple times
+        SharedObject shared = new SharedObject();
+        shared.value = 42;
+
+        // Create a counting estimator to track how many times estimate is called
+        AtomicInteger estimateCount = new AtomicInteger(0);
+        Estimator.registerCustomEstimator(SharedObject.class, obj -> {
+            estimateCount.incrementAndGet();
+            return 100L;
+        });
+
+        // Create an object that references the same SharedObject multiple times
+        MultiReferenceHolder holder = new MultiReferenceHolder();
+        holder.ref1 = shared;
+        holder.ref2 = shared;
+        holder.ref3 = shared;
+
+        Estimator.estimate(holder);
+
+        // The shared object should only be counted once due to sampled deduplication
+        assertEquals(1, estimateCount.get());
+    }
+
+    @Test
+    void testSameObjectInCollectionCountedOnce() {
+        SharedObject shared = new SharedObject();
+        shared.value = 100;
+
+        AtomicInteger estimateCount = new AtomicInteger(0);
+        Estimator.registerCustomEstimator(SharedObject.class, obj -> {
+            estimateCount.incrementAndGet();
+            return 50L;
+        });
+
+        // Add the same object to a list multiple times
+        List<SharedObject> list = new ArrayList<>();
+        list.add(shared);
+        list.add(shared);
+        list.add(shared);
+        list.add(shared);
+        list.add(shared);
+
+        Estimator.estimate(list);
+
+        // The shared object should only be counted once
+        assertEquals(1, estimateCount.get());
+    }
+
+    @Test
+    void testSameObjectInArrayCountedOnce() {
+        SharedObject shared = new SharedObject();
+        shared.value = 200;
+
+        AtomicInteger estimateCount = new AtomicInteger(0);
+        Estimator.registerCustomEstimator(SharedObject.class, obj -> {
+            estimateCount.incrementAndGet();
+            return 75L;
+        });
+
+        // Create an array with the same object multiple times
+        SharedObject[] array = new SharedObject[] {shared, shared, shared, shared, shared};
+
+        Estimator.estimate(array);
+
+        // The shared object should only be counted once
+        assertEquals(1, estimateCount.get());
+    }
+
+    @Test
+    void testSameObjectInMapKeyAndValueCountedOnce() {
+        SharedObject shared = new SharedObject();
+        shared.value = 300;
+
+        AtomicInteger estimateCount = new AtomicInteger(0);
+        Estimator.registerCustomEstimator(SharedObject.class, obj -> {
+            estimateCount.incrementAndGet();
+            return 60L;
+        });
+
+        // Use the same object as both key and value
+        Map<SharedObject, SharedObject> map = new HashMap<>();
+        map.put(shared, shared);
+
+        Estimator.estimate(map);
+
+        // The shared object should only be counted once
+        assertEquals(1, estimateCount.get());
+    }
+
+    @Test
+    void testSameObjectInNestedStructureCountedOnce() {
+        SharedObject shared = new SharedObject();
+        shared.value = 400;
+
+        AtomicInteger estimateCount = new AtomicInteger(0);
+        Estimator.registerCustomEstimator(SharedObject.class, obj -> {
+            estimateCount.incrementAndGet();
+            return 80L;
+        });
+
+        // Create a nested structure where the same object appears at different levels
+        NestedReferenceHolder nested = new NestedReferenceHolder();
+        nested.direct = shared;
+        nested.holder = new MultiReferenceHolder();
+        nested.holder.ref1 = shared;
+        nested.holder.ref2 = shared;
+        nested.list = new ArrayList<>();
+        nested.list.add(shared);
+        nested.list.add(shared);
+
+        Estimator.estimate(nested);
+
+        // The shared object should only be counted once despite appearing in multiple places
+        assertEquals(1, estimateCount.get());
+    }
+
+    @Test
+    void testDifferentObjectsCountedSeparately() {
+        AtomicInteger estimateCount = new AtomicInteger(0);
+        Estimator.registerCustomEstimator(SharedObject.class, obj -> {
+            estimateCount.incrementAndGet();
+            return 100L;
+        });
+
+        // Create different objects
+        SharedObject obj1 = new SharedObject();
+        obj1.value = 1;
+        SharedObject obj2 = new SharedObject();
+        obj2.value = 2;
+        SharedObject obj3 = new SharedObject();
+        obj3.value = 3;
+
+        MultiReferenceHolder holder = new MultiReferenceHolder();
+        holder.ref1 = obj1;
+        holder.ref2 = obj2;
+        holder.ref3 = obj3;
+
+        Estimator.estimate(holder);
+
+        // Each different object should be counted once
+        assertEquals(3, estimateCount.get());
+    }
+
+    @Test
+    void testCircularReferenceCountedOnce() {
+        AtomicInteger estimateCount = new AtomicInteger(0);
+        Estimator.registerCustomEstimator(CircularRefClass.class, obj -> {
+            estimateCount.incrementAndGet();
+            return 120L;
+        });
+
+        // Create circular reference
+        CircularRefClass obj = new CircularRefClass();
+        obj.self = obj;
+
+        Estimator.estimate(obj);
+
+        // The object should only be counted once even with circular reference
+        assertEquals(1, estimateCount.get());
+    }
+
+    @Test
+    void testMutualReferenceDoesNotCauseInfiniteLoop() {
+        // Create mutual reference: A -> B -> A
+        MutualRefA a = new MutualRefA();
+        MutualRefB b = new MutualRefB();
+        a.refB = b;
+        b.refA = a;
+
+        // Should not hang or throw StackOverflowError due to sampled deduplication
+        long size = Estimator.estimate(a);
+        assertTrue(size > 0);
+    }
+
+    @Test
+    void testSharedObjectInMutualReferenceCountedOnce() {
+        // Use a shared object that both A and B reference
+        SharedObject shared = new SharedObject();
+        shared.value = 999;
+
+        AtomicInteger estimateCount = new AtomicInteger(0);
+        Estimator.registerCustomEstimator(SharedObject.class, obj -> {
+            estimateCount.incrementAndGet();
+            return 100L;
+        });
+
+        // Create mutual reference with shared object
+        MutualRefWithShared a = new MutualRefWithShared();
+        MutualRefWithShared b = new MutualRefWithShared();
+        a.other = b;
+        a.shared = shared;
+        b.other = a;
+        b.shared = shared;  // Same shared object
+
+        Estimator.estimate(a);
+
+        // The shared object should only be counted once
+        assertEquals(1, estimateCount.get());
+    }
+
+    // Helper classes for sampled deduplication tests
+    static class SharedObject {
+        int value;
+    }
+
+    static class MultiReferenceHolder {
+        SharedObject ref1;
+        SharedObject ref2;
+        SharedObject ref3;
+    }
+
+    static class NestedReferenceHolder {
+        SharedObject direct;
+        MultiReferenceHolder holder;
+        List<SharedObject> list;
+    }
+
+    static class CircularRefClass {
+        CircularRefClass self;
+    }
+
+    static class MutualRefA {
+        MutualRefB refB;
+    }
+
+    static class MutualRefB {
+        MutualRefA refA;
+    }
+
+    static class MutualRefWithShared {
+        MutualRefWithShared other;
+        SharedObject shared;
+    }
+
+    // ==================== Ignore Classes Tests ====================
+
+    @Test
+    void testEstimateWithIgnoreClasses() {
+        // Create an object that contains a SharedData instance
+        ObjectWithSharedData obj = new ObjectWithSharedData();
+        obj.name = "test";
+        obj.sharedData = new SharedData();
+        obj.sharedData.largeArray = new int[1000];
+
+        // Estimate without ignoring - should include SharedData size
+        long sizeWithSharedData = Estimator.estimate(obj);
+
+        // Estimate with ignoring SharedData class
+        Set<Class<?>> ignoreClasses = Set.of(SharedData.class);
+        long sizeWithoutSharedData = Estimator.estimate(obj, ignoreClasses);
+
+        // Size without SharedData should be smaller
+        assertTrue(sizeWithoutSharedData < sizeWithSharedData);
+
+        // The difference should be approximately the size of SharedData
+        long sharedDataSize = Estimator.estimate(obj.sharedData);
+        assertTrue(sharedDataSize > 0);
+    }
+
+    @Test
+    void testEstimateWithIgnoreClassesInNestedObject() {
+        // Create nested structure with shared data at different levels
+        NestedWithSharedData nested = new NestedWithSharedData();
+        nested.name = "outer";
+        nested.sharedData = new SharedData();
+        nested.sharedData.largeArray = new int[500];
+        nested.inner = new ObjectWithSharedData();
+        nested.inner.name = "inner";
+        nested.inner.sharedData = new SharedData();
+        nested.inner.sharedData.largeArray = new int[500];
+
+        // Estimate without ignoring
+        long sizeWithSharedData = Estimator.estimate(nested);
+
+        // Estimate with ignoring SharedData class
+        Set<Class<?>> ignoreClasses = Set.of(SharedData.class);
+        long sizeWithoutSharedData = Estimator.estimate(nested, ignoreClasses);
+
+        // Size without SharedData should be smaller
+        assertTrue(sizeWithoutSharedData < sizeWithSharedData);
+    }
+
+    @Test
+    void testEstimateWithIgnoreClassesInCollection() {
+        // Create a list containing objects with SharedData
+        List<ObjectWithSharedData> list = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            ObjectWithSharedData item = new ObjectWithSharedData();
+            item.name = "item" + i;
+            item.sharedData = new SharedData();
+            item.sharedData.largeArray = new int[100];
+            list.add(item);
+        }
+
+        // Estimate without ignoring
+        long sizeWithSharedData = Estimator.estimate(list);
+
+        // Estimate with ignoring SharedData class
+        Set<Class<?>> ignoreClasses = Set.of(SharedData.class);
+        long sizeWithoutSharedData = Estimator.estimate(list, ignoreClasses);
+
+        // Size without SharedData should be smaller
+        assertTrue(sizeWithoutSharedData < sizeWithSharedData);
+    }
+
+    @Test
+    void testEstimateWithIgnoreClassesInArray() {
+        // Create an array containing SharedData objects
+        SharedData[] array = new SharedData[5];
+        for (int i = 0; i < 5; i++) {
+            array[i] = new SharedData();
+            array[i].largeArray = new int[200];
+        }
+
+        // Estimate without ignoring
+        long sizeWithSharedData = Estimator.estimate(array);
+
+        // Estimate with ignoring SharedData class
+        Set<Class<?>> ignoreClasses = Set.of(SharedData.class);
+        long sizeWithoutSharedData = Estimator.estimate(array, ignoreClasses);
+
+        // Size without SharedData should be only the array shell (header + references)
+        long arrayShellSize = Estimator.ARRAY_HEADER_SIZE + 5 * 4; // 5 references
+        assertEquals(arrayShellSize, sizeWithoutSharedData);
+        assertTrue(sizeWithoutSharedData < sizeWithSharedData);
+    }
+
+    @Test
+    void testEstimateWithEmptyIgnoreClasses() {
+        ObjectWithSharedData obj = new ObjectWithSharedData();
+        obj.name = "test";
+        obj.sharedData = new SharedData();
+        obj.sharedData.largeArray = new int[100];
+
+        // Estimate with empty ignore set should be same as normal estimate
+        long normalSize = Estimator.estimate(obj);
+        long sizeWithEmptyIgnore = Estimator.estimate(obj, Set.of());
+
+        assertEquals(normalSize, sizeWithEmptyIgnore);
+    }
+
+    @Test
+    void testEstimateWithNullIgnoreClasses() {
+        ObjectWithSharedData obj = new ObjectWithSharedData();
+        obj.name = "test";
+        obj.sharedData = new SharedData();
+        obj.sharedData.largeArray = new int[100];
+
+        // Estimate with null ignore set should be same as normal estimate
+        long normalSize = Estimator.estimate(obj);
+        long sizeWithNullIgnore = Estimator.estimate(obj, (Set<Class<?>>) null);
+
+        assertEquals(normalSize, sizeWithNullIgnore);
+    }
+
+    @Test
+    void testEstimateWithIgnoreClassesAndMaxDepth() {
+        NestedWithSharedData nested = new NestedWithSharedData();
+        nested.name = "outer";
+        nested.sharedData = new SharedData();
+        nested.sharedData.largeArray = new int[500];
+        nested.inner = new ObjectWithSharedData();
+        nested.inner.name = "inner";
+        nested.inner.sharedData = new SharedData();
+        nested.inner.sharedData.largeArray = new int[500];
+
+        Set<Class<?>> ignoreClasses = Set.of(SharedData.class);
+
+        // Test with different max depths
+        long depth2 = Estimator.estimate(nested, 5, 2, ignoreClasses);
+        long depth8 = Estimator.estimate(nested, 5, 8, ignoreClasses);
+
+        // Both should be smaller than without ignore
+        long normalDepth8 = Estimator.estimate(nested, 5, 8);
+        assertTrue(depth8 < normalDepth8);
+
+        // Deeper traversal should generally give larger size
+        assertTrue(depth8 >= depth2);
+    }
+
+    @Test
+    void testEstimateWithIgnoreClassesAndSampleSize() {
+        // Create a large list with SharedData
+        List<ObjectWithSharedData> list = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            ObjectWithSharedData item = new ObjectWithSharedData();
+            item.name = "item" + i;
+            item.sharedData = new SharedData();
+            item.sharedData.largeArray = new int[50];
+            list.add(item);
+        }
+
+        Set<Class<?>> ignoreClasses = Set.of(SharedData.class);
+
+        // Test with all parameters
+        long size = Estimator.estimate(list, 5, 8, ignoreClasses);
+
+        // Should be smaller than without ignore
+        long normalSize = Estimator.estimate(list, 5, 8);
+        assertTrue(size < normalSize);
+    }
+
+    @Test
+    void testEstimateWithMultipleIgnoreClasses() {
+        // Create object with multiple types to ignore
+        ObjectWithMultipleShared obj = new ObjectWithMultipleShared();
+        obj.name = "test";
+        obj.sharedData1 = new SharedData();
+        obj.sharedData1.largeArray = new int[100];
+        obj.sharedData2 = new AnotherSharedData();
+        obj.sharedData2.largeList = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            obj.sharedData2.largeList.add("item" + i);
+        }
+
+        // Estimate without ignoring
+        long normalSize = Estimator.estimate(obj);
+
+        // Ignore only SharedData
+        long ignoreOne = Estimator.estimate(obj, Set.of(SharedData.class));
+
+        // Ignore both classes
+        long ignoreBoth = Estimator.estimate(obj, Set.of(SharedData.class, AnotherSharedData.class));
+
+        // Ignoring more classes should result in smaller size
+        assertTrue(ignoreOne < normalSize);
+        assertTrue(ignoreBoth < ignoreOne);
+    }
+
+    @Test
+    void testIgnoreClassesWithSharedReference() {
+        // This is the main use case: multiple objects reference the same shared object
+        SharedData shared = new SharedData();
+        shared.largeArray = new int[1000];
+
+        ObjectWithSharedData obj1 = new ObjectWithSharedData();
+        obj1.name = "obj1";
+        obj1.sharedData = shared;
+
+        ObjectWithSharedData obj2 = new ObjectWithSharedData();
+        obj2.name = "obj2";
+        obj2.sharedData = shared; // Same reference
+
+        // Put them in a container
+        List<ObjectWithSharedData> container = new ArrayList<>();
+        container.add(obj1);
+        container.add(obj2);
+
+        // Estimate with ignoring SharedData - useful when we want to calculate
+        // the size without the shared data that's counted elsewhere
+        Set<Class<?>> ignoreClasses = Set.of(SharedData.class);
+        long sizeWithoutShared = Estimator.estimate(container, ignoreClasses);
+
+        // Verify SharedData is not counted
+        long normalSize = Estimator.estimate(container);
+        assertTrue(sizeWithoutShared < normalSize);
+    }
+
+    // Helper classes for ignore classes tests
+    static class SharedData {
+        int[] largeArray;
+    }
+
+    static class AnotherSharedData {
+        List<String> largeList;
+    }
+
+    static class ObjectWithSharedData {
+        String name;
+        SharedData sharedData;
+    }
+
+    static class NestedWithSharedData {
+        String name;
+        SharedData sharedData;
+        ObjectWithSharedData inner;
+    }
+
+    static class ObjectWithMultipleShared {
+        String name;
+        SharedData sharedData1;
+        AnotherSharedData sharedData2;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/CacheRelaxDictManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/CacheRelaxDictManagerTest.java
@@ -252,7 +252,6 @@ public class CacheRelaxDictManagerTest {
             Assertions.assertEquals(size + 1, optional.get().getDictSize());
             Assertions.assertEquals(1,
                     ((CacheRelaxDictManager) manager).estimateCount().get("ExternalTableColumnDict").intValue());
-            Assertions.assertEquals(1, ((CacheRelaxDictManager) manager).getSamples().get(0).first.size());
 
             manager.removeGlobalDict(tableUUID, columnName);
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Introduce utils for memory estimate, see `fe/fe-core/src/main/java/com/starrocks/memory/estimate/README.md`

use `/api/memory_usage` to estimate all modules' memory

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
