### PR TITLE
[BugFix] Fix a bug that will lead profile can not be parsed

### DIFF
--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -652,8 +652,11 @@ Status PartitionedSpillerWriter::_pick_and_compact_skew_partitions(std::vector<S
             COUNTER_UPDATE(_spiller->metrics().skew_mem_table_output_bytes, output_mem_size);
             COUNTER_UPDATE(_spiller->metrics().skew_mem_table_input_rows, input_num_rows);
             COUNTER_UPDATE(_spiller->metrics().skew_mem_table_output_rows, output_num_rows);
-            COUNTER_SET(_spiller->metrics().skew_mem_table_skew_ratio,
-                        (input_mem_size - output_mem_size) * 100.0 / input_mem_size);
+            int64_t skew_ratio =
+                    input_mem_size > 0
+                            ? (static_cast<int64_t>((input_mem_size - output_mem_size) * 100 / input_mem_size))
+                            : 0;
+            COUNTER_SET(_spiller->metrics().skew_mem_table_skew_ratio, skew_ratio);
         }
     }
     return Status::OK();

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -114,8 +114,8 @@ SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile, std::atomic_in
 
     skew_mem_table_count = ADD_CHILD_COUNTER(profile, "SkewMemTableCount", TUnit::UNIT, parent);
     skew_mem_table_skew_ratio = profile->AddLowWaterMarkCounter(
-            "SkewMemTableSkewRatio", TUnit::DOUBLE_VALUE,
-            RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG), parent);
+            "SkewMemTableSkewRatio", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG),
+            parent);
     skew_mem_table_merge_timer = ADD_CHILD_TIMER(profile, "SkewMemTableMergeTime", parent);
     skew_mem_table_input_bytes = ADD_CHILD_COUNTER(profile, "SkewMemTableInputBytes", TUnit::BYTES, parent);
     skew_mem_table_output_bytes = ADD_CHILD_COUNTER(profile, "SkewMemTableOutputBytes", TUnit::BYTES, parent);


### PR DESCRIPTION
## Why I'm doing:
Fix a bug that profile can not be parsed that will lead progress can not be calculated
The error log will be as following.
<img width="2126" height="1100" alt="image" src="https://github.com/user-attachments/assets/7aeff561-1afa-40bb-ad91-4044b5e866e2" />
The root cause is FE can not parse double.
## What I'm doing:
Here we will use uint replace double for the profile.
And after changed. the progress can be calculated normally.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
