### PR TITLE
[BugFix] Remove unnecessary warnings of parse_url

### DIFF
--- a/be/src/util/url_parser.h
+++ b/be/src/util/url_parser.h
@@ -60,10 +60,13 @@ public:
     // Parts of a URL that can be requested.
     enum UrlPart { INVALID, AUTHORITY, FILE, HOST, PATH, PROTOCOL, QUERY, REF, USERINFO };
 
+    enum class ParseStatus { OK, NOT_FOUND, INVALID };
+
     // Tries to parse the part from url. Places the result in result.
-    // Returns false if the URL is malformed or if part is invalid. True otherwise.
-    // If false is returned the contents of results are undefined.
-    static bool parse_url(const Slice& url, UrlPart part, Slice* result);
+    // Returns OK if the part exists, NOT_FOUND if the URL is valid but the part is missing,
+    // and INVALID if the URL is malformed or the part is invalid.
+    // If INVALID is returned the contents of results are undefined.
+    static ParseStatus parse_url(const Slice& url, UrlPart part, Slice* result);
 
     // Compares part against url_authority, url_file, url_host, etc.,
     // and returns the corresponding enum.

--- a/be/test/util/url_parser_test.cpp
+++ b/be/test/util/url_parser_test.cpp
@@ -17,12 +17,12 @@
 #include <gtest/gtest.h>
 
 namespace starrocks {
-#define TEST_URL_PARSE(URL, PART, EXPECTED)                                           \
-    {                                                                                 \
-        Slice result;                                                                 \
-        bool res = UrlParser::parse_url(URL, UrlParser::get_url_part(PART), &result); \
-        result = res ? result : "<null>";                                             \
-        EXPECT_EQ(result.to_string(), EXPECTED);                                      \
+#define TEST_URL_PARSE(URL, PART, EXPECTED)                                              \
+    {                                                                                    \
+        Slice result;                                                                    \
+        auto status = UrlParser::parse_url(URL, UrlParser::get_url_part(PART), &result); \
+        result = (status == UrlParser::ParseStatus::OK) ? result : "<null>";             \
+        EXPECT_EQ(result.to_string(), EXPECTED);                                         \
     }
 TEST(UrlParserTest, normal) {
     const char* url = "http://user:pass@example.com:80/docs/books/tutorial/index.html?name=networking#DOWNLOADING";


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
