### PR TITLE
[BugFix] Fix Arrow Flight Proxy with Multiple FE

### DIFF
--- a/docs/en/unloading/arrow_flight.md
+++ b/docs/en/unloading/arrow_flight.md
@@ -176,6 +176,8 @@ SET GLOBAL arrow_flight_proxy = 'your-proxy-hostname:Port';
 
 - The proxy feature is enabled by default, which may result in 8-10% lower throughput compared to direct BE connections. If your clients have direct network access to BE nodes, you can disable the proxy to achieve optimal performance: `SET GLOBAL arrow_flight_proxy_enabled = false;`
 - When `arrow_flight_proxy` is empty, tickets will automatically route through the FE node that the client initially connected to.
+- **Important**: The `arrow_flight_proxy` and `arrow_flight_proxy_enabled` settings should be configured globally using `SET GLOBAL`. Session-level settings are not supported.
+- **Session restart required**: Changing the proxy settings only affects new sessions. Existing Arrow Flight SQL sessions will continue using their original settings until they reconnect.
 
 :::
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -77,6 +77,8 @@ public final class GlobalVariable {
     public static final String ACTIVATE_ALL_ROLES_ON_LOGIN = "activate_all_roles_on_login";
     public static final String ACTIVATE_ALL_ROLES_ON_LOGIN_V2 = "activate_all_roles_on_login_v2";
     public static final String ENABLE_TDE = "enable_tde";
+    public static final String ARROW_FLIGHT_PROXY = "arrow_flight_proxy";
+    public static final String ARROW_FLIGHT_PROXY_ENABLED = "arrow_flight_proxy_enabled";
     public static final String MAX_UNKNOWN_STRING_META_LENGTH = "max_unknown_string_meta_length";
 
     // cngroup
@@ -222,6 +224,14 @@ public final class GlobalVariable {
 
     @VariableMgr.VarAttr(name = ENABLE_TDE, flag = VariableMgr.GLOBAL | VariableMgr.READ_ONLY)
     public static boolean enableTde = KeyMgr.isEncrypted();
+
+    // Arrow Flight SQL proxy endpoint. Format: "hostname:port" or "grpcs://hostname:port" for TLS.
+    @VariableMgr.VarAttr(name = ARROW_FLIGHT_PROXY, flag = VariableMgr.GLOBAL)
+    private static volatile String arrowFlightProxy = "";
+
+    // Enable Arrow Flight SQL proxy mode.
+    @VariableMgr.VarAttr(name = ARROW_FLIGHT_PROXY_ENABLED, flag = VariableMgr.GLOBAL)
+    private static volatile boolean arrowFlightProxyEnabled = false;
 
     @VariableMgr.VarAttr(name = MAX_UNKNOWN_STRING_META_LENGTH, flag = VariableMgr.GLOBAL)
     private static int maxUnknownStringMetaLength = 64;
@@ -392,6 +402,22 @@ public final class GlobalVariable {
 
     public static void setActivateAllRolesOnLogin(boolean activateAllRolesOnLogin) {
         GlobalVariable.activateAllRolesOnLogin = activateAllRolesOnLogin;
+    }
+
+    public static String getArrowFlightProxy() {
+        return arrowFlightProxy;
+    }
+
+    public static void setArrowFlightProxy(String arrowFlightProxy) {
+        GlobalVariable.arrowFlightProxy = arrowFlightProxy;
+    }
+
+    public static boolean isArrowFlightProxyEnabled() {
+        return arrowFlightProxyEnabled;
+    }
+
+    public static void setArrowFlightProxyEnabled(boolean arrowFlightProxyEnabled) {
+        GlobalVariable.arrowFlightProxyEnabled = arrowFlightProxyEnabled;
     }
 
     public static int getMaxUnknownStringMetaLength() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -231,7 +231,7 @@ public final class GlobalVariable {
 
     // Enable Arrow Flight SQL proxy mode.
     @VariableMgr.VarAttr(name = ARROW_FLIGHT_PROXY_ENABLED, flag = VariableMgr.GLOBAL)
-    private static volatile boolean arrowFlightProxyEnabled = false;
+    private static volatile boolean arrowFlightProxyEnabled = true;
 
     @VariableMgr.VarAttr(name = MAX_UNKNOWN_STRING_META_LENGTH, flag = VariableMgr.GLOBAL)
     private static int maxUnknownStringMetaLength = 64;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1058,9 +1058,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String PUSH_DOWN_HEAVY_EXPRS = "push_down_heavy_exprs";
 
-    public static final String ARROW_FLIGHT_PROXY = "arrow_flight_proxy";
-    public static final String ARROW_FLIGHT_PROXY_ENABLED = "arrow_flight_proxy_enabled";
-
     public static final String TOPN_PUSH_DOWN_AGG_MODE = "topn_push_down_agg_mode";
 
     public static final String ENABLE_LABELED_COLUMN_STATISTIC_OUTPUT = "enable_labeled_column_statistic_output";
@@ -2226,11 +2223,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = PUSH_DOWN_HEAVY_EXPRS)
     private boolean pushDownHeavyExprs = true;
-
-    @VarAttr(name = ARROW_FLIGHT_PROXY)
-    private String arrowFlightProxy = "";
-    @VarAttr(name = ARROW_FLIGHT_PROXY_ENABLED)
-    private boolean arrowFlightProxyEnabled = true;
 
     @VarAttr(name = TOPN_PUSH_DOWN_AGG_MODE, flag = VariableMgr.INVISIBLE)
     private int topNPushDownAggMode = 1;
@@ -5800,22 +5792,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isPushDownHeavyExprs() {
         return this.pushDownHeavyExprs;
-    }
-
-    public void setArrowFlightProxy(String proxy) {
-        this.arrowFlightProxy = proxy;
-    }
-
-    public String getArrowFlightProxy() {
-        return this.arrowFlightProxy;
-    }
-
-    public void setArrowFlightProxyEnabled(boolean flag) {
-        this.arrowFlightProxyEnabled = flag;
-    }
-
-    public boolean isArrowFlightProxyEnabled() {
-        return this.arrowFlightProxyEnabled;
     }
 
     public void setEnablePreAggTopNPushDown(int  topNPushDownAggMode) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -147,7 +147,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
         String token = context.peerIdentity();
 
         // When proxy is enabled and token is from another FE, forward the request
-        if (GlobalVariable.isArrowFlightProxyEnabled() && !sessionManager.isLocalToken(token)) {
+        if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
             forwardCloseSessionToRemoteFE(token, listener);
             return;
         }
@@ -182,7 +182,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
                 String token = context.peerIdentity();
 
                 // When proxy is enabled and token is from another FE, forward the request
-                if (GlobalVariable.isArrowFlightProxyEnabled() && !sessionManager.isLocalToken(token)) {
+                if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
                     forwardActionToRemoteFE(token, request, listener);
                     return;
                 }
@@ -224,7 +224,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
         String token = context.peerIdentity();
 
         // When proxy is enabled and token is from another FE, forward the request
-        if (GlobalVariable.isArrowFlightProxyEnabled() && !sessionManager.isLocalToken(token)) {
+        if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
             EXECUTOR.submit(() -> {
                 forwardActionToRemoteFE(token, request, listener);
             });
@@ -252,7 +252,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
 
         // When proxy is enabled and token is from another FE, forward the request
         // The prepared statement state exists only on the FE that created it
-        if (GlobalVariable.isArrowFlightProxyEnabled() && !sessionManager.isLocalToken(token)) {
+        if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
             return forwardGetFlightInfoToRemoteFE(token, command);
         }
 
@@ -289,7 +289,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
         String token = context.peerIdentity();
 
         // When proxy is enabled and token is from another FE, forward the request
-        if (GlobalVariable.isArrowFlightProxyEnabled() && !sessionManager.isLocalToken(token)) {
+        if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
             return forwardGetFlightInfoToRemoteFE(token, command);
         }
 
@@ -319,7 +319,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
             String token = context.peerIdentity();
 
             // When proxy is enabled and token is from another FE, forward the request
-            if (GlobalVariable.isArrowFlightProxyEnabled() && !sessionManager.isLocalToken(token)) {
+            if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
                 forwardSetSessionOptionsToRemoteFE(token, request, listener);
                 return;
             }
@@ -925,5 +925,13 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
     @VisibleForTesting
     protected FlightClient getClientFromCacheForTesting(String key) {
         return this.clientCache.getIfPresent(key);
+    }
+
+    /**
+     * Check if Arrow Flight proxy is enabled. Override in tests to control behavior.
+     */
+    @VisibleForTesting
+    protected boolean isProxyEnabled() {
+        return GlobalVariable.isArrowFlightProxyEnabled();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -155,6 +155,9 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
         ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(token);
         ctx.kill(true, "Close Arrow Flight SQL session via RPC request");
         sessionManager.closeSession(ctx.getArrowFlightSqlToken());
+
+        CloseSessionResult result = new CloseSessionResult(CloseSessionResult.Status.CLOSED);
+        listener.onNext(result);
         listener.onCompleted();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -877,8 +877,15 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
 
     private <T extends Message> FlightInfo buildFlightInfoFromFE(T request, FlightDescriptor descriptor,
                                                                  Schema schema, CallContext context) {
+        String token = context.peerIdentity();
+
+        // When proxy is enabled and token is from another FE, forward the request
+        if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
+            return forwardGetFlightInfoToRemoteFE(token, request);
+        }
+
         try {
-            sessionManager.validateAndGetConnectContext(context.peerIdentity());
+            sessionManager.validateAndGetConnectContext(token);
             Location endpoint = getFELocation();
             return buildFlightInfo(request, descriptor, schema, endpoint);
         } catch (InvalidConfException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -303,13 +303,15 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
 
     @Override
     public void getStreamStatement(FlightSql.TicketStatementQuery ticket, CallContext context, ServerStreamListener listener) {
-        getStreamResult(ticket.getStatementHandle().toStringUtf8(), listener);
+        String token = context.peerIdentity();
+        getStreamResult(ticket.getStatementHandle().toStringUtf8(), token, listener);
     }
 
     @Override
     public void getStreamPreparedStatement(FlightSql.CommandPreparedStatementQuery command, CallContext context,
                                            ServerStreamListener listener) {
-        getStreamResult(command.getPreparedStatementHandle().toStringUtf8(), listener);
+        String token = context.peerIdentity();
+        getStreamResult(command.getPreparedStatementHandle().toStringUtf8(), token, listener);
     }
 
     /**
@@ -525,15 +527,16 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
         }
     }
 
-    private void getStreamResult(String ticket, ServerStreamListener listener) {
-        ArrowFlightSqlTicketManager.ParsedTicket parsedTicket = ticketManager.parseTicket(ticket);
+    private void getStreamResult(String ticketString, String bearerToken, ServerStreamListener listener) {
+        ArrowFlightSqlTicketManager.ParsedTicket parsedTicket = ticketManager.parseTicket(ticketString);
 
         switch (parsedTicket.getType()) {
             case FE_LOCAL:
-                getStreamResultFromFE(parsedTicket.getToken(), parsedTicket.getQueryId(), listener);
+                // Use bearer token from auth header for session lookup
+                getStreamResultFromFE(bearerToken, parsedTicket.getQueryId(), listener);
                 break;
             case FE_PROXY:
-                getStreamResultFromRemoteFE(parsedTicket, listener);
+                getStreamResultFromRemoteFE(parsedTicket, bearerToken, listener);
                 break;
             case BE_PROXY:
                 getStreamResultFromBE(parsedTicket, listener);
@@ -559,15 +562,17 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
     }
 
     private void getStreamResultFromRemoteFE(ArrowFlightSqlTicketManager.ParsedTicket ticket,
+                                              String bearerToken,
                                               ServerStreamListener listener) {
         // Check if this is the local FE - if so, handle locally to avoid unnecessary network hop
         if (ticketManager.isLocalFE(ticket)) {
-            getStreamResultFromFE(ticket.getToken(), ticket.getQueryId(), listener);
+            getStreamResultFromFE(bearerToken, ticket.getQueryId(), listener);
             return;
         }
 
-        ByteString ticketHandle = ByteString.copyFromUtf8(ticket.getToken() + "|" + ticket.getQueryId());
-        getStreamResultFromRemoteNode(ticket.getHost(), ticket.getPort(), ticketHandle, ticket.getToken(), "FE", listener);
+        String uuid = extractUuidFromToken(bearerToken);
+        ByteString ticketHandle = ByteString.copyFromUtf8(uuid + "|" + ticket.getQueryId());
+        getStreamResultFromRemoteNode(ticket.getHost(), ticket.getPort(), ticketHandle, bearerToken, "FE", listener);
     }
 
     private void getStreamResultFromRemoteNode(String host, int port,
@@ -928,6 +933,23 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
     @VisibleForTesting
     protected FlightClient getClientFromCacheForTesting(String key) {
         return this.clientCache.getIfPresent(key);
+    }
+
+    /**
+     * Extracts the UUID portion from a bearer token.
+     * When proxy is enabled, tokens have format "FE_HOST|UUID", otherwise just "UUID".
+     */
+    private static String extractUuidFromToken(String token) {
+        if (token == null || token.isEmpty()) {
+            return token;
+        }
+        int lastDelimiter = token.lastIndexOf('|');
+        if (lastDelimiter > 0) {
+            // Token contains delimiter, extract UUID after last '|'
+            return token.substring(lastDelimiter + 1);
+        }
+        // Token doesn't contain delimiter, return as-is
+        return token;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManager.java
@@ -1,0 +1,367 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.service.arrow.flight.sql;
+
+import com.google.protobuf.ByteString;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.InvalidConfException;
+import com.starrocks.common.Pair;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.NetUtils;
+import com.starrocks.qe.GlobalVariable;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TUniqueId;
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.Location;
+import org.apache.arrow.util.VisibleForTesting;
+
+import java.net.URI;
+
+
+/**
+ * Manages Arrow Flight SQL ticket creation, parsing, and endpoint resolution.
+ *
+ * <p>Ticket formats:
+ * <ul>
+ *   <li>FE Local: {@code <Token>|<QueryId>} - 2 parts, handled by this FE</li>
+ *   <li>FE Proxy: {@code <Token>|<QueryId>|<FEHost>:<FEPort>} - 3 parts, proxied through FE</li>
+ *   <li>BE Proxy: {@code <QueryId>|<FragmentInstanceId>|<BEHost>|<BEPort>} - 4 parts, proxied to BE</li>
+ *   <li>BE Direct: {@code <QueryId>:<FragmentInstanceId>} - used for direct BE connection</li>
+ * </ul>
+ */
+public class ArrowFlightSqlTicketManager {
+
+    private static final String TICKET_DELIMITER = "\\|";
+    private static final String BE_TICKET_DELIMITER = ":";
+    private static final String GRPCS_SCHEME = "grpcs://";
+    private static final String GRPC_SCHEME = "grpc://";
+
+    private final Location feEndpoint;
+
+    public enum TicketType {
+        // FE local ticket: Token|QueryId
+        FE_LOCAL,
+        // FE proxy ticket: Token|QueryId|FEHost:FEPort
+        FE_PROXY,
+        //BE proxy ticket: QueryId|FragmentInstanceId|BEHost|BEPort
+        BE_PROXY
+    }
+
+    public static class ParsedTicket {
+        private final TicketType type;
+        private final String token;
+        private final String queryId;
+        private final String fragmentInstanceId;
+        private final String host;
+        private final int port;
+
+        private ParsedTicket(TicketType type, String token, String queryId,
+                             String fragmentInstanceId, String host, int port) {
+            this.type = type;
+            this.token = token;
+            this.queryId = queryId;
+            this.fragmentInstanceId = fragmentInstanceId;
+            this.host = host;
+            this.port = port;
+        }
+
+        public TicketType getType() {
+            return type;
+        }
+
+        public String getToken() {
+            return token;
+        }
+
+        public String getQueryId() {
+            return queryId;
+        }
+
+        public String getFragmentInstanceId() {
+            return fragmentInstanceId;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        static ParsedTicket feLocal(String token, String queryId) {
+            return new ParsedTicket(TicketType.FE_LOCAL, token, queryId, null, null, 0);
+        }
+
+        static ParsedTicket feProxy(String token, String queryId, String host, int port) {
+            return new ParsedTicket(TicketType.FE_PROXY, token, queryId, null, host, port);
+        }
+
+        static ParsedTicket beProxy(String queryId, String fragmentInstanceId, String host, int port) {
+            return new ParsedTicket(TicketType.BE_PROXY, null, queryId, fragmentInstanceId, host, port);
+        }
+    }
+
+    public ArrowFlightSqlTicketManager(Location feEndpoint) {
+        this.feEndpoint = feEndpoint;
+    }
+
+    /**
+     * Parses a ticket string and returns the parsed ticket data.
+     *
+     * @param ticket the ticket string to parse
+     * @return parsed ticket data
+     * @throws org.apache.arrow.flight.FlightRuntimeException if the ticket format is invalid
+     */
+    public ParsedTicket parseTicket(String ticket) {
+        String[] ticketParts = ticket.split(TICKET_DELIMITER);
+
+        switch (ticketParts.length) {
+            case 2:
+                return ParsedTicket.feLocal(ticketParts[0], ticketParts[1]);
+            case 3:
+                return parseFEProxyTicket(ticketParts);
+            case 4:
+                return parseBEProxyTicket(ticketParts);
+            default:
+                throw CallStatus.INVALID_ARGUMENT.withDescription(
+                        String.format("Invalid ticket format: expected 2, 3, or 4 parts, got [%d]",
+                                ticketParts.length)).toRuntimeException();
+        }
+    }
+
+    private ParsedTicket parseFEProxyTicket(String[] ticketParts) {
+        String[] hostPort;
+        try {
+            hostPort = NetUtils.resolveHostInfoFromHostPort(ticketParts[2]);
+        } catch (AnalysisException e) { // deprecated, but NetUtils uses
+            throw CallStatus.INVALID_ARGUMENT.withDescription(
+                    "Invalid FE host:port format: " + ticketParts[2]).toRuntimeException();
+        }
+
+        int port;
+        try {
+            port = Integer.parseInt(hostPort[1]);
+        } catch (NumberFormatException e) {
+            throw CallStatus.INVALID_ARGUMENT.withDescription(
+                    "Invalid FE port: " + hostPort[1]).toRuntimeException();
+        }
+
+        return ParsedTicket.feProxy(ticketParts[0], ticketParts[1], hostPort[0], port);
+    }
+
+    private ParsedTicket parseBEProxyTicket(String[] ticketParts) {
+        int port;
+        try {
+            port = Integer.parseInt(ticketParts[3]);
+        } catch (NumberFormatException e) {
+            throw CallStatus.INVALID_ARGUMENT.withDescription(
+                    String.format("Invalid ticket format: expected numerical port, received [%s]",
+                            ticketParts[3])).toRuntimeException();
+        }
+
+        return ParsedTicket.beProxy(ticketParts[0], ticketParts[1], ticketParts[2], port);
+    }
+
+    public boolean isLocalFE(ParsedTicket ticket) {
+        if (ticket.getType() != TicketType.FE_PROXY) {
+            return false;
+        }
+
+        URI feUri = feEndpoint.getUri(); 
+        return ticket.getHost().equals(feUri.getHost()) && ticket.getPort() == feUri.getPort();
+    }
+
+    public ByteString buildBETicket(TUniqueId queryId, TUniqueId fragmentInstanceId) {
+        return ByteString.copyFromUtf8(
+                hexStringFromUniqueId(queryId) + BE_TICKET_DELIMITER + hexStringFromUniqueId(fragmentInstanceId));
+    }
+
+    public ByteString buildBETicket(String queryId, String fragmentInstanceId) {
+        return ByteString.copyFromUtf8(queryId + BE_TICKET_DELIMITER + fragmentInstanceId);
+    }
+
+    public ByteString buildFEProxyTicketForBE(TUniqueId queryId, TUniqueId fragmentInstanceId,
+                                               ComputeNode worker) {
+        // BE proxy tickets use | as delimiter between host and port, so IPv6 addresses work without brackets
+        return ByteString.copyFromUtf8(
+                hexStringFromUniqueId(queryId) + "|"
+                        + hexStringFromUniqueId(fragmentInstanceId) + "|"
+                        + worker.getHost() + "|"
+                        + worker.getArrowFlightPort());
+    }
+
+    public ByteString buildFELocalTicket(String token, TUniqueId queryId) {
+        return ByteString.copyFromUtf8(token + "|" + DebugUtil.printId(queryId));
+    }
+
+    public ByteString buildFEProxyTicket(String token, TUniqueId queryId) {
+        String feHost = feEndpoint.getUri().getHost();
+        int fePort = feEndpoint.getUri().getPort();
+        String hostPort = NetUtils.getHostPortInAccessibleFormat(feHost, fePort);
+        return ByteString.copyFromUtf8(token + "|" + DebugUtil.printId(queryId) + "|" + hostPort);
+    }
+
+    /**
+     * Gets the FE endpoint and ticket handle for FE tasks.
+     *
+     * @return a pair of (endpoint location, ticket handle)
+     */
+    public Pair<Location, ByteString> getFEEndpoint(ArrowFlightSqlConnectContext ctx)
+            throws InvalidConfException {
+        ByteString handle;
+        Location endpoint;
+
+        if (isProxyEnabled()) {
+            String arrowFlightProxy = getProxyAddress();
+            handle = buildFEProxyTicket(ctx.getArrowFlightSqlToken(), ctx.getExecutionId());
+
+            if (!arrowFlightProxy.isEmpty()) {
+                endpoint = getProxyLocation(arrowFlightProxy);
+            } else {
+                endpoint = feEndpoint;
+            }
+        } else {
+            handle = buildFELocalTicket(ctx.getArrowFlightSqlToken(), ctx.getExecutionId());
+            endpoint = feEndpoint;
+        }
+
+        return new Pair<>(endpoint, handle);
+    }
+
+    /**
+     * Gets the BE endpoint and ticket handle for BE tasks.
+     *
+     * @return a pair of (endpoint location, ticket handle)
+     */
+    public Pair<Location, ByteString> getBEEndpoint(TUniqueId queryId, ComputeNode worker,
+                                                     TUniqueId rootFragmentInstanceId)
+            throws InvalidConfException {
+        ByteString handle;
+        Location endpoint;
+
+        if (isProxyEnabled()) {
+            String arrowFlightProxy = getProxyAddress();
+            handle = buildFEProxyTicketForBE(queryId, rootFragmentInstanceId, worker);
+            if (arrowFlightProxy.isEmpty()) {
+                endpoint = feEndpoint;
+            } else {
+                endpoint = getProxyLocation(arrowFlightProxy);
+            }
+        } else {
+            handle = buildBETicket(queryId, rootFragmentInstanceId);
+            endpoint = Location.forGrpcInsecure(worker.getHost(), worker.getArrowFlightPort());
+        }
+
+        return new Pair<>(endpoint, handle);
+    }
+
+    public Location getFELocation() throws InvalidConfException {
+        if (isProxyEnabled()) {
+            String arrowFlightProxy = getProxyAddress();
+            if (!arrowFlightProxy.isEmpty()) {
+                return getProxyLocation(arrowFlightProxy);
+            }
+        }
+        return feEndpoint;
+    }
+
+    public Location getProxyLocation(String arrowFlightProxy) throws InvalidConfException {
+        validateProxyFormat(arrowFlightProxy);
+
+        boolean useTls = arrowFlightProxy.startsWith(GRPCS_SCHEME);
+        String hostPortStr = arrowFlightProxy;
+
+        // Strip scheme if present
+        if (arrowFlightProxy.startsWith(GRPCS_SCHEME)) {
+            hostPortStr = arrowFlightProxy.substring(GRPCS_SCHEME.length());
+        } else if (arrowFlightProxy.startsWith(GRPC_SCHEME)) {
+            hostPortStr = arrowFlightProxy.substring(GRPC_SCHEME.length());
+        }
+
+        String[] hostPort;
+        try {
+            hostPort = NetUtils.resolveHostInfoFromHostPort(hostPortStr);
+        } catch (AnalysisException e) { // deprecated, but NetUtils uses
+            throw new InvalidConfException(e.getMessage());
+        }
+        int port = Integer.parseInt(hostPort[1]);
+
+        if (useTls) {
+            return Location.forGrpcTls(hostPort[0], port);
+        }
+        return Location.forGrpcInsecure(hostPort[0], port);
+    }
+
+    public void validateProxyFormat(String arrowFlightProxy) throws InvalidConfException {
+        if (arrowFlightProxy.isEmpty()) {
+            return;
+        }
+
+        String hostPortStr = arrowFlightProxy;
+        // Strip scheme if present (grpcs:// or grpc://)
+        if (arrowFlightProxy.startsWith(GRPCS_SCHEME)) {
+            hostPortStr = arrowFlightProxy.substring(GRPCS_SCHEME.length());
+        } else if (arrowFlightProxy.startsWith(GRPC_SCHEME)) {
+            hostPortStr = arrowFlightProxy.substring(GRPC_SCHEME.length());
+        }
+
+        String[] hostPort;
+        try {
+            hostPort = NetUtils.resolveHostInfoFromHostPort(hostPortStr);
+        } catch (AnalysisException e) { // deprecated, but NetUtils uses
+            throw new InvalidConfException(
+                    String.format("Expected format 'hostname:port' or 'grpcs://hostname:port', got '%s'",
+                            arrowFlightProxy));
+        }
+
+        if (hostPort[0].isEmpty()) {
+            throw new InvalidConfException(
+                    String.format("Hostname cannot be empty, got '%s'", arrowFlightProxy));
+        }
+
+        try {
+            int port = Integer.parseInt(hostPort[1]);
+            if (port < 1 || port > 65535) {
+                throw new InvalidConfException(
+                        String.format("Port must be between 1 and 65535, got '%d'", port));
+            }
+        } catch (NumberFormatException e) {
+            throw new InvalidConfException(
+                    String.format("Port must be a valid integer, got '%s'", hostPort[1]));
+        }
+    }
+
+    public Location getInternalFEEndpoint() {
+        return feEndpoint;
+    }
+
+    @VisibleForTesting
+    protected boolean isProxyEnabled() {
+        return GlobalVariable.isArrowFlightProxyEnabled();
+    }
+
+    @VisibleForTesting
+    protected String getProxyAddress() {
+        return GlobalVariable.getArrowFlightProxy();
+    }
+
+    private static String hexStringFromUniqueId(TUniqueId id) {
+        if (id == null) {
+            return "";
+        }
+        return Long.toHexString(id.hi) + "-" + Long.toHexString(id.lo);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManager.java
@@ -222,14 +222,18 @@ public class ArrowFlightSqlTicketManager {
     }
 
     public ByteString buildFELocalTicket(String token, TUniqueId queryId) {
-        return ByteString.copyFromUtf8(token + "|" + DebugUtil.printId(queryId));
+        // Extract UUID from token (token may be "host|uuid" or just "uuid")
+        String uuid = extractUuidFromToken(token);
+        return ByteString.copyFromUtf8(uuid + "|" + DebugUtil.printId(queryId));
     }
 
     public ByteString buildFEProxyTicket(String token, TUniqueId queryId) {
+        // Extract UUID from token (token may be "host|uuid" or just "uuid")
+        String uuid = extractUuidFromToken(token);
         String feHost = feEndpoint.getUri().getHost();
         int fePort = feEndpoint.getUri().getPort();
         String hostPort = NetUtils.getHostPortInAccessibleFormat(feHost, fePort);
-        return ByteString.copyFromUtf8(token + "|" + DebugUtil.printId(queryId) + "|" + hostPort);
+        return ByteString.copyFromUtf8(uuid + "|" + DebugUtil.printId(queryId) + "|" + hostPort);
     }
 
     /**
@@ -374,6 +378,24 @@ public class ArrowFlightSqlTicketManager {
     @VisibleForTesting
     protected String getProxyAddress() {
         return GlobalVariable.getArrowFlightProxy();
+    }
+
+    /**
+     * Extracts the UUID portion from a token.
+     * When proxy is enabled, tokens have format "FE_HOST|UUID", otherwise just "UUID".
+     * This method returns just the UUID part to avoid delimiter conflicts in tickets.
+     */
+    private static String extractUuidFromToken(String token) {
+        if (token == null || token.isEmpty()) {
+            return token;
+        }
+        int lastDelimiter = token.lastIndexOf('|');
+        if (lastDelimiter > 0) {
+            // Token contains delimiter, extract UUID after last '|'
+            return token.substring(lastDelimiter + 1);
+        }
+        // Token doesn't contain delimiter, return as-is
+        return token;
     }
 
     private static String hexStringFromUniqueId(TUniqueId id) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManager.java
@@ -195,7 +195,6 @@ public class ArrowFlightSqlTicketManager {
 
     public ByteString buildFEProxyTicketForBE(TUniqueId queryId, TUniqueId fragmentInstanceId,
                                                ComputeNode worker) {
-        // BE proxy tickets use | as delimiter between host and port, so IPv6 addresses work without brackets
         return ByteString.copyFromUtf8(
                 hexStringFromUniqueId(queryId) + "|"
                         + hexStringFromUniqueId(fragmentInstanceId) + "|"

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManager.java
@@ -43,8 +43,9 @@ import java.net.URI;
  */
 public class ArrowFlightSqlTicketManager {
 
-    private static final String TICKET_DELIMITER = "\\|";
+    private static final String TICKET_DELIMITER = "\\|"; // regexp
     private static final String BE_TICKET_DELIMITER = ":";
+    private static final String FE_TICKET_DELIMITER = "|";
     private static final String GRPCS_SCHEME = "grpcs://";
     private static final String GRPC_SCHEME = "grpc://";
 
@@ -224,7 +225,7 @@ public class ArrowFlightSqlTicketManager {
     public ByteString buildFELocalTicket(String token, TUniqueId queryId) {
         // Extract UUID from token (token may be "host|uuid" or just "uuid")
         String uuid = extractUuidFromToken(token);
-        return ByteString.copyFromUtf8(uuid + "|" + DebugUtil.printId(queryId));
+        return ByteString.copyFromUtf8(uuid + FE_TICKET_DELIMITER + DebugUtil.printId(queryId));
     }
 
     public ByteString buildFEProxyTicket(String token, TUniqueId queryId) {
@@ -233,7 +234,7 @@ public class ArrowFlightSqlTicketManager {
         String feHost = feEndpoint.getUri().getHost();
         int fePort = feEndpoint.getUri().getPort();
         String hostPort = NetUtils.getHostPortInAccessibleFormat(feHost, fePort);
-        return ByteString.copyFromUtf8(uuid + "|" + DebugUtil.printId(queryId) + "|" + hostPort);
+        return ByteString.copyFromUtf8(uuid + FE_TICKET_DELIMITER + DebugUtil.printId(queryId) + FE_TICKET_DELIMITER + hostPort);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManager.java
@@ -121,6 +121,11 @@ public class ArrowFlightSqlTicketManager {
     /**
      * Parses a ticket string and returns the parsed ticket data.
      *
+     * Ticket formats:
+     * - FE_LOCAL (2 parts):  token|queryId
+     * - FE_PROXY (3 parts):  token|queryId|feHost:fePort
+     * - BE_PROXY (4 parts):  queryId|fragmentInstanceId|beHost|bePort
+     *
      * @param ticket the ticket string to parse
      * @return parsed ticket data
      * @throws org.apache.arrow.flight.FlightRuntimeException if the ticket format is invalid
@@ -130,6 +135,7 @@ public class ArrowFlightSqlTicketManager {
 
         switch (ticketParts.length) {
             case 2:
+                // FE_LOCAL: token|queryId
                 return ParsedTicket.feLocal(ticketParts[0], ticketParts[1]);
             case 3:
                 return parseFEProxyTicket(ticketParts);
@@ -142,6 +148,12 @@ public class ArrowFlightSqlTicketManager {
         }
     }
 
+    /**
+     * Parses FE proxy ticket format: token|queryId|feHost:fePort
+     * ticketParts[0] = token
+     * ticketParts[1] = queryId
+     * ticketParts[2] = feHost:fePort (or [ipv6]:fePort)
+     */
     private ParsedTicket parseFEProxyTicket(String[] ticketParts) {
         String[] hostPort;
         try {
@@ -162,6 +174,13 @@ public class ArrowFlightSqlTicketManager {
         return ParsedTicket.feProxy(ticketParts[0], ticketParts[1], hostPort[0], port);
     }
 
+    /**
+     * Parses BE proxy ticket format: queryId|fragmentInstanceId|beHost|bePort
+     * ticketParts[0] = queryId
+     * ticketParts[1] = fragmentInstanceId
+     * ticketParts[2] = beHost
+     * ticketParts[3] = bePort
+     */
     private ParsedTicket parseBEProxyTicket(String[] ticketParts) {
         int port;
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/session/ArrowFlightSqlSessionManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/session/ArrowFlightSqlSessionManager.java
@@ -27,9 +27,11 @@ import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectScheduler;
+import com.starrocks.qe.GlobalVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlConnectContext;
+import com.starrocks.system.Frontend;
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightRuntimeException;
 import org.apache.commons.lang3.StringUtils;
@@ -65,7 +67,7 @@ public class ArrowFlightSqlSessionManager {
     }
 
     public String initializeSession(String username, String remoteIP, String password) {
-        String token = UUIDUtil.genUUID().toString();
+        String token = generateToken();
         ArrowFlightSqlConnectContext ctx = new ArrowFlightSqlConnectContext(token);
         ctx.setRemoteIP(remoteIP);
 
@@ -130,5 +132,62 @@ public class ArrowFlightSqlSessionManager {
                     .toRuntimeException();
         }
         return connectContext;
+    }
+
+    public boolean isLocalToken(String token) {
+        if (!GlobalVariable.isArrowFlightProxyEnabled()) {
+            return true;  // Without proxy, all tokens are local
+        }
+        String feHost = extractFeHost(token);
+        if (feHost == null) {
+            return true;  // Legacy token format (no host prefix)
+        }
+        String selfHost = GlobalStateMgr.getCurrentState().getNodeMgr().getSelfNode().first;
+        return feHost.equals(selfHost);
+    }
+
+    /**
+     * Extract the FE host from a token.
+     * Token format when proxy enabled: "FE_HOST:UUID"
+     * Returns null if token doesn't contain host prefix.
+     */
+    public static String extractFeHost(String token) {
+        if (StringUtils.isEmpty(token)) {
+            return null;
+        }
+        int colonIndex = token.indexOf(':');
+        if (colonIndex <= 0) {
+            return null;  // No host prefix or invalid format
+        }
+        return token.substring(0, colonIndex);
+    }
+
+    /**
+     * Validate that a host is a known FE in the cluster.
+     * This prevents forwarding requests to arbitrary/malicious hosts.
+     */
+    public static boolean isValidFeHost(String host) {
+        if (StringUtils.isEmpty(host)) {
+            return false;
+        }
+        for (Frontend fe : GlobalStateMgr.getCurrentState().getNodeMgr().getFrontends(null)) {
+            if (host.equals(fe.getHost())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Generate a token. When proxy is enabled, includes FE host prefix.
+     * Format: "FE_HOST:UUID" (proxy enabled) or "UUID" (proxy disabled)
+     */
+    private String generateToken() {
+        String uuid = UUIDUtil.genUUID().toString();
+        if (GlobalVariable.isArrowFlightProxyEnabled()) {
+            String selfHost = GlobalStateMgr.getCurrentState().getNodeMgr().getSelfNode().first;
+            return selfHost + ":" + uuid;
+        }
+        return uuid;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/session/ArrowFlightSqlSessionManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/session/ArrowFlightSqlSessionManager.java
@@ -148,18 +148,19 @@ public class ArrowFlightSqlSessionManager {
 
     /**
      * Extract the FE host from a token.
-     * Token format when proxy enabled: "FE_HOST:UUID"
+     * Token format when proxy enabled: "FE_HOST|UUID"
+     * Uses '|' as delimiter to support IPv6 addresses (which contain ':').
      * Returns null if token doesn't contain host prefix.
      */
     public static String extractFeHost(String token) {
         if (StringUtils.isEmpty(token)) {
             return null;
         }
-        int colonIndex = token.indexOf(':');
-        if (colonIndex <= 0) {
+        int separatorIndex = token.indexOf('|');
+        if (separatorIndex <= 0) {
             return null;  // No host prefix or invalid format
         }
-        return token.substring(0, colonIndex);
+        return token.substring(0, separatorIndex);
     }
 
     /**
@@ -180,13 +181,14 @@ public class ArrowFlightSqlSessionManager {
 
     /**
      * Generate a token. When proxy is enabled, includes FE host prefix.
-     * Format: "FE_HOST:UUID" (proxy enabled) or "UUID" (proxy disabled)
+     * Format: "FE_HOST|UUID" (proxy enabled) or "UUID" (proxy disabled)
+     * Uses '|' as delimiter to support IPv6 addresses (which contain ':').
      */
     private String generateToken() {
         String uuid = UUIDUtil.genUUID().toString();
         if (GlobalVariable.isArrowFlightProxyEnabled()) {
             String selfHost = GlobalStateMgr.getCurrentState().getNodeMgr().getSelfNode().first;
-            return selfHost + ":" + uuid;
+            return selfHost + "|" + uuid;
         }
         return uuid;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlAuthenticatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlAuthenticatorTest.java
@@ -97,7 +97,7 @@ class ArrowFlightSqlAuthenticatorTest {
         ArrowFlightSqlAuthenticator authenticator = new ArrowFlightSqlAuthenticator(sessionManager);
 
         // Token from valid remote FE, not found in local cache
-        String remoteToken = "10.0.6.7:some-uuid";
+        String remoteToken = "10.0.6.7|some-uuid";
         doThrow(new IllegalArgumentException("Invalid token")).when(sessionManager).validateToken(remoteToken);
 
         try (MockedStatic<GlobalVariable> mockedGlobalVar = mockStatic(GlobalVariable.class);
@@ -129,7 +129,7 @@ class ArrowFlightSqlAuthenticatorTest {
         ArrowFlightSqlAuthenticator authenticator = new ArrowFlightSqlAuthenticator(sessionManager);
 
         // Token from unknown FE, not found in local cache
-        String maliciousToken = "malicious.host:some-uuid";
+        String maliciousToken = "malicious.host|some-uuid";
         doThrow(new IllegalArgumentException("Invalid token")).when(sessionManager).validateToken(maliciousToken);
 
         try (MockedStatic<GlobalVariable> mockedGlobalVar = mockStatic(GlobalVariable.class);

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -183,8 +183,17 @@ public class ArrowFlightSqlServiceImplTest {
         doNothing().when(mockContext).kill(anyBoolean(), anyString());
         doNothing().when(sessionManager).closeSession(anyString());
         FlightSqlProducer.StreamListener<CloseSessionResult> listener = mock(FlightSqlProducer.StreamListener.class);
+
         service.closeSession(new CloseSessionRequest(), mockCallContext, listener);
+
         verify(sessionManager).closeSession("token123");
+
+        ArgumentCaptor<CloseSessionResult> resultCaptor = ArgumentCaptor.forClass(CloseSessionResult.class);
+        verify(listener).onNext(resultCaptor.capture());
+        verify(listener).onCompleted();
+
+        CloseSessionResult result = resultCaptor.getValue();
+        assertEquals(CloseSessionResult.Status.CLOSED, result.getStatus());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -1113,4 +1113,79 @@ public class ArrowFlightSqlServiceImplTest {
         }
     }
 
+    @Test
+    public void testProxyForwarding_metadataRequests_forwardToRemoteFE() throws Exception {
+        try (MockedStatic<ArrowFlightSqlSessionManager> mockedSessionMgr =
+                     mockStatic(ArrowFlightSqlSessionManager.class)) {
+            TestableArrowFlightSqlServiceImpl testService =
+                    new TestableArrowFlightSqlServiceImpl(sessionManager,
+                            Location.forGrpcInsecure("localhost", 1234));
+            testService.setProxyEnabled(true);
+
+            String remoteToken = "remote-fe|550e8400-e29b-41d4-a716-446655440000";
+            FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
+            when(callContext.peerIdentity()).thenReturn(remoteToken);
+            when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
+            mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost(remoteToken))
+                    .thenReturn("remote-fe");
+
+            FlightClient mockFeClient = mock(FlightClient.class);
+            FlightInfo mockFlightInfo = mock(FlightInfo.class);
+            when(mockFeClient.getInfo(any(FlightDescriptor.class), any())).thenReturn(mockFlightInfo);
+
+            Config.arrow_flight_port = 9408;
+            testService.addToCacheForTesting("remote-fe:9408", mockFeClient);
+
+            FlightDescriptor descriptor = FlightDescriptor.command("".getBytes());
+
+            FlightSql.CommandGetCatalogs catalogsCmd = FlightSql.CommandGetCatalogs.newBuilder().build();
+            FlightInfo catalogsResult = testService.getFlightInfoCatalogs(catalogsCmd, callContext, descriptor);
+            assertEquals(mockFlightInfo, catalogsResult);
+
+            FlightSql.CommandGetDbSchemas schemasCmd = FlightSql.CommandGetDbSchemas.newBuilder().build();
+            FlightInfo schemasResult = testService.getFlightInfoSchemas(schemasCmd, callContext, descriptor);
+            assertEquals(mockFlightInfo, schemasResult);
+
+            FlightSql.CommandGetTables tablesCmd = FlightSql.CommandGetTables.newBuilder()
+                    .setIncludeSchema(true).build();
+            FlightInfo tablesResult = testService.getFlightInfoTables(tablesCmd, callContext, descriptor);
+            assertEquals(mockFlightInfo, tablesResult);
+
+            FlightSql.CommandGetSqlInfo sqlInfoCmd = FlightSql.CommandGetSqlInfo.newBuilder().build();
+            FlightInfo sqlInfoResult = testService.getFlightInfoSqlInfo(sqlInfoCmd, callContext, descriptor);
+            assertEquals(mockFlightInfo, sqlInfoResult);
+
+            FlightSql.CommandGetXdbcTypeInfo typeInfoCmd = FlightSql.CommandGetXdbcTypeInfo.newBuilder().build();
+            FlightInfo typeInfoResult = testService.getFlightInfoTypeInfo(typeInfoCmd, callContext, descriptor);
+            assertEquals(mockFlightInfo, typeInfoResult);
+
+            verify(mockFeClient, org.mockito.Mockito.atLeast(5)).getInfo(any(FlightDescriptor.class), any());
+        }
+    }
+
+    @Test
+    public void testProxyForwarding_metadataRequests_invalidToken() throws Exception {
+        try (MockedStatic<ArrowFlightSqlSessionManager> mockedSessionMgr =
+                     mockStatic(ArrowFlightSqlSessionManager.class)) {
+            TestableArrowFlightSqlServiceImpl testService =
+                    new TestableArrowFlightSqlServiceImpl(sessionManager,
+                            Location.forGrpcInsecure("localhost", 1234));
+            testService.setProxyEnabled(true);
+
+            String invalidToken = "invalid-token-format";
+            FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
+            when(callContext.peerIdentity()).thenReturn(invalidToken);
+            when(sessionManager.isLocalToken(invalidToken)).thenReturn(false);
+            mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost(invalidToken))
+                    .thenReturn(null);
+
+            FlightDescriptor descriptor = FlightDescriptor.command("".getBytes());
+
+            FlightSql.CommandGetCatalogs catalogsCmd = FlightSql.CommandGetCatalogs.newBuilder().build();
+            FlightRuntimeException ex = assertThrows(FlightRuntimeException.class, () ->
+                    testService.getFlightInfoCatalogs(catalogsCmd, callContext, descriptor));
+            assertTrue(ex.getMessage().contains("Invalid token format"));
+        }
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -123,6 +123,7 @@ public class ArrowFlightSqlServiceImplTest {
         mockCallContext = mock(FlightProducer.CallContext.class);
         when(mockCallContext.peerIdentity()).thenReturn("token123");
         when(sessionManager.validateAndGetConnectContext("token123")).thenReturn(mockContext);
+        when(sessionManager.isLocalToken("token123")).thenReturn(true);
         when(mockContext.getState()).thenReturn(mock(QueryState.class));
         when(mockContext.getResult(anyString())).thenReturn(mock(VectorSchemaRoot.class));
         when(mockContext.getExecutionId()).thenReturn(new com.starrocks.thrift.TUniqueId(1, 1));
@@ -724,7 +725,7 @@ public class ArrowFlightSqlServiceImplTest {
                         mockStatic(ArrowFlightSqlSessionManager.class)) {
             mockedGlobal.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
 
-            String remoteToken = "remote-fe:some-uuid-token";
+            String remoteToken = "remote-fe|some-uuid-token";
             when(mockCallContext.peerIdentity()).thenReturn(remoteToken);
             when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
             mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost(remoteToken))
@@ -772,7 +773,7 @@ public class ArrowFlightSqlServiceImplTest {
                         mockStatic(ArrowFlightSqlSessionManager.class)) {
             mockedGlobal.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
 
-            String remoteToken = "remote-fe:some-uuid-token";
+            String remoteToken = "remote-fe|some-uuid-token";
             FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
             when(callContext.peerIdentity()).thenReturn(remoteToken);
             when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
@@ -815,7 +816,7 @@ public class ArrowFlightSqlServiceImplTest {
                         mockStatic(ArrowFlightSqlSessionManager.class)) {
             mockedGlobal.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
 
-            String remoteToken = "remote-fe:some-uuid-token";
+            String remoteToken = "remote-fe|some-uuid-token";
             FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
             when(callContext.peerIdentity()).thenReturn(remoteToken);
             when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
@@ -930,7 +931,7 @@ public class ArrowFlightSqlServiceImplTest {
                             Location.forGrpcInsecure("localhost", 1234));
             testService.setProxyEnabled(true);
 
-            String remoteToken = "remote-fe:some-uuid-token";
+            String remoteToken = "remote-fe|some-uuid-token";
             FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
             when(callContext.peerIdentity()).thenReturn(remoteToken);
             when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
@@ -971,7 +972,7 @@ public class ArrowFlightSqlServiceImplTest {
                             Location.forGrpcInsecure("localhost", 1234));
             testService.setProxyEnabled(true);
 
-            String remoteToken = "remote-fe:some-uuid-token";
+            String remoteToken = "remote-fe|some-uuid-token";
             FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
             when(callContext.peerIdentity()).thenReturn(remoteToken);
             when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
@@ -1009,7 +1010,7 @@ public class ArrowFlightSqlServiceImplTest {
                             Location.forGrpcInsecure("localhost", 1234));
             testService.setProxyEnabled(true);
 
-            String remoteToken = "remote-fe:some-uuid-token";
+            String remoteToken = "remote-fe|some-uuid-token";
             FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
             when(callContext.peerIdentity()).thenReturn(remoteToken);
             when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
@@ -1079,7 +1080,7 @@ public class ArrowFlightSqlServiceImplTest {
                             Location.forGrpcInsecure("localhost", 1234));
             testService.setProxyEnabled(true);
 
-            String remoteToken = "remote-fe:some-uuid-token";
+            String remoteToken = "remote-fe|some-uuid-token";
             FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
             when(callContext.peerIdentity()).thenReturn(remoteToken);
             when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlSessionManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlSessionManagerTest.java
@@ -23,23 +23,31 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectScheduler;
+import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.service.arrow.flight.sql.session.ArrowFlightSqlSessionManager;
+import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TUniqueId;
 import org.apache.arrow.flight.FlightRuntimeException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -139,7 +147,7 @@ public class ArrowFlightSqlSessionManagerTest {
     }
 
     @Test
-    public void testValidateToken_success() {
+    public void testValidateToken() {
         try (MockedStatic<ExecuteEnv> mockedEnv = mockStatic(ExecuteEnv.class);
                 MockedStatic<UUIDUtil> mockedUUID = mockStatic(UUIDUtil.class);
                 MockedStatic<GlobalStateMgr> mockedGlobalState = mockStatic(GlobalStateMgr.class);
@@ -160,18 +168,11 @@ public class ArrowFlightSqlSessionManagerTest {
 
             String token = sessionManager.initializeSession("testUser", "127.0.0.1", "testPassword");
             assertDoesNotThrow(() -> sessionManager.validateToken(token));
+
+            assertThrows(IllegalArgumentException.class, () -> sessionManager.validateToken(null));
+            assertThrows(IllegalArgumentException.class, () -> sessionManager.validateToken(""));
+            assertThrows(IllegalArgumentException.class, () -> sessionManager.validateToken("non-exist-token"));
         }
-    }
-
-    @Test
-    public void testValidateToken_emptyOrNull() {
-        assertThrows(IllegalArgumentException.class, () -> sessionManager.validateToken(null));
-        assertThrows(IllegalArgumentException.class, () -> sessionManager.validateToken(""));
-    }
-
-    @Test
-    public void testValidateToken_invalidToken() {
-        assertThrows(IllegalArgumentException.class, () -> sessionManager.validateToken("non-exist-token"));
     }
 
     @Test
@@ -224,6 +225,127 @@ public class ArrowFlightSqlSessionManagerTest {
             when(mockScheduler.getArrowFlightSqlConnectContext(mockToken)).thenReturn(null);
 
             assertThrows(FlightRuntimeException.class, () -> sessionManager.validateAndGetConnectContext(mockToken));
+        }
+    }
+
+    @Test
+    public void testExtractFeHost() {
+        assertEquals("fe1.example.com",
+                ArrowFlightSqlSessionManager.extractFeHost("fe1.example.com:123e4567-e89b-12d3-a456-426614174000"));
+        assertEquals("127.0.0.1",
+                ArrowFlightSqlSessionManager.extractFeHost("127.0.0.1:123e4567-e89b-12d3-a456-426614174000"));
+        assertNull(ArrowFlightSqlSessionManager.extractFeHost("123e4567-e89b-12d3-a456-426614174000"));
+        assertNull(ArrowFlightSqlSessionManager.extractFeHost("simpletoken"));
+        assertNull(ArrowFlightSqlSessionManager.extractFeHost(""));
+        assertNull(ArrowFlightSqlSessionManager.extractFeHost(null));
+    }
+
+    @Test
+    public void testIsLocalToken_proxyDisabled() {
+        try (MockedStatic<GlobalVariable> mockedGlobalVar = mockStatic(GlobalVariable.class)) {
+            mockedGlobalVar.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(false);
+
+            // When proxy is disabled, all tokens are considered local
+            assertTrue(sessionManager.isLocalToken("any-token"));
+            assertTrue(sessionManager.isLocalToken("fe1.example.com:some-uuid"));
+        }
+    }
+
+    @Test
+    public void testIsLocalToken_proxyEnabled() {
+        try (MockedStatic<GlobalVariable> mockedGlobalVar = mockStatic(GlobalVariable.class);
+                MockedStatic<GlobalStateMgr> mockedGlobalState = mockStatic(GlobalStateMgr.class)) {
+
+            mockedGlobalVar.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+
+            GlobalStateMgr mockGlobalState = mock(GlobalStateMgr.class);
+            NodeMgr mockNodeMgr = mock(NodeMgr.class);
+            mockedGlobalState.when(GlobalStateMgr::getCurrentState).thenReturn(mockGlobalState);
+            when(mockGlobalState.getNodeMgr()).thenReturn(mockNodeMgr);
+            when(mockNodeMgr.getSelfNode()).thenReturn(Pair.create("127.0.0.1", 9010));
+
+            assertTrue(sessionManager.isLocalToken("127.0.0.1:123e4567-e89b-12d3-a456-426614174000"));
+            assertFalse(sessionManager.isLocalToken("127.0.0.2:123e4567-e89b-12d3-a456-426614174000"));
+            assertTrue(sessionManager.isLocalToken("simpletoken"));
+        }
+    }
+
+    @Test
+    public void testIsValidFeHost() {
+        try (MockedStatic<GlobalStateMgr> mockedGlobalState = mockStatic(GlobalStateMgr.class)) {
+            GlobalStateMgr mockGlobalState = mock(GlobalStateMgr.class);
+            NodeMgr mockNodeMgr = mock(NodeMgr.class);
+            Frontend mockFe1 = mock(Frontend.class);
+            Frontend mockFe2 = mock(Frontend.class);
+            Frontend mockFe3 = mock(Frontend.class);
+
+            mockedGlobalState.when(GlobalStateMgr::getCurrentState).thenReturn(mockGlobalState);
+            when(mockGlobalState.getNodeMgr()).thenReturn(mockNodeMgr);
+            when(mockNodeMgr.getFrontends(null)).thenReturn(List.of(mockFe1, mockFe2, mockFe3));
+            when(mockFe1.getHost()).thenReturn("127.0.0.1");
+            when(mockFe2.getHost()).thenReturn("127.0.0.2");
+            when(mockFe3.getHost()).thenReturn("127.0.0.3");
+
+            assertTrue(ArrowFlightSqlSessionManager.isValidFeHost("127.0.0.1"));
+            assertTrue(ArrowFlightSqlSessionManager.isValidFeHost("127.0.0.2"));
+            assertTrue(ArrowFlightSqlSessionManager.isValidFeHost("127.0.0.3"));
+            assertFalse(ArrowFlightSqlSessionManager.isValidFeHost("malicious.host.com"));
+            assertFalse(ArrowFlightSqlSessionManager.isValidFeHost("127.0.0.99"));
+            assertFalse(ArrowFlightSqlSessionManager.isValidFeHost(""));
+            assertFalse(ArrowFlightSqlSessionManager.isValidFeHost(null));
+        }
+    }
+
+    @Test
+    public void testInitializeSession_tokenFormat() {
+        try (MockedStatic<ExecuteEnv> mockedEnv = mockStatic(ExecuteEnv.class);
+                MockedStatic<UUIDUtil> mockedUUID = mockStatic(UUIDUtil.class);
+                MockedStatic<GlobalStateMgr> mockedGlobalState = mockStatic(GlobalStateMgr.class);
+                MockedStatic<GlobalVariable> mockedGlobalVar = mockStatic(GlobalVariable.class);
+                MockedStatic<AuthenticationHandler> mockedAuth = mockStatic(AuthenticationHandler.class)) {
+
+            mockAuthentication(mockedAuth);
+
+            ExecuteEnv mockEnv = mock(ExecuteEnv.class);
+            mockedEnv.when(ExecuteEnv::getInstance).thenReturn(mockEnv);
+            when(mockEnv.getScheduler()).thenReturn(mockScheduler);
+            when(mockScheduler.getNextConnectionId()).thenReturn(123);
+            when(mockScheduler.registerConnection(any())).thenReturn(Pair.create(true, ""));
+
+            mockedUUID.when(UUIDUtil::genUUID).thenReturn(mockUUID);
+            mockedUUID.when(() -> UUIDUtil.toTUniqueId(mockUUID)).thenReturn(mockTUniqueId);
+
+            GlobalStateMgr mockGlobalState = mock(GlobalStateMgr.class);
+            NodeMgr mockNodeMgr = mock(NodeMgr.class);
+            VariableMgr mockVariableMgr = mock(VariableMgr.class);
+            SessionVariable mockSessionVariable = mock(SessionVariable.class);
+            com.starrocks.authorization.AuthorizationMgr mockAuthMgr =
+                    mock(com.starrocks.authorization.AuthorizationMgr.class);
+
+            mockedGlobalState.when(GlobalStateMgr::getCurrentState).thenReturn(mockGlobalState);
+            when(mockGlobalState.getNodeMgr()).thenReturn(mockNodeMgr);
+            when(mockNodeMgr.getSelfNode()).thenReturn(Pair.create("127.0.0.1", 9010));
+            when(mockGlobalState.getVariableMgr()).thenReturn(mockVariableMgr);
+            when(mockVariableMgr.newSessionVariable()).thenReturn(mockSessionVariable);
+            when(mockGlobalState.getAuthorizationMgr()).thenReturn(mockAuthMgr);
+            try {
+                when(mockAuthMgr.getDefaultRoleIdsByUser(any())).thenReturn(Set.of(1L, 2L, 3L));
+            } catch (PrivilegeException e) {
+                throw new RuntimeException(e);
+            }
+
+            // Test with proxy enabled - token includes FE host prefix
+            mockedGlobalVar.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            String tokenWithProxy = sessionManager.initializeSession("testUser", "127.0.0.1", "testPassword");
+            assertNotNull(tokenWithProxy);
+            assertTrue(tokenWithProxy.startsWith("127.0.0.1:"), "Token should include FE host prefix");
+            assertTrue(tokenWithProxy.contains(mockUUID.toString()), "Token should contain UUID");
+
+            // Test with proxy disabled - token is plain UUID
+            mockedGlobalVar.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(false);
+            String tokenWithoutProxy = sessionManager.initializeSession("testUser", "127.0.0.1", "testPassword");
+            assertNotNull(tokenWithoutProxy);
+            assertEquals(mockUUID.toString(), tokenWithoutProxy, "Token should be plain UUID when proxy disabled");
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlSessionManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlSessionManagerTest.java
@@ -73,7 +73,8 @@ public class ArrowFlightSqlSessionManagerTest {
         GlobalStateMgr mockGlobalState = mock(GlobalStateMgr.class);
         VariableMgr mockVariableMgr = mock(VariableMgr.class);
         SessionVariable mockSessionVariable = mock(SessionVariable.class);
-        com.starrocks.authorization.AuthorizationMgr mockAuthMgr = mock(com.starrocks.authorization.AuthorizationMgr.class);
+        com.starrocks.authorization.AuthorizationMgr mockAuthMgr =
+                mock(com.starrocks.authorization.AuthorizationMgr.class);
 
         mockedGlobalState.when(GlobalStateMgr::getCurrentState).thenReturn(mockGlobalState);
         when(mockGlobalState.getVariableMgr()).thenReturn(mockVariableMgr);
@@ -84,6 +85,10 @@ public class ArrowFlightSqlSessionManagerTest {
         } catch (PrivilegeException e) {
             throw new RuntimeException(e);
         }
+
+        NodeMgr mockNodeMgr = mock(NodeMgr.class);
+        when(mockGlobalState.getNodeMgr()).thenReturn(mockNodeMgr);
+        when(mockNodeMgr.getSelfNode()).thenReturn(Pair.create("localhost", 9010));
     }
 
     private void mockAuthentication(MockedStatic<AuthenticationHandler> mockedAuth) {
@@ -231,9 +236,11 @@ public class ArrowFlightSqlSessionManagerTest {
     @Test
     public void testExtractFeHost() {
         assertEquals("fe1.example.com",
-                ArrowFlightSqlSessionManager.extractFeHost("fe1.example.com:123e4567-e89b-12d3-a456-426614174000"));
+                ArrowFlightSqlSessionManager.extractFeHost("fe1.example.com|123e4567-e89b-12d3-a456-426614174000"));
         assertEquals("127.0.0.1",
-                ArrowFlightSqlSessionManager.extractFeHost("127.0.0.1:123e4567-e89b-12d3-a456-426614174000"));
+                ArrowFlightSqlSessionManager.extractFeHost("127.0.0.1|123e4567-e89b-12d3-a456-426614174000"));
+        assertEquals("2001:db8::1",
+                ArrowFlightSqlSessionManager.extractFeHost("2001:db8::1|123e4567-e89b-12d3-a456-426614174000"));
         assertNull(ArrowFlightSqlSessionManager.extractFeHost("123e4567-e89b-12d3-a456-426614174000"));
         assertNull(ArrowFlightSqlSessionManager.extractFeHost("simpletoken"));
         assertNull(ArrowFlightSqlSessionManager.extractFeHost(""));
@@ -247,7 +254,7 @@ public class ArrowFlightSqlSessionManagerTest {
 
             // When proxy is disabled, all tokens are considered local
             assertTrue(sessionManager.isLocalToken("any-token"));
-            assertTrue(sessionManager.isLocalToken("fe1.example.com:some-uuid"));
+            assertTrue(sessionManager.isLocalToken("fe1.example.com|some-uuid"));
         }
     }
 
@@ -264,8 +271,8 @@ public class ArrowFlightSqlSessionManagerTest {
             when(mockGlobalState.getNodeMgr()).thenReturn(mockNodeMgr);
             when(mockNodeMgr.getSelfNode()).thenReturn(Pair.create("127.0.0.1", 9010));
 
-            assertTrue(sessionManager.isLocalToken("127.0.0.1:123e4567-e89b-12d3-a456-426614174000"));
-            assertFalse(sessionManager.isLocalToken("127.0.0.2:123e4567-e89b-12d3-a456-426614174000"));
+            assertTrue(sessionManager.isLocalToken("127.0.0.1|123e4567-e89b-12d3-a456-426614174000"));
+            assertFalse(sessionManager.isLocalToken("127.0.0.2|123e4567-e89b-12d3-a456-426614174000"));
             assertTrue(sessionManager.isLocalToken("simpletoken"));
         }
     }
@@ -338,7 +345,7 @@ public class ArrowFlightSqlSessionManagerTest {
             mockedGlobalVar.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
             String tokenWithProxy = sessionManager.initializeSession("testUser", "127.0.0.1", "testPassword");
             assertNotNull(tokenWithProxy);
-            assertTrue(tokenWithProxy.startsWith("127.0.0.1:"), "Token should include FE host prefix");
+            assertTrue(tokenWithProxy.startsWith("127.0.0.1|"), "Token should include FE host prefix");
             assertTrue(tokenWithProxy.contains(mockUUID.toString()), "Token should contain UUID");
 
             // Test with proxy disabled - token is plain UUID

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManagerTest.java
@@ -1,0 +1,294 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.service.arrow.flight.sql;
+
+import com.google.protobuf.ByteString;
+import com.starrocks.common.InvalidConfException;
+import com.starrocks.common.Pair;
+import com.starrocks.qe.GlobalVariable;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TUniqueId;
+import org.apache.arrow.flight.FlightRuntimeException;
+import org.apache.arrow.flight.Location;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+public class ArrowFlightSqlTicketManagerTest {
+
+    private ArrowFlightSqlTicketManager ticketManager;
+    private Location feEndpoint;
+
+    @BeforeEach
+    public void setUp() {
+        feEndpoint = Location.forGrpcInsecure("localhost", 1234);
+        ticketManager = new ArrowFlightSqlTicketManager(feEndpoint);
+    }
+
+    @Test
+    public void testParseTicketValidFormats() {
+        ArrowFlightSqlTicketManager.ParsedTicket feLocal = ticketManager.parseTicket("token123|queryId456");
+        assertEquals(ArrowFlightSqlTicketManager.TicketType.FE_LOCAL, feLocal.getType());
+        assertEquals("token123", feLocal.getToken());
+        assertEquals("queryId456", feLocal.getQueryId());
+        assertNull(feLocal.getFragmentInstanceId());
+        assertNull(feLocal.getHost());
+        assertEquals(0, feLocal.getPort());
+
+        ArrowFlightSqlTicketManager.ParsedTicket feProxy = ticketManager.parseTicket("token123|queryId456|fe-host:9408");
+        assertEquals(ArrowFlightSqlTicketManager.TicketType.FE_PROXY, feProxy.getType());
+        assertEquals("token123", feProxy.getToken());
+        assertEquals("queryId456", feProxy.getQueryId());
+        assertNull(feProxy.getFragmentInstanceId());
+        assertEquals("fe-host", feProxy.getHost());
+        assertEquals(9408, feProxy.getPort());
+
+        ArrowFlightSqlTicketManager.ParsedTicket beProxy = ticketManager.parseTicket("queryId|fragmentId|be-host|8815");
+        assertEquals(ArrowFlightSqlTicketManager.TicketType.BE_PROXY, beProxy.getType());
+        assertNull(beProxy.getToken());
+        assertEquals("queryId", beProxy.getQueryId());
+        assertEquals("fragmentId", beProxy.getFragmentInstanceId());
+        assertEquals("be-host", beProxy.getHost());
+        assertEquals(8815, beProxy.getPort());
+    }
+
+    @Test
+    public void testParseTicketInvalidFormats() {
+        FlightRuntimeException ex1 = assertThrows(FlightRuntimeException.class,
+                () -> ticketManager.parseTicket("just-one-part"));
+        assertTrue(ex1.getMessage().contains("expected 2, 3, or 4 parts, got [1]"));
+
+        FlightRuntimeException ex5 = assertThrows(FlightRuntimeException.class,
+                () -> ticketManager.parseTicket("a|b|c|d|e"));
+        assertTrue(ex5.getMessage().contains("expected 2, 3, or 4 parts, got [5]"));
+
+        FlightRuntimeException exFeHost = assertThrows(FlightRuntimeException.class,
+                () -> ticketManager.parseTicket("token123|queryId|invalid_host_port"));
+        assertTrue(exFeHost.getMessage().contains("Invalid FE host:port format"));
+
+        FlightRuntimeException exFePort = assertThrows(FlightRuntimeException.class,
+                () -> ticketManager.parseTicket("token123|queryId|hostname:abc"));
+        assertTrue(exFePort.getMessage().contains("Invalid FE port"));
+
+        FlightRuntimeException exBePort = assertThrows(FlightRuntimeException.class,
+                () -> ticketManager.parseTicket("queryId|fragmentId|hostname|non-numeric"));
+        assertTrue(exBePort.getMessage().contains("expected numerical port"));
+    }
+
+    @Test
+    public void testIsLocalFE() {
+        ArrowFlightSqlTicketManager.ParsedTicket localMatch = ticketManager.parseTicket("token|query|localhost:1234");
+        assertTrue(ticketManager.isLocalFE(localMatch));
+
+        ArrowFlightSqlTicketManager.ParsedTicket diffHost = ticketManager.parseTicket("token|query|remote-host:1234");
+        assertFalse(ticketManager.isLocalFE(diffHost));
+
+        ArrowFlightSqlTicketManager.ParsedTicket diffPort = ticketManager.parseTicket("token|query|localhost:9999");
+        assertFalse(ticketManager.isLocalFE(diffPort));
+
+        ArrowFlightSqlTicketManager.ParsedTicket notProxy = ticketManager.parseTicket("token|query");
+        assertFalse(ticketManager.isLocalFE(notProxy));
+    }
+
+    @Test
+    public void testBuildTickets() {
+        ByteString beTicketStr = ticketManager.buildBETicket("queryId", "fragmentId");
+        assertEquals("queryId:fragmentId", beTicketStr.toStringUtf8());
+
+        ByteString beTicketId = ticketManager.buildBETicket(new TUniqueId(0x1234L, 0x5678L), new TUniqueId(0xABCDL, 0xEF01L));
+        assertEquals("1234-5678:abcd-ef01", beTicketId.toStringUtf8());
+
+        ByteString feLocal = ticketManager.buildFELocalTicket("test-token", new TUniqueId(5L, 6L));
+        assertEquals("test-token|00000000-0000-0005-0000-000000000006", feLocal.toStringUtf8());
+
+        ByteString feProxy = ticketManager.buildFEProxyTicket("test-token", new TUniqueId(5L, 6L));
+        assertEquals("test-token|00000000-0000-0005-0000-000000000006|localhost:1234", feProxy.toStringUtf8());
+
+        ComputeNode worker = mock(ComputeNode.class);
+        when(worker.getHost()).thenReturn("be-host");
+        when(worker.getArrowFlightPort()).thenReturn(8815);
+        ByteString feProxyBe = ticketManager.buildFEProxyTicketForBE(new TUniqueId(3L, 4L), new TUniqueId(1L, 2L), worker);
+        assertEquals("3-4|1-2|be-host|8815", feProxyBe.toStringUtf8());
+    }
+
+    @Test
+    public void testValidateProxyFormatValid() throws InvalidConfException {
+        // All valid formats should not throw
+        ticketManager.validateProxyFormat("hostname:9408");
+        ticketManager.validateProxyFormat("grpc://hostname:9408");
+        ticketManager.validateProxyFormat("grpcs://hostname:443");
+        ticketManager.validateProxyFormat("hostname:1");
+        ticketManager.validateProxyFormat("hostname:65535");
+        ticketManager.validateProxyFormat(""); // empty is valid
+    }
+
+    @Test
+    public void testValidateProxyFormatInvalid() {
+        InvalidConfException noPort = assertThrows(InvalidConfException.class,
+                () -> ticketManager.validateProxyFormat("hostname-only"));
+        assertTrue(noPort.getMessage().contains("Expected format 'hostname:port'"));
+
+        InvalidConfException emptyHost = assertThrows(InvalidConfException.class,
+                () -> ticketManager.validateProxyFormat(":9408"));
+        assertTrue(emptyHost.getMessage().contains("Hostname cannot be empty"));
+
+        InvalidConfException nonNumeric = assertThrows(InvalidConfException.class,
+                () -> ticketManager.validateProxyFormat("hostname:abc"));
+        assertTrue(nonNumeric.getMessage().contains("Port must be a valid integer"));
+
+        InvalidConfException portLow = assertThrows(InvalidConfException.class,
+                () -> ticketManager.validateProxyFormat("hostname:0"));
+        assertTrue(portLow.getMessage().contains("Port must be between 1 and 65535"));
+
+        InvalidConfException portHigh = assertThrows(InvalidConfException.class,
+                () -> ticketManager.validateProxyFormat("hostname:99999"));
+        assertTrue(portHigh.getMessage().contains("Port must be between 1 and 65535"));
+    }
+
+    @Test
+    public void testGetProxyLocation() throws InvalidConfException {
+        assertEquals(Location.forGrpcInsecure("proxy-host", 9408),
+                ticketManager.getProxyLocation("proxy-host:9408"));
+
+        assertEquals(Location.forGrpcInsecure("proxy-host", 9408),
+                ticketManager.getProxyLocation("grpc://proxy-host:9408"));
+
+        assertEquals(Location.forGrpcTls("proxy-host", 443),
+                ticketManager.getProxyLocation("grpcs://proxy-host:443"));
+
+        assertEquals(Location.forGrpcInsecure("::1", 9408),
+                ticketManager.getProxyLocation("[::1]:9408"));
+
+        assertEquals(Location.forGrpcTls("2001:db8::1", 443),
+                ticketManager.getProxyLocation("grpcs://[2001:db8::1]:443"));
+    }
+
+    @Test
+    public void testParseTicketWithIPv6() {
+        ArrowFlightSqlTicketManager.ParsedTicket ipv6Ticket =
+                ticketManager.parseTicket("token123|queryId456|[::1]:9408");
+        assertEquals(ArrowFlightSqlTicketManager.TicketType.FE_PROXY, ipv6Ticket.getType());
+        assertEquals("token123", ipv6Ticket.getToken());
+        assertEquals("queryId456", ipv6Ticket.getQueryId());
+        assertEquals("::1", ipv6Ticket.getHost());
+        assertEquals(9408, ipv6Ticket.getPort());
+    }
+
+    @Test
+    public void testGetFEEndpoint() throws Exception {
+        ArrowFlightSqlConnectContext mockCtx = mock(ArrowFlightSqlConnectContext.class);
+        when(mockCtx.getArrowFlightSqlToken()).thenReturn("test-token");
+        when(mockCtx.getExecutionId()).thenReturn(new TUniqueId(5L, 6L));
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(false);
+
+            Pair<Location, ByteString> result = ticketManager.getFEEndpoint(mockCtx);
+            assertEquals(Location.forGrpcInsecure("localhost", 1234), result.first);
+            assertTrue(result.second.toStringUtf8().startsWith("test-token|"));
+            assertFalse(result.second.toStringUtf8().contains("localhost:1234"));
+        }
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mocked.when(GlobalVariable::getArrowFlightProxy).thenReturn("");
+
+            Pair<Location, ByteString> emptyProxy = ticketManager.getFEEndpoint(mockCtx);
+            assertEquals(Location.forGrpcInsecure("localhost", 1234), emptyProxy.first);
+            assertTrue(emptyProxy.second.toStringUtf8().contains("localhost:1234"));
+        }
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mocked.when(GlobalVariable::getArrowFlightProxy).thenReturn("proxy-host:9408");
+
+            Pair<Location, ByteString> withProxy = ticketManager.getFEEndpoint(mockCtx);
+            assertEquals(Location.forGrpcInsecure("proxy-host", 9408), withProxy.first);
+            assertTrue(withProxy.second.toStringUtf8().contains("localhost:1234"));
+        }
+    }
+
+    @Test
+    public void testGetBEEndpoint() throws Exception {
+        ComputeNode mockWorker = mock(ComputeNode.class);
+        when(mockWorker.getHost()).thenReturn("be-host");
+        when(mockWorker.getArrowFlightPort()).thenReturn(8815);
+        TUniqueId queryId = new TUniqueId(3L, 4L);
+        TUniqueId fragmentId = new TUniqueId(1L, 2L);
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(false);
+
+            Pair<Location, ByteString> result = ticketManager.getBEEndpoint(queryId, mockWorker, fragmentId);
+            assertEquals(Location.forGrpcInsecure("be-host", 8815), result.first);
+            assertEquals("3-4:1-2", result.second.toStringUtf8());
+        }
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mocked.when(GlobalVariable::getArrowFlightProxy).thenReturn("");
+
+            Pair<Location, ByteString> emptyProxy = ticketManager.getBEEndpoint(queryId, mockWorker, fragmentId);
+            assertEquals(Location.forGrpcInsecure("localhost", 1234), emptyProxy.first);
+            assertEquals("3-4|1-2|be-host|8815", emptyProxy.second.toStringUtf8());
+        }
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mocked.when(GlobalVariable::getArrowFlightProxy).thenReturn("proxy-host:9400");
+
+            Pair<Location, ByteString> withProxy = ticketManager.getBEEndpoint(queryId, mockWorker, fragmentId);
+            assertEquals(Location.forGrpcInsecure("proxy-host", 9400), withProxy.first);
+            assertEquals("3-4|1-2|be-host|8815", withProxy.second.toStringUtf8());
+        }
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mocked.when(GlobalVariable::getArrowFlightProxy).thenReturn("grpcs://proxy-host:443");
+
+            Pair<Location, ByteString> grpcs = ticketManager.getBEEndpoint(queryId, mockWorker, fragmentId);
+            assertEquals(Location.forGrpcTls("proxy-host", 443), grpcs.first);
+        }
+    }
+
+    @Test
+    public void testGetFELocation() throws Exception {
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(false);
+            assertEquals(Location.forGrpcInsecure("localhost", 1234), ticketManager.getFELocation());
+        }
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mocked.when(GlobalVariable::getArrowFlightProxy).thenReturn("");
+            assertEquals(Location.forGrpcInsecure("localhost", 1234), ticketManager.getFELocation());
+        }
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mocked.when(GlobalVariable::getArrowFlightProxy).thenReturn("proxy-host:9408");
+            assertEquals(Location.forGrpcInsecure("proxy-host", 9408), ticketManager.getFELocation());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManagerTest.java
@@ -140,7 +140,7 @@ public class ArrowFlightSqlTicketManagerTest {
         ticketManager.validateProxyFormat("grpcs://hostname:443");
         ticketManager.validateProxyFormat("hostname:1");
         ticketManager.validateProxyFormat("hostname:65535");
-        ticketManager.validateProxyFormat(""); // empty is valid
+        ticketManager.validateProxyFormat("");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManagerTest.java
@@ -196,6 +196,33 @@ public class ArrowFlightSqlTicketManagerTest {
     }
 
     @Test
+    public void testBuildTicketsWithProxyToken() {
+        // When proxy is enabled, tokens have format "FE_HOST|UUID"
+        String proxyToken = "fe-host-1|550e8400-e29b-41d4-a716-446655440000";
+
+        ByteString feLocal = ticketManager.buildFELocalTicket(proxyToken, new TUniqueId(5L, 6L));
+        String feLocalStr = feLocal.toStringUtf8();
+        assertEquals("550e8400-e29b-41d4-a716-446655440000|00000000-0000-0005-0000-000000000006", feLocalStr);
+
+        ArrowFlightSqlTicketManager.ParsedTicket parsedFeLocal = ticketManager.parseTicket(feLocalStr);
+        assertEquals(ArrowFlightSqlTicketManager.TicketType.FE_LOCAL, parsedFeLocal.getType());
+        assertEquals("550e8400-e29b-41d4-a716-446655440000", parsedFeLocal.getToken());
+        assertEquals("00000000-0000-0005-0000-000000000006", parsedFeLocal.getQueryId());
+
+        ByteString feProxy = ticketManager.buildFEProxyTicket(proxyToken, new TUniqueId(7L, 8L));
+        String feProxyStr = feProxy.toStringUtf8();
+        assertEquals("550e8400-e29b-41d4-a716-446655440000|00000000-0000-0007-0000-000000000008|localhost:1234",
+                     feProxyStr);
+
+        ArrowFlightSqlTicketManager.ParsedTicket parsedFeProxy = ticketManager.parseTicket(feProxyStr);
+        assertEquals(ArrowFlightSqlTicketManager.TicketType.FE_PROXY, parsedFeProxy.getType());
+        assertEquals("550e8400-e29b-41d4-a716-446655440000", parsedFeProxy.getToken());
+        assertEquals("00000000-0000-0007-0000-000000000008", parsedFeProxy.getQueryId());
+        assertEquals("localhost", parsedFeProxy.getHost());
+        assertEquals(1234, parsedFeProxy.getPort());
+    }
+
+    @Test
     public void testGetFEEndpoint() throws Exception {
         ArrowFlightSqlConnectContext mockCtx = mock(ArrowFlightSqlConnectContext.class);
         when(mockCtx.getArrowFlightSqlToken()).thenReturn("test-token");


### PR DESCRIPTION
## Why I'm doing:
When the Arrow Flight proxy is directed towards a load balancer, requests from a single client may be routed to multiple FEs. This causes problems with authentication, as the token responsible for authentication is local to an FE. 
## What I'm doing:
- Add support for grpcs:// and grpc:// scheme prefixes in proxy configuration for TLS connections
- Include originating FE host:port in proxy tickets to enable routing back to the correct FE
- Forward bearer tokens when proxying requests to remote FE nodes for authentication
- Add local FE detection to avoid unnecessary network hops when proxy routes back to same node  
- Refactor FE endpoint and ticket building logic to match BE pattern
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4