### PR TITLE
[Enhancement] supporting dictification of union all with constants

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -98,6 +98,8 @@ class DecodeContext {
 
     Map<ScalarOperator, ScalarOperator> stringExprToDictExprMap = Maps.newHashMap();
 
+    UnionDictionaryManager unionDictionaryManager;
+
     DecodeContext(ColumnRefFactory factory) {
         this.factory = factory;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -215,8 +215,9 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
             HashMap<ColumnRefOperator, ColumnRefOperator> columnMapping = Maps.newHashMap();
             constantMapping.forEach((key, value) ->
                     columnMapping.put(key, factory.create(value, value.getType(), value.isNullable())));
-            unionOp.getChildOutputColumns().get(i).forEach(c -> columnMapping.putIfAbsent(
-                    c, info.inputStringColumns.contains(c.getId()) ? context.stringRefToDictRefMap.get(c) : c));
+            unionOp.getChildOutputColumns().get(i).forEach(c -> columnMapping.putIfAbsent(c,
+                    info.inputStringColumns.contains(c.getId()) ? context.stringRefToDictRefMap.getOrDefault(c, c) : c)
+            );
             newChildOutputColumns.add(unionOp.getChildOutputColumns().get(i).stream().map(columnMapping::get).toList());
             if (constantMapping.isEmpty()) {
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -46,6 +46,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalHiveScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
@@ -53,6 +54,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
@@ -60,6 +62,7 @@ import com.starrocks.type.Type;
 import org.apache.commons.collections4.CollectionUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -203,20 +206,43 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
     public OptExpression visitPhysicalUnion(OptExpression optExpression, ColumnRefSet fragmentUseDictExprs) {
         PhysicalUnionOperator unionOp = optExpression.getOp().cast();
         DecodeInfo info = context.operatorDecodeInfo.getOrDefault(unionOp, DecodeInfo.EMPTY);
+        List<Map<ColumnRefOperator, ConstantOperator>> constantMappings =
+                context.unionDictionaryManager.generateConstantEncodingMap(
+                        unionOp.getOutputColumnRefOp(), unionOp.getChildOutputColumns(), context.allStringColumns);
+        List<List<ColumnRefOperator>> newChildOutputColumns = Lists.newArrayList();
+        for (int i = 0; i < optExpression.arity(); ++i) {
+            Map<ColumnRefOperator, ConstantOperator> constantMapping = constantMappings.get(i);
+            HashMap<ColumnRefOperator, ColumnRefOperator> columnMapping = Maps.newHashMap();
+            constantMapping.forEach((key, value) ->
+                    columnMapping.put(key, factory.create(value, value.getType(), value.isNullable())));
+            unionOp.getChildOutputColumns().get(i).forEach(c -> columnMapping.putIfAbsent(
+                    c, info.inputStringColumns.contains(c.getId()) ? context.stringRefToDictRefMap.get(c) : c));
+            newChildOutputColumns.add(unionOp.getChildOutputColumns().get(i).stream().map(columnMapping::get).toList());
+            if (constantMapping.isEmpty()) {
+                continue;
+            }
+            PhysicalProjectOperator projectOp = new PhysicalProjectOperator(
+                    unionOp.getChildOutputColumns().get(i).stream().distinct().collect(Collectors.toMap(
+                            columnMapping::get,
+                            c -> constantMapping.containsKey(c) ? constantMapping.get(c) : columnMapping.get(c))),
+                    Map.of()
+            );
+            LogicalProperty property = new LogicalProperty(optExpression.getInputs().get(i).getLogicalProperty());
+            property.setOutputColumns(new ColumnRefSet(projectOp.getOutputColumns()));
+            OptExpression newChild = OptExpression.builder().with(optExpression.getInputs().get(i)).setOp(projectOp)
+                    .setLogicalProperty(property).setInputs(List.of(optExpression.getInputs().get(i))).build();
+            optExpression.setChild(i, newChild);
+        }
+        List<ColumnRefOperator> newColumnRefOp = unionOp.getOutputColumnRefOp().stream().map(
+                c -> context.allStringColumns.contains(c.getId())
+                        ? context.stringRefToDictRefMap.get(c) : c).toList();
+
         ColumnRefSet inputColumns = new ColumnRefSet();
         inputColumns.union(info.inputStringColumns);
         unionOp.getOutputColumnRefOp().stream().map(ColumnRefOperator::getId).filter(context.allStringColumns::contains)
                 .forEach(inputColumns::union);
         ScalarOperator newPredicate = rewritePredicate(unionOp.getPredicate(), inputColumns);
         Projection newProjection = rewriteProjection(unionOp.getProjection(), inputColumns);
-        List<ColumnRefOperator> newColumnRefOp = unionOp.getOutputColumnRefOp().stream().map(
-                c -> context.allStringColumns.contains(c.getId())
-                        ? context.stringRefToDictRefMap.getOrDefault(c, c) : c).toList();
-        List<List<ColumnRefOperator>> newChildOutputColumns = unionOp.getChildOutputColumns().stream()
-                .map(l -> l.stream()
-                        .map(c -> info.inputStringColumns.contains(c) ?
-                                context.stringRefToDictRefMap.getOrDefault(c, c) : c).toList()
-                ).toList();
 
         PhysicalUnionOperator newUnionOp = new PhysicalUnionOperator(newColumnRefOp, newChildOutputColumns,
                 unionOp.isUnionAll(), unionOp.getLimit(), newPredicate, newProjection,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
@@ -14,21 +14,25 @@
 
 package com.starrocks.sql.optimizer.rule.tree.lowcardinality;
 
-import com.google.common.base.Preconditions;
+import com.google.api.client.util.Maps;
+import com.google.api.client.util.Preconditions;
+import com.google.api.client.util.Sets;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
+import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.UnionFind;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
+import com.starrocks.type.IntegerType;
 
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -39,6 +43,9 @@ public class UnionDictionaryManager {
     private final Map<Integer, ScalarOperator> stringRefToDefineExprMap;
     private final Map<Integer, ColumnDict> globalDicts;
     private final Set<Integer> joinEqColumnGroupIds;
+    private final Map<Integer, ByteBuffer> constantColumns = Maps.newHashMap();
+
+    private static final int CONSTANT_ID = -1;
 
     public UnionDictionaryManager(SessionVariable sessionVariable,
                                   Map<Integer, ScalarOperator> stringRefToDefineExprMap,
@@ -50,8 +57,10 @@ public class UnionDictionaryManager {
         this.joinEqColumnGroupIds = joinEqColumnGroupIds;
     }
 
-    private static ImmutableMap<ByteBuffer, Integer> mergeDictionaryData(List<ImmutableMap<ByteBuffer, Integer>> dicts) {
+    private static ImmutableMap<ByteBuffer, Integer> mergeDictionaryData(List<ImmutableMap<ByteBuffer, Integer>> dicts,
+                                                                         Collection<ByteBuffer> constants) {
         Set<ByteBuffer> uniques = Sets.newHashSet();
+        uniques.addAll(constants);
         dicts.forEach(d -> uniques.addAll(d.keySet()));
         int totalDictSize = uniques.stream().map(b -> b.remaining() + 4).reduce(0, Integer::sum);
         // TODO(farhad-celo): This constant is hardcoded in other places, refactor to a config.
@@ -71,6 +80,9 @@ public class UnionDictionaryManager {
         if (globalDicts.containsKey(cid)) {
             return cid;
         }
+        if (constantColumns.containsKey(cid)) {
+            return CONSTANT_ID;
+        }
         ScalarOperator define = stringRefToDefineExprMap.get(cid);
         if (define == null || !define.isColumnRef()) {
             return null;
@@ -82,38 +94,44 @@ public class UnionDictionaryManager {
         return getSourceDictionaryColumnId(newId);
     }
 
-    boolean mergeDictionaries(List<Integer> columnIds) {
+    Integer mergeDictionaries(List<Integer> columnIds) {
         if (!sessionVariable.isEnableLowCardinalityOptimizeForUnionAll()) {
-            return false;
+            return null;
         }
-        columnIds = columnIds.stream().map(this::getSourceDictionaryColumnId).toList();
-        if (columnIds.contains(null) || !columnIds.stream().allMatch(globalDicts::containsKey)
-                || columnIds.stream().anyMatch(joinEqColumnGroupIds::contains)) {
-            return false;
+        List<ByteBuffer> allConstantData =
+                columnIds.stream().map(constantColumns::get).filter(Objects::nonNull).toList();
+        List<Integer> nonConstantColumnIds = columnIds.stream().map(this::getSourceDictionaryColumnId)
+                .filter(cid -> cid == null || cid != CONSTANT_ID).toList();
+        if (nonConstantColumnIds.isEmpty()
+                || nonConstantColumnIds.contains(null)
+                || !nonConstantColumnIds.stream().allMatch(globalDicts::containsKey)
+                || nonConstantColumnIds.stream().anyMatch(joinEqColumnGroupIds::contains)) {
+            return null;
         }
-        columnIds.forEach(cid -> {
+        nonConstantColumnIds.forEach(cid -> {
             Integer groupId = unionColumnGroups.getGroupIdOrAdd(cid);
             if (!unionDictData.containsKey(groupId)) {
                 Preconditions.checkState(globalDicts.containsKey(cid));
                 unionDictData.put(groupId, globalDicts.get(cid).getDict());
             }
         });
-        List<Integer> columnGroupIds = columnIds.stream().map(
+        List<Integer> columnGroupIds = nonConstantColumnIds.stream().map(
                 cid -> unionColumnGroups.getGroupId(cid).orElseThrow()).distinct().toList();
-        List<ImmutableMap<ByteBuffer, Integer>> allData = columnGroupIds.stream().map(unionDictData::get).toList();
-        ImmutableMap<ByteBuffer, Integer> mergedDictData = mergeDictionaryData(allData);
+        List<ImmutableMap<ByteBuffer, Integer>> allDictData = columnGroupIds.stream().map(unionDictData::get).toList();
+        ImmutableMap<ByteBuffer, Integer> mergedDictData = mergeDictionaryData(allDictData, allConstantData);
         if (mergedDictData == null) {
-            return false;
+            return null;
         }
-        final Integer firstElement = columnIds.get(0);
-        columnIds.forEach(cid -> unionColumnGroups.union(cid, firstElement));
+        final Integer firstElement = nonConstantColumnIds.get(0);
+        nonConstantColumnIds.forEach(cid -> unionColumnGroups.union(cid, firstElement));
         Integer finalGroup = unionColumnGroups.getGroupId(firstElement).orElseThrow();
         unionDictData.put(finalGroup, mergedDictData);
-        return true;
+        return columnIds.stream().filter(cid -> firstElement.equals(getSourceDictionaryColumnId(cid))).findAny()
+                .orElseThrow();
     }
 
     void finalizeColumnDictionaries() {
-        unionColumnGroups.getAllGroups().stream().filter(s -> s.size() > 1).forEach(s -> {
+        unionColumnGroups.getAllGroups().forEach(s -> {
             Integer groupId = unionColumnGroups.getGroupId(s.stream().findAny().orElseThrow()).orElseThrow();
             ImmutableMap<ByteBuffer, Integer> dictData = unionDictData.get(groupId);
             Preconditions.checkNotNull(dictData);
@@ -126,11 +144,64 @@ public class UnionDictionaryManager {
     }
 
     Collection<Set<Integer>> getUnionColumnGroups() {
-        return unionColumnGroups.getAllGroups().stream().filter(s -> s.size() > 1).toList();
+        return unionColumnGroups.getAllGroups().stream().toList();
     }
 
     Set<Integer> getMergedDictColumnIds() {
-        return unionColumnGroups.getAllGroups().stream().filter(s -> s.size() > 1).flatMap(Set::stream)
+        return unionColumnGroups.getAllGroups().stream().flatMap(Set::stream)
                 .collect(Collectors.toSet());
+    }
+
+    void recordIfConstant(ColumnRefOperator key, ScalarOperator value) {
+        if (value.isConstantRef() && (value.getType().isStringType() || value.getType().isNull())) {
+            ConstantOperator constant = value.cast();
+            ByteBuffer buffer = constant.isConstantNull() ? null : ByteBuffer.wrap(constant.getVarchar().getBytes());
+            constantColumns.put(key.getId(), buffer);
+        } else if (value.isColumnRef()) {
+            ColumnRefOperator c = value.cast();
+            if (constantColumns.containsKey(c.getId())) {
+                constantColumns.put(key.getId(), constantColumns.get(c.getId()));
+            }
+        }
+    }
+
+    private ConstantOperator generateConstantOperator(ColumnRefOperator column, Map<ByteBuffer, Integer> dict) {
+        ByteBuffer constantValue = constantColumns.get(column.getId());
+        if (constantValue == null) {
+            return ConstantOperator.createNull(IntegerType.INT);
+        }
+        Integer index = dict.get(constantValue);
+        Preconditions.checkNotNull(index);
+        return ConstantOperator.createInt(index);
+    }
+
+    List<Map<ColumnRefOperator, ConstantOperator>> generateConstantEncodingMap(List<ColumnRefOperator> outputColumns,
+                                                                               List<List<ColumnRefOperator>> childColumns,
+                                                                               Set<Integer> allStringColumns) {
+        List<Map<ColumnRefOperator, ConstantOperator>> result = Lists.newArrayList();
+        childColumns.forEach(c -> result.add(Maps.newHashMap()));
+        for (int i = 0; i < outputColumns.size(); ++i) {
+            if (!allStringColumns.contains(outputColumns.get(i).getId())) {
+                result.add(Map.of());
+                continue;
+            }
+            Integer dictColumnId = getSourceDictionaryColumnId(outputColumns.get(i).getId());
+            Preconditions.checkNotNull(dictColumnId);
+            Map<ByteBuffer, Integer> dictData = unionDictData.get(
+                    unionColumnGroups.getGroupId(dictColumnId).orElseThrow());
+            Preconditions.checkNotNull(dictData);
+            for (int j = 0; j < childColumns.size(); ++j) {
+                ColumnRefOperator c = childColumns.get(j).get(i);
+                if (constantColumns.containsKey(c.getId())) {
+                    result.get(j).put(c, generateConstantOperator(c, dictData));
+                }
+            }
+        }
+        return result;
+
+    }
+
+    boolean isSupportedConstant(ColumnRefOperator c) {
+        return constantColumns.containsKey(c.getId());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
@@ -182,7 +182,6 @@ public class UnionDictionaryManager {
         childColumns.forEach(c -> result.add(Maps.newHashMap()));
         for (int i = 0; i < outputColumns.size(); ++i) {
             if (!allStringColumns.contains(outputColumns.get(i).getId())) {
-                result.add(Map.of());
                 continue;
             }
             Integer dictColumnId = getSourceDictionaryColumnId(outputColumns.get(i).getId());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
@@ -146,9 +146,10 @@ class UnionDictionaryManagerTest {
         Assertions.assertEquals(getDictValues(globalDicts.get(2)), bigList);
         Assertions.assertEquals(getDictValues(globalDicts.get(3)), bigList);
 
-        Assertions.assertEquals(unionDictionaryManager.getMergedDictColumnIds(), Set.of(2, 3));
+        Assertions.assertEquals(unionDictionaryManager.getMergedDictColumnIds(), Set.of(1, 2, 3));
         Collection<Set<Integer>> columnGroups = unionDictionaryManager.getUnionColumnGroups();
-        Assertions.assertEquals(1, columnGroups.size());
+        Assertions.assertEquals(2, columnGroups.size());
+        Assertions.assertTrue(columnGroups.contains(Set.of(1)));
         Assertions.assertTrue(columnGroups.contains(Set.of(2, 3)));
     }
 
@@ -171,9 +172,10 @@ class UnionDictionaryManagerTest {
         Assertions.assertEquals(getDictValues(globalDicts.get(2)), bigList);
         Assertions.assertEquals(getDictValues(globalDicts.get(3)), bigList);
 
-        Assertions.assertEquals(unionDictionaryManager.getMergedDictColumnIds(), Set.of(2, 3));
+        Assertions.assertEquals(unionDictionaryManager.getMergedDictColumnIds(), Set.of(1, 2, 3));
         Collection<Set<Integer>> columnGroups = unionDictionaryManager.getUnionColumnGroups();
-        Assertions.assertEquals(1, columnGroups.size());
+        Assertions.assertEquals(2, columnGroups.size());
+        Assertions.assertTrue(columnGroups.contains(Set.of(1)));
         Assertions.assertTrue(columnGroups.contains(Set.of(2, 3)));
     }
 
@@ -274,10 +276,8 @@ class UnionDictionaryManagerTest {
                 unionDictionaryManager.generateConstantEncodingMap(List.of(col4, col5, col6),
                         List.of(List.of(col1, col8, col3), List.of(col7, col2, col9)), Set.of(1, 2, 4, 5));
 
-        Assertions.assertEquals(3, constantEncodingMap.size());
+        Assertions.assertEquals(2, constantEncodingMap.size());
         Assertions.assertEquals(Map.of(col8, ConstantOperator.createInt(3)), constantEncodingMap.get(0));
         Assertions.assertEquals(Map.of(col7, ConstantOperator.createInt(2)), constantEncodingMap.get(1));
-        Assertions.assertEquals(Map.of(), constantEncodingMap.get(2));
-
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
@@ -15,9 +15,11 @@
 package com.starrocks.sql.optimizer.rule.tree.lowcardinality;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
 import com.starrocks.type.StringType;
@@ -79,7 +81,7 @@ class UnionDictionaryManagerTest {
                 4, makeDict(List.of("z"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
-        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(1, 2, 3)));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2, 3)));
         unionDictionaryManager.finalizeColumnDictionaries();
         Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b", "c", "e", "f", "g"));
         Assertions.assertEquals(getDictValues(globalDicts.get(2)), List.of("a", "b", "c", "e", "f", "g"));
@@ -99,10 +101,10 @@ class UnionDictionaryManagerTest {
                 7, makeDict(List.of("x", "y"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
-        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(1, 2)));
-        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(5, 6)));
-        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(1, 5)));
-        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(4, 7)));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2)));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(5, 6)));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 5)));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(4, 7)));
         unionDictionaryManager.finalizeColumnDictionaries();
         Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(2).getDict());
         Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(5).getDict());
@@ -122,7 +124,6 @@ class UnionDictionaryManagerTest {
         Assertions.assertEquals(2, columnGroups.size());
         Assertions.assertTrue(columnGroups.contains(Set.of(1, 2, 5, 6)));
         Assertions.assertTrue(columnGroups.contains(Set.of(4, 7)));
-
     }
 
     @Test
@@ -135,8 +136,8 @@ class UnionDictionaryManagerTest {
                 3, makeDict(List.of("z"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
-        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(2, 3)));
-        Assertions.assertFalse(unionDictionaryManager.mergeDictionaries(List.of(3, 1)));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(2, 3)));
+        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(3, 1)));
         unionDictionaryManager.finalizeColumnDictionaries();
         Assertions.assertEquals(globalDicts.get(2).getDict(), globalDicts.get(3).getDict());
 
@@ -160,8 +161,8 @@ class UnionDictionaryManagerTest {
                 3, makeDict(List.of("z"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
-        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(2, 3)));
-        Assertions.assertFalse(unionDictionaryManager.mergeDictionaries(List.of(3, 1)));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(2, 3)));
+        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(3, 1)));
         unionDictionaryManager.finalizeColumnDictionaries();
         Assertions.assertEquals(globalDicts.get(2).getDict(), globalDicts.get(3).getDict());
 
@@ -184,8 +185,8 @@ class UnionDictionaryManagerTest {
                 3, makeDict(List.of("e"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of(3));
-        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(1, 2)));
-        Assertions.assertFalse(unionDictionaryManager.mergeDictionaries(List.of(1, 3)));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2)));
+        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(1, 3)));
         unionDictionaryManager.finalizeColumnDictionaries();
         Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(2).getDict());
 
@@ -213,8 +214,8 @@ class UnionDictionaryManagerTest {
         );
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, stringRefToDefineExprMap, globalDicts, Set.of(2));
-        Assertions.assertTrue(unionDictionaryManager.mergeDictionaries(List.of(4, 7)));
-        Assertions.assertFalse(unionDictionaryManager.mergeDictionaries(List.of(4, 5)));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(4, 7)));
+        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(4, 5)));
         unionDictionaryManager.finalizeColumnDictionaries();
         Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(3).getDict());
 
@@ -226,5 +227,57 @@ class UnionDictionaryManagerTest {
         Collection<Set<Integer>> columnGroups = unionDictionaryManager.getUnionColumnGroups();
         Assertions.assertEquals(1, columnGroups.size());
         Assertions.assertTrue(columnGroups.contains(Set.of(1, 3)));
+    }
+
+    @Test
+    void testConstantHandling() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, StringType.STRING, "col1", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, StringType.STRING, "col2", true);
+        ColumnRefOperator col3 = new ColumnRefOperator(3, StringType.STRING, "col3", true);
+        ColumnRefOperator col4 = new ColumnRefOperator(4, StringType.STRING, "col4", true);
+        ColumnRefOperator col5 = new ColumnRefOperator(5, StringType.STRING, "col5", true);
+        ColumnRefOperator col6 = new ColumnRefOperator(6, StringType.STRING, "col6", true);
+        ColumnRefOperator col7 = new ColumnRefOperator(7, StringType.STRING, "col7", true);
+        ColumnRefOperator col8 = new ColumnRefOperator(8, StringType.STRING, "col8", true);
+        ColumnRefOperator col9 = new ColumnRefOperator(9, StringType.STRING, "col9", true);
+        ColumnRefOperator col10 = new ColumnRefOperator(9, StringType.STRING, "col9", true);
+        Map<Integer, ColumnDict> globalDicts = new HashMap<>(Map.of(
+                1, makeDict(List.of("a", "g")),
+                2, makeDict(List.of("a", "aa")),
+                3, makeDict(List.of("c", "cc"))));
+        Map<Integer,  ScalarOperator> stringRefToDefineExprMap = Maps.newHashMap();
+        UnionDictionaryManager unionDictionaryManager =
+                new UnionDictionaryManager(SESSION_VARIABLE, stringRefToDefineExprMap, globalDicts, Set.of());
+        unionDictionaryManager.recordIfConstant(col7, ConstantOperator.createVarchar("bbb"));
+        unionDictionaryManager.recordIfConstant(col8, col7);
+        unionDictionaryManager.recordIfConstant(col9, col8);
+
+        Assertions.assertTrue(unionDictionaryManager.isSupportedConstant(col7));
+        Assertions.assertTrue(unionDictionaryManager.isSupportedConstant(col8));
+        Assertions.assertTrue(unionDictionaryManager.isSupportedConstant(col9));
+        Assertions.assertTrue(unionDictionaryManager.isSupportedConstant(col10));
+
+        Assertions.assertEquals(1, unionDictionaryManager.mergeDictionaries(List.of(1, 7)));
+        Assertions.assertEquals(2, unionDictionaryManager.mergeDictionaries(List.of(2, 8)));
+        Assertions.assertEquals(3, unionDictionaryManager.mergeDictionaries(List.of(3, 9)));
+
+        unionDictionaryManager.finalizeColumnDictionaries();
+
+        Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "bbb", "g"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(2)), List.of("a", "aa", "bbb"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(3)), List.of("bbb", "c", "cc"));
+
+        stringRefToDefineExprMap.put(4, col1);
+        stringRefToDefineExprMap.put(5, col2);
+        stringRefToDefineExprMap.put(6, col3);
+        List<Map<ColumnRefOperator, ConstantOperator>> constantEncodingMap =
+                unionDictionaryManager.generateConstantEncodingMap(List.of(col4, col5, col6),
+                        List.of(List.of(col1, col8, col3), List.of(col7, col2, col9)), Set.of(1, 2, 4, 5));
+
+        Assertions.assertEquals(3, constantEncodingMap.size());
+        Assertions.assertEquals(Map.of(col8, ConstantOperator.createInt(3)), constantEncodingMap.get(0));
+        Assertions.assertEquals(Map.of(col7, ConstantOperator.createInt(2)), constantEncodingMap.get(1));
+        Assertions.assertEquals(Map.of(), constantEncodingMap.get(2));
+
     }
 }


### PR DESCRIPTION
## Why I'm doing:
UNION ALL queries often mix column inputs with constant inputs (e.g., adding a static label column).

Previously, if a UNION ALL mixed a dictionary-encoded column with a constant, the engine would disable dictionary optimization. It forced the dictionary-encoded column to be decoded into raw strings to match the constant, causing performance regression.

## What I'm doing:
Updating UnionDictManager to track constant columns. When merging dictionaries for UNION ALL with constant values, instead of falling back to string encoding, it now appends the constant values to the merged dictionary.
This ensures the output column remains dictionary encoded, preserving performance for downstream operators.

Example:

```
SELECT employee_name, role 
FROM employees
UNION ALL
SELECT contractor_name, 'contractor' -- Constant input
FROM contractors; 
```

**Before this PR**: The engine saw 'contractor' and decoded employees.role into strings.
**After this PR**: The engine keeps employees.role as a dictionary and simply adds 'contractor' to that dictionary.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
