### PR TITLE
[Tool] Gradle code style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,12 @@ compile_commands.json
 .classpath
 .vimspector.json
 .gdb_history
+
+# FE Plugin
 fe/plugin/hive-udf/target
 fe/plugin/spark-dpp/target
+fe/plugin/hive-udf/bin/
+fe/plugin/spark-dpp/bin/
 
 # ignore generated files
 StarRocksLex.tokens

--- a/fe/README-gradle.md
+++ b/fe/README-gradle.md
@@ -1,0 +1,68 @@
+# Building FE with Gradle
+
+This repository still ships a Maven build, but you can use the included Gradle scripts to produce the same artifacts, run the same checks, and execute unit tests. The Gradle configuration mirrors the Maven goals so you can migrate workflows or adapt CI jobs without rewriting the style/config rules.
+
+## Prerequisites and environment
+
+- **Java** – the modules in `fe-core`, `fe-parser`, `fe-type`, etc. target Java 17. Set `JAVA_HOME` accordingly and make sure `java -version` reports 17 (`JAVA_HOME` is also used by Maven-style generation scripts invoked from Gradle).
+- **Protobuf & Thrift toolchains** – some modules invoke `generateProtoSources`/`generateThriftSources` via the embedded Gradle tasks and expect the CLI tools from Apache Protobuf/Thrift. Install them system-wide and expose them on `PATH`, for example:
+  ```sh
+  brew install protobuf thrift
+  export PATH="$HOME/.local/bin:$PATH"
+  ```
+  If you need a specific version, download the official releases and set `PROTOC`/`THRIFT` environment variables so Gradle picks them up (the projects mostly rely on code generated under `build/generated-sources` so it must exist before compilation).
+- **Python** – some build scripts still call Python helpers (`gen_build_version.py`, `gen_functions.py`). Ensure the `python` (or `python3`) command is in your `PATH`.
+- **System memory** – Gradle runs code generation and JMockit-heavy tests; the default `org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m` (from `gradle.properties`) is usually enough, but you can bump it if you see `OutOfMemoryError`.
+- **Optional tools** – install `curl`, `unzip`, etc., if not already available; they are used by some helper scripts but not enforced.
+
+## Common Gradle workflows
+
+1. **Download dependencies & build everything** (fastest full build):
+   ```sh
+   ./gradlew clean build
+   ```
+   This runs production compilation, test execution, checkstyle, and packaging across all modules (connectors, plugins and the FE server jar).
+
+2. **Build a single module** – focus on `fe-core` when making FE changes:
+   ```sh
+   ./gradlew :fe-core:build
+   ```
+   Gradle will run all the required generate-sources tasks before compiling and will publish the module to the local Gradle cache.
+
+3. **Run style checks only** – the Gradle `checkstyleMain/checkstyleTest` tasks track the Maven setup:
+   ```sh
+   ./gradlew :fe-core:checkstyleMain :fe-core:checkstyleTest
+   ```
+   This uses the shared `checkstyle.xml`, disables generated sources, and fails on violations, consistent with Maven.
+
+4. **Execute helper sub-tasks** – you can invoke any reusable task directly:
+   ```sh
+   ./gradlew :fe-core:generateProtoSources
+   ./gradlew :fe-core:generateThriftSources
+   ./gradlew :fe-core:generateByScripts
+   ```
+   Bind the generated sources to `compileJava` (via `dependsOn`), so those updates happen automatically during `build`.
+
+## Running unit tests
+
+- **Module-level tests**: Most modules still “behave like Maven,” meaning they incorporate the same JMockit agent arguments and `fe_ut_parallel` tuning flags.
+  ```sh
+  ./gradlew :fe-core:test
+  ```
+- **Control concurrency**: the build defines a project property `fe_ut_parallel`. To run tests with a lower parallelism (or to match local resources), pass it on the command line:
+  ```sh
+  ./gradlew :fe-core:test -Pfe_ut_parallel=4
+  ```
+- **JUnit filtering**: target individual tests with `--tests`, e.g.
+  ```sh
+  ./gradlew :fe-core:test --tests "com.starrocks.qe.QueryPlannerTest"
+  ```
+- **Reuse forks**: the Gradle config mirrors Maven’s `reuseForks=false` by forcing `forkEvery = 1`. There’s no need to pass additional JVM arguments unless you tweak memory yourself.
+
+## Troubleshooting tips
+
+- The build generates sources under `build/generated-sources`. If a Gradle task fails because the generated files are missing, rerun the relevant `generate…` task with `--info`.
+- Checkstyle uses the same `puppycrawl.version` defined in `pom.xml`, so updating Maven’s checkstyle version automatically updates Gradle. No manual sync is required.
+- Some connectors rely on the `:plugin:hive-udf:shadowJar` artifact. The `fe-core` compilation explicitly depends on that shadow JAR to avoid “missing class” errors.
+
+Feel free to reuse this file in your documentation, CI scripts, or onboarding guides; the Gradle paths stay stable even if the Maven configuration remains the canonical build reference. Let's chat if you need help wiring this into your CI pipeline. 

--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -478,7 +478,7 @@ tasks.test {
 
 // Checkstyle configuration to match Maven behavior
 checkstyle {
-    toolVersion = "10.21.1"  // puppycrawl.version from parent pom
+    toolVersion = project.ext["puppycrawl.version"].toString()
     configFile = rootProject.file("checkstyle.xml")
 }
 
@@ -500,9 +500,14 @@ tasks.withType<Checkstyle>().configureEach {
 
 // Bind checkstyle to run before compilation
 tasks.compileJava {
+    dependsOn("checkstyleMain")
     dependsOn("generateThriftSources", "generateProtoSources", "generateByScripts")
     // Add explicit dependency on hive-udf shadowJar task
     dependsOn(":plugin:hive-udf:shadowJar")
+}
+
+tasks.named<JavaCompile>("compileTestJava") {
+    dependsOn("checkstyleTest")
 }
 
 // Configure JAR task

--- a/fe/fe-parser/build.gradle.kts
+++ b/fe/fe-parser/build.gradle.kts
@@ -52,9 +52,17 @@ tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
 }
 
+tasks.named<JavaCompile>("compileJava") {
+    dependsOn("checkstyleMain")
+}
+
+tasks.named<JavaCompile>("compileTestJava") {
+    dependsOn("checkstyleTest")
+}
+
 // Checkstyle configuration to match Maven behavior
 checkstyle {
-    toolVersion = "10.21.1"  // puppycrawl.version from parent pom
+    toolVersion = project.ext["puppycrawl.version"].toString()
     configFile = rootProject.file("checkstyle.xml")
 }
 

--- a/fe/fe-testing/build.gradle.kts
+++ b/fe/fe-testing/build.gradle.kts
@@ -36,7 +36,7 @@ tasks.withType<JavaCompile> {
 }
 
 checkstyle {
-    toolVersion = project.findProperty("puppycrawl.version") as String? ?: "10.21.1"
+    toolVersion = project.ext["puppycrawl.version"].toString()
     configFile = rootProject.file("checkstyle.xml")
 }
 
@@ -44,4 +44,9 @@ tasks.withType<Checkstyle> {
     exclude("**/jmockit/**/*")
     isShowViolations = true
     ignoreFailures = false
+}
+
+tasks.named<Checkstyle>("checkstyleTest") {
+    // Maven does not check test sources for this module.
+    enabled = false
 }

--- a/fe/fe-testing/build.gradle.kts
+++ b/fe/fe-testing/build.gradle.kts
@@ -35,6 +35,14 @@ tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
 }
 
+tasks.named<JavaCompile>("compileJava") {
+    dependsOn("checkstyleMain")
+}
+
+tasks.named<JavaCompile>("compileTestJava") {
+    dependsOn("checkstyleTest")
+}
+
 checkstyle {
     toolVersion = project.ext["puppycrawl.version"].toString()
     configFile = rootProject.file("checkstyle.xml")
@@ -44,9 +52,6 @@ tasks.withType<Checkstyle> {
     exclude("**/jmockit/**/*")
     isShowViolations = true
     ignoreFailures = false
-}
-
-tasks.named<Checkstyle>("checkstyleTest") {
-    // Maven does not check test sources for this module.
-    enabled = false
+    // Avoid circular dependency: Checkstyle should not depend on compiled classes.
+    classpath = files()
 }

--- a/fe/fe-type/build.gradle.kts
+++ b/fe/fe-type/build.gradle.kts
@@ -14,7 +14,6 @@
 
 plugins {
     java
-    checkstyle
 }
 
 java {
@@ -47,18 +46,4 @@ tasks.withType<Test> {
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
-}
-
-// Checkstyle configuration to match Maven behavior
-checkstyle {
-    toolVersion = "10.21.1"  // puppycrawl.version from parent pom
-    configFile = rootProject.file("checkstyle.xml")
-}
-
-// Configure Checkstyle tasks to match Maven behavior
-tasks.withType<Checkstyle>().configureEach {
-    exclude("**/sql/parser/gen/**")
-    ignoreFailures = false  // Match Maven behavior: failsOnError=true
-    // Avoid circular dependency: Checkstyle should not depend on compiled classes
-    classpath = files()
 }

--- a/fe/plugin/spark-dpp/build.gradle.kts
+++ b/fe/plugin/spark-dpp/build.gradle.kts
@@ -77,6 +77,14 @@ tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"
 }
 
+tasks.named<JavaCompile>("compileJava") {
+    dependsOn("checkstyleMain")
+}
+
+tasks.named<JavaCompile>("compileTestJava") {
+    dependsOn("checkstyleTest")
+}
+
 checkstyle {
     toolVersion = project.ext["puppycrawl.version"].toString()
     configFile = rootProject.file("checkstyle.xml")
@@ -86,11 +94,8 @@ tasks.withType<Checkstyle> {
     exclude("**/jmockit/**/*")
     isShowViolations = true
     ignoreFailures = false
-}
-
-tasks.named<Checkstyle>("checkstyleTest") {
-    // Maven does not check test sources for this module.
-    enabled = false
+    // Avoid circular dependency: Checkstyle should not depend on compiled classes.
+    classpath = files()
 }
 
 // Equivalent to Maven Assembly plugin to create a jar with dependencies

--- a/fe/plugin/spark-dpp/build.gradle.kts
+++ b/fe/plugin/spark-dpp/build.gradle.kts
@@ -78,7 +78,7 @@ tasks.withType<JavaCompile> {
 }
 
 checkstyle {
-    toolVersion = project.findProperty("puppycrawl.version") as String? ?: "10.21.1"
+    toolVersion = project.ext["puppycrawl.version"].toString()
     configFile = rootProject.file("checkstyle.xml")
 }
 
@@ -86,6 +86,11 @@ tasks.withType<Checkstyle> {
     exclude("**/jmockit/**/*")
     isShowViolations = true
     ignoreFailures = false
+}
+
+tasks.named<Checkstyle>("checkstyleTest") {
+    // Maven does not check test sources for this module.
+    enabled = false
 }
 
 // Equivalent to Maven Assembly plugin to create a jar with dependencies


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns Gradle code style with Maven and enforces style checks in FE modules.
> 
> - Standardizes Checkstyle to use `project.ext["puppycrawl.version"]` and disables classpath for Checkstyle to avoid cycles
> - Runs `checkstyleMain`/`checkstyleTest` before `compileJava`/`compileTestJava` in `fe-core`, `fe-parser`, `fe-testing`, and `plugin/spark-dpp`; removes Checkstyle from `fe-type`
> - Keeps existing codegen/test deps; adds memory settings and exclusions unchanged; minor `fe-core` task dependency ordering tweaks
> - Adds `fe/README-gradle.md` documenting Gradle build/test workflows; updates `.gitignore` to ignore FE plugin `bin/` directories
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e2b55b3104715e27b2b1ce4f061bf46ed6f4c1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->