### PR TITLE
[Enhancement] Support WITH LABEL syntax for BEGIN/START TRANSACTION

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -5645,7 +5645,11 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
     @Override
     public ParseNode visitBeginStatement(com.starrocks.sql.parser.StarRocksParser.BeginStatementContext context) {
-        return new BeginStmt(createPos(context));
+        String label = null;
+        if (context.label != null) {
+            label = ((Identifier) visit(context.label)).getValue();
+        }
+        return new BeginStmt(createPos(context), label);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -53,6 +53,8 @@ import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.FeNameFormat;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.CreateTableAsSelectStmt;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.sql.ast.DmlStmt;
@@ -91,7 +93,7 @@ public class TransactionStmtExecutor {
     }
 
     // Overload allowing explicit label override for creating the transaction state.
-    // If labelOverride is null or empty, it falls back to the default label built from executionId.
+    // Label priority: 1. stmt.getLabel() 2. labelOverride 3. executionId
     public static void beginStmt(ConnectContext context, BeginStmt stmt,
                                  TransactionState.LoadJobSourceType sourceType,
                                  String labelOverride) {
@@ -99,18 +101,34 @@ public class TransactionStmtExecutor {
         if (context.getTxnId() != 0) {
             // Repeated begin does not create a new transaction
             ExplicitTxnState explicitTxnState = globalTransactionMgr.getExplicitTxnState(context.getTxnId());
-            String label = explicitTxnState.getTransactionState().getLabel();
+            String existingLabel = explicitTxnState.getTransactionState().getLabel();
             long transactionId = explicitTxnState.getTransactionState().getTransactionId();
+
+            // If user explicitly specifies a different label, throw an error
+            String requestedLabel = stmt.getLabel();
+            if (requestedLabel != null && !requestedLabel.isEmpty() && !requestedLabel.equals(existingLabel)) {
+                throw new SemanticException("Transaction already exists with label '" + existingLabel +
+                        "', cannot begin with different label '" + requestedLabel + "'");
+            }
+
             context.getState().setOk(0, 0,
-                    buildMessage(label, TransactionStatus.PREPARE, transactionId, -1));
+                    buildMessage(existingLabel, TransactionStatus.PREPARE, transactionId, -1));
             return;
         }
 
         long transactionId = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
                 .getTransactionIDGenerator().getNextTransactionId();
-        String label = (labelOverride != null && !labelOverride.isEmpty())
-                ? labelOverride
-                : DebugUtil.printId(context.getExecutionId());
+        // Label priority: 1. stmt.getLabel() 2. labelOverride 3. executionId
+        String stmtLabel = stmt.getLabel();
+        String label;
+        if (stmtLabel != null && !stmtLabel.isEmpty()) {
+            FeNameFormat.checkLabel(stmtLabel);
+            label = stmtLabel;
+        } else if (labelOverride != null && !labelOverride.isEmpty()) {
+            label = labelOverride;
+        } else {
+            label = DebugUtil.printId(context.getExecutionId());
+        }
         TransactionState transactionState = new TransactionState(
                 transactionId,
                 label,

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2304,8 +2304,8 @@ alterCNGroupStatement
 // ------------------------------------------- Transaction Statement ---------------------------------------------------
 
 beginStatement
-    : START TRANSACTION (WITH CONSISTENT SNAPSHOT)?
-    | BEGIN WORK?
+    : START TRANSACTION (WITH CONSISTENT SNAPSHOT)? (WITH LABEL label=identifier)?
+    | BEGIN WORK? (WITH LABEL label=identifier)?
     ;
 
 commitStatement

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/txn/BeginStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/txn/BeginStmt.java
@@ -19,8 +19,19 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.NodePosition;
 
 public class BeginStmt extends StatementBase {
+    private final String label;
+
     public BeginStmt(NodePosition pos) {
+        this(pos, null);
+    }
+
+    public BeginStmt(NodePosition pos, String label) {
         super(pos);
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
     }
 
     @Override


### PR DESCRIPTION
Add the ability to specify a custom label when starting a transaction using the WITH LABEL clause. This allows users to assign meaningful names to their transactions for better tracking and debugging.

Syntax:
- BEGIN WITH LABEL label_name
- BEGIN WORK WITH LABEL label_name
- START TRANSACTION WITH LABEL label_name
- START TRANSACTION WITH CONSISTENT SNAPSHOT WITH LABEL label_name

Changes:
- Modify StarRocks.g4 to add WITH LABEL syntax to beginStatement rule
- Add label field and getter method to BeginStmt.java
- Update AstBuilder.visitBeginStatement() to parse the label parameter
- Modify TransactionStmtExecutor.beginStmt() to use label from BeginStmt
- Add unit tests for the new functionality

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
