### PR TITLE
[Enhancement] Reset legacy baseIndex in PhysicalPartition when upgrading

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -776,6 +776,9 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
             // set baseIndexMetaId
             baseIndexMetaId = baseIndex.getMetaId();
+
+            // reset baseIndex to null
+            baseIndex = null;
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexTest.java
@@ -37,6 +37,7 @@ package com.starrocks.catalog;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.type.IntegerType;
@@ -102,12 +103,16 @@ public class MaterializedIndexTest {
     }
 
     @Test
-    public void testGsonPostProcess() {
+    public void testMaterializedIndexUpgrade() {
         MaterializedIndex index = new MaterializedIndex();
         Deencapsulation.setField(index, "id", 1L);
         Assertions.assertEquals(1L, index.getId());
         Assertions.assertEquals(0L, index.getMetaId());
-        index.gsonPostProcess();
-        Assertions.assertEquals(1L, index.getMetaId());
+
+        // Serialization/Deserialization
+        String json = GsonUtils.GSON.toJson(index);
+        MaterializedIndex newIndex = GsonUtils.GSON.fromJson(json, MaterializedIndex.class);
+
+        Assertions.assertEquals(1L, newIndex.getMetaId());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. Explicitly set the legacy `baseIndex` field to null in `PhysicalPartition.gsonPostProcess` to release memory reference after upgrading from old version.
2. Refactor UT.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
