### PR TITLE
[Enhancement] remove iceberg-specific partition position validation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ListPartitionDesc.java
@@ -137,19 +137,8 @@ public class ListPartitionDesc extends PartitionDesc {
             }
         }
 
-        if (engineName.equalsIgnoreCase("iceberg")) {
-            checkIcebergPartitionColPos(columnDefs);
-        } else if (engineName.equalsIgnoreCase("hive")) {
+        if (engineName.equalsIgnoreCase("hive")) {
             checkHivePartitionColPos(columnDefs);
-        }
-    }
-
-    public void checkIcebergPartitionColPos(List<ColumnDef> columnDefs) {
-        for (int i = 0; i < columnDefs.size() - partitionColNames.size(); i++) {
-            String colName = columnDefs.get(i).getName();
-            if (partitionColNames.contains(colName)) {
-                throw new SemanticException("Partition columns must be at the end of column defs");
-            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
@@ -392,6 +392,15 @@ public class AnalyzeCreateTableTest {
                         + "(k1 int, k2 date) partition by bucket(k2, 1)");
         analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table" 
                         + "(k1 int, k2 datetime) partition by bucket(k2, 1)");
+
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table" 
+                        + "(k1 int, k2 int, k3 int) partition by (k2)");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table" 
+                        + "(k1 int, k2 int, k3 int) partition by (k1)");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table" 
+                        + "(k1 int, k2 int, k3 int) partition by (k3)");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table" 
+                        + "(k1 int, k2 int, k3 int, k4 int) partition by (k2, k3)");
     }
 
     @Test

--- a/test/sql/test_iceberg/R/test_iceberg_partition_column_position
+++ b/test/sql/test_iceberg/R/test_iceberg_partition_column_position
@@ -1,0 +1,295 @@
+-- name: test_iceberg_partition_column_position
+create external catalog ice_cat_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog ice_cat_${uuid0};
+-- result:
+-- !result
+create database ice_db_${uuid0};
+-- result:
+-- !result
+use ice_db_${uuid0};
+-- result:
+-- !result
+create table test_part_beginning (
+  dt date,
+  id bigint,
+  data string
+)
+partition by (dt);
+-- result:
+-- !result
+insert into test_part_beginning values ('2023-01-01', 1, 'data1');
+-- result:
+-- !result
+insert into test_part_beginning values ('2023-01-02', 2, 'data2');
+-- result:
+-- !result
+select * from test_part_beginning order by id;
+-- result:
+2023-01-01	1	data1
+2023-01-02	2	data2
+-- !result
+drop table test_part_beginning force;
+-- result:
+-- !result
+create table test_part_middle (
+  id bigint,
+  dt date,
+  data string
+)
+partition by (dt);
+-- result:
+-- !result
+insert into test_part_middle values (1, '2023-01-01', 'data1');
+-- result:
+-- !result
+insert into test_part_middle values (2, '2023-01-02', 'data2');
+-- result:
+-- !result
+select * from test_part_middle order by id;
+-- result:
+1	2023-01-01	data1
+2	2023-01-02	data2
+-- !result
+drop table test_part_middle force;
+-- result:
+-- !result
+create table test_part_end (
+  id bigint,
+  data string,
+  dt date
+)
+partition by (dt);
+-- result:
+-- !result
+insert into test_part_end values (1, 'data1', '2023-01-01');
+-- result:
+-- !result
+insert into test_part_end values (2, 'data2', '2023-01-02');
+-- result:
+-- !result
+select * from test_part_end order by id;
+-- result:
+1	data1	2023-01-01
+2	data2	2023-01-02
+-- !result
+drop table test_part_end force;
+-- result:
+-- !result
+create table test_multi_part (
+  id bigint,
+  dt date,
+  region string,
+  data string
+)
+partition by (dt, region);
+-- result:
+-- !result
+insert into test_multi_part values (1, '2023-01-01', 'east', 'data1');
+-- result:
+-- !result
+insert into test_multi_part values (2, '2023-01-02', 'west', 'data2');
+-- result:
+-- !result
+select * from test_multi_part order by id;
+-- result:
+1	2023-01-01	east	data1
+2	2023-01-02	west	data2
+-- !result
+drop table test_multi_part force;
+-- result:
+-- !result
+create table test_part_year_beginning (
+  dt date,
+  id bigint,
+  data string
+)
+partition by year(dt);
+-- result:
+-- !result
+insert into test_part_year_beginning values ('2023-01-01', 1, 'data1');
+-- result:
+-- !result
+insert into test_part_year_beginning values ('2024-01-01', 2, 'data2');
+-- result:
+-- !result
+select * from test_part_year_beginning order by id;
+-- result:
+2023-01-01	1	data1
+2024-01-01	2	data2
+-- !result
+drop table test_part_year_beginning force;
+-- result:
+-- !result
+create table test_part_month_middle (
+  id bigint,
+  dt date,
+  data string
+)
+partition by month(dt);
+-- result:
+-- !result
+insert into test_part_month_middle values (1, '2023-01-01', 'data1');
+-- result:
+-- !result
+insert into test_part_month_middle values (2, '2023-02-01', 'data2');
+-- result:
+-- !result
+select * from test_part_month_middle order by id;
+-- result:
+1	2023-01-01	data1
+2	2023-02-01	data2
+-- !result
+drop table test_part_month_middle force;
+-- result:
+-- !result
+create table test_part_day_end (
+  id bigint,
+  data string,
+  dt date
+)
+partition by day(dt);
+-- result:
+-- !result
+insert into test_part_day_end values (1, 'data1', '2023-01-01');
+-- result:
+-- !result
+insert into test_part_day_end values (2, 'data2', '2023-01-15');
+-- result:
+-- !result
+select * from test_part_day_end order by id;
+-- result:
+1	data1	2023-01-01
+2	data2	2023-01-15
+-- !result
+drop table test_part_day_end force;
+-- result:
+-- !result
+create table test_part_hour_beginning (
+  ts datetime,
+  id bigint,
+  data string
+)
+partition by hour(ts);
+-- result:
+-- !result
+insert into test_part_hour_beginning values ('2023-01-01 10:00:00', 1, 'data1');
+-- result:
+-- !result
+insert into test_part_hour_beginning values ('2023-01-01 15:00:00', 2, 'data2');
+-- result:
+-- !result
+select * from test_part_hour_beginning order by id;
+-- result:
+2023-01-01 10:00:00	1	data1
+2023-01-01 15:00:00	2	data2
+-- !result
+drop table test_part_hour_beginning force;
+-- result:
+-- !result
+create table test_part_truncate_middle (
+  id bigint,
+  name string,
+  data string
+)
+partition by truncate(name, 5);
+-- result:
+-- !result
+insert into test_part_truncate_middle values (1, 'hello', 'data1');
+-- result:
+-- !result
+insert into test_part_truncate_middle values (2, 'world', 'data2');
+-- result:
+-- !result
+select * from test_part_truncate_middle order by id;
+-- result:
+1	hello	data1
+2	world	data2
+-- !result
+drop table test_part_truncate_middle force;
+-- result:
+-- !result
+create table test_part_bucket_end (
+  id bigint,
+  data string,
+  user_id bigint
+)
+partition by bucket(user_id, 10);
+-- result:
+-- !result
+insert into test_part_bucket_end values (1, 'data1', 100);
+-- result:
+-- !result
+insert into test_part_bucket_end values (2, 'data2', 200);
+-- result:
+-- !result
+select * from test_part_bucket_end order by id;
+-- result:
+1	data1	100
+2	data2	200
+-- !result
+drop table test_part_bucket_end force;
+-- result:
+-- !result
+create table test_multi_transform (
+  id bigint,
+  dt date,
+  region string,
+  data string
+)
+partition by year(dt), bucket(region, 5);
+-- result:
+-- !result
+insert into test_multi_transform values (1, '2023-01-01', 'east', 'data1');
+-- result:
+-- !result
+insert into test_multi_transform values (2, '2023-02-01', 'west', 'data2');
+-- result:
+-- !result
+select * from test_multi_transform order by id;
+-- result:
+1	2023-01-01	east	data1
+2	2023-02-01	west	data2
+-- !result
+drop table test_multi_transform force;
+-- result:
+-- !result
+create table test_part_beginning_multi (
+  dt date,
+  region string,
+  id bigint,
+  data string
+)
+partition by (dt, region);
+-- result:
+-- !result
+insert into test_part_beginning_multi values ('2023-01-01', 'east', 1, 'data1');
+-- result:
+-- !result
+insert into test_part_beginning_multi values ('2023-01-02', 'west', 2, 'data2');
+-- result:
+-- !result
+select * from test_part_beginning_multi order by id;
+-- result:
+2023-01-01	east	1	data1
+2023-01-02	west	2	data2
+-- !result
+drop table test_part_beginning_multi force;
+-- result:
+-- !result
+drop database ice_db_${uuid0};
+-- result:
+-- !result
+drop catalog ice_cat_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_partition_column_position
+++ b/test/sql/test_iceberg/T/test_iceberg_partition_column_position
@@ -1,0 +1,176 @@
+-- name: test_iceberg_partition_column_position
+
+create external catalog ice_cat_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog ice_cat_${uuid0};
+create database ice_db_${uuid0};
+use ice_db_${uuid0};
+
+-- test partition column at the beginning
+create table test_part_beginning (
+  dt date,
+  id bigint,
+  data string
+)
+partition by (dt);
+
+insert into test_part_beginning values ('2023-01-01', 1, 'data1');
+insert into test_part_beginning values ('2023-01-02', 2, 'data2');
+select * from test_part_beginning order by id;
+drop table test_part_beginning force;
+
+-- test partition column in the middle
+create table test_part_middle (
+  id bigint,
+  dt date,
+  data string
+)
+partition by (dt);
+
+insert into test_part_middle values (1, '2023-01-01', 'data1');
+insert into test_part_middle values (2, '2023-01-02', 'data2');
+select * from test_part_middle order by id;
+drop table test_part_middle force;
+
+-- test partition column at the end
+create table test_part_end (
+  id bigint,
+  data string,
+  dt date
+)
+partition by (dt);
+
+insert into test_part_end values (1, 'data1', '2023-01-01');
+insert into test_part_end values (2, 'data2', '2023-01-02');
+select * from test_part_end order by id;
+drop table test_part_end force;
+
+-- test multiple partition columns at different positions
+create table test_multi_part (
+  id bigint,
+  dt date,
+  region string,
+  data string
+)
+partition by (dt, region);
+
+insert into test_multi_part values (1, '2023-01-01', 'east', 'data1');
+insert into test_multi_part values (2, '2023-01-02', 'west', 'data2');
+select * from test_multi_part order by id;
+drop table test_multi_part force;
+
+-- test partition column at the beginning with year transform
+create table test_part_year_beginning (
+  dt date,
+  id bigint,
+  data string
+)
+partition by year(dt);
+
+insert into test_part_year_beginning values ('2023-01-01', 1, 'data1');
+insert into test_part_year_beginning values ('2024-01-01', 2, 'data2');
+select * from test_part_year_beginning order by id;
+drop table test_part_year_beginning force;
+
+-- test partition column in the middle with month transform
+create table test_part_month_middle (
+  id bigint,
+  dt date,
+  data string
+)
+partition by month(dt);
+
+insert into test_part_month_middle values (1, '2023-01-01', 'data1');
+insert into test_part_month_middle values (2, '2023-02-01', 'data2');
+select * from test_part_month_middle order by id;
+drop table test_part_month_middle force;
+
+-- test partition column at the end with day transform
+create table test_part_day_end (
+  id bigint,
+  data string,
+  dt date
+)
+partition by day(dt);
+
+insert into test_part_day_end values (1, 'data1', '2023-01-01');
+insert into test_part_day_end values (2, 'data2', '2023-01-15');
+select * from test_part_day_end order by id;
+drop table test_part_day_end force;
+
+-- test partition column at the beginning with hour transform
+create table test_part_hour_beginning (
+  ts datetime,
+  id bigint,
+  data string
+)
+partition by hour(ts);
+
+insert into test_part_hour_beginning values ('2023-01-01 10:00:00', 1, 'data1');
+insert into test_part_hour_beginning values ('2023-01-01 15:00:00', 2, 'data2');
+select * from test_part_hour_beginning order by id;
+drop table test_part_hour_beginning force;
+
+-- test partition column in the middle with truncate transform
+create table test_part_truncate_middle (
+  id bigint,
+  name string,
+  data string
+)
+partition by truncate(name, 5);
+
+insert into test_part_truncate_middle values (1, 'hello', 'data1');
+insert into test_part_truncate_middle values (2, 'world', 'data2');
+select * from test_part_truncate_middle order by id;
+drop table test_part_truncate_middle force;
+
+-- test partition column at the end with bucket transform
+create table test_part_bucket_end (
+  id bigint,
+  data string,
+  user_id bigint
+)
+partition by bucket(user_id, 10);
+
+insert into test_part_bucket_end values (1, 'data1', 100);
+insert into test_part_bucket_end values (2, 'data2', 200);
+select * from test_part_bucket_end order by id;
+drop table test_part_bucket_end force;
+
+-- test multiple partition columns with transforms at different positions
+create table test_multi_transform (
+  id bigint,
+  dt date,
+  region string,
+  data string
+)
+partition by year(dt), bucket(region, 5);
+
+insert into test_multi_transform values (1, '2023-01-01', 'east', 'data1');
+insert into test_multi_transform values (2, '2023-02-01', 'west', 'data2');
+select * from test_multi_transform order by id;
+drop table test_multi_transform force;
+
+-- test partition column at the beginning with multiple columns
+create table test_part_beginning_multi (
+  dt date,
+  region string,
+  id bigint,
+  data string
+)
+partition by (dt, region);
+
+insert into test_part_beginning_multi values ('2023-01-01', 'east', 1, 'data1');
+insert into test_part_beginning_multi values ('2023-01-02', 'west', 2, 'data2');
+select * from test_part_beginning_multi order by id;
+drop table test_part_beginning_multi force;
+
+drop database ice_db_${uuid0};
+drop catalog ice_cat_${uuid0};
+
+set catalog default_catalog;


### PR DESCRIPTION
## Why I'm doing:
create iceberg table requires Partition columns must be at the end of column defs, this is not necessary
## What I'm doing:
This pull request removes the restriction that required partition columns for Iceberg external tables to be positioned at the end of the column definitions. Now, partition columns for Iceberg tables can appear in any position within the column list. The change is validated with new and expanded test cases to ensure correct behavior.

Validation logic update:

* Removed the `checkIcebergPartitionColPos` method and its invocation from `ListPartitionDesc.java`, allowing Iceberg partition columns to be defined anywhere in the column list.

Test coverage improvements:

* Added multiple test cases in `AnalyzeCreateTableTest.java` to verify that Iceberg tables can have partition columns at any position and with multiple partition columns.
* Introduced comprehensive SQL tests in `test_iceberg_partition_column_position` (both R and T files) to cover various scenarios of partition column placement and transformations for Iceberg tables. 
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
