### PR TITLE
[Feature] Implement merge tablet SQL plumbing

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -80,6 +80,7 @@ import com.starrocks.sql.ast.DropIndexClause;
 import com.starrocks.sql.ast.DropPartitionClause;
 import com.starrocks.sql.ast.DropPersistentIndexClause;
 import com.starrocks.sql.ast.DropRollupClause;
+import com.starrocks.sql.ast.MergeTabletClause;
 import com.starrocks.sql.ast.ModifyColumnClause;
 import com.starrocks.sql.ast.ModifyPartitionClause;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
@@ -702,6 +703,13 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
 
     @Override
     public Void visitSplitTabletClause(SplitTabletClause clause, ConnectContext context) {
+        ErrorReport.wrapWithRuntimeException(() -> GlobalStateMgr.getCurrentState().getTabletReshardJobMgr()
+                .createTabletReshardJob(db, (OlapTable) table, clause));
+        return null;
+    }
+
+    @Override
+    public Void visitMergeTabletClause(MergeTabletClause clause, ConnectContext context) {
         ErrorReport.wrapWithRuntimeException(() -> GlobalStateMgr.getCurrentState().getTabletReshardJobMgr()
                 .createTabletReshardJob(db, (OlapTable) table, clause));
         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
@@ -30,6 +30,7 @@ import com.starrocks.persist.metablock.SRMetaBlockID;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockWriter;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.MergeTabletClause;
 import com.starrocks.sql.ast.SplitTabletClause;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
@@ -78,6 +79,13 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
             throws StarRocksException {
         TabletReshardJob job = new SplitTabletJobFactory(db, table, splitTabletClause).createTabletReshardJob();
         addTabletReshardJob(job);
+    }
+
+    public void createTabletReshardJob(Database db, OlapTable table, MergeTabletClause mergeTabletClause)
+            throws StarRocksException {
+        // TODO: implement merge tablet reshard job creation.
+        LOG.warn("Merge tablet reshard job creation is not implemented yet. db={}, table={}",
+                db.getFullName(), table.getName());
     }
 
     public void addTabletReshardJob(TabletReshardJob tabletReshardJob) throws StarRocksException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
@@ -520,6 +520,10 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
         return visitNode(clause, context);
     }
 
+    default R visitMergeTabletClause(MergeTabletClause clause, C context) {
+        return visitNode(clause, context);
+    }
+
     //Alter partition clause
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/MergeTabletClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/MergeTabletClause.java
@@ -20,36 +20,36 @@ import com.starrocks.sql.parser.NodePosition;
 
 import java.util.Map;
 
-public class SplitTabletClause extends AlterTableClause {
+public class MergeTabletClause extends AlterTableClause {
 
     private final PartitionRef partitionNames;
 
-    private final TabletList tabletList;
+    private final TabletGroupList tabletGroupList;
 
     private final Map<String, String> properties;
 
     private long tabletReshardTargetSize;
 
-    public SplitTabletClause() {
+    public MergeTabletClause() {
         this(null, null, null);
         this.tabletReshardTargetSize = Config.tablet_reshard_target_size;
     }
 
-    public SplitTabletClause(
+    public MergeTabletClause(
             PartitionRef partitionNames,
-            TabletList tabletList,
+            TabletGroupList tabletGroupList,
             Map<String, String> properties) {
-        this(partitionNames, tabletList, properties, NodePosition.ZERO);
+        this(partitionNames, tabletGroupList, properties, NodePosition.ZERO);
     }
 
-    public SplitTabletClause(
+    public MergeTabletClause(
             PartitionRef partitionNames,
-            TabletList tabletList,
+            TabletGroupList tabletGroupList,
             Map<String, String> properties,
             NodePosition pos) {
         super(pos);
         this.partitionNames = partitionNames;
-        this.tabletList = tabletList;
+        this.tabletGroupList = tabletGroupList;
         this.properties = properties;
     }
 
@@ -57,8 +57,8 @@ public class SplitTabletClause extends AlterTableClause {
         return partitionNames;
     }
 
-    public TabletList getTabletList() {
-        return tabletList;
+    public TabletGroupList getTabletGroupList() {
+        return tabletGroupList;
     }
 
     public Map<String, String> getProperties() {
@@ -77,15 +77,15 @@ public class SplitTabletClause extends AlterTableClause {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         if (partitionNames != null) {
-            sb.append("SPLIT TABLET ");
+            sb.append("MERGE TABLET ");
             sb.append(partitionNames.toString());
             sb.append('\n');
-        } else if (tabletList != null) {
-            sb.append("SPLIT ");
-            sb.append(tabletList.toString());
+        } else if (tabletGroupList != null) {
+            sb.append("MERGE ");
+            sb.append(tabletGroupList.toString());
             sb.append('\n');
         } else {
-            sb.append("SPLIT TABLET\n");
+            sb.append("MERGE TABLET\n");
         }
         if (properties != null && !properties.isEmpty()) {
             sb.append("PROPERTIES (\n").append(new PrintableMap<>(properties, "=", true, true)).append(")");
@@ -95,6 +95,6 @@ public class SplitTabletClause extends AlterTableClause {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitSplitTabletClause(this, context);
+        return ((AstVisitorExtendInterface<R, C>) visitor).visitMergeTabletClause(this, context);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletClauseExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletClauseExecutorTest.java
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard;
+
+import com.starrocks.alter.AlterJobExecutor;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Config;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.ast.MergeTabletClause;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class MergeTabletClauseExecutorTest {
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+    private static Database db;
+    private static OlapTable table;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        Config.enable_range_distribution = true;
+
+        starRocksAssert.withDatabase("test").useDatabase("test");
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+
+        String sql = "create table test_table (key1 int, key2 varchar(10))\n" +
+                "order by(key1)\n" +
+                "properties('replication_num' = '1'); ";
+        starRocksAssert.withTable(sql);
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "test_table");
+        Assertions.assertNotNull(table);
+    }
+
+    @Test
+    public void testMergeTabletClauseExecution() throws Exception {
+        AtomicBoolean invoked = new AtomicBoolean(false);
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public void createTabletReshardJob(Database db, OlapTable table, MergeTabletClause mergeTabletClause)
+                    throws StarRocksException {
+                invoked.set(true);
+            }
+        };
+
+        String sql = "ALTER TABLE test.test_table\n" +
+                "MERGE TABLETS (1, 2) (3, 4)";
+        AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        new AlterJobExecutor().process(alterTableStmt, connectContext);
+        Assertions.assertTrue(invoked.get());
+    }
+
+    @Test
+    public void testMergeTabletJobMgrStub() throws Exception {
+        TabletReshardJobMgr jobMgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        jobMgr.createTabletReshardJob(db, table, new MergeTabletClause());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MergeTabletClauseAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MergeTabletClauseAnalyzerTest.java
@@ -1,0 +1,160 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Config;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.MergeTabletClause;
+import com.starrocks.sql.ast.PartitionRef;
+import com.starrocks.sql.ast.TabletGroupList;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MergeTabletClauseAnalyzerTest {
+    private static Database db;
+    private static OlapTable table;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        Config.enable_range_distribution = true;
+
+        starRocksAssert.withDatabase("test").useDatabase("test");
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+
+        String sql = "create table test_table (key1 int, key2 varchar(10))\n" +
+                "order by(key1)\n" +
+                "properties('replication_num' = '1'); ";
+        starRocksAssert.withTable(sql);
+        table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "test_table");
+        Assertions.assertNotNull(table);
+    }
+
+    @Test
+    public void testRejectNonCloudNativeTable() {
+        AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(new IcebergTable());
+        MergeTabletClause clause = new MergeTabletClause();
+        SemanticException exception = Assertions.assertThrows(SemanticException.class,
+                () -> analyzer.analyze(null, clause));
+        Assertions.assertTrue(exception.getMessage().contains("Merge tablet only support cloud native tables"));
+    }
+
+    @Test
+    public void testRejectPartitionAndTablets() {
+        AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
+        PartitionRef partitionRef = new PartitionRef(List.of("p1"), false, NodePosition.ZERO);
+        MergeTabletClause clause = new MergeTabletClause(partitionRef,
+                new TabletGroupList(List.of(List.of(1L, 2L))), null);
+        SemanticException exception = Assertions.assertThrows(SemanticException.class,
+                () -> analyzer.analyze(null, clause));
+        Assertions.assertTrue(exception.getMessage().contains("Partitions and tablets cannot be specified"));
+    }
+
+    @Test
+    public void testRejectTempPartition() {
+        AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
+        PartitionRef partitionRef = new PartitionRef(List.of("p1"), true, NodePosition.ZERO);
+        MergeTabletClause clause = new MergeTabletClause(partitionRef, null, null);
+        SemanticException exception = Assertions.assertThrows(SemanticException.class,
+                () -> analyzer.analyze(null, clause));
+        Assertions.assertTrue(exception.getMessage().contains("Cannot merge tablet in temp partition"));
+    }
+
+    @Test
+    public void testRejectEmptyPartitions() {
+        AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
+        PartitionRef partitionRef = new PartitionRef(new ArrayList<>(), false, NodePosition.ZERO);
+        MergeTabletClause clause = new MergeTabletClause(partitionRef, null, null);
+        SemanticException exception = Assertions.assertThrows(SemanticException.class,
+                () -> analyzer.analyze(null, clause));
+        Assertions.assertTrue(exception.getMessage().contains("Empty partitions"));
+    }
+
+    @Test
+    public void testRejectEmptyTabletGroups() {
+        AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
+        MergeTabletClause clause = new MergeTabletClause(null, new TabletGroupList(List.of()), null);
+        SemanticException exception = Assertions.assertThrows(SemanticException.class,
+                () -> analyzer.analyze(null, clause));
+        Assertions.assertTrue(exception.getMessage().contains("Empty tablets"));
+    }
+
+    @Test
+    public void testRejectEmptyTabletGroup() {
+        AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
+        MergeTabletClause clause = new MergeTabletClause(null, new TabletGroupList(List.of(new ArrayList<>())), null);
+        SemanticException exception = Assertions.assertThrows(SemanticException.class,
+                () -> analyzer.analyze(null, clause));
+        Assertions.assertTrue(exception.getMessage().contains("Empty tablets"));
+    }
+
+    @Test
+    public void testRejectSingleTabletGroup() {
+        AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
+        MergeTabletClause clause = new MergeTabletClause(null, new TabletGroupList(List.of(List.of(1L))), null);
+        SemanticException exception = Assertions.assertThrows(SemanticException.class,
+                () -> analyzer.analyze(null, clause));
+        Assertions.assertTrue(exception.getMessage().contains("at least 2 tablets"));
+    }
+
+    @Test
+    public void testRejectInvalidProperty() {
+        AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
+        Map<String, String> properties = Map.of("tablet_reshard_target_size", "abc");
+        MergeTabletClause clause = new MergeTabletClause(null,
+                new TabletGroupList(List.of(List.of(1L, 2L))), properties);
+        Assertions.assertThrows(SemanticException.class, () -> analyzer.analyze(null, clause));
+    }
+
+    @Test
+    public void testRejectUnknownProperty() {
+        AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
+        Map<String, String> properties = new HashMap<>();
+        properties.put("tablet_reshard_target_size", "1024");
+        properties.put("unknown_key", "1");
+        MergeTabletClause clause = new MergeTabletClause(null,
+                new TabletGroupList(List.of(List.of(1L, 2L))), properties);
+        SemanticException exception = Assertions.assertThrows(SemanticException.class,
+                () -> analyzer.analyze(null, clause));
+        Assertions.assertTrue(exception.getMessage().contains("Unknown properties"));
+    }
+
+    @Test
+    public void testAcceptValidClause() {
+        AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(table);
+        Map<String, String> properties = Map.of("tablet_reshard_target_size", "1024");
+        MergeTabletClause clause = new MergeTabletClause(null,
+                new TabletGroupList(List.of(List.of(1L, 2L))), properties);
+        analyzer.analyze(null, clause);
+        Assertions.assertEquals(1024L, clause.getTabletReshardTargetSize());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/MergeTabletClauseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/MergeTabletClauseTest.java
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.common.Config;
+import com.starrocks.sql.parser.NodePosition;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class MergeTabletClauseTest {
+
+    @Test
+    public void testDefaultConstructorAndGetters() {
+        MergeTabletClause clause = new MergeTabletClause();
+        Assertions.assertNull(clause.getPartitionNames());
+        Assertions.assertNull(clause.getTabletGroupList());
+        Assertions.assertNull(clause.getProperties());
+        Assertions.assertEquals(Config.tablet_reshard_target_size, clause.getTabletReshardTargetSize());
+        Assertions.assertTrue(clause.toString().contains("MERGE TABLET"));
+
+        clause.setTabletReshardTargetSize(1024L);
+        Assertions.assertEquals(1024L, clause.getTabletReshardTargetSize());
+    }
+
+    @Test
+    public void testConstructorAndAccept() {
+        TabletGroupList tabletGroupList = new TabletGroupList(List.of(List.of(1L, 2L)), NodePosition.ZERO);
+        Map<String, String> properties = Map.of("tablet_reshard_target_size", "1024");
+        MergeTabletClause clause = new MergeTabletClause(null, tabletGroupList, properties);
+
+        Assertions.assertNull(clause.getPartitionNames());
+        Assertions.assertEquals(tabletGroupList, clause.getTabletGroupList());
+        Assertions.assertEquals(properties, clause.getProperties());
+        Assertions.assertTrue(clause.toString().contains("MERGE TABLETS (1, 2)"));
+
+        PartitionRef partitionRef = new PartitionRef(List.of("p1"), false, NodePosition.ZERO);
+        MergeTabletClause partitionClause = new MergeTabletClause(partitionRef, null, properties);
+        Assertions.assertTrue(partitionClause.toString().contains("MERGE TABLET PARTITIONS"));
+
+        AstVisitorExtendInterface<String, Void> visitor = new AstVisitorExtendInterface<>() {
+            @Override
+            public String visitNode(ParseNode node, Void context) {
+                return "visitNode";
+            }
+        };
+        Assertions.assertEquals("visitNode", clause.accept(visitor, null));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/TabletGroupListTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/TabletGroupListTest.java
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.sql.parser.NodePosition;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class TabletGroupListTest {
+
+    @Test
+    public void testToStringAndGetters() {
+        List<List<Long>> groups = List.of(List.of(1L, 2L), List.of(3L, 4L));
+        TabletGroupList list = new TabletGroupList(groups, NodePosition.ZERO);
+        Assertions.assertEquals(groups, list.getTabletIdGroups());
+        Assertions.assertNotNull(list.getPos());
+        Assertions.assertEquals("TABLETS (1, 2) (3, 4)", list.toString());
+
+        TabletGroupList single = new TabletGroupList(List.of(List.of(1L, 2L)), NodePosition.ZERO);
+        Assertions.assertEquals("TABLETS (1, 2)", single.toString());
+    }
+}

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -984,6 +984,7 @@ alterClause
     | tableOperationClause
     | dropPersistentIndexClause
     | splitTabletClause
+    | mergeTabletClause
     | alterTableAutoIncrementClause
 
     //Alter partition clause
@@ -1243,6 +1244,16 @@ splitTabletClause
     : SPLIT
       (((TABLET | TABLETS) partitionNames?) | tabletList)
       properties?
+    ;
+
+mergeTabletClause
+    : MERGE
+      (((TABLET | TABLETS) partitionNames?) | tabletGroupList)
+      properties?
+    ;
+
+tabletGroupList
+    : (TABLET | TABLETS) integer_list+
     ;
 
 alterTableAutoIncrementClause

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/TabletGroupList.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/TabletGroupList.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.google.common.base.Joiner;
+import com.starrocks.sql.parser.NodePosition;
+
+import java.util.List;
+
+/*
+ * To represent following stmt:
+ *      TABLETS (id1, id2) (id3, id4)
+ */
+public class TabletGroupList implements ParseNode {
+
+    private final List<List<Long>> tabletIdGroups;
+
+    private final NodePosition pos;
+
+    public TabletGroupList(List<List<Long>> tabletIdGroups) {
+        this(tabletIdGroups, NodePosition.ZERO);
+    }
+
+    public TabletGroupList(List<List<Long>> tabletIdGroups, NodePosition pos) {
+        this.tabletIdGroups = tabletIdGroups;
+        this.pos = pos;
+    }
+
+    public List<List<Long>> getTabletIdGroups() {
+        return tabletIdGroups;
+    }
+
+    @Override
+    public NodePosition getPos() {
+        return pos;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("TABLETS ");
+        for (int i = 0; i < tabletIdGroups.size(); i++) {
+            if (i > 0) {
+                sb.append(' ');
+            }
+            sb.append('(').append(Joiner.on(", ").join(tabletIdGroups.get(i))).append(')');
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
Implement merge tablet SQL plumbing.
```
ALTER TABLE <table_name> MERGE
    [(TABLET | TABLETS) (PARTITION | PARTITIONS) (<partiton_name1>, <partition_name2>, ...)]
    [(TABLET | TABLETS) (tablet_id11, tablet_id12, tablet_id13, ...)
                        (tablet_id21, tablet_id22, tablet_id23, ...)
                        ...]
[PROPERTIES (
    "tablet_reshard_target_size"="<target_size>")]
```

## What I'm doing:
  - add MERGE tablet grammar/AST/parser/analyzer
  - wire MERGE clause through AlterJobExecutor to TabletReshardJobMgr
  - add reshard job mgr stub and execution test
  - extend parser tests for MERGE tablet syntax

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
