### PR TITLE
[Enhancement] validate Iceberg DELETE operation's file format

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
@@ -34,6 +34,7 @@ public class GetRemoteFilesParams {
     private boolean checkPartitionExistence = true;
     private boolean enableColumnStats = false;
     private Optional<Boolean> isRecursive = Optional.empty();
+    private boolean usedForDelete = false;
 
     protected GetRemoteFilesParams(Builder builder) {
         this.partitionKeys = builder.partitionKeys;
@@ -47,6 +48,7 @@ public class GetRemoteFilesParams {
         this.checkPartitionExistence = builder.checkPartitionExistence;
         this.enableColumnStats = builder.enableColumnStats;
         this.isRecursive = builder.isRecursive;
+        this.usedForDelete = builder.usedForDelete;
     }
 
     public int getPartitionSize() {
@@ -153,6 +155,10 @@ public class GetRemoteFilesParams {
         return isRecursive;
     }
 
+    public boolean usdForDelete() {
+        return usedForDelete;
+    }
+
     public static class Builder {
         private List<PartitionKey> partitionKeys;
         private List<String> partitionNames;
@@ -165,6 +171,7 @@ public class GetRemoteFilesParams {
         private boolean checkPartitionExistence = true;
         private boolean enableColumnStats = false;
         private Optional<Boolean> isRecursive = Optional.empty();
+        private boolean usedForDelete = false;
 
         public Builder setPartitionKeys(List<PartitionKey> partitionKeys) {
             this.partitionKeys = partitionKeys;
@@ -218,6 +225,11 @@ public class GetRemoteFilesParams {
 
         public Builder setIsRecursive(boolean isRecursive) {
             this.isRecursive = Optional.of(isRecursive);
+            return this;
+        }
+
+        public Builder setUsedForDelete(boolean usedForDelete) {
+            this.usedForDelete = usedForDelete;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
@@ -156,7 +156,7 @@ public class GetRemoteFilesParams {
         return isRecursive;
     }
 
-    public boolean usdForDelete() {
+    public boolean usedForDelete() {
         return usedForDelete;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
@@ -72,7 +72,8 @@ public class GetRemoteFilesParams {
                 .setLimit(limit)
                 .setUseCache(useCache)
                 .setCheckPartitionExistence(checkPartitionExistence)
-                .setEnableColumnStats(enableColumnStats);
+                .setEnableColumnStats(enableColumnStats)
+                .setUsedForDelete(usedForDelete);
         if (isRecursive.isPresent()) {
             paramsBuilder.setIsRecursive(isRecursive.get());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -87,6 +87,7 @@ import static com.starrocks.catalog.IcebergTable.DATA_SEQUENCE_NUMBER;
 import static com.starrocks.catalog.IcebergTable.FILE_PATH;
 import static com.starrocks.catalog.IcebergTable.SPEC_ID;
 import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
+import static com.starrocks.connector.iceberg.IcebergUtil.checkFileFormatSupportedDelete;
 
 public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     private static final Logger LOG = LogManager.getLogger(IcebergConnectorScanRangeSource.class);
@@ -118,6 +119,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     private final boolean recordScanFiles;
     private final boolean useMinMaxOpt;
     private final PartitionIdGenerator partitionIdGenerator;
+    private final boolean usedForDelete;
 
     public IcebergConnectorScanRangeSource(IcebergTable table,
                                            RemoteFileInfoSource remoteFileInfoSource,
@@ -127,6 +129,19 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
                                            PartitionIdGenerator partitionIdGenerator,
                                            boolean recordScanFiles,
                                            boolean useMinMaxOpt) {
+        this(table, remoteFileInfoSource, morParams, desc, bucketProperties, partitionIdGenerator, recordScanFiles,
+                useMinMaxOpt, false);
+    }
+
+    public IcebergConnectorScanRangeSource(IcebergTable table,
+                                           RemoteFileInfoSource remoteFileInfoSource,
+                                           IcebergMORParams morParams,
+                                           TupleDescriptor desc,
+                                           Optional<List<BucketProperty>> bucketProperties,
+                                           PartitionIdGenerator partitionIdGenerator,
+                                           boolean recordScanFiles,
+                                           boolean useMinMaxOpt,
+                                           boolean usedForDelete) {
         this.table = table;
         this.remoteFileInfoSource = remoteFileInfoSource;
         this.morParams = morParams;
@@ -139,6 +154,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         this.appliedEqualDeleteFiles = new HashSet<>();
         this.partitionIdGenerator = partitionIdGenerator;
         this.useMinMaxOpt = useMinMaxOpt;
+        this.usedForDelete = usedForDelete;
     }
 
     public void clearScannedFiles() {
@@ -162,6 +178,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
                 RemoteFileInfo remoteFileInfo = remoteFileInfoSource.getOutput();
                 IcebergRemoteFileInfo icebergRemoteFileInfo = remoteFileInfo.cast();
                 FileScanTask fileScanTask = icebergRemoteFileInfo.getFileScanTask();
+                checkFileFormatSupportedDelete(fileScanTask, usedForDelete);
                 res.addAll(toScanRanges(fileScanTask));
                 if (recordScanFiles) {
                     scannedDataFiles.add(fileScanTask.file());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -973,7 +973,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             @Override
             public RemoteFileInfo getOutput() {
                 FileScanTask fileScanTask = iterator.next();
-                checkFileFormatSupportedDelete(fileScanTask, params.usdForDelete());
+                checkFileFormatSupportedDelete(fileScanTask, params.usedForDelete());
                 return new IcebergRemoteFileInfo(fileScanTask);
             }
 
@@ -990,7 +990,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             @Override
             public RemoteFileInfo getOutput() {
                 FileScanTask fileScanTask = iterator.next();
-                checkFileFormatSupportedDelete(fileScanTask, params.usdForDelete());
+                checkFileFormatSupportedDelete(fileScanTask, params.usedForDelete());
                 return new IcebergRemoteFileInfo(fileScanTask);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -73,6 +73,7 @@ public class IcebergScanNode extends ScanNode {
     private Optional<List<BucketProperty>> bucketProperties = Optional.empty();
     private PartitionIdGenerator partitionIdGenerator = null;
     private IcebergMetricsReporter icebergScanMetricsReporter;
+    private boolean usedForDelete = false;
 
     public IcebergScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName,
                            IcebergTableMORParams tableFullMORParams, IcebergMORParams morParams,
@@ -162,6 +163,7 @@ public class IcebergScanNode extends ScanNode {
                         .setTableVersionRange(tvrVersionRange)
                         .setPredicate(icebergJobPlanningPredicate)
                         .setEnableColumnStats(scanOptimizeOption.getCanUseMinMaxOpt())
+                        .setUsedForDelete(usedForDelete)
                         .build();
 
         RemoteFileInfoSource remoteFileInfoSource;
@@ -186,7 +188,7 @@ public class IcebergScanNode extends ScanNode {
 
         scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
                 remoteFileInfoSource, morParams, desc, bucketProperties, partitionIdGenerator, false,
-                scanOptimizeOption.getCanUseMinMaxOpt());
+                scanOptimizeOption.getCanUseMinMaxOpt(), usedForDelete);
     }
 
     private void setupCloudCredential() {
@@ -200,6 +202,14 @@ public class IcebergScanNode extends ScanNode {
 
     public void setCloudConfiguration(CloudConfiguration cloudConfiguration) {
         this.cloudConfiguration = cloudConfiguration;
+    }
+
+    public void setUsedForDelete(boolean usedForDelete) {
+        this.usedForDelete = usedForDelete;
+    }
+
+    public boolean isUsedForDelete() {
+        return usedForDelete;
     }
 
     public void preProcessIcebergPredicate(ScalarOperator predicate) {


### PR DESCRIPTION
## Why I'm doing:
we only support delete iceberg table with parquet file format now.
## What I'm doing:
This pull request introduces support for handling Iceberg table DELETE operations, with a focus on ensuring that only Parquet file formats are used for such operations. It adds a new flag to indicate when a scan or file retrieval is intended for DELETE, propagates this flag through relevant classes, and enforces the file format check. Comprehensive unit tests are also added to verify this behavior.

**DELETE operation support and file format enforcement:**

* Added a `usedForDelete` flag to `GetRemoteFilesParams`, `IcebergScanNode`, and `IcebergConnectorScanRangeSource` to track when operations are intended for DELETE. The flag is set based on scan context and propagated through the planning and scanning pipeline.
* Implemented logic to detect DELETE operations in the plan builder, setting the `usedForDelete` flag when appropriate columns are present. 
* Enforced that DELETE operations are only allowed on Parquet files via the new `checkFileFormatSupportedDelete` method in `IcebergUtil`. This check is called at multiple points in the scan and metadata retrieval logic.

**Plumbing and API changes:**

* Updated builder patterns, constructors, and method signatures to accept and propagate the new `usedForDelete` flag throughout the relevant classes. 

**Testing and validation:**

* Added unit tests in `IcebergUtilTest` to verify that the file format check correctly allows Parquet and rejects ORC/AVRO formats for DELETE operations, including proper exception messages. 

These changes ensure that DELETE operations on Iceberg tables are safely restricted to Parquet files, preventing unsupported formats from being used and improving robustness of the connector.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
