### PR TITLE
[BugFix] fix aws glue catalog cases

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/AWSGlueClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/AWSGlueClientFactory.java
@@ -25,7 +25,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.GlueClientBuilder;
 
-import static com.starrocks.credential.aws.AwsCloudCredential.ensureSchemeInEndpoint;
+import static com.starrocks.connector.share.credential.AwsCredentialUtil.ensureSchemeInEndpoint;
 
 public final class AWSGlueClientFactory implements GlueClientFactory {
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/AWSGlueClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/AWSGlueClientFactory.java
@@ -25,7 +25,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.GlueClientBuilder;
 
-import java.net.URI;
+import static com.starrocks.credential.aws.AwsCloudCredential.ensureSchemeInEndpoint;
 
 public final class AWSGlueClientFactory implements GlueClientFactory {
 
@@ -50,7 +50,7 @@ public final class AWSGlueClientFactory implements GlueClientFactory {
                 glueClientBuilder.region(glueCloudCredential.tryToResolveRegion());
 
                 if (!glueCloudCredential.getEndpoint().isEmpty()) {
-                    glueClientBuilder.endpointOverride(URI.create(glueCloudCredential.getEndpoint()));
+                    glueClientBuilder.endpointOverride(ensureSchemeInEndpoint(glueCloudCredential.getEndpoint()));
                 }
             }
             return glueClientBuilder.build();

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
@@ -89,6 +89,8 @@ public class AwsCloudCredential implements CloudCredential {
     private static final String SIMPLE_CREDENTIAL_PROVIDER = SimpleAWSCredentialsProvider.class.getName();
     private static final String TEMPORARY_CREDENTIAL_PROVIDER = TemporaryAWSCredentialsProvider.class.getName();
 
+    public static final String HTTPS_SCHEME = "https://";
+
     private final boolean useAWSSDKDefaultBehavior;
 
     private final boolean useInstanceProfile;
@@ -175,7 +177,7 @@ public class AwsCloudCredential implements CloudCredential {
             stsClientBuilder.region(Region.of(region));
         }
         if (!endpoint.isEmpty()) {
-            stsClientBuilder.endpointOverride(URI.create(endpoint));
+            stsClientBuilder.endpointOverride(ensureSchemeInEndpoint(endpoint));
         }
 
         // Build AssumeRoleRequest
@@ -373,5 +375,19 @@ public class AwsCloudCredential implements CloudCredential {
                     e);
         }
         return region;
+    }
+
+    /**
+     * Checks if the given 'endpoint' contains a scheme. If not, the default HTTPS scheme is added.
+     *
+     * @param endpoint The endpoint string to be checked
+     * @return The URI with the added scheme
+     */
+    public static URI ensureSchemeInEndpoint(String endpoint) {
+        URI uri = URI.create(endpoint);
+        if (uri.getScheme() != null) {
+            return uri;
+        }
+        return URI.create(HTTPS_SCHEME + endpoint);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
@@ -384,9 +384,11 @@ public class AwsCloudCredential implements CloudCredential {
      * @return The URI with the added scheme
      */
     public static URI ensureSchemeInEndpoint(String endpoint) {
-        URI uri = URI.create(endpoint);
-        if (uri.getScheme() != null) {
-            return uri;
+        // Check if endpoint contains a valid scheme (contains "://")
+        // This handles cases like "localhost:4566" where URI.create() incorrectly
+        // parses the hostname as a scheme
+        if (endpoint.contains("://")) {
+            return URI.create(endpoint);
         }
         return URI.create(HTTPS_SCHEME + endpoint);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AwsCloudCredential.java
@@ -23,6 +23,7 @@ import com.staros.proto.AwsSimpleCredentialInfo;
 import com.staros.proto.FileStoreInfo;
 import com.staros.proto.FileStoreType;
 import com.staros.proto.S3FileStoreInfo;
+import com.starrocks.connector.share.credential.AwsCredentialUtil;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.credential.CloudCredential;
 import com.starrocks.credential.provider.AssumedRoleCredentialProvider;
@@ -49,7 +50,6 @@ import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
-import java.net.URI;
 import java.util.Map;
 import java.util.UUID;
 
@@ -88,8 +88,6 @@ public class AwsCloudCredential implements CloudCredential {
     private static final String ASSUME_ROLE_CREDENTIAL_PROVIDER = AssumedRoleCredentialProvider.class.getName();
     private static final String SIMPLE_CREDENTIAL_PROVIDER = SimpleAWSCredentialsProvider.class.getName();
     private static final String TEMPORARY_CREDENTIAL_PROVIDER = TemporaryAWSCredentialsProvider.class.getName();
-
-    public static final String HTTPS_SCHEME = "https://";
 
     private final boolean useAWSSDKDefaultBehavior;
 
@@ -177,7 +175,7 @@ public class AwsCloudCredential implements CloudCredential {
             stsClientBuilder.region(Region.of(region));
         }
         if (!endpoint.isEmpty()) {
-            stsClientBuilder.endpointOverride(ensureSchemeInEndpoint(endpoint));
+            stsClientBuilder.endpointOverride(AwsCredentialUtil.ensureSchemeInEndpoint(endpoint));
         }
 
         // Build AssumeRoleRequest
@@ -377,19 +375,4 @@ public class AwsCloudCredential implements CloudCredential {
         return region;
     }
 
-    /**
-     * Checks if the given 'endpoint' contains a scheme. If not, the default HTTPS scheme is added.
-     *
-     * @param endpoint The endpoint string to be checked
-     * @return The URI with the added scheme
-     */
-    public static URI ensureSchemeInEndpoint(String endpoint) {
-        // Check if endpoint contains a valid scheme (contains "://")
-        // This handles cases like "localhost:4566" where URI.create() incorrectly
-        // parses the hostname as a scheme
-        if (endpoint.contains("://")) {
-            return URI.create(endpoint);
-        }
-        return URI.create(HTTPS_SCHEME + endpoint);
-    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/metastore/AWSGlueClientFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/metastore/AWSGlueClientFactoryTest.java
@@ -1,0 +1,61 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.metastore;
+
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.glue.GlueClient;
+
+
+public class AWSGlueClientFactoryTest {
+
+    @Test
+    public void testNewClientWithEndpointWithoutScheme() throws MetaException {
+        // Test line 53: ensureSchemeInEndpoint is called when endpoint is set
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set("aws.glue.access_key", "ak");
+        hiveConf.set("aws.glue.secret_key", "sk");
+        hiveConf.set("aws.glue.region", "us-west-1");
+        hiveConf.set("aws.glue.endpoint", "localhost:4566");
+
+        AWSGlueClientFactory factory = new AWSGlueClientFactory(hiveConf);
+        GlueClient client = factory.newClient();
+        Assertions.assertNotNull(client);
+
+        // Verify that endpointOverride was set with https:// prefix
+        // We can't directly access the endpointOverride, but we can verify
+        // that the client was created successfully with the endpoint
+        client.close();
+    }
+
+    @Test
+    public void testNewClientWithEndpointWithScheme() throws MetaException {
+        // Test line 53: ensureSchemeInEndpoint preserves existing scheme
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set("aws.glue.access_key", "ak");
+        hiveConf.set("aws.glue.secret_key", "sk");
+        hiveConf.set("aws.glue.region", "us-west-1");
+        hiveConf.set("aws.glue.endpoint", "https://glue.us-west-1.amazonaws.com");
+
+        AWSGlueClientFactory factory = new AWSGlueClientFactory(hiveConf);
+        GlueClient client = factory.newClient();
+        Assertions.assertNotNull(client);
+        client.close();
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergAwsClientFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergAwsClientFactoryTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.iceberg;
 
+import com.starrocks.connector.share.credential.AwsCredentialUtil;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.connector.share.iceberg.IcebergAwsClientFactory;
 import org.apache.iceberg.aws.AwsClientProperties;
@@ -77,27 +78,27 @@ public class IcebergAwsClientFactoryTest {
     @Test
     public void testEnsureSchemeInEndpoint() {
         // test endpoint without scheme
-        URI uriWithoutScheme = IcebergAwsClientFactory.ensureSchemeInEndpoint("s3.aa-bbbbb-3.amazonaws.com.cn");
+        URI uriWithoutScheme = AwsCredentialUtil.ensureSchemeInEndpoint("s3.aa-bbbbb-3.amazonaws.com.cn");
         Assertions.assertEquals("https://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithoutScheme.toString());
 
         // test endpoint with scheme HTTPS
-        URI uriWithHttps = IcebergAwsClientFactory.ensureSchemeInEndpoint("https://s3.aa-bbbbb-3.amazonaws.com.cn");
+        URI uriWithHttps = AwsCredentialUtil.ensureSchemeInEndpoint("https://s3.aa-bbbbb-3.amazonaws.com.cn");
         Assertions.assertEquals("https://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithHttps.toString());
 
         // test endpoint with scheme HTTP
-        URI uriWithHttp = IcebergAwsClientFactory.ensureSchemeInEndpoint("http://s3.aa-bbbbb-3.amazonaws.com.cn");
+        URI uriWithHttp = AwsCredentialUtil.ensureSchemeInEndpoint("http://s3.aa-bbbbb-3.amazonaws.com.cn");
         Assertions.assertEquals("http://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithHttp.toString());
 
         // test endpoint with port but without scheme (the bug case)
         // URI.create("localhost:4566") incorrectly parses "localhost" as scheme and "4566" as path
-        URI uriWithPort = IcebergAwsClientFactory.ensureSchemeInEndpoint("localhost:4566");
+        URI uriWithPort = AwsCredentialUtil.ensureSchemeInEndpoint("localhost:4566");
         Assertions.assertEquals("https://localhost:4566", uriWithPort.toString());
         Assertions.assertEquals("https", uriWithPort.getScheme());
         Assertions.assertEquals("localhost", uriWithPort.getHost());
         Assertions.assertEquals(4566, uriWithPort.getPort());
 
         // test endpoint with port and path but without scheme
-        URI uriWithPortAndPath = IcebergAwsClientFactory.ensureSchemeInEndpoint("example.com:8080/path");
+        URI uriWithPortAndPath = AwsCredentialUtil.ensureSchemeInEndpoint("example.com:8080/path");
         Assertions.assertEquals("https://example.com:8080/path", uriWithPortAndPath.toString());
         Assertions.assertEquals("https", uriWithPortAndPath.getScheme());
         Assertions.assertEquals("example.com", uriWithPortAndPath.getHost());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergAwsClientFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergAwsClientFactoryTest.java
@@ -87,5 +87,20 @@ public class IcebergAwsClientFactoryTest {
         // test endpoint with scheme HTTP
         URI uriWithHttp = IcebergAwsClientFactory.ensureSchemeInEndpoint("http://s3.aa-bbbbb-3.amazonaws.com.cn");
         Assertions.assertEquals("http://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithHttp.toString());
+
+        // test endpoint with port but without scheme (the bug case)
+        // URI.create("localhost:4566") incorrectly parses "localhost" as scheme and "4566" as path
+        URI uriWithPort = IcebergAwsClientFactory.ensureSchemeInEndpoint("localhost:4566");
+        Assertions.assertEquals("https://localhost:4566", uriWithPort.toString());
+        Assertions.assertEquals("https", uriWithPort.getScheme());
+        Assertions.assertEquals("localhost", uriWithPort.getHost());
+        Assertions.assertEquals(4566, uriWithPort.getPort());
+
+        // test endpoint with port and path but without scheme
+        URI uriWithPortAndPath = IcebergAwsClientFactory.ensureSchemeInEndpoint("example.com:8080/path");
+        Assertions.assertEquals("https://example.com:8080/path", uriWithPortAndPath.toString());
+        Assertions.assertEquals("https", uriWithPortAndPath.getScheme());
+        Assertions.assertEquals("example.com", uriWithPortAndPath.getHost());
+        Assertions.assertEquals(8080, uriWithPortAndPath.getPort());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -159,7 +160,10 @@ public class AwsCloudConfigurationTest {
         {
             AwsCloudCredential credential = CloudConfigurationFactory.buildGlueCloudCredential(hiveConf);
             Assertions.assertNotNull(credential);
-            Assertions.assertThrows(NullPointerException.class, credential::generateAWSCredentialsProvider);
+            // After fixing ensureSchemeInEndpoint, the endpoint URI is now properly formatted,
+            // so AWS SDK validates the configuration and throws SdkClientException when region
+            // is missing (instead of NullPointerException from malformed URI)
+            Assertions.assertThrows(SdkClientException.class, credential::generateAWSCredentialsProvider);
         }
 
         hiveConf.set("aws.glue.sts.region", "region");

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
@@ -15,7 +15,6 @@
 package com.starrocks.credential;
 
 import com.staros.proto.FileStoreInfo;
-import com.starrocks.connector.share.credential.AwsCredentialUtil;
 import com.starrocks.credential.aws.AwsCloudConfiguration;
 import com.starrocks.credential.aws.AwsCloudCredential;
 import com.starrocks.credential.provider.OverwriteAwsDefaultCredentialsProvider;
@@ -225,35 +224,5 @@ public class AwsCloudConfigurationTest {
             Assertions.assertTrue(fsInfo.getS3FsInfo().getPartitionedPrefixEnabled());
             Assertions.assertEquals(1024, fsInfo.getS3FsInfo().getNumPartitionedPrefix());
         }
-    }
-
-    @Test
-    public void testEnsureSchemeInEndpoint() {
-        // Test endpoint without scheme
-        URI uriWithoutScheme = AwsCredentialUtil.ensureSchemeInEndpoint("s3.aa-bbbbb-3.amazonaws.com.cn");
-        Assertions.assertEquals("https://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithoutScheme.toString());
-
-        // Test endpoint with scheme HTTPS
-        URI uriWithHttps = AwsCredentialUtil.ensureSchemeInEndpoint("https://s3.aa-bbbbb-3.amazonaws.com.cn");
-        Assertions.assertEquals("https://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithHttps.toString());
-
-        // Test endpoint with scheme HTTP
-        URI uriWithHttp = AwsCredentialUtil.ensureSchemeInEndpoint("http://s3.aa-bbbbb-3.amazonaws.com.cn");
-        Assertions.assertEquals("http://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithHttp.toString());
-
-        // Test endpoint with port but without scheme (the bug case)
-        // URI.create("localhost:4566") incorrectly parses "localhost" as scheme and "4566" as path
-        URI uriWithPort = AwsCredentialUtil.ensureSchemeInEndpoint("localhost:4566");
-        Assertions.assertEquals("https://localhost:4566", uriWithPort.toString());
-        Assertions.assertEquals("https", uriWithPort.getScheme());
-        Assertions.assertEquals("localhost", uriWithPort.getHost());
-        Assertions.assertEquals(4566, uriWithPort.getPort());
-
-        // Test endpoint with port and path but without scheme
-        URI uriWithPortAndPath = AwsCredentialUtil.ensureSchemeInEndpoint("example.com:8080/path");
-        Assertions.assertEquals("https://example.com:8080/path", uriWithPortAndPath.toString());
-        Assertions.assertEquals("https", uriWithPortAndPath.getScheme());
-        Assertions.assertEquals("example.com", uriWithPortAndPath.getHost());
-        Assertions.assertEquals(8080, uriWithPortAndPath.getPort());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
@@ -221,4 +221,34 @@ public class AwsCloudConfigurationTest {
             Assertions.assertEquals(1024, fsInfo.getS3FsInfo().getNumPartitionedPrefix());
         }
     }
+
+    @Test
+    public void testEnsureSchemeInEndpoint() {
+        // Test endpoint without scheme
+        URI uriWithoutScheme = AwsCloudCredential.ensureSchemeInEndpoint("s3.aa-bbbbb-3.amazonaws.com.cn");
+        Assertions.assertEquals("https://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithoutScheme.toString());
+
+        // Test endpoint with scheme HTTPS
+        URI uriWithHttps = AwsCloudCredential.ensureSchemeInEndpoint("https://s3.aa-bbbbb-3.amazonaws.com.cn");
+        Assertions.assertEquals("https://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithHttps.toString());
+
+        // Test endpoint with scheme HTTP
+        URI uriWithHttp = AwsCloudCredential.ensureSchemeInEndpoint("http://s3.aa-bbbbb-3.amazonaws.com.cn");
+        Assertions.assertEquals("http://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithHttp.toString());
+
+        // Test endpoint with port but without scheme (the bug case)
+        // URI.create("localhost:4566") incorrectly parses "localhost" as scheme and "4566" as path
+        URI uriWithPort = AwsCloudCredential.ensureSchemeInEndpoint("localhost:4566");
+        Assertions.assertEquals("https://localhost:4566", uriWithPort.toString());
+        Assertions.assertEquals("https", uriWithPort.getScheme());
+        Assertions.assertEquals("localhost", uriWithPort.getHost());
+        Assertions.assertEquals(4566, uriWithPort.getPort());
+
+        // Test endpoint with port and path but without scheme
+        URI uriWithPortAndPath = AwsCloudCredential.ensureSchemeInEndpoint("example.com:8080/path");
+        Assertions.assertEquals("https://example.com:8080/path", uriWithPortAndPath.toString());
+        Assertions.assertEquals("https", uriWithPortAndPath.getScheme());
+        Assertions.assertEquals("example.com", uriWithPortAndPath.getHost());
+        Assertions.assertEquals(8080, uriWithPortAndPath.getPort());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AwsCloudConfigurationTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.credential;
 
 import com.staros.proto.FileStoreInfo;
+import com.starrocks.connector.share.credential.AwsCredentialUtil;
 import com.starrocks.credential.aws.AwsCloudConfiguration;
 import com.starrocks.credential.aws.AwsCloudCredential;
 import com.starrocks.credential.provider.OverwriteAwsDefaultCredentialsProvider;
@@ -229,27 +230,27 @@ public class AwsCloudConfigurationTest {
     @Test
     public void testEnsureSchemeInEndpoint() {
         // Test endpoint without scheme
-        URI uriWithoutScheme = AwsCloudCredential.ensureSchemeInEndpoint("s3.aa-bbbbb-3.amazonaws.com.cn");
+        URI uriWithoutScheme = AwsCredentialUtil.ensureSchemeInEndpoint("s3.aa-bbbbb-3.amazonaws.com.cn");
         Assertions.assertEquals("https://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithoutScheme.toString());
 
         // Test endpoint with scheme HTTPS
-        URI uriWithHttps = AwsCloudCredential.ensureSchemeInEndpoint("https://s3.aa-bbbbb-3.amazonaws.com.cn");
+        URI uriWithHttps = AwsCredentialUtil.ensureSchemeInEndpoint("https://s3.aa-bbbbb-3.amazonaws.com.cn");
         Assertions.assertEquals("https://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithHttps.toString());
 
         // Test endpoint with scheme HTTP
-        URI uriWithHttp = AwsCloudCredential.ensureSchemeInEndpoint("http://s3.aa-bbbbb-3.amazonaws.com.cn");
+        URI uriWithHttp = AwsCredentialUtil.ensureSchemeInEndpoint("http://s3.aa-bbbbb-3.amazonaws.com.cn");
         Assertions.assertEquals("http://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithHttp.toString());
 
         // Test endpoint with port but without scheme (the bug case)
         // URI.create("localhost:4566") incorrectly parses "localhost" as scheme and "4566" as path
-        URI uriWithPort = AwsCloudCredential.ensureSchemeInEndpoint("localhost:4566");
+        URI uriWithPort = AwsCredentialUtil.ensureSchemeInEndpoint("localhost:4566");
         Assertions.assertEquals("https://localhost:4566", uriWithPort.toString());
         Assertions.assertEquals("https", uriWithPort.getScheme());
         Assertions.assertEquals("localhost", uriWithPort.getHost());
         Assertions.assertEquals(4566, uriWithPort.getPort());
 
         // Test endpoint with port and path but without scheme
-        URI uriWithPortAndPath = AwsCloudCredential.ensureSchemeInEndpoint("example.com:8080/path");
+        URI uriWithPortAndPath = AwsCredentialUtil.ensureSchemeInEndpoint("example.com:8080/path");
         Assertions.assertEquals("https://example.com:8080/path", uriWithPortAndPath.toString());
         Assertions.assertEquals("https", uriWithPortAndPath.getScheme());
         Assertions.assertEquals("example.com", uriWithPortAndPath.getHost());

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/credential/AwsCredentialUtil.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/credential/AwsCredentialUtil.java
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.share.credential;
+
+import java.net.URI;
+
+/**
+ * Utility class for AWS credential-related operations.
+ * This class provides shared functionality used across different modules.
+ */
+public class AwsCredentialUtil {
+    public static final String HTTPS_SCHEME = "https://";
+
+    /**
+     * Checks if the given 'endpoint' contains a scheme. If not, the default HTTPS scheme is added.
+     *
+     * @param endpoint The endpoint string to be checked
+     * @return The URI with the added scheme
+     */
+    public static URI ensureSchemeInEndpoint(String endpoint) {
+        // Check if endpoint contains a valid scheme (contains "://")
+        // This handles cases like "localhost:4566" where URI.create() incorrectly
+        // parses the hostname as a scheme
+        if (endpoint.contains("://")) {
+            return URI.create(endpoint);
+        }
+        return URI.create(HTTPS_SCHEME + endpoint);
+    }
+}
+

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/IcebergAwsClientFactory.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/IcebergAwsClientFactory.java
@@ -304,9 +304,11 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
      * @return The URI with the added scheme
      */
     public static URI ensureSchemeInEndpoint(String endpoint) {
-        URI uri = URI.create(endpoint);
-        if (uri.getScheme() != null) {
-            return uri;
+        // Check if endpoint contains a valid scheme (contains "://")
+        // This handles cases like "localhost:4566" where URI.create() incorrectly
+        // parses the hostname as a scheme
+        if (endpoint.contains("://")) {
+            return URI.create(endpoint);
         }
         return URI.create(HTTPS_SCHEME + endpoint);
     }

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/IcebergAwsClientFactory.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/iceberg/IcebergAwsClientFactory.java
@@ -45,10 +45,10 @@ import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
-import java.net.URI;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.starrocks.connector.share.credential.AwsCredentialUtil.ensureSchemeInEndpoint;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_GLUE_ACCESS_KEY;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_GLUE_CATALOG_ID;
 import static com.starrocks.connector.share.credential.CloudConfigurationConstants.AWS_GLUE_ENDPOINT;
@@ -79,7 +79,6 @@ import static com.starrocks.connector.share.credential.CloudConfigurationConstan
 
 public class IcebergAwsClientFactory implements AwsClientFactory {
     private static final Logger LOG = LoggerFactory.getLogger(IcebergAwsClientFactory.class);
-    public static final String HTTPS_SCHEME = "https://";
 
     private AwsProperties awsProperties;
 
@@ -295,22 +294,6 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
     @Override
     public DynamoDbClient dynamo() {
         return null;
-    }
-
-    /**
-     * Checks if the given 'endpoint' contains a scheme. If not, the default HTTPS scheme is added.
-     *
-     * @param endpoint The endpoint string to be checked
-     * @return The URI with the added scheme
-     */
-    public static URI ensureSchemeInEndpoint(String endpoint) {
-        // Check if endpoint contains a valid scheme (contains "://")
-        // This handles cases like "localhost:4566" where URI.create() incorrectly
-        // parses the hostname as a scheme
-        if (endpoint.contains("://")) {
-            return URI.create(endpoint);
-        }
-        return URI.create(HTTPS_SCHEME + endpoint);
     }
 
     public static Region tryToResolveRegion(String strRegion) {

--- a/test/sql/test_aws_authentication/R/test_aws_glue_s3_deltalake
+++ b/test/sql/test_aws_authentication/R/test_aws_glue_s3_deltalake
@@ -32,13 +32,13 @@ PROPERTIES
 "aws.glue.access_key"="${aws_ak}",
 "aws.glue.secret_key"="${aws_sk}",
 "aws.glue.region"="${aws_region}",
-"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.iam_role_arn"="${aws_assume_role}",
 "aws.glue.sts.region"="${aws_sts_region}",
 "aws.glue.sts.endpoint"="${aws_sts_endpoint}",
 "aws.s3.access_key"="${aws_ak}",
 "aws.s3.secret_key"="${aws_sk}",
 "aws.s3.region"="${aws_region}",
-"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.iam_role_arn"="${aws_assume_role}",
 "aws.s3.sts.region"="${aws_sts_region}",
 "aws.s3.sts.endpoint"="${aws_sts_endpoint}"
 );

--- a/test/sql/test_aws_authentication/R/test_aws_glue_s3_deltalake
+++ b/test/sql/test_aws_authentication/R/test_aws_glue_s3_deltalake
@@ -1,5 +1,5 @@
 -- name: test_aws_glue_s3_deltalake
-CREATE EXTERNAL CATALOG test_aws_glue_s3_deltalake
+CREATE EXTERNAL CATALOG test_aws_glue_s3_deltalake_${uuid0}
 PROPERTIES
 (
 "type"="deltalake",
@@ -13,7 +13,7 @@ PROPERTIES
 );
 -- result:
 -- !result
-select * from test_aws_glue_s3_deltalake.sql_test_db.deltalake_glue_s3;
+select * from test_aws_glue_s3_deltalake_${uuid0}.sql_test_db.deltalake_glue_s3;
 -- result:
 3	2003-01-01	Reform to further facilitate maturity of capital market
 2	2002-01-01	Mathematical Description of Systems
@@ -21,10 +21,10 @@ select * from test_aws_glue_s3_deltalake.sql_test_db.deltalake_glue_s3;
 1	2001-01-01	youth is a wonderful thing
 5	2005-01-01	China leading engine for global economy
 -- !result
-drop catalog test_aws_glue_s3_deltalake;
+drop catalog test_aws_glue_s3_deltalake_${uuid0};
 -- result:
 -- !result
-CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_deltalake
+CREATE EXTERNAL CATALOG test_assume_role_deltalake_${uuid0}
 PROPERTIES
 (
 "type"="deltalake",
@@ -44,7 +44,7 @@ PROPERTIES
 );
 -- result:
 -- !result
-select * from test_aws_assume_role_glue_s3_deltalake.sql_test_db.deltalake_glue_s3;
+select * from test_assume_role_deltalake_${uuid0}.sql_test_db.deltalake_glue_s3;
 -- result:
 4	2004-01-01	KMT official from Taiwan to visit mainland
 1	2001-01-01	youth is a wonderful thing
@@ -52,6 +52,6 @@ select * from test_aws_assume_role_glue_s3_deltalake.sql_test_db.deltalake_glue_
 2	2002-01-01	Mathematical Description of Systems
 3	2003-01-01	Reform to further facilitate maturity of capital market
 -- !result
-drop catalog test_aws_assume_role_glue_s3_deltalake;
+drop catalog test_assume_role_deltalake_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_aws_authentication/R/test_aws_glue_s3_hive
+++ b/test/sql/test_aws_authentication/R/test_aws_glue_s3_hive
@@ -1,5 +1,5 @@
 -- name: test_aws_glue_s3_hive
-CREATE EXTERNAL CATALOG test_aws_glue_s3_hive
+CREATE EXTERNAL CATALOG test_aws_glue_s3_hive_${uuid0}
 PROPERTIES
 (
 "type"="hive",
@@ -13,18 +13,44 @@ PROPERTIES
 );
 -- result:
 -- !result
-select * from test_aws_glue_s3_hive.sql_test_db.hive_glue_s3_parquet;
+select * from test_aws_glue_s3_hive_${uuid0}.sql_test_db.hive_glue_s3_parquet;
 -- result:
 2	2002-01-01	Mathematical Description of Systems
-4	2004-01-01	KMT official from Taiwan to visit mainland
 1	2001-01-01	youth is a wonderful thing
 3	2003-01-01	Reform to further facilitate maturity of capital market
 5	2005-01-01	China leading engine for global economy
+4	2004-01-01	KMT official from Taiwan to visit mainland
 -- !result
-drop catalog test_aws_glue_s3_hive;
+drop catalog test_aws_glue_s3_hive_${uuid0};
 -- result:
 -- !result
-CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_hive
+CREATE EXTERNAL CATALOG test_aws_glue_s3_hive_${uuid0}
+PROPERTIES
+(
+"type"="hive",
+"hive.metastore.type"="glue",
+"hive.metastore.glue.catalogid" = "${aws_account_id}",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}"
+);
+-- result:
+-- !result
+select * from test_aws_glue_s3_hive_${uuid0}.sql_test_db.hive_glue_s3_parquet;
+-- result:
+3	2003-01-01	Reform to further facilitate maturity of capital market
+5	2005-01-01	China leading engine for global economy
+1	2001-01-01	youth is a wonderful thing
+2	2002-01-01	Mathematical Description of Systems
+4	2004-01-01	KMT official from Taiwan to visit mainland
+-- !result
+drop catalog test_aws_glue_s3_hive_${uuid0};
+-- result:
+-- !result
+CREATE EXTERNAL CATALOG test_assume_role_hive_${uuid0}
 PROPERTIES
 (
 "type"="hive",
@@ -32,26 +58,26 @@ PROPERTIES
 "aws.glue.access_key"="${aws_ak}",
 "aws.glue.secret_key"="${aws_sk}",
 "aws.glue.region"="${aws_region}",
-"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.iam_role_arn"="${aws_assume_role}",
 "aws.glue.sts.region"="${aws_sts_region}",
 "aws.glue.sts.endpoint"="${aws_sts_endpoint}",
 "aws.s3.access_key"="${aws_ak}",
 "aws.s3.secret_key"="${aws_sk}",
 "aws.s3.region"="${aws_region}",
-"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.iam_role_arn"="${aws_assume_role}",
 "aws.s3.sts.region"="${aws_sts_region}",
 "aws.s3.sts.endpoint"="${aws_sts_endpoint}"
 );
 -- result:
 -- !result
-select * from test_aws_assume_role_glue_s3_hive.sql_test_db.hive_glue_s3_parquet;
+select * from test_assume_role_hive_${uuid0}.sql_test_db.hive_glue_s3_parquet;
 -- result:
 2	2002-01-01	Mathematical Description of Systems
-3	2003-01-01	Reform to further facilitate maturity of capital market
-4	2004-01-01	KMT official from Taiwan to visit mainland
 5	2005-01-01	China leading engine for global economy
 1	2001-01-01	youth is a wonderful thing
+4	2004-01-01	KMT official from Taiwan to visit mainland
+3	2003-01-01	Reform to further facilitate maturity of capital market
 -- !result
-drop catalog test_aws_assume_role_glue_s3_hive;
+drop catalog test_assume_role_hive_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_aws_authentication/R/test_aws_glue_s3_hudi
+++ b/test/sql/test_aws_authentication/R/test_aws_glue_s3_hudi
@@ -32,13 +32,13 @@ PROPERTIES
 "aws.glue.access_key"="${aws_ak}",
 "aws.glue.secret_key"="${aws_sk}",
 "aws.glue.region"="${aws_region}",
-"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.iam_role_arn"="${aws_assume_role}",
 "aws.glue.sts.region"="${aws_sts_region}",
 "aws.glue.sts.endpoint"="${aws_sts_endpoint}",
 "aws.s3.access_key"="${aws_ak}",
 "aws.s3.secret_key"="${aws_sk}",
 "aws.s3.region"="${aws_region}",
-"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.iam_role_arn"="${aws_assume_role}",
 "aws.s3.sts.region"="${aws_sts_region}",
 "aws.s3.sts.endpoint"="${aws_sts_endpoint}"
 );

--- a/test/sql/test_aws_authentication/R/test_aws_glue_s3_hudi
+++ b/test/sql/test_aws_authentication/R/test_aws_glue_s3_hudi
@@ -1,5 +1,5 @@
 -- name: test_aws_glue_s3_hudi
-CREATE EXTERNAL CATALOG test_aws_glue_s3_hudi
+CREATE EXTERNAL CATALOG test_aws_glue_s3_hudi_${uuid0}
 PROPERTIES
 (
 "type"="hudi",
@@ -13,7 +13,7 @@ PROPERTIES
 );
 -- result:
 -- !result
-select * from test_aws_glue_s3_hudi.sql_test_db.hudi_glue_s3_parquet;
+select * from test_aws_glue_s3_hudi_${uuid0}.sql_test_db.hudi_glue_s3_parquet;
 -- result:
 20231214112322440	20231214112322440_0_0	20231214112322440_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	1	1	2001-01-01	youth is a wonderful thing
 20231214112358551	20231214112358551_0_1	20231214112358551_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	2	2	2002-01-01	Mathematical Description of Systems
@@ -21,10 +21,10 @@ select * from test_aws_glue_s3_hudi.sql_test_db.hudi_glue_s3_parquet;
 20231214112430418	20231214112430418_0_3	20231214112430418_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	4	4	2004-01-01	KMT official from Taiwan to visit mainland
 20231214112445066	20231214112445066_0_4	20231214112445066_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	5	5	2005-01-01	China leading engine for global economy
 -- !result
-drop catalog test_aws_glue_s3_hudi;
+drop catalog test_aws_glue_s3_hudi_${uuid0};
 -- result:
 -- !result
-CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_hudi
+CREATE EXTERNAL CATALOG test_assume_role_hudi_${uuid0}
 PROPERTIES
 (
 "type"="hudi",
@@ -44,7 +44,7 @@ PROPERTIES
 );
 -- result:
 -- !result
-select * from test_aws_assume_role_glue_s3_hudi.sql_test_db.hudi_glue_s3_parquet;
+select * from test_assume_role_hudi_${uuid0}.sql_test_db.hudi_glue_s3_parquet;
 -- result:
 20231214112322440	20231214112322440_0_0	20231214112322440_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	1	1	2001-01-01	youth is a wonderful thing
 20231214112358551	20231214112358551_0_1	20231214112358551_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	2	2	2002-01-01	Mathematical Description of Systems
@@ -52,6 +52,6 @@ select * from test_aws_assume_role_glue_s3_hudi.sql_test_db.hudi_glue_s3_parquet
 20231214112430418	20231214112430418_0_3	20231214112430418_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	4	4	2004-01-01	KMT official from Taiwan to visit mainland
 20231214112445066	20231214112445066_0_4	20231214112445066_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	5	5	2005-01-01	China leading engine for global economy
 -- !result
-drop catalog test_aws_assume_role_glue_s3_hudi;
+drop catalog test_assume_role_hudi_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_aws_authentication/R/test_aws_glue_s3_iceberg
+++ b/test/sql/test_aws_authentication/R/test_aws_glue_s3_iceberg
@@ -1,5 +1,5 @@
 -- name: test_aws_glue_s3_iceberg
-CREATE EXTERNAL CATALOG test_aws_glue_s3_iceberg
+CREATE EXTERNAL CATALOG test_aws_glue_s3_iceberg_${uuid0}
 PROPERTIES
 (
 "type"="iceberg",
@@ -13,18 +13,44 @@ PROPERTIES
 );
 -- result:
 -- !result
-select * from test_aws_glue_s3_iceberg.sql_test_db.iceberg_glue_s3_orc;
+select * from test_aws_glue_s3_iceberg_${uuid0}.sql_test_db.iceberg_glue_s3_orc;
 -- result:
+2	2002-01-01	Mathematical Description of Systems
+3	2003-01-01	Reform to further facilitate maturity of capital market
 4	2004-01-01	KMT official from Taiwan to visit mainland
+1	2001-01-01	youth is a wonderful thing
 5	2005-01-01	China leading engine for global economy
+-- !result
+drop catalog test_aws_glue_s3_iceberg_${uuid0};
+-- result:
+-- !result
+CREATE EXTERNAL CATALOG test_aws_glue_s3_iceberg_${uuid0}
+PROPERTIES
+(
+"type"="iceberg",
+"iceberg.catalog.type"="glue",
+"aws.glue.catalog_id"="${aws_account_id}",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}"
+);
+-- result:
+-- !result
+select * from test_aws_glue_s3_iceberg_${uuid0}.sql_test_db.iceberg_glue_s3_orc;
+-- result:
+2	2002-01-01	Mathematical Description of Systems
+5	2005-01-01	China leading engine for global economy
+4	2004-01-01	KMT official from Taiwan to visit mainland
 1	2001-01-01	youth is a wonderful thing
 3	2003-01-01	Reform to further facilitate maturity of capital market
-2	2002-01-01	Mathematical Description of Systems
 -- !result
-drop catalog test_aws_glue_s3_iceberg;
+drop catalog test_aws_glue_s3_iceberg_${uuid0};
 -- result:
 -- !result
-CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_iceberg
+CREATE EXTERNAL CATALOG test_assume_role_iceberg_${uuid0}
 PROPERTIES
 (
 "type"="iceberg",
@@ -32,26 +58,26 @@ PROPERTIES
 "aws.glue.access_key"="${aws_ak}",
 "aws.glue.secret_key"="${aws_sk}",
 "aws.glue.region"="${aws_region}",
-"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.iam_role_arn"="${aws_assume_role}",
 "aws.glue.sts.region"="${aws_sts_region}",
 "aws.glue.sts.endpoint"="${aws_sts_endpoint}",
 "aws.s3.access_key"="${aws_ak}",
 "aws.s3.secret_key"="${aws_sk}",
 "aws.s3.region"="${aws_region}",
-"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.iam_role_arn"="${aws_assume_role}",
 "aws.s3.sts.region"="${aws_sts_region}",
 "aws.s3.sts.endpoint"="${aws_sts_endpoint}"
 );
 -- result:
 -- !result
-select * from test_aws_assume_role_glue_s3_iceberg.sql_test_db.iceberg_glue_s3_orc;
+select * from test_assume_role_iceberg_${uuid0}.sql_test_db.iceberg_glue_s3_orc;
 -- result:
 1	2001-01-01	youth is a wonderful thing
-4	2004-01-01	KMT official from Taiwan to visit mainland
 2	2002-01-01	Mathematical Description of Systems
 5	2005-01-01	China leading engine for global economy
 3	2003-01-01	Reform to further facilitate maturity of capital market
+4	2004-01-01	KMT official from Taiwan to visit mainland
 -- !result
-drop catalog test_aws_assume_role_glue_s3_iceberg;
+drop catalog test_assume_role_iceberg_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_aws_authentication/T/test_aws_glue_s3_deltalake
+++ b/test/sql/test_aws_authentication/T/test_aws_glue_s3_deltalake
@@ -1,5 +1,5 @@
 -- name: test_aws_glue_s3_deltalake
-CREATE EXTERNAL CATALOG test_aws_glue_s3_deltalake
+CREATE EXTERNAL CATALOG test_aws_glue_s3_deltalake_${uuid0}
 PROPERTIES
 (
 "type"="deltalake",
@@ -12,11 +12,11 @@ PROPERTIES
 "aws.s3.region"="${aws_region}"
 );
 
-select * from test_aws_glue_s3_deltalake.sql_test_db.deltalake_glue_s3;
+select * from test_aws_glue_s3_deltalake_${uuid0}.sql_test_db.deltalake_glue_s3;
 
-drop catalog test_aws_glue_s3_deltalake;
+drop catalog test_aws_glue_s3_deltalake_${uuid0};
 
-CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_deltalake
+CREATE EXTERNAL CATALOG test_assume_role_deltalake_${uuid0}
 PROPERTIES
 (
 "type"="deltalake",
@@ -35,7 +35,7 @@ PROPERTIES
 "aws.s3.sts.endpoint"="${aws_sts_endpoint}"
 );
 
-select * from test_aws_assume_role_glue_s3_deltalake.sql_test_db.deltalake_glue_s3;
+select * from test_assume_role_deltalake_${uuid0}.sql_test_db.deltalake_glue_s3;
 
-drop catalog test_aws_assume_role_glue_s3_deltalake;
+drop catalog test_assume_role_deltalake_${uuid0};
 

--- a/test/sql/test_aws_authentication/T/test_aws_glue_s3_deltalake
+++ b/test/sql/test_aws_authentication/T/test_aws_glue_s3_deltalake
@@ -24,13 +24,13 @@ PROPERTIES
 "aws.glue.access_key"="${aws_ak}",
 "aws.glue.secret_key"="${aws_sk}",
 "aws.glue.region"="${aws_region}",
-"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.iam_role_arn"="${aws_assume_role}",
 "aws.glue.sts.region"="${aws_sts_region}",
 "aws.glue.sts.endpoint"="${aws_sts_endpoint}",
 "aws.s3.access_key"="${aws_ak}",
 "aws.s3.secret_key"="${aws_sk}",
 "aws.s3.region"="${aws_region}",
-"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.iam_role_arn"="${aws_assume_role}",
 "aws.s3.sts.region"="${aws_sts_region}",
 "aws.s3.sts.endpoint"="${aws_sts_endpoint}"
 );

--- a/test/sql/test_aws_authentication/T/test_aws_glue_s3_hive
+++ b/test/sql/test_aws_authentication/T/test_aws_glue_s3_hive
@@ -1,6 +1,6 @@
 -- name: test_aws_glue_s3_hive
 
-CREATE EXTERNAL CATALOG test_aws_glue_s3_hive
+CREATE EXTERNAL CATALOG test_aws_glue_s3_hive_${uuid0}
 PROPERTIES
 (
 "type"="hive",
@@ -13,11 +13,29 @@ PROPERTIES
 "aws.s3.region"="${aws_region}"
 );
 
-select * from test_aws_glue_s3_hive.sql_test_db.hive_glue_s3_parquet;
+select * from test_aws_glue_s3_hive_${uuid0}.sql_test_db.hive_glue_s3_parquet;
 
-drop catalog test_aws_glue_s3_hive;
+drop catalog test_aws_glue_s3_hive_${uuid0};
 
-CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_hive
+CREATE EXTERNAL CATALOG test_aws_glue_s3_hive_${uuid0}
+PROPERTIES
+(
+"type"="hive",
+"hive.metastore.type"="glue",
+"hive.metastore.glue.catalogid" = "${aws_account_id}",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}"
+);
+
+select * from test_aws_glue_s3_hive_${uuid0}.sql_test_db.hive_glue_s3_parquet;
+
+drop catalog test_aws_glue_s3_hive_${uuid0};
+
+CREATE EXTERNAL CATALOG test_assume_role_hive_${uuid0}
 PROPERTIES
 (
 "type"="hive",
@@ -25,17 +43,17 @@ PROPERTIES
 "aws.glue.access_key"="${aws_ak}",
 "aws.glue.secret_key"="${aws_sk}",
 "aws.glue.region"="${aws_region}",
-"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.iam_role_arn"="${aws_assume_role}",
 "aws.glue.sts.region"="${aws_sts_region}",
 "aws.glue.sts.endpoint"="${aws_sts_endpoint}",
 "aws.s3.access_key"="${aws_ak}",
 "aws.s3.secret_key"="${aws_sk}",
 "aws.s3.region"="${aws_region}",
-"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.iam_role_arn"="${aws_assume_role}",
 "aws.s3.sts.region"="${aws_sts_region}",
 "aws.s3.sts.endpoint"="${aws_sts_endpoint}"
 );
 
-select * from test_aws_assume_role_glue_s3_hive.sql_test_db.hive_glue_s3_parquet;
+select * from test_assume_role_hive_${uuid0}.sql_test_db.hive_glue_s3_parquet;
 
-drop catalog test_aws_assume_role_glue_s3_hive;
+drop catalog test_assume_role_hive_${uuid0};

--- a/test/sql/test_aws_authentication/T/test_aws_glue_s3_hudi
+++ b/test/sql/test_aws_authentication/T/test_aws_glue_s3_hudi
@@ -24,13 +24,13 @@ PROPERTIES
 "aws.glue.access_key"="${aws_ak}",
 "aws.glue.secret_key"="${aws_sk}",
 "aws.glue.region"="${aws_region}",
-"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.iam_role_arn"="${aws_assume_role}",
 "aws.glue.sts.region"="${aws_sts_region}",
 "aws.glue.sts.endpoint"="${aws_sts_endpoint}",
 "aws.s3.access_key"="${aws_ak}",
 "aws.s3.secret_key"="${aws_sk}",
 "aws.s3.region"="${aws_region}",
-"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.iam_role_arn"="${aws_assume_role}",
 "aws.s3.sts.region"="${aws_sts_region}",
 "aws.s3.sts.endpoint"="${aws_sts_endpoint}"
 );

--- a/test/sql/test_aws_authentication/T/test_aws_glue_s3_hudi
+++ b/test/sql/test_aws_authentication/T/test_aws_glue_s3_hudi
@@ -1,5 +1,5 @@
 -- name: test_aws_glue_s3_hudi
-CREATE EXTERNAL CATALOG test_aws_glue_s3_hudi
+CREATE EXTERNAL CATALOG test_aws_glue_s3_hudi_${uuid0}
 PROPERTIES
 (
 "type"="hudi",
@@ -12,11 +12,11 @@ PROPERTIES
 "aws.s3.region"="${aws_region}"
 );
 
-select * from test_aws_glue_s3_hudi.sql_test_db.hudi_glue_s3_parquet;
+select * from test_aws_glue_s3_hudi_${uuid0}.sql_test_db.hudi_glue_s3_parquet;
 
-drop catalog test_aws_glue_s3_hudi;
+drop catalog test_aws_glue_s3_hudi_${uuid0};
 
-CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_hudi
+CREATE EXTERNAL CATALOG test_assume_role_hudi_${uuid0}
 PROPERTIES
 (
 "type"="hudi",
@@ -35,6 +35,6 @@ PROPERTIES
 "aws.s3.sts.endpoint"="${aws_sts_endpoint}"
 );
 
-select * from test_aws_assume_role_glue_s3_hudi.sql_test_db.hudi_glue_s3_parquet;
+select * from test_assume_role_hudi_${uuid0}.sql_test_db.hudi_glue_s3_parquet;
 
-drop catalog test_aws_assume_role_glue_s3_hudi;
+drop catalog test_assume_role_hudi_${uuid0};

--- a/test/sql/test_aws_authentication/T/test_aws_glue_s3_iceberg
+++ b/test/sql/test_aws_authentication/T/test_aws_glue_s3_iceberg
@@ -1,5 +1,5 @@
 -- name: test_aws_glue_s3_iceberg
-CREATE EXTERNAL CATALOG test_aws_glue_s3_iceberg
+CREATE EXTERNAL CATALOG test_aws_glue_s3_iceberg_${uuid0}
 PROPERTIES
 (
 "type"="iceberg",
@@ -12,11 +12,29 @@ PROPERTIES
 "aws.s3.region"="${aws_region}"
 );
 
-select * from test_aws_glue_s3_iceberg.sql_test_db.iceberg_glue_s3_orc;
+select * from test_aws_glue_s3_iceberg_${uuid0}.sql_test_db.iceberg_glue_s3_orc;
 
-drop catalog test_aws_glue_s3_iceberg;
+drop catalog test_aws_glue_s3_iceberg_${uuid0};
 
-CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_iceberg
+CREATE EXTERNAL CATALOG test_aws_glue_s3_iceberg_${uuid0}
+PROPERTIES
+(
+"type"="iceberg",
+"iceberg.catalog.type"="glue",
+"aws.glue.catalog_id"="${aws_account_id}",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}"
+);
+
+select * from test_aws_glue_s3_iceberg_${uuid0}.sql_test_db.iceberg_glue_s3_orc;
+
+drop catalog test_aws_glue_s3_iceberg_${uuid0};
+
+CREATE EXTERNAL CATALOG test_assume_role_iceberg_${uuid0}
 PROPERTIES
 (
 "type"="iceberg",
@@ -24,17 +42,17 @@ PROPERTIES
 "aws.glue.access_key"="${aws_ak}",
 "aws.glue.secret_key"="${aws_sk}",
 "aws.glue.region"="${aws_region}",
-"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.iam_role_arn"="${aws_assume_role}",
 "aws.glue.sts.region"="${aws_sts_region}",
 "aws.glue.sts.endpoint"="${aws_sts_endpoint}",
 "aws.s3.access_key"="${aws_ak}",
 "aws.s3.secret_key"="${aws_sk}",
 "aws.s3.region"="${aws_region}",
-"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.iam_role_arn"="${aws_assume_role}",
 "aws.s3.sts.region"="${aws_sts_region}",
 "aws.s3.sts.endpoint"="${aws_sts_endpoint}"
 );
 
-select * from test_aws_assume_role_glue_s3_iceberg.sql_test_db.iceberg_glue_s3_orc;
+select * from test_assume_role_iceberg_${uuid0}.sql_test_db.iceberg_glue_s3_orc;
 
-drop catalog test_aws_assume_role_glue_s3_iceberg;
+drop catalog test_assume_role_iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

1. **Fix endpoint configuration issue**: When users configure AWS Glue or STS endpoint, if the endpoint string doesn't contain a URI scheme (such as `https://`), directly using `URI.create()` will create a URI without a scheme, causing AWS SDK to throw `NullPointerException` or `UnknownHostException` when calling `endpointOverride()`.

2. **Correct configuration parameter names**: The test cases used incorrect configuration parameter names `aws.glue.assume_role` and `aws.s3.assume_role`, which should be the correct parameter names `aws.glue.iam_role_arn` and `aws.s3.iam_role_arn`.

3. **Fix test case issues**:
   - Catalog names are too long, exceeding the 64-character limit (`test_aws_assume_role_glue_s3_iceberg` plus UUID exceeds the limit)
   - Test cases using fixed names may cause name conflicts during concurrent testing
   - Missing some test scenarios (such as test cases with `catalog_id`)

## What I'm doing:

1. **Add `ensureSchemeInEndpoint()` method**:
   - Add a new static method `ensureSchemeInEndpoint()` in `AwsCloudCredential.java`
   - Check if the endpoint contains a URI scheme, and automatically add `https://` prefix if not
   - Prevent URI parsing errors caused by missing scheme

2. **Fix endpoint handling logic**:
   - Use `ensureSchemeInEndpoint()` in `AWSGlueClientFactory.java` to handle Glue endpoint
   - Use `ensureSchemeInEndpoint()` in `AwsCloudCredential.getAssumeRoleCredentialsProvider()` to handle STS endpoint
   - Ensure all endpoint configurations contain the correct URI scheme

3. **Correct test cases**:
   - Change all catalog names in test cases to use `${uuid0}` variable to avoid name conflicts
   - Correct the wrong configuration parameters `aws.glue.assume_role` and `aws.s3.assume_role` to `aws.glue.iam_role_arn` and `aws.s3.iam_role_arn`
   - Shorten catalog names (e.g., `test_aws_assume_role_glue_s3_iceberg` → `test_assume_role_iceberg`) to ensure they don't exceed the 64-character limit when combined with UUID
   - Add test scenarios with `catalog_id` for Hive and Iceberg catalog tests

4. **Update test result files**:
   - Synchronously update all related R files (expected result files)
   - Adjust the order of test results to match the actual execution results

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
