### PR TITLE
[Enhancement] improve error handling for iceberg transform functions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -1018,7 +1018,12 @@ public class FunctionAnalyzer {
             }
         } else if (FunctionSet.ICEBERG_TRANSFORM_BUCKET.equalsIgnoreCase(fnName) ||
                 FunctionSet.ICEBERG_TRANSFORM_TRUNCATE.equalsIgnoreCase(fnName)) {
-            Preconditions.checkState(argumentTypes.length == 2);
+            if (argumentTypes.length != 2) {
+                String functionName = fnName.replace(FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX, "");
+                throw new SemanticException(String.format(
+                        "Function '%s' requires exactly 2 arguments: column and number, but got %d argument(s)",
+                        functionName, argumentTypes.length));
+            }
             Type[] args = new Type[] {argumentTypes[0], IntegerType.INT};
             fn = ExprUtils.getBuiltinFunction(fnName, args, Function.CompareMode.IS_IDENTICAL);
             if (args[0].isDecimalV3()) {


### PR DESCRIPTION
## Why I'm doing:
```
StarRocks>CREATE TABLE `iceberg_sample_par` (  
 `id` bigint(20) DEFAULT NULL,  
`date` date DEFAULT NULL, `data` string DEFAULT NULL,   
`category` string DEFAULT NULL) 
PARTITION BY bucket(`data`);
ERROR 1064 (HY000): Unknown error
StarRocks>
```
partition by bucket/truncate with one argument, give unknown error 
## What I'm doing:
This pull request improves the error handling and testing for Iceberg partition transform functions (`bucket` and `truncate`). Specifically, it ensures that these functions provide clear error messages when called with an incorrect number of arguments, and adds tests to verify this behavior.

Error handling improvements:

* Updated `FunctionAnalyzer.java` to throw a `SemanticException` with a descriptive message if `bucket` or `truncate` functions are called with an argument count other than 2, specifying the function name and the number of arguments received.

Testing enhancements:

* Added `testIcebergPartitionTransformError` in `AnalyzeCreateTableTest.java` to verify that creating Iceberg tables with partition transforms using the wrong number of arguments produces the expected error messages.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
