### PR TITLE
StarRocks streamload commit failure

### DIFF
--- a/docs/en/loading/Json_loading.md
+++ b/docs/en/loading/Json_loading.md
@@ -13,24 +13,74 @@ You can import semi-structured data (for example, JSON) by using stream load or 
 
 ### Stream Load Import
 
-Sample data:
+StarRocks supports importing JSON data in the following formats:
+
+1. **Single JSON object**: A single JSON object per file.
+2. **JSON Array**: Multiple JSON objects wrapped in an array `[]`. Requires setting `strip_outer_array: true`.
+3. **NDJSON (Newline Delimited JSON)**: Multiple JSON objects, each on its own line without trailing commas.
+
+> **IMPORTANT**
+>
+> Comma-separated JSON objects **without** array brackets (e.g., `{...}, {...}, {...}`) is **NOT valid JSON** and will cause parsing failures. Always use JSON Array format with `strip_outer_array: true` or NDJSON format when loading multiple records.
+
+#### Example 1: Single JSON object
+
+Sample data (`example.json`):
 
 ~~~json
-{ "id": 123, "city" : "beijing"},
-{ "id": 456, "city" : "shanghai"},
-    ...
+{"id": 123, "city": "beijing"}
 ~~~
 
-Example:
+Import command:
 
 ~~~shell
 curl -v --location-trusted -u <username>:<password> \
-    -H "format: json" -H "jsonpaths: [\"$.id\", \"$.city\"]" \
+    -H "format: json" \
     -T example.json \
     http://FE_HOST:HTTP_PORT/api/DATABASE/TABLE/_stream_load
 ~~~
 
-The `format: json` parameter allows you to execute the format of the imported data. `jsonpaths` is used to execute the corresponding data import path.
+#### Example 2: JSON Array format (recommended for multiple records)
+
+Sample data (`example.json`):
+
+~~~json
+[
+    {"id": 123, "city": "beijing"},
+    {"id": 456, "city": "shanghai"}
+]
+~~~
+
+Import command (note the `strip_outer_array: true` header):
+
+~~~shell
+curl -v --location-trusted -u <username>:<password> \
+    -H "format: json" -H "strip_outer_array: true" \
+    -H "jsonpaths: [\"$.id\", \"$.city\"]" \
+    -T example.json \
+    http://FE_HOST:HTTP_PORT/api/DATABASE/TABLE/_stream_load
+~~~
+
+#### Example 3: NDJSON format (Newline Delimited JSON)
+
+Sample data (`example.json`):
+
+~~~json
+{"id": 123, "city": "beijing"}
+{"id": 456, "city": "shanghai"}
+~~~
+
+Import command:
+
+~~~shell
+curl -v --location-trusted -u <username>:<password> \
+    -H "format: json" \
+    -H "jsonpaths: [\"$.id\", \"$.city\"]" \
+    -T example.json \
+    http://FE_HOST:HTTP_PORT/api/DATABASE/TABLE/_stream_load
+~~~
+
+The `format: json` parameter specifies the format of the imported data. `jsonpaths` is used to specify the corresponding data import path.
 
 Related parameters:
 

--- a/docs/en/loading/Stream_Load_transaction_interface.md
+++ b/docs/en/loading/Stream_Load_transaction_interface.md
@@ -21,6 +21,20 @@ The Stream Load transaction interface supports using an HTTP protocol-compatible
 Stream Load supports CSV and JSON file formats. This method is recommended if you want to load data from a small number of files whose individual sizes do not exceed 10 GB. Stream Load does not support Parquet file format. If you need to load data from Parquet files, use [INSERT+files()](../loading/InsertInto.md#insert-data-directly-from-files-in-an-external-source-using-files).
 :::
 
+:::caution Important: Valid JSON Formats
+When loading JSON data, StarRocks supports the following formats:
+
+1. **Single JSON object**: `{"key": "value"}`
+2. **JSON Array** (requires `-H "strip_outer_array: true"`): `[{"key": "value"}, {"key": "value"}]`
+3. **NDJSON (Newline Delimited JSON)**: Each JSON object on its own line, **without trailing commas**:
+   ```
+   {"key": "value"}
+   {"key": "value"}
+   ```
+
+**IMPORTANT**: Comma-separated JSON objects **without** array brackets (e.g., `{...}, {...}, {...}`) is **NOT valid JSON** and will cause the error "No partitions have data available for loading". Always use JSON Array format with `strip_outer_array: true` or NDJSON format when loading multiple records.
+:::
+
 ### Transaction management
 
 The Stream Load transaction interface provides the following API operations, which are used to manage transactions:

--- a/docs/ja/loading/Json_loading.md
+++ b/docs/ja/loading/Json_loading.md
@@ -13,24 +13,74 @@ displayed_sidebar: docs
 
 ### Stream Load インポート
 
-サンプルデータ:
+StarRocks は以下の JSON 形式でのデータインポートをサポートしています：
+
+1. **単一 JSON オブジェクト**: ファイルごとに 1 つの JSON オブジェクト。
+2. **JSON 配列**: 配列 `[]` で囲まれた複数の JSON オブジェクト。`strip_outer_array: true` の設定が必要です。
+3. **NDJSON (改行区切り JSON)**: 複数の JSON オブジェクト、各オブジェクトは独自の行に配置され、末尾のカンマはありません。
+
+> **重要**
+>
+> 配列括弧**なし**でカンマで区切られた JSON オブジェクト（例：`{...}, {...}, {...}`）は**有効な JSON ではありません**。パース失敗の原因となります。複数のレコードをロードする場合は、必ず `strip_outer_array: true` を設定した JSON 配列形式か、NDJSON 形式を使用してください。
+
+#### 例 1: 単一 JSON オブジェクト
+
+サンプルデータ (`example.json`):
 
 ~~~json
-{ "id": 123, "city" : "beijing"},
-{ "id": 456, "city" : "shanghai"},
-    ...
+{"id": 123, "city": "beijing"}
 ~~~
 
-例:
+インポートコマンド:
 
 ~~~shell
 curl -v --location-trusted -u <username>:<password> \
-    -H "format: json" -H "jsonpaths: [\"$.id\", \"$.city\"]" \
+    -H "format: json" \
     -T example.json \
     http://FE_HOST:HTTP_PORT/api/DATABASE/TABLE/_stream_load
 ~~~
 
-`format: json` パラメータは、インポートするデータの形式を実行することを可能にします。`jsonpaths` は、対応するデータインポートパスを実行するために使用されます。
+#### 例 2: JSON 配列形式（複数レコードの場合に推奨）
+
+サンプルデータ (`example.json`):
+
+~~~json
+[
+    {"id": 123, "city": "beijing"},
+    {"id": 456, "city": "shanghai"}
+]
+~~~
+
+インポートコマンド（`strip_outer_array: true` ヘッダーに注意）:
+
+~~~shell
+curl -v --location-trusted -u <username>:<password> \
+    -H "format: json" -H "strip_outer_array: true" \
+    -H "jsonpaths: [\"$.id\", \"$.city\"]" \
+    -T example.json \
+    http://FE_HOST:HTTP_PORT/api/DATABASE/TABLE/_stream_load
+~~~
+
+#### 例 3: NDJSON 形式（改行区切り JSON）
+
+サンプルデータ (`example.json`):
+
+~~~json
+{"id": 123, "city": "beijing"}
+{"id": 456, "city": "shanghai"}
+~~~
+
+インポートコマンド:
+
+~~~shell
+curl -v --location-trusted -u <username>:<password> \
+    -H "format: json" \
+    -H "jsonpaths: [\"$.id\", \"$.city\"]" \
+    -T example.json \
+    http://FE_HOST:HTTP_PORT/api/DATABASE/TABLE/_stream_load
+~~~
+
+`format: json` パラメータは、インポートするデータの形式を指定します。`jsonpaths` は、対応するデータインポートパスを指定するために使用されます。
 
 関連パラメータ:
 

--- a/docs/ja/loading/Stream_Load_transaction_interface.md
+++ b/docs/ja/loading/Stream_Load_transaction_interface.md
@@ -21,6 +21,20 @@ Stream Load トランザクションインターフェースは、HTTP プロト
 Stream Load は CSV および JSON ファイル形式をサポートします。個々のサイズが 10 GB を超えない少数のファイルからデータをロードしたい場合、この方法が推奨されます。Stream Load は Parquet ファイル形式をサポートしていません。Parquet ファイルからデータをロードする必要がある場合は、[INSERT+files()](../loading/InsertInto.md#insert-data-directly-from-files-in-an-external-source-using-files) を使用してください。
 :::
 
+:::caution 重要：有効な JSON 形式
+JSON データをロードする場合、StarRocks は以下の形式をサポートしています：
+
+1. **単一 JSON オブジェクト**: `{"key": "value"}`
+2. **JSON 配列**（`-H "strip_outer_array: true"` が必要）: `[{"key": "value"}, {"key": "value"}]`
+3. **NDJSON（改行区切り JSON）**: 各 JSON オブジェクトを独自の行に配置し、**末尾のカンマなし**：
+   ```
+   {"key": "value"}
+   {"key": "value"}
+   ```
+
+**重要**: 配列括弧**なし**でカンマで区切られた JSON オブジェクト（例: `{...}, {...}, {...}`）は**有効な JSON ではありません**。「No partitions have data available for loading」エラーの原因となります。複数のレコードをロードする場合は、必ず `strip_outer_array: true` を設定した JSON 配列形式か、NDJSON 形式を使用してください。
+:::
+
 ### トランザクション管理
 
 Stream Load トランザクションインターフェースは、トランザクションを管理するために使用される以下の API 操作を提供します。

--- a/docs/zh/loading/Stream_Load_transaction_interface.md
+++ b/docs/zh/loading/Stream_Load_transaction_interface.md
@@ -21,6 +21,20 @@ Stream Load 事务接口支持通过兼容 HTTP 协议的工具或语言发起�
 Stream Load 支持导入 CSV 和 JSON 格式的数据，并且建议在导入的数据文件数量较少、单个数据文件的大小不超过 10 GB 时使用。Stream Load 不支持 Parquet 文件格式。如果要导入 Parquet 格式的数据，请使用 [INSERT+files()](../loading/InsertInto.md#通过-insert-into-select-以及表函数-files-导入外部数据文件).
 :::
 
+:::caution 重要：有效的 JSON 格式
+导入 JSON 数据时，StarRocks 支持以下格式：
+
+1. **单个 JSON 对象**：`{"key": "value"}`
+2. **JSON 数组**（需要添加 `-H "strip_outer_array: true"`）：`[{"key": "value"}, {"key": "value"}]`
+3. **NDJSON（换行分隔的 JSON）**：每个 JSON 对象独占一行，**末尾不带逗号**：
+   ```
+   {"key": "value"}
+   {"key": "value"}
+   ```
+
+**重要提示**：用逗号分隔的 JSON 对象但**没有**数组括号（如 `{...}, {...}, {...}`）**不是有效的 JSON**，会导致 "No partitions have data available for loading" 错误。导入多条记录时，请务必使用带 `strip_outer_array: true` 的 JSON 数组格式，或 NDJSON 格式。
+:::
+
 ### 事务管理
 
 提供如下标准接口，用于管理事务：


### PR DESCRIPTION
## Why I'm doing:
The Stream Load transaction API failed to commit with "No partitions have data available for loading" when users provided invalid JSON data. The root cause was that the provided JSON format (comma-separated objects without an outer array) is not valid JSON, and existing documentation examples were misleading or incorrect.

## What I'm doing:
Updated the documentation for Stream Load and JSON loading in English, Japanese, and Chinese to:
1. Clarify the three supported valid JSON formats: single object, JSON array (with `strip_outer_array: true`), and NDJSON.
2. Explicitly state that comma-separated JSON objects without an outer array are invalid.
3. Corrected an invalid JSON example in `Json_loading.md`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

---
<a href="https://cursor.com/background-agent?bcId=bc-bbc729ba-95b1-4a62-81e6-1394dbcc23c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bbc729ba-95b1-4a62-81e6-1394dbcc23c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>