### PR TITLE
[UT] handle macOS getopt for --test parsing in run-fe-ut.sh

### DIFF
--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -exo pipefail
+set -eo pipefail
 
 ROOT=`dirname "$0"`
 ROOT=`cd "$ROOT"; pwd`

--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -eo pipefail
+set -exo pipefail
 
 ROOT=`dirname "$0"`
 ROOT=`cd "$ROOT"; pwd`
@@ -53,26 +53,6 @@ Usage: $0 <options>
   exit 1
 }
 
-# -l run only used for compatibility
-OPTS=$(getopt \
-  -n $0 \
-  -o 'j:' \
-  -l 'test:' \
-  -l 'filter:' \
-  -l 'dry-run' \
-  -l 'coverage' \
-  -l 'dumpcase' \
-  -l 'enable-profiler:' \
-  -l 'help' \
-  -l 'run' \
-  -- "$@")
-
-if [ $? != 0 ] ; then
-    usage
-fi
-
-eval set -- "$OPTS"
-
 HELP=0
 DRY_RUN=0
 RUN_SPECIFIED_TEST=0
@@ -82,21 +62,76 @@ COVERAGE=0
 DUMPCASE=0
 ENABLE_PROFILER=0
 PARALLEL=${FE_UT_PARALLEL:-4}
-while true; do
-    case "$1" in
-        --coverage) COVERAGE=1 ; shift ;;
-        --test) RUN_SPECIFIED_TEST=1; TEST_NAME=$2; shift 2;;
-        --filter) FILTER_TEST=$2; shift 2;;
-        --run) shift ;; # only used for compatibility
-        --dumpcase) DUMPCASE=1; shift ;;
-        --dry-run) DRY_RUN=1 ; shift ;;
-        --enable-profiler) ENABLE_PROFILER=$2; shift 2;;
-        --help) HELP=1 ; shift ;;
-        -j) PARALLEL=$2; shift 2 ;;
-        --) shift ;  break ;;
-        *) echo "Internal error" ; exit 1 ;;
-    esac
-done
+
+# Prefer GNU getopt when available. Fall back to a manual parser on macOS/BSD.
+USE_GNU_GETOPT=0
+if getopt --version >/dev/null 2>&1; then
+    if getopt --version 2>/dev/null | grep -qiE 'gnu|util-linux'; then
+        USE_GNU_GETOPT=1
+    fi
+fi
+
+if [ ${USE_GNU_GETOPT} -eq 1 ]; then
+    # -l run only used for compatibility
+    OPTS=$(getopt \
+      -n $0 \
+      -o 'j:' \
+      -l 'test:' \
+      -l 'filter:' \
+      -l 'dry-run' \
+      -l 'coverage' \
+      -l 'dumpcase' \
+      -l 'enable-profiler:' \
+      -l 'help' \
+      -l 'run' \
+      -- "$@")
+
+    if [ $? != 0 ] ; then
+        usage
+    fi
+
+    eval set -- "$OPTS"
+    while true; do
+        case "$1" in
+            --coverage) COVERAGE=1 ; shift ;;
+            --test) RUN_SPECIFIED_TEST=1; TEST_NAME=$2; shift 2;;
+            --filter) FILTER_TEST=$2; shift 2;;
+            --run) shift ;; # only used for compatibility
+            --dumpcase) DUMPCASE=1; shift ;;
+            --dry-run) DRY_RUN=1 ; shift ;;
+            --enable-profiler) ENABLE_PROFILER=$2; shift 2;;
+            --help) HELP=1 ; shift ;;
+            -j) PARALLEL=$2; shift 2 ;;
+            --) shift ;  break ;;
+            *) echo "Internal error" ; exit 1 ;;
+        esac
+    done
+else
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --coverage) COVERAGE=1 ; shift ;;
+            --test)
+                if [ -z "$2" ]; then usage; fi
+                RUN_SPECIFIED_TEST=1; TEST_NAME=$2; shift 2;;
+            --filter)
+                if [ -z "$2" ]; then usage; fi
+                FILTER_TEST=$2; shift 2;;
+            --run) shift ;; # only used for compatibility
+            --dumpcase) DUMPCASE=1; shift ;;
+            --dry-run) DRY_RUN=1 ; shift ;;
+            --enable-profiler)
+                if [ -z "$2" ]; then usage; fi
+                ENABLE_PROFILER=$2; shift 2;;
+            --help) HELP=1 ; shift ;;
+            -j)
+                if [ -z "$2" ]; then usage; fi
+                PARALLEL=$2; shift 2 ;;
+            --) shift ; break ;;
+            -*) usage ;;
+            *) break ;;
+        esac
+    done
+fi
 
 if [ ${HELP} -eq 1 ]; then
     usage


### PR DESCRIPTION
## Why I'm doing:
macOS doesn't use GNU getopt, but BSD getopt, so the current code
doesn't work on macOS when you want to just run a single test case.

## What I'm doing:
Instead of relying on GNU getopt, we use a manual parsing logic when
macOS has been detected.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
