### PR TITLE
[BugFix] Fix manually downloaded cluster snapshot restore metadata tracking

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -299,11 +299,12 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         String restoredSnapshotName = restoredSnapshotInfo.getSnapshotName();
         long feJournalId = restoredSnapshotInfo.getFeJournalId();
         long starMgrJournalId = restoredSnapshotInfo.getStarMgrJournalId();
-        if (restoredSnapshotName == null) {
-            return;
+        ClusterSnapshotJob job = null;
+        if (restoredSnapshotName != null) {
+            job = getClusterSnapshotJobByName(restoredSnapshotName);
+        } else {
+            job = getUnfinishedClusterSnapshotJob();
         }
-
-        ClusterSnapshotJob job = getClusterSnapshotJobByName(restoredSnapshotName);
         // snapshot job may in init state, because it does not include the
         // editlog for the state transtition after ClusterSnapshotJobState.INITIALIZING
         if (job != null && job.isInitializing()) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/RestoreClusterSnapshotMgr.java
@@ -124,6 +124,7 @@ public class RestoreClusterSnapshotMgr {
     private void downloadSnapshot() throws StarRocksException {
         ClusterSnapshotConfig.ClusterSnapshot clusterSnapshot = config.getClusterSnapshot();
         if (clusterSnapshot == null) {
+            collectSnapshotInfoFromLocalImage();
             return;
         }
 
@@ -153,22 +154,16 @@ public class RestoreClusterSnapshotMgr {
         LOG.info("Download cluster snapshot {} to local dir {}", snapshotImagePath, localImagePath);
         HdfsUtil.copyToLocal(snapshotImagePath, localImagePath, clusterSnapshot.getStorageVolume().getProperties());
 
-        collectSnapshotInfoAfterDownloaded(snapshotImagePath, localImagePath);
+        collectSnapshotInfoAfterDownloaded(snapshotImagePath);
     }
 
-    private void collectSnapshotInfoAfterDownloaded(String snapshotImagePath, String localImagePath)
-            throws StarRocksException {
-        long feImageJournalId = 0L;
-        long starMgrImageJournalId = 0L;
+    private void collectSnapshotInfoFromLocalImage() throws StarRocksException {
+        restoredSnapshotInfo = buildRestoredSnapshotInfo(null);
+        LOG.info("Use local image for cluster snapshot restore, FE image version: {}, StarMgr image version: {}",
+                restoredSnapshotInfo.getFeJournalId(), restoredSnapshotInfo.getStarMgrJournalId());
+    }
 
-        try {
-            // Get image version, use image loader to support v2 image format
-            feImageJournalId = new ImageLoader(localImagePath).getImageJournalId();
-            starMgrImageJournalId = new Storage(localImagePath + StarMgrServer.IMAGE_SUBDIR).getImageJournalId();
-        } catch (Exception e) {
-            throw new StarRocksException("Failed to get local image version", e);
-        }
-
+    private void collectSnapshotInfoAfterDownloaded(String snapshotImagePath) throws StarRocksException {
         int lastSlashIndex = snapshotImagePath.lastIndexOf('/');
         if (lastSlashIndex < 0) {
             throw new StarRocksException("Failed to get snapshot name from snapshot path " + snapshotImagePath);
@@ -176,11 +171,22 @@ public class RestoreClusterSnapshotMgr {
 
         String restoredSnapshotName = snapshotImagePath.substring(lastSlashIndex + 1);
 
-        restoredSnapshotInfo = new RestoredSnapshotInfo(restoredSnapshotName,
-                feImageJournalId, starMgrImageJournalId);
+        restoredSnapshotInfo = buildRestoredSnapshotInfo(restoredSnapshotName);
 
         LOG.info("Downloaded cluster snapshot {} successfully, FE image version: {}, StarMgr image version: {}",
-                restoredSnapshotName, feImageJournalId, starMgrImageJournalId);
+                restoredSnapshotName, restoredSnapshotInfo.getFeJournalId(), restoredSnapshotInfo.getStarMgrJournalId());
+    }
+
+    private RestoredSnapshotInfo buildRestoredSnapshotInfo(String snapshotName) throws StarRocksException {
+        try {
+            String localImagePath = GlobalStateMgr.getImageDirPath();
+            // Get image version, use image loader to support v2 image format
+            long feImageJournalId = new ImageLoader(localImagePath).getImageJournalId();
+            long starMgrImageJournalId = new Storage(localImagePath + StarMgrServer.IMAGE_SUBDIR).getImageJournalId();
+            return new RestoredSnapshotInfo(snapshotName, feImageJournalId, starMgrImageJournalId);
+        } catch (Exception e) {
+            throw new StarRocksException("Failed to get local image version for restore", e);
+        }
     }
 
     private void updateFrontends() throws StarRocksException {

--- a/fe/fe-core/src/test/resources/conf/cluster_snapshot_manual.yaml
+++ b/fe/fe-core/src/test/resources/conf/cluster_snapshot_manual.yaml
@@ -1,0 +1,2 @@
+--- {}
+# manual restore with local image only; no cluster_snapshot section


### PR DESCRIPTION
## Why I'm doing:
Fix manually downloaded cluster snapshot restore metadata tracking

## What I'm doing:
  Ensure manually downloaded cluster snapshot restores still record restored snapshot info from local images, and mark the appropriate snapshot job as finished to avoid erroneous ERROR state. 
  Add unit test coverage for manual restore config and journal id collection.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
