### PR TITLE
[Enhancement] Support convert Arrow::Decimal32 to StarRocks Decimal

### DIFF
--- a/be/src/exec/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/arrow_to_starrocks_converter.cpp
@@ -358,54 +358,68 @@ struct RectifyDecimalType<DecimalV2Value> {
 template <typename T>
 using rectify_decimal_type = typename RectifyDecimalType<T>::type;
 VALUE_GUARD(LogicalType, ArrowDecimalOfAnyVersionLTGuard, arrow_lt_is_decimal_of_any_version, TYPE_DECIMAL,
-            TYPE_DECIMALV2, TYPE_DECIMAL32, TYPE_DECIMAL64, TYPE_DECIMAL128)
+            TYPE_DECIMALV2, TYPE_DECIMAL32, TYPE_DECIMAL64, TYPE_DECIMAL128, TYPE_DECIMAL256)
 
-template <LogicalType LT, bool is_nullable, bool is_strict>
-struct ArrowConverter<ArrowTypeId::DECIMAL, LT, is_nullable, is_strict, guard::Guard,
-                      ArrowDecimalOfAnyVersionLTGuard<LT>> {
-    static constexpr ArrowTypeId AT = ArrowTypeId::DECIMAL;
+VALUE_GUARD(ArrowTypeId, ArrowDecimalATGuard, at_is_decimal, ArrowTypeId::DECIMAL, ArrowTypeId::DECIMAL32,
+            ArrowTypeId::DECIMAL64, ArrowTypeId::DECIMAL256)
+
+template <ArrowTypeId AT>
+struct ArrowDecimalCppType {};
+
+template <>
+struct ArrowDecimalCppType<ArrowTypeId::DECIMAL32> {
+    using type = int32_t;
+};
+
+template <>
+struct ArrowDecimalCppType<ArrowTypeId::DECIMAL64> {
+    using type = int64_t;
+};
+
+template <>
+struct ArrowDecimalCppType<ArrowTypeId::DECIMAL> {
+    using type = int128_t;
+};
+
+template <>
+struct ArrowDecimalCppType<ArrowTypeId::DECIMAL256> {
+    using type = int256_t;
+};
+
+template <ArrowTypeId AT>
+using ArrowDecimalCppTypeT = typename ArrowDecimalCppType<AT>::type;
+
+template <ArrowTypeId AT, LogicalType LT, bool is_nullable, bool is_strict>
+struct ArrowConverter<AT, LT, is_nullable, is_strict, ArrowDecimalATGuard<AT>, ArrowDecimalOfAnyVersionLTGuard<LT>> {
     using ArrowType = ArrowTypeIdToType<AT>;
     using ArrowArrayType = ArrowTypeIdToArrayType<AT>;
-    using ArrowCppType = ArrowTypeIdToCppType<AT>;
+    using SrcType = ArrowDecimalCppTypeT<AT>;
     using CppType = RunTimeCppType<LT>;
     using ColumnType = RunTimeColumnType<LT>;
 
-    static void optimize_decimal128_with_same_scale(const arrow::Decimal128Array* array, size_t array_start_idx,
-                                                    size_t num_elements, ColumnType* column, size_t column_start_idx) {
-        column->resize(column->size() + num_elements);
-        auto* data = &column->get_data().front() + column_start_idx;
-        auto* arrow_data = array->raw_values() + sizeof(CppType) * array_start_idx;
-        strings::memcpy_inlined(data, arrow_data, sizeof(CppType) * num_elements);
-    }
-
     template <bool is_aligned>
-    static void copy_int128_t(int128_t* dst, const uint8_t* src) {
+    static void copy_decimal_value(SrcType* dst, const uint8_t* src) {
         if constexpr (is_aligned) {
-            *dst = *(int128_t*)src;
+            *dst = *reinterpret_cast<const SrcType*>(src);
         } else {
-            memcpy(dst, src, sizeof(int128_t));
+            memcpy(dst, src, sizeof(SrcType));
         }
-    }
-
-    static Status cast_error(int bits, int dst_scale, int src_scale, int128_t value) {
-        std::string s = DecimalV3Cast::to_string<int128_t>(value, decimal_precision_limit<int128_t>, src_scale);
-        return Status::InternalError(strings::Substitute("Decimal$0(*,$1) cannot hold $2", bits, dst_scale, s));
     }
 
     template <bool is_aligned, typename T>
     static Status fill_column(T* data, const uint8_t* arrow_data, const size_t num_elements, int dst_scale,
                               int src_scale, [[maybe_unused]] uint8_t* null_data,
                               [[maye_unused]] uint8_t* filter_data) {
-        int128_t datum;
+        SrcType datum;
         const uint8_t* arrow_p = arrow_data;
         int adjust_scale = dst_scale - src_scale;
         if (adjust_scale == 0) {
-            for (auto i = 0; i < num_elements; ++i, arrow_p += sizeof(int128_t)) {
+            for (auto i = 0; i < num_elements; ++i, arrow_p += sizeof(SrcType)) {
                 if constexpr (is_nullable) {
                     if (null_data[i] == DATUM_NULL) continue;
                 }
-                copy_int128_t<is_aligned>(&datum, arrow_p);
-                auto overflow = DecimalV3Cast::to_decimal_trivial<int128_t, T, true>(datum, data + i);
+                copy_decimal_value<is_aligned>(&datum, arrow_p);
+                auto overflow = DecimalV3Cast::to_decimal_trivial<SrcType, T, true>(datum, data + i);
                 if (UNLIKELY(overflow)) {
                     if constexpr (is_nullable && !is_strict) {
                         null_data[i] = DATUM_NULL;
@@ -416,12 +430,12 @@ struct ArrowConverter<ArrowTypeId::DECIMAL, LT, is_nullable, is_strict, guard::G
             }
         } else if (adjust_scale > 0) {
             const auto scale_factor = get_scale_factor<T>(adjust_scale);
-            for (auto i = 0; i < num_elements; ++i, arrow_p += sizeof(int128_t)) {
+            for (auto i = 0; i < num_elements; ++i, arrow_p += sizeof(SrcType)) {
                 if constexpr (is_nullable) {
                     if (null_data[i] == DATUM_NULL) continue;
                 }
-                copy_int128_t<is_aligned>(&datum, arrow_p);
-                auto overflow = DecimalV3Cast::to_decimal<int128_t, T, T, true, true>(datum, scale_factor, data + i);
+                copy_decimal_value<is_aligned>(&datum, arrow_p);
+                auto overflow = DecimalV3Cast::to_decimal<SrcType, T, T, true, true>(datum, scale_factor, data + i);
                 if (UNLIKELY(overflow)) {
                     if constexpr (is_nullable && !is_strict) {
                         null_data[i] = DATUM_NULL;
@@ -431,14 +445,14 @@ struct ArrowConverter<ArrowTypeId::DECIMAL, LT, is_nullable, is_strict, guard::G
                 }
             }
         } else {
-            const auto scale_factor = get_scale_factor<int128_t>(-adjust_scale);
-            for (auto i = 0; i < num_elements; ++i, arrow_p += sizeof(int128_t)) {
+            const auto scale_factor = get_scale_factor<SrcType>(-adjust_scale);
+            for (auto i = 0; i < num_elements; ++i, arrow_p += sizeof(SrcType)) {
                 if constexpr (is_nullable) {
                     if (null_data[i] == DATUM_NULL) continue;
                 }
-                copy_int128_t<is_aligned>(&datum, arrow_p);
-                auto overflow =
-                        DecimalV3Cast::to_decimal<int128_t, T, int128_t, false, true>(datum, scale_factor, data + i);
+                copy_decimal_value<is_aligned>(&datum, arrow_p);
+                auto overflow = DecimalV3Cast::to_decimal<SrcType, T, SrcType, false, true>(datum, scale_factor,
+                                                                                            data + i);
                 if (UNLIKELY(overflow)) {
                     if constexpr (is_nullable && !is_strict) {
                         null_data[i] = DATUM_NULL;
@@ -465,18 +479,18 @@ struct ArrowConverter<ArrowTypeId::DECIMAL, LT, is_nullable, is_strict, guard::G
             dst_scale = concrete_column->scale();
         }
 
+        using RectifiedCppType = rectify_decimal_type<CppType>;
         if constexpr (!is_nullable) {
-            if constexpr (lt_is_decimal128<LT> || lt_is_decimalv2<LT>) {
-                if (src_scale == dst_scale) {
-                    optimize_decimal128_with_same_scale(concrete_array, array_start_idx, num_elements, concrete_column,
-                                                        column_start_idx);
-                    return Status::OK();
-                }
+            if (src_scale == dst_scale && sizeof(SrcType) == sizeof(RectifiedCppType)) {
+                concrete_column->resize(column->size() + num_elements);
+                auto* data = (RectifiedCppType*)(&concrete_column->get_data().front() + column_start_idx);
+                auto* arrow_data = concrete_array->raw_values() + array_start_idx * concrete_type->byte_width();
+                strings::memcpy_inlined(data, arrow_data, sizeof(RectifiedCppType) * num_elements);
+                return Status::OK();
             }
         }
 
         concrete_column->resize(column->size() + num_elements);
-        using RectifiedCppType = rectify_decimal_type<CppType>;
         auto* data = (RectifiedCppType*)(&concrete_column->get_data().front() + column_start_idx);
         auto* arrow_data = concrete_array->raw_values() + array_start_idx * concrete_type->byte_width();
         bool is_aligned = ((uintptr_t)arrow_data & (concrete_type->byte_width() - 1)) == 0;
@@ -971,7 +985,9 @@ static const std::unordered_map<ArrowTypeId, LogicalType> global_strict_arrow_co
                                   ArrowTypeId::LARGE_BINARY, ArrowTypeId::FIXED_SIZE_BINARY),
         STRICT_ARROW_CONV_ENTRY_R(TYPE_DATE, ArrowTypeId::DATE32),
         STRICT_ARROW_CONV_ENTRY_R(TYPE_DATETIME, ArrowTypeId::DATE64, ArrowTypeId::TIMESTAMP),
-        STRICT_ARROW_CONV_ENTRY_R(TYPE_DECIMAL128, ArrowTypeId::DECIMAL),
+        STRICT_ARROW_CONV_ENTRY_R(TYPE_DECIMAL128, ArrowTypeId::DECIMAL, ArrowTypeId::DECIMAL32,
+                                  ArrowTypeId::DECIMAL64),
+        STRICT_ARROW_CONV_ENTRY_R(TYPE_DECIMAL256, ArrowTypeId::DECIMAL256),
         STRICT_ARROW_CONV_ENTRY_R(TYPE_JSON, ArrowTypeId::STRUCT, ArrowTypeId::MAP, ArrowTypeId::LIST),
         STRICT_ARROW_CONV_ENTRY_R(TYPE_ARRAY, ArrowTypeId::LIST, ArrowTypeId::LARGE_LIST, ArrowTypeId::FIXED_SIZE_LIST),
         STRICT_ARROW_CONV_ENTRY_R(TYPE_MAP, ArrowTypeId::MAP),
@@ -1006,7 +1022,13 @@ static const std::unordered_map<int32_t, ConvertFunc> global_optimized_arrow_con
         ARROW_CONV_ENTRY(ArrowTypeId::DATE32, TYPE_DATE, TYPE_DATETIME, TYPE_JSON),
         ARROW_CONV_ENTRY(ArrowTypeId::DATE64, TYPE_DATE, TYPE_DATETIME, TYPE_JSON),
         ARROW_CONV_ENTRY(ArrowTypeId::TIMESTAMP, TYPE_DATE, TYPE_DATETIME, TYPE_JSON),
-        ARROW_CONV_ENTRY(ArrowTypeId::DECIMAL, TYPE_DECIMALV2, TYPE_DECIMAL32, TYPE_DECIMAL64, TYPE_DECIMAL128),
+        ARROW_CONV_ENTRY(ArrowTypeId::DECIMAL, TYPE_DECIMALV2, TYPE_DECIMAL32, TYPE_DECIMAL64, TYPE_DECIMAL128,
+                         TYPE_DECIMAL256),
+        ARROW_CONV_ENTRY(ArrowTypeId::DECIMAL32, TYPE_DECIMALV2, TYPE_DECIMAL32, TYPE_DECIMAL64, TYPE_DECIMAL128,
+                         TYPE_DECIMAL256),
+        ARROW_CONV_ENTRY(ArrowTypeId::DECIMAL64, TYPE_DECIMALV2, TYPE_DECIMAL32, TYPE_DECIMAL64, TYPE_DECIMAL128,
+                         TYPE_DECIMAL256),
+        ARROW_CONV_ENTRY(ArrowTypeId::DECIMAL256, TYPE_DECIMAL256),
 
         // JSON converters
         ARROW_CONV_ENTRY(ArrowTypeId::MAP, TYPE_MAP, TYPE_JSON),

--- a/be/src/exec/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/arrow_to_starrocks_converter.cpp
@@ -451,8 +451,8 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, ArrowDecimalATGuard<AT>, A
                     if (null_data[i] == DATUM_NULL) continue;
                 }
                 copy_decimal_value<is_aligned>(&datum, arrow_p);
-                auto overflow = DecimalV3Cast::to_decimal<SrcType, T, SrcType, false, true>(datum, scale_factor,
-                                                                                            data + i);
+                auto overflow = 
+                        DecimalV3Cast::to_decimal<SrcType, T, SrcType, false, true>(datum, scale_factor, data + i);
                 if (UNLIKELY(overflow)) {
                     if constexpr (is_nullable && !is_strict) {
                         null_data[i] = DATUM_NULL;

--- a/be/src/exec/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/arrow_to_starrocks_converter.cpp
@@ -451,7 +451,7 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, ArrowDecimalATGuard<AT>, A
                     if (null_data[i] == DATUM_NULL) continue;
                 }
                 copy_decimal_value<is_aligned>(&datum, arrow_p);
-                auto overflow = 
+                auto overflow =
                         DecimalV3Cast::to_decimal<SrcType, T, SrcType, false, true>(datum, scale_factor, data + i);
                 if (UNLIKELY(overflow)) {
                     if constexpr (is_nullable && !is_strict) {

--- a/be/src/exec/arrow_type_traits.h
+++ b/be/src/exec/arrow_type_traits.h
@@ -48,6 +48,8 @@ M_ArrowTypeIdToTypeStruct(ArrowTypeId::STRING, arrow::StringType);
 M_ArrowTypeIdToTypeStruct(ArrowTypeId::FIXED_SIZE_BINARY, arrow::FixedSizeBinaryType);
 M_ArrowTypeIdToTypeStruct(ArrowTypeId::LARGE_BINARY, arrow::LargeBinaryType);
 M_ArrowTypeIdToTypeStruct(ArrowTypeId::LARGE_STRING, arrow::LargeStringType);
+M_ArrowTypeIdToTypeStruct(ArrowTypeId::DECIMAL32, arrow::Decimal32Type);
+M_ArrowTypeIdToTypeStruct(ArrowTypeId::DECIMAL64, arrow::Decimal64Type);
 M_ArrowTypeIdToTypeStruct(ArrowTypeId::DECIMAL, arrow::Decimal128Type);
 M_ArrowTypeIdToTypeStruct(ArrowTypeId::DECIMAL256, arrow::Decimal256Type);
 M_ArrowTypeIdToTypeStruct(ArrowTypeId::DATE32, arrow::Date32Type);
@@ -82,6 +84,14 @@ struct ArrowTypeIdToCppTypeStruct<AT, BinaryATGuard<AT>> {
 };
 template <>
 struct ArrowTypeIdToCppTypeStruct<ArrowTypeId::DECIMAL, guard::Guard> {
+    using type = const uint8_t*;
+};
+template <>
+struct ArrowTypeIdToCppTypeStruct<ArrowTypeId::DECIMAL32, guard::Guard> {
+    using type = const uint8_t*;
+};
+template <>
+struct ArrowTypeIdToCppTypeStruct<ArrowTypeId::DECIMAL64, guard::Guard> {
     using type = const uint8_t*;
 };
 template <>

--- a/be/src/exec/file_scanner/parquet_scanner.cpp
+++ b/be/src/exec/file_scanner/parquet_scanner.cpp
@@ -257,11 +257,14 @@ Status ParquetScanner::build_dest(const arrow::DataType* arrow_type, const TypeD
             conv_func->func = strict_conv_func;
             raw_type_desc->type = strict_pt;
             switch (strict_pt) {
-            case TYPE_DECIMAL128: {
-                const auto* discrete_type = down_cast<const arrow::Decimal128Type*>(arrow_type);
-                auto precision = discrete_type->precision();
-                auto scale = discrete_type->scale();
-                if (precision < 1 || precision > decimal_precision_limit<int128_t> || scale < 0 || scale > precision) {
+            case TYPE_DECIMAL128:
+            case TYPE_DECIMAL256: {
+                const auto* decimal_type = down_cast<const arrow::DecimalType*>(arrow_type);
+                auto precision = decimal_type->precision();
+                auto scale = decimal_type->scale();
+                auto max_precision = strict_pt == TYPE_DECIMAL256 ? decimal_precision_limit<int256_t>
+                                                                  : decimal_precision_limit<int128_t>;
+                if (precision < 1 || precision > max_precision || scale < 0 || scale > precision) {
                     return Status::InternalError(
                             strings::Substitute("Decimal($0, $1) is out of range.", precision, scale));
                 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands Arrow decimal ingestion and optimizes conversion.
> 
> - Generalizes decimal converter to handle `ArrowTypeId::{DECIMAL32, DECIMAL64, DECIMAL, DECIMAL256}` mapping to `TYPE_{DECIMAL32, DECIMAL64, DECIMAL128, DECIMAL256}` with a unified path
> - Adds memcpy fast-path for non-nullable decimals when `src_scale == dst_scale` and element sizes match
> - Extends strict and optimized conversion tables to include `DECIMAL32`, `DECIMAL64`, and `DECIMAL256`
> - Updates `arrow_type_traits.h` to map `DECIMAL32`/`DECIMAL64` types and cpp-type traits
> - Enhances Parquet scanner to validate precision/scale for `TYPE_DECIMAL128` and `TYPE_DECIMAL256`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 660d8918c5289c4faab3f1356e0e1e7c27504d50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->