### PR TITLE
[Feature] Add benchmark scan node

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -483,6 +483,7 @@ set(STARROCKS_DEPENDENCIES
     arrow
     arrow_flight
     arrow_flight_sql
+    benchgen
     gRPC::grpc
     gRPC::grpc++
     parquet

--- a/be/cmake_modules/ThirdParty.cmake
+++ b/be/cmake_modules/ThirdParty.cmake
@@ -324,6 +324,9 @@ set_target_properties(azure-storage-blobs PROPERTIES IMPORTED_LOCATION ${THIRDPA
 add_library(azure-storage-files-datalake STATIC IMPORTED GLOBAL)
 set_target_properties(azure-storage-files-datalake PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libazure-storage-files-datalake.a)
 
+add_library(benchgen STATIC IMPORTED GLOBAL)
+set_target_properties(benchgen PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libbenchgen.a)
+
 set(absl_DIR "${THIRDPARTY_DIR}/lib/cmake/absl" CACHE PATH "absl search path" FORCE)
 find_package(absl CONFIG REQUIRED)
 set(gRPC_DIR "${THIRDPARTY_DIR}/lib/cmake/grpc" CACHE PATH "grpc search path")

--- a/be/src/connector/CMakeLists.txt
+++ b/be/src/connector/CMakeLists.txt
@@ -21,6 +21,7 @@ ADD_BE_LIB(Connector
         jdbc_connector.cpp
         lake_connector.cpp
         mysql_connector.cpp
+        benchmark_connector.cpp
         file_connector.cpp
         binlog_connector.cpp
         iceberg_connector.cpp

--- a/be/src/connector/benchmark_connector.cpp
+++ b/be/src/connector/benchmark_connector.cpp
@@ -97,29 +97,16 @@ Status BenchmarkDataSource::_init_params(RuntimeState* state) {
     }
 
     BenchmarkScannerParam param;
-    if (_has_scan_range && _benchmark_scan_range.__isset.db_name && !_benchmark_scan_range.db_name.empty()) {
-        param.db_name = _benchmark_scan_range.db_name;
-    } else if (scan_node.__isset.db_name && !scan_node.db_name.empty()) {
-        param.db_name = scan_node.db_name;
-    } else {
-        param.db_name = "tpcds";
-    }
+    param.db_name = scan_node.db_name;
     param.table_name = scan_node.table_name;
     param.options.scale_factor = scan_node.__isset.scale_factor ? scan_node.scale_factor : 1.0;
-    if (_has_scan_range && _benchmark_scan_range.__isset.start_row) {
-        param.options.start_row = _benchmark_scan_range.start_row;
-    } else {
-        param.options.start_row = scan_node.__isset.start_row ? scan_node.start_row : 0;
-    }
+    param.options.start_row = _benchmark_scan_range.start_row;
     if (_has_scan_range && _benchmark_scan_range.__isset.row_count) {
         param.options.row_count = _benchmark_scan_range.row_count;
     } else {
-        param.options.row_count = scan_node.__isset.row_count ? scan_node.row_count : -1;
+        param.options.row_count = -1;
     }
     param.options.chunk_size = state->chunk_size();
-    if (param.options.chunk_size <= 0) {
-        param.options.chunk_size = 4096;
-    }
     if (_read_limit != -1) {
         if (param.options.row_count < 0) {
             param.options.row_count = _read_limit;

--- a/be/src/connector/benchmark_connector.cpp
+++ b/be/src/connector/benchmark_connector.cpp
@@ -1,0 +1,135 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "connector/benchmark_connector.h"
+
+#include <algorithm>
+
+#include "runtime/runtime_state.h"
+
+namespace starrocks::connector {
+
+DataSourceProviderPtr BenchmarkConnector::create_data_source_provider(ConnectorScanNode* scan_node,
+                                                                      const TPlanNode& plan_node) const {
+    return std::make_unique<BenchmarkDataSourceProvider>(scan_node, plan_node);
+}
+
+BenchmarkDataSourceProvider::BenchmarkDataSourceProvider(ConnectorScanNode* scan_node, const TPlanNode& plan_node)
+        : _scan_node(scan_node), _benchmark_scan_node(plan_node.benchmark_scan_node) {}
+
+DataSourcePtr BenchmarkDataSourceProvider::create_data_source(const TScanRange& scan_range) {
+    return std::make_unique<BenchmarkDataSource>(this, scan_range);
+}
+
+const TupleDescriptor* BenchmarkDataSourceProvider::tuple_descriptor(RuntimeState* state) const {
+    return state->desc_tbl().get_tuple_descriptor(_benchmark_scan_node.tuple_id);
+}
+
+BenchmarkDataSource::BenchmarkDataSource(const BenchmarkDataSourceProvider* provider, const TScanRange& scan_range)
+        : _provider(provider) {
+    if (scan_range.__isset.benchmark_scan_range) {
+        _benchmark_scan_range = scan_range.benchmark_scan_range;
+        _has_scan_range = true;
+    }
+}
+
+std::string BenchmarkDataSource::name() const {
+    return "BenchmarkDataSource";
+}
+
+Status BenchmarkDataSource::open(RuntimeState* state) {
+    RETURN_IF_ERROR(_init_params(state));
+    RETURN_IF_ERROR(_scanner->open(state));
+    return Status::OK();
+}
+
+void BenchmarkDataSource::close(RuntimeState* state) {
+    if (_scanner != nullptr) {
+        _scanner->close(state);
+    }
+}
+
+Status BenchmarkDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
+    bool eos = false;
+    do {
+        RETURN_IF_ERROR(_scanner->get_next(state, chunk, &eos));
+    } while (!eos && (*chunk)->num_rows() == 0);
+    if (eos) {
+        return Status::EndOfFile("");
+    }
+    _rows_read += (*chunk)->num_rows();
+    _bytes_read += (*chunk)->bytes_usage();
+    return Status::OK();
+}
+
+int64_t BenchmarkDataSource::raw_rows_read() const {
+    return _rows_read;
+}
+
+int64_t BenchmarkDataSource::num_rows_read() const {
+    return _rows_read;
+}
+
+int64_t BenchmarkDataSource::num_bytes_read() const {
+    return _bytes_read;
+}
+
+int64_t BenchmarkDataSource::cpu_time_spent() const {
+    return 0;
+}
+
+Status BenchmarkDataSource::_init_params(RuntimeState* state) {
+    const TBenchmarkScanNode& scan_node = _provider->_benchmark_scan_node;
+    _tuple_desc = state->desc_tbl().get_tuple_descriptor(scan_node.tuple_id);
+    if (_tuple_desc == nullptr) {
+        return Status::InternalError("Failed to get tuple descriptor for benchmark scan");
+    }
+
+    BenchmarkScannerParam param;
+    if (_has_scan_range && _benchmark_scan_range.__isset.db_name && !_benchmark_scan_range.db_name.empty()) {
+        param.db_name = _benchmark_scan_range.db_name;
+    } else if (scan_node.__isset.db_name && !scan_node.db_name.empty()) {
+        param.db_name = scan_node.db_name;
+    } else {
+        param.db_name = "tpcds";
+    }
+    param.table_name = scan_node.table_name;
+    param.options.scale_factor = scan_node.__isset.scale_factor ? scan_node.scale_factor : 1.0;
+    if (_has_scan_range && _benchmark_scan_range.__isset.start_row) {
+        param.options.start_row = _benchmark_scan_range.start_row;
+    } else {
+        param.options.start_row = scan_node.__isset.start_row ? scan_node.start_row : 0;
+    }
+    if (_has_scan_range && _benchmark_scan_range.__isset.row_count) {
+        param.options.row_count = _benchmark_scan_range.row_count;
+    } else {
+        param.options.row_count = scan_node.__isset.row_count ? scan_node.row_count : -1;
+    }
+    param.options.chunk_size = state->chunk_size();
+    if (param.options.chunk_size <= 0) {
+        param.options.chunk_size = 4096;
+    }
+    if (_read_limit != -1) {
+        if (param.options.row_count < 0) {
+            param.options.row_count = _read_limit;
+        } else {
+            param.options.row_count = std::min(param.options.row_count, _read_limit);
+        }
+    }
+
+    _scanner = std::make_unique<BenchmarkScanner>(std::move(param), _tuple_desc);
+    return Status::OK();
+}
+
+} // namespace starrocks::connector

--- a/be/src/connector/benchmark_connector.h
+++ b/be/src/connector/benchmark_connector.h
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "connector/connector.h"
+#include "exec/benchmark_scanner.h"
+
+namespace starrocks::connector {
+
+class BenchmarkConnector final : public Connector {
+public:
+    ~BenchmarkConnector() override = default;
+
+    DataSourceProviderPtr create_data_source_provider(ConnectorScanNode* scan_node,
+                                                      const TPlanNode& plan_node) const override;
+
+    ConnectorType connector_type() const override { return ConnectorType::BENCHMARK; }
+};
+
+class BenchmarkDataSource;
+class BenchmarkDataSourceProvider;
+
+class BenchmarkDataSourceProvider final : public DataSourceProvider {
+public:
+    ~BenchmarkDataSourceProvider() override = default;
+    friend class BenchmarkDataSource;
+    BenchmarkDataSourceProvider(ConnectorScanNode* scan_node, const TPlanNode& plan_node);
+    DataSourcePtr create_data_source(const TScanRange& scan_range) override;
+
+    bool insert_local_exchange_operator() const override { return true; }
+    bool accept_empty_scan_ranges() const override { return false; }
+    const TupleDescriptor* tuple_descriptor(RuntimeState* state) const override;
+
+protected:
+    ConnectorScanNode* _scan_node;
+    const TBenchmarkScanNode _benchmark_scan_node;
+};
+
+class BenchmarkDataSource final : public DataSource {
+public:
+    ~BenchmarkDataSource() override = default;
+
+    BenchmarkDataSource(const BenchmarkDataSourceProvider* provider, const TScanRange& scan_range);
+    std::string name() const override;
+    Status open(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
+    Status get_next(RuntimeState* state, ChunkPtr* chunk) override;
+
+    int64_t raw_rows_read() const override;
+    int64_t num_rows_read() const override;
+    int64_t num_bytes_read() const override;
+    int64_t cpu_time_spent() const override;
+
+private:
+    Status _init_params(RuntimeState* state);
+
+    const BenchmarkDataSourceProvider* _provider;
+    TBenchmarkScanRange _benchmark_scan_range;
+    bool _has_scan_range = false;
+    std::unique_ptr<BenchmarkScanner> _scanner;
+    int64_t _rows_read = 0;
+    int64_t _bytes_read = 0;
+};
+
+} // namespace starrocks::connector

--- a/be/src/connector/connector.cpp
+++ b/be/src/connector/connector.cpp
@@ -24,6 +24,7 @@
 #include "connector/jdbc_connector.h"
 #include "connector/lake_connector.h"
 #include "connector/mysql_connector.h"
+#include "connector/benchmark_connector.h"
 
 namespace starrocks::connector {
 
@@ -51,6 +52,7 @@ const std::string Connector::FILE = "file";
 const std::string Connector::LAKE = "lake";
 const std::string Connector::BINLOG = "binlog";
 const std::string Connector::ICEBERG = "iceberg";
+const std::string Connector::BENCHMARK = "benchmark";
 
 class ConnectorManagerInit {
 public:
@@ -60,6 +62,7 @@ public:
         cm->put(Connector::ES, std::make_unique<ESConnector>());
         cm->put(Connector::JDBC, std::make_unique<JDBCConnector>());
         cm->put(Connector::MYSQL, std::make_unique<MySQLConnector>());
+        cm->put(Connector::BENCHMARK, std::make_unique<BenchmarkConnector>());
         cm->put(Connector::FILE, std::make_unique<FileConnector>());
         cm->put(Connector::LAKE, std::make_unique<LakeConnector>());
         cm->put(Connector::BINLOG, std::make_unique<BinlogConnector>());

--- a/be/src/connector/connector.cpp
+++ b/be/src/connector/connector.cpp
@@ -21,10 +21,10 @@
 #ifndef __APPLE__
 #include "connector/iceberg_connector.h"
 #endif
+#include "connector/benchmark_connector.h"
 #include "connector/jdbc_connector.h"
 #include "connector/lake_connector.h"
 #include "connector/mysql_connector.h"
-#include "connector/benchmark_connector.h"
 
 namespace starrocks::connector {
 

--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -199,6 +199,7 @@ enum ConnectorType {
     LAKE = 5,
     BINLOG = 6,
     ICEBERG = 7,
+    BENCHMARK = 8,
 };
 
 class Connector {
@@ -212,6 +213,7 @@ public:
     static const std::string LAKE;
     static const std::string BINLOG;
     static const std::string ICEBERG;
+    static const std::string BENCHMARK;
 
     virtual ~Connector() = default;
     // First version we use TPlanNode to construct data source provider.

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -43,6 +43,7 @@ set(EXEC_FILES
     write_combined_txn_log.cpp
     multi_olap_table_sink.cpp
     mysql_scanner.cpp
+    benchmark_scanner.cpp
     es/es_predicate.cpp
     es/es_scan_reader.cpp
     es/es_scroll_query.cpp

--- a/be/src/exec/benchmark_scanner.cpp
+++ b/be/src/exec/benchmark_scanner.cpp
@@ -29,7 +29,7 @@
 namespace starrocks {
 
 BenchmarkScanner::BenchmarkScanner(BenchmarkScannerParam param, const TupleDescriptor* tuple_desc)
-        : _param(std::move(param)), _tuple_desc(tuple_desc), _slot_descs(tuple_desc->slots()) {}
+        : _param(std::move(param)), _slot_descs(tuple_desc->slots()) {}
 
 Status BenchmarkScanner::open(RuntimeState* state) {
     _conv_ctx.state = state;

--- a/be/src/exec/benchmark_scanner.cpp
+++ b/be/src/exec/benchmark_scanner.cpp
@@ -1,0 +1,178 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/benchmark_scanner.h"
+
+#include <algorithm>
+
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "exprs/cast_expr.h"
+#include "exprs/column_ref.h"
+#include "exec/file_scanner/parquet_scanner.h"
+#include "runtime/runtime_state.h"
+#include "benchgen/benchmark_suite.h"
+#include "benchgen/record_batch_iterator_factory.h"
+#include "util/arrow/utils.h"
+
+namespace starrocks {
+
+BenchmarkScanner::BenchmarkScanner(BenchmarkScannerParam param, const TupleDescriptor* tuple_desc)
+        : _param(std::move(param)), _tuple_desc(tuple_desc), _slot_descs(tuple_desc->slots()) {}
+
+Status BenchmarkScanner::open(RuntimeState* state) {
+    _conv_ctx.state = state;
+    _conv_ctx.current_file = _param.table_name;
+    if (_param.options.chunk_size <= 0) {
+        _param.options.chunk_size = state->chunk_size();
+    }
+
+    benchgen::SuiteId suite = benchgen::SuiteIdFromString(_param.db_name);
+    if (suite == benchgen::SuiteId::kUnknown) {
+        return Status::InvalidArgument("Unknown benchmark database: " + _param.db_name);
+    }
+    RETURN_STATUS_IF_ERROR(benchgen::MakeRecordBatchIterator(suite, _param.table_name, _param.options, &_iter));
+    _schema = _iter->schema();
+    if (_schema == nullptr) {
+        return Status::InternalError("Benchmark iterator returned a null schema");
+    }
+
+    _max_chunk_size = state->chunk_size();
+    if (_max_chunk_size == 0) {
+        _max_chunk_size = static_cast<size_t>(_param.options.chunk_size);
+    }
+    if (_max_chunk_size == 0) {
+        _max_chunk_size = 4096;
+    }
+
+    return _init_converters(_schema);
+}
+
+Status BenchmarkScanner::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
+    (void)state;
+    *eos = false;
+    if (_scanner_eof) {
+        *eos = true;
+        return Status::OK();
+    }
+
+    if (_batch == nullptr || _batch_start_idx >= _batch->num_rows()) {
+        RETURN_IF_ERROR(_next_batch(eos));
+        if (*eos) {
+            return Status::OK();
+        }
+    }
+
+    size_t batch_rows = static_cast<size_t>(_batch->num_rows());
+    size_t num_elements = std::min(_max_chunk_size, batch_rows - _batch_start_idx);
+    _chunk_filter.assign(num_elements, 1);
+
+    ChunkPtr raw_chunk = std::make_shared<Chunk>();
+
+    for (size_t i = 0; i < _slot_descs.size(); ++i) {
+        SlotDescriptor* slot_desc = _slot_descs[i];
+        MutableColumnPtr column = ColumnHelper::create_column(*_raw_type_descs[i], slot_desc->is_nullable());
+        column->reserve(num_elements);
+        raw_chunk->append_column(std::move(column), slot_desc->id());
+
+        auto array = _batch->GetColumnByName(slot_desc->col_name());
+        if (array == nullptr) {
+            return Status::NotFound("Benchmark column " + slot_desc->col_name() + " not found in schema");
+        }
+
+        _conv_ctx.current_slot = slot_desc;
+        RETURN_IF_ERROR(ParquetScanner::convert_array_to_column(_conv_funcs[i].get(), num_elements, array.get(),
+                                                                raw_chunk->get_column_raw_ptr_by_slot_id(slot_desc->id()),
+                                                                _batch_start_idx, 0, &_chunk_filter, &_conv_ctx));
+    }
+
+    raw_chunk->filter(_chunk_filter);
+
+    ChunkPtr cast_chunk = std::make_shared<Chunk>();
+    cast_chunk->reserve(raw_chunk->num_rows());
+    for (size_t i = 0; i < _slot_descs.size(); ++i) {
+        SlotDescriptor* slot_desc = _slot_descs[i];
+        ASSIGN_OR_RETURN(auto column, _cast_exprs[i]->evaluate_checked(nullptr, raw_chunk.get()));
+        column = ColumnHelper::unfold_const_column(slot_desc->type(), raw_chunk->num_rows(), std::move(column));
+        cast_chunk->append_column(column, slot_desc->id());
+    }
+
+    *chunk = std::move(cast_chunk);
+    _batch_start_idx += num_elements;
+    return Status::OK();
+}
+
+void BenchmarkScanner::close(RuntimeState* state) {
+    (void)state;
+    _iter.reset();
+    _batch.reset();
+    _schema.reset();
+}
+
+Status BenchmarkScanner::_init_converters(const std::shared_ptr<arrow::Schema>& schema) {
+    size_t slot_count = _slot_descs.size();
+    _raw_type_descs.clear();
+    _conv_funcs.clear();
+    _cast_exprs.assign(slot_count, nullptr);
+    _raw_type_descs.reserve(slot_count);
+    _conv_funcs.reserve(slot_count);
+
+    for (size_t i = 0; i < slot_count; ++i) {
+        SlotDescriptor* slot_desc = _slot_descs[i];
+        auto field = schema->GetFieldByName(slot_desc->col_name());
+        if (field == nullptr) {
+            return Status::NotFound("Benchmark column " + slot_desc->col_name() + " not found in schema");
+        }
+
+        auto raw_type_desc = std::make_unique<TypeDescriptor>();
+        auto conv_func = std::make_unique<ConvertFuncTree>();
+        bool need_cast = false;
+        RETURN_IF_ERROR(ParquetScanner::build_dest(field->type().get(), &slot_desc->type(), slot_desc->is_nullable(),
+                                                   raw_type_desc.get(), conv_func.get(), need_cast, false));
+
+        Expr* expr = nullptr;
+        if (!need_cast) {
+            expr = _pool.add(new ColumnRef(slot_desc));
+        } else {
+            auto* slot = _pool.add(new ColumnRef(slot_desc));
+            expr = VectorizedCastExprFactory::from_type(*raw_type_desc, slot_desc->type(), slot, &_pool);
+            if (expr == nullptr) {
+                return illegal_converting_error(field->type()->name(), slot_desc->type().debug_string());
+            }
+        }
+
+        _raw_type_descs.emplace_back(std::move(raw_type_desc));
+        _conv_funcs.emplace_back(std::move(conv_func));
+        _cast_exprs[i] = expr;
+    }
+
+    return Status::OK();
+}
+
+Status BenchmarkScanner::_next_batch(bool* eos) {
+    std::shared_ptr<arrow::RecordBatch> batch;
+    RETURN_STATUS_IF_ERROR(_iter->Next(&batch));
+    if (batch == nullptr) {
+        _scanner_eof = true;
+        *eos = true;
+        return Status::OK();
+    }
+
+    _batch = std::move(batch);
+    _batch_start_idx = 0;
+    *eos = false;
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/exec/benchmark_scanner.cpp
+++ b/be/src/exec/benchmark_scanner.cpp
@@ -16,14 +16,14 @@
 
 #include <algorithm>
 
-#include "column/chunk.h"
-#include "column/column_helper.h"
-#include "exprs/cast_expr.h"
-#include "exprs/column_ref.h"
-#include "exec/file_scanner/parquet_scanner.h"
-#include "runtime/runtime_state.h"
 #include "benchgen/benchmark_suite.h"
 #include "benchgen/record_batch_iterator_factory.h"
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "exec/file_scanner/parquet_scanner.h"
+#include "exprs/cast_expr.h"
+#include "exprs/column_ref.h"
+#include "runtime/runtime_state.h"
 #include "util/arrow/utils.h"
 
 namespace starrocks {
@@ -92,9 +92,10 @@ Status BenchmarkScanner::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eo
         }
 
         _conv_ctx.current_slot = slot_desc;
-        RETURN_IF_ERROR(ParquetScanner::convert_array_to_column(_conv_funcs[i].get(), num_elements, array.get(),
-                                                                raw_chunk->get_column_raw_ptr_by_slot_id(slot_desc->id()),
-                                                                _batch_start_idx, 0, &_chunk_filter, &_conv_ctx));
+        RETURN_IF_ERROR(
+                ParquetScanner::convert_array_to_column(_conv_funcs[i].get(), num_elements, array.get(),
+                                                        raw_chunk->get_column_raw_ptr_by_slot_id(slot_desc->id()),
+                                                        _batch_start_idx, 0, &_chunk_filter, &_conv_ctx));
     }
 
     raw_chunk->filter(_chunk_filter);

--- a/be/src/exec/benchmark_scanner.h
+++ b/be/src/exec/benchmark_scanner.h
@@ -18,13 +18,13 @@
 #include <string>
 #include <vector>
 
+#include "benchgen/generator_options.h"
+#include "benchgen/record_batch_iterator.h"
 #include "column/vectorized_fwd.h"
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "exec/arrow_to_starrocks_converter.h"
 #include "runtime/descriptors.h"
-#include "benchgen/generator_options.h"
-#include "benchgen/record_batch_iterator.h"
 
 namespace arrow {
 class RecordBatch;

--- a/be/src/exec/benchmark_scanner.h
+++ b/be/src/exec/benchmark_scanner.h
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "column/vectorized_fwd.h"
+#include "common/object_pool.h"
+#include "common/status.h"
+#include "exec/arrow_to_starrocks_converter.h"
+#include "runtime/descriptors.h"
+#include "benchgen/generator_options.h"
+#include "benchgen/record_batch_iterator.h"
+
+namespace arrow {
+class RecordBatch;
+class Schema;
+} // namespace arrow
+
+namespace starrocks {
+
+class Expr;
+class RuntimeState;
+
+struct BenchmarkScannerParam {
+    std::string db_name;
+    std::string table_name;
+    benchgen::GeneratorOptions options;
+};
+
+class BenchmarkScanner {
+public:
+    BenchmarkScanner(BenchmarkScannerParam param, const TupleDescriptor* tuple_desc);
+
+    Status open(RuntimeState* state);
+    Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos);
+    void close(RuntimeState* state);
+
+private:
+    Status _init_converters(const std::shared_ptr<arrow::Schema>& schema);
+    Status _next_batch(bool* eos);
+
+    BenchmarkScannerParam _param;
+    const TupleDescriptor* _tuple_desc;
+    std::vector<SlotDescriptor*> _slot_descs;
+
+    std::unique_ptr<benchgen::RecordBatchIterator> _iter;
+    std::shared_ptr<arrow::Schema> _schema;
+    std::shared_ptr<arrow::RecordBatch> _batch;
+    size_t _batch_start_idx = 0;
+    size_t _max_chunk_size = 0;
+
+    std::vector<std::unique_ptr<TypeDescriptor>> _raw_type_descs;
+    std::vector<std::unique_ptr<ConvertFuncTree>> _conv_funcs;
+    std::vector<Expr*> _cast_exprs;
+
+    ObjectPool _pool;
+    ArrowConvertContext _conv_ctx;
+    Filter _chunk_filter;
+    bool _scanner_eof = false;
+};
+
+} // namespace starrocks

--- a/be/src/exec/benchmark_scanner.h
+++ b/be/src/exec/benchmark_scanner.h
@@ -55,7 +55,6 @@ private:
     Status _next_batch(bool* eos);
 
     BenchmarkScannerParam _param;
-    const TupleDescriptor* _tuple_desc;
     std::vector<SlotDescriptor*> _slot_descs;
 
     std::unique_ptr<benchgen::RecordBatchIterator> _iter;

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -522,6 +522,14 @@ Status ExecNode::create_vectorized_node(starrocks::RuntimeState* state, starrock
         *node = pool->add(new ConnectorScanNode(pool, new_node, descs));
         return Status::OK();
     }
+    case TPlanNodeType::BENCHMARK_SCAN_NODE: {
+        TPlanNode new_node = tnode;
+        TConnectorScanNode connector_scan_node;
+        connector_scan_node.connector_name = connector::Connector::BENCHMARK;
+        new_node.connector_scan_node = connector_scan_node;
+        *node = pool->add(new ConnectorScanNode(pool, new_node, descs));
+        return Status::OK();
+    }
     case TPlanNodeType::ES_HTTP_SCAN_NODE: {
         TPlanNode new_node = tnode;
         TConnectorScanNode connector_scan_node;
@@ -858,6 +866,7 @@ void ExecNode::collect_scan_nodes(vector<ExecNode*>* nodes) {
     collect_nodes(TPlanNodeType::LAKE_META_SCAN_NODE, nodes);
     collect_nodes(TPlanNodeType::JDBC_SCAN_NODE, nodes);
     collect_nodes(TPlanNodeType::MYSQL_SCAN_NODE, nodes);
+    collect_nodes(TPlanNodeType::BENCHMARK_SCAN_NODE, nodes);
     collect_nodes(TPlanNodeType::LAKE_SCAN_NODE, nodes);
     collect_nodes(TPlanNodeType::SCHEMA_SCAN_NODE, nodes);
     collect_nodes(TPlanNodeType::STREAM_SCAN_NODE, nodes);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -33,6 +33,7 @@ set(EXEC_FILES
         ./common/tracer_test.cpp
         ./common/uri_test.cpp
         ./common/cow_test.cpp
+        ./connector/benchmark_connector_test.cpp
         ./connector/deletion_vector/deletion_vector_test.cpp
         ./connector_sink/hive_chunk_sink_test.cpp
         ./connector_sink/iceberg_chunk_sink_test.cpp
@@ -106,6 +107,7 @@ set(EXEC_FILES
         ./exec/analytor_test.cpp
         ./exec/analytor_test.cpp
         ./exec/arrow_converter_test.cpp
+        ./exec/benchmark_scanner_test.cpp
         ./exec/chunks_sorter_heap_sort_test.cpp
         ./exec/chunks_sorter_test.cpp
         ./exec/connector_scan_node_test.cpp

--- a/be/test/connector/benchmark_connector_test.cpp
+++ b/be/test/connector/benchmark_connector_test.cpp
@@ -14,7 +14,7 @@
 
 #include "connector/benchmark_connector.h"
 
-#include <arrow/schema.h>
+#include <arrow/type.h>
 #include <arrow/status.h>
 #include <gtest/gtest.h>
 

--- a/be/test/connector/benchmark_connector_test.cpp
+++ b/be/test/connector/benchmark_connector_test.cpp
@@ -1,0 +1,201 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "connector/benchmark_connector.h"
+
+#include <arrow/schema.h>
+#include <arrow/status.h>
+#include <gtest/gtest.h>
+
+#include "benchgen/benchmark_suite.h"
+#include "benchgen/record_batch_iterator_factory.h"
+#include "benchgen/table.h"
+#include "common/config.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+#include "runtime/types.h"
+#include "testutil/assert.h"
+
+namespace starrocks::connector {
+
+class BenchmarkConnectorTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        config::enable_system_metrics = false;
+        config::enable_metric_calculator = false;
+
+        _exec_env = ExecEnv::GetInstance();
+        _runtime_state = _create_runtime_state();
+        _pool = _runtime_state->obj_pool();
+    }
+
+protected:
+    std::shared_ptr<RuntimeState> _create_runtime_state() {
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        query_options.batch_size = 16;
+        TQueryGlobals query_globals;
+        auto runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, _exec_env);
+        TUniqueId id;
+        runtime_state->init_mem_trackers(id);
+        return runtime_state;
+    }
+
+    DescriptorTbl* _create_table_desc(const std::string& column_name, const TypeDescriptor& type_desc) {
+        TDescriptorTableBuilder desc_tbl_builder;
+        TTupleDescriptorBuilder tuple_desc_builder;
+        TSlotDescriptorBuilder slot_desc_builder;
+        slot_desc_builder.type(type_desc)
+                .length(type_desc.len)
+                .precision(type_desc.precision)
+                .scale(type_desc.scale)
+                .nullable(true)
+                .column_name(column_name);
+        tuple_desc_builder.add_slot(slot_desc_builder.build());
+        tuple_desc_builder.build(&desc_tbl_builder);
+
+        DescriptorTbl* tbl = nullptr;
+        CHECK(DescriptorTbl::create(_runtime_state.get(), _pool, desc_tbl_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size)
+                      .ok());
+        _runtime_state->set_desc_tbl(tbl);
+        return tbl;
+    }
+
+    static bool _map_arrow_type(const std::shared_ptr<arrow::DataType>& type, TypeDescriptor* type_desc) {
+        switch (type->id()) {
+        case arrow::Type::BOOL:
+            *type_desc = TypeDescriptor(TYPE_BOOLEAN);
+            return true;
+        case arrow::Type::INT8:
+            *type_desc = TypeDescriptor(TYPE_TINYINT);
+            return true;
+        case arrow::Type::INT16:
+            *type_desc = TypeDescriptor(TYPE_SMALLINT);
+            return true;
+        case arrow::Type::INT32:
+            *type_desc = TypeDescriptor(TYPE_INT);
+            return true;
+        case arrow::Type::INT64:
+            *type_desc = TypeDescriptor(TYPE_BIGINT);
+            return true;
+        case arrow::Type::FLOAT:
+            *type_desc = TypeDescriptor(TYPE_FLOAT);
+            return true;
+        case arrow::Type::DOUBLE:
+            *type_desc = TypeDescriptor(TYPE_DOUBLE);
+            return true;
+        case arrow::Type::STRING:
+        case arrow::Type::LARGE_STRING:
+            *type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    static bool _pick_supported_field(const std::shared_ptr<arrow::Schema>& schema, std::string* column_name,
+                                      TypeDescriptor* type_desc) {
+        for (const auto& field : schema->fields()) {
+            if (_map_arrow_type(field->type(), type_desc)) {
+                *column_name = field->name();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    ExecEnv* _exec_env = nullptr;
+    std::shared_ptr<RuntimeState> _runtime_state = nullptr;
+    ObjectPool* _pool = nullptr;
+};
+
+TEST_F(BenchmarkConnectorTest, ProviderTupleDescriptor) {
+    _create_table_desc("col", TypeDescriptor(TYPE_INT));
+
+    TBenchmarkScanNode scan_node;
+    scan_node.__set_tuple_id(0);
+    scan_node.__set_db_name("tpcds");
+    scan_node.__set_table_name("call_center");
+    scan_node.__set_scale_factor(1.0);
+
+    TPlanNode plan_node;
+    plan_node.__set_benchmark_scan_node(scan_node);
+
+    BenchmarkDataSourceProvider provider(nullptr, plan_node);
+    const TupleDescriptor* tuple_desc = provider.tuple_descriptor(_runtime_state.get());
+    ASSERT_NE(tuple_desc, nullptr);
+    ASSERT_EQ(tuple_desc, _runtime_state->desc_tbl().get_tuple_descriptor(0));
+    ASSERT_TRUE(provider.insert_local_exchange_operator());
+    ASSERT_FALSE(provider.accept_empty_scan_ranges());
+}
+
+TEST_F(BenchmarkConnectorTest, DataSourceOpenAndGetNext) {
+    benchgen::SuiteId suite = benchgen::SuiteId::kTpcds;
+    std::string db_name(benchgen::SuiteIdToString(suite));
+    std::string table_name(benchgen::tpcds::TableIdToString(benchgen::tpcds::TableId::kCallCenter));
+
+    benchgen::GeneratorOptions options;
+    options.row_count = 3;
+    options.chunk_size = 8;
+
+    std::unique_ptr<benchgen::RecordBatchIterator> iter;
+    auto status = benchgen::MakeRecordBatchIterator(suite, table_name, options, &iter);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    auto schema = iter->schema();
+    ASSERT_NE(schema, nullptr);
+
+    std::string column_name;
+    TypeDescriptor type_desc;
+    ASSERT_TRUE(_pick_supported_field(schema, &column_name, &type_desc));
+    _create_table_desc(column_name, type_desc);
+
+    TBenchmarkScanNode scan_node;
+    scan_node.__set_tuple_id(0);
+    scan_node.__set_db_name(db_name);
+    scan_node.__set_table_name(table_name);
+    scan_node.__set_scale_factor(1.0);
+
+    TPlanNode plan_node;
+    plan_node.__set_benchmark_scan_node(scan_node);
+
+    BenchmarkDataSourceProvider provider(nullptr, plan_node);
+    TBenchmarkScanRange benchmark_range;
+    benchmark_range.__set_start_row(0);
+    benchmark_range.__set_row_count(3);
+
+    TScanRange scan_range;
+    scan_range.__set_benchmark_scan_range(benchmark_range);
+    auto data_source = provider.create_data_source(scan_range);
+
+    ASSERT_OK(data_source->open(_runtime_state.get()));
+    ChunkPtr chunk;
+    Status next_status = data_source->get_next(_runtime_state.get(), &chunk);
+    ASSERT_OK(next_status);
+    ASSERT_NE(chunk, nullptr);
+    ASSERT_EQ(chunk->num_columns(), 1);
+    ASSERT_GT(chunk->num_rows(), 0);
+    ASSERT_EQ(data_source->raw_rows_read(), data_source->num_rows_read());
+    ASSERT_EQ(data_source->num_rows_read(), chunk->num_rows());
+    ASSERT_EQ(data_source->num_bytes_read(), chunk->bytes_usage());
+    ASSERT_GT(data_source->num_bytes_read(), 0);
+    ASSERT_EQ(data_source->cpu_time_spent(), 0);
+    ASSERT_EQ(data_source->name(), "BenchmarkDataSource");
+
+    data_source->close(_runtime_state.get());
+}
+
+} // namespace starrocks::connector

--- a/be/test/connector/benchmark_connector_test.cpp
+++ b/be/test/connector/benchmark_connector_test.cpp
@@ -14,8 +14,8 @@
 
 #include "connector/benchmark_connector.h"
 
-#include <arrow/type.h>
 #include <arrow/status.h>
+#include <arrow/type.h>
 #include <gtest/gtest.h>
 
 #include "benchgen/benchmark_suite.h"

--- a/be/test/exec/benchmark_scanner_test.cpp
+++ b/be/test/exec/benchmark_scanner_test.cpp
@@ -1,0 +1,179 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/benchmark_scanner.h"
+
+#include <arrow/schema.h>
+#include <arrow/status.h>
+#include <gtest/gtest.h>
+
+#include "benchgen/benchmark_suite.h"
+#include "benchgen/record_batch_iterator_factory.h"
+#include "benchgen/table.h"
+#include "common/config.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+#include "runtime/types.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class BenchmarkScannerTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        config::enable_system_metrics = false;
+        config::enable_metric_calculator = false;
+
+        _exec_env = ExecEnv::GetInstance();
+        _runtime_state = _create_runtime_state();
+        _pool = _runtime_state->obj_pool();
+    }
+
+protected:
+    std::shared_ptr<RuntimeState> _create_runtime_state() {
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        query_options.batch_size = 16;
+        TQueryGlobals query_globals;
+        auto runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, _exec_env);
+        TUniqueId id;
+        runtime_state->init_mem_trackers(id);
+        return runtime_state;
+    }
+
+    DescriptorTbl* _create_table_desc(const std::string& column_name, const TypeDescriptor& type_desc) {
+        TDescriptorTableBuilder desc_tbl_builder;
+        TTupleDescriptorBuilder tuple_desc_builder;
+        TSlotDescriptorBuilder slot_desc_builder;
+        slot_desc_builder.type(type_desc)
+                .length(type_desc.len)
+                .precision(type_desc.precision)
+                .scale(type_desc.scale)
+                .nullable(true)
+                .column_name(column_name);
+        tuple_desc_builder.add_slot(slot_desc_builder.build());
+        tuple_desc_builder.build(&desc_tbl_builder);
+
+        DescriptorTbl* tbl = nullptr;
+        CHECK(DescriptorTbl::create(_runtime_state.get(), _pool, desc_tbl_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size)
+                      .ok());
+        _runtime_state->set_desc_tbl(tbl);
+        return tbl;
+    }
+
+    static bool _map_arrow_type(const std::shared_ptr<arrow::DataType>& type, TypeDescriptor* type_desc) {
+        switch (type->id()) {
+        case arrow::Type::BOOL:
+            *type_desc = TypeDescriptor(TYPE_BOOLEAN);
+            return true;
+        case arrow::Type::INT8:
+            *type_desc = TypeDescriptor(TYPE_TINYINT);
+            return true;
+        case arrow::Type::INT16:
+            *type_desc = TypeDescriptor(TYPE_SMALLINT);
+            return true;
+        case arrow::Type::INT32:
+            *type_desc = TypeDescriptor(TYPE_INT);
+            return true;
+        case arrow::Type::INT64:
+            *type_desc = TypeDescriptor(TYPE_BIGINT);
+            return true;
+        case arrow::Type::FLOAT:
+            *type_desc = TypeDescriptor(TYPE_FLOAT);
+            return true;
+        case arrow::Type::DOUBLE:
+            *type_desc = TypeDescriptor(TYPE_DOUBLE);
+            return true;
+        case arrow::Type::STRING:
+        case arrow::Type::LARGE_STRING:
+            *type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    static bool _pick_supported_field(const std::shared_ptr<arrow::Schema>& schema, std::string* column_name,
+                                      TypeDescriptor* type_desc) {
+        for (const auto& field : schema->fields()) {
+            if (_map_arrow_type(field->type(), type_desc)) {
+                *column_name = field->name();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    ExecEnv* _exec_env = nullptr;
+    std::shared_ptr<RuntimeState> _runtime_state = nullptr;
+    ObjectPool* _pool = nullptr;
+};
+
+TEST_F(BenchmarkScannerTest, OpenUnknownDatabase) {
+    _create_table_desc("col", TypeDescriptor(TYPE_INT));
+
+    BenchmarkScannerParam param;
+    param.db_name = "unknown_db";
+    param.table_name = "table";
+    param.options.row_count = 1;
+
+    BenchmarkScanner scanner(std::move(param), _runtime_state->desc_tbl().get_tuple_descriptor(0));
+    Status status = scanner.open(_runtime_state.get());
+    ASSERT_FALSE(status.ok());
+    ASSERT_NE(status.message().find("Unknown benchmark database"), std::string::npos);
+}
+
+TEST_F(BenchmarkScannerTest, OpenAndGetNext) {
+    benchgen::SuiteId suite = benchgen::SuiteId::kTpcds;
+    std::string db_name(benchgen::SuiteIdToString(suite));
+    std::string table_name(benchgen::tpcds::TableIdToString(benchgen::tpcds::TableId::kCallCenter));
+
+    benchgen::GeneratorOptions options;
+    options.row_count = 3;
+    options.chunk_size = 8;
+
+    std::unique_ptr<benchgen::RecordBatchIterator> iter;
+    auto status = benchgen::MakeRecordBatchIterator(suite, table_name, options, &iter);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    auto schema = iter->schema();
+    ASSERT_NE(schema, nullptr);
+
+    std::string column_name;
+    TypeDescriptor type_desc;
+    ASSERT_TRUE(_pick_supported_field(schema, &column_name, &type_desc));
+    _create_table_desc(column_name, type_desc);
+
+    options.column_names = {column_name};
+    BenchmarkScannerParam param;
+    param.db_name = db_name;
+    param.table_name = table_name;
+    param.options = options;
+
+    BenchmarkScanner scanner(std::move(param), _runtime_state->desc_tbl().get_tuple_descriptor(0));
+    ASSERT_OK(scanner.open(_runtime_state.get()));
+
+    ChunkPtr chunk;
+    bool eos = false;
+    ASSERT_OK(scanner.get_next(_runtime_state.get(), &chunk, &eos));
+    ASSERT_FALSE(eos);
+    ASSERT_NE(chunk, nullptr);
+    ASSERT_EQ(chunk->num_columns(), 1);
+    ASSERT_GT(chunk->num_rows(), 0);
+
+    scanner.close(_runtime_state.get());
+}
+
+} // namespace starrocks

--- a/be/test/exec/benchmark_scanner_test.cpp
+++ b/be/test/exec/benchmark_scanner_test.cpp
@@ -14,8 +14,8 @@
 
 #include "exec/benchmark_scanner.h"
 
-#include <arrow/schema.h>
 #include <arrow/status.h>
+#include <arrow/type.h>
 #include <gtest/gtest.h>
 
 #include "benchgen/benchmark_suite.h"


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a synthetic data scan path for benchmarks without external storage.
> 
> - New `BenchmarkConnector`, `BenchmarkDataSource(Provider)` and `BenchmarkScanner` to produce chunks from `benchgen` record batches
> - Registers connector name/type `benchmark`; maps `TPlanNodeType::BENCHMARK_SCAN_NODE` to `ConnectorScanNode`; included in scan node collection
> - CMake: imports and links `benchgen`; builds new connector/exec sources; minor build fix for `FINALIZE_BE_LIBS`
> - Tests: `benchmark_scanner_test` and `benchmark_connector_test` validate open/get_next, tuple descriptor, and metrics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cfbff6511ee569468408b1c03f059e1f935b247. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->