### PR TITLE
[UT] fix sql test related to FILES sink

### DIFF
--- a/test/sql/test_external_file/R/test_parquet_arrary_check
+++ b/test/sql/test_external_file/R/test_parquet_arrary_check
@@ -6,10 +6,10 @@ shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_array_check/${uuid0}/ >/
 -- !result
 insert into files
 (
-    "path" = "oss://${oss_bucket}/test_parquet_array_check/${uuid0}/000/",
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+    "path" = "s3://${oss_bucket}/test_parquet_array_check/${uuid0}/000/",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
     "format" = "parquet"
 ) 
 with tt  (tme_mv_id, fid,  fsinger_id_max) as ((select 10, "10", null) union all (select 20, "20", "aaa")),

--- a/test/sql/test_external_file/T/test_parquet_arrary_check
+++ b/test/sql/test_external_file/T/test_parquet_arrary_check
@@ -4,10 +4,10 @@ shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_array_check/${uuid0}/ >/
 
 insert into files
 (
-    "path" = "oss://${oss_bucket}/test_parquet_array_check/${uuid0}/000/",
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+    "path" = "s3://${oss_bucket}/test_parquet_array_check/${uuid0}/000/",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
     "format" = "parquet"
 ) 
 with tt  (tme_mv_id, fid,  fsinger_id_max) as ((select 10, "10", null) union all (select 20, "20", "aaa")),

--- a/test/sql/test_files/R/test_avro_data_quality_error
+++ b/test/sql/test_files/R/test_avro_data_quality_error
@@ -13,7 +13,7 @@ Succeed: Total num: 1, size: 217. OK num: 1(upload 1 files).
 -- !result
 
 desc files(
-    "path" = "oss://${oss_bucket}/test_files/avro_format/${uuid0}/*",
+    "path" = "s3://${oss_bucket}/test_files/avro_format/${uuid0}/*",
     "format" = "avro",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -24,7 +24,7 @@ name	varchar(1048576)	YES
 -- !result
 
 select * from files(
-    "path" = "oss://${oss_bucket}/test_files/avro_format/${uuid0}/*",
+    "path" = "s3://${oss_bucket}/test_files/avro_format/${uuid0}/*",
     "format" = "avro",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -42,7 +42,7 @@ create table t1 (id int, name varchar(5));
 
 insert into t1
 select * from files(
-    "path" = "oss://${oss_bucket}/test_files/avro_format/${uuid0}/*",
+    "path" = "s3://${oss_bucket}/test_files/avro_format/${uuid0}/*",
     "format" = "avro",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -66,7 +66,7 @@ select * from t1;
 
 insert into t1 properties("max_filter_ratio" = "1")
 select * from files(
-    "path" = "oss://${oss_bucket}/test_files/avro_format/${uuid0}/*",
+    "path" = "s3://${oss_bucket}/test_files/avro_format/${uuid0}/*",
     "format" = "avro",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -86,7 +86,7 @@ truncate table t1;
 
 insert into t1 properties("strict_mode" = "false")
 select * from files(
-    "path" = "oss://${oss_bucket}/test_files/avro_format/${uuid0}/*",
+    "path" = "s3://${oss_bucket}/test_files/avro_format/${uuid0}/*",
     "format" = "avro",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",

--- a/test/sql/test_files/T/test_avro_data_quality_error
+++ b/test/sql/test_files/T/test_avro_data_quality_error
@@ -7,13 +7,13 @@ shell: ossutil64 mkdir oss://${oss_bucket}/test_files/avro_format/${uuid0} >/dev
 shell: ossutil64 cp --force ./sql/test_files/avro_format/user.avro oss://${oss_bucket}/test_files/avro_format/${uuid0}/ | grep -Pv "(average|elapsed)"
 
 desc files(
-    "path" = "oss://${oss_bucket}/test_files/avro_format/${uuid0}/*",
+    "path" = "s3://${oss_bucket}/test_files/avro_format/${uuid0}/*",
     "format" = "avro",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
     "aws.s3.endpoint" = "${oss_endpoint}");
 select * from files(
-    "path" = "oss://${oss_bucket}/test_files/avro_format/${uuid0}/*",
+    "path" = "s3://${oss_bucket}/test_files/avro_format/${uuid0}/*",
     "format" = "avro",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -25,7 +25,7 @@ create table t1 (id int, name varchar(5));
 
 insert into t1
 select * from files(
-    "path" = "oss://${oss_bucket}/test_files/avro_format/${uuid0}/*",
+    "path" = "s3://${oss_bucket}/test_files/avro_format/${uuid0}/*",
     "format" = "avro",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -36,7 +36,7 @@ select * from t1;
 
 insert into t1 properties("max_filter_ratio" = "1")
 select * from files(
-    "path" = "oss://${oss_bucket}/test_files/avro_format/${uuid0}/*",
+    "path" = "s3://${oss_bucket}/test_files/avro_format/${uuid0}/*",
     "format" = "avro",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -46,7 +46,7 @@ truncate table t1;
 
 insert into t1 properties("strict_mode" = "false")
 select * from files(
-    "path" = "oss://${oss_bucket}/test_files/avro_format/${uuid0}/*",
+    "path" = "s3://${oss_bucket}/test_files/avro_format/${uuid0}/*",
     "format" = "avro",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",

--- a/test/sql/test_sink/R/test_csv_file_sink
+++ b/test/sql/test_sink/R/test_csv_file_sink
@@ -1,10 +1,10 @@
 -- name: testCsvFilesSink1
-insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/testCsvFilesSink1/${uuid0}/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
-	"format" = "csv", 
+insert into files (
+	"path" = "s3://${oss_bucket}/test_sink/testCsvFilesSink1/${uuid0}/",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+	"format" = "csv",
 	"compression" = "uncompressed",
 	"csv.column_separator" = ",",
 	"csv.row_delimiter" = "\n"
@@ -31,12 +31,12 @@ shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testCsvFilesSink1/${uuid0}
 
 -- !result
 -- name: testCsvFilesSink2
-insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/testCsvFilesSink2/${uuid0}/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
-	"format" = "csv", 
+insert into files (
+	"path" = "s3://${oss_bucket}/test_sink/testCsvFilesSink2/${uuid0}/",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+	"format" = "csv",
 	"compression" = "uncompressed"
 )
 select 1 as k1, "A" as k2 union select 2 as k1, "B" as k2;
@@ -48,7 +48,7 @@ select * from files (
     "fs.oss.accessKeyId" = "${oss_ak}",
     "fs.oss.accessKeySecret" = "${oss_sk}",
 	"format" = "csv"
-);
+) order by 1;
 -- result:
 1	A
 2	B

--- a/test/sql/test_sink/R/test_files_sink
+++ b/test/sql/test_sink/R/test_files_sink
@@ -1,9 +1,9 @@
 -- name: testFilesSink
 insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+	"path" = "s3://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
 	"format"="parquet", 
 	"compression" = "uncompressed"
 )
@@ -14,10 +14,10 @@ set pipeline_sink_dop = 1;
 -- result:
 -- !result
 insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+	"path" = "s3://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
 	"format"="parquet", 
 	"compression" = "uncompressed"
 )
@@ -48,10 +48,10 @@ insert into t1 select 1, bitmap_to_binary(bitmap_agg(generate_series)) from TABL
 -- result:
 -- !result
 insert into files (
-	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/",
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+	"path" = "s3://${oss_bucket}/test_sink/test_files_sink/${uuid0}/",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
 	"format"="parquet",
 	"compression" = "uncompressed"
 ) select * from t1;

--- a/test/sql/test_sink/R/test_global_shuffle
+++ b/test/sql/test_sink/R/test_global_shuffle
@@ -3,10 +3,10 @@ set enable_connector_sink_global_shuffle = true;
 -- result:
 -- !result
 insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/test_global_shuffle/${uuid0}/1/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+	"path" = "s3://${oss_bucket}/test_sink/test_global_shuffle/${uuid0}/1/", 
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
 	"format"="parquet", 
 	"compression" = "uncompressed"
 ) 
@@ -14,10 +14,10 @@ select 1 as k1, "A" as k2;
 -- result:
 -- !result
 insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/test_global_shuffle/${uuid0}/2/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+	"path" = "s3://${oss_bucket}/test_sink/test_global_shuffle/${uuid0}/2/", 
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
 	"format"="parquet", 
 	"compression" = "uncompressed",
 	"partition_by"="k1"

--- a/test/sql/test_sink/R/test_orc_file_sink
+++ b/test/sql/test_sink/R/test_orc_file_sink
@@ -1,9 +1,9 @@
 -- name: testOrcFilesSink1
 insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/testOrcFilesSink1/${uuid0}/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+	"path" = "s3://${oss_bucket}/test_sink/testOrcFilesSink1/${uuid0}/", 
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
 	"format" = "orc", 
 	"compression" = "uncompressed"
 )
@@ -18,8 +18,8 @@ select * from files (
 	"format" = "orc"
 );
 -- result:
-1	A
 2	B
+1	A
 -- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testOrcFilesSink1/${uuid0} >/dev/null || echo "exit 0" >/dev/null
 -- result:
@@ -28,10 +28,10 @@ shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testOrcFilesSink1/${uuid0}
 -- !result
 -- name: testOrcFilesSink2
 insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/testOrcFilesSink2/${uuid0}/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+	"path" = "s3://${oss_bucket}/test_sink/testOrcFilesSink2/${uuid0}/", 
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
 	"format" = "orc", 
 	"compression" = "uncompressed"
 )

--- a/test/sql/test_sink/R/test_select_into_outfile_csv_inconsistent_converter_and_column
+++ b/test/sql/test_sink/R/test_select_into_outfile_csv_inconsistent_converter_and_column
@@ -13,7 +13,11 @@ insert into t2 values(1,1,1), (2,2,2), (2,2,3), (3,3,4), (3,3,5), (3,3,6);
 -- result:
 -- !result
 
-select t1.k1, t1.k2, count(distinct t1.k3) as k33 from t1 left join t2 on t1.k1 = t2.k1 group by t1.k1,t1.k2 order by k33 into outfile "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/" format as csv;
+select t1.k1, t1.k2, count(distinct t1.k3) as k33 from t1 left join t2 on t1.k1 = t2.k1 group by t1.k1,t1.k2 order by k33 into outfile "s3://${oss_bucket}/test_sink/test_files_sink/${uuid0}/" format as csv properties (
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}"
+);
 -- result:
 -- !result
 shell: ossutil64 cat oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/0.csv | head -3

--- a/test/sql/test_sink/T/test_csv_file_sink
+++ b/test/sql/test_sink/T/test_csv_file_sink
@@ -1,11 +1,11 @@
 -- name: testCsvFilesSink1
 
-insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/testCsvFilesSink1/${uuid0}/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
-	"format" = "csv", 
+insert into files (
+	"path" = "s3://${oss_bucket}/test_sink/testCsvFilesSink1/${uuid0}/",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+	"format" = "csv",
 	"compression" = "uncompressed",
 	"csv.column_separator" = ",",
 	"csv.row_delimiter" = "\n"
@@ -26,12 +26,12 @@ shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testCsvFilesSink1/${uuid0}
 
 -- name: testCsvFilesSink2
 
-insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/testCsvFilesSink2/${uuid0}/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
-	"format" = "csv", 
+insert into files (
+	"path" = "s3://${oss_bucket}/test_sink/testCsvFilesSink2/${uuid0}/",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+	"format" = "csv",
 	"compression" = "uncompressed"
 )
 select 1 as k1, "A" as k2 union select 2 as k1, "B" as k2;
@@ -42,6 +42,6 @@ select * from files (
     "fs.oss.accessKeyId" = "${oss_ak}",
     "fs.oss.accessKeySecret" = "${oss_sk}",
 	"format" = "csv"
-);
+) order by 1;
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testCsvFilesSink2/${uuid0} >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_sink/T/test_files_sink
+++ b/test/sql/test_sink/T/test_files_sink
@@ -1,10 +1,10 @@
 -- name: testFilesSink
 
 insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+	"path" = "s3://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
 	"format"="parquet", 
 	"compression" = "uncompressed"
 )
@@ -13,10 +13,10 @@ select 1 as k1, "A" as k2;
 set pipeline_sink_dop = 1;
 
 insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+	"path" = "s3://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
 	"format"="parquet", 
 	"compression" = "uncompressed"
 )
@@ -39,10 +39,10 @@ create table t1 (c1 int, c2 binary);
 insert into t1 select 1, bitmap_to_binary(bitmap_agg(generate_series)) from TABLE(generate_series(1,10));
 
 insert into files (
-	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/",
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+	"path" = "s3://${oss_bucket}/test_sink/test_files_sink/${uuid0}/",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
 	"format"="parquet",
 	"compression" = "uncompressed"
 ) select * from t1;

--- a/test/sql/test_sink/T/test_global_shuffle
+++ b/test/sql/test_sink/T/test_global_shuffle
@@ -3,20 +3,20 @@
 set enable_connector_sink_global_shuffle = true;
 
 insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/test_global_shuffle/${uuid0}/1/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+	"path" = "s3://${oss_bucket}/test_sink/test_global_shuffle/${uuid0}/1/", 
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
 	"format"="parquet", 
 	"compression" = "uncompressed"
 ) 
 select 1 as k1, "A" as k2;
 
 insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/test_global_shuffle/${uuid0}/2/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+	"path" = "s3://${oss_bucket}/test_sink/test_global_shuffle/${uuid0}/2/", 
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
 	"format"="parquet", 
 	"compression" = "uncompressed",
 	"partition_by"="k1"

--- a/test/sql/test_sink/T/test_orc_file_sink
+++ b/test/sql/test_sink/T/test_orc_file_sink
@@ -1,10 +1,10 @@
 -- name: testOrcFilesSink1
 
 insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/testOrcFilesSink1/${uuid0}/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+	"path" = "s3://${oss_bucket}/test_sink/testOrcFilesSink1/${uuid0}/", 
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
 	"format" = "orc", 
 	"compression" = "uncompressed"
 )
@@ -23,10 +23,10 @@ shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/testOrcFilesSink1/${uuid0}
 -- name: testOrcFilesSink2
 
 insert into files ( 
-	"path" = "oss://${oss_bucket}/test_sink/testOrcFilesSink2/${uuid0}/", 
-    "fs.oss.endpoint" = "${oss_endpoint}",
-    "fs.oss.accessKeyId" = "${oss_ak}",
-    "fs.oss.accessKeySecret" = "${oss_sk}",
+	"path" = "s3://${oss_bucket}/test_sink/testOrcFilesSink2/${uuid0}/", 
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
 	"format" = "orc", 
 	"compression" = "uncompressed"
 )

--- a/test/sql/test_sink/T/test_select_into_outfile_csv_inconsistent_converter_and_column
+++ b/test/sql/test_sink/T/test_select_into_outfile_csv_inconsistent_converter_and_column
@@ -5,7 +5,12 @@ insert into t1 values(1,1,1), (2,2,2), (2,2,3), (3,3,4), (3,3,5), (3,3,6);
 create table t2 (k1 int, k2 int, k3 int) distributed by hash(k1) buckets 1;
 insert into t2 values(1,1,1), (2,2,2), (2,2,3), (3,3,4), (3,3,5), (3,3,6);
 
-select t1.k1, t1.k2, count(distinct t1.k3) as k33 from t1 left join t2 on t1.k1 = t2.k1 group by t1.k1,t1.k2 order by k33 into outfile "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/" format as csv;
+select t1.k1, t1.k2, count(distinct t1.k3) as k33 from t1 left join t2 on t1.k1 = t2.k1 group by t1.k1,t1.k2 order by k33 into outfile "s3://${oss_bucket}/test_sink/test_files_sink/${uuid0}/" format as csv properties (
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}"
+);
+
 shell: ossutil64 cat oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/0.csv | head -3
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink/${uuid0} >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_view/R/test_files_view
+++ b/test/sql/test_view/R/test_files_view
@@ -17,7 +17,7 @@ shell: ossutil64 cp --force ./sql/test_files/parquet_format/basic_type.parquet o
 Succeed: Total num: 1, size: 2,281. OK num: 1(upload 1 files).
 -- !result
 select * from files(
-    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
     "format" = "parquet",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
@@ -27,7 +27,7 @@ select * from files(
 1	11	12	13.20	2024-10-02	2024-10-02 13:13:13	b	14.3
 -- !result
 create view files_view as select * from files(
-    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
     "format" = "parquet",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",

--- a/test/sql/test_view/T/test_files_view
+++ b/test/sql/test_view/T/test_files_view
@@ -8,13 +8,13 @@ shell: ossutil64 cp --force ./sql/test_files/parquet_format/basic_type.parquet o
 
 
 select * from files(
-    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
     "format" = "parquet",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",
     "aws.s3.endpoint" = "${oss_endpoint}");
 create view files_view as select * from files(
-    "path" = "oss://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
+    "path" = "s3://${oss_bucket}/test_files/parquet_format/${uuid0}/*",
     "format" = "parquet",
     "aws.s3.access_key" = "${oss_ak}",
     "aws.s3.secret_key" = "${oss_sk}",


### PR DESCRIPTION
* FILES used as sink takes different parameters as used as scan source

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
