### PR TITLE
[UT] fix unstable fe unit test

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -329,8 +329,12 @@ public class IcebergTable extends Table {
 
     @Override
     public String getTableIdentifier() {
-        String uuid = ((BaseTable) getNativeTable()).operations().current().uuid();
-        return Joiner.on(":").join(name, uuid == null ? "" : uuid);
+        org.apache.iceberg.Table nativeTable = getNativeTable();
+        String uuid = null;
+        if (nativeTable instanceof BaseTable) {
+            uuid = ((BaseTable) nativeTable).operations().current().uuid();
+        }
+        return Joiner.on(":").join(catalogTableName, uuid == null ? "" : uuid);
     }
 
     public IcebergCatalogType getCatalogType() {


### PR DESCRIPTION
## Why I'm doing:

Because of some historical reasons,  we have `name` and `catalogTableName` inside `Table`
- `name` means which is defined in internal table
- `catalogTableName` means which is defined in catalog.

For iceberg table,  in most cases, we should use `catalogTableName` not `name`

------------

And in some unit tests, we mock iceberg table by using `Table` not `BaseTable`,  so we end up casting problem like https://github.com/StarRocks/starrocks/pull/68381/checks?check_run_id=61348655978

```
java.lang.ClassCastException: class org.apache.iceberg.$Impl_Table cannot be cast to class org.apache.iceberg.BaseTable (org.apache.iceberg.$Impl_Table is in unnamed module of loader mockit.internal.classGeneration.ImplementationClass$1 @673c4f6e; org.apache.iceberg.BaseTable is in unnamed module of loader 'app')
	at com.starrocks.catalog.IcebergTable.getTableIdentifier(IcebergTable.java:332)
	at com.starrocks.catalog.IcebergTable.equals(IcebergTable.java:598)
	at com.starrocks.connector.iceberg.CachingIcebergCatalog$2.load(CachingIcebergCatalog.java:126)
	at com.starrocks.connector.iceberg.CachingIcebergCatalog$2.load(CachingIcebergCatalog.java:119)
	at com.github.benmanes.caffeine.cache.LocalLoadingCache.lambda$newMappingFunction$2(LocalLoadingCache.java:145)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.lambda$doComputeIfAbsent$14(BoundedLocalCache.java:2406)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.doComputeIfAbsent(BoundedLocalCache.java:2404)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.computeIfAbsent(BoundedLocalCache.java:2387)
	at com.github.benmanes.caffeine.cache.LocalCache.computeIfAbsent(LocalCache.java:108)
	at com.github.benmanes.caffeine.cache.LocalLoadingCache.get(LocalLoadingCache.java:56)
	at com.starrocks.connector.iceberg.CachingIcebergCatalog.getPartitions(CachingIcebergCatalog.java:306)
	at com.starrocks.connector.iceberg.CachingIcebergCatalog.listPartitionNames(CachingIcebergCatalog.java:326)
	at com.starrocks.connector.iceberg.CachingIcebergCatalogTest.testListPartitionNames(CachingIcebergCatalogTest.java:128)
```

So it's better to check if this table object is `BaseTable` or not.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
