### PR TITLE
[Enhancement] Support MULTIPLY/DIVIDE for interval operation

### DIFF
--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/ArithmeticExpr.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/ArithmeticExpr.java
@@ -178,6 +178,10 @@ public class ArithmeticExpr extends Expr {
         public boolean isMonotonic() {
             return monotonic;
         }
+
+        public boolean isMultiplyOrDivide() {
+            return this == Operator.MULTIPLY || this == Operator.DIVIDE;
+        }
     }
 
     public static class TypeTriple {

--- a/test/sql/test_datetime/R/test_intervals
+++ b/test/sql/test_datetime/R/test_intervals
@@ -16,6 +16,18 @@ select date('2023-12-10')-interval '1' day;
 -- result:
 2023-12-09
 -- !result
+select date('2023-12-10') - interval '1' day * 3;
+-- result:
+2023-12-07
+-- !result
+select date('2023-12-10') - 3 * interval '1' day;
+-- result:
+2023-12-07
+-- !result
+select date('2023-12-10') - interval '6' day / 3;
+-- result:
+2023-12-08
+-- !result
 select TIMESTAMP '2023-12-10 01:00:00' - interval '1' day;
 -- result:
 2023-12-09 01:00:00

--- a/test/sql/test_datetime/T/test_intervals
+++ b/test/sql/test_datetime/T/test_intervals
@@ -5,6 +5,9 @@ select date_add('day', -1, date(concat(substr('2023-12-10', 1, 7), '-01')));
 SELECT date_add('day', -1, TIMESTAMP '2020-03-01 00:00:00');
 
 select date('2023-12-10')-interval '1' day;
+select date('2023-12-10') - interval '1' day * 3;
+select date('2023-12-10') - 3 * interval '1' day;
+select date('2023-12-10') - interval '6' day / 3;
 select date('2023-12-10 01:00:00')-interval '1' day;
 
 SELECT date_add('day', -1, '2023-12-10');

--- a/test/sql/test_function/R/test_days_add
+++ b/test/sql/test_function/R/test_days_add
@@ -11,6 +11,22 @@ select adddate('2023-10-31 23:59:59', INTERVAL 1 YEAR);
 -- result:
 2024-10-31 23:59:59
 -- !result
+select adddate('2023-10-31 23:59:59', INTERVAL 1 YEAR * 2);
+-- result:
+2025-10-31 23:59:59
+-- !result
+select adddate('2023-10-31 23:59:59', 2 * INTERVAL 1 YEAR);
+-- result:
+2025-10-31 23:59:59
+-- !result
+select adddate('2023-10-31 23:59:59', INTERVAL 2 YEAR / 2);
+-- result:
+2024-10-31 23:59:59
+-- !result
+select adddate('2023-10-31 23:59:59', 2 / INTERVAL 2 YEAR);
+-- result:
+E: (1064, 'Getting syntax error. Detail message: Do not support Expr divide IntervalLiteral syntax.')
+-- !result
 select adddate('2023-10-31 23:59:59', INTERVAL 100 YEAR);
 -- result:
 2123-10-31 23:59:59

--- a/test/sql/test_function/T/test_days_add
+++ b/test/sql/test_function/T/test_days_add
@@ -2,6 +2,10 @@
 select days_add('2023-10-31 23:59:59', 1);
 select days_add('2023-10-31 23:59:59', 1000);
 select adddate('2023-10-31 23:59:59', INTERVAL 1 YEAR);
+select adddate('2023-10-31 23:59:59', INTERVAL 1 YEAR * 2);
+select adddate('2023-10-31 23:59:59', 2 * INTERVAL 1 YEAR);
+select adddate('2023-10-31 23:59:59', INTERVAL 2 YEAR / 2);
+select adddate('2023-10-31 23:59:59', 2 / INTERVAL 2 YEAR);
 select adddate('2023-10-31 23:59:59', INTERVAL 100 YEAR);
 select adddate('2023-10-31 23:59:59', INTERVAL 1 MONTH);
 select adddate('2023-10-31 23:59:59', INTERVAL 11 MONTH);


### PR DESCRIPTION
## Why I'm doing:
In trino the syntax like 
"select current_date - interval '2' day * 2" and select "current_date - interval '2' day / 2"
is supported.
While when I executed the SQL like ' select current_date - interval '2' day * 2;' I will got unknown error.
<img width="808" height="88" alt="image" src="https://github.com/user-attachments/assets/4feccf18-64fd-44e9-8fe7-bfa786d61f70" />
I checked the log for the error:
<img width="2928" height="1360" alt="image" src="https://github.com/user-attachments/assets/a9a77549-c816-4c4a-9175-6fa63b85ce2f" />
That is because the `TimestampArithmeticExpr` do not support multiply.
While the expr in IntervalLiteral can have MULTIPLY and DIVIDE.
<img width="778" height="202" alt="image" src="https://github.com/user-attachments/assets/a10b88e6-1788-436d-977d-d1618da61e6c" />
Here I will try to implement it to move the MULTIPLY and DIVIDE into interval.
## What I'm doing:
Try to implement it to move the MULTIPLY and DIVIDE into interval.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
