### PR TITLE
[BugFix] Fix subquery scope check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeState.java
@@ -94,7 +94,7 @@ public class AnalyzeState {
     }
 
     public void addColumnReference(Expr e, FieldId fieldId) {
-        this.columnReferences.put(e, fieldId);
+        this.columnReferences.computeIfAbsent(e, k -> fieldId);
     }
 
     public Map<Expr, FieldId> getColumnReferences() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -2017,4 +2017,14 @@ public class SubqueryTest extends PlanTestBase {
             connectContext.getSessionVariable().setCboCTERuseRatio(1.5);
         }
     }
+
+    @Test
+    public void testOrderBySubquery() throws Exception {
+        String sql = "SELECT t0.* "
+                + " FROM t0"
+                + " left join t1 x1 on t0.v2 = x1.v4 and x1.v6 = (select v8 from t2 where v9 = 1 order by v8 limit 1, 1) "
+                + " left join t1 xx1 on x1.v5 = xx1.v5 and xx1.v6 = (select v8 from t2 where v9 = 1 order by v8 limit 1) ";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "ASSERT NUMBER OF ROWS");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Fix subquery analyze correlation-column from order by scope error

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures column reference mapping stability and adds coverage for ORDER BY subqueries.
> 
> - Updates `AnalyzeState.addColumnReference` to use `computeIfAbsent` so existing `columnReferences` entries aren’t overwritten
> - Adds `SubqueryTest.testOrderBySubquery` validating subqueries with `ORDER BY ... LIMIT` in JOIN predicates emit `ASSERT NUMBER OF ROWS`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7243f75d5280a67c28133915dcb3294311300833. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->