### PR TITLE
[Enhancement] support varbinary for count distinct like agg functions

### DIFF
--- a/be/src/exec/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/arrow_to_starrocks_converter.cpp
@@ -166,13 +166,13 @@ void offsets_copy(const T* __restrict arrow_offsets_data, T arrow_base_offset, s
     }
 }
 
-template <LogicalType LT, typename = StringOrBinaryGaurd<LT>>
+template <LogicalType LT, typename = StringOrBinaryGuard<LT>>
 static inline constexpr uint32_t binary_max_length = (LT == TYPE_VARCHAR || LT == TYPE_VARBINARY)
                                                              ? TypeDescriptor::MAX_VARCHAR_LENGTH
                                                              : TypeDescriptor::MAX_CHAR_LENGTH;
 
 template <ArrowTypeId AT, LogicalType LT, bool is_nullable, bool is_strict>
-struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringOrBinaryGaurd<LT>> {
+struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringOrBinaryGuard<LT>> {
     using ArrowArrayType = ArrowTypeIdToArrayType<AT>;
     using ArrowCppType = ArrowTypeIdToCppType<AT>;
     using CppType = RunTimeCppType<LT>;

--- a/be/src/exprs/agg/aggregate_traits.h
+++ b/be/src/exprs/agg/aggregate_traits.h
@@ -116,7 +116,7 @@ struct AggDataTypeTraits<lt, ArrayGuard<lt>> {
 };
 
 template <LogicalType lt>
-struct AggDataTypeTraits<lt, StringOrBinaryLTGuard<lt>> {
+struct AggDataTypeTraits<lt, StringOrBinaryGuard<lt>> {
     using ColumnType = RunTimeColumnType<lt>;
     using ValueType = Buffer<uint8_t>;
     using RefType = Slice;

--- a/be/src/exprs/agg/aggregate_traits.h
+++ b/be/src/exprs/agg/aggregate_traits.h
@@ -116,7 +116,7 @@ struct AggDataTypeTraits<lt, ArrayGuard<lt>> {
 };
 
 template <LogicalType lt>
-struct AggDataTypeTraits<lt, StringLTGuard<lt>> {
+struct AggDataTypeTraits<lt, StringOrBinaryLTGuard<lt>> {
     using ColumnType = RunTimeColumnType<lt>;
     using ValueType = Buffer<uint8_t>;
     using RefType = Slice;

--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -245,7 +245,7 @@ struct AdaptiveSliceHashSet {
 };
 
 template <LogicalType LT, LogicalType SumLT>
-struct DistinctAggregateState<LT, SumLT, StringOrBinaryGaurd<LT>> {
+struct DistinctAggregateState<LT, SumLT, StringOrBinaryGuard<LT>> {
     DistinctAggregateState() = default;
     using KeyType = typename SliceHashSet::key_type;
 
@@ -376,7 +376,7 @@ struct DistinctAggregateStateV2Base<LT, SumLT, compute_sum, FixedLengthLTGuard<L
 };
 
 template <LogicalType LT, LogicalType SumLT>
-struct DistinctAggregateStateV2Base<LT, SumLT, false, StringOrBinaryGaurd<LT>>
+struct DistinctAggregateStateV2Base<LT, SumLT, false, StringOrBinaryGuard<LT>>
         : public DistinctAggregateState<LT, SumLT> {};
 
 template <LogicalType LT, LogicalType SumLT, typename = guard::Guard>

--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -245,7 +245,7 @@ struct AdaptiveSliceHashSet {
 };
 
 template <LogicalType LT, LogicalType SumLT>
-struct DistinctAggregateState<LT, SumLT, StringLTGuard<LT>> {
+struct DistinctAggregateState<LT, SumLT, StringOrBinaryGaurd<LT>> {
     DistinctAggregateState() = default;
     using KeyType = typename SliceHashSet::key_type;
 
@@ -376,7 +376,8 @@ struct DistinctAggregateStateV2Base<LT, SumLT, compute_sum, FixedLengthLTGuard<L
 };
 
 template <LogicalType LT, LogicalType SumLT>
-struct DistinctAggregateStateV2Base<LT, SumLT, false, StringLTGuard<LT>> : public DistinctAggregateState<LT, SumLT> {};
+struct DistinctAggregateStateV2Base<LT, SumLT, false, StringOrBinaryGaurd<LT>>
+        : public DistinctAggregateState<LT, SumLT> {};
 
 template <LogicalType LT, LogicalType SumLT, typename = guard::Guard>
 struct DistinctAggregateStateV2 : public DistinctAggregateStateV2Base<LT, SumLT, false> {};

--- a/be/src/exprs/agg/ds_hll_count_distinct.h
+++ b/be/src/exprs/agg/ds_hll_count_distinct.h
@@ -61,7 +61,7 @@ public:
         uint64_t value = 0;
         const ColumnType* column = down_cast<const ColumnType*>(columns[0]);
 
-        if constexpr (lt_is_string<LT>) {
+        if constexpr (lt_is_string_or_binary<LT>) {
             Slice s = column->get_slice(row_num);
             value = HashUtil::murmur_hash64A(s.data, s.size, HashUtil::MURMUR_SEED);
         } else {
@@ -77,7 +77,7 @@ public:
         // init state if needed
         _init_if_needed(ctx, columns, state);
         const ColumnType* column = down_cast<const ColumnType*>(columns[0]);
-        if constexpr (lt_is_string<LT>) {
+        if constexpr (lt_is_string_or_binary<LT>) {
             uint64_t value = 0;
             for (size_t i = frame_start; i < frame_end; ++i) {
                 Slice s = column->get_slice(i);
@@ -163,7 +163,7 @@ public:
         for (size_t i = 0; i < chunk_size; ++i) {
             int64_t memory_usage = 0;
             DataSketchesHll hll{log_k, tgt_type, &memory_usage};
-            if constexpr (lt_is_string<LT>) {
+            if constexpr (lt_is_string_or_binary<LT>) {
                 Slice s = column->get_slice(i);
                 value = HashUtil::murmur_hash64A(s.data, s.size, HashUtil::MURMUR_SEED);
             } else {

--- a/be/src/exprs/agg/ds_theta_count_distinct.h
+++ b/be/src/exprs/agg/ds_theta_count_distinct.h
@@ -56,7 +56,7 @@ public:
         uint64_t value = 0;
         const ColumnType* column = down_cast<const ColumnType*>(columns[0]);
 
-        if constexpr (lt_is_string<LT>) {
+        if constexpr (lt_is_string_or_binary<LT>) {
             Slice s = column->get_slice(row_num);
             value = HashUtil::murmur_hash64A(s.data, s.size, HashUtil::MURMUR_SEED);
         } else {
@@ -72,7 +72,7 @@ public:
         // init state if needed
         _init_if_needed(state);
         const ColumnType* column = down_cast<const ColumnType*>(columns[0]);
-        if constexpr (lt_is_string<LT>) {
+        if constexpr (lt_is_string_or_binary<LT>) {
             uint64_t value = 0;
             for (size_t i = frame_start; i < frame_end; ++i) {
                 Slice s = column->get_slice(i);
@@ -147,7 +147,7 @@ public:
         size_t old_size = bytes.size();
         uint64_t value = 0;
         for (size_t i = 0; i < chunk_size; ++i) {
-            if constexpr (lt_is_string<LT>) {
+            if constexpr (lt_is_string_or_binary<LT>) {
                 Slice s = input->get_slice(i);
                 value = HashUtil::murmur_hash64A(s.data, s.size, HashUtil::MURMUR_SEED);
             } else {

--- a/be/src/exprs/agg/factory/aggregate_resolver_distinct.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_distinct.cpp
@@ -22,7 +22,7 @@ namespace starrocks {
 struct DistinctDispatcher {
     template <LogicalType lt>
     void operator()(AggregateFuncResolver* resolver) {
-        if constexpr (lt_is_aggregate<lt>) {
+        if constexpr (lt_is_aggregate<lt> || lt_is_binary<lt>) {
             using DistinctState = DistinctAggregateState<lt, SumResultLT<lt>>;
             using DistinctState2 = DistinctAggregateStateV2<lt, SumResultLT<lt>>;
             resolver->add_aggregate_mapping<lt, TYPE_BIGINT, DistinctState>(
@@ -60,7 +60,9 @@ struct DistinctDispatcher {
 };
 
 void AggregateFuncResolver::register_distinct() {
-    for (auto type : aggregate_types()) {
+    auto multi_distinct_types = aggregate_types();
+    multi_distinct_types.push_back(TYPE_VARBINARY);
+    for (auto type : multi_distinct_types) {
         type_dispatch_all(type, DistinctDispatcher(), this);
     }
 }

--- a/be/src/exprs/agg/histogram_hll_ndv.h
+++ b/be/src/exprs/agg/histogram_hll_ndv.h
@@ -80,7 +80,7 @@ public:
         uint64_t hash = 0;
 
         // find the correct bucket for the current value.
-        if constexpr (lt_is_string<LT>) {
+        if constexpr (lt_is_string_or_binary<LT>) {
             Slice s = column->get_slice(row_num);
             bucket_it = std::upper_bound(buckets.begin(), buckets.end(), s,
                                          [](auto& s, Bucket<LT>& bucket) { return bucket.is_less_equal_to_upper(s); });

--- a/be/src/exprs/agg/hll_ndv.h
+++ b/be/src/exprs/agg/hll_ndv.h
@@ -53,7 +53,7 @@ public:
         uint64_t value = 0;
         const auto* column = down_cast<const ColumnType*>(columns[0]);
 
-        if constexpr (lt_is_string<LT>) {
+        if constexpr (lt_is_string_or_binary<LT>) {
             Slice s = column->get_slice(row_num);
             value = HashUtil::murmur_hash64A(s.data, s.size, HashUtil::MURMUR_SEED);
         } else {
@@ -71,7 +71,7 @@ public:
                                               int64_t frame_end) const override {
         const auto* column = down_cast<const ColumnType*>(columns[0]);
 
-        if constexpr (lt_is_string<LT>) {
+        if constexpr (lt_is_string_or_binary<LT>) {
             uint64_t value = 0;
             for (size_t i = frame_start; i < frame_end; ++i) {
                 Slice s = column->get_slice(i);
@@ -140,7 +140,7 @@ public:
         uint64_t value = 0;
         for (size_t i = 0; i < chunk_size; ++i) {
             HyperLogLog hll;
-            if constexpr (lt_is_string<LT>) {
+            if constexpr (lt_is_string_or_binary<LT>) {
                 Slice s = column->get_slice(i);
                 value = HashUtil::murmur_hash64A(s.data, s.size, HashUtil::MURMUR_SEED);
             } else {

--- a/be/src/exprs/agg/intersect_count.h
+++ b/be/src/exprs/agg/intersect_count.h
@@ -51,6 +51,11 @@ struct BitmapIntersectInternalKey<TYPE_CHAR> {
     using InternalKeyType = std::string;
 };
 
+template <>
+struct BitmapIntersectInternalKey<TYPE_BINARY> {
+    using InternalKeyType = Slice;
+};
+
 template <LogicalType LT>
 using BitmapRuntimeCppType = typename BitmapIntersectInternalKey<LT>::InternalKeyType;
 

--- a/be/src/exprs/agg/intersect_count.h
+++ b/be/src/exprs/agg/intersect_count.h
@@ -51,11 +51,6 @@ struct BitmapIntersectInternalKey<TYPE_CHAR> {
     using InternalKeyType = std::string;
 };
 
-template <>
-struct BitmapIntersectInternalKey<TYPE_BINARY> {
-    using InternalKeyType = Slice;
-};
-
 template <LogicalType LT>
 using BitmapRuntimeCppType = typename BitmapIntersectInternalKey<LT>::InternalKeyType;
 
@@ -79,11 +74,11 @@ public:
             for (int i = 2; i < ctx->get_num_constant_columns(); ++i) {
                 auto arg_column = ctx->get_constant_column(i);
                 auto arg_value = ColumnHelper::get_const_value<LT>(arg_column);
-                if constexpr (LT != TYPE_VARCHAR && LT != TYPE_CHAR) {
-                    intersect.add_key(arg_value);
-                } else {
+                if constexpr (lt_is_string_or_binary<LT>) {
                     std::string key(arg_value.data, arg_value.size);
                     intersect.add_key(key);
+                } else {
+                    intersect.add_key(arg_value);
                 }
             }
             this->data(state).initial = true;
@@ -97,11 +92,11 @@ public:
         auto bimtap_value = bitmap_column->get_pool()[row_num];
         auto key_value = GetContainer<LT>::get_data(key_column)[row_num];
 
-        if constexpr (LT != TYPE_VARCHAR && LT != TYPE_CHAR) {
-            intersect.update(key_value, bimtap_value);
-        } else {
+        if constexpr (lt_is_string_or_binary<LT>) {
             std::string key(key_value.data, key_value.size);
             intersect.update(key, bimtap_value);
+        } else {
+            intersect.update(key_value, bimtap_value);
         }
     }
 
@@ -135,11 +130,11 @@ public:
         BitmapIntersect<BitmapRuntimeCppType<LT>> intersect;
         for (int i = 2; i < src.size(); ++i) {
             auto arg_value = ColumnHelper::get_const_value<LT>(src[i]);
-            if constexpr (LT != TYPE_VARCHAR && LT != TYPE_CHAR) {
-                intersect.add_key(arg_value);
-            } else {
+            if constexpr (lt_is_string_or_binary<LT>) {
                 std::string key(arg_value.data, arg_value.size);
                 intersect.add_key(key);
+            } else {
+                intersect.add_key(arg_value);
             }
         }
 
@@ -156,11 +151,11 @@ public:
             auto bimtap_value = bitmap_column->get_pool()[i];
             auto key_value = GetContainer<LT>::get_data(key_column)[i];
 
-            if constexpr (LT != TYPE_VARCHAR && LT != TYPE_CHAR) {
-                intersect_per_row.update(key_value, bimtap_value);
-            } else {
+            if constexpr (lt_is_string_or_binary<LT>) {
                 std::string key(key_value.data, key_value.size);
                 intersect_per_row.update(key, bimtap_value);
+            } else {
+                intersect_per_row.update(key_value, bimtap_value);
             }
 
             new_size += intersect_per_row.size();

--- a/be/src/types/logical_type.h
+++ b/be/src/types/logical_type.h
@@ -366,7 +366,7 @@ UNION_VALUE_GUARD(LogicalType, AggregateComplexLTGuard, lt_is_complex_aggregate,
                   lt_is_decimalv2_struct, lt_is_decimal_struct, lt_is_datetime_struct, lt_is_date_struct,
                   lt_is_json_struct)
 
-UNION_VALUE_GUARD(LogicalType, StringOrBinaryGaurd, lt_is_string_or_binary, lt_is_string_struct, lt_is_binary_struct)
+UNION_VALUE_GUARD(LogicalType, StringOrBinaryGuard, lt_is_string_or_binary, lt_is_string_struct, lt_is_binary_struct)
 
 TExprOpcode::type to_in_opcode(LogicalType t);
 LogicalType thrift_to_type(TPrimitiveType::type ttype);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -689,6 +689,7 @@ public class FunctionSet {
                     .addAll(FloatType.FLOAT_TYPES)
                     .addAll(DecimalType.DECIMAL_TYPES)
                     .addAll(STRING_TYPES)
+                    .add(VarbinaryType.VARBINARY)
                     .add(DateType.DATE)
                     .add(DateType.DATETIME)
                     .add(DecimalType.DECIMALV2)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -398,13 +398,17 @@ public class FunctionAnalyzer {
                     functionCallExpr.getPos());
         }
 
-        if ((fnName.equals(FunctionSet.MIN)
-                || fnName.equals(FunctionSet.MAX)
-                || fnName.equals(FunctionSet.NDV)
+        if ((fnName.equals(FunctionSet.MIN) || fnName.equals(FunctionSet.MAX))
+                && !arg.getType().canApplyToNumeric()) {
+            throw new SemanticException(Type.NOT_SUPPORT_AGG_ERROR_MSG);
+        }
+
+        // ndv and approx_count_distinct cannot be applied to non-numeric types
+        if ((fnName.equals(FunctionSet.NDV)
                 || fnName.equals(FunctionSet.APPROX_COUNT_DISTINCT)
                 || fnName.equals(FunctionSet.DS_THETA_COUNT_DISTINCT)
                 || fnName.equals(FunctionSet.DS_HLL_COUNT_DISTINCT))
-                && !arg.getType().canApplyToNumeric()) {
+                && !(arg.getType().canApplyToNumeric() || arg.getType().isBinaryType())) {
             throw new SemanticException(Type.NOT_SUPPORT_AGG_ERROR_MSG);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
@@ -144,6 +144,15 @@ public class AnalyzeFunctionTest {
     }
 
     @Test
+    public void testApproxCountDistinctWithVarbinary() {
+        analyzeSuccess("select approx_count_distinct(v_varbinary) from tbinary");
+        analyzeSuccess("select ndv(v_varbinary) from tbinary");
+        analyzeSuccess("select ds_hll_count_distinct(v_varbinary) from tbinary");
+        analyzeSuccess("select ds_theta_count_distinct(v_varbinary) from tbinary");
+        analyzeSuccess("select count(distinct v_varbinary) from tbinary");
+    }
+
+    @Test
     public void testMatrixTypeCast() {
         analyzeFail("select trim(b1) from test_object");
         analyzeFail("select trim(h1) from test_object");

--- a/test/sql/test_agg_function/R/test_ndv_with_varbinary_type
+++ b/test/sql/test_agg_function/R/test_ndv_with_varbinary_type
@@ -1,0 +1,353 @@
+-- name: test_ndv_with_varbinary_type
+CREATE TABLE tbinary_ndv_test (
+    id INT,
+    data VARBINARY,
+    category INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO tbinary_ndv_test
+SELECT generate_series,
+       to_binary(CONCAT('value_', CAST(generate_series AS VARCHAR))),
+       (generate_series - 1) % 5 + 1
+FROM TABLE(GENERATE_SERIES(1, 100));
+-- result:
+-- !result
+SELECT ndv(data) AS ndv_result FROM tbinary_ndv_test;
+-- result:
+1
+-- !result
+SELECT category, ndv(data) AS ndv_result FROM tbinary_ndv_test GROUP BY category ORDER BY category;
+-- result:
+1	1
+2	1
+3	1
+4	1
+5	1
+-- !result
+SELECT approx_count_distinct(data) AS approx_count_result FROM tbinary_ndv_test;
+-- result:
+1
+-- !result
+SELECT category, approx_count_distinct(data) AS approx_count_result FROM tbinary_ndv_test GROUP BY category ORDER BY category;
+-- result:
+1	1
+2	1
+3	1
+4	1
+5	1
+-- !result
+SELECT ds_hll_count_distinct(data) AS ds_hll_result FROM tbinary_ndv_test;
+-- result:
+1
+-- !result
+SELECT ds_hll_count_distinct(data, 10) AS ds_hll_result_with_logk FROM tbinary_ndv_test;
+-- result:
+1
+-- !result
+SELECT category, ds_hll_count_distinct(data) AS ds_hll_result FROM tbinary_ndv_test GROUP BY category ORDER BY category;
+-- result:
+1	1
+2	1
+3	1
+4	1
+5	1
+-- !result
+SELECT ds_theta_count_distinct(data) AS theta_result FROM tbinary_ndv_test;
+-- result:
+1
+-- !result
+SELECT category, ds_theta_count_distinct(data) AS theta_result FROM tbinary_ndv_test GROUP BY category ORDER BY category;
+-- result:
+1	1
+2	1
+3	1
+4	1
+5	1
+-- !result
+SELECT COUNT(DISTINCT data) AS distinct_count FROM tbinary_ndv_test;
+-- result:
+1
+-- !result
+SELECT category, COUNT(DISTINCT data) AS distinct_count FROM tbinary_ndv_test GROUP BY category ORDER BY category;
+-- result:
+1	1
+2	1
+3	1
+4	1
+5	1
+-- !result
+CREATE TABLE tbinary_ndv_null_test (
+    id INT,
+    data VARBINARY,
+    category INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO tbinary_ndv_null_test VALUES
+(1, to_binary('aaa'), 1),
+(2, to_binary('bbb'), 1),
+(3, NULL, 1),
+(4, to_binary('aaa'), 2),
+(5, to_binary('ccc'), 2),
+(6, NULL, 2),
+(7, to_binary('ddd'), 3),
+(8, to_binary('eee'), 3),
+(9, to_binary('fff'), 3);
+-- result:
+-- !result
+SELECT ndv(data) AS ndv_with_null FROM tbinary_ndv_null_test;
+-- result:
+1
+-- !result
+SELECT category, ndv(data) AS ndv_with_null FROM tbinary_ndv_null_test GROUP BY category ORDER BY category;
+-- result:
+1	1
+2	1
+3	1
+-- !result
+SELECT COUNT(DISTINCT data) AS distinct_count_with_null FROM tbinary_ndv_null_test;
+-- result:
+1
+-- !result
+SELECT category, COUNT(DISTINCT data) AS distinct_count_with_null FROM tbinary_ndv_null_test GROUP BY category ORDER BY category;
+-- result:
+1	1
+2	1
+3	1
+-- !result
+CREATE TABLE tbinary_ndv_dup_test (
+    id INT,
+    data VARBINARY
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO tbinary_ndv_dup_test VALUES
+(1, to_binary('same_value')),
+(2, to_binary('same_value')),
+(3, to_binary('same_value')),
+(4, to_binary('different_value')),
+(5, to_binary('different_value')),
+(6, NULL),
+(7, NULL);
+-- result:
+-- !result
+SELECT ndv(data) AS ndv_dup_result FROM tbinary_ndv_dup_test;
+-- result:
+1
+-- !result
+SELECT COUNT(DISTINCT data) AS distinct_count_dup FROM tbinary_ndv_dup_test;
+-- result:
+1
+-- !result
+CREATE TABLE tbinary_multi_distinct_test (
+    id INT,
+    data1 VARBINARY,
+    data2 VARBINARY,
+    data3 VARBINARY,
+    category INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO tbinary_multi_distinct_test VALUES
+(1, to_binary('value1'), to_binary('val1'), to_binary('v1'), 1),
+(2, to_binary('value2'), to_binary('val1'), to_binary('v1'), 1),
+(3, to_binary('value1'), to_binary('val2'), to_binary('v2'), 1),
+(4, to_binary('value3'), to_binary('val2'), to_binary('v1'), 2),
+(5, to_binary('value4'), to_binary('val3'), to_binary('v3'), 2),
+(6, to_binary('value3'), to_binary('val3'), to_binary('v2'), 2),
+(7, to_binary('value5'), to_binary('val4'), to_binary('v4'), 3),
+(8, to_binary('value6'), to_binary('val4'), to_binary('v4'), 3),
+(9, to_binary('value5'), to_binary('val5'), to_binary('v5'), 3);
+-- result:
+-- !result
+SELECT COUNT(DISTINCT data1) AS distinct_data1, 
+       COUNT(DISTINCT data2) AS distinct_data2,
+       COUNT(DISTINCT data3) AS distinct_data3
+FROM tbinary_multi_distinct_test;
+-- result:
+1	1	1
+-- !result
+SELECT category,
+       COUNT(DISTINCT data1) AS distinct_data1,
+       COUNT(DISTINCT data2) AS distinct_data2,
+       COUNT(DISTINCT data3) AS distinct_data3
+FROM tbinary_multi_distinct_test
+GROUP BY category
+ORDER BY category;
+-- result:
+1	1	1	1
+2	1	1	1
+3	1	1	1
+-- !result
+SELECT ndv(data1) AS ndv_data1,
+       approx_count_distinct(data2) AS approx_data2,
+       ds_hll_count_distinct(data3) AS hll_data3
+FROM tbinary_multi_distinct_test;
+-- result:
+1	1	1
+-- !result
+SELECT category,
+       ndv(data1) AS ndv_data1,
+       approx_count_distinct(data2) AS approx_data2,
+       ds_theta_count_distinct(data3) AS theta_data3
+FROM tbinary_multi_distinct_test
+GROUP BY category
+ORDER BY category;
+-- result:
+1	1	1	1
+2	1	1	1
+3	1	1	1
+-- !result
+SELECT COUNT(DISTINCT data1) AS exact_count1,
+       ndv(data2) AS approx_count2,
+       COUNT(DISTINCT data3) AS exact_count3,
+       ds_hll_count_distinct(data1) AS hll_count1
+FROM tbinary_multi_distinct_test;
+-- result:
+1	1	1	1
+-- !result
+SELECT category,
+       COUNT(DISTINCT data1) AS exact_count1,
+       ndv(data2) AS approx_count2,
+       approx_count_distinct(data3) AS approx_count3
+FROM tbinary_multi_distinct_test
+GROUP BY category
+ORDER BY category;
+-- result:
+1	1	1	1
+2	1	1	1
+3	1	1	1
+-- !result
+SELECT COUNT(DISTINCT data1) AS distinct_data1,
+       COUNT(DISTINCT data2) AS distinct_data2,
+       COUNT(*) AS total_rows,
+       MAX(id) AS max_id
+FROM tbinary_multi_distinct_test;
+-- result:
+1	1	9	9
+-- !result
+SELECT category,
+       COUNT(DISTINCT data1) AS distinct_data1,
+       COUNT(DISTINCT data2) AS distinct_data2,
+       COUNT(*) AS total_rows,
+       MIN(id) AS min_id,
+       MAX(id) AS max_id
+FROM tbinary_multi_distinct_test
+GROUP BY category
+ORDER BY category;
+-- result:
+1	1	1	3	1	3
+2	1	1	3	4	6
+3	1	1	3	7	9
+-- !result
+SELECT category,
+       COUNT(DISTINCT data1) AS distinct_data1,
+       COUNT(DISTINCT data2) AS distinct_data2,
+       ndv(data3) AS ndv_data3,
+       COUNT(*) AS total
+FROM tbinary_multi_distinct_test
+WHERE id > 2
+GROUP BY category
+HAVING COUNT(DISTINCT data1) > 1
+ORDER BY category;
+-- result:
+-- !result
+SELECT ndv(data1) AS ndv1,
+       approx_count_distinct(data2) AS approx2,
+       ds_hll_count_distinct(data3) AS hll3,
+       ds_theta_count_distinct(data1) AS theta1
+FROM tbinary_multi_distinct_test;
+-- result:
+1	1	1	1
+-- !result
+SELECT category,
+       ndv(data1) AS ndv1,
+       approx_count_distinct(data2) AS approx2,
+       ds_hll_count_distinct(data3) AS hll3,
+       ds_theta_count_distinct(data1) AS theta1
+FROM tbinary_multi_distinct_test
+GROUP BY category
+ORDER BY category;
+-- result:
+1	1	1	1	1
+2	1	1	1	1
+3	1	1	1	1
+-- !result
+CREATE TABLE tbinary_multi_null_test (
+    id INT,
+    data1 VARBINARY,
+    data2 VARBINARY,
+    category INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO tbinary_multi_null_test VALUES
+(1, to_binary('val1'), to_binary('valA'), 1),
+(2, NULL, to_binary('valA'), 1),
+(3, to_binary('val1'), NULL, 1),
+(4, NULL, NULL, 1),
+(5, to_binary('val2'), to_binary('valB'), 2),
+(6, to_binary('val2'), NULL, 2),
+(7, NULL, to_binary('valB'), 2);
+-- result:
+-- !result
+SELECT COUNT(DISTINCT data1) AS distinct_data1,
+       COUNT(DISTINCT data2) AS distinct_data2
+FROM tbinary_multi_null_test;
+-- result:
+1	1
+-- !result
+SELECT category,
+       COUNT(DISTINCT data1) AS distinct_data1,
+       COUNT(DISTINCT data2) AS distinct_data2
+FROM tbinary_multi_null_test
+GROUP BY category
+ORDER BY category;
+-- result:
+1	1	1
+2	1	1
+-- !result
+SELECT COUNT(DISTINCT data1) AS exact1,
+       ndv(data2) AS approx2,
+       approx_count_distinct(data1) AS approx1,
+       COUNT(DISTINCT data2) AS exact2
+FROM tbinary_multi_null_test;
+-- result:
+1	1	1	1
+-- !result
+DROP TABLE IF EXISTS tbinary_ndv_test;
+-- result:
+-- !result
+DROP TABLE IF EXISTS tbinary_ndv_null_test;
+-- result:
+-- !result
+DROP TABLE IF EXISTS tbinary_ndv_dup_test;
+-- result:
+-- !result
+DROP TABLE IF EXISTS tbinary_multi_distinct_test;
+-- result:
+-- !result
+DROP TABLE IF EXISTS tbinary_multi_null_test;
+-- result:
+-- !result

--- a/test/sql/test_agg_function/R/test_ndv_with_varbinary_type
+++ b/test/sql/test_agg_function/R/test_ndv_with_varbinary_type
@@ -12,74 +12,74 @@ PROPERTIES ("replication_num" = "1");
 -- !result
 INSERT INTO tbinary_ndv_test
 SELECT generate_series,
-       to_binary(CONCAT('value_', CAST(generate_series AS VARCHAR))),
+       to_binary(CONCAT('value_', CAST(generate_series AS VARCHAR)), 'utf8'),
        (generate_series - 1) % 5 + 1
 FROM TABLE(GENERATE_SERIES(1, 100));
 -- result:
 -- !result
 SELECT ndv(data) AS ndv_result FROM tbinary_ndv_test;
 -- result:
-1
+100
 -- !result
 SELECT category, ndv(data) AS ndv_result FROM tbinary_ndv_test GROUP BY category ORDER BY category;
 -- result:
-1	1
-2	1
-3	1
-4	1
-5	1
+1	20
+2	20
+3	20
+4	20
+5	20
 -- !result
 SELECT approx_count_distinct(data) AS approx_count_result FROM tbinary_ndv_test;
 -- result:
-1
+100
 -- !result
 SELECT category, approx_count_distinct(data) AS approx_count_result FROM tbinary_ndv_test GROUP BY category ORDER BY category;
 -- result:
-1	1
-2	1
-3	1
-4	1
-5	1
+1	20
+2	20
+3	20
+4	20
+5	20
 -- !result
 SELECT ds_hll_count_distinct(data) AS ds_hll_result FROM tbinary_ndv_test;
 -- result:
-1
+100
 -- !result
 SELECT ds_hll_count_distinct(data, 10) AS ds_hll_result_with_logk FROM tbinary_ndv_test;
 -- result:
-1
+100
 -- !result
 SELECT category, ds_hll_count_distinct(data) AS ds_hll_result FROM tbinary_ndv_test GROUP BY category ORDER BY category;
 -- result:
-1	1
-2	1
-3	1
-4	1
-5	1
+1	20
+2	20
+3	20
+4	20
+5	20
 -- !result
 SELECT ds_theta_count_distinct(data) AS theta_result FROM tbinary_ndv_test;
 -- result:
-1
+100
 -- !result
 SELECT category, ds_theta_count_distinct(data) AS theta_result FROM tbinary_ndv_test GROUP BY category ORDER BY category;
 -- result:
-1	1
-2	1
-3	1
-4	1
-5	1
+1	20
+2	20
+3	20
+4	20
+5	20
 -- !result
 SELECT COUNT(DISTINCT data) AS distinct_count FROM tbinary_ndv_test;
 -- result:
-1
+100
 -- !result
 SELECT category, COUNT(DISTINCT data) AS distinct_count FROM tbinary_ndv_test GROUP BY category ORDER BY category;
 -- result:
-1	1
-2	1
-3	1
-4	1
-5	1
+1	20
+2	20
+3	20
+4	20
+5	20
 -- !result
 CREATE TABLE tbinary_ndv_null_test (
     id INT,
@@ -93,36 +93,36 @@ PROPERTIES ("replication_num" = "1");
 -- result:
 -- !result
 INSERT INTO tbinary_ndv_null_test VALUES
-(1, to_binary('aaa'), 1),
-(2, to_binary('bbb'), 1),
+(1, to_binary('aaa', 'utf8'), 1),
+(2, to_binary('bbb', 'utf8'), 1),
 (3, NULL, 1),
-(4, to_binary('aaa'), 2),
-(5, to_binary('ccc'), 2),
+(4, to_binary('aaa', 'utf8'), 2),
+(5, to_binary('ccc', 'utf8'), 2),
 (6, NULL, 2),
-(7, to_binary('ddd'), 3),
-(8, to_binary('eee'), 3),
-(9, to_binary('fff'), 3);
+(7, to_binary('ddd', 'utf8'), 3),
+(8, to_binary('eee', 'utf8'), 3),
+(9, to_binary('fff', 'utf8'), 3);
 -- result:
 -- !result
 SELECT ndv(data) AS ndv_with_null FROM tbinary_ndv_null_test;
 -- result:
-1
+6
 -- !result
 SELECT category, ndv(data) AS ndv_with_null FROM tbinary_ndv_null_test GROUP BY category ORDER BY category;
 -- result:
-1	1
-2	1
-3	1
+1	2
+2	2
+3	3
 -- !result
 SELECT COUNT(DISTINCT data) AS distinct_count_with_null FROM tbinary_ndv_null_test;
 -- result:
-1
+6
 -- !result
 SELECT category, COUNT(DISTINCT data) AS distinct_count_with_null FROM tbinary_ndv_null_test GROUP BY category ORDER BY category;
 -- result:
-1	1
-2	1
-3	1
+1	2
+2	2
+3	3
 -- !result
 CREATE TABLE tbinary_ndv_dup_test (
     id INT,
@@ -135,22 +135,22 @@ PROPERTIES ("replication_num" = "1");
 -- result:
 -- !result
 INSERT INTO tbinary_ndv_dup_test VALUES
-(1, to_binary('same_value')),
-(2, to_binary('same_value')),
-(3, to_binary('same_value')),
-(4, to_binary('different_value')),
-(5, to_binary('different_value')),
+(1, to_binary('same_value', 'utf8')),
+(2, to_binary('same_value', 'utf8')),
+(3, to_binary('same_value', 'utf8')),
+(4, to_binary('different_value', 'utf8')),
+(5, to_binary('different_value', 'utf8')),
 (6, NULL),
 (7, NULL);
 -- result:
 -- !result
 SELECT ndv(data) AS ndv_dup_result FROM tbinary_ndv_dup_test;
 -- result:
-1
+2
 -- !result
 SELECT COUNT(DISTINCT data) AS distinct_count_dup FROM tbinary_ndv_dup_test;
 -- result:
-1
+2
 -- !result
 CREATE TABLE tbinary_multi_distinct_test (
     id INT,
@@ -166,15 +166,15 @@ PROPERTIES ("replication_num" = "1");
 -- result:
 -- !result
 INSERT INTO tbinary_multi_distinct_test VALUES
-(1, to_binary('value1'), to_binary('val1'), to_binary('v1'), 1),
-(2, to_binary('value2'), to_binary('val1'), to_binary('v1'), 1),
-(3, to_binary('value1'), to_binary('val2'), to_binary('v2'), 1),
-(4, to_binary('value3'), to_binary('val2'), to_binary('v1'), 2),
-(5, to_binary('value4'), to_binary('val3'), to_binary('v3'), 2),
-(6, to_binary('value3'), to_binary('val3'), to_binary('v2'), 2),
-(7, to_binary('value5'), to_binary('val4'), to_binary('v4'), 3),
-(8, to_binary('value6'), to_binary('val4'), to_binary('v4'), 3),
-(9, to_binary('value5'), to_binary('val5'), to_binary('v5'), 3);
+(1, to_binary('value1', 'utf8'), to_binary('val1', 'utf8'), to_binary('v1', 'utf8'), 1),
+(2, to_binary('value2', 'utf8'), to_binary('val1', 'utf8'), to_binary('v1', 'utf8'), 1),
+(3, to_binary('value1', 'utf8'), to_binary('val2', 'utf8'), to_binary('v2', 'utf8'), 1),
+(4, to_binary('value3', 'utf8'), to_binary('val2', 'utf8'), to_binary('v1', 'utf8'), 2),
+(5, to_binary('value4', 'utf8'), to_binary('val3', 'utf8'), to_binary('v3', 'utf8'), 2),
+(6, to_binary('value3', 'utf8'), to_binary('val3', 'utf8'), to_binary('v2', 'utf8'), 2),
+(7, to_binary('value5', 'utf8'), to_binary('val4', 'utf8'), to_binary('v4', 'utf8'), 3),
+(8, to_binary('value6', 'utf8'), to_binary('val4', 'utf8'), to_binary('v4', 'utf8'), 3),
+(9, to_binary('value5', 'utf8'), to_binary('val5', 'utf8'), to_binary('v5', 'utf8'), 3);
 -- result:
 -- !result
 SELECT COUNT(DISTINCT data1) AS distinct_data1, 
@@ -182,7 +182,7 @@ SELECT COUNT(DISTINCT data1) AS distinct_data1,
        COUNT(DISTINCT data3) AS distinct_data3
 FROM tbinary_multi_distinct_test;
 -- result:
-1	1	1
+6	5	5
 -- !result
 SELECT category,
        COUNT(DISTINCT data1) AS distinct_data1,
@@ -192,16 +192,16 @@ FROM tbinary_multi_distinct_test
 GROUP BY category
 ORDER BY category;
 -- result:
-1	1	1	1
-2	1	1	1
-3	1	1	1
+1	2	2	2
+2	2	2	3
+3	2	2	2
 -- !result
 SELECT ndv(data1) AS ndv_data1,
        approx_count_distinct(data2) AS approx_data2,
        ds_hll_count_distinct(data3) AS hll_data3
 FROM tbinary_multi_distinct_test;
 -- result:
-1	1	1
+6	5	5
 -- !result
 SELECT category,
        ndv(data1) AS ndv_data1,
@@ -211,9 +211,9 @@ FROM tbinary_multi_distinct_test
 GROUP BY category
 ORDER BY category;
 -- result:
-1	1	1	1
-2	1	1	1
-3	1	1	1
+1	2	2	2
+2	2	2	3
+3	2	2	2
 -- !result
 SELECT COUNT(DISTINCT data1) AS exact_count1,
        ndv(data2) AS approx_count2,
@@ -221,7 +221,7 @@ SELECT COUNT(DISTINCT data1) AS exact_count1,
        ds_hll_count_distinct(data1) AS hll_count1
 FROM tbinary_multi_distinct_test;
 -- result:
-1	1	1	1
+6	5	5	6
 -- !result
 SELECT category,
        COUNT(DISTINCT data1) AS exact_count1,
@@ -231,9 +231,9 @@ FROM tbinary_multi_distinct_test
 GROUP BY category
 ORDER BY category;
 -- result:
-1	1	1	1
-2	1	1	1
-3	1	1	1
+1	2	2	2
+2	2	2	3
+3	2	2	2
 -- !result
 SELECT COUNT(DISTINCT data1) AS distinct_data1,
        COUNT(DISTINCT data2) AS distinct_data2,
@@ -241,7 +241,7 @@ SELECT COUNT(DISTINCT data1) AS distinct_data1,
        MAX(id) AS max_id
 FROM tbinary_multi_distinct_test;
 -- result:
-1	1	9	9
+6	5	9	9
 -- !result
 SELECT category,
        COUNT(DISTINCT data1) AS distinct_data1,
@@ -253,9 +253,9 @@ FROM tbinary_multi_distinct_test
 GROUP BY category
 ORDER BY category;
 -- result:
-1	1	1	3	1	3
-2	1	1	3	4	6
-3	1	1	3	7	9
+1	2	2	3	1	3
+2	2	2	3	4	6
+3	2	2	3	7	9
 -- !result
 SELECT category,
        COUNT(DISTINCT data1) AS distinct_data1,
@@ -268,6 +268,8 @@ GROUP BY category
 HAVING COUNT(DISTINCT data1) > 1
 ORDER BY category;
 -- result:
+2	2	2	3	3
+3	2	2	2	3
 -- !result
 SELECT ndv(data1) AS ndv1,
        approx_count_distinct(data2) AS approx2,
@@ -275,7 +277,7 @@ SELECT ndv(data1) AS ndv1,
        ds_theta_count_distinct(data1) AS theta1
 FROM tbinary_multi_distinct_test;
 -- result:
-1	1	1	1
+6	5	5	6
 -- !result
 SELECT category,
        ndv(data1) AS ndv1,
@@ -286,9 +288,9 @@ FROM tbinary_multi_distinct_test
 GROUP BY category
 ORDER BY category;
 -- result:
-1	1	1	1	1
-2	1	1	1	1
-3	1	1	1	1
+1	2	2	2	2
+2	2	2	3	2
+3	2	2	2	2
 -- !result
 CREATE TABLE tbinary_multi_null_test (
     id INT,
@@ -303,20 +305,20 @@ PROPERTIES ("replication_num" = "1");
 -- result:
 -- !result
 INSERT INTO tbinary_multi_null_test VALUES
-(1, to_binary('val1'), to_binary('valA'), 1),
-(2, NULL, to_binary('valA'), 1),
-(3, to_binary('val1'), NULL, 1),
+(1, to_binary('val1', 'utf8'), to_binary('valA', 'utf8'), 1),
+(2, NULL, to_binary('valA', 'utf8'), 1),
+(3, to_binary('val1', 'utf8'), NULL, 1),
 (4, NULL, NULL, 1),
-(5, to_binary('val2'), to_binary('valB'), 2),
-(6, to_binary('val2'), NULL, 2),
-(7, NULL, to_binary('valB'), 2);
+(5, to_binary('val2', 'utf8'), to_binary('valB', 'utf8'), 2),
+(6, to_binary('val2', 'utf8'), NULL, 2),
+(7, NULL, to_binary('valB', 'utf8'), 2);
 -- result:
 -- !result
 SELECT COUNT(DISTINCT data1) AS distinct_data1,
        COUNT(DISTINCT data2) AS distinct_data2
 FROM tbinary_multi_null_test;
 -- result:
-1	1
+2	2
 -- !result
 SELECT category,
        COUNT(DISTINCT data1) AS distinct_data1,
@@ -334,7 +336,7 @@ SELECT COUNT(DISTINCT data1) AS exact1,
        COUNT(DISTINCT data2) AS exact2
 FROM tbinary_multi_null_test;
 -- result:
-1	1	1	1
+2	2	2	2
 -- !result
 DROP TABLE IF EXISTS tbinary_ndv_test;
 -- result:

--- a/test/sql/test_agg_function/T/test_ndv_with_varbinary_type
+++ b/test/sql/test_agg_function/T/test_ndv_with_varbinary_type
@@ -1,0 +1,254 @@
+-- name: test_ndv_with_varbinary_type
+-- Test table with VARBINARY column
+CREATE TABLE tbinary_ndv_test (
+    id INT,
+    data VARBINARY,
+    category INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+-- Insert test data with various varbinary values
+INSERT INTO tbinary_ndv_test
+SELECT generate_series,
+       to_binary(CONCAT('value_', CAST(generate_series AS VARCHAR))),
+       (generate_series - 1) % 5 + 1
+FROM TABLE(GENERATE_SERIES(1, 100));
+
+-- Test ndv (alias for approx_count_distinct) with varbinary
+SELECT ndv(data) AS ndv_result FROM tbinary_ndv_test;
+SELECT category, ndv(data) AS ndv_result FROM tbinary_ndv_test GROUP BY category ORDER BY category;
+
+-- Test approx_count_distinct with varbinary
+SELECT approx_count_distinct(data) AS approx_count_result FROM tbinary_ndv_test;
+SELECT category, approx_count_distinct(data) AS approx_count_result FROM tbinary_ndv_test GROUP BY category ORDER BY category;
+
+-- Test ds_hll_count_distinct with varbinary
+SELECT ds_hll_count_distinct(data) AS ds_hll_result FROM tbinary_ndv_test;
+SELECT ds_hll_count_distinct(data, 10) AS ds_hll_result_with_logk FROM tbinary_ndv_test;
+SELECT category, ds_hll_count_distinct(data) AS ds_hll_result FROM tbinary_ndv_test GROUP BY category ORDER BY category;
+
+-- Test ds_theta_count_distinct with varbinary
+SELECT ds_theta_count_distinct(data) AS theta_result FROM tbinary_ndv_test;
+SELECT category, ds_theta_count_distinct(data) AS theta_result FROM tbinary_ndv_test GROUP BY category ORDER BY category;
+
+-- Test count(distinct) with varbinary (uses multi_distinct_count internally)
+SELECT COUNT(DISTINCT data) AS distinct_count FROM tbinary_ndv_test;
+SELECT category, COUNT(DISTINCT data) AS distinct_count FROM tbinary_ndv_test GROUP BY category ORDER BY category;
+
+-- Test with NULL values
+CREATE TABLE tbinary_ndv_null_test (
+    id INT,
+    data VARBINARY,
+    category INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO tbinary_ndv_null_test VALUES
+(1, to_binary('aaa'), 1),
+(2, to_binary('bbb'), 1),
+(3, NULL, 1),
+(4, to_binary('aaa'), 2),
+(5, to_binary('ccc'), 2),
+(6, NULL, 2),
+(7, to_binary('ddd'), 3),
+(8, to_binary('eee'), 3),
+(9, to_binary('fff'), 3);
+
+SELECT ndv(data) AS ndv_with_null FROM tbinary_ndv_null_test;
+SELECT category, ndv(data) AS ndv_with_null FROM tbinary_ndv_null_test GROUP BY category ORDER BY category;
+
+SELECT COUNT(DISTINCT data) AS distinct_count_with_null FROM tbinary_ndv_null_test;
+SELECT category, COUNT(DISTINCT data) AS distinct_count_with_null FROM tbinary_ndv_null_test GROUP BY category ORDER BY category;
+
+-- Test with duplicate varbinary values
+CREATE TABLE tbinary_ndv_dup_test (
+    id INT,
+    data VARBINARY
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO tbinary_ndv_dup_test VALUES
+(1, to_binary('same_value')),
+(2, to_binary('same_value')),
+(3, to_binary('same_value')),
+(4, to_binary('different_value')),
+(5, to_binary('different_value')),
+(6, NULL),
+(7, NULL);
+
+SELECT ndv(data) AS ndv_dup_result FROM tbinary_ndv_dup_test;
+SELECT COUNT(DISTINCT data) AS distinct_count_dup FROM tbinary_ndv_dup_test;
+
+-- Test multiple count distinct functions in the same query
+CREATE TABLE tbinary_multi_distinct_test (
+    id INT,
+    data1 VARBINARY,
+    data2 VARBINARY,
+    data3 VARBINARY,
+    category INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO tbinary_multi_distinct_test VALUES
+(1, to_binary('value1'), to_binary('val1'), to_binary('v1'), 1),
+(2, to_binary('value2'), to_binary('val1'), to_binary('v1'), 1),
+(3, to_binary('value1'), to_binary('val2'), to_binary('v2'), 1),
+(4, to_binary('value3'), to_binary('val2'), to_binary('v1'), 2),
+(5, to_binary('value4'), to_binary('val3'), to_binary('v3'), 2),
+(6, to_binary('value3'), to_binary('val3'), to_binary('v2'), 2),
+(7, to_binary('value5'), to_binary('val4'), to_binary('v4'), 3),
+(8, to_binary('value6'), to_binary('val4'), to_binary('v4'), 3),
+(9, to_binary('value5'), to_binary('val5'), to_binary('v5'), 3);
+
+-- Multiple COUNT(DISTINCT) in the same SELECT
+SELECT COUNT(DISTINCT data1) AS distinct_data1, 
+       COUNT(DISTINCT data2) AS distinct_data2,
+       COUNT(DISTINCT data3) AS distinct_data3
+FROM tbinary_multi_distinct_test;
+
+-- Multiple COUNT(DISTINCT) with GROUP BY
+SELECT category,
+       COUNT(DISTINCT data1) AS distinct_data1,
+       COUNT(DISTINCT data2) AS distinct_data2,
+       COUNT(DISTINCT data3) AS distinct_data3
+FROM tbinary_multi_distinct_test
+GROUP BY category
+ORDER BY category;
+
+-- Multiple approximate count distinct functions in the same SELECT
+SELECT ndv(data1) AS ndv_data1,
+       approx_count_distinct(data2) AS approx_data2,
+       ds_hll_count_distinct(data3) AS hll_data3
+FROM tbinary_multi_distinct_test;
+
+-- Multiple approximate count distinct with GROUP BY
+SELECT category,
+       ndv(data1) AS ndv_data1,
+       approx_count_distinct(data2) AS approx_data2,
+       ds_theta_count_distinct(data3) AS theta_data3
+FROM tbinary_multi_distinct_test
+GROUP BY category
+ORDER BY category;
+
+-- Mix of COUNT(DISTINCT) and approximate count distinct functions
+SELECT COUNT(DISTINCT data1) AS exact_count1,
+       ndv(data2) AS approx_count2,
+       COUNT(DISTINCT data3) AS exact_count3,
+       ds_hll_count_distinct(data1) AS hll_count1
+FROM tbinary_multi_distinct_test;
+
+-- Mix with GROUP BY
+SELECT category,
+       COUNT(DISTINCT data1) AS exact_count1,
+       ndv(data2) AS approx_count2,
+       approx_count_distinct(data3) AS approx_count3
+FROM tbinary_multi_distinct_test
+GROUP BY category
+ORDER BY category;
+
+-- Multiple COUNT(DISTINCT) combined with other aggregate functions
+SELECT COUNT(DISTINCT data1) AS distinct_data1,
+       COUNT(DISTINCT data2) AS distinct_data2,
+       COUNT(*) AS total_rows,
+       MAX(id) AS max_id
+FROM tbinary_multi_distinct_test;
+
+-- Multiple COUNT(DISTINCT) with GROUP BY and other aggregates
+SELECT category,
+       COUNT(DISTINCT data1) AS distinct_data1,
+       COUNT(DISTINCT data2) AS distinct_data2,
+       COUNT(*) AS total_rows,
+       MIN(id) AS min_id,
+       MAX(id) AS max_id
+FROM tbinary_multi_distinct_test
+GROUP BY category
+ORDER BY category;
+
+-- Complex query with multiple distinct aggregations and filters
+SELECT category,
+       COUNT(DISTINCT data1) AS distinct_data1,
+       COUNT(DISTINCT data2) AS distinct_data2,
+       ndv(data3) AS ndv_data3,
+       COUNT(*) AS total
+FROM tbinary_multi_distinct_test
+WHERE id > 2
+GROUP BY category
+HAVING COUNT(DISTINCT data1) > 1
+ORDER BY category;
+
+-- Test with all approximate count distinct variants in one query
+SELECT ndv(data1) AS ndv1,
+       approx_count_distinct(data2) AS approx2,
+       ds_hll_count_distinct(data3) AS hll3,
+       ds_theta_count_distinct(data1) AS theta1
+FROM tbinary_multi_distinct_test;
+
+-- Test with all approximate count distinct variants with GROUP BY
+SELECT category,
+       ndv(data1) AS ndv1,
+       approx_count_distinct(data2) AS approx2,
+       ds_hll_count_distinct(data3) AS hll3,
+       ds_theta_count_distinct(data1) AS theta1
+FROM tbinary_multi_distinct_test
+GROUP BY category
+ORDER BY category;
+
+-- Test multiple COUNT(DISTINCT) with NULL handling
+CREATE TABLE tbinary_multi_null_test (
+    id INT,
+    data1 VARBINARY,
+    data2 VARBINARY,
+    category INT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO tbinary_multi_null_test VALUES
+(1, to_binary('val1'), to_binary('valA'), 1),
+(2, NULL, to_binary('valA'), 1),
+(3, to_binary('val1'), NULL, 1),
+(4, NULL, NULL, 1),
+(5, to_binary('val2'), to_binary('valB'), 2),
+(6, to_binary('val2'), NULL, 2),
+(7, NULL, to_binary('valB'), 2);
+
+-- Multiple COUNT(DISTINCT) with NULLs
+SELECT COUNT(DISTINCT data1) AS distinct_data1,
+       COUNT(DISTINCT data2) AS distinct_data2
+FROM tbinary_multi_null_test;
+
+-- Multiple COUNT(DISTINCT) with NULLs and GROUP BY
+SELECT category,
+       COUNT(DISTINCT data1) AS distinct_data1,
+       COUNT(DISTINCT data2) AS distinct_data2
+FROM tbinary_multi_null_test
+GROUP BY category
+ORDER BY category;
+
+-- Mix of COUNT(DISTINCT) and approximate functions with NULLs
+SELECT COUNT(DISTINCT data1) AS exact1,
+       ndv(data2) AS approx2,
+       approx_count_distinct(data1) AS approx1,
+       COUNT(DISTINCT data2) AS exact2
+FROM tbinary_multi_null_test;
+
+-- Clean up
+DROP TABLE IF EXISTS tbinary_ndv_test;
+DROP TABLE IF EXISTS tbinary_ndv_null_test;
+DROP TABLE IF EXISTS tbinary_ndv_dup_test;
+DROP TABLE IF EXISTS tbinary_multi_distinct_test;
+DROP TABLE IF EXISTS tbinary_multi_null_test;

--- a/test/sql/test_agg_function/T/test_ndv_with_varbinary_type
+++ b/test/sql/test_agg_function/T/test_ndv_with_varbinary_type
@@ -13,7 +13,7 @@ PROPERTIES ("replication_num" = "1");
 -- Insert test data with various varbinary values
 INSERT INTO tbinary_ndv_test
 SELECT generate_series,
-       to_binary(CONCAT('value_', CAST(generate_series AS VARCHAR))),
+       to_binary(CONCAT('value_', CAST(generate_series AS VARCHAR)), 'utf8'),
        (generate_series - 1) % 5 + 1
 FROM TABLE(GENERATE_SERIES(1, 100));
 
@@ -50,15 +50,15 @@ BUCKETS 1
 PROPERTIES ("replication_num" = "1");
 
 INSERT INTO tbinary_ndv_null_test VALUES
-(1, to_binary('aaa'), 1),
-(2, to_binary('bbb'), 1),
+(1, to_binary('aaa', 'utf8'), 1),
+(2, to_binary('bbb', 'utf8'), 1),
 (3, NULL, 1),
-(4, to_binary('aaa'), 2),
-(5, to_binary('ccc'), 2),
+(4, to_binary('aaa', 'utf8'), 2),
+(5, to_binary('ccc', 'utf8'), 2),
 (6, NULL, 2),
-(7, to_binary('ddd'), 3),
-(8, to_binary('eee'), 3),
-(9, to_binary('fff'), 3);
+(7, to_binary('ddd', 'utf8'), 3),
+(8, to_binary('eee', 'utf8'), 3),
+(9, to_binary('fff', 'utf8'), 3);
 
 SELECT ndv(data) AS ndv_with_null FROM tbinary_ndv_null_test;
 SELECT category, ndv(data) AS ndv_with_null FROM tbinary_ndv_null_test GROUP BY category ORDER BY category;
@@ -77,11 +77,11 @@ BUCKETS 1
 PROPERTIES ("replication_num" = "1");
 
 INSERT INTO tbinary_ndv_dup_test VALUES
-(1, to_binary('same_value')),
-(2, to_binary('same_value')),
-(3, to_binary('same_value')),
-(4, to_binary('different_value')),
-(5, to_binary('different_value')),
+(1, to_binary('same_value', 'utf8')),
+(2, to_binary('same_value', 'utf8')),
+(3, to_binary('same_value', 'utf8')),
+(4, to_binary('different_value', 'utf8')),
+(5, to_binary('different_value', 'utf8')),
 (6, NULL),
 (7, NULL);
 
@@ -102,15 +102,15 @@ BUCKETS 1
 PROPERTIES ("replication_num" = "1");
 
 INSERT INTO tbinary_multi_distinct_test VALUES
-(1, to_binary('value1'), to_binary('val1'), to_binary('v1'), 1),
-(2, to_binary('value2'), to_binary('val1'), to_binary('v1'), 1),
-(3, to_binary('value1'), to_binary('val2'), to_binary('v2'), 1),
-(4, to_binary('value3'), to_binary('val2'), to_binary('v1'), 2),
-(5, to_binary('value4'), to_binary('val3'), to_binary('v3'), 2),
-(6, to_binary('value3'), to_binary('val3'), to_binary('v2'), 2),
-(7, to_binary('value5'), to_binary('val4'), to_binary('v4'), 3),
-(8, to_binary('value6'), to_binary('val4'), to_binary('v4'), 3),
-(9, to_binary('value5'), to_binary('val5'), to_binary('v5'), 3);
+(1, to_binary('value1', 'utf8'), to_binary('val1', 'utf8'), to_binary('v1', 'utf8'), 1),
+(2, to_binary('value2', 'utf8'), to_binary('val1', 'utf8'), to_binary('v1', 'utf8'), 1),
+(3, to_binary('value1', 'utf8'), to_binary('val2', 'utf8'), to_binary('v2', 'utf8'), 1),
+(4, to_binary('value3', 'utf8'), to_binary('val2', 'utf8'), to_binary('v1', 'utf8'), 2),
+(5, to_binary('value4', 'utf8'), to_binary('val3', 'utf8'), to_binary('v3', 'utf8'), 2),
+(6, to_binary('value3', 'utf8'), to_binary('val3', 'utf8'), to_binary('v2', 'utf8'), 2),
+(7, to_binary('value5', 'utf8'), to_binary('val4', 'utf8'), to_binary('v4', 'utf8'), 3),
+(8, to_binary('value6', 'utf8'), to_binary('val4', 'utf8'), to_binary('v4', 'utf8'), 3),
+(9, to_binary('value5', 'utf8'), to_binary('val5', 'utf8'), to_binary('v5', 'utf8'), 3);
 
 -- Multiple COUNT(DISTINCT) in the same SELECT
 SELECT COUNT(DISTINCT data1) AS distinct_data1, 
@@ -218,13 +218,13 @@ BUCKETS 1
 PROPERTIES ("replication_num" = "1");
 
 INSERT INTO tbinary_multi_null_test VALUES
-(1, to_binary('val1'), to_binary('valA'), 1),
-(2, NULL, to_binary('valA'), 1),
-(3, to_binary('val1'), NULL, 1),
+(1, to_binary('val1', 'utf8'), to_binary('valA', 'utf8'), 1),
+(2, NULL, to_binary('valA', 'utf8'), 1),
+(3, to_binary('val1', 'utf8'), NULL, 1),
 (4, NULL, NULL, 1),
-(5, to_binary('val2'), to_binary('valB'), 2),
-(6, to_binary('val2'), NULL, 2),
-(7, NULL, to_binary('valB'), 2);
+(5, to_binary('val2', 'utf8'), to_binary('valB', 'utf8'), 2),
+(6, to_binary('val2', 'utf8'), NULL, 2),
+(7, NULL, to_binary('valB', 'utf8'), 2);
 
 -- Multiple COUNT(DISTINCT) with NULLs
 SELECT COUNT(DISTINCT data1) AS distinct_data1,


### PR DESCRIPTION
## Why I'm doing:

This pull request expands support for aggregate functions to include the `VARBINARY` type alongside string types, and unifies the handling of string and binary types in aggregate function implementations. It introduces a new type guard, `StringOrBinaryGuard`, to replace previous string-only guards, and updates both backend (C++) and frontend (Java) code to enable and validate aggregate operations on binary columns. Additionally, new tests are added to verify this extended support.

**Backend (C++):**

* **Unified handling of string and binary types in aggregate functions:**
  - Replaced `StringLTGuard` with `StringOrBinaryGuard` in aggregate state and trait templates, allowing aggregate functions to operate on both string and binary types. [[1]](diffhunk://#diff-dd0c66356a4b68ed0b796d266afea5ed1e484bd7ac2f40eedc4a11686aade7caL119-R119) [[2]](diffhunk://#diff-92cfd0099e6c0197575c3a3800dcb5e04fa4ebf9b844331bed6281c251c69595L248-R248) [[3]](diffhunk://#diff-92cfd0099e6c0197575c3a3800dcb5e04fa4ebf9b844331bed6281c251c69595L379-R380) [[4]](diffhunk://#diff-82fd89e54b4a0ef2de25e0f6977fe7d2cd4498a1c6b980d341a4f0afec40e9c8L369-R369)
  - Updated all relevant aggregate function implementations (e.g., HLL, Theta Sketch, Histogram, Intersect Count) to use `lt_is_string_or_binary` checks instead of string-only checks, ensuring correct processing for `VARBINARY` columns. [[1]](diffhunk://#diff-a0a2b09f616a6594a16b9099f5d048cbc05ba265e72745e6c65210f26ccebfccL64-R64) [[2]](diffhunk://#diff-a0a2b09f616a6594a16b9099f5d048cbc05ba265e72745e6c65210f26ccebfccL80-R80) [[3]](diffhunk://#diff-a0a2b09f616a6594a16b9099f5d048cbc05ba265e72745e6c65210f26ccebfccL166-R166) [[4]](diffhunk://#diff-c8277e418eaba73d1cf27fabde5c92e6c1d36505e6a741df558f2258724deba2L59-R59) [[5]](diffhunk://#diff-c8277e418eaba73d1cf27fabde5c92e6c1d36505e6a741df558f2258724deba2L75-R75) [[6]](diffhunk://#diff-c8277e418eaba73d1cf27fabde5c92e6c1d36505e6a741df558f2258724deba2L150-R150) [[7]](diffhunk://#diff-e87c7ee6de08bc7cf109fa945ef9d4501c8f970e298f546adb03a1637dcd2c1eL83-R83) [[8]](diffhunk://#diff-4d86dfe097db30f2d4c01557bdf25b152964c7eec0b4e196c2e52556f20ad91fL56-R56) [[9]](diffhunk://#diff-4d86dfe097db30f2d4c01557bdf25b152964c7eec0b4e196c2e52556f20ad91fL74-R74) [[10]](diffhunk://#diff-4d86dfe097db30f2d4c01557bdf25b152964c7eec0b4e196c2e52556f20ad91fL143-R143) [[11]](diffhunk://#diff-83c139556a5d374e9fca23e4abbf0e5d8a624099b6277b23c2f8b14c954ba768L77-R81) [[12]](diffhunk://#diff-83c139556a5d374e9fca23e4abbf0e5d8a624099b6277b23c2f8b14c954ba768L95-R99) [[13]](diffhunk://#diff-83c139556a5d374e9fca23e4abbf0e5d8a624099b6277b23c2f8b14c954ba768L133-R137) [[14]](diffhunk://#diff-83c139556a5d374e9fca23e4abbf0e5d8a624099b6277b23c2f8b14c954ba768L154-R158)

* **Aggregate function registration enhancements:**
  - Modified aggregate function resolver logic to include `TYPE_VARBINARY` in the set of supported types for approximate and distinct aggregate functions, enabling their use on binary columns. [[1]](diffhunk://#diff-fc0511429465b4bd69e6d4c57ecc9c467633698082aa57a6771e62fb6677ec6bL28-R28) [[2]](diffhunk://#diff-fc0511429465b4bd69e6d4c57ecc9c467633698082aa57a6771e62fb6677ec6bL67-R73) [[3]](diffhunk://#diff-30c995b960a26c20ad1283eeee63e21943acb94a667fa6963a6317b3e02d9996L25-R25) [[4]](diffhunk://#diff-30c995b960a26c20ad1283eeee63e21943acb94a667fa6963a6317b3e02d9996L63-R65)

* **Typo fix:**
  - Fixed a typo in the guard name from `StringOrBinaryGaurd` to `StringOrBinaryGuard` across relevant files. [[1]](diffhunk://#diff-d790d76989fb4c32e97bb291b754f1af2171d573c68541f823fcc6925bc00215L169-R175) [[2]](diffhunk://#diff-82fd89e54b4a0ef2de25e0f6977fe7d2cd4498a1c6b980d341a4f0afec40e9c8L369-R369)

**Frontend (Java):**

* **Catalog and analyzer updates:**
  - Added `VarbinaryType.VARBINARY` to the set of types supported by aggregate functions in the function catalog.
  - Updated function analyzer logic to allow approximate count distinct functions (e.g., `ndv`, `approx_count_distinct`, `ds_hll_count_distinct`, `ds_theta_count_distinct`, and `count(distinct ...)`) to accept binary types in addition to numeric types.

* **Testing:**
  - Added tests to verify that approximate count distinct and distinct aggregate functions work correctly with `VARBINARY` columns.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
