### PR TITLE
[Enhancement] Auto recollect FULL stats for predicate columns on unpartitioned tables

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
@@ -241,8 +241,8 @@ class ColumnUsageTest extends PlanTestBase {
             List<StatisticsCollectJob> collectJobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(analyzeJob);
             Assertions.assertEquals(1, collectJobs.size());
             StatisticsCollectJob job0 = collectJobs.get(0);
-            Assertions.assertEquals(StatsConstants.AnalyzeType.SAMPLE, job0.getAnalyzeType());
-            Assertions.assertEquals(List.of("v1", "v2", "v3"), job0.getColumnNames());
+            Assertions.assertEquals(StatsConstants.AnalyzeType.FULL, job0.getAnalyzeType());
+            Assertions.assertEquals(List.of("v1"), job0.getColumnNames());
             Config.statistic_auto_collect_small_table_size = defaultSmallTableSize;
             Config.statistic_auto_collect_max_predicate_column_size_on_sample_strategy = defaultPredicateColumnSize;
         }


### PR DESCRIPTION
## Why I'm doing:
StarRocks already supports **auto analyze**, but some existing users still run **manual ANALYZE on only a subset of columns** after overwriting table or routine maintenance. When the manually analyzed columns do **not fully cover predicate-related columns**, the optimizer may lack statistics for important predicate/join/group-by columns.  
Today, the background auto-collection logic is primarily **table/partition health based** (row/data-change driven) and does not validate **column-level coverage**, so it may skip collecting the missing predicate-column stats because the table is considered “healthy”. This creates a conflict between legacy user behavior and the current auto-collection strategy, leading to unstable plans and regressions.

## What I'm doing:
- Add a **column-coverage check** for **unpartitioned tables**: verify whether existing **FULL** stats actually cover **all predicate columns**.
- If any predicate columns are missing FULL stats, force a **FULL recollection** to compensate stats for:
  - **predicate columns**, plus
  - columns that are already **FULL** analyzed (to keep meta consistent),
  while bypassing the “healthy / interval” skip logic that only reflects data change.
- Scope the change to **unpartitioned tables only**, since these tables are typically smaller and this avoids unexpected heavy workloads on large partitioned tables.
- The compensation collection is **focused on predicate columns**, so it addresses the user-visible issue with minimal impact.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
