### PR TITLE
[BugFix] Fix IP column for leader detection in different version

### DIFF
--- a/docker/dockerfiles/fe/fe_entrypoint.sh
+++ b/docker/dockerfiles/fe/fe_entrypoint.sh
@@ -94,7 +94,12 @@ probe_leader_for_pod0()
             log_stderr "FE service is alive, check if has leader ..."
 
             memlist=`show_frontends $svc`
-            local leader=`echo "$memlist" | grep '\<LEADER\>' | awk '{print $3}'`
+            local leader=`echo "$memlist" | grep '\<LEADER\>' | awk '{
+                for(i=1;i<=NF;i++){
+                    if($i=="IP") ip_col=i;
+                }
+                print $ip_col;
+            }'`
             if [[ "x$leader" != "x" ]] ; then
                 # has leader, done
                 log_stderr "Find leader: $leader!"
@@ -145,7 +150,12 @@ probe_leader_for_podX()
         NC="nc -z -w 2"
         if $NC $svc $QUERY_PORT ; then
             log_stderr "FE service is alive, check if has leader ..."
-            local leader=`show_frontends $svc | grep '\<LEADER\>' | awk '{print $3}'`
+            local leader=`show_frontends $svc | grep '\<LEADER\>' | awk '{
+                for(i=1;i<=NF;i++){
+                    if($i=="IP") ip_col=i;
+                }
+                print $ip_col;
+            }'`
             if [[ "x$leader" != "x" ]] ; then
                 # has leader, done
                 log_stderr "Find leader: $leader!"


### PR DESCRIPTION
## Why I'm doing:

The Fe IP is in different col in different version  which will be difficult to regist with leader ip is some scenario
such as upgrade ...



version: 3.3.21-20149de

+------------------------------+-----------+-------------+----------+-----------+---------+--------+-----------+------+-------+-------------------+---------------------+----------+--------+---------------------+----------------+
| Name                         | IP        | EditLogPort | HttpPort | QueryPort | RpcPort | Role   | ClusterId | Join | Alive | ReplayedJournalId | LastHeartbeat       | IsHelper | ErrMsg | StartTime           | Version        |
+------------------------------+-----------+-------------+----------+-----------+---------+--------+-----------+------+-------+-------------------+---------------------+----------+--------+---------------------+----------------+
| 10.*.*.*_9010_1768629725172 | 10.*.*.* | 9010        | 8030     | 9030      | 9020    | LEADER | 170949080 | true | true  | 846               | 2026-01-26 19:22:21 | true     |        | 2026-01-26 19:21:18 | 3.3.21-20149de |
+------------------------------+-----------+-------------+----------+-----------+---------+--------+-----------+------+-------+-------------------+---------------------+----------+--------+---------------------+----------------+



version: 3.5.11-0a8fcec

+------+------------------------------+-----------+-------------+----------+-----------+---------+--------+------------+------+-------+-------------------+---------------------+----------+--------+---------------------+----------------+
| Id   | Name                         | IP        | EditLogPort | HttpPort | QueryPort | RpcPort | Role   | ClusterId  | Join | Alive | ReplayedJournalId | LastHeartbeat       | IsHelper | ErrMsg | StartTime           | Version        |
+------+------------------------------+-----------+-------------+----------+-----------+---------+--------+------------+------+-------+-------------------+---------------------+----------+--------+---------------------+----------------+
| 1    | 10.*.*.*_9010_1768627834242 | 10.*.*.* | 9010        | 8030     | 9030      | 9020    | LEADER | 1027869889 | true | true  | 396533            | 2026-01-26 19:17:46 | true     |        | 2026-01-17 15:18:30 | 3.5.11-0a8fcec |
+------+------------------------------+-----------+-------------+----------+-----------+---------+--------+------------+------+-------+-------------------+---------------------+----------+--------+---------------------+----------------+



## What I'm doing:

- Replace fixed column index with dynamic IP column lookup in awk scripts
- Fix shellcheck lint errors: parameter mixing and ls iteration issues
- Ensure compatibility with both low and high version StarRocks FE node tables


Fixes #issue

NO

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [X] This pr needs user documentation (for new or modified features or behaviors)
  - [X] I have added documentation for my new feature or new function
  - [X] This pr needs auto generate documentation
- [X] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.1
  - [X] 4.0

