### PR TITLE
[Enhancement] Add ADMIN SHOW AUTOMATED CLUSTER SNAPSHOT status output

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJobScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJobScheduler.java
@@ -32,7 +32,7 @@ public class ClusterSnapshotJobScheduler extends FrontendDaemon implements Snaps
     // cluster snapshot information used for start
     protected final RestoredSnapshotInfo restoredSnapshotInfo;
 
-    protected long lastAutomatedJobStartTimeMs;
+    protected volatile long lastAutomatedJobStartTimeMs;
     protected volatile ClusterSnapshotJob runningJob;
 
     public ClusterSnapshotJobScheduler(CheckpointController feController,
@@ -78,6 +78,10 @@ public class ClusterSnapshotJobScheduler extends FrontendDaemon implements Snaps
             --retryTime;
         }
         return null;
+    }
+
+    public long getLastAutomatedJobStartTimeMs() {
+        return lastAutomatedJobStartTimeMs;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -18,7 +18,9 @@ import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.alter.AlterJobV2;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.lake.snapshot.ClusterSnapshotJob.ClusterSnapshotJobState;
 import com.starrocks.persist.ClusterSnapshotLog;
 import com.starrocks.persist.ImageWriter;
@@ -33,6 +35,7 @@ import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AdminAlterAutomatedSnapshotIntervalStmt;
 import com.starrocks.sql.ast.AdminSetAutomatedSnapshotOffStmt;
 import com.starrocks.sql.ast.AdminSetAutomatedSnapshotOnStmt;
+import com.starrocks.sql.ast.expression.IntervalLiteral;
 import com.starrocks.staros.StarMgrServer;
 import com.starrocks.storagevolume.StorageVolume;
 import com.starrocks.thrift.TClusterSnapshotJobsResponse;
@@ -131,6 +134,54 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
             return automatedSnapshotIntervalSeconds;
         }
         return Config.automated_cluster_snapshot_interval_seconds;
+    }
+
+    public long getNextAutomatedSnapshotTimeMs() {
+        if (!isAutomatedSnapshotOn()) {
+            return -1L;
+        }
+        long intervalSeconds = getEffectiveAutomatedSnapshotIntervalSeconds();
+        if (intervalSeconds <= 0) {
+            return -1L;
+        }
+
+        long lastStartTimeMs = 0L;
+        ClusterSnapshotJobScheduler scheduler = clusterSnapshotJobScheduler;
+        if (scheduler != null) {
+            lastStartTimeMs = scheduler.getLastAutomatedJobStartTimeMs();
+        }
+        if (lastStartTimeMs <= 0L) {
+            ClusterSnapshotJob lastFinishedJob = getLastFinishedAutomatedClusterSnapshotJob();
+            if (lastFinishedJob != null) {
+                lastStartTimeMs = lastFinishedJob.getCreatedTimeMs();
+            }
+        }
+        if (lastStartTimeMs <= 0L) {
+            return -1L;
+        }
+        return lastStartTimeMs + intervalSeconds * 1000L;
+    }
+
+    public List<List<String>> getAutomatedSnapshotShowResult() {
+        List<List<String>> rows = Lists.newArrayList();
+        if (!isAutomatedSnapshotOn()) {
+            rows.add(Lists.newArrayList("false", FeConstants.NULL_STRING, FeConstants.NULL_STRING,
+                    FeConstants.NULL_STRING, FeConstants.NULL_STRING));
+            return rows;
+        }
+
+        String interval = IntervalLiteral.formatIntervalSeconds(getEffectiveAutomatedSnapshotIntervalSeconds());
+        if (interval == null) {
+            interval = FeConstants.NULL_STRING;
+        }
+        String storageVolume = storageVolumeName == null ? FeConstants.NULL_STRING : storageVolumeName;
+        ClusterSnapshot snapshot = getAutomatedSnapshot();
+        String lastSnapshotTime = snapshot == null ? FeConstants.NULL_STRING
+                : TimeUtils.longToTimeString(snapshot.getCreatedTimeMs());
+        String nextSnapshotTime = TimeUtils.longToTimeString(getNextAutomatedSnapshotTimeMs());
+
+        rows.add(Lists.newArrayList("true", interval, storageVolume, lastSnapshotTime, nextSnapshotTime));
+        return rows;
     }
 
     protected void clearFinishedAutomatedClusterSnapshot(String keepSnapshotName) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/RedirectStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/RedirectStatus.java
@@ -30,6 +30,7 @@ import com.starrocks.sql.ast.AdminSetAutomatedSnapshotOnStmt;
 import com.starrocks.sql.ast.AdminSetConfigStmt;
 import com.starrocks.sql.ast.AdminSetPartitionVersionStmt;
 import com.starrocks.sql.ast.AdminSetReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
@@ -713,6 +714,16 @@ public class RedirectStatus {
         @Override
         public RedirectStatus visitAdminShowConfigStatement(AdminShowConfigStmt statement, Void context) {
             return visitShowStatement(statement, context);
+        }
+
+        @Override
+        public RedirectStatus visitAdminShowAutomatedSnapshotStatement(AdminShowAutomatedSnapshotStmt statement,
+                                                                       Void context) {
+            if (ConnectContext.get().getSessionVariable().getForwardToLeader()) {
+                return RedirectStatus.FORWARD_NO_SYNC;
+            } else {
+                return RedirectStatus.NO_FORWARD;
+            }
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -148,6 +148,7 @@ import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
@@ -2316,6 +2317,13 @@ public class ShowExecutor {
                 throw new SemanticException(e.getMessage());
             }
             return new ShowResultSet(showResultMetaFactory.getMetadata(statement), results);
+        }
+
+        @Override
+        public ShowResultSet visitAdminShowAutomatedSnapshotStatement(AdminShowAutomatedSnapshotStmt statement,
+                                                                      ConnectContext context) {
+            return new ShowResultSet(showResultMetaFactory.getMetadata(statement),
+                    GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().getAutomatedSnapshotShowResult());
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
@@ -33,6 +33,7 @@ import com.starrocks.common.proc.ProcService;
 import com.starrocks.common.proc.RollupProcDir;
 import com.starrocks.common.proc.SchemaChangeProcDir;
 import com.starrocks.common.proc.TransProcDir;
+import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
@@ -768,6 +769,18 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
                 .addColumn(new Column("Type", TypeFactory.createVarcharType(30)))
                 .addColumn(new Column("IsMutable", TypeFactory.createVarcharType(30)))
                 .addColumn(new Column("Comment", TypeFactory.createVarcharType(30)))
+                .build();
+    }
+
+    @Override
+    public ShowResultSetMetaData visitAdminShowAutomatedSnapshotStatement(AdminShowAutomatedSnapshotStmt statement,
+                                                                          Void context) {
+        return ShowResultSetMetaData.builder()
+                .addColumn(new Column("Enabled", TypeFactory.createVarcharType(5)))
+                .addColumn(new Column("Interval", TypeFactory.createVarcharType(32)))
+                .addColumn(new Column("StorageVolume", TypeFactory.createVarcharType(256)))
+                .addColumn(new Column("LastSnapshotTime", TypeFactory.createVarcharType(20)))
+                .addColumn(new Column("NextSnapshotTime", TypeFactory.createVarcharType(20)))
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AdminStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AdminStmtAnalyzer.java
@@ -27,6 +27,7 @@ import com.starrocks.sql.ast.AdminRepairTableStmt;
 import com.starrocks.sql.ast.AdminSetConfigStmt;
 import com.starrocks.sql.ast.AdminSetPartitionVersionStmt;
 import com.starrocks.sql.ast.AdminSetReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
@@ -107,6 +108,12 @@ public class AdminStmtAnalyzer {
             if (Strings.isNullOrEmpty(dbName) && Strings.isNullOrEmpty(session.getDatabase())) {
                 throw new SemanticException(PARSER_ERROR_MSG.noDbSelected(), pos);
             }
+            return null;
+        }
+
+        @Override
+        public Void visitAdminShowAutomatedSnapshotStatement(AdminShowAutomatedSnapshotStmt statement,
+                                                             ConnectContext session) {
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Analyzer.java
@@ -27,6 +27,7 @@ import com.starrocks.sql.ast.AdminSetAutomatedSnapshotOnStmt;
 import com.starrocks.sql.ast.AdminSetConfigStmt;
 import com.starrocks.sql.ast.AdminSetPartitionVersionStmt;
 import com.starrocks.sql.ast.AdminSetReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
@@ -456,6 +457,13 @@ public class Analyzer {
         @Override
         public Void visitAdminShowConfigStatement(AdminShowConfigStmt adminShowConfigStmt, ConnectContext session) {
             AdminStmtAnalyzer.analyze(adminShowConfigStmt, session);
+            return null;
+        }
+
+        @Override
+        public Void visitAdminShowAutomatedSnapshotStatement(AdminShowAutomatedSnapshotStmt statement,
+                                                             ConnectContext session) {
+            AdminStmtAnalyzer.analyze(statement, session);
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -61,6 +61,7 @@ import com.starrocks.sql.ast.AdminCheckTabletsStmt;
 import com.starrocks.sql.ast.AdminRepairTableStmt;
 import com.starrocks.sql.ast.AdminSetConfigStmt;
 import com.starrocks.sql.ast.AdminSetReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
@@ -2167,6 +2168,20 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
 
     @Override
     public Void visitAdminShowConfigStatement(AdminShowConfigStmt statement, ConnectContext context) {
+        try {
+            Authorizer.checkSystemAction(context, PrivilegeType.OPERATE);
+        } catch (AccessDeniedException e) {
+            AccessDeniedException.reportAccessDenied(
+                    InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                    context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                    PrivilegeType.OPERATE.name(), ObjectType.SYSTEM.name(), null);
+        }
+        return null;
+    }
+
+    @Override
+    public Void visitAdminShowAutomatedSnapshotStatement(AdminShowAutomatedSnapshotStmt statement,
+                                                         ConnectContext context) {
         try {
             Authorizer.checkSystemAction(context, PrivilegeType.OPERATE);
         } catch (AccessDeniedException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -73,6 +73,7 @@ import com.starrocks.sql.ast.AdminSetAutomatedSnapshotOnStmt;
 import com.starrocks.sql.ast.AdminSetConfigStmt;
 import com.starrocks.sql.ast.AdminSetPartitionVersionStmt;
 import com.starrocks.sql.ast.AdminSetReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
@@ -2764,6 +2765,12 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             return new AdminShowConfigStmt(AdminSetConfigStmt.ConfigType.FRONTEND, stringLiteral.getValue(), pos);
         }
         return new AdminShowConfigStmt(AdminSetConfigStmt.ConfigType.FRONTEND, null, pos);
+    }
+
+    @Override
+    public ParseNode visitAdminShowAutomatedSnapshotStatement(
+            com.starrocks.sql.parser.StarRocksParser.AdminShowAutomatedSnapshotStatementContext context) {
+        return new AdminShowAutomatedSnapshotStmt(createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
@@ -29,6 +29,7 @@ import com.starrocks.sql.ast.AdminSetAutomatedSnapshotOnStmt;
 import com.starrocks.sql.ast.AdminSetConfigStmt;
 import com.starrocks.sql.ast.AdminSetPartitionVersionStmt;
 import com.starrocks.sql.ast.AdminSetReplicaStatusStmt;
+import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
@@ -945,6 +946,12 @@ public class RedirectStatusTest {
     @Test
     public void testAdminShowConfigStmt() {
         AdminShowConfigStmt stmt = new AdminShowConfigStmt(AdminSetConfigStmt.ConfigType.FRONTEND, null);
+        Assertions.assertEquals(RedirectStatus.NO_FORWARD, RedirectStatus.getRedirectStatus(stmt));
+    }
+
+    @Test
+    public void testAdminShowAutomatedSnapshotStmt() {
+        AdminShowAutomatedSnapshotStmt stmt = new AdminShowAutomatedSnapshotStmt();
         Assertions.assertEquals(RedirectStatus.NO_FORWARD, RedirectStatus.getRedirectStatus(stmt));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
@@ -16,6 +16,7 @@ package com.starrocks.qe;
 
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.TableName;
+import com.starrocks.sql.ast.AdminShowAutomatedSnapshotStmt;
 import com.starrocks.sql.ast.AdminShowConfigStmt;
 import com.starrocks.sql.ast.AdminShowReplicaDistributionStmt;
 import com.starrocks.sql.ast.AdminShowReplicaStatusStmt;
@@ -539,6 +540,18 @@ public class ShowStmtMetaTest {
         Assertions.assertEquals("Type", metaData.getColumn(3).getName());
         Assertions.assertEquals("IsMutable", metaData.getColumn(4).getName());
         Assertions.assertEquals("Comment", metaData.getColumn(5).getName());
+    }
+
+    @Test
+    public void testAdminShowAutomatedSnapshotStmt() {
+        AdminShowAutomatedSnapshotStmt stmt = new AdminShowAutomatedSnapshotStmt();
+        ShowResultSetMetaData metaData = new ShowResultMetaFactory().getMetadata(stmt);
+        Assertions.assertEquals(5, metaData.getColumnCount());
+        Assertions.assertEquals("Enabled", metaData.getColumn(0).getName());
+        Assertions.assertEquals("Interval", metaData.getColumn(1).getName());
+        Assertions.assertEquals("StorageVolume", metaData.getColumn(2).getName());
+        Assertions.assertEquals("LastSnapshotTime", metaData.getColumn(3).getName());
+        Assertions.assertEquals("NextSnapshotTime", metaData.getColumn(4).getName());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminShowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminShowTest.java
@@ -39,6 +39,11 @@ public class AdminShowTest {
     }
 
     @Test
+    public void testAdminShowAutomatedClusterSnapshot() {
+        analyzeSuccess("ADMIN SHOW AUTOMATED CLUSTER SNAPSHOT");
+    }
+
+    @Test
     public void testAdminShowReplicaDistribution() {
         analyzeSuccess("ADMIN SHOW REPLICA DISTRIBUTION FROM tbl1;");
         analyzeSuccess("ADMIN SHOW REPLICA DISTRIBUTION FROM db1.tbl1 PARTITION(p1, p2);");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -1977,6 +1977,13 @@ public class PrivilegeCheckerTest extends StarRocksTestBase {
                 "revoke OPERATE on system from test",
                 "Access denied;");
 
+        // AdminShowAutomatedSnapshotStmt
+        verifyGrantRevoke(
+                "ADMIN SHOW AUTOMATED CLUSTER SNAPSHOT;",
+                "grant OPERATE on system to test",
+                "revoke OPERATE on system from test",
+                "Access denied;");
+
         // AdminShowReplicaDistributionStatement
         verifyGrantRevoke(
                 "ADMIN SHOW REPLICA DISTRIBUTION FROM example_db.example_table PARTITION(p1, p2);",

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -119,6 +119,7 @@ statement
     | adminSetConfigStatement
     | adminSetReplicaStatusStatement
     | adminShowConfigStatement
+    | adminShowAutomatedSnapshotStatement
     | adminShowReplicaDistributionStatement
     | adminShowReplicaStatusStatement
     | adminRepairTableStatement
@@ -760,6 +761,10 @@ adminSetReplicaStatusStatement
     ;
 adminShowConfigStatement
     : ADMIN SHOW FRONTEND CONFIG (LIKE pattern=string)?
+    ;
+
+adminShowAutomatedSnapshotStatement
+    : ADMIN SHOW AUTOMATED CLUSTER SNAPSHOT
     ;
 
 adminShowReplicaDistributionStatement

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AdminShowAutomatedSnapshotStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AdminShowAutomatedSnapshotStmt.java
@@ -1,0 +1,32 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.sql.parser.NodePosition;
+
+public class AdminShowAutomatedSnapshotStmt extends ShowStmt {
+    public AdminShowAutomatedSnapshotStmt() {
+        this(NodePosition.ZERO);
+    }
+
+    public AdminShowAutomatedSnapshotStmt(NodePosition pos) {
+        super(pos);
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitAdminShowAutomatedSnapshotStatement(this, context);
+    }
+}

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -174,6 +174,10 @@ public interface AstVisitor<R, C> {
         return visitShowStatement(statement, context);
     }
 
+    default R visitAdminShowAutomatedSnapshotStatement(AdminShowAutomatedSnapshotStmt statement, C context) {
+        return visitShowStatement(statement, context);
+    }
+
     default R visitAdminShowReplicaStatusStatement(AdminShowReplicaStatusStmt statement, C context) {
         return visitShowStatement(statement, context);
     }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/IntervalLiteral.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/IntervalLiteral.java
@@ -67,6 +67,32 @@ public class IntervalLiteral extends LiteralExpr {
         }
     }
 
+    public static String formatIntervalSeconds(long intervalSeconds) {
+        if (intervalSeconds <= 0) {
+            return null;
+        }
+
+        long value;
+        String unit;
+        if (intervalSeconds % 604800L == 0) {
+            value = intervalSeconds / 604800L;
+            unit = "WEEK";
+        } else if (intervalSeconds % 86400L == 0) {
+            value = intervalSeconds / 86400L;
+            unit = "DAY";
+        } else if (intervalSeconds % 3600L == 0) {
+            value = intervalSeconds / 3600L;
+            unit = "HOUR";
+        } else if (intervalSeconds % 60L == 0) {
+            value = intervalSeconds / 60L;
+            unit = "MINUTE";
+        } else {
+            value = intervalSeconds;
+            unit = "SECOND";
+        }
+        return value + " " + unit;
+    }
+
     @Override
     public Expr clone() {
         return new IntervalLiteral(this.value, this.unitIdentifier, this.pos);


### PR DESCRIPTION
## Why I'm doing:
Add ADMIN SHOW AUTOMATED CLUSTER SNAPSHOT status output
```
ADMIN SHOW AUTOMATED CLUSTER SNAPSHOT;

```

**Result:**
```
+----------+----------+----------------+---------------------+---------------------+
| Enabled  | Interval | StorageVolume  | LastSnapshotTime    | NextSnapshotTime    |
+----------+----------+----------------+---------------------+---------------------+
| true     | 1 DAY    | default_volume | 2025-01-26 08:00:00 | 2025-01-27 08:00:00 |
+----------+----------+----------------+---------------------+---------------------+
```

---

**Alternative: When Disabled or Not Configured:**

If automated snapshots haven't been configured:
```
+----------+----------+---------------+------------------+------------------+
| Enabled  | Interval | StorageVolume | LastSnapshotTime | NextSnapshotTime |
+----------+----------+---------------+------------------+------------------+
| false    | NULL     | NULL          | NULL             | NULL             |
+----------+----------+---------------+------------------+------------------+
```

## What I'm doing:
 Introduce a new admin show statement that reports automated cluster snapshot enablement, interval, storage volume, and last/next snapshot times in shared-data mode. Wire the statement through grammar/AST/
  analyzer/auth/redirect/meta, and implement result construction in ClusterSnapshotMgr with interval formatting centralized in IntervalLiteral. Include unit tests for parsing, metadata, redirect, privilege checks,
  and show executor output.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
