### PR TITLE
[BugFix] Fixed an issue that meta lock held for a long time caused by the external rpc hung in mixed internal and external table queries.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3516,6 +3516,14 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_experimental_temporary_table = true;
 
+    /**
+     * Enable pre-resolution of external tables (JDBC, Iceberg, etc.) before acquiring internal table locks.
+     * This avoids holding meta lock while fetching external metadata via RPC.
+     * Set to false to fallback to the original behavior if issues occur.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_experimental_external_table_preparse = true;
+
     @ConfField(mutable = true)
     public static long max_per_node_grep_log_limit = 500000;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -266,6 +266,11 @@ public class StatementPlanner {
                 ExplicitTxnStatementValidator.validate(statement, session);
                 return true;
             } else {
+                // Only pre-resolve external tables when there are internal tables to lock.
+                // This avoids holding meta lock while fetching external metadata.
+                if (locker != null && !locker.isEmpty()) {
+                    new QueryAnalyzer(session).analyzeExternalTablesOnly(statement);
+                }
                 takeLock.run();
                 Analyzer.analyze(statement, session);
                 ExplicitTxnStatementValidator.validate(statement, session);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -268,7 +268,8 @@ public class StatementPlanner {
             } else {
                 // Only pre-resolve external tables when there are internal tables to lock.
                 // This avoids holding meta lock while fetching external metadata.
-                if (locker != null && !locker.isEmpty()) {
+                // Check config first (cheapest), then locker state.
+                if (Config.enable_experimental_external_table_preparse && locker != null && !locker.isEmpty()) {
                     new QueryAnalyzer(session).analyzeExternalTablesOnly(statement);
                 }
                 takeLock.run();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -104,6 +104,10 @@ public class PlannerMetaLocker implements AutoCloseable {
         return true;
     }
 
+    public boolean isEmpty() {
+        return tables.isEmpty();
+    }
+
     public void lock() {
         Locker locker = new Locker(queryId);
         for (Map.Entry<Long, Set<Long>> entry : tables.entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -106,8 +106,10 @@ import com.starrocks.type.NullType;
 import com.starrocks.type.Type;
 import org.apache.commons.collections.CollectionUtils;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -1839,20 +1841,39 @@ public class QueryAnalyzer {
     /**
      * A lightweight visitor that pre-resolves only external (non-internal catalog) TableRelation,
      * so connector metadata fetch is done without holding PlannerMetaLock.
+     * Similar to TableCollector but inverts the logic: skips internal tables, pre-resolves external tables.
      */
     private class ExternalTablesOnlyVisitor extends AstTraverser<Void, Void> {
-        private final Set<String> cteNames = new HashSet<>();
-
-        @Override
-        public Void visitCTE(CTERelation node, Void context) {
-            if (node.getName() != null) {
-                cteNames.add(node.getName());
-            }
-            return super.visitCTE(node, context);
-        }
+        private final Deque<Set<String>> cteNameStack = new ArrayDeque<>();
 
         public void process(StatementBase node) {
             visit(node);
+        }
+
+        @Override
+        public Void visitSelect(SelectRelation node, Void context) {
+            if (node.hasWithClause()) {
+                cteNameStack.push(collectCteNames(node.getCteRelations()));
+                try {
+                    return super.visitSelect(node, context);
+                } finally {
+                    cteNameStack.pop();
+                }
+            }
+            return super.visitSelect(node, context);
+        }
+
+        @Override
+        public Void visitSetOp(SetOperationRelation node, Void context) {
+            if (node.hasWithClause()) {
+                cteNameStack.push(collectCteNames(node.getCteRelations()));
+                try {
+                    return super.visitSetOp(node, context);
+                } finally {
+                    cteNameStack.pop();
+                }
+            }
+            return super.visitSetOp(node, context);
         }
 
         @Override
@@ -1864,22 +1885,46 @@ public class QueryAnalyzer {
             if (tableName == null) {
                 return null;
             }
-            if (Strings.isNullOrEmpty(tableName.getDb()) && cteNames.contains(tableName.getTbl())) {
+
+            if (Strings.isNullOrEmpty(tableName.getDb()) && Strings.isNullOrEmpty(tableName.getCatalog())
+                    && isCteName(tableName.getTbl())) {
                 return null;
             }
-            TableName tempTableName = new TableName(tableName.getCatalog(),
-                    tableName.getDb(), tableName.getTbl(), tableName.getPos());
-            tempTableName.normalization(session);
-            String catalogName = tempTableName.getCatalog();
-            if (Strings.isNullOrEmpty(catalogName) || CatalogMgr.isInternalCatalog(catalogName)) {
+
+            // Use session to fill in catalog/db (same approach as TableCollector.resolveTable)
+            String catalogName = tableName.getCatalog();
+            String dbName = tableName.getDb();
+
+            if (Strings.isNullOrEmpty(catalogName)) {
+                catalogName = session.getCurrentCatalog();
+            }
+            if (Strings.isNullOrEmpty(dbName)) {
+                dbName = session.getDatabase();
+            }
+
+            if (catalogName == null || dbName == null) {
                 return null;
             }
+
+            // Only pre-resolve external tables (non-internal catalog)
+            if (CatalogMgr.isInternalCatalog(catalogName)) {
+                return null;
+            }
+
+            // Pre-resolve external table using metadataMgr.getTable (returns null if not found)
+            // This approach:
+            // 1. Simplifies error handling (no try-catch needed)
+            // 2. Handles CTEs correctly (getTable returns null, main visitor handles them)
+            // 3. Pre-resolves real external tables (avoiding lock during RPC)
+            // Similar to TableCollector.resolveTable but inverts the logic (handles external tables only)
             try (Timer ignored = Tracers.watchScope("AnalyzeTable")) {
-                tableRelation.setTable(resolveTable(tableRelation));
+                Table table = metadataMgr.getTable(session, catalogName, dbName, tableName.getTbl());
+                if (table != null) {
+                    tableRelation.setTable(table);
+                }
+                // If table == null (CTE or non-existent table), leave it unresolved.
+                // The main visitor will handle it correctly.
             }
-            // Do NOT catch exceptions here. If pre-resolution fails (e.g., JDBC timeout),
-            // we want the entire query to fail rather than fallback to main analyzer
-            // which would hold meta lock while doing RPC.
             return null;
         }
 
@@ -1899,6 +1944,28 @@ public class QueryAnalyzer {
                 visit(statement.getQueryStatement());
             }
             return null;
+        }
+
+        private Set<String> collectCteNames(List<CTERelation> cteRelations) {
+            Set<String> names = Sets.newHashSet();
+            for (CTERelation cteRelation : cteRelations) {
+                if (cteRelation.getName() != null) {
+                    names.add(cteRelation.getName());
+                }
+            }
+            return names;
+        }
+
+        private boolean isCteName(String name) {
+            if (cteNameStack.isEmpty()) {
+                return false;
+            }
+            for (Set<String> names : cteNameStack) {
+                if (names.contains(name)) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1920,6 +1920,11 @@ public class QueryAnalyzer {
             try (Timer ignored = Tracers.watchScope("AnalyzeTable")) {
                 Table table = metadataMgr.getTable(session, catalogName, dbName, tableName.getTbl());
                 if (table != null) {
+                    // Validate constraints similar to resolveTable
+                    PartitionRef partitionNamesObject = tableRelation.getPartitionNames();
+                    if (table.isExternalTableWithFileSystem() && partitionNamesObject != null) {
+                        throw unsupportedException("Unsupported table type for partition clause, type: " + table.getType());
+                    }
                     tableRelation.setTable(table);
                 }
                 // If table == null (CTE or non-existent table), leave it unresolved.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -46,14 +46,17 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.AstTraverser;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.CTERelation;
+import com.starrocks.sql.ast.CreateTableAsSelectStmt;
 import com.starrocks.sql.ast.ExceptRelation;
 import com.starrocks.sql.ast.FileTableFunctionRelation;
 import com.starrocks.sql.ast.HintNode;
+import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.IntersectRelation;
 import com.starrocks.sql.ast.JoinOperator;
 import com.starrocks.sql.ast.JoinRelation;
@@ -144,6 +147,15 @@ public class QueryAnalyzer {
      */
     public void analyzeFilesOnly(StatementBase node) {
         new FilesOnlyVisitor().process(node, new Scope(RelationId.anonymous(), new RelationFields()));
+    }
+
+    /**
+     * Pre-resolve external (non-internal catalog) table relations without touching internal table metadata.
+     * This is used to avoid holding PlannerMetaLock while doing potentially slow connector metadata fetch
+     * (e.g. JDBC).
+     */
+    public void analyzeExternalTablesOnly(StatementBase node) {
+        new ExternalTablesOnlyVisitor().process(node);
     }
 
     public void analyze(StatementBase node, Scope parent) {
@@ -669,7 +681,13 @@ public class QueryAnalyzer {
                             resolveTableName.getTbl()));
                 }
 
-                Table table = resolveTable(tableRelation);
+                Table table = tableRelation.getTable();
+                String catalogName = resolveTableName.getCatalog();
+                // External connector table has been pre-resolved in the unlocked phase.
+                if (table == null || catalogName == null || CatalogMgr.isInternalCatalog(catalogName)) {
+                    table = resolveTable(tableRelation);
+                }
+
                 Relation r;
                 if (table instanceof View) {
                     View view = (View) table;
@@ -1816,6 +1834,72 @@ public class QueryAnalyzer {
             return result;
         }
 
+    }
+
+    /**
+     * A lightweight visitor that pre-resolves only external (non-internal catalog) TableRelation,
+     * so connector metadata fetch is done without holding PlannerMetaLock.
+     */
+    private class ExternalTablesOnlyVisitor extends AstTraverser<Void, Void> {
+        private final Set<String> cteNames = new HashSet<>();
+
+        @Override
+        public Void visitCTE(CTERelation node, Void context) {
+            if (node.getName() != null) {
+                cteNames.add(node.getName());
+            }
+            return super.visitCTE(node, context);
+        }
+
+        public void process(StatementBase node) {
+            visit(node);
+        }
+
+        @Override
+        public Void visitTable(TableRelation tableRelation, Void context) {
+            if (tableRelation.getTable() != null) {
+                return null;
+            }
+            TableName tableName = tableRelation.getName();
+            if (tableName == null) {
+                return null;
+            }
+            if (Strings.isNullOrEmpty(tableName.getDb()) && cteNames.contains(tableName.getTbl())) {
+                return null;
+            }
+            TableName tempTableName = new TableName(tableName.getCatalog(),
+                    tableName.getDb(), tableName.getTbl(), tableName.getPos());
+            tempTableName.normalization(session);
+            String catalogName = tempTableName.getCatalog();
+            if (Strings.isNullOrEmpty(catalogName) || CatalogMgr.isInternalCatalog(catalogName)) {
+                return null;
+            }
+            try (Timer ignored = Tracers.watchScope("AnalyzeTable")) {
+                tableRelation.setTable(resolveTable(tableRelation));
+            }
+            // Do NOT catch exceptions here. If pre-resolution fails (e.g., JDBC timeout),
+            // we want the entire query to fail rather than fallback to main analyzer
+            // which would hold meta lock while doing RPC.
+            return null;
+        }
+
+        @Override
+        public Void visitInsertStatement(InsertStmt statement, Void context) {
+            // Avoid touching target table metadata here; only pre-resolve external tables in the query part.
+            if (statement.getQueryStatement() != null) {
+                visit(statement.getQueryStatement());
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitCreateTableAsSelectStatement(CreateTableAsSelectStmt statement, Void context) {
+            // Avoid touching target table metadata here; only pre-resolve external tables in the query part.
+            if (statement.getQueryStatement() != null) {
+                visit(statement.getQueryStatement());
+            }
+            return null;
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
@@ -1,0 +1,276 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql;
+
+import com.starrocks.catalog.JDBCResource;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.FeConstants;
+import com.starrocks.connector.MockedMetadataMgr;
+import com.starrocks.connector.jdbc.MockedJDBCMetadata;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.PlannerMetaLocker;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Regression test for mixed queries (internal + JDBC) where connector metadata fetch can block.
+ * The analyzer must not hold PlannerMetaLock while doing connector metadata requests.
+ */
+public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBase {
+
+    private static class BlockingJDBCMetadata extends MockedJDBCMetadata {
+        private final CountDownLatch started;
+        private final CountDownLatch allowReturn;
+        private final AtomicInteger getTableCalls;
+
+        public BlockingJDBCMetadata(Map<String, String> properties,
+                                   CountDownLatch started,
+                                   CountDownLatch allowReturn,
+                                   AtomicInteger getTableCalls) {
+            super(properties);
+            this.started = started;
+            this.allowReturn = allowReturn;
+            this.getTableCalls = getTableCalls;
+        }
+
+        @Override
+        public Table getTable(ConnectContext context, String dbName, String tblName) {
+            getTableCalls.incrementAndGet();
+            started.countDown();
+            try {
+                // Simulate connector metadata request blocking
+                allowReturn.await(20, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return super.getTable(context, dbName, tblName);
+        }
+    }
+
+    @Test
+    public void testCTEWithInternalTable() throws Exception {
+        // Test that CTE with internal table works correctly
+        String sql = "with cte as (select * from t0) select * from cte";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        try {
+            StatementPlanner.plan(stmt, connectContext);
+        } catch (Exception e) {
+            throw new RuntimeException("CTE with internal table test failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void testCTEWithExternalTable() throws Exception {
+        // Test that CTE with external table works correctly
+        String sql = "with cte as (select * from jdbc0.partitioned_db0.tbl0) select * from cte";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        try {
+            StatementPlanner.plan(stmt, connectContext);
+        } catch (Exception e) {
+            throw new RuntimeException("CTE with external table test failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void testCTEJoinInternalTable() throws Exception {
+        // Test CTE joined with internal table
+        String sql = "with cte as (select * from jdbc0.partitioned_db0.tbl0) " +
+                     "select * from t0 join cte on t0.v1 = cte.a";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        try {
+            StatementPlanner.plan(stmt, connectContext);
+        } catch (Exception e) {
+            throw new RuntimeException("CTE join with internal table test failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void testInternalTableCTEJoinExternalTable() throws Exception {
+        // Test external table joined with CTE (based on internal table)
+        // This is the key scenario: CTE with internal table, joined with external table
+        // Should pre-parse external table before acquiring lock on internal tables
+        String sql = "with cte as (select * from t0) " +
+                     "select * from jdbc0.partitioned_db0.tbl0 " +
+                     "join cte on jdbc0.partitioned_db0.tbl0.a = cte.v1";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        try {
+            StatementPlanner.plan(stmt, connectContext);
+        } catch (Exception e) {
+            throw new RuntimeException("Internal table CTE join external table test failed: "
+                    + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void testMixedQueryExternalMetadataNotUnderLock() throws Exception {
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch allowReturn = new CountDownLatch(1);
+        AtomicInteger getTableCalls = new AtomicInteger();
+
+        // Replace jdbc0 metadata with a blocking one
+        GlobalStateMgr gsm = GlobalStateMgr.getCurrentState();
+        MockedMetadataMgr metadataMgr = (MockedMetadataMgr) gsm.getMetadataMgr();
+        Map<String, String> props = new HashMap<>();
+        props.put(JDBCResource.TYPE, "jdbc");
+        props.put(JDBCResource.DRIVER_CLASS, "org.mariadb.jdbc.Driver");
+        props.put(JDBCResource.URI, "jdbc:mariadb://127.0.0.1:3306");
+        props.put(JDBCResource.USER, "root");
+        props.put(JDBCResource.PASSWORD, "123456");
+        props.put(JDBCResource.CHECK_SUM, "xxxx");
+        props.put(JDBCResource.DRIVER_URL, "xxxx");
+        BlockingJDBCMetadata blocking = new BlockingJDBCMetadata(props, started, allowReturn, getTableCalls);
+        metadataMgr.registerMockedMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME, blocking);
+
+        String sql = "select * from t0 join jdbc0.partitioned_db0.tbl0 on true";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
+
+        AtomicBoolean lockCalled = new AtomicBoolean(false);
+        PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt) {
+            @Override
+            public void lock() {
+                // Don't take real locks in UT; just record timing.
+                lockCalled.set(true);
+            }
+
+            @Override
+            public void unlock() {
+                // no-op
+            }
+        };
+
+        AtomicBoolean finished = new AtomicBoolean(false);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        Thread t = new Thread(() -> {
+            try {
+                StatementPlanner.analyzeStatement(stmt, connectContext, locker);
+                finished.set(true);
+            } catch (Throwable t0) {
+                error.set(t0);
+            }
+        });
+        t.start();
+
+        // Wait for getTable to be called and blocking
+        Assertions.assertTrue(started.await(10, TimeUnit.SECONDS));
+        // While connector metadata is blocked, we must not take PlannerMetaLock
+        Assertions.assertFalse(lockCalled.get());
+
+        allowReturn.countDown();
+        t.join(TimeUnit.SECONDS.toMillis(20));
+
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+        Assertions.assertTrue(finished.get());
+        Assertions.assertTrue(lockCalled.get());
+        // Analyzer should reuse pre-resolved external table; metadata getTable must not be called twice.
+        Assertions.assertEquals(1, getTableCalls.get());
+    }
+
+    @Test
+    public void testInsertSelectMixedTablesWithBlockingExternal() throws Exception {
+        // Test INSERT ... SELECT from external table to internal table
+        // Verify: external metadata is fetched BEFORE acquiring meta lock (analyzeExternalTablesOnly path)
+        // Verify: getTable is called only once (no duplicate calls)
+        //
+        // Note: Set runningUnitTest=false to test analyzeExternalTablesOnly path instead of deferredLock path
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        try {
+            FeConstants.runningUnitTest = false;
+
+            CountDownLatch started = new CountDownLatch(1);
+            CountDownLatch allowReturn = new CountDownLatch(1);
+            AtomicInteger getTableCalls = new AtomicInteger();
+
+            // Replace jdbc0 metadata with a blocking one
+            GlobalStateMgr gsm = GlobalStateMgr.getCurrentState();
+            MockedMetadataMgr metadataMgr = (MockedMetadataMgr) gsm.getMetadataMgr();
+            Map<String, String> props = new HashMap<>();
+            props.put(JDBCResource.TYPE, "jdbc");
+            props.put(JDBCResource.DRIVER_CLASS, "org.mariadb.jdbc.Driver");
+            props.put(JDBCResource.URI, "jdbc:mariadb://127.0.0.1:3306");
+            props.put(JDBCResource.USER, "root");
+            props.put(JDBCResource.PASSWORD, "123456");
+            props.put(JDBCResource.CHECK_SUM, "xxxx");
+            props.put(JDBCResource.DRIVER_URL, "xxxx");
+            BlockingJDBCMetadata blocking =
+                    new BlockingJDBCMetadata(props, started, allowReturn, getTableCalls);
+            metadataMgr.registerMockedMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME, blocking);
+
+            // Use INSERT with specific column names to avoid schema mismatch
+            String sql = "insert into t0 (v1, v2) select a, b from jdbc0.partitioned_db0.tbl0";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
+
+            AtomicBoolean lockCalled = new AtomicBoolean(false);
+            PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt) {
+                @Override
+                public void lock() {
+                    lockCalled.set(true);
+                }
+
+                @Override
+                public void unlock() {
+                    // no-op
+                }
+            };
+
+            AtomicBoolean finished = new AtomicBoolean(false);
+            AtomicReference<Throwable> error = new AtomicReference<>();
+            Thread t = new Thread(() -> {
+                try {
+                    StatementPlanner.analyzeStatement(stmt, connectContext, locker);
+                    finished.set(true);
+                } catch (Throwable t0) {
+                    error.set(t0);
+                }
+            });
+            t.start();
+
+            // Wait for getTable to be called (external metadata fetch starts)
+            Assertions.assertTrue(started.await(10, TimeUnit.SECONDS));
+            // CRITICAL: While external metadata is blocked, we must NOT take meta lock
+            Assertions.assertFalse(lockCalled.get(),
+                    "Meta lock was acquired while external metadata was blocked! " +
+                            "This indicates the fix is not working for INSERT ... SELECT.");
+
+            allowReturn.countDown();
+            t.join(TimeUnit.SECONDS.toMillis(20));
+
+            if (error.get() != null) {
+                throw new RuntimeException("INSERT ... SELECT failed: " + error.get().getMessage(), error.get());
+            }
+            Assertions.assertTrue(finished.get(), "INSERT ... SELECT did not finish");
+
+            // CRITICAL: getTable must be called only once (pre-resolved, not called again during analysis)
+            Assertions.assertEquals(1, getTableCalls.get(),
+                    "getTable was called " + getTableCalls.get() + " times, expected 1. " +
+                            "This indicates duplicate external metadata fetch.");
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerExternalTablesLockTest.java
@@ -273,4 +273,168 @@ public class StatementPlannerExternalTablesLockTest extends ConnectorPlanTestBas
             FeConstants.runningUnitTest = originalRunningUnitTest;
         }
     }
+
+    @Test
+    public void testNestedSubqueryWithSameNameCTE() throws Exception {
+        // Test that CTE in nested subquery doesn't affect external table pre-resolution in outer query.
+        // Scenario: Outer query uses external table "tbl0", nested subquery has CTE with same name "tbl0".
+        // The external table should still be pre-resolved (not skipped due to CTE name collision).
+        String sql = "select * from jdbc0.partitioned_db0.tbl0 t " +
+                     "where exists (with tbl0 as (select * from t0) select * from tbl0)";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        try {
+            StatementPlanner.plan(stmt, connectContext);
+            // Success: External table was correctly pre-resolved despite nested CTE having same name
+        } catch (Exception e) {
+            throw new RuntimeException("Nested subquery with same-name CTE test failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void testNestedSubqueryCTEDoesNotPolluteOuterScope() throws Exception {
+        // Test that CTE defined in WHERE clause subquery doesn't pollute outer scope.
+        // This verifies the session-based approach works correctly.
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch allowReturn = new CountDownLatch(1);
+        AtomicInteger getTableCalls = new AtomicInteger();
+
+        // Replace jdbc0 metadata with a blocking one
+        GlobalStateMgr gsm = GlobalStateMgr.getCurrentState();
+        MockedMetadataMgr metadataMgr = (MockedMetadataMgr) gsm.getMetadataMgr();
+        Map<String, String> props = new HashMap<>();
+        props.put(JDBCResource.TYPE, "jdbc");
+        props.put(JDBCResource.DRIVER_CLASS, "org.mariadb.jdbc.Driver");
+        props.put(JDBCResource.URI, "jdbc:mariadb://127.0.0.1:3306");
+        props.put(JDBCResource.USER, "root");
+        props.put(JDBCResource.PASSWORD, "123456");
+        props.put(JDBCResource.CHECK_SUM, "xxxx");
+        props.put(JDBCResource.DRIVER_URL, "xxxx");
+        BlockingJDBCMetadata blocking = new BlockingJDBCMetadata(props, started, allowReturn, getTableCalls);
+        metadataMgr.registerMockedMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME, blocking);
+
+        // Outer query uses external table "tbl0", nested subquery has CTE "tbl0"
+        String sql = "select * from t0 join jdbc0.partitioned_db0.tbl0 on true " +
+                     "where exists (with tbl0 as (select * from t0) select * from tbl0)";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
+
+        AtomicBoolean lockCalled = new AtomicBoolean(false);
+        PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt) {
+            @Override
+            public void lock() {
+                lockCalled.set(true);
+            }
+
+            @Override
+            public void unlock() {
+                // no-op
+            }
+        };
+
+        AtomicBoolean finished = new AtomicBoolean(false);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        Thread t = new Thread(() -> {
+            try {
+                StatementPlanner.analyzeStatement(stmt, connectContext, locker);
+                finished.set(true);
+            } catch (Throwable t0) {
+                error.set(t0);
+            }
+        });
+        t.start();
+
+        // Wait for getTable to be called
+        Assertions.assertTrue(started.await(10, TimeUnit.SECONDS));
+        // CRITICAL: While external metadata is blocked, we must NOT take meta lock
+        Assertions.assertFalse(lockCalled.get(),
+                "Meta lock was acquired while external metadata was blocked! " +
+                        "This indicates CTE in nested subquery incorrectly prevented external table pre-resolution.");
+
+        allowReturn.countDown();
+        t.join(TimeUnit.SECONDS.toMillis(20));
+
+        if (error.get() != null) {
+            throw new RuntimeException(error.get());
+        }
+        Assertions.assertTrue(finished.get());
+        Assertions.assertTrue(lockCalled.get());
+        // Verify getTable was called only once (pre-resolved, not called again during analysis)
+        Assertions.assertEquals(1, getTableCalls.get(),
+                "getTable was called " + getTableCalls.get() + " times, expected 1. " +
+                        "This indicates CTE scoping issue prevented proper pre-resolution.");
+    }
+
+    @Test
+    public void testCteReferenceNotResolvedAsExternalTableInExternalCatalog() throws Exception {
+        String originalCatalog = connectContext.getCurrentCatalog();
+        String originalDb = connectContext.getDatabase();
+        try {
+            connectContext.setCurrentCatalog(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME);
+            connectContext.setDatabase(MockedJDBCMetadata.MOCKED_PARTITIONED_DB_NAME);
+
+            CountDownLatch started = new CountDownLatch(1);
+            CountDownLatch allowReturn = new CountDownLatch(1);
+            AtomicInteger getTableCalls = new AtomicInteger();
+
+            // Replace jdbc0 metadata with a blocking one
+            GlobalStateMgr gsm = GlobalStateMgr.getCurrentState();
+            MockedMetadataMgr metadataMgr = (MockedMetadataMgr) gsm.getMetadataMgr();
+            Map<String, String> props = new HashMap<>();
+            props.put(JDBCResource.TYPE, "jdbc");
+            props.put(JDBCResource.DRIVER_CLASS, "org.mariadb.jdbc.Driver");
+            props.put(JDBCResource.URI, "jdbc:mariadb://127.0.0.1:3306");
+            props.put(JDBCResource.USER, "root");
+            props.put(JDBCResource.PASSWORD, "123456");
+            props.put(JDBCResource.CHECK_SUM, "xxxx");
+            props.put(JDBCResource.DRIVER_URL, "xxxx");
+            BlockingJDBCMetadata blocking = new BlockingJDBCMetadata(props, started, allowReturn, getTableCalls);
+            metadataMgr.registerMockedMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME, blocking);
+
+            String sql = "with tbl0 as (select * from jdbc0.partitioned_db0.tbl0) " +
+                         "select * from default_catalog.test.t0 join tbl0 on true";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
+
+            AtomicBoolean lockCalled = new AtomicBoolean(false);
+            PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt) {
+                @Override
+                public void lock() {
+                    lockCalled.set(true);
+                }
+
+                @Override
+                public void unlock() {
+                    // no-op
+                }
+            };
+
+            AtomicBoolean finished = new AtomicBoolean(false);
+            AtomicReference<Throwable> error = new AtomicReference<>();
+            Thread t = new Thread(() -> {
+                try {
+                    StatementPlanner.analyzeStatement(stmt, connectContext, locker);
+                    finished.set(true);
+                } catch (Throwable t0) {
+                    error.set(t0);
+                }
+            });
+            t.start();
+
+            // getTable should be called only for the CTE definition table, not for the CTE reference
+            Assertions.assertTrue(started.await(10, TimeUnit.SECONDS));
+            Assertions.assertFalse(lockCalled.get(), "Meta lock was acquired while external metadata was blocked.");
+
+            allowReturn.countDown();
+            t.join(TimeUnit.SECONDS.toMillis(20));
+
+            if (error.get() != null) {
+                throw new RuntimeException(error.get());
+            }
+            Assertions.assertTrue(finished.get());
+            Assertions.assertTrue(lockCalled.get());
+            Assertions.assertEquals(1, getTableCalls.get(),
+                    "CTE reference was incorrectly resolved as external table.");
+        } finally {
+            connectContext.setCurrentCatalog(originalCatalog);
+            connectContext.setDatabase(originalDb);
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
When executing queries that mix internal tables (StarRocks native tables) with external tables (JDBC, Iceberg, Hive, etc.), the analyzer would acquire metadata locks on internal tables before fetching external table metadata from remote connectors via RPC calls. If the external metadata request is slow or blocked (e.g., due to network issues or remote catalog unavailability), the internal table locks are held for an extended period, causing lock contention and blocking other concurrent queries that need to access the same internal tables.


## What I'm doing:
This pull request improves how the query planner handles external tables (such as JDBC connectors) in mixed queries involving both internal and external tables. The main goal is to avoid holding the internal metadata lock while fetching potentially slow external metadata, which can block other queries. It introduces a pre-resolution phase for external tables, ensures proper lock acquisition order, and adds regression tests to verify the new behavior.

Key changes include:

**Query planning and locking improvements:**

* Added a pre-resolution step in `StatementPlanner.analyzeStatement` to resolve external tables before acquiring the internal meta lock, but only if there are internal tables to lock. This prevents holding the lock during slow external metadata fetches.
* Added a new method `analyzeExternalTablesOnly` and a lightweight visitor in `QueryAnalyzer` to pre-resolve only external (non-internal catalog) tables without touching internal table metadata.
* Updated table resolution logic in `QueryAnalyzer` to skip re-resolving external tables if they've already been pre-resolved.
* Added an `isEmpty()` method to `PlannerMetaLocker` to check if there are any internal tables to lock, used to decide whether pre-resolution is needed.

**Testing and regression coverage:**

* Added a new test class `StatementPlannerExternalTablesLockTest.java` that verifies external metadata fetches do not occur under the internal meta lock, covering various scenarios including CTEs, joins, and INSERT ... SELECT with mixed table types.

**Other:**

* Added necessary imports for new AST nodes and catalog utilities in `QueryAnalyzer.java`.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
