### PR TITLE
[Enhancement] Support semantic equivalence in RewriteDuplicateAggregateFnRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
@@ -164,11 +164,30 @@ public class CompoundPredicateOperator extends PredicateOperator {
 
     @Override
     public boolean equivalent(Object obj) {
-        if (!super.equivalent(obj)) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
         CompoundPredicateOperator that = (CompoundPredicateOperator) obj;
-        return type == that.type;
+        if (type != that.type) {
+            return false;
+        }
+
+        List<ScalarOperator> thisArgs = this.normalizeChildren();
+        List<ScalarOperator> thatArgs = that.normalizeChildren();
+
+        if (thisArgs.size() != thatArgs.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < thisArgs.size(); ++i) {
+            if (!thisArgs.get(i).equivalent(thatArgs.get(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteDuplicateAggregateFnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteDuplicateAggregateFnRule.java
@@ -72,7 +72,11 @@ public class RewriteDuplicateAggregateFnRule extends TransformationRule {
         if (agg1.isDistinct() != agg2.isDistinct()) {
             return false;
         }
-        
+
+        if (agg1.getIgnoreNulls() != agg2.getIgnoreNulls()) {
+            return false;
+        }
+
         List<ScalarOperator> args1 = agg1.getArguments();
         List<ScalarOperator> args2 = agg2.getArguments();
         

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/RewriteDuplicateAggregateFnRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/RewriteDuplicateAggregateFnRuleTest.java
@@ -1,0 +1,266 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.AggType;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RewriteDuplicateAggregateFnRuleTest {
+
+    /**
+     * Test case 1: Semantic equivalence with AND predicates in different order
+     * 
+     * This is the core issue from the bug report:
+     * ds_hll_count_distinct(IF(province > 5 AND id > 5, age, NULL), 21) AS d1
+     * ds_hll_count_distinct(IF(id > 5 AND province > 5, age, NULL), 21) AS d2
+     * 
+     * Expected: d1 and d2 should be recognized as duplicates, only one aggregate is computed
+     */
+    @Test
+    public void testSemanticEquivalenceWithAndPredicate() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, IntegerType.INT, "v1", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, IntegerType.INT, "v2", true);
+        ColumnRefOperator col3 = new ColumnRefOperator(3, IntegerType.INT, "v3", true);
+        ColumnRefOperator col4 = new ColumnRefOperator(4, IntegerType.INT, "v4", true);
+        
+        CompoundPredicateOperator and1 = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND,
+                createGreaterThan(col1, 5),
+                createGreaterThan(col2, 5)
+        );
+        
+        CompoundPredicateOperator and2 = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND,
+                createGreaterThan(col2, 5),
+                createGreaterThan(col1, 5)
+        );
+        
+        CallOperator if1 = createIfOperator(and1, col3);
+        CallOperator if2 = createIfOperator(and2, col3);
+        
+        CallOperator agg1 = createDsHllCountDistinct(if1);
+        CallOperator agg2 = createDsHllCountDistinct(if2);
+        
+        assertTrue(agg1.equivalent(agg2), 
+                "Aggregations with AND predicates in different order should be semantically equivalent");
+        
+        ColumnRefOperator aggCol1 = new ColumnRefOperator(10, IntegerType.BIGINT, "d1", true);
+        ColumnRefOperator aggCol2 = new ColumnRefOperator(11, IntegerType.BIGINT, "d2", true);
+        
+        Map<ColumnRefOperator, CallOperator> aggMap = Maps.newHashMap();
+        aggMap.put(aggCol1, agg1);
+        aggMap.put(aggCol2, agg2);
+        
+        LogicalAggregationOperator aggOp = new LogicalAggregationOperator(
+                AggType.GLOBAL,
+                Lists.newArrayList(col4),
+                aggMap
+        );
+        
+        RewriteDuplicateAggregateFnRule rule = new RewriteDuplicateAggregateFnRule();
+        OptExpression aggExpr = new OptExpression(aggOp);
+        
+        // Check if the rule detects duplicates
+        assertTrue(rule.check(aggExpr, OptimizerFactory.mockContext(new ColumnRefFactory())),
+                "Rule should detect semantic duplicates");
+    }
+
+    /**
+     * Test case 2: Semantic equivalence with OR predicates in different order
+     */
+    @Test
+    public void testSemanticEquivalenceWithOrPredicate() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, IntegerType.INT, "v1", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, IntegerType.INT, "v2", true);
+        ColumnRefOperator col3 = new ColumnRefOperator(3, IntegerType.INT, "v3", true);
+        ColumnRefOperator col4 = new ColumnRefOperator(4, IntegerType.INT, "v4", true);
+        
+        CompoundPredicateOperator or1 = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.OR,
+                createGreaterThan(col1, 5),
+                createGreaterThan(col2, 5)
+        );
+        
+        CompoundPredicateOperator or2 = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.OR,
+                createGreaterThan(col2, 5),
+                createGreaterThan(col1, 5)
+        );
+        
+        CallOperator if1 = createIfOperator(or1, col3);
+        CallOperator if2 = createIfOperator(or2, col3);
+        
+        CallOperator agg1 = createDsHllCountDistinct(if1);
+        CallOperator agg2 = createDsHllCountDistinct(if2);
+        
+        // Verify they are semantically equivalent
+        assertTrue(agg1.equivalent(agg2),
+                "Aggregations with OR predicates in different order should be semantically equivalent");
+    }
+
+    /**
+     * Test case 3: Exact duplicates (backward compatibility)
+     */
+    @Test
+    public void testExactDuplicateAggregations() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, IntegerType.INT, "v1", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, IntegerType.INT, "v2", true);
+        ColumnRefOperator col3 = new ColumnRefOperator(3, IntegerType.INT, "v3", true);
+        ColumnRefOperator col4 = new ColumnRefOperator(4, IntegerType.INT, "v4", true);
+        
+        CompoundPredicateOperator and1 = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND,
+                createGreaterThan(col1, 5),
+                createGreaterThan(col2, 5)
+        );
+        
+        CompoundPredicateOperator and2 = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND,
+                createGreaterThan(col1, 5),
+                createGreaterThan(col2, 5)
+        );
+        
+        CallOperator if1 = createIfOperator(and1, col3);
+        CallOperator if2 = createIfOperator(and2, col3);
+        
+        CallOperator agg1 = createDsHllCountDistinct(if1);
+        CallOperator agg2 = createDsHllCountDistinct(if2);
+        
+        assertEquals(agg1, agg2, "Exact duplicate aggregations should be equal");
+    }
+
+    /**
+     * Test case 4: Non-duplicate aggregations (different input columns)
+     */
+    @Test
+    public void testNonDuplicateAggregations() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, IntegerType.INT, "v1", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, IntegerType.INT, "v2", true);
+        ColumnRefOperator col3 = new ColumnRefOperator(3, IntegerType.INT, "v3", true);
+        ColumnRefOperator col4 = new ColumnRefOperator(4, IntegerType.INT, "v4", true);
+        
+        CompoundPredicateOperator and1 = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND,
+                createGreaterThan(col1, 5),
+                createGreaterThan(col2, 5)
+        );
+        
+        CallOperator if1 = createIfOperator(and1, col3);
+        CallOperator if2 = createIfOperator(and1, col4);  // Different input column
+        
+        CallOperator agg1 = createDsHllCountDistinct(if1);
+        CallOperator agg2 = createDsHllCountDistinct(if2);
+        
+        // Verify they are NOT semantically equivalent
+        assertTrue(!agg1.equivalent(agg2),
+                "Aggregations with different input columns should not be semantically equivalent");
+    }
+
+    /**
+     * Test case 5: Transform with semantic duplicates
+     */
+    @Test
+    public void testTransformWithSemanticDuplicates() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, IntegerType.INT, "v1", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, IntegerType.INT, "v2", true);
+        ColumnRefOperator col3 = new ColumnRefOperator(3, IntegerType.INT, "v3", true);
+        ColumnRefOperator col4 = new ColumnRefOperator(4, IntegerType.INT, "v4", true);
+        
+        CompoundPredicateOperator and1 = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND,
+                createGreaterThan(col1, 5),
+                createGreaterThan(col2, 5)
+        );
+        
+        CompoundPredicateOperator and2 = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND,
+                createGreaterThan(col2, 5),
+                createGreaterThan(col1, 5)
+        );
+        
+        CallOperator if1 = createIfOperator(and1, col3);
+        CallOperator if2 = createIfOperator(and2, col3);
+        
+        CallOperator agg1 = createDsHllCountDistinct(if1);
+        CallOperator agg2 = createDsHllCountDistinct(if2);
+        
+        ColumnRefOperator aggCol1 = new ColumnRefOperator(10, IntegerType.BIGINT, "d1", true);
+        ColumnRefOperator aggCol2 = new ColumnRefOperator(11, IntegerType.BIGINT, "d2", true);
+        
+        Map<ColumnRefOperator, CallOperator> aggMap = Maps.newHashMap();
+        aggMap.put(aggCol1, agg1);
+        aggMap.put(aggCol2, agg2);
+        
+        LogicalAggregationOperator aggOp = new LogicalAggregationOperator(
+                AggType.GLOBAL,
+                Lists.newArrayList(col4),
+                aggMap
+        );
+        
+        OptExpression aggExpr = new OptExpression(aggOp);
+        
+        RewriteDuplicateAggregateFnRule rule = new RewriteDuplicateAggregateFnRule();
+        List<OptExpression> result = rule.transform(aggExpr, OptimizerFactory.mockContext(new ColumnRefFactory()));
+        
+        assertEquals(1, result.size(), "Should return one transformed expression");
+        
+        OptExpression transformed = result.get(0);
+        assertEquals(OperatorType.LOGICAL_PROJECT, transformed.getOp().getOpType(),
+                "Top operator should be PROJECT");
+        
+        OptExpression aggChild = transformed.getInputs().get(0);
+        assertEquals(OperatorType.LOGICAL_AGGR, aggChild.getOp().getOpType(),
+                "Child operator should be AGGREGATE");
+        
+        LogicalAggregationOperator newAggOp = (LogicalAggregationOperator) aggChild.getOp();
+        assertEquals(1, newAggOp.getAggregations().size(),
+                "Should have only one aggregation after deduplication");
+    }
+
+    private ScalarOperator createGreaterThan(ColumnRefOperator col, int value) {
+        return new BinaryPredicateOperator(BinaryType.GT, col, ConstantOperator.createInt(value));
+    }
+
+    private CallOperator createIfOperator(ScalarOperator condition, ColumnRefOperator value) {
+        return new CallOperator("if", IntegerType.INT,
+                Lists.newArrayList(condition, value, ConstantOperator.createNull(IntegerType.INT)));
+    }
+
+    private CallOperator createDsHllCountDistinct(CallOperator ifExpr) {
+        return new CallOperator("ds_hll_count_distinct", IntegerType.BIGINT,
+                Lists.newArrayList(ifExpr, ConstantOperator.createInt(21)));
+    }
+}


### PR DESCRIPTION

## Why I'm doing:
The RewriteDuplicateAggregateFnRule fails to recognize aggregate functions that are
semantically equivalent but have different argument orders in commutative operators.

Example:

- ds_hll_count_distinct(IF(province > 5 AND id > 5, age, NULL), 21)
- ds_hll_count_distinct(IF(id > 5 AND province > 5, age, NULL), 21)

These are semantically identical (AND is commutative) but CallOperator.equals()
performs exact comparison, so they are not recognized as duplicates.

Impact
1. Duplicate aggregate calculations (performance regression)
2. Incorrect column types after TVF (VARBINARY instead of BIGINT)
3. CN crash in subsequent aggregations with type mismatch

Reproduction:

```sql

CREATE TABLE t1 (
      id BIGINT NOT NULL,
      province VARCHAR(64),
      age SMALLINT,
      dt VARCHAR(10) NOT NULL
    )
DUPLICATE KEY(id)
DISTRIBUTED BY HASH(id) BUCKETS 4;
 
insert into t1 select generate_series, generate_series, generate_series % 100, "2024-07-24" from table(generate_series(1, 10));
 
StarRocks :) select * from t1;
+----+----------+-----+------------+
| id | province | age | dt         |
+----+----------+-----+------------+
| 1  | 1        | 1   | 2024-07-24 |
| 4  | 4        | 4   | 2024-07-24 |
| 2  | 2        | 2   | 2024-07-24 |
| 7  | 7        | 7   | 2024-07-24 |
| 8  | 8        | 8   | 2024-07-24 |
| 3  | 3        | 3   | 2024-07-24 |
| 6  | 6        | 6   | 2024-07-24 |
| 9  | 9        | 9   | 2024-07-24 |
| 5  | 5        | 5   | 2024-07-24 |
| 10 | 10       | 10  | 2024-07-24 |
+----+----------+-----+------------+
 

-- Q1: The query plan for this SQL statement is as expected.
SELECT t2.dt, unnest, sum(d1), sum(d2)
FROM (
        select * from (
            SELECT dt
                    , ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d1
                    , ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d2
            FROM test.t1
            group by dt
        ) t0
        , unnest([1, 2, 3]) as unnest
    ) t2
GROUP BY 1, 2
limit 10;


-- Q2: The query plan for this SQL query does not meet expectations.
SELECT t2.dt, unnest, sum(d1), sum(d2)
FROM (
        select * from (
            SELECT dt
                    , ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d1
                    , ds_hll_count_distinct(if(id>5 and province>5, age, null), 21) as d2
            FROM test.t1
            group by dt
        ) t0
        , unnest([1, 2, 3]) as unnest
    ) t2
GROUP BY 1, 2
limit 10;

```

Q1 plan:
<img width="1334" height="906" alt="image" src="https://github.com/user-attachments/assets/38c8ae87-a342-42ed-8a92-4677fdbfdc78" />

Q2 plan:
<img width="1318" height="968" alt="image" src="https://github.com/user-attachments/assets/7c49caba-41a8-4f6e-a79b-f1f19413d744" />

Q2 can cause a **CN crash** or **incorrect query results**. stack:
```c++
F20260121 02:48:47.128046 140321472108096 sum.h:60] Check failed: columns[0]->is_numeric() || columns[0]->is_decimal() 
xhs/dev/3.5-cache-select-crash ASAN (build 36cae61 distro ubuntu arch x86_64)
query_id:b380317e-f673-11f0-a52c-da1c6a176461, fragment_instance:b380317e-f673-11f0-a52c-da1c6a176463
[1768963727.128][thread: 140321472108096] je_mallctl execute purge success
[1768963727.128][thread: 140321472108096] je_mallctl execute dontdump success
*** Aborted at 1768963727 (unix time) try "date -d @1768963727" if you are using GNU date ***
PC: @     0x7fa1810969fc pthread_kill
*** SIGABRT (@0x312e2) received by PID 201442 (TID 0x7f9f237fd640) LWP(202026) from PID 201442; stack trace: ***
    @         0x2ab9a246 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7fa181099ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x2ab99a89 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fa181042520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7fa1810969fc pthread_kill
    @     0x7fa181042476 raise
    @     0x7fa1810287f3 abort
    @         0x25244e5c starrocks::failure_function()
    @         0x2ab8d21e google::LogMessage::Fail()
    @         0x2ab8e499 google::LogMessageFatal::~LogMessageFatal()
    @         0x1ed7c9d2 starrocks::SumAggregateFunction<(starrocks::LogicalType)7, long, (starrocks::LogicalType)7, long>::update(starrocks::FunctionContext*, starrocks::Column const**, unsigned char*, unsigned long) const
    @         0x1ed7eb1d starrocks::AggregateFunctionBatchHelper<starrocks::SumAggregateState<long>, starrocks::SumAggregateFunction<(starrocks::LogicalType)7, long, (starrocks::LogicalType)7, long> >::update_batch(starrocks::FunctionContext*, unsigned long, unsigned long, starroc
    @         0x1d728410 starrocks::AggregateFunction::update_batch_exception_safe(starrocks::FunctionContext*, unsigned long, unsigned long, starrocks::Column const**, unsigned char**) const
    @         0x21873b6a starrocks::Aggregator::compute_batch_agg_states(starrocks::Chunk*, unsigned long)
    @         0x223a1d13 starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @         0x17e532df starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x24458b38 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
```

After this PR optimization, the query plan for Q2 will be the same as that for Q1. There will be no crashes or incorrect query results.


## What I'm doing:

Introduce semantic equivalence comparison using ScalarOperator.equivalent():

- New method: isSemanticallySameAggregation()
- Updated check() method
  - Enables detection of semantically equivalent aggregations
- Updated transform() method

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
