### PR TITLE
[BugFix] Add a timeout for mv metric collector

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -232,15 +232,14 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
 
                 MaterializedView mv = (MaterializedView) table;
                 Locker locker = new Locker();
-                if (locker.tryLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()),
+                if (!locker.tryLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()),
                         LockType.READ, 1, TimeUnit.SECONDS)) {
-                    try {
-                        return mv.getRowCount();
-                    } finally {
-                        locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
-                    }
-                } else {
                     return 0L;
+                }
+                try {
+                    return mv.getRowCount();
+                } finally {
+                    locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
                 }
             }
         };
@@ -261,15 +260,14 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
 
                 MaterializedView mv = (MaterializedView) table;
                 Locker locker = new Locker();
-                if (locker.tryLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()),
+                if (!locker.tryLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()),
                         LockType.READ, 1, TimeUnit.SECONDS)) {
-                    try {
-                        return mv.getDataSize();
-                    } finally {
-                        locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
-                    }
-                } else {
                     return 0L;
+                }
+                try {
+                    return mv.getDataSize();
+                } finally {
+                    locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
                 }
             }
         };
@@ -315,15 +313,14 @@ public final class MaterializedViewMetricsEntity implements IMaterializedViewMet
                 }
 
                 Locker locker = new Locker();
-                if (locker.tryLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()),
+                if (!locker.tryLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()),
                         LockType.READ, 1, TimeUnit.SECONDS)) {
-                    try {
-                        return mv.getPartitions().size();
-                    } finally {
-                        locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
-                    }
-                } else {
                     return 0;
+                }
+                try {
+                    return mv.getPartitions().size();
+                } finally {
+                    locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
                 }
             }
         };

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
@@ -36,6 +36,7 @@ public class MaterializedViewMetricsRegistry {
     private final Map<MvId, IMaterializedViewMetricsEntity> idToMVMetrics;
     private final ScheduledThreadPoolExecutor timer;
     private static final MaterializedViewMetricsRegistry INSTANCE = new MaterializedViewMetricsRegistry();
+    private static final IMaterializedViewMetricsEntity BLACK_HOLE_ENTITY = new MaterializedViewMetricsBlackHoleEntity();
 
     private MaterializedViewMetricsRegistry() {
         idToMVMetrics = Maps.newHashMap();
@@ -55,7 +56,7 @@ public class MaterializedViewMetricsRegistry {
     }
     private IMaterializedViewMetricsEntity initMaterializedViewMetricsEntity(MvId mvId) {
         if (!Config.enable_materialized_view_metrics_collect) {
-            return new MaterializedViewMetricsBlackHoleEntity();
+            return BLACK_HOLE_ENTITY;
         } else {
             return new MaterializedViewMetricsEntity(metricRegistry, mvId);
         }


### PR DESCRIPTION
## Why I'm doing:
Fix possible deadlock with multi-locks between the analyze thread and the MV metrics collector thread:
```
"analyze-task-concurrency-pool-2" #267 daemon prio=5 os_prio=0 cpu=201421.26ms elapsed=22594.39s tid=0x00002addd46da9b0 nid=0x10b5 waiting for monitor entry  [0x00002addf8d39000]
   java.lang.Thread.State: BLOCKED (on object monitor)
  at com.starrocks.metric.MetricRepo.init(MetricRepo.java:295)
  - waiting to lock <0x0000000508c212a8> (a java.lang.Class for com.starrocks.metric.MetricRepo)
  at com.starrocks.metric.MetricRepo.addMetric(MetricRepo.java:1315)
  at com.starrocks.metric.MetricWithLabelGroup.lambda$getMetric$0(MetricWithLabelGroup.java:37)
  at com.starrocks.metric.MetricWithLabelGroup$$Lambda$1371/0x00002add39b6e3a8.apply(Unknown Source)
  at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(java.base@17.0.13/ConcurrentHashMap.java:1708)
  - locked <0x000000057c5edc20> (a java.util.concurrent.ConcurrentHashMap$ReservationNode)
  at com.starrocks.metric.MetricWithLabelGroup.getMetric(MetricWithLabelGroup.java:34)
  at com.starrocks.statistic.StatisticExecutor.collectStatistics(StatisticExecutor.java:582)
  at com.starrocks.statistic.StatisticsCollectionTrigger.lambda$executeCollect$1(StatisticsCollectionTrigger.java:237)
  at com.starrocks.statistic.StatisticsCollectionTrigger$$Lambda$1368/0x00002add39b6da20.run(Unknown Source)
  at com.starrocks.statistic.CancelableAnalyzeTask.run(CancelableAnalyzeTask.java:57)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.13/ThreadPoolExecutor.java:1136)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.13/ThreadPoolExecutor.java:635)
  at java.lang.Thread.run(java.base@17.0.13/Thread.java:840)


"starrocks-http-pool-5" #1545 daemon prio=5 os_prio=0 cpu=1320.84ms elapsed=21991.31s tid=0x00002adde0959c00 nid=0x192f in Object.wait()  [0x00002addfcb77000]
   java.lang.Thread.State: WAITING (on object monitor)
  at java.lang.Object.wait(java.base@17.0.13/Native Method)
  - waiting on <no object reference available>
  at com.starrocks.common.util.concurrent.lock.LockManager.lockAcquireSlowPath(LockManager.java:174)
  - locked <0x0000000556000258> (a com.starrocks.common.util.concurrent.lock.Locker)
  at com.starrocks.common.util.concurrent.lock.LockManager.lock(LockManager.java:142)
  at com.starrocks.common.util.concurrent.lock.Locker.lock(Locker.java:93)
  at com.starrocks.common.util.concurrent.lock.Locker.lockTablesWithIntensiveDbLock(Locker.java:300)
  at com.starrocks.common.util.concurrent.lock.AutoCloseableLock.<init>(AutoCloseableLock.java:45)
  at com.starrocks.metric.MaterializedViewMetricsEntity$3.getValue(MaterializedViewMetricsEntity.java:234)
  at com.starrocks.metric.MaterializedViewMetricsEntity$3.getValue(MaterializedViewMetricsEntity.java:221)
  at com.starrocks.metric.JsonMetricVisitor.visit(JsonMetricVisitor.java:151)
  at com.starrocks.metric.MaterializedViewMetricsRegistry.doCollectMetrics(MaterializedViewMetricsRegistry.java:107)
  at com.starrocks.metric.MaterializedViewMetricsRegistry.collectMaterializedViewMetrics(MaterializedViewMetricsRegistry.java:122)
  at com.starrocks.metric.MetricRepo.getMetric(MetricRepo.java:1071)
  - locked <0x0000000508c212a8> (a java.lang.Class for com.starrocks.metric.MetricRepo)
  at com.starrocks.http.rest.MetricsAction.execute(MetricsAction.java:143)
  at com.starrocks.http.rest.RestBaseAction.handleRequest(RestBaseAction.java:117)
  at com.starrocks.http.HttpServerHandler.lambda$handleActionAsync$0(HttpServerHandler.java:140)
  at com.starrocks.http.HttpServerHandler$$Lambda$1396/0x00002add39b9b670.run(Unknown Source)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.13/ThreadPoolExecutor.java:1136)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.13/ThreadPoolExecutor.java:635)
  at java.lang.Thread.run(java.base@17.0.13/Thread.java:840)
```

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10917

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
