### PR TITLE
[Enhancement] Auto recollect FULL stats for predicate columns on unpartitioned tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -483,16 +483,20 @@ public class StatisticsCollectJobFactory {
         // Use predicate columns if suitable
         TableName tableName = new TableName(db.getOriginName(), table.getName());
         int numColumns = table.getColumns().size();
-        List<String> predicateColNames = null;
+        List<String> predicateColNames = List.of();
         boolean existsPredicateColumns = false;
         boolean enablePredicateColumnStrategy = false;
+        boolean needRecollectPredicateColumnsOnUnpartitioned = false;
         if (basicStatsMeta != null && !basicStatsMeta.isInitJobMeta() && useBasicStats &&
                 Config.statistic_auto_collect_predicate_columns_threshold > 0 &&
                 CollectionUtils.isEmpty(columnNames) && table.isNativeTableOrMaterializedView()) {
             List<ColumnUsage> predicateColumns = PredicateColumnsMgr.getInstance().queryPredicateColumns(tableName);
             if (CollectionUtils.isNotEmpty(predicateColumns) && predicateColumns.size() <= numColumns) {
                 OlapTable olap = (OlapTable) table;
-                predicateColNames = predicateColumns.stream().flatMap(x -> x.getOlapColumnName(olap).stream()).toList();
+                predicateColNames = predicateColumns.stream()
+                        .flatMap(x -> x.getOlapColumnName(olap).stream())
+                        .distinct()
+                        .toList();
                 existsPredicateColumns = true;
                 if (numColumns > Config.statistic_auto_collect_predicate_columns_threshold) {
                     enablePredicateColumnStrategy = true;
@@ -500,15 +504,39 @@ public class StatisticsCollectJobFactory {
             }
         }
 
+
         if (basicStatsMeta != null) {
+            if (table.isUnPartitioned() && CollectionUtils.isNotEmpty(predicateColNames)) {
+                List<String> fullCols = basicStatsMeta.getAnalyzedColumns().values().stream()
+                        .filter(x -> x.getType() == StatsConstants.AnalyzeType.FULL)
+                        .map(ColumnStatsMeta::getColumnName)
+                        .filter(col -> table.getColumn(col) != null)
+                        .toList();
+                Set<String> fullColSet = Set.copyOf(fullCols);
+                boolean missingPredicateColumns = predicateColNames.stream().anyMatch(c -> !fullColSet.contains(c));
+                if (missingPredicateColumns) {
+                    needRecollectPredicateColumnsOnUnpartitioned = true;
+                    columnNames = java.util.stream.Stream.concat(predicateColNames.stream(), fullCols.stream())
+                            .distinct()
+                            .filter(col -> table.getColumn(col) != null)
+                            .toList();
+                    columnTypes = columnNames.stream()
+                            .map(col -> table.getColumn(col).getType())
+                            .collect(Collectors.toList());
+                    analyzeType = StatsConstants.AnalyzeType.FULL;
+                }
+            }
+
             // 1. if the table has no update after the stats collection
-            if (useBasicStats && basicStatsMeta.isUpdatedAfterLoad(tableUpdateTime)) {
+            if (!needRecollectPredicateColumnsOnUnpartitioned &&
+                    useBasicStats && basicStatsMeta.isUpdatedAfterLoad(tableUpdateTime)) {
                 LOG.debug("statistics job doesn't work on non-update table: {}, " +
                                 "last update time: {}, last collect time: {}",
                         table.getName(), tableUpdateTime, basicStatsMeta.getUpdateTime());
                 return;
             }
-            if (!useBasicStats && !isInitJob && statsUpdateTime.isAfter(tableUpdateTime)) {
+            if (!needRecollectPredicateColumnsOnUnpartitioned &&
+                    !useBasicStats && !isInitJob && statsUpdateTime.isAfter(tableUpdateTime)) {
                 return;
             }
 
@@ -518,7 +546,7 @@ public class StatisticsCollectJobFactory {
                             Config.statistic_auto_collect_ratio);
 
             healthy = basicStatsMeta.getHealthy();
-            if (healthy > statisticAutoCollectRatio) {
+            if (!needRecollectPredicateColumnsOnUnpartitioned && healthy > statisticAutoCollectRatio) {
                 LOG.debug("statistics job doesn't work on health table: {}, healthy: {}, collect healthy limit: <{}",
                         table.getName(), healthy, statisticAutoCollectRatio);
                 return;
@@ -541,7 +569,8 @@ public class StatisticsCollectJobFactory {
 
             long timeInterval = PropertyUtil.propertyAsLong(jobProperties, STATISTIC_AUTO_COLLECT_INTERVAL, defaultInterval);
 
-            if (!isInitJob && statsUpdateTime.plusSeconds(timeInterval).isAfter(LocalDateTime.now())) {
+            if (!needRecollectPredicateColumnsOnUnpartitioned &&
+                    !isInitJob && statsUpdateTime.plusSeconds(timeInterval).isAfter(LocalDateTime.now())) {
                 LOG.debug("statistics job doesn't work on the interval table: {}, " +
                                 "last collect time: {}, interval: {}, table size: {}MB",
                         table.getName(), tableUpdateTime, timeInterval, ByteSizeUnit.BYTES.toMB(sumDataSize));
@@ -550,6 +579,7 @@ public class StatisticsCollectJobFactory {
 
             // 4. frequent-update big table without predicate column, choose sample strategy to collect statistics
             if (analyzeType != StatsConstants.AnalyzeType.HISTOGRAM &&
+                    !needRecollectPredicateColumnsOnUnpartitioned &&
                     healthy < Config.statistic_auto_collect_sample_threshold &&
                     sumDataSize > Config.statistic_auto_collect_small_table_size) {
                 if (!(Config.statistic_auto_collect_use_full_predicate_column_for_sample && existsPredicateColumns &&
@@ -583,7 +613,8 @@ public class StatisticsCollectJobFactory {
         } else if (analyzeType.equals(StatsConstants.AnalyzeType.HISTOGRAM)) {
             createHistogramJob(allTableJobMap, job, db, table, columnNames, columnTypes, priority);
         } else if (analyzeType.equals(StatsConstants.AnalyzeType.FULL)) {
-            createFullStatsJob(allTableJobMap, job, basicStatsMeta, db, table, columnNames, columnTypes, priority);
+            createFullStatsJob(allTableJobMap, job, basicStatsMeta, db, table, columnNames, columnTypes, priority,
+                    needRecollectPredicateColumnsOnUnpartitioned);
         } else {
             throw new StarRocksPlannerException("Unknown analyze type " + analyzeType, ErrorType.INTERNAL_ERROR);
         }
@@ -626,14 +657,22 @@ public class StatisticsCollectJobFactory {
     private static void createFullStatsJob(List<StatisticsCollectJob> allTableJobMap,
                                            NativeAnalyzeJob job, BasicStatsMeta stats,
                                            Database db, Table table, List<String> columnNames, List<Type> columnTypes,
-                                           StatisticsCollectJob.Priority priority) {
+                                           StatisticsCollectJob.Priority priority,
+                                           boolean forceRecollect) {
         StatsConstants.AnalyzeType analyzeType;
-        List<Partition> partitionList = table.getPartitions().stream()
-                .filter(partition -> !StatisticUtils.isPartitionStatsHealthy(table, partition, stats))
-                .toList();
+        List<Partition> partitionList;
+        if (forceRecollect) {
+            partitionList = table.getPartitions().stream()
+                    .filter(p -> p.hasData() && !p.getName().startsWith(SHADOW_PARTITION_PREFIX))
+                    .toList();
+        } else {
+            partitionList = table.getPartitions().stream()
+                    .filter(partition -> !StatisticUtils.isPartitionStatsHealthy(table, partition, stats))
+                    .toList();
+        }
 
         long totalDataSize = partitionList.stream().mapToLong(Partition::getDataSize).sum();
-        if (job.isDefaultJob() && totalDataSize > Config.statistic_max_full_collect_data_size) {
+        if (!forceRecollect && job.isDefaultJob() && totalDataSize > Config.statistic_max_full_collect_data_size) {
             analyzeType = StatsConstants.AnalyzeType.SAMPLE;
             LOG.debug("statistics job choose sample on table: {}, partition data size greater than config: {}",
                     table.getName(), Config.statistic_max_full_collect_data_size);

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
@@ -241,8 +241,8 @@ class ColumnUsageTest extends PlanTestBase {
             List<StatisticsCollectJob> collectJobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(analyzeJob);
             Assertions.assertEquals(1, collectJobs.size());
             StatisticsCollectJob job0 = collectJobs.get(0);
-            Assertions.assertEquals(StatsConstants.AnalyzeType.SAMPLE, job0.getAnalyzeType());
-            Assertions.assertEquals(List.of("v1", "v2", "v3"), job0.getColumnNames());
+            Assertions.assertEquals(StatsConstants.AnalyzeType.FULL, job0.getAnalyzeType());
+            Assertions.assertEquals(List.of("v1"), job0.getColumnNames());
             Config.statistic_auto_collect_small_table_size = defaultSmallTableSize;
             Config.statistic_auto_collect_max_predicate_column_size_on_sample_strategy = defaultPredicateColumnSize;
         }


### PR DESCRIPTION
## Why I'm doing:
StarRocks already supports **auto analyze**, but some existing users still run **manual ANALYZE on only a subset of columns** after overwriting table or routine maintenance. When the manually analyzed columns do **not fully cover predicate-related columns**, the optimizer may lack statistics for important predicate/join/group-by columns.  
Today, the background auto-collection logic is primarily **table/partition health based** (row/data-change driven) and does not validate **column-level coverage**, so it may skip collecting the missing predicate-column stats because the table is considered “healthy”. This creates a conflict between legacy user behavior and the current auto-collection strategy, leading to unstable plans and regressions.

## What I'm doing:
- Add a **column-coverage check** for **unpartitioned tables**: verify whether existing **FULL** stats actually cover **all predicate columns**.
- If any predicate columns are missing FULL stats, force a **FULL recollection** to compensate stats for:
  - **predicate columns**, plus
  - columns that are already **FULL** analyzed (to keep meta consistent),
  while bypassing the “healthy / interval” skip logic that only reflects data change.
- Scope the change to **unpartitioned tables only**, since these tables are typically smaller and this avoids unexpected heavy workloads on large partitioned tables.
- The compensation collection is **focused on predicate columns**, so it addresses the user-visible issue with minimal impact.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
