### PR TITLE
[Enhancement] Add table property disable_query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -587,6 +587,8 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT)) {
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
+                    } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DISABLE_QUERY)) {
+                        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else {
                         schemaChangeHandler.process(Lists.newArrayList(clause), db, olapTable);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2227,6 +2227,24 @@ public class OlapTable extends Table {
         tableProperty.buildTableQueryTimeout();
     }
 
+    public boolean isDisableQuery() {
+        if (tableProperty != null) {
+            return tableProperty.isDisableQuery();
+        }
+
+        return false;
+    }
+
+    public void setDisableQuery(boolean disableQuery) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_DISABLE_QUERY,
+                Boolean.valueOf(disableQuery).toString());
+        tableProperty.buildDisableQuery();
+    }
+
+
     public boolean allowBucketSizeSetting() {
         return (defaultDistributionInfo instanceof RandomDistributionInfo) && Config.enable_automatic_bucket;
     }
@@ -3006,6 +3024,11 @@ public class OlapTable extends Table {
             } catch (NumberFormatException e) {
                 LOG.warn("fail to parse table query_timeout.", e);
             }
+        }
+
+        // disable query (only show if true, default is false)
+        if (isDisableQuery()) {
+            properties.put(PropertyAnalyzer.PROPERTIES_DISABLE_QUERY, "true");
         }
 
         // partition live number

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -342,6 +342,12 @@ public class TableProperty implements Writable, GsonPostProcessable {
     @SerializedName(value = "tableQueryTimeout")
     private int tableQueryTimeout = -1;
 
+    // control whether query is disabled on this table.
+    // false (default): query is allowed
+    // true: query is disabled
+    @SerializedName(value = "disableQuery")
+    private boolean disableQuery = false;
+
     /**
      * Whether to enable the v2 implementation of fast schema evolution for cloud-native tables.
      * This version is more lightweight, modifying only FE metadata instead of both FE and tablet metadata.
@@ -503,6 +509,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 buildCloudNativeFastSchemaEvolutionV2();
                 buildLakeCompactionMaxParallel();
                 buildTableQueryTimeout();
+                buildDisableQuery();
                 break;
             case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY:
                 buildConstraint();
@@ -1357,6 +1364,12 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    public TableProperty buildDisableQuery() {
+        disableQuery = Boolean.parseBoolean(
+                properties.getOrDefault(PropertyAnalyzer.PROPERTIES_DISABLE_QUERY, "false"));
+        return this;
+    }
+
     public TableProperty buildCloudNativeFastSchemaEvolutionV2() {
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)) {
             cloudNativeFastSchemaEvolutionV2 = Boolean.parseBoolean(
@@ -1402,6 +1415,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     public int getTableQueryTimeout() {
         return tableQueryTimeout;
+    }
+
+    public boolean isDisableQuery() {
+        return disableQuery;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -214,6 +214,7 @@ public class PropertyAnalyzer {
 
     // default: same as cluster query_timeout
     public static final String PROPERTIES_TABLE_QUERY_TIMEOUT = "table_query_timeout";
+    public static final String PROPERTIES_DISABLE_QUERY = "disable_query";
 
     public static final String PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT = "auto_refresh_partitions_limit";
     public static final String PROPERTIES_PARTITION_REFRESH_STRATEGY = "partition_refresh_strategy";

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3954,6 +3954,14 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
     }
 
+    private void alterDisableQuery(OlapTable table,
+                                  Map<String, String> properties,
+                                  List<Runnable> appliers) {
+        boolean disableQuery = PropertyAnalyzer.analyzeBooleanProp(
+                properties, PropertyAnalyzer.PROPERTIES_DISABLE_QUERY, false);
+        appliers.add(() -> table.setDisableQuery(disableQuery));
+    }
+
     public void alterTableProperties(Database db, OlapTable table, Map<String, String> properties)
             throws DdlException {
         Map<String, String> propertiesToPersist = new HashMap<>(properties);
@@ -3993,6 +4001,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
         if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT)) {
             alterTableQueryTimeout(table, properties, appliers);
+        }
+        if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_DISABLE_QUERY)) {
+            alterDisableQuery(table, properties, appliers);
         }
         if (!properties.isEmpty()) {
             throw new DdlException("Modify failed because unknown properties: " + properties);

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -366,6 +366,11 @@ public class OlapTableFactory implements AbstractTableFactory {
             // consume deprecated in_memory property if present
             PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_INMEMORY, false);
 
+            // set disable_query (default false)
+            boolean disableQuery = PropertyAnalyzer.analyzeBooleanProp(
+                    properties, PropertyAnalyzer.PROPERTIES_DISABLE_QUERY, false);
+            table.setDisableQuery(disableQuery);
+
             boolean enablePersistentIndex = PropertyAnalyzer.analyzeEnablePersistentIndex(properties);
             if (table.getKeysType() == KeysType.PRIMARY_KEYS) {
                 if (!enablePersistentIndex) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -373,6 +373,12 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                 }
             }
             PropertyAnalyzer.analyzeBaseCompactionForbiddenTimeRanges(properties);
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DISABLE_QUERY)) {
+            String disableQuery = properties.get(PropertyAnalyzer.PROPERTIES_DISABLE_QUERY);
+            if (!disableQuery.equalsIgnoreCase("true") && !disableQuery.equalsIgnoreCase("false")) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Property " + PropertyAnalyzer.PROPERTIES_DISABLE_QUERY + " must be bool type(false/true)");
+            }
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_ENABLE) ||
                 properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_TTL) ||
                 properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_SIZE)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -794,6 +794,22 @@ public class AnalyzerUtils {
         return tables;
     }
 
+    // Validate table level property: disable_query.
+    // When disable_query is true on an OlapTable, any query that tries to read this table should be rejected.
+    public static void validateDisableQueryOnTables(StatementBase statementBase) {
+        Map<TableName, Table> tables = collectAllTable(statementBase);
+        for (Map.Entry<TableName, Table> entry : tables.entrySet()) {
+            Table table = entry.getValue();
+            if (table instanceof OlapTable) {
+                OlapTable olapTable = (OlapTable) table;
+                if (olapTable.isDisableQuery()) {
+                    String fullName = entry.getKey() != null ? entry.getKey().toString() : table.getName();
+                    throw new SemanticException("The table " + fullName + " property disable_query is true");
+                }
+            }
+        }
+    }
+
     public static Multimap<String, TableRelation> collectAllTableRelation(StatementBase statementBase) {
         Multimap<String, TableRelation> tableRelations = ArrayListMultimap.create();
         new AnalyzerUtils.TableRelationCollector(tableRelations).visit(statementBase);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DisableQueryPropertyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DisableQueryPropertyTest.java
@@ -1,0 +1,256 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowExecutor;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.sql.ast.ShowCreateTableStmt;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for table property "disable_query".
+ *
+ * 1. SHOW CREATE TABLE should display "disable_query" in PROPERTIES only when it's true (default is false).
+ * 2. ALTER TABLE ... SET ("disable_query" = "true") should succeed and be reflected in SHOW CREATE TABLE.
+ * 3. When disable_query is true, any query which reads that table should fail at analyze phase
+ *    with message "the table <name> disable_query is true".
+ */
+public class DisableQueryPropertyTest {
+
+    private static ConnectContext ctx;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(ctx);
+        starRocksAssert.withDatabase("test").useDatabase("test");
+    }
+
+    @Test
+    public void testShowCreateTableContainsDisableQuery() throws Exception {
+        starRocksAssert
+                .withTable("CREATE TABLE `t_disable_query_1` (\n" +
+                        "  `id` int(11) NOT NULL,\n" +
+                        "  `v1` int(11) NOT NULL\n" +
+                        ") ENGINE=OLAP \n" +
+                        "DUPLICATE KEY(`id`)\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 1 \n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"disable_query\" = \"true\"\n" +
+                        ");");
+
+        String sql = "show create table test.t_disable_query_1";
+        ShowCreateTableStmt showStmt =
+                (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        ShowResultSet resultSet = ShowExecutor.execute(showStmt, ctx);
+        String createSql = resultSet.getResultRows().get(0).get(1);
+        Assertions.assertTrue(createSql.contains("\"disable_query\" = \"true\""),
+                "SHOW CREATE TABLE should contain disable_query property. Got: " + createSql);
+    }
+
+    @Test
+    public void testAlterTableDisableQueryAndBlockQuery() throws Exception {
+        // create table with default disable_query (false, meaning query is allowed)
+        starRocksAssert
+                .withTable("CREATE TABLE `t_disable_query_2` (\n" +
+                        "  `id` int(11) NOT NULL,\n" +
+                        "  `v1` int(11) NOT NULL\n" +
+                        ") ENGINE=OLAP \n" +
+                        "DUPLICATE KEY(`id`)\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 1 \n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\"\n" +
+                        ");");
+
+        // alter disable_query to true (disable query)
+        String alterSql = "ALTER TABLE test.t_disable_query_2 SET (\"disable_query\" = \"true\")";
+        starRocksAssert.alterTableProperties(alterSql);
+        
+        // verify the property is set correctly
+        String sql = "show create table test.t_disable_query_2";
+        ShowCreateTableStmt showStmt =
+                (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        ShowResultSet resultSet = ShowExecutor.execute(showStmt, ctx);
+        String createSql = resultSet.getResultRows().get(0).get(1);
+        Assertions.assertTrue(createSql.contains("\"disable_query\" = \"true\""),
+                "After ALTER TABLE, SHOW CREATE TABLE should contain disable_query = true. Got: " + createSql);
+
+        // now query should be rejected because disable_query is true
+        String querySql = "SELECT * FROM test.t_disable_query_2";
+        Exception ex = Assertions.assertThrows(Exception.class, () ->
+                UtFrameUtils.getPlanAndFragment(ctx, querySql));
+        // message format is checked in outer error handling; we only check core text here
+        Assertions.assertTrue(ex.getMessage().contains("the table test.t_disable_query_2 property disable_query is true") ||
+                        ex.getMessage().contains("disable_query is true"),
+                "Query error message should mention disable_query is true. Got: " + ex.getMessage());
+    }
+
+    @Test
+    public void testCreateTableWithInvalidDisableQuery() throws Exception {
+        // Test that CREATE TABLE with invalid disable_query value is silently parsed as false
+        // (Boolean.parseBoolean returns false for any non-"true" string)
+        String createSqlInvalid = "CREATE TABLE `t_disable_query_invalid` (\n" +
+                "  `id` int(11) NOT NULL\n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`id`)\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 1 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"disable_query\" = \"yes\"\n" +
+                ");";
+
+        // Table creation should succeed (invalid value is silently parsed as false)
+        starRocksAssert.withTable(createSqlInvalid);
+
+        // Verify that disable_query is false (default) and not shown in SHOW CREATE TABLE
+        String sql = "show create table test.t_disable_query_invalid";
+        ShowCreateTableStmt showStmt =
+                (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        ShowResultSet resultSet = ShowExecutor.execute(showStmt, ctx);
+        String createSql = resultSet.getResultRows().get(0).get(1);
+        boolean hasDisableQueryProperty = createSql.contains("\"disable_query\" = \"true\"") ||
+                createSql.contains("\"disable_query\" = \"false\"");
+        Assertions.assertFalse(hasDisableQueryProperty,
+                "SHOW CREATE TABLE should not contain disable_query when invalid value is parsed as false. Got: " + createSql);
+
+        // Test with another invalid value
+        String createSqlInvalid2 = "CREATE TABLE `t_disable_query_invalid2` (\n" +
+                "  `id` int(11) NOT NULL\n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`id`)\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 1 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"disable_query\" = \"invalid\"\n" +
+                ");";
+
+        // Table creation should succeed (invalid value is silently parsed as false)
+        starRocksAssert.withTable(createSqlInvalid2);
+
+        // Verify that disable_query is false (default) and not shown in SHOW CREATE TABLE
+        String sql2 = "show create table test.t_disable_query_invalid2";
+        ShowCreateTableStmt showStmt2 =
+                (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql2, ctx);
+        ShowResultSet resultSet2 = ShowExecutor.execute(showStmt2, ctx);
+        String createSql2 = resultSet2.getResultRows().get(0).get(1);
+        boolean hasDisableQueryProperty2 = createSql2.contains("\"disable_query\" = \"true\"") ||
+                createSql2.contains("\"disable_query\" = \"false\"");
+        Assertions.assertFalse(hasDisableQueryProperty2,
+                "SHOW CREATE TABLE should not contain disable_query when invalid value is parsed as false. Got: " + createSql2);
+    }
+
+    @Test
+    public void testAlterTableDisableQueryFromTrueToFalse() throws Exception {
+        // create table with disable_query = true
+        starRocksAssert
+                .withTable("CREATE TABLE `t_disable_query_toggle` (\n" +
+                        "  `id` int(11) NOT NULL\n" +
+                        ") ENGINE=OLAP \n" +
+                        "DUPLICATE KEY(`id`)\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 1 \n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"disable_query\" = \"true\"\n" +
+                        ");");
+
+        // verify it's shown when true
+        String sql1 = "show create table test.t_disable_query_toggle";
+        ShowCreateTableStmt showStmt1 =
+                (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql1, ctx);
+        ShowResultSet resultSet1 = ShowExecutor.execute(showStmt1, ctx);
+        String createSql1 = resultSet1.getResultRows().get(0).get(1);
+        Assertions.assertTrue(createSql1.contains("\"disable_query\" = \"true\""),
+                "SHOW CREATE TABLE should contain disable_query = true. Got: " + createSql1);
+
+        // alter disable_query to false
+        String alterSql = "ALTER TABLE test.t_disable_query_toggle SET (\"disable_query\" = \"false\")";
+        starRocksAssert.alterTableProperties(alterSql);
+
+        // verify it's not shown when false
+        String sql2 = "show create table test.t_disable_query_toggle";
+        ShowCreateTableStmt showStmt2 =
+                (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql2, ctx);
+        ShowResultSet resultSet2 = ShowExecutor.execute(showStmt2, ctx);
+        String createSql2 = resultSet2.getResultRows().get(0).get(1);
+        boolean hasDisableQueryProperty = createSql2.contains("\"disable_query\" = \"true\"") ||
+                createSql2.contains("\"disable_query\" = \"false\"");
+        Assertions.assertFalse(hasDisableQueryProperty,
+                "SHOW CREATE TABLE should not contain disable_query property when set to false. Got: " + createSql2);
+    }
+
+    @Test
+    public void testUpdateStmtBlockedByDisableQuery() throws Exception {
+        // create table with disable_query = true
+        starRocksAssert
+                .withTable("CREATE TABLE `t_disable_query_update` (\n" +
+                        "  `id` int(11) NOT NULL,\n" +
+                        "  `v1` int(11) NOT NULL\n" +
+                        ") ENGINE=OLAP \n" +
+                        "PRIMARY KEY(`id`)\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 1 \n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"disable_query\" = \"true\"\n" +
+                        ");");
+
+        // UPDATE should be rejected because disable_query is true
+        String updateSql = "UPDATE test.t_disable_query_update SET v1 = 100 WHERE id = 1";
+        Exception ex = Assertions.assertThrows(Exception.class, () ->
+                UtFrameUtils.getPlanAndFragment(ctx, updateSql));
+        Assertions.assertTrue(ex.getMessage().contains("the table test.t_disable_query_update property disable_query is true") ||
+                        ex.getMessage().contains("disable_query is true"),
+                "UPDATE error message should mention disable_query is true. Got: " + ex.getMessage());
+    }
+
+    @Test
+    public void testDeleteStmtBlockedByDisableQuery() throws Exception {
+        starRocksAssert
+                .withTable("CREATE TABLE `t_disable_query_delete_pk` (\n" +
+                        "  `id` int(11) NOT NULL,\n" +
+                        "  `v1` int(11) NOT NULL\n" +
+                        ") ENGINE=OLAP \n" +
+                        "PRIMARY KEY(`id`)\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 1 \n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"disable_query\" = \"true\"\n" +
+                        ");");
+
+        String deleteSql = "DELETE FROM test.t_disable_query_delete_pk WHERE id = 1";
+        Exception ex = Assertions.assertThrows(Exception.class, () ->
+                UtFrameUtils.getPlanAndFragment(ctx, deleteSql));
+        Assertions.assertTrue(
+                ex.getMessage().contains("the table test.t_disable_query_delete_pk property disable_query is true") ||
+                        ex.getMessage().contains("disable_query is true"),
+                "DELETE error message should mention disable_query is true. Got: " + ex.getMessage());
+    }
+}
+
+
+
+
+
+


### PR DESCRIPTION
## Why I'm doing:
Add a table property enable_query as a table-level query switch to protect the cluster from abnormal queries.

disable_query vs. SQL Blacklist

Metric | enable_query | SQL Blacklist
-- | -- | --
Performance | Minimal. Reads property once; no pattern matching. | High. Regex matching per query adds overhead.
Ease of Use | High. Simple ALTER TABLE to toggle. | Low. Requires complex, error-prone regex.
Maintainability | High. Auto-invalidates when table is dropped. | Low. Orphaned rules require manual cleanup.
Flexibility | Low. Table-level only. | High. Fine-grained SQL pattern control.


## What I'm doing:
Add a table property disable_query.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
