### PR TITLE
[Enhancement] add partition scan num limit when query external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -942,6 +942,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String SCAN_OLAP_PARTITION_NUM_LIMIT = "scan_olap_partition_num_limit";
 
+    public static final String SCAN_PAIMON_PARTITION_NUM_LIMIT = "scan_paimon_partition_num_limit";
+
     public static final String ENABLE_CROSS_JOIN = "enable_cross_join";
 
     public static final String ENABLE_NESTED_LOOP_JOIN = "enable_nested_loop_join";
@@ -2861,6 +2863,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // For the maximum number of partitions allowed to be scanned in a single olap table, 0 means no limit.
     @VarAttr(name = SCAN_OLAP_PARTITION_NUM_LIMIT)
     private int scanOlapPartitionNumLimit = 0;
+
+    // For the maximum number of partitions allowed to be scanned in a single paimon table, 0 means no limit.
+    @VarAttr(name = SCAN_PAIMON_PARTITION_NUM_LIMIT)
+    private int scanPaimonPartitionNumLimit = 0;
 
     @VarAttr(name = ENABLE_CROSS_JOIN)
     private boolean enableCrossJoin = true;
@@ -5325,6 +5331,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setScanOlapPartitionNumLimit(int scanOlapPartitionNumLimit) {
         this.scanOlapPartitionNumLimit = scanOlapPartitionNumLimit;
+    }
+
+    public int getScanPaimonPartitionNumLimit() {
+        return scanPaimonPartitionNumLimit;
+    }
+
+    public void setScanPaimonPartitionNumLimit(int scanPaimonPartitionNumLimit) {
+        this.scanPaimonPartitionNumLimit = scanPaimonPartitionNumLimit;
     }
 
     public boolean isEnableCrossJoin() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -942,7 +942,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String SCAN_OLAP_PARTITION_NUM_LIMIT = "scan_olap_partition_num_limit";
 
-    public static final String SCAN_PAIMON_PARTITION_NUM_LIMIT = "scan_paimon_partition_num_limit";
+    public static final String SCAN_LAKE_PARTITION_NUM_LIMIT = "scan_lake_partition_num_limit";
 
     public static final String ENABLE_CROSS_JOIN = "enable_cross_join";
 
@@ -2864,9 +2864,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = SCAN_OLAP_PARTITION_NUM_LIMIT)
     private int scanOlapPartitionNumLimit = 0;
 
-    // For the maximum number of partitions allowed to be scanned in a single paimon table, 0 means no limit.
-    @VarAttr(name = SCAN_PAIMON_PARTITION_NUM_LIMIT)
-    private int scanPaimonPartitionNumLimit = 0;
+    // For the maximum number of partitions allowed to be scanned in a single lake table, 0 means no limit.
+    @VarAttr(name = SCAN_LAKE_PARTITION_NUM_LIMIT)
+    private int scanLakePartitionNumLimit = 0;
 
     @VarAttr(name = ENABLE_CROSS_JOIN)
     private boolean enableCrossJoin = true;
@@ -5333,12 +5333,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.scanOlapPartitionNumLimit = scanOlapPartitionNumLimit;
     }
 
-    public int getScanPaimonPartitionNumLimit() {
-        return scanPaimonPartitionNumLimit;
+    public int getScanLakePartitionNumLimit() {
+        return scanLakePartitionNumLimit;
     }
 
-    public void setScanPaimonPartitionNumLimit(int scanPaimonPartitionNumLimit) {
-        this.scanPaimonPartitionNumLimit = scanPaimonPartitionNumLimit;
+    public void setScanLakePartitionNumLimit(int scanLakePartitionNumLimit) {
+        this.scanLakePartitionNumLimit = scanLakePartitionNumLimit;
     }
 
     public boolean isEnableCrossJoin() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2856,16 +2856,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ALLOW_HIVE_WITHOUT_PARTITION_FILTER)
     private boolean allowHiveWithoutPartitionFilter = true;
 
-    // For the maximum number of partitions allowed to be scanned in a single hive table, 0 means no limit.
-    @VarAttr(name = SCAN_HIVE_PARTITION_NUM_LIMIT)
-    private int scanHivePartitionNumLimit = 0;
-
     // For the maximum number of partitions allowed to be scanned in a single olap table, 0 means no limit.
     @VarAttr(name = SCAN_OLAP_PARTITION_NUM_LIMIT)
     private int scanOlapPartitionNumLimit = 0;
 
     // For the maximum number of partitions allowed to be scanned in a single lake table, 0 means no limit.
-    @VarAttr(name = SCAN_LAKE_PARTITION_NUM_LIMIT)
+    @VarAttr(name = SCAN_LAKE_PARTITION_NUM_LIMIT, alias = SCAN_HIVE_PARTITION_NUM_LIMIT)
     private int scanLakePartitionNumLimit = 0;
 
     @VarAttr(name = ENABLE_CROSS_JOIN)
@@ -5315,14 +5311,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setAllowHiveWithoutPartitionFilter(boolean allowHiveWithoutPartitionFilter) {
         this.allowHiveWithoutPartitionFilter = allowHiveWithoutPartitionFilter;
-    }
-
-    public int getScanHivePartitionNumLimit() {
-        return scanHivePartitionNumLimit;
-    }
-
-    public void setScanHivePartitionNumLimit(int scanHivePartitionNumLimit) {
-        this.scanHivePartitionNumLimit = scanHivePartitionNumLimit;
     }
 
     public int getScanOlapPartitionNumLimit() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -60,6 +60,8 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.transformation.ListPartitionPruner;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.Split;
 
 import java.util.ArrayList;
@@ -450,6 +452,26 @@ public class OptExternalPartitionPruner {
             long rowCount = getRowCount(splits);
             if (rowCount > 0) {
                 scanOperatorPredicates.getSelectedPartitionIds().add(1L);
+            }
+
+            //check scan partition num
+            Set<BinaryRow> selectedPartitions = new HashSet<>();
+            for (Split split : splits) {
+                if (split instanceof DataSplit) {
+                    DataSplit dataSplit = (DataSplit) split;
+                    selectedPartitions.add(dataSplit.partition());
+                } else {
+                    // paimon system table, do nothing
+                }
+            }
+            int scanPaimonPartitionNumLimit = context.getSessionVariable().getScanPaimonPartitionNumLimit();
+            if (scanPaimonPartitionNumLimit > 0 && selectedPartitions.size() > scanPaimonPartitionNumLimit) {
+                String msg = "Exceeded the limit of number of paimon table partitions to be scanned. " +
+                        "Number of partitions allowed: " + scanPaimonPartitionNumLimit +
+                        ", number of partitions to be scanned: " + selectedPartitions.size() +
+                        ". Please adjust the SQL or change the limit by set variable scan_paimon_partition_num_limit.";
+                LOG.warn("{} queryId: {}", msg, DebugUtil.printId(context.getQueryId()));
+                throw new AnalysisException(msg);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -460,16 +460,14 @@ public class OptExternalPartitionPruner {
                 if (split instanceof DataSplit) {
                     DataSplit dataSplit = (DataSplit) split;
                     selectedPartitions.add(dataSplit.partition());
-                } else {
-                    // paimon system table, do nothing
                 }
             }
-            int scanPaimonPartitionNumLimit = context.getSessionVariable().getScanPaimonPartitionNumLimit();
-            if (scanPaimonPartitionNumLimit > 0 && selectedPartitions.size() > scanPaimonPartitionNumLimit) {
+            int scanLakePartitionNumLimit = context.getSessionVariable().getScanLakePartitionNumLimit();
+            if (scanLakePartitionNumLimit > 0 && selectedPartitions.size() > scanLakePartitionNumLimit) {
                 String msg = "Exceeded the limit of number of paimon table partitions to be scanned. " +
-                        "Number of partitions allowed: " + scanPaimonPartitionNumLimit +
+                        "Number of partitions allowed: " + scanLakePartitionNumLimit +
                         ", number of partitions to be scanned: " + selectedPartitions.size() +
-                        ". Please adjust the SQL or change the limit by set variable scan_paimon_partition_num_limit.";
+                        ". Please adjust the SQL or change the limit by set variable scan_lake_partition_num_limit.";
                 LOG.warn("{} queryId: {}", msg, DebugUtil.printId(context.getQueryId()));
                 throw new AnalysisException(msg);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -418,10 +418,10 @@ public class OptExternalPartitionPruner {
                 selectedPartitionIds = scanOperatorPredicates.getIdToPartitionKey().keySet();
             }
 
-            int scanHivePartitionNumLimit = context.getSessionVariable().getScanHivePartitionNumLimit();
-            if (scanHivePartitionNumLimit > 0 && !table.isUnPartitioned()
-                    && selectedPartitionIds.size() > scanHivePartitionNumLimit) {
-                String msg = "Exceeded the limit of " + scanHivePartitionNumLimit + " max scan hive external partitions";
+            int scanLakePartitionNumLimit = context.getSessionVariable().getScanLakePartitionNumLimit();
+            if (scanLakePartitionNumLimit > 0 && !table.isUnPartitioned()
+                    && selectedPartitionIds.size() > scanLakePartitionNumLimit) {
+                String msg = "Exceeded the limit of " + scanLakePartitionNumLimit + " max scan hive external partitions";
                 LOG.warn("{} queryId: {}", msg, DebugUtil.printId(context.getQueryId()));
                 throw new AnalysisException(msg);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneLimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneLimitTest.java
@@ -31,7 +31,7 @@ public class HivePartitionPruneLimitTest extends ConnectorPlanTestBase {
         try {
             connectContext.changeCatalogDb("hive0.partitioned_db");
             connectContext.getSessionVariable().setAllowHiveWithoutPartitionFilter(false);
-            connectContext.getSessionVariable().setScanHivePartitionNumLimit(10);
+            connectContext.getSessionVariable().setScanLakePartitionNumLimit(10);
         } catch (DdlException e) {
             throw new RuntimeException(e);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PaimonPartitionPruneLimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PaimonPartitionPruneLimitTest.java
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.DdlException;
+import com.starrocks.common.ExceptionChecker;
+import com.starrocks.sql.common.StarRocksPlannerException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PaimonPartitionPruneLimitTest extends ConnectorPlanTestBase {
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        try {
+            connectContext.changeCatalogDb("paimon0.pmn_db1");
+        } catch (DdlException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testPaimonPartitionPruneLimit() throws Exception {
+        // 1.partition table
+        String sql1 = "select * from partitioned_table;";
+
+        // param default value: 0
+        String plan1 = getFragmentPlan(sql1);
+        assertContains(plan1, "partitions=10/10");
+
+        // param value > scan partition num
+        connectContext.getSessionVariable().setScanPaimonPartitionNumLimit(20);
+        String plan2 = getFragmentPlan(sql1);
+        assertContains(plan2, "partitions=10/10");
+
+        // param value < scan partition num
+        connectContext.getSessionVariable().setScanPaimonPartitionNumLimit(3);
+        String msg = "Exceeded the limit of number of paimon table partitions to be scanned. " +
+                "Number of partitions allowed: 3, number of partitions to be scanned: 10. " +
+                "Please adjust the SQL or change the limit by set variable scan_paimon_partition_num_limit.";
+        ExceptionChecker.expectThrowsWithMsg(StarRocksPlannerException.class, msg,
+                () -> getFragmentPlan(sql1));
+
+        // 2.unpartition table
+        String sql2 = "select * from unpartitioned_table;";
+
+        connectContext.getSessionVariable().setScanPaimonPartitionNumLimit(3);
+        String plan3 = getFragmentPlan(sql2);
+        assertContains(plan3, "partitions=1/1");
+
+        // 3.system table
+        String sql3 = "select * from partitioned_table$snapshots;";
+
+        connectContext.getSessionVariable().setScanPaimonPartitionNumLimit(3);
+        String plan4 = getFragmentPlan(sql3);
+        assertContains(plan4, "partitions=0/10");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PaimonPartitionPruneLimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PaimonPartitionPruneLimitTest.java
@@ -36,35 +36,35 @@ public class PaimonPartitionPruneLimitTest extends ConnectorPlanTestBase {
         // 1.partition table
         String sql1 = "select * from partitioned_table;";
 
-        // param default value: 0
+        // variable default value: 0
         String plan1 = getFragmentPlan(sql1);
         assertContains(plan1, "partitions=10/10");
 
-        // param value > scan partition num
-        connectContext.getSessionVariable().setScanPaimonPartitionNumLimit(20);
+        // variable value > scan partition num
+        connectContext.getSessionVariable().setScanLakePartitionNumLimit(20);
         String plan2 = getFragmentPlan(sql1);
         assertContains(plan2, "partitions=10/10");
 
-        // param value < scan partition num
-        connectContext.getSessionVariable().setScanPaimonPartitionNumLimit(3);
+        // variable value < scan partition num
+        connectContext.getSessionVariable().setScanLakePartitionNumLimit(3);
         String msg = "Exceeded the limit of number of paimon table partitions to be scanned. " +
                 "Number of partitions allowed: 3, number of partitions to be scanned: 10. " +
-                "Please adjust the SQL or change the limit by set variable scan_paimon_partition_num_limit.";
+                "Please adjust the SQL or change the limit by set variable scan_lake_partition_num_limit.";
         ExceptionChecker.expectThrowsWithMsg(StarRocksPlannerException.class, msg,
                 () -> getFragmentPlan(sql1));
 
         // 2.unpartition table
         String sql2 = "select * from unpartitioned_table;";
 
-        connectContext.getSessionVariable().setScanPaimonPartitionNumLimit(3);
+        connectContext.getSessionVariable().setScanLakePartitionNumLimit(3);
         String plan3 = getFragmentPlan(sql2);
         assertContains(plan3, "partitions=1/1");
 
         // 3.system table
         String sql3 = "select * from partitioned_table$snapshots;";
 
-        connectContext.getSessionVariable().setScanPaimonPartitionNumLimit(3);
+        connectContext.getSessionVariable().setScanLakePartitionNumLimit(3);
         String plan4 = getFragmentPlan(sql3);
-        assertContains(plan4, "partitions=0/10");
+        assertContains(plan4, "partitions=0/1");
     }
 }


### PR DESCRIPTION
## Why I'm doing:
when query big size paimon table or other external table with full table scan or scan too many partitions, would cause BE/CN node high load, lead to cluster instability.

## What I'm doing:
add a new FE session variable scan_lake_partition_num_limit to limit partition scan num when query paimon table.
(default value is 0, means no limitation)

note: the new session variable `scan_lake_partition_num_limit` replace the old variable `scan_hive_partition_num_limit`(still remain) to uniformly handle the lake partition limit . 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
