### PR TITLE
[BugFix] fix unstable case test_parallel_upsert_with_multiple_memtables

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -48,6 +48,13 @@ LakePersistentIndex::~LakePersistentIndex() {
     if (_memtable) {
         _memtable->clear();
     }
+    // Cancel all flushing memtable tasks
+    for (auto& memtable : _inactive_memtables) {
+        if (memtable) {
+            memtable->cancel();
+        }
+    }
+    _inactive_memtables.clear();
     _sstable_filesets.clear();
 }
 

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -2146,6 +2146,9 @@ TEST_P(LakePrimaryKeyPublishTest, test_parallel_upsert_with_multiple_memtables) 
     // update memory usage, should large than zero
     EXPECT_TRUE(_update_mgr->mem_tracker()->consumption() > 0);
     ASSERT_EQ(chunk_size, read_rows(tablet_id, version));
+    if (config::enable_pk_index_parallel_execution) {
+        ExecEnv::GetInstance()->pk_index_memtable_flush_thread_pool()->wait();
+    }
     // reset configs
     config::enable_pk_index_parallel_execution = old_enable_pk_index_parallel_execution;
     config::pk_index_parallel_execution_min_rows = old_pk_index_parallel_execution_min_rows;


### PR DESCRIPTION
## Why I'm doing:
unstable case: LakePrimaryKeyPublishTest/LakePrimaryKeyPublishTest.test_parallel_upsert_with_multiple_memtables

## What I'm doing:
### Summary

  - Fix unstable unit test test_parallel_upsert_with_multiple_memtables by properly canceling background memtable flush tasks in LakePersistentIndex destructor

 ### Problem

  The test test_parallel_upsert_with_multiple_memtables was flaky because of a race condition during test cleanup:

  1. The test enables parallel memtable flush by submitting tasks to pk_index_memtable_flush_thread_pool
  2. When the test completes, TearDown() deletes the test directory
  3. Background flush tasks in _inactive_memtables may still be running
  4. These tasks access TabletManager::sst_location() which references the deleted directory
  5. This causes "No such file or directory" errors followed by SIGSEGV

 ### Solution

  Cancel all pending memtable flush tasks in LakePersistentIndex::~LakePersistentIndex() before the object is destroyed:
```
  // Cancel all flushing memtable tasks
  for (auto& memtable : _inactive_memtables) {
      if (memtable) {
          memtable->cancel();
      }
  }
  _inactive_memtables.clear();
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
