### PR TITLE
[Enhancement] Add optimizer trace logging for planning failures

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2261,6 +2261,10 @@ public class Config extends ConfigBase {
             "will not be recorded during query optimization")
     public static boolean enable_predicate_columns_collection = true;
 
+    @ConfField(mutable = true, comment = "If enabled, FE will always collect optimizer timer traces during plan " +
+            "generation and dump them to logs when plan generation fails (e.g. CBO timeout) for diagnosis.")
+    public static boolean enable_dump_optimizer_trace_on_error = false;
+
     /**
      * Num of thread to handle statistic collect(analyze command)
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -157,6 +157,22 @@ public class Tracers {
         return (tracers.moduleMask & 1 << m.ordinal()) != 0;
     }
 
+    public static void enableTraceModule(Module m) {
+        if (m == null || m == Module.NONE) {
+            return;
+        }
+        Tracers tracers = THREAD_LOCAL.get();
+        tracers.moduleMask |= 1 << m.ordinal();
+    }
+
+    public static void enableTraceMode(Mode m) {
+        if (m == null || m == Mode.NONE) {
+            return;
+        }
+        Tracers tracers = THREAD_LOCAL.get();
+        tracers.modeMask |= 1 << m.ordinal();
+    }
+
     public static void close() {
         THREAD_LOCAL.remove();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
@@ -241,8 +241,8 @@ class ColumnUsageTest extends PlanTestBase {
             List<StatisticsCollectJob> collectJobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(analyzeJob);
             Assertions.assertEquals(1, collectJobs.size());
             StatisticsCollectJob job0 = collectJobs.get(0);
-            Assertions.assertEquals(StatsConstants.AnalyzeType.SAMPLE, job0.getAnalyzeType());
-            Assertions.assertEquals(List.of("v1", "v2", "v3"), job0.getColumnNames());
+            Assertions.assertEquals(StatsConstants.AnalyzeType.FULL, job0.getAnalyzeType());
+            Assertions.assertEquals(List.of("v1"), job0.getColumnNames());
             Config.statistic_auto_collect_small_table_size = defaultSmallTableSize;
             Config.statistic_auto_collect_max_predicate_column_size_on_sample_strategy = defaultPredicateColumnSize;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ColumnUsageTest.java
@@ -241,8 +241,8 @@ class ColumnUsageTest extends PlanTestBase {
             List<StatisticsCollectJob> collectJobs = StatisticsCollectJobFactory.buildStatisticsCollectJob(analyzeJob);
             Assertions.assertEquals(1, collectJobs.size());
             StatisticsCollectJob job0 = collectJobs.get(0);
-            Assertions.assertEquals(StatsConstants.AnalyzeType.FULL, job0.getAnalyzeType());
-            Assertions.assertEquals(List.of("v1"), job0.getColumnNames());
+            Assertions.assertEquals(StatsConstants.AnalyzeType.SAMPLE, job0.getAnalyzeType());
+            Assertions.assertEquals(List.of("v1", "v2", "v3"), job0.getColumnNames());
             Config.statistic_auto_collect_small_table_size = defaultSmallTableSize;
             Config.statistic_auto_collect_max_predicate_column_size_on_sample_strategy = defaultPredicateColumnSize;
         }


### PR DESCRIPTION
## Why I'm doing:
StarRocks supports `TRACE TIMES OPTIMIZER` to help diagnose slow optimizer rules/tasks, but it requires users to **explicitly add TRACE** to the SQL. In production incidents (especially **planning failures / CBO timeout / planner exceptions**), users often only have the failed SQL and an error message, and cannot easily reproduce the exact environment to run `TRACE TIMES OPTIMIZER` again. As a result, it’s hard to quickly identify **which optimizer stage/rule is slow** or where the planning time is spent.

## What I'm doing:
- Add a new FE config **`enable_dump_optimizer_trace_on_error`** (mutable, default `false`).
- When this config is enabled, FE will **collect optimizer TIMER trace during plan generation** and **dump a `trace times optimizer`-style timing tree** into FE logs **only when plan generation fails** (e.g. CBO timeout / planner exception), including:
  - `query_id`
  - redacted `sql`
  - `err` (exception type + message)
  - timing tree output (with truncation protection)

log example
default:
<img width="538" height="199" alt="image" src="https://github.com/user-attachments/assets/a0bfa394-9550-4bb7-b709-052e0fa61656" />

enable enable_dump_optimizer_trace_on_error:
<img width="606" height="866" alt="image" src="https://github.com/user-attachments/assets/6e1ac68e-8500-4d81-9785-73c8d92c195c" />


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
