### PR TITLE
[Enhancement] Support dry run mode for repairing cloud native tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -288,6 +288,8 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_ENFORCE_CONSISTENT_VERSION = "enforce_consistent_version";
     // Allows empty tablet recovery of tablets with no valid metadata
     public static final String PROPERTIES_ALLOW_EMPTY_TABLET_RECOVERY = "allow_empty_tablet_recovery";
+    // If true, just return the repair plan without executing it
+    public static final String PROPERTIES_DRY_RUN = "dry_run";
 
     /**
      * Matches location labels like : ["*", "a:*", "bcd_123:*", "123bcd_:val_123", "  a :  b  "],

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -829,6 +829,9 @@ public class DDLStmtExecutor {
 
         @Override
         public ShowResultSet visitAdminRepairTableStatement(AdminRepairTableStmt stmt, ConnectContext context) {
+            List<List<String>> result = Lists.newArrayList();
+            boolean isDryRun = stmt.isDryRun();
+
             ErrorReport.wrapWithRuntimeException(() -> {
                 String dbName = stmt.getDbName() != null ? stmt.getDbName() : context.getDatabase();
                 Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
@@ -847,16 +850,31 @@ public class DDLStmtExecutor {
                     PartitionRef partitionRef = stmt.getPartitionRef();
                     List<String> partitionNames = partitionRef != null ? partitionRef.getPartitionNames() : Lists.newArrayList();
                     ComputeResource computeResource = context.getCurrentComputeResource();
-                    TabletRepairHelper.repair(stmt, db, (OlapTable) table, partitionNames, computeResource);
+
+                    if (isDryRun) {
+                        List<List<String>> rows =
+                                TabletRepairHelper.dryRunRepair(stmt, db, (OlapTable) table, partitionNames, computeResource);
+                        result.addAll(rows);
+                    } else {
+                        TabletRepairHelper.repair(stmt, db, (OlapTable) table, partitionNames, computeResource);
+                    }
                 } else if (table.isCloudNativeMaterializedView()) {
                     // cloud native mv
                     throw new DdlException("Repair cloud native materialized view is not supported");
                 } else {
                     // olap table or mv
+                    if (isDryRun) {
+                        throw new DdlException("Dry run is only supported for cloud-native tables");
+                    }
                     GlobalStateMgr.getCurrentState().getTabletChecker().repairTable(context, stmt);
                 }
             });
-            return null;
+
+            if (isDryRun) {
+                return new ShowResultSet(TabletRepairHelper.getDryRunRepairResultMetaData(), result);
+            } else {
+                return null;
+            }
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AdminStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AdminStmtAnalyzer.java
@@ -175,6 +175,9 @@ public class AdminStmtAnalyzer {
                         properties, PropertyAnalyzer.PROPERTIES_ALLOW_EMPTY_TABLET_RECOVERY, false);
                 adminRepairTableStmt.setAllowEmptyTabletRecovery(allowEmptyTabletRecovery);
 
+                boolean dryRun = PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_DRY_RUN, false);
+                adminRepairTableStmt.setDryRun(dryRun);
+
                 if (!properties.isEmpty()) {
                     ErrorReport.reportSemanticException(ErrorCode.ERR_UNKNOWN_PROPERTY, properties);
                 }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AdminRepairTableStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AdminRepairTableStmt.java
@@ -28,6 +28,8 @@ public class AdminRepairTableStmt extends DdlStmt {
     private boolean enforceConsistentVersion = true;
     // Allows empty tablet recovery of tablets with no valid metadata
     private boolean allowEmptyTabletRecovery = false;
+    // If true, just return the repair plan without executing it
+    private boolean dryRun = false;
 
     public AdminRepairTableStmt(TableRef tblRef, Map<String, String> properties, NodePosition pos) {
         super(pos);
@@ -65,6 +67,14 @@ public class AdminRepairTableStmt extends DdlStmt {
 
     public void setAllowEmptyTabletRecovery(boolean allowEmptyTabletRecovery) {
         this.allowEmptyTabletRecovery = allowEmptyTabletRecovery;
+    }
+
+    public boolean isDryRun() {
+        return dryRun;
+    }
+
+    public void setDryRun(boolean dryRun) {
+        this.dryRun = dryRun;
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This PR adds a `dry_run` option to the `ADMIN REPAIR TABLE` statement, allowing users to preview the repair plan without executing it. This is currently only supported for cloud native tables.

Usage:
```
ADMIN REPAIR TABLE table_name PARTITION (p1) PROPERTIES ("dry_run" = "true");
```

```
mysql> admin repair table t properties("dry_run" = "true");
+-------------+----------------+--------------+-------------------+----------+
| PartitionId | VisibleVersion | RepairStatus | TabletRecoverInfo | ErrorMsg |
+-------------+----------------+--------------+-------------------+----------+
| 10183       | 5              | NORMAL       | []                |          |
+-------------+----------------+--------------+-------------------+----------+
1 row in set (0.04 sec)

mysql> admin repair table t1 properties("dry_run" = "true");
+-------------+----------------+---------------+-------------------+-----------------------------------------------------------------------------------------------------+
| PartitionId | VisibleVersion | RepairStatus  | TabletRecoverInfo | ErrorMsg                                                                                            |
+-------------+----------------+---------------+-------------------+-----------------------------------------------------------------------------------------------------+
| 86039       | 4              | UNRECOVERABLE | []                | no consistent valid tablet metadata version was found, you can set enforce_consistent_version=false |
+-------------+----------------+---------------+-------------------+-----------------------------------------------------------------------------------------------------+
1 row in set (0.10 sec)

mysql> admin repair table t1 properties("dry_run" = "true", "enforce_consistent_version" = "false");
+-------------+----------------+---------------+-------------------+---------------------------------------------------------------------------------------------------------------------------------------+
| PartitionId | VisibleVersion | RepairStatus  | TabletRecoverInfo | ErrorMsg                                                                                                                              |
+-------------+----------------+---------------+-------------------+---------------------------------------------------------------------------------------------------------------------------------------+
| 86039       | 4              | UNRECOVERABLE | []                | no tablet metadatas were found for tablets [86042], you can set enforce_consistent_version=false and allow_empty_tablet_recovery=true |
+-------------+----------------+---------------+-------------------+---------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.15 sec)

mysql> admin repair table t1 properties("dry_run" = "true", "enforce_consistent_version" = "false", "allow_empty_tablet_recovery" = "true");
+-------------+----------------+--------------+---------------------------------------------------------------------------------------------------------------------+----------+
| PartitionId | VisibleVersion | RepairStatus | TabletRecoverInfo                                                                                                   | ErrorMsg |
+-------------+----------------+--------------+---------------------------------------------------------------------------------------------------------------------+----------+
| 86039       | 4              | RECOVERABLE  | [{"tabletId":86040,"recoverVersion":4},{"tabletId":86041,"recoverVersion":3},{"tabletId":86042,"recoverVersion":0}] |          |
+-------------+----------------+--------------+---------------------------------------------------------------------------------------------------------------------+----------+
1 row in set (0.14 sec)
```

https://github.com/StarRocks/starrocks/issues/66015

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
