### PR TITLE
[Enhancement] Add interface to add physical partition for random distribution table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1710,6 +1710,12 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
     public void addSubPartitions(Database db, OlapTable table, Partition partition,
                                  int numSubPartition, ComputeResource computeResource) throws DdlException {
+        addSubPartitions(db, table, partition, numSubPartition, 0, computeResource);
+    }
+
+    public void addSubPartitions(Database db, OlapTable table, Partition partition,
+                                 int numSubPartition, int bucketNum,
+                                 ComputeResource computeResource) throws DdlException {
         try {
             table.setAutomaticBucketing(true);
 
@@ -1727,6 +1733,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 copiedTable = AnalyzerUtils.getShadowCopyTable(olapTable);
             } finally {
                 locker.unLockTableWithIntensiveDbLock(db.getId(), olapTable.getId(), LockType.READ);
+            }
+
+            // Set user-specified bucket number on the copied table (thread-safe, no impact on the original table)
+            if (bucketNum > 0) {
+                copiedTable.setMutableBucketNum(bucketNum);
             }
 
             Preconditions.checkNotNull(olapTable);
@@ -1772,6 +1783,88 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         } finally {
             table.setAutomaticBucketing(false);
         }
+    }
+
+    /**
+     * Add a new physical partition to an existing logical partition.
+     * This method is designed to be called via admin execute script for cross-cluster
+     * data replication scenarios.
+     *
+     *
+     * @param dbName        the database name
+     * @param tableName     the table name
+     * @param partitionName the partition name (null for non-partitioned table)
+     * @param bucketNum     the bucket number (0 to use system default)
+     */
+    public void addPhysicalPartition(String dbName, String tableName, String partitionName,
+                                     int bucketNum) throws DdlException {
+        Database db = getDb(dbName);
+        if (db == null) {
+            throw new DdlException("Database '" + dbName + "' does not exist");
+        }
+
+        Table table = getTable(dbName, tableName);
+        if (table == null) {
+            throw new DdlException("Table '" + tableName + "' does not exist in database '" + dbName + "'");
+        }
+
+        if (!(table instanceof OlapTable)) {
+            throw new DdlException("Only OLAP table supports adding physical partition");
+        }
+
+        OlapTable olapTable = (OlapTable) table;
+
+        // Check if the table uses random distribution
+        if (olapTable.getDefaultDistributionInfo().getType() != DistributionInfo.DistributionInfoType.RANDOM) {
+            throw new DdlException("Only random distribution table supports adding physical partition");
+        }
+
+        Partition partition;
+        if (partitionName == null) {
+            // For non-partitioned table, get the single partition
+            if (olapTable.getPartitionInfo().isPartitioned()) {
+                throw new DdlException("Partition name must be specified for partitioned table");
+            }
+            Collection<Partition> partitions = olapTable.getPartitions();
+            if (partitions.size() != 1) {
+                throw new DdlException("Non-partitioned table should have exactly one partition");
+            }
+            partition = partitions.iterator().next();
+        } else {
+            partition = olapTable.getPartition(partitionName);
+            if (partition == null) {
+                throw new DdlException("Partition '" + partitionName + "' does not exist");
+            }
+        }
+
+        // Validate distribution type at partition level
+        if (partition.getDistributionInfo().getType() != DistributionInfo.DistributionInfoType.RANDOM) {
+            throw new DdlException("Only random distribution table supports adding physical partition");
+        }
+
+        if (bucketNum < 0) {
+            throw new DdlException("Bucket number must be non-negative");
+        }
+
+        if (bucketNum > Config.max_bucket_number_per_partition) {
+            throw new DdlException("Bucket number exceeds maximum allowed: " + Config.max_bucket_number_per_partition);
+        }
+
+        // Get compute resource
+        long warehouseId = ConnectContext.get() != null
+                ? ConnectContext.get().getCurrentWarehouseId()
+                : WarehouseManager.DEFAULT_WAREHOUSE_ID;
+        final WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        final CRAcquireContext acquireContext = CRAcquireContext.of(warehouseId);
+        final ComputeResource computeResource = warehouseManager.acquireComputeResource(acquireContext);
+
+        // Add one physical partition with the specified bucket number.
+        // The bucketNum is set on the shadow-copied table inside addSubPartitions,
+        // so there is no concurrent safety issue with the original table object.
+        addSubPartitions(db, olapTable, partition, 1, bucketNum, computeResource);
+
+        LOG.info("Successfully added physical partition to partition '{}' in table '{}'",
+                partition.getName(), olapTable.getName());
     }
 
     public void replayAddSubPartition(PhysicalPartitionPersistInfoV2 info) throws DdlException {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -1362,6 +1362,21 @@ public class AlterTest {
             Assertions.assertFalse(physicalPartition.isFirstLoad());
         }
 
+        // Test addSubPartitions with custom bucket number
+        long originalMutableBucketNum = table.getMutableBucketNum();
+        GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table, partition.get(), 1,
+                    5, WarehouseManager.DEFAULT_RESOURCE);
+        Assertions.assertEquals(partition.get().getSubPartitions().size(), 5);
+        Assertions.assertEquals(table.getPhysicalPartitions().size(), 5);
+
+        // Verify the new physical partition has the specified bucket number
+        PhysicalPartition newPartition = partition.get().getSubPartitions().stream()
+                .reduce((first, second) -> second).orElseThrow(); // get last added
+        Assertions.assertEquals(5, newPartition.getBucketNum());
+
+        // Verify original table's mutableBucketNum is not modified
+        Assertions.assertEquals(originalMutableBucketNum, table.getMutableBucketNum());
+
         dropSQL = "drop table test_partition";
         dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
         GlobalStateMgr.getCurrentState().getLocalMetastore().dropTable(dropTableStmt);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -1364,6 +1364,8 @@ public class AlterTest {
 
         // Test addSubPartitions with custom bucket number
         long originalMutableBucketNum = table.getMutableBucketNum();
+        Set<Long> existingIds = partition.get().getSubPartitions().stream()
+                .map(PhysicalPartition::getId).collect(java.util.stream.Collectors.toSet());
         GlobalStateMgr.getCurrentState().getLocalMetastore().addSubPartitions(db, table, partition.get(), 1,
                     5, WarehouseManager.DEFAULT_RESOURCE);
         Assertions.assertEquals(partition.get().getSubPartitions().size(), 5);
@@ -1371,7 +1373,8 @@ public class AlterTest {
 
         // Verify the new physical partition has the specified bucket number
         PhysicalPartition newPartition = partition.get().getSubPartitions().stream()
-                .reduce((first, second) -> second).orElseThrow(); // get last added
+                .filter(p -> !existingIds.contains(p.getId()))
+                .findFirst().orElseThrow();
         Assertions.assertEquals(5, newPartition.getBucketNum());
 
         // Verify original table's mutableBucketNum is not modified


### PR DESCRIPTION
## Why I'm doing:
StarRocks supports automatic bucketing for random distribution tables, where multiple physical partitions (sub-partitions) can exist within a single logical partition.

For cross-cluster data replication scenarios, the target cluster needs the ability to create matching physical partition structures. Since this capability is only used by internal migration tools (not end users), we expose it via ADMIN EXECUTE ON FRONTEND script
## What I'm doing:

Fixes #68502

Add a LocalMetastore.addPhysicalPartition(dbName, tableName, partitionName, bucketNum) method that can be invoked via admin execute script:
```sql
-- For partitioned tables:
ADMIN EXECUTE ON FRONTEND 'metastore.addPhysicalPartition("db_name", "table_name", "partition_name", 8)';

-- For non-partitioned tables (pass null as partition name):
ADMIN EXECUTE ON FRONTEND 'metastore.addPhysicalPartition("db_name", "table_name", null, 0)';
```
Parameters:
- dbName: database name
- tableName: table name
- partitionName: partition name (null for non-partitioned tables, required for partitioned tables)
- bucketNum: bucket number (0 to use system default)
Validation:
- Only OLAP tables with random distribution are supported
- Bucket number must be non-negative and within max_bucket_number_per_partition
- For partitioned tables, partition name must be specified and must exist

Demo 
```sql
MySQL [test]> show create table details1\G
*************************** 1. row ***************************
       Table: details1
Create Table: CREATE TABLE `details1` (
  `event_day` date NULL COMMENT "",
  `site_id` int(11) NULL DEFAULT "10" COMMENT "",
  `pv` bigint(20) NULL DEFAULT "0" COMMENT "",
  `city_code` varchar(100) NULL COMMENT "",
  `user_name` varchar(32) NULL DEFAULT "" COMMENT ""
) ENGINE=OLAP 
DUPLICATE KEY(`event_day`, `site_id`, `pv`)
COMMENT "OLAP"
DISTRIBUTED BY RANDOM
PROPERTIES (
"bucket_size" = "1024",
"compression" = "LZ4",
"datacache.enable" = "true",
"enable_async_write_back" = "false",
"replication_num" = "1",
"storage_volume" = "builtin_storage_volume"
);
1 row in set (0.01 sec)

MySQL [test]> ADMIN EXECUTE ON FRONTEND 'metastore.addPhysicalPartition("test", "details1", "details1", 8)';

+--------+
| result |
+--------+
|        |
+--------+
1 row in set (0.74 sec)

MySQL [test]> 
MySQL [test]> show partitions from details1;
+-------------+---------------+----------------+----------------+-------------+--------+--------------+-------+-----------------+---------+----------+-------------+----------+-----------------+------------+-------+-------+-------+-------------+--------------------+----------------+
| PartitionId | PartitionName | CompactVersion | VisibleVersion | NextVersion | State  | PartitionKey | Range | DistributionKey | Buckets | DataSize | StorageSize | RowCount | EnableDataCache | AsyncWrite | AvgCS | P50CS | MaxCS | DataVersion | VersionEpoch       | VersionTxnType |
+-------------+---------------+----------------+----------------+-------------+--------+--------------+-------+-----------------+---------+----------+-------------+----------+-----------------+------------+-------+-------+-------+-------------+--------------------+----------------+
| 15541       | details1      | 0              | 1              | 2           | NORMAL |              |       | ALL KEY         | 6       | 0B       | 0B          | 0        | true            | false      | 0.00  | 0.00  | 0.00  | 1           | 404889879156097024 | TXN_NORMAL     |
| 15510       | details1      | 0              | 2              | 3           | NORMAL |              |       | ALL KEY         | 6       | 0B       | 0B          | 0        | true            | false      | 0.00  | 0.00  | 0.00  | 2           | 404889266135498752 | TXN_NORMAL     |
+-------------+---------------+----------------+----------------+-------------+--------+--------------+-------+-----------------+---------+----------+-------------+----------+-----------------+------------+-------+-------+-------+-------------+--------------------+----------------+
2 rows in set (0.00 sec)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
