### PR TITLE
[BugFix] pk table char column no padding during alter

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -4400,6 +4400,7 @@ Status TabletUpdates::_convert_from_base_rowset(const Schema& base_schema, const
                                                 const std::unique_ptr<RowsetWriter>& rowset_writer) {
     ChunkPtr base_chunk = ChunkHelper::new_chunk(base_schema, config::vector_chunk_size);
     ChunkPtr new_chunk = ChunkHelper::new_chunk(new_schema, config::vector_chunk_size);
+    auto char_field_indexes = ChunkHelper::get_char_field_indexes(new_schema);
 
     std::unique_ptr<MemPool> mem_pool(new MemPool());
 
@@ -4426,6 +4427,8 @@ Status TabletUpdates::_convert_from_base_rowset(const Schema& base_schema, const
             if (!status.ok()) {
                 return Status::InternalError("failed to fill generated column");
             }
+            ChunkHelper::padding_char_columns(char_field_indexes, new_schema, _tablet.tablet_schema(), new_chunk.get());
+
             RETURN_IF_ERROR(rowset_writer->add_chunk(*new_chunk));
         }
     }
@@ -4503,6 +4506,7 @@ Status TabletUpdates::reorder_from(const std::shared_ptr<Tablet>& base_tablet, i
         cids.push_back(i);
     }
     Schema new_schema = ChunkHelper::convert_schema(tschema, cids);
+    auto char_field_indexes = ChunkHelper::get_char_field_indexes(new_schema);
     for (int i = 0; i < src_rowsets.size(); i++) {
         const auto& src_rowset = src_rowsets[i];
 
@@ -4570,6 +4574,8 @@ Status TabletUpdates::reorder_from(const std::shared_ptr<Tablet>& base_tablet, i
                     RETURN_ERROR_IF_FALSE(chunk_sort_ok, "chunk data sort failed");
                 }
                 chunk_arr.push_back(new_chunk);
+                ChunkHelper::padding_char_columns(char_field_indexes, new_schema, _tablet.tablet_schema(),
+                                                  new_chunk.get());
             }
         }
 

--- a/test/sql/test_alter_table/R/test_alter_table_abnormal
+++ b/test/sql/test_alter_table/R/test_alter_table_abnormal
@@ -317,3 +317,37 @@ insert into test values('2020-01-01', '2024-10-30 11:17:01', 'asfgrgte', 'werger
 alter table test modify PARTITION (*) set ("storage_cooldown_ttl" = "1 year", "storage_medium" = "SSD");
 -- result:
 -- !result
+
+-- name: test_pk_alter_char
+CREATE TABLE test2
+(
+    k1 BIGINT,
+    v1 LARGEINT,
+    v2 CHAR(4)
+)
+ENGINE=olap
+PRIMARY KEY(k1)
+DISTRIBUTED BY HASH (k1) BUCKETS 3
+PROPERTIES(
+    "replication_num"="1"
+);
+-- result:
+-- !result
+insert into test2 values (1, 1, '1');
+-- result:
+-- !result
+select * from test2 where v2 = '1';
+-- result:
+1	1	1
+-- !result
+alter table test2 add index test_bitmap(v1);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from test2 where v2 = '1';
+-- result:
+1	1	1
+-- !result

--- a/test/sql/test_alter_table/T/test_alter_table_abnormal
+++ b/test/sql/test_alter_table/T/test_alter_table_abnormal
@@ -149,3 +149,26 @@ PROPERTIES (
 );
 insert into test values('2020-01-01', '2024-10-30 11:17:01', 'asfgrgte', 'wergergqer', 0, 11, 111, 1111, 11111, 111111, 11.11, 111.111, 1111.1111),('2020-01-01', '2024-10-30 10:17:01', 'asfgrgte', 'wergergqer', 0, 11, 111, 1111, 11111, 111111, 11.11, 111.111, 1111.1111),('2020-01-01', '2024-10-30 09:17:01', 'asfgrgte', 'wergergqer', 0, 11, 111, 1111, 11111, 111111, 11.11, 111.111, 1111.1111),('2020-01-01', '2024-10-30 12:17:01', 'asfgrgte', 'wergergqer', 0, 11, 111, 1111, 11111, 111111, 11.11, 111.111, 1111.1111);
 alter table test modify PARTITION (*) set ("storage_cooldown_ttl" = "1 year", "storage_medium" = "SSD");
+
+
+-- name: test_pk_alter_char
+CREATE TABLE test2
+(
+    k1 BIGINT,
+    v1 LARGEINT,
+    v2 CHAR(4)
+)
+ENGINE=olap
+PRIMARY KEY(k1)
+DISTRIBUTED BY HASH (k1) BUCKETS 3
+PROPERTIES(
+    "replication_num"="1"
+);
+insert into test2 values (1, 1, '1');
+
+select * from test2 where v2 = '1';
+
+alter table test2 add index test_bitmap(v1);
+function: wait_alter_table_finish()
+
+select * from test2 where v2 = '1';


### PR DESCRIPTION
## Why I'm doing:
when pk alter table, char column miss padding, and it will generate an error zone map index.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
