### PR TITLE
[BugFix] Ensure ResultSet is closed after getTable() to prevent cursor leaks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -243,8 +243,8 @@ public class JDBCMetadata implements ConnectorMetadata {
         JDBCTableName jdbcTable = new JDBCTableName(null, dbName, tblName);
         return tableInstanceCache.get(jdbcTable,
                 k -> {
-                    try (Connection connection = getConnection()) {
-                        ResultSet columnSet = schemaResolver.getColumns(connection, dbName, tblName);
+                    try (Connection connection = getConnection();
+                            ResultSet columnSet = schemaResolver.getColumns(connection, dbName, tblName)) {
                         List<Column> fullSchema = schemaResolver.convertToSRTable(columnSet);
                         List<Column> partitionColumns = Lists.newArrayList();
                         if (schemaResolver.isSupportPartitionInformation()) {


### PR DESCRIPTION
## Why I'm doing:
![img_v3_02ub_6d9cff8f-ee89-440d-ad10-6abb7fcbd96g](https://github.com/user-attachments/assets/69d9540f-32d1-44ff-ad0a-3b1121c83b0b)
cursor leaks when query jdbc table
## What I'm doing:
This pull request addresses resource management in the JDBC connector by ensuring that `ResultSet` objects are properly closed after table retrieval, preventing potential cursor leaks. It also introduces a regression test to verify this behavior and avoid issues like "ORA-01000: maximum open cursors exceeded."

Resource management improvements:

* Updated `JDBCMetadata.getTable` to use try-with-resources for both `Connection` and `ResultSet`, ensuring `ResultSet` is always closed after use.

Testing enhancements:

* Added a regression test `testGetTableResultSetClosed` in `JDBCMetadataTest` to verify that `ResultSet` is properly closed after calling `getTable`, preventing open cursor leaks.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
