### PR TITLE
[Doc] Fix bloom filter index documentation example

### DIFF
--- a/docs/en/table_design/indexes/Bloomfilter_index.md
+++ b/docs/en/table_design/indexes/Bloomfilter_index.md
@@ -9,7 +9,7 @@ This topic describes how to create and modify bloom filter indexes, along with h
 
 A bloom filter index is a space-efficiency data structure that is used to detect the possible presence of filtered data in data files of a table. If the bloom filter index detects that the data to be filtered are not in a certain data file, StarRocks skips scanning the data file. Bloom filter indexes can reduce response time when the column (such as ID) has a relatively high cardinality.
 
-If a query hits a sort key column, StarRocks efficiently returns the query result by using the [prefix index](./Prefix_index_sort_key.md). However, the prefix index entry for a data block cannot exceed 36 bytes in length. If you want to improve the query performance on a column, which is not used as a sort key and has a relatively high cardinality, you can create a bloom filter index for the column.
+If a query hits a sort key column, StarRocks efficiently returns the query result by using the [prefix index](./Prefix_index_sort_key.md). However, the prefix index entry for a data block cannot exceed 36 bytes in length. If you want to improve the query performance on a column, **which is not used as a sort key** and has a **relatively high cardinality**, you can create a bloom filter index for the column.
 
 ## How it works
 
@@ -30,20 +30,20 @@ For example, you create a bloom filter index on a `column1` of a given table `ta
 
 ## Create bloom filter indexes
 
-You can create a bloom filter index for a column when you create a table by specifying the `bloom_filter_columns` parameter in `PROPERTIES`. For example, create bloom filter indexes for the `k1` and `k2` columns in `table1`.
+You can create a bloom filter index for a column when you create a table by specifying the `bloom_filter_columns` parameter in `PROPERTIES`. For example, create a bloom filter index for the `v1` column in `table1`.
 
 ```SQL
 CREATE TABLE table1
 (
     k1 BIGINT,
     k2 LARGEINT,
-    v1 VARCHAR(2048) REPLACE,
+    v1 VARCHAR(2048),
     v2 SMALLINT DEFAULT "10"
 )
 ENGINE = olap
-PRIMARY KEY(k1, k2)
+DUPLICATE KEY(k1, k2)
 DISTRIBUTED BY HASH (k1, k2)
-PROPERTIES("bloom_filter_columns" = "k1,k2");
+PROPERTIES("bloom_filter_columns" = "v1");
 ```
 
 You can create bloom filter indexes for multiple columns at a time by specifying these column names. Note that you need to separate these column names with commas (`,`). For other parameter descriptions of the CREATE TABLE statement, see [CREATE TABLE](../../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md).
@@ -60,16 +60,16 @@ SHOW CREATE TABLE table1;
 
 You can add, reduce, and delete bloom filter indexes by using the [ALTER TABLE](../../sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md) statement.
 
-- The following statement adds a bloom filter index on the `v1` column.
+- The following statement adds a bloom filter index on the `v2` column.
 
     ```SQL
-    ALTER TABLE table1 SET ("bloom_filter_columns" = "k1,k2,v1");
+    ALTER TABLE table1 SET ("bloom_filter_columns" = "v1,v2");
     ```
 
-- The following statement reduces the bloom filter index on the `k2` column.
-  
+- The following statement reduces the bloom filter index to only the `v1` column.
+
     ```SQL
-    ALTER TABLE table1 SET ("bloom_filter_columns" = "k1");
+    ALTER TABLE table1 SET ("bloom_filter_columns" = "v1");
     ```
 
 - The following statement deletes all bloom filter indexes of `table1`.

--- a/docs/ja/table_design/indexes/Bloomfilter_index.md
+++ b/docs/ja/table_design/indexes/Bloomfilter_index.md
@@ -9,7 +9,7 @@ sidebar_position: 30
 
 ブルームフィルターインデックスは、テーブルのデータファイル内のフィルタリングされたデータの存在の可能性を検出するために使用される、空間効率の高いデータ構造です。ブルームフィルターインデックスがフィルタリング対象のデータが特定のデータファイルに存在しないことを検出した場合、StarRocks はそのデータファイルのスキャンをスキップします。ブルームフィルターインデックスは、列（例えば ID）のカーディナリティが比較的高い場合に応答時間を短縮することができます。
 
-クエリがソートキー列にヒットした場合、StarRocks は [プレフィックスインデックス](./Prefix_index_sort_key.md) を使用して効率的にクエリ結果を返します。ただし、データブロックのプレフィックスインデックスエントリは36バイトを超えることはできません。ソートキーとして使用されておらず、カーディナリティが比較的高い列のクエリパフォーマンスを向上させたい場合、その列にブルームフィルターインデックスを作成することができます。
+クエリがソートキー列にヒットした場合、StarRocks は [プレフィックスインデックス](./Prefix_index_sort_key.md) を使用して効率的にクエリ結果を返します。ただし、データブロックのプレフィックスインデックスエントリは36バイトを超えることはできません。**ソートキーとして使用されておらず**、**カーディナリティが比較的高い**列のクエリパフォーマンスを向上させたい場合、その列にブルームフィルターインデックスを作成することができます。
 
 ## 動作の仕組み
 
@@ -30,20 +30,20 @@ sidebar_position: 30
 
 ## ブルームフィルターインデックスの作成
 
-テーブルを作成する際に `PROPERTIES` の `bloom_filter_columns` パラメータを指定することで、列に対してブルームフィルターインデックスを作成できます。例えば、`table1` の `k1` および `k2` 列にブルームフィルターインデックスを作成します。
+テーブルを作成する際に `PROPERTIES` の `bloom_filter_columns` パラメータを指定することで、列に対してブルームフィルターインデックスを作成できます。例えば、`table1` の `v1` 列にブルームフィルターインデックスを作成します。
 
 ```SQL
 CREATE TABLE table1
 (
     k1 BIGINT,
     k2 LARGEINT,
-    v1 VARCHAR(2048) REPLACE,
+    v1 VARCHAR(2048),
     v2 SMALLINT DEFAULT "10"
 )
 ENGINE = olap
-PRIMARY KEY(k1, k2)
+DUPLICATE KEY(k1, k2)
 DISTRIBUTED BY HASH (k1, k2)
-PROPERTIES("bloom_filter_columns" = "k1,k2");
+PROPERTIES("bloom_filter_columns" = "v1");
 ```
 
 複数の列に対して一度にブルームフィルターインデックスを作成することができます。これらの列名を指定する際には、カンマ（`,`）で区切る必要があります。CREATE TABLE 文の他のパラメータの説明については、[CREATE TABLE](../../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md) を参照してください。
@@ -60,16 +60,16 @@ SHOW CREATE TABLE table1;
 
 [ALTER TABLE](../../sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md) 文を使用して、ブルームフィルターインデックスを追加、削減、削除することができます。
 
-- 次の文は、`v1` 列にブルームフィルターインデックスを追加します。
+- 次の文は、`v2` 列にブルームフィルターインデックスを追加します。
 
     ```SQL
-    ALTER TABLE table1 SET ("bloom_filter_columns" = "k1,k2,v1");
+    ALTER TABLE table1 SET ("bloom_filter_columns" = "v1,v2");
     ```
 
-- 次の文は、`k2` 列のブルームフィルターインデックスを削減します。
+- 次の文は、ブルームフィルターインデックスを `v1` 列のみに削減します。
 
     ```SQL
-    ALTER TABLE table1 SET ("bloom_filter_columns" = "k1");
+    ALTER TABLE table1 SET ("bloom_filter_columns" = "v1");
     ```
 
 - 次の文は、`table1` のすべてのブルームフィルターインデックスを削除します。

--- a/docs/zh/table_design/indexes/Bloomfilter_index.md
+++ b/docs/zh/table_design/indexes/Bloomfilter_index.md
@@ -8,7 +8,7 @@ sidebar_position: 30
 
 本文介绍了 Bloom filter（布隆过滤器）索引的原理，以及如何创建和修改 Bloom filter 索引。
 
-Bloom filter 索引可以快速判断表的数据文件中是否可能包含要查询的数据，如果不包含就跳过，从而减少扫描的数据量。Bloom filter 索引空间效率高，适用于基数较高的列，如 ID 列。如果一个查询条件命中前缀索引列，StarRocks 会使用[前缀索引](./Prefix_index_sort_key.md)快速返回查询结果。但是前缀索引的长度有限，如果想要快速查询一个非前缀索引列且该列基数较高，即可为这个列创建 Bloom filter 索引。
+Bloom filter 索引可以快速判断表的数据文件中是否可能包含要查询的数据，如果不包含就跳过，从而减少扫描的数据量。Bloom filter 索引空间效率高，适用于基数较高的列，如 ID 列。如果一个查询条件命中前缀索引列，StarRocks 会使用[前缀索引](./Prefix_index_sort_key.md)快速返回查询结果。但是前缀索引的长度有限，如果想要快速查询一个**非前缀索引列**且该列**基数较高**，即可为这个列创建 Bloom filter 索引。
 
 ## 索引原理
 
@@ -29,20 +29,20 @@ Bloom filter 索引可以快速判断表的数据文件中是否可能包含要�
 
 ## 创建索引
 
-建表时，通过在 `PROPERTIES` 中指定 `bloom_filter_columns` 来创建索引。例如，如下语句为表 `table1` 的 `k1` 和 `k2` 列创建 Bloom filter 索引。
+建表时，通过在 `PROPERTIES` 中指定 `bloom_filter_columns` 来创建索引。例如，如下语句为表 `table1` 的 `v1` 列创建 Bloom filter 索引。
 
 ```SQL
 CREATE TABLE table1
 (
     k1 BIGINT,
     k2 LARGEINT,
-    v1 VARCHAR(2048) REPLACE,
+    v1 VARCHAR(2048),
     v2 SMALLINT DEFAULT "10"
 )
 ENGINE = olap
-PRIMARY KEY(k1, k2)
+DUPLICATE KEY(k1, k2)
 DISTRIBUTED BY HASH (k1, k2)
-PROPERTIES("bloom_filter_columns" = "k1,k2");
+PROPERTIES("bloom_filter_columns" = "v1");
 ```
 
 您可以同时创建多个索引，多个索引列之间需用逗号 (`,`) 隔开。关于建表的其他参数说明，请参见 [CREATE TABLE](../../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md)。
@@ -59,16 +59,16 @@ SHOW CREATE TABLE table1;
 
 您可以使用 [ALTER TABLE](../../sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md) 语句来增加，减少和删除索引。
 
-- 如下语句增加了一个 Bloom filter 索引列 `v1`。
+- 如下语句增加了一个 Bloom filter 索引列 `v2`。
 
     ```SQL
-    ALTER TABLE table1 SET ("bloom_filter_columns" = "k1,k2,v1");
+    ALTER TABLE table1 SET ("bloom_filter_columns" = "v1,v2");
     ```
 
-- 如下语句减少了一个 Bloom filter 索引列 `k2`。
+- 如下语句将 Bloom filter 索引缩减为仅 `v1` 列。
 
     ```SQL
-    ALTER TABLE table1 SET ("bloom_filter_columns" = "k1");
+    ALTER TABLE table1 SET ("bloom_filter_columns" = "v1");
     ```
 
 - 如下语句删除了 `table1` 的所有 Bloom filter 索引。


### PR DESCRIPTION
## Why I'm doing:

The bloom filter index documentation contains an example that contradicts its own explanation. The docs state that bloom filters are for columns **not used as a sort key**, but the example creates bloom filter indexes on `k1, k2` — the PRIMARY KEY columns, which ARE the sort key. This makes the bloom filter useless (confirmed: `BloomFilterFilterRows: 0`).

Additionally, the example uses `REPLACE` aggregate type in a `PRIMARY KEY` table, which is confusing/misleading syntax.

## What I'm doing:

Updated the bloom filter index documentation (EN, ZH, JA) to fix the broken example:

1. **Bolded key concept**: emphasized that bloom filters are for non-sort-key, high-cardinality columns
2. **Fixed CREATE TABLE example**:
   - Changed from `PRIMARY KEY` to `DUPLICATE KEY` (more realistic use case)
   - Bloom filter now on `v1` (non-key VARCHAR column) instead of `k1, k2` (sort key)
   - Removed misleading `REPLACE` aggregate type
3. **Updated ALTER TABLE examples**: made them consistent with the new CREATE TABLE example

Fixes #68524

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [x] This PR needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4

---

## Additional Context

The old example would show `BloomFilterFilterRows: 0` because bloom filters on sort key columns are redundant — the prefix index already handles filtering for those columns. The new example demonstrates the actual intended use case: a bloom filter on a non-key, high-cardinality column like a VARCHAR field.

This documentation fix should be backported to all active release branches since users on those versions may copy the broken example.