### PR TITLE
[BugFix] local pass-through interpolation disrupt query cache

### DIFF
--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -31,6 +31,7 @@
 #include "exec/pipeline/limit_operator.h"
 #include "exec/pipeline/noop_sink_operator.h"
 #include "exec/pipeline/pipeline_fwd.h"
+#include "exec/pipeline/scan/scan_operator.h"
 #include "exec/pipeline/spill_process_operator.h"
 #include "exec/pipeline/wait_operator.h"
 #include "exec/query_cache/cache_manager.h"
@@ -508,7 +509,7 @@ bool PipelineBuilderContext::should_interpolate_cache_operator(int32_t plan_node
     if (cache_param.plan_node_id != plan_node_id) {
         return false;
     }
-    return dynamic_cast<pipeline::OperatorFactory*>(source_op.get()) != nullptr;
+    return dynamic_cast<pipeline::ScanOperatorFactory*>(source_op.get()) != nullptr;
 }
 
 OpFactories PipelineBuilderContext::interpolate_cache_operator(

--- a/test/sql/test_hash_join_interpolate_passthrough_disrupt_query_cache/R/test_hash_join_interpolate_passthrough_disrupt_query_cache
+++ b/test/sql/test_hash_join_interpolate_passthrough_disrupt_query_cache/R/test_hash_join_interpolate_passthrough_disrupt_query_cache
@@ -1,0 +1,169 @@
+-- name: test_hash_join_interpolate_passthrough_disrupt_query_cache
+drop table if exists t0;
+-- result:
+-- !result
+drop table if exists t1;
+-- result:
+-- !result
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`, `c1`)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 10
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`, `c1`)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 10
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 select i%100 as c0, i%100 as c1, i%100 as c2 from table(generate_series(1,100000))t(i);
+-- result:
+-- !result
+insert into t1 select i%100 as c0, i%100 as c1, i%100 as c2 from table(generate_series(1,1000))t(i);
+-- result:
+-- !result
+with cte0 as (
+select c0, sum(c2) as sum_c2 from t0 where c2 in (select c2 from t1) group by c0
+),
+cte1 as(
+select c1, sum(c2) as sum_c2 from t0 where c2 in (select c2 from t1) group by c1
+),
+cte2 as(select count(sum_c2) a from cte0
+),
+cte3 as(select count(sum_c2) a from cte1
+)
+select /*+SET_VAR(hash_join_interpolate_passthrough = true,enable_query_cache=true)*/ assert_true(cte2.a= cte3.a) from cte2, cte3;
+-- result:
+1
+-- !result
+drop table if exists t0;
+-- result:
+-- !result
+drop table if exists t1;
+-- result:
+-- !result
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`, `c1`)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 13
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`, `c1`)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 13
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 select i%100 as c0, i%100 as c1, i%100 as c2 from table(generate_series(1,100000))t(i);
+-- result:
+-- !result
+insert into t1 select i%100 as c0, i%100 as c1, i%100 as c2 from table(generate_series(1,1000))t(i);
+-- result:
+-- !result
+with cte0 as (
+select c0, sum(c2) as sum_c2 from t0 where c2 in (select c2 from t1) group by c0
+),
+cte1 as(
+select c1, sum(c2) as sum_c2 from t0 where c2 in (select c2 from t1) group by c1
+),
+cte2 as(select count(sum_c2) a from cte0
+),
+cte3 as(select count(sum_c2) a from cte1
+)
+select /*+SET_VAR(hash_join_interpolate_passthrough = true,enable_query_cache=true)*/ assert_true(cte2.a= cte3.a) from cte2, cte3;
+-- result:
+1
+-- !result
+drop table if exists t0;
+-- result:
+-- !result
+drop table if exists t1;
+-- result:
+-- !result
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`, `c1`)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 19
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`, `c1`)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 19
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 select i%100 as c0, i%100 as c1, i%100 as c2 from table(generate_series(1,100000))t(i);
+-- result:
+-- !result
+insert into t1 select i%100 as c0, i%100 as c1, i%100 as c2 from table(generate_series(1,1000))t(i);
+-- result:
+-- !result
+with cte0 as (
+select c0, sum(c2) as sum_c2 from t0 where c2 in (select c2 from t1) group by c0
+),
+cte1 as(
+select c1, sum(c2) as sum_c2 from t0 where c2 in (select c2 from t1) group by c1
+),
+cte2 as(select count(sum_c2) a from cte0
+),
+cte3 as(select count(sum_c2) a from cte1
+)
+select /*+SET_VAR(hash_join_interpolate_passthrough = true,enable_query_cache=true)*/ assert_true(cte2.a= cte3.a) from cte2, cte3;
+-- result:
+1
+-- !result

--- a/test/sql/test_hash_join_interpolate_passthrough_disrupt_query_cache/T/test_hash_join_interpolate_passthrough_disrupt_query_cache
+++ b/test/sql/test_hash_join_interpolate_passthrough_disrupt_query_cache/T/test_hash_join_interpolate_passthrough_disrupt_query_cache
@@ -1,0 +1,138 @@
+-- name: test_hash_join_interpolate_passthrough_disrupt_query_cache
+drop table if exists t0;
+drop table if exists t1;
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`, `c1`)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 10
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+CREATE TABLE `t1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`, `c1`)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 10
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+insert into t0 select i%100 as c0, i%100 as c1, i%100 as c2 from table(generate_series(1,100000))t(i);
+insert into t1 select i%100 as c0, i%100 as c1, i%100 as c2 from table(generate_series(1,1000))t(i);
+
+with cte0 as (
+select c0, sum(c2) as sum_c2 from t0 where c2 in (select c2 from t1) group by c0
+),
+cte1 as(
+select c1, sum(c2) as sum_c2 from t0 where c2 in (select c2 from t1) group by c1
+),
+cte2 as(select count(sum_c2) a from cte0
+),
+cte3 as(select count(sum_c2) a from cte1
+)
+select /*+SET_VAR(hash_join_interpolate_passthrough = true,enable_query_cache=true)*/ assert_true(cte2.a= cte3.a) from cte2, cte3;
+
+drop table if exists t0;
+drop table if exists t1;
+
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`, `c1`)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 13
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+CREATE TABLE `t1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`, `c1`)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 13
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+
+insert into t0 select i%100 as c0, i%100 as c1, i%100 as c2 from table(generate_series(1,100000))t(i);
+insert into t1 select i%100 as c0, i%100 as c1, i%100 as c2 from table(generate_series(1,1000))t(i);
+
+with cte0 as (
+select c0, sum(c2) as sum_c2 from t0 where c2 in (select c2 from t1) group by c0
+),
+cte1 as(
+select c1, sum(c2) as sum_c2 from t0 where c2 in (select c2 from t1) group by c1
+),
+cte2 as(select count(sum_c2) a from cte0
+),
+cte3 as(select count(sum_c2) a from cte1
+)
+select /*+SET_VAR(hash_join_interpolate_passthrough = true,enable_query_cache=true)*/ assert_true(cte2.a= cte3.a) from cte2, cte3;
+
+drop table if exists t0;
+drop table if exists t1;
+
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`, `c1`)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 19
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+CREATE TABLE `t1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`, `c1`)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 19
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+insert into t0 select i%100 as c0, i%100 as c1, i%100 as c2 from table(generate_series(1,100000))t(i);
+insert into t1 select i%100 as c0, i%100 as c1, i%100 as c2 from table(generate_series(1,1000))t(i);
+
+with cte0 as (
+select c0, sum(c2) as sum_c2 from t0 where c2 in (select c2 from t1) group by c0
+),
+cte1 as(
+select c1, sum(c2) as sum_c2 from t0 where c2 in (select c2 from t1) group by c1
+),
+cte2 as(select count(sum_c2) a from cte0
+),
+cte3 as(select count(sum_c2) a from cte1
+)
+select /*+SET_VAR(hash_join_interpolate_passthrough = true,enable_query_cache=true)*/ assert_true(cte2.a= cte3.a) from cte2, cte3;


### PR DESCRIPTION
## Why I'm doing:
For scan->join_probe(broadcast)->agg, when scan's actual dop is less that pipeline_dop, a pass-through operator would be interpolate to form two pipelines: 
P0: scan->pass_through_sink, 
P1: pass_through_source->join_probe(broadcast)->agg, 

In this situation, turning P1 into cache pipeline: pass_through_source->ML[join_probe(broadcast)]->ML[agg]->cache->agg would miss some data since that violate per-tablet compuation constraints. so forbid turning P1 into cache pipeline.

Reproducing procedure as follows
```
CREATE TABLE `t0` (
  `c0` int(11) NULL COMMENT "",
  `c1` int(11) NULL COMMENT "",
  `c2` int(11) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`c0`, `c1`)
DISTRIBUTED BY HASH(`c0`) BUCKETS 13
PROPERTIES (
"compression" = "LZ4",
"fast_schema_evolution" = "true",
"replicated_storage" = "true",
"replication_num" = "1"
);
-- result:
-- !result
CREATE TABLE `t1` (
  `c0` int(11) NULL COMMENT "",
  `c1` int(11) NULL COMMENT "",
  `c2` int(11) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`c0`, `c1`)
DISTRIBUTED BY HASH(`c0`) BUCKETS 13
PROPERTIES (
"compression" = "LZ4",
"fast_schema_evolution" = "true",
"replicated_storage" = "true",
"replication_num" = "1"
);
-- result:
-- !result
insert into t0 select i%100 as c0, i%100 as c1, i%100 as c2 from table(generate_series(1,100000))t(i);
-- result:
-- !result
insert into t1 select i%100 as c0, i%100 as c1, i%100 as c2 from table(generate_series(1,1000))t(i);
-- result:
-- !result
with cte0 as (
select c0, sum(c2) as sum_c2 from t0 where c2 in (select c2 from t1) group by c0
),
cte1 as(
select c1, sum(c2) as sum_c2 from t0 where c2 in (select c2 from t1) group by c1
),
cte2 as(select count(sum_c2) a from cte0
),
cte3 as(select count(sum_c2) a from cte1
)
select /*+SET_VAR(hash_join_interpolate_passthrough = true,enable_query_cache=true)*/ assert_true(cte2.a= cte3.a) from cte2, cte3;
-- result:
E: (1064, 'Expr evaluate meet error: assert_true failed due to false value: BE:10003')
-- !result

```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
