### PR TITLE
[BugFix] Fix multi-statement stream load transaction behavior inconsistencies

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
@@ -22,19 +22,24 @@ import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.http.rest.ActionStatus;
 import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.txn.BeginStmt;
 import com.starrocks.sql.ast.txn.CommitStmt;
+import com.starrocks.sql.ast.txn.RollbackStmt;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.thrift.TLoadInfo;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TStreamLoadInfo;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.transaction.ExplicitTxnState;
+import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TransactionException;
 import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionStatus;
 import com.starrocks.transaction.TransactionStmtExecutor;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -47,8 +52,38 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+/**
+ * Multi-statement stream load task state transition diagram:
+ *
+ * <pre>
+ *   BEGIN
+ *     |
+ *     +--[commitTxn]-------------------------> COMMITING
+ *     |                                            |
+ *     |                                            +--[success]---------> COMMITED
+ *     |                                            +--[fail]------------> ABORTING
+ *     |
+ *     +--[manualCancel / timeout / exception]----> ABORTING
+ *     +--[cancelAfterRestart, txnId!=0]---------> ABORTING
+ *     +--[cancelAfterRestart, txnId==0]---------> CANCELLED
+ *
+ *   ABORTING
+ *     |
+ *     +--[tryRollbackNow / reconcile success]----> CANCELLED
+ *     +--[reconcile finds txn committed]---------> COMMITED
+ * </pre>
+ *
+ * Final states: CANCELLED, COMMITED, FINISHED.
+ * COMMITING and ABORTING are intermediate; cancel is rejected in COMMITING.
+ * BEFORE_LOAD, LOADING, PREPARING, PREPARED are defined for compatibility but not used in this class.
+ */
 public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
     private static final Logger LOG = LogManager.getLogger(StreamLoadMultiStmtTask.class);
+
+    /** Initial retry interval (ms) for stream load abort rollback. */
+    private static final long ABORT_RETRY_INTERVAL_MS = 5000;
+    /** Max retry interval (ms) for stream load abort rollback backoff. */
+    private static final long ABORT_RETRY_MAX_INTERVAL_MS = 60000;
 
     public enum State {
         BEGIN,
@@ -56,6 +91,8 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
         LOADING,
         PREPARING,
         PREPARED,
+        COMMITING,  // Intermediate state: commit in progress, reject cancel during this state
+        ABORTING,   // Intermediate state: rollback in progress or pending retry, non-final
         COMMITED,
         CANCELLED,
         FINISHED
@@ -101,10 +138,17 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
     @SerializedName(value = "endTimeMs")
     private long endTimeMs = -1;
 
-    // Add missing fields
     private String errorMsg = "";
     private int channelNum = 0;
     private List<Object> channels = Lists.newArrayList();
+
+    @SerializedName(value = "abortRetryCount")
+    private int abortRetryCount = 0;
+    @SerializedName(value = "nextAbortRetryTimeMs")
+    private long nextAbortRetryTimeMs = 0;
+    @SerializedName(value = "abortReason")
+    private String abortReason = "";
+    private String lastAbortErrorMsg = "";
 
     public StreamLoadMultiStmtTask(long id, Database db, String label, String user, String clientIp,
                           long timeoutMs, long createTimeMs, ComputeResource computeResource) {
@@ -136,6 +180,144 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
         this.lock = new ReentrantReadWriteLock(true);
     }
 
+    /**
+     * Transition state to ABORTING and record the reason.
+     * Caller MUST hold writeLock.
+     */
+    private void transitionToAborting(String reason) {
+        this.state = State.ABORTING;
+        this.abortReason = reason;
+        this.abortRetryCount = 0;
+        this.nextAbortRetryTimeMs = 0;
+        this.lastAbortErrorMsg = "";
+    }
+
+    /**
+     * Attempt to rollback the transaction right now.
+     * If rollback succeeds, transitions state from ABORTING to CANCELLED.
+     * If rollback fails, stays in ABORTING with retry info updated.
+     * Also cancels sub-task coordinators on success.
+     *
+     * @return true if transaction has reached final state (CANCELLED or COMMITED)
+     */
+    private boolean tryRollbackNow() {
+        if (txnId == 0 || context == null) {
+            writeLock();
+            try {
+                this.state = State.CANCELLED;
+                this.endTimeMs = System.currentTimeMillis();
+            } finally {
+                writeUnlock();
+            }
+            return true;
+        }
+
+        boolean rollbackSuccess = false;
+        try {
+            TransactionStmtExecutor.rollbackStmt(context, new RollbackStmt(NodePosition.ZERO));
+            rollbackSuccess = true;
+        } catch (Exception e) {
+            this.lastAbortErrorMsg = e.getMessage();
+            LOG.warn("Failed to rollback transaction, label: {}, txnId: {}, reason: {}, " +
+                    "retryCount: {}", label, txnId, abortReason, abortRetryCount, e);
+        }
+
+        if (!rollbackSuccess) {
+            rollbackSuccess = reconcileWithTxnManager();
+        }
+
+        if (rollbackSuccess) {
+            for (StreamLoadTask task : taskMaps.values()) {
+                task.cancelCoordinatorOnly(abortReason);
+            }
+            writeLock();
+            try {
+                if (this.state != State.COMMITED) {
+                    this.state = State.CANCELLED;
+                }
+                this.endTimeMs = System.currentTimeMillis();
+            } finally {
+                writeUnlock();
+            }
+            LOG.info("Transaction rollback succeeded, label: {}, txnId: {}, reason: {}, " +
+                    "retryCount: {}", label, txnId, abortReason, abortRetryCount);
+            return true;
+        }
+
+        writeLock();
+        try {
+            this.abortRetryCount++;
+            long backoffMs = Math.min(
+                    ABORT_RETRY_INTERVAL_MS * (1L << Math.min(abortRetryCount, 10)),
+                    ABORT_RETRY_MAX_INTERVAL_MS);
+            this.nextAbortRetryTimeMs = System.currentTimeMillis() + backoffMs;
+        } finally {
+            writeUnlock();
+        }
+        return false;
+    }
+
+    /**
+     * Check the actual transaction status in the transaction manager to handle cases
+     * where rollbackStmt fails but the transaction has already reached a final state.
+     *
+     * @return true if the transaction is confirmed to be in a final state
+     */
+    private boolean reconcileWithTxnManager() {
+        try {
+            GlobalTransactionMgr txnMgr =
+                    GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+            ExplicitTxnState explicitState = txnMgr.getExplicitTxnState(txnId);
+            if (explicitState == null) {
+                LOG.info("ExplicitTxnState already cleared for txnId: {}, label: {}, " +
+                        "treating as aborted", txnId, label);
+                return true;
+            }
+            TransactionState txnState = explicitState.getTransactionState();
+            if (txnState != null) {
+                TransactionStatus status = txnState.getTransactionStatus();
+                if (status == TransactionStatus.ABORTED || status == TransactionStatus.VISIBLE
+                        || status == TransactionStatus.COMMITTED) {
+                    LOG.info("Transaction already in final status {}, label: {}, txnId: {}",
+                            status, label, txnId);
+                    if (status == TransactionStatus.VISIBLE
+                            || status == TransactionStatus.COMMITTED) {
+                        writeLock();
+                        try {
+                            this.state = State.COMMITED;
+                            this.endTimeMs = System.currentTimeMillis();
+                        } finally {
+                            writeUnlock();
+                        }
+                    }
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to reconcile transaction status, label: {}, txnId: {}",
+                    label, txnId, e);
+        }
+        return false;
+    }
+
+    /**
+     * Called by background cleanup thread to retry abort for tasks stuck in ABORTING state.
+     *
+     * @param currentMs current time in milliseconds
+     * @return true if task is no longer in ABORTING state (either CANCELLED or reconciled)
+     */
+    public boolean retryAbortIfNeeded(long currentMs) {
+        if (this.state != State.ABORTING) {
+            return true;
+        }
+        if (currentMs < this.nextAbortRetryTimeMs) {
+            return false;
+        }
+        LOG.info("Background retry abort for label: {}, txnId: {}, retryCount: {}, reason: {}",
+                label, txnId, abortRetryCount, abortReason);
+        return tryRollbackNow();
+    }
+
     @Override
     public void beginTxnFromFrontend(TransactionResult resp) {
         beginTxn(resp);
@@ -156,6 +338,23 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
     }
 
     public void beginTxn(TransactionResult resp) {
+        // Check if task already committed or finished - return LABEL_ALREADY_EXISTS like basic transaction
+        if (this.state == State.COMMITED || this.state == State.FINISHED) {
+            resp.status = ActionStatus.LABEL_ALREADY_EXISTS;
+            resp.msg = String.format("Label [%s] has already been used.", label);
+            resp.addResultEntry("ExistingJobStatus", state.name());
+            return;
+        }
+
+        // Check if transaction already started (Double Begin) - return LABEL_ALREADY_EXISTS like basic transaction
+        if (this.txnId != 0) {
+            resp.status = ActionStatus.LABEL_ALREADY_EXISTS;
+            resp.msg = String.format("Transaction already started with label [%s], txnId: %d", label, txnId);
+            resp.addResultEntry("ExistingJobStatus", state.name());
+            resp.addResultEntry("TxnId", txnId);
+            return;
+        }
+
         // Ensure a non-empty label is generated in TransactionStmtExecutor.beginStmt
         // by providing a valid executionId. Use the pre-generated loadId as executionId.
         if (context.getExecutionId() == null) {
@@ -185,44 +384,192 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
 
     @Override
     public void commitTxn(HttpHeaders headers, TransactionResult resp) throws StarRocksException {
-        // Commit all sub-tasks
-        LOG.info("commit {} sub tasks", taskMaps.size());
-        for (StreamLoadTask task : taskMaps.values()) {
-            task.prepareChannel(0, task.getTableName(), headers, resp);
-            if (!resp.stateOK()) {
+        // Phase 1: Check state and mark as COMMITING (with lock)
+        writeLock();
+        try {
+            if (this.state == State.COMMITED || this.state == State.FINISHED) {
+                resp.setOKMsg(String.format("Transaction %d has already committed, label is %s", txnId, label));
+                resp.addResultEntry("Label", label);
+                resp.addResultEntry("TxnId", txnId);
                 return;
             }
-            if (task.checkNeedPrepareTxn()) {
-                task.waitCoordFinish(resp);
-            }
-            if (!resp.stateOK()) {
+            if (this.state == State.CANCELLED) {
+                resp.setErrorMsg(String.format("Can not commit CANCELLED transaction %d, label is %s", txnId, label));
                 return;
             }
-            TransactionStmtExecutor.loadData(dbId, task.getTable().getId(), task.getTxnStateItem(), context);
+            if (this.state == State.ABORTING) {
+                resp.setErrorMsg(String.format("Transaction %d is aborting (reason: %s), label is %s",
+                        txnId, abortReason, label));
+                return;
+            }
+            if (this.state == State.COMMITING) {
+                resp.setErrorMsg(String.format("Transaction %d is already committing, label is %s", txnId, label));
+                return;
+            }
+            this.state = State.COMMITING;
+        } finally {
+            writeUnlock();
         }
-        TransactionStmtExecutor.commitStmt(context, new CommitStmt(NodePosition.ZERO));
-        this.state = State.COMMITED;
+
+        // Phase 2: Execute time-consuming operations (without lock)
+        boolean success = false;
+        String commitErrorMsg = null;
+        try {
+            LOG.info("commit {} sub tasks", taskMaps.size());
+            for (StreamLoadTask task : taskMaps.values()) {
+                task.prepareChannel(0, task.getTableName(), headers, resp);
+                if (!resp.stateOK()) {
+                    commitErrorMsg = "prepareChannel failed";
+                    return;
+                }
+                if (task.checkNeedPrepareTxn()) {
+                    task.waitCoordFinish(resp);
+                }
+                if (!resp.stateOK()) {
+                    commitErrorMsg = "waitCoordFinish failed";
+                    return;
+                }
+                TransactionStmtExecutor.loadData(dbId, task.getTable().getId(), task.getTxnStateItem(), context);
+            }
+            TransactionStmtExecutor.commitStmt(context, new CommitStmt(NodePosition.ZERO));
+            if (context.getState().isError()) {
+                commitErrorMsg = context.getState().getErrorMessage();
+            } else {
+                success = true;
+            }
+        } catch (Exception e) {
+            commitErrorMsg = e.getMessage();
+            throw e;
+        } finally {
+            if (success) {
+                writeLock();
+                try {
+                    this.state = State.COMMITED;
+                    this.endTimeMs = System.currentTimeMillis();
+                } finally {
+                    writeUnlock();
+                }
+            } else {
+                this.errorMsg = commitErrorMsg != null ? commitErrorMsg : "commit failed";
+                LOG.warn("Commit failed for transaction {}, label: {}, error: {}",
+                        txnId, label, this.errorMsg);
+                writeLock();
+                try {
+                    transitionToAborting("commit failed: " + this.errorMsg);
+                } finally {
+                    writeUnlock();
+                }
+                tryRollbackNow();
+            }
+        }
     }
 
     @Override
     public void manualCancelTask(TransactionResult resp) throws StarRocksException {
-        // Cancel all sub-tasks
-        for (StreamLoadTask task : taskMaps.values()) {
-            task.manualCancelTask(resp);
+        writeLock();
+        try {
+            if (this.state == State.COMMITED || this.state == State.FINISHED) {
+                resp.setErrorMsg(String.format("Can not abort VISIBLE transaction %d, label is %s", txnId, label));
+                return;
+            }
+            if (this.state == State.CANCELLED) {
+                resp.setOKMsg(String.format("Transaction %d has already aborted, label is %s", txnId, label));
+                resp.addResultEntry("Label", label);
+                resp.addResultEntry("TxnId", txnId);
+                return;
+            }
+            if (this.state == State.COMMITING) {
+                resp.setErrorMsg(String.format("Can not abort transaction %d during committing, label is %s",
+                        txnId, label));
+                return;
+            }
+            if (this.state == State.ABORTING) {
+                resp.setOKMsg(String.format("Transaction %d abort is already in progress, label is %s. " +
+                        "Background retry will continue.", txnId, label));
+                return;
+            }
+            transitionToAborting("manual abort");
+        } finally {
+            writeUnlock();
         }
-        this.state = State.CANCELLED;
-        this.endTimeMs = System.currentTimeMillis();
+
+        if (tryRollbackNow()) {
+            resp.setOKMsg("stream load " + label + " abort");
+        } else {
+            resp.setOKMsg(String.format("stream load %s abort initiated, rollback pending " +
+                    "(background retry will continue), label is %s, txnId is %d", label, label, txnId));
+        }
     }
 
     @Override
     public boolean checkNeedRemove(long currentMs, boolean isForce) {
-        if (!isFinalState()) {
+        if (this.state == State.ABORTING) {
             return false;
         }
-        if (endTimeMs == -1) {
+
+        if (isFinalState()) {
+            if (endTimeMs == -1) {
+                endTimeMs = currentMs;
+            }
+            return isForce || ((currentMs - endTimeMs) > Config.stream_load_task_keep_max_second * 1000L);
+        }
+
+        if (isTimeout(currentMs)) {
+            cancelOnTimeout();
             return false;
         }
-        return isForce || ((currentMs - endTimeMs) > Config.stream_load_task_keep_max_second * 1000L);
+
+        return false;
+    }
+
+    public boolean isAborting() {
+        return this.state == State.ABORTING;
+    }
+
+    /**
+     * Check if the task has exceeded its timeout period.
+     * Timeout is calculated from createTimeMs (when BEGIN was called).
+     */
+    public boolean isTimeout(long currentMs) {
+        if (isFinalState() || this.state == State.ABORTING) {
+            return false;
+        }
+        return currentMs - createTimeMs > timeoutMs;
+    }
+
+    public void cancelOnTimeout() {
+        writeLock();
+        try {
+            if (isFinalState() || this.state == State.COMMITING || this.state == State.ABORTING) {
+                return;
+            }
+            LOG.info("Cancel multi-statement stream load task due to timeout, label: {}, txnId: {}, " +
+                    "createTimeMs: {}, timeoutMs: {}", label, txnId, createTimeMs, timeoutMs);
+            this.errorMsg = "transaction timeout after " + timeoutMs + "ms";
+            transitionToAborting("timeout");
+        } finally {
+            writeUnlock();
+        }
+
+        tryRollbackNow();
+    }
+
+    public void cancelOnException(String errorMessage) {
+        writeLock();
+        try {
+            if (isFinalState() || this.state == State.COMMITING || this.state == State.ABORTING) {
+                return;
+            }
+            LOG.warn("Multi-statement stream load task cancelled due to exception, label: {}, txnId: {}, " +
+                    "error: {}. Transaction auto-aborted (consistent with basic transaction behavior).",
+                    label, txnId, errorMessage);
+            this.errorMsg = errorMessage;
+            transitionToAborting("LOAD exception: " + errorMessage);
+        } finally {
+            writeUnlock();
+        }
+
+        tryRollbackNow();
     }
 
     @Override
@@ -232,7 +579,8 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
 
     @Override
     public boolean isDurableLoadState() {
-        return state == State.PREPARED || state == State.CANCELLED || state == State.COMMITED || state == State.FINISHED;
+        return state == State.PREPARED || state == State.CANCELLED || state == State.COMMITED
+                || state == State.FINISHED || state == State.ABORTING;
     }
 
     @Override
@@ -301,12 +649,11 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
 
     @Override
     public boolean isFinalState() {
-        for (StreamLoadTask task : taskMaps.values()) {
-            if (!task.isFinalState()) {
-                return false;
-            }
+        if (this.state == State.CANCELLED || this.state == State.COMMITED || this.state == State.FINISHED) {
+            return true;
         }
-        return true;
+        // ABORTING is NOT a final state - rollback is pending
+        return false;
     }
 
     @Override
@@ -342,6 +689,19 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
 
     @Override
     public TNetworkAddress tryLoad(int channelId, String tableName, TransactionResult resp) throws StarRocksException {
+        if (this.state == State.CANCELLED) {
+            resp.setErrorMsg(String.format("stream load task %s has already been cancelled: %s", label, errorMsg));
+            return null;
+        }
+        if (this.state == State.ABORTING) {
+            resp.setErrorMsg(String.format("stream load task %s is aborting: %s", label, abortReason));
+            return null;
+        }
+        if (this.state == State.COMMITED || this.state == State.FINISHED) {
+            resp.setErrorMsg(String.format("stream load task %s has already been %s", label, state.name().toLowerCase()));
+            return null;
+        }
+
         // For multi-statement tasks, delegate to specific table task if exists
         StreamLoadTask task = taskMaps.get(tableName);
         if (task != null) {
@@ -366,6 +726,19 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
 
     @Override
     public TNetworkAddress executeTask(int channelId, String tableName, HttpHeaders headers, TransactionResult resp) {
+        if (this.state == State.CANCELLED) {
+            resp.setErrorMsg(String.format("stream load task %s has already been cancelled: %s", label, errorMsg));
+            return null;
+        }
+        if (this.state == State.ABORTING) {
+            resp.setErrorMsg(String.format("stream load task %s is aborting: %s", label, abortReason));
+            return null;
+        }
+        if (this.state == State.COMMITED || this.state == State.FINISHED) {
+            resp.setErrorMsg(String.format("stream load task %s has already been %s", label, state.name().toLowerCase()));
+            return null;
+        }
+
         // For multi-statement tasks, delegate to specific table task if exists
         StreamLoadTask task = taskMaps.get(tableName);
         if (task != null) {
@@ -392,11 +765,17 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
 
     @Override
     public void cancelAfterRestart() {
-        // loop taskMaps and execute cancelAfterRestart
         for (StreamLoadTask task : taskMaps.values()) {
             task.cancelAfterRestart();
         }
-        state = State.CANCELLED;
+        this.errorMsg = "cancelled after FE restart";
+        if (txnId != 0) {
+            transitionToAborting("recover after FE restart");
+            tryRollbackNow();
+        } else {
+            this.state = State.CANCELLED;
+            this.endTimeMs = System.currentTimeMillis();
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
@@ -21,6 +21,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.http.rest.ActionStatus;
 import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.WALApplier;
@@ -31,6 +32,7 @@ import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionStatus;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -82,12 +84,14 @@ public class StreamLoadManagerTest {
             }
 
             @Mock
-            public void logCreateStreamLoadJob(StreamLoadTask streamLoadTask, WALApplier walApplier) {
+            public void logCreateStreamLoadJob(StreamLoadTask streamLoadTask,
+                                               WALApplier walApplier) {
                 walApplier.apply(streamLoadTask);
             }
 
             @Mock
-            public void logCreateMultiStmtStreamLoadJob(StreamLoadMultiStmtTask streamLoadTask, WALApplier walApplier) {
+            public void logCreateMultiStmtStreamLoadJob(
+                    StreamLoadMultiStmtTask streamLoadTask, WALApplier walApplier) {
                 walApplier.apply(streamLoadTask);
             }
         };
@@ -158,17 +162,9 @@ public class StreamLoadManagerTest {
     @Test
     public void testBeginStreamLoadTask() throws StarRocksException {
         StreamLoadMgr streamLoadManager = new StreamLoadMgr();
-
-        String dbName = "test_db";
-        String tableName = "test_tbl";
-        String labelName = "label1";
-        long timeoutMillis = 100000;
-        int channelNum = 1;
-        int channelId = 0;
-
         TransactionResult resp = new TransactionResult();
         streamLoadManager.beginLoadTaskFromFrontend(
-                dbName, tableName, labelName, "", "", timeoutMillis, channelNum, channelId, resp);
+                "test_db", "test_tbl", "label1", "", "", 100000, 1, 0, resp);
 
         Map<String, StreamLoadTask> idToStreamLoadTask =
                 Deencapsulation.getField(streamLoadManager, "idToStreamLoadTask");
@@ -178,27 +174,14 @@ public class StreamLoadManagerTest {
         Assertions.assertEquals("test_db", task.getDBName());
         Assertions.assertEquals(20000, task.getDBId());
         Assertions.assertEquals("test_tbl", task.getTableName());
-
-        Map<String, StreamLoadTask> dbToLabelToStreamLoadTask =
-                Deencapsulation.getField(streamLoadManager, "dbToLabelToStreamLoadTask");
-        Assertions.assertEquals(1, idToStreamLoadTask.size());
-
     }
 
     @Test
     public void testChannelIdEqualChannelNum() throws StarRocksException {
         StreamLoadMgr streamLoadManager = new StreamLoadMgr();
-
-        String dbName = "test_db";
-        String tableName = "test_tbl";
-        String labelName = "label1";
-        long timeoutMillis = 100000;
-        int channelNum = 1;
-        int channelId = 1;
-
         TransactionResult resp = new TransactionResult();
         streamLoadManager.beginLoadTaskFromFrontend(
-                dbName, tableName, labelName, "", "", timeoutMillis, channelNum, channelId, resp);
+                "test_db", "test_tbl", "label1", "", "", 100000, 1, 1, resp);
         Map<String, StreamLoadTask> idToStreamLoadTask =
                 Deencapsulation.getField(streamLoadManager, "idToStreamLoadTask");
         Assertions.assertEquals(1, idToStreamLoadTask.size());
@@ -209,89 +192,43 @@ public class StreamLoadManagerTest {
     @Test
     public void testGetTaskByName() throws StarRocksException {
         StreamLoadMgr streamLoadManager = new StreamLoadMgr();
-
-        String dbName = "test_db";
-        String tableName = "test_tbl";
-        String labelName = "label1";
-        long timeoutMillis = 100000;
-        int channelNum = 5;
-        int channelId = 0;
-
         TransactionResult resp = new TransactionResult();
         streamLoadManager.beginLoadTaskFromFrontend(
-                dbName, tableName, labelName, "", "", timeoutMillis, channelNum, channelId, resp);
-
-        List<AbstractStreamLoadTask> tasks = streamLoadManager.getTaskByName(labelName);
+                "test_db", "test_tbl", "label1", "", "", 100000, 5, 0, resp);
+        List<AbstractStreamLoadTask> tasks = streamLoadManager.getTaskByName("label1");
         Assertions.assertEquals(1, tasks.size());
         Assertions.assertEquals("label1", tasks.get(0).getLabel());
-        Assertions.assertEquals("test_db", tasks.get(0).getDBName());
-        Assertions.assertEquals(20000, tasks.get(0).getDBId());
-        Assertions.assertEquals("test_tbl", tasks.get(0).getTableName());
     }
 
     @Test
     public void testGetTaskByNameWithNullLabelName() throws StarRocksException {
         StreamLoadMgr streamLoadManager = new StreamLoadMgr();
-
-        String dbName = "test_db";
-        String tableName = "test_tbl";
-        String labelName1 = "label1";
-        String labelName2 = "label2";
-        long timeoutMillis = 100000;
-        int channelNum = 5;
-        int channelId = 0;
-
         TransactionResult resp = new TransactionResult();
         streamLoadManager.beginLoadTaskFromFrontend(
-                dbName, tableName, labelName1, "", "", timeoutMillis, channelNum, channelId, resp);
+                "test_db", "test_tbl", "label1", "", "", 100000, 5, 0, resp);
         streamLoadManager.beginLoadTaskFromFrontend(
-                dbName, tableName, labelName2, "", "", timeoutMillis, channelNum, channelId, resp);
-
+                "test_db", "test_tbl", "label2", "", "", 100000, 5, 0, resp);
         List<AbstractStreamLoadTask> tasks = streamLoadManager.getTaskByName(null);
         Assertions.assertEquals(2, tasks.size());
-        Assertions.assertEquals("label1", tasks.get(0).getLabel());
-        Assertions.assertEquals("label2", tasks.get(1).getLabel());
     }
 
     @Test
     public void testGetTaskByIdWhenMatched() throws StarRocksException {
         StreamLoadMgr streamLoadManager = new StreamLoadMgr();
-
-        String dbName = "test_db";
-        String tableName = "test_tbl";
-        String labelName = "label1";
-        long timeoutMillis = 100000;
-        int channelNum = 5;
-        int channelId = 0;
-
         TransactionResult resp = new TransactionResult();
         streamLoadManager.beginLoadTaskFromFrontend(
-                dbName, tableName, labelName, "", "", timeoutMillis, channelNum, channelId, resp);
-
+                "test_db", "test_tbl", "label1", "", "", 100000, 5, 0, resp);
         AbstractStreamLoadTask task = streamLoadManager.getTaskById(1001L);
         Assertions.assertNotNull(task);
         Assertions.assertEquals("label1", task.getLabel());
-        Assertions.assertEquals(1001L, task.getId());
-        Assertions.assertEquals("test_db", task.getDBName());
-        Assertions.assertEquals(20000, task.getDBId());
-        Assertions.assertEquals("test_tbl", task.getTableName());
     }
 
     @Test
     public void testGetTaskByIdWhenNotMatched() throws StarRocksException {
         StreamLoadMgr streamLoadManager = new StreamLoadMgr();
-
-        String dbName = "test_db";
-        String tableName = "test_tbl";
-        String labelName = "label1";
-        long timeoutMillis = 100000;
-        int channelNum = 5;
-        int channelId = 0;
-
         TransactionResult resp = new TransactionResult();
         streamLoadManager.beginLoadTaskFromFrontend(
-                dbName, tableName, labelName, "", "", timeoutMillis, channelNum, channelId, resp);
-
+                "test_db", "test_tbl", "label1", "", "", 100000, 5, 0, resp);
         AbstractStreamLoadTask task = streamLoadManager.getTaskById(1002L);
         Assertions.assertNull(task);
     }
@@ -299,32 +236,110 @@ public class StreamLoadManagerTest {
     @Test
     public void testStreamLoadTaskAfterCommit() throws StarRocksException {
         StreamLoadMgr streamLoadManager = new StreamLoadMgr();
-
-        String dbName = "test_db";
-        String tableName = "test_tbl";
-        String labelName = "label2";
-        long timeoutMillis = 100000;
-
         TransactionResult resp = new TransactionResult();
         streamLoadManager.beginLoadTaskFromBackend(
-                dbName, tableName, labelName, null, "", "", timeoutMillis, resp, false, WarehouseManager.DEFAULT_RESOURCE, 10001);
+                "test_db", "test_tbl", "label2", null, "", "", 100000, resp,
+                false, WarehouseManager.DEFAULT_RESOURCE, 10001);
 
         Map<String, StreamLoadTask> idToStreamLoadTask =
                 Deencapsulation.getField(streamLoadManager, "idToStreamLoadTask");
-
         Assertions.assertEquals(1, idToStreamLoadTask.size());
-
-        StreamLoadTask task = idToStreamLoadTask.get(labelName);
+        StreamLoadTask task = idToStreamLoadTask.get("label2");
 
         TransactionState state = new TransactionState();
         task.afterCommitted(state, true);
         Assertions.assertNotEquals(-1, task.commitTimeMs());
-
         Assertions.assertTrue(task.isUnreversibleState());
         Assertions.assertFalse(task.isFinalState());
 
         streamLoadManager.cleanSyncStreamLoadTasks();
         Assertions.assertEquals(1, streamLoadManager.getStreamLoadTaskCount());
+    }
+
+    // ---- Cover lines 149-153: beginMultiStatementLoadTask label exists in txn history ----
+    @Test
+    public void testBeginMultiStmtLoadTaskLabelAlreadyExists() throws StarRocksException {
+        String label = "label_exists_in_txn";
+        TransactionState existingTxn = new TransactionState();
+        existingTxn.setTransactionStatus(TransactionStatus.VISIBLE);
+
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getLabelTransactionState(long dbId, String lbl) {
+                if (label.equals(lbl)) {
+                    return existingTxn;
+                }
+                return null;
+            }
+        };
+
+        StreamLoadMgr streamLoadManager = new StreamLoadMgr();
+        TransactionResult resp = new TransactionResult();
+        streamLoadManager.beginMultiStatementLoadTask(
+                CatalogMocker.TEST_DB_NAME, label, "", "127.0.0.1", 100000L, resp,
+                WarehouseManager.DEFAULT_RESOURCE);
+        Assertions.assertEquals(ActionStatus.LABEL_ALREADY_EXISTS, resp.status);
+    }
+
+    // ---- Cover line 406: tryPrepareLoadTaskTxn ----
+    @Test
+    public void testTryPrepareLoadTaskTxn() throws StarRocksException {
+        StreamLoadMgr streamLoadManager = new StreamLoadMgr();
+        TransactionResult resp = new TransactionResult();
+        streamLoadManager.beginLoadTaskFromFrontend(
+                "test_db", "test_tbl", "prep_label", "", "", 100000, 1, 0, resp);
+
+        TransactionResult prepResp = new TransactionResult();
+        streamLoadManager.tryPrepareLoadTaskTxn("prep_label", 5000, prepResp);
+        Assertions.assertTrue(prepResp.stateOK());
+    }
+
+    @Test
+    public void testTryPrepareLoadTaskTxnNotExist() throws StarRocksException {
+        StreamLoadMgr streamLoadManager = new StreamLoadMgr();
+        TransactionResult resp = new TransactionResult();
+        streamLoadManager.beginLoadTaskFromFrontend(
+                "test_db", "test_tbl", "some_label", "", "", 100000, 1, 0, resp);
+        Assertions.assertThrows(StarRocksException.class, () -> {
+            streamLoadManager.tryPrepareLoadTaskTxn("not_exist", 5000, new TransactionResult());
+        });
+    }
+
+    // ---- Cover lines 511-514: cleanOldStreamLoadTasks with aborting MultiStmtTasks ----
+    @Test
+    public void testCleanOldStreamLoadTasksWithAbortingMultiStmt() throws StarRocksException {
+        StreamLoadMgr streamLoadManager = new StreamLoadMgr();
+        TransactionResult beginResp = new TransactionResult();
+        streamLoadManager.beginMultiStatementLoadTask(
+                CatalogMocker.TEST_DB_NAME, "aborting_label", "", "127.0.0.1",
+                100000L, beginResp, WarehouseManager.DEFAULT_RESOURCE);
+        AbstractStreamLoadTask task = streamLoadManager.getTaskByLabel("aborting_label");
+        Deencapsulation.setField(task, "state",
+                StreamLoadMultiStmtTask.State.ABORTING);
+
+        streamLoadManager.cleanOldStreamLoadTasks(false);
+        Assertions.assertNotNull(streamLoadManager.getTaskByLabel("aborting_label"));
+    }
+
+    // ---- Cover lines 538-541: cleanSyncStreamLoadTasks actually removes tasks ----
+    @Test
+    public void testCleanSyncStreamLoadTasksRemovesFinished() throws StarRocksException {
+        StreamLoadMgr streamLoadManager = new StreamLoadMgr();
+        TransactionResult resp = new TransactionResult();
+        streamLoadManager.beginLoadTaskFromBackend(
+                CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME,
+                "sync_label", null, "", "", 100000, resp, false,
+                WarehouseManager.DEFAULT_RESOURCE, 10001);
+
+        StreamLoadTask task = (StreamLoadTask) streamLoadManager.getTaskByLabel(
+                "sync_label");
+        task.setIsSyncStreamLoad(true);
+        Deencapsulation.setField(task, "state", StreamLoadTask.State.FINISHED);
+        Deencapsulation.setField(task, "endTimeMs",
+                System.currentTimeMillis() - 10000);
+
+        streamLoadManager.cleanSyncStreamLoadTasks();
+        Assertions.assertNull(streamLoadManager.getTaskByLabel("sync_label"));
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadMultiStmtTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadMultiStmtTaskTest.java
@@ -20,11 +20,18 @@ import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.http.rest.ActionStatus;
 import com.starrocks.http.rest.TransactionResult;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.transaction.ExplicitTxnState;
+import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionStatus;
 import com.starrocks.transaction.TransactionStmtExecutor;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
@@ -39,7 +46,6 @@ public class StreamLoadMultiStmtTaskTest {
 
     @BeforeEach
     public void setUp() {
-        // Initialize basic fixtures
         db = new Database(1L, "test_db");
         multiTask = new StreamLoadMultiStmtTask(1L, db, "label_multi", "u", "127.0.0.1",
                 1000L, System.currentTimeMillis(), WarehouseManager.DEFAULT_RESOURCE);
@@ -77,37 +83,24 @@ public class StreamLoadMultiStmtTaskTest {
 
     @Test
     public void testBeginTxnSetsExecutionIdAndResource() throws Exception {
-        // Capture loadId from task for later comparison
         TUniqueId expectedLoadId = (TUniqueId) Deencapsulation.getField(multiTask, "loadId");
-
-        // Mock static beginStmt to assert context is pre-populated and set a fake txnId
         new MockUp<TransactionStmtExecutor>() {
             @Mock
             public void beginStmt(com.starrocks.qe.ConnectContext ctx,
                                   com.starrocks.sql.ast.txn.BeginStmt stmt,
                                   TransactionState.LoadJobSourceType sourceType,
                                   String labelOverride) {
-                // executionId must be set and convertible to non-empty label
                 Assertions.assertNotNull(ctx.getExecutionId());
                 String label = DebugUtil.printId(ctx.getExecutionId());
-                Assertions.assertNotNull(label);
                 Assertions.assertFalse(label.isEmpty());
-
-                // executionId should equal task.loadId
                 Assertions.assertEquals(expectedLoadId.getHi(), ctx.getExecutionId().getHi());
                 Assertions.assertEquals(expectedLoadId.getLo(), ctx.getExecutionId().getLo());
-
-                // compute resource should be propagated
-                Assertions.assertEquals(WarehouseManager.DEFAULT_RESOURCE, ctx.getCurrentComputeResource());
-
-                // labelOverride should equal the multi-statement task's label
+                Assertions.assertEquals(WarehouseManager.DEFAULT_RESOURCE,
+                        ctx.getCurrentComputeResource());
                 Assertions.assertEquals("label_multi", labelOverride);
-
-                // simulate txn id assignment inside begin
                 ctx.setTxnId(987654321L);
             }
         };
-
         TransactionResult resp = new TransactionResult();
         multiTask.beginTxn(resp);
         Assertions.assertTrue(resp.stateOK());
@@ -117,14 +110,19 @@ public class StreamLoadMultiStmtTaskTest {
     @Test
     public void testCheckNeedRemoveAndDurable() throws Exception {
         Assertions.assertFalse(multiTask.checkNeedRemove(System.currentTimeMillis(), false));
-        StreamLoadTask sub = new StreamLoadTask(2L, db, new OlapTable(), "label_sub", "u", "127.0.0.1", 1000, 1, 0,
+        StreamLoadTask sub = new StreamLoadTask(2L, db, new OlapTable(), "label_sub", "u",
+                "127.0.0.1", 1000, 1, 0,
                 System.currentTimeMillis(), WarehouseManager.DEFAULT_RESOURCE);
         Deencapsulation.setField(sub, "state", StreamLoadTask.State.FINISHED);
-        @SuppressWarnings("unchecked") java.util.Map<String, StreamLoadTask> map =
-                (java.util.Map<String, StreamLoadTask>) Deencapsulation.getField(multiTask, "taskMaps");
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, StreamLoadTask> map =
+                (java.util.Map<String, StreamLoadTask>) Deencapsulation.getField(multiTask,
+                        "taskMaps");
         map.put("tbl", sub);
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.FINISHED);
         Deencapsulation.setField(multiTask, "endTimeMs",
-                System.currentTimeMillis() - (Config.stream_load_task_keep_max_second * 1000L + 10));
+                System.currentTimeMillis()
+                        - (Config.stream_load_task_keep_max_second * 1000L + 10));
         Assertions.assertTrue(multiTask.isFinalState());
         Assertions.assertTrue(multiTask.checkNeedRemove(System.currentTimeMillis(), false));
     }
@@ -137,12 +135,16 @@ public class StreamLoadMultiStmtTaskTest {
 
     @Test
     public void testCallbackDelegations() throws Exception {
-        StreamLoadTask sub1 = new StreamLoadTask(3L, db, new OlapTable(), "l1", "u", "127.0.0.1", 1000, 1, 0,
+        StreamLoadTask sub1 = new StreamLoadTask(3L, db, new OlapTable(), "l1", "u",
+                "127.0.0.1", 1000, 1, 0,
                 System.currentTimeMillis(), WarehouseManager.DEFAULT_RESOURCE);
-        StreamLoadTask sub2 = new StreamLoadTask(4L, db, new OlapTable(), "l2", "u", "127.0.0.1", 1000, 1, 0,
+        StreamLoadTask sub2 = new StreamLoadTask(4L, db, new OlapTable(), "l2", "u",
+                "127.0.0.1", 1000, 1, 0,
                 System.currentTimeMillis(), WarehouseManager.DEFAULT_RESOURCE);
+        @SuppressWarnings("unchecked")
         java.util.Map<String, StreamLoadTask> map =
-                (java.util.Map<String, StreamLoadTask>) Deencapsulation.getField(multiTask, "taskMaps");
+                (java.util.Map<String, StreamLoadTask>) Deencapsulation.getField(multiTask,
+                        "taskMaps");
         map.put("t1", sub1);
         map.put("t2", sub2);
         TransactionState txnState = new TransactionState();
@@ -158,5 +160,396 @@ public class StreamLoadMultiStmtTaskTest {
         multiTask.replayOnVisible(txnState);
         List<List<String>> show = multiTask.getShowInfo();
         Assertions.assertEquals(2, show.size());
+    }
+
+    // ---- Cover beginTxn Double Begin (lines 281-289) ----
+    @Test
+    public void testBeginTxnDoubleBegin() throws Exception {
+        new MockUp<TransactionStmtExecutor>() {
+            @Mock
+            public void beginStmt(com.starrocks.qe.ConnectContext ctx,
+                                  com.starrocks.sql.ast.txn.BeginStmt stmt,
+                                  TransactionState.LoadJobSourceType sourceType,
+                                  String labelOverride) {
+                ctx.setTxnId(12345L);
+            }
+        };
+        TransactionResult resp1 = new TransactionResult();
+        multiTask.beginTxn(resp1);
+        Assertions.assertEquals(12345L, multiTask.getTxnId());
+
+        TransactionResult resp2 = new TransactionResult();
+        multiTask.beginTxn(resp2);
+        Assertions.assertEquals(ActionStatus.LABEL_ALREADY_EXISTS, resp2.status);
+    }
+
+    // ---- Cover tryRollbackNow rollback exception + reconcile returns null (lines 190-197, 218-228) ----
+    @Test
+    public void testManualCancelWithTxnRollbackFailAndReconcileFail() throws Exception {
+        new MockUp<TransactionStmtExecutor>() {
+            @Mock
+            public void beginStmt(com.starrocks.qe.ConnectContext ctx,
+                                  com.starrocks.sql.ast.txn.BeginStmt stmt,
+                                  TransactionState.LoadJobSourceType sourceType,
+                                  String labelOverride) {
+                ctx.setTxnId(100L);
+            }
+
+            @Mock
+            public void rollbackStmt(com.starrocks.qe.ConnectContext ctx,
+                                     com.starrocks.sql.ast.txn.RollbackStmt stmt) {
+                throw new RuntimeException("rollback failed");
+            }
+        };
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public GlobalStateMgr getCurrentState() {
+                return null;
+            }
+        };
+
+        multiTask.beginTxn(new TransactionResult());
+        Assertions.assertEquals(100L, multiTask.getTxnId());
+
+        TransactionResult resp = new TransactionResult();
+        multiTask.manualCancelTask(resp);
+        Assertions.assertEquals("ABORTING", multiTask.getStateName());
+        Assertions.assertTrue(resp.stateOK());
+    }
+
+    private void setupRollbackFailWithReconcileMock(long txnId,
+            ExplicitTxnState reconcileResult, boolean reconcileThrows) {
+        new MockUp<TransactionStmtExecutor>() {
+            @Mock
+            public void beginStmt(com.starrocks.qe.ConnectContext ctx,
+                                  com.starrocks.sql.ast.txn.BeginStmt stmt,
+                                  TransactionState.LoadJobSourceType sourceType,
+                                  String labelOverride) {
+                ctx.setTxnId(txnId);
+            }
+
+            @Mock
+            public void rollbackStmt(com.starrocks.qe.ConnectContext ctx,
+                                     com.starrocks.sql.ast.txn.RollbackStmt stmt) {
+                throw new RuntimeException("rollback failed");
+            }
+        };
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public GlobalTransactionMgr getGlobalTransactionMgr() {
+                return new GlobalTransactionMgr(null) {
+                    @Override
+                    public ExplicitTxnState getExplicitTxnState(long id) {
+                        if (reconcileThrows) {
+                            throw new RuntimeException("reconcile exception");
+                        }
+                        return reconcileResult;
+                    }
+                };
+            }
+        };
+    }
+
+    // ---- Cover reconcileWithTxnManager explicitState==null (lines 240-244) ----
+    @Test
+    public void testManualCancelWithReconcileExplicitStateNull() throws Exception {
+        setupRollbackFailWithReconcileMock(200L, null, false);
+        multiTask.beginTxn(new TransactionResult());
+        TransactionResult resp = new TransactionResult();
+        multiTask.manualCancelTask(resp);
+        Assertions.assertEquals("CANCELLED", multiTask.getStateName());
+    }
+
+    // ---- Cover reconcileWithTxnManager VISIBLE/COMMITTED (lines 246-264) ----
+    @Test
+    public void testManualCancelWithReconcileVisible() throws Exception {
+        ExplicitTxnState explicitState = new ExplicitTxnState();
+        TransactionState txnState = new TransactionState();
+        txnState.setTransactionStatus(TransactionStatus.VISIBLE);
+        explicitState.setTransactionState(txnState);
+
+        setupRollbackFailWithReconcileMock(300L, explicitState, false);
+        multiTask.beginTxn(new TransactionResult());
+        TransactionResult resp = new TransactionResult();
+        multiTask.manualCancelTask(resp);
+        Assertions.assertEquals("COMMITED", multiTask.getStateName());
+    }
+
+    // ---- Cover reconcileWithTxnManager exception (lines 267-270) ----
+    @Test
+    public void testManualCancelWithReconcileException() throws Exception {
+        setupRollbackFailWithReconcileMock(400L, null, true);
+        multiTask.beginTxn(new TransactionResult());
+        TransactionResult resp = new TransactionResult();
+        multiTask.manualCancelTask(resp);
+        Assertions.assertEquals("ABORTING", multiTask.getStateName());
+    }
+
+    // ---- Cover retryAbortIfNeeded (lines 280-289) ----
+    @Test
+    public void testRetryAbortIfNeededNotAborting() {
+        Assertions.assertTrue(multiTask.retryAbortIfNeeded(System.currentTimeMillis()));
+    }
+
+    @Test
+    public void testRetryAbortIfNeededNotYetTime() {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.ABORTING);
+        Deencapsulation.setField(multiTask, "nextAbortRetryTimeMs",
+                System.currentTimeMillis() + 100000);
+        Assertions.assertFalse(multiTask.retryAbortIfNeeded(System.currentTimeMillis()));
+    }
+
+    @Test
+    public void testRetryAbortIfNeededTimeReached() {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.ABORTING);
+        Deencapsulation.setField(multiTask, "nextAbortRetryTimeMs", 0L);
+        boolean result = multiTask.retryAbortIfNeeded(System.currentTimeMillis());
+        Assertions.assertTrue(result);
+        Assertions.assertEquals("CANCELLED", multiTask.getStateName());
+    }
+
+    // ---- Cover commitTxn state checks (lines 377-378, 393-394, 400-401, 407-433) ----
+    @Test
+    public void testCommitTxnWhenAlreadyCommitted() throws StarRocksException {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.COMMITED);
+        Deencapsulation.setField(multiTask, "txnId", 999L);
+        TransactionResult resp = new TransactionResult();
+        multiTask.commitTxn(null, resp);
+        Assertions.assertTrue(resp.stateOK());
+    }
+
+    @Test
+    public void testCommitTxnWhenCancelled() throws StarRocksException {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.CANCELLED);
+        TransactionResult resp = new TransactionResult();
+        multiTask.commitTxn(null, resp);
+        Assertions.assertFalse(resp.stateOK());
+    }
+
+    @Test
+    public void testCommitTxnWhenAborting() throws StarRocksException {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.ABORTING);
+        Deencapsulation.setField(multiTask, "abortReason", "test");
+        TransactionResult resp = new TransactionResult();
+        multiTask.commitTxn(null, resp);
+        Assertions.assertFalse(resp.stateOK());
+    }
+
+    @Test
+    public void testCommitTxnWhenCommiting() throws StarRocksException {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.COMMITING);
+        TransactionResult resp = new TransactionResult();
+        multiTask.commitTxn(null, resp);
+        Assertions.assertFalse(resp.stateOK());
+        Assertions.assertTrue(resp.msg.contains("already committing"));
+    }
+
+    // ---- Cover manualCancelTask all branches (lines 452-471) ----
+    @Test
+    public void testManualCancelTaskWhenAlreadyCommitted() throws StarRocksException {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.COMMITED);
+        TransactionResult resp = new TransactionResult();
+        multiTask.manualCancelTask(resp);
+        Assertions.assertFalse(resp.stateOK());
+    }
+
+    @Test
+    public void testManualCancelTaskWhenAlreadyCancelled() throws StarRocksException {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.CANCELLED);
+        Deencapsulation.setField(multiTask, "txnId", 999L);
+        TransactionResult resp = new TransactionResult();
+        multiTask.manualCancelTask(resp);
+        Assertions.assertTrue(resp.stateOK());
+    }
+
+    @Test
+    public void testManualCancelTaskWhenCommiting() throws StarRocksException {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.COMMITING);
+        TransactionResult resp = new TransactionResult();
+        multiTask.manualCancelTask(resp);
+        Assertions.assertFalse(resp.stateOK());
+        Assertions.assertTrue(resp.msg.contains("committing"));
+    }
+
+    @Test
+    public void testManualCancelTaskWhenAborting() throws StarRocksException {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.ABORTING);
+        Deencapsulation.setField(multiTask, "txnId", 999L);
+        TransactionResult resp = new TransactionResult();
+        multiTask.manualCancelTask(resp);
+        Assertions.assertTrue(resp.stateOK());
+        Assertions.assertTrue(resp.msg.contains("abort is already in progress"));
+    }
+
+    // ---- Cover manualCancelTask rollback pending path (lines 469-471) ----
+    @Test
+    public void testManualCancelTaskRollbackPending() throws Exception {
+        new MockUp<TransactionStmtExecutor>() {
+            @Mock
+            public void beginStmt(com.starrocks.qe.ConnectContext ctx,
+                                  com.starrocks.sql.ast.txn.BeginStmt stmt,
+                                  TransactionState.LoadJobSourceType sourceType,
+                                  String labelOverride) {
+                ctx.setTxnId(500L);
+            }
+
+            @Mock
+            public void rollbackStmt(com.starrocks.qe.ConnectContext ctx,
+                                     com.starrocks.sql.ast.txn.RollbackStmt stmt) {
+                throw new RuntimeException("rollback failed");
+            }
+        };
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public GlobalStateMgr getCurrentState() {
+                return null;
+            }
+        };
+
+        multiTask.beginTxn(new TransactionResult());
+        TransactionResult resp = new TransactionResult();
+        multiTask.manualCancelTask(resp);
+        Assertions.assertTrue(resp.stateOK());
+        Assertions.assertTrue(resp.msg.contains("rollback pending"));
+    }
+
+    // ---- Cover checkNeedRemove endTimeMs==-1 branch (line 483) ----
+    @Test
+    public void testCheckNeedRemoveWhenAborting() {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.ABORTING);
+        Assertions.assertFalse(multiTask.checkNeedRemove(System.currentTimeMillis(), true));
+    }
+
+    @Test
+    public void testCheckNeedRemoveFinalStateEndTimeMissing() {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.CANCELLED);
+        Deencapsulation.setField(multiTask, "endTimeMs", -1L);
+        boolean result = multiTask.checkNeedRemove(System.currentTimeMillis(), true);
+        Assertions.assertTrue(result);
+        Assertions.assertTrue(multiTask.endTimeMs() > 0);
+    }
+
+    // ---- Cover checkNeedRemove timeout path (line 515 = cancelOnTimeout) ----
+    @Test
+    public void testCheckNeedRemoveTriggersTimeout() {
+        Deencapsulation.setField(multiTask, "createTimeMs",
+                System.currentTimeMillis() - 2000);
+        Deencapsulation.setField(multiTask, "timeoutMs", 1000L);
+        boolean result = multiTask.checkNeedRemove(System.currentTimeMillis(), false);
+        Assertions.assertFalse(result);
+        Assertions.assertEquals("CANCELLED", multiTask.getStateName());
+    }
+
+    @Test
+    public void testCancelOnTimeoutEarlyReturn() {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.COMMITING);
+        multiTask.cancelOnTimeout();
+        Assertions.assertEquals("COMMITING", multiTask.getStateName());
+    }
+
+    @Test
+    public void testCancelOnExceptionWhenInFinalState() {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.CANCELLED);
+        multiTask.cancelOnException("ignored");
+        Assertions.assertEquals("CANCELLED", multiTask.getStateName());
+    }
+
+    // ---- Cover executeTask with existing subtask (line 715) ----
+    @Test
+    public void testExecuteTaskWithExistingSubTask() {
+        StreamLoadTask sub = new StreamLoadTask(2L, db, new OlapTable(), "l", "u",
+                "127.0.0.1", 1000, 1, 0,
+                System.currentTimeMillis(), WarehouseManager.DEFAULT_RESOURCE);
+        Deencapsulation.setField(sub, "tableName", "tbl1");
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, StreamLoadTask> map =
+                (java.util.Map<String, StreamLoadTask>) Deencapsulation.getField(multiTask,
+                        "taskMaps");
+        map.put("tbl1", sub);
+        HttpHeaders headers = new DefaultHttpHeaders();
+        TransactionResult resp = new TransactionResult();
+        multiTask.executeTask(0, "tbl1", headers, resp);
+        Assertions.assertTrue(resp.stateOK());
+    }
+
+    // ---- Cover executeTask when ABORTING (line 704) ----
+    @Test
+    public void testExecuteTaskWhenAborting() {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.ABORTING);
+        Deencapsulation.setField(multiTask, "abortReason", "test");
+        HttpHeaders headers = new DefaultHttpHeaders();
+        TransactionResult resp = new TransactionResult();
+        Assertions.assertNull(multiTask.executeTask(0, "t", headers, resp));
+        Assertions.assertFalse(resp.stateOK());
+    }
+
+    // ---- Cover tryLoad when CANCELLED/ABORTING/COMMITED (lines 700-710) ----
+    @Test
+    public void testTryLoadWhenCancelled() throws StarRocksException {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.CANCELLED);
+        Deencapsulation.setField(multiTask, "errorMsg", "test");
+        TransactionResult resp = new TransactionResult();
+        Assertions.assertNull(multiTask.tryLoad(0, "t", resp));
+        Assertions.assertFalse(resp.stateOK());
+    }
+
+    @Test
+    public void testTryLoadWhenAborting() throws StarRocksException {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.ABORTING);
+        Deencapsulation.setField(multiTask, "abortReason", "test");
+        TransactionResult resp = new TransactionResult();
+        Assertions.assertNull(multiTask.tryLoad(0, "t", resp));
+        Assertions.assertFalse(resp.stateOK());
+    }
+
+    @Test
+    public void testTryLoadWhenCommitted() throws StarRocksException {
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.COMMITED);
+        TransactionResult resp = new TransactionResult();
+        Assertions.assertNull(multiTask.tryLoad(0, "t", resp));
+        Assertions.assertFalse(resp.stateOK());
+    }
+
+    // ---- Cover prepareChannel with existing subtask (line 728) ----
+    @Test
+    public void testPrepareChannelWithSubTask() {
+        StreamLoadTask sub = new StreamLoadTask(2L, db, new OlapTable(), "l", "u",
+                "127.0.0.1", 1000, 1, 0,
+                System.currentTimeMillis(), WarehouseManager.DEFAULT_RESOURCE);
+        Deencapsulation.setField(sub, "tableName", "tbl1");
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, StreamLoadTask> map =
+                (java.util.Map<String, StreamLoadTask>) Deencapsulation.getField(multiTask,
+                        "taskMaps");
+        map.put("tbl1", sub);
+        HttpHeaders headers = new DefaultHttpHeaders();
+        TransactionResult resp = new TransactionResult();
+        multiTask.prepareChannel(0, "tbl1", headers, resp);
+        Assertions.assertTrue(resp.stateOK());
+    }
+
+    // ---- Cover cancelAfterRestart with txnId (covers transitionToAborting + tryRollbackNow) ----
+    @Test
+    public void testCancelAfterRestartWithTxnId() throws Exception {
+        new MockUp<TransactionStmtExecutor>() {
+            @Mock
+            public void beginStmt(com.starrocks.qe.ConnectContext ctx,
+                                  com.starrocks.sql.ast.txn.BeginStmt stmt,
+                                  TransactionState.LoadJobSourceType sourceType,
+                                  String labelOverride) {
+                ctx.setTxnId(999L);
+            }
+        };
+        multiTask.beginTxn(new TransactionResult());
+        Deencapsulation.setField(multiTask, "state", StreamLoadMultiStmtTask.State.LOADING);
+        multiTask.cancelAfterRestart();
+        Assertions.assertTrue("CANCELLED".equals(multiTask.getStateName())
+                || "ABORTING".equals(multiTask.getStateName()));
+    }
+
+    @Test
+    public void testCancelAfterRestartWithNoTxnId() {
+        multiTask.cancelAfterRestart();
+        Assertions.assertEquals("CANCELLED", multiTask.getStateName());
     }
 }

--- a/test/sql/test_stream_load/R/test_stream_load_basic_txn
+++ b/test/sql/test_stream_load/R/test_stream_load_basic_txn
@@ -1,0 +1,184 @@
+-- name: test_basic_txn_commit_operations @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+[UC]shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -d '1,alice' -XPUT ${url}/api/transaction/load
+-- result:
+0
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -d '2,bob' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+TXN_NOT_EXISTS
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+select * from table1 order by id;
+-- result:
+1	alice
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+LABEL_ALREADY_EXISTS
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_basic_txn_rollback_operations @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+[UC]shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -d '1,alice' -XPUT ${url}/api/transaction/load
+-- result:
+0
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -d '2,bob' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+TXN_NOT_EXISTS
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+select count(*) from table1;
+-- result:
+0
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_basic_txn_edge_cases @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:no_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:no_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:no_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:empty_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:empty_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+INTERNAL_ERROR
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:empty_rollback_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:empty_rollback_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:double_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:double_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+LABEL_ALREADY_EXISTS
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:double_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+select count(*) from table1;
+-- result:
+0
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_stream_load/R/test_stream_load_exception_handling
+++ b/test/sql/test_stream_load/R/test_stream_load_exception_handling
@@ -1,0 +1,215 @@
+-- name: test_basic_txn_load_failure @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table_strict` (
+  `id` int,
+  `name` varchar(100),
+  `required_col` bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:load_fail_basic_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:load_fail_basic_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+ANALYSIS_ERROR
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:load_fail_basic_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+select count(*) from table_strict;
+-- result:
+0
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_multi_txn_load_failure @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table_strict` (
+  `id` int,
+  `name` varchar(100),
+  `required_col` bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:load_fail_multi_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:load_fail_multi_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:load_fail_multi_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+select count(*) from table_strict;
+-- result:
+0
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_load_failure_commit_behavior @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table_strict` (
+  `id` int,
+  `name` varchar(100),
+  `required_col` bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:basic_fail_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:basic_fail_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+ANALYSIS_ERROR
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:basic_fail_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:multi_fail_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:multi_fail_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:multi_fail_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+select count(*) from table_strict;
+-- result:
+0
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_basic_txn_load_failure_then_retry @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table_strict` (
+  `id` int,
+  `name` varchar(100),
+  `required_col` bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:basic_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:basic_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+ANALYSIS_ERROR
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:basic_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -d '2,bob,100' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+TXN_NOT_EXISTS
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:basic_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+select count(*) from table_strict;
+-- result:
+0
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_multi_txn_load_failure_then_retry @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table_strict` (
+  `id` int,
+  `name` varchar(100),
+  `required_col` bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:multi_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:multi_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:multi_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "transaction_type:multi" -d '2,bob,100' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:multi_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+select count(*) from table_strict;
+-- result:
+0
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_stream_load/R/test_stream_load_multi_table_rollback
+++ b/test/sql/test_stream_load/R/test_stream_load_multi_table_rollback
@@ -1,0 +1,184 @@
+-- name: test_multi_txn_commit_operations @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+[UC]shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load
+-- result:
+0
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '2,bob' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+select * from table1 order by id;
+-- result:
+1	alice
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+LABEL_ALREADY_EXISTS
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_multi_txn_rollback_operations @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+[UC]shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load
+-- result:
+0
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '2,bob' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+select count(*) from table1;
+-- result:
+0
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+LABEL_ALREADY_EXISTS
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_multi_txn_edge_cases @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:no_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:no_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:no_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:empty_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:empty_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:empty_rollback_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:empty_rollback_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:double_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:double_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+LABEL_ALREADY_EXISTS
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:double_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+select count(*) from table1;
+-- result:
+0
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_stream_load/R/test_stream_load_timeout_cleanup
+++ b/test/sql/test_stream_load/R/test_stream_load_timeout_cleanup
@@ -1,0 +1,191 @@
+-- name: test_multi_txn_timeout @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:timeout_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "timeout:5" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: sleep 8 && echo "waited"
+-- result:
+0
+waited
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:timeout_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:timeout_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+select count(*) from table1;
+-- result:
+0
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_multi_txn_load_failure_then_retry_same_table @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table_strict` (
+  `id` int,
+  `name` varchar(100),
+  `required_col` bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:retry_same_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:retry_same_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:retry_same_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "transaction_type:multi" -d '2,bob,100' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:retry_same_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+select count(*) from table_strict;
+-- result:
+0
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_multi_txn_load_failure_then_load_different_table @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table_strict` (
+  `id` int,
+  `name` varchar(100),
+  `required_col` bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+CREATE TABLE `table_normal` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:multi_table_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:multi_table_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:multi_table_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_normal" -H "column_separator:," -H "transaction_type:multi" -d '2,bob' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:multi_table_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+select count(*) from table_strict;
+-- result:
+0
+-- !result
+select count(*) from table_normal;
+-- result:
+0
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result
+-- name: test_multi_txn_task_final_state @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:final_state_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+[UC]shell: curl -s --location-trusted -u root: -H "label:final_state_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load
+-- result:
+0
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:final_state_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:final_state_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '2,bob' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:final_state_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+-- result:
+0
+FAILED
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:final_state_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+LABEL_ALREADY_EXISTS
+-- !result
+select * from table1 order by id;
+-- result:
+1	alice
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_stream_load/T/test_stream_load_basic_txn
+++ b/test/sql/test_stream_load/T/test_stream_load_basic_txn
@@ -1,0 +1,122 @@
+-- name: test_basic_txn_commit_operations @sequential
+-- Test basic transaction stream load commit related operations (no channel, no multi)
+-- Note: BEGIN and LOAD are redirected to BE in this mode
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- 1. Begin transaction (basic mode - redirected to BE)
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- 2. Load data (basic mode - redirected to BE)
+[UC]shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -d '1,alice' -XPUT ${url}/api/transaction/load
+
+-- 3. First commit
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 4. Double commit
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 5. Load after commit
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -d '2,bob' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 6. Rollback after commit
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 7. Verify data was committed
+select * from table1 order by id;
+
+-- 8. Begin with same label after commit
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+drop database db_${uuid0};
+
+-- name: test_basic_txn_rollback_operations @sequential
+-- Test basic transaction stream load rollback related operations (no channel, no multi)
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- 1. Begin transaction
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- 2. Load data
+[UC]shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -d '1,alice' -XPUT ${url}/api/transaction/load
+
+-- 3. First rollback
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 4. Double rollback
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 5. Load after rollback
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -d '2,bob' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 6. Commit after rollback
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 7. Verify data was not committed
+select count(*) from table1;
+
+-- 8. Begin with same label after rollback
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+drop database db_${uuid0};
+
+-- name: test_basic_txn_edge_cases @sequential
+-- Test empty transactions and operations without begin (no channel, no multi)
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- 1. Load without begin
+shell: curl -s --location-trusted -u root: -H "label:no_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 2. Commit without begin
+shell: curl -s --location-trusted -u root: -H "label:no_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 3. Rollback without begin
+shell: curl -s --location-trusted -u root: -H "label:no_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 4. Empty transaction commit: begin -> commit (no load)
+shell: curl -s --location-trusted -u root: -H "label:empty_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+shell: curl -s --location-trusted -u root: -H "label:empty_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 5. Empty transaction rollback: begin -> rollback (no load)
+shell: curl -s --location-trusted -u root: -H "label:empty_rollback_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+shell: curl -s --location-trusted -u root: -H "label:empty_rollback_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 6. Double Begin: begin -> begin (same label, transaction still active)
+shell: curl -s --location-trusted -u root: -H "label:double_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+shell: curl -s --location-trusted -u root: -H "label:double_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+shell: curl -s --location-trusted -u root: -H "label:double_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 7. Verify table is still empty
+select count(*) from table1;
+
+drop database db_${uuid0};

--- a/test/sql/test_stream_load/T/test_stream_load_exception_handling
+++ b/test/sql/test_stream_load/T/test_stream_load_exception_handling
@@ -1,0 +1,161 @@
+-- name: test_basic_txn_load_failure @sequential
+-- Test basic transaction stream load: LOAD failure behavior
+-- LOAD failure auto-aborts the transaction in basic mode (returns ANALYSIS_ERROR)
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- Create table with NOT NULL column without default value
+CREATE TABLE `table_strict` (
+  `id` int,
+  `name` varchar(100),
+  `required_col` bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- 1. Begin transaction
+shell: curl -s --location-trusted -u root: -H "label:load_fail_basic_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- 2. First LOAD - should fail with ANALYSIS_ERROR (missing required_col)
+shell: curl -s --location-trusted -u root: -H "label:load_fail_basic_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 3. Rollback - transaction was auto-aborted, so this returns OK
+shell: curl -s --location-trusted -u root: -H "label:load_fail_basic_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 4. Verify table is empty
+select count(*) from table_strict;
+
+drop database db_${uuid0};
+
+-- name: test_multi_txn_load_failure @sequential
+-- Test multi-statement stream load: LOAD failure behavior
+-- LOAD failure returns FAILED and records error
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- Create table with NOT NULL column without default value
+CREATE TABLE `table_strict` (
+  `id` int,
+  `name` varchar(100),
+  `required_col` bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- 1. Begin transaction
+shell: curl -s --location-trusted -u root: -H "label:load_fail_multi_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- 2. First LOAD - should fail with FAILED (missing required_col)
+shell: curl -s --location-trusted -u root: -H "label:load_fail_multi_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 3. Rollback - should succeed
+shell: curl -s --location-trusted -u root: -H "label:load_fail_multi_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 4. Verify table is empty
+select count(*) from table_strict;
+
+drop database db_${uuid0};
+
+-- name: test_load_failure_commit_behavior @sequential
+-- Test LOAD failure followed by commit attempt
+-- Both basic and multi-statement should fail to commit after LOAD failure
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `table_strict` (
+  `id` int,
+  `name` varchar(100),
+  `required_col` bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- Test 1: Basic transaction - LOAD fails, commit should fail
+shell: curl -s --location-trusted -u root: -H "label:basic_fail_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- LOAD with missing column (should return ANALYSIS_ERROR)
+shell: curl -s --location-trusted -u root: -H "label:basic_fail_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- Commit should fail (transaction was auto-aborted)
+shell: curl -s --location-trusted -u root: -H "label:basic_fail_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- Test 2: Multi-statement - LOAD fails, commit should fail
+shell: curl -s --location-trusted -u root: -H "label:multi_fail_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- LOAD with missing column (should return FAILED)
+shell: curl -s --location-trusted -u root: -H "label:multi_fail_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- Commit should fail
+shell: curl -s --location-trusted -u root: -H "label:multi_fail_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- Verify table is empty
+select count(*) from table_strict;
+
+drop database db_${uuid0};
+
+-- name: test_basic_txn_load_failure_then_retry @sequential
+-- Test basic transaction: LOAD failure auto-aborts transaction, retry LOAD fails
+-- Key difference: Basic transaction auto-aborts on LOAD failure, multi-statement does not
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `table_strict` (
+  `id` int,
+  `name` varchar(100),
+  `required_col` bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- 1. Begin transaction
+shell: curl -s --location-trusted -u root: -H "label:basic_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- 2. First LOAD - fails with ANALYSIS_ERROR (transaction auto-aborted)
+shell: curl -s --location-trusted -u root: -H "label:basic_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 3. Retry LOAD - fails with TXN_NOT_EXISTS (transaction was auto-aborted)
+shell: curl -s --location-trusted -u root: -H "label:basic_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -d '2,bob,100' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 4. Commit - fails (transaction was auto-aborted)
+shell: curl -s --location-trusted -u root: -H "label:basic_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 5. Verify table is empty
+select count(*) from table_strict;
+
+drop database db_${uuid0};
+
+-- name: test_multi_txn_load_failure_then_retry @sequential
+-- Test multi-statement transaction: LOAD failure auto-aborts transaction
+-- Now consistent with basic transaction: LOAD failure auto-aborts, retry LOAD fails
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `table_strict` (
+  `id` int,
+  `name` varchar(100),
+  `required_col` bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- 1. Begin transaction
+shell: curl -s --location-trusted -u root: -H "label:multi_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- 2. First LOAD - fails with FAILED (transaction auto-aborted)
+shell: curl -s --location-trusted -u root: -H "label:multi_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 3. Retry LOAD - fails (transaction was auto-aborted)
+shell: curl -s --location-trusted -u root: -H "label:multi_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "transaction_type:multi" -d '2,bob,100' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 4. Commit - fails (transaction was auto-aborted)
+shell: curl -s --location-trusted -u root: -H "label:multi_retry_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 5. Verify table is empty
+select count(*) from table_strict;
+
+drop database db_${uuid0};

--- a/test/sql/test_stream_load/T/test_stream_load_multi_table_rollback
+++ b/test/sql/test_stream_load/T/test_stream_load_multi_table_rollback
@@ -1,0 +1,121 @@
+-- name: test_multi_txn_commit_operations @sequential
+-- Test multi-table transaction commit related operations
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- 1. Begin transaction
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- 2. Load data
+[UC]shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load
+
+-- 3. First commit (should succeed)
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 4. Double commit (should return OK with already committed message)
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 5. Load after commit (should fail)
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '2,bob' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 6. Rollback after commit (should fail)
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 7. Verify data was committed
+select * from table1 order by id;
+
+-- 8. Begin with same label after commit (should fail - label already used)
+shell: curl -s --location-trusted -u root: -H "label:commit_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+drop database db_${uuid0};
+
+-- name: test_multi_txn_rollback_operations @sequential
+-- Test multi-table transaction rollback related operations
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- 1. Begin transaction
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- 2. Load data
+[UC]shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load
+
+-- 3. First rollback (should succeed)
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 4. Double rollback (should return OK with already aborted message)
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 5. Load after rollback (should fail)
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '2,bob' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 6. Commit after rollback (should fail)
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 7. Verify data was not committed
+select count(*) from table1;
+
+-- 8. Begin with same label after rollback (should return LABEL_ALREADY_EXISTS)
+shell: curl -s --location-trusted -u root: -H "label:rollback_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+drop database db_${uuid0};
+
+-- name: test_multi_txn_edge_cases @sequential
+-- Test empty transactions and operations without begin
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- 1. Load without begin (should fail)
+shell: curl -s --location-trusted -u root: -H "label:no_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 2. Commit without begin (should fail)
+shell: curl -s --location-trusted -u root: -H "label:no_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 3. Rollback without begin (should fail)
+shell: curl -s --location-trusted -u root: -H "label:no_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 4. Empty transaction commit: begin -> commit (no load)
+shell: curl -s --location-trusted -u root: -H "label:empty_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+shell: curl -s --location-trusted -u root: -H "label:empty_commit_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 5. Empty transaction rollback: begin -> rollback (no load)
+shell: curl -s --location-trusted -u root: -H "label:empty_rollback_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+shell: curl -s --location-trusted -u root: -H "label:empty_rollback_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 6. Double Begin: begin -> begin (same label, transaction still active)
+shell: curl -s --location-trusted -u root: -H "label:double_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+shell: curl -s --location-trusted -u root: -H "label:double_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+shell: curl -s --location-trusted -u root: -H "label:double_begin_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 7. Verify table is still empty
+select count(*) from table1;
+
+drop database db_${uuid0};

--- a/test/sql/test_stream_load/T/test_stream_load_timeout_cleanup
+++ b/test/sql/test_stream_load/T/test_stream_load_timeout_cleanup
@@ -1,0 +1,139 @@
+-- name: test_multi_txn_timeout @sequential
+-- Test multi-statement stream load transaction timeout mechanism
+-- Use a short timeout (5 seconds) and verify operations fail after timeout
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- 1. Begin transaction with short timeout (5 seconds)
+shell: curl -s --location-trusted -u root: -H "label:timeout_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "timeout:5" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- 2. Wait for timeout (8 seconds to ensure timeout is triggered)
+shell: sleep 8 && echo "waited"
+
+-- 3. Try to load after timeout - should fail because task was cancelled by timeout
+shell: curl -s --location-trusted -u root: -H "label:timeout_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 4. Try to commit after timeout - should also fail
+shell: curl -s --location-trusted -u root: -H "label:timeout_test_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 5. Verify table is empty (no data committed)
+select count(*) from table1;
+
+drop database db_${uuid0};
+
+-- name: test_multi_txn_load_failure_then_retry_same_table @sequential
+-- Test LOAD failure followed by retry LOAD to same table
+-- Now consistent with basic transaction: LOAD failure auto-aborts, retry LOAD fails
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- Create table with NOT NULL column
+CREATE TABLE `table_strict` (
+  `id` int,
+  `name` varchar(100),
+  `required_col` bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- 1. Begin transaction
+shell: curl -s --location-trusted -u root: -H "label:retry_same_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- 2. First LOAD - should fail (missing required_col), transaction auto-aborted
+shell: curl -s --location-trusted -u root: -H "label:retry_same_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 3. Second LOAD to SAME table - should fail (transaction was auto-aborted)
+shell: curl -s --location-trusted -u root: -H "label:retry_same_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "transaction_type:multi" -d '2,bob,100' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 4. Commit - should fail (transaction was auto-aborted)
+shell: curl -s --location-trusted -u root: -H "label:retry_same_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 5. Verify table is empty
+select count(*) from table_strict;
+
+drop database db_${uuid0};
+
+-- name: test_multi_txn_load_failure_then_load_different_table @sequential
+-- Test LOAD failure to one table, then LOAD to different table
+-- Now consistent with basic transaction: LOAD failure auto-aborts entire transaction
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- Create two tables
+CREATE TABLE `table_strict` (
+  `id` int,
+  `name` varchar(100),
+  `required_col` bigint NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+CREATE TABLE `table_normal` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- 1. Begin transaction
+shell: curl -s --location-trusted -u root: -H "label:multi_table_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- 2. First LOAD to table_strict - should fail (missing required_col), transaction auto-aborted
+shell: curl -s --location-trusted -u root: -H "label:multi_table_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_strict" -H "column_separator:," -H "columns:id,name" -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 3. Second LOAD to table_normal - should fail (transaction was auto-aborted)
+shell: curl -s --location-trusted -u root: -H "label:multi_table_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table_normal" -H "column_separator:," -H "transaction_type:multi" -d '2,bob' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 4. Commit - should fail (transaction was auto-aborted)
+shell: curl -s --location-trusted -u root: -H "label:multi_table_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 5. Verify both tables are empty
+select count(*) from table_strict;
+select count(*) from table_normal;
+
+drop database db_${uuid0};
+
+-- name: test_multi_txn_task_final_state @sequential
+-- Test that task enters final state correctly after commit/rollback
+-- Verify subsequent operations fail
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `table1` (
+  `id` int,
+  `name` varchar(100)
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1;
+
+-- 1. Begin, Load, Commit
+shell: curl -s --location-trusted -u root: -H "label:final_state_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+[UC]shell: curl -s --location-trusted -u root: -H "label:final_state_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '1,alice' -XPUT ${url}/api/transaction/load
+
+shell: curl -s --location-trusted -u root: -H "label:final_state_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 2. Try Load after commit - should fail (task in final state)
+shell: curl -s --location-trusted -u root: -H "label:final_state_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "column_separator:," -H "transaction_type:multi" -d '2,bob' -XPUT ${url}/api/transaction/load | jq -r '.Status'
+
+-- 3. Try Rollback after commit - should fail
+shell: curl -s --location-trusted -u root: -H "label:final_state_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/rollback | jq -r '.Status'
+
+-- 4. Try Begin with same label - should fail (label already used)
+shell: curl -s --location-trusted -u root: -H "label:final_state_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:table1" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- 5. Verify only first LOAD data exists
+select * from table1 order by id;
+
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
Multi-statement stream load transactions had several behavioral issues:
1. Rollback returned OK but actually failed with "transaction not found" because the transaction was looked up from idToRunningTransactionState instead of explicitTxnStateMap where it was created.
2. Error conditions incorrectly returned OK status instead of FAILED, misleading users about the actual operation result.
3. Inconsistent behavior with basic transactions for operations like double begin, double commit, rollback after commit, and label reuse after commit.


## What I'm doing:
- StreamLoadMultiStmtTask: Use TransactionStmtExecutor.rollbackStmt() to properly abort transactions from explicitTxnStateMap
- StreamLoadMultiStmtTask: Add state checks in beginTxn/commitTxn/ manualCancelTask to align behavior with basic transactions:
  - Double Begin: return LABEL_ALREADY_EXISTS
  - Double Commit: return OK with "already committed" message
  - Rollback after Commit: return FAILED
  - Label Reuse after Commit: return LABEL_ALREADY_EXISTS
- StreamLoadTask: Change setOKMsg to setErrorMsg for CANCELLED state in tryLoad/executeTask/prepareChannel/waitCoordFinish/commitTxn/ manualCancelTask methods
- StreamLoadTask: Add cancelCoordinatorOnly() for sub-tasks in multi-statement transactions to cancel coordinator without aborting the parent transaction
- StreamLoadMgr: Add label existence check in beginMultiStatementLoadTask to prevent reusing committed transaction labels

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [x] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
