### PR TITLE
[Refactor] Remove some boost

### DIFF
--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -38,12 +38,12 @@
 
 #include <boost/container/flat_set.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/variant.hpp>
 #include <cstdint>
 #include <map>
 #include <sstream>
 #include <string>
 #include <utility>
+#include <variant>
 
 #include "exec/olap_utils.h"
 #include "exec/scan_node.h"

--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -14,8 +14,8 @@
 
 #include "exec/olap_scan_prepare.h"
 
-#include <variant>
 #include <boost/variant/static_visitor.hpp>
+#include <variant>
 
 #include "column/type_traits.h"
 #include "exprs/binary_predicate.h"

--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -15,6 +15,7 @@
 #include "exec/olap_scan_prepare.h"
 
 #include <variant>
+#include <boost/variant/static_visitor.hpp>
 
 #include "column/type_traits.h"
 #include "exprs/binary_predicate.h"

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -37,7 +37,6 @@
 #include <protocol/TDebugProtocol.h>
 #include <util/timezone_utils.h>
 
-#include <boost/algorithm/string/join.hpp>
 #include <ios>
 #include <sstream>
 
@@ -53,8 +52,6 @@
 #include "util/thrift_util.h"
 
 namespace starrocks {
-using boost::algorithm::join;
-
 const int RowDescriptor::INVALID_IDX = -1;
 std::string NullIndicatorOffset::debug_string() const {
     std::stringstream out;

--- a/be/src/runtime/jdbc_driver_manager.cpp
+++ b/be/src/runtime/jdbc_driver_manager.cpp
@@ -15,7 +15,6 @@
 #include "runtime/jdbc_driver_manager.h"
 
 #include <atomic>
-#include <boost/algorithm/string/predicate.hpp> // boost::algorithm::ends_with
 #include <chrono>
 #include <memory>
 #include <utility>
@@ -93,13 +92,13 @@ Status JDBCDriverManager::init(const std::string& driver_dir) {
             continue;
         }
         // remove all temporary files
-        if (boost::algorithm::ends_with(file, TMP_FILE_SUFFIX)) {
+        if (file.ends_with(TMP_FILE_SUFFIX)) {
             LOG(INFO) << fmt::format("try to remove temporary file {}", target_file);
             RETURN_IF_ERROR(FileSystem::Default()->delete_file(target_file));
             continue;
         }
         // try to load drivers from jar file
-        if (boost::algorithm::ends_with(file, JAR_FILE_SUFFIX)) {
+        if (file.ends_with(JAR_FILE_SUFFIX)) {
             std::string name;
             std::string checksum;
             int64_t first_access_ts;

--- a/be/src/runtime/load_path_mgr.cpp
+++ b/be/src/runtime/load_path_mgr.cpp
@@ -38,13 +38,13 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <boost/algorithm/string/join.hpp>
 #include <string>
 
 #include "common/config.h"
 #include "fs/fs.h"
 #include "fs/fs_util.h"
 #include "gen_cpp/Types_types.h"
+#include "gutil/strings/join.h"
 #include "runtime/base_load_path_mgr.h"
 #include "runtime/exec_env.h"
 #include "storage/olap_define.h"
@@ -66,7 +66,7 @@ Status LoadPathMgr::init() {
     for (auto& path : _exec_env->store_paths()) {
         _path_vec.push_back(path.path + MINI_PREFIX);
     }
-    LOG(INFO) << "Load path configured to [" << boost::join(_path_vec, ",") << "]";
+    LOG(INFO) << "Load path configured to [" << JoinStrings(_path_vec, ",") << "]";
 
     // error log is saved in first root path
     _error_log_dir = _exec_env->store_paths()[0].path + ERROR_LOG_PREFIX;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -34,7 +34,6 @@
 
 #include "runtime/runtime_state.h"
 
-#include <boost/algorithm/string/join.hpp>
 #include <cstring>
 #include <memory>
 #include <sstream>

--- a/be/src/runtime/user_function_cache.cpp
+++ b/be/src/runtime/user_function_cache.cpp
@@ -36,7 +36,6 @@
 
 #include <any>
 #include <atomic>
-#include <boost/algorithm/string/predicate.hpp> // boost::algorithm::ends_with
 #include <memory>
 #include <utility>
 #include <vector>
@@ -154,9 +153,9 @@ StatusOr<std::any> UserFunctionCache::load_cacheable_java_udf(
 }
 
 auto UserFunctionCache::_get_function_type(const std::string& url) -> FuncType {
-    if (boost::algorithm::ends_with(url, JAVA_UDF_SUFFIX)) {
+    if (url.ends_with(JAVA_UDF_SUFFIX)) {
         return UDF_TYPE_JAVA;
-    } else if (boost::algorithm::ends_with(url, PY_UDF_SUFFIX)) {
+    } else if (url.ends_with(PY_UDF_SUFFIX)) {
         return UDF_TYPE_PYTHON;
     }
     return UDF_TYPE_UNKNOWN;
@@ -323,8 +322,7 @@ Status UserFunctionCache::_remove_all_lib_file() {
             if (file == "." || file == "..") {
                 return true;
             }
-            if (!boost::algorithm::ends_with(file, JAVA_UDF_SUFFIX) ||
-                !boost::algorithm::ends_with(file, PY_UDF_SUFFIX)) {
+            if (!file.ends_with(JAVA_UDF_SUFFIX) || !file.ends_with(PY_UDF_SUFFIX)) {
                 return true;
             }
             if (unlink((sub_dir + "/").append(file).c_str()) != 0) {

--- a/be/src/storage/merge_iterator.cpp
+++ b/be/src/storage/merge_iterator.cpp
@@ -14,7 +14,6 @@
 
 #include "storage/merge_iterator.h"
 
-#include <boost/heap/skew_heap.hpp>
 #include <memory>
 #include <queue>
 #include <vector>

--- a/be/src/util/cpu_info.h
+++ b/be/src/util/cpu_info.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <string>

--- a/be/src/util/debug_util.h
+++ b/be/src/util/debug_util.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <ostream>
 #include <string>
 

--- a/be/src/util/disk_info.h
+++ b/be/src/util/disk_info.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <map>
 #include <set>
 #include <string>

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <string>
 
 #include "common/logging.h"

--- a/be/src/util/parse_util.h
+++ b/be/src/util/parse_util.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <string>
 
 #include "common/statusor.h"

--- a/be/src/util/pretty_printer.h
+++ b/be/src/util/pretty_printer.h
@@ -17,12 +17,12 @@
 
 #pragma once
 
-#include <boost/algorithm/string.hpp>
 #include <cmath>
 #include <iomanip>
 #include <sstream>
 
 #include "gen_cpp/RuntimeProfile_types.h"
+#include "gutil/strings/join.h"
 #include "util/cpu_info.h"
 #include "util/template_util.h"
 
@@ -177,7 +177,7 @@ public:
             strings.push_back(ss.str());
         }
 
-        (*out) << "[" << boost::algorithm::join(strings, ", ") << "]";
+        (*out) << "[" << JoinStrings(strings, ", ") << "]";
     }
 
     /// Convenience method

--- a/be/src/util/static_asserts.cpp
+++ b/be/src/util/static_asserts.cpp
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <boost/static_assert.hpp>
+#include <cstddef>
 
 #include "runtime/datetime_value.h"
 
@@ -25,10 +25,10 @@ namespace starrocks {
 // at compile time.  If these asserts fail, the compile will fail.
 class UnusedClass {
 private:
-    BOOST_STATIC_ASSERT(sizeof(Slice) == 16);
-    BOOST_STATIC_ASSERT(offsetof(Slice, size) == 8);
+    static_assert(sizeof(Slice) == 16, "Slice size mismatch");
+    static_assert(offsetof(Slice, size) == 8, "Slice.size offset mismatch");
     // Datetime value
-    BOOST_STATIC_ASSERT(sizeof(DateTimeValue) == 16);
+    static_assert(sizeof(DateTimeValue) == 16, "DateTimeValue size mismatch");
 };
 
 } // namespace starrocks

--- a/be/src/util/stopwatch.hpp
+++ b/be/src/util/stopwatch.hpp
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <ctime>
 
 namespace starrocks {

--- a/be/src/util/template_util.h
+++ b/be/src/util/template_util.h
@@ -17,10 +17,7 @@
 
 #pragma once
 
-#include <boost/type_traits/is_arithmetic.hpp>
-#include <boost/type_traits/is_float.hpp>
-#include <boost/type_traits/is_integral.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <type_traits>
 
 /// The ENABLE_IF_* macros are used to 'enable' - i.e. to make available to the compiler -
 /// a method only if a type parameter belongs to the set described by each macro. Each
@@ -32,18 +29,18 @@
 /// Enables a method only if 'type_param' is arithmetic, that is an integral type or a
 /// floating-point type
 #define ENABLE_IF_ARITHMETIC(type_param, return_type) \
-    typename boost::enable_if_c<boost::is_arithmetic<type_param>::value, return_type>::type
+    typename std::enable_if<std::is_arithmetic<type_param>::value, return_type>::type
 
 /// Enables a method only if 'type_param' is not arithmetic, that is neither an integral
 /// type or a floating-point type
 #define ENABLE_IF_NOT_ARITHMETIC(type_param, return_type) \
-    typename boost::enable_if_c<!boost::is_arithmetic<type_param>::value, return_type>::type
+    typename std::enable_if<!std::is_arithmetic<type_param>::value, return_type>::type
 
 /// Enables a method only if 'type_param' is integral, i.e. some variant of int or long
 #define ENABLE_IF_INTEGRAL(type_param, return_type) \
-    typename boost::enable_if_c<boost::is_integral<type_param>::value, return_type>::type
+    typename std::enable_if<std::is_integral<type_param>::value, return_type>::type
 
 /// Enables a method only if 'type_param' is a floating point type, i.e. some variant of
 /// float or double.
 #define ENABLE_IF_FLOAT(type_param, return_type) \
-    typename boost::enable_if_c<!boost::is_integral<type_param>::value, return_type>::type
+    typename std::enable_if<!std::is_integral<type_param>::value, return_type>::type

--- a/be/src/util/url_coding.h
+++ b/be/src/util/url_coding.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/be/test/util/bit_stream_utils_test.cpp
+++ b/be/test/util/bit_stream_utils_test.cpp
@@ -40,8 +40,6 @@
 // Must come before gtest.h.
 #include <gtest/gtest.h>
 
-#include <boost/utility/binary.hpp>
-
 #include "util/bit_packing_default.h"
 #include "util/bit_stream_utils.h"
 #include "util/bit_stream_utils.inline.h"
@@ -67,7 +65,7 @@ TEST(TestBitStreamUtil, TestBool) {
         writer.PutValue(i % 2, 1);
     }
     writer.Flush();
-    EXPECT_EQ(buffer[0], BOOST_BINARY(1 0 1 0 1 0 1 0));
+    EXPECT_EQ(buffer[0], 0b10101010);
 
     // Write 00110011
     for (int i = 0; i < 8; ++i) {
@@ -86,8 +84,8 @@ TEST(TestBitStreamUtil, TestBool) {
     writer.Flush();
 
     // Validate the exact bit value
-    EXPECT_EQ(buffer[0], BOOST_BINARY(1 0 1 0 1 0 1 0));
-    EXPECT_EQ(buffer[1], BOOST_BINARY(1 1 0 0 1 1 0 0));
+    EXPECT_EQ(buffer[0], 0b10101010);
+    EXPECT_EQ(buffer[1], 0b11001100);
 
     // Use the reader and validate
     BitReader reader(buffer.data(), buffer.size());

--- a/be/test/util/bit_util_test.cpp
+++ b/be/test/util/bit_util_test.cpp
@@ -36,8 +36,6 @@
 
 #include <gtest/gtest.h>
 
-#include <boost/utility.hpp>
-
 namespace starrocks {
 
 TEST(BitUtil, Ceil) {
@@ -51,12 +49,12 @@ TEST(BitUtil, Ceil) {
 }
 
 TEST(BitUtil, Popcount) {
-    EXPECT_EQ(BitUtil::popcount(BOOST_BINARY(0 1 0 1 0 1 0 1)), 4);
-    EXPECT_EQ(BitUtil::popcount_no_hw(BOOST_BINARY(0 1 0 1 0 1 0 1)), 4);
-    EXPECT_EQ(BitUtil::popcount(BOOST_BINARY(1 1 1 1 0 1 0 1)), 6);
-    EXPECT_EQ(BitUtil::popcount_no_hw(BOOST_BINARY(1 1 1 1 0 1 0 1)), 6);
-    EXPECT_EQ(BitUtil::popcount(BOOST_BINARY(1 1 1 1 1 1 1 1)), 8);
-    EXPECT_EQ(BitUtil::popcount_no_hw(BOOST_BINARY(1 1 1 1 1 1 1 1)), 8);
+    EXPECT_EQ(BitUtil::popcount(0b01010101), 4);
+    EXPECT_EQ(BitUtil::popcount_no_hw(0b01010101), 4);
+    EXPECT_EQ(BitUtil::popcount(0b11110101), 6);
+    EXPECT_EQ(BitUtil::popcount_no_hw(0b11110101), 6);
+    EXPECT_EQ(BitUtil::popcount(0b11111111), 8);
+    EXPECT_EQ(BitUtil::popcount_no_hw(0b11111111), 8);
     EXPECT_EQ(BitUtil::popcount(0), 0);
     EXPECT_EQ(BitUtil::popcount_no_hw(0), 0);
 }

--- a/be/test/util/rle_encoding_test.cpp
+++ b/be/test/util/rle_encoding_test.cpp
@@ -45,8 +45,6 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
-#include <boost/utility/binary.hpp>
-
 #include "util/bit_util.h"
 #include "util/debug_util.h"
 #include "util/faststring.h"
@@ -157,10 +155,10 @@ TEST(Rle, SpecificSequences) {
     int num_groups = BitUtil::Ceil(100, 8);
     expected_buffer[0] = (num_groups << 1) | 1;
     for (int i = 0; i < 100 / 8; ++i) {
-        expected_buffer[i + 1] = BOOST_BINARY(1 0 1 0 1 0 1 0); // 0xaa
+        expected_buffer[i + 1] = 0b10101010; // 0xaa
     }
     // Values for the last 4 0 and 1's
-    expected_buffer[1 + 100 / 8] = BOOST_BINARY(0 0 0 0 1 0 1 0); // 0x0a
+    expected_buffer[1 + 100 / 8] = 0b00001010; // 0x0a
 
     // num_groups and expected_buffer only valid for bit width = 1
     ValidateRle(values, 1, expected_buffer, 1 + num_groups);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly mechanical dependency refactors (headers and equivalent helpers) with minimal logic change; main risk is compiler/standard-library compatibility (e.g., `std::string::ends_with`) across build targets.
> 
> **Overview**
> This PR continues the Boost reduction effort by replacing Boost utilities with standard C++ or StarRocks helpers across the BE.
> 
> Notable swaps include `boost::variant` -> `std::variant` for OLAP scan range types, Boost string helpers (`ends_with`, `join`) -> `std::string::ends_with` and `JoinStrings`, and Boost type traits / static asserts -> `std::type_traits` and `static_assert`. Unit tests also replace `BOOST_BINARY` literals with C++14/17 binary literals (`0b...`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9da3ccf814db0a537c8cdf40b51ff0a1d81edb3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->