### PR TITLE
[Enhancement] Manage the memory usage of the Iceberg delete sink writer with the SinkOperatorMemoryManager.

### DIFF
--- a/be/src/connector/connector_chunk_sink.h
+++ b/be/src/connector/connector_chunk_sink.h
@@ -82,6 +82,8 @@ protected:
     std::vector<std::function<void()>> _rollback_actions;
 
     std::map<PartitionKey, PartitionChunkWriterPtr> _partition_chunk_writers;
+    // passed to SinkOperatorMemoryManager to check memory usage
+    std::vector<PartitionChunkWriterPtr> _writers;
     inline static std::string DEFAULT_PARTITION = "__DEFAULT_PARTITION__";
 
     std::shared_mutex _mutex;

--- a/be/src/connector/iceberg_delete_sink.cpp
+++ b/be/src/connector/iceberg_delete_sink.cpp
@@ -23,6 +23,7 @@
 #include "column/datum.h"
 #include "connector/async_flush_stream_poller.h"
 #include "connector/partition_chunk_writer.h"
+#include "connector/sink_memory_manager.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exec/sorting/sorting.h"
 #include "exprs/expr.h"
@@ -343,6 +344,7 @@ Status IcebergDeleteSink::write_file_level_chunk(const std::string& partition,
     RETURN_IF_ERROR(writer->init());
 
     _file_writers[key] = writer;
+    _writers.push_back(writer);
     return writer->write(chunk);
 }
 

--- a/be/src/connector/sink_memory_manager.cpp
+++ b/be/src/connector/sink_memory_manager.cpp
@@ -54,6 +54,7 @@ bool SinkOperatorMemoryManager::kill_victim() {
     const auto filename = victim->out_stream()->filename();
     size_t flush_bytes = victim->get_flushable_bytes();
     const auto result = victim->flush();
+    LOG(INFO) << "kill victim: " << filename << ", result: " << result << ", flushable_bytes: " << flush_bytes;
     return true;
 }
 

--- a/be/src/connector/sink_memory_manager.h
+++ b/be/src/connector/sink_memory_manager.h
@@ -28,8 +28,8 @@ class SinkOperatorMemoryManager {
 public:
     SinkOperatorMemoryManager() = default;
 
-    void init(std::map<PartitionKey, PartitionChunkWriterPtr>* partition_chunk_writers,
-              AsyncFlushStreamPoller* io_poller, CommitFunc commit_func);
+    Status init(std::vector<PartitionChunkWriterPtr>* writers, AsyncFlushStreamPoller* io_poller,
+                CommitFunc commit_func);
 
     // return true if a victim is found and killed, otherwise return false
     bool kill_victim();
@@ -45,7 +45,7 @@ public:
     int64_t writer_occupied_memory() { return _writer_occupied_memory.load(); }
 
 private:
-    std::map<PartitionKey, PartitionChunkWriterPtr>* _candidates = nullptr; // reference, owned by sink operator
+    std::vector<PartitionChunkWriterPtr>* _candidates = nullptr; // reference, owned by sink operator
     CommitFunc _commit_func;
     AsyncFlushStreamPoller* _io_poller;
     std::atomic_int64_t _releasable_memory{0};

--- a/be/test/connector_sink/sink_memory_manager_test.cpp
+++ b/be/test/connector_sink/sink_memory_manager_test.cpp
@@ -105,7 +105,7 @@ TEST_F(SinkMemoryManagerTest, kill_victim) {
                     nullptr, nullptr, 1024, false, nullptr, _fragment_context.get(), tuple_desc, nullptr});
 
     auto sink_mem_mgr = std::make_shared<SinkOperatorMemoryManager>();
-    std::map<PartitionKey, PartitionChunkWriterPtr> partition_chunk_writers;
+    std::vector<PartitionChunkWriterPtr> writers;
 
     std::vector<int8_t> partition_field_null_list = {};
     const int64_t max_flush_bytes = 9;
@@ -116,7 +116,7 @@ TEST_F(SinkMemoryManagerTest, kill_victim) {
         writer->set_flushable_bytes(i);
         auto out_stream = std::make_unique<Stream>(std::make_unique<MockFile>(), nullptr, nullptr);
         writer->_out_stream = std::move(out_stream);
-        partition_chunk_writers[std::make_pair(partition, partition_field_null_list)] = writer;
+        writers.push_back(writer);
     }
     for (size_t i = max_flush_bytes; i >= 5; --i) {
         std::string partition = std::to_string(i);
@@ -125,16 +125,156 @@ TEST_F(SinkMemoryManagerTest, kill_victim) {
         writer->set_flushable_bytes(i);
         auto out_stream = std::make_unique<Stream>(std::make_unique<MockFile>(), nullptr, nullptr);
         writer->_out_stream = std::move(out_stream);
-        partition_chunk_writers[std::make_pair(partition, partition_field_null_list)] = writer;
+        writers.push_back(writer);
     }
 
     auto commit_callback = [this](const CommitResult& r) {};
-    sink_mem_mgr->init(&partition_chunk_writers, nullptr, commit_callback);
+    sink_mem_mgr->init(&writers, nullptr, commit_callback);
 
     EXPECT_TRUE(sink_mem_mgr->kill_victim());
-    for (auto& [key, writer] : partition_chunk_writers) {
+    for (auto& writer : writers) {
         auto mock_writer = std::dynamic_pointer_cast<MockPartitionChunkWriter>(writer);
-        if (key.first == std::to_string(max_flush_bytes)) {
+        if (mock_writer->get_flushable_bytes() == max_flush_bytes) {
+            EXPECT_TRUE(mock_writer->is_flushed());
+        } else {
+            EXPECT_FALSE(mock_writer->is_flushed());
+        }
+    }
+}
+
+TEST_F(SinkMemoryManagerTest, init_with_vector) {
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_VARCHAR_DESC}, {"c2", TYPE_VARCHAR_DESC}, {""}};
+    TupleDescriptor* tuple_desc =
+            parquet::Utils::create_tuple_descriptor(_fragment_context->runtime_state(), &_pool, slot_descs);
+
+    auto partition_chunk_writer_ctx =
+            std::make_shared<SpillPartitionChunkWriterContext>(SpillPartitionChunkWriterContext{
+                    nullptr, nullptr, 1024, false, nullptr, _fragment_context.get(), tuple_desc, nullptr});
+
+    auto sink_mem_mgr = std::make_shared<SinkOperatorMemoryManager>();
+    std::vector<PartitionChunkWriterPtr> writers;
+
+    std::vector<int8_t> partition_field_null_list = {};
+    for (size_t i = 0; i < 3; ++i) {
+        std::string partition = std::to_string(i);
+        auto writer = std::make_shared<MockPartitionChunkWriter>(partition, partition_field_null_list,
+                                                                 partition_chunk_writer_ctx);
+        writer->set_flushable_bytes(100);
+        auto out_stream = std::make_unique<Stream>(std::make_unique<MockFile>(), nullptr, nullptr);
+        writer->_out_stream = std::move(out_stream);
+        writers.push_back(writer);
+    }
+
+    auto commit_callback = [this](const CommitResult& r) {};
+    Status status = sink_mem_mgr->init(&writers, nullptr, commit_callback);
+    EXPECT_OK(status);
+    EXPECT_EQ(sink_mem_mgr->update_writer_occupied_memory(), 300);
+}
+
+TEST_F(SinkMemoryManagerTest, kill_victim_selects_max_flushable_bytes) {
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_VARCHAR_DESC}, {"c2", TYPE_VARCHAR_DESC}, {""}};
+    TupleDescriptor* tuple_desc =
+            parquet::Utils::create_tuple_descriptor(_fragment_context->runtime_state(), &_pool, slot_descs);
+
+    auto partition_chunk_writer_ctx =
+            std::make_shared<SpillPartitionChunkWriterContext>(SpillPartitionChunkWriterContext{
+                    nullptr, nullptr, 1024, false, nullptr, _fragment_context.get(), tuple_desc, nullptr});
+
+    auto sink_mem_mgr = std::make_shared<SinkOperatorMemoryManager>();
+    std::vector<PartitionChunkWriterPtr> writers;
+
+    std::vector<int8_t> partition_field_null_list = {};
+    std::vector<int64_t> flushable_bytes = {10, 50, 30, 80, 20};
+    for (size_t i = 0; i < flushable_bytes.size(); ++i) {
+        std::string partition = std::to_string(i);
+        auto writer = std::make_shared<MockPartitionChunkWriter>(partition, partition_field_null_list,
+                                                                 partition_chunk_writer_ctx);
+        writer->set_flushable_bytes(flushable_bytes[i]);
+        auto out_stream = std::make_unique<Stream>(std::make_unique<MockFile>(), nullptr, nullptr);
+        writer->_out_stream = std::move(out_stream);
+        writers.push_back(writer);
+    }
+
+    auto commit_callback = [this](const CommitResult& r) {};
+    sink_mem_mgr->init(&writers, nullptr, commit_callback);
+
+    EXPECT_TRUE(sink_mem_mgr->kill_victim());
+    for (auto& writer : writers) {
+        auto mock_writer = std::dynamic_pointer_cast<MockPartitionChunkWriter>(writer);
+        if (mock_writer->get_flushable_bytes() == 80) {
+            EXPECT_TRUE(mock_writer->is_flushed());
+        } else {
+            EXPECT_FALSE(mock_writer->is_flushed());
+        }
+    }
+}
+
+TEST_F(SinkMemoryManagerTest, update_writer_occupied_memory) {
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_VARCHAR_DESC}, {"c2", TYPE_VARCHAR_DESC}, {""}};
+    TupleDescriptor* tuple_desc =
+            parquet::Utils::create_tuple_descriptor(_fragment_context->runtime_state(), &_pool, slot_descs);
+
+    auto partition_chunk_writer_ctx =
+            std::make_shared<SpillPartitionChunkWriterContext>(SpillPartitionChunkWriterContext{
+                    nullptr, nullptr, 1024, false, nullptr, _fragment_context.get(), tuple_desc, nullptr});
+
+    auto sink_mem_mgr = std::make_shared<SinkOperatorMemoryManager>();
+    std::vector<PartitionChunkWriterPtr> writers;
+
+    std::vector<int8_t> partition_field_null_list = {};
+    std::vector<int64_t> flushable_bytes = {100, 200, 300, 400, 500};
+    for (size_t i = 0; i < flushable_bytes.size(); ++i) {
+        std::string partition = std::to_string(i);
+        auto writer = std::make_shared<MockPartitionChunkWriter>(partition, partition_field_null_list,
+                                                                 partition_chunk_writer_ctx);
+        writer->set_flushable_bytes(flushable_bytes[i]);
+        auto out_stream = std::make_unique<Stream>(std::make_unique<MockFile>(), nullptr, nullptr);
+        writer->_out_stream = std::move(out_stream);
+        writers.push_back(writer);
+    }
+
+    auto commit_callback = [this](const CommitResult& r) {};
+    sink_mem_mgr->init(&writers, nullptr, commit_callback);
+
+    int64_t total_memory = sink_mem_mgr->update_writer_occupied_memory();
+    EXPECT_EQ(total_memory, 1500);
+    EXPECT_EQ(sink_mem_mgr->writer_occupied_memory(), 1500);
+}
+
+TEST_F(SinkMemoryManagerTest, iceberg_delete_sink_scenario) {
+    parquet::Utils::SlotDesc slot_descs[] = {{"c1", TYPE_VARCHAR_DESC}, {"c2", TYPE_VARCHAR_DESC}, {""}};
+    TupleDescriptor* tuple_desc =
+            parquet::Utils::create_tuple_descriptor(_fragment_context->runtime_state(), &_pool, slot_descs);
+
+    auto partition_chunk_writer_ctx =
+            std::make_shared<SpillPartitionChunkWriterContext>(SpillPartitionChunkWriterContext{
+                    nullptr, nullptr, 1024, false, nullptr, _fragment_context.get(), tuple_desc, nullptr});
+
+    auto sink_mem_mgr = std::make_shared<SinkOperatorMemoryManager>();
+    std::vector<PartitionChunkWriterPtr> writers;
+
+    std::vector<int8_t> partition_field_null_list = {};
+    for (size_t i = 0; i < 10; ++i) {
+        std::string partition = "partition_" + std::to_string(i);
+        auto writer = std::make_shared<MockPartitionChunkWriter>(partition, partition_field_null_list,
+                                                                 partition_chunk_writer_ctx);
+        writer->set_flushable_bytes(1000 + i * 100);
+        auto out_stream = std::make_unique<Stream>(std::make_unique<MockFile>(), nullptr, nullptr);
+        writer->_out_stream = std::move(out_stream);
+        writers.push_back(writer);
+    }
+
+    auto commit_callback = [this](const CommitResult& r) {};
+    sink_mem_mgr->init(&writers, nullptr, commit_callback);
+
+    int64_t total_memory = sink_mem_mgr->update_writer_occupied_memory();
+    EXPECT_EQ(total_memory, 14500);
+
+    EXPECT_TRUE(sink_mem_mgr->kill_victim());
+    int64_t max_flushable = 1900;
+    for (auto& writer : writers) {
+        auto mock_writer = std::dynamic_pointer_cast<MockPartitionChunkWriter>(writer);
+        if (mock_writer->get_flushable_bytes() == max_flushable) {
             EXPECT_TRUE(mock_writer->is_flushed());
         } else {
             EXPECT_FALSE(mock_writer->is_flushed());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.planner.DataSink;
 import com.starrocks.planner.HiveTableSink;
+import com.starrocks.planner.IcebergDeleteSink;
 import com.starrocks.planner.IcebergTableSink;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanFragmentId;
@@ -354,7 +355,9 @@ public class FragmentInstance {
 
         DataSink dataSink = fragment.getSink();
         int dop = fragment.getPipelineDop();
-        if (!(dataSink instanceof IcebergTableSink || dataSink instanceof HiveTableSink
+        if (!(dataSink instanceof IcebergTableSink 
+                || dataSink instanceof IcebergDeleteSink
+                || dataSink instanceof HiveTableSink
                 || dataSink instanceof TableFunctionTableSink)) {
             return dop;
         } else {


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/issues/66944,  Manage the memory usage of the Iceberg delete sink writer with the SinkOperatorMemoryManager.
## What I'm doing:
This pull request refactors the memory management logic for sink operators by changing the internal data structures from maps to vectors, simplifying the code and improving efficiency. It updates the `SinkOperatorMemoryManager` and related classes and tests, and ensures compatibility with both existing and new sink types such as `IcebergDeleteSink`.

Key changes include:

### Memory Manager Refactoring

* Changed `SinkOperatorMemoryManager` to use a `std::vector<PartitionChunkWriterPtr>` instead of a `std::map<PartitionKey, PartitionChunkWriterPtr>` for tracking candidate writers, simplifying memory management and iteration logic. The `init` method now returns a `Status` and accepts a vector pointer. (`be/src/connector/sink_memory_manager.h`, `be/src/connector/sink_memory_manager.cpp`, 
* Updated all usages in `ConnectorChunkSink`, `IcebergDeleteSink`, and related code to maintain a writers vector and pass it to the memory manager. (`be/src/connector/connector_chunk_sink.cpp`, 

### Test Suite Enhancements

* Refactored and extended tests in `sink_memory_manager_test.cpp` to use vectors instead of maps. Added new test cases for initialization, victim selection, memory calculation, and an end-to-end scenario with `IcebergDeleteSink`. (`be/test/connector_sink/sink_memory_manager_test.cpp`

### Planner and Scheduling Integration

* Added support for the new `IcebergDeleteSink` in the FE scheduler logic by updating type checks in `FragmentInstance#getTableSinkDop`.

These changes streamline the sink memory management, improve test coverage, and ensure future extensibility for additional sink types.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
