### PR TITLE
[UT] Add test case for lz4_bug-1268

### DIFF
--- a/be/test/io/compressed_input_stream_test.cpp
+++ b/be/test/io/compressed_input_stream_test.cpp
@@ -21,10 +21,8 @@
 #include "fs/fs_posix.h"
 #include "io/string_input_stream.h"
 #include "io_test_base.h"
-#include "runtime/mem_pool.h"
 #include "testutil/assert.h"
 #include "util/compression/block_compression.h"
-#include "util/compression/compression_context.h"
 #include "util/compression/stream_compression.h"
 namespace starrocks::io {
 
@@ -110,7 +108,7 @@ protected:
 
 std::string CompressedInputStreamTest::gen_normal_frame() {
     char src[9] = {};
-    size_t compressed_len = LZ4F_compressFrameBound(sizeof(src), nullptr);;
+    size_t compressed_len = LZ4F_compressFrameBound(sizeof(src), nullptr);
     std::unique_ptr<char[]> compressed_buf(new char[compressed_len]);
 
     LZ4F_preferences_t pref = LZ4F_INIT_PREFERENCES;

--- a/be/test/io/compressed_input_stream_test.cpp
+++ b/be/test/io/compressed_input_stream_test.cpp
@@ -72,7 +72,8 @@ protected:
         ASSERT_EQ(t.data, decompressed_data);
     }
 
-    static void read_compressed_file_ctx(CompressionTypePB type, const char* path, std::string& out, const ReadContext& ctx) {
+    static void read_compressed_file_ctx(CompressionTypePB type, const char* path, std::string& out,
+                                         const ReadContext& ctx) {
         auto fs = new_fs_posix();
         auto st = fs->new_random_access_file(path);
         ASSERT_TRUE(st.ok()) << st.status().message();
@@ -80,7 +81,7 @@ protected:
 
         using DecompressorPtr = std::shared_ptr<StreamCompression>;
         std::unique_ptr<StreamCompression> dec;
-        (void) StreamCompression::create_decompressor(type, &dec);
+        (void)StreamCompression::create_decompressor(type, &dec);
 
         auto compressed_input_stream = std::make_shared<io::CompressedInputStream>(
                 file->stream(), DecompressorPtr(dec.release()), ctx.decompressor_buffer_size);
@@ -143,7 +144,7 @@ TEST_F(CompressedInputStreamTest, test_lz4_bug_1268_1) {
     std::string decompressed_str2;
     decompressed_str2.resize(8192);
     Slice decompressed_slice2(decompressed_str2);
-    const BlockCompressionCodec* codec= nullptr;
+    const BlockCompressionCodec* codec = nullptr;
     EXPECT_OK(get_block_compression_codec(LZ4_FRAME, &codec));
     EXPECT_OK(codec->decompress(compressed_slice2, &decompressed_slice2));
 }
@@ -159,7 +160,7 @@ TEST_F(CompressedInputStreamTest, test_lz4_bug_1268_2) {
 
     // read empty frame
     std::string empty_frame = gen_empty_frame();
-    const BlockCompressionCodec* codec= nullptr;
+    const BlockCompressionCodec* codec = nullptr;
     EXPECT_OK(get_block_compression_codec(LZ4_FRAME, &codec));
     Slice compressed_slice(empty_frame);
     std::string decompressed_str;

--- a/be/test/io/compressed_input_stream_test.cpp
+++ b/be/test/io/compressed_input_stream_test.cpp
@@ -106,8 +106,6 @@ protected:
 
     static std::string gen_normal_frame();
     static std::string gen_empty_frame();
-
-    MemPool _mem_pool;
 };
 
 std::string CompressedInputStreamTest::gen_normal_frame() {
@@ -123,7 +121,7 @@ std::string CompressedInputStreamTest::gen_normal_frame() {
 }
 
 std::string CompressedInputStreamTest::gen_empty_frame() {
-    size_t compressed_len = LZ4F_compressFrameBound(0, nullptr);;
+    size_t compressed_len = LZ4F_compressFrameBound(0, nullptr);
     std::unique_ptr<char[]> compressed_buf(new char[compressed_len]);
 
     size_t compressed_size = LZ4F_compressFrame(compressed_buf.get(), compressed_len, nullptr, 0, nullptr);

--- a/be/test/io/compressed_input_stream_test.cpp
+++ b/be/test/io/compressed_input_stream_test.cpp
@@ -15,6 +15,7 @@
 #include "io/compressed_input_stream.h"
 
 #include <gtest/gtest.h>
+#include <lz4/lz4frame.h>
 
 #include <memory>
 


### PR DESCRIPTION
## Why I'm doing:

https://github.com/StarRocks/starrocks/pull/67075 already fix the bug.

This pr only add test case for https://github.com/lz4/lz4/pull/1268

```
W20251213 12:30:12.132500 23389162923584 rowset_merger.cpp:576] reader get next error. tablet=5837714594, err=Invalid argument: Fail to do LZ4FRAME decompress, res=ERROR_frameSize_wrong
be/src/storage/rowset/page_io.cpp:239 opts.codec->decompress(compressed_body, &decompressed_body)
be/src/storage/rowset/scalar_column_iterator.cpp:398 _reader->read_page(_opts, iter.page(), &handle, &page_body, &footer)
be/src/storage/rowset/scalar_column_iterator.cpp:348 _read_data_page(_page_iter)
be/src/storage/rowset/scalar_column_iterator.cpp:290 _load_next_page(&eos)
be/src/storage/rowset/segment_iterator.cpp:158 _column_iterators[i]->next_batch(range, col.get())
be/src/storage/rowset/segment_iterator.cpp:1339 _context->read_columns(chunk, range)
```

## What I'm doing:

If the decompression stream has not completed, the remaining row count in the context will not be reset to 0 after a reset operation is performed. As a result, using this context to decompress other frames will cause the operation to fail.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
