### PR TITLE
[Enhancement] Refactor rebuildCreateTableProperties to improve format and compression handling

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -460,29 +460,46 @@ public class IcebergApiConverter {
                 nullValueCounts, null, lowerBounds, upperBounds);
     }
 
+    private static void setFormatProperties(ImmutableMap.Builder<String, String> tableProperties,
+                                         String fileFormat, String compressionCodec) {
+        String format = "parquet";
+        String compressionKey = TableProperties.PARQUET_COMPRESSION;
+        if ("avro".equalsIgnoreCase(fileFormat)) {
+            format = "avro";
+            compressionKey = TableProperties.AVRO_COMPRESSION;
+        } else if ("orc".equalsIgnoreCase(fileFormat)) {
+            format = "orc";
+            compressionKey = TableProperties.ORC_COMPRESSION;
+        } else if (fileFormat != null && !"parquet".equalsIgnoreCase(fileFormat)) {
+            throw new IllegalArgumentException("Unsupported format in USING: " + fileFormat);
+        }
+        tableProperties.put(TableProperties.DEFAULT_FILE_FORMAT, format);
+        if (compressionCodec != null) {
+            tableProperties.put(compressionKey, compressionCodec);
+        }
+    }
+
+    private static void setCompressionProperties(ImmutableMap.Builder<String, String> tableProperties,
+                                             String fileFormat, String compressionCodec) {
+        if ("parquet".equalsIgnoreCase(fileFormat)) {
+            tableProperties.put(TableProperties.PARQUET_COMPRESSION, compressionCodec);
+        } else if ("avro".equalsIgnoreCase(fileFormat)) {
+            tableProperties.put(TableProperties.AVRO_COMPRESSION, compressionCodec);
+        } else if ("orc".equalsIgnoreCase(fileFormat)) {
+            tableProperties.put(TableProperties.ORC_COMPRESSION, compressionCodec);
+        }
+    }
+
     public static Map<String, String> rebuildCreateTableProperties(Map<String, String> createProperties) {
         ImmutableMap.Builder<String, String> tableProperties = ImmutableMap.builder();
         createProperties.entrySet().forEach(tableProperties::put);
         String fileFormat = createProperties.getOrDefault(FILE_FORMAT, TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
         String compressionCodec = createProperties.get(COMPRESSION_CODEC);
 
-        if ("parquet".equalsIgnoreCase(fileFormat)) {
-            tableProperties.put(TableProperties.DEFAULT_FILE_FORMAT, "parquet");
-            if (compressionCodec != null) {
-                tableProperties.put(TableProperties.PARQUET_COMPRESSION, compressionCodec);
-            }
-        } else if ("avro".equalsIgnoreCase(fileFormat)) {
-            tableProperties.put(TableProperties.DEFAULT_FILE_FORMAT, "avro");
-            if (compressionCodec != null) {
-                tableProperties.put(TableProperties.AVRO_COMPRESSION, compressionCodec);
-            }
-        } else if ("orc".equalsIgnoreCase(fileFormat)) {
-            tableProperties.put(TableProperties.DEFAULT_FILE_FORMAT, "orc");
-            if (compressionCodec != null) {
-                tableProperties.put(TableProperties.ORC_COMPRESSION, compressionCodec);
-            }
-        } else if (fileFormat != null) {
-            throw new IllegalArgumentException("Unsupported format in USING: " + fileFormat);
+        if (!createProperties.containsKey(TableProperties.DEFAULT_FILE_FORMAT)) {
+            setFormatProperties(tableProperties, fileFormat, compressionCodec);
+        } else if (compressionCodec != null) {
+            setCompressionProperties(tableProperties, fileFormat, compressionCodec);
         }
 
         if (!createProperties.containsKey(TableProperties.FORMAT_VERSION)) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -318,6 +318,20 @@ public class IcebergApiConverterTest {
         source = ImmutableMap.of("file_format", "avro", "compression_codec", "zstd");
         target = IcebergApiConverter.rebuildCreateTableProperties(source);
         assertEquals("zstd", target.get(AVRO_COMPRESSION));
+
+        source = ImmutableMap.of("write.format.default", "orc");
+        target = IcebergApiConverter.rebuildCreateTableProperties(source);
+        assertEquals("orc", target.get(DEFAULT_FILE_FORMAT));
+
+        source = ImmutableMap.of("write.format.default", "parquet", "compression_codec", "snappy");
+        target = IcebergApiConverter.rebuildCreateTableProperties(source);
+        assertEquals("parquet", target.get(DEFAULT_FILE_FORMAT));
+        assertEquals("snappy", target.get(PARQUET_COMPRESSION));
+
+        source = ImmutableMap.of("write.format.default", "parquet", "write.parquet.compression-codec", "snappy");
+        target = IcebergApiConverter.rebuildCreateTableProperties(source);
+        assertEquals("parquet", target.get(DEFAULT_FILE_FORMAT));
+        assertEquals("snappy", target.get(PARQUET_COMPRESSION));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
<img width="1258" height="86" alt="image" src="https://github.com/user-attachments/assets/1969db57-16c3-41b5-a6f5-340933636a50" />

## What I'm doing:
This pull request refactors how table format and compression properties are set when rebuilding Iceberg table creation properties, improving code clarity and handling for different file formats. It also expands the test coverage for these scenarios to ensure correctness.

Refactoring of table property logic:

* Extracted logic for setting format and compression properties into two new helper methods, `setFormatProperties` and `setCompressionProperties`, in `IcebergApiConverter.java` for better separation of concerns and maintainability.
* Updated `rebuildCreateTableProperties` to use these new helpers and to more clearly handle cases where the format or compression codec is specified, including validation for unsupported formats.

Expanded test coverage:

* Added new test cases to `IcebergApiConverterTest.java` to verify correct handling of default formats and compression codecs for ORC and Parquet, including scenarios where properties are set via `write.format.default` and `write.parquet.compression-codec`.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
