### PR TITLE
[Feature] Implement tablet merge metadata with delvec merge and rssid_offset

### DIFF
--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -16,6 +16,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "column/vectorized_fwd.h"
 #include "fs/fs.h"
@@ -130,6 +131,15 @@ private:
     // Pending rowset data for batch processing
     PendingRowsetData _pending_rowset_data;
 };
+
+struct DelvecFileInfo {
+    int64_t tablet_id;
+    FileMetaPB delvec_file;
+};
+
+Status merge_delvec_files(TabletManager* tablet_mgr, const std::vector<DelvecFileInfo>& old_delvec_files,
+                          int64_t new_tablet_id, int64_t txn_id, FileMetaPB* new_delvec_file,
+                          std::vector<uint64_t>* offsets);
 
 Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, const DelvecPagePB& delvec_page,
                    bool fill_cache, const LakeIOOptions& lake_io_opts, DelVector* delvec);

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -15,9 +15,12 @@
 #include "storage/lake/tablet_reshard.h"
 
 #include <algorithm>
+#include <limits>
 #include <set>
 #include <span>
+#include <unordered_map>
 
+#include "base/testutil/sync_point.h"
 #include "storage/del_vector.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/metacache.h"
@@ -89,14 +92,14 @@ static void set_all_data_files_shared(TxnLogPB* txn_log) {
     }
 }
 
-static void set_all_data_files_shared(TabletMetadataPB* tablet_metadata) {
+static void set_all_data_files_shared(TabletMetadataPB* tablet_metadata, bool skip_delvecs = false) {
     // rowset (dat and del)
     for (auto& rowset_metadata : *tablet_metadata->mutable_rowsets()) {
         set_all_data_files_shared(&rowset_metadata);
     }
 
     // delvec
-    if (tablet_metadata->has_delvec_meta()) {
+    if (!skip_delvecs && tablet_metadata->has_delvec_meta()) {
         for (auto& pair : *tablet_metadata->mutable_delvec_meta()->mutable_version_to_file()) {
             pair.second.set_shared(true);
         }
@@ -117,6 +120,138 @@ static void set_all_data_files_shared(TabletMetadataPB* tablet_metadata) {
             sstable.set_shared(true);
         }
     }
+}
+
+static int64_t compute_rssid_offset(const TabletMetadataPB& base_metadata, const TabletMetadataPB& append_metadata) {
+    uint32_t min_id = std::numeric_limits<uint32_t>::max();
+    for (const auto& rowset : append_metadata.rowsets()) {
+        min_id = std::min(min_id, rowset.id());
+    }
+    if (min_id == std::numeric_limits<uint32_t>::max()) {
+        return 0;
+    }
+    return static_cast<int64_t>(base_metadata.next_rowset_id()) - min_id;
+}
+
+static Status merge_rowsets(const TabletMetadataPB& old_metadata, int64_t rssid_offset,
+                            TabletMetadataPB* new_metadata) {
+    for (const auto& rowset : old_metadata.rowsets()) {
+        auto* new_rowset = new_metadata->add_rowsets();
+        new_rowset->CopyFrom(rowset);
+        new_rowset->set_id(static_cast<uint32_t>(static_cast<int64_t>(rowset.id()) + rssid_offset));
+        if (rowset.has_max_compact_input_rowset_id()) {
+            new_rowset->set_max_compact_input_rowset_id(
+                    static_cast<uint32_t>(static_cast<int64_t>(rowset.max_compact_input_rowset_id()) + rssid_offset));
+        }
+        for (auto& del : *new_rowset->mutable_del_files()) {
+            del.set_origin_rowset_id(
+                    static_cast<uint32_t>(static_cast<int64_t>(del.origin_rowset_id()) + rssid_offset));
+        }
+
+        const auto& rowset_to_schema = old_metadata.rowset_to_schema();
+        const auto rowset_schema_it = rowset_to_schema.find(rowset.id());
+        if (rowset_schema_it != rowset_to_schema.end()) {
+            (*new_metadata->mutable_rowset_to_schema())[new_rowset->id()] = rowset_schema_it->second;
+        }
+    }
+    return Status::OK();
+}
+
+static Status merge_sstables(const TabletMetadataPB& old_metadata, int64_t rssid_offset,
+                             TabletMetadataPB* new_metadata) {
+    if (!old_metadata.has_sstable_meta()) {
+        return Status::OK();
+    }
+    auto* dest_sstables = new_metadata->mutable_sstable_meta()->mutable_sstables();
+    for (const auto& sstable : old_metadata.sstable_meta().sstables()) {
+        auto* new_sstable = dest_sstables->Add();
+        new_sstable->CopyFrom(sstable);
+        new_sstable->set_rssid_offset(static_cast<int32_t>(rssid_offset));
+        const uint64_t max_rss_rowid = sstable.max_rss_rowid();
+        const uint64_t low = max_rss_rowid & 0xffffffffULL;
+        const int64_t high = static_cast<int64_t>(max_rss_rowid >> 32);
+        new_sstable->set_max_rss_rowid((static_cast<uint64_t>(high + rssid_offset) << 32) | low);
+        new_sstable->clear_delvec();
+    }
+    return Status::OK();
+}
+
+struct TabletMergeInfo {
+    TabletMetadataPtr metadata;
+    int64_t rssid_offset = 0;
+};
+
+static Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMergeInfo>& merge_infos,
+                            int64_t new_version, int64_t txn_id, TabletMetadataPB* new_metadata) {
+    std::vector<DelvecFileInfo> old_delvec_files;
+    old_delvec_files.reserve(merge_infos.size());
+    std::unordered_map<int64_t, std::unordered_map<std::string, size_t>> file_index_by_tablet;
+
+    for (const auto& info : merge_infos) {
+        const auto& metadata = info.metadata;
+        if (!metadata->has_delvec_meta()) {
+            continue;
+        }
+        for (const auto& [ver, file] : metadata->delvec_meta().version_to_file()) {
+            auto& file_index = file_index_by_tablet[metadata->id()];
+            if (file_index.emplace(file.name(), old_delvec_files.size()).second) {
+                DelvecFileInfo file_info;
+                file_info.tablet_id = metadata->id();
+                file_info.delvec_file = file;
+                old_delvec_files.emplace_back(std::move(file_info));
+            }
+        }
+    }
+
+    if (old_delvec_files.empty()) {
+        return Status::OK();
+    }
+
+    FileMetaPB new_delvec_file;
+    std::vector<uint64_t> offsets;
+    RETURN_IF_ERROR(merge_delvec_files(tablet_manager, old_delvec_files, new_metadata->id(), txn_id, &new_delvec_file,
+                                       &offsets));
+
+    std::unordered_map<int64_t, std::unordered_map<std::string, uint64_t>> base_offset_by_tablet;
+    for (size_t i = 0; i < old_delvec_files.size(); ++i) {
+        base_offset_by_tablet[old_delvec_files[i].tablet_id][old_delvec_files[i].delvec_file.name()] = offsets[i];
+    }
+    TEST_SYNC_POINT_CALLBACK("merge_delvecs:before_apply_offsets", &base_offset_by_tablet);
+
+    auto* delvec_meta = new_metadata->mutable_delvec_meta();
+    delvec_meta->Clear();
+    for (const auto& info : merge_infos) {
+        const auto& metadata = info.metadata;
+        if (!metadata->has_delvec_meta()) {
+            continue;
+        }
+        for (const auto& [segment_id, page] : metadata->delvec_meta().delvecs()) {
+            auto file_it = metadata->delvec_meta().version_to_file().find(page.version());
+            if (file_it == metadata->delvec_meta().version_to_file().end()) {
+                return Status::InvalidArgument("Delvec file not found for page version");
+            }
+            auto tablet_it = base_offset_by_tablet.find(metadata->id());
+            if (tablet_it == base_offset_by_tablet.end()) {
+                return Status::InvalidArgument("Delvec file not merged for page version");
+            }
+            auto offset_it = tablet_it->second.find(file_it->second.name());
+            if (offset_it == tablet_it->second.end()) {
+                return Status::InvalidArgument("Delvec file not merged for page version");
+            }
+            const int64_t new_segment_id = static_cast<int64_t>(segment_id) + info.rssid_offset;
+            if (new_segment_id < 0 || new_segment_id > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+                return Status::InvalidArgument("Segment id overflow during delvec merge");
+            }
+            DelvecPagePB new_page = page;
+            new_page.set_version(new_version);
+            new_page.set_crc32c_gen_version(new_version);
+            new_page.set_offset(offset_it->second + page.offset());
+            (*delvec_meta->mutable_delvecs())[static_cast<uint32_t>(new_segment_id)] = std::move(new_page);
+        }
+    }
+
+    (*delvec_meta->mutable_version_to_file())[new_version] = std::move(new_delvec_file);
+    return Status::OK();
 }
 
 struct Statistic {
@@ -528,8 +663,171 @@ CONTINUE_HANDLE_SPLITTING_TABLET:
 
 static Status handle_merging_tablet(TabletManager* tablet_manager, const MergingTabletInfoPB& merging_tablet,
                                     int64_t base_version, int64_t new_version, const TxnInfoPB& txn_info,
-                                    std::unordered_map<int64_t, TabletMetadataPtr>& new_metadatas) {
-    return Status::NotSupported("Tablet merging is not implemented");
+                                    std::unordered_map<int64_t, TabletMetadataPtr>& new_metadatas,
+                                    std::unordered_map<int64_t, TabletRangePB>& tablet_ranges) {
+    // Check tablet metadata cache
+    {
+        for (auto old_tablet_id : merging_tablet.old_tablet_ids()) {
+            auto old_tablet_new_metadata_location =
+                    tablet_manager->tablet_metadata_location(old_tablet_id, new_version);
+            auto cached_old_tablet_new_metadata =
+                    tablet_manager->metacache()->lookup_tablet_metadata(old_tablet_new_metadata_location);
+            if (cached_old_tablet_new_metadata == nullptr) {
+                goto CONTINUE_HANDLE_MERGING_TABLET;
+            }
+            new_metadatas.emplace(old_tablet_id, std::move(cached_old_tablet_new_metadata));
+        }
+
+        auto new_tablet_new_metadata_location =
+                tablet_manager->tablet_metadata_location(merging_tablet.new_tablet_id(), new_version);
+        auto cached_new_tablet_new_metadata =
+                tablet_manager->metacache()->lookup_tablet_metadata(new_tablet_new_metadata_location);
+        if (cached_new_tablet_new_metadata == nullptr) {
+            new_metadatas.clear();
+            goto CONTINUE_HANDLE_MERGING_TABLET;
+        }
+        tablet_ranges.emplace(merging_tablet.new_tablet_id(), cached_new_tablet_new_metadata->range());
+        new_metadatas.emplace(merging_tablet.new_tablet_id(), std::move(cached_new_tablet_new_metadata));
+
+        // All new metadatas found in cache, return ok
+        return Status::OK();
+    }
+
+CONTINUE_HANDLE_MERGING_TABLET:
+
+    std::vector<TabletMetadataPtr> old_tablet_metadatas;
+    old_tablet_metadatas.reserve(merging_tablet.old_tablet_ids_size());
+    for (auto old_tablet_id : merging_tablet.old_tablet_ids()) {
+        auto old_tablet_old_metadata_or = tablet_manager->get_tablet_metadata(old_tablet_id, base_version, false);
+        if (old_tablet_old_metadata_or.status().is_not_found()) {
+            new_metadatas.clear();
+            for (auto retry_tablet_id : merging_tablet.old_tablet_ids()) {
+                auto old_tablet_new_metadata_or =
+                        tablet_manager->get_tablet_metadata(retry_tablet_id, new_version, txn_info.gtid());
+                if (!old_tablet_new_metadata_or.ok()) {
+                    return old_tablet_old_metadata_or.status();
+                }
+                new_metadatas.emplace(retry_tablet_id, std::move(old_tablet_new_metadata_or.value()));
+            }
+            auto new_tablet_new_metadata_or =
+                    tablet_manager->get_tablet_metadata(merging_tablet.new_tablet_id(), new_version, txn_info.gtid());
+            if (!new_tablet_new_metadata_or.ok()) {
+                return old_tablet_old_metadata_or.status();
+            }
+            auto& new_tablet_new_metadata = new_tablet_new_metadata_or.value();
+            tablet_ranges.emplace(merging_tablet.new_tablet_id(), new_tablet_new_metadata->range());
+            new_metadatas.emplace(merging_tablet.new_tablet_id(), std::move(new_tablet_new_metadata));
+            return Status::OK();
+        }
+        if (!old_tablet_old_metadata_or.ok()) {
+            LOG(WARNING) << "Failed to get tablet: " << old_tablet_id << ", version: " << base_version
+                         << ", txn_id: " << txn_info.txn_id() << ", status: " << old_tablet_old_metadata_or.status();
+            return old_tablet_old_metadata_or.status();
+        }
+        old_tablet_metadatas.emplace_back(std::move(old_tablet_old_metadata_or.value()));
+    }
+
+    // Update old tablets to new version and mark shared data files.
+    for (const auto& old_tablet_old_metadata : old_tablet_metadatas) {
+        auto old_tablet_new_metadata = std::make_shared<TabletMetadataPB>(*old_tablet_old_metadata);
+        old_tablet_new_metadata->set_version(new_version);
+        old_tablet_new_metadata->set_commit_time(txn_info.commit_time());
+        old_tablet_new_metadata->set_gtid(txn_info.gtid());
+        set_all_data_files_shared(old_tablet_new_metadata.get(), true);
+        new_metadatas.emplace(old_tablet_old_metadata->id(), std::move(old_tablet_new_metadata));
+    }
+
+    // Collect tablet metadata in order.
+    std::vector<TabletMergeInfo> merge_infos;
+    merge_infos.reserve(old_tablet_metadatas.size());
+    for (const auto& old_tablet_old_metadata : old_tablet_metadatas) {
+        merge_infos.push_back({old_tablet_old_metadata, 0});
+    }
+
+    // Build new merged tablet metadata.
+    auto new_tablet_metadata = std::make_shared<TabletMetadataPB>(*merge_infos.front().metadata);
+    new_tablet_metadata->set_id(merging_tablet.new_tablet_id());
+    new_tablet_metadata->set_version(new_version);
+    new_tablet_metadata->set_commit_time(txn_info.commit_time());
+    new_tablet_metadata->set_gtid(txn_info.gtid());
+    new_tablet_metadata->clear_rowsets();
+    new_tablet_metadata->clear_delvec_meta();
+    new_tablet_metadata->clear_sstable_meta();
+    new_tablet_metadata->clear_dcg_meta();
+    new_tablet_metadata->clear_rowset_to_schema();
+    new_tablet_metadata->clear_compaction_inputs();
+    new_tablet_metadata->clear_orphan_files();
+    new_tablet_metadata->clear_prev_garbage_version();
+    new_tablet_metadata->set_cumulative_point(0);
+
+    // Merge historical schemas.
+    auto* merged_historical_schemas = new_tablet_metadata->mutable_historical_schemas();
+    merged_historical_schemas->clear();
+    for (const auto& info : merge_infos) {
+        for (const auto& [schema_id, schema] : info.metadata->historical_schemas()) {
+            (*merged_historical_schemas)[schema_id] = schema;
+        }
+    }
+    if (new_tablet_metadata->schema().has_id()) {
+        (*merged_historical_schemas)[new_tablet_metadata->schema().id()] = new_tablet_metadata->schema();
+    }
+
+    // Merge ranges.
+    auto* merged_range = new_tablet_metadata->mutable_range();
+    const auto& first_range = merge_infos.front().metadata->range();
+    const auto& last_range = merge_infos.back().metadata->range();
+    merged_range->clear_lower_bound();
+    merged_range->clear_upper_bound();
+    if (first_range.has_lower_bound()) {
+        merged_range->mutable_lower_bound()->CopyFrom(first_range.lower_bound());
+    }
+    merged_range->set_lower_bound_included(first_range.lower_bound_included());
+    if (last_range.has_upper_bound()) {
+        merged_range->mutable_upper_bound()->CopyFrom(last_range.upper_bound());
+    }
+    merged_range->set_upper_bound_included(last_range.upper_bound_included());
+
+    uint32_t next_rowset_id = merge_infos.front().metadata->next_rowset_id();
+    merge_infos.front().rssid_offset = 0;
+    for (size_t i = 1; i < merge_infos.size(); ++i) {
+        new_tablet_metadata->set_next_rowset_id(next_rowset_id);
+        const int64_t offset = compute_rssid_offset(*new_tablet_metadata, *merge_infos[i].metadata);
+        merge_infos[i].rssid_offset = offset;
+
+        uint32_t max_end = 0;
+        for (const auto& rowset : merge_infos[i].metadata->rowsets()) {
+            max_end = std::max(max_end, rowset.id() + std::max(1, rowset.segments_size()));
+        }
+        if (max_end > 0) {
+            next_rowset_id = std::max(next_rowset_id, static_cast<uint32_t>(static_cast<int64_t>(max_end) + offset));
+        }
+    }
+
+    for (const auto& info : merge_infos) {
+        RETURN_IF_ERROR(merge_rowsets(*info.metadata, info.rssid_offset, new_tablet_metadata.get()));
+        if (info.metadata->has_dcg_meta()) {
+            for (const auto& [segment_id, dcg_ver] : info.metadata->dcg_meta().dcgs()) {
+                const int64_t new_segment_id = static_cast<int64_t>(segment_id) + info.rssid_offset;
+                if (new_segment_id < 0 || new_segment_id > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+                    return Status::InvalidArgument("Segment id overflow during tablet merge");
+                }
+                (*new_tablet_metadata->mutable_dcg_meta()->mutable_dcgs())[static_cast<uint32_t>(new_segment_id)] =
+                        dcg_ver;
+            }
+        }
+        RETURN_IF_ERROR(merge_sstables(*info.metadata, info.rssid_offset, new_tablet_metadata.get()));
+    }
+
+    new_tablet_metadata->set_next_rowset_id(next_rowset_id);
+
+    if (is_primary_key(*new_tablet_metadata)) {
+        RETURN_IF_ERROR(
+                merge_delvecs(tablet_manager, merge_infos, new_version, txn_info.txn_id(), new_tablet_metadata.get()));
+    }
+
+    tablet_ranges.emplace(merging_tablet.new_tablet_id(), new_tablet_metadata->range());
+    new_metadatas.emplace(merging_tablet.new_tablet_id(), std::move(new_tablet_metadata));
+    return Status::OK();
 }
 
 static Status handle_identical_tablet(TabletManager* tablet_manager, const IdenticalTabletInfoPB& identical_tablet,
@@ -652,7 +950,7 @@ Status publish_resharding_tablet(TabletManager* tablet_manager, const Resharding
                                                 new_version, txn_info, tablet_metadatas, tablet_ranges));
     } else if (resharding_tablet.has_merging_tablet_info()) {
         RETURN_IF_ERROR(handle_merging_tablet(tablet_manager, resharding_tablet.merging_tablet_info(), base_version,
-                                              new_version, txn_info, tablet_metadatas));
+                                              new_version, txn_info, tablet_metadatas, tablet_ranges));
     } else if (resharding_tablet.has_identical_tablet_info()) {
         RETURN_IF_ERROR(handle_identical_tablet(tablet_manager, resharding_tablet.identical_tablet_info(), base_version,
                                                 new_version, txn_info, tablet_metadatas));

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -18,8 +18,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <limits>
+
 #include "base/testutil/assert.h"
 #include "base/testutil/id_generator.h"
+#include "base/testutil/sync_point.h"
 #include "common/config.h"
 #include "fs/fs.h"
 #include "fs/fs_util.h"
@@ -64,6 +67,76 @@ public:
     }
 
 protected:
+    void prepare_tablet_dirs(int64_t tablet_id) {
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->metadata_root_location(tablet_id)));
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->txn_log_root_location(tablet_id)));
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->segment_root_location(tablet_id)));
+    }
+
+    void write_file(const std::string& path, const std::string& content) {
+        WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        ASSIGN_OR_ABORT(auto writer, fs::new_writable_file(opts, path));
+        ASSERT_OK(writer->append(Slice(content)));
+        ASSERT_OK(writer->close());
+    }
+
+    void set_primary_key_schema(TabletMetadataPB* metadata, int64_t schema_id) {
+        auto* schema = metadata->mutable_schema();
+        schema->set_keys_type(PRIMARY_KEYS);
+        schema->set_id(schema_id);
+    }
+
+    void add_historical_schema(TabletMetadataPB* metadata, int64_t schema_id) {
+        auto& schema = (*metadata->mutable_historical_schemas())[schema_id];
+        schema.set_id(schema_id);
+        schema.set_keys_type(PRIMARY_KEYS);
+    }
+
+    RowsetMetadataPB* add_rowset(TabletMetadataPB* metadata, uint32_t rowset_id, uint32_t max_compact_input_rowset_id,
+                                 uint32_t del_origin_rowset_id) {
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(rowset_id);
+        rowset->set_max_compact_input_rowset_id(max_compact_input_rowset_id);
+        rowset->add_segments("segment.dat");
+        rowset->add_segment_size(128);
+        auto* del_file = rowset->add_del_files();
+        del_file->set_name("del.dat");
+        del_file->set_origin_rowset_id(del_origin_rowset_id);
+        return rowset;
+    }
+
+    void add_delvec(TabletMetadataPB* metadata, int64_t tablet_id, int64_t version, uint32_t segment_id,
+                    const std::string& file_name, const std::string& content) {
+        FileMetaPB file_meta;
+        file_meta.set_name(file_name);
+        file_meta.set_size(content.size());
+        (*metadata->mutable_delvec_meta()->mutable_version_to_file())[version] = file_meta;
+
+        DelvecPagePB page;
+        page.set_version(version);
+        page.set_offset(0);
+        page.set_size(content.size());
+        (*metadata->mutable_delvec_meta()->mutable_delvecs())[segment_id] = page;
+
+        write_file(_tablet_manager->delvec_location(tablet_id, file_name), content);
+    }
+
+    void add_sstable(TabletMetadataPB* metadata, const std::string& filename, uint64_t max_rss_rowid,
+                     bool with_delvec) {
+        auto* sstable = metadata->mutable_sstable_meta()->add_sstables();
+        sstable->set_filename(filename);
+        sstable->set_max_rss_rowid(max_rss_rowid);
+        if (with_delvec) {
+            sstable->mutable_delvec()->set_version(1);
+        }
+    }
+
+    void add_dcg(TabletMetadataPB* metadata, uint32_t segment_id, const std::string& file_name) {
+        DeltaColumnGroupVerPB dcg;
+        dcg.add_column_files(file_name);
+        metadata->mutable_dcg_meta()->mutable_dcgs()->insert({segment_id, dcg});
+    }
+
     std::unique_ptr<starrocks::lake::TabletManager> _tablet_manager;
     std::string _test_dir;
     std::shared_ptr<lake::LocationProvider> _location_provider;
@@ -278,6 +351,556 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting_with_gap_boundary) {
         EXPECT_GT(meta->rowsets(0).num_rows(), 0);
         EXPECT_GT(meta->rowsets(0).data_size(), 0);
     }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_basic) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id_1 = next_id();
+    const int64_t old_tablet_id_2 = next_id();
+    const int64_t new_tablet_id = next_id();
+
+    prepare_tablet_dirs(old_tablet_id_1);
+    prepare_tablet_dirs(old_tablet_id_2);
+    prepare_tablet_dirs(new_tablet_id);
+
+    auto meta1 = std::make_shared<TabletMetadataPB>();
+    meta1->set_id(old_tablet_id_1);
+    meta1->set_version(base_version);
+    meta1->set_next_rowset_id(100);
+    set_primary_key_schema(meta1.get(), 1001);
+    add_historical_schema(meta1.get(), 5001);
+    add_rowset(meta1.get(), 10, 7, 10);
+    (*meta1->mutable_rowset_to_schema())[10] = 1001;
+    add_delvec(meta1.get(), old_tablet_id_1, base_version, 10, "delvec-1", "aaaa");
+    add_sstable(meta1.get(), "sst-1", (static_cast<uint64_t>(1) << 32) | 7, true);
+    add_dcg(meta1.get(), 10, "dcg-1");
+
+    auto meta2 = std::make_shared<TabletMetadataPB>();
+    meta2->set_id(old_tablet_id_2);
+    meta2->set_version(base_version);
+    meta2->set_next_rowset_id(3);
+    set_primary_key_schema(meta2.get(), 2002);
+    add_historical_schema(meta2.get(), 5002);
+    add_rowset(meta2.get(), 1, 3, 1);
+    (*meta2->mutable_rowset_to_schema())[1] = 2002;
+    add_delvec(meta2.get(), old_tablet_id_2, base_version, 1, "delvec-2", "bbbbbb");
+    add_sstable(meta2.get(), "sst-2", (static_cast<uint64_t>(2) << 32) | 5, true);
+    add_dcg(meta2.get(), 1, "dcg-2");
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(old_tablet_id_1);
+    merging_tablet.add_old_tablet_ids(old_tablet_id_2);
+    merging_tablet.set_new_tablet_id(new_tablet_id);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(10);
+    txn_info.set_commit_time(111);
+    txn_info.set_gtid(222);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(new_tablet_id);
+    const int64_t offset = static_cast<int64_t>(meta1->next_rowset_id()) - 1;
+    const uint32_t expected_rowset_id = static_cast<uint32_t>(1 + offset);
+
+    bool found_rowset = false;
+    for (const auto& rowset : merged->rowsets()) {
+        if (rowset.id() == expected_rowset_id) {
+            found_rowset = true;
+            ASSERT_TRUE(rowset.has_max_compact_input_rowset_id());
+            EXPECT_EQ(static_cast<uint32_t>(3 + offset), rowset.max_compact_input_rowset_id());
+            ASSERT_EQ(1, rowset.del_files_size());
+            EXPECT_EQ(static_cast<uint32_t>(1 + offset), rowset.del_files(0).origin_rowset_id());
+            break;
+        }
+    }
+    ASSERT_TRUE(found_rowset);
+
+    auto rowset_schema_it = merged->rowset_to_schema().find(expected_rowset_id);
+    ASSERT_TRUE(rowset_schema_it != merged->rowset_to_schema().end());
+    EXPECT_EQ(2002, rowset_schema_it->second);
+
+    bool found_sstable = false;
+    for (const auto& sstable : merged->sstable_meta().sstables()) {
+        if (sstable.filename() == "sst-2") {
+            found_sstable = true;
+            EXPECT_EQ(static_cast<int32_t>(offset), sstable.rssid_offset());
+            const uint64_t expected_max_rss = (static_cast<uint64_t>(2 + offset) << 32) | 5;
+            EXPECT_EQ(expected_max_rss, sstable.max_rss_rowid());
+            EXPECT_FALSE(sstable.has_delvec());
+            break;
+        }
+    }
+    ASSERT_TRUE(found_sstable);
+
+    const uint32_t expected_segment_id = static_cast<uint32_t>(1 + offset);
+    auto delvec_it = merged->delvec_meta().delvecs().find(expected_segment_id);
+    ASSERT_TRUE(delvec_it != merged->delvec_meta().delvecs().end());
+    EXPECT_EQ(new_version, delvec_it->second.version());
+    EXPECT_EQ(static_cast<uint64_t>(4), delvec_it->second.offset());
+
+    EXPECT_TRUE(merged->delvec_meta().version_to_file().find(new_version) !=
+                merged->delvec_meta().version_to_file().end());
+
+    auto dcg_it = merged->dcg_meta().dcgs().find(expected_segment_id);
+    ASSERT_TRUE(dcg_it != merged->dcg_meta().dcgs().end());
+    ASSERT_EQ(1, dcg_it->second.column_files_size());
+    EXPECT_EQ("dcg-2", dcg_it->second.column_files(0));
+
+    EXPECT_TRUE(merged->historical_schemas().find(5001) != merged->historical_schemas().end());
+    EXPECT_TRUE(merged->historical_schemas().find(5002) != merged->historical_schemas().end());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_without_delvec) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id_1 = next_id();
+    const int64_t old_tablet_id_2 = next_id();
+    const int64_t new_tablet_id = next_id();
+
+    prepare_tablet_dirs(old_tablet_id_1);
+    prepare_tablet_dirs(old_tablet_id_2);
+    prepare_tablet_dirs(new_tablet_id);
+
+    auto meta1 = std::make_shared<TabletMetadataPB>();
+    meta1->set_id(old_tablet_id_1);
+    meta1->set_version(base_version);
+    meta1->set_next_rowset_id(5);
+    set_primary_key_schema(meta1.get(), 1001);
+    add_rowset(meta1.get(), 1, 1, 1);
+
+    auto meta2 = std::make_shared<TabletMetadataPB>();
+    meta2->set_id(old_tablet_id_2);
+    meta2->set_version(base_version);
+    meta2->set_next_rowset_id(5);
+    set_primary_key_schema(meta2.get(), 1002);
+    add_rowset(meta2.get(), 2, 2, 2);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(old_tablet_id_1);
+    merging_tablet.add_old_tablet_ids(old_tablet_id_2);
+    merging_tablet.set_new_tablet_id(new_tablet_id);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    EXPECT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_skip_missing_delvec_meta) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id_1 = next_id();
+    const int64_t old_tablet_id_2 = next_id();
+    const int64_t new_tablet_id = next_id();
+
+    prepare_tablet_dirs(old_tablet_id_1);
+    prepare_tablet_dirs(old_tablet_id_2);
+    prepare_tablet_dirs(new_tablet_id);
+
+    auto meta1 = std::make_shared<TabletMetadataPB>();
+    meta1->set_id(old_tablet_id_1);
+    meta1->set_version(base_version);
+    meta1->set_next_rowset_id(10);
+    set_primary_key_schema(meta1.get(), 1001);
+    add_rowset(meta1.get(), 1, 1, 1);
+    add_delvec(meta1.get(), old_tablet_id_1, base_version, 1, "delvec-1", "aaa");
+
+    auto meta2 = std::make_shared<TabletMetadataPB>();
+    meta2->set_id(old_tablet_id_2);
+    meta2->set_version(base_version);
+    meta2->set_next_rowset_id(10);
+    set_primary_key_schema(meta2.get(), 1002);
+    add_rowset(meta2.get(), 2, 2, 2);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(old_tablet_id_1);
+    merging_tablet.add_old_tablet_ids(old_tablet_id_2);
+    merging_tablet.set_new_tablet_id(new_tablet_id);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    EXPECT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_version_missing) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id_1 = next_id();
+    const int64_t old_tablet_id_2 = next_id();
+    const int64_t new_tablet_id = next_id();
+
+    prepare_tablet_dirs(old_tablet_id_1);
+    prepare_tablet_dirs(old_tablet_id_2);
+    prepare_tablet_dirs(new_tablet_id);
+
+    auto meta1 = std::make_shared<TabletMetadataPB>();
+    meta1->set_id(old_tablet_id_1);
+    meta1->set_version(base_version);
+    meta1->set_next_rowset_id(10);
+    set_primary_key_schema(meta1.get(), 1001);
+    add_rowset(meta1.get(), 1, 1, 1);
+    add_delvec(meta1.get(), old_tablet_id_1, base_version, 1, "delvec-1", "aaa");
+
+    auto meta2 = std::make_shared<TabletMetadataPB>();
+    meta2->set_id(old_tablet_id_2);
+    meta2->set_version(base_version);
+    meta2->set_next_rowset_id(10);
+    set_primary_key_schema(meta2.get(), 1002);
+    add_rowset(meta2.get(), 2, 2, 2);
+    auto* delvec_meta = meta2->mutable_delvec_meta();
+    DelvecPagePB page;
+    page.set_version(base_version);
+    page.set_offset(0);
+    page.set_size(1);
+    (*delvec_meta->mutable_delvecs())[2] = page;
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(old_tablet_id_1);
+    merging_tablet.add_old_tablet_ids(old_tablet_id_2);
+    merging_tablet.set_new_tablet_id(new_tablet_id);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_TRUE(st.is_invalid_argument());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_missing_tablet_offset) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id_1 = next_id();
+    const int64_t old_tablet_id_2 = next_id();
+    const int64_t new_tablet_id = next_id();
+
+    prepare_tablet_dirs(old_tablet_id_1);
+    prepare_tablet_dirs(old_tablet_id_2);
+    prepare_tablet_dirs(new_tablet_id);
+
+    auto meta1 = std::make_shared<TabletMetadataPB>();
+    meta1->set_id(old_tablet_id_1);
+    meta1->set_version(base_version);
+    meta1->set_next_rowset_id(10);
+    set_primary_key_schema(meta1.get(), 1001);
+    add_rowset(meta1.get(), 1, 1, 1);
+    add_delvec(meta1.get(), old_tablet_id_1, base_version, 1, "delvec-1", "aaa");
+
+    auto meta2 = std::make_shared<TabletMetadataPB>();
+    meta2->set_id(old_tablet_id_2);
+    meta2->set_version(base_version);
+    meta2->set_next_rowset_id(10);
+    set_primary_key_schema(meta2.get(), 1002);
+    add_rowset(meta2.get(), 2, 2, 2);
+    add_delvec(meta2.get(), old_tablet_id_2, base_version, 2, "delvec-2", "bbb");
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(old_tablet_id_1);
+    merging_tablet.add_old_tablet_ids(old_tablet_id_2);
+    merging_tablet.set_new_tablet_id(new_tablet_id);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("merge_delvecs:before_apply_offsets", [old_tablet_id_2](void* arg) {
+        auto* base_offset_by_tablet =
+                reinterpret_cast<std::unordered_map<int64_t, std::unordered_map<std::string, uint64_t>>*>(arg);
+        base_offset_by_tablet->erase(old_tablet_id_2);
+    });
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_TRUE(st.is_invalid_argument());
+
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_missing_file_offset) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id_1 = next_id();
+    const int64_t old_tablet_id_2 = next_id();
+    const int64_t new_tablet_id = next_id();
+
+    prepare_tablet_dirs(old_tablet_id_1);
+    prepare_tablet_dirs(old_tablet_id_2);
+    prepare_tablet_dirs(new_tablet_id);
+
+    auto meta1 = std::make_shared<TabletMetadataPB>();
+    meta1->set_id(old_tablet_id_1);
+    meta1->set_version(base_version);
+    meta1->set_next_rowset_id(10);
+    set_primary_key_schema(meta1.get(), 1001);
+    add_rowset(meta1.get(), 1, 1, 1);
+    add_delvec(meta1.get(), old_tablet_id_1, base_version, 1, "delvec-1", "aaa");
+
+    auto meta2 = std::make_shared<TabletMetadataPB>();
+    meta2->set_id(old_tablet_id_2);
+    meta2->set_version(base_version);
+    meta2->set_next_rowset_id(10);
+    set_primary_key_schema(meta2.get(), 1002);
+    add_rowset(meta2.get(), 2, 2, 2);
+    add_delvec(meta2.get(), old_tablet_id_2, base_version, 2, "delvec-2", "bbb");
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(old_tablet_id_1);
+    merging_tablet.add_old_tablet_ids(old_tablet_id_2);
+    merging_tablet.set_new_tablet_id(new_tablet_id);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("merge_delvecs:before_apply_offsets", [old_tablet_id_2](void* arg) {
+        auto* base_offset_by_tablet =
+                reinterpret_cast<std::unordered_map<int64_t, std::unordered_map<std::string, uint64_t>>*>(arg);
+        auto tablet_it = base_offset_by_tablet->find(old_tablet_id_2);
+        if (tablet_it != base_offset_by_tablet->end()) {
+            tablet_it->second.erase("delvec-2");
+        }
+    });
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_TRUE(st.is_invalid_argument());
+
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_cache_miss_fallback) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id_1 = next_id();
+    const int64_t old_tablet_id_2 = next_id();
+    const int64_t new_tablet_id = next_id();
+
+    prepare_tablet_dirs(old_tablet_id_1);
+    prepare_tablet_dirs(old_tablet_id_2);
+    prepare_tablet_dirs(new_tablet_id);
+
+    auto meta1 = std::make_shared<TabletMetadataPB>();
+    meta1->set_id(old_tablet_id_1);
+    meta1->set_version(base_version);
+    meta1->set_next_rowset_id(5);
+    add_rowset(meta1.get(), 1, 1, 1);
+
+    auto meta2 = std::make_shared<TabletMetadataPB>();
+    meta2->set_id(old_tablet_id_2);
+    meta2->set_version(base_version);
+    meta2->set_next_rowset_id(5);
+    add_rowset(meta2.get(), 2, 2, 2);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+
+    auto cached_meta1 = std::make_shared<TabletMetadataPB>(*meta1);
+    cached_meta1->set_version(new_version);
+    cached_meta1->set_commit_time(999);
+    EXPECT_OK(_tablet_manager->cache_tablet_metadata(cached_meta1));
+
+    auto cached_meta2 = std::make_shared<TabletMetadataPB>(*meta2);
+    cached_meta2->set_version(new_version);
+    cached_meta2->set_commit_time(999);
+    EXPECT_OK(_tablet_manager->cache_tablet_metadata(cached_meta2));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(old_tablet_id_1);
+    merging_tablet.add_old_tablet_ids(old_tablet_id_2);
+    merging_tablet.set_new_tablet_id(new_tablet_id);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(10);
+    txn_info.set_commit_time(123);
+    txn_info.set_gtid(456);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    ASSERT_TRUE(tablet_metadatas.find(old_tablet_id_1) != tablet_metadatas.end());
+    EXPECT_EQ(txn_info.commit_time(), tablet_metadatas.at(old_tablet_id_1)->commit_time());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_base_version_not_found) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id_1 = next_id();
+    const int64_t old_tablet_id_2 = next_id();
+    const int64_t new_tablet_id = next_id();
+
+    prepare_tablet_dirs(old_tablet_id_1);
+    prepare_tablet_dirs(old_tablet_id_2);
+    prepare_tablet_dirs(new_tablet_id);
+
+    auto meta1 = std::make_shared<TabletMetadataPB>();
+    meta1->set_id(old_tablet_id_1);
+    meta1->set_version(new_version);
+    meta1->set_next_rowset_id(5);
+    meta1->set_gtid(100);
+
+    auto meta2 = std::make_shared<TabletMetadataPB>();
+    meta2->set_id(old_tablet_id_2);
+    meta2->set_version(new_version);
+    meta2->set_next_rowset_id(5);
+    meta2->set_gtid(100);
+
+    auto meta_new = std::make_shared<TabletMetadataPB>();
+    meta_new->set_id(new_tablet_id);
+    meta_new->set_version(new_version);
+    meta_new->set_next_rowset_id(5);
+    meta_new->set_gtid(100);
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta_new));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(old_tablet_id_1);
+    merging_tablet.add_old_tablet_ids(old_tablet_id_2);
+    merging_tablet.set_new_tablet_id(new_tablet_id);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(100);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    EXPECT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+    EXPECT_EQ(3, tablet_metadatas.size());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_get_metadata_error) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id = next_id();
+    const int64_t new_tablet_id = next_id();
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(old_tablet_id);
+    merging_tablet.set_new_tablet_id(new_tablet_id);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    TEST_ENABLE_ERROR_POINT("TabletManager::get_tablet_metadata", Status::Corruption("injected"));
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_TRUE(st.is_corruption());
+
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->ClearAllCallBacks();
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_segment_overflow) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t old_tablet_id_1 = next_id();
+    const int64_t old_tablet_id_2 = next_id();
+    const int64_t new_tablet_id = next_id();
+
+    prepare_tablet_dirs(old_tablet_id_1);
+    prepare_tablet_dirs(old_tablet_id_2);
+    prepare_tablet_dirs(new_tablet_id);
+
+    auto meta1 = std::make_shared<TabletMetadataPB>();
+    meta1->set_id(old_tablet_id_1);
+    meta1->set_version(base_version);
+    meta1->set_next_rowset_id(100);
+    add_rowset(meta1.get(), 50, 50, 50);
+
+    auto meta2 = std::make_shared<TabletMetadataPB>();
+    meta2->set_id(old_tablet_id_2);
+    meta2->set_version(base_version);
+    meta2->set_next_rowset_id(10);
+    add_rowset(meta2.get(), 90, 90, 90);
+    add_dcg(meta2.get(), std::numeric_limits<uint32_t>::max() - 5, "dcg-overflow");
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta1));
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(meta2));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(old_tablet_id_1);
+    merging_tablet.add_old_tablet_ids(old_tablet_id_2);
+    merging_tablet.set_new_tablet_id(new_tablet_id);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_TRUE(st.is_invalid_argument());
 }
 
 } // namespace starrocks

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -64,6 +64,8 @@ message PersistentIndexSstablePB {
     optional PersistentIndexSstableRangePB range = 11;
     // This file's fileset id. All files under same fileset should be non-overlapped.
     optional PUniqueId fileset_id = 12;
+    // Offset applied to rssid when reusing sstables across tablets (e.g., tablet merge).
+    optional int32 rssid_offset = 13 [default = 0];
 }
 
 message PersistentIndexSstableMetaPB {


### PR DESCRIPTION
## Why I'm doing:
 Implement tablet merge metadata with delvec merge and rssid_offset.
This PR does not handle the delete predicate, it will be addressed in a subsequent PR.

## What I'm doing:
  - Add delvec file concatenation (with encryption support) for tablet merge metadata.
  - Build merged tablet metadata: merge rowsets, sstables, delvecs; compute rowset/segment offsets and preserve shared flags.
  - Return merged tablet range in reshard publish and update merge tests.
  - Add rssid_offset to sstable proto definition and refactor merge helpers.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
