### PR TITLE
[Enhancement] Introduce rssid_offset in cloud native pk index read and compaction paths

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -517,6 +517,7 @@ Status LakePersistentIndex::prepare_merging_iterator(
         }
         read_options.shared_rssid = sstable_pb.shared_rssid();
         read_options.shared_version = sstable_pb.shared_version();
+        read_options.rssid_offset = sstable_pb.rssid_offset();
         read_options.delvec = merging_sstable->delvec();
         sstable::Iterator* iter = merging_sstable->new_iterator(read_options);
         iters.emplace_back(iter);

--- a/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
+++ b/be/src/storage/lake/lake_persistent_index_key_value_merger.cpp
@@ -62,6 +62,16 @@ Status KeyValueMerger::merge(const sstable::Iterator* iter_ptr) {
             index_value_ver.mutable_values(i)->set_rssid(iter_ptr->shared_rssid());
         }
     }
+    if (iter_ptr->rssid_offset() != 0) {
+        const int32_t rssid_offset = iter_ptr->rssid_offset();
+        for (size_t i = 0; i < index_value_ver.values_size(); ++i) {
+            const int64_t rssid = static_cast<int64_t>(index_value_ver.values(i).rssid()) + rssid_offset;
+            index_value_ver.mutable_values(i)->set_rssid(static_cast<uint32_t>(rssid));
+        }
+        const uint64_t low = max_rss_rowid & 0xffffffffULL;
+        const int64_t high = static_cast<int64_t>(max_rss_rowid >> 32) + rssid_offset;
+        max_rss_rowid = (static_cast<uint64_t>(high) << 32) | low;
+    }
 
     /*
      * Do not distinguish between base compaction and cumulative compaction here.

--- a/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
+++ b/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
@@ -133,6 +133,7 @@ Status LakePersistentIndexParallelCompactTask::do_run() {
             read_options.max_rss_rowid = sstable_pb.max_rss_rowid();
             read_options.shared_rssid = sstable_pb.shared_rssid();
             read_options.shared_version = sstable_pb.shared_version();
+            read_options.rssid_offset = sstable_pb.rssid_offset();
             read_options.delvec = sst->delvec();
 
             sstable::Iterator* iter = sst->new_iterator(read_options);

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -141,6 +141,13 @@ Status PersistentIndexSstable::multi_get(const Slice* keys, const KeyIndexSet& k
                 index_value_with_ver_pb.mutable_values(j)->set_version(_sstable_pb.shared_version());
             }
         }
+        if (_sstable_pb.rssid_offset() != 0) {
+            for (size_t j = 0; j < index_value_with_ver_pb.values_size(); ++j) {
+                const int64_t rssid =
+                        static_cast<int64_t>(index_value_with_ver_pb.values(j).rssid()) + _sstable_pb.rssid_offset();
+                index_value_with_ver_pb.mutable_values(j)->set_rssid(static_cast<uint32_t>(rssid));
+            }
+        }
 
         if (index_value_with_ver_pb.values_size() > 0) {
             if (version < 0) {

--- a/be/src/storage/sstable/concatenating_iterator.cpp
+++ b/be/src/storage/sstable/concatenating_iterator.cpp
@@ -144,6 +144,11 @@ public:
         return children_[current_index_].shared_version();
     }
 
+    int32_t rssid_offset() const override {
+        assert(Valid());
+        return children_[current_index_].rssid_offset();
+    }
+
     DelVectorPtr delvec() const override {
         assert(Valid());
         return children_[current_index_].delvec();

--- a/be/src/storage/sstable/iterator.h
+++ b/be/src/storage/sstable/iterator.h
@@ -68,6 +68,7 @@ public:
     // Return the shared rssid & version the iterator contains.
     virtual uint32_t shared_rssid() const { return 0; };
     virtual int64_t shared_version() const { return 0; };
+    virtual int32_t rssid_offset() const { return 0; };
     virtual DelVectorPtr delvec() const { return nullptr; };
 
     /*

--- a/be/src/storage/sstable/iterator_wrapper.h
+++ b/be/src/storage/sstable/iterator_wrapper.h
@@ -58,6 +58,10 @@ public:
         assert(iter_);
         return iter_->shared_version();
     }
+    int32_t rssid_offset() const {
+        assert(iter_);
+        return iter_->rssid_offset();
+    }
     DelVectorPtr delvec() const {
         assert(iter_);
         return iter_->delvec();

--- a/be/src/storage/sstable/merger.cpp
+++ b/be/src/storage/sstable/merger.cpp
@@ -143,6 +143,11 @@ public:
         return current_->shared_version();
     }
 
+    int32_t rssid_offset() const override {
+        assert(Valid());
+        return current_->rssid_offset();
+    }
+
     DelVectorPtr delvec() const override {
         assert(Valid());
         return current_->delvec();

--- a/be/src/storage/sstable/options.h
+++ b/be/src/storage/sstable/options.h
@@ -138,6 +138,7 @@ struct ReadOptions {
     // these two fields are used to indicate the shared rssid & version
     uint32_t shared_rssid = 0;
     int64_t shared_version = 0;
+    int32_t rssid_offset = 0;
 
     // Mark rows that have been deleted in this sst
     DelVectorPtr delvec = nullptr;

--- a/be/src/storage/sstable/two_level_iterator.cpp
+++ b/be/src/storage/sstable/two_level_iterator.cpp
@@ -126,6 +126,7 @@ public:
 
     uint32_t shared_rssid() const override { return options_.shared_rssid; };
     int64_t shared_version() const override { return options_.shared_version; };
+    int32_t rssid_offset() const override { return options_.rssid_offset; };
     DelVectorPtr delvec() const override { return options_.delvec; };
 
 private:

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -64,6 +64,8 @@ message PersistentIndexSstablePB {
     optional PersistentIndexSstableRangePB range = 11;
     // This file's fileset id. All files under same fileset should be non-overlapped.
     optional PUniqueId fileset_id = 12;
+    // Offset applied to rssid when reusing sstables across tablets (e.g., tablet merge).
+    optional int32 rssid_offset = 13 [default = 0];
 }
 
 message PersistentIndexSstableMetaPB {


### PR DESCRIPTION
## Why I'm doing:
 Introduce rssid_offset in cloud native pk index read and compaction paths

## What I'm doing:
  - Add rssid_offset in PersistentIndexSstablePB.
  - Propagate rssid_offset through sstable ReadOptions and iterator interfaces.
  - Apply rssid_offset during multi_get and compaction merge so rssid is shifted correctly.
  - Add unit tests covering rssid_offset in sstable reads and parallel compaction output.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
