### PR TITLE
[BugFix] Fix PhysicalPartition cleanup and multi-version materialized index handling

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/MergePartitionJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MergePartitionJob.java
@@ -726,7 +726,7 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
                 Partition partition = targetTable.getPartition(sourcePartitionName);
                 if (partition != null) {
                     for (MaterializedIndex index : partition.getDefaultPhysicalPartition()
-                            .getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                            .getAllMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
                         sourceTablets.addAll(index.getTablets());
                     }
                 }
@@ -844,7 +844,7 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
                     Partition partition = targetTable.getPartition(pid);
                     if (partition != null) {
                         for (MaterializedIndex index : partition.getDefaultPhysicalPartition()
-                                .getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                                .getAllMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
                             // hash set is able to deduplicate the elements
                             sourceTablets.addAll(index.getTablets());
                         }
@@ -938,7 +938,7 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
             Partition partition = targetTable.getPartition(id);
             if (partition != null) {
                 for (MaterializedIndex index :
-                        partition.getDefaultPhysicalPartition().getLatestMaterializedIndices(IndexExtState.ALL)) {
+                        partition.getDefaultPhysicalPartition().getAllMaterializedIndices(IndexExtState.ALL)) {
                     sourceTablets.addAll(index.getTablets());
                 }
                 targetTable.dropTempPartition(partition.getName(), true);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
@@ -476,7 +476,7 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
             Set<Tablet> sourceTablets = Sets.newHashSet();
             Partition partition = targetTable.getPartition(sourcePartitionName);
             for (MaterializedIndex index
-                    : partition.getDefaultPhysicalPartition().getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                    : partition.getDefaultPhysicalPartition().getAllMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
                 sourceTablets.addAll(index.getTablets());
             }
 
@@ -583,7 +583,7 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
                     Partition partition = targetTable.getPartition(pid);
                     if (partition != null) {
                         for (MaterializedIndex index : partition.getDefaultPhysicalPartition()
-                                .getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                                .getAllMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
                             // hash set is able to deduplicate the elements
                             tmpTablets.addAll(index.getTablets());
                         }
@@ -688,7 +688,7 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
             Partition partition = targetTable.getPartition(id);
             if (partition != null) {
                 for (MaterializedIndex index : partition.getDefaultPhysicalPartition()
-                        .getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                        .getAllMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
                     sourceTablets.addAll(index.getTablets());
                 }
                 targetTable.dropTempPartition(partition.getName(), true);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
@@ -561,7 +561,7 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
             sourcePartitionNames.forEach(name -> {
                 Partition partition = targetTable.getPartition(name);
                 for (MaterializedIndex index
-                        : partition.getDefaultPhysicalPartition().getLatestMaterializedIndices(IndexExtState.ALL)) {
+                        : partition.getDefaultPhysicalPartition().getAllMaterializedIndices(IndexExtState.ALL)) {
                     sourceTablets.addAll(index.getTablets());
                 }
             });
@@ -667,7 +667,7 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
                     Partition partition = targetTable.getPartition(pid);
                     if (partition != null) {
                         for (MaterializedIndex index : partition.getDefaultPhysicalPartition()
-                                .getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                                .getAllMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
                             // hash set is able to deduplicate the elements
                             sourceTablets.addAll(index.getTablets());
                         }
@@ -761,7 +761,7 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
             Partition partition = targetTable.getPartition(id);
             if (partition != null) {
                 for (MaterializedIndex index
-                        : partition.getDefaultPhysicalPartition().getLatestMaterializedIndices(IndexExtState.ALL)) {
+                        : partition.getDefaultPhysicalPartition().getAllMaterializedIndices(IndexExtState.ALL)) {
                     sourceTablets.addAll(index.getTablets());
                 }
                 targetTable.dropTempPartition(partition.getName(), true);

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1572,7 +1572,7 @@ public class RestoreJob extends AbstractJob {
     protected void modifyInvertedIndex(OlapTable restoreTbl, Partition restorePart) {
         // ensure modify for all physical partitions, not only for the first one (default physical partition)
         for (PhysicalPartition physicalPartition : restorePart.getSubPartitions()) {
-            for (MaterializedIndex restoreIdx : physicalPartition.getLatestMaterializedIndices(IndexExtState.VISIBLE)) {
+            for (MaterializedIndex restoreIdx : physicalPartition.getAllMaterializedIndices(IndexExtState.VISIBLE)) {
                 TabletMeta tabletMeta = new TabletMeta(dbId, restoreTbl.getId(), physicalPartition.getId(),
                         restoreIdx.getId(), TStorageMedium.HDD);
                 for (Tablet restoreTablet : restoreIdx.getTablets()) {
@@ -2080,7 +2080,7 @@ public class RestoreJob extends AbstractJob {
         for (Partition part : restoreTbl.getPartitions()) {
             // ensure clear all physical partitions, not only for the first one (default physical partition)
             for (PhysicalPartition physicalPartition : part.getSubPartitions()) {
-                for (MaterializedIndex idx : physicalPartition.getLatestMaterializedIndices(IndexExtState.VISIBLE)) {
+                for (MaterializedIndex idx : physicalPartition.getAllMaterializedIndices(IndexExtState.VISIBLE)) {
                     for (Tablet tablet : idx.getTablets()) {
                         globalStateMgr.getTabletInvertedIndex().deleteTablet(tablet.getId());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1735,7 +1735,7 @@ public class OlapTable extends Table {
                     for (MaterializedIndex deleteIndex : shadowIndex) {
                         physicalPartition.deleteMaterializedIndexByMetaId(deleteIndex.getMetaId());
                     }
-                    for (MaterializedIndex idx : physicalPartition.getLatestMaterializedIndices(extState)) {
+                    for (MaterializedIndex idx : physicalPartition.getAllMaterializedIndices(extState)) {
                         idx.setState(IndexState.NORMAL);
                         if (copied.isCloudNativeTableOrMaterializedView()) {
                             continue;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -373,6 +373,8 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
         return indices;
     }
 
+    // Create new rollup index.
+    // 1. indexMetaIdToIndexIds currently does not contain mIndex.metaId.
     public void createRollupIndex(MaterializedIndex mIndex) {
         Preconditions.checkState(!indexMetaIdToIndexIds.containsKey(mIndex.getMetaId()),
                 String.format("index meta id %d already exists", mIndex.getMetaId()));
@@ -387,6 +389,9 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
         }
     }
 
+    // Add new version base or rollup materialized index.
+    // 1. mIndex.state is NORMAL.
+    // 2. indexMetaIdToIndexIds currently contains mIndex.metaId.
     public void addMaterializedIndex(MaterializedIndex mIndex, boolean isBaseIndex) {
         Preconditions.checkState(indexMetaIdToIndexIds.containsKey(mIndex.getMetaId()),
                 String.format("index meta id %d not exist", mIndex.getMetaId()));
@@ -411,6 +416,10 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
             List<Long> indexIds = indexMetaIdToIndexIds.get(index.getMetaId());
             Preconditions.checkState(indexIds != null && indexIds.remove(indexId),
                     String.format("index id %d not found in indexMetaIdToIndexIds", indexId));
+
+            if (indexIds.isEmpty()) {
+                indexMetaIdToIndexIds.remove(index.getMetaId());
+            }
         }
 
         return index;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -233,7 +233,7 @@ public class LakeTable extends OlapTable {
             .flatMap(partition -> partition.getSubPartitions().stream())
             .allMatch(physicalPartition -> {
                 long physicalPartitionId = physicalPartition.getId();
-                List<Long> shardIds = physicalPartition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL).stream()
+                List<Long> shardIds = physicalPartition.getAllMaterializedIndices(MaterializedIndex.IndexExtState.ALL).stream()
                         .flatMap(index -> index.getTablets().stream())
                         .map(tablet -> ((LakeTablet) tablet).getShardId())
                         .collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
@@ -263,7 +263,7 @@ public class LakeRestoreJob extends RestoreJob {
     @Override
     protected void modifyInvertedIndex(OlapTable restoreTbl, Partition restorePart) {
         for (MaterializedIndex restoredIdx : restorePart.getDefaultPhysicalPartition()
-                .getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
+                .getAllMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
             TStorageMedium medium = restoreTbl.getPartitionInfo().getDataProperty(restorePart.getId()).getStorageMedium();
             TabletMeta tabletMeta = new TabletMeta(dbId, restoreTbl.getId(), restorePart.getId(),
                     restoredIdx.getId(), medium, true);

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -549,7 +549,7 @@ public class InsertOverwriteJobRunner {
 
     private void collectTabletsFromPartition(Partition partition, Set<Tablet> tablets) {
         for (PhysicalPartition subPartition : partition.getSubPartitions()) {
-            for (MaterializedIndex index : subPartition.getLatestMaterializedIndices(IndexExtState.ALL)) {
+            for (MaterializedIndex index : subPartition.getAllMaterializedIndices(IndexExtState.ALL)) {
                 tablets.addAll(index.getTablets());
             }
         }
@@ -636,7 +636,7 @@ public class InsertOverwriteJobRunner {
             sourcePartitionNames.forEach(name -> {
                 Partition partition = targetTable.getPartition(name);
                 for (PhysicalPartition subPartition : partition.getSubPartitions()) {
-                    for (MaterializedIndex index : subPartition.getLatestMaterializedIndices(IndexExtState.ALL)) {
+                    for (MaterializedIndex index : subPartition.getAllMaterializedIndices(IndexExtState.ALL)) {
                         sourceTablets.addAll(index.getTablets());
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -28,6 +28,7 @@ import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
@@ -769,8 +770,9 @@ public class InformationSchemaDataSource {
             if (partition.getVisibleVersionTime() > lastUpdateTime) {
                 lastUpdateTime = partition.getVisibleVersionTime();
             }
-            totalRowsOfTable = partition.getLatestBaseIndex().getRowCount() + totalRowsOfTable;
-            totalBytesOfTable = partition.getLatestBaseIndex().getDataSize() + totalBytesOfTable;
+            MaterializedIndex baseIndex = partition.getLatestBaseIndex();
+            totalRowsOfTable = baseIndex.getRowCount() + totalRowsOfTable;
+            totalBytesOfTable = baseIndex.getDataSize() + totalBytesOfTable;
         }
         // TABLE_ROWS
         info.setTable_rows(totalRowsOfTable);

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -681,7 +681,7 @@ public class SystemInfoService implements GsonPostProcessable {
                                     db.getOriginName(), table.getName(), droppedBackend.getHost(),
                                     droppedBackend.getHeartbeatPort(), db.getOriginName(), table.getName());
 
-                            partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)
+                            partition.getAllMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)
                                     .forEach(rollupIdx -> {
                                         boolean existIntersection = rollupIdx.getTablets().stream()
                                                 .map(Tablet::getId).anyMatch(tabletIds::contains);

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletTaskExecutor.java
@@ -456,7 +456,7 @@ public class TabletTaskExecutor {
         for (Partition partition : olapTable.getAllPartitions()) {
             for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                 List<MaterializedIndex> allIndices = physicalPartition
-                        .getLatestMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
+                        .getAllMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
                 for (MaterializedIndex materializedIndex : allIndices) {
                     int schemaHash = olapTable.getSchemaHashByIndexMetaId(materializedIndex.getMetaId());
                     for (Tablet tablet : materializedIndex.getTablets()) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -885,7 +885,9 @@ public class TransactionState implements Writable, GsonPreProcessable {
         Preconditions.checkState(!indexIds.isEmpty());
         Map<Long, List<Long>> loadedPartitionIndexes = loadedTblPartitionIndexes.computeIfAbsent(
                 tableId, k -> Maps.newHashMap());
-        loadedPartitionIndexes.put(physicalPartitionId, indexIds);
+        if (!loadedPartitionIndexes.containsKey(physicalPartitionId)) {
+            loadedPartitionIndexes.put(physicalPartitionId, indexIds);
+        }
     }
 
     public void addPartitionLoadedIndexes(long tableId, long physicalPartitionId, List<Long> indexIds) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -885,9 +885,7 @@ public class TransactionState implements Writable, GsonPreProcessable {
         Preconditions.checkState(!indexIds.isEmpty());
         Map<Long, List<Long>> loadedPartitionIndexes = loadedTblPartitionIndexes.computeIfAbsent(
                 tableId, k -> Maps.newHashMap());
-        if (!loadedPartitionIndexes.containsKey(physicalPartitionId)) {
-            loadedPartitionIndexes.put(physicalPartitionId, indexIds);
-        }
+        loadedPartitionIndexes.putIfAbsent(physicalPartitionId, indexIds);
     }
 
     public void addPartitionLoadedIndexes(long tableId, long physicalPartitionId, List<Long> indexIds) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PhysicalPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PhysicalPartitionTest.java
@@ -450,4 +450,32 @@ public class PhysicalPartitionTest {
         Assertions.assertTrue(latestIndices.contains(baseIndex2));
         Assertions.assertTrue(latestIndices.contains(rollup2));
     }
+
+    @Test
+    public void testDeleteMaterializedIndexOperations() {
+        long partitionId = 1000L;
+        long parentId = 2000L;
+        long baseIndexId1 = 3001L;
+        long baseIndexId2 = 3002L;
+        long baseMetaId = 3100L;
+        long baseShardGroupId = 100L;
+
+        MaterializedIndex baseIndex1 = new MaterializedIndex(baseIndexId1, baseMetaId, IndexState.NORMAL, baseShardGroupId);
+        PhysicalPartition partition = new PhysicalPartition(partitionId, parentId, baseIndex1);
+
+        MaterializedIndex baseIndex2 = new MaterializedIndex(baseIndexId2, baseMetaId, IndexState.NORMAL, baseShardGroupId);
+        partition.addMaterializedIndex(baseIndex2, true);
+
+        Map<Long, List<Long>> indexMetaIdToIndexIds = Deencapsulation.getField(partition, "indexMetaIdToIndexIds");
+        Assertions.assertTrue(indexMetaIdToIndexIds.containsKey(baseMetaId));
+        Assertions.assertEquals(2, indexMetaIdToIndexIds.get(baseMetaId).size());
+
+        partition.deleteMaterializedIndexByIndexId(baseIndexId1);
+        Assertions.assertTrue(indexMetaIdToIndexIds.containsKey(baseMetaId));
+        Assertions.assertEquals(1, indexMetaIdToIndexIds.get(baseMetaId).size());
+        Assertions.assertEquals(baseIndexId2, (long) indexMetaIdToIndexIds.get(baseMetaId).get(0));
+
+        partition.deleteMaterializedIndexByIndexId(baseIndexId2);
+        Assertions.assertFalse(indexMetaIdToIndexIds.containsKey(baseMetaId));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -355,6 +355,13 @@ public class FrontendServiceImplTest {
 
     @Test
     public void testImmutablePartitionException() throws TException {
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                return new TransactionState();
+            }
+        };
+
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                     .getTable(db.getFullName(), "site_access_exception");
@@ -364,38 +371,45 @@ public class FrontendServiceImplTest {
         TImmutablePartitionResult partition = impl.updateImmutablePartition(request);
         Table t = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "v");
 
-        Assertions.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.RUNTIME_ERROR);
+        Assertions.assertEquals(TStatusCode.RUNTIME_ERROR, partition.getStatus().getStatus_code());
 
         request.setDb_id(db.getId());
         partition = impl.updateImmutablePartition(request);
-        Assertions.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.RUNTIME_ERROR);
+        Assertions.assertEquals(TStatusCode.RUNTIME_ERROR, partition.getStatus().getStatus_code());
 
         request.setTable_id(t.getId());
         partition = impl.updateImmutablePartition(request);
-        Assertions.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.RUNTIME_ERROR);
+        Assertions.assertEquals(TStatusCode.RUNTIME_ERROR, partition.getStatus().getStatus_code());
 
         request.setTable_id(table.getId());
         partition = impl.updateImmutablePartition(request);
-        Assertions.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.RUNTIME_ERROR);
+        Assertions.assertEquals(TStatusCode.RUNTIME_ERROR, partition.getStatus().getStatus_code());
 
         request.setPartition_ids(partitionIds);
         partition = impl.updateImmutablePartition(request);
-        Assertions.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.OK);
+        Assertions.assertEquals(TStatusCode.OK, partition.getStatus().getStatus_code());
 
         partitionIds.add(1L);
         request.setPartition_ids(partitionIds);
         partition = impl.updateImmutablePartition(request);
-        Assertions.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.OK);
+        Assertions.assertEquals(TStatusCode.OK, partition.getStatus().getStatus_code());
 
         partitionIds = table.getPhysicalPartitions().stream()
                     .map(PhysicalPartition::getId).collect(Collectors.toList());
         request.setPartition_ids(partitionIds);
         partition = impl.updateImmutablePartition(request);
-        Assertions.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.OK);
+        Assertions.assertEquals(TStatusCode.OK, partition.getStatus().getStatus_code());
     }
 
     @Test
     public void testImmutablePartitionApi() throws TException {
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public TransactionState getTransactionState(long dbId, long transactionId) {
+                return new TransactionState();
+            }
+        };
+
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
         OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                     .getTable(db.getFullName(), "site_access_auto");
@@ -408,18 +422,18 @@ public class FrontendServiceImplTest {
         request.setPartition_ids(partitionIds);
         TImmutablePartitionResult partition = impl.updateImmutablePartition(request);
 
-        Assertions.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.OK);
+        Assertions.assertEquals(TStatusCode.OK, partition.getStatus().getStatus_code());
         Assertions.assertEquals(2, table.getPhysicalPartitions().size());
 
         partition = impl.updateImmutablePartition(request);
-        Assertions.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.OK);
+        Assertions.assertEquals(TStatusCode.OK, partition.getStatus().getStatus_code());
         Assertions.assertEquals(2, table.getPhysicalPartitions().size());
 
         partitionIds = table.getPhysicalPartitions().stream()
                     .map(PhysicalPartition::getId).collect(Collectors.toList());
         request.setPartition_ids(partitionIds);
         partition = impl.updateImmutablePartition(request);
-        Assertions.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.OK);
+        Assertions.assertEquals(TStatusCode.OK, partition.getStatus().getStatus_code());
         Assertions.assertEquals(3, table.getPhysicalPartitions().size());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -315,6 +316,18 @@ public class TransactionStateTest {
         assertEquals(2, loadedIndexes.size());
         assertEquals(indexId11, loadedIndexes.get(0).getId());
         assertEquals(indexId21, loadedIndexes.get(1).getId());
+
+        // Add same physicalPartitionId with 2 specific latest indexes failed
+        loadedIndexIds = Lists.newArrayList(indexId12, indexId22);
+        txn.addPartitionLoadedIndexes(tableId, physicalPartitionId, loadedIndexIds);
+        loadedIndexes = txn.getPartitionLoadedIndexes(tableId, physicalPartition);
+        assertEquals(2, loadedIndexes.size());
+        assertEquals(indexId11, loadedIndexes.get(0).getId()); // Still indexId11
+        assertEquals(indexId21, loadedIndexes.get(1).getId()); // Still indexId21
+
+        // Clear loadedTblPartitionIndexes
+        Map<Long, Map<Long, List<Long>>> loadedTblPartitionIndexes = Deencapsulation.getField(txn, "loadedTblPartitionIndexes");
+        loadedTblPartitionIndexes.clear();
 
         // Add 2 specific latest indexes
         loadedIndexIds = Lists.newArrayList(indexId12, indexId22);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. Fix a bug in `PhysicalPartition` where the `metaId` key was not removed after deleting the last index version.
2. Use `getAllMaterializedIndices` instead of `getLatestMaterializedIndices` in various jobs (Restore, MergePartition, etc.) to ensure all index versions are processed.
3. Use `metaId` instead of `id` in `FrontendServiceImpl` to support loading data into correct index when creating new physical partitions in load job.

https://github.com/StarRocks/starrocks/issues/64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
