### PR TITLE
[Enhancement] Support user-level default warehouse for merge commit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -39,7 +39,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.starrocks.authentication.UserProperty;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.AuthorizationMgr;
 import com.starrocks.catalog.UserIdentity;
@@ -59,10 +58,8 @@ import com.starrocks.http.WebUtils;
 import com.starrocks.http.rest.v2.RestBaseResultV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectScheduler;
-import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.ExecuteEnv;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TNetworkAddress;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -413,26 +410,5 @@ public class RestBaseAction extends BaseAction {
                 response,
                 status,
                 new RestBaseResultV2<>(status.code(), message));
-    }
-
-    public static Optional<String> getUserDefaultWarehouse(BaseRequest request) {
-        ConnectContext ctx = request.getConnectContext();
-        if (ctx != null && ctx.getCurrentUserIdentity() != null) {
-            UserIdentity userIdentity = ctx.getCurrentUserIdentity();
-            if (!userIdentity.isEphemeral()) {
-                try {
-                    UserProperty userProperty = GlobalStateMgr.getCurrentState().getAuthenticationMgr()
-                            .getUserProperty(userIdentity.getUser());
-                    String userWarehouse = userProperty.getSessionVariables().get(SessionVariable.WAREHOUSE_NAME);
-                    if (!Strings.isNullOrEmpty(userWarehouse)) {
-                        return Optional.of(userWarehouse);
-                    }
-                } catch (SemanticException e) {
-                    // user does not exist, use default warehouse
-                    LOG.warn("Failed to get user property. user: {}", userIdentity.getUser(), e);
-                }
-            }
-        }
-        return Optional.empty();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -337,8 +337,8 @@ public class TransactionLoadAction extends RestBaseAction {
             warehouseName = request.getRequest().headers().get(WAREHOUSE_KEY);
         } else {
             ConnectContext ctx = request.getConnectContext();
-            if (ctx != null && ctx.getCurrentUserIdentity() != null) {
-                Optional<String> userWarehouseName = Utils.getUserDefaultWarehouse(ctx.getCurrentUserIdentity().getUser());
+            if (ctx != null) {
+                Optional<String> userWarehouseName = Utils.getUserDefaultWarehouse(ctx.getCurrentUserIdentity());
                 if (userWarehouseName.isPresent() &&
                         GlobalStateMgr.getCurrentState().getWarehouseMgr().warehouseExists(userWarehouseName.get())) {
                     warehouseName = userWarehouseName.get();

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -62,12 +62,14 @@ import com.starrocks.http.rest.transaction.TransactionWithoutChannelHandler;
 import com.starrocks.metric.GaugeMetric;
 import com.starrocks.metric.LongCounterMetric;
 import com.starrocks.metric.Metric;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionState.LoadJobSourceType;
+import com.starrocks.warehouse.Utils;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.commons.lang3.StringUtils;
@@ -334,10 +336,13 @@ public class TransactionLoadAction extends RestBaseAction {
         if (request.getRequest().headers().contains(WAREHOUSE_KEY)) {
             warehouseName = request.getRequest().headers().get(WAREHOUSE_KEY);
         } else {
-            Optional<String> userWarehouseName = getUserDefaultWarehouse(request);
-            if (userWarehouseName.isPresent() &&
-                    GlobalStateMgr.getCurrentState().getWarehouseMgr().warehouseExists(userWarehouseName.get())) {
-                warehouseName = userWarehouseName.get();
+            ConnectContext ctx = request.getConnectContext();
+            if (ctx != null && ctx.getCurrentUserIdentity() != null) {
+                Optional<String> userWarehouseName = Utils.getUserDefaultWarehouse(ctx.getCurrentUserIdentity().getUser());
+                if (userWarehouseName.isPresent() &&
+                        GlobalStateMgr.getCurrentState().getWarehouseMgr().warehouseExists(userWarehouseName.get())) {
+                    warehouseName = userWarehouseName.get();
+                }
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitJob.java
@@ -134,6 +134,10 @@ public class MergeCommitJob implements MergeCommitTaskCallback {
         return streamLoadInfo.getWarehouseId();
     }
 
+    public String getWarehouseName() {
+        return warehouseName;
+    }
+
     public int getBatchWriteParallel() {
         return batchWriteParallel;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -77,6 +77,7 @@ import com.starrocks.transaction.TransactionState.TxnCoordinator;
 import com.starrocks.transaction.TxnCommitAttachment;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.WarehouseIdleChecker;
+import com.starrocks.warehouse.cngroup.CRAcquireContext;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import io.netty.handler.codec.http.HttpHeaders;
 import org.apache.logging.log4j.LogManager;
@@ -907,14 +908,15 @@ public class StreamLoadTask extends AbstractStreamLoadTask {
 
     public void unprotectedExecute(HttpHeaders headers) throws StarRocksException {
         try (var scope = context.bindScope()) {
-            do_unprotectedExecute(headers);
+            doUnprotectedExecute(headers);
         }
     }
 
-    private void do_unprotectedExecute(HttpHeaders headers) throws StarRocksException {
+    private void doUnprotectedExecute(HttpHeaders headers) throws StarRocksException {
         streamLoadParams = StreamLoadKvParams.fromHttpHeaders(headers);
+        CRAcquireContext acquireContext = CRAcquireContext.of(warehouseId);
         streamLoadInfo = StreamLoadInfo.fromHttpStreamLoadRequest(
-                loadId, txnId, Optional.of((int) timeoutMs / 1000), streamLoadParams);
+                loadId, txnId, Optional.of((int) timeoutMs / 1000), streamLoadParams, acquireContext);
         if (table == null) {
             getTable();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/Utils.java
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.warehouse;
+
+import com.google.common.base.Strings;
+import com.starrocks.authentication.AuthenticationMgr;
+import com.starrocks.authentication.UserProperty;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.SemanticException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Optional;
+
+public class Utils {
+    private static final Logger LOG = LogManager.getLogger(Utils.class);
+
+    private Utils() {
+    }
+
+    public static Optional<String> getUserDefaultWarehouse(String user) {
+        if (Strings.isNullOrEmpty(user)) {
+            return Optional.empty();
+        }
+
+        AuthenticationMgr mgr = GlobalStateMgr.getCurrentState().getAuthenticationMgr();
+        try {
+            UserIdentity userIdentity = mgr.getUserIdentityByName(user);
+            if (!userIdentity.isEphemeral()) {
+                UserProperty userProperty = mgr.getUserProperty(user);
+                String userWarehouse = userProperty.getSessionVariables().get(SessionVariable.WAREHOUSE_NAME);
+                if (!Strings.isNullOrEmpty(userWarehouse)) {
+                    return Optional.of(userWarehouse);
+                }
+            }
+        } catch (SemanticException e) {
+            LOG.warn("Failed to get user property. user: {}", user, e);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
@@ -16,6 +16,7 @@ package com.starrocks.http;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.proc.ProcResult;
@@ -100,7 +101,7 @@ public class LoadActionTest extends StarRocksHttpTestCase {
         new MockUp<BatchWriteMgr>() {
             @Mock
             public RequestCoordinatorBackendResult requestCoordinatorBackends(
-                    TableId tableId, StreamLoadKvParams params, String user) {
+                    TableId tableId, StreamLoadKvParams params, UserIdentity userIdentity) {
                 return new RequestCoordinatorBackendResult(new TStatus(TStatusCode.OK), computeNodes);
             }
         };
@@ -121,7 +122,7 @@ public class LoadActionTest extends StarRocksHttpTestCase {
         new MockUp<BatchWriteMgr>() {
             @Mock
             public RequestCoordinatorBackendResult requestCoordinatorBackends(
-                    TableId tableId, StreamLoadKvParams params, String user) {
+                    TableId tableId, StreamLoadKvParams params, UserIdentity userIdentity) {
                 TStatus status = new TStatus();
                 status.setStatus_code(TStatusCode.INTERNAL_ERROR);
                 status.addToError_msgs("artificial failure");
@@ -569,7 +570,7 @@ public class LoadActionTest extends StarRocksHttpTestCase {
 
         new MockUp<Utils>() {
             @Mock
-            public Optional<String> getUserDefaultWarehouse(String user) {
+            public Optional<String> getUserDefaultWarehouse(UserIdentity userIdentity) {
                 return Optional.of("user_wh");
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/LoadActionTest.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Lists;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.proc.ProcResult;
-import com.starrocks.http.rest.LoadAction;
 import com.starrocks.load.batchwrite.BatchWriteMgr;
 import com.starrocks.load.batchwrite.RequestCoordinatorBackendResult;
 import com.starrocks.load.batchwrite.TableId;
@@ -37,6 +36,7 @@ import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
+import com.starrocks.warehouse.Utils;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.CRAcquireContext;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -567,9 +567,9 @@ public class LoadActionTest extends StarRocksHttpTestCase {
             }
         };
 
-        new MockUp<LoadAction>() {
+        new MockUp<Utils>() {
             @Mock
-            public Optional<String> getUserDefaultWarehouse(BaseRequest request) {
+            public Optional<String> getUserDefaultWarehouse(String user) {
                 return Optional.of("user_wh");
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -15,16 +15,11 @@
 package com.starrocks.http;
 
 import com.google.common.collect.Lists;
-import com.starrocks.authentication.AuthenticationMgr;
-import com.starrocks.authentication.UserProperty;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.http.rest.RestBaseAction;
-import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TNetworkAddress;
 import io.netty.channel.ChannelHandlerContext;
@@ -42,10 +37,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -179,62 +171,5 @@ public class RestBaseActionTest {
         Assertions.assertEquals(1, result.size());
         Assertions.assertEquals(frontend.getHost(), result.get(0).first);
         Assertions.assertEquals(Config.http_port, result.get(0).second);
-    }
-
-    @Test
-    public void testGetUserDefaultWarehouse() {
-        HttpConnectContext connectContext = new HttpConnectContext();
-        UserIdentity userIdentity = UserIdentity.ROOT;
-        connectContext.setCurrentUserIdentity(userIdentity);
-        when(mockRequest.getConnectContext()).thenReturn(connectContext);
-
-        AuthenticationMgr authenticationMgr = new AuthenticationMgr();
-        new Expectations(GlobalStateMgr.getCurrentState()) {
-            {
-                GlobalStateMgr.getCurrentState().getAuthenticationMgr();
-                result = authenticationMgr;
-            }
-        };
-
-        new MockUp<AuthenticationMgr>() {
-            @Mock
-            public UserProperty getUserProperty(String user) {
-                UserProperty userProperty = new UserProperty();
-                Map<String, String> sessionVariables = new HashMap<>();
-                sessionVariables.put(SessionVariable.WAREHOUSE_NAME, "test_warehouse");
-                userProperty.setSessionVariables(sessionVariables);
-                return userProperty;
-            }
-        };
-
-        Optional<String> warehouse = restBaseAction.getUserDefaultWarehouse(mockRequest);
-        Assertions.assertEquals("test_warehouse", warehouse.get());
-
-        new MockUp<AuthenticationMgr>() {
-            @Mock
-            public boolean doesUserExist(UserIdentity userIdentity) {
-                return true;
-            }
-
-            @Mock
-            public UserProperty getUserProperty(String user) {
-                throw new SemanticException("Unknown user");
-            }
-        };
-        warehouse = restBaseAction.getUserDefaultWarehouse(mockRequest);
-        Assertions.assertFalse(warehouse.isPresent());
-
-        new MockUp<AuthenticationMgr>() {
-            @Mock
-            public boolean doesUserExist(UserIdentity userIdentity) {
-                return false;
-            }
-        };
-        warehouse = restBaseAction.getUserDefaultWarehouse(mockRequest);
-        Assertions.assertFalse(warehouse.isPresent());
-
-        when(mockRequest.getConnectContext()).thenReturn(null);
-        warehouse = restBaseAction.getUserDefaultWarehouse(mockRequest);
-        Assertions.assertFalse(warehouse.isPresent());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/StreamLoadMetaActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StreamLoadMetaActionTest.java
@@ -16,6 +16,7 @@ package com.starrocks.http;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import com.starrocks.catalog.UserIdentity;
 import com.starrocks.load.batchwrite.BatchWriteMgr;
 import com.starrocks.load.batchwrite.RequestCoordinatorBackendResult;
 import com.starrocks.load.batchwrite.TableId;
@@ -108,7 +109,7 @@ public class StreamLoadMetaActionTest extends StarRocksHttpTestCase {
         new MockUp<BatchWriteMgr>() {
             @Mock
             public RequestCoordinatorBackendResult requestCoordinatorBackends(
-                    TableId tableId, StreamLoadKvParams params, String user) {
+                    TableId tableId, StreamLoadKvParams params, UserIdentity userIdentity) {
                 return new RequestCoordinatorBackendResult(new TStatus(TStatusCode.OK), computeNodes);
             }
         };
@@ -133,7 +134,7 @@ public class StreamLoadMetaActionTest extends StarRocksHttpTestCase {
         new MockUp<BatchWriteMgr>() {
             @Mock
             public RequestCoordinatorBackendResult requestCoordinatorBackends(
-                    TableId tableId, StreamLoadKvParams params, String user) {
+                    TableId tableId, StreamLoadKvParams params, UserIdentity userIdentity) {
                 ComputeNode node = new ComputeNode(1, "192.0.0.1", 9050);
                 node.setHttpPort(8040);
                 node.setBrpcPort(8060);
@@ -166,7 +167,7 @@ public class StreamLoadMetaActionTest extends StarRocksHttpTestCase {
         new MockUp<BatchWriteMgr>() {
             @Mock
             public RequestCoordinatorBackendResult requestCoordinatorBackends(
-                    TableId tableId, StreamLoadKvParams params, String user) {
+                    TableId tableId, StreamLoadKvParams params, UserIdentity userIdentity) {
                 TStatus status = new TStatus();
                 status.setStatus_code(TStatusCode.INTERNAL_ERROR);
                 status.addToError_msgs("artificial failure");

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
+import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.proc.ProcResult;
@@ -576,7 +577,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
 
             new MockUp<Utils>() {
                 @Mock
-                public Optional<String> getUserDefaultWarehouse(String user) {
+                public Optional<String> getUserDefaultWarehouse(UserIdentity userIdentity) {
                     return Optional.of("user_wh");
                 }
             };

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -22,7 +22,6 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.proc.ProcResult;
 import com.starrocks.http.rest.ActionStatus;
-import com.starrocks.http.rest.RestBaseAction;
 import com.starrocks.http.rest.TransactionLoadAction;
 import com.starrocks.http.rest.TransactionLoadCoordinatorMgr;
 import com.starrocks.http.rest.TransactionResult;
@@ -49,6 +48,7 @@ import com.starrocks.transaction.TransactionState.TxnCoordinator;
 import com.starrocks.transaction.TransactionState.TxnSourceType;
 import com.starrocks.transaction.TransactionStatus;
 import com.starrocks.transaction.TxnCommitAttachment;
+import com.starrocks.warehouse.Utils;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -574,9 +574,9 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 }
             };
 
-            new MockUp<RestBaseAction>() {
+            new MockUp<Utils>() {
                 @Mock
-                public Optional<String> getUserDefaultWarehouse(BaseRequest request) {
+                public Optional<String> getUserDefaultWarehouse(String user) {
                     return Optional.of("user_wh");
                 }
             };

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/BatchWriteMgrTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.load.batchwrite;
 
+import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.proc.ProcResult;
@@ -75,7 +76,7 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
                 put(HTTP_BATCH_WRITE_PARALLEL, "1");
             }});
         RequestCoordinatorBackendResult result1 =
-                batchWriteMgr.requestCoordinatorBackends(tableId1, params1, "root");
+                batchWriteMgr.requestCoordinatorBackends(tableId1, params1, UserIdentity.ROOT);
         assertTrue(result1.isOk());
         assertEquals(1, result1.getValue().size());
         assertEquals(1, batchWriteMgr.numJobs());
@@ -86,7 +87,7 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
                 put(HTTP_BATCH_WRITE_PARALLEL, "1");
             }});
         RequestCoordinatorBackendResult result2 =
-                batchWriteMgr.requestCoordinatorBackends(tableId1, params2, "root");
+                batchWriteMgr.requestCoordinatorBackends(tableId1, params2, UserIdentity.ROOT);
         assertTrue(result2.isOk());
         assertEquals(1, result2.getValue().size());
         assertEquals(2, batchWriteMgr.numJobs());
@@ -96,7 +97,7 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
                 put(HTTP_BATCH_WRITE_PARALLEL, "4");
             }});
         RequestCoordinatorBackendResult result3 =
-                batchWriteMgr.requestCoordinatorBackends(tableId2, params3, "root");
+                batchWriteMgr.requestCoordinatorBackends(tableId2, params3, UserIdentity.ROOT);
         assertTrue(result3.isOk());
         assertEquals(4, result3.getValue().size());
         assertEquals(3, batchWriteMgr.numJobs());
@@ -106,7 +107,7 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
                 put(HTTP_BATCH_WRITE_PARALLEL, "4");
             }});
         RequestCoordinatorBackendResult result4 =
-                batchWriteMgr.requestCoordinatorBackends(tableId3, params4, "root");
+                batchWriteMgr.requestCoordinatorBackends(tableId3, params4, UserIdentity.ROOT);
         assertTrue(result4.isOk());
         assertEquals(4, result4.getValue().size());
         assertEquals(4, batchWriteMgr.numJobs());
@@ -119,13 +120,13 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
                 put(HTTP_BATCH_WRITE_PARALLEL, "4");
             }});
         RequestLoadResult result1 = batchWriteMgr.requestLoad(
-                tableId4, params, "root", allNodes.get(0).getId(), allNodes.get(0).getHost());
+                tableId4, params, UserIdentity.ROOT, allNodes.get(0).getId(), allNodes.get(0).getHost());
         assertTrue(result1.isOk());
         assertNotNull(result1.getValue());
         assertEquals(1, batchWriteMgr.numJobs());
 
         RequestLoadResult result2 = batchWriteMgr.requestLoad(
-                tableId4, params, "root", allNodes.get(0).getId(), allNodes.get(0).getHost());
+                tableId4, params, UserIdentity.ROOT, allNodes.get(0).getId(), allNodes.get(0).getHost());
         assertTrue(result2.isOk());
         assertEquals(result1.getValue(), result2.getValue());
         assertEquals(1, batchWriteMgr.numJobs());
@@ -135,7 +136,7 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
     public void testCheckParameters() {
         StreamLoadKvParams params1 = new StreamLoadKvParams(new HashMap<>());
         RequestCoordinatorBackendResult result1 =
-                batchWriteMgr.requestCoordinatorBackends(tableId1, params1, "root");
+                batchWriteMgr.requestCoordinatorBackends(tableId1, params1, UserIdentity.ROOT);
         assertFalse(result1.isOk());
         assertEquals(TStatusCode.INVALID_ARGUMENT, result1.getStatus().getStatus_code());
         assertEquals(0, batchWriteMgr.numJobs());
@@ -144,7 +145,7 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
                 put(HTTP_BATCH_WRITE_INTERVAL_MS, "10000");
             }});
         RequestCoordinatorBackendResult result2 =
-                batchWriteMgr.requestCoordinatorBackends(tableId2, params2, "root");
+                batchWriteMgr.requestCoordinatorBackends(tableId2, params2, UserIdentity.ROOT);
         assertFalse(result2.isOk());
         assertEquals(TStatusCode.INVALID_ARGUMENT, result2.getStatus().getStatus_code());
         assertEquals(0, batchWriteMgr.numJobs());
@@ -155,7 +156,7 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
                 put(HTTP_WAREHOUSE, "no_exist");
             }});
         RequestCoordinatorBackendResult result3 =
-                batchWriteMgr.requestCoordinatorBackends(tableId3, params3, "root");
+                batchWriteMgr.requestCoordinatorBackends(tableId3, params3, UserIdentity.ROOT);
         assertFalse(result3.isOk());
         assertEquals(TStatusCode.INVALID_ARGUMENT, result3.getStatus().getStatus_code());
         assertEquals(0, batchWriteMgr.numJobs());
@@ -167,7 +168,7 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
                 put(HTTP_BATCH_WRITE_INTERVAL_MS, "10000");
                 put(HTTP_BATCH_WRITE_PARALLEL, "4");
             }});
-        RequestCoordinatorBackendResult result1 = batchWriteMgr.requestCoordinatorBackends(tableId1, params1, "root");
+        RequestCoordinatorBackendResult result1 = batchWriteMgr.requestCoordinatorBackends(tableId1, params1, UserIdentity.ROOT);
         assertTrue(result1.isOk());
         assertEquals(1, batchWriteMgr.numJobs());
 
@@ -176,7 +177,7 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
                 put(HTTP_BATCH_WRITE_PARALLEL, "4");
             }});
         RequestLoadResult result2 = batchWriteMgr.requestLoad(
-                tableId4, params2, "root", allNodes.get(0).getId(), allNodes.get(0).getHost());
+                tableId4, params2, UserIdentity.ROOT, allNodes.get(0).getId(), allNodes.get(0).getHost());
         assertTrue(result2.isOk());
         assertEquals(2, batchWriteMgr.numJobs());
 
@@ -204,7 +205,7 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
                 result = new Exception("registerBatchWrite failed");
             }
         };
-        RequestCoordinatorBackendResult result = batchWriteMgr.requestCoordinatorBackends(tableId1, params1, "root");
+        RequestCoordinatorBackendResult result = batchWriteMgr.requestCoordinatorBackends(tableId1, params1, UserIdentity.ROOT);
         assertEquals(TStatusCode.INTERNAL_ERROR, result.getStatus().getStatus_code());
         assertEquals(0, batchWriteMgr.numJobs());
     }
@@ -216,7 +217,7 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
 
         new MockUp<Utils>() {
             @Mock
-            public Optional<String> getUserDefaultWarehouse(String user) {
+            public Optional<String> getUserDefaultWarehouse(UserIdentity userIdentity) {
                 return Optional.of(warehouse);
             }
         };
@@ -316,7 +317,8 @@ public class BatchWriteMgrTest extends BatchWriteTestBase {
             }
         });
 
-        RequestCoordinatorBackendResult result = batchWriteMgr.requestCoordinatorBackends(tableId1, params, user);
+        RequestCoordinatorBackendResult result = batchWriteMgr.requestCoordinatorBackends(
+                tableId1, params, new UserIdentity(user, "%"));
         assertTrue(result.isOk());
         ConcurrentHashMap<BatchWriteId, MergeCommitJob> jobs = Deencapsulation.getField(batchWriteMgr, "mergeCommitJobs");
         assertEquals(1, jobs.size());

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitJobTest.java
@@ -36,6 +36,7 @@ import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTabletFailInfo;
 import com.starrocks.transaction.TransactionStatus;
 import com.starrocks.transaction.TxnStateCallbackFactory;
+import com.starrocks.warehouse.cngroup.CRAcquireContext;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.jetbrains.annotations.NotNull;
@@ -85,7 +86,8 @@ public class MergeCommitJobTest extends BatchWriteTestBase {
         map.put(StreamLoadHttpHeader.HTTP_BATCH_WRITE_ASYNC, "false");
         StreamLoadKvParams params = new StreamLoadKvParams(map);
         StreamLoadInfo streamLoadInfo =
-                StreamLoadInfo.fromHttpStreamLoadRequest(null, -1, Optional.empty(), params);
+                StreamLoadInfo.fromHttpStreamLoadRequest(null, -1, Optional.empty(), params,
+                        CRAcquireContext.of(WarehouseManager.DEFAULT_WAREHOUSE_NAME));
         load = new MergeCommitJob(
                 1,
                 new TableId(DB_NAME_1, TABLE_NAME_1_1),
@@ -297,7 +299,8 @@ public class MergeCommitJobTest extends BatchWriteTestBase {
         map.put(StreamLoadHttpHeader.HTTP_BATCH_WRITE_ASYNC, "false");
         StreamLoadKvParams params = new StreamLoadKvParams(map);
         StreamLoadInfo streamLoadInfo =
-                StreamLoadInfo.fromHttpStreamLoadRequest(null, -1, Optional.empty(), params);
+                StreamLoadInfo.fromHttpStreamLoadRequest(null, -1, Optional.empty(), params,
+                        CRAcquireContext.of(WarehouseManager.DEFAULT_WAREHOUSE_NAME));
 
         MergeCommitJob mergeCommitJob = new MergeCommitJob(
                 1,

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
@@ -26,6 +26,7 @@ import com.starrocks.load.streamload.StreamLoadInfo;
 import com.starrocks.load.streamload.StreamLoadKvParams;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.LoadPlanner;
 import com.starrocks.task.LoadEtlTask;
 import com.starrocks.thrift.TLoadInfo;
@@ -34,6 +35,7 @@ import com.starrocks.thrift.TStreamLoadInfo;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TransactionStatus;
 import com.starrocks.transaction.TxnStateCallbackFactory;
+import com.starrocks.warehouse.cngroup.CRAcquireContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -89,7 +91,8 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
         map.put(StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE, "true");
         map.put(StreamLoadHttpHeader.HTTP_BATCH_WRITE_ASYNC, "true");
         kvParams = new StreamLoadKvParams(map);
-        streamLoadInfo = StreamLoadInfo.fromHttpStreamLoadRequest(null, -1, Optional.empty(), kvParams);
+        streamLoadInfo = StreamLoadInfo.fromHttpStreamLoadRequest(null, -1, Optional.empty(), kvParams,
+                CRAcquireContext.of(WarehouseManager.DEFAULT_WAREHOUSE_NAME));
         warehouseName = "default_warehouse";
         loadExecuteCallback = new TestMergeCommitTaskCallback();
         coordinatorFactory = Mockito.mock(Coordinator.Factory.class);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadPlannerTest.java
@@ -46,6 +46,7 @@ import com.starrocks.load.routineload.RoutineLoadJob;
 import com.starrocks.load.streamload.StreamLoadInfo;
 import com.starrocks.load.streamload.StreamLoadKvParams;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.ImportColumnsStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.expression.CompoundPredicate;
@@ -57,6 +58,7 @@ import com.starrocks.thrift.TStreamLoadPutRequest;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.CRAcquireContext;
 import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mocked;
@@ -177,7 +179,8 @@ public class StreamLoadPlannerTest {
         StreamLoadKvParams param = new StreamLoadKvParams(
                 Collections.singletonMap(HTTP_PARTIAL_UPDATE_MODE, "column"));
         TUniqueId loadId = UUIDUtil.genTUniqueId();
-        StreamLoadInfo.fromHttpStreamLoadRequest(loadId, 100, Optional.of(100), param);
+        StreamLoadInfo.fromHttpStreamLoadRequest(loadId, 100, Optional.of(100), param,
+                CRAcquireContext.of(WarehouseManager.DEFAULT_WAREHOUSE_NAME));
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
         StreamLoadInfo.fromRoutineLoadJob(routineLoadJob);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ConfigBase;
@@ -1525,7 +1526,7 @@ public class FrontendServiceImplTest {
 
             @Mock
             public RequestLoadResult requestLoad(
-                    TableId tableId, StreamLoadKvParams params, String user, long backendId, String backendHost) {
+                    TableId tableId, StreamLoadKvParams params, UserIdentity userIdentity, long backendId, String backendHost) {
                 return new RequestLoadResult(new TStatus(TStatusCode.OK), "test_label");
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/warehouse/UtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/warehouse/UtilsTest.java
@@ -53,13 +53,14 @@ public class UtilsTest {
     @Test
     public void testGetUserDefaultWarehouse() throws Exception {
         Assertions.assertEquals(Optional.empty(), Utils.getUserDefaultWarehouse(null));
-        Assertions.assertEquals(Optional.empty(), Utils.getUserDefaultWarehouse(""));
-        Assertions.assertEquals(Optional.empty(), Utils.getUserDefaultWarehouse("non_exist_user"));
+        Assertions.assertEquals(Optional.empty(), Utils.getUserDefaultWarehouse(new UserIdentity("", "%")));
+        Assertions.assertEquals(Optional.empty(), Utils.getUserDefaultWarehouse(new UserIdentity("non_exist_user", "%")));
+        Assertions.assertEquals(Optional.empty(), Utils.getUserDefaultWarehouse(new UserIdentity(true, "ephemeral_user", "%")));
 
         // Test user without warehouse
         String userName = "test_user_no_wh";
         createUser("CREATE USER '" + userName + "' IDENTIFIED BY ''");
-        Assertions.assertEquals(Optional.empty(), Utils.getUserDefaultWarehouse(userName));
+        Assertions.assertEquals(Optional.empty(), Utils.getUserDefaultWarehouse(new UserIdentity(userName, "%")));
 
         // Test user with warehouse
         String userWithWh = "test_user_with_wh";
@@ -69,7 +70,7 @@ public class UtilsTest {
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(setPropSql, ctx);
         DDLStmtExecutor.execute(stmt, ctx);
 
-        Optional<String> wh = Utils.getUserDefaultWarehouse(userWithWh);
+        Optional<String> wh = Utils.getUserDefaultWarehouse(new UserIdentity(userWithWh, "%"));
         Assertions.assertTrue(wh.isPresent());
         Assertions.assertEquals("default_warehouse", wh.get());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/warehouse/UtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/warehouse/UtilsTest.java
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.warehouse;
+
+import com.starrocks.authentication.AuthenticationMgr;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.ast.CreateUserStmt;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+public class UtilsTest {
+    private static StarRocksAssert starRocksAssert;
+    private static ConnectContext ctx;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        starRocksAssert = new StarRocksAssert(ctx);
+        starRocksAssert.getCtx().setRemoteIP("localhost");
+        starRocksAssert.getCtx().getGlobalStateMgr().getAuthorizationMgr().initBuiltinRolesAndUsers();
+    }
+
+    private static void createUser(String createUserSql) throws Exception {
+        CreateUserStmt createUserStmt =
+                (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(createUserSql, starRocksAssert.getCtx());
+        AuthenticationMgr authenticationManager =
+                starRocksAssert.getCtx().getGlobalStateMgr().getAuthenticationMgr();
+        authenticationManager.createUser(createUserStmt);
+    }
+
+    @Test
+    public void testGetUserDefaultWarehouse() throws Exception {
+        Assertions.assertEquals(Optional.empty(), Utils.getUserDefaultWarehouse(null));
+        Assertions.assertEquals(Optional.empty(), Utils.getUserDefaultWarehouse(""));
+        Assertions.assertEquals(Optional.empty(), Utils.getUserDefaultWarehouse("non_exist_user"));
+
+        // Test user without warehouse
+        String userName = "test_user_no_wh";
+        createUser("CREATE USER '" + userName + "' IDENTIFIED BY ''");
+        Assertions.assertEquals(Optional.empty(), Utils.getUserDefaultWarehouse(userName));
+
+        // Test user with warehouse
+        String userWithWh = "test_user_with_wh";
+        createUser("CREATE USER '" + userWithWh + "' IDENTIFIED BY ''");
+        String setPropSql = "ALTER USER '" + userWithWh + "' SET PROPERTIES ('session." + SessionVariable.WAREHOUSE_NAME +
+                "' = 'default_warehouse')";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(setPropSql, ctx);
+        DDLStmtExecutor.execute(stmt, ctx);
+
+        Optional<String> wh = Utils.getUserDefaultWarehouse(userWithWh);
+        Assertions.assertTrue(wh.isPresent());
+        Assertions.assertEquals("default_warehouse", wh.get());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Previously, merge commit defaulted to the system-wide 'default_warehouse' if no header was provided.

1. This PR improves the selection logic to prioritize the user's configured `session.warehouse` before falling back to the system default.
2. Refactor `getUserDefaultWarehouse`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
