### PR TITLE
[Refactor] Refactor logging.h

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -227,7 +227,7 @@ static void failure_function() {
 std::string lite_exec(const std::vector<std::string>& argv_vec, int timeout_ms);
 static std::mutex gcore_mutex;
 static bool gcore_done = false;
-void hook_on_query_timeout(TUniqueId& query_id, size_t timeout_seconds) {
+void hook_on_query_timeout(const TUniqueId& query_id, size_t timeout_seconds) {
     if (config::pipeline_gcore_timeout_threshold_sec > 0 &&
         timeout_seconds > static_cast<size_t>(config::pipeline_gcore_timeout_threshold_sec)) {
         std::unique_lock<std::mutex> lock(gcore_mutex);

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -45,6 +45,7 @@
 #include "cache/datacache.h"
 #include "cache/mem_cache/page_cache.h"
 #include "common/config.h"
+#include "common/logconfig.h"
 #include "gutil/endian.h"
 #include "gutil/stringprintf.h"
 #include "gutil/sysinfo.h"

--- a/be/src/common/logconfig.h
+++ b/be/src/common/logconfig.h
@@ -1,0 +1,22 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+
+namespace starrocks {
+struct TUniqueId;
+void hook_on_query_timeout(TUniqueId& query_id, size_t timeout_seconds);
+} // namespace starrocks

--- a/be/src/common/logconfig.h
+++ b/be/src/common/logconfig.h
@@ -17,6 +17,6 @@
 #include <cstddef>
 
 namespace starrocks {
-struct TUniqueId;
+class TUniqueId;
 void hook_on_query_timeout(TUniqueId& query_id, size_t timeout_seconds);
 } // namespace starrocks

--- a/be/src/common/logconfig.h
+++ b/be/src/common/logconfig.h
@@ -18,5 +18,5 @@
 
 namespace starrocks {
 class TUniqueId;
-void hook_on_query_timeout(TUniqueId& query_id, size_t timeout_seconds);
+void hook_on_query_timeout(const TUniqueId& query_id, size_t timeout_seconds);
 } // namespace starrocks

--- a/be/src/common/logging.h
+++ b/be/src/common/logging.h
@@ -12,52 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/be/src/common/logging.h
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 #pragma once
-// This is a wrapper around the glog header.  When we are compiling to IR,
-// we don't want to pull in the glog headers.  Pulling them in causes linking
-// issues when we try to dynamically link the codegen'd functions.
-#ifdef IR_COMPILE
-#include <iostream>
-#define DCHECK(condition) \
-    while (false) std::cout
-#define DCHECK_EQ(a, b) \
-    while (false) std::cout
-#define DCHECK_NE(a, b) \
-    while (false) std::cout
-#define DCHECK_GT(a, b) \
-    while (false) std::cout
-#define DCHECK_LT(a, b) \
-    while (false) std::cout
-#define DCHECK_GE(a, b) \
-    while (false) std::cout
-#define DCHECK_LE(a, b) \
-    while (false) std::cout
-// Similar to how glog defines DCHECK for release.
-#define LOG(level) \
-    while (false) std::cout
-#define VLOG(level) \
-    while (false) std::cout
-#else
 // GLOG defines this based on the system but doesn't check if it's already
 // been defined.  undef it first to avoid warnings.
 // glog MUST be included before gflags.  Instead of including them,
@@ -67,7 +22,6 @@
 // function to get the stack trace.
 #include <glog/logging.h>
 #undef MutexLock
-#endif
 
 // Define VLOG levels.  We want display per-row info less than per-file which
 // is less than per-query.  For now per-connection is the same as per-query.
@@ -87,12 +41,3 @@
 #define VLOG_OPERATOR_IS_ON VLOG_IS_ON(3)
 #define VLOG_ROW_IS_ON VLOG_IS_ON(10)
 #define VLOG_PROGRESS_IS_ON VLOG_IS_ON(2)
-
-namespace starrocks {
-class TUniqueId;
-void hook_on_query_timeout(TUniqueId& query_id, size_t timeout_seconds);
-} // namespace starrocks
-
-// Print log with query id.
-#define QUERY_LOG(level) LOG(level) << "[" << tls_thread_status.query_id() << "] "
-#define QUERY_LOG_IF(level, cond) LOG_IF(level, cond) << "[" << tls_thread_status.query_id() << "] "

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -48,6 +48,10 @@
 #include "util/priority_thread_pool.hpp"
 #include "util/runtime_profile.h"
 
+// Print log with query id.
+#define QUERY_LOG(level) LOG(level) << "[" << tls_thread_status.query_id() << "] "
+#define QUERY_LOG_IF(level, cond) LOG_IF(level, cond) << "[" << tls_thread_status.query_id() << "] "
+
 namespace starrocks {
 
 OlapScanNode::OlapScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -49,7 +49,6 @@
 #include "util/runtime_profile.h"
 
 // Print log with query id.
-#define QUERY_LOG(level) LOG(level) << "[" << tls_thread_status.query_id() << "] "
 #define QUERY_LOG_IF(level, cond) LOG_IF(level, cond) << "[" << tls_thread_status.query_id() << "] "
 
 namespace starrocks {

--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <thread>
 
+#include "common/logconfig.h"
 #include "common/logging.h"
 #include "exec/data_sink.h"
 #include "exec/pipeline/group_execution/execution_group.h"

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -16,6 +16,7 @@
 
 #include <chrono>
 
+#include "common/logconfig.h"
 #include "exec/pipeline/pipeline_fwd.h"
 #include "exec/pipeline/pipeline_metrics.h"
 #include "runtime/exec_env.h"

--- a/be/src/exec/pipeline/schedule/timeout_tasks.cpp
+++ b/be/src/exec/pipeline/schedule/timeout_tasks.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/pipeline/schedule/timeout_tasks.h"
 
+#include "common/logconfig.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exec/pipeline/pipeline_fwd.h"
 #include "exec/pipeline/schedule/common.h"


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a header refactor, but it changes exported macros and a function signature, which can cause widespread compile/link fallout or subtle include-order issues.
> 
> **Overview**
> Refactors logging-related headers by slimming `common/logging.h` down to a pure glog wrapper and moving query-timeout hook declarations into a new `common/logconfig.h`.
> 
> Updates `hook_on_query_timeout` to take `const TUniqueId&` and adjusts call sites to include `logconfig.h` explicitly; also relocates the `QUERY_LOG_IF` macro usage by defining it locally in `olap_scan_node.cpp` instead of exporting it via `logging.h`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53feec7a34476ff45645506254bec2e9cde84b20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->