### PR TITLE
[BugFix] fix iceberg delete column nullability

### DIFF
--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -222,7 +222,8 @@ SlotDescriptor IcebergDeleteFileMeta::gen_slot_helper(const IcebergColumnMeta& m
     desc.__set_slotIdx(meta.id);
     desc.__set_isMaterialized(true);
     desc.__set_nullIndicatorByte(0);
-    desc.__set_nullIndicatorBit(-1);
+    desc.__set_nullIndicatorBit(0); // this field is nullable
+    desc.__set_isNullable(true);
 
     return {desc};
 }


### PR DESCRIPTION
## Why I'm doing:

Hidden column like `file_path` and `pos` is optional, thus they are `nullable`

```
Created by: parquet-cpp-arrow version 16.1.0 starrocks-yanz-debug-jem-starrocks-clang-88aeb7e
Properties: (none)
Schema:
message table {
  optional binary file_path (STRING) = 2147483546;
  optional int64 pos (INTEGER(64,true)) = 2147483545;
}


Row group 0:  count: 1  302.00 B records  start: 4  total(compressed): 302 B total(uncompressed):302 B
--------------------------------------------------------------------------------
           type      encodings count     avg size   nulls   min / max
file_path  BINARY    _ _ R     1         254.00 B   0       "hdfs://emr-header-1.clust..." / "hdfs://emr-header-1.clust..."
pos        INT64     _ _ R     1         48.00 B    0       "0" / "0"
```

This file is written by starrocks.  However if it's written in spark, then those fields are required.

```
File path:  00000-5-2b3f2dac-6c73-41cd-b3b9-b67359895b5d-00001-deletes.parquet
Created by: parquet-mr version 1.15.1 (build c7257b8faff5699e13bbc781679dc03f48c1102a)
Properties:
     delete-type: position
  iceberg.schema: {"type":"struct","schema-id":0,"fields":[{"id":2147483546,"name":"file_path","required":true,"type":"string","doc":"Path of a file in which a deleted row is stored"},{"id":2147483545,"name":"pos","required":true,"type":"long","doc":"Ordinal position of a deleted row in the data file"}]}
Schema:
message table {
  required binary file_path (STRING) = 2147483546;
  required int64 pos = 2147483545;
}
```

Set those fields to nullable can be compatible with the spark case.

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10920

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
