### PR TITLE
[Refactor] deprecate `null_indicator_byte` and `null_indicator_bit` fields

### DIFF
--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -221,8 +221,6 @@ SlotDescriptor IcebergDeleteFileMeta::gen_slot_helper(const IcebergColumnMeta& m
     desc.__set_colName(meta.col_name);
     desc.__set_slotIdx(meta.id);
     desc.__set_isMaterialized(true);
-    desc.__set_nullIndicatorByte(0);
-    desc.__set_nullIndicatorBit(0); // this field is nullable
     desc.__set_isNullable(true);
 
     return {desc};

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -264,9 +264,6 @@ Status SchemaScanner::_create_slot_descs(ObjectPool* pool) {
     }
 
     int offset = (null_column + 7) / 8;
-    int null_byte = 0;
-    int null_bit = 0;
-
     for (int i = 0; i < _column_num; ++i) {
         TSlotDescriptor t_slot_desc;
         const TypeDescriptor& type_desc = _columns[i].type;
@@ -276,18 +273,7 @@ Status SchemaScanner::_create_slot_descs(ObjectPool* pool) {
         t_slot_desc.__set_columnPos(i);
         t_slot_desc.__set_byteOffset(offset);
 
-        if (_columns[i].is_null) {
-            t_slot_desc.__set_nullIndicatorByte(null_byte);
-            t_slot_desc.__set_nullIndicatorBit(null_bit);
-            null_bit = (null_bit + 1) % 8;
-
-            if (0 == null_bit) {
-                null_byte++;
-            }
-        } else {
-            t_slot_desc.__set_nullIndicatorByte(0);
-            t_slot_desc.__set_nullIndicatorBit(-1);
-        }
+        t_slot_desc.__set_isNullable(_columns[i].is_null);
 
         t_slot_desc.__set_slotIdx(i);
         t_slot_desc.__set_isMaterialized(true);

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -90,7 +90,7 @@ SlotDescriptor::SlotDescriptor(const PSlotDescriptor& pdesc)
           _slot_size(_type.get_slot_size()),
           _is_materialized(pdesc.is_materialized()),
           _is_output_column(true),
-          _is_nullable(pdesc.null_indicator_bit() != -1) {}
+          _is_nullable(pdesc.has_is_nullable() ? pdesc.is_nullable() : pdesc.null_indicator_bit() != -1) {}
 
 void SlotDescriptor::to_protobuf(PSlotDescriptor* pslot) const {
     pslot->set_id(_id);
@@ -105,6 +105,7 @@ void SlotDescriptor::to_protobuf(PSlotDescriptor* pslot) const {
     pslot->set_col_name(_col_name);
     pslot->set_slot_idx(_slot_idx);
     pslot->set_is_materialized(_is_materialized);
+    pslot->set_is_nullable(_is_nullable);
 }
 
 std::string SlotDescriptor::debug_string() const {

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -53,22 +53,10 @@
 
 namespace starrocks {
 const int RowDescriptor::INVALID_IDX = -1;
-std::string NullIndicatorOffset::debug_string() const {
-    std::stringstream out;
-    out << "(offset=" << byte_offset << " mask=" << std::hex << static_cast<int>(bit_mask) << std::dec << ")";
-    return out.str();
-}
-
-std::ostream& operator<<(std::ostream& os, const NullIndicatorOffset& null_indicator) {
-    os << null_indicator.debug_string();
-    return os;
-}
-
 SlotDescriptor::SlotDescriptor(SlotId id, std::string name, TypeDescriptor type)
         : _id(id),
           _type(std::move(type)),
           _parent(0),
-          _null_indicator_offset(0, 0),
           _col_name(std::move(name)),
           _col_unique_id(-1),
           _slot_idx(0),
@@ -81,7 +69,6 @@ SlotDescriptor::SlotDescriptor(const TSlotDescriptor& tdesc)
         : _id(tdesc.id),
           _type(TypeDescriptor::from_thrift(tdesc.slotType)),
           _parent(tdesc.parent),
-          _null_indicator_offset(tdesc.nullIndicatorByte, tdesc.nullIndicatorBit),
           _col_name(tdesc.colName),
           _col_unique_id(tdesc.col_unique_id),
           _col_physical_name(tdesc.col_physical_name),
@@ -89,21 +76,21 @@ SlotDescriptor::SlotDescriptor(const TSlotDescriptor& tdesc)
           _slot_size(_type.get_slot_size()),
           _is_materialized(tdesc.isMaterialized),
           _is_output_column(tdesc.__isset.isOutputColumn ? tdesc.isOutputColumn : true),
-          _is_nullable(tdesc.__isset.isNullable ? tdesc.isNullable : true) {}
+          _is_nullable(tdesc.__isset.isNullable
+                               ? tdesc.isNullable
+                               : (tdesc.__isset.nullIndicatorBit ? tdesc.nullIndicatorBit != -1 : true)) {}
 
 SlotDescriptor::SlotDescriptor(const PSlotDescriptor& pdesc)
         : _id(pdesc.id()),
           _type(TypeDescriptor::from_protobuf(pdesc.slot_type())),
           _parent(pdesc.parent()),
-          _null_indicator_offset(pdesc.null_indicator_byte(), pdesc.null_indicator_bit()),
           _col_name(pdesc.col_name()),
           _col_unique_id(-1),
           _slot_idx(pdesc.slot_idx()),
           _slot_size(_type.get_slot_size()),
           _is_materialized(pdesc.is_materialized()),
           _is_output_column(true),
-          // keep same as is_nullable()
-          _is_nullable(_null_indicator_offset.bit_mask != 0) {}
+          _is_nullable(pdesc.null_indicator_bit() != -1) {}
 
 void SlotDescriptor::to_protobuf(PSlotDescriptor* pslot) const {
     pslot->set_id(_id);
@@ -113,8 +100,8 @@ void SlotDescriptor::to_protobuf(PSlotDescriptor* pslot) const {
     pslot->set_column_pos(0);
     // NOTE: _tuple_offset is not used anymore, use default value 0.
     pslot->set_byte_offset(0);
-    pslot->set_null_indicator_byte(_null_indicator_offset.byte_offset);
-    pslot->set_null_indicator_bit(_null_indicator_offset.bit_offset);
+    pslot->set_null_indicator_byte(0);
+    pslot->set_null_indicator_bit(_is_nullable ? 0 : -1);
     pslot->set_col_name(_col_name);
     pslot->set_slot_idx(_slot_idx);
     pslot->set_is_materialized(_is_materialized);
@@ -123,7 +110,7 @@ void SlotDescriptor::to_protobuf(PSlotDescriptor* pslot) const {
 std::string SlotDescriptor::debug_string() const {
     std::stringstream out;
     out << "Slot(id=" << _id << " type=" << _type << " name=" << _col_name << " col_unique_id=" << _col_unique_id
-        << " col_physical_name=" << _col_physical_name << " null=" << _null_indicator_offset.debug_string() << ")";
+        << " col_physical_name=" << _col_physical_name << " nullable=" << _is_nullable << ")";
     return out.str();
 }
 

--- a/be/src/testutil/desc_tbl_builder.cc
+++ b/be/src/testutil/desc_tbl_builder.cc
@@ -56,8 +56,6 @@ TupleDescBuilder& DescriptorTblBuilder::declare_tuple() {
 // item_id of -1 indicates no itemTupleId
 static TSlotDescriptor make_slot_descriptor(int id, int parent_id, const TypeDescriptor& type, int slot_idx,
                                             int byte_offset, int item_id) {
-    int null_byte = slot_idx / 8;
-    int null_bit = slot_idx % 8;
     TSlotDescriptor slot_desc;
     slot_desc.__set_id(id);
     slot_desc.__set_parent(parent_id);
@@ -65,10 +63,9 @@ static TSlotDescriptor make_slot_descriptor(int id, int parent_id, const TypeDes
     // For now no tests depend on the materialized path being populated correctly.
     // slot_desc.__set_materializedPath(vector<int>());
     slot_desc.__set_byteOffset(byte_offset);
-    slot_desc.__set_nullIndicatorByte(null_byte);
-    slot_desc.__set_nullIndicatorBit(null_bit);
     slot_desc.__set_slotIdx(slot_idx);
     slot_desc.__set_isMaterialized(true);
+    slot_desc.__set_isNullable(true);
     // if (item_id != -1) {
     //     slot_desc.__set_itemTupleId(item_id);
     // }

--- a/be/src/testutil/exprs_test_helper.h
+++ b/be/src/testutil/exprs_test_helper.h
@@ -109,11 +109,10 @@ public:
         slot_desc.slotType = type;
         slot_desc.columnPos = -1;
         slot_desc.byteOffset = 4;
-        slot_desc.nullIndicatorByte = 0;
-        slot_desc.nullIndicatorBit = 1;
         slot_desc.colName = col_name;
         slot_desc.slotIdx = 1;
         slot_desc.isMaterialized = true;
+        slot_desc.__set_isNullable(true);
         return slot_desc;
     }
 

--- a/be/test/exprs/exprs_test_helper.h
+++ b/be/test/exprs/exprs_test_helper.h
@@ -51,11 +51,10 @@ public:
         slot_desc.slotType = type;
         slot_desc.columnPos = -1;
         slot_desc.byteOffset = 4;
-        slot_desc.nullIndicatorByte = 0;
-        slot_desc.nullIndicatorBit = 1;
         slot_desc.colName = col_name;
         slot_desc.slotIdx = 1;
         slot_desc.isMaterialized = true;
+        slot_desc.__set_isNullable(true);
         return slot_desc;
     }
 

--- a/be/test/runtime/memory_scratch_sink_test.cpp
+++ b/be/test/runtime/memory_scratch_sink_test.cpp
@@ -239,10 +239,9 @@ void MemoryScratchSinkTest::init_desc_tbl() {
         t_slot_desc.__set_slotType(gen_type_desc(TPrimitiveType::INT));
         t_slot_desc.__set_columnPos(i);
         t_slot_desc.__set_byteOffset(offset);
-        t_slot_desc.__set_nullIndicatorByte(0);
-        t_slot_desc.__set_nullIndicatorBit(-1);
         t_slot_desc.__set_slotIdx(i);
         t_slot_desc.__set_isMaterialized(true);
+        t_slot_desc.__set_isNullable(false);
         t_slot_desc.__set_colName("second_column");
         t_slot_desc.__set_parent(0);
 

--- a/be/test/runtime/memory_scratch_sink_test_issue_8676.cpp
+++ b/be/test/runtime/memory_scratch_sink_test_issue_8676.cpp
@@ -262,10 +262,9 @@ void MemoryScratchSinkIssue8676Test::init_desc_tbl() {
         t_slot_desc.__set_slotType(gen_type_desc(TPrimitiveType::DOUBLE));
         t_slot_desc.__set_columnPos(i);
         t_slot_desc.__set_byteOffset(offset);
-        t_slot_desc.__set_nullIndicatorByte(0);
-        t_slot_desc.__set_nullIndicatorBit(-1);
         t_slot_desc.__set_slotIdx(i);
         t_slot_desc.__set_isMaterialized(true);
+        t_slot_desc.__set_isNullable(false);
         t_slot_desc.__set_colName("first_column");
         t_slot_desc.__set_parent(0);
 
@@ -281,10 +280,9 @@ void MemoryScratchSinkIssue8676Test::init_desc_tbl() {
         t_slot_desc.__set_slotType(gen_type_desc(TPrimitiveType::INT));
         t_slot_desc.__set_columnPos(i);
         t_slot_desc.__set_byteOffset(offset);
-        t_slot_desc.__set_nullIndicatorByte(0);
-        t_slot_desc.__set_nullIndicatorBit(-1);
         t_slot_desc.__set_slotIdx(i);
         t_slot_desc.__set_isMaterialized(true);
+        t_slot_desc.__set_isNullable(false);
         t_slot_desc.__set_colName("second_column");
         t_slot_desc.__set_parent(0);
 

--- a/be/test/storage/push_handler_test.cpp
+++ b/be/test/storage/push_handler_test.cpp
@@ -74,11 +74,10 @@ void PushHandlerTest::_create_src_dst_tuple(TDescriptorTable& t_desc_table) {
             slot_desc.slotType = type;
             slot_desc.columnPos = -1;
             slot_desc.byteOffset = 4;
-            slot_desc.nullIndicatorByte = 0;
-            slot_desc.nullIndicatorBit = 1;
             slot_desc.colName = "k1_int";
             slot_desc.slotIdx = 1;
             slot_desc.isMaterialized = true;
+            slot_desc.__set_isNullable(true);
 
             t_desc_table.slotDescriptors.push_back(slot_desc);
         }
@@ -100,11 +99,10 @@ void PushHandlerTest::_create_src_dst_tuple(TDescriptorTable& t_desc_table) {
             slot_desc.slotType = type;
             slot_desc.columnPos = -1;
             slot_desc.byteOffset = 2;
-            slot_desc.nullIndicatorByte = 0;
-            slot_desc.nullIndicatorBit = 0;
             slot_desc.colName = "k2_smallint";
             slot_desc.slotIdx = 0;
             slot_desc.isMaterialized = true;
+            slot_desc.__set_isNullable(true);
 
             t_desc_table.slotDescriptors.push_back(slot_desc);
         }
@@ -127,11 +125,10 @@ void PushHandlerTest::_create_src_dst_tuple(TDescriptorTable& t_desc_table) {
             slot_desc.slotType = type;
             slot_desc.columnPos = -1;
             slot_desc.byteOffset = 16;
-            slot_desc.nullIndicatorByte = 0;
-            slot_desc.nullIndicatorBit = 3;
             slot_desc.colName = "k3_varchar";
             slot_desc.slotIdx = 3;
             slot_desc.isMaterialized = true;
+            slot_desc.__set_isNullable(true);
 
             t_desc_table.slotDescriptors.push_back(slot_desc);
         }
@@ -153,11 +150,10 @@ void PushHandlerTest::_create_src_dst_tuple(TDescriptorTable& t_desc_table) {
             slot_desc.slotType = type;
             slot_desc.columnPos = -1;
             slot_desc.byteOffset = 8;
-            slot_desc.nullIndicatorByte = 0;
-            slot_desc.nullIndicatorBit = 2;
             slot_desc.colName = "v_bigint";
             slot_desc.slotIdx = 2;
             slot_desc.isMaterialized = true;
+            slot_desc.__set_isNullable(true);
 
             t_desc_table.slotDescriptors.push_back(slot_desc);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -718,7 +718,8 @@ public class TableFunctionTable extends Table {
 
         List<Column> columns = new ArrayList<>();
         for (PSlotDescriptor slot : result.schema) {
-            columns.add(new Column(slot.colName, TypeDeserializer.fromProtobuf(slot.slotType), true));
+            boolean isNullable = slot.hasIsNullable ? slot.isNullable : slot.nullIndicatorBit != -1;
+            columns.add(new Column(slot.colName, TypeDeserializer.fromProtobuf(slot.slotType), isNullable));
         }
         return columns;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -718,7 +718,7 @@ public class TableFunctionTable extends Table {
 
         List<Column> columns = new ArrayList<>();
         for (PSlotDescriptor slot : result.schema) {
-            boolean isNullable = slot.hasIsNullable ? slot.isNullable : slot.nullIndicatorBit != -1;
+            boolean isNullable = slot.isIsNullable() ? slot.isNullable : slot.nullIndicatorBit != -1;
             columns.add(new Column(slot.colName, TypeDeserializer.fromProtobuf(slot.slotType), isNullable));
         }
         return columns;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SlotDescriptor.java
@@ -200,12 +200,6 @@ public class SlotDescriptor {
 
     public void setIsNullable(boolean value) {
         isNullable = value;
-        // NullIndicatorBit is deprecated in BE, we mock bit to avoid BE crash
-        if (isNullable) {
-            nullIndicatorBit = 0;
-        } else {
-            nullIndicatorBit = -1;
-        }
     }
 
     public String getLabel() {
@@ -239,11 +233,6 @@ public class SlotDescriptor {
 
     // TODO
     public TSlotDescriptor toThrift() {
-        if (isNullable) {
-            nullIndicatorBit = 1;
-        } else {
-            nullIndicatorBit = -1;
-        }
         Preconditions.checkState(isMaterialized, "isMaterialized must be true");
         TSlotDescriptor tSlotDescriptor = new TSlotDescriptor();
         tSlotDescriptor.setId(id.asInt());
@@ -270,8 +259,6 @@ public class SlotDescriptor {
         }
         tSlotDescriptor.setColumnPos(-1);
         tSlotDescriptor.setByteOffset(-1);
-        tSlotDescriptor.setNullIndicatorByte(-1);
-        tSlotDescriptor.setNullIndicatorBit(nullIndicatorBit);
         String colName = "";
         if (column != null) {
             colName = column.isShadowColumn() ? column.getName() : column.getColumnId().getId();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SlotDescriptor.java
@@ -84,8 +84,6 @@ public class SlotDescriptor {
     // physical layout parameters
     private int byteSize;
     private int byteOffset;  // within tuple
-    private int nullIndicatorByte;  // index into byte array
-    private int nullIndicatorBit; // index within byte
     private int slotIdx;          // index within tuple struct
 
     // used for load to get more information of varchar and decimal
@@ -113,8 +111,6 @@ public class SlotDescriptor {
         this.id = id;
         this.parent = parent;
         this.byteOffset = src.byteOffset;
-        this.nullIndicatorBit = src.nullIndicatorBit;
-        this.nullIndicatorByte = src.nullIndicatorByte;
         this.slotIdx = src.slotIdx;
         this.isMaterialized = src.isMaterialized;
         this.isOutputColumn = src.isOutputColumn;
@@ -277,10 +273,8 @@ public class SlotDescriptor {
         String parentTupleId = (parent == null) ? "null" : parent.getId().toString();
         return MoreObjects.toStringHelper(this).add("id", id.asInt()).add("parent", parentTupleId)
                 .add("col", colStr).add("type", typeStr).add("materialized", isMaterialized)
-                .add("isOutputColumns", isOutputColumn)
+                .add("isOutputColumns", isOutputColumn).add("isNullable", isNullable)
                 .add("byteSize", byteSize).add("byteOffset", byteOffset)
-                .add("nullIndicatorByte", nullIndicatorByte)
-                .add("nullIndicatorBit", nullIndicatorBit)
                 .add("slotIdx", slotIdx).toString();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -1767,12 +1767,12 @@ public class WindowTest extends PlanTestBase {
         plan = getDescTbl(sql);
         assertContains(plan, "TSlotDescriptor(id:11, parent:3, " +
                 "slotType:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:BIGINT))]), " +
-                "columnPos:-1, byteOffset:-1, nullIndicatorByte:-1, nullIndicatorBit:-1, " +
-                "colName:, slotIdx:-1, isMaterialized:true, isOutputColumn:false, isNullable:false)");
+                "columnPos:-1, byteOffset:-1, colName:, slotIdx:-1, " +
+                "isMaterialized:true, isOutputColumn:false, isNullable:false)");
         assertContains(plan, "TSlotDescriptor(id:11, parent:5, " +
                 "slotType:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:BIGINT))]), " +
-                "columnPos:-1, byteOffset:-1, nullIndicatorByte:-1, nullIndicatorBit:-1, " +
-                "colName:, slotIdx:-1, isMaterialized:true, isOutputColumn:false, isNullable:false)");
+                "columnPos:-1, byteOffset:-1, colName:, slotIdx:-1, " +
+                "isMaterialized:true, isOutputColumn:false, isNullable:false)");
     }
 
     @Test

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -46,13 +46,14 @@ message PSlotDescriptor {
     required PTypeDesc slot_type = 3;
     required int32 column_pos = 4;   // in originating table
     required int32 byte_offset = 5;  // into tuple
-    required int32 null_indicator_byte = 6;
-    required int32 null_indicator_bit = 7;
+    required int32 null_indicator_byte = 6; // deprecated
+    required int32 null_indicator_bit = 7; // deprecated
     required string col_name = 8;
     required int32 slot_idx = 9;
     required bool is_materialized = 10;
     repeated string global_dict_words = 11; 
     optional int64 global_dict_version = 12;
+    optional bool is_nullable = 13; // replace null_indicator_bit & null_indicator_byte
 };
 
 message PTupleDescriptor {
@@ -91,4 +92,3 @@ message POlapTableSchemaParam {
     required PTupleDescriptor tuple_desc = 5;
     repeated POlapTableIndexSchema indexes = 6;
 };
-

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -46,8 +46,8 @@ message PSlotDescriptor {
     required PTypeDesc slot_type = 3;
     required int32 column_pos = 4;   // in originating table
     required int32 byte_offset = 5;  // into tuple
-    required int32 null_indicator_byte = 6; // deprecated
-    required int32 null_indicator_bit = 7; // deprecated
+    // optional int32 null_indicator_byte = 6 [default = 0]; // deprecated
+    // optional int32 null_indicator_bit = 7 [default = 0]; // deprecated
     required string col_name = 8;
     required int32 slot_idx = 9;
     required bool is_materialized = 10;

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -46,8 +46,8 @@ message PSlotDescriptor {
     required PTypeDesc slot_type = 3;
     required int32 column_pos = 4;   // in originating table
     required int32 byte_offset = 5;  // into tuple
-    optional int32 null_indicator_byte = 6 [default = 0]; // deprecated
-    optional int32 null_indicator_bit = 7 [default = -1]; // deprecated
+    required int32 null_indicator_byte = 6; // deprecated
+    required int32 null_indicator_bit = 7; // deprecated
     required string col_name = 8;
     required int32 slot_idx = 9;
     required bool is_materialized = 10;

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -46,8 +46,8 @@ message PSlotDescriptor {
     required PTypeDesc slot_type = 3;
     required int32 column_pos = 4;   // in originating table
     required int32 byte_offset = 5;  // into tuple
-    // optional int32 null_indicator_byte = 6 [default = 0]; // deprecated
-    // optional int32 null_indicator_bit = 7 [default = 0]; // deprecated
+    optional int32 null_indicator_byte = 6 [default = 0]; // deprecated
+    optional int32 null_indicator_bit = 7 [default = -1]; // deprecated
     required string col_name = 8;
     required int32 slot_idx = 9;
     required bool is_materialized = 10;

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -57,8 +57,8 @@ struct TSlotDescriptor {
   3: optional Types.TTypeDesc slotType
   4: optional i32 columnPos   // Deprecated
   5: optional i32 byteOffset  // Deprecated
-  // 6: optional i32 nullIndicatorByte = 0 // Deprecated
-  // 7: optional i32 nullIndicatorBit = 0 // Deprecated
+  6: optional i32 nullIndicatorByte = 0 // Deprecated
+  7: optional i32 nullIndicatorBit = -1 // Deprecated
   8: optional string colName;
   9: optional i32 slotIdx // Deprecated
   10: optional bool isMaterialized // Deprecated

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -57,8 +57,8 @@ struct TSlotDescriptor {
   3: optional Types.TTypeDesc slotType
   4: optional i32 columnPos   // Deprecated
   5: optional i32 byteOffset  // Deprecated
-  6: optional i32 nullIndicatorByte // Deprecated
-  7: optional i32 nullIndicatorBit // Deprecated
+  // 6: optional i32 nullIndicatorByte = 0 // Deprecated
+  // 7: optional i32 nullIndicatorBit = 0 // Deprecated
   8: optional string colName;
   9: optional i32 slotIdx // Deprecated
   10: optional bool isMaterialized // Deprecated


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
