### PR TITLE
[BugFix] Check label already used when BEGIN TRANSACTION specifies label

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
+import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.LoadException;
 import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.StarRocksException;
@@ -122,6 +123,12 @@ public class TransactionStmtExecutor {
         String label;
         if (stmtLabel != null && !stmtLabel.isEmpty()) {
             FeNameFormat.checkLabel(stmtLabel);
+            // Check if label is already used in any database, align with INSERT statement behavior
+            try {
+                globalTransactionMgr.checkLabelUsedInAnyDatabase(stmtLabel);
+            } catch (LabelAlreadyUsedException e) {
+                throw new SemanticException(e.getMessage());
+            }
             label = stmtLabel;
         } else if (labelOverride != null && !labelOverride.isEmpty()) {
             label = labelOverride;

--- a/test/sql/test_explicit_txn_label/R/test_explicit_txn_label
+++ b/test/sql/test_explicit_txn_label/R/test_explicit_txn_label
@@ -1,0 +1,95 @@
+-- name: test_begin_with_label_already_used_by_insert @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t1(id int) primary key(id);
+-- result:
+-- !result
+insert /*+ SET_VAR(query_timeout=300) */ into t1 with label test_label_${uuid0} values(1);
+-- result:
+-- !result
+begin with label test_label_${uuid0};
+-- result:
+[REGEX]E: \(1064, 'Getting analyzing error. Detail message: Label \[test_label_.*\] has already been used..'\)
+-- !result
+-- name: test_begin_with_label_already_used_by_another_begin @sequential
+create database db_${uuid1};
+-- result:
+-- !result
+use db_${uuid1};
+-- result:
+-- !result
+create table t1(id int) primary key(id);
+-- result:
+-- !result
+begin with label test_label_${uuid1};
+-- result:
+-- !result
+insert into t1 values(1);
+-- result:
+-- !result
+commit;
+-- result:
+-- !result
+begin with label test_label_${uuid1};
+-- result:
+[REGEX]E: \(1064, 'Getting analyzing error. Detail message: Label \[test_label_.*\] has already been used..'\)
+-- !result
+-- name: test_begin_with_valid_label @sequential
+create database db_${uuid2};
+-- result:
+-- !result
+use db_${uuid2};
+-- result:
+-- !result
+create table t1(id int) primary key(id);
+-- result:
+-- !result
+begin with label test_unique_label_${uuid2};
+-- result:
+-- !result
+insert into t1 values(100);
+-- result:
+-- !result
+commit;
+-- result:
+-- !result
+select * from t1 order by id;
+-- result:
+100
+-- !result
+-- name: test_begin_with_label_reuse_after_rollback @sequential
+create database db_${uuid3};
+-- result:
+-- !result
+use db_${uuid3};
+-- result:
+-- !result
+create table t1(id int) primary key(id);
+-- result:
+-- !result
+begin with label test_label_${uuid3};
+-- result:
+-- !result
+insert into t1 values(1);
+-- result:
+-- !result
+rollback;
+-- result:
+-- !result
+begin with label test_label_${uuid3};
+-- result:
+-- !result
+insert into t1 values(200);
+-- result:
+-- !result
+commit;
+-- result:
+-- !result
+select * from t1 order by id;
+-- result:
+200
+-- !result

--- a/test/sql/test_explicit_txn_label/T/test_explicit_txn_label
+++ b/test/sql/test_explicit_txn_label/T/test_explicit_txn_label
@@ -1,0 +1,63 @@
+-- name: test_begin_with_label_already_used_by_insert @sequential
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t1(id int) primary key(id);
+
+-- First, start a transaction with INSERT using a specific label
+insert /*+ SET_VAR(query_timeout=300) */ into t1 with label test_label_${uuid0} values(1);
+
+-- Attempt to begin a new transaction with the same label should fail
+begin with label test_label_${uuid0};
+
+-- name: test_begin_with_label_already_used_by_another_begin @sequential
+create database db_${uuid1};
+use db_${uuid1};
+
+create table t1(id int) primary key(id);
+
+-- Start a transaction with BEGIN using a specific label
+begin with label test_label_${uuid1};
+insert into t1 values(1);
+
+-- Attempt to begin another transaction with the same label should fail (in another session)
+-- Since we cannot test multi-session in this framework, we verify that commit works
+-- and then test that the same label cannot be reused while the first txn is still active
+commit;
+
+-- After commit, the label should still be marked as used (VISIBLE status)
+-- Trying to use it again should fail
+begin with label test_label_${uuid1};
+
+-- name: test_begin_with_valid_label @sequential
+create database db_${uuid2};
+use db_${uuid2};
+
+create table t1(id int) primary key(id);
+
+-- Begin with a new unique label should succeed
+begin with label test_unique_label_${uuid2};
+insert into t1 values(100);
+commit;
+
+select * from t1 order by id;
+
+-- name: test_begin_with_label_reuse_after_rollback @sequential
+create database db_${uuid3};
+use db_${uuid3};
+
+create table t1(id int) primary key(id);
+
+-- Start a transaction with BEGIN using a specific label
+begin with label test_label_${uuid3};
+insert into t1 values(1);
+
+-- Rollback the transaction (ABORTED status)
+rollback;
+
+-- After rollback, the label should be reusable (ABORTED transactions don't block label reuse)
+begin with label test_label_${uuid3};
+insert into t1 values(200);
+commit;
+
+select * from t1 order by id;


### PR DESCRIPTION
## Why I'm doing:
When using INSERT INTO ... WITH LABEL 'xxx', the system checks if the label is already used and throws "Label [xxx] has already been used" error immediately. However, when using BEGIN TRANSACTION WITH LABEL 'xxx', the label check was missing at the BEGIN stage, leading to inconsistent behavior. Users would only get the error later when executing DML statements within the transaction, which is confusing.

## What I'm doing:
- Add checkLabelUsedInAnyDatabase() method in GlobalTransactionMgr to check if a label is already used in any database's transaction or in any existing explicit transaction state
- Call this check in TransactionStmtExecutor.beginStmt() when user specifies a label, throwing SemanticException if label already exists
- Add SQL tests to verify the label check behavior

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
