### PR TITLE
[BugFix] fix lake table mem leak

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakeTable.java
@@ -120,6 +120,11 @@ public class DeltaLakeTable extends Table {
         return metastoreTable.getCloudConfiguration();
     }
 
+    public void clearMetadata() {
+        this.deltaSnapshot = null;
+        this.deltaEngine = null;
+    }
+
     @Override
     public List<Column> getPartitionColumns() {
         return partColumnNames.stream()

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakeTable.java
@@ -122,7 +122,6 @@ public class DeltaLakeTable extends Table {
 
     public void clearMetadata() {
         this.deltaSnapshot = null;
-        this.deltaEngine = null;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -188,6 +188,10 @@ public class IcebergTable extends Table {
         return partitionColumns;
     }
 
+    public void clearMetadata() {
+        this.nativeTable = null;
+    }
+
     public List<Column> getPartitionColumnsIncludeTransformed() {
         List<Column> allPartitionColumns = new ArrayList<>();
         for (PartitionField field : getNativeTable().spec().fields()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorScanRangeSource.java
@@ -18,7 +18,7 @@ import com.starrocks.thrift.TScanRangeLocations;
 
 import java.util.List;
 
-public abstract class ConnectorScanRangeSource {
+public abstract class ConnectorScanRangeSource implements AutoCloseable {
     RemoteFilesSampleStrategy strategy = new RemoteFilesSampleStrategy();
 
     protected abstract List<TScanRangeLocations> getSourceOutputs(int maxSize);
@@ -42,5 +42,10 @@ public abstract class ConnectorScanRangeSource {
 
     public void setSampleStrategy(RemoteFilesSampleStrategy strategy) {
         this.strategy = strategy;
+    }
+
+    @Override
+    public void close() throws Exception {
+        // default no-op
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileInfoSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileInfoSource.java
@@ -17,7 +17,7 @@ package com.starrocks.connector;
 import java.util.ArrayList;
 import java.util.List;
 
-public interface RemoteFileInfoSource {
+public interface RemoteFileInfoSource extends AutoCloseable {
     RemoteFileInfo getOutput();
 
     boolean hasMoreOutput();
@@ -28,5 +28,10 @@ public interface RemoteFileInfoSource {
             res.add(getOutput());
         }
         return res;
+    }
+
+    @Override
+    default void close() throws Exception {
+        // default no-op
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSource.java
@@ -150,6 +150,15 @@ public class DeltaConnectorScanRangeSource extends ConnectorScanRangeSource {
         }
     }
 
+    @Override
+    public void close() {
+        try {
+            remoteFileInfoSource.close();
+        } catch (Exception e) {
+            LOG.warn("close Delta RemoteFileInfoSource failed", e);
+        }
+    }
+
     public int selectedPartitionCount() {
         return partitionKeys.size();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -62,7 +62,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -207,7 +206,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
         }
     }
 
-    private Iterator<Pair<FileScanTask, DeltaLakeAddFileStatsSerDe>> buildFileScanTaskIterator(
+    private CloseableIterator<Pair<FileScanTask, DeltaLakeAddFileStatsSerDe>> buildFileScanTaskIterator(
             Table table, ScalarOperator operator, boolean enableCollectColumnStats) {
         DeltaLakeTable deltaLakeTable = (DeltaLakeTable) table;
         Metadata metadata = deltaLakeTable.getDeltaMetadata();
@@ -225,7 +224,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
         ScanBuilderImpl scanBuilder = (ScanBuilderImpl) snapshot.getScanBuilder(engine);
         ScanImpl scan = (ScanImpl) scanBuilder.withFilter(engine, deltaLakePredicate).build();
         long estimateRowSize = table.getColumns().stream().mapToInt(column -> column.getType().getTypeSize()).sum();
-        return new Iterator<>() {
+        return new CloseableIterator<>() {
             CloseableIterator<FilteredColumnarBatch> scanFilesAsBatches;
             CloseableIterator<Row> scanFileRows;
             boolean hasMore = true;
@@ -270,11 +269,31 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
                     throw new StarRocksConnectorException("Failed to get delta lake scan files", e);
                 }
             }
+
+            @Override
+            public void close() {
+                try {
+                    if (scanFileRows != null) {
+                        scanFileRows.close();
+                    }
+                } catch (Exception ignored) {
+                }
+                try {
+                    if (scanFilesAsBatches != null) {
+                        scanFilesAsBatches.close();
+                    }
+                } catch (Exception ignored) {
+                } finally {
+                    scanFileRows = null;
+                    scanFilesAsBatches = null;
+                    hasMore = false;
+                }
+            }
         };
     }
 
     private RemoteFileInfoSource buildRemoteInfoSource(Table table, GetRemoteFilesParams params) {
-        Iterator<Pair<FileScanTask, DeltaLakeAddFileStatsSerDe>> iterator =
+        CloseableIterator<Pair<FileScanTask, DeltaLakeAddFileStatsSerDe>> iterator =
                 buildFileScanTaskIterator(table, params.getPredicate(), params.isEnableColumnStats());
         return new RemoteFileInfoSource() {
             @Override
@@ -286,6 +305,14 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
             @Override
             public boolean hasMoreOutput() {
                 return iterator.hasNext();
+            }
+
+            @Override
+            public void close() {
+                try {
+                    iterator.close();
+                } catch (Exception ignored) {
+                }
             }
         };
     }
@@ -322,15 +349,18 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
         String traceLabel = enableCollectColumnStats ? "DELTA_LAKE.updateDeltaLakeFileStats" :
                 "DELTA_LAKE.updateDeltaLakeCardinality";
 
-        Iterator<Pair<FileScanTask, DeltaLakeAddFileStatsSerDe>> iterator =
-                buildFileScanTaskIterator(table, operator, enableCollectColumnStats);
-        while (iterator.hasNext()) {
-            Pair<FileScanTask, DeltaLakeAddFileStatsSerDe> pair = iterator.next();
-            files.add(pair.first);
-            try (Timer ignored = Tracers.watchScope(EXTERNAL, traceLabel)) {
-                statisticProvider.updateFileStats(deltaLakeTable, key, pair.first, pair.second,
-                        nonPartitionPrimitiveColumns, partitionPrimitiveColumns);
+        try (CloseableIterator<Pair<FileScanTask, DeltaLakeAddFileStatsSerDe>> iterator =
+                buildFileScanTaskIterator(table, operator, enableCollectColumnStats)) {
+            while (iterator.hasNext()) {
+                Pair<FileScanTask, DeltaLakeAddFileStatsSerDe> pair = iterator.next();
+                files.add(pair.first);
+                try (Timer ignored = Tracers.watchScope(EXTERNAL, traceLabel)) {
+                    statisticProvider.updateFileStats(deltaLakeTable, key, pair.first, pair.second,
+                            nonPartitionPrimitiveColumns, partitionPrimitiveColumns);
+                }
             }
+        } catch (IOException e) {
+            throw new StarRocksConnectorException("Failed to iter deltalake file scan iterator", e);
         }
         splitTasks.put(key, files);
         scannedTables.add(key);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -81,7 +81,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.IcebergTable.DATA_SEQUENCE_NUMBER;
@@ -92,8 +91,6 @@ import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     private static final Logger LOG = LogManager.getLogger(IcebergConnectorScanRangeSource.class);
     // Debug hook: set -Diceberg.debug.throw_after_scanrange=N to throw after N scan ranges are produced.
-    private static final int DEBUG_THROW_AFTER_SCAN_RANGE = 2000;
-    private static final AtomicInteger DEBUG_SCAN_RANGE_COUNTER = new AtomicInteger();
 
     private final IcebergTable table;
     private final TupleDescriptor desc;
@@ -218,6 +215,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
                             // we can eliminate the equality delete files.
                         }
                     }
+                }
             }
             return res;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -90,7 +90,6 @@ import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 
 public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     private static final Logger LOG = LogManager.getLogger(IcebergConnectorScanRangeSource.class);
-    // Debug hook: set -Diceberg.debug.throw_after_scanrange=N to throw after N scan ranges are produced.
 
     private final IcebergTable table;
     private final TupleDescriptor desc;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1117,7 +1117,6 @@ public class IcebergMetadata implements ConnectorMetadata {
                                 Tracers.record(Tracers.Module.EXTERNAL, name, value);
                             }
                         }
-                        System.out.println("Iceberg TableScan stop iter");
                     }
                     hasMore = false;
                 }
@@ -1131,6 +1130,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                     }
                 } catch (Exception ignore) {
                 }
+
                 try {
                     if (fileScanTaskIterable != null) {
                         fileScanTaskIterable.close();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -110,9 +110,6 @@ public class DeltaLakeScanNode extends ScanNode {
     @Override
     public void clear() {
         try {
-            if (deltaLakeTable != null) {
-                deltaLakeTable.clearMetadata();
-            }
             if (scanRangeSource != null) {
                 scanRangeSource.close();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -107,6 +107,21 @@ public class DeltaLakeScanNode extends ScanNode {
         reachLimit = true;
     }
 
+    @Override
+    public void clear() {
+        try {
+            if (deltaLakeTable != null) {
+                deltaLakeTable.clearMetadata();
+            }
+            if (scanRangeSource != null) {
+                scanRangeSource.close();
+            }
+        } catch (Exception e) {
+            LOG.warn("close DeltaLake scanRangeSource failed", e);
+        }
+        scanRangeSource = null;
+    }
+
     public void setupScanRangeSource(ScalarOperator predicate, List<String> fieldNames,
                                      PartitionIdGenerator partitionIdGenerator,
                                      boolean enableIncrementalScanRanges)

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -102,6 +102,21 @@ public class IcebergScanNode extends ScanNode {
     }
 
     @Override
+    public void clear() {
+        try {
+            if (icebergTable != null) {
+                icebergTable.clearMetadata();
+            }
+            if (scanRangeSource != null) {
+                scanRangeSource.close();
+            }
+        } catch (Exception e) {
+            LOG.warn("close Iceberg scanRangeSource failed", e);
+        }
+        scanRangeSource = null;
+    }
+
+    @Override
     public List<TScanRangeLocations> getScanRangeLocations(long maxScanRangeLength) {
         if (tvrVersionRange.isEmpty() || scanRangeSource == null) {
             return List.of();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -153,6 +153,13 @@ public abstract class ScanNode extends PlanNode {
     }
 
     /**
+     * Hook for subclasses that hold external resources (scan range sources, iterators, etc.)
+     * to release them when query finishes/cancels. Default no-op.
+     */
+    public void clear() {
+    }
+
+    /**
      * cast expr to SlotDescriptor type
      */
     protected Expr castToSlot(SlotDescriptor slotDesc, Expr expr) throws StarRocksException {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1101,7 +1101,8 @@ public class DefaultCoordinator extends Coordinator {
         }
     }
 
-    private void clearExternalResources() {
+    @Override
+    public void clearExternalResources() {
         for (ScanNode scanNode : jobSpec.getScanNodes()) {
             try {
                 scanNode.clear();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1075,6 +1075,8 @@ public class DefaultCoordinator extends Coordinator {
 
     private void cancelInternal(PPlanFragmentCancelReason cancelReason) {
         jobSpec.getSlotProvider().cancelSlotRequirement(slot);
+        clearExternalResources();
+
         if (!isInternalCancel(cancelReason) && StringUtils.isEmpty(connectContext.getState().getErrorMessage())) {
             String errorMsg = String.format("[reason=%s] [msg=%s]", cancelReason, queryStatus.getErrorMsg());
             connectContext.getState().setError(errorMsg);
@@ -1095,6 +1097,16 @@ public class DefaultCoordinator extends Coordinator {
                 if (!unFinishedInstanceIds.isEmpty()) {
                     LOG.info("query: {} has unfinished instances: {}", connectContext.queryId, unFinishedInstanceIds);
                 }
+            }
+        }
+    }
+
+    private void clearExternalResources() {
+        for (ScanNode scanNode : jobSpec.getScanNodes()) {
+            try {
+                scanNode.clear();
+            } catch (Exception e) {
+                LOG.warn("clear scan code failed for {}", scanNode.getClass().getSimpleName(), e);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1109,6 +1109,9 @@ public class StmtExecutor {
                 clearQueryScopeHintContext();
             }
 
+            // release parsed statement references (may hold external tables/metadata)
+            parsedStmt = null;
+
             // restore session variable in connect context
             if (!skipRestore) {
                 context.setSessionVariable(sessionVariableBackup);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1105,12 +1105,13 @@ public class StmtExecutor {
                 coord.cancel(PPlanFragmentCancelReason.INTERNAL_ERROR, context.getState().getErrorMessage());
             }
 
+            if (coord != null) {
+                coord.clearExternalResources();
+            }
+
             if (parsedStmt != null && parsedStmt.isExistQueryScopeHint()) {
                 clearQueryScopeHintContext();
             }
-
-            // release parsed statement references (may hold external tables/metadata)
-            parsedStmt = null;
 
             // restore session variable in connect context
             if (!skipRestore) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -261,4 +261,10 @@ public abstract class Coordinator {
     public abstract String getResourceGroupName();
 
     public abstract boolean isShortCircuit();
+
+    /**
+     * Release external resources held by scan nodes or connectors. Default no-op.
+     */
+    public void clearExternalResources() {
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
@@ -1,0 +1,907 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DeltaLakeTable;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.common.Pair;
+import com.starrocks.common.tvr.TvrTableDelta;
+import com.starrocks.common.tvr.TvrTableSnapshot;
+import com.starrocks.common.tvr.TvrVersionRange;
+import com.starrocks.connector.ConnectorProperties;
+import com.starrocks.connector.ConnectorScanRangeSource;
+import com.starrocks.connector.ConnectorType;
+import com.starrocks.connector.GetRemoteFilesParams;
+import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.PredicateSearchKey;
+import com.starrocks.connector.delta.DeltaConnectorScanRangeSource;
+import com.starrocks.connector.delta.DeltaLakeAddFileStatsSerDe;
+import com.starrocks.connector.delta.DeltaLakeMetadata;
+import com.starrocks.connector.delta.DeltaMetastoreOperations;
+import com.starrocks.connector.delta.DeltaStatisticProvider;
+import com.starrocks.connector.delta.ScanFileUtils;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergCatalog;
+import com.starrocks.connector.iceberg.IcebergCatalogProperties;
+import com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource;
+import com.starrocks.connector.iceberg.IcebergGetRemoteFilesParams;
+import com.starrocks.connector.iceberg.IcebergMORParams;
+import com.starrocks.connector.iceberg.IcebergMetadata;
+import com.starrocks.connector.iceberg.IcebergRemoteFileInfo;
+import com.starrocks.connector.iceberg.IcebergTableMORParams;
+import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
+import com.starrocks.connector.metastore.MetastoreTable;
+import com.starrocks.planner.DeltaLakeScanNode;
+import com.starrocks.planner.IcebergScanNode;
+import com.starrocks.planner.PartitionIdGenerator;
+import com.starrocks.planner.PlanNodeId;
+import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.planner.SlotId;
+import com.starrocks.planner.TupleDescriptor;
+import com.starrocks.planner.TupleId;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.thrift.TScanRangeLocations;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import io.delta.kernel.data.FilteredColumnarBatch;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.InternalScanFileUtils;
+import io.delta.kernel.internal.ScanBuilderImpl;
+import io.delta.kernel.internal.ScanImpl;
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
+import io.delta.kernel.internal.actions.Format;
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.types.StructField;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.CloseableIterator;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.IncrementalAppendScan;
+import org.apache.iceberg.StarRocksIcebergTableScan;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.util.TableScanUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Resource cleanup tests shared by Iceberg and Delta Lake connectors / scan nodes.
+ */
+public class ExternalResourceCleanupTest {
+
+    private TupleDescriptor tupleDescriptor;
+
+    @BeforeEach
+    public void setUp() {
+        tupleDescriptor = new TupleDescriptor(new TupleId(1));
+        SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), tupleDescriptor);
+        idSlot.setType(IntegerType.INT);
+        idSlot.setColumn(new Column("id", IntegerType.INT));
+
+        SlotDescriptor dataSlot = new SlotDescriptor(new SlotId(2), tupleDescriptor);
+        dataSlot.setType(VarcharType.VARCHAR);
+        dataSlot.setColumn(new Column("data", VarcharType.VARCHAR));
+
+        tupleDescriptor.addSlot(idSlot);
+        tupleDescriptor.addSlot(dataSlot);
+    }
+
+    @Test
+    public void testIcebergScanRangeSourceClosePropagates() {
+        CountingRemoteFileInfoSource countingSource = new CountingRemoteFileInfoSource();
+
+        List<Column> schema = new ArrayList<>();
+        schema.add(new Column("id", IntegerType.INT));
+        schema.add(new Column("k1", IntegerType.INT));
+        schema.add(new Column("k2", VarcharType.VARCHAR));
+
+
+        // minimal IcebergTable: nativeTable can be null for this test because getNativeTable isn't invoked in close().
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table", "iceberg_catalog",
+                "resource", "db", "table", "", schema, null, java.util.Collections.emptyMap());
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(
+                icebergTable,
+                countingSource,
+                IcebergMORParams.EMPTY,
+                tupleDescriptor,
+                Optional.empty(),
+                PartitionIdGenerator.of(),
+                false,
+                false);
+
+        scanRangeSource.close();
+        Assertions.assertEquals(1, countingSource.closeCount.get());
+        Assertions.assertTrue(countingSource.closed);
+    }
+
+    @Test
+    public void testIcebergScanRangeSourceCloseIdempotentAndSuppressesException() {
+        CountingRemoteFileInfoSource countingSource = new CountingRemoteFileInfoSource(true /*throwOnClose*/);
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table", "iceberg_catalog",
+                "resource", "db", "table", "", List.of(), null, java.util.Collections.emptyMap());
+
+        IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(
+                icebergTable,
+                countingSource,
+                IcebergMORParams.EMPTY,
+                tupleDescriptor,
+                Optional.empty(),
+                PartitionIdGenerator.of(),
+                false,
+                false);
+
+        // two closes: first throws (suppressed inside close), second also throws; should not escape
+        scanRangeSource.close();
+        scanRangeSource.close();
+        Assertions.assertEquals(2, countingSource.closeCount.get());
+        Assertions.assertTrue(countingSource.closed);
+    }
+
+    @Test
+    public void testDeltaConnectorScanRangeSourceClosePropagates() {
+        Format format = Mockito.mock(Format.class);
+        Mockito.when(format.getProvider()).thenReturn("parquet");
+
+        Metadata metadata = Mockito.mock(Metadata.class);
+        Mockito.when(metadata.getFormat()).thenReturn(format);
+
+        DeltaLakeTable table = Mockito.mock(DeltaLakeTable.class);
+        Mockito.when(table.getPartitionColumnNames()).thenReturn(List.of());
+        Mockito.when(table.getDeltaMetadata()).thenReturn(metadata);
+        Mockito.when(table.getDeltaSnapshot()).thenReturn(Mockito.mock(SnapshotImpl.class));
+        Mockito.when(table.getDeltaEngine()).thenReturn(Mockito.mock(Engine.class));
+        Mockito.when(table.getTableLocation()).thenReturn("/tmp/table");
+        Mockito.when(table.getId()).thenReturn(1L);
+
+        CountingRemoteFileInfoSource countingSource = new CountingRemoteFileInfoSource();
+        DeltaConnectorScanRangeSource scanRangeSource =
+                new DeltaConnectorScanRangeSource(table, countingSource, com.starrocks.planner.PartitionIdGenerator.of());
+
+        scanRangeSource.close();
+        Assertions.assertEquals(1, countingSource.closeCount.get());
+        Assertions.assertTrue(countingSource.closed);
+    }
+
+    @Test
+    public void testDeltaConnectorScanRangeSourceCloseIdempotent() {
+        Format format = Mockito.mock(Format.class);
+        Mockito.when(format.getProvider()).thenReturn("parquet");
+
+        Metadata metadata = Mockito.mock(Metadata.class);
+        Mockito.when(metadata.getFormat()).thenReturn(format);
+
+        DeltaLakeTable table = Mockito.mock(DeltaLakeTable.class);
+        Mockito.when(table.getPartitionColumnNames()).thenReturn(List.of());
+        Mockito.when(table.getDeltaMetadata()).thenReturn(metadata);
+        Mockito.when(table.getDeltaSnapshot()).thenReturn(Mockito.mock(SnapshotImpl.class));
+        Mockito.when(table.getDeltaEngine()).thenReturn(Mockito.mock(Engine.class));
+        Mockito.when(table.getTableLocation()).thenReturn("/tmp/table");
+        Mockito.when(table.getId()).thenReturn(1L);
+
+        CountingRemoteFileInfoSource countingSource = new CountingRemoteFileInfoSource();
+        DeltaConnectorScanRangeSource scanRangeSource =
+                new DeltaConnectorScanRangeSource(table, countingSource, com.starrocks.planner.PartitionIdGenerator.of());
+
+        scanRangeSource.close();
+        scanRangeSource.close();
+        Assertions.assertEquals(2, countingSource.closeCount.get());
+        Assertions.assertTrue(countingSource.closed);
+    }
+
+    @Test
+    public void testDeltaConnectorScanRangeSourceCloseSuppressesException() {
+        Format format = Mockito.mock(Format.class);
+        Mockito.when(format.getProvider()).thenReturn("parquet");
+        Metadata metadata = Mockito.mock(Metadata.class);
+        Mockito.when(metadata.getFormat()).thenReturn(format);
+
+        DeltaLakeTable table = Mockito.mock(DeltaLakeTable.class);
+        Mockito.when(table.getPartitionColumnNames()).thenReturn(List.of());
+        Mockito.when(table.getDeltaMetadata()).thenReturn(metadata);
+        Mockito.when(table.getDeltaSnapshot()).thenReturn(Mockito.mock(SnapshotImpl.class));
+        Mockito.when(table.getDeltaEngine()).thenReturn(Mockito.mock(Engine.class));
+        Mockito.when(table.getTableLocation()).thenReturn("/tmp/table");
+        Mockito.when(table.getId()).thenReturn(1L);
+
+        CountingRemoteFileInfoSource countingSource = new CountingRemoteFileInfoSource(true /*throwOnClose*/);
+        DeltaConnectorScanRangeSource scanRangeSource =
+                new DeltaConnectorScanRangeSource(table, countingSource, com.starrocks.planner.PartitionIdGenerator.of());
+
+        scanRangeSource.close();
+        scanRangeSource.close();
+        Assertions.assertEquals(2, countingSource.closeCount.get());
+        Assertions.assertTrue(countingSource.closed);
+    }
+
+    @Test
+    public void testDeltaScanNodeClearClosesScanRangeSource() throws Exception {
+        DeltaLakeTable table = Mockito.mock(DeltaLakeTable.class);
+        Mockito.when(table.getCatalogName()).thenReturn(null); // skip cloud credential setup
+        TupleDescriptor tupleDescriptor = new TupleDescriptor(new TupleId(1));
+        tupleDescriptor.setTable(table);
+
+        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(1), tupleDescriptor, "DeltaLakeScanNode");
+        DeltaConnectorScanRangeSource scanRangeSource = Mockito.mock(DeltaConnectorScanRangeSource.class);
+
+        Field field = DeltaLakeScanNode.class.getDeclaredField("scanRangeSource");
+        field.setAccessible(true);
+        field.set(scanNode, scanRangeSource);
+
+        scanNode.clear();
+
+        Mockito.verify(scanRangeSource, Mockito.times(1)).close();
+        Assertions.assertNull(field.get(scanNode));
+    }
+
+    @Test
+    public void testDeltaScanNodeClearIdempotent() throws Exception {
+        DeltaLakeTable table = Mockito.mock(DeltaLakeTable.class);
+        Mockito.when(table.getCatalogName()).thenReturn(null);
+        TupleDescriptor tupleDescriptor = new TupleDescriptor(new TupleId(1));
+        tupleDescriptor.setTable(table);
+
+        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(1), tupleDescriptor, "DeltaLakeScanNode");
+        DeltaConnectorScanRangeSource scanRangeSource = Mockito.mock(DeltaConnectorScanRangeSource.class);
+
+        Field field = DeltaLakeScanNode.class.getDeclaredField("scanRangeSource");
+        field.setAccessible(true);
+        field.set(scanNode, scanRangeSource);
+
+        scanNode.clear();
+        scanNode.clear(); // second clear should be safe
+
+        Mockito.verify(scanRangeSource, Mockito.times(1)).close();
+        Assertions.assertNull(field.get(scanNode));
+    }
+
+    @Test
+    public void testDeltaScanNodeClearWhenNoSource() {
+        DeltaLakeTable table = Mockito.mock(DeltaLakeTable.class);
+        Mockito.when(table.getCatalogName()).thenReturn(null);
+        TupleDescriptor tupleDescriptor = new TupleDescriptor(new TupleId(1));
+        tupleDescriptor.setTable(table);
+
+        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(1), tupleDescriptor, "DeltaLakeScanNode");
+        // scanRangeSource remains null
+        scanNode.clear(); // should not throw
+    }
+
+    @Test
+    public void testIcebergScanNodeClearClosesAndClearsMetadata() throws Exception {
+        IcebergTable icebergTable = Mockito.mock(IcebergTable.class);
+        Mockito.when(icebergTable.getCatalogName()).thenReturn(null); // skip cloud credential lookup
+        TupleDescriptor tupleDescriptor = new TupleDescriptor(new TupleId(2));
+        tupleDescriptor.setTable(icebergTable);
+
+        IcebergScanNode scanNode = new IcebergScanNode(new PlanNodeId(2), tupleDescriptor, "IcebergScanNode",
+                IcebergTableMORParams.EMPTY, IcebergMORParams.EMPTY, PartitionIdGenerator.of());
+        IcebergConnectorScanRangeSource scanRangeSource = Mockito.mock(IcebergConnectorScanRangeSource.class);
+        Field field = IcebergScanNode.class.getDeclaredField("scanRangeSource");
+        field.setAccessible(true);
+        field.set(scanNode, scanRangeSource);
+
+        scanNode.clear();
+
+        Mockito.verify(icebergTable, Mockito.times(1)).clearMetadata();
+        Mockito.verify(scanRangeSource, Mockito.times(1)).close();
+        Assertions.assertNull(field.get(scanNode));
+    }
+
+    @Test
+    public void testIcebergTableClearMetadataNullsNativeTable() throws Exception {
+        List<Column> schema = List.of(new Column("c1", IntegerType.INT));
+        IcebergTable icebergTable = new IcebergTable(2, "tbl", "cat", "res", "db", "tbl",
+                "", schema, null, java.util.Collections.emptyMap());
+        Field nativeField = IcebergTable.class.getDeclaredField("nativeTable");
+        nativeField.setAccessible(true);
+        nativeField.set(icebergTable, Mockito.mock(Table.class));
+
+        icebergTable.clearMetadata();
+
+        Assertions.assertNull(nativeField.get(icebergTable));
+    }
+
+    @Test
+    public void testDeltaLakeTableClearMetadataNullsSnapshotAndEngine() throws Exception {
+        MetastoreTable metastore = Mockito.mock(MetastoreTable.class);
+        Mockito.when(metastore.getCreateTime()).thenReturn(0L);
+        Mockito.when(metastore.getTableLocation()).thenReturn("/tmp");
+        SnapshotImpl snapshot = Mockito.mock(SnapshotImpl.class);
+        Engine engine = Mockito.mock(Engine.class);
+        DeltaLakeTable table = new DeltaLakeTable(3, "catalog", "db", "tbl",
+                List.of(), List.of(), snapshot, engine, metastore);
+
+        table.clearMetadata();
+
+        Assertions.assertNull(table.getDeltaSnapshot());
+    }
+
+    @Test
+    public void testConnectorScanRangeSourceDefaultCloseNoOp() throws Exception {
+        ConnectorScanRangeSource source = new ConnectorScanRangeSource() {
+            @Override
+            protected List<TScanRangeLocations> getSourceOutputs(int maxSize) {
+                return List.of();
+            }
+
+            @Override
+            protected boolean sourceHasMoreOutput() {
+                return false;
+            }
+        };
+
+        Assertions.assertDoesNotThrow(source::close);
+        Assertions.assertFalse(source.hasMoreOutput());
+        Assertions.assertTrue(source.getOutputs(1).isEmpty());
+    }
+
+    @Test
+    public void testDeltaLakeMetadataIteratorAndCollect() throws Exception {
+        // Prepare metadata with mocked delta ops and statistic provider.
+        DeltaMetastoreOperations deltaOps = Mockito.mock(DeltaMetastoreOperations.class);
+        DeltaLakeMetadata metadata = new DeltaLakeMetadata(
+                new HdfsEnvironment(new java.util.HashMap<>()), "delta0", deltaOps, null,
+                new ConnectorProperties(ConnectorType.DELTALAKE));
+        Field statField = DeltaLakeMetadata.class.getDeclaredField("statisticProvider");
+        statField.setAccessible(true);
+        statField.set(metadata, Mockito.mock(DeltaStatisticProvider.class));
+
+        // Prepare table and delta components.
+        DeltaLakeTable table = Mockito.mock(DeltaLakeTable.class);
+        Engine engine = Mockito.mock(Engine.class);
+        SnapshotImpl snapshot = Mockito.mock(SnapshotImpl.class);
+        Metadata meta = Mockito.mock(Metadata.class);
+        StructType schema = Mockito.mock(StructType.class);
+        StructField structField = Mockito.mock(StructField.class);
+        Mockito.when(structField.getDataType()).thenReturn(Mockito.mock(io.delta.kernel.types.DataType.class));
+        Mockito.when(schema.fieldNames()).thenReturn(List.of("c1"));
+        Mockito.when(schema.get("c1")).thenReturn(structField);
+
+        Mockito.when(table.getDeltaMetadata()).thenReturn(meta);
+        Mockito.when(table.getDeltaEngine()).thenReturn(engine);
+        Mockito.when(table.getDeltaSnapshot()).thenReturn(snapshot);
+        Mockito.when(table.getColumns()).thenReturn(List.of(new Column("c1", IntegerType.INT)));
+        Mockito.when(table.getCatalogDBName()).thenReturn("db");
+        Mockito.when(table.getCatalogTableName()).thenReturn("tbl");
+        Mockito.when(meta.getSchema()).thenReturn(schema);
+        Mockito.when(meta.getPartitionColNames()).thenReturn(Set.of());
+        Mockito.when(snapshot.getVersion(engine)).thenReturn(1L);
+
+        // Mock scan builder flow.
+        ScanBuilderImpl scanBuilder = Mockito.mock(ScanBuilderImpl.class);
+        ScanImpl scan = Mockito.mock(ScanImpl.class);
+        Mockito.when(snapshot.getScanBuilder(engine)).thenReturn(scanBuilder);
+        Mockito.when(scanBuilder.withFilter(Mockito.eq(engine), Mockito.any())).thenReturn(scanBuilder);
+        Mockito.when(scanBuilder.build()).thenReturn(scan);
+
+        // Mock row/batch iterators.
+        Row row = Mockito.mock(Row.class);
+        TestRowIterator rowIter = new TestRowIterator(row);
+        FilteredColumnarBatch batch = Mockito.mock(FilteredColumnarBatch.class);
+        Mockito.when(batch.getRows()).thenReturn(rowIter);
+        TestBatchIterator batchIter = new TestBatchIterator(batch);
+        Mockito.when(scan.getScanFiles(engine, true)).thenReturn(batchIter);
+
+        FileScanTask fileTask = Mockito.mock(FileScanTask.class);
+        DeltaLakeAddFileStatsSerDe serDe = Mockito.mock(DeltaLakeAddFileStatsSerDe.class);
+
+        try (MockedStatic<InternalScanFileUtils> internalMock = Mockito.mockStatic(InternalScanFileUtils.class);
+                MockedStatic<ScanFileUtils> scanFileMock = Mockito.mockStatic(ScanFileUtils.class)) {
+            internalMock.when(() -> InternalScanFileUtils.getDeletionVectorDescriptorFromRow(row))
+                    .thenReturn((DeletionVectorDescriptor) null);
+            scanFileMock.when(() -> ScanFileUtils.convertFromRowToFileScanTask(
+                    Mockito.anyBoolean(), Mockito.eq(row), Mockito.eq(meta), Mockito.anyLong(), Mockito.isNull()))
+                    .thenReturn(Pair.create(fileTask, serDe));
+
+            // invoke iterator
+            Method iteratorMethod = DeltaLakeMetadata.class.getDeclaredMethod(
+                    "buildFileScanTaskIterator", com.starrocks.catalog.Table.class,
+                    com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.class, boolean.class);
+            iteratorMethod.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            CloseableIterator<Pair<FileScanTask, DeltaLakeAddFileStatsSerDe>> iterator =
+                    (CloseableIterator<Pair<FileScanTask, DeltaLakeAddFileStatsSerDe>>)
+                            iteratorMethod.invoke(metadata, table, ConstantOperator.TRUE, false);
+
+            Assertions.assertTrue(iterator.hasNext());
+            Pair<FileScanTask, DeltaLakeAddFileStatsSerDe> pair = iterator.next();
+            Assertions.assertEquals(fileTask, pair.first);
+            Assertions.assertFalse(iterator.hasNext());
+            iterator.close();
+            Assertions.assertTrue(rowIter.closed);
+            Assertions.assertTrue(batchIter.closed);
+
+            // trigger collectDeltaLakePlanFiles to populate splitTasks
+            GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                    .setPredicate(ConstantOperator.TRUE)
+                    .setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)))
+                    .build();
+            PredicateSearchKey key = PredicateSearchKey.of("db", "tbl", params);
+
+            Method collectMethod = DeltaLakeMetadata.class.getDeclaredMethod(
+                    "collectDeltaLakePlanFiles", PredicateSearchKey.class, com.starrocks.catalog.Table.class,
+                    com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.class,
+                    com.starrocks.qe.ConnectContext.class, List.class);
+            collectMethod.setAccessible(true);
+            collectMethod.invoke(metadata, key, table, ConstantOperator.TRUE, null, List.of("c1"));
+
+            Field splitField = DeltaLakeMetadata.class.getDeclaredField("splitTasks");
+            splitField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<PredicateSearchKey, List<FileScanTask>> splits =
+                    (Map<PredicateSearchKey, List<FileScanTask>>) splitField.get(metadata);
+            Assertions.assertTrue(splits.containsKey(key));
+        }
+    }
+
+    @Test
+    public void testIcebergMetadataUsesCachedSplitTasks() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        IcebergCatalog icebergCatalog = Mockito.mock(IcebergCatalog.class);
+        IcebergCatalogProperties catalogProps = new IcebergCatalogProperties(
+                java.util.Map.of(IcebergCatalogProperties.ICEBERG_CATALOG_TYPE, "hive"));
+        IcebergMetadata metadata = new IcebergMetadata("ice", new HdfsEnvironment(new java.util.HashMap<>()),
+                icebergCatalog, exec, exec, catalogProps);
+
+        IcebergTable table = Mockito.mock(IcebergTable.class);
+        Mockito.when(table.getCatalogDBName()).thenReturn("db");
+        Mockito.when(table.getCatalogTableName()).thenReturn("tbl");
+
+        IcebergGetRemoteFilesParams.Builder builder = IcebergGetRemoteFilesParams.newBuilder();
+        builder.setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
+        builder.setPredicate(ConstantOperator.TRUE);
+        builder.setAllParams(IcebergTableMORParams.EMPTY);
+        builder.setParams(IcebergMORParams.EMPTY);
+        IcebergGetRemoteFilesParams params = (IcebergGetRemoteFilesParams) builder.build();
+        PredicateSearchKey key = PredicateSearchKey.of("db", "tbl", params);
+
+        FileScanTask task = Mockito.mock(FileScanTask.class);
+        Field splitField = IcebergMetadata.class.getDeclaredField("splitTasks");
+        splitField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<PredicateSearchKey, List<FileScanTask>> splitTasks =
+                (Map<PredicateSearchKey, List<FileScanTask>>) splitField.get(metadata);
+        splitTasks.put(key, List.of(task));
+
+        com.starrocks.connector.RemoteFileInfoSource source = metadata.getRemoteFilesAsync(table, params);
+        Assertions.assertTrue(source.hasMoreOutput());
+        IcebergRemoteFileInfo info = (IcebergRemoteFileInfo) source.getOutput();
+        Assertions.assertEquals(task, info.getFileScanTask());
+    }
+
+    @Test
+    public void testIcebergMetadataEmptyVersionIterator() throws Exception {
+        IcebergCatalog icebergCatalog = Mockito.mock(IcebergCatalog.class);
+        IcebergCatalogProperties catalogProps = new IcebergCatalogProperties(
+                java.util.Map.of(IcebergCatalogProperties.ICEBERG_CATALOG_TYPE, "hive"));
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        IcebergMetadata metadata = new IcebergMetadata("ice", new HdfsEnvironment(new java.util.HashMap<>()),
+                icebergCatalog, exec, exec, catalogProps);
+
+        IcebergTable table = Mockito.mock(IcebergTable.class);
+        Method m = IcebergMetadata.class.getDeclaredMethod(
+                "buildFileScanTaskIterator", IcebergTable.class, org.apache.iceberg.expressions.Expression.class,
+                TvrVersionRange.class, com.starrocks.qe.ConnectContext.class, boolean.class);
+        m.setAccessible(true);
+        org.apache.iceberg.io.CloseableIterator<FileScanTask> iter =
+                (org.apache.iceberg.io.CloseableIterator<FileScanTask>) m.invoke(
+                        metadata, table, org.apache.iceberg.expressions.Expressions.alwaysTrue(),
+                        TvrTableSnapshot.empty(), null, false);
+        Assertions.assertFalse(iter.hasNext());
+        iter.close();
+    }
+
+    @Test
+    public void testIcebergMetadataNullMetricsReporterThrows() throws Exception {
+        IcebergCatalog icebergCatalog = Mockito.mock(IcebergCatalog.class);
+        IcebergCatalogProperties catalogProps = new IcebergCatalogProperties(
+                java.util.Map.of(IcebergCatalogProperties.ICEBERG_CATALOG_TYPE, "hive"));
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        IcebergMetadata metadata = new IcebergMetadata("ice", new HdfsEnvironment(new java.util.HashMap<>()),
+                icebergCatalog, exec, exec, catalogProps);
+
+        IcebergTable table = Mockito.mock(IcebergTable.class);
+        org.apache.iceberg.Schema schema = new org.apache.iceberg.Schema(List.of());
+        org.apache.iceberg.Table nativeTbl = Mockito.mock(org.apache.iceberg.Table.class);
+        Mockito.when(nativeTbl.schema()).thenReturn(schema);
+        Mockito.when(table.getNativeTable()).thenReturn(nativeTbl);
+        Mockito.when(table.getCatalogDBName()).thenReturn("db");
+        Mockito.when(table.getCatalogTableName()).thenReturn("tbl");
+        Mockito.when(table.getIcebergMetricsReporter()).thenReturn(null);
+
+        Method m = IcebergMetadata.class.getDeclaredMethod(
+                "buildFileScanTaskIterator", IcebergTable.class, org.apache.iceberg.expressions.Expression.class,
+                TvrVersionRange.class, com.starrocks.qe.ConnectContext.class, boolean.class);
+        m.setAccessible(true);
+        Assertions.assertThrows(java.lang.reflect.InvocationTargetException.class, () -> m.invoke(
+                metadata, table, org.apache.iceberg.expressions.Expressions.alwaysTrue(),
+                TvrTableSnapshot.of(Optional.of(1L)), null, false));
+    }
+
+    @Test
+    public void testIcebergMetadataIncrementalIterator() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        IcebergCatalog icebergCatalog = Mockito.mock(IcebergCatalog.class);
+        IcebergCatalogProperties catalogProps = new IcebergCatalogProperties(
+                java.util.Map.of(IcebergCatalogProperties.ICEBERG_CATALOG_TYPE, "hive"));
+        IcebergMetadata metadata = new IcebergMetadata("ice", new HdfsEnvironment(new java.util.HashMap<>()),
+                icebergCatalog, exec, exec, catalogProps);
+
+        IcebergTable table = Mockito.mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTbl = Mockito.mock(org.apache.iceberg.Table.class);
+        org.apache.iceberg.Schema schema = new org.apache.iceberg.Schema(List.of());
+        IcebergMetricsReporter reporter = new IcebergMetricsReporter();
+        Mockito.when(table.getNativeTable()).thenReturn(nativeTbl);
+        Mockito.when(table.getIcebergMetricsReporter()).thenReturn(reporter);
+        Mockito.when(table.getCatalogDBName()).thenReturn("db");
+        Mockito.when(table.getCatalogTableName()).thenReturn("tbl");
+        Mockito.when(nativeTbl.schema()).thenReturn(schema);
+
+        IncrementalAppendScan incScan = Mockito.mock(IncrementalAppendScan.class);
+        Mockito.when(nativeTbl.newIncrementalAppendScan()).thenReturn(incScan);
+        Mockito.when(incScan.fromSnapshotExclusive(Mockito.anyLong())).thenReturn(incScan);
+        Mockito.when(incScan.toSnapshot(Mockito.anyLong())).thenReturn(incScan);
+        Mockito.when(incScan.metricsReporter(Mockito.any())).thenReturn(incScan);
+        Mockito.when(incScan.planWith(Mockito.any())).thenReturn(incScan);
+        Mockito.when(incScan.includeColumnStats()).thenReturn(incScan);
+        Mockito.when(incScan.filter(Mockito.any())).thenReturn(incScan);
+        FileScanTask task = Mockito.mock(FileScanTask.class);
+        CloseableIterable<FileScanTask> iterable = CloseableIterable.withNoopClose(List.of(task));
+        Mockito.when(incScan.planFiles()).thenReturn(iterable);
+        Mockito.when(incScan.targetSplitSize()).thenReturn(128L);
+
+        Method m = IcebergMetadata.class.getDeclaredMethod(
+                "buildFileScanTaskIterator", IcebergTable.class, org.apache.iceberg.expressions.Expression.class,
+                TvrVersionRange.class, com.starrocks.qe.ConnectContext.class, boolean.class);
+        m.setAccessible(true);
+        org.apache.iceberg.io.CloseableIterator<FileScanTask> iter =
+                (org.apache.iceberg.io.CloseableIterator<FileScanTask>) m.invoke(
+                        metadata, table, org.apache.iceberg.expressions.Expressions.alwaysTrue(),
+                        TvrTableDelta.of(Optional.of(1L), Optional.of(2L)), null, true);
+        // iterator should be created and be consumable without exception
+        iter.hasNext();
+        iter.close();
+    }
+
+    @Test
+    public void testIcebergMetadataGetDeleteFiles() {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        IcebergCatalog icebergCatalog = Mockito.mock(IcebergCatalog.class);
+        IcebergCatalogProperties catalogProps = new IcebergCatalogProperties(
+                java.util.Map.of(IcebergCatalogProperties.ICEBERG_CATALOG_TYPE, "hive"));
+        IcebergMetadata metadata = new IcebergMetadata("ice", new HdfsEnvironment(new java.util.HashMap<>()),
+                icebergCatalog, exec, exec, catalogProps);
+
+        IcebergTable table = Mockito.mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTbl = Mockito.mock(org.apache.iceberg.Table.class);
+        org.apache.iceberg.Schema schema = new org.apache.iceberg.Schema(List.of());
+        Mockito.when(nativeTbl.schema()).thenReturn(schema);
+        Mockito.when(table.getNativeTable()).thenReturn(nativeTbl);
+        Mockito.when(table.getCatalogDBName()).thenReturn("db");
+        Mockito.when(table.getCatalogTableName()).thenReturn("tbl");
+
+        StarRocksIcebergTableScan scan = Mockito.mock(StarRocksIcebergTableScan.class);
+        Mockito.when(scan.useSnapshot(Mockito.anyLong())).thenReturn(scan);
+        Mockito.when(scan.metricsReporter(Mockito.any())).thenReturn(scan);
+        Mockito.when(scan.planWith(Mockito.any())).thenReturn(scan);
+        Mockito.when(scan.filter(Mockito.any())).thenReturn(scan);
+        Mockito.when(scan.getDeleteFiles(Mockito.any(FileContent.class))).thenReturn(Set.<DeleteFile>of());
+        Mockito.when(icebergCatalog.getTableScan(Mockito.eq(nativeTbl), Mockito.any())).thenReturn(scan);
+
+        Assertions.assertTrue(metadata.getDeleteFiles(table, 1L, ConstantOperator.TRUE, FileContent.EQUALITY_DELETES).isEmpty());
+    }
+
+    private static class CountingRemoteFileInfoSource implements RemoteFileInfoSource {
+        private final AtomicInteger closeCount = new AtomicInteger();
+        private volatile boolean closed = false;
+        private final boolean throwOnClose;
+
+        CountingRemoteFileInfoSource() {
+            this(false);
+        }
+
+        CountingRemoteFileInfoSource(boolean throwOnClose) {
+            this.throwOnClose = throwOnClose;
+        }
+
+        @Override
+        public RemoteFileInfo getOutput() {
+            throw new UnsupportedOperationException("not used");
+        }
+
+        @Override
+        public boolean hasMoreOutput() {
+            return false;
+        }
+
+        @Override
+        public List<RemoteFileInfo> getAllOutputs() {
+            return List.of();
+        }
+
+        @Override
+        public void close() {
+            closeCount.incrementAndGet();
+            closed = true;
+            if (throwOnClose) {
+                throw new RuntimeException("close error");
+            }
+        }
+    }
+
+    // Minimal CloseableIterator implementations to validate close propagation.
+    private static class TestBatchIterator implements CloseableIterator<FilteredColumnarBatch> {
+        private final FilteredColumnarBatch batch;
+        boolean closed = false;
+        boolean used = false;
+
+        TestBatchIterator(FilteredColumnarBatch batch) {
+            this.batch = batch;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return !used;
+        }
+
+        @Override
+        public FilteredColumnarBatch next() {
+            used = true;
+            return batch;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+
+    private static class TestRowIterator implements CloseableIterator<Row> {
+        private final Row row;
+        boolean closed = false;
+        boolean used = false;
+
+        TestRowIterator(Row row) {
+            this.row = row;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return !used;
+        }
+
+        @Override
+        public Row next() {
+            used = true;
+            return row;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+
+    @Test
+    public void testDeltaScanNodeClearHandlesCloseException() throws Exception {
+        DeltaLakeTable table = Mockito.mock(DeltaLakeTable.class);
+        Mockito.when(table.getCatalogName()).thenReturn(null);
+        TupleDescriptor tupleDescriptor = new TupleDescriptor(new TupleId(1));
+        tupleDescriptor.setTable(table);
+
+        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(1), tupleDescriptor, "DeltaLakeScanNode");
+        DeltaConnectorScanRangeSource scanRangeSource = Mockito.mock(DeltaConnectorScanRangeSource.class);
+        Mockito.doThrow(new RuntimeException("close error")).when(scanRangeSource).close();
+
+        Field field = DeltaLakeScanNode.class.getDeclaredField("scanRangeSource");
+        field.setAccessible(true);
+        field.set(scanNode, scanRangeSource);
+
+        Assertions.assertDoesNotThrow(scanNode::clear);
+        Mockito.verify(scanRangeSource, Mockito.times(1)).close();
+        Assertions.assertNull(field.get(scanNode));
+    }
+
+    @Test
+    public void testIcebergScanNodeClearHandlesCloseException() throws Exception {
+        IcebergTable icebergTable = Mockito.mock(IcebergTable.class);
+        Mockito.when(icebergTable.getCatalogName()).thenReturn(null);
+        TupleDescriptor tupleDescriptor = new TupleDescriptor(new TupleId(2));
+        tupleDescriptor.setTable(icebergTable);
+
+        IcebergScanNode scanNode = new IcebergScanNode(new PlanNodeId(2), tupleDescriptor, "IcebergScanNode",
+                IcebergTableMORParams.EMPTY, IcebergMORParams.EMPTY, PartitionIdGenerator.of());
+        IcebergConnectorScanRangeSource scanRangeSource = Mockito.mock(IcebergConnectorScanRangeSource.class);
+        Mockito.doThrow(new RuntimeException("close error")).when(scanRangeSource).close();
+
+        Field field = IcebergScanNode.class.getDeclaredField("scanRangeSource");
+        field.setAccessible(true);
+        field.set(scanNode, scanRangeSource);
+
+        Assertions.assertDoesNotThrow(scanNode::clear);
+        Mockito.verify(icebergTable, Mockito.times(1)).clearMetadata();
+        Mockito.verify(scanRangeSource, Mockito.times(1)).close();
+        Assertions.assertNull(field.get(scanNode));
+    }
+
+    @Test
+    public void testIcebergMetadataIteratorThrowsIOException() throws Exception {
+        ExecutorService exec = Executors.newSingleThreadExecutor();
+        IcebergCatalog icebergCatalog = Mockito.mock(IcebergCatalog.class);
+        IcebergCatalogProperties catalogProps = new IcebergCatalogProperties(
+                java.util.Map.of(IcebergCatalogProperties.ICEBERG_CATALOG_TYPE, "hive"));
+        IcebergMetadata metadata = new IcebergMetadata("ice", new HdfsEnvironment(new java.util.HashMap<>()),
+                icebergCatalog, exec, exec, catalogProps);
+
+        IcebergTable table = Mockito.mock(IcebergTable.class);
+        org.apache.iceberg.Table nativeTbl = Mockito.mock(org.apache.iceberg.Table.class);
+        org.apache.iceberg.Schema schema = new org.apache.iceberg.Schema(List.of());
+        Mockito.when(nativeTbl.schema()).thenReturn(schema);
+        Mockito.when(table.getNativeTable()).thenReturn(nativeTbl);
+        Mockito.when(table.getCatalogDBName()).thenReturn("db");
+        Mockito.when(table.getCatalogTableName()).thenReturn("tbl");
+        Mockito.when(table.getIcebergMetricsReporter()).thenReturn(new IcebergMetricsReporter());
+
+        org.apache.iceberg.StarRocksIcebergTableScan tableScan =
+                Mockito.mock(org.apache.iceberg.StarRocksIcebergTableScan.class);
+        Mockito.when(icebergCatalog.getTableScan(Mockito.eq(nativeTbl), Mockito.any())).thenReturn(tableScan);
+        Mockito.when(tableScan.useSnapshot(Mockito.anyLong())).thenReturn(tableScan);
+        Mockito.when(tableScan.metricsReporter(Mockito.any())).thenReturn(tableScan);
+        Mockito.when(tableScan.planWith(Mockito.any())).thenReturn(tableScan);
+        Mockito.when(tableScan.includeColumnStats()).thenReturn(tableScan);
+        Mockito.when(tableScan.filter(Mockito.any())).thenReturn(tableScan);
+        Mockito.when(tableScan.targetSplitSize()).thenReturn(128L);
+        Mockito.when(tableScan.planFiles()).thenReturn(null);
+        Mockito.when(tableScan.getMetricsReporter()).thenReturn(new IcebergMetricsReporter());
+
+        Method collectMethod = IcebergMetadata.class.getDeclaredMethod(
+                "collectTableStatisticsAndCacheIcebergSplit", PredicateSearchKey.class, com.starrocks.catalog.Table.class,
+                com.starrocks.common.profile.Tracers.class, com.starrocks.qe.ConnectContext.class);
+        collectMethod.setAccessible(true);
+
+        IcebergGetRemoteFilesParams.Builder builder = IcebergGetRemoteFilesParams.newBuilder();
+        builder.setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)));
+        builder.setPredicate(ConstantOperator.TRUE);
+        builder.setAllParams(IcebergTableMORParams.EMPTY);
+        builder.setParams(IcebergMORParams.EMPTY);
+        IcebergGetRemoteFilesParams params = (IcebergGetRemoteFilesParams) builder.build();
+        PredicateSearchKey key = PredicateSearchKey.of("db", "tbl", params);
+
+        try (MockedStatic<TableScanUtil> tableScanUtilMock = Mockito.mockStatic(TableScanUtil.class)) {
+            CloseableIterable<FileScanTask> iterable = new CloseableIterable<>() {
+                @Override
+                public void close() throws IOException {
+                    // no-op
+                }
+
+                @Override
+                public org.apache.iceberg.io.CloseableIterator<FileScanTask> iterator() {
+                    return new org.apache.iceberg.io.CloseableIterator<>() {
+                        @Override
+                        public void close() throws IOException {
+                            // simulate close error; swallowed by iterator implementation
+                            throw new IOException("boom");
+                        }
+
+                        @Override
+                        public boolean hasNext() {
+                            return false;
+                        }
+
+                        @Override
+                        public FileScanTask next() {
+                            throw new NoSuchElementException();
+                        }
+                    };
+                }
+            };
+            tableScanUtilMock.when(() -> TableScanUtil.splitFiles(Mockito.any(), Mockito.anyLong()))
+                    .thenReturn(iterable);
+
+            // current implementation swallows close errors; just assert no exception bubbles up
+            Assertions.assertDoesNotThrow(() -> collectMethod.invoke(metadata, key, table, null, null));
+        }
+    }
+
+    @Test
+    public void testDeltaLakeMetadataIteratorThrowsIOException() throws Exception {
+        DeltaMetastoreOperations deltaOps = Mockito.mock(DeltaMetastoreOperations.class);
+        DeltaLakeMetadata metadata = new DeltaLakeMetadata(
+                new HdfsEnvironment(new java.util.HashMap<>()), "delta0", deltaOps, null,
+                new ConnectorProperties(ConnectorType.DELTALAKE));
+
+        DeltaLakeTable table = Mockito.mock(DeltaLakeTable.class);
+        Engine engine = Mockito.mock(Engine.class);
+        SnapshotImpl snapshot = Mockito.mock(SnapshotImpl.class);
+        Metadata meta = Mockito.mock(Metadata.class);
+        StructType schema = Mockito.mock(StructType.class);
+        StructField structField = Mockito.mock(StructField.class);
+        Mockito.when(structField.getDataType()).thenReturn(Mockito.mock(io.delta.kernel.types.DataType.class));
+        Mockito.when(schema.fieldNames()).thenReturn(List.of("c1"));
+        Mockito.when(schema.get("c1")).thenReturn(structField);
+
+        Mockito.when(table.getDeltaMetadata()).thenReturn(meta);
+        Mockito.when(table.getDeltaEngine()).thenReturn(engine);
+        Mockito.when(table.getDeltaSnapshot()).thenReturn(snapshot);
+        Mockito.when(table.getColumns()).thenReturn(List.of(new Column("c1", IntegerType.INT)));
+        Mockito.when(table.getCatalogDBName()).thenReturn("db");
+        Mockito.when(table.getCatalogTableName()).thenReturn("tbl");
+        Mockito.when(meta.getSchema()).thenReturn(schema);
+        Mockito.when(meta.getPartitionColNames()).thenReturn(Set.of());
+        Mockito.when(snapshot.getVersion(engine)).thenReturn(1L);
+
+        ScanBuilderImpl scanBuilder = Mockito.mock(ScanBuilderImpl.class);
+        ScanImpl scan = Mockito.mock(ScanImpl.class);
+        Mockito.when(snapshot.getScanBuilder(engine)).thenReturn(scanBuilder);
+        Mockito.when(scanBuilder.withFilter(Mockito.eq(engine), Mockito.any())).thenReturn(scanBuilder);
+        Mockito.when(scanBuilder.build()).thenReturn(scan);
+
+        CloseableIterator<FilteredColumnarBatch> emptyIter = new CloseableIterator<>() {
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public FilteredColumnarBatch next() {
+                throw new NoSuchElementException();
+            }
+
+            @Override
+            public void close() throws IOException {
+                throw new IOException("boom");
+            }
+        };
+        Mockito.when(scan.getScanFiles(engine, true)).thenReturn(emptyIter);
+
+        Method collectMethod = DeltaLakeMetadata.class.getDeclaredMethod(
+                "collectDeltaLakePlanFiles", PredicateSearchKey.class, com.starrocks.catalog.Table.class,
+                com.starrocks.sql.optimizer.operator.scalar.ScalarOperator.class,
+                com.starrocks.qe.ConnectContext.class, List.class);
+        collectMethod.setAccessible(true);
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                .setPredicate(ConstantOperator.TRUE)
+                .setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L)))
+                .build();
+        PredicateSearchKey key = PredicateSearchKey.of("db", "tbl", params);
+
+        java.lang.reflect.InvocationTargetException ex = Assertions.assertThrows(
+                java.lang.reflect.InvocationTargetException.class,
+                () -> collectMethod.invoke(metadata, key, table, ConstantOperator.TRUE, null, List.of("c1")));
+        Assertions.assertInstanceOf(StarRocksConnectorException.class, ex.getCause());
+        Assertions.assertTrue(ex.getCause().getMessage().contains("Failed to get delta lake scan files"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
![img_v3_02ud_473484a2-6c76-4545-856f-ced22d612f2g](https://github.com/user-attachments/assets/003fd712-5e5d-4690-ab63-6d50e7562128)

The deploy/scheduler thread can keep a lot of lake-table memory after execution: native table references and planned Iceberg/Delta FileScanTask/BaseFileScanTask will not close if a failure occur during the execution, which will be hold in it unitl the thread has the next task, and a lot of memory will be occupied and can not GC.


## What I'm doing:
Implement close() across Iceberg/Delta RemoteFileInfoSource and ScanRangeSource, and call it explicitly on failure/cancel.
Use ScanNode.clear() as a hook to release external resources; ensure DefaultCoordinator and StmtExecutor invoke cleanup when finishing.
Clear Iceberg table native metadata at query end to reduce cross-query retention.
Add idempotent/exception-swallowing unit tests to verify multiple close()/clear() calls are safe.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
