### PR TITLE
[Enhancement] Improve skew join v2 rewrite with stats-based detection and NULL skew

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -474,6 +474,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_STATS_TO_OPTIMIZE_SKEW_JOIN = "enable_stats_to_optimize_skew_join";
     public static final String SKEW_JOIN_OPTIMIZE_USE_MCV_COUNT = "skew_join_use_mcv_count";
     public static final String SKEW_JOIN_DATA_SKEW_THRESHOLD = "skew_join_data_skew_threshold";
+    public static final String SKEW_JOIN_MCV_SINGLE_THRESHOLD = "skew_join_mcv_single_threshold";
+    public static final String SKEW_JOIN_MCV_MIN_INPUT_ROWS = "skew_join_mcv_min_input_rows";
 
     public static final String CHOOSE_EXECUTE_INSTANCES_MODE = "choose_execute_instances_mode";
 
@@ -3017,6 +3019,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = SKEW_JOIN_DATA_SKEW_THRESHOLD, flag = VariableMgr.INVISIBLE)
     private double skewJoinDataSkewThreshold = 0.2;
 
+    // A single MCV value must exceed this total-domain ratio to be considered as a skew value candidate.
+    @VarAttr(name = SKEW_JOIN_MCV_SINGLE_THRESHOLD, flag = VariableMgr.INVISIBLE)
+    private double skewJoinMcvSingleThreshold = 0.1;
+
+    // Minimal input rows (estimated) to enable MCV-based skew join elimination rewrite.
+    @VarAttr(name = SKEW_JOIN_MCV_MIN_INPUT_ROWS, flag = VariableMgr.INVISIBLE)
+    private long skewJoinMcvMinInputRows = 10000000;
+
     @VarAttr(name = LARGE_DECIMAL_UNDERLYING_TYPE)
     private String largeDecimalUnderlyingType = SessionVariableConstants.PANIC;
 
@@ -5490,6 +5500,22 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setSkewJoinDataSkewThreshold(double skewJoinDataSkewThreshold) {
         this.skewJoinDataSkewThreshold = skewJoinDataSkewThreshold;
+    }
+
+    public double getSkewJoinMcvSingleThreshold() {
+        return skewJoinMcvSingleThreshold;
+    }
+
+    public void setSkewJoinMcvSingleThreshold(double skewJoinMcvSingleThreshold) {
+        this.skewJoinMcvSingleThreshold = skewJoinMcvSingleThreshold;
+    }
+
+    public long getSkewJoinMcvMinInputRows() {
+        return skewJoinMcvMinInputRows;
+    }
+
+    public void setSkewJoinMcvMinInputRows(long skewJoinMcvMinInputRows) {
+        this.skewJoinMcvMinInputRows = skewJoinMcvMinInputRows;
     }
 
     public boolean isEnableStrictOrderBy() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
@@ -327,7 +327,7 @@ public class SkewJoinOptimizeRule extends TransformationRule {
         inPredicateArgs.add(skewColumn);
         // build a defensive copy and remove NULL from it
         List<ScalarOperator> nonNullSkewValues = Lists.newArrayList(skewValues);
-        nonNullSkewValues.removeIf(value -> value instanceof ConstantOperator && ((ConstantOperator) value).isNull());
+        nonNullSkewValues.removeIf(ScalarOperator::isConstantNull);
         inPredicateArgs.addAll(nonNullSkewValues);
         InPredicateOperator inPredicateOperator = new InPredicateOperator(false, inPredicateArgs);
 
@@ -369,7 +369,8 @@ public class SkewJoinOptimizeRule extends TransformationRule {
 
         Map<ColumnRefOperator, ScalarOperator> valueProjectMap = Maps.newHashMap();
         // use skew value to generate array
-        List<Type> skewTypes = skewValues.stream().map(ScalarOperator::getType).collect(Collectors.toList());
+        List<com.starrocks.type.Type> skewTypes =
+                skewValues.stream().map(v -> v.getType()).collect(Collectors.toList());
         ArrayType arrayType = new ArrayType(TypeManager.getCommonType(
                 skewTypes.toArray(new Type[0]), 0, skewTypes.size()));
         ArrayOperator arrayOperator = new ArrayOperator(arrayType, true, skewValues);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SkewShuffleJoinEliminationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SkewShuffleJoinEliminationRule.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.common.LocalExchangerType;
 import com.starrocks.common.Pair;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.ast.HintNode;
 import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -40,14 +41,19 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalSplitProduceOperato
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ReduceCastRule;
+import com.starrocks.sql.optimizer.skew.DataSkew;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.task.TaskContext;
 
 import java.util.ArrayList;
@@ -56,6 +62,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /* rewrite the tree top down
@@ -75,7 +82,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
     private final AtomicInteger uniqueSplitId;
 
-    private SkewShuffleJoinEliminationVisitor handler = null;
+    private SessionVariable sessionVariable;
 
     public SkewShuffleJoinEliminationRule() {
         this.uniqueSplitId = new AtomicInteger();
@@ -83,13 +90,17 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
 
     @Override
     public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
-        handler = new SkewShuffleJoinEliminationVisitor(taskContext.getOptimizerContext().getColumnRefFactory());
+        sessionVariable = taskContext.getOptimizerContext().getSessionVariable();
+        SkewShuffleJoinEliminationVisitor handler = new SkewShuffleJoinEliminationVisitor(
+                taskContext.getOptimizerContext().getColumnRefFactory());
         return root.getOp().accept(handler, root, null);
     }
 
-    record SkewColumnAndValues(List<ScalarOperator> skewValues,
-                               Pair<ScalarOperator, ScalarOperator> skewColumns,
-                               int skewColumnSide) {
+    record SkewJoinSplitInfo(List<ScalarOperator> nonNullSkewValues,
+                             ScalarOperator skewSideJoinKeyExpr,
+                             ScalarOperator nonSkewSideJoinKeyExpr,
+                             int skewSideChildIndex,
+                             boolean includeNullSkew) {
     }
 
     record SplitProducerAndConsumer(OptExpression splitProducer,
@@ -125,42 +136,59 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
                 return visitChild(opt, context);
             }
 
-            // find skew columns, rewrite skew values if needed
-            // right now skew hint only support skew in left table
-            // originalSkewColumn is column in left table which is skew, and skew values have same type with originalSkewColumn
-            ScalarOperator originalSkewColumn = originalShuffleJoinOperator.getSkewColumn();
-            if (originalSkewColumn == null || !(originalSkewColumn instanceof ColumnRefOperator)) {
+            SkewJoinSplitInfo splitInfo;
+            if (isSkew(opt)) {
+                // Hint-based skew join (manual).
+                ScalarOperator originalSkewColumn = originalShuffleJoinOperator.getSkewColumn();
+                if (!(originalSkewColumn instanceof ColumnRefOperator skewColumnRef)) {
+                    return visitChild(opt, context);
+                }
+
+                List<ScalarOperator> hintSkewValues = originalShuffleJoinOperator.getSkewValues();
+                if (hintSkewValues == null || hintSkewValues.isEmpty()) {
+                    return visitChild(opt, context);
+                }
+                boolean includeNullSkew = hintSkewValues.stream().anyMatch(ScalarOperator::isConstantNull);
+                List<ScalarOperator> nonNullSkewValues = hintSkewValues.stream()
+                        .filter(v -> !v.isConstantNull())
+                        .toList();
+
+                splitInfo = findSkewJoinSplitInfo(opt, skewColumnRef, nonNullSkewValues, includeNullSkew);
+            } else {
+                // Auto-detect skew from statistics (MCV/NULL skew).
+                Optional<SkewJoinSplitInfo> detected = detectSkewFromStats(opt);
+                if (detected.isEmpty()) {
+                    return visitChild(opt, context);
+                }
+                splitInfo = detected.get();
+            }
+
+            ScalarOperator skewSideJoinKeyExpr = splitInfo.skewSideJoinKeyExpr;
+            ScalarOperator nonSkewSideJoinKeyExpr = splitInfo.nonSkewSideJoinKeyExpr;
+            List<ScalarOperator> nonNullSkewValues = splitInfo.nonNullSkewValues;
+            boolean includeNullSkew = splitInfo.includeNullSkew;
+            if (skewSideJoinKeyExpr == null || nonSkewSideJoinKeyExpr == null || nonNullSkewValues == null ||
+                    (nonNullSkewValues.isEmpty() && !includeNullSkew)) {
                 return visitChild(opt, context);
             }
-            ColumnRefOperator skewColumnRef  = (ColumnRefOperator) originalSkewColumn;
-            // find left and right skew column according to on predicate
-            SkewColumnAndValues skewColumnAndValues = findSkewColumns(opt, skewColumnRef);
-            if (skewColumnAndValues == null) {
-                return visitChild(opt, context);
-            }
-            ScalarOperator leftSkewColumn = skewColumnAndValues.skewColumns.first;
-            ScalarOperator rightSkewColumn = skewColumnAndValues.skewColumns.second;
-            List<ScalarOperator> skewValues = skewColumnAndValues.skewValues;
-            if (leftSkewColumn == null || rightSkewColumn == null || skewValues == null || skewValues.isEmpty()) {
-                return opt;
-            }
-            int skewColumnSide = skewColumnAndValues.skewColumnSide;
+            int skewSideChildIndex = splitInfo.skewSideChildIndex;
 
             // if this is a left join, and the right side is skew side, we cannot do optimization because
             // the right side's broadcast will cause result incorrect.
-            if (originalShuffleJoinOperator.getJoinType().isAnyLeftOuterJoin() && skewColumnSide == 1) {
+            if (originalShuffleJoinOperator.getJoinType().isAnyLeftOuterJoin() && skewSideChildIndex == 1) {
                 return visitChild(opt, context);
             }
 
             // rewrite plan
-            OptExpression skewOptInput = opt.inputAt(skewColumnSide);
-            OptExpression nonSkewOptInput = opt.inputAt(1 - skewColumnSide);
+            OptExpression skewSideChild = opt.inputAt(skewSideChildIndex);
+            OptExpression nonSkewSideChild = opt.inputAt(1 - skewSideChildIndex);
 
-            SplitProducerAndConsumer leftSplitProducerAndConsumer =
-                    generateSplitProducerAndConsumer(skewOptInput, leftSkewColumn, skewValues, true);
+            SplitProducerAndConsumer skewSideSplit = generateSplitProducerAndConsumer(skewSideChild, skewSideJoinKeyExpr,
+                    nonNullSkewValues, includeNullSkew, true);
 
-            SplitProducerAndConsumer rightSplitProducerAndConsumer =
-                    generateSplitProducerAndConsumer(nonSkewOptInput, rightSkewColumn, skewValues, false);
+            SplitProducerAndConsumer nonSkewSideSplit =
+                    generateSplitProducerAndConsumer(nonSkewSideChild, nonSkewSideJoinKeyExpr,
+                            nonNullSkewValues, includeNullSkew, false);
 
             // keep projection for new join opt
             Projection projectionOnJoin = originalShuffleJoinOperator.getProjection();
@@ -169,13 +197,13 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
                     new PhysicalHashJoinOperator(originalShuffleJoinOperator.getJoinType(),
                             originalShuffleJoinOperator.getOnPredicate(), originalShuffleJoinOperator.getJoinHint(),
                             originalShuffleJoinOperator.getLimit(), originalShuffleJoinOperator.getPredicate(),
-                            projectionOnJoin, leftSkewColumn, skewValues);
+                            projectionOnJoin, skewSideJoinKeyExpr, nonNullSkewValues);
 
             PhysicalHashJoinOperator newBroadcastJoinOpt =
                     new PhysicalHashJoinOperator(originalShuffleJoinOperator.getJoinType(),
                             originalShuffleJoinOperator.getOnPredicate(), originalShuffleJoinOperator.getJoinHint(),
                             originalShuffleJoinOperator.getLimit(), originalShuffleJoinOperator.getPredicate(),
-                            projectionOnJoin, leftSkewColumn, skewValues);
+                            projectionOnJoin, skewSideJoinKeyExpr, nonNullSkewValues);
 
             // we have to let them know each other for runtime filter
             newBroadcastJoinOpt.setSkewJoinFriend(newShuffleJoinOpt);
@@ -193,12 +221,12 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
                     }
                 }
             }
-            PhysicalConcatenateOperator concatenateOperator = buildConcatenateOperator(outputColumns, 2,
-                            localExchangerType, originalShuffleJoinOperator.getLimit());
+            PhysicalConcatenateOperator concatenateOperator = buildConcatenateOperator(outputColumns,
+                    localExchangerType, originalShuffleJoinOperator.getLimit());
 
             OptExpression newShuffleJoin = OptExpression.builder().setOp(newShuffleJoinOpt).setInputs(
-                            List.of(leftSplitProducerAndConsumer.splitConsumerOptForShuffleJoin,
-                                    rightSplitProducerAndConsumer.splitConsumerOptForShuffleJoin))
+                            List.of(skewSideSplit.splitConsumerOptForShuffleJoin,
+                                    nonSkewSideSplit.splitConsumerOptForShuffleJoin))
                     .setLogicalProperty(opt.getLogicalProperty()).setStatistics(opt.getStatistics())
                     .setRequiredProperties(opt.getRequiredProperties()).setCost(opt.getCost()).build();
 
@@ -207,35 +235,33 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
             List<PhysicalPropertySet> requiredPropertiesForBroadcastJoin =
                     Lists.newArrayList(PhysicalPropertySet.EMPTY, rightBroadcastProperty);
             OptExpression newBroadcastJoin = OptExpression.builder().setOp(newBroadcastJoinOpt).setInputs(
-                            List.of(leftSplitProducerAndConsumer.splitConsumerOptForBroadcastJoin,
-                                    rightSplitProducerAndConsumer.splitConsumerOptForBroadcastJoin))
+                            List.of(skewSideSplit.splitConsumerOptForBroadcastJoin,
+                                    nonSkewSideSplit.splitConsumerOptForBroadcastJoin))
                     .setLogicalProperty(opt.getLogicalProperty()).setStatistics(opt.getStatistics())
                     .setRequiredProperties(requiredPropertiesForBroadcastJoin).setCost(opt.getCost()).build();
 
             OptExpression rightChildOfConcatenate = newBroadcastJoin;
             if (opt.isExistRequiredDistribution()) {
                 PhysicalDistributionOperator rightExchangeOpOfOriginalShuffleJoin =
-                        (PhysicalDistributionOperator) nonSkewOptInput.getOp();
+                        (PhysicalDistributionOperator) nonSkewSideChild.getOp();
 
                 PhysicalDistributionOperator newExchangeForBroadcastJoin =
                         new PhysicalDistributionOperator(rightExchangeOpOfOriginalShuffleJoin.getDistributionSpec());
                 // we need add exchange node to make broadcast join's output distribution can be same as shuffle join's
-                OptExpression exchangeOptExpForBroadcastJoin =
-                        OptExpression.builder().setOp(newExchangeForBroadcastJoin)
-                                .setInputs(Collections.singletonList(newBroadcastJoin))
-                                .setLogicalProperty(newBroadcastJoin.getLogicalProperty())
-                                .setStatistics(newBroadcastJoin.getStatistics()).setCost(newBroadcastJoin.getCost())
-                                .build();
-                rightChildOfConcatenate = exchangeOptExpForBroadcastJoin;
+                rightChildOfConcatenate = OptExpression.builder().setOp(newExchangeForBroadcastJoin)
+                        .setInputs(Collections.singletonList(newBroadcastJoin))
+                        .setLogicalProperty(newBroadcastJoin.getLogicalProperty())
+                        .setStatistics(newBroadcastJoin.getStatistics()).setCost(newBroadcastJoin.getCost())
+                        .build();
                 if (projectionOnJoin != null) {
                     // broadcast join's projection should keep the columns used in exchange
                     Projection projectionForBroadcast = projectionOnJoin.deepClone();
 
                     ColumnRefSet usedColumnsOfRightExchangeOp =
-                            rightExchangeOpOfOriginalShuffleJoin.getRowOutputInfo(nonSkewOptInput.getInputs())
+                            rightExchangeOpOfOriginalShuffleJoin.getRowOutputInfo(nonSkewSideChild.getInputs())
                                     .getUsedColumnRefSet();
                     usedColumnsOfRightExchangeOp.except(projectionOnJoin.getOutputColumns());
-                    usedColumnsOfRightExchangeOp.getColumnRefOperators(columnRefFactory).stream()
+                    usedColumnsOfRightExchangeOp.getColumnRefOperators(columnRefFactory)
                             .forEach(columnRefOperator -> {
                                 projectionForBroadcast.getColumnRefMap()
                                         .putIfAbsent(columnRefOperator, columnRefOperator);
@@ -251,23 +277,21 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
 
             OptExpression cteAnchorOptExp1 =
                     OptExpression.builder().setOp(new PhysicalCTEAnchorOperator(uniqueSplitId.getAndIncrement()))
-                            .setInputs(List.of(rightSplitProducerAndConsumer.splitProducer, concatenateOptExp))
-                            .setLogicalProperty(opt.getLogicalProperty()).setStatistics(opt.getStatistics())
-                            .setCost(opt.getCost()).build();
-
-            OptExpression cteAnchorOptExp2 =
-                    OptExpression.builder().setOp(new PhysicalCTEAnchorOperator(uniqueSplitId.getAndIncrement()))
-                            .setInputs(List.of(leftSplitProducerAndConsumer.splitProducer, cteAnchorOptExp1))
+                            .setInputs(List.of(nonSkewSideSplit.splitProducer, concatenateOptExp))
                             .setLogicalProperty(opt.getLogicalProperty()).setStatistics(opt.getStatistics())
                             .setCost(opt.getCost()).build();
 
             // if hit once, we give up rewriting the following subtree
-            return cteAnchorOptExp2;
+            return OptExpression.builder().setOp(new PhysicalCTEAnchorOperator(uniqueSplitId.getAndIncrement()))
+                    .setInputs(List.of(skewSideSplit.splitProducer, cteAnchorOptExp1))
+                    .setLogicalProperty(opt.getLogicalProperty()).setStatistics(opt.getStatistics())
+                    .setCost(opt.getCost()).build();
         }
 
         private SplitProducerAndConsumer generateSplitProducerAndConsumer(OptExpression exchangeOptExp,
                                                                           ScalarOperator skewColumn,
                                                                           List<ScalarOperator> skewValues,
+                                                                          boolean includeNullSkew,
                                                                           boolean isLeft) {
             PhysicalDistributionOperator exchangeOpOfOriginalShuffleJoin =
                     (PhysicalDistributionOperator) exchangeOptExp.getOp();
@@ -279,7 +303,8 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
                             .setLogicalProperty(exchangeOptExp.getLogicalProperty())
                             .setStatistics(exchangeOptExp.getStatistics()).setCost(exchangeOptExp.getCost()).build();
 
-            Pair<ScalarOperator, ScalarOperator> tablePredicates = generateInAndNotInPredicate(skewColumn, skewValues);
+            Pair<ScalarOperator, ScalarOperator> tablePredicates =
+                    generateSkewAndNonSkewPredicate(skewColumn, skewValues, includeNullSkew);
 
             List<ColumnRefOperator> splitOutputColumns =
                     exchangeOptExp.getOutputColumns().getColumnRefOperators(columnRefFactory);
@@ -319,122 +344,193 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
                     splitConsumerOptExpForBroadcastJoin);
         }
 
-        private Pair<ScalarOperator, ScalarOperator> generateInAndNotInPredicate(ScalarOperator skewColumn,
-                                                                                 List<ScalarOperator> skewValues) {
-            List<ScalarOperator> inPredicateParams = new ArrayList<>();
-            inPredicateParams.add(skewColumn);
-            inPredicateParams.addAll(skewValues);
+        /**
+         * Build split predicates for skew/non-skew branches.
+         * <p>
+         * - Skew branch (broadcast join): {@code IN (nonNullSkewValues)} and/or {@code IS NULL} (if includeNullSkew)
+         * - Non-skew branch (shuffle join): the complement of skew branch
+         * <p>
+         * NOTE: Do not put NULL into IN-list due to SQL three-valued logic. Use explicit IS NULL/IS NOT NULL instead.
+         * <p>
+         * Examples (let join key be {@code k}):
+         * <ul>
+         *   <li>Only non-NULL skew values (S={1,2,3}, includeNullSkew=false):
+         *     <ul>
+         *       <li>Skew branch: {@code k IN (1,2,3)}</li>
+         *       <li>Non-skew branch: {@code k NOT IN (1,2,3) OR k IS NULL}</li>
+         *     </ul>
+         *   </li>
+         *   <li>Only NULL skew (S={}, includeNullSkew=true):
+         *     <ul>
+         *       <li>Skew branch: {@code k IS NULL}</li>
+         *       <li>Non-skew branch: {@code k IS NOT NULL}</li>
+         *     </ul>
+         *   </li>
+         *   <li>Both non-NULL and NULL skew (S={1,2,3}, includeNullSkew=true):
+         *     <ul>
+         *       <li>Skew branch: {@code k IN (1,2,3) OR k IS NULL}</li>
+         *       <li>Non-skew branch: {@code k NOT IN (1,2,3) AND k IS NOT NULL}</li>
+         *     </ul>
+         *   </li>
+         * </ul>
+         */
+        private Pair<ScalarOperator, ScalarOperator> generateSkewAndNonSkewPredicate(ScalarOperator skewColumn,
+                                                                                     List<ScalarOperator> skewValues,
+                                                                                     boolean includeNullSkew) {
+            ScalarOperator inSkewPredicate = null;
+            if (skewValues != null && !skewValues.isEmpty()) {
+                List<ScalarOperator> inPredicateParams = new ArrayList<>();
+                inPredicateParams.add(skewColumn);
+                inPredicateParams.addAll(skewValues);
+                inSkewPredicate = new InPredicateOperator(false, inPredicateParams);
+                ScalarOperatorRewriter rewriter = new ScalarOperatorRewriter();
+                inSkewPredicate = rewriter.rewrite(inSkewPredicate,
+                        ImmutableList.of(new ImplicitCastRule(), new ReduceCastRule(), new FoldConstantsRule()));
+            }
 
-            ScalarOperator inSkewPredicate = new InPredicateOperator(false, inPredicateParams);
-            ScalarOperatorRewriter rewriter = new ScalarOperatorRewriter();
-            inSkewPredicate =
-                    rewriter.rewrite(inSkewPredicate, ImmutableList.of(new ImplicitCastRule(), new ReduceCastRule()));
-            ScalarOperator notInSkewPredicate = new InPredicateOperator(true, inSkewPredicate.getChildren());
-            ScalarOperator notInSkewOrNullPredicate =
-                    CompoundPredicateOperator.or(notInSkewPredicate, new IsNullPredicateOperator(skewColumn));
+            ScalarOperator isNullPredicate = new IsNullPredicateOperator(skewColumn);
 
-            return Pair.create(inSkewPredicate, notInSkewOrNullPredicate);
+            // Skew predicate (broadcast-join branch)
+            ScalarOperator skewPredicate;
+            if (includeNullSkew) {
+                skewPredicate = (inSkewPredicate == null) ? isNullPredicate
+                        : CompoundPredicateOperator.or(inSkewPredicate, isNullPredicate);
+            } else {
+                if (inSkewPredicate == null) {
+                    throw new IllegalStateException("skewValues is empty while includeNullSkew is false");
+                }
+                skewPredicate = inSkewPredicate;
+            }
 
+            // Non-skew predicate (shuffle-join branch)
+            ScalarOperator nonSkewPredicate;
+            if (includeNullSkew) {
+                ScalarOperator isNotNullPredicate = new IsNullPredicateOperator(true, skewColumn);
+                if (inSkewPredicate == null) {
+                    nonSkewPredicate = isNotNullPredicate;
+                } else {
+                    ScalarOperator notInSkewPredicate = new InPredicateOperator(true, inSkewPredicate.getChildren());
+                    nonSkewPredicate = CompoundPredicateOperator.and(notInSkewPredicate, isNotNullPredicate);
+                }
+            } else {
+                ScalarOperator notInSkewPredicate = new InPredicateOperator(true, inSkewPredicate.getChildren());
+                nonSkewPredicate = CompoundPredicateOperator.or(notInSkewPredicate, isNullPredicate);
+            }
+
+            return Pair.create(skewPredicate, nonSkewPredicate);
         }
 
-        private boolean isExchangeWithDistributionType(Operator child, DistributionSpec.DistributionType expectedType) {
+        private boolean isExchangeWithDistributionType(Operator child) {
             if (!(child.getOpType() == OperatorType.PHYSICAL_DISTRIBUTION)) {
                 return false;
             }
-            PhysicalDistributionOperator operator = (PhysicalDistributionOperator) child;
-            return Objects.equals(operator.getDistributionSpec().getType(), expectedType);
+            PhysicalDistributionOperator operator = child.cast();
+            return Objects.equals(operator.getDistributionSpec().getType(), DistributionSpec.DistributionType.SHUFFLE);
         }
 
         private PhysicalConcatenateOperator buildConcatenateOperator(List<ColumnRefOperator> outputColumns,
-                                                                     int childNum, LocalExchangerType localExchangeType,
+                                                                     LocalExchangerType localExchangeType,
                                                                      long limit) {
             List<List<ColumnRefOperator>> childOutputColumns = new ArrayList<>();
-            for (int i = 0; i < childNum; i++) {
+            for (int i = 0; i < 2; i++) {
                 childOutputColumns.add(outputColumns);
             }
             return new PhysicalConcatenateOperator(outputColumns, childOutputColumns, localExchangeType, limit);
         }
 
-        private SkewColumnAndValues findSkewColumns(OptExpression input,
-                                                    ColumnRefOperator skewColumnRef) {
+        private SkewJoinSplitInfo findSkewJoinSplitInfo(OptExpression input,
+                                                        ColumnRefOperator skewColumnRef,
+                                                        List<ScalarOperator> nonNullSkewValues,
+                                                        boolean includeNullSkew) {
             ColumnRefSet leftOutputColumns = input.inputAt(0).getOutputColumns();
             ColumnRefSet rightOutputColumns = input.inputAt(1).getOutputColumns();
             if (leftOutputColumns.contains(skewColumnRef)) {
-                return findSkewColumns(input, skewColumnRef, 0);
+                return findSkewJoinSplitInfo(input, skewColumnRef, 0, nonNullSkewValues, includeNullSkew);
             } else if (rightOutputColumns.contains(skewColumnRef)) {
-                return findSkewColumns(input, skewColumnRef, 1);
+                return findSkewJoinSplitInfo(input, skewColumnRef, 1, nonNullSkewValues, includeNullSkew);
             } else {
                 // for join's on predicates contain expressions with skew column, try left and right sides both.
                 // try left side first
-                SkewColumnAndValues result = findSkewColumns(input, skewColumnRef, 0);
-                if (result != null && result.skewColumns != null &&
-                        result.skewColumns.first != null && result.skewColumns.second != null) {
+                SkewJoinSplitInfo result = findSkewJoinSplitInfo(input, skewColumnRef, 0, nonNullSkewValues, includeNullSkew);
+                if (result.skewSideJoinKeyExpr != null && result.nonSkewSideJoinKeyExpr != null) {
                     return result;
                 }
                 // then try right side
-                return findSkewColumns(input, skewColumnRef, 1);
+                return findSkewJoinSplitInfo(input, skewColumnRef, 1, nonNullSkewValues, includeNullSkew);
             }
         }
 
-        private SkewColumnAndValues findSkewColumns(OptExpression input,
-                                                    ColumnRefOperator skewColumnRef,
-                                                    int skewColumnSide) {
-            PhysicalHashJoinOperator oldJoinOperator = (PhysicalHashJoinOperator) input.getOp();
+        private SkewJoinSplitInfo findSkewJoinSplitInfo(OptExpression input,
+                                                        ColumnRefOperator skewColumnRef,
+                                                        int skewSideChildIndex,
+                                                        List<ScalarOperator> nonNullSkewValues,
+                                                        boolean includeNullSkew) {
+            PhysicalHashJoinOperator joinOperator = input.getOp().cast();
             ColumnRefSet leftOutputColumns = input.inputAt(0).getOutputColumns();
             ColumnRefSet rightOutputColumns = input.inputAt(1).getOutputColumns();
-            ScalarOperator leftSkewColumn = null;
-            ScalarOperator rightSkewColumn = null;
-            List<ScalarOperator> skewValues = oldJoinOperator.getSkewValues();
+            ScalarOperator skewSideJoinKeyExpr = null;
+            ScalarOperator nonSkewSideJoinKeyExpr = null;
+            List<ScalarOperator> rewrittenNonNullSkewValues = nonNullSkewValues;
 
-            OptExpression skewInputOpt = input.inputAt(skewColumnSide);
+            OptExpression skewSideChild = input.inputAt(skewSideChildIndex);
             // get equal conjuncts from on predicate, every eq predicate's child can't be constant
             List<BinaryPredicateOperator> equalConjs =
                     JoinHelper.getEqualsPredicate(leftOutputColumns, rightOutputColumns,
-                            Utils.extractConjuncts(oldJoinOperator.getOnPredicate()));
-            Projection skewInputProject = skewInputOpt.getInputs().isEmpty() ? null :
-                    skewInputOpt.inputAt(0).getOp().getProjection();
+                            Utils.extractConjuncts(joinOperator.getOnPredicate()));
+            Projection skewSideProject = skewSideChild.getInputs().isEmpty() ? null :
+                    skewSideChild.inputAt(0).getOp().getProjection();
             for (BinaryPredicateOperator equalConj : equalConjs) {
                 ScalarOperator child0 = equalConj.getChild(0);
                 ScalarOperator child1 = equalConj.getChild(1);
 
-                // firstly,we need to find rightSkewColumn in equalConj. if one side of equalConj using originalSkewColumn
-                // then another side of equalConj is rightSkewColumn
-                // Besides, we want to know whether originalSkewColumn is equalConj's child or it is part of some expr
-                // for example: select xx from t1 join[skew|t1.c_tinyint(1,2,3)] t2 on t1.c_tinyint = t2.int
-                // then on predicate will be: cast(t1.c_tinyint as int) = t2.int, in this case we have to rewrite skew values with this expr
+                // Find the join key expressions on skew side / non-skew side.
+                // If one side of the equality uses the skew column (or an expression derived from it),
+                // the other side is the corresponding join key expression on the opposite child.
+                //
+                // Example:
+                //   SELECT ... FROM t1 JOIN[skew|t1.c_tinyint(1,2,3)] t2 ON t1.c_tinyint = t2.c_int
+                // After type coercion, on predicate may become:
+                //   cast(t1.c_tinyint as int) = t2.c_int
+                // In this case we need to rewrite non-null skew values as:
+                //   cast(1 as int), cast(2 as int), cast(3 as int)
                 if (child0.equals(skewColumnRef)) {
-                    leftSkewColumn = skewColumnRef;
-                    rightSkewColumn = child1;
+                    skewSideJoinKeyExpr = skewColumnRef;
+                    nonSkewSideJoinKeyExpr = child1;
                 } else if (child1.equals(skewColumnRef)) {
-                    leftSkewColumn = skewColumnRef;
-                    rightSkewColumn = child0;
+                    skewSideJoinKeyExpr = skewColumnRef;
+                    nonSkewSideJoinKeyExpr = child0;
                 } else {
                     // originalSkewColumn is part of some expr
-                    if (skewInputProject != null) {
-                        ScalarOperator rewriteChild0 = replaceColumnRef(child0, skewInputProject);
-                        ScalarOperator rewriteChild1 = replaceColumnRef(child1, skewInputProject);
+                    if (skewSideProject != null) {
+                        ScalarOperator rewriteChild0 = replaceColumnRef(child0, skewSideProject);
+                        ScalarOperator rewriteChild1 = replaceColumnRef(child1, skewSideProject);
                         if (rewriteChild0.getUsedColumns().contains(skewColumnRef)) {
-                            leftSkewColumn = child0;
-                            rightSkewColumn = child1;
+                            skewSideJoinKeyExpr = child0;
+                            nonSkewSideJoinKeyExpr = child1;
                         } else if (rewriteChild1.getUsedColumns().contains(skewColumnRef)) {
-                            rightSkewColumn = child0;
-                            leftSkewColumn = child1;
+                            nonSkewSideJoinKeyExpr = child0;
+                            skewSideJoinKeyExpr = child1;
                         } else {
                             continue;
                         }
 
-                        Map<ColumnRefOperator, ScalarOperator> leftColumnRefMap = skewInputProject.getAllMaps();
-                        if (leftColumnRefMap.containsKey(leftSkewColumn)) {
-                            // this means leftSkewColumn is not a simple columnRef operator, so we need to rewrite skew values
-                            // for example: if leftSkewColumn is  cast(t1.c_tinyint as int), and skew values are (1,2,3)
-                            // then we need to rewrite skew values as (cast(1 as int), cast(2 as int), cast(3 as int))
-                            skewValues = rewriteSkewValues(skewValues, leftSkewColumn);
+                        if (skewSideJoinKeyExpr instanceof ColumnRefOperator skewSideJoinKeyRef) {
+                            Map<ColumnRefOperator, ScalarOperator> skewSideProjectMap = skewSideProject.getAllMaps();
+                            ScalarOperator definingExpr = skewSideProjectMap.get(skewSideJoinKeyRef);
+                            if (definingExpr != null && definingExpr.getUsedColumns().contains(skewColumnRef)) {
+                                rewrittenNonNullSkewValues =
+                                        rewriteSkewValues(rewrittenNonNullSkewValues, definingExpr, skewColumnRef);
+                            }
                         }
                     }
                 }
             }
 
-            return new SkewColumnAndValues(skewValues, Pair.create(leftSkewColumn, rightSkewColumn), skewColumnSide);
+            return new SkewJoinSplitInfo(rewrittenNonNullSkewValues,
+                    skewSideJoinKeyExpr,
+                    nonSkewSideJoinKeyExpr,
+                    skewSideChildIndex,
+                    includeNullSkew);
         }
 
         private ScalarOperator replaceColumnRef(ScalarOperator scalarOperator, Projection projection) {
@@ -447,11 +543,12 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
         }
 
         private List<ScalarOperator> rewriteSkewValues(List<ScalarOperator> originalSkewValues,
-                                                       ScalarOperator predicate) {
+                                                       ScalarOperator predicate,
+                                                       ColumnRefOperator targetColumnRef) {
             List<ScalarOperator> result = new LinkedList<>();
-            // for each skew value, we replace the columnRef in left  with skew value
+            // For each skew value, replace only the target column ref with that constant value.
             originalSkewValues.forEach(value -> {
-                ColumnRefReplacer refReplacer = new ColumnRefReplacer(value);
+                ColumnRefReplacer refReplacer = new ColumnRefReplacer(targetColumnRef, value);
                 ScalarOperator newSkewValue = predicate.accept(refReplacer, null);
                 result.add(newSkewValue);
             });
@@ -459,7 +556,7 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
         }
 
         private boolean canOptimize(PhysicalHashJoinOperator joinOp, OptExpression opt) {
-            return isValidJoinType(joinOp) && isShuffleJoin(opt) && isSkew(opt);
+            return isValidJoinType(joinOp) && isShuffleJoin(opt);
         }
 
         // currently only support inner join and left outer join
@@ -471,14 +568,11 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
             if (opt.getOp().getOpType() != OperatorType.PHYSICAL_HASH_JOIN) {
                 return false;
             }
-            return isExchangeWithDistributionType(opt.getInputs().get(0).getOp(),
-                    DistributionSpec.DistributionType.SHUFFLE) &&
-                    isExchangeWithDistributionType(opt.getInputs().get(1).getOp(),
-                            DistributionSpec.DistributionType.SHUFFLE);
+            return isExchangeWithDistributionType(opt.getInputs().get(0).getOp()) &&
+                    isExchangeWithDistributionType(opt.getInputs().get(1).getOp());
         }
 
-        // right now only support join hint with left skew table, since left table is bigger
-        // TODO(jerry): support MCV-based skew detection
+        // Hint-based skew join (manual).
         private boolean isSkew(OptExpression opt) {
             PhysicalHashJoinOperator joinOperator = (PhysicalHashJoinOperator) opt.getOp();
 
@@ -491,17 +585,105 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
             return joinOperator.getJoinHint().equals(HintNode.HINT_JOIN_SKEW);
         }
 
-        private class ColumnRefReplacer extends BaseScalarOperatorShuttle {
+        private Optional<SkewJoinSplitInfo> detectSkewFromStats(OptExpression joinOpt) {
+            if (sessionVariable == null || !sessionVariable.isEnableStatsToOptimizeSkewJoin()) {
+                return Optional.empty();
+            }
+            PhysicalHashJoinOperator joinOperator = joinOpt.getOp().cast();
 
+            ColumnRefSet leftOutputColumns = joinOpt.inputAt(0).getOutputColumns();
+            ColumnRefSet rightOutputColumns = joinOpt.inputAt(1).getOutputColumns();
+            List<BinaryPredicateOperator> equalConjs =
+                    JoinHelper.getEqualsPredicate(leftOutputColumns, rightOutputColumns,
+                            Utils.extractConjuncts(joinOperator.getOnPredicate()));
+            if (equalConjs.size() != 1) {
+                return Optional.empty();
+            }
+
+            BinaryPredicateOperator eq = equalConjs.get(0);
+            if (!eq.getChild(0).isColumnRef() || !eq.getChild(1).isColumnRef()) {
+                return Optional.empty();
+            }
+
+            ColumnRefOperator c0 = eq.getChild(0).cast();
+            ColumnRefOperator c1 = eq.getChild(1).cast();
+            ColumnRefOperator leftKey = leftOutputColumns.contains(c0) ? c0 :
+                    (leftOutputColumns.contains(c1) ? c1 : null);
+            ColumnRefOperator rightKey = (leftKey == null) ? null : (leftKey.equals(c0) ? c1 : c0);
+            if (leftKey == null || rightKey == null) {
+                return Optional.empty();
+            }
+
+            double bestScore = -1.0;
+            SkewJoinSplitInfo best = null;
+            for (int side = 0; side < 2; side++) {
+                if (joinOperator.getJoinType().isAnyLeftOuterJoin() && side == 1) {
+                    continue;
+                }
+                ColumnRefOperator skewSideKeyColumn = (side == 0) ? leftKey : rightKey;
+                Statistics stats = joinOpt.inputAt(side).getStatistics();
+                if (stats == null || stats.getOutputRowCount() < sessionVariable.getSkewJoinMcvMinInputRows()) {
+                    continue;
+                }
+
+                if (!stats.getColumnStatistics().containsKey(skewSideKeyColumn)) {
+                    continue;
+                }
+                ColumnStatistic cs = stats.getColumnStatistic(skewSideKeyColumn);
+                if (cs.isUnknown() || cs.getHistogram() == null) {
+                    continue;
+                }
+
+                DataSkew.Thresholds thresholds = new DataSkew.Thresholds(
+                        sessionVariable.getSkewJoinOptimizeUseMCVCount(),
+                        sessionVariable.getSkewJoinDataSkewThreshold());
+                DataSkew.SkewCandidates candidates =
+                        DataSkew.getSkewCandidates(stats, cs, thresholds, sessionVariable.getSkewJoinMcvSingleThreshold());
+                if (!candidates.isSkewed()) {
+                    continue;
+                }
+
+                // Pick the side with larger skew factor.
+                double score = Math.max(candidates.nullSkewFactor().orElse(0.0),
+                        candidates.mcvSkewFactor().orElse(0.0));
+                if (score <= bestScore) {
+                    continue;
+                }
+
+                List<ScalarOperator> nonNullValues = new ArrayList<>();
+                for (Pair<String, Long> p : candidates.mcvs()) {
+                    ConstantOperator keyConst = ConstantOperator.createVarchar(p.first);
+                    keyConst.castTo(skewSideKeyColumn.getType()).ifPresent(nonNullValues::add);
+                }
+                boolean includeNullSkew = candidates.includeNull();
+                if (nonNullValues.isEmpty() && !includeNullSkew) {
+                    continue;
+                }
+
+                SkewJoinSplitInfo mapped = findSkewJoinSplitInfo(joinOpt, skewSideKeyColumn, nonNullValues, includeNullSkew);
+                bestScore = score;
+                best = mapped;
+            }
+
+            return Optional.ofNullable(best);
+        }
+
+        private static class ColumnRefReplacer extends BaseScalarOperatorShuttle {
+
+            private final ColumnRefOperator targetColumnRef;
             private final ScalarOperator scalarOperator;
 
-            public ColumnRefReplacer(ScalarOperator scalarOperator) {
+            public ColumnRefReplacer(ColumnRefOperator targetColumnRef, ScalarOperator scalarOperator) {
+                this.targetColumnRef = targetColumnRef;
                 this.scalarOperator = scalarOperator;
             }
 
             @Override
             public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void context) {
-                return scalarOperator;
+                if (targetColumnRef != null && targetColumnRef.equals(variable)) {
+                    return scalarOperator;
+                }
+                return variable;
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinV2Test.java
@@ -13,9 +13,27 @@
 // limitations under the License.
 package com.starrocks.sql.plan;
 
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.FeConstants;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.statistics.Bucket;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Histogram;
+import com.starrocks.sql.optimizer.statistics.StatisticStorage;
+import com.starrocks.statistic.BasicStatsMeta;
+import com.starrocks.statistic.StatsConstants;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class SkewJoinV2Test extends PlanTestBase {
     @BeforeAll
@@ -30,11 +48,104 @@ public class SkewJoinV2Test extends PlanTestBase {
         PlanTestBase.afterClass();
     }
 
+    private static ColumnStatistic buildIntMcvColumnStat(long bucketCount, Map<String, Long> mcv, double nullFraction) {
+        List<Bucket> buckets = bucketCount <= 0 ? List.of() : List.of(new Bucket(1, 3, bucketCount, 0L));
+        Histogram hist = new Histogram(buckets, mcv);
+        return ColumnStatistic.builder()
+                .setMinValue(1)
+                .setMaxValue(100000)
+                .setNullsFraction(nullFraction)
+                .setAverageRowSize(8)
+                .setDistinctValuesCount(1000)
+                .setHistogram(hist)
+                .build();
+    }
+
+    private static class TestStatisticStorage implements StatisticStorage {
+        private final Map<Long, Map<String, ColumnStatistic>> colStats = new HashMap<>();
+        private final Map<Long, Map<String, Histogram>> histStats = new HashMap<>();
+
+        @Override
+        public ColumnStatistic getColumnStatistic(Table table, String column) {
+            Map<String, ColumnStatistic> m = colStats.get(table.getId());
+            if (m == null) {
+                return ColumnStatistic.unknown();
+            }
+            return m.getOrDefault(column, ColumnStatistic.unknown());
+        }
+
+        @Override
+        public List<ColumnStatistic> getColumnStatistics(Table table, List<String> columns) {
+            return columns.stream().map(c -> getColumnStatistic(table, c)).toList();
+        }
+
+        @Override
+        public Map<String, Histogram> getHistogramStatistics(Table table, List<String> columns) {
+            Map<String, Histogram> m = histStats.getOrDefault(table.getId(), Map.of());
+            Map<String, Histogram> out = new HashMap<>();
+            for (String c : columns) {
+                Histogram h = m.get(c);
+                if (h != null) {
+                    out.put(c, h);
+                }
+            }
+            return out;
+        }
+
+        @Override
+        public Map<Long, Optional<Long>> getTableStatistics(Long tableId, Collection<Partition> partitions) {
+            return partitions.stream().collect(java.util.stream.Collectors.toMap(
+                    Partition::getId,
+                    p -> Optional.of(p.getDefaultPhysicalPartition().getLatestBaseIndex().getRowCount())));
+        }
+
+        @Override
+        public void addColumnStatistic(Table table, String column, ColumnStatistic columnStatistic) {
+            colStats.computeIfAbsent(table.getId(), k -> new HashMap<>()).put(column, columnStatistic);
+            if (columnStatistic != null && columnStatistic.getHistogram() != null) {
+                histStats.computeIfAbsent(table.getId(), k -> new HashMap<>()).put(column, columnStatistic.getHistogram());
+            }
+        }
+    }
+
+    private void withMockedMcvStats(long t0Rows, long t1Rows, ColumnStatistic t0V1, ColumnStatistic t1V4, Runnable action) {
+        StatisticStorage old = connectContext.getGlobalStateMgr().getStatisticStorage();
+        boolean oldEnable = connectContext.getSessionVariable().isEnableStatsToOptimizeSkewJoin();
+
+        try {
+            connectContext.getGlobalStateMgr().setStatisticStorage(new TestStatisticStorage());
+            connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(true);
+
+            OlapTable t0 = getOlapTable("t0");
+            OlapTable t1 = getOlapTable("t1");
+            setTableStatistics(t0, t0Rows);
+            setTableStatistics(t1, t1Rows);
+
+            StatisticStorage storage = connectContext.getGlobalStateMgr().getStatisticStorage();
+            storage.addColumnStatistic(t0, "v1", t0V1);
+            storage.addColumnStatistic(t1, "v4", t1V4);
+
+            long dbId = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getId();
+            connectContext.getGlobalStateMgr().getAnalyzeMgr().addBasicStatsMeta(
+                    new BasicStatsMeta(dbId, t0.getId(), null, StatsConstants.AnalyzeType.FULL,
+                            java.time.LocalDateTime.now(), Maps.newHashMap(), t0Rows));
+            connectContext.getGlobalStateMgr().getAnalyzeMgr().addBasicStatsMeta(
+                    new BasicStatsMeta(dbId, t1.getId(), null, StatsConstants.AnalyzeType.FULL,
+                            java.time.LocalDateTime.now(), Maps.newHashMap(), t1Rows));
+
+            connectContext.getSessionVariable().disableJoinReorder();
+            action.run();
+        } finally {
+            connectContext.getSessionVariable().enableJoinReorder();
+            connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(oldEnable);
+            connectContext.getGlobalStateMgr().setStatisticStorage(old);
+        }
+    }
+
     @Test
     public void testSkewJoinV2WithRightSideHint1() throws Exception {
         String sql = "select v2, v5 from t0 join[skew|t1.v4(1,2)] t1 on v1 = v4 ";
         String sqlPlan = getVerboseExplain(sql);
-        System.out.println(sqlPlan);
         assertCContains(sqlPlan, "  Input Partition: RANDOM\n" +
                 "  SplitCastDataSink:\n" +
                 "  OutPut Partition: HASH_PARTITIONED: 1: v1\n" +
@@ -52,7 +163,6 @@ public class SkewJoinV2Test extends PlanTestBase {
     public void testSkewJoinV2WithRightSideHint2() throws Exception {
         String sql = "select v2, v5 from t1 join[skew|t1.v4(1,2)] t0 on v1 = v4 ";
         String sqlPlan = getVerboseExplain(sql);
-        System.out.println(sqlPlan);
         PlanTestBase.assertContains(sqlPlan, "  SplitCastDataSink:\n" +
                 "  OutPut Partition: HASH_PARTITIONED: 1: v4\n" +
                 "  OutPut Exchange Id: 02\n" +
@@ -141,23 +251,28 @@ public class SkewJoinV2Test extends PlanTestBase {
         String sql = "select v2, v5 from t0 join[skew|t0.v1(1,2)] t1 on abs(v1) = abs(v4) ";
         String sqlPlan = getVerboseExplain(sql);
         // if on predicate's input is not column from table, then split expr should use Project's output column like "7: abs"
-        assertCContains(sqlPlan, "SplitCastDataSink:\n"
-                + "  OutPut Partition: HASH_PARTITIONED: 7: abs\n"
-                + "  OutPut Exchange Id: 04\n"
-                + "  Split expr: ([7: abs, LARGEINT, true] NOT IN (1, 2)) OR ([7: abs, LARGEINT, true] IS NULL)\n"
-                + "  OutPut Partition: RANDOM\n"
-                + "  OutPut Exchange Id: 08\n"
-                + "  Split expr: [7: abs, LARGEINT, true] IN (1, 2)\n"
-                + "\n"
-                + "  1:Project\n"
-                + "  |  output columns:\n"
-                + "  |  2 <-> [2: v2, BIGINT, true]\n"
-                + "  |  7 <-> abs[([1: v1, BIGINT, true]); args: BIGINT; result: LARGEINT; args nullable: true; result "
-                + "nullable: true]\n"
-                + "  |  cardinality: 1\n"
-                + "  |  \n"
-                + "  0:OlapScanNode\n"
-                + "     table: t0, rollup: t0");
+        assertCContains(sqlPlan, "SplitCastDataSink:\n" +
+                "  OutPut Partition: HASH_PARTITIONED: 8: abs\n" +
+                "  OutPut Exchange Id: 05\n" +
+                "  Split expr: ([8: abs, LARGEINT, true] NOT IN (abs[(1); args: BIGINT; result: LARGEINT; args nullable: false;" +
+                " result nullable: true], abs[(2); args: BIGINT; result: LARGEINT; args nullable: false; result nullable: " +
+                "true])) OR ([8: abs, LARGEINT, true] IS NULL)\n" +
+                "  OutPut Partition: UNPARTITIONED\n" +
+                "  OutPut Exchange Id: 09\n" +
+                "  Split expr: [8: abs, LARGEINT, true] IN (abs[(1); args: BIGINT; result: LARGEINT; args nullable: false; " +
+                "result nullable: true], abs[(2); args: BIGINT; result: LARGEINT; args nullable: false; result nullable: " +
+                "true])\n" +
+                "\n" +
+                "  3:Project\n" +
+                "  |  output columns:\n" +
+                "  |  5 <-> [5: v5, BIGINT, true]\n" +
+                "  |  8 <-> abs[([4: v4, BIGINT, true]); args: BIGINT; result: LARGEINT; args nullable: true; result nullable:" +
+                " true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  2:OlapScanNode\n" +
+                "     table: t1, rollup: t1\n" +
+                "     preAggregation: on");
     }
 
     @Test
@@ -165,22 +280,313 @@ public class SkewJoinV2Test extends PlanTestBase {
         String sql = "select v2, v5 from t1 join[skew|t0.v1(1,2)] t0 on abs(v1) = abs(v4) ";
         String sqlPlan = getVerboseExplain(sql);
         // if on predicate's input is not column from table, then split expr should use Project's output column like "7: abs"
-        PlanTestBase.assertContains(sqlPlan, "  Input Partition: RANDOM\n" +
+        PlanTestBase.assertContains(sqlPlan, "Input Partition: RANDOM\n" +
                 "  SplitCastDataSink:\n" +
                 "  OutPut Partition: HASH_PARTITIONED: 8: abs\n" +
                 "  OutPut Exchange Id: 05\n" +
-                "  Split expr: ([8: abs, LARGEINT, true] NOT IN (1, 2)) OR ([8: abs, LARGEINT, true] IS NULL)\n" +
+                "  Split expr: ([8: abs, LARGEINT, true] NOT IN (abs[(1); args: BIGINT; result: LARGEINT; args nullable: false;" +
+                " result nullable: true], abs[(2); args: BIGINT; result: LARGEINT; args nullable: false; result nullable: " +
+                "true])) OR ([8: abs, LARGEINT, true] IS NULL)\n" +
                 "  OutPut Partition: UNPARTITIONED\n" +
                 "  OutPut Exchange Id: 09\n" +
-                "  Split expr: [8: abs, LARGEINT, true] IN (1, 2)");
-        PlanTestBase.assertContains(sqlPlan, "  Input Partition: RANDOM\n" +
+                "  Split expr: [8: abs, LARGEINT, true] IN (abs[(1); args: BIGINT; result: LARGEINT; args nullable: false; " +
+                "result nullable: true], abs[(2); args: BIGINT; result: LARGEINT; args nullable: false; result nullable: " +
+                "true])");
+        PlanTestBase.assertContains(sqlPlan, "Input Partition: RANDOM\n" +
                 "  SplitCastDataSink:\n" +
                 "  OutPut Partition: HASH_PARTITIONED: 7: abs\n" +
                 "  OutPut Exchange Id: 04\n" +
-                "  Split expr: ([7: abs, LARGEINT, true] NOT IN (1, 2)) OR ([7: abs, LARGEINT, true] IS NULL)\n" +
+                "  Split expr: ([7: abs, LARGEINT, true] NOT IN (abs[(1); args: BIGINT; result: LARGEINT; args nullable: " +
+                "false; result nullable: true], abs[(2); args: BIGINT; result: LARGEINT; args nullable: false; result nullable:" +
+                " true])) OR ([7: abs, LARGEINT, true] IS NULL)\n" +
                 "  OutPut Partition: RANDOM\n" +
                 "  OutPut Exchange Id: 08\n" +
-                "  Split expr: [7: abs, LARGEINT, true] IN (1, 2)");
+                "  Split expr: [7: abs, LARGEINT, true] IN (abs[(1); args: BIGINT; result: LARGEINT; args nullable: false; " +
+                "result nullable: true], abs[(2); args: BIGINT; result: LARGEINT; args nullable: false; result nullable: true])");
+    }
+
+    @Test
+    public void testSkewJoinV2WithNullSkewHintOnly() throws Exception {
+        // Hint: only NULL is skew.
+        // Expected split (conceptually):
+        // - skew branch: k IS NULL
+        // - non-skew branch: k IS NOT NULL
+        String sql = "select v2, v5 from t0 join[skew|t0.v1(null)] t1 on v1 = v4 ";
+        String plan = getVerboseExplain(sql);
+        assertCContains(plan, "SplitCastDataSink:\n" +
+                "  OutPut Partition: HASH_PARTITIONED: 1: v1\n" +
+                "  OutPut Exchange Id: 02\n" +
+                "  Split expr: [1: v1, BIGINT, true] IS NOT NULL\n" +
+                "  OutPut Partition: RANDOM\n" +
+                "  OutPut Exchange Id: 06\n" +
+                "  Split expr: [1: v1, BIGINT, true] IS NULL");
+        assertCContains(plan, "SplitCastDataSink:\n" +
+                "  OutPut Partition: HASH_PARTITIONED: 4: v4\n" +
+                "  OutPut Exchange Id: 03\n" +
+                "  Split expr: [4: v4, BIGINT, true] IS NOT NULL\n" +
+                "  OutPut Partition: UNPARTITIONED\n" +
+                "  OutPut Exchange Id: 07\n" +
+                "  Split expr: [4: v4, BIGINT, true] IS NULL");
+    }
+
+    @Test
+    public void testSkewJoinV2WithNullAndNonNullSkewHint() throws Exception {
+        // Hint: both {1,2} and NULL are skew.
+        // Expected split (conceptually):
+        // - skew branch: k IN (1,2) OR k IS NULL
+        // - non-skew branch: k NOT IN (1,2) AND k IS NOT NULL
+        String sql = "select v2, v5 from t0 join[skew|t0.v1(1,2,null)] t1 on v1 = v4 ";
+        String plan = getVerboseExplain(sql);
+        assertCContains(plan, "SplitCastDataSink:\n" +
+                "  OutPut Partition: HASH_PARTITIONED: 1: v1\n" +
+                "  OutPut Exchange Id: 02\n" +
+                "  Split expr: ([1: v1, BIGINT, true] NOT IN (1, 2)) AND ([1: v1, BIGINT, true] IS NOT NULL)\n" +
+                "  OutPut Partition: RANDOM\n" +
+                "  OutPut Exchange Id: 06\n" +
+                "  Split expr: ([1: v1, BIGINT, true] IN (1, 2)) OR ([1: v1, BIGINT, true] IS NULL)");
+        assertCContains(plan, "SplitCastDataSink:\n" +
+                "  OutPut Partition: HASH_PARTITIONED: 4: v4\n" +
+                "  OutPut Exchange Id: 03\n" +
+                "  Split expr: ([4: v4, BIGINT, true] NOT IN (1, 2)) AND ([4: v4, BIGINT, true] IS NOT NULL)\n" +
+                "  OutPut Partition: UNPARTITIONED\n" +
+                "  OutPut Exchange Id: 07\n" +
+                "  Split expr: ([4: v4, BIGINT, true] IN (1, 2)) OR ([4: v4, BIGINT, true] IS NULL)");
+    }
+
+    @Test
+    public void testSkewJoinV2LeftOuterJoinWithRightSideHintShouldNotRewrite() throws Exception {
+        // For LEFT OUTER JOIN, right-side skew rewrite is forbidden.
+        String sql = "select v2, v5 from t0 left join[skew|t1.v4(1,2)] t1 on v1 = v4 ";
+        String plan = getVerboseExplain(sql);
+        assertNotContains(plan, "SplitCastDataSink:");
+        assertNotContains(plan, "Split expr:");
+    }
+
+    @Test
+    public void testSkewJoinV2AutoDetectFromMcvBasic() {
+        Map<String, Long> mcv = Map.of("1", 6_000_000L, "2", 4_000_000L);
+        ColumnStatistic t0V1 = buildIntMcvColumnStat(0, mcv, 0.0);
+        ColumnStatistic t1V4 = buildIntMcvColumnStat(0, mcv, 0.0);
+
+        FeConstants.runningUnitTest = true;
+        withMockedMcvStats(20_000_000L, 20_000_000L, t0V1, t1V4, () -> {
+            try {
+                String sql = "select v2, v5 from t0 join[shuffle] t1 on v1 = v4";
+                String plan = getVerboseExplain(sql);
+                assertCContains(plan, "SplitCastDataSink:\n" +
+                        "  OutPut Partition: HASH_PARTITIONED: 1: v1\n" +
+                        "  OutPut Exchange Id: 02\n" +
+                        "  Split expr: ([1: v1, BIGINT, true] NOT IN (1, 2)) OR ([1: v1, BIGINT, true] IS NULL)\n" +
+                        "  OutPut Partition: RANDOM\n" +
+                        "  OutPut Exchange Id: 06\n" +
+                        "  Split expr: [1: v1, BIGINT, true] IN (1, 2)");
+                assertCContains(plan, "SplitCastDataSink:\n" +
+                        "  OutPut Partition: HASH_PARTITIONED: 4: v4\n" +
+                        "  OutPut Exchange Id: 03\n" +
+                        "  Split expr: ([4: v4, BIGINT, true] NOT IN (1, 2)) OR ([4: v4, BIGINT, true] IS NULL)\n" +
+                        "  OutPut Partition: UNPARTITIONED\n" +
+                        "  OutPut Exchange Id: 07\n" +
+                        "  Split expr: [4: v4, BIGINT, true] IN (1, 2)");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void testSkewJoinV2AutoDetectNotTriggeredWhenBelowThresholdBasic() {
+        // Auto-detect should NOT trigger when MCV skew is not strong enough.
+        FeConstants.runningUnitTest = true;
+        Map<String, Long> mcv = Map.of("1", 2_000L, "2", 2_000L, "3", 2_000L);
+        ColumnStatistic t0V1 = buildIntMcvColumnStat(100_000_000L, mcv, 0.0);
+        ColumnStatistic t1V4 = buildIntMcvColumnStat(100_000_000L, mcv, 0.0);
+
+        withMockedMcvStats(20_000_000L, 20_000_000L, t0V1, t1V4, () -> {
+            try {
+                String sql = "select v2, v5 from t0 join[shuffle] t1 on v1 = v4";
+                String plan = getVerboseExplain(sql);
+                assertNotContains(plan, "SplitCastDataSink:");
+                assertNotContains(plan, "Split expr:");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void testSkewJoinV2AutoDetectPrefersRightSideWhenMoreSkewedBasic() {
+        FeConstants.runningUnitTest = true;
+        Map<String, Long> leftMcv = Map.of("1", 2_000L, "2", 2_000L); // not skew
+        Map<String, Long> rightMcv = Map.of("1", 12_000_000L, "2", 8_000_000L); // heavily skewed
+        ColumnStatistic t0V1 = buildIntMcvColumnStat(0, leftMcv, 0.0);
+        ColumnStatistic t1V4 = buildIntMcvColumnStat(0, rightMcv, 0.0);
+
+        withMockedMcvStats(20_000_000L, 20_000_000L, t0V1, t1V4, () -> {
+            try {
+                String sql = "select v2, v5 from t0 join[shuffle] t1 on v1 = v4";
+                String plan = getVerboseExplain(sql);
+                assertCContains(plan, "SplitCastDataSink:\n" +
+                        "  OutPut Partition: HASH_PARTITIONED: 4: v4\n" +
+                        "  OutPut Exchange Id: 02\n" +
+                        "  Split expr: ([4: v4, BIGINT, true] NOT IN (1, 2)) OR ([4: v4, BIGINT, true] IS NULL)\n" +
+                        "  OutPut Partition: RANDOM\n" +
+                        "  OutPut Exchange Id: 06\n" +
+                        "  Split expr: [4: v4, BIGINT, true] IN (1, 2)");
+                assertCContains(plan, "SplitCastDataSink:\n" +
+                        "  OutPut Partition: HASH_PARTITIONED: 1: v1\n" +
+                        "  OutPut Exchange Id: 03\n" +
+                        "  Split expr: ([1: v1, BIGINT, true] NOT IN (1, 2)) OR ([1: v1, BIGINT, true] IS NULL)\n" +
+                        "  OutPut Partition: UNPARTITIONED\n" +
+                        "  OutPut Exchange Id: 07\n" +
+                        "  Split expr: [1: v1, BIGINT, true] IN (1, 2)");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void testSkewJoinV2AutoDetectNotTriggeredWhenBelowMinInputRows_basic() {
+        FeConstants.runningUnitTest = true;
+        Map<String, Long> mcv = Map.of("1", 10_000L, "2", 10_000L);
+        ColumnStatistic t0V1 = buildIntMcvColumnStat(0, mcv, 0.0);
+        ColumnStatistic t1V4 = buildIntMcvColumnStat(0, mcv, 0.0);
+
+        withMockedMcvStats(5_000L, 5_000L, t0V1, t1V4, () -> {
+            try {
+                String sql = "select v2, v5 from t0 join[shuffle] t1 on v1 = v4";
+                String plan = getVerboseExplain(sql);
+                assertNotContains(plan, "SplitCastDataSink:");
+                assertNotContains(plan, "Split expr:");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void testSkewJoinV2AutoDetectNullSkewOnlyNotTriggeredForInnerJoin() {
+        FeConstants.runningUnitTest = true;
+        ColumnStatistic t0V1 = buildIntMcvColumnStat(0, Map.of(), 0.9);
+        ColumnStatistic t1V4 = buildIntMcvColumnStat(0, Map.of(), 0.0);
+
+        withMockedMcvStats(20_000_000L, 20_000_000L, t0V1, t1V4, () -> {
+            try {
+                String sql = "select v2, v5 from t0 join[shuffle] t1 on v1 = v4";
+                String plan = getVerboseExplain(sql);
+                assertNotContains(plan, "SplitCastDataSink:");
+                assertNotContains(plan, "Split expr:");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void testSkewJoinV2AutoDetectNullSkewForLeftOuterJoinBasic() {
+        FeConstants.runningUnitTest = true;
+        // For LEFT OUTER JOIN, NULLs on the left join key are preserved (as non-matching rows) and can be skewed.
+        ColumnStatistic t0V1 = buildIntMcvColumnStat(0, Map.of(), 0.9);
+        ColumnStatistic t1V4 = buildIntMcvColumnStat(0, Map.of(), 0.3);
+
+        withMockedMcvStats(20_000_000L, 20_000_000L, t0V1, t1V4, () -> {
+            try {
+                String sql = "select v2, v5 from t0 left join[shuffle] t1 on v1 = v4";
+                String plan = getVerboseExplain(sql);
+                assertCContains(plan, "SplitCastDataSink:\n" +
+                        "  OutPut Partition: HASH_PARTITIONED: 1: v1\n" +
+                        "  OutPut Exchange Id: 02\n" +
+                        "  Split expr: [1: v1, BIGINT, true] IS NOT NULL\n" +
+                        "  OutPut Partition: RANDOM\n" +
+                        "  OutPut Exchange Id: 06\n" +
+                        "  Split expr: [1: v1, BIGINT, true] IS NULL");
+                assertCContains(plan, "SplitCastDataSink:\n" +
+                        "  OutPut Partition: HASH_PARTITIONED: 4: v4\n" +
+                        "  OutPut Exchange Id: 03\n" +
+                        "  Split expr: [4: v4, BIGINT, true] IS NOT NULL\n" +
+                        "  OutPut Partition: UNPARTITIONED\n" +
+                        "  OutPut Exchange Id: 07\n" +
+                        "  Split expr: [4: v4, BIGINT, true] IS NULL");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void testSkewJoinV2AutoDetectMcvAndNullSkewForLeftOuterJoinBasic() {
+        FeConstants.runningUnitTest = true;
+        Map<String, Long> mcv = Map.of("1", 12_000_000L, "2", 8_000_000L);
+        ColumnStatistic t0V1 = buildIntMcvColumnStat(0, mcv, 0.9);
+        ColumnStatistic t1V4 = buildIntMcvColumnStat(0, Map.of(), 0.0);
+
+        withMockedMcvStats(20_000_000L, 20_000_000L, t0V1, t1V4, () -> {
+            try {
+                String sql = "select v2, v5 from t0 left join[shuffle] t1 on v1 = v4";
+                String plan = getVerboseExplain(sql);
+                assertCContains(plan, "SplitCastDataSink:\n" +
+                        "  OutPut Partition: HASH_PARTITIONED: 1: v1\n" +
+                        "  OutPut Exchange Id: 02\n" +
+                        "  Split expr: ([1: v1, BIGINT, true] NOT IN (1, 2)) AND ([1: v1, BIGINT, true] IS NOT NULL)\n" +
+                        "  OutPut Partition: RANDOM\n" +
+                        "  OutPut Exchange Id: 06\n" +
+                        "  Split expr: ([1: v1, BIGINT, true] IN (1, 2)) OR ([1: v1, BIGINT, true] IS NULL)");
+                assertCContains(plan, "SplitCastDataSink:\n" +
+                        "  OutPut Partition: HASH_PARTITIONED: 4: v4\n" +
+                        "  OutPut Exchange Id: 03\n" +
+                        "  Split expr: ([4: v4, BIGINT, true] NOT IN (1, 2)) AND ([4: v4, BIGINT, true] IS NOT NULL)\n" +
+                        "  OutPut Partition: UNPARTITIONED\n" +
+                        "  OutPut Exchange Id: 07\n" +
+                        "  Split expr: ([4: v4, BIGINT, true] IN (1, 2)) OR ([4: v4, BIGINT, true] IS NULL)");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void testSkewJoinV2AutoDetectWithExpressionJoinKey_basic() {
+        // Auto-detect with expression join key should propagate skew values through expressions.
+        // Example: k2 = cast(v1 as bigint) + 10 => skew values (1,2) become (11,12).
+        Map<String, Long> baseMcv = Map.of("1", 6_000_000L, "2", 4_000_000L);
+        ColumnStatistic t0V1 = buildIntMcvColumnStat(0, baseMcv, 0.0);
+        ColumnStatistic t1V4 = buildIntMcvColumnStat(0, baseMcv, 0.0);
+
+        FeConstants.runningUnitTest = true;
+        withMockedMcvStats(20_000_000L, 20_000_000L, t0V1, t1V4, () -> {
+            try {
+                String sql = "with l as (select (cast(v1 as bigint) + 10) as k2, v2 from t0) "
+                        + ", r as (select (cast(v4 as bigint) + 10) as k2, v5 from t1) "
+                        + "select v2, v5 from l join[shuffle] r on l.k2 = r.k2";
+                String plan = getVerboseExplain(sql);
+                assertCContains(plan, "Input Partition: RANDOM\n" +
+                        "  SplitCastDataSink:\n" +
+                        "  OutPut Partition: HASH_PARTITIONED: 4: expr\n" +
+                        "  OutPut Exchange Id: 04\n" +
+                        "  Split expr: ([4: expr, BIGINT, true] NOT IN (11, 12)) OR ([4: expr, BIGINT, true] IS NULL)\n" +
+                        "  OutPut Partition: RANDOM\n" +
+                        "  OutPut Exchange Id: 08\n" +
+                        "  Split expr: [4: expr, BIGINT, true] IN (11, 12)");
+                assertCContains(plan, "Input Partition: RANDOM\n" +
+                        "  SplitCastDataSink:\n" +
+                        "  OutPut Partition: HASH_PARTITIONED: 8: expr\n" +
+                        "  OutPut Exchange Id: 05\n" +
+                        "  Split expr: ([8: expr, BIGINT, true] NOT IN (11, 12)) OR ([8: expr, BIGINT, true] IS NULL)\n" +
+                        "  OutPut Partition: UNPARTITIONED\n" +
+                        "  OutPut Exchange Id: 09\n" +
+                        "  Split expr: [8: expr, BIGINT, true] IN (11, 12)");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        FeConstants.runningUnitTest = false;
     }
 
     @Test

--- a/test/sql/test_join/R/test_skew_join_v2
+++ b/test/sql/test_join/R/test_skew_join_v2
@@ -714,6 +714,26 @@ truncate table t1;
 truncate table t2;
 -- result:
 -- !result
+insert into t1(c_key, c_bigint) values (1, null), (2, 1), (3, 2), (4, -1);
+-- result:
+-- !result
+insert into t2(c_key, c_int) values (1, 1), (2, 2), (3, 3);
+-- result:
+-- !result
+function: assert_explain_contains("select count(*) from t1 left join [skew|t1.c_bigint(1,2,null)] t2 on abs(t1.c_bigint)=abs(t2.c_int)", "SplitCastDataSink", "IN (abs[(1)", "IN (")
+-- result:
+None
+-- !result
+function: assert_explain_contains("select count(*) from t1 left join [skew|t1.c_bigint(null)] t2 on abs(t1.c_bigint)=abs(t2.c_int)", "SplitCastDataSink")
+-- result:
+None
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
 insert into t1(c_key, c_string) values (1, "1"), (2, "1"), (3, "1"), (4, "1234567"), (5, "1234567"), (6, "3");
 -- result:
 -- !result
@@ -1172,6 +1192,252 @@ select count(1) from skew_t1 as t1 left join [skew|t1.c_bigint(1,2,99999)] t2 on
 select count(1) from skew_t1 as t1 left join [skew|t1.c_bigint(1,2,99999)] t2 on t1.c_string=t2.c_string;
 -- result:
 16380
+-- !result
+drop table if exists t_mcv_l;
+-- result:
+-- !result
+drop table if exists t_mcv_r;
+-- result:
+-- !result
+create table t_mcv_l (
+    k bigint null,
+    v int null
+)
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+-- result:
+-- !result
+create table t_mcv_r (
+    k bigint null,
+    v int null
+)
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+-- result:
+-- !result
+set enable_stats_to_optimize_skew_join = true;
+-- result:
+-- !result
+set skew_join_use_mcv_count = 5;
+-- result:
+-- !result
+set skew_join_data_skew_threshold = 0.1;
+-- result:
+-- !result
+set skew_join_mcv_single_threshold = 0.05;
+-- result:
+-- !result
+set skew_join_mcv_min_input_rows = 1000;
+-- result:
+-- !result
+set broadcast_row_limit = 0;
+-- result:
+-- !result
+insert into t_mcv_l select 1, 1 from table(generate_series(1, 5000));
+-- result:
+-- !result
+insert into t_mcv_l select 2, 1 from table(generate_series(1, 2500));
+-- result:
+-- !result
+insert into t_mcv_l select generate_series + 2, 1 from table(generate_series(1, 2500));
+-- result:
+-- !result
+insert into t_mcv_r select (generate_series % 2502) + 1, 1 from table(generate_series(1, 20000));
+-- result:
+-- !result
+[UC] analyze full table t_mcv_l;
+-- result:
+test_db_5f945d55a63b4408a30c60ccc09dd5c1.t_mcv_l	analyze	status	OK
+-- !result
+[UC] analyze full table t_mcv_r;
+-- result:
+test_db_5f945d55a63b4408a30c60ccc09dd5c1.t_mcv_r	analyze	status	OK
+-- !result
+[UC] analyze table t_mcv_l update histogram on k properties('histogram_sample_ratio' = '1.0', 'histogram_mcv_size' = '20');
+-- result:
+test_db_5f945d55a63b4408a30c60ccc09dd5c1.t_mcv_l	histogram	status	OK
+-- !result
+[UC] analyze table t_mcv_r update histogram on k properties('histogram_sample_ratio' = '1.0', 'histogram_mcv_size' = '20');
+-- result:
+test_db_5f945d55a63b4408a30c60ccc09dd5c1.t_mcv_r	histogram	status	OK
+-- !result
+function: assert_explain_contains("select count(*) from t_mcv_l join[shuffle] t_mcv_r on t_mcv_l.k = t_mcv_r.k", "SplitCastDataSink")
+-- result:
+None
+-- !result
+function: assert_explain_contains("select count(*) from t_mcv_l join[shuffle] t_mcv_r on t_mcv_l.k = t_mcv_r.k", "IN (1, 2)")
+-- result:
+None
+-- !result
+function: assert_explain_contains("with l as (select (cast(k as bigint) + 10) as k2, v from t_mcv_l), r as (select (cast(k as bigint) + 10) as k2, v from t_mcv_r) select count(*) from l join[shuffle] r on l.k2 = r.k2", "SplitCastDataSink", "IN (11, 12)")
+-- result:
+None
+-- !result
+set skew_join_data_skew_threshold = 0.9;
+-- result:
+-- !result
+function: assert_explain_not_contains("select count(*) from t_mcv_l join[shuffle] t_mcv_r on t_mcv_l.k = t_mcv_r.k", "SplitCastDataSink")
+-- result:
+None
+-- !result
+set skew_join_data_skew_threshold = 0.1;
+-- result:
+-- !result
+set skew_join_mcv_single_threshold = 0.3;
+-- result:
+-- !result
+function: assert_explain_contains("select count(*) from t_mcv_l join[shuffle] t_mcv_r on t_mcv_l.k = t_mcv_r.k", "SplitCastDataSink", "IN (1)")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains("select count(*) from t_mcv_l join[shuffle] t_mcv_r on t_mcv_l.k = t_mcv_r.k", "IN (1, 2)")
+-- result:
+None
+-- !result
+set skew_join_mcv_single_threshold = 0.05;
+-- result:
+-- !result
+set skew_join_mcv_min_input_rows = 20000;
+-- result:
+-- !result
+function: assert_explain_not_contains("select count(*) from t_mcv_l join[shuffle] t_mcv_r on t_mcv_l.k = t_mcv_r.k", "SplitCastDataSink")
+-- result:
+None
+-- !result
+set skew_join_mcv_min_input_rows = 1000;
+-- result:
+-- !result
+drop table if exists t_mcv_l2;
+-- result:
+-- !result
+drop table if exists t_mcv_r2;
+-- result:
+-- !result
+create table t_mcv_l2 (
+    k bigint null,
+    v int null
+)
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+-- result:
+-- !result
+create table t_mcv_r2 (
+    k bigint null,
+    v int null
+)
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+-- result:
+-- !result
+insert into t_mcv_l2 select generate_series, 1 from table(generate_series(1, 10000));
+-- result:
+-- !result
+insert into t_mcv_r2 select 1, 1 from table(generate_series(1, 8000));
+-- result:
+-- !result
+insert into t_mcv_r2 select 2, 1 from table(generate_series(1, 4000));
+-- result:
+-- !result
+insert into t_mcv_r2 select generate_series + 2, 1 from table(generate_series(1, 8000));
+-- result:
+-- !result
+[UC] analyze full table t_mcv_l2;
+-- result:
+test_db_5f945d55a63b4408a30c60ccc09dd5c1.t_mcv_l2	analyze	status	OK
+-- !result
+[UC] analyze full table t_mcv_r2;
+-- result:
+test_db_5f945d55a63b4408a30c60ccc09dd5c1.t_mcv_r2	analyze	status	OK
+-- !result
+[UC] analyze table t_mcv_r2 update histogram on k properties('histogram_sample_ratio' = '1.0', 'histogram_mcv_size' = '20');
+-- result:
+test_db_5f945d55a63b4408a30c60ccc09dd5c1.t_mcv_r2	histogram	status	OK
+-- !result
+function: assert_explain_contains("select count(*) from t_mcv_l2 join[shuffle] t_mcv_r2 on t_mcv_l2.k = t_mcv_r2.k", "SplitCastDataSink", "IN (1, 2)")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains("select count(*) from t_mcv_l2 left join[shuffle] t_mcv_r2 on t_mcv_l2.k = t_mcv_r2.k", "SplitCastDataSink")
+-- result:
+None
+-- !result
+drop table t_mcv_l2;
+-- result:
+-- !result
+drop table t_mcv_r2;
+-- result:
+-- !result
+drop table if exists t_null_l;
+-- result:
+-- !result
+drop table if exists t_null_r;
+-- result:
+-- !result
+create table t_null_l (
+    k bigint null,
+    v int null
+)
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+-- result:
+-- !result
+create table t_null_r (
+    k bigint null,
+    v int null
+)
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+-- result:
+-- !result
+insert into t_null_l select null, 1 from table(generate_series(1, 7000));
+-- result:
+-- !result
+insert into t_null_l select 1, 1 from table(generate_series(1, 2000));
+-- result:
+-- !result
+insert into t_null_l select 2, 1 from table(generate_series(1, 1000));
+-- result:
+-- !result
+insert into t_null_r select (generate_series % 2000) + 1, 1 from table(generate_series(1, 10000));
+-- result:
+-- !result
+[UC] analyze full table t_null_l;
+-- result:
+test_db_5f945d55a63b4408a30c60ccc09dd5c1.t_null_l	analyze	status	OK
+-- !result
+[UC] analyze full table t_null_r;
+-- result:
+test_db_5f945d55a63b4408a30c60ccc09dd5c1.t_null_r	analyze	status	OK
+-- !result
+[UC] analyze table t_null_l update histogram on k properties('histogram_sample_ratio' = '1.0', 'histogram_mcv_size' = '20');
+-- result:
+test_db_5f945d55a63b4408a30c60ccc09dd5c1.t_null_l	histogram	status	OK
+-- !result
+[UC] analyze table t_null_r update histogram on k properties('histogram_sample_ratio' = '1.0', 'histogram_mcv_size' = '20');
+-- result:
+test_db_5f945d55a63b4408a30c60ccc09dd5c1.t_null_r	histogram	status	OK
+-- !result
+function: assert_explain_contains("select count(*) from t_null_l left join[shuffle] t_null_r on t_null_l.k = t_null_r.k", "SplitCastDataSink", "([1: k, BIGINT, true] IN (1, 2)) OR ([1: k, BIGINT, true] IS NULL)")
+-- result:
+None
+-- !result
+drop table t_null_l;
+-- result:
+-- !result
+drop table t_null_r;
+-- result:
+-- !result
+drop table t_mcv_l;
+-- result:
+-- !result
+drop table t_mcv_r;
+-- result:
 -- !result
 drop table skew_t1;
 -- result:

--- a/test/sql/test_join/T/test_skew_join_v2
+++ b/test/sql/test_join/T/test_skew_join_v2
@@ -183,6 +183,21 @@ select t1.c_key, t2.c_key from t2 join [skew|t2.c_int(1,2,99999)] t1 on abs(t2.c
 select t1.c_key, t2.c_key from t2 join [skew|t2.c_int(1,2,99999)] t1 on t1.c_key = t2.c_key and abs(t2.c_int) = abs(t1.c_bigint) order by t1.c_key, t2.c_key;
 select t1.c_key, t2.c_key from t1 join [skew|t2.c_int(1,2,99999)] t2 on t1.c_key = t2.c_key and abs(t1.c_bigint) = abs(t2.c_int) order by t1.c_key, t2.c_key;
 
+-- ----------------------------------------------------------------
+-- Manual skew hint with expression join key + NULL skew (LEFT OUTER JOIN)
+-- NOTE: Use LEFT OUTER JOIN because NULL skew is meaningful there.
+-- ----------------------------------------------------------------
+truncate table t1;
+truncate table t2;
+insert into t1(c_key, c_bigint) values (1, null), (2, 1), (3, 2), (4, -1);
+insert into t2(c_key, c_int) values (1, 1), (2, 2), (3, 3);
+
+-- Mixed skew values + NULL skew: expect IN(...) OR IS NULL / NOT IN(...) AND IS NOT NULL.
+function: assert_explain_contains("select count(*) from t1 left join [skew|t1.c_bigint(1,2,null)] t2 on abs(t1.c_bigint)=abs(t2.c_int)", "SplitCastDataSink", "IN (abs[(1)", "IN (")
+
+-- NULL-only skew: expect IS NULL / IS NOT NULL split without relying on IN-list.
+function: assert_explain_contains("select count(*) from t1 left join [skew|t1.c_bigint(null)] t2 on abs(t1.c_bigint)=abs(t2.c_int)", "SplitCastDataSink")
+
 -- type not match
 truncate table t1;
 truncate table t2;
@@ -313,6 +328,163 @@ select count(1) from skew_t1 as t1 left join [skew|t1.c_bigint(1,2,99999)] t2 on
 select count(1) from skew_t1 as t1 left join [skew|t1.c_bigint(1,2,99999)] t2 on t1.c_date=t2.c_date;
 select count(1) from skew_t1 as t1 left join [skew|t1.c_bigint(1,2,99999)] t2 on t1.c_datetime=t2.c_datetime;
 select count(1) from skew_t1 as t1 left join [skew|t1.c_bigint(1,2,99999)] t2 on t1.c_string=t2.c_string;
+
+-- ----------------------------------------------------------------
+-- MCV-based auto detection for skew join v2
+-- ----------------------------------------------------------------
+drop table if exists t_mcv_l;
+drop table if exists t_mcv_r;
+
+create table t_mcv_l (
+    k bigint null,
+    v int null
+)
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+
+create table t_mcv_r (
+    k bigint null,
+    v int null
+)
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+
+set enable_stats_to_optimize_skew_join = true;
+set skew_join_use_mcv_count = 5;
+set skew_join_data_skew_threshold = 0.1;
+set skew_join_mcv_single_threshold = 0.05;
+set skew_join_mcv_min_input_rows = 1000;
+set broadcast_row_limit = 0;
+
+-- Build a left table with strong MCVs on k: 1 (5000 rows), 2 (2500 rows)
+insert into t_mcv_l select 1, 1 from table(generate_series(1, 5000));
+insert into t_mcv_l select 2, 1 from table(generate_series(1, 2500));
+insert into t_mcv_l select generate_series + 2, 1 from table(generate_series(1, 2500));
+
+-- Right table has keys in [1..2502] with near-uniform distribution.
+insert into t_mcv_r select (generate_series % 2502) + 1, 1 from table(generate_series(1, 20000));
+
+-- Collect basic stats + histogram(MCV) for join key.
+[UC] analyze full table t_mcv_l;
+[UC] analyze full table t_mcv_r;
+[UC] analyze table t_mcv_l update histogram on k properties('histogram_sample_ratio' = '1.0', 'histogram_mcv_size' = '20');
+[UC] analyze table t_mcv_r update histogram on k properties('histogram_sample_ratio' = '1.0', 'histogram_mcv_size' = '20');
+
+-- Plan check: should auto-detect skew values from MCV and apply v2 skew join rewrite.
+function: assert_explain_contains("select count(*) from t_mcv_l join[shuffle] t_mcv_r on t_mcv_l.k = t_mcv_r.k", "SplitCastDataSink")
+function: assert_explain_contains("select count(*) from t_mcv_l join[shuffle] t_mcv_r on t_mcv_l.k = t_mcv_r.k", "IN (1, 2)")
+
+-- Expression join key (MCV propagation through expression stats): (k + 10) => IN (11, 12)
+function: assert_explain_contains("with l as (select (cast(k as bigint) + 10) as k2, v from t_mcv_l), r as (select (cast(k as bigint) + 10) as k2, v from t_mcv_r) select count(*) from l join[shuffle] r on l.k2 = r.k2", "SplitCastDataSink", "IN (11, 12)")
+
+-- 2) Make skew threshold too high => no rewrite
+set skew_join_data_skew_threshold = 0.9;
+function: assert_explain_not_contains("select count(*) from t_mcv_l join[shuffle] t_mcv_r on t_mcv_l.k = t_mcv_r.k", "SplitCastDataSink")
+set skew_join_data_skew_threshold = 0.1;
+
+-- 3) Per-value threshold filters MCV candidates (keep only the strongest)
+-- Here k=1 accounts for ~50% of rows, k=2 accounts for ~25%.
+set skew_join_mcv_single_threshold = 0.3;
+function: assert_explain_contains("select count(*) from t_mcv_l join[shuffle] t_mcv_r on t_mcv_l.k = t_mcv_r.k", "SplitCastDataSink", "IN (1)")
+function: assert_explain_not_contains("select count(*) from t_mcv_l join[shuffle] t_mcv_r on t_mcv_l.k = t_mcv_r.k", "IN (1, 2)")
+set skew_join_mcv_single_threshold = 0.05;
+
+-- 4) Minimal input rows gating => no rewrite
+set skew_join_mcv_min_input_rows = 20000;
+function: assert_explain_not_contains("select count(*) from t_mcv_l join[shuffle] t_mcv_r on t_mcv_l.k = t_mcv_r.k", "SplitCastDataSink")
+set skew_join_mcv_min_input_rows = 1000;
+
+-- ----------------------------------------------------------------
+-- Auto detection chooses right side as skew side (INNER JOIN)
+-- ----------------------------------------------------------------
+drop table if exists t_mcv_l2;
+drop table if exists t_mcv_r2;
+
+create table t_mcv_l2 (
+    k bigint null,
+    v int null
+)
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+
+create table t_mcv_r2 (
+    k bigint null,
+    v int null
+)
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+
+-- Left table: near-uniform keys 1..10000
+insert into t_mcv_l2 select generate_series, 1 from table(generate_series(1, 10000));
+-- Right table: strong MCVs 1/2 plus others
+insert into t_mcv_r2 select 1, 1 from table(generate_series(1, 8000));
+insert into t_mcv_r2 select 2, 1 from table(generate_series(1, 4000));
+insert into t_mcv_r2 select generate_series + 2, 1 from table(generate_series(1, 8000));
+
+[UC] analyze full table t_mcv_l2;
+[UC] analyze full table t_mcv_r2;
+-- Only collect histogram on right key, so left side is not eligible in stats auto detection.
+[UC] analyze table t_mcv_r2 update histogram on k properties('histogram_sample_ratio' = '1.0', 'histogram_mcv_size' = '20');
+
+function: assert_explain_contains("select count(*) from t_mcv_l2 join[shuffle] t_mcv_r2 on t_mcv_l2.k = t_mcv_r2.k", "SplitCastDataSink", "IN (1, 2)")
+
+-- LEFT OUTER JOIN forbids right-side skew rewrite => should not rewrite
+function: assert_explain_not_contains("select count(*) from t_mcv_l2 left join[shuffle] t_mcv_r2 on t_mcv_l2.k = t_mcv_r2.k", "SplitCastDataSink")
+
+drop table t_mcv_l2;
+drop table t_mcv_r2;
+
+-- ----------------------------------------------------------------
+-- NULL skew and (MCV + NULL) skew for LEFT OUTER JOIN (stats-based)
+-- ----------------------------------------------------------------
+drop table if exists t_null_l;
+drop table if exists t_null_r;
+
+create table t_null_l (
+    k bigint null,
+    v int null
+)
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+
+create table t_null_r (
+    k bigint null,
+    v int null
+)
+duplicate key(k)
+distributed by hash(k) buckets 1
+properties("replication_num"="1");
+
+-- Left table: many NULLs + skewed non-NULL values (1/2)
+-- Make both NULL skew and MCV skew trigger under:
+--   skew_join_data_skew_threshold = 0.1
+--   skew_join_mcv_single_threshold = 0.05
+-- Distribution (total 10000): NULL=7000 (70%), 1=2000 (20%), 2=1000 (10%)
+insert into t_null_l select null, 1 from table(generate_series(1, 7000));
+insert into t_null_l select 1, 1 from table(generate_series(1, 2000));
+insert into t_null_l select 2, 1 from table(generate_series(1, 1000));
+-- Right table: some keys, mostly non-NULL
+insert into t_null_r select (generate_series % 2000) + 1, 1 from table(generate_series(1, 10000));
+
+[UC] analyze full table t_null_l;
+[UC] analyze full table t_null_r;
+[UC] analyze table t_null_l update histogram on k properties('histogram_sample_ratio' = '1.0', 'histogram_mcv_size' = '20');
+[UC] analyze table t_null_r update histogram on k properties('histogram_sample_ratio' = '1.0', 'histogram_mcv_size' = '20');
+
+-- Expect split predicates to include NULL handling in LOJ (IS NULL / IS NOT NULL),
+-- and may include IN-list if MCV candidates are also selected.
+function: assert_explain_contains("select count(*) from t_null_l left join[shuffle] t_null_r on t_null_l.k = t_null_r.k", "SplitCastDataSink", "([1: k, BIGINT, true] IN (1, 2)) OR ([1: k, BIGINT, true] IS NULL)")
+
+drop table t_null_l;
+drop table t_null_r;
+
+drop table t_mcv_l;
+drop table t_mcv_r;
 
 drop table skew_t1;
 drop table t1;


### PR DESCRIPTION
## Why I'm doing:
Skew join v2 works well when join keys are simple column references or when skew values are manually provided in a comparable form. In production, join keys frequently contain expressions (casts/functions/projection-derived keys), and we also want to leverage histogram MCV/NULL statistics to automatically identify skew values. Without these improvements, the rewrite may not trigger, may miss real skew, or may generate ineffective split predicates.

## What I'm doing:
- Add **NULL skew** support in split predicates using `IS NULL` / `IS NOT NULL` (instead of putting NULL into `IN` lists) to avoid SQL three-valued logic pitfalls.
- Integrate **stats-based skew detection** (MCV/NULL) with session-variable controls and safety guardrails.
- Enhance skew join v2 rewrite to better handle **expression join keys**, including rewriting skew values to match derived join-key expressions.

## Skew values selection strategy (parameters & defaults)
This change introduces **two new session variables** specifically for **MCV-based skew-value evaluation**. The remaining parameters below **already existed** and are reused to gate the rewrite.

### New parameters (added in this change)
- `skew_join_mcv_single_threshold` (default: 0.1)
  - Per-value MCV filter: keep a value `v` only if `count(v) / rowCount >= 0.1`.
  - This prevents many small MCVs from being treated as skew values.

- `skew_join_mcv_min_input_rows` (default: 10000000)
  - Minimum input rows gating for enabling MCV-based rewrite on a join side.
  - Skip a side if `Statistics.getOutputRowCount() < 10000000`.

### Existing parameters (already present)
- `enable_stats_to_optimize_skew_join` (default: false)
  - Master switch for stats-based skew detection. If false, only hint-based skew values are used.

- `skew_join_use_mcv_count` (default: 5)
  - Top-K limit: how many MCV entries are considered as skew-value candidates.

- `skew_join_data_skew_threshold` (default: 0.2)
  - Overall skew gating threshold.
  - MCV skew triggers when:
    - `mcvSkewFactor = sum_{v in topK} count(v) / rowCount` is greater than `skew_join_data_skew_threshold`.
  - NULL skew triggers when:
    - `nullFraction >= skew_join_data_skew_threshold`.

### Side selection and predicate construction 
- Evaluate both join children (subject to join-type constraints) and pick the side with larger:
  - `score = max(nullSkewFactor, mcvSkewFactor)`.
- LEFT OUTER JOIN constraint:
  - Right-side skew rewrite is forbidden, so the right child is excluded from candidates.
- Predicate construction:
  - MCV candidates become `IN (...)` values (after type casting and expression-key rewriting when needed).
  - NULL candidate is represented explicitly via `IS NULL` / `IS NOT NULL` (never `IN (NULL)`).
  - Final split predicate patterns:
    - MCV-only:
      - skew branch: `k IN (S)`
      - non-skew branch: `k NOT IN (S) OR k IS NULL`
    - NULL-only:
      - skew branch: `k IS NULL`
      - non-skew branch: `k IS NOT NULL`
    - MCV + NULL:
      - skew branch: `k IN (S) OR k IS NULL`
      - non-skew branch: `k NOT IN (S) AND k IS NOT NULL`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
