### PR TITLE
[Feature] Add schema_resolver property for JDBC catalog

### DIFF
--- a/docs/en/data_source/catalog/jdbc_catalog.md
+++ b/docs/en/data_source/catalog/jdbc_catalog.md
@@ -57,6 +57,7 @@ The properties of the JDBC Catalog. `PROPERTIES` must include the following para
 | jdbc_uri          | The URI that the JDBC driver uses to connect to the target database. For MySQL, the URI is in the `"jdbc:mysql://ip:port"` format. For PostgreSQL, the URI is in the `"jdbc:postgresql://ip:port/db_name"` format. For more information: [PostgreSQL](https://jdbc.postgresql.org/documentation/head/connect.html). |
 | driver_url        | The download URL of the JDBC driver JAR package. An HTTP URL or file URL is supported, for example, `https://repo1.maven.org/maven2/org/postgresql/postgresql/42.3.3/postgresql-42.3.3.jar` and `file:///home/disk1/postgresql-42.3.3.jar`.<br />**NOTE**<br />You can also put the JDBC driver to any same path on the FE and BE or CN nodes and set `driver_url` to that path, which must be in the `file:///<path>/to/the/driver` format. |
 | driver_class      | The class name of the JDBC driver. The JDBC driver class names of common database engines are as follows:<ul><li>MySQL: `com.mysql.jdbc.Driver` (MySQL v5.x and earlier) and `com.mysql.cj.jdbc.Driver` (MySQL v6.x and later)</li><li>PostgreSQL: `org.postgresql.Driver`</li></ul> |
+| schema_resolver   | (Optional) Explicitly specifies the schema resolver to use. Valid values: `postgresql`, `mysql`, `oracle`, `sqlserver`, `clickhouse`. Use this parameter when working with non-standard JDBC drivers that cannot be auto-detected by driver class name. If not specified, StarRocks will auto-detect the appropriate resolver based on the `driver_class` parameter. |
 
 > **NOTE**
 >
@@ -120,6 +121,18 @@ PROPERTIES
     "jdbc_uri"="jdbc:clickhouse://127.0.0.1:8443",
     "driver_url"="file:///path/to/clickhouse-jdbc-0.4.6.jar",
     "driver_class"="com.clickhouse.jdbc.ClickHouseDriver"
+);
+-- Using schema_resolver for non-standard driver
+CREATE EXTERNAL CATALOG jdbc5
+PROPERTIES
+(
+    "type"="jdbc",
+    "user"="postgres",
+    "password"="changeme",
+    "jdbc_uri"="jdbc:postgresql://127.0.0.1:5432/mydb",
+    "driver_url"="file:///path/to/custom-postgresql-driver.jar",
+    "driver_class"="com.custom.PostgresDriver",
+    "schema_resolver"="postgresql"
 );
 ```
 

--- a/docs/ja/data_source/catalog/jdbc_catalog.md
+++ b/docs/ja/data_source/catalog/jdbc_catalog.md
@@ -57,6 +57,7 @@ JDBC catalog のプロパティ。`PROPERTIES` には以下のパラメーター
 | jdbc_uri          | JDBC ドライバーがターゲットデータベースに接続するために使用する URI。MySQL の場合、URI は `"jdbc:mysql://ip:port"` 形式です。PostgreSQL の場合、URI は `"jdbc:postgresql://ip:port/db_name"` 形式です。詳細は [PostgreSQL](https://jdbc.postgresql.org/documentation/head/connect.html) を参照してください。 |
 | driver_url        | JDBC ドライバー JAR パッケージのダウンロード URL。HTTP URL またはファイル URL がサポートされます。例えば、`https://repo1.maven.org/maven2/org/postgresql/postgresql/42.3.3/postgresql-42.3.3.jar` や `file:///home/disk1/postgresql-42.3.3.jar` です。<br />**注意**<br />JDBC ドライバーを FE と BE または CN ノードの同じパスに配置し、`driver_url` をそのパスに設定することもできます。この場合、`file:///<path>/to/the/driver` 形式でなければなりません。 |
 | driver_class      | JDBC ドライバーのクラス名。一般的なデータベースエンジンの JDBC ドライバークラス名は以下の通りです：<ul><li>MySQL: `com.mysql.jdbc.Driver` (MySQL v5.x およびそれ以前) および `com.mysql.cj.jdbc.Driver` (MySQL v6.x およびそれ以降)</li><li>PostgreSQL: `org.postgresql.Driver`</li></ul> |
+| schema_resolver   | (オプション) 使用するスキーマリゾルバーを明示的に指定します。有効な値：`postgresql`、`mysql`、`oracle`、`sqlserver`、`clickhouse`。ドライバークラス名から自動検出できない非標準の JDBC ドライバーを使用する場合にこのパラメーターを使用します。指定しない場合、StarRocks は `driver_class` パラメーターに基づいて適切なリゾルバーを自動検出します。 |
 
 > **注意**
 >
@@ -120,7 +121,19 @@ PROPERTIES
     "jdbc_uri"="jdbc:clickhouse://127.0.0.1:8443",
     "driver_url"="file:///path/to/clickhouse-jdbc-0.4.6.jar",
     "driver_class"="com.clickhouse.jdbc.ClickHouseDriver"
-);    
+);
+-- 非標準ドライバーに schema_resolver を使用
+CREATE EXTERNAL CATALOG jdbc5
+PROPERTIES
+(
+    "type"="jdbc",
+    "user"="postgres",
+    "password"="changeme",
+    "jdbc_uri"="jdbc:postgresql://127.0.0.1:5432/mydb",
+    "driver_url"="file:///path/to/custom-postgresql-driver.jar",
+    "driver_class"="com.custom.PostgresDriver",
+    "schema_resolver"="postgresql"
+);
 ```
 
 ## JDBC catalog の表示

--- a/docs/zh/data_source/catalog/jdbc_catalog.md
+++ b/docs/zh/data_source/catalog/jdbc_catalog.md
@@ -58,6 +58,7 @@ JDBC Catalog 的属性，包含如下必填配置项：
 | jdbc_uri     | JDBC 驱动程序连接目标数据库的 URI。如果使用 MySQL，格式为：`"jdbc:mysql://ip:port"`。如果使用 PostgreSQL，格式为 `"jdbc:postgresql://ip:port/db_name"`。 |
 | driver_url   | 用于下载 JDBC 驱动程序 JAR 包的 URL。支持使用 HTTP 协议或者 file 协议，例如`https://repo1.maven.org/maven2/org/postgresql/postgresql/42.3.3/postgresql-42.3.3.jar` 和 `file:///home/disk1/postgresql-42.3.3.jar`。<br />**说明**<br />您也可以把 JDBC 驱动程序部署在 FE 或 BE（或 CN）所在节点上任意相同路径下，然后把 `driver_url` 设置为该路径，格式为 `file:///<path>/to/the/driver`。 |
 | driver_class | JDBC 驱动程序的类名称。以下是常见数据库引擎支持的 JDBC 驱动程序类名称：<ul><li>MySQL：`com.mysql.jdbc.Driver`（MySQL 5.x 及之前版本）、`com.mysql.cj.jdbc.Driver`（MySQL 6.x 及之后版本）</li><li>PostgreSQL: `org.postgresql.Driver`</li></ul> |
+| schema_resolver | （可选）显式指定要使用的 Schema Resolver。有效值：`postgresql`、`mysql`、`oracle`、`sqlserver`、`clickhouse`。当使用非标准 JDBC 驱动程序且无法通过驱动类名自动检测时，请使用此参数。如果未指定，StarRocks 将根据 `driver_class` 参数自动检测相应的 Resolver。 |
 
 > **说明**
 >
@@ -121,6 +122,18 @@ PROPERTIES
     "jdbc_uri"="jdbc:clickhouse://127.0.0.1:8443",
     "driver_url"="file:///path/to/clickhouse-jdbc-0.4.6.jar",
     "driver_class"="com.clickhouse.jdbc.ClickHouseDriver"
+);
+-- 使用 schema_resolver 处理非标准驱动
+CREATE EXTERNAL CATALOG jdbc5
+PROPERTIES
+(
+    "type"="jdbc",
+    "user"="postgres",
+    "password"="changeme",
+    "jdbc_uri"="jdbc:postgresql://127.0.0.1:5432/mydb",
+    "driver_url"="file:///path/to/custom-postgresql-driver.jar",
+    "driver_class"="com.custom.PostgresDriver",
+    "schema_resolver"="postgresql"
 );
 ```
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCResource.java
@@ -54,6 +54,7 @@ public class JDBCResource extends Resource {
     public static final String PASSWORD = "password";
     public static final String CHECK_SUM = "checksum";
     public static final String DRIVER_CLASS = "driver_class";
+    public static final String SCHEMA_RESOLVER = "schema_resolver";
 
     // @TODO is this necessary?
     // private static final String JDBC_TYPE = "jdbc_type";
@@ -110,7 +111,8 @@ public class JDBCResource extends Resource {
         Preconditions.checkState(properties != null);
         for (String key : properties.keySet()) {
             if (!DRIVER_URL.equals(key) && !URI.equals(key) && !USER.equals(key) && !PASSWORD.equals(key)
-                    && !TYPE.equals(key) && !NAME.equals(key) && !DRIVER_CLASS.equals(key)) {
+                    && !TYPE.equals(key) && !NAME.equals(key) && !DRIVER_CLASS.equals(key)
+                    && !SCHEMA_RESOLVER.equals(key)) {
                 throw new DdlException("Property " + key + " is unknown");
             }
         }


### PR DESCRIPTION
## Why I'm doing:

When using custom JDBC drivers (that are not on the SR list), it is desirable to override schema resolver to supported one (e.g. PG-compatible DB does not need a new resolver and users do not necessarily need for SR to adopt some new DB).

## What I'm doing:

Add configurable schema_resolver property for JDBC catalogs to allow
explicit override of the auto-detected schema resolver.

Changes:
- Add `SCHEMA_RESOLVER` property to `JDBCResource`
- Add `createSchemaResolver()` method with property-first priority
- Add `createSchemaResolverFromProperty()` factory method
- Use `SUPPORTED_SCHEMA_RESOLVERS` constant for error messages

Supported schema_resolver values: `postgresql`, `mysql`, `oracle`, `sqlserver`, `clickhouse`

Fixes #68597 

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4


