### PR TITLE
[Tool] Refactor Makefile not to generate Descriptor all the time

### DIFF
--- a/gensrc/proto/Makefile
+++ b/gensrc/proto/Makefile
@@ -11,27 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# This file is based on code available under the Apache license here:
-#   https://github.com/apache/incubator-doris/blob/master/gensrc/proto/Makefile
-#
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
 
 # This file compile all protobuf files.
 
@@ -44,15 +23,33 @@ else
 endif
 
 SOURCES = $(shell find ${CURDIR} -name "*.proto")
-OBJECTS = $(patsubst ${CURDIR}/%.proto, ${BUILD_DIR}/gen_cpp/%.pb.cc, ${SOURCES})
-HEADERS = $(patsubst ${CURDIR}/%.proto, ${BUILD_DIR}/gen_cpp/%.pb.h, ${SOURCES})
+STAMPS = $(patsubst ${CURDIR}/%.proto, ${BUILD_DIR}/gen_cpp/.%_proto.stamp, ${SOURCES})
 
 #all: ${JAVA_OBJECTS} ${OBJECTS} ${HEADERS}
-all: ${OBJECTS} ${HEADERS}
+all: ${STAMPS}
 .PHONY: all
 
-${BUILD_DIR}/gen_cpp/%.pb.h ${BUILD_DIR}/gen_cpp/%.pb.cc: ${CURDIR}/%.proto | ${BUILD_DIR}/gen_cpp
-	${PROTOC} --proto_path=${CURDIR} --cpp_out=${BUILD_DIR}/gen_cpp $<
+FORCE:
+.PHONY: FORCE
+
+# Use a content hash stamp to avoid regenerating when only timestamps change.
+# Use sha256sum if available, otherwise fall back to shasum (macOS).
+# If generated outputs were removed, force regeneration even with a matching hash.
+${BUILD_DIR}/gen_cpp/.%_proto.stamp: ${CURDIR}/%.proto FORCE | ${BUILD_DIR}/gen_cpp
+	@set -e; \
+	checksum="$$( (command -v sha256sum >/dev/null 2>&1 && sha256sum "$<" || shasum -a 256 "$<") | awk '{print $$1}')"; \
+	if [ -f "$@" ] && [ "$$(cat "$@")" = "$$checksum" ]; then \
+		base="$$(basename "$<" .proto)"; \
+		if [ -f "${BUILD_DIR}/gen_cpp/$${base}.pb.h" ] && [ -f "${BUILD_DIR}/gen_cpp/$${base}.pb.cc" ]; then \
+			touch "$@"; \
+			exit 0; \
+		fi; \
+	fi; \
+	echo "Generating proto $<"; \
+	${PROTOC} --proto_path=${CURDIR} --cpp_out=${BUILD_DIR}/gen_cpp "$<"; \
+	echo "$$checksum" > "$@"
+
+${BUILD_DIR}/gen_cpp/%.pb.h ${BUILD_DIR}/gen_cpp/%.pb.cc: ${BUILD_DIR}/gen_cpp/.%_proto.stamp ;
 
 ${BUILD_DIR}/gen_cpp:
 	mkdir -p $@

--- a/gensrc/thrift/Makefile
+++ b/gensrc/thrift/Makefile
@@ -11,26 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# This file is based on code available under the Apache license here:
-#   https://github.com/apache/incubator-doris/blob/master/gensrc/thrift/Makefile
-
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
 
 # This file used to compile all thrift files.
 BUILD_DIR = ${CURDIR}/../build/
@@ -42,25 +22,61 @@ else
 endif
 
 SOURCES = $(shell find ${CURDIR} -name "*.thrift")
-OBJECTS = $(patsubst ${CURDIR}/%.thrift, ${BUILD_DIR}/gen_cpp/%_types.cpp, ${SOURCES})
+STAMPS = $(patsubst ${CURDIR}/%.thrift, ${BUILD_DIR}/gen_cpp/.%_thrift.stamp, ${SOURCES})
 
-GEN_SOURCES = $(shell find ${CURDIR} -name "*.thrift")
-GEN_OBJECTS = $(patsubst ${BUILD_DIR}/thrift/%.thrift, ${BUILD_DIR}/gen_cpp/%_types.cpp, ${GEN_SOURCES})
-
-all: ${GEN_OBJECTS} ${OBJECTS}
+all: ${STAMPS}
 .PHONY: all
+
+FORCE:
+.PHONY: FORCE
 
 THRIFT_CPP_ARGS = -I ${CURDIR} -I ${BUILD_DIR}/thrift/ --allow-64bit-consts --gen cpp -out ${BUILD_DIR}/gen_cpp
 
 ${BUILD_DIR}/gen_cpp:
 	mkdir -p $@
 
-# handwrite thrift
-${BUILD_DIR}/gen_cpp/%_types.cpp: ${CURDIR}/%.thrift | ${BUILD_DIR}/gen_cpp
-	${THRIFT} ${THRIFT_CPP_ARGS} $<
+# Only regenerate when the thrift content changes, not when timestamps differ.
+# We record a content hash in a stamp file and compare it on subsequent runs.
+# Use sha256sum if available, otherwise fall back to shasum (macOS).
+# If generated outputs were removed, force regeneration even with a matching hash.
+define THRIFT_STAMP_RECIPE
+@set -e; \
+checksum="$$( (command -v sha256sum >/dev/null 2>&1 && sha256sum "$<" || shasum -a 256 "$<") | awk '{print $$1}')"; \
+if [ -f "$@" ] && [ "$$(cat "$@")" = "$$checksum" ]; then \
+	missing=0; \
+	check_file() { [ -f "$$1" ] || missing=1; }; \
+	base="$$(basename "$<" .thrift)"; \
+	check_file "${BUILD_DIR}/gen_cpp/$${base}_types.h"; \
+	check_file "${BUILD_DIR}/gen_cpp/$${base}_types.cpp"; \
+	if grep -Eq '^[[:space:]]*const[[:space:]]' "$<"; then \
+		check_file "${BUILD_DIR}/gen_cpp/$${base}_constants.h"; \
+		check_file "${BUILD_DIR}/gen_cpp/$${base}_constants.cpp"; \
+	fi; \
+	services="$$(awk '/^[[:space:]]*service[[:space:]]+[A-Za-z_][A-Za-z0-9_]*/ {print $$2}' "$<")"; \
+	for svc in $$services; do \
+		check_file "${BUILD_DIR}/gen_cpp/$${svc}.h"; \
+		check_file "${BUILD_DIR}/gen_cpp/$${svc}.cpp"; \
+		check_file "${BUILD_DIR}/gen_cpp/$${svc}_server.skeleton.cpp"; \
+	done; \
+	if [ "$$missing" -eq 0 ]; then \
+		touch "$@"; \
+		exit 0; \
+	fi; \
+fi; \
+echo "Generating thrift $<"; \
+${THRIFT} ${THRIFT_CPP_ARGS} "$<"; \
+$(if $(strip $(1)),$(1),:) ; \
+echo "$$checksum" > "$@"
+endef
+
+${BUILD_DIR}/gen_cpp/.%_thrift.stamp: ${CURDIR}/%.thrift FORCE | ${BUILD_DIR}/gen_cpp
+	$(call THRIFT_STAMP_RECIPE,)
 
 # The default generated header file contains too many unnecessary includes, this will leads a
 # slow compilation speed. We patch a diff to remove these includes.
-${BUILD_DIR}/gen_cpp/StatusCode_types.cpp: ${CURDIR}/StatusCode.thrift | ${BUILD_DIR}/gen_cpp
-	${THRIFT} ${THRIFT_CPP_ARGS} $<
-	patch -p0 -d ${BUILD_DIR}/gen_cpp < StatusCode_types.diff 2>&1 1>/dev/null
+# Use sha256sum if available, otherwise fall back to shasum (macOS).
+# If generated outputs were removed, force regeneration even with a matching hash.
+${BUILD_DIR}/gen_cpp/.StatusCode_thrift.stamp: ${CURDIR}/StatusCode.thrift FORCE | ${BUILD_DIR}/gen_cpp
+	$(call THRIFT_STAMP_RECIPE,if grep -q "TApplicationException" "${BUILD_DIR}/gen_cpp/StatusCode_types.h"; then \
+		patch -p0 -d ${BUILD_DIR}/gen_cpp < StatusCode_types.diff 2>&1 1>/dev/null; \
+	fi)


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
