### PR TITLE
[Enhancement] Modify iceberg position delete file file_path/pos columns to required

### DIFF
--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -219,7 +219,8 @@ ParquetFileWriter::ParquetFileWriter(std::string location, std::shared_ptr<arrow
                                      std::vector<std::unique_ptr<ColumnEvaluator>>&& column_evaluators,
                                      TCompressionType::type compression_type,
                                      std::shared_ptr<ParquetWriterOptions> writer_options,
-                                     const std::function<void()>& rollback_action)
+                                     const std::function<void()>& rollback_action,
+                                     const std::vector<bool>& nullable)
         : _location(std::move(location)),
           _output_stream(std::move(output_stream)),
           _column_names(std::move(column_names)),
@@ -227,19 +228,22 @@ ParquetFileWriter::ParquetFileWriter(std::string location, std::shared_ptr<arrow
           _column_evaluators(std::move(column_evaluators)),
           _compression_type(compression_type),
           _writer_options(std::move(writer_options)),
-          _rollback_action(std::move(rollback_action)) {}
+          _rollback_action(std::move(rollback_action)),
+          _nullable(nullable) {}
 
 arrow::Result<std::shared_ptr<::parquet::schema::GroupNode>> ParquetFileWriter::_make_schema(
         const std::vector<std::string>& column_names, const std::vector<TypeDescriptor>& type_descs,
-        const std::vector<FileColumnId>& file_column_ids) {
+        const std::vector<FileColumnId>& file_column_ids, const std::vector<bool>& nullable) {
     ::parquet::schema::NodeVector fields;
     parquet::ParquetSchemaOptions schema_options{
             .use_legacy_decimal_encoding = _writer_options->use_legacy_decimal_encoding,
             .use_int96_timestamp_encoding = _writer_options->use_int96_timestamp_encoding,
     };
     for (int i = 0; i < type_descs.size(); i++) {
+        ::parquet::Repetition::type repetition =
+                (nullable.empty() || nullable[i]) ? ::parquet::Repetition::OPTIONAL : ::parquet::Repetition::REQUIRED;
         ARROW_ASSIGN_OR_RAISE(auto node, parquet::ParquetBuildHelper::make_schema_node(
-                                                 column_names[i], type_descs[i], ::parquet::Repetition::OPTIONAL,
+                                                 column_names[i], type_descs[i], repetition,
                                                  file_column_ids[i], schema_options))
         DCHECK(node != nullptr);
         fields.push_back(std::move(node));
@@ -257,10 +261,10 @@ Status ParquetFileWriter::init() {
     auto status = [&]() {
         if (_writer_options->column_ids.has_value()) {
             ARROW_ASSIGN_OR_RAISE(_schema,
-                                  _make_schema(_column_names, _type_descs, _writer_options->column_ids.value()));
+                                  _make_schema(_column_names, _type_descs, _writer_options->column_ids.value(), _nullable));
         } else {
             std::vector<FileColumnId> column_ids(_type_descs.size());
-            ARROW_ASSIGN_OR_RAISE(_schema, _make_schema(_column_names, _type_descs, column_ids));
+            ARROW_ASSIGN_OR_RAISE(_schema, _make_schema(_column_names, _type_descs, column_ids, _nullable));
         }
         return arrow::Status::OK();
     }();
@@ -292,7 +296,7 @@ ParquetFileWriterFactory::ParquetFileWriterFactory(
         std::map<std::string, std::string> options, std::vector<std::string> column_names,
         std::shared_ptr<std::vector<std::unique_ptr<ColumnEvaluator>>> column_evaluators,
         std::optional<std::vector<formats::FileColumnId>> field_ids, PriorityThreadPool* executors,
-        RuntimeState* runtime_state)
+        RuntimeState* runtime_state, const std::vector<bool>& nullable)
         : _fs(std::move(fs)),
           _compression_type(compression_type),
           _field_ids(std::move(field_ids)),
@@ -300,7 +304,8 @@ ParquetFileWriterFactory::ParquetFileWriterFactory(
           _column_names(std::move(column_names)),
           _column_evaluators(std::move(column_evaluators)),
           _executors(executors),
-          _runtime_state(runtime_state) {}
+          _runtime_state(runtime_state),
+          _nullable(nullable) {}
 
 Status ParquetFileWriterFactory::init() {
     RETURN_IF_ERROR(ColumnEvaluator::init(*_column_evaluators));
@@ -347,7 +352,7 @@ StatusOr<WriterAndStream> ParquetFileWriterFactory::create(const std::string& pa
     auto parquet_output_stream = std::make_shared<parquet::AsyncParquetOutputStream>(async_output_stream.get());
     auto writer = std::make_unique<ParquetFileWriter>(path, parquet_output_stream, _column_names, types,
                                                       std::move(column_evaluators), _compression_type, _parsed_options,
-                                                      rollback_action);
+                                                      rollback_action, _nullable);
     return WriterAndStream{
             .writer = std::move(writer),
             .stream = std::move(async_output_stream),

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -219,8 +219,7 @@ ParquetFileWriter::ParquetFileWriter(std::string location, std::shared_ptr<arrow
                                      std::vector<std::unique_ptr<ColumnEvaluator>>&& column_evaluators,
                                      TCompressionType::type compression_type,
                                      std::shared_ptr<ParquetWriterOptions> writer_options,
-                                     const std::function<void()>& rollback_action,
-                                     const std::vector<bool>& nullable)
+                                     const std::function<void()>& rollback_action, const std::vector<bool>& nullable)
         : _location(std::move(location)),
           _output_stream(std::move(output_stream)),
           _column_names(std::move(column_names)),
@@ -242,9 +241,9 @@ arrow::Result<std::shared_ptr<::parquet::schema::GroupNode>> ParquetFileWriter::
     for (int i = 0; i < type_descs.size(); i++) {
         ::parquet::Repetition::type repetition =
                 (nullable.empty() || nullable[i]) ? ::parquet::Repetition::OPTIONAL : ::parquet::Repetition::REQUIRED;
-        ARROW_ASSIGN_OR_RAISE(auto node, parquet::ParquetBuildHelper::make_schema_node(
-                                                 column_names[i], type_descs[i], repetition,
-                                                 file_column_ids[i], schema_options))
+        ARROW_ASSIGN_OR_RAISE(auto node,
+                              parquet::ParquetBuildHelper::make_schema_node(column_names[i], type_descs[i], repetition,
+                                                                            file_column_ids[i], schema_options))
         DCHECK(node != nullptr);
         fields.push_back(std::move(node));
     }
@@ -260,8 +259,8 @@ Status ParquetFileWriter::init() {
 
     auto status = [&]() {
         if (_writer_options->column_ids.has_value()) {
-            ARROW_ASSIGN_OR_RAISE(_schema,
-                                  _make_schema(_column_names, _type_descs, _writer_options->column_ids.value(), _nullable));
+            ARROW_ASSIGN_OR_RAISE(
+                    _schema, _make_schema(_column_names, _type_descs, _writer_options->column_ids.value(), _nullable));
         } else {
             std::vector<FileColumnId> column_ids(_type_descs.size());
             ARROW_ASSIGN_OR_RAISE(_schema, _make_schema(_column_names, _type_descs, column_ids, _nullable));

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -219,7 +219,7 @@ ParquetFileWriter::ParquetFileWriter(std::string location, std::shared_ptr<arrow
                                      std::vector<std::unique_ptr<ColumnEvaluator>>&& column_evaluators,
                                      TCompressionType::type compression_type,
                                      std::shared_ptr<ParquetWriterOptions> writer_options,
-                                     const std::function<void()>& rollback_action, const std::vector<bool>& nullable)
+                                     std::function<void()> rollback_action, std::vector<bool> nullable)
         : _location(std::move(location)),
           _output_stream(std::move(output_stream)),
           _column_names(std::move(column_names)),
@@ -227,8 +227,8 @@ ParquetFileWriter::ParquetFileWriter(std::string location, std::shared_ptr<arrow
           _column_evaluators(std::move(column_evaluators)),
           _compression_type(compression_type),
           _writer_options(std::move(writer_options)),
-          _rollback_action(std::move(rollback_action)),
-          _nullable(nullable) {}
+          _nullable(std::move(nullable)),
+          _rollback_action(std::move(rollback_action)) {}
 
 arrow::Result<std::shared_ptr<::parquet::schema::GroupNode>> ParquetFileWriter::_make_schema(
         const std::vector<std::string>& column_names, const std::vector<TypeDescriptor>& type_descs,
@@ -295,7 +295,7 @@ ParquetFileWriterFactory::ParquetFileWriterFactory(
         std::map<std::string, std::string> options, std::vector<std::string> column_names,
         std::shared_ptr<std::vector<std::unique_ptr<ColumnEvaluator>>> column_evaluators,
         std::optional<std::vector<formats::FileColumnId>> field_ids, PriorityThreadPool* executors,
-        RuntimeState* runtime_state, const std::vector<bool>& nullable)
+        RuntimeState* runtime_state, std::vector<bool> nullable)
         : _fs(std::move(fs)),
           _compression_type(compression_type),
           _field_ids(std::move(field_ids)),
@@ -304,7 +304,7 @@ ParquetFileWriterFactory::ParquetFileWriterFactory(
           _column_evaluators(std::move(column_evaluators)),
           _executors(executors),
           _runtime_state(runtime_state),
-          _nullable(nullable) {}
+          _nullable(std::move(nullable)) {}
 
 Status ParquetFileWriterFactory::init() {
     RETURN_IF_ERROR(ColumnEvaluator::init(*_column_evaluators));

--- a/be/src/formats/parquet/parquet_file_writer.h
+++ b/be/src/formats/parquet/parquet_file_writer.h
@@ -104,7 +104,7 @@ public:
                       std::vector<std::string> column_names, std::vector<TypeDescriptor> type_descs,
                       std::vector<std::unique_ptr<ColumnEvaluator>>&& column_evaluators,
                       TCompressionType::type compression_type, std::shared_ptr<ParquetWriterOptions> writer_options,
-                      const std::function<void()>& rollback_action, const std::vector<bool>& nullable = {});
+                      std::function<void()> rollback_action, std::vector<bool> nullable = {});
 
     ~ParquetFileWriter() override;
 
@@ -154,7 +154,7 @@ public:
                              std::map<std::string, std::string> options, std::vector<std::string> column_names,
                              std::shared_ptr<std::vector<std::unique_ptr<ColumnEvaluator>>> column_evaluators,
                              std::optional<std::vector<formats::FileColumnId>> field_ids, PriorityThreadPool* executors,
-                             RuntimeState* runtime_state, const std::vector<bool>& nullable = {});
+                             RuntimeState* runtime_state, std::vector<bool> nullable = {});
 
     Status init() override;
 

--- a/be/src/formats/parquet/parquet_file_writer.h
+++ b/be/src/formats/parquet/parquet_file_writer.h
@@ -104,7 +104,8 @@ public:
                       std::vector<std::string> column_names, std::vector<TypeDescriptor> type_descs,
                       std::vector<std::unique_ptr<ColumnEvaluator>>&& column_evaluators,
                       TCompressionType::type compression_type, std::shared_ptr<ParquetWriterOptions> writer_options,
-                      const std::function<void()>& rollback_action);
+                      const std::function<void()>& rollback_action,
+                      const std::vector<bool>& nullable = {});
 
     ~ParquetFileWriter() override;
 
@@ -123,7 +124,7 @@ public:
 private:
     arrow::Result<std::shared_ptr<::parquet::schema::GroupNode>> _make_schema(
             const std::vector<std::string>& file_column_names, const std::vector<TypeDescriptor>& type_descs,
-            const std::vector<FileColumnId>& file_column_ids);
+            const std::vector<FileColumnId>& file_column_ids, const std::vector<bool>& nullable);
 
     static FileStatistics _statistics(const ::parquet::FileMetaData* meta_data, bool has_field_id);
 
@@ -141,6 +142,7 @@ private:
     TCompressionType::type _compression_type = TCompressionType::UNKNOWN_COMPRESSION;
     std::shared_ptr<ParquetWriterOptions> _writer_options;
     std::function<StatusOr<ColumnPtr>(Chunk*, size_t)> _eval_func;
+    std::vector<bool> _nullable;
 
     std::shared_ptr<::parquet::ParquetFileWriter> _writer;
     std::shared_ptr<parquet::ChunkWriter> _rowgroup_writer;
@@ -153,7 +155,7 @@ public:
                              std::map<std::string, std::string> options, std::vector<std::string> column_names,
                              std::shared_ptr<std::vector<std::unique_ptr<ColumnEvaluator>>> column_evaluators,
                              std::optional<std::vector<formats::FileColumnId>> field_ids, PriorityThreadPool* executors,
-                             RuntimeState* runtime_state);
+                             RuntimeState* runtime_state, const std::vector<bool>& nullable = {});
 
     Status init() override;
 
@@ -170,6 +172,7 @@ private:
     std::shared_ptr<std::vector<std::unique_ptr<ColumnEvaluator>>> _column_evaluators;
     PriorityThreadPool* _executors = nullptr;
     RuntimeState* _runtime_state = nullptr;
+    std::vector<bool> _nullable;
 };
 
 } // namespace starrocks::formats

--- a/be/src/formats/parquet/parquet_file_writer.h
+++ b/be/src/formats/parquet/parquet_file_writer.h
@@ -104,8 +104,7 @@ public:
                       std::vector<std::string> column_names, std::vector<TypeDescriptor> type_descs,
                       std::vector<std::unique_ptr<ColumnEvaluator>>&& column_evaluators,
                       TCompressionType::type compression_type, std::shared_ptr<ParquetWriterOptions> writer_options,
-                      const std::function<void()>& rollback_action,
-                      const std::vector<bool>& nullable = {});
+                      const std::function<void()>& rollback_action, const std::vector<bool>& nullable = {});
 
     ~ParquetFileWriter() override;
 

--- a/be/test/connector_sink/iceberg_delete_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_delete_sink_test.cpp
@@ -527,4 +527,30 @@ TEST_F(IcebergDeleteSinkTest, invalid_tuple_descriptor_id) {
     EXPECT_THAT(std::string(result.status().message()), testing::HasSubstr("Failed to find tuple descriptor"));
 }
 
+// Test that Iceberg delete file has REQUIRED columns for file_path and pos
+TEST_F(IcebergDeleteSinkTest, verify_required_columns_in_parquet) {
+    auto context = create_delete_sink_context();
+    auto provider = std::make_unique<IcebergDeleteSinkProvider>();
+    auto result = provider->create_chunk_sink(context, 0);
+    ASSERT_TRUE(result.ok());
+
+    auto sink = std::move(result).value();
+    auto delete_sink = dynamic_cast<IcebergDeleteSink*>(sink.get());
+    ASSERT_NE(delete_sink, nullptr);
+
+    // Verify that the context has the correct tuple descriptor
+    auto tuple_desc = _runtime_state->desc_tbl().get_tuple_descriptor(context->tuple_desc_id);
+    ASSERT_NE(tuple_desc, nullptr);
+    ASSERT_EQ(tuple_desc->slots().size(), 2);
+
+    // Verify that file_path and pos columns are not nullable
+    // This is what determines whether Parquet columns will be REQUIRED
+    for (auto& slot : tuple_desc->slots()) {
+        if (slot->col_name() == "file_path" || slot->col_name() == "pos") {
+            EXPECT_FALSE(slot->is_nullable())
+                    << "Column " << slot->col_name() << " should be NOT NULL for Iceberg delete files";
+        }
+    }
+}
+
 } // namespace starrocks::connector

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -1172,4 +1172,252 @@ TEST_F(ParquetFileWriterTest, TestWriteJson) {
     // _read_chunk does not support read json
 }
 
+TEST_F(ParquetFileWriterTest, TestNullableColumnsAllRequired) {
+    std::vector<TypeDescriptor> type_descs{
+            TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+            TypeDescriptor::from_logical_type(TYPE_BIGINT),
+    };
+
+    auto column_names = _make_type_names(type_descs);
+    auto output_file = _fs.new_writable_file(_file_path).value();
+    auto output_stream = std::make_unique<parquet::ParquetOutputStream>(std::move(output_file));
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::ParquetWriterOptions>();
+
+    // Test with nullable={false, false} - both columns should be REQUIRED
+    std::vector<bool> nullable = {false, false};
+    auto writer = std::make_unique<formats::ParquetFileWriter>(
+            _file_path, std::move(output_stream), column_names, type_descs, std::move(column_evaluators),
+            TCompressionType::NO_COMPRESSION, writer_options, []() {}, nullable);
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    {
+        // file_path column (VARCHAR) - non-null
+        auto col0 = BinaryColumn::create();
+        col0->append(Slice("file1.parquet"));
+        col0->append(Slice("file2.parquet"));
+        col0->append(Slice("file3.parquet"));
+        chunk->append_column(std::move(col0), chunk->num_columns());
+
+        // pos column (BIGINT) - non-null
+        auto col1 = Int64Column::create();
+        std::vector<int64_t> positions = {100, 200, 300};
+        col1->append_numbers(positions.data(), positions.size() * sizeof(int64_t));
+        chunk->append_column(std::move(col1), chunk->num_columns());
+    }
+
+    // write chunk
+    ASSERT_TRUE(writer->write(chunk.get()).ok());
+    auto result = writer->commit();
+
+    ASSERT_TRUE(result.io_status.ok());
+    ASSERT_EQ(result.file_statistics.record_count, 3);
+
+    // Verify Parquet schema has REQUIRED columns
+    ASSIGN_OR_ABORT(auto file, _fs.new_random_access_file(_file_path));
+    ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
+    auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size);
+    auto ctx = _create_scan_context(type_descs);
+    ASSERT_OK(file_reader->init(ctx));
+    auto file_metadata = file_reader->get_file_metadata();
+
+    // Check that both columns are REQUIRED
+    for (int i = 0; i < file_metadata->schema().get_fields_size(); i++) {
+        auto field = file_metadata->schema().get_stored_column_by_field_idx(i);
+        auto repetition = field->schema_element.repetition_type;
+        EXPECT_EQ(repetition, tparquet::FieldRepetitionType::REQUIRED)
+                << "Column " << i << " should be REQUIRED but is " << repetition;
+    }
+}
+
+TEST_F(ParquetFileWriterTest, TestNullableColumnsMixed) {
+    std::vector<TypeDescriptor> type_descs{
+            TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+            TypeDescriptor::from_logical_type(TYPE_BIGINT),
+    };
+
+    auto column_names = _make_type_names(type_descs);
+    auto output_file = _fs.new_writable_file(_file_path).value();
+    auto output_stream = std::make_unique<parquet::ParquetOutputStream>(std::move(output_file));
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::ParquetWriterOptions>();
+
+    // Test with nullable={true, false} - first column OPTIONAL, second REQUIRED
+    std::vector<bool> nullable = {true, false};
+    auto writer = std::make_unique<formats::ParquetFileWriter>(
+            _file_path, std::move(output_stream), column_names, type_descs, std::move(column_evaluators),
+            TCompressionType::NO_COMPRESSION, writer_options, []() {}, nullable);
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    {
+        // file_path column (VARCHAR) - nullable
+        auto data_col0 = BinaryColumn::create();
+        data_col0->append(Slice("file1.parquet"));
+        data_col0->append(Slice("file2.parquet"));
+        data_col0->append_default();
+        auto null_col0 = UInt8Column::create();
+        std::vector<uint8_t> nulls = {0, 0, 1};
+        null_col0->append_numbers(nulls.data(), nulls.size());
+        auto nullable_col0 = NullableColumn::create(std::move(data_col0), std::move(null_col0));
+        chunk->append_column(std::move(nullable_col0), chunk->num_columns());
+
+        // pos column (BIGINT) - non-null
+        auto col1 = Int64Column::create();
+        std::vector<int64_t> positions = {100, 200, 300};
+        col1->append_numbers(positions.data(), positions.size() * sizeof(int64_t));
+        chunk->append_column(std::move(col1), chunk->num_columns());
+    }
+
+    // write chunk
+    ASSERT_TRUE(writer->write(chunk.get()).ok());
+    auto result = writer->commit();
+
+    ASSERT_TRUE(result.io_status.ok());
+    ASSERT_EQ(result.file_statistics.record_count, 3);
+
+    // Verify Parquet schema has correct Repetition types
+    ASSIGN_OR_ABORT(auto file, _fs.new_random_access_file(_file_path));
+    ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
+    auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size);
+    auto ctx = _create_scan_context(type_descs);
+    ASSERT_OK(file_reader->init(ctx));
+    auto file_metadata = file_reader->get_file_metadata();
+
+    // Check first column is OPTIONAL
+    auto col0_field = file_metadata->schema().get_stored_column_by_field_idx(0);
+    auto repetition0 = col0_field->schema_element.repetition_type;
+    EXPECT_EQ(repetition0, tparquet::FieldRepetitionType::OPTIONAL)
+            << "Column 0 should be OPTIONAL but is " << repetition0;
+
+    // Check second column is REQUIRED
+    auto col1_field = file_metadata->schema().get_stored_column_by_field_idx(1);
+    auto repetition1 = col1_field->schema_element.repetition_type;
+    EXPECT_EQ(repetition1, tparquet::FieldRepetitionType::REQUIRED)
+            << "Column 1 should be REQUIRED but is " << repetition1;
+}
+
+TEST_F(ParquetFileWriterTest, TestNullableColumnsDefaultEmpty) {
+    std::vector<TypeDescriptor> type_descs{
+            TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+            TypeDescriptor::from_logical_type(TYPE_BIGINT),
+    };
+
+    auto column_names = _make_type_names(type_descs);
+    auto output_file = _fs.new_writable_file(_file_path).value();
+    auto output_stream = std::make_unique<parquet::ParquetOutputStream>(std::move(output_file));
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::ParquetWriterOptions>();
+
+    // Test with default nullable={} - all columns should be OPTIONAL (backward compatibility)
+    auto writer = std::make_unique<formats::ParquetFileWriter>(
+            _file_path, std::move(output_stream), column_names, type_descs, std::move(column_evaluators),
+            TCompressionType::NO_COMPRESSION, writer_options, []() {});
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    {
+        // file_path column (VARCHAR)
+        auto col0 = BinaryColumn::create();
+        col0->append(Slice("file1.parquet"));
+        col0->append(Slice("file2.parquet"));
+        col0->append(Slice("file3.parquet"));
+        chunk->append_column(std::move(col0), chunk->num_columns());
+
+        // pos column (BIGINT)
+        auto col1 = Int64Column::create();
+        std::vector<int64_t> positions = {100, 200, 300};
+        col1->append_numbers(positions.data(), positions.size() * sizeof(int64_t));
+        chunk->append_column(std::move(col1), chunk->num_columns());
+    }
+
+    // write chunk
+    ASSERT_TRUE(writer->write(chunk.get()).ok());
+    auto result = writer->commit();
+
+    ASSERT_TRUE(result.io_status.ok());
+    ASSERT_EQ(result.file_statistics.record_count, 3);
+
+    // Verify Parquet schema has OPTIONAL columns (backward compatibility)
+    ASSIGN_OR_ABORT(auto file, _fs.new_random_access_file(_file_path));
+    ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
+    auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size);
+    auto ctx = _create_scan_context(type_descs);
+    ASSERT_OK(file_reader->init(ctx));
+    auto file_metadata = file_reader->get_file_metadata();
+
+    // Check that both columns are OPTIONAL (default behavior)
+    for (int i = 0; i < file_metadata->schema().get_fields_size(); i++) {
+        auto field = file_metadata->schema().get_stored_column_by_field_idx(i);
+        auto repetition = field->schema_element.repetition_type;
+        EXPECT_EQ(repetition, tparquet::FieldRepetitionType::OPTIONAL)
+                << "Column " << i << " should be OPTIONAL (default) but is " << repetition;
+    }
+}
+
+TEST_F(ParquetFileWriterTest, TestIcebergDeleteFileColumnsRequired) {
+    // Test specific use case: Iceberg position delete file with file_path and pos columns as REQUIRED
+    std::vector<TypeDescriptor> type_descs{
+            TypeDescriptor::from_logical_type(TYPE_VARCHAR), // file_path
+            TypeDescriptor::from_logical_type(TYPE_BIGINT),  // pos
+    };
+    std::vector<std::string> column_names = {"file_path", "pos"};
+
+    auto output_file = _fs.new_writable_file(_file_path).value();
+    auto output_stream = std::make_unique<parquet::ParquetOutputStream>(std::move(output_file));
+    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+    auto writer_options = std::make_shared<formats::ParquetWriterOptions>();
+
+    // Iceberg position delete files require both file_path and pos to be REQUIRED
+    std::vector<bool> nullable = {false, false};
+    auto writer = std::make_unique<formats::ParquetFileWriter>(
+            _file_path, std::move(output_stream), column_names, type_descs, std::move(column_evaluators),
+            TCompressionType::NO_COMPRESSION, writer_options, []() {}, nullable);
+    ASSERT_OK(writer->init());
+
+    auto chunk = std::make_shared<Chunk>();
+    {
+        // file_path column (VARCHAR) - REQUIRED for Iceberg delete files
+        auto col0 = BinaryColumn::create();
+        col0->append(Slice("s3://bucket/table/data/file1.parquet"));
+        col0->append(Slice("s3://bucket/table/data/file1.parquet"));
+        col0->append(Slice("s3://bucket/table/data/file2.parquet"));
+        chunk->append_column(std::move(col0), chunk->num_columns());
+
+        // pos column (BIGINT) - REQUIRED for Iceberg delete files
+        auto col1 = Int64Column::create();
+        std::vector<int64_t> positions = {100, 200, 50};
+        col1->append_numbers(positions.data(), positions.size() * sizeof(int64_t));
+        chunk->append_column(std::move(col1), chunk->num_columns());
+    }
+
+    // write chunk
+    ASSERT_TRUE(writer->write(chunk.get()).ok());
+    auto result = writer->commit();
+
+    ASSERT_TRUE(result.io_status.ok());
+    ASSERT_EQ(result.file_statistics.record_count, 3);
+
+    // Verify Parquet schema has REQUIRED columns for Iceberg delete file
+    ASSIGN_OR_ABORT(auto file, _fs.new_random_access_file(_file_path));
+    ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
+    auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size);
+    auto ctx = _create_scan_context(type_descs);
+    ASSERT_OK(file_reader->init(ctx));
+    auto file_metadata = file_reader->get_file_metadata();
+
+    // Verify column names
+    EXPECT_EQ(file_metadata->schema().get_stored_column_by_field_idx(0)->name, "file_path");
+    EXPECT_EQ(file_metadata->schema().get_stored_column_by_field_idx(1)->name, "pos");
+
+    // Verify both columns are REQUIRED (Iceberg spec requirement)
+    for (int i = 0; i < file_metadata->schema().get_fields_size(); i++) {
+        auto field = file_metadata->schema().get_stored_column_by_field_idx(i);
+        auto repetition = field->schema_element.repetition_type;
+        EXPECT_EQ(repetition, tparquet::FieldRepetitionType::REQUIRED)
+                << "Column " << field->name << " should be REQUIRED for Iceberg delete files but is " << repetition;
+    }
+}
+
 } // namespace starrocks::formats


### PR DESCRIPTION
## Why I'm doing:
#66944
Follow the Spark/Trino specification for writing position delete files, and mark the **file_path** and **pos** columns as required.
## What I'm doing:
This pull request improves the correctness and robustness of Iceberg position delete file generation by ensuring that required columns (`file_path` and `pos`) are non-nullable and that this constraint is accurately reflected in the Parquet file schema. The changes also enhance the handling of column selection and chunk creation for delete files, and introduce corresponding tests to verify the new behavior.

**Iceberg Delete File Generation Improvements:**

- Ensured that the `file_path` and `pos` columns are set as non-nullable in the tuple descriptor used for delete files, so they are written as REQUIRED fields in Parquet according to the Iceberg spec.
- Updated the logic in `IcebergDeleteSink::add` to select and group only the relevant columns (`file_path` and `pos`) and to handle their non-nullable status when creating delete chunks. 

**Parquet Writer Enhancements:**

- Modified `ParquetFileWriter` and `ParquetFileWriterFactory` to accept and propagate column nullability information, and to use this when constructing the Parquet schema, ensuring required fields are marked as such. 

**Testing:**

- Added a unit test to verify that the generated Iceberg delete files have `file_path` and `pos` columns marked as REQUIRED (not nullable) in the Parquet schema.


These changes collectively ensure that Iceberg position delete files are written in strict compliance with the specification, improving data integrity and compatibility.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
