### PR TITLE
[BugFix] Reset relationAliasCaseInsensitive when rollback to StarRocks parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -99,26 +99,17 @@ public class SqlParser {
             // In Trino parser AstBuilder, it could throw ParsingException for unexpected exception,
             // use StarRocks parser to parse now.
             LOG.warn("Trino parse sql [{}] error, cause by {}", sql, e);
-            if (sessionVariable.isEnableDialectDowngrade()) {
-                return tryParseWithStarRocksDialect(sql, sessionVariable, e);
-            }
-            throw e;
+            return rollbackStarRocksDialect(sql, sessionVariable, e);
         } catch (io.trino.sql.parser.ParsingException e) {
             // This sql does not use Trino syntax，use StarRocks parser to parse now.
             if (sql.toLowerCase().contains("select")) {
                 LOG.warn("Trino parse sql [{}] error, cause by {}", sql, e);
             }
-            if (sessionVariable.isEnableDialectDowngrade()) {
-                return tryParseWithStarRocksDialect(sql, sessionVariable, e);
-            }
-            throw e;
+            return rollbackStarRocksDialect(sql, sessionVariable, e);
         } catch (TrinoParserUnsupportedException e) {
             // We only support Trino partial syntax now, and for Trino parser unsupported statement,
             // try to use StarRocks parser to parse
-            if (sessionVariable.isEnableDialectDowngrade()) {
-                return tryParseWithStarRocksDialect(sql, sessionVariable, e);
-            }
-            throw e;
+            return rollbackStarRocksDialect(sql, sessionVariable, e);
         } catch (UnsupportedException e) {
             // For unsupported statement, it can not be parsed by trino or StarRocks parser, both parser
             // can not support it now, we just throw the exception here to give user more information
@@ -129,6 +120,17 @@ public class SqlParser {
             return parseWithStarRocksDialect(sql, sessionVariable);
         }
         return statements;
+    }
+
+    private static List<StatementBase> rollbackStarRocksDialect(String sql, SessionVariable sessionVariable,
+                                                                RuntimeException exception) {
+        if (ConnectContext.get() != null) {
+            ConnectContext.get().setRelationAliasCaseInSensitive(false);
+        }
+        if (sessionVariable.isEnableDialectDowngrade()) {
+            return tryParseWithStarRocksDialect(sql, sessionVariable, exception);
+        }
+        throw exception;
     }
 
     private static List<StatementBase> tryParseWithStarRocksDialect(String sql, SessionVariable sessionVariable,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoDialectDowngradeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoDialectDowngradeTest.java
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 package com.starrocks.connector.parser.trino;
+
+import com.starrocks.sql.ast.StatementBase;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +36,80 @@ public class TrinoDialectDowngradeTest extends TrinoTestBase {
             analyzeFail(querySql, "mismatched input '3'. Expecting: '+', '-', <string>");
         } finally {
             connectContext.getSessionVariable().setSqlDialect("trino");
+        }
+    }
+
+    @Test
+    public void testRelationAliasCaseInsensitiveResetOnDowngrade() {
+        // Test that relationAliasCaseInsensitive is reset to false when rollback to StarRocks parser
+        String querySql = "select date_add('2010-11-30 23:59:59', INTERVAL 3 DAY);";
+        try {
+            connectContext.getSessionVariable().setEnableDialectDowngrade(true);
+            connectContext.getSessionVariable().setSqlDialect("trino");
+
+            // Before parsing, relationAliasCaseInsensitive should be false
+            Assertions.assertFalse(connectContext.isRelationAliasCaseInsensitive(),
+                    "relationAliasCaseInsensitive should be false before parsing");
+
+            // This SQL will fail in Trino parser but succeed in StarRocks parser after downgrade
+            StatementBase stmt = analyzeSuccess(querySql);
+            Assertions.assertNotNull(stmt);
+
+            // After rollback to StarRocks parser, relationAliasCaseInsensitive should be reset to false
+            Assertions.assertFalse(connectContext.isRelationAliasCaseInsensitive(),
+                    "relationAliasCaseInsensitive should be reset to false after downgrade");
+        } finally {
+            connectContext.getSessionVariable().setSqlDialect("trino");
+            connectContext.setRelationAliasCaseInSensitive(false);
+        }
+    }
+
+    @Test
+    public void testRelationAliasCaseInsensitiveWithTrinoUnsupportedSyntax() {
+        // Test with SQL that uses Trino unsupported syntax, triggering TrinoParserUnsupportedException
+        // This SQL uses StarRocks-specific syntax that Trino parser doesn't support
+        String querySql = "select * from t0 order by 1 limit 10 offset 5";
+        try {
+            connectContext.getSessionVariable().setEnableDialectDowngrade(true);
+            connectContext.getSessionVariable().setSqlDialect("trino");
+
+            // Before parsing
+            Assertions.assertFalse(connectContext.isRelationAliasCaseInsensitive());
+
+            // This should trigger downgrade and reset the flag
+            StatementBase stmt = analyzeSuccess(querySql);
+            Assertions.assertNotNull(stmt);
+
+            // After rollback, flag should be false
+            Assertions.assertFalse(connectContext.isRelationAliasCaseInsensitive(),
+                    "relationAliasCaseInsensitive should be reset to false after Trino unsupported syntax downgrade");
+        } finally {
+            connectContext.getSessionVariable().setSqlDialect("trino");
+            connectContext.setRelationAliasCaseInSensitive(false);
+        }
+    }
+
+    @Test
+    public void testRelationAliasCaseInsensitiveWithDowngradeDisabled() {
+        // Test that relationAliasCaseInsensitive is reset even when downgrade is disabled
+        // This SQL uses StarRocks-specific interval syntax which Trino parser cannot handle
+        String querySql = "select date_add('2010-11-30 23:59:59', INTERVAL 3 DAY)";
+        try {
+            connectContext.getSessionVariable().setEnableDialectDowngrade(false);
+            connectContext.getSessionVariable().setSqlDialect("trino");
+
+            // Before parsing
+            Assertions.assertFalse(connectContext.isRelationAliasCaseInsensitive());
+
+            analyzeFail(querySql);
+
+            // Even when exception is thrown, the flag should be false
+            Assertions.assertFalse(connectContext.isRelationAliasCaseInsensitive(),
+                    "relationAliasCaseInsensitive should be reset to false even when downgrade is disabled");
+        } finally {
+            connectContext.getSessionVariable().setSqlDialect("trino");
+            connectContext.getSessionVariable().setEnableDialectDowngrade(true);
+            connectContext.setRelationAliasCaseInSensitive(false);
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Fix #68144
## What I'm doing:
This pull request improves the handling of SQL dialect downgrades from Trino to StarRocks by centralizing the logic for resetting the `relationAliasCaseInsensitive` flag and adds comprehensive tests to ensure this behavior is correct in various scenarios. The main changes are:

**Parser Logic Refactoring:**

* Introduced a new private method `rollbackStarRocksDialect` in `SqlParser.java` that resets the `relationAliasCaseInsensitive` flag to `false` and centralizes the logic for downgrading from Trino to StarRocks parser, replacing repeated code in multiple exception handlers. [[1]](diffhunk://#diff-f08c8f41e6eb6232556b1a20f0c7d215822e53cd9b2927e2dc43189e75a4f3e9L102-R112) [[2]](diffhunk://#diff-f08c8f41e6eb6232556b1a20f0c7d215822e53cd9b2927e2dc43189e75a4f3e9R125-R135)

**Testing Improvements:**

* Added three new test cases in `TrinoDialectDowngradeTest.java` to verify that the `relationAliasCaseInsensitive` flag is correctly reset to `false`:
  - When downgrading occurs due to a Trino parsing failure.
  - When Trino encounters unsupported syntax.
  - Even when dialect downgrade is disabled and parsing fails.

**Test Setup:**

* Added necessary imports to support the new test cases in `TrinoDialectDowngradeTest.java`.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
