### PR TITLE
[Enhancement] Add SQL expressions to project operator profile

### DIFF
--- a/be/src/exec/pipeline/project_operator.cpp
+++ b/be/src/exec/pipeline/project_operator.cpp
@@ -18,6 +18,7 @@
 #include "column/column_helper.h"
 #include "column/nullable_column.h"
 #include "exprs/expr.h"
+#include "gutil/casts.h"
 #include "runtime/current_thread.h"
 #include "runtime/runtime_state.h"
 
@@ -25,6 +26,12 @@ namespace starrocks::pipeline {
 Status ProjectOperator::prepare(RuntimeState* state) {
     _expr_compute_timer = ADD_TIMER(_unique_metrics, "ExprComputeTime");
     _common_sub_expr_compute_timer = ADD_TIMER(_unique_metrics, "CommonSubExprComputeTime");
+    if (!_sql_project_exprs.empty()) {
+        _unique_metrics->add_info_string("ProjectExpressions", _sql_project_exprs);
+    }
+    if (!_sql_common_exprs.empty()) {
+        _unique_metrics->add_info_string("CommonExpressions", _sql_common_exprs);
+    }
     return Operator::prepare(state);
 }
 

--- a/be/src/exec/pipeline/project_operator.h
+++ b/be/src/exec/pipeline/project_operator.h
@@ -25,13 +25,16 @@ public:
     ProjectOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
                     std::vector<int32_t>& column_ids, const std::vector<ExprContext*>& expr_ctxs,
                     const std::vector<bool>& type_is_nullable, const std::vector<int32_t>& common_sub_column_ids,
-                    const std::vector<ExprContext*>& common_sub_expr_ctxs)
+                    const std::vector<ExprContext*>& common_sub_expr_ctxs, const std::string& sql_project_exprs,
+                    const std::string& sql_common_exprs)
             : Operator(factory, id, "project", plan_node_id, false, driver_sequence),
               _column_ids(column_ids),
               _expr_ctxs(expr_ctxs),
               _type_is_nullable(type_is_nullable),
               _common_sub_column_ids(common_sub_column_ids),
-              _common_sub_expr_ctxs(common_sub_expr_ctxs) {}
+              _common_sub_expr_ctxs(common_sub_expr_ctxs),
+              _sql_project_exprs(sql_project_exprs),
+              _sql_common_exprs(sql_common_exprs) {}
 
     ~ProjectOperator() override = default;
 
@@ -66,6 +69,9 @@ private:
     const std::vector<int32_t>& _common_sub_column_ids;
     const std::vector<ExprContext*>& _common_sub_expr_ctxs;
 
+    const std::string& _sql_project_exprs;
+    const std::string& _sql_common_exprs;
+
     bool _is_finished = false;
     ChunkPtr _cur_chunk = nullptr;
 
@@ -78,19 +84,23 @@ public:
     ProjectOperatorFactory(int32_t id, int32_t plan_node_id, std::vector<int32_t>&& column_ids,
                            std::vector<ExprContext*>&& expr_ctxs, std::vector<bool>&& type_is_nullable,
                            std::vector<int32_t>&& common_sub_column_ids,
-                           std::vector<ExprContext*>&& common_sub_expr_ctxs)
+                           std::vector<ExprContext*>&& common_sub_expr_ctxs, std::string&& sql_project_exprs,
+                           std::string sql_common_exprs)
             : OperatorFactory(id, "project", plan_node_id),
               _column_ids(std::move(column_ids)),
               _expr_ctxs(std::move(expr_ctxs)),
               _type_is_nullable(std::move(type_is_nullable)),
               _common_sub_column_ids(std::move(common_sub_column_ids)),
-              _common_sub_expr_ctxs(std::move(common_sub_expr_ctxs)) {}
+              _common_sub_expr_ctxs(std::move(common_sub_expr_ctxs)),
+              _sql_project_exprs(std::move(sql_project_exprs)),
+              _sql_common_exprs(std::move(sql_common_exprs)) {}
 
     ~ProjectOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
         return std::make_shared<ProjectOperator>(this, _id, _plan_node_id, driver_sequence, _column_ids, _expr_ctxs,
-                                                 _type_is_nullable, _common_sub_column_ids, _common_sub_expr_ctxs);
+                                                 _type_is_nullable, _common_sub_column_ids, _common_sub_expr_ctxs,
+                                                 _sql_project_exprs, _sql_common_exprs);
     }
 
     Status prepare(RuntimeState* state) override;
@@ -103,6 +113,9 @@ private:
 
     std::vector<int32_t> _common_sub_column_ids;
     std::vector<ExprContext*> _common_sub_expr_ctxs;
+
+    std::string _sql_project_exprs;
+    std::string _sql_common_exprs;
 };
 
 } // namespace pipeline

--- a/be/src/exec/project_node.h
+++ b/be/src/exec/project_node.h
@@ -50,6 +50,10 @@ private:
     std::vector<SlotId> _common_sub_slot_ids;
     std::vector<ExprContext*> _common_sub_expr_ctxs;
 
+    // SQL form of expressions for profile
+    std::string _sql_project_exprs;
+    std::string _sql_common_exprs;
+
     RuntimeProfile::Counter* _expr_compute_timer = nullptr;
     RuntimeProfile::Counter* _common_sub_expr_compute_timer = nullptr;
 };

--- a/be/src/exec/union_node.cpp
+++ b/be/src/exec/union_node.cpp
@@ -412,7 +412,8 @@ pipeline::OpFactories UnionNode::decompose_to_pipeline(pipeline::PipelineBuilder
 
         auto project_op = std::make_shared<ProjectOperatorFactory>(
                 context->next_operator_id(), id(), std::move(dst_column_ids), std::move(_child_expr_lists[i]),
-                std::move(dst_column_is_nullables), std::vector<int32_t>(), std::vector<ExprContext*>());
+                std::move(dst_column_is_nullables), std::vector<int32_t>(), std::vector<ExprContext*>(), std::string(),
+                std::string());
         operators_list[i].emplace_back(std::move(project_op));
         // Initialize OperatorFactory's fields involving runtime filters.
         this->init_runtime_filter_for_operator(operators_list[i].back().get(), context, rc_rf_probe_collector);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
@@ -66,6 +66,19 @@ public class ProjectNode extends PlanNode {
         slotMap.forEach((key, value) -> msg.project_node.putToSlot_map(key.asInt(), ExprToThrift.treeToThrift(value)));
         commonSlotMap.forEach((key, value) -> msg.project_node.putToCommon_slot_map(
                 key.asInt(), ExprToThrift.treeToThrift(value)));
+        if (!slotMap.isEmpty()) {
+            String sqlProjectExprs = slotMap.entrySet().stream()
+                    .map(e -> e.getKey() + "->" + explainExpr(e.getValue()))
+                    .collect(Collectors.joining(", "));
+            msg.project_node.setSql_project_exprs(sqlProjectExprs);
+        }
+
+        if (!commonSlotMap.isEmpty()) {
+            String sqlCommonExprs = commonSlotMap.entrySet().stream()
+                    .map(e -> e.getKey() + "->" + explainExpr(e.getValue()))
+                    .collect(Collectors.joining(", "));
+            msg.project_node.setSql_common_exprs(sqlCommonExprs);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
@@ -68,6 +68,7 @@ public class ProjectNode extends PlanNode {
                 key.asInt(), ExprToThrift.treeToThrift(value)));
         if (!slotMap.isEmpty()) {
             String sqlProjectExprs = slotMap.entrySet().stream()
+                    .sorted(Comparator.comparingInt(e -> e.getKey().asInt()))
                     .map(e -> e.getKey() + "->" + explainExpr(e.getValue()))
                     .collect(Collectors.joining(", "));
             msg.project_node.setSql_project_exprs(sqlProjectExprs);
@@ -75,6 +76,7 @@ public class ProjectNode extends PlanNode {
 
         if (!commonSlotMap.isEmpty()) {
             String sqlCommonExprs = commonSlotMap.entrySet().stream()
+                    .sorted(Comparator.comparingInt(e -> e.getKey().asInt()))
                     .map(e -> e.getKey() + "->" + explainExpr(e.getValue()))
                     .collect(Collectors.joining(", "));
             msg.project_node.setSql_common_exprs(sqlCommonExprs);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -151,8 +151,11 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
                         " has_nullable_child:false, is_nullable:true, is_monotonic:true, is_index_only_filter:false)," +
                         " TExprNode(node_type:DECIMAL_LITERAL, type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:DECIMAL128, precision:3, scale:2))])," +
                         " num_children:0, decimal_literal:TDecimalLiteral(value:3.14, integer_value:3A 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00), " +
-                        "output_scale:-1, has_nullable_child:false, is_nullable:false, is_monotonic:true, is_index_only_filter:false)])})";
+                        "output_scale:-1, has_nullable_child:false, is_nullable:false, is_monotonic:true, is_index_only_filter:false)])}, " +
+                        "sql_project_exprs:6->5: col_decimal128p20s3 * 3.14)";
+
         String plan = UtFrameUtils.getPlanThriftString(ctx, sql);
+        System.out.println(plan);
         Assertions.assertTrue(plan.contains(expectString));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -155,7 +155,6 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
                         "sql_project_exprs:6->5: col_decimal128p20s3 * 3.14)";
 
         String plan = UtFrameUtils.getPlanThriftString(ctx, sql);
-        System.out.println(plan);
         Assertions.assertTrue(plan.contains(expectString));
     }
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1291,6 +1291,10 @@ struct TProjectNode {
     1: optional map<Types.TSlotId, Exprs.TExpr> slot_map
     // Used for common operator compute result reuse
     2: optional map<Types.TSlotId, Exprs.TExpr> common_slot_map
+    // SQL form of projection expressions for profile
+    3: optional string sql_project_exprs
+    // SQL form of common subexpressions for profile
+    4: optional string sql_common_exprs
 }
 
 struct TSelectNode {


### PR DESCRIPTION
## Why I'm doing:
- Generally useful.
- Particularly useful to us for profiling custom native function calls.

## What I'm doing:
- Add SQL expressions to project operator profile as info strings.

Example SQL:
```
select s_store_name, length(s_store_name) from store
```

Profile output:
```
...
        PROJECT (plan_node_id=1):
          CommonMetrics:
             - OperatorTotalTime: 83.235us
...
          UniqueMetrics:
             - ProjectExpressions: 30->DictDecode(31: s_store_name, [length()]), 31->31: s_store_name
...
```

EXPLAIN output (existing behavior):
```
mysql> explain select s_store_name, length(s_store_name) from store;
+-------------------------------------------------------------------------+
| Explain String                                                          |
+-------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                         |
|  OUTPUT EXPRS:6: s_store_name | 30: length                              |
|   PARTITION: RANDOM                                                     |
|                                                                         |
|   RESULT SINK                                                           |
|                                                                         |
|   2:Decode                                                              |
|   |  <dict id 31> : <string id 6>                                       |
|   |                                                                     |
|   1:Project                                                             |
|   |  <slot 30> : DictDecode(31: s_store_name, [length(<place-holder>)]) |
|   |  <slot 31> : 31: s_store_name                                       |
|   |                                                                     |
|   0:OlapScanNode                                                        |
|      TABLE: store                                                       |
|      PREAGGREGATION: ON                                                 |
|      partitions=1/1                                                     |
|      rollup: store                                                      |
|      tabletRatio=1/1                                                    |
|      tabletList=11745                                                   |
|      cardinality=12                                                     |
|      avgRowSize=5.25                                                    |
+-------------------------------------------------------------------------+
22 rows in set (0.00 sec)

mysql> 
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
