### PR TITLE
[BugFix] Strip trailing slash from repository location path

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -234,7 +234,11 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
 
         BlobStorage storage = new BlobStorage(stmt.getBrokerName(), stmt.getProperties(), stmt.hasBroker());
         long repoId = globalStateMgr.getNextId();
-        Repository repo = new Repository(repoId, stmt.getName(), stmt.isReadOnly(), stmt.getLocation(), storage);
+        String location = stmt.getLocation();
+        while (location.endsWith("/")) {
+            location = location.substring(0, location.length() - 1);
+        }
+        Repository repo = new Repository(repoId, stmt.getName(), stmt.isReadOnly(), location, storage);
 
         Status st = repoMgr.addAndInitRepoIfNotExist(repo);
         if (!st.ok()) {

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupHandlerTest.java
@@ -704,4 +704,34 @@ public class BackupHandlerTest {
                 Maps.newHashMap());
         Assertions.assertEquals(true, AuditEncryptionChecker.needEncrypt(stmt));
     }
+
+    @Test
+    public void testCreateRepositoryStripsTrailingSlash(@Mocked BrokerMgr brokerMgr) throws Exception {
+        setUpMocker();
+
+        new MockUp<Repository>() {
+            @Mock
+            public Status initRepository() {
+                return Status.OK;
+            }
+        };
+
+        new Expectations() {
+            {
+                brokerMgr.containsBroker(anyString);
+                minTimes = 0;
+                result = true;
+            }
+        };
+
+        GlobalStateMgr.getCurrentState().getNodeMgr().setBrokerMgr(brokerMgr);
+        BackupHandler handler = new BackupHandler(GlobalStateMgr.getCurrentState());
+
+        CreateRepositoryStmt stmt = new CreateRepositoryStmt(false, "test_repo", brokerName,
+                "bos://location/path/", Maps.newHashMap());
+        handler.createRepository(stmt);
+
+        Repository repo = handler.getRepoMgr().getRepo("test_repo");
+        Assertions.assertEquals("bos://location/path", repo.getLocation());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
Fix double slashes in backup paths when location ends with `/`. Minor fix annoying me for quite a while 😅 

## What I'm doing:
Strip trailing slashes from repository location in `createRepository()`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4