### PR TITLE
[Enhancement] Separate Iceberg pushed/non-pushed predicates in EXPLAIN output

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1083,6 +1083,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             ScalarOperatorToIcebergExpr.IcebergContext icebergContext = new ScalarOperatorToIcebergExpr.IcebergContext(
                     icebergTable.getNativeTable().schema().asStruct());
             Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(scalarOperators, icebergContext);
+
             baseSource = buildRemoteInfoSource(icebergTable, icebergPredicate, tvrVersionRange, params);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
@@ -100,43 +100,72 @@ import static org.apache.iceberg.expressions.Expressions.startsWith;
 public class ScalarOperatorToIcebergExpr {
     private static final Logger LOG = LogManager.getLogger(ScalarOperatorToIcebergExpr.class);
 
+    public static class ConvertResult {
+        private final Expression icebergExpression;
+        private final List<ScalarOperator> pushedOperators;
+        private final List<ScalarOperator> failedOperators;
+
+        public ConvertResult(Expression icebergExpression, List<ScalarOperator> pushedOperators,
+                             List<ScalarOperator> failedOperators) {
+            this.icebergExpression = icebergExpression;
+            this.pushedOperators = pushedOperators;
+            this.failedOperators = failedOperators;
+        }
+
+        public Expression getIcebergExpression() {
+            return icebergExpression;
+        }
+
+        public List<ScalarOperator> getPushedOperators() {
+            return pushedOperators;
+        }
+
+        public List<ScalarOperator> getFailedOperators() {
+            return failedOperators;
+        }
+    }
+
     public Expression convert(List<ScalarOperator> operators, IcebergContext context) {
-        return convert(operators, context, false);
+        return convertWithDetails(operators, context).getIcebergExpression();
     }
 
     public Expression convertStrict(List<ScalarOperator> operators, IcebergContext context) {
-        return convert(operators, context, true);
+        ConvertResult result = convertWithDetails(operators, context);
+        if (!result.getFailedOperators().isEmpty()) {
+            LOG.debug("Strict mode: {} operators failed to convert", result.getFailedOperators().size());
+            return null;
+        }
+        return result.getIcebergExpression();
     }
 
-    public Expression convert(List<ScalarOperator> operators, IcebergContext context, boolean strict) {
+    public ConvertResult convertWithDetails(List<ScalarOperator> operators, IcebergContext context) {
         IcebergExprVisitor visitor = new IcebergExprVisitor();
         List<Expression> expressions = Lists.newArrayList();
+        List<ScalarOperator> pushedOperators = Lists.newArrayList();
+        List<ScalarOperator> failedOperators = Lists.newArrayList();
         for (ScalarOperator operator : operators) {
             Expression filterExpr = operator.accept(visitor, context);
-            if (filterExpr == null) {
-                if (strict) {
-                    LOG.debug("Strict mode: cannot convert operator {}", operator.debugString());
-                    return null;
+            if (filterExpr != null) {
+                try {
+                    Binder.bind(context.getSchema(), filterExpr, false);
+                    expressions.add(filterExpr);
+                    pushedOperators.add(operator);
+                } catch (ValidationException e) {
+                    LOG.error("binding to the table schema failed, cannot be pushed down scanOperator: {}",
+                            operator.debugString());
+                    failedOperators.add(operator);
                 }
-                continue;
-            }
-
-            try {
-                Binder.bind(context.getSchema(), filterExpr, false);
-                expressions.add(filterExpr);
-            } catch (ValidationException e) {
-                if (strict) {
-                    LOG.debug("Strict mode: bind failed, {}", operator.debugString());
-                    return null;
-                }
-                LOG.error("binding to the table schema failed, cannot be pushed down scanOperator: {}",
+            } else {
+                LOG.warn("Failed to convert predicate to Iceberg expression, cannot be pushed down: {}",
                         operator.debugString());
+                failedOperators.add(operator);
             }
         }
 
         LOG.debug("Number of predicates pushed down / Total number of predicates: {}/{}",
                 expressions.size(), operators.size());
-        return expressions.stream().reduce(Expressions.alwaysTrue(), Expressions::and);
+        Expression icebergExpression = expressions.stream().reduce(Expressions.alwaysTrue(), Expressions::and);
+        return new ConvertResult(icebergExpression, pushedOperators, failedOperators);
     }
 
     public static class IcebergContext {
@@ -445,10 +474,10 @@ public class ScalarOperatorToIcebergExpr {
                         //In iceberg transform expr, the decimal's scale will influence the result, like truncate and bucket...
                         //For column value 123.40 and const value 123.4, column = value should be true
                         //But in iceberg transform, 123.40 and 123.4 are not the same, and the partition may be pruned incorretly.
-                        return operator.getDecimal().setScale(((Types.DecimalType) context).scale(), 
+                        return operator.getDecimal().setScale(((Types.DecimalType) context).scale(),
                                 RoundingMode.HALF_UP);
                     } else {
-                        return operator.getDecimal().setScale(((ScalarType) operator.getType()).getScalarScale(), 
+                        return operator.getDecimal().setScale(((ScalarType) operator.getType()).getScalarScale(),
                                 RoundingMode.HALF_UP);
                     }
                 case HLL:

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -309,7 +309,17 @@ public class IcebergScanNode extends ScanNode {
         if (null != sortColumn) {
             output.append(prefix).append("SORT COLUMN: ").append(sortColumn).append("\n");
         }
-        if (!conjuncts.isEmpty()) {
+        if (!scanNodePredicates.getPushedConjuncts().isEmpty()
+                || !scanNodePredicates.getNonPushedConjuncts().isEmpty()) {
+            if (!scanNodePredicates.getPushedConjuncts().isEmpty()) {
+                output.append(prefix).append("PREDICATES: ").append(
+                        explainExpr(scanNodePredicates.getPushedConjuncts())).append("\n");
+            }
+            if (!scanNodePredicates.getNonPushedConjuncts().isEmpty()) {
+                output.append(prefix).append("NON-PUSHED PREDICATES: ").append(
+                        explainExpr(scanNodePredicates.getNonPushedConjuncts())).append("\n");
+            }
+        } else if (!conjuncts.isEmpty()) {
             output.append(prefix).append("PREDICATES: ").append(
                     explainExpr(conjuncts)).append("\n");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -33,9 +33,12 @@ import com.starrocks.connector.iceberg.IcebergRemoteSourceTrigger;
 import com.starrocks.connector.iceberg.IcebergTableMORParams;
 import com.starrocks.connector.iceberg.IcebergUtil;
 import com.starrocks.connector.iceberg.QueueIcebergRemoteFileInfoSource;
+import com.starrocks.connector.iceberg.ScalarOperatorToIcebergExpr;
 import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.plan.HDFSScanNodePredicates;
 import com.starrocks.thrift.TExplainLevel;
@@ -50,7 +53,10 @@ import org.apache.iceberg.metrics.ScanReportParser;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -309,15 +315,37 @@ public class IcebergScanNode extends ScanNode {
         if (null != sortColumn) {
             output.append(prefix).append("SORT COLUMN: ").append(sortColumn).append("\n");
         }
-        if (!scanNodePredicates.getPushedConjuncts().isEmpty()
-                || !scanNodePredicates.getNonPushedConjuncts().isEmpty()) {
-            if (!scanNodePredicates.getPushedConjuncts().isEmpty()) {
+        if (detailLevel == TExplainLevel.VERBOSE && icebergJobPlanningPredicate != null) {
+            List<ScalarOperator> ops = Utils.extractConjuncts(icebergJobPlanningPredicate);
+            ScalarOperatorToIcebergExpr.IcebergContext icebergContext =
+                    new ScalarOperatorToIcebergExpr.IcebergContext(
+                            icebergTable.getNativeTable().schema().asStruct());
+            ScalarOperatorToIcebergExpr.ConvertResult convertResult =
+                    new ScalarOperatorToIcebergExpr().convertWithDetails(ops, icebergContext);
+
+            if (ops.size() == conjuncts.size()) {
+                Set<ScalarOperator> pushedSet = Collections.newSetFromMap(new IdentityHashMap<>());
+                pushedSet.addAll(convertResult.getPushedOperators());
+                List<Expr> pushed = new ArrayList<>();
+                List<Expr> nonPushed = new ArrayList<>();
+                for (int i = 0; i < ops.size(); i++) {
+                    if (pushedSet.contains(ops.get(i))) {
+                        pushed.add(conjuncts.get(i));
+                    } else {
+                        nonPushed.add(conjuncts.get(i));
+                    }
+                }
+                if (!pushed.isEmpty()) {
+                    output.append(prefix).append("PREDICATES: ").append(
+                            explainExpr(pushed)).append("\n");
+                }
+                if (!nonPushed.isEmpty()) {
+                    output.append(prefix).append("NON-PUSHED PREDICATES: ").append(
+                            explainExpr(nonPushed)).append("\n");
+                }
+            } else if (!conjuncts.isEmpty()) {
                 output.append(prefix).append("PREDICATES: ").append(
-                        explainExpr(scanNodePredicates.getPushedConjuncts())).append("\n");
-            }
-            if (!scanNodePredicates.getNonPushedConjuncts().isEmpty()) {
-                output.append(prefix).append("NON-PUSHED PREDICATES: ").append(
-                        explainExpr(scanNodePredicates.getNonPushedConjuncts())).append("\n");
+                        explainExpr(conjuncts)).append("\n");
             }
         } else if (!conjuncts.isEmpty()) {
             output.append(prefix).append("PREDICATES: ").append(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/HDFSScanNodePredicates.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/HDFSScanNodePredicates.java
@@ -38,6 +38,11 @@ public class HDFSScanNodePredicates {
     // nonPartitionConjuncts contains non-partition filters, and will be sent to backend.
     private final List<Expr> nonPartitionConjuncts = Lists.newArrayList();
 
+    // Predicates that were successfully pushed down to the connector (e.g. Iceberg).
+    private final List<Expr> pushedConjuncts = Lists.newArrayList();
+    // Predicates that failed to push down, evaluated by backend.
+    private final List<Expr> nonPushedConjuncts = Lists.newArrayList();
+
     // List of conjuncts for min/max values that are used to skip data when scanning Parquet files.
     private final List<Expr> minMaxConjuncts = new ArrayList<>();
     private TupleDescriptor minMaxTuple;
@@ -76,6 +81,14 @@ public class HDFSScanNodePredicates {
 
     public List<Expr> getNonPartitionConjuncts() {
         return nonPartitionConjuncts;
+    }
+
+    public List<Expr> getPushedConjuncts() {
+        return pushedConjuncts;
+    }
+
+    public List<Expr> getNonPushedConjuncts() {
+        return nonPushedConjuncts;
     }
 
     public List<Expr> getMinMaxConjuncts() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/HDFSScanNodePredicates.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/HDFSScanNodePredicates.java
@@ -38,11 +38,6 @@ public class HDFSScanNodePredicates {
     // nonPartitionConjuncts contains non-partition filters, and will be sent to backend.
     private final List<Expr> nonPartitionConjuncts = Lists.newArrayList();
 
-    // Predicates that were successfully pushed down to the connector (e.g. Iceberg).
-    private final List<Expr> pushedConjuncts = Lists.newArrayList();
-    // Predicates that failed to push down, evaluated by backend.
-    private final List<Expr> nonPushedConjuncts = Lists.newArrayList();
-
     // List of conjuncts for min/max values that are used to skip data when scanning Parquet files.
     private final List<Expr> minMaxConjuncts = new ArrayList<>();
     private TupleDescriptor minMaxTuple;
@@ -81,14 +76,6 @@ public class HDFSScanNodePredicates {
 
     public List<Expr> getNonPartitionConjuncts() {
         return nonPartitionConjuncts;
-    }
-
-    public List<Expr> getPushedConjuncts() {
-        return pushedConjuncts;
-    }
-
-    public List<Expr> getNonPushedConjuncts() {
-        return nonPushedConjuncts;
     }
 
     public List<Expr> getMinMaxConjuncts() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -51,7 +51,6 @@ import com.starrocks.common.LocalExchangerType;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.connector.BucketProperty;
-import com.starrocks.connector.iceberg.ScalarOperatorToIcebergExpr;
 import com.starrocks.connector.metadata.MetadataTable;
 import com.starrocks.load.BrokerFileGroup;
 import com.starrocks.planner.AggregateInfo;
@@ -1631,27 +1630,6 @@ public class PlanFragmentBuilder {
                 }
                 icebergScanNode.setupScanRangeLocations(
                         context.getConnectContext().getSessionVariable().isEnableConnectorIncrementalScanRanges());
-
-                // Classify predicates into pushed/non-pushed for EXPLAIN output
-                ScalarOperator icebergPred = icebergScanNode.getIcebergJobPlanningPredicate();
-                if (icebergPred != null) {
-                    List<ScalarOperator> ops = Utils.extractConjuncts(icebergPred);
-                    IcebergTable icebergTable = icebergScanNode.getIcebergTable();
-                    ScalarOperatorToIcebergExpr.IcebergContext icebergContext =
-                            new ScalarOperatorToIcebergExpr.IcebergContext(
-                                    icebergTable.getNativeTable().schema().asStruct());
-                    ScalarOperatorToIcebergExpr.ConvertResult convertResult =
-                            new ScalarOperatorToIcebergExpr().convertWithDetails(ops, icebergContext);
-                    HDFSScanNodePredicates scanNodePreds = icebergScanNode.getScanNodePredicates();
-                    for (ScalarOperator pushed : convertResult.getPushedOperators()) {
-                        scanNodePreds.getPushedConjuncts()
-                                .add(ScalarOperatorToExpr.buildExecExpression(pushed, formatterContext));
-                    }
-                    for (ScalarOperator failed : convertResult.getFailedOperators()) {
-                        scanNodePreds.getNonPushedConjuncts()
-                                .add(ScalarOperatorToExpr.buildExecExpression(failed, formatterContext));
-                    }
-                }
 
                 if (!isEqDeleteScan) {
                     HDFSScanNodePredicates scanNodePredicates = icebergScanNode.getScanNodePredicates();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -51,6 +51,7 @@ import com.starrocks.common.LocalExchangerType;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.connector.BucketProperty;
+import com.starrocks.connector.iceberg.ScalarOperatorToIcebergExpr;
 import com.starrocks.connector.metadata.MetadataTable;
 import com.starrocks.load.BrokerFileGroup;
 import com.starrocks.planner.AggregateInfo;
@@ -1630,6 +1631,28 @@ public class PlanFragmentBuilder {
                 }
                 icebergScanNode.setupScanRangeLocations(
                         context.getConnectContext().getSessionVariable().isEnableConnectorIncrementalScanRanges());
+
+                // Classify predicates into pushed/non-pushed for EXPLAIN output
+                ScalarOperator icebergPred = icebergScanNode.getIcebergJobPlanningPredicate();
+                if (icebergPred != null) {
+                    List<ScalarOperator> ops = Utils.extractConjuncts(icebergPred);
+                    IcebergTable icebergTable = icebergScanNode.getIcebergTable();
+                    ScalarOperatorToIcebergExpr.IcebergContext icebergContext =
+                            new ScalarOperatorToIcebergExpr.IcebergContext(
+                                    icebergTable.getNativeTable().schema().asStruct());
+                    ScalarOperatorToIcebergExpr.ConvertResult convertResult =
+                            new ScalarOperatorToIcebergExpr().convertWithDetails(ops, icebergContext);
+                    HDFSScanNodePredicates scanNodePreds = icebergScanNode.getScanNodePredicates();
+                    for (ScalarOperator pushed : convertResult.getPushedOperators()) {
+                        scanNodePreds.getPushedConjuncts()
+                                .add(ScalarOperatorToExpr.buildExecExpression(pushed, formatterContext));
+                    }
+                    for (ScalarOperator failed : convertResult.getFailedOperators()) {
+                        scanNodePreds.getNonPushedConjuncts()
+                                .add(ScalarOperatorToExpr.buildExecExpression(failed, formatterContext));
+                    }
+                }
+
                 if (!isEqDeleteScan) {
                     HDFSScanNodePredicates scanNodePredicates = icebergScanNode.getScanNodePredicates();
                     prepareMinMaxExpr(scanNodePredicates, node.getScanOperatorPredicates(), context, referenceTable);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
@@ -435,6 +435,86 @@ public class IcebergExprVisitorTest {
     }
 
     @Test
+    public void testConvertWithDetails() {
+        ScalarOperatorToIcebergExpr.IcebergContext context =
+                new ScalarOperatorToIcebergExpr.IcebergContext(SCHEMA.asStruct());
+        ScalarOperatorToIcebergExpr converter = new ScalarOperatorToIcebergExpr();
+
+        // pushable: k1 > 5
+        BinaryPredicateOperator pushable = new BinaryPredicateOperator(
+                BinaryType.GT, K1, ConstantOperator.createInt(5));
+        // non-pushable: k6 LIKE '%suffix' (mid-match LIKE not supported by Iceberg)
+        LikePredicateOperator nonPushable = new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE, K6, ConstantOperator.createVarchar("%suffix"));
+
+        // Case 1: Mixed pushed and failed
+        ScalarOperatorToIcebergExpr.ConvertResult result =
+                converter.convertWithDetails(Lists.newArrayList(pushable, nonPushable), context);
+        Assertions.assertEquals(1, result.getPushedOperators().size());
+        Assertions.assertEquals(1, result.getFailedOperators().size());
+        Assertions.assertSame(pushable, result.getPushedOperators().get(0));
+        Assertions.assertSame(nonPushable, result.getFailedOperators().get(0));
+
+        // Case 2: All pushable
+        ScalarOperatorToIcebergExpr.ConvertResult allPushed =
+                converter.convertWithDetails(Lists.newArrayList(pushable), context);
+        Assertions.assertEquals(1, allPushed.getPushedOperators().size());
+        Assertions.assertEquals(0, allPushed.getFailedOperators().size());
+
+        // Case 3: All failed
+        ScalarOperatorToIcebergExpr.ConvertResult allFailed =
+                converter.convertWithDetails(Lists.newArrayList(nonPushable), context);
+        Assertions.assertEquals(0, allFailed.getPushedOperators().size());
+        Assertions.assertEquals(1, allFailed.getFailedOperators().size());
+
+        // Case 4: Empty input
+        ScalarOperatorToIcebergExpr.ConvertResult empty =
+                converter.convertWithDetails(Lists.newArrayList(), context);
+        Assertions.assertEquals(0, empty.getPushedOperators().size());
+        Assertions.assertEquals(0, empty.getFailedOperators().size());
+        Assertions.assertEquals(Expressions.alwaysTrue(), empty.getIcebergExpression());
+    }
+
+    @Test
+    public void testConvertWithDetailsExpressionCorrectness() {
+        ScalarOperatorToIcebergExpr.IcebergContext context =
+                new ScalarOperatorToIcebergExpr.IcebergContext(SCHEMA.asStruct());
+        ScalarOperatorToIcebergExpr converter = new ScalarOperatorToIcebergExpr();
+
+        // Two pushable predicates: k1 > 5 AND k1 < 10
+        BinaryPredicateOperator gt = new BinaryPredicateOperator(
+                BinaryType.GT, K1, ConstantOperator.createInt(5));
+        BinaryPredicateOperator lt = new BinaryPredicateOperator(
+                BinaryType.LT, K1, ConstantOperator.createInt(10));
+
+        ScalarOperatorToIcebergExpr.ConvertResult result =
+                converter.convertWithDetails(Lists.newArrayList(gt, lt), context);
+
+        // Both should be pushed, expression should be AND of the two
+        Assertions.assertEquals(2, result.getPushedOperators().size());
+        Assertions.assertEquals(0, result.getFailedOperators().size());
+        Expression expr = result.getIcebergExpression();
+        Assertions.assertNotEquals(Expressions.alwaysTrue(), expr);
+        Assertions.assertEquals(Expression.Operation.AND, expr.op());
+    }
+
+    @Test
+    public void testConvertDelegatesToConvertWithDetails() {
+        ScalarOperatorToIcebergExpr.IcebergContext context =
+                new ScalarOperatorToIcebergExpr.IcebergContext(SCHEMA.asStruct());
+        ScalarOperatorToIcebergExpr converter = new ScalarOperatorToIcebergExpr();
+
+        BinaryPredicateOperator pred = new BinaryPredicateOperator(
+                BinaryType.EQ, K1, ConstantOperator.createInt(5));
+
+        // convert() and convertWithDetails() should produce the same expression
+        Expression fromConvert = converter.convert(Lists.newArrayList(pred), context);
+        Expression fromDetails = converter.convertWithDetails(Lists.newArrayList(pred), context)
+                .getIcebergExpression();
+        Assertions.assertEquals(fromConvert.toString(), fromDetails.toString());
+    }
+
+    @Test
     public void testToIcebergExpressionDotColumn() {
         ScalarOperatorToIcebergExpr.IcebergContext context = new ScalarOperatorToIcebergExpr.IcebergContext(SCHEMA.asStruct());
         ScalarOperatorToIcebergExpr converter = new ScalarOperatorToIcebergExpr();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergExplainTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergExplainTest.java
@@ -1,0 +1,61 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class IcebergExplainTest extends ConnectorPlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        ConnectorPlanTestBase.beforeClass();
+    }
+
+    @Test
+    public void testVerboseExplainSeparatesPushedAndNonPushedPredicates() throws Exception {
+        // id > 10: pushable to Iceberg (integer comparison)
+        // data LIKE '%test': NOT pushable (only 'prefix%' is supported)
+        String sql = "SELECT * FROM iceberg0.unpartitioned_db.t0 WHERE id > 10 AND data LIKE '%test'";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "PREDICATES: 1: id > 10");
+        assertContains(plan, "NON-PUSHED PREDICATES: 2: data LIKE '%test'");
+    }
+
+    @Test
+    public void testNormalExplainDoesNotSeparatePredicates() throws Exception {
+        String sql = "SELECT * FROM iceberg0.unpartitioned_db.t0 WHERE id > 10 AND data LIKE '%test'";
+        String plan = getFragmentPlan(sql);
+        assertNotContains(plan, "NON-PUSHED PREDICATES:");
+        assertContains(plan, "PREDICATES: 1: id > 10, 2: data LIKE '%test'");
+    }
+
+    @Test
+    public void testVerboseExplainAllPushable() throws Exception {
+        // All predicates are pushable: integer comparison only
+        String sql = "SELECT * FROM iceberg0.unpartitioned_db.t0 WHERE id > 10 AND id < 100";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "PREDICATES: 1: id > 10, 1: id < 100");
+        assertNotContains(plan, "NON-PUSHED PREDICATES:");
+    }
+
+    @Test
+    public void testVerboseExplainNoPredicates() throws Exception {
+        String sql = "SELECT * FROM iceberg0.unpartitioned_db.t0";
+        String plan = getVerboseExplain(sql);
+        assertNotContains(plan, "PREDICATES:");
+        assertNotContains(plan, "NON-PUSHED PREDICATES:");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

When looking at Iceberg EXPLAIN VERBOSE output, all predicates are shown under a single `PREDICATES:` label regardless of whether they were successfully pushed down to Iceberg or not. This makes it difficult to identify which predicates contribute to file pruning during query tuning.

## What I'm doing:

- Add `NON-PUSHED PREDICATES:` line in `EXPLAIN VERBOSE` output for predicates that failed to push down to Iceberg
- Pushed predicates remain under the existing `PREDICATES:` label for backward compatibility
- Add `convertWithDetails()` to `ScalarOperatorToIcebergExpr` to return pushed/failed predicates separately
- Perform lazy predicate classification in `IcebergScanNode.getNodeExplainString()` only when VERBOSE explain level is requested, avoiding extra conversion work on non-EXPLAIN queries
- Normal `EXPLAIN` output remains unchanged (all predicates under single `PREDICATES:` label)

```
-- EXPLAIN VERBOSE (before)
0:IcebergScanNode
     PREDICATES: c_name = 'Customer#000000001', c_comment LIKE '%abc%'

-- EXPLAIN VERBOSE (after)
0:IcebergScanNode
     PREDICATES: c_name = 'Customer#000000001'
     NON-PUSHED PREDICATES: c_comment LIKE '%abc%'

-- Normal EXPLAIN (unchanged)
0:IcebergScanNode
     PREDICATES: c_name = 'Customer#000000001', c_comment LIKE '%abc%'
```

Fixes #

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4