### PR TITLE
[BugFix] Fix CN crash caused by uncaught tenann::Error during vector index flush

### DIFF
--- a/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
+++ b/be/src/storage/index/vector/tenann/tenann_index_builder.cpp
@@ -149,7 +149,7 @@ Status TenAnnIndexBuilderProxy::add(const Column& array_column, const size_t off
 Status TenAnnIndexBuilderProxy::flush() {
     try {
         _index_builder->Flush();
-    } catch (tenann::FatalError& e) {
+    } catch (tenann::Error& e) {
         LOG(WARNING) << e.what();
         return Status::InternalError(e.what());
     }


### PR DESCRIPTION
## Why I'm doing:

The `tenann` library throws `tenann::Error` when `Finalize()` fails (as seen in the crash stack trace). However, the `TenAnnIndexBuilderProxy::flush()` function was only catching `tenann::FatalError`.

Because of this exception type mismatch, the exception remained uncaught, causing the Compute Node (CN) to crash with `SIGABRT` during vector index construction.

## What I'm doing:

I have updated the `TenAnnIndexBuilderProxy::flush()` method in `be/src/storage/index/vector/tenann/tenann_index_builder.cpp`.

- Changed the catch block to catch `tenann::Error&` instead of `tenann::FatalError&`.

This change aligns the behavior with the `add()` function and ensures that if `Flush()` fails, the error is correctly logged and returned as a `Status::InternalError` instead of crashing the entire process.

Fixes #68543

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
