### PR TITLE
[Enhancement] Use column-level statistics for Iceberg averageRowSize estimation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergFileStats.java
@@ -80,7 +80,7 @@ public class IcebergFileStats {
                             (!nullCounts.containsKey(id) || nullCounts.get(id) != recordCount))
                     .collect(toSet());
             this.nullCounts = new HashMap<>(nullCounts);
-            this.columnSizes = columnSizes != null ? new HashMap<>(columnSizes) : null;
+            this.columnSizes = columnSizes != null ? new HashMap<>(columnSizes) : new HashMap<>();
             this.columnSizeRecordCounts = new HashMap<>();
             if (columnSizes != null) {
                 for (Integer fieldId : columnSizes.keySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergFileStats.java
@@ -47,6 +47,7 @@ public class IcebergFileStats {
     private Map<Integer, Long> columnSizes;
     private Set<Integer> corruptedStats;
     private boolean hasValidColumnMetrics;
+    private Map<Integer, Long> columnSizeRecordCounts;
 
     public IcebergFileStats(
             Map<Integer, Type.PrimitiveType> idToTypeMapping,
@@ -80,6 +81,12 @@ public class IcebergFileStats {
                     .collect(toSet());
             this.nullCounts = new HashMap<>(nullCounts);
             this.columnSizes = columnSizes != null ? new HashMap<>(columnSizes) : null;
+            this.columnSizeRecordCounts = new HashMap<>();
+            if (columnSizes != null) {
+                for (Integer fieldId : columnSizes.keySet()) {
+                    columnSizeRecordCounts.put(fieldId, recordCount);
+                }
+            }
             hasValidColumnMetrics = true;
         }
     }
@@ -159,6 +166,22 @@ public class IcebergFileStats {
 
     public void incrementRecordCount(long count) {
         this.recordCount += count;
+    }
+
+    public void incrementColumnSizeRecordCounts(Set<Integer> fieldIds, long recordCount) {
+        if (columnSizeRecordCounts == null) {
+            columnSizeRecordCounts = new HashMap<>();
+        }
+        for (Integer fieldId : fieldIds) {
+            columnSizeRecordCounts.merge(fieldId, recordCount, Long::sum);
+        }
+    }
+
+    public long getColumnSizeRecordCount(Integer fieldId) {
+        if (columnSizeRecordCounts == null) {
+            return 0;
+        }
+        return columnSizeRecordCounts.getOrDefault(fieldId, 0L);
     }
 
     public void incrementFileCount() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.iceberg.cost;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
@@ -68,6 +69,11 @@ public class IcebergStatisticProvider {
     private final Map<PredicateSearchKey, Set<String>> scannedFiles = new HashMap<>();
 
     public IcebergStatisticProvider() {
+    }
+
+    @VisibleForTesting
+    void putIcebergFileStats(PredicateSearchKey key, IcebergFileStats fileStats) {
+        icebergFileStatistics.put(key, fileStats);
     }
 
     public Statistics getCardinalityStats(
@@ -214,7 +220,7 @@ public class IcebergStatisticProvider {
             updateSummaryMax(icebergFileStats, partitionFields, IcebergFileStats.toMap(idToTypeMapping,
                     dataFile.upperBounds()), dataFile.nullValueCounts(), dataFile.recordCount());
             icebergFileStats.updateNullCount(dataFile.nullValueCounts());
-            updateColumnSizes(icebergFileStats, dataFile.columnSizes());
+            updateColumnSizes(icebergFileStats, dataFile.columnSizes(), dataFile.recordCount());
         }
     }
 
@@ -285,7 +291,18 @@ public class IcebergStatisticProvider {
             builder.setNullsFraction(0);
         }
 
-        builder.setAverageRowSize(1);
+        Map<Integer, Long> columnSizes = icebergStats.getColumnSizes();
+        long columnSizeRecordCount = icebergStats.getColumnSizeRecordCount(fieldId);
+        if (columnSizes != null && columnSizes.containsKey(fieldId) && columnSizeRecordCount > 0) {
+            // columnSizes from Iceberg is compressed (physical) size, so use typeSize as lower bound
+            // Use per-field columnSizeRecordCount to get accurate average when
+            // some files lack column size metrics for specific fields
+            double physicalSize = (double) columnSizes.get(fieldId) / columnSizeRecordCount;
+            double logicalSize = column.getType().getTypeSize();
+            builder.setAverageRowSize(Math.max(physicalSize, logicalSize));
+        } else {
+            builder.setAverageRowSize(column.getType().getTypeSize());
+        }
 
         Long ndv = colIdToNdv.get(fieldId);
         if (ndv != null) {
@@ -299,18 +316,24 @@ public class IcebergStatisticProvider {
         return builder.build();
     }
 
-    public void updateColumnSizes(IcebergFileStats icebergFileStats, Map<Integer, Long> addedColumnSizes) {
+    public void updateColumnSizes(IcebergFileStats icebergFileStats, Map<Integer, Long> addedColumnSizes,
+                                  long recordCount) {
         Map<Integer, Long> columnSizes = icebergFileStats.getColumnSizes();
         if (!icebergFileStats.hasValidColumnMetrics() || columnSizes == null || addedColumnSizes == null) {
             return;
         }
+        Set<Integer> updatedFieldIds = new HashSet<>();
         for (Types.NestedField column : icebergFileStats.getNonPartitionPrimitiveColumns()) {
             int id = column.fieldId();
 
             Long addedSize = addedColumnSizes.get(id);
             if (addedSize != null) {
                 columnSizes.put(id, addedSize + columnSizes.getOrDefault(id, 0L));
+                updatedFieldIds.add(id);
             }
+        }
+        if (!updatedFieldIds.isEmpty()) {
+            icebergFileStats.incrementColumnSizeRecordCounts(updatedFieldIds, recordCount);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.iceberg.cost;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
@@ -21,9 +22,11 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.GetRemoteFilesParams;
+import com.starrocks.connector.PredicateSearchKey;
 import com.starrocks.connector.iceberg.TableTestBase;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.StringType;
@@ -132,6 +135,282 @@ public class IcebergStatisticProviderTest extends TableTestBase {
         Assertions.assertEquals(121.0, convertObjectToOptionalDouble(Types.DecimalType.of(5, 2), new BigDecimal(121)).get(),
                 0.001);
         Assertions.assertFalse(convertObjectToOptionalDouble(Types.BinaryType.get(), "11").isPresent());
+    }
+
+    /**
+     * Helper to build an IcebergFileStats directly (bypassing DataFiles.builder which may not
+     * preserve column-level metrics in newer Iceberg versions).
+     */
+    private IcebergFileStats buildFileStats(
+            Map<Integer, org.apache.iceberg.types.Type.PrimitiveType> idToTypeMapping,
+            List<Types.NestedField> nonPartitionPrimitiveColumns,
+            long recordCount, long size,
+            Map<Integer, Object> minValues,
+            Map<Integer, Object> maxValues,
+            Map<Integer, Long> nullCounts,
+            Map<Integer, Long> columnSizes) {
+        return new IcebergFileStats(idToTypeMapping, nonPartitionPrimitiveColumns,
+                recordCount, size, minValues, maxValues, nullCounts, columnSizes);
+    }
+
+    private Map<Integer, org.apache.iceberg.types.Type.PrimitiveType> getIdToTypeMappingB() {
+        return mockedNativeTableB.schema().columns().stream()
+                .filter(c -> c.type().isPrimitiveType())
+                .collect(Collectors.toMap(Types.NestedField::fieldId, c -> c.type().asPrimitiveType()));
+    }
+
+    private List<Types.NestedField> getNonPartitionColumnsB() {
+        return mockedNativeTableB.schema().columns().stream()
+                .filter(c -> c.fieldId() != 2 && c.type().isPrimitiveType())
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void testAverageRowSizeWithColumnSizes() {
+        Map<Integer, org.apache.iceberg.types.Type.PrimitiveType> idToTypeMapping = getIdToTypeMappingB();
+        List<Types.NestedField> nonPartitionCols = getNonPartitionColumnsB();
+
+        IcebergFileStats fileStats = buildFileStats(idToTypeMapping, nonPartitionCols,
+                2, 20,
+                ImmutableMap.of(1, 1, 2, 2),
+                ImmutableMap.of(1, 2, 2, 2),
+                ImmutableMap.of(1, 0L, 2, 0L),
+                ImmutableMap.of(1, 50L, 2, 50L));
+
+        IcebergStatisticProvider statisticProvider = new IcebergStatisticProvider();
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).commit();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog", "resource_name", "db_name",
+                "table_name", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        TvrVersionRange version = TvrTableSnapshot.of(Optional.of(
+                mockedNativeTableB.currentSnapshot().snapshotId()));
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                .setTableVersionRange(version)
+                .build();
+
+        PredicateSearchKey key = PredicateSearchKey.of(icebergTable.getCatalogDBName(),
+                icebergTable.getCatalogTableName(), params);
+        statisticProvider.putIcebergFileStats(key, fileStats);
+
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<>();
+        ColumnRefOperator k1Ref = new ColumnRefOperator(3, IntegerType.INT, "k1", true);
+        ColumnRefOperator k2Ref = new ColumnRefOperator(4, IntegerType.INT, "k2", true);
+        colRefToColumnMetaMap.put(k1Ref, new Column("k1", IntegerType.INT));
+        colRefToColumnMetaMap.put(k2Ref, new Column("k2", IntegerType.INT));
+
+        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap, null, params);
+
+        // k1 (fieldId=1): averageRowSize = max(50.0/2, 4) = 25.0
+        ColumnStatistic k1Stat = statistics.getColumnStatistic(k1Ref);
+        Assertions.assertEquals(25.0, k1Stat.getAverageRowSize(), 0.001);
+
+        // k2 (fieldId=2): also has columnSizes
+        ColumnStatistic k2Stat = statistics.getColumnStatistic(k2Ref);
+        Assertions.assertEquals(25.0, k2Stat.getAverageRowSize(), 0.001);
+    }
+
+    @Test
+    public void testAverageRowSizeWithPartialColumnSizes() {
+        Map<Integer, org.apache.iceberg.types.Type.PrimitiveType> idToTypeMapping = getIdToTypeMappingB();
+        List<Types.NestedField> nonPartitionCols = getNonPartitionColumnsB();
+
+        // File 1: 1000 rows with columnSizes
+        IcebergFileStats fileStats = buildFileStats(idToTypeMapping, nonPartitionCols,
+                1000, 5000,
+                ImmutableMap.of(1, 1, 2, 2),
+                ImmutableMap.of(1, 100, 2, 200),
+                ImmutableMap.of(1, 0L, 2, 0L),
+                ImmutableMap.of(1, 25000L, 2, 25000L));
+
+        // File 2: 2000 rows without columnSizes (simulates older Iceberg writer)
+        fileStats.incrementRecordCount(2000);
+        fileStats.incrementSize(10000);
+        // updateColumnSizes with null should NOT increment columnSizeRecordCounts
+        IcebergStatisticProvider statisticProvider = new IcebergStatisticProvider();
+        statisticProvider.updateColumnSizes(fileStats, null, 2000);
+
+        // File 3: 1500 rows with columnSizes
+        fileStats.incrementRecordCount(1500);
+        fileStats.incrementSize(7500);
+        statisticProvider.updateColumnSizes(fileStats, ImmutableMap.of(1, 37500L, 2, 37500L), 1500);
+
+        // Total: recordCount=4500, columnSizeRecordCount=2500 (File1+File3)
+        // columnSizes[1] = 25000 + 37500 = 62500
+        // averageRowSize = max(62500/2500, 4) = max(25.0, 4) = 25.0
+        // Without fix: 62500/4500 = 13.89 (underestimated)
+
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).commit();
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog", "resource_name", "db_name",
+                "table_name", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        TvrVersionRange version = TvrTableSnapshot.of(Optional.of(
+                mockedNativeTableB.currentSnapshot().snapshotId()));
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                .setTableVersionRange(version)
+                .build();
+
+        PredicateSearchKey key = PredicateSearchKey.of(icebergTable.getCatalogDBName(),
+                icebergTable.getCatalogTableName(), params);
+        statisticProvider.putIcebergFileStats(key, fileStats);
+
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<>();
+        ColumnRefOperator k1Ref = new ColumnRefOperator(3, IntegerType.INT, "k1", true);
+        colRefToColumnMetaMap.put(k1Ref, new Column("k1", IntegerType.INT));
+
+        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap, null, params);
+
+        ColumnStatistic k1Stat = statistics.getColumnStatistic(k1Ref);
+        Assertions.assertEquals(25.0, k1Stat.getAverageRowSize(), 0.001);
+    }
+
+    @Test
+    public void testAverageRowSizeWithoutColumnSizes() {
+        IcebergFileStats fileStats = new IcebergFileStats(4);
+
+        IcebergStatisticProvider statisticProvider = new IcebergStatisticProvider();
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_5).commit();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog", "resource_name", "db_name",
+                "table_name", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        TvrVersionRange version = TvrTableSnapshot.of(Optional.of(
+                mockedNativeTableB.currentSnapshot().snapshotId()));
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                .setTableVersionRange(version)
+                .build();
+
+        PredicateSearchKey key = PredicateSearchKey.of(icebergTable.getCatalogDBName(),
+                icebergTable.getCatalogTableName(), params);
+        statisticProvider.putIcebergFileStats(key, fileStats);
+
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<>();
+        ColumnRefOperator k1Ref = new ColumnRefOperator(3, IntegerType.INT, "k1", true);
+        colRefToColumnMetaMap.put(k1Ref, new Column("k1", IntegerType.INT));
+
+        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap, null, params);
+
+        // No columnSizes → fallback to type size (INT = 4 bytes)
+        ColumnStatistic k1Stat = statistics.getColumnStatistic(k1Ref);
+        Assertions.assertEquals(4.0, k1Stat.getAverageRowSize(), 0.001);
+    }
+
+    @Test
+    public void testPerFieldColumnSizeRecordCounts() {
+        // Use unpartitioned table (mockedNativeTableH) to include all columns
+        List<Types.NestedField> allColumns = Lists.newArrayList(
+                Types.NestedField.required(1, "k1", Types.IntegerType.get()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        Map<Integer, org.apache.iceberg.types.Type.PrimitiveType> idToTypeMapping = allColumns.stream()
+                .collect(Collectors.toMap(Types.NestedField::fieldId, c -> c.type().asPrimitiveType()));
+
+        // File 1: 100 rows, both fields have columnSizes
+        IcebergFileStats fileStats = buildFileStats(idToTypeMapping, allColumns,
+                100, 1000,
+                ImmutableMap.of(1, 1, 2, 1),
+                ImmutableMap.of(1, 100, 2, 100),
+                ImmutableMap.of(1, 0L, 2, 0L),
+                ImmutableMap.of(1, 2500L, 2, 5000L));  // k1: 2500 bytes, k2: 5000 bytes
+
+        IcebergStatisticProvider statisticProvider = new IcebergStatisticProvider();
+
+        // File 2: 200 rows, only field 1 has columnSize
+        fileStats.incrementRecordCount(200);
+        fileStats.incrementSize(2000);
+        statisticProvider.updateColumnSizes(fileStats, ImmutableMap.of(1, 5000L), 200);  // only k1
+
+        // File 3: 300 rows, only field 2 has columnSize
+        fileStats.incrementRecordCount(300);
+        fileStats.incrementSize(3000);
+        statisticProvider.updateColumnSizes(fileStats, ImmutableMap.of(2, 15000L), 300);  // only k2
+
+        // Expected per-field record counts:
+        // field 1: 100 (File1) + 200 (File2) = 300
+        // field 2: 100 (File1) + 300 (File3) = 400
+
+        // Expected columnSizes:
+        // field 1: 2500 + 5000 = 7500
+        // field 2: 5000 + 15000 = 20000
+
+        // Expected averageRowSize:
+        // field 1: max(7500/300, 4) = max(25.0, 4) = 25.0
+        // field 2: max(20000/400, 4) = max(50.0, 4) = 50.0
+
+        Assertions.assertEquals(300, fileStats.getColumnSizeRecordCount(1));
+        Assertions.assertEquals(400, fileStats.getColumnSizeRecordCount(2));
+
+        mockedNativeTableG.newFastAppend().appendFile(FILE_B_5).commit();
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog", "resource_name", "db_name",
+                "table_name", "", Lists.newArrayList(), mockedNativeTableG, Maps.newHashMap());
+
+        TvrVersionRange version = TvrTableSnapshot.of(Optional.of(
+                mockedNativeTableG.currentSnapshot().snapshotId()));
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                .setTableVersionRange(version)
+                .build();
+
+        PredicateSearchKey key = PredicateSearchKey.of(icebergTable.getCatalogDBName(),
+                icebergTable.getCatalogTableName(), params);
+        statisticProvider.putIcebergFileStats(key, fileStats);
+
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<>();
+        ColumnRefOperator k1Ref = new ColumnRefOperator(3, IntegerType.INT, "k1", true);
+        ColumnRefOperator k2Ref = new ColumnRefOperator(4, IntegerType.INT, "k2", true);
+        colRefToColumnMetaMap.put(k1Ref, new Column("k1", IntegerType.INT));
+        colRefToColumnMetaMap.put(k2Ref, new Column("k2", IntegerType.INT));
+
+        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap, null, params);
+
+        ColumnStatistic k1Stat = statistics.getColumnStatistic(k1Ref);
+        ColumnStatistic k2Stat = statistics.getColumnStatistic(k2Ref);
+
+        // Per-field averageRowSize calculation
+        Assertions.assertEquals(25.0, k1Stat.getAverageRowSize(), 0.001);
+        Assertions.assertEquals(50.0, k2Stat.getAverageRowSize(), 0.001);
+    }
+
+    @Test
+    public void testColumnSizeRecordCountNotInflatedWhenStatsInvalid() {
+        // Use all columns (no partition filtering)
+        List<Types.NestedField> allColumns = Lists.newArrayList(
+                Types.NestedField.required(1, "k1", Types.IntegerType.get()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        Map<Integer, org.apache.iceberg.types.Type.PrimitiveType> idToTypeMapping = allColumns.stream()
+                .collect(Collectors.toMap(Types.NestedField::fieldId, c -> c.type().asPrimitiveType()));
+
+        // File 1: 100 rows with valid stats and columnSizes
+        IcebergFileStats fileStats = buildFileStats(idToTypeMapping, allColumns,
+                100, 1000,
+                ImmutableMap.of(1, 1, 2, 1),
+                ImmutableMap.of(1, 100, 2, 100),
+                ImmutableMap.of(1, 0L, 2, 0L),
+                ImmutableMap.of(1, 2500L, 2, 2500L));
+
+        Assertions.assertTrue(fileStats.hasValidColumnMetrics());
+        Assertions.assertEquals(100, fileStats.getColumnSizeRecordCount(1));
+
+        IcebergStatisticProvider statisticProvider = new IcebergStatisticProvider();
+
+        // File 2: 200 rows with null min/max stats (invalidates hasValidColumnMetrics)
+        // but still has columnSizes
+        fileStats.incrementRecordCount(200);
+        fileStats.incrementSize(2000);
+        // Simulate updateStats with null bounds which sets hasValidColumnMetrics = false
+        fileStats.updateStats(fileStats.getMinValues(), null, null, 200, i -> i < 0);
+
+        Assertions.assertFalse(fileStats.hasValidColumnMetrics());
+
+        // Now updateColumnSizes should NOT add to columnSizeRecordCounts because hasValidColumnMetrics is false
+        statisticProvider.updateColumnSizes(fileStats, ImmutableMap.of(1, 5000L, 2, 5000L), 200);
+
+        // columnSizeRecordCount should still be 100 (only from File 1)
+        Assertions.assertEquals(100, fileStats.getColumnSizeRecordCount(1));
+        Assertions.assertEquals(100, fileStats.getColumnSizeRecordCount(2));
+
+        // columnSizes should also not be updated (still 2500)
+        Assertions.assertEquals(2500L, fileStats.getColumnSizes().get(1).longValue());
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
@@ -413,4 +413,83 @@ public class IcebergStatisticProviderTest extends TableTestBase {
         Assertions.assertEquals(2500L, fileStats.getColumnSizes().get(1).longValue());
     }
 
+    @Test
+    public void testAverageRowSizeFirstNullThenPresent() {
+        List<Types.NestedField> allColumns = Lists.newArrayList(
+                Types.NestedField.required(1, "k1", Types.IntegerType.get()),
+                Types.NestedField.required(2, "k2", Types.IntegerType.get())
+        );
+        Map<Integer, org.apache.iceberg.types.Type.PrimitiveType> idToTypeMapping = allColumns.stream()
+                .collect(Collectors.toMap(Types.NestedField::fieldId, c -> c.type().asPrimitiveType()));
+
+        // File 1: 100 rows, valid min/max/null stats but NO columnSizes
+        IcebergFileStats fileStats = buildFileStats(idToTypeMapping, allColumns,
+                100, 1000,
+                ImmutableMap.of(1, 1, 2, 1),
+                ImmutableMap.of(1, 100, 2, 100),
+                ImmutableMap.of(1, 0L, 2, 0L),
+                null);
+
+        Assertions.assertTrue(fileStats.getColumnSizes().isEmpty());
+        Assertions.assertTrue(fileStats.hasValidColumnMetrics());
+
+        IcebergStatisticProvider statisticProvider = new IcebergStatisticProvider();
+
+        // File 2: 200 rows WITH columnSizes
+        fileStats.incrementRecordCount(200);
+        fileStats.incrementSize(2000);
+        statisticProvider.updateColumnSizes(fileStats, ImmutableMap.of(1, 5000L, 2, 10000L), 200);
+
+        // columnSizes should now be lazy-initialized with File 2's data
+        Assertions.assertNotNull(fileStats.getColumnSizes());
+        Assertions.assertEquals(5000L, fileStats.getColumnSizes().get(1).longValue());
+        Assertions.assertEquals(10000L, fileStats.getColumnSizes().get(2).longValue());
+
+        // columnSizeRecordCount should be 200 (only File 2)
+        Assertions.assertEquals(200, fileStats.getColumnSizeRecordCount(1));
+        Assertions.assertEquals(200, fileStats.getColumnSizeRecordCount(2));
+
+        // File 3: 300 rows WITH columnSizes
+        fileStats.incrementRecordCount(300);
+        fileStats.incrementSize(3000);
+        statisticProvider.updateColumnSizes(fileStats, ImmutableMap.of(1, 7500L, 2, 15000L), 300);
+
+        // columnSizeRecordCount = 200 + 300 = 500
+        Assertions.assertEquals(500, fileStats.getColumnSizeRecordCount(1));
+        Assertions.assertEquals(500, fileStats.getColumnSizeRecordCount(2));
+
+        // Verify averageRowSize through getTableStatistics
+        mockedNativeTableG.newFastAppend().appendFile(FILE_B_5).commit();
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog", "resource_name", "db_name",
+                "table_name", "", Lists.newArrayList(), mockedNativeTableG, Maps.newHashMap());
+
+        TvrVersionRange version = TvrTableSnapshot.of(Optional.of(
+                mockedNativeTableG.currentSnapshot().snapshotId()));
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                .setTableVersionRange(version)
+                .build();
+
+        PredicateSearchKey key = PredicateSearchKey.of(icebergTable.getCatalogDBName(),
+                icebergTable.getCatalogTableName(), params);
+        statisticProvider.putIcebergFileStats(key, fileStats);
+
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<>();
+        ColumnRefOperator k1Ref = new ColumnRefOperator(3, IntegerType.INT, "k1", true);
+        ColumnRefOperator k2Ref = new ColumnRefOperator(4, IntegerType.INT, "k2", true);
+        colRefToColumnMetaMap.put(k1Ref, new Column("k1", IntegerType.INT));
+        colRefToColumnMetaMap.put(k2Ref, new Column("k2", IntegerType.INT));
+
+        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, colRefToColumnMetaMap, null, params);
+
+        // k1: columnSizes = 5000 + 7500 = 12500, recordCount = 500
+        //     averageRowSize = max(12500/500, 4) = max(25.0, 4) = 25.0
+        ColumnStatistic k1Stat = statistics.getColumnStatistic(k1Ref);
+        Assertions.assertEquals(25.0, k1Stat.getAverageRowSize(), 0.001);
+
+        // k2: columnSizes = 10000 + 15000 = 25000, recordCount = 500
+        //     averageRowSize = max(25000/500, 4) = max(50.0, 4) = 50.0
+        ColumnStatistic k2Stat = statistics.getColumnStatistic(k2Ref);
+        Assertions.assertEquals(50.0, k2Stat.getAverageRowSize(), 0.001);
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:

`IcebergStatisticProvider.makeColumnStatistics()` hardcodes `averageRowSize` to `1` for every column, ignoring per-column physical sizes (`columnSizes`) and `recordCount` already available from Iceberg manifest metadata. This causes the optimizer to significantly underestimate memory costs and data transfer sizes, potentially producing suboptimal query plans for joins, aggregations, and memory-intensive operations.

## What I'm doing:

Replace hardcoded `averageRowSize(1)` with a computation based on Iceberg manifest metadata:
- When `columnSizes` and `recordCount` are available: `max(columnSizes[fieldId] / recordCount, typeSize)` — using `typeSize` as a lower bound since Iceberg `columnSizes` reflects compressed (physical) size
- When unavailable: fall back to `column.getType().getTypeSize()` instead of `1`

Added unit tests covering both cases.

Fixes #68784

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
