### PR TITLE
[BugFix] accurate iceberg data file size estimation 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -33,9 +33,11 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
@@ -50,6 +52,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.parquet.Strings;
 import org.apache.spark.util.SizeEstimator;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -69,8 +72,10 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     public static final long DEFAULT_CACHE_NUM = 100000;
     private static final int MEMORY_META_SAMPLES = 10;
     private static final int MEMORY_FILE_SAMPLES = 100;
-    private static final int MEMORY_SNAPSHOT_SIZE = 1536; // approx memory size of one snapshot object without manifests
-    private static final int MEMORY_MANIFEST_SIZE = 512; // approx memory size of one manifest object in snapshot
+    private static final int MEMORY_SNAPSHOT_SIZE = 2048; // approx memory size of one snapshot object without manifests
+    private static final int MEMORY_MANIFEST_SIZE = 1024; // approx memory size of one manifest object in snapshot
+    private static final int MEMORY_DATA_FILE_SIZE = 1536; // approx memory size of one data file in manifest
+    private static final int MEMORY_PARTITION_DATA_SIZE = 768; // approx memory size of one partition data in data file
     private static final ThreadLocal<ConnectContext> TABLE_LOAD_CONTEXT = new ThreadLocal<>();
     private final String catalogName;
     private final IcebergCatalog delegate;
@@ -176,7 +181,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                 .weigher((Weigher<String, Set<DataFile>>) (String key, Set<DataFile> files) -> {
                     long size = SizeEstimator.estimate(key);
                     if (!files.isEmpty()) {
-                        size += 1L * SizeEstimator.estimate(files.iterator().next()) * files.size();
+                        size += 1L * estimateDataFileSizeInBytes(files.iterator().next()) * files.size();
                     }
                     return (size > Integer.MAX_VALUE) ? Integer.MAX_VALUE : (int) size;
                 })
@@ -194,7 +199,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                 .weigher((Weigher<String, Set<DeleteFile>>) (String key, Set<DeleteFile> files) -> {
                     long size = SizeEstimator.estimate(key);
                     if (!files.isEmpty()) {
-                        size += 1L * SizeEstimator.estimate(files.iterator().next()) * files.size();
+                        size += 1L * estimateDataFileSizeInBytes(files.iterator().next()) * files.size();
                     }
                     return (size > Integer.MAX_VALUE) ? Integer.MAX_VALUE : (int) size;
                 })
@@ -639,6 +644,63 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         Pair<List<Object>, Long> deleteFileSamples = Pair.create(deleteFiles, deleteFilesTotal);
 
         return Lists.newArrayList(dbSamples, partitionSamples, dataFileSamples, deleteFileSamples);
+    }
+
+    public static long estimatePartitionDataInBytes(PartitionData pd) {
+        if (pd == null) {
+            return 0L;
+        }
+        long size = MEMORY_PARTITION_DATA_SIZE;
+        size += 64L * pd.size(); // estimate an object as 64Byte in partition data objects
+        return size;
+    }
+    /**
+     * Roughly estimates the payload size (in bytes) of the statistics carried on a content file.
+     */
+    public static long estimateDataFileSizeInBytes(ContentFile<?> file) {
+        if (file == null) {
+            return 0L;
+        }
+
+        long size = MEMORY_DATA_FILE_SIZE;
+
+        size += sizeOfLongMap(file.columnSizes());
+        size += sizeOfLongMap(file.valueCounts());
+        size += sizeOfLongMap(file.nullValueCounts());
+        size += sizeOfLongMap(file.nanValueCounts());
+        size += sizeOfByteBufferMap(file.lowerBounds());
+        size += sizeOfByteBufferMap(file.upperBounds());
+        if (file.keyMetadata() != null) {
+            size += file.keyMetadata().remaining();
+        }
+        if (file.partition() instanceof PartitionData) {
+            size += estimatePartitionDataInBytes((PartitionData) file.partition());
+        }
+        return size;
+    }
+
+    private static long sizeOfLongMap(Map<Integer, Long> map) {
+        if (map == null || map.isEmpty()) {
+            return 0L;
+        }
+
+        return 1L * map.size() * (Integer.BYTES + Long.BYTES);
+    }
+
+    private static long sizeOfByteBufferMap(Map<Integer, ByteBuffer> map) {
+        if (map == null || map.isEmpty()) {
+            return 0L;
+        }
+
+        long size = 0L;
+        for (Map.Entry<Integer, ByteBuffer> entry : map.entrySet()) {
+            size += Integer.BYTES; // key
+            ByteBuffer buffer = entry.getValue();
+            if (buffer != null) {
+                size += buffer.remaining();
+            }
+        }
+        return size;
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:
Now the data file size estimation will be inaccurate with metrics.
## What I'm doing:

revise the estimation function.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
