### PR TITLE
[BugFix] fix get_json_string flatten logic

### DIFF
--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -867,8 +867,10 @@ bool JsonFlattener::_flatten_json(const vpack::Slice& value, const JsonFlatPath*
             }
         }
 
-        if (child->second->children.empty()) {
-            // leaf node
+        // Type-conflict leaf: selected for output as TYPE_JSON but also has children from other rows.
+        const bool is_conflict_leaf = child->second->index >= 0 && child->second->type == LogicalType::TYPE_JSON;
+        if (child->second->children.empty() || is_conflict_leaf) {
+            // Treat as leaf if selected for output, even when it has children (e.g. type-conflict paths).
             auto index = child->second->index;
             DCHECK(_flat_columns.size() > index);
             DCHECK(_flat_columns[index]->is_nullable());

--- a/test/sql/test_json/R/test_get_json_string_object
+++ b/test/sql/test_json/R/test_get_json_string_object
@@ -1,0 +1,41 @@
+-- name: test_get_json_string_object
+-- Test case from issue #68789: get_json_string should return object JSON string, not NULL
+DROP TABLE IF EXISTS json_test;
+-- result:
+-- !result
+CREATE TABLE json_test (
+    id int,
+    data json
+)
+PROPERTIES
+("flat_json.enable" = "true");
+-- result:
+-- !result
+INSERT INTO json_test VALUES (1, '{"key":"aaa"}');
+-- result:
+-- !result
+INSERT INTO json_test VALUES (2, '{"key":2}');
+-- result:
+-- !result
+INSERT INTO json_test VALUES (3, '{"key": {"a1":1}}');
+-- result:
+-- !result
+SELECT id, get_json_string(data, '$.key')
+FROM json_test
+ORDER BY id;
+-- result:
+1	aaa
+2	2
+3	{"a1":1}
+-- !result
+-- Test nested object path extraction under flat_json
+SELECT id, get_json_string(data, '$.key.a1')
+FROM json_test
+WHERE id = 3
+ORDER BY id;
+-- result:
+3	1
+-- !result
+DROP TABLE IF EXISTS json_test;
+-- result:
+-- !result

--- a/test/sql/test_json/T/test_get_json_string_object
+++ b/test/sql/test_json/T/test_get_json_string_object
@@ -1,0 +1,26 @@
+-- name: test_get_json_string_object
+-- Test case from issue #68789: get_json_string should return object JSON string, not NULL
+DROP TABLE IF EXISTS json_test;
+
+CREATE TABLE json_test (
+    id int,
+    data json
+)
+PROPERTIES
+("flat_json.enable" = "true");
+
+INSERT INTO json_test VALUES (1, '{"key":"aaa"}');
+INSERT INTO json_test VALUES (2, '{"key":2}');
+INSERT INTO json_test VALUES (3, '{"key": {"a1":1}}');
+
+SELECT id, get_json_string(data, '$.key')
+FROM json_test
+ORDER BY id;
+
+-- Test nested object path extraction under flat_json
+SELECT id, get_json_string(data, '$.key.a1')
+FROM json_test
+WHERE id = 3
+ORDER BY id;
+
+DROP TABLE IF EXISTS json_test;


### PR DESCRIPTION
## Why I'm doing:
Fix https://github.com/StarRocks/starrocks/issues/68789

## What I'm doing:

Fixed a bug in `get_json_string` related to type conflicts in flat JSON structures.

Key improvements:

Allows JSON nodes with type conflicts to be treated as leaf nodes even if they have child nodes.
Ensures `get_json_string` correctly returns JSON strings for object types.
Added test cases to verify the fix.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
