### PR TITLE
[BugFix] Fix low-cardinality rewrite NPE caused by shared DecodeInfo

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeInfo.java
@@ -20,8 +20,18 @@ import com.starrocks.sql.optimizer.base.ColumnRefSet;
 /*
  * For record the string columns on operator
  */
-class DecodeInfo {
-    public static final DecodeInfo EMPTY = new DecodeInfo();
+public class DecodeInfo {
+    private DecodeInfo() {
+    }
+
+    public static DecodeInfo create() {
+        return new DecodeInfo();
+    }
+
+    public static DecodeInfo empty() {
+        return new DecodeInfo();
+    }
+
     OptExpression parent = null;
 
     // operator's input string columns
@@ -36,12 +46,24 @@ class DecodeInfo {
     // operator used string column but not output to downstream operator
     ColumnRefSet usedStringColumns = new ColumnRefSet();
 
+    public ColumnRefSet getInputStringColumns() {
+        return inputStringColumns;
+    }
+
+    public ColumnRefSet getDecodeStringColumns() {
+        return decodeStringColumns;
+    }
+
+    public ColumnRefSet getOutputStringColumns() {
+        return outputStringColumns;
+    }
+
     public DecodeInfo createOutputInfo() {
         if (this.outputStringColumns.isEmpty()) {
-            return EMPTY;
+            return DecodeInfo.empty();
         }
 
-        DecodeInfo info = new DecodeInfo();
+        DecodeInfo info = DecodeInfo.create();
         info.inputStringColumns.union(this.outputStringColumns);
         info.outputStringColumns.union(this.outputStringColumns);
         return info;
@@ -49,10 +71,10 @@ class DecodeInfo {
 
     public DecodeInfo createDecodeInfo() {
         if (this.outputStringColumns.isEmpty()) {
-            return EMPTY;
+            return DecodeInfo.empty();
         }
 
-        DecodeInfo info = new DecodeInfo();
+        DecodeInfo info = DecodeInfo.create();
         info.decodeStringColumns.union(this.outputStringColumns);
         return info;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -19,6 +19,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeCollector;
+import com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeInfo;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
@@ -2799,5 +2800,19 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  |    |  30 <-> [30: cast, INT, true]\n" +
                 "  |    |  35 <-> 2\n" +
                 "  |    |  36 <-> NULL", plan);
+    }
+
+    @Test
+    public void testCreateDecodeInfoDoesNotReturnSharedMutableSingleton() {
+        DecodeInfo empty1 = DecodeInfo.create();
+        DecodeInfo empty2 = DecodeInfo.create();
+
+        DecodeInfo d1 = empty1.createDecodeInfo();
+        d1.getDecodeStringColumns().union(new com.starrocks.sql.optimizer.base.ColumnRefSet(1));
+
+        DecodeInfo d2 = empty2.createDecodeInfo();
+        Assertions.assertTrue(d2.getOutputStringColumns().isEmpty());
+        Assertions.assertTrue(d2.getInputStringColumns().isEmpty());
+        Assertions.assertTrue(d2.getDecodeStringColumns().isEmpty());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
We observed intermittent FE-side `NullPointerException` during low-cardinality optimization (stack: `DecodeCollector.visitPhysicalTopN` → `ColumnRefSet.union` → `RoaringBitmap.or` → `RoaringArray.extendArray`). This NPE is caused by **shared mutable state**: an “empty” `DecodeInfo` instance was reused across code paths and then **mutated** (e.g., `clear/union/intersect/except`). Under concurrent planning, multiple queries could modify the same underlying `RoaringBitmap`, corrupting its internal arrays and eventually triggering the NPE inside `RoaringArray.extendArray`.

## What I'm doing:
- Remove the shared mutable “empty” `DecodeInfo` usage so empty results always return **fresh instances** and cannot be mutated across queries.
- Make `DecodeInfo` creation explicit via factory methods (prevent direct `new`) to avoid accidentally reintroducing a shared mutable singleton pattern.
- Update low-cardinality collector/rewriter code paths to use the new `DecodeInfo` creation APIs and avoid null dereferences.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
