### PR TITLE
[BugFix] Fix ClonExpr nullable bug

### DIFF
--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q14.sql
@@ -1,3 +1,4 @@
+
 [fragment statistics]
 PLAN FRAGMENT 0(F03)
 Output Exprs:32: expr
@@ -30,7 +31,7 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 07
 
 6:AGGREGATE (update serialize)
-|  aggregate: sum[(if[([22: P_TYPE, VARCHAR, false] LIKE 'PROMO%', [34: multiply, DOUBLE, false], 0.0); args: BOOLEAN,DOUBLE,DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true], sum[([29: expr, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
+|  aggregate: sum[(if[([22: P_TYPE, VARCHAR, false] LIKE 'PROMO%', [34: multiply, DOUBLE, false], 0.0); args: BOOLEAN,DOUBLE,DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true], sum[([29: expr, DOUBLE, false]); args: DOUBLE; result: DOUBLE; args nullable: false; result nullable: true]
 |  cardinality: 1
 |  column statistics:
 |  * sum-->[0.0, 104949.5, 0.0, 8.0, 1.0] ESTIMATE
@@ -74,6 +75,7 @@ OutPut Exchange Id: 07
 table: part, rollup: part
 preAggregation: on
 partitionsRatio=1/1, tabletsRatio=10/10
+tabletList=10314,10316,10318,10320,10322,10324,10326,10328,10330,10332
 actualRows=0, avgRowSize=33.0
 cardinality: 20000000
 probe runtime filters:
@@ -104,6 +106,7 @@ table: lineitem, rollup: lineitem
 preAggregation: on
 Predicates: [11: L_SHIPDATE, DATE, false] >= '1997-02-01', [11: L_SHIPDATE, DATE, false] < '1997-03-01'
 partitionsRatio=1/1, tabletsRatio=20/20
+tabletList=10338,10340,10342,10344,10346,10348,10350,10352,10354,10356 ...
 actualRows=0, avgRowSize=28.0
 cardinality: 7013947
 column statistics:
@@ -112,3 +115,4 @@ column statistics:
 * L_DISCOUNT-->[0.0, 0.1, 0.0, 8.0, 11.0] MCV: [[0.05:54639500][0.07:54619200][0.02:54617300][0.01:54583400][0.10:54581500]] ESTIMATE
 * L_SHIPDATE-->[8.547264E8, 8.571456E8, 0.0, 4.0, 2526.0] MCV: [[1997-02-16:261100]] ESTIMATE
 [end]
+

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/CloneExpr.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/CloneExpr.java
@@ -36,6 +36,10 @@ public class CloneExpr extends Expr {
         getChild(0).setType(type);
     }
 
+    @Override
+    public boolean isNullable() {
+        return getChild(0).isNullable();
+    }
 
     @Override
     public Expr clone() {

--- a/test/sql/test_expr_reuese/R/test_clone_expr
+++ b/test/sql/test_expr_reuese/R/test_clone_expr
@@ -12,7 +12,7 @@ DISTRIBUTED BY HASH(id) BUCKETS 4;
 insert into t1 select generate_series, generate_series, generate_series % 100, "2024-07-24" from table(generate_series(1, 10));
 -- result:
 -- !result
-SELECT t2.dt, unnest, sum(d1), sum(d2) FROM (select * from (SELECT dt, ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d1, ds_hll_count_distinct(if(id>5 and province>5, age, null), 21) as d2 FROM test.t1 group by dt) t0, unnest([1, 2, 3]) as unnest) t2 GROUP BY 1, 2 ORDER BY 1, 2 limit 10;
+SELECT t2.dt, unnest, sum(d1), sum(d2) FROM (select * from (SELECT dt, ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d1, ds_hll_count_distinct(if(id>5 and province>5, age, null), 21) as d2 FROM t1 group by dt) t0, unnest([1, 2, 3]) as unnest) t2 GROUP BY 1, 2 ORDER BY 1, 2 limit 10;
 -- result:
 2024-07-24	1	5	5
 2024-07-24	2	5	5
@@ -21,7 +21,7 @@ SELECT t2.dt, unnest, sum(d1), sum(d2) FROM (select * from (SELECT dt, ds_hll_co
 insert into t1 select generate_series, generate_series, generate_series % 100, "2024-07-24" from table(generate_series(1, 10));
 -- result:
 -- !result
-SELECT t2.dt, unnest, sum(d1), sum(d2) FROM (select * from (SELECT dt, ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d1, ds_hll_count_distinct(if(id>5 and province>5, age, null), 21) as d2 FROM test.t1 group by dt) t0, unnest([1, 2, 3]) as unnest) t2 GROUP BY 1, 2 ORDER BY 1, 2 limit 10;
+SELECT t2.dt, unnest, sum(d1), sum(d2) FROM (select * from (SELECT dt, ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d1, ds_hll_count_distinct(if(id>5 and province>5, age, null), 21) as d2 FROM t1 group by dt) t0, unnest([1, 2, 3]) as unnest) t2 GROUP BY 1, 2 ORDER BY 1, 2 limit 10;
 -- result:
 2024-07-24	1	5	5
 2024-07-24	2	5	5

--- a/test/sql/test_expr_reuese/R/test_clone_expr
+++ b/test/sql/test_expr_reuese/R/test_clone_expr
@@ -1,0 +1,29 @@
+-- name: test_clone_expr
+CREATE TABLE t1 (
+      id BIGINT NOT NULL,
+      province VARCHAR(64),
+      age SMALLINT,
+      dt VARCHAR(10) NOT NULL
+    )
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 4;
+-- result:
+-- !result
+insert into t1 select generate_series, generate_series, generate_series % 100, "2024-07-24" from table(generate_series(1, 10));
+-- result:
+-- !result
+SELECT t2.dt, unnest, sum(d1), sum(d2) FROM (select * from (SELECT dt, ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d1, ds_hll_count_distinct(if(id>5 and province>5, age, null), 21) as d2 FROM test.t1 group by dt) t0, unnest([1, 2, 3]) as unnest) t2 GROUP BY 1, 2 ORDER BY 1, 2 limit 10;
+-- result:
+2024-07-24	1	5	5
+2024-07-24	2	5	5
+2024-07-24	3	5	5
+-- !result
+insert into t1 select generate_series, generate_series, generate_series % 100, "2024-07-24" from table(generate_series(1, 10));
+-- result:
+-- !result
+SELECT t2.dt, unnest, sum(d1), sum(d2) FROM (select * from (SELECT dt, ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d1, ds_hll_count_distinct(if(id>5 and province>5, age, null), 21) as d2 FROM test.t1 group by dt) t0, unnest([1, 2, 3]) as unnest) t2 GROUP BY 1, 2 ORDER BY 1, 2 limit 10;
+-- result:
+2024-07-24	1	5	5
+2024-07-24	2	5	5
+2024-07-24	3	5	5
+-- !result

--- a/test/sql/test_expr_reuese/T/test_clone_expr
+++ b/test/sql/test_expr_reuese/T/test_clone_expr
@@ -1,0 +1,16 @@
+-- name: test_clone_expr
+
+CREATE TABLE t1 (
+      id BIGINT NOT NULL,
+      province VARCHAR(64),
+      age SMALLINT,
+      dt VARCHAR(10) NOT NULL
+    )
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 4;
+
+insert into t1 select generate_series, generate_series, generate_series % 100, "2024-07-24" from table(generate_series(1, 10));
+SELECT t2.dt, unnest, sum(d1), sum(d2) FROM (select * from (SELECT dt, ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d1, ds_hll_count_distinct(if(id>5 and province>5, age, null), 21) as d2 FROM test.t1 group by dt) t0, unnest([1, 2, 3]) as unnest) t2 GROUP BY 1, 2 ORDER BY 1, 2 limit 10;
+
+insert into t1 select generate_series, generate_series, generate_series % 100, "2024-07-24" from table(generate_series(1, 10));
+SELECT t2.dt, unnest, sum(d1), sum(d2) FROM (select * from (SELECT dt, ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d1, ds_hll_count_distinct(if(id>5 and province>5, age, null), 21) as d2 FROM test.t1 group by dt) t0, unnest([1, 2, 3]) as unnest) t2 GROUP BY 1, 2 ORDER BY 1, 2 limit 10;

--- a/test/sql/test_expr_reuese/T/test_clone_expr
+++ b/test/sql/test_expr_reuese/T/test_clone_expr
@@ -10,7 +10,7 @@ DUPLICATE KEY(id)
 DISTRIBUTED BY HASH(id) BUCKETS 4;
 
 insert into t1 select generate_series, generate_series, generate_series % 100, "2024-07-24" from table(generate_series(1, 10));
-SELECT t2.dt, unnest, sum(d1), sum(d2) FROM (select * from (SELECT dt, ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d1, ds_hll_count_distinct(if(id>5 and province>5, age, null), 21) as d2 FROM test.t1 group by dt) t0, unnest([1, 2, 3]) as unnest) t2 GROUP BY 1, 2 ORDER BY 1, 2 limit 10;
+SELECT t2.dt, unnest, sum(d1), sum(d2) FROM (select * from (SELECT dt, ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d1, ds_hll_count_distinct(if(id>5 and province>5, age, null), 21) as d2 FROM t1 group by dt) t0, unnest([1, 2, 3]) as unnest) t2 GROUP BY 1, 2 ORDER BY 1, 2 limit 10;
 
 insert into t1 select generate_series, generate_series, generate_series % 100, "2024-07-24" from table(generate_series(1, 10));
-SELECT t2.dt, unnest, sum(d1), sum(d2) FROM (select * from (SELECT dt, ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d1, ds_hll_count_distinct(if(id>5 and province>5, age, null), 21) as d2 FROM test.t1 group by dt) t0, unnest([1, 2, 3]) as unnest) t2 GROUP BY 1, 2 ORDER BY 1, 2 limit 10;
+SELECT t2.dt, unnest, sum(d1), sum(d2) FROM (select * from (SELECT dt, ds_hll_count_distinct(if(province>5 and id>5, age, null), 21) as d1, ds_hll_count_distinct(if(id>5 and province>5, age, null), 21) as d2 FROM t1 group by dt) t0, unnest([1, 2, 3]) as unnest) t2 GROUP BY 1, 2 ORDER BY 1, 2 limit 10;


### PR DESCRIPTION
## Why I'm doing:
CloneExpr's nullable is wrong:
```
F20260130 11:08:08.581553 140153981888064 sum.h:60] Check failed: columns[0]->is_numeric() || columns[0]->is_decimal() 
F20260130 11:08:08.582600 140154763994688 sum.h:60] Check failed: columns[0]->is_numeric() || columns[0]->is_decimal() F20260130 11:08:08.582769 140154543400512 sum.h:60] Check failed: columns[0]->is_numeric() || columns[0]->is_decimal() 
F00000000 00:00:00.000000 140154543400512 logging.cc:1962] RAW: Check data_->num_chars_to_log_ > 0 && data_->message_text_[data_->num_chars_to_log_ - 1] == '\n' failed: 
zeno/fix-ds-hll-error-res ASAN (build 6e8b90d distro ubuntu arch x86_64)
query_id:019c0e96-c78f-7969-aa4b-9e3a6e10bd77, fragment_instance:019c0e96-c78f-7969-aa4b-9e3a6e10bd79, plan_node_id:6
zeno/fix-ds-hll-error-res ASAN (build 6e8b90d distro ubuntu arch x86_64)
query_id:019c0e96-c78f-7969-aa4b-9e3a6e10bd77, fragment_instance:019c0e96-c78f-7969-aa4b-9e3a6e10bd79, plan_node_id:6
[1769771288.624][thread: 140154763994688] je_mallctl execute purge success
[1769771288.624][thread: 140154763994688] je_mallctl execute dontdump success
*** Aborted at 1769771288 (unix time) try "date -d @1769771288" if you are using GNU date ***
[1769771288.624][thread: 140153981888064] je_mallctl execute purge success
[1769771288.624][thread: 140153981888064] je_mallctl execute dontdump success
[1769771288.624][thread: 140154543400512] je_mallctl execute purge success
[1769771288.624][thread: 140154543400512] je_mallctl execute dontdump success
PC: @     0x7f7a942969fc pthread_kill
*** SIGABRT (@0x27677) received by PID 161399 (TID 0x7f7852ebe640) LWP(161919) from PID 161399; stack trace: ***
    @         0x3a202447 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f7a94299ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x3a201c46 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f7a94242520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7f7a942969fc pthread_kill
    @     0x7f7a94242476 raise
    @     0x7f7a942287f3 abort
    @         0x2e6530c1 starrocks::failure_function()
    @         0x3a1f5c9d google::LogMessage::Fail()
    @         0x3a1f6d84 google::LogMessageFatal::~LogMessageFatal()
    @         0x23a318db starrocks::SumAggregateFunction<(starrocks::LogicalType)7, long, (starrocks::LogicalType)7, long>::update(starrocks::FunctionContext*, starrocks::Column const**, unsigned char*, unsigned long) const
    @         0x23a33833 starrocks::AggregateFunctionBatchHelper<starrocks::SumAggregateState<long>, starrocks::SumAggregateFunction<(starrocks::LogicalType)7, long, (starrocks::LogicalType)7, long> >::update_batch(starrocks::FunctionContext*, unsigned long, unsigned long, starroc@
    @         0x1fd367cd starrocks::AggregateFunction::update_batch_exception_safe(starrocks::FunctionContext*, unsigned long, unsigned long, starrocks::Column const**, unsigned char**) const
    @         0x27e02cbd starrocks::Aggregator::compute_batch_agg_states(starrocks::Chunk*, unsigned long)
    @         0x2e48a74a starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @         0x27ad2145 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x2f7e1f1e starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x2f7e054a starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x2f7eb82e void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @         0x2f7eab98 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(starrocks::pipeline::GlobalDriver@
    @         0x2f7ea531 std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @         0x2011837a std::function<void ()>::operator()() const
    @         0x358fedbc starrocks::FunctionRunnable::run()
    @         0x358f8cd5 starrocks::ThreadPool::dispatch_thread()
    @         0x3591a1be void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x35918b5d std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x359175ae void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>)
    @         0x35915c0a void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>()
    @         0x35913e90 void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&)
    @         0x35911793 std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool:@
    @         0x3590d029 std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&)
    @         0x2011837a std::function<void ()>::operator()() const
```
## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/issues/68735

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
