### PR TITLE
[BugFix] wait merge jobs finish before LoadSpillPipelineMergeContext destroy

### DIFF
--- a/be/src/storage/load_spill_pipeline_merge_context.cpp
+++ b/be/src/storage/load_spill_pipeline_merge_context.cpp
@@ -18,8 +18,16 @@
 #include "storage/lake/tablet_writer.h"
 #include "storage/load_spill_block_manager.h"
 #include "storage/storage_engine.h"
+#include "util/threadpool.h"
 
 namespace starrocks {
+
+LoadSpillPipelineMergeContext::~LoadSpillPipelineMergeContext() {
+    _quit_flag.store(true);
+    if (_token != nullptr) {
+        _token->shutdown();
+    }
+}
 
 void LoadSpillPipelineMergeContext::create_thread_pool_token() {
     std::lock_guard<std::mutex> lg(_merge_tasks_mutex);

--- a/be/src/storage/load_spill_pipeline_merge_context.h
+++ b/be/src/storage/load_spill_pipeline_merge_context.h
@@ -52,7 +52,7 @@ class TabletWriter;
 class LoadSpillPipelineMergeContext {
 public:
     LoadSpillPipelineMergeContext(lake::TabletWriter* writer) : _writer(writer) {}
-    ~LoadSpillPipelineMergeContext() = default;
+    ~LoadSpillPipelineMergeContext();
 
     /**
      * Lazily create thread pool token for submitting parallel merge tasks.


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request introduces an important improvement to the `LoadSpillPipelineMergeContext` class by implementing a custom destructor to ensure proper shutdown of resources, specifically the thread pool token. This change helps prevent potential resource leaks and ensures a clean shutdown process.

Resource management improvements:

* Added a custom destructor to `LoadSpillPipelineMergeContext` in `load_spill_pipeline_merge_context.cpp` that sets a quit flag and shuts down the thread pool token if it exists, ensuring proper resource cleanup.
* Updated the class definition in `load_spill_pipeline_merge_context.h` to declare the new destructor, replacing the default implementation.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
