### PR TITLE
[Enhancement] Defer remote load spill directory removal

### DIFF
--- a/be/src/exec/spill/block_manager.h
+++ b/be/src/exec/spill/block_manager.h
@@ -116,6 +116,8 @@ struct AcquireBlockOptions {
     BlockAffinityGroup affinity_group = kDefaultBlockAffinityGroup;
     // force to use remote block
     bool force_remote = false;
+    // skip parent path deletion
+    bool skip_parent_path_deletion = false;
 };
 
 // BlockManager is used to manage the life cycle of the Block.

--- a/be/src/exec/spill/block_manager.h
+++ b/be/src/exec/spill/block_manager.h
@@ -116,7 +116,9 @@ struct AcquireBlockOptions {
     BlockAffinityGroup affinity_group = kDefaultBlockAffinityGroup;
     // force to use remote block
     bool force_remote = false;
-    // skip parent path deletion
+    // When true, the container will not attempt to delete the parent directory (e.g. query_id dir)
+    // in its destructor. This is used by LoadSpillBlockManager which defers parent path cleanup
+    // to its own destructor via clear_parent_path(), ensuring all spill files are removed first.
     bool skip_parent_path_deletion = false;
 };
 

--- a/be/src/exec/spill/file_block_manager.cpp
+++ b/be/src/exec/spill/file_block_manager.cpp
@@ -28,22 +28,26 @@ namespace starrocks::spill {
 class FileBlockContainer {
 public:
     FileBlockContainer(DirPtr dir, const TUniqueId& query_id, const TUniqueId& fragment_instance_id,
-                       int32_t plan_node_id, std::string plan_node_name, uint64_t id, size_t acquired_size)
+                       int32_t plan_node_id, std::string plan_node_name, uint64_t id, size_t acquired_size,
+                       bool skip_parent_path_deletion)
             : _dir(std::move(dir)),
               _query_id(query_id),
               _fragment_instance_id(fragment_instance_id),
               _plan_node_id(plan_node_id),
               _plan_node_name(std::move(plan_node_name)),
               _id(id),
-              _acquired_data_size(acquired_size) {}
+              _acquired_data_size(acquired_size),
+              _skip_parent_path_deletion(skip_parent_path_deletion) {}
 
     ~FileBlockContainer() {
         // @TODO we need add a gc thread to delete file
         TRACE_SPILL_LOG << "delete spill container file: " << path();
         WARN_IF_ERROR(_dir->fs()->delete_file(path()), fmt::format("cannot delete spill container file: {}", path()));
         _dir->dec_size(_acquired_data_size);
-        // try to delete related dir, only the last one can success, we ignore the error
-        (void)(_dir->fs()->delete_dir(parent_path()));
+        if (!_skip_parent_path_deletion) {
+            // try to delete related dir, only the last one can success, we ignore the error
+            (void)(_dir->fs()->delete_dir(parent_path()));
+        }
     }
 
     Status open();
@@ -85,7 +89,8 @@ public:
 
     static StatusOr<FileBlockContainerPtr> create(const DirPtr& dir, const TUniqueId& query_id,
                                                   const TUniqueId& fragment_instance_id, int32_t plan_node_id,
-                                                  const std::string& plan_node_name, uint64_t id, size_t block_size);
+                                                  const std::string& plan_node_name, uint64_t id, size_t block_size,
+                                                  bool skip_parent_path_deletion);
 
 private:
     DirPtr _dir;
@@ -100,6 +105,8 @@ private:
     size_t _data_size = 0;
     // acquired data size from Dir
     size_t _acquired_data_size = 0;
+    // skip parent path deletion
+    bool _skip_parent_path_deletion = false;
 };
 
 Status FileBlockContainer::open() {
@@ -141,9 +148,9 @@ StatusOr<std::unique_ptr<io::InputStreamWrapper>> FileBlockContainer::get_readab
 StatusOr<FileBlockContainerPtr> FileBlockContainer::create(const DirPtr& dir, const TUniqueId& query_id,
                                                            const TUniqueId& fragment_instance_id, int32_t plan_node_id,
                                                            const std::string& plan_node_name, uint64_t id,
-                                                           size_t block_size) {
+                                                           size_t block_size, bool skip_parent_path_deletion) {
     auto container = std::make_shared<FileBlockContainer>(dir, query_id, fragment_instance_id, plan_node_id,
-                                                          plan_node_name, id, block_size);
+                                                          plan_node_name, id, block_size, skip_parent_path_deletion);
     RETURN_IF_ERROR(container->open());
     return container;
 }
@@ -193,7 +200,9 @@ public:
 #endif
     }
 
-    bool try_acquire_sizes(size_t size) override { return _container->try_acquire_sizes(size); }
+    bool try_acquire_sizes(size_t size) override {
+        return _container->try_acquire_sizes(size);
+    }
 
 private:
     FileBlockContainerPtr _container;
@@ -212,8 +221,9 @@ StatusOr<BlockPtr> FileBlockManager::acquire_block(const AcquireBlockOptions& op
     AcquireDirOptions acquire_dir_opts;
     acquire_dir_opts.data_size = opts.block_size;
     ASSIGN_OR_RETURN(auto dir, _dir_mgr->acquire_writable_dir(acquire_dir_opts));
-    ASSIGN_OR_RETURN(auto block_container, get_or_create_container(dir, opts.fragment_instance_id, opts.plan_node_id,
-                                                                   opts.name, opts.block_size));
+    ASSIGN_OR_RETURN(auto block_container,
+                     get_or_create_container(dir, opts.fragment_instance_id, opts.plan_node_id, opts.name,
+                                             opts.block_size, opts.skip_parent_path_deletion));
     auto res = std::make_shared<FileBlock>(block_container);
     res->set_is_remote(dir->is_remote());
     return res;
@@ -227,21 +237,21 @@ Status FileBlockManager::release_block(BlockPtr block) {
     return Status::OK();
 }
 
-StatusOr<FileBlockContainerPtr> FileBlockManager::get_or_create_container(const DirPtr& dir,
-                                                                          const TUniqueId& fragment_instance_id,
-                                                                          int32_t plan_node_id,
-                                                                          const std::string& plan_node_name,
-                                                                          size_t block_size) {
+StatusOr<FileBlockContainerPtr> FileBlockManager::get_or_create_container(
+        const DirPtr& dir, const TUniqueId& fragment_instance_id, int32_t plan_node_id,
+        const std::string& plan_node_name, size_t block_size, bool skip_parent_path_deletion) {
     TRACE_SPILL_LOG << "get_or_create_container at dir: " << dir->dir() << ", plan node:" << plan_node_id << ", "
-                    << plan_node_name;
+                    << plan_node_name << ", block size: " << block_size << " bytes"
+                    << ", skip parent path deletion: " << skip_parent_path_deletion;
     uint64_t id = _next_container_id++;
     std::string container_dir = dir->dir() + "/" + print_id(_query_id);
     if (_last_created_container_dir != container_dir) {
         RETURN_IF_ERROR(dir->fs()->create_dir_if_missing(container_dir));
         _last_created_container_dir = container_dir;
     }
-    ASSIGN_OR_RETURN(auto block_container, FileBlockContainer::create(dir, _query_id, fragment_instance_id,
-                                                                      plan_node_id, plan_node_name, id, block_size));
+    ASSIGN_OR_RETURN(auto block_container,
+                     FileBlockContainer::create(dir, _query_id, fragment_instance_id, plan_node_id, plan_node_name, id,
+                                                block_size, skip_parent_path_deletion));
     RETURN_IF_ERROR(block_container->open());
     return block_container;
 }

--- a/be/src/exec/spill/file_block_manager.cpp
+++ b/be/src/exec/spill/file_block_manager.cpp
@@ -105,7 +105,8 @@ private:
     size_t _data_size = 0;
     // acquired data size from Dir
     size_t _acquired_data_size = 0;
-    // skip parent path deletion
+    // When true, skip deleting the parent directory in destructor.
+    // The caller (e.g. LoadSpillBlockManager) is responsible for cleaning up the parent path.
     bool _skip_parent_path_deletion = false;
 };
 
@@ -200,9 +201,7 @@ public:
 #endif
     }
 
-    bool try_acquire_sizes(size_t size) override {
-        return _container->try_acquire_sizes(size);
-    }
+    bool try_acquire_sizes(size_t size) override { return _container->try_acquire_sizes(size); }
 
 private:
     FileBlockContainerPtr _container;

--- a/be/src/exec/spill/file_block_manager.h
+++ b/be/src/exec/spill/file_block_manager.h
@@ -44,7 +44,7 @@ public:
 private:
     StatusOr<FileBlockContainerPtr> get_or_create_container(const DirPtr& dir, const TUniqueId& fragment_instance_id,
                                                             int32_t plan_node_id, const std::string& plan_node_name,
-                                                            size_t block_size);
+                                                            size_t block_size, bool skip_parent_path_deletion);
 
     TUniqueId _query_id;
     std::atomic<uint64_t> _next_container_id = 0;

--- a/be/src/storage/load_spill_block_manager.cpp
+++ b/be/src/storage/load_spill_block_manager.cpp
@@ -106,10 +106,13 @@ spill::BlockPtr LoadSpillBlockContainer::get_block(size_t gid, size_t bid) {
 LoadSpillBlockManager::~LoadSpillBlockManager() {
     // release blocks before block manager
     _block_container.reset();
-    auto status = clear_parent_path();
-    if (!status.ok() && !status.is_not_found()) {
-        LOG(WARNING) << "Failed to clear load spill parent path, load_id=" << print_id(_load_id)
-                     << ", error=" << status;
+    // _remote_dir_manager is initialized in init(), skip cleanup if init() was not called or failed
+    if (_remote_dir_manager != nullptr) {
+        auto status = clear_parent_path();
+        if (!status.ok() && !status.is_not_found()) {
+            LOG(WARNING) << "Failed to clear load spill parent path, load_id=" << print_id(_load_id)
+                         << ", error=" << status;
+        }
     }
 }
 
@@ -159,6 +162,8 @@ StatusOr<spill::BlockPtr> LoadSpillBlockManager::acquire_block(size_t block_size
     opts.name = "load_spill";
     opts.block_size = block_size;
     opts.force_remote = force_remote;
+    // Defer parent path deletion to LoadSpillBlockManager::~LoadSpillBlockManager(),
+    // so the directory is only removed after all spill files have been cleaned up.
     opts.skip_parent_path_deletion = true;
     return _block_manager->acquire_block(opts);
 }

--- a/be/src/storage/load_spill_block_manager.h
+++ b/be/src/storage/load_spill_block_manager.h
@@ -99,6 +99,8 @@ public:
 
     bool is_initialized() const { return _initialized; }
 
+    Status clear_parent_path();
+
     // acquire Block from BlockManager
     StatusOr<spill::BlockPtr> acquire_block(size_t block_size, bool force_remote = false);
     // return Block to BlockManager

--- a/be/src/storage/load_spill_block_manager.h
+++ b/be/src/storage/load_spill_block_manager.h
@@ -99,6 +99,9 @@ public:
 
     bool is_initialized() const { return _initialized; }
 
+    // Delete the remote spill parent directory (e.g. <remote_spill_path>/<load_id>).
+    // Called in destructor after all spill blocks have been released, so that individual
+    // container destructors only delete their own files and this method cleans up the directory.
     Status clear_parent_path();
 
     // acquire Block from BlockManager

--- a/be/test/storage/load_spill_block_manager_test.cpp
+++ b/be/test/storage/load_spill_block_manager_test.cpp
@@ -20,6 +20,7 @@
 #include "fs/fs.h"
 #include "util/raw_container.h"
 #include "util/runtime_profile.h"
+#include "util/uid_util.h"
 
 namespace starrocks {
 
@@ -32,6 +33,15 @@ public:
 protected:
     constexpr static const char* const kTestDir = "./lake_load_spill_block_manager_test";
 };
+
+// Test that destroying LoadSpillBlockManager without calling init() does not crash.
+// This covers the case where init() fails or is never called, and the destructor
+// should safely skip clear_parent_path() when _remote_dir_manager is null.
+TEST_F(LoadSpillBlockManagerTest, test_destroy_without_init) {
+    auto block_manager = std::make_unique<LoadSpillBlockManager>(TUniqueId(), TUniqueId(), kTestDir, nullptr);
+    // Destroy without calling init() — should not crash
+    block_manager.reset();
+}
 
 TEST_F(LoadSpillBlockManagerTest, test_basic) {
     std::unique_ptr<LoadSpillBlockManager> block_manager =
@@ -55,6 +65,35 @@ TEST_F(LoadSpillBlockManagerTest, test_write_read) {
     ASSERT_OK(input_stream->read_fully(buffer.data(), 10));
     ASSERT_EQ(buffer, "helloworld");
     ASSERT_OK(block_manager->release_block(block));
+}
+
+// Test that the spill parent directory is cleaned up after LoadSpillBlockManager is destroyed.
+TEST_F(LoadSpillBlockManagerTest, test_clear_parent_path_on_destroy) {
+    TUniqueId load_id;
+    load_id.hi = 12345;
+    load_id.lo = 67890;
+    auto block_manager = std::make_unique<LoadSpillBlockManager>(load_id, TUniqueId(), kTestDir, nullptr);
+    ASSERT_OK(block_manager->init());
+
+    // Acquire a block with force_remote=true to create the remote spill directory
+    ASSIGN_OR_ABORT(auto block, block_manager->acquire_block(1024, /*force_remote=*/true));
+    ASSERT_OK(block->append({Slice("test_data")}));
+    ASSERT_OK(block->flush());
+
+    // Check that the parent path exists
+    std::string parent_path = std::string(kTestDir) + "/load_spill/" + print_id(load_id);
+    auto status = FileSystem::Default()->iterate_dir(parent_path, [](std::string_view) -> bool { return true; });
+    ASSERT_OK(status);
+
+    ASSERT_OK(block_manager->release_block(block));
+    block.reset();
+
+    // Destroy the manager — should clean up the parent path
+    block_manager.reset();
+
+    // The parent directory should have been deleted
+    status = FileSystem::Default()->iterate_dir(parent_path, [](std::string_view) -> bool { return true; });
+    ASSERT_TRUE(status.is_not_found()) << "Expected parent path to be deleted, but got: " << status;
 }
 
 class LoadSpillBlockMergeExecutorTest : public ::testing::Test {


### PR DESCRIPTION
## Why I'm doing:
When `FileBlockContainer` destructs, it tries to delete its parent directory (the query_id/load_id directory). 
For load spill scenarios, multiple containers share the same parent directory, and the early deletion attempts 
would fail for all but the last container. More importantly, on remote storage (e.g., S3), 
`delete_dir` on a non-empty directory can be expensive or behave differently than local FS.

This PR defers the parent directory cleanup to `LoadSpillBlockManager`'s destructor, ensuring all spill files 
are removed first, and then the empty directory is cleaned up in a single call.

Additionally, this PR fixes a null pointer dereference bug: if `init()` was never called or failed, 
`_remote_dir_manager` would be null, and calling `clear_parent_path()` in the destructor would crash.

## What I'm doing:
- Add `skip_parent_path_deletion` option to `AcquireBlockOptions` and `FileBlockContainer`, allowing callers 
  to skip parent directory deletion in the container destructor.
- `LoadSpillBlockManager` sets `skip_parent_path_deletion = true` when acquiring blocks, and performs the 
  parent directory cleanup in its own destructor via `clear_parent_path()`.
- Add null check for `_remote_dir_manager` in `LoadSpillBlockManager::~LoadSpillBlockManager()` to prevent 
  crash when `init()` was not called.
- Add unit tests for both the null-safety fix and the parent path cleanup behavior.
- Improve code comments explaining the deferred deletion design.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)