### PR TITLE
[BugFix] Fix JSON flatten array and object conflict on identical paths

### DIFF
--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -199,7 +199,7 @@ using JsonFlatExtractFunc = void (*)(const vpack::Slice* json, NullableColumn* r
 using JsonFlatMergeFunc = void (*)(vpack::Builder* builder, const std::string_view& name, const Column* src, size_t idx);
 static const uint8_t JSON_BASE_TYPE_BITS = 0;   // least flat to JSON type
 static const uint8_t JSON_BIGINT_TYPE_BITS = 7; // bigint compatible type
-static const uint8_t JSON_NULL_TYPE_BITS = 31;  // JSON_NULL_TYPE_BITS, initial value for JsonFlatDesc::type
+// static const uint8_t JSON_NULL_TYPE_BITS = 31;  // JSON_NULL_TYPE_BITS, initial value for JsonFlatDesc::type
 
 // bool will flatting as string, because it's need save string-literal(true/false)
 // int & string compatible type is json, because int cast to string will add double quote, it's different with json

--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -410,7 +410,7 @@ void JsonPathDeriver::derived(const std::vector<const Column*>& json_datas) {
     _total_rows = res.value();
 
     _path_root = std::make_shared<JsonFlatPath>();
-    // init path by flat json
+    // init path by flat JSON
     _derived_on_flat_json(json_datas);
 
     // extract common keys, type
@@ -600,19 +600,18 @@ void JsonPathDeriver::_visit_json_paths(const vpack::Slice& value, JsonFlatPath*
         child->last_row = mark_row;
 
         if (v.isObject()) {
-            // Accumulate remain status: if node is ever empty in any row, mark as remain
-            child->remain |= v.isEmptyObject();
-            // If this node was previously visited as primitive (desc->type != JSON_BASE_TYPE_BITS and != initial value),
-            // but now we see an object, this indicates a type mismatch.
-            // Mark the parent node as remain to preserve the actual data structure.
-            if (child->json_type != flat_json::JSON_BASE_TYPE_BITS &&
-                child->json_type != flat_json::JSON_NULL_TYPE_BITS) {
+            // If we have seen any non-object value on the same key before, keep parent as remain.
+            // This covers array<->object and primitive<->object conflicts and preserves the original structure.
+            if (child->hits > child->object_count + 1) {
                 root->remain = true;
             }
+            child->object_count++;
+            // Accumulate remain status: if node is ever empty in any row, mark as remain
+            child->remain |= v.isEmptyObject();
             child->json_type = flat_json::JSON_BASE_TYPE_BITS;
             _visit_json_paths(v, child, mark_row);
-        } else {
-            // If this node has children (was previously visited as object), but now we see a primitive,
+        } else { // NOTE that array is also treated as primitive here.
+            // If this node was previously visited as object, but now we see a primitive,
             // this indicates a type mismatch: path tree expects object but actual data has primitive.
             // Mark the parent node as remain to preserve the actual data structure.
             if (!child->children.empty()) {

--- a/be/src/util/json_flattener.h
+++ b/be/src/util/json_flattener.h
@@ -84,6 +84,7 @@ public:
     uint32_t last_row = -1;
     uint32_t multi_times = 0;
     uint32_t base_type_count = 0; // for count the base type, e.g: int, double, string
+    uint32_t object_count = 0;    // for count the object type
 
     JsonFlatPath() = default;
     JsonFlatPath(JsonFlatPath&&) = default;
@@ -117,7 +118,7 @@ public:
     static std::pair<std::string_view, std::string_view> split_path(const std::string_view& path);
 };
 
-// to deriver json flanttern path
+// to deriver json flatten path
 class JsonPathDeriver {
 public:
     JsonPathDeriver() = default;
@@ -126,7 +127,7 @@ public:
 
     ~JsonPathDeriver() = default;
 
-    // dervie paths
+    // derive paths
     void derived(const std::vector<const Column*>& json_datas);
 
     StatusOr<size_t> check_null_factor(const std::vector<const Column*>& json_datas);

--- a/test/sql/test_semi/R/test_flat_json_consistency2
+++ b/test/sql/test_semi/R/test_flat_json_consistency2
@@ -1,0 +1,309 @@
+-- name: test_flat_json_consistency2
+drop table if exists test_json;
+-- result:
+-- !result
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+-- result:
+-- !result
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": 23234982794}}}}');
+-- result:
+-- !result
+select * from test_json order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+2	{"level1": {"level2": {"level3": {"4": 23234982794}}}}
+-- !result
+select flat_json_meta(c2) from test_json [_META_];
+-- result:
+[]
+-- !result
+drop table if exists test_json;
+-- result:
+-- !result
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+-- result:
+-- !result
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": 3.14}}}}');
+-- result:
+-- !result
+select * from test_json order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+2	{"level1": {"level2": {"level3": {"4": 3.14}}}}
+-- !result
+select flat_json_meta(c2) from test_json [_META_];
+-- result:
+[]
+-- !result
+drop table if exists test_json;
+-- result:
+-- !result
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+-- result:
+-- !result
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": "abc"}}}}');
+-- result:
+-- !result
+select * from test_json order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+2	{"level1": {"level2": {"level3": {"4": "abc"}}}}
+-- !result
+select flat_json_meta(c2) from test_json [_META_];
+-- result:
+[]
+-- !result
+drop table if exists test_json;
+-- result:
+-- !result
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+-- result:
+-- !result
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": {"5":"abc"}}}}}');
+-- result:
+-- !result
+select * from test_json order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+2	{"level1": {"level2": {"level3": {"4": {"5": "abc"}}}}}
+-- !result
+select flat_json_meta(c2) from test_json [_META_];
+-- result:
+["nulls(TINYINT), level1.level2.level3.4.5(VARCHAR), remain(JSON)"]
+-- !result
+drop table if exists test_json;
+-- result:
+-- !result
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+-- result:
+-- !result
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": {}}}}}');
+-- result:
+-- !result
+select * from test_json order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+2	{"level1": {"level2": {"level3": {"4": {}}}}}
+-- !result
+select flat_json_meta(c2) from test_json [_META_];
+-- result:
+[]
+-- !result
+drop table if exists test_json;
+-- result:
+-- !result
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+-- result:
+-- !result
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": null}}}}');
+-- result:
+-- !result
+select * from test_json order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+2	{"level1": {"level2": {"level3": {"4": null}}}}
+-- !result
+select flat_json_meta(c2) from test_json [_META_];
+-- result:
+[]
+-- !result
+drop table if exists test_json;
+-- result:
+-- !result
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+-- result:
+-- !result
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
+(2, NULL);
+-- result:
+-- !result
+select * from test_json order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+2	None
+-- !result
+select flat_json_meta(c2) from test_json [_META_];
+-- result:
+[]
+-- !result
+drop table if exists test_json;
+-- result:
+-- !result
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+-- result:
+-- !result
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": 23234982794}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}');
+-- result:
+-- !result
+select * from test_json order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"4": 23234982794}}}}
+2	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+-- !result
+select flat_json_meta(c2) from test_json [_META_];
+-- result:
+[]
+-- !result
+drop table if exists test_json;
+-- result:
+-- !result
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+-- result:
+-- !result
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": 3.14}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}');
+-- result:
+-- !result
+select * from test_json order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"4": 3.14}}}}
+2	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+-- !result
+select flat_json_meta(c2) from test_json [_META_];
+-- result:
+[]
+-- !result
+drop table if exists test_json;
+-- result:
+-- !result
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+-- result:
+-- !result
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": "abc"}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}');
+-- result:
+-- !result
+select * from test_json order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"4": "abc"}}}}
+2	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+-- !result
+select flat_json_meta(c2) from test_json [_META_];
+-- result:
+[]
+-- !result
+drop table if exists test_json;
+-- result:
+-- !result
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+-- result:
+-- !result
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": {"5":"abc"}}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}');
+-- result:
+-- !result
+select * from test_json order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"4": {"5": "abc"}}}}}
+2	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+-- !result
+select flat_json_meta(c2) from test_json [_META_];
+-- result:
+["nulls(TINYINT), level1.level2.level3.4.5(VARCHAR), remain(JSON)"]
+-- !result
+drop table if exists test_json;
+-- result:
+-- !result
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+-- result:
+-- !result
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": {}}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}');
+-- result:
+-- !result
+select * from test_json order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"4": {}}}}}
+2	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+-- !result
+select flat_json_meta(c2) from test_json [_META_];
+-- result:
+[]
+-- !result
+drop table if exists test_json;
+-- result:
+-- !result
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+-- result:
+-- !result
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": null}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}');
+-- result:
+-- !result
+select * from test_json order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"4": null}}}}
+2	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+-- !result
+select flat_json_meta(c2) from test_json [_META_];
+-- result:
+[]
+-- !result
+drop table if exists test_json;
+-- result:
+-- !result
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+-- result:
+-- !result
+insert into test_json values
+(1, NULL),
+(2, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}');
+-- result:
+-- !result
+select * from test_json order by c1;
+-- result:
+1	None
+2	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+-- !result
+select flat_json_meta(c2) from test_json [_META_];
+-- result:
+[]
+-- !result

--- a/test/sql/test_semi/T/test_flat_json_consistency2
+++ b/test/sql/test_semi/T/test_flat_json_consistency2
@@ -1,0 +1,185 @@
+-- name: test_flat_json_consistency2
+-- array paired with selected mixed types for path level1.level2.level3.4
+
+-- case 01: array -> int
+drop table if exists test_json;
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": 23234982794}}}}');
+
+select * from test_json order by c1;
+select flat_json_meta(c2) from test_json [_META_];
+
+-- case 02: array -> double
+drop table if exists test_json;
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": 3.14}}}}');
+
+select * from test_json order by c1;
+select flat_json_meta(c2) from test_json [_META_];
+
+-- case 03: array -> string
+drop table if exists test_json;
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": "abc"}}}}');
+
+select * from test_json order by c1;
+select flat_json_meta(c2) from test_json [_META_];
+
+-- case 04: array -> object
+drop table if exists test_json;
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": {"5":"abc"}}}}}');
+
+select * from test_json order by c1;
+select flat_json_meta(c2) from test_json [_META_];
+
+-- case 05: array -> empty_object
+drop table if exists test_json;
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": {}}}}}');
+
+select * from test_json order by c1;
+select flat_json_meta(c2) from test_json [_META_];
+
+-- case 06: array -> null_value
+drop table if exists test_json;
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": null}}}}');
+
+select * from test_json order by c1;
+select flat_json_meta(c2) from test_json [_META_];
+
+-- case 07: array -> json_null
+drop table if exists test_json;
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
+(2, NULL);
+
+select * from test_json order by c1;
+select flat_json_meta(c2) from test_json [_META_];
+
+-- case 08: int -> array
+drop table if exists test_json;
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": 23234982794}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}');
+
+select * from test_json order by c1;
+select flat_json_meta(c2) from test_json [_META_];
+
+-- case 09: double -> array
+drop table if exists test_json;
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": 3.14}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}');
+
+select * from test_json order by c1;
+select flat_json_meta(c2) from test_json [_META_];
+
+-- case 10: string -> array
+drop table if exists test_json;
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": "abc"}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}');
+
+select * from test_json order by c1;
+select flat_json_meta(c2) from test_json [_META_];
+
+-- case 11: object -> array
+drop table if exists test_json;
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": {"5":"abc"}}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}');
+
+select * from test_json order by c1;
+select flat_json_meta(c2) from test_json [_META_];
+
+-- case 12: empty_object -> array
+drop table if exists test_json;
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": {}}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}');
+
+select * from test_json order by c1;
+select flat_json_meta(c2) from test_json [_META_];
+
+-- case 13: null_value -> array
+drop table if exists test_json;
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+
+insert into test_json values
+(1, '{"level1": {"level2": {"level3": {"4": null}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}');
+
+select * from test_json order by c1;
+select flat_json_meta(c2) from test_json [_META_];
+
+-- case 14: json_null -> array
+drop table if exists test_json;
+create table test_json (c1 int, c2 json)
+distributed by random buckets 1
+properties("flat_json.enable"="true");
+
+insert into test_json values
+(1, NULL),
+(2, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}');
+
+select * from test_json order by c1;
+select flat_json_meta(c2) from test_json [_META_];
+


### PR DESCRIPTION
## Why I'm doing:

Fix the SQL test case `test_flat_json_consistency`, **which is not unstable but indicates a real bug**.


#64939 fixes the following issue:
- When the same JSON path contains both an **object** and a **primitive** value, we must mark that path as `remain=true` to preserve the original structure in the `remain` column.

**The problem is**: when the current row’s value is an **object**, how do we tell whether earlier rows had a **primitive value**?
- The previous logic used `json_type != JSON_BASE_TYPE_BITS`. However, **arrays** are also treated as a **primitive** type in this context, yet their `json_type` equals `JSON_BASE_TYPE_BITS`.

```sql
create table test_json (c1 int, c2 json)
distributed by random buckets 1
properties("flat_json.enable"="true");

insert into test_json values
(1, '{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}'),
(2, '{"level1": {"level2": {"level3": {"4": {"5":"abc"}}}}}');

select * from test_json order by c1;
-- Expected:
1	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
2	{"level1": {"level2": {"level3": {"4": {"5": "abc"}}}}}
-- Actual:
1	{}
2	{"level1": {"level2": {"level3": {"4": {"5": "abc"}}}}}


select flat_json_meta(c2) from test_json [_META_];
-- Expected:
["nulls(TINYINT), level1.level2.level3.4.5(VARCHAR), remain(JSON)"]
-- Actual:
["nulls(TINYINT), level1.level2.level3.4.5(VARCHAR), level1.level2.level3.level4.5(VARCHAR)"]
```


## What I'm doing:
Introduce `object_count` to track how many objects appear under a given path, and use `hits > object_count + 1` to infer that there was a primitive value previously.

Why not use `base_type_count > 0` to detect prior primitive values?
Because array values do not increment `base_type_count`, even though arrays are considered a primitive type here.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
