### PR TITLE
[BugFix] fix be compile failed while use Clang

### DIFF
--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -105,7 +105,9 @@ Status init_datacache(GlobalEnv* global_env, const std::vector<StorePath>& stora
         }
 #endif
 
+#ifdef USE_STAROS
         int idx = 0;
+#endif
         size_t total_quota_bytes = 0;
         for (auto& root_path : storage_paths) {
             // Because we have unified the datacache between datalake and starlet, we also need to unify the


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Compile branch-3.4 with Clang and without use USE_STAROS, got the following error:
```
/root/starrocks/be/src/service/service_be/starrocks_be.cpp:108:13: error: unused variable 'idx' [-Werror,-Wunused-variable]
        int idx = 0;
            ^
1 error generated.
```

Only Branch-3.4 and Branch-3.5 have this problem.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

