### PR TITLE
[BugFix] Error query results after modify CHAR column length in shared-data

### DIFF
--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -127,6 +127,7 @@ ColumnReader::~ColumnReader() {
 
 Status ColumnReader::_init(ColumnMetaPB* meta, const TabletColumn* column) {
     _column_type = static_cast<LogicalType>(meta->type());
+    _column_length = meta->length();
     _dict_page_pointer = PagePointer(meta->dict_page());
     _total_mem_footprint = meta->total_mem_footprint();
     if (column == nullptr) {

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -143,6 +143,7 @@ public:
 
     PagePointer get_dict_page_pointer() const { return _dict_page_pointer; }
     LogicalType column_type() const { return _column_type; }
+    int32_t column_length() const { return _column_length; }
     bool has_all_dict_encoded() const { return _flags & kHasAllDictEncodedMask; }
     bool all_dict_encoded() const { return _flags & kAllDictEncodedMask; }
 
@@ -258,6 +259,7 @@ private:
     // and now the content that is not needed in Meta is not saved to ColumnReader
     LogicalType _column_type = TYPE_UNKNOWN;
     LogicalType _column_child_type = TYPE_UNKNOWN;
+    int32_t _column_length = 0;  // Original column length from segment footer
     PagePointer _dict_page_pointer;
     uint64_t _total_mem_footprint = 0;
     uint32 _column_unique_id = std::numeric_limits<uint32_t>::max();

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -259,7 +259,7 @@ private:
     // and now the content that is not needed in Meta is not saved to ColumnReader
     LogicalType _column_type = TYPE_UNKNOWN;
     LogicalType _column_child_type = TYPE_UNKNOWN;
-    int32_t _column_length = 0;  // Original column length from segment footer
+    int32_t _column_length = 0; // Original column length from segment footer
     PagePointer _dict_page_pointer;
     uint64_t _total_mem_footprint = 0;
     uint32 _column_unique_id = std::numeric_limits<uint32_t>::max();

--- a/test/sql/test_alter_table/R/test_alter_table_abnormal
+++ b/test/sql/test_alter_table/R/test_alter_table_abnormal
@@ -353,7 +353,7 @@ select * from test2 where v2 = '1';
 -- !result
 
 -- name: test_alter_table_char_padding @cloud
-CREATE TABLE 3
+CREATE TABLE test3
 (
     k1 BIGINT,
     v1 LARGEINT,

--- a/test/sql/test_alter_table/R/test_alter_table_abnormal
+++ b/test/sql/test_alter_table/R/test_alter_table_abnormal
@@ -351,3 +351,37 @@ select * from test2 where v2 = '1';
 -- result:
 1	1	1
 -- !result
+
+-- name: test_alter_table_char_padding @cloud
+CREATE TABLE 3
+(
+    k1 BIGINT,
+    v1 LARGEINT,
+    v2 CHAR(4)
+)
+ENGINE=olap
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH (k1) BUCKETS 3
+PROPERTIES(
+    "replication_num"="1"
+);
+-- result:
+-- !result
+insert into test3 values (1, 1, 'a');
+-- result:
+-- !result
+select * from test3 where v2 = 'a';
+-- result:
+1	1	a
+-- !result
+alter table test3 modify column v2 CHAR(10);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from test3 where v2 = 'a';
+-- result:
+1	1	a
+-- !result

--- a/test/sql/test_alter_table/T/test_alter_table_abnormal
+++ b/test/sql/test_alter_table/T/test_alter_table_abnormal
@@ -172,3 +172,26 @@ alter table test2 add index test_bitmap(v1);
 function: wait_alter_table_finish()
 
 select * from test2 where v2 = '1';
+
+
+-- name: test_alter_table_char_padding @cloud
+CREATE TABLE 3
+(
+    k1 BIGINT,
+    v1 LARGEINT,
+    v2 CHAR(4)
+)
+ENGINE=olap
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH (k1) BUCKETS 3
+PROPERTIES(
+    "replication_num"="1"
+);
+insert into test3 values (1, 1, 'a');
+
+select * from test3 where v2 = 'a';
+
+alter table test3 modify column v2 CHAR(10);
+function: wait_alter_table_finish()
+
+select * from test3 where v2 = 'a';

--- a/test/sql/test_alter_table/T/test_alter_table_abnormal
+++ b/test/sql/test_alter_table/T/test_alter_table_abnormal
@@ -175,7 +175,7 @@ select * from test2 where v2 = '1';
 
 
 -- name: test_alter_table_char_padding @cloud
-CREATE TABLE 3
+CREATE TABLE test3
 (
     k1 BIGINT,
     v1 LARGEINT,


### PR DESCRIPTION
## Why I'm doing:
The bug happens because fast schema evolution does not rewrite CHAR data when its length changes, but CHAR values are stored with fixed-length padding that is used by the zone map and bitmap index. After the length change, we must cast the read CHAR data to the new length so that the padding matches the index and filtering remains correct.

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10943

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
