### PR TITLE
[Enhancement] support iceberg rewrite manifests procedure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -38,6 +38,7 @@ import com.starrocks.connector.iceberg.procedure.FastForwardProcedure;
 import com.starrocks.connector.iceberg.procedure.IcebergTableProcedure;
 import com.starrocks.connector.iceberg.procedure.RemoveOrphanFilesProcedure;
 import com.starrocks.connector.iceberg.procedure.RewriteDataFilesProcedure;
+import com.starrocks.connector.iceberg.procedure.RewriteManifestsProcedure;
 import com.starrocks.connector.iceberg.procedure.RollbackToSnapshotProcedure;
 import com.starrocks.persist.ColumnIdExpr;
 import com.starrocks.planner.DescriptorTable;
@@ -622,6 +623,7 @@ public class IcebergTable extends Table {
             case REMOVE_ORPHAN_FILES -> RemoveOrphanFilesProcedure.getInstance();
             case ROLLBACK_TO_SNAPSHOT -> RollbackToSnapshotProcedure.getInstance();
             case REWRITE_DATA_FILES -> RewriteDataFilesProcedure.getInstance();
+            case REWRITE_MANIFESTS -> RewriteManifestsProcedure.getInstance();
             case ADD_FILES -> AddFilesProcedure.getInstance();
             default -> throw new StarRocksConnectorException("Unsupported table operation %s", op);
         };

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergTableOperation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergTableOperation.java
@@ -21,6 +21,7 @@ public enum IcebergTableOperation {
     REMOVE_ORPHAN_FILES,
     ROLLBACK_TO_SNAPSHOT,
     REWRITE_DATA_FILES,
+    REWRITE_MANIFESTS,
     ADD_FILES,
     UNKNOWN;
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedure.java
@@ -1,0 +1,97 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.procedure;
+
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergTableOperation;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.RewriteManifests;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.StructLikeWrapper;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES;
+import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES_DEFAULT;
+
+public class RewriteManifestsProcedure extends IcebergTableProcedure {
+    private static final String PROCEDURE_NAME = "rewrite_manifests";
+    private static final int MAX_MANIFEST_CLUSTERS = 100;
+
+    private static final RewriteManifestsProcedure INSTANCE = new RewriteManifestsProcedure();
+
+    public static RewriteManifestsProcedure getInstance() {
+        return INSTANCE;
+    }
+
+    private RewriteManifestsProcedure() {
+        super(
+                PROCEDURE_NAME,
+                Collections.emptyList(),
+                IcebergTableOperation.REWRITE_MANIFESTS
+        );
+    }
+
+    @Override
+    public void execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args) {
+        if (!args.isEmpty()) {
+            throw new StarRocksConnectorException(
+                    "invalid args. rewrite_manifests operation does not support any arguments");
+        }
+
+        Table icebergTable = context.table();
+        Snapshot currentSnapshot = icebergTable.currentSnapshot();
+        if (currentSnapshot == null) {
+            return;
+        }
+
+        List<ManifestFile> manifests = currentSnapshot.allManifests(icebergTable.io());
+        if (manifests.isEmpty()) {
+            return;
+        }
+
+        long manifestTargetSizeBytes = PropertyUtil.propertyAsLong(
+                icebergTable.properties(), MANIFEST_TARGET_SIZE_BYTES, MANIFEST_TARGET_SIZE_BYTES_DEFAULT);
+
+        if (manifests.size() == 1 && manifests.get(0).length() < manifestTargetSizeBytes) {
+            return;
+        }
+
+        long totalManifestsSize = manifests.stream().mapToLong(ManifestFile::length).sum();
+        // Having too many open manifest writers can potentially cause OOM on the coordinator
+        long targetManifestClusters = Math.min(
+                ((totalManifestsSize + manifestTargetSizeBytes - 1) / manifestTargetSizeBytes),
+                MAX_MANIFEST_CLUSTERS);
+
+        RewriteManifests rewriteManifests = context.transaction().rewriteManifests();
+        Types.StructType structType = icebergTable.spec().partitionType();
+
+        rewriteManifests
+                .clusterBy(file -> {
+                    // Cluster by partitions for better locality when reading data files
+                    StructLikeWrapper partitionWrapper = StructLikeWrapper.forType(structType).set(file.partition());
+                    // Limit the number of clustering buckets to avoid creating too many small manifest files
+                    return Objects.hash(partitionWrapper) % targetManifestClusters;
+                })
+                .commit();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedure.java
@@ -71,6 +71,9 @@ public class RewriteManifestsProcedure extends IcebergTableProcedure {
 
         long manifestTargetSizeBytes = PropertyUtil.propertyAsLong(
                 icebergTable.properties(), MANIFEST_TARGET_SIZE_BYTES, MANIFEST_TARGET_SIZE_BYTES_DEFAULT);
+        if (manifestTargetSizeBytes <= 0) {
+            manifestTargetSizeBytes = MANIFEST_TARGET_SIZE_BYTES_DEFAULT;
+        }
 
         if (manifests.size() == 1 && manifests.get(0).length() < manifestTargetSizeBytes) {
             return;
@@ -78,9 +81,10 @@ public class RewriteManifestsProcedure extends IcebergTableProcedure {
 
         long totalManifestsSize = manifests.stream().mapToLong(ManifestFile::length).sum();
         // Having too many open manifest writers can potentially cause OOM on the coordinator
-        long targetManifestClusters = Math.min(
+        // Floor to at least 1 to avoid modulo-by-zero when totalManifestsSize is 0 (e.g., manifests report length 0)
+        long targetManifestClusters = Math.max(1, Math.min(
                 ((totalManifestsSize + manifestTargetSizeBytes - 1) / manifestTargetSizeBytes),
-                MAX_MANIFEST_CLUSTERS);
+                MAX_MANIFEST_CLUSTERS));
 
         RewriteManifests rewriteManifests = context.transaction().rewriteManifests();
         Types.StructType structType = icebergTable.spec().partitionType();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedure.java
@@ -94,7 +94,7 @@ public class RewriteManifestsProcedure extends IcebergTableProcedure {
                     // Cluster by partitions for better locality when reading data files
                     StructLikeWrapper partitionWrapper = StructLikeWrapper.forType(structType).set(file.partition());
                     // Limit the number of clustering buckets to avoid creating too many small manifest files
-                    return Objects.hash(partitionWrapper) % targetManifestClusters;
+                    return Integer.toUnsignedLong(Objects.hash(partitionWrapper)) % targetManifestClusters;
                 })
                 .commit();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterTableOperationStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterTableOperationStmtTest.java
@@ -24,6 +24,7 @@ import com.starrocks.connector.iceberg.procedure.ExpireSnapshotsProcedure;
 import com.starrocks.connector.iceberg.procedure.FastForwardProcedure;
 import com.starrocks.connector.iceberg.procedure.RemoveOrphanFilesProcedure;
 import com.starrocks.connector.iceberg.procedure.RewriteDataFilesProcedure;
+import com.starrocks.connector.iceberg.procedure.RewriteManifestsProcedure;
 import com.starrocks.connector.iceberg.procedure.RollbackToSnapshotProcedure;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
@@ -199,6 +200,15 @@ public class AlterTableOperationStmtTest {
     }
 
     @Test
+    public void testRewriteManifestsProcedure() {
+        String sql = "ALTER TABLE iceberg_catalog.iceberg_db.test_table EXECUTE rewrite_manifests()";
+        StatementBase stmt = AnalyzeTestUtil.analyzeSuccess(sql);
+        Assertions.assertInstanceOf(AlterTableStmt.class, stmt);
+        AlterTableStmt alterStmt = (AlterTableStmt) stmt;
+        Assertions.assertEquals("test_table", alterStmt.getTableName());
+    }
+
+    @Test
     public void testRewriteDataFilesProcedureWithWhereClause(@Mocked IcebergTable icebergTable) {
         new MockUp<ExpressionAnalyzer>() {
             @Mock
@@ -364,6 +374,10 @@ public class AlterTableOperationStmtTest {
         Assertions.assertEquals(1, rollbackProc.getArguments().size());
         Assertions.assertEquals("snapshot_id", rollbackProc.getArguments().get(0).getName());
         Assertions.assertTrue(rollbackProc.getArguments().get(0).isRequired());
+
+        RewriteManifestsProcedure rewriteManifestsProc = RewriteManifestsProcedure.getInstance();
+        Assertions.assertEquals("rewrite_manifests", rewriteManifestsProc.getProcedureName());
+        Assertions.assertEquals(0, rewriteManifestsProc.getArguments().size());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedureTest.java
@@ -1,0 +1,200 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.procedure;
+
+import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergTableOperation;
+import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.AlterTableOperationClause;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RewriteManifests;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.Transaction;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RewriteManifestsProcedureTest {
+
+    public static final HdfsEnvironment HDFS_ENVIRONMENT = new HdfsEnvironment();
+
+    @Test
+    void testProcedureCreation() {
+        RewriteManifestsProcedure procedure = RewriteManifestsProcedure.getInstance();
+
+        assertNotNull(procedure);
+        assertEquals("rewrite_manifests", procedure.getProcedureName());
+        assertEquals(Collections.emptyList(), procedure.getArguments());
+        assertEquals(IcebergTableOperation.REWRITE_MANIFESTS, procedure.getOperation());
+    }
+
+    @Test
+    void testExecuteWithInvalidArgs() {
+        RewriteManifestsProcedure procedure = RewriteManifestsProcedure.getInstance();
+        Table table = Mockito.mock(Table.class);
+        IcebergTableProcedureContext context = createContext(table, Mockito.mock(Transaction.class));
+
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put("some_arg", ConstantOperator.createVarchar("value"));
+
+        StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class,
+                () -> procedure.execute(context, args));
+
+        assertTrue(ex.getMessage().contains("invalid args"));
+        assertTrue(ex.getMessage().contains("rewrite_manifests"));
+        assertTrue(ex.getMessage().contains("does not support any arguments"));
+    }
+
+    @Test
+    void testExecuteWithNoSnapshot() {
+        RewriteManifestsProcedure procedure = RewriteManifestsProcedure.getInstance();
+        Table table = Mockito.mock(Table.class);
+        when(table.currentSnapshot()).thenReturn(null);
+        IcebergTableProcedureContext context = createContext(table, Mockito.mock(Transaction.class));
+
+        assertDoesNotThrow(() -> procedure.execute(context, Collections.emptyMap()));
+        verify(table, never()).io();
+    }
+
+    @Test
+    void testExecuteWithEmptyManifests() {
+        RewriteManifestsProcedure procedure = RewriteManifestsProcedure.getInstance();
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+        when(snapshot.allManifests(any())).thenReturn(Collections.emptyList());
+
+        Table table = Mockito.mock(Table.class);
+        when(table.currentSnapshot()).thenReturn(snapshot);
+        IcebergTableProcedureContext context = createContext(table, Mockito.mock(Transaction.class));
+
+        assertDoesNotThrow(() -> procedure.execute(context, Collections.emptyMap()));
+
+        Transaction txn = context.transaction();
+        verify(txn, never()).rewriteManifests();
+    }
+
+    @Test
+    void testExecuteWithSingleSmallManifest() {
+        RewriteManifestsProcedure procedure = RewriteManifestsProcedure.getInstance();
+        ManifestFile smallManifest = Mockito.mock(ManifestFile.class);
+        when(smallManifest.length()).thenReturn(100L);
+
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+        when(snapshot.allManifests(any())).thenReturn(List.of(smallManifest));
+
+        Table table = Mockito.mock(Table.class);
+        when(table.currentSnapshot()).thenReturn(snapshot);
+        when(table.properties()).thenReturn(Collections.emptyMap());
+        when(table.spec()).thenReturn(PartitionSpec.unpartitioned());
+
+        Transaction txn = Mockito.mock(Transaction.class);
+        IcebergTableProcedureContext context = createContext(table, txn);
+
+        assertDoesNotThrow(() -> procedure.execute(context, Collections.emptyMap()));
+        verify(txn, never()).rewriteManifests();
+    }
+
+    @Test
+    void testExecuteRewriteSuccess() {
+        RewriteManifestsProcedure procedure = RewriteManifestsProcedure.getInstance();
+
+        ManifestFile m1 = Mockito.mock(ManifestFile.class);
+        ManifestFile m2 = Mockito.mock(ManifestFile.class);
+        when(m1.length()).thenReturn(10 * 1024 * 1024L);
+        when(m2.length()).thenReturn(10 * 1024 * 1024L);
+
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+        when(snapshot.allManifests(any())).thenReturn(List.of(m1, m2));
+
+        Table table = Mockito.mock(Table.class);
+        when(table.currentSnapshot()).thenReturn(snapshot);
+        when(table.properties()).thenReturn(Collections.emptyMap());
+        when(table.spec()).thenReturn(PartitionSpec.unpartitioned());
+
+        RewriteManifests rewriteManifests = Mockito.mock(RewriteManifests.class);
+        when(rewriteManifests.clusterBy(any())).thenReturn(rewriteManifests);
+        doNothing().when(rewriteManifests).commit();
+
+        Transaction txn = Mockito.mock(Transaction.class);
+        when(txn.rewriteManifests()).thenReturn(rewriteManifests);
+
+        IcebergTableProcedureContext context = createContext(table, txn);
+
+        assertDoesNotThrow(() -> procedure.execute(context, Collections.emptyMap()));
+
+        verify(txn).rewriteManifests();
+        verify(rewriteManifests).clusterBy(any());
+        verify(rewriteManifests).commit();
+    }
+
+    @Test
+    void testExecuteWithSingleLargeManifestTriggersRewrite() {
+        RewriteManifestsProcedure procedure = RewriteManifestsProcedure.getInstance();
+        // One manifest larger than default target (8MB) still triggers rewrite
+        ManifestFile largeManifest = Mockito.mock(ManifestFile.class);
+        when(largeManifest.length()).thenReturn(10 * 1024 * 1024L);
+
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+        when(snapshot.allManifests(any())).thenReturn(List.of(largeManifest));
+
+        Table table = Mockito.mock(Table.class);
+        when(table.currentSnapshot()).thenReturn(snapshot);
+        when(table.properties()).thenReturn(Collections.emptyMap());
+        when(table.spec()).thenReturn(PartitionSpec.unpartitioned());
+
+        RewriteManifests rewriteManifests = Mockito.mock(RewriteManifests.class);
+        when(rewriteManifests.clusterBy(any())).thenReturn(rewriteManifests);
+        doNothing().when(rewriteManifests).commit();
+
+        Transaction txn = Mockito.mock(Transaction.class);
+        when(txn.rewriteManifests()).thenReturn(rewriteManifests);
+
+        IcebergTableProcedureContext context = createContext(table, txn);
+
+        assertDoesNotThrow(() -> procedure.execute(context, Collections.emptyMap()));
+
+        verify(txn).rewriteManifests();
+        verify(rewriteManifests).clusterBy(any());
+        verify(rewriteManifests).commit();
+    }
+
+    private IcebergTableProcedureContext createContext(Table table, Transaction transaction) {
+        IcebergHiveCatalog catalog = Mockito.mock(IcebergHiveCatalog.class);
+        ConnectContext ctx = Mockito.mock(ConnectContext.class);
+        AlterTableStmt stmt = Mockito.mock(AlterTableStmt.class);
+        AlterTableOperationClause clause = Mockito.mock(AlterTableOperationClause.class);
+        return new IcebergTableProcedureContext(catalog, table, ctx, transaction, HDFS_ENVIRONMENT, stmt, clause);
+    }
+}

--- a/test/sql/test_iceberg/R/test_iceberg_rewrite_manifests
+++ b/test/sql/test_iceberg/R/test_iceberg_rewrite_manifests
@@ -1,0 +1,49 @@
+-- name: test_iceberg_remove_orphan_files
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+create table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}(k1 int);
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 1;
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 2;
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 3;
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 4;
+-- result:
+-- !result
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests;
+-- result:
+4
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute rewrite_data_files();
+-- result:
+-- !result
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests;
+-- result:
+5
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute rewrite_manifests();
+-- result:
+-- !result
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests;
+-- result:
+1
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+-- result:
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_rewrite_manifests
+++ b/test/sql/test_iceberg/T/test_iceberg_rewrite_manifests
@@ -1,0 +1,21 @@
+-- name: test_iceberg_remove_orphan_files
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+create table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}(k1 int);
+
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 1;
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 2;
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 3;
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 4;
+
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests;
+
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute rewrite_data_files();
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests;
+
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute rewrite_manifests();
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests;
+
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Iceberg tables can accumulate many small manifest files over time due to frequent commits and rewrites. This increases metadata size, slows down metadata reads and query planning, and can affect overall query performance. Apache Iceberg provides a `rewrite_manifests` operation to compact and reorganize these manifests, but StarRocks’ Iceberg integration did not expose it. This PR adds support so users can maintain Iceberg table metadata (compact manifests) directly from StarRocks.

## What I'm doing:

- **Rewrite Manifests**  
  - New procedure **`rewrite_manifests()`** (no arguments): rewrites current snapshot’s manifest files by clustering by partition (for better read locality), respects `commit.manifest.target-size-bytes`, and caps the number of manifest clusters to avoid OOM.  
  - Registered in `IcebergTable` / `IcebergTableOperation` and wired to `ALTER TABLE ... EXECUTE rewrite_manifests()`.

- **Tests**  
  - Add/update unit tests for the new procedures (e.g.`RewriteManifestsProcedureTest`) and for `AlterTableOperationStmt` (e.g. `rewrite_manifests` parsing).
  - Add a dedicated SQL integration test `test_iceberg_rewrite_manifests` that creates an Iceberg table, inserts data, runs rewrite_data_files() and rewrite_manifests(), and checks manifest counts via $manifests.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [x] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
