### PR TITLE
[UT] Fix race-condition in CastStringToArray multi-threaded mutation 

### DIFF
--- a/be/src/exprs/cast_expr_array.cpp
+++ b/be/src/exprs/cast_expr_array.cpp
@@ -145,7 +145,7 @@ StatusOr<ColumnPtr> CastStringToArray::evaluate_checked(ExprContext* context, Ch
         if (input->only_null()) {
             return ColumnHelper::create_const_null_column(rows);
         } else {
-            return ConstColumn::create(std::move(*(input->data_column())).mutate(), rows);
+            return ConstColumn::create(std::move(*(input->data_column())).clone(), rows);
         }
     }
     ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, input_chunk));

--- a/test/sql/test_array/R/test_cast_array
+++ b/test/sql/test_array/R/test_cast_array
@@ -33,6 +33,10 @@ select count(*) from (select @arr_str arr from (select t1.k3 from tbl t1 join tb
 -- result:
 100
 -- !result
+select /*+SET_VAR(pipeline_dop=100)*/ count(*) from (select @arr_str arr from (select t1.k3 from tbl t1 join tbl t2) t) t group by arr[1];
+-- result:
+100
+-- !result
 select count(*), array_length(array_agg(arr)) from (select @arr_str arr from (select t1.k3 from tbl t1) t) t group by arr[1];
 -- result:
 10	10

--- a/test/sql/test_array/T/test_cast_array
+++ b/test/sql/test_array/T/test_cast_array
@@ -20,6 +20,7 @@ select @arr_str[1];
 select element_at(array_agg(array_length(@arr_str)), 5) from (select t1.k3 from tbl t1 join tbl t2 join tbl t3 join tbl t4) t;
 select * from (select array_length(@arr_str) array_len from (select t1.k3 from tbl t1 join tbl t2 join tbl t3 join tbl t4) t) t where array_len = 1;
 select count(*) from (select @arr_str arr from (select t1.k3 from tbl t1 join tbl t2) t) t group by arr[1];
+select /*+SET_VAR(pipeline_dop=100)*/ count(*) from (select @arr_str arr from (select t1.k3 from tbl t1 join tbl t2) t) t group by arr[1];
 select count(*), array_length(array_agg(arr)) from (select @arr_str arr from (select t1.k3 from tbl t1) t) t group by arr[1];
 select array_length(array_agg(arr)) from (select cast("[[1, 2, 3], [1, 2, 3]]" as array<array<int>>) arr from (select t1.k3 from tbl t1 join tbl t2) t)  t;
 select array_agg(arr)[1] from (select cast("[[1, 2, 3], [1, 2, 3]]" as array<array<int>>) arr from (select t1.k3 from tbl t1 join tbl t2) t)  t;


### PR DESCRIPTION
## Why I'm doing:
Fix the SQL test case `test_cast_array`, **which is not unstable but indicates a real bug**.

Why the PR is tagged as `[UT]` rather than `[BugFix]`:
This test case was marked as unstable and I was added to the blacklist. However, before fixing this bug, the case could not pass reliably.


`CastStringToArray::evaluate_checked` concurrently mutates the same column from multiple threads.
- When the input string of `CastStringToArray` is a constant large string, a single `CastStringToArray` expression caches a `_constant_res`.
- Multiple `ProjectOperator` share the same `CastStringToArray`, and when they call `CastStringToArray::evaluate_checked` concurrently, they may end up calling `_constant_res.mutate()` at the same time.

`mutate()` is not thread-safe
- `mutate()` checks whether the current Rc’s reference count is 1. If it is, it returns `self` directly; otherwise, it clones the data and returns the clone. 
- Multiple threads may simultaneously observe the reference count as 1 and therefore all return `self` directly.

```
*** Aborted at 1770026809 (unix time) try "date -d @1770026809" if you are using GNU date ***
PC: @          0xa776aa0 void std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, starrocks::ColumnAllocator<unsigned char> > >::_M_range_insert<char*>(__gnu_cxx::__normal_iterator<unsigned char*, std::vector<unsigned char, starrocks::raw::RawAllocator<uns@
*** SIGSEGV (@0x14c5bc200000) received by PID 75041 (TID 0x14c5e8dff640) LWP(75384) from PID 18446744072570798080; stack trace: ***
    @     0x14c611c21ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x14b78546 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x14c611bca520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0xa776aa0 void std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, starrocks::ColumnAllocator<unsigned char> > >::_M_range_insert<char*>(__gnu_cxx::__normal_iterator<unsigned char*, std::vector<unsigned char, starrocks::raw::RawAllocator<uns@
    @          0xa782a39 starrocks::BinaryColumnBase<unsigned int>::append(starrocks::Slice const&)
    @          0xa766769 starrocks::BinaryColumnBase<unsigned int>::append_datum(starrocks::Datum const&)
    @          0xa79b3ad starrocks::NullableColumn::append_datum(starrocks::Datum const&)
    @          0xa8f0bdc starrocks::ArrayColumn::append_value_multiple_times(void const*, unsigned long)
    @          0xa8f33fe starrocks::ArrayColumn::assign(unsigned long, unsigned long)
    @          0xc00d514 starrocks::ArrayElementExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @          0xbe9d583 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @          0xbe9da4b starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @          0xee6ae43 starrocks::pipeline::ProjectOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0xd37ad86 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0xf1a6d80 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x10d880fb starrocks::ThreadPool::dispatch_thread()
    @         0x10d7e65e starrocks::Thread::supervise_thread(void*)
    @     0x14c611c1cac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x14c611cae8c0 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1268bf)
```

## What I'm doing:

Change `mutate()` to `clone()` in `CastStringToArray::evaluate_checked`.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
