### PR TITLE
[BugFix] fix be compile failed while use Clang

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -441,9 +441,9 @@ Status CacheEnv::_init_datacache() {
                 corresponding_starlet_dirs = *s;
             }
         }
+        int idx = 0;
 #endif
 
-        int idx = 0;
         size_t total_quota_bytes = 0;
         for (auto& root_path : _store_paths) {
             // Because we have unified the datacache between datalake and starlet, we also need to unify the


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


This pr fix compile failed with Clang and without USE_STAROS, on Branch-3.5.
```
/root/starrocks/be/src/runtime/exec_env.cpp:446:13: error: unused variable 'idx' [-Werror,-Wunused-variable]
        int idx = 0;
            ^
1 error generated.
```

https://github.com/StarRocks/starrocks/pull/68805 already fix this problem on Branch-3.4.

Other branches do not have this problem.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

