### PR TITLE
[Enhancement] support where/order/limit in show stmt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultSet.java
@@ -91,6 +91,10 @@ public class ShowResultSet {
         return true;
     }
 
+    public void setResultRows(List<List<String>> resultRows) {
+        this.resultRows = resultRows;
+    }
+
     public List<List<String>> getResultRows() {
         return resultRows;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeJobStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeJobStmt.java
@@ -22,8 +22,8 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.LimitElement;
-import com.starrocks.sql.ast.expression.Predicate;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.statistic.AnalyzeJob;
 
@@ -33,7 +33,7 @@ import java.util.List;
 
 public class ShowAnalyzeJobStmt extends ShowStmt {
 
-    public ShowAnalyzeJobStmt(Predicate predicate, List<OrderByElement> orderByElements,
+    public ShowAnalyzeJobStmt(Expr predicate, List<OrderByElement> orderByElements,
                               LimitElement limitElement, NodePosition pos) {
         super(pos);
         this.predicate = predicate;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeStatusStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeStatusStmt.java
@@ -22,8 +22,8 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.LimitElement;
-import com.starrocks.sql.ast.expression.Predicate;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.statistic.AnalyzeStatus;
 import com.starrocks.statistic.StatisticUtils;
@@ -37,7 +37,7 @@ import java.util.List;
 public class ShowAnalyzeStatusStmt extends ShowStmt {
     private static final Logger LOG = LogManager.getLogger(ShowAnalyzeStatusStmt.class);
 
-    public ShowAnalyzeStatusStmt(Predicate predicate, List<OrderByElement> orderByElements,
+    public ShowAnalyzeStatusStmt(Expr predicate, List<OrderByElement> orderByElements,
                                  LimitElement limitElement, NodePosition pos) {
         super(pos);
         this.predicate = predicate;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBasicStatsMetaStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBasicStatsMetaStmt.java
@@ -14,15 +14,15 @@
 
 package com.starrocks.sql.ast;
 
+import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.LimitElement;
-import com.starrocks.sql.ast.expression.Predicate;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
 
 public class ShowBasicStatsMetaStmt extends ShowStmt {
 
-    public ShowBasicStatsMetaStmt(Predicate predicate, List<OrderByElement> orderByElements,
+    public ShowBasicStatsMetaStmt(Expr predicate, List<OrderByElement> orderByElements,
                                   LimitElement limitElement, NodePosition pos) {
         super(pos);
         this.predicate = predicate;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowHistogramStatsMetaStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowHistogramStatsMetaStmt.java
@@ -14,15 +14,15 @@
 
 package com.starrocks.sql.ast;
 
+import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.LimitElement;
-import com.starrocks.sql.ast.expression.Predicate;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
 
 public class ShowHistogramStatsMetaStmt extends ShowStmt {
 
-    public ShowHistogramStatsMetaStmt(Predicate predicate, List<OrderByElement> orderByElements,
+    public ShowHistogramStatsMetaStmt(Expr predicate, List<OrderByElement> orderByElements,
                                       LimitElement limitElement, NodePosition pos) {
         super(pos);
         this.predicate = predicate;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMultiColumnStatsMetaStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMultiColumnStatsMetaStmt.java
@@ -14,15 +14,15 @@
 
 package com.starrocks.sql.ast;
 
+import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.LimitElement;
-import com.starrocks.sql.ast.expression.Predicate;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
 
 public class ShowMultiColumnStatsMetaStmt extends ShowStmt {
-    public ShowMultiColumnStatsMetaStmt(Predicate predicate, List<OrderByElement> orderByElements,
-                                      LimitElement limitElement, NodePosition pos) {
+    public ShowMultiColumnStatsMetaStmt(Expr predicate, List<OrderByElement> orderByElements,
+                                        LimitElement limitElement, NodePosition pos) {
         super(pos);
         this.predicate = predicate;
         this.limitElement = limitElement;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -380,6 +380,7 @@ import com.starrocks.sql.ast.ShowSnapshotStmt;
 import com.starrocks.sql.ast.ShowSqlBlackListStmt;
 import com.starrocks.sql.ast.ShowSqlDigestBlackListStmt;
 import com.starrocks.sql.ast.ShowStatusStmt;
+import com.starrocks.sql.ast.ShowStmt;
 import com.starrocks.sql.ast.ShowStorageVolumesStmt;
 import com.starrocks.sql.ast.ShowStreamLoadStmt;
 import com.starrocks.sql.ast.ShowTableStatusStmt;
@@ -737,14 +738,17 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             catalog = normalizeName(dbName.toString());
         }
 
+        ShowDbStmt stmt = null;
         if (context.pattern != null) {
             StringLiteral stringLiteral = (StringLiteral) visit(context.pattern);
-            return new ShowDbStmt(stringLiteral.getValue(), null, catalog, pos);
-        } else if (context.expression() != null) {
-            return new ShowDbStmt(null, (Expr) visit(context.expression()), catalog, pos);
+            stmt = new ShowDbStmt(stringLiteral.getValue(), null, catalog, pos);
         } else {
-            return new ShowDbStmt(null, null, catalog, pos);
+            stmt = new ShowDbStmt(null, getWhereFrom(context.showPredicateClauses()), catalog, pos);
         }
+
+        stmt.markSelfPredicate();
+        visitShowPredicateClauses(context.showPredicateClauses(), stmt);
+        return stmt;
     }
 
     @Override
@@ -823,13 +827,16 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowDataStmt(com.starrocks.sql.parser.StarRocksParser.ShowDataStmtContext context) {
         NodePosition pos = createPos(context);
+        ShowDataStmt showDataStmt = null;
         if (context.FROM() != null) {
             QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
             TableName targetTableName = qualifiedNameToTableName(qualifiedName);
-            return new ShowDataStmt(targetTableName.getDb(), targetTableName.getTbl(), pos);
+            showDataStmt = new ShowDataStmt(targetTableName.getDb(), targetTableName.getTbl(), pos);
         } else {
-            return new ShowDataStmt(null, null, pos);
+            showDataStmt = new ShowDataStmt(null, null, pos);
         }
+        visitShowPredicateClauses(context.showPredicateClauses(), showDataStmt);
+        return showDataStmt;
     }
 
     @Override
@@ -846,8 +853,11 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             partitionRef = new PartitionRef(partitionNames.getPartitionNames(), partitionNames.isTemp(), partitionNames.getPos());
         }
 
-        return new ShowDataDistributionStmt(new TableRef(normalizeName(qualifiedName), partitionRef, createPos(start, stop)),
+        ShowDataDistributionStmt stmt =
+                new ShowDataDistributionStmt(new TableRef(normalizeName(qualifiedName), partitionRef, createPos(start, stop)),
                 createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), stmt);
+        return stmt;
     }
 
     // ------------------------------------------- Table Statement -----------------------------------------------------
@@ -1418,6 +1428,47 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         return new TruncateTableStmt(new TableRef(qualifiedName, partitionRef, pos));
     }
 
+    public void visitShowPredicateClauses(StarRocksParser.ShowPredicateClausesContext ctx, ShowStmt showStmt) {
+        if (ctx == null) {
+            return;
+        }
+
+        Expr where;
+        if (!showStmt.isSelfPredicate() && ctx.WHERE() != null) {
+            where = (Expr) visit(ctx.expression());
+            showStmt.setPredicate(where);
+        }
+        if (!showStmt.isSelfOrderBy() && ctx.ORDER() != null) {
+            List<OrderByElement> orderByElements = visit(ctx.sortItem(), OrderByElement.class);
+            showStmt.setOrderByElements(orderByElements);
+        }
+        if (!showStmt.isSelfLimit() && ctx.limitElement() != null) {
+            LimitElement limitElement = (LimitElement) visit(ctx.limitElement());
+            showStmt.setLimitElement(limitElement);
+        }
+    }
+
+    public Expr getWhereFrom(StarRocksParser.ShowPredicateClausesContext ctx) {
+        if (ctx == null || ctx.WHERE() == null) {
+            return null;
+        }
+        return (Expr) visit(ctx.expression());
+    }
+
+    public List<OrderByElement> getOrderByFrom(StarRocksParser.ShowPredicateClausesContext ctx) {
+        if (ctx == null || ctx.ORDER() == null) {
+            return List.of();
+        }
+        return visit(ctx.sortItem(), OrderByElement.class);
+    }
+
+    public LimitElement getLimitFrom(StarRocksParser.ShowPredicateClausesContext ctx) {
+        if (ctx == null || ctx.limitElement() == null) {
+            return null;
+        }
+        return (LimitElement) visit(ctx.limitElement());
+    }
+
     @Override
     public ParseNode visitShowTableStatement(com.starrocks.sql.parser.StarRocksParser.ShowTableStatementContext context) {
         boolean isVerbose = context.FULL() != null;
@@ -1439,14 +1490,17 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
         NodePosition pos = createPos(context);
 
+        ShowTableStmt showTableStmt;
         if (context.pattern != null) {
             StringLiteral stringLiteral = (StringLiteral) visit(context.pattern);
-            return new ShowTableStmt(database, isVerbose, stringLiteral.getValue(), null, catalog, pos);
-        } else if (context.expression() != null) {
-            return new ShowTableStmt(database, isVerbose, null, (Expr) visit(context.expression()), catalog, pos);
+            showTableStmt = new ShowTableStmt(database, isVerbose, stringLiteral.getValue(), null, catalog, pos);
         } else {
-            return new ShowTableStmt(database, isVerbose, null, null, catalog, pos);
+            showTableStmt = new ShowTableStmt(database, isVerbose, null,
+                    getWhereFrom(context.showPredicateClauses()), catalog, pos);
         }
+        showTableStmt.markSelfPredicate();
+        visitShowPredicateClauses(context.showPredicateClauses(), showTableStmt);
+        return showTableStmt;
     }
 
     @Override
@@ -1468,14 +1522,17 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
         NodePosition pos = createPos(context);
 
+        ShowTemporaryTableStmt showTemporaryTableStmt;
         if (context.pattern != null) {
             StringLiteral stringLiteral = (StringLiteral) visit(context.pattern);
-            return new ShowTemporaryTableStmt(database, stringLiteral.getValue(), null, catalog, pos);
-        } else if (context.expression() != null) {
-            return new ShowTemporaryTableStmt(database, null, (Expr) visit(context.expression()), catalog, pos);
+            showTemporaryTableStmt = new ShowTemporaryTableStmt(database, stringLiteral.getValue(), null, catalog, pos);
         } else {
-            return new ShowTemporaryTableStmt(database, null, null, catalog, pos);
+            showTemporaryTableStmt = new ShowTemporaryTableStmt(database, null,
+                    getWhereFrom(context.showPredicateClauses()), catalog, pos);
         }
+        showTemporaryTableStmt.markSelfPredicate();
+        visitShowPredicateClauses(context.showPredicateClauses(), showTemporaryTableStmt);
+        return showTemporaryTableStmt;
     }
 
     @Override
@@ -1505,13 +1562,14 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             pattern = stringLiteral.getValue();
         }
 
-        Expr where = null;
-        if (context.expression() != null) {
-            where = (Expr) visit(context.expression());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(context.showPredicateClauses());
 
         String normalizedDb = dbName == null ? null : normalizeName(dbName.toString());
-        return new ShowTableStatusStmt(normalizedDb, pattern, where, createPos(context));
+        ShowTableStatusStmt showTableStatusStmt = new ShowTableStatusStmt(normalizedDb, pattern, where, createPos(context));
+        showTableStatusStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, showTableStatusStmt);
+        return showTableStatusStmt;
     }
 
     @Override
@@ -1539,12 +1597,13 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             pattern = stringLiteral.getValue();
         }
 
-        Expr where = null;
-        if (context.expression() != null) {
-            where = (Expr) visit(context.expression());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(context.showPredicateClauses());
 
-        return new ShowColumnStmt(tableRef, pattern, context.FULL() != null, where, createPos(context));
+        ShowColumnStmt showColumnStmt = new ShowColumnStmt(tableRef, pattern, context.FULL() != null, where, createPos(context));
+        showColumnStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, showColumnStmt);
+        return showColumnStmt;
     }
 
     @Override
@@ -1776,10 +1835,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         if (context.db != null) {
             dbName = getQualifiedName(context.db);
         }
-        Expr where = null;
-        if (context.expression() != null) {
-            where = (Expr) visit(context.expression());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(context.showPredicateClauses());
         ShowAlterStmt.AlterType alterType;
         if (context.ROLLUP() != null) {
             alterType = ShowAlterStmt.AlterType.ROLLUP;
@@ -1790,17 +1847,13 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         } else {
             alterType = ShowAlterStmt.AlterType.COLUMN;
         }
-        List<OrderByElement> orderByElements = null;
-        if (context.ORDER() != null) {
-            orderByElements = new ArrayList<>();
-            orderByElements.addAll(visit(context.sortItem(), OrderByElement.class));
-        }
-        LimitElement limitElement = null;
-        if (context.limitElement() != null) {
-            limitElement = (LimitElement) visit(context.limitElement());
-        }
+        List<OrderByElement> orderByElements = getOrderByFrom(showPredicateClauses);
+        LimitElement limitElement = getLimitFrom(showPredicateClauses);
         String normalizedDb = dbName == null ? null : normalizeName(dbName.toString());
-        return new ShowAlterStmt(alterType, normalizedDb, where, orderByElements, limitElement, createPos(context));
+        ShowAlterStmt showAlterStmt =
+                new ShowAlterStmt(alterType, normalizedDb, where, orderByElements, limitElement, createPos(context));
+        showAlterStmt.markSelfPredicateOrderLimit(true, true, true);
+        return showAlterStmt;
     }
 
     // ------------------------------------------- View Statement ------------------------------------------------------
@@ -1898,21 +1951,16 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         NodePosition tablePos = createPos(context.qualifiedName().start, context.qualifiedName().stop);
         TableRef tableRef = new TableRef(normalizeName(qualifiedName), null, tablePos);
 
-        Expr where = null;
-        if (context.expression() != null) {
-            where = (Expr) visit(context.expression());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(context.showPredicateClauses());
 
-        List<OrderByElement> orderByElements = new ArrayList<>();
-        if (context.ORDER() != null) {
-            orderByElements.addAll(visit(context.sortItem(), OrderByElement.class));
-        }
+        List<OrderByElement> orderByElements = getOrderByFrom(showPredicateClauses);
 
-        LimitElement limitElement = null;
-        if (context.limitElement() != null) {
-            limitElement = (LimitElement) visit(context.limitElement());
-        }
-        return new ShowPartitionsStmt(tableRef, where, orderByElements, limitElement, temp, createPos(context));
+        LimitElement limitElement = getLimitFrom(showPredicateClauses);
+        ShowPartitionsStmt showPartitionsStmt =
+                new ShowPartitionsStmt(tableRef, where, orderByElements, limitElement, temp, createPos(context));
+        showPartitionsStmt.markSelfPredicateOrderLimit(true, true, true);
+        return showPartitionsStmt;
     }
 
     @Override
@@ -1940,21 +1988,14 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             if (context.partitionNames() != null) {
                 partitionNames = (PartitionRef) visit(context.partitionNames());
             }
-            Expr where = null;
-            if (context.expression() != null) {
-                where = (Expr) visit(context.expression());
-            }
-            List<OrderByElement> orderByElements = null;
-            if (context.ORDER() != null) {
-                orderByElements = new ArrayList<>();
-                orderByElements.addAll(visit(context.sortItem(), OrderByElement.class));
-            }
-            LimitElement limitElement = null;
-            if (context.limitElement() != null) {
-                limitElement = (LimitElement) visit(context.limitElement());
-            }
-            return new ShowTabletStmt(tableRef, -1L, partitionNames, where, orderByElements, limitElement,
-                    createPos(context));
+            StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+            Expr where = getWhereFrom(showPredicateClauses);
+            List<OrderByElement> orderByElements = getOrderByFrom(showPredicateClauses);
+            LimitElement limitElement = getLimitFrom(showPredicateClauses);
+            ShowTabletStmt showTabletStmt = new ShowTabletStmt(tableRef, -1L, partitionNames, where, orderByElements,
+                    limitElement, createPos(context));
+            showTabletStmt.markSelfPredicateOrderLimit(true, true, true);
+            return showTabletStmt;
         }
     }
 
@@ -2013,7 +2054,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                     tableRef.getPartitionRef(), alias, tableRef.getPos());
         }
 
-        return new ShowIndexStmt(tableRef, createPos(context));
+        ShowIndexStmt showIndexStmt = new ShowIndexStmt(tableRef, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showIndexStmt);
+        return showIndexStmt;
     }
 
     // ------------------------------------------- Task Statement ------------------------------------------------------
@@ -2292,14 +2335,18 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
         catalog = normalizeName(catalog);
         database = normalizeName(database);
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(context.showPredicateClauses());
+        ShowMaterializedViewsStmt showMaterializedViewsStmt;
         if (context.pattern != null) {
             StringLiteral stringLiteral = (StringLiteral) visit(context.pattern);
-            return new ShowMaterializedViewsStmt(catalog, database, stringLiteral.getValue(), null, pos);
-        } else if (context.expression() != null) {
-            return new ShowMaterializedViewsStmt(catalog, database, null, (Expr) visit(context.expression()), pos);
+            showMaterializedViewsStmt = new ShowMaterializedViewsStmt(catalog, database, stringLiteral.getValue(), where, pos);
         } else {
-            return new ShowMaterializedViewsStmt(catalog, database, null, null, pos);
+            showMaterializedViewsStmt = new ShowMaterializedViewsStmt(catalog, database, null, where, pos);
         }
+        showMaterializedViewsStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, showMaterializedViewsStmt);
+        return showMaterializedViewsStmt;
     }
 
     @Override
@@ -2440,11 +2487,15 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowCatalogsStatement(com.starrocks.sql.parser.StarRocksParser.ShowCatalogsStatementContext context) {
         NodePosition pos = createPos(context);
+        ShowCatalogsStmt showCatalogsStmt;
         if (context.pattern != null) {
             StringLiteral stringLiteral = (StringLiteral) visit(context.pattern);
-            return new ShowCatalogsStmt(stringLiteral.getValue(), pos);
+            showCatalogsStmt = new ShowCatalogsStmt(stringLiteral.getValue(), pos);
+        } else {
+            showCatalogsStmt = new ShowCatalogsStmt(null, createPos(context));
         }
-        return new ShowCatalogsStmt(null, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showCatalogsStmt);
+        return showCatalogsStmt;
     }
 
     @Override
@@ -2629,7 +2680,10 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowCreateRoutineLoadStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowCreateRoutineLoadStatementContext context) {
-        return new ShowCreateRoutineLoadStmt(createLabelName(context.db, context.name));
+        ShowCreateRoutineLoadStmt showCreateRoutineLoadStmt =
+                new ShowCreateRoutineLoadStmt(createLabelName(context.db, context.name));
+        visitShowPredicateClauses(context.showPredicateClauses(), showCreateRoutineLoadStmt);
+        return showCreateRoutineLoadStmt;
     }
 
     @Override
@@ -2685,21 +2739,14 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             com.starrocks.sql.parser.StarRocksParser.ShowRoutineLoadStatementContext context) {
         boolean isVerbose = context.ALL() != null;
         String database = null;
-        Expr where = null;
-        if (context.expression() != null) {
-            where = (Expr) visit(context.expression());
-        }
-        List<OrderByElement> orderByElements = null;
-        if (context.ORDER() != null) {
-            orderByElements = new ArrayList<>();
-            orderByElements.addAll(visit(context.sortItem(), OrderByElement.class));
-        }
-        LimitElement limitElement = null;
-        if (context.limitElement() != null) {
-            limitElement = (LimitElement) visit(context.limitElement());
-        }
-        return new ShowRoutineLoadStmt(createLabelName(context.db, context.name), isVerbose, where, orderByElements,
-                limitElement, createPos(context));
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(context.showPredicateClauses());
+        List<OrderByElement> orderByElements = getOrderByFrom(context.showPredicateClauses());
+        LimitElement limitElement = getLimitFrom(context.showPredicateClauses());
+        ShowRoutineLoadStmt showRoutineLoadStmt = new ShowRoutineLoadStmt(createLabelName(context.db, context.name),
+                isVerbose, where, orderByElements, limitElement, createPos(context));
+        showRoutineLoadStmt.markSelfPredicateOrderLimit(true, true, true);
+        return showRoutineLoadStmt;
     }
 
     @Override
@@ -2710,34 +2757,26 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             dbName = getQualifiedName(context.db);
         }
 
-        Expr where = null;
-        if (context.expression() != null) {
-            where = (Expr) visit(context.expression());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(context.showPredicateClauses());
         String normalizedDb = dbName == null ? null : normalizeName(dbName.toString());
-        return new ShowRoutineLoadTaskStmt(normalizedDb, where, createPos(context));
+        ShowRoutineLoadTaskStmt showRoutineLoadTaskStmt = new ShowRoutineLoadTaskStmt(normalizedDb, where, createPos(context));
+        showRoutineLoadTaskStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, showRoutineLoadTaskStmt);
+        return showRoutineLoadTaskStmt;
     }
 
     @Override
     public ParseNode visitShowStreamLoadStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowStreamLoadStatementContext context) {
         boolean isVerbose = context.ALL() != null;
-        String database = null;
-        Expr where = null;
-        if (context.expression() != null) {
-            where = (Expr) visit(context.expression());
-        }
-        List<OrderByElement> orderByElements = null;
-        if (context.ORDER() != null) {
-            orderByElements = new ArrayList<>();
-            orderByElements.addAll(visit(context.sortItem(), OrderByElement.class));
-        }
-        LimitElement limitElement = null;
-        if (context.limitElement() != null) {
-            limitElement = (LimitElement) visit(context.limitElement());
-        }
-        return new ShowStreamLoadStmt(createLabelName(context.db, context.name), isVerbose, where, orderByElements,
-                limitElement, createPos(context));
+        Expr where = getWhereFrom(context.showPredicateClauses());
+        List<OrderByElement> orderByElements = getOrderByFrom(context.showPredicateClauses());
+        LimitElement limitElement = getLimitFrom(context.showPredicateClauses());
+        ShowStreamLoadStmt showStreamLoadStmt = new ShowStreamLoadStmt(createLabelName(context.db, context.name),
+                isVerbose, where, orderByElements, limitElement, createPos(context));
+        showStreamLoadStmt.markSelfPredicateOrderLimit(true, true, true);
+        return showStreamLoadStmt;
     }
 
     // ------------------------------------------- Admin Statement -----------------------------------------------------
@@ -2762,11 +2801,16 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     public ParseNode visitAdminShowConfigStatement(
             com.starrocks.sql.parser.StarRocksParser.AdminShowConfigStatementContext context) {
         NodePosition pos = createPos(context);
+        AdminShowConfigStmt adminShowConfigStmt;
         if (context.pattern != null) {
             StringLiteral stringLiteral = (StringLiteral) visit(context.pattern);
-            return new AdminShowConfigStmt(AdminSetConfigStmt.ConfigType.FRONTEND, stringLiteral.getValue(), pos);
+            adminShowConfigStmt =
+                    new AdminShowConfigStmt(AdminSetConfigStmt.ConfigType.FRONTEND, stringLiteral.getValue(), pos);
+        } else {
+            adminShowConfigStmt = new AdminShowConfigStmt(AdminSetConfigStmt.ConfigType.FRONTEND, null, pos);
         }
-        return new AdminShowConfigStmt(AdminSetConfigStmt.ConfigType.FRONTEND, null, pos);
+        visitShowPredicateClauses(context.showPredicateClauses(), adminShowConfigStmt);
+        return adminShowConfigStmt;
     }
 
     @Override
@@ -2790,7 +2834,10 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         TableRef tableRef = new TableRef(normalizeName(qualifiedName), partitionRef, createPos(start, stop));
-        return new AdminShowReplicaDistributionStmt(tableRef, createPos(context));
+        AdminShowReplicaDistributionStmt adminShowReplicaDistributionStmt =
+                new AdminShowReplicaDistributionStmt(tableRef, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), adminShowReplicaDistributionStmt);
+        return adminShowReplicaDistributionStmt;
     }
 
     @Override
@@ -2799,7 +2846,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         Token start = context.qualifiedName().start;
         Token stop = context.qualifiedName().stop;
         QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
-        Expr where = context.where != null ? (Expr) visit(context.where) : null;
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(context.showPredicateClauses());
 
         PartitionRef partitionRef = null;
         if (context.partitionNames() != null) {
@@ -2809,7 +2857,11 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         TableRef tableRef = new TableRef(normalizeName(qualifiedName), partitionRef, createPos(start, stop));
-        return new AdminShowReplicaStatusStmt(tableRef, where, createPos(context));
+        AdminShowReplicaStatusStmt adminShowReplicaStatusStmt =
+                new AdminShowReplicaStatusStmt(tableRef, where, createPos(context));
+        adminShowReplicaStatusStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, adminShowReplicaStatusStmt);
+        return adminShowReplicaStatusStmt;
     }
 
     @Override
@@ -2951,7 +3003,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowComputeNodesStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowComputeNodesStatementContext context) {
-        return new ShowComputeNodesStmt(createPos(context));
+        ShowComputeNodesStmt showComputeNodesStmt = new ShowComputeNodesStmt(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showComputeNodesStmt);
+        return showComputeNodesStmt;
     }
 
     // ------------------------------------------- Analyze Statement ---------------------------------------------------
@@ -3079,73 +3133,63 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
     @Override
     public ParseNode visitShowAnalyzeStatement(com.starrocks.sql.parser.StarRocksParser.ShowAnalyzeStatementContext context) {
-        Predicate predicate = null;
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr predicate = getWhereFrom(showPredicateClauses);
         NodePosition pos = createPos(context);
-        if (context.expression() != null) {
-            predicate = (Predicate) visit(context.expression());
-        }
-
-        List<OrderByElement> orderByElements = null;
-        if (context.ORDER() != null) {
-            orderByElements = new ArrayList<>(visit(context.sortItem(), OrderByElement.class));
-        }
-        LimitElement limitElement = null;
-        if (context.limitElement() != null) {
-            limitElement = (LimitElement) visit(context.limitElement());
-        }
+        List<OrderByElement> orderByElements = getOrderByFrom(showPredicateClauses);
+        LimitElement limitElement = getLimitFrom(showPredicateClauses);
 
         if (context.STATUS() != null) {
-            return new ShowAnalyzeStatusStmt(predicate, orderByElements, limitElement, pos);
+            ShowAnalyzeStatusStmt showAnalyzeStatusStmt =
+                    new ShowAnalyzeStatusStmt(predicate, orderByElements, limitElement, pos);
+            showAnalyzeStatusStmt.markSelfPredicateOrderLimit(true, true, true);
+            return showAnalyzeStatusStmt;
         } else if (context.JOB() != null) {
-            return new ShowAnalyzeJobStmt(predicate, orderByElements, limitElement, pos);
+            ShowAnalyzeJobStmt showAnalyzeJobStmt = new ShowAnalyzeJobStmt(predicate, orderByElements, limitElement, pos);
+            visitShowPredicateClauses(showPredicateClauses, showAnalyzeJobStmt);
+            showAnalyzeJobStmt.markSelfPredicateOrderLimit(true, true, true);
+            return showAnalyzeJobStmt;
         } else {
-            return new ShowAnalyzeJobStmt(predicate, orderByElements, limitElement, pos);
+            ShowAnalyzeJobStmt showAnalyzeJobStmt = new ShowAnalyzeJobStmt(predicate, orderByElements, limitElement, pos);
+            visitShowPredicateClauses(showPredicateClauses, showAnalyzeJobStmt);
+            showAnalyzeJobStmt.markSelfPredicateOrderLimit(true, true, true);
+            return showAnalyzeJobStmt;
         }
     }
 
     @Override
     public ParseNode visitShowStatsMetaStatement(com.starrocks.sql.parser.StarRocksParser.ShowStatsMetaStatementContext context) {
-        Predicate predicate = null;
-        if (context.expression() != null) {
-            predicate = (Predicate) visit(context.expression());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr predicate = getWhereFrom(showPredicateClauses);
 
-        List<OrderByElement> orderByElements = null;
-        if (context.ORDER() != null) {
-            orderByElements = new ArrayList<>();
-            orderByElements.addAll(visit(context.sortItem(), OrderByElement.class));
-        }
-        LimitElement limitElement = null;
-        if (context.limitElement() != null) {
-            limitElement = (LimitElement) visit(context.limitElement());
-        }
+        List<OrderByElement> orderByElements = getOrderByFrom(showPredicateClauses);
+        LimitElement limitElement = getLimitFrom(showPredicateClauses);
 
         if (context.MULTIPLE() != null) {
-            return new ShowMultiColumnStatsMetaStmt(predicate, orderByElements, limitElement, createPos(context));
+            ShowMultiColumnStatsMetaStmt showMultiColumnStatsMetaStmt =
+                    new ShowMultiColumnStatsMetaStmt(predicate, orderByElements, limitElement, createPos(context));
+            showMultiColumnStatsMetaStmt.markSelfPredicateOrderLimit(true, true, true);
+            return showMultiColumnStatsMetaStmt;
         } else {
-            return new ShowBasicStatsMetaStmt(predicate, orderByElements, limitElement, createPos(context));
+            ShowBasicStatsMetaStmt showBasicStatsMetaStmt =
+                    new ShowBasicStatsMetaStmt(predicate, orderByElements, limitElement, createPos(context));
+            showBasicStatsMetaStmt.markSelfPredicateOrderLimit(true, true, true);
+            return showBasicStatsMetaStmt;
         }
     }
 
     @Override
     public ParseNode visitShowHistogramMetaStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowHistogramMetaStatementContext context) {
-        Predicate predicate = null;
-        if (context.expression() != null) {
-            predicate = (Predicate) visit(context.expression());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr predicate = getWhereFrom(showPredicateClauses);
+        List<OrderByElement> orderByElements = getOrderByFrom(showPredicateClauses);
+        LimitElement limitElement = getLimitFrom(showPredicateClauses);
 
-        List<OrderByElement> orderByElements = null;
-        if (context.ORDER() != null) {
-            orderByElements = new ArrayList<>();
-            orderByElements.addAll(visit(context.sortItem(), OrderByElement.class));
-        }
-        LimitElement limitElement = null;
-        if (context.limitElement() != null) {
-            limitElement = (LimitElement) visit(context.limitElement());
-        }
-
-        return new ShowHistogramStatsMetaStmt(predicate, orderByElements, limitElement, createPos(context));
+        ShowHistogramStatsMetaStmt showHistogramStatsMetaStmt =
+                new ShowHistogramStatsMetaStmt(predicate, orderByElements, limitElement, createPos(context));
+        showHistogramStatsMetaStmt.markSelfPredicateOrderLimit(true, true, true);
+        return showHistogramStatsMetaStmt;
     }
 
     private AnalyzeStmt histogramStatement(com.starrocks.sql.parser.StarRocksParser.HistogramStatementContext context) {
@@ -3282,12 +3326,15 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     public ParseNode visitShowResourceGroupStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowResourceGroupStatementContext context) {
         NodePosition pos = createPos(context);
+        ShowResourceGroupStmt showResourceGroupStmt;
         if (context.GROUPS() != null) {
-            return new ShowResourceGroupStmt(null, context.ALL() != null, context.VERBOSE() != null, pos);
+            showResourceGroupStmt = new ShowResourceGroupStmt(null, context.ALL() != null, context.VERBOSE() != null, pos);
         } else {
             Identifier identifier = (Identifier) visit(context.identifier());
-            return new ShowResourceGroupStmt(identifier.getValue(), false, context.VERBOSE() != null, pos);
+            showResourceGroupStmt = new ShowResourceGroupStmt(identifier.getValue(), false, context.VERBOSE() != null, pos);
         }
+        visitShowPredicateClauses(context.showPredicateClauses(), showResourceGroupStmt);
+        return showResourceGroupStmt;
     }
 
     // ------------------------------------------- External Resource Statement -----------------------------------------
@@ -3312,7 +3359,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     }
 
     public ParseNode visitShowResourceStatement(com.starrocks.sql.parser.StarRocksParser.ShowResourceStatementContext context) {
-        return new ShowResourcesStmt(createPos(context));
+        ShowResourcesStmt showResourcesStmt = new ShowResourcesStmt(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showResourcesStmt);
+        return showResourcesStmt;
     }
 
     // ------------------------------------------- Load Statement ------------------------------------------------------
@@ -3491,22 +3540,14 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             db = ((Identifier) visit(context.identifier())).getValue();
         }
         db = normalizeName(db);
-        Expr labelExpr = null;
-        if (context.expression() != null) {
-            labelExpr = (Expr) visit(context.expression());
-        }
-        List<OrderByElement> orderByElements = null;
-        if (context.ORDER() != null) {
-            orderByElements = new ArrayList<>();
-            orderByElements.addAll(visit(context.sortItem(), OrderByElement.class));
-        }
-        LimitElement limitElement = null;
-        if (context.limitElement() != null) {
-            limitElement = (LimitElement) visit(context.limitElement());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr labelExpr = getWhereFrom(showPredicateClauses);
+        List<OrderByElement> orderByElements = getOrderByFrom(showPredicateClauses);
+        LimitElement limitElement = getLimitFrom(showPredicateClauses);
         boolean all = context.ALL() != null;
         ShowLoadStmt res = new ShowLoadStmt(db, labelExpr, orderByElements, limitElement, createPos(context));
         res.setAll(all);
+        res.markSelfPredicateOrderLimit(true, true, true);
         return res;
     }
 
@@ -3522,15 +3563,14 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             db = ((Identifier) visit(context.identifier())).getValue();
         }
         db = normalizeName(db);
-        Expr labelExpr = null;
-        if (context.expression() != null) {
-            labelExpr = (Expr) visit(context.expression());
-        }
-        LimitElement limitElement = null;
-        if (context.limitElement() != null) {
-            limitElement = (LimitElement) visit(context.limitElement());
-        }
-        return new ShowLoadWarningsStmt(db, null, labelExpr, limitElement, createPos(context));
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr labelExpr = getWhereFrom(showPredicateClauses);
+        LimitElement limitElement = getLimitFrom(showPredicateClauses);
+        ShowLoadWarningsStmt showLoadWarningsStmt =
+                new ShowLoadWarningsStmt(db, null, labelExpr, limitElement, createPos(context));
+        showLoadWarningsStmt.markSelfPredicateOrderLimit(true, false, true);
+        visitShowPredicateClauses(showPredicateClauses, showLoadWarningsStmt);
+        return showLoadWarningsStmt;
     }
 
     @Override
@@ -3562,17 +3602,23 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
     @Override
     public ParseNode visitShowAuthorStatement(com.starrocks.sql.parser.StarRocksParser.ShowAuthorStatementContext context) {
-        return new ShowAuthorStmt(createPos(context));
+        ShowAuthorStmt showAuthorStmt = new ShowAuthorStmt(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showAuthorStmt);
+        return showAuthorStmt;
     }
 
     @Override
     public ParseNode visitShowBackendsStatement(com.starrocks.sql.parser.StarRocksParser.ShowBackendsStatementContext context) {
-        return new ShowBackendsStmt(createPos(context));
+        ShowBackendsStmt showBackendsStmt = new ShowBackendsStmt(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showBackendsStmt);
+        return showBackendsStmt;
     }
 
     @Override
     public ParseNode visitShowBrokerStatement(com.starrocks.sql.parser.StarRocksParser.ShowBrokerStatementContext context) {
-        return new ShowBrokerStmt(createPos(context));
+        ShowBrokerStmt showBrokerStmt = new ShowBrokerStmt(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showBrokerStmt);
+        return showBrokerStmt;
     }
 
     @Override
@@ -3583,12 +3629,13 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             pattern = stringLiteral.getValue();
         }
 
-        Expr where = null;
-        if (context.expression() != null) {
-            where = (Expr) visit(context.expression());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(showPredicateClauses);
 
-        return new ShowCharsetStmt(pattern, where, createPos(context));
+        ShowCharsetStmt showCharsetStmt = new ShowCharsetStmt(pattern, where, createPos(context));
+        showCharsetStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, showCharsetStmt);
+        return showCharsetStmt;
     }
 
     @Override
@@ -3599,12 +3646,13 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             pattern = stringLiteral.getValue();
         }
 
-        Expr where = null;
-        if (context.expression() != null) {
-            where = (Expr) visit(context.expression());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(showPredicateClauses);
 
-        return new ShowCollationStmt(pattern, where, createPos(context));
+        ShowCollationStmt showCollationStmt = new ShowCollationStmt(pattern, where, createPos(context));
+        showCollationStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, showCollationStmt);
+        return showCollationStmt;
     }
 
     @Override
@@ -3614,7 +3662,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             dbName = getQualifiedName(context.db);
         }
         String normalizedDb = dbName == null ? null : normalizeName(dbName.toString());
-        return new ShowDeleteStmt(normalizedDb, createPos(context));
+        ShowDeleteStmt showDeleteStmt = new ShowDeleteStmt(normalizedDb, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showDeleteStmt);
+        return showDeleteStmt;
     }
 
     @Override
@@ -3627,51 +3677,70 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         String normalizedDb = dbName == null ? null : normalizeName(dbName.toString());
-        return new ShowDynamicPartitionStmt(normalizedDb, createPos(context));
+        ShowDynamicPartitionStmt showDynamicPartitionStmt = new ShowDynamicPartitionStmt(normalizedDb, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showDynamicPartitionStmt);
+        return showDynamicPartitionStmt;
     }
 
     @Override
     public ParseNode visitShowEventsStatement(com.starrocks.sql.parser.StarRocksParser.ShowEventsStatementContext context) {
-        return new ShowEventsStmt(createPos(context));
+        ShowEventsStmt showEventsStmt = new ShowEventsStmt(createPos(context));
+        showEventsStmt.markSelfPredicate();
+        visitShowPredicateClauses(context.showPredicateClauses(), showEventsStmt);
+        return showEventsStmt;
     }
 
     @Override
     public ParseNode visitShowEnginesStatement(com.starrocks.sql.parser.StarRocksParser.ShowEnginesStatementContext context) {
-        return new ShowEnginesStmt(createPos(context));
+        ShowEnginesStmt showEnginesStmt = new ShowEnginesStmt(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showEnginesStmt);
+        return showEnginesStmt;
     }
 
     @Override
     public ParseNode visitShowFrontendsStatement(com.starrocks.sql.parser.StarRocksParser.ShowFrontendsStatementContext context) {
-        return new ShowFrontendsStmt(createPos(context));
+        ShowFrontendsStmt showFrontendsStmt = new ShowFrontendsStmt(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showFrontendsStmt);
+        return showFrontendsStmt;
     }
 
     @Override
     public ParseNode visitShowPluginsStatement(com.starrocks.sql.parser.StarRocksParser.ShowPluginsStatementContext context) {
-        return new ShowPluginsStmt(createPos(context));
+        ShowPluginsStmt showPluginsStmt = new ShowPluginsStmt(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showPluginsStmt);
+        return showPluginsStmt;
     }
 
     @Override
     public ParseNode visitShowRepositoriesStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowRepositoriesStatementContext context) {
-        return new ShowRepositoriesStmt(createPos(context));
+        ShowRepositoriesStmt showRepositoriesStmt = new ShowRepositoriesStmt(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showRepositoriesStmt);
+        return showRepositoriesStmt;
     }
 
     @Override
     public ParseNode visitShowOpenTableStatement(com.starrocks.sql.parser.StarRocksParser.ShowOpenTableStatementContext context) {
-        return new ShowOpenTableStmt(createPos(context));
+        ShowOpenTableStmt showOpenTableStmt = new ShowOpenTableStmt(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showOpenTableStmt);
+        return showOpenTableStmt;
     }
 
     @Override
     public ParseNode visitShowProcedureStatement(com.starrocks.sql.parser.StarRocksParser.ShowProcedureStatementContext context) {
         NodePosition pos = createPos(context);
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(showPredicateClauses);
+        ShowProcedureStmt showProcedureStmt;
         if (context.pattern != null) {
             StringLiteral stringLiteral = (StringLiteral) visit(context.pattern);
-            return new ShowProcedureStmt(stringLiteral.getValue(), null, pos);
-        } else if (context.expression() != null) {
-            return new ShowProcedureStmt(null, (Expr) visit(context.expression()), pos);
+            showProcedureStmt = new ShowProcedureStmt(stringLiteral.getValue(), where, pos);
         } else {
-            return new ShowProcedureStmt(null, null, pos);
+            showProcedureStmt = new ShowProcedureStmt(null, where, pos);
         }
+        showProcedureStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, showProcedureStmt);
+        return showProcedureStmt;
     }
 
     @Override
@@ -3688,32 +3757,53 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             forUser = ((StringLiteral) visit(context.string())).getValue();
         }
         boolean isShowFull = context.FULL() != null;
-        return new ShowProcesslistStmt(isShowFull, forUser, createPos(context));
+        ShowProcesslistStmt showProcesslistStmt = new ShowProcesslistStmt(isShowFull, forUser, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showProcesslistStmt);
+        return showProcesslistStmt;
     }
 
     @Override
     public ParseNode visitShowProfilelistStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowProfilelistStatementContext context) {
-        int limit = context.LIMIT() != null ? Integer.parseInt(context.limit.getText()) : -1;
-        return new ShowProfilelistStmt(limit, createPos(context));
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        int limit = -1;
+        if (showPredicateClauses != null && showPredicateClauses.limitElement() != null) {
+            LimitElement limitElement = (LimitElement) visit(showPredicateClauses.limitElement());
+            limit = (int) limitElement.getLimit();
+        }
+        ShowProfilelistStmt showProfilelistStmt = new ShowProfilelistStmt(limit, createPos(context));
+        showProfilelistStmt.markSelfPredicateOrderLimit(false, false, true);
+        visitShowPredicateClauses(showPredicateClauses, showProfilelistStmt);
+        return showProfilelistStmt;
     }
 
     @Override
     public ParseNode visitShowRunningQueriesStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowRunningQueriesStatementContext context) {
-        int limit = context.LIMIT() != null ? Integer.parseInt(context.limit.getText()) : -1;
-        return new ShowRunningQueriesStmt(limit, createPos(context));
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        int limit = -1;
+        if (showPredicateClauses != null && showPredicateClauses.limitElement() != null) {
+            LimitElement limitElement = (LimitElement) visit(showPredicateClauses.limitElement());
+            limit = (int) limitElement.getLimit();
+        }
+        ShowRunningQueriesStmt showRunningQueriesStmt = new ShowRunningQueriesStmt(limit, createPos(context));
+        showRunningQueriesStmt.markSelfPredicateOrderLimit(false, false, true);
+        visitShowPredicateClauses(showPredicateClauses, showRunningQueriesStmt);
+        return showRunningQueriesStmt;
     }
 
     @Override
     public ParseNode visitShowResourceGroupUsageStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowResourceGroupUsageStatementContext context) {
+        ShowResourceGroupUsageStmt showResourceGroupUsageStmt;
         if (context.GROUPS() != null) {
-            return new ShowResourceGroupUsageStmt(null, createPos(context));
+            showResourceGroupUsageStmt = new ShowResourceGroupUsageStmt(null, createPos(context));
+        } else {
+            Identifier groupName = (Identifier) visit(context.identifier());
+            showResourceGroupUsageStmt = new ShowResourceGroupUsageStmt(groupName.getValue(), createPos(context));
         }
-
-        Identifier groupName = (Identifier) visit(context.identifier());
-        return new ShowResourceGroupUsageStmt(groupName.getValue(), createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showResourceGroupUsageStmt);
+        return showResourceGroupUsageStmt;
     }
 
     @Override
@@ -3725,12 +3815,13 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             database = getQualifiedName(context.qualifiedName()).toString();
         }
 
-        Expr where = null;
-        if (context.expression() != null) {
-            where = (Expr) visit(context.expression());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(showPredicateClauses);
 
-        return new ShowTransactionStmt(normalizeName(database), where, createPos(context));
+        ShowTransactionStmt showTransactionStmt = new ShowTransactionStmt(normalizeName(database), where, createPos(context));
+        showTransactionStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, showTransactionStmt);
+        return showTransactionStmt;
     }
 
     @Override
@@ -3741,17 +3832,21 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             pattern = stringLiteral.getValue();
         }
 
-        Expr where = null;
-        if (context.expression() != null) {
-            where = (Expr) visit(context.expression());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(showPredicateClauses);
 
-        return new ShowStatusStmt(getVariableType(context.varType()), pattern, where, createPos(context));
+        ShowStatusStmt showStatusStmt =
+                new ShowStatusStmt(getVariableType(context.varType()), pattern, where, createPos(context));
+        showStatusStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, showStatusStmt);
+        return showStatusStmt;
     }
 
     @Override
     public ParseNode visitShowTriggersStatement(com.starrocks.sql.parser.StarRocksParser.ShowTriggersStatementContext context) {
-        return new ShowTriggersStmt(createPos(context));
+        ShowTriggersStmt showTriggersStmt = new ShowTriggersStmt(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showTriggersStmt);
+        return showTriggersStmt;
     }
 
     @Override
@@ -3766,7 +3861,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             user = ((StringLiteral) visit(context.string(0))).getValue();
             pattern = context.LIKE() == null ? null : ((StringLiteral) visit(context.string(1))).getValue();
         }
-        return new ShowUserPropertyStmt(user, pattern, createPos(context));
+        ShowUserPropertyStmt showUserPropertyStmt = new ShowUserPropertyStmt(user, pattern, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showUserPropertyStmt);
+        return showUserPropertyStmt;
     }
 
     @Override
@@ -3777,21 +3874,26 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             pattern = stringLiteral.getValue();
         }
 
-        Expr where = null;
-        if (context.expression() != null) {
-            where = (Expr) visit(context.expression());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(showPredicateClauses);
 
-        return new ShowVariablesStmt(getVariableType(context.varType()), pattern, where, createPos(context));
+        ShowVariablesStmt showVariablesStmt =
+                new ShowVariablesStmt(getVariableType(context.varType()), pattern, where, createPos(context));
+        showVariablesStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, showVariablesStmt);
+        return showVariablesStmt;
     }
 
     @Override
     public ParseNode visitShowWarningStatement(com.starrocks.sql.parser.StarRocksParser.ShowWarningStatementContext context) {
         NodePosition pos = createPos(context);
-        if (context.limitElement() != null) {
-            return new ShowWarningStmt((LimitElement) visit(context.limitElement()), pos);
-        }
-        return new ShowWarningStmt(null, pos);
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        LimitElement limit = getLimitFrom(context.showPredicateClauses());
+        ShowWarningStmt showWarningStmt = new ShowWarningStmt(limit, pos);
+
+        showWarningStmt.markSelfPredicateOrderLimit(false, false, true);
+        visitShowPredicateClauses(showPredicateClauses, showWarningStmt);
+        return showWarningStmt;
     }
 
     @Override
@@ -4021,10 +4123,14 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowBackupStatement(com.starrocks.sql.parser.StarRocksParser.ShowBackupStatementContext context) {
         NodePosition pos = createPos(context);
+        ShowBackupStmt showBackupStmt;
         if (context.identifier() == null) {
-            return new ShowBackupStmt(null, pos);
+            showBackupStmt = new ShowBackupStmt(null, pos);
+        } else {
+            showBackupStmt = new ShowBackupStmt(normalizeName(((Identifier) visit(context.identifier())).getValue()), pos);
         }
-        return new ShowBackupStmt(normalizeName(((Identifier) visit(context.identifier())).getValue()), pos);
+        visitShowPredicateClauses(context.showPredicateClauses(), showBackupStmt);
+        return showBackupStmt;
     }
 
     @Override
@@ -4045,28 +4151,31 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowRestoreStatement(com.starrocks.sql.parser.StarRocksParser.ShowRestoreStatementContext context) {
         NodePosition pos = createPos(context);
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(showPredicateClauses);
+        ShowRestoreStmt showRestoreStmt;
         if (context.identifier() == null) {
-            return new ShowRestoreStmt(null, null, pos);
-        }
-        if (context.expression() != null) {
-            return new ShowRestoreStmt(normalizeName(((Identifier) visit(context.identifier())).getValue()),
-                    (Expr) visit(context.expression()), pos);
+            showRestoreStmt = new ShowRestoreStmt(null, where, pos);
         } else {
-            return new ShowRestoreStmt(normalizeName(((Identifier) visit(context.identifier())).getValue()), null, pos);
+            showRestoreStmt =
+                    new ShowRestoreStmt(normalizeName(((Identifier) visit(context.identifier())).getValue()), where, pos);
         }
+        showRestoreStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, showRestoreStmt);
+        return showRestoreStmt;
     }
 
     @Override
     public ParseNode visitShowSnapshotStatement(com.starrocks.sql.parser.StarRocksParser.ShowSnapshotStatementContext context) {
-        com.starrocks.sql.parser.StarRocksParser.ExpressionContext expression = context.expression();
-        Expr where = null;
-        if (expression != null) {
-            where = (Expr) visit(context.expression());
-        }
-
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(showPredicateClauses);
         String repoName = ((Identifier) visit(context.identifier())).getValue();
 
-        return new ShowSnapshotStmt(repoName, where, createPos(context));
+        ShowSnapshotStmt showSnapshotStmt = new ShowSnapshotStmt(repoName, where, createPos(context));
+
+        showSnapshotStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, showSnapshotStmt);
+        return showSnapshotStmt;
     }
 
     // ----------------------------------------------- Repository Statement --------------------------------------------
@@ -4117,12 +4226,16 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowSqlBlackListStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowSqlBlackListStatementContext context) {
-        return new ShowSqlBlackListStmt(createPos(context));
+        ShowSqlBlackListStmt showSqlBlackListStmt = new ShowSqlBlackListStmt(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showSqlBlackListStmt);
+        return showSqlBlackListStmt;
     }
 
     @Override
     public ParseNode visitShowWhiteListStatement(com.starrocks.sql.parser.StarRocksParser.ShowWhiteListStatementContext context) {
-        return new ShowWhiteListStmt();
+        ShowWhiteListStmt showWhiteListStmt = new ShowWhiteListStmt();
+        visitShowPredicateClauses(context.showPredicateClauses(), showWhiteListStmt);
+        return showWhiteListStmt;
     }
 
     // -------------------------------- Sql Digest BlackList Statement ------------------------------------------
@@ -4147,7 +4260,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowSqlDigestBlackListStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowSqlDigestBlackListStatementContext context) {
-        return new ShowSqlDigestBlackListStmt(createPos(context));
+        ShowSqlDigestBlackListStmt showSqlDigestBlackListStmt = new ShowSqlDigestBlackListStmt(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showSqlDigestBlackListStmt);
+        return showSqlDigestBlackListStmt;
     }
 
     // -------------------------------- backend BlackList Statement ---------------------------------------------------
@@ -4171,7 +4286,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowBackendBlackListStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowBackendBlackListStatementContext ctx) {
-        return new ShowBackendBlackListStmt(createPos(ctx));
+        ShowBackendBlackListStmt showBackendBlackListStmt = new ShowBackendBlackListStmt(createPos(ctx));
+        visitShowPredicateClauses(ctx.showPredicateClauses(), showBackendBlackListStmt);
+        return showBackendBlackListStmt;
     }
 
     // -------------------------------- Compute Node BlackList Statement ---------------------------------------------------
@@ -4195,7 +4312,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowComputeNodeBlackListStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowComputeNodeBlackListStatementContext ctx) {
-        return new ShowComputeNodeBlackListStmt(createPos(ctx));
+        ShowComputeNodeBlackListStmt showComputeNodeBlackListStmt = new ShowComputeNodeBlackListStmt(createPos(ctx));
+        visitShowPredicateClauses(ctx.showPredicateClauses(), showComputeNodeBlackListStmt);
+        return showComputeNodeBlackListStmt;
     }
 
     // --------------------------------------- DataCache Management Statement -----------------------------------------
@@ -4227,7 +4346,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowDataCacheRulesStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowDataCacheRulesStatementContext ctx) {
-        return new ShowDataCacheRulesStmt(createPos(ctx));
+        ShowDataCacheRulesStmt showDataCacheRulesStmt = new ShowDataCacheRulesStmt(createPos(ctx));
+        visitShowPredicateClauses(ctx.showPredicateClauses(), showDataCacheRulesStmt);
+        return showDataCacheRulesStmt;
     }
 
     @Override
@@ -4330,20 +4451,13 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             catalog = normalizeName(dbName.toString());
         }
 
-        LimitElement le = null;
-        if (context.limitElement() != null) {
-            le = (LimitElement) visit(context.limitElement());
-        }
-        List<OrderByElement> orderByElements = null;
-        if (context.ORDER() != null) {
-            orderByElements = new ArrayList<>();
-            orderByElements.addAll(visit(context.sortItem(), OrderByElement.class));
-        }
-        Expr whereExpr = null;
-        if (context.expression() != null) {
-            whereExpr = (Expr) visit(context.expression());
-        }
-        return new ShowExportStmt(catalog, whereExpr, orderByElements, le, createPos(context));
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        LimitElement le = getLimitFrom(showPredicateClauses);
+        List<OrderByElement> orderByElements = getOrderByFrom(showPredicateClauses);
+        Expr whereExpr = getWhereFrom(showPredicateClauses);
+        ShowExportStmt showExportStmt = new ShowExportStmt(catalog, whereExpr, orderByElements, le, createPos(context));
+        showExportStmt.markSelfPredicateOrderLimit(true, true, true);
+        return showExportStmt;
     }
 
     // ------------------------------------------------- Plugin Statement --------------------------------------------------------
@@ -4402,7 +4516,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             catalog = normalizeName(dbName.toString());
         }
 
-        return new ShowSmallFilesStmt(catalog, createPos(context));
+        ShowSmallFilesStmt showSmallFilesStmt = new ShowSmallFilesStmt(catalog, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showSmallFilesStmt);
+        return showSmallFilesStmt;
     }
 
     // ------------------------------------------------- Set Statement -----------------------------------------------------------
@@ -4569,7 +4685,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             pattern = stringLiteral.getValue();
         }
 
-        return new ShowStorageVolumesStmt(pattern, createPos(context));
+        ShowStorageVolumesStmt showStorageVolumesStmt = new ShowStorageVolumesStmt(pattern, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showStorageVolumesStmt);
+        return showStorageVolumesStmt;
     }
 
     @Override
@@ -4682,7 +4800,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             String tmp = ((StringLiteral) visit(ctx.string(idx++))).getStringValue();
             backendList = Lists.newArrayList(tmp.split(","));
         }
-        return new ShowFailPointStatement(pattern, backendList, createPos(ctx));
+        ShowFailPointStatement showFailPointStatement = new ShowFailPointStatement(pattern, backendList, createPos(ctx));
+        visitShowPredicateClauses(ctx.showPredicateClauses(), showFailPointStatement);
+        return showFailPointStatement;
     }
 
     // ----------------------------------------------- Dictionary Statement -----------------------------------------------------
@@ -4736,7 +4856,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         if (context.qualifiedName() != null) {
             dictionaryName = getQualifiedName(context.qualifiedName()).toString();
         }
-        return new ShowDictionaryStmt(dictionaryName, createPos(context));
+        ShowDictionaryStmt showDictionaryStmt = new ShowDictionaryStmt(dictionaryName, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showDictionaryStmt);
+        return showDictionaryStmt;
     }
 
     @Override
@@ -5432,24 +5554,20 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             dbName = getQualifiedName(context.qualifiedName()).toString();
         }
         dbName = normalizeName(dbName);
-        List<OrderByElement> orderBy = null;
-        if (context.ORDER() != null) {
-            orderBy = new ArrayList<>();
-            orderBy.addAll(visit(context.sortItem(), OrderByElement.class));
-        }
-        LimitElement limit = null;
-        if (context.limitElement() != null) {
-            limit = (LimitElement) visit(context.limitElement());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        List<OrderByElement> orderBy = getOrderByFrom(showPredicateClauses);
+        LimitElement limit = getLimitFrom(showPredicateClauses);
+        Expr where = getWhereFrom(showPredicateClauses);
+        ShowPipeStmt showPipeStmt;
         if (context.LIKE() != null) {
             StringLiteral stringLiteral = (StringLiteral) visit(context.pattern);
-            return new ShowPipeStmt(dbName, stringLiteral.getValue(), null, orderBy, limit, createPos(context));
-        } else if (context.WHERE() != null) {
-            return new ShowPipeStmt(dbName, null, (Expr) visit(context.expression()), orderBy, limit,
-                    createPos(context));
+            showPipeStmt = new ShowPipeStmt(dbName, stringLiteral.getValue(), where, orderBy, limit, createPos(context));
         } else {
-            return new ShowPipeStmt(dbName, null, null, orderBy, limit, createPos(context));
+            showPipeStmt = new ShowPipeStmt(dbName, null, where, orderBy, limit, createPos(context));
         }
+        showPipeStmt.markSelfPredicateOrderLimit(true, true, true);
+        visitShowPredicateClauses(showPredicateClauses, showPipeStmt);
+        return showPipeStmt;
     }
 
     @Override
@@ -5572,13 +5690,17 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             pattern = stringLiteral.getValue();
         }
 
-        return new ShowWarehousesStmt(pattern, createPos(context));
+        ShowWarehousesStmt showWarehousesStmt = new ShowWarehousesStmt(pattern, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showWarehousesStmt);
+        return showWarehousesStmt;
     }
 
     @Override
     public ParseNode visitShowClustersStatement(com.starrocks.sql.parser.StarRocksParser.ShowClustersStatementContext context) {
         String whName = ((Identifier) visit(context.identifier())).getValue();
-        return new ShowClustersStmt(whName, createPos(context));
+        ShowClustersStmt showClustersStmt = new ShowClustersStmt(whName, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showClustersStmt);
+        return showClustersStmt;
     }
 
     @Override
@@ -5597,7 +5719,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                 pattern = stringLiteral.getValue();
             }
         }
-        return new ShowNodesStmt(warehouseName, cnGroupName, pattern, createPos(context));
+        ShowNodesStmt showNodesStmt = new ShowNodesStmt(warehouseName, cnGroupName, pattern, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), showNodesStmt);
+        return showNodesStmt;
     }
 
     @Override
@@ -6596,17 +6720,21 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             pattern = ((StringLiteral) visit(context.pattern)).getValue();
         }
 
-        Expr where = null;
-        if (context.expression() != null) {
-            where = (Expr) visit(context.expression());
-        }
+        StarRocksParser.ShowPredicateClausesContext showPredicateClauses = context.showPredicateClauses();
+        Expr where = getWhereFrom(showPredicateClauses);
 
-        return new ShowFunctionsStmt(dbName, isBuiltIn, isGlobal, isVerbose, pattern, where, createPos(context));
+        ShowFunctionsStmt showFunctionsStmt =
+                new ShowFunctionsStmt(dbName, isBuiltIn, isGlobal, isVerbose, pattern, where, createPos(context));
+        showFunctionsStmt.markSelfPredicate();
+        visitShowPredicateClauses(showPredicateClauses, showFunctionsStmt);
+        return showFunctionsStmt;
     }
 
     @Override
     public ParseNode visitShowPrivilegesStatement(com.starrocks.sql.parser.StarRocksParser.ShowPrivilegesStatementContext ctx) {
-        return new ShowPrivilegesStmt();
+        ShowPrivilegesStmt showPrivilegesStmt = new ShowPrivilegesStmt();
+        visitShowPredicateClauses(ctx.showPredicateClauses(), showPrivilegesStmt);
+        return showPrivilegesStmt;
     }
 
     @Override
@@ -6758,11 +6886,14 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowUserStatement(com.starrocks.sql.parser.StarRocksParser.ShowUserStatementContext context) {
         NodePosition pos = createPos(context);
+        ShowUserStmt showUserStmt;
         if (context.USERS() != null) {
-            return new ShowUserStmt(true, pos);
+            showUserStmt = new ShowUserStmt(true, pos);
         } else {
-            return new ShowUserStmt(false, pos);
+            showUserStmt = new ShowUserStmt(false, pos);
         }
+        visitShowPredicateClauses(context.showPredicateClauses(), showUserStmt);
+        return showUserStmt;
     }
 
     @Override
@@ -6816,7 +6947,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
     @Override
     public ParseNode visitShowRolesStatement(com.starrocks.sql.parser.StarRocksParser.ShowRolesStatementContext context) {
-        return new ShowRolesStmt();
+        ShowRolesStmt showRolesStmt = new ShowRolesStmt();
+        visitShowPredicateClauses(context.showPredicateClauses(), showRolesStmt);
+        return showRolesStmt;
     }
 
     @Override
@@ -6937,16 +7070,19 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowGrantsStatement(com.starrocks.sql.parser.StarRocksParser.ShowGrantsStatementContext context) {
         NodePosition pos = createPos(context);
+        ShowGrantsStmt showGrantsStmt;
         if (context.ROLE() != null) {
             Identifier role = (Identifier) visit(context.identifierOrString());
-            return new ShowGrantsStmt(role.getValue(), GrantType.ROLE, pos);
+            showGrantsStmt = new ShowGrantsStmt(role.getValue(), GrantType.ROLE, pos);
         } else if (context.GROUP() != null) {
             Identifier group = (Identifier) visit(context.identifierOrString());
-            return new ShowGrantsStmt(group.getValue(), GrantType.GROUP, pos);
+            showGrantsStmt = new ShowGrantsStmt(group.getValue(), GrantType.GROUP, pos);
         } else {
             UserRef userId = context.user() == null ? null : (UserRef) visit(context.user());
-            return new ShowGrantsStmt(userId, pos);
+            showGrantsStmt = new ShowGrantsStmt(userId, pos);
         }
+        visitShowPredicateClauses(context.showPredicateClauses(), showGrantsStmt);
+        return showGrantsStmt;
     }
 
     @Override
@@ -7246,13 +7382,17 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     public ParseNode visitShowCreateSecurityIntegrationStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowCreateSecurityIntegrationStatementContext context) {
         String name = ((Identifier) visit(context.identifier())).getValue();
-        return new ShowCreateSecurityIntegrationStatement(name, createPos(context));
+        ShowCreateSecurityIntegrationStatement stmt = new ShowCreateSecurityIntegrationStatement(name, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), stmt);
+        return stmt;
     }
 
     @Override
     public ParseNode visitShowSecurityIntegrationStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowSecurityIntegrationStatementContext context) {
-        return new ShowSecurityIntegrationStatement(createPos(context));
+        ShowSecurityIntegrationStatement stmt = new ShowSecurityIntegrationStatement(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), stmt);
+        return stmt;
     }
 
     // ---------------------------------------- Group Provider Statement --------------------------------------
@@ -7276,13 +7416,17 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     public ParseNode visitShowCreateGroupProviderStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowCreateGroupProviderStatementContext context) {
         String name = ((Identifier) visit(context.identifier())).getValue();
-        return new ShowCreateGroupProviderStmt(name, createPos(context));
+        var stmt = new ShowCreateGroupProviderStmt(name, createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), stmt);
+        return stmt;
     }
 
     @Override
     public ParseNode visitShowGroupProvidersStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowGroupProvidersStatementContext context) {
-        return new ShowGroupProvidersStmt(createPos(context));
+        ShowGroupProvidersStmt stmt = new ShowGroupProvidersStmt(createPos(context));
+        visitShowPredicateClauses(context.showPredicateClauses(), stmt);
+        return stmt;
     }
 
     // ------------------------------------------- Expression ----------------------------------------------------------
@@ -9168,16 +9312,17 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitShowBaselinePlanStatement(
             com.starrocks.sql.parser.StarRocksParser.ShowBaselinePlanStatementContext ctx) {
-        Expr where = null;
-        if (ctx.WHERE() != null) {
-            where = (Expr) visit(ctx.expression());
-            return new ShowBaselinePlanStmt(createPos(ctx), where);
-        }
         if (ctx.ON() != null) {
             QueryRelation queryRelation = (QueryRelation) visit(ctx.queryRelation());
             return new ShowBaselinePlanStmt(createPos(ctx), queryRelation);
         }
-        return new ShowBaselinePlanStmt(createPos(ctx), where);
+
+        Expr where = getWhereFrom(ctx.showPredicateClauses());
+
+        ShowBaselinePlanStmt stmt = new ShowBaselinePlanStmt(createPos(ctx), where);
+        stmt.markSelfPredicate();
+        visitShowPredicateClauses(ctx.showPredicateClauses(), stmt);
+        return stmt;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ShowStmtPredicateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ShowStmtPredicateTest.java
@@ -1,0 +1,246 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.qe.ShowExecutor;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.ast.ShowStmt;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ShowStmtPredicateTest extends PlanTestBase {
+    public ShowResultSet execute(String originStmt) {
+        try {
+            StatementBase stmt = SqlParser.parse(originStmt, connectContext.getSessionVariable()).get(0);
+            Analyzer.analyze(stmt, connectContext);
+
+            if (stmt instanceof ShowStmt show) {
+                return ShowExecutor.execute(show, connectContext);
+            }
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assertions.fail();
+            throw ex;
+        }
+        return null;
+    }
+
+    @Test
+    public void testShowDatabaseTest() {
+        String sql = "show data where tableName like 't%' order by `TableName` limit 2; ";
+
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+        Assertions.assertEquals("tprimary_multi_cols", show.getResultRows().get(0).get(0));
+    }
+
+    @Test
+    public void testShowDataWithWhere() {
+        String sql = "show data where tableName = 'tprimary_multi_cols';";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+        Assertions.assertEquals(1, show.getResultRows().size());
+        Assertions.assertEquals("tprimary_multi_cols", show.getResultRows().get(0).get(0));
+    }
+
+    @Test
+    public void testShowDataWithOrder() {
+        String sql = "show data order by `TableName` asc;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+        Assertions.assertTrue(show.getResultRows().size() > 1);
+        // Verify order is ascending
+        String first = show.getResultRows().get(0).get(0);
+        String second = show.getResultRows().get(1).get(0);
+        Assertions.assertTrue(first.compareTo(second) <= 0);
+    }
+
+    @Test
+    public void testShowDataWithLimit() {
+        String sql = "show data limit 1;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+        Assertions.assertEquals(1, show.getResultRows().size());
+    }
+
+    @Test
+    public void testShowDataWithLimitAndOffset() {
+        String sql = "show data limit 1 offset 1;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+        Assertions.assertEquals(1, show.getResultRows().size());
+    }
+
+    @Test
+    public void testShowDataWithOrderAndLimit() {
+        String sql = "show data order by `TableName` limit 1;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+        Assertions.assertEquals(1, show.getResultRows().size());
+    }
+
+    @Test
+    public void testShowTablesWithWhere() {
+        String sql = "show tables where tableName like 't%';";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+        // At least one table starts with 't'
+        boolean hasTableStartsWithT = show.getResultRows().stream()
+                .anyMatch(row -> row.get(0).startsWith("t"));
+        Assertions.assertTrue(hasTableStartsWithT);
+    }
+
+    @Test
+    public void testShowTablesWithLimit() {
+        String sql = "show tables limit 2;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+        Assertions.assertTrue(show.getResultRows().size() <= 2);
+    }
+    @Test
+    public void testShowDatabasesWithWhere() {
+        String sql = "show databases where `Database` = 'default_cluster';";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+    }
+
+    @Test
+    public void testShowDatabasesWithOrder() {
+        String sql = "show databases order by `Database` desc;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+        Assertions.assertTrue(show.getResultRows().size() > 0);
+    }
+
+    @Test
+    public void testShowDatabasesWithLimit() {
+        String sql = "show databases limit 1;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+        Assertions.assertEquals(1, show.getResultRows().size());
+    }
+
+    @Test
+    public void testShowColumnsWithWhere() {
+        String sql = "show columns from tprimary_multi_cols where Field = 'pk';";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+    }
+
+    @Test
+    public void testShowColumnsWithOrder() {
+        String sql = "show columns from tprimary_multi_cols order by Field asc;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+        Assertions.assertTrue(show.getResultRows().size() > 0);
+    }
+
+    @Test
+    public void testShowColumnsWithLimit() {
+        String sql = "show columns from tprimary_multi_cols limit 2;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+        Assertions.assertTrue(show.getResultRows().size() <= 2);
+    }
+
+    @Test
+    public void testShowBackendsWithLimit() {
+        String sql = "show backends limit 1;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+    }
+
+    @Test
+    public void testShowBackendsWithWhere() {
+        String sql = "show backends where Alive = 'true';";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+    }
+
+    @Test
+    public void testShowFrontendsWithLimit() {
+        String sql = "show frontends limit 1;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+    }
+
+    @Test
+    public void testShowVariablesWithWhere() {
+        String sql = "show variables where Variable_name = 'query_timeout';";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+    }
+
+    @Test
+    public void testShowVariablesWithLike() {
+        String sql = "show variables like 'query%';";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+    }
+
+    @Test
+    public void testShowVariablesWithOrder() {
+        String sql = "show variables order by Variable_name asc limit 5;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+        Assertions.assertTrue(show.getResultRows().size() <= 5);
+    }
+
+    @Test
+    public void testShowCatalogsWithLimit() {
+        String sql = "show catalogs limit 1;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+    }
+
+    @Test
+    public void testShowCatalogsWithWhere() {
+        String sql = "show catalogs where `Catalog` = 'default_catalog';";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+    }
+
+    @Test
+    public void testShowMaterializedViewsWithWhere() {
+        String sql = "show materialized views where Name like 'test%';";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+    }
+
+    @Test
+    public void testShowMaterializedViewsWithOrder() {
+        String sql = "show materialized views order by Name limit 3;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+    }
+
+    @Test
+    public void testShowProcesslistWithLimit() {
+        String sql = "show processlist limit 5;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+    }
+
+    @Test
+    public void testShowMultipleOrderBy() {
+        String sql = "show data order by `TableName` asc, Size desc limit 3;";
+        ShowResultSet show = execute(sql);
+        Assertions.assertNotNull(show);
+        Assertions.assertTrue(show.getResultRows().size() <= 3);
+    }
+}

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -377,6 +377,12 @@ statement
     | unsupportedStatement
     ;
 
+
+// show-predicate-clauses
+showPredicateClauses
+    : (WHERE expression)? (ORDER BY sortItem (',' sortItem)*)? limitElement?
+    ;
+
 // ---------------------------------------- DataBase Statement ---------------------------------------------------------
 
 useDatabaseStatement
@@ -392,8 +398,8 @@ setCatalogStatement
     ;
 
 showDatabasesStatement
-    : SHOW DATABASES ((FROM | IN) catalog=qualifiedName)? ((LIKE pattern=string) | (WHERE expression))?
-    | SHOW SCHEMAS ((LIKE pattern=string) | (WHERE expression))?
+    : SHOW DATABASES ((FROM | IN) catalog=qualifiedName)? (LIKE pattern=string)? showPredicateClauses
+    | SHOW SCHEMAS (LIKE pattern=string)? showPredicateClauses
     ;
 
 alterDbQuotaStatement
@@ -426,12 +432,12 @@ recoverDbStmt
     ;
 
 showDataStmt
-    : SHOW DATA
-    | SHOW DATA FROM qualifiedName
+    : SHOW DATA showPredicateClauses
+    | SHOW DATA FROM qualifiedName showPredicateClauses
     ;
 
 showDataDistributionStmt
-    : SHOW DATA DISTRIBUTION FROM qualifiedName partitionNames?
+    : SHOW DATA DISTRIBUTION FROM qualifiedName partitionNames? showPredicateClauses
     ;
 
 // ------------------------------------------- Table Statement ---------------------------------------------------------
@@ -586,11 +592,11 @@ indexType
     ;
 
 showTableStatement
-    : SHOW FULL? TABLES ((FROM | IN) db=qualifiedName)? ((LIKE pattern=string) | (WHERE expression))?
+    : SHOW FULL? TABLES ((FROM | IN) db=qualifiedName)? (LIKE pattern=string)? showPredicateClauses
     ;
 
 showTemporaryTablesStatement
-    : SHOW TEMPORARY TABLES ((FROM | IN) db=qualifiedName)? ((LIKE pattern=string) | (WHERE expression))?
+    : SHOW TEMPORARY TABLES ((FROM | IN) db=qualifiedName)? (LIKE pattern=string)? showPredicateClauses
     ;
 
 showCreateTableStatement
@@ -599,11 +605,11 @@ showCreateTableStatement
 
 showColumnStatement
     : SHOW FULL? (COLUMNS | FIELDS) ((FROM | IN) table=qualifiedName) ((FROM | IN) db=qualifiedName)?
-        ((LIKE pattern=string) | (WHERE expression))?
+        (LIKE pattern=string)? showPredicateClauses
     ;
 
 showTableStatusStatement
-    : SHOW TABLE STATUS ((FROM | IN) db=qualifiedName)? ((LIKE pattern=string) | (WHERE expression))?
+    : SHOW TABLE STATUS ((FROM | IN) db=qualifiedName)? (LIKE pattern=string)? showPredicateClauses
     ;
 
 refreshTableStatement
@@ -611,10 +617,8 @@ refreshTableStatement
     ;
 
 showAlterStatement
-    : SHOW ALTER TABLE (COLUMN | ROLLUP | OPTIMIZE) ((FROM | IN) db=qualifiedName)?
-        (WHERE expression)? (ORDER BY sortItem (',' sortItem)*)? (limitElement)?
-    | SHOW ALTER MATERIALIZED VIEW ((FROM | IN) db=qualifiedName)?
-              (WHERE expression)? (ORDER BY sortItem (',' sortItem)*)? (limitElement)?
+    : SHOW ALTER TABLE (COLUMN | ROLLUP | OPTIMIZE) ((FROM | IN) db=qualifiedName)? showPredicateClauses
+    | SHOW ALTER MATERIALIZED VIEW ((FROM | IN) db=qualifiedName)? showPredicateClauses
     ;
 
 descTableStatement
@@ -630,7 +634,7 @@ createTableLikeStatement
     ;
 
 showIndexStatement
-    : SHOW (INDEX | INDEXES | KEY | KEYS) ((FROM | IN) table=qualifiedName) ((FROM | IN) db=qualifiedName)?
+    : SHOW (INDEX | INDEXES | KEY | KEYS) ((FROM | IN) table=qualifiedName) ((FROM | IN) db=qualifiedName)? showPredicateClauses
     ;
 
 recoverTableStatement
@@ -647,9 +651,7 @@ cancelAlterTableStatement
     ;
 
 showPartitionsStatement
-    : SHOW TEMPORARY? PARTITIONS FROM table=qualifiedName
-    (WHERE expression)?
-    (ORDER BY sortItem (',' sortItem)*)? limitElement?
+    : SHOW TEMPORARY? PARTITIONS FROM table=qualifiedName showPredicateClauses
     ;
 
 recoverPartitionStatement
@@ -727,7 +729,7 @@ materializedViewDesc
     ;
 
 showMaterializedViewsStatement
-    : SHOW MATERIALIZED VIEWS ((FROM | IN) db=qualifiedName)? ((LIKE pattern=string) | (WHERE expression))?
+    : SHOW MATERIALIZED VIEWS ((FROM | IN) db=qualifiedName)? (LIKE pattern=string)? showPredicateClauses
     ;
 
 dropMaterializedViewStatement
@@ -760,7 +762,7 @@ adminSetReplicaStatusStatement
     : ADMIN SET REPLICA STATUS properties
     ;
 adminShowConfigStatement
-    : ADMIN SHOW FRONTEND CONFIG (LIKE pattern=string)?
+    : ADMIN SHOW FRONTEND CONFIG (LIKE pattern=string)? showPredicateClauses
     ;
 
 adminShowAutomatedSnapshotStatement
@@ -768,11 +770,11 @@ adminShowAutomatedSnapshotStatement
     ;
 
 adminShowReplicaDistributionStatement
-    : ADMIN SHOW REPLICA DISTRIBUTION FROM qualifiedName partitionNames?
+    : ADMIN SHOW REPLICA DISTRIBUTION FROM qualifiedName partitionNames? showPredicateClauses
     ;
 
 adminShowReplicaStatusStatement
-    : ADMIN SHOW REPLICA STATUS FROM qualifiedName partitionNames? (WHERE where=expression)?
+    : ADMIN SHOW REPLICA STATUS FROM qualifiedName partitionNames? showPredicateClauses
     ;
 
 adminRepairTableStatement
@@ -822,7 +824,7 @@ cancelAlterSystemStatement
     ;
 
 showComputeNodesStatement
-    : SHOW COMPUTE NODES
+    : SHOW COMPUTE NODES showPredicateClauses
     ;
 
 // ------------------------------------------- Catalog Statement -------------------------------------------------------
@@ -840,7 +842,7 @@ dropExternalCatalogStatement
     ;
 
 showCatalogsStatement
-    : SHOW CATALOGS (LIKE pattern=string)?
+    : SHOW CATALOGS (LIKE pattern=string)? showPredicateClauses
     ;
 
 alterCatalogStatement
@@ -863,7 +865,7 @@ locationsDesc
     ;
 
 showStorageVolumesStatement
-    : SHOW STORAGE VOLUMES (LIKE pattern=string)?
+    : SHOW STORAGE VOLUMES (LIKE pattern=string)? showPredicateClauses
     ;
 
 dropStorageVolumeStatement
@@ -904,7 +906,7 @@ updateFailPointStatusStatement
     ;
 
 showFailPointStatement
-    : SHOW FAILPOINTS ((LIKE pattern=string))? (ON BACKEND string)?
+    : SHOW FAILPOINTS (LIKE pattern=string)? (ON BACKEND string)? showPredicateClauses
     ;
 
 // ------------------------------------------- Dictionary Statement -----------------------------------------------------
@@ -924,7 +926,7 @@ refreshDictionaryStatement
     ;
 
 showDictionaryStatement
-    : SHOW DICTIONARY qualifiedName?
+    : SHOW DICTIONARY qualifiedName? showPredicateClauses
     ;
 
 cancelRefreshDictionaryStatement
@@ -1391,24 +1393,21 @@ pauseRoutineLoadStatement
 
 showRoutineLoadStatement
     : SHOW ALL? ROUTINE LOAD (FOR (db=qualifiedName '.')? name=identifier)?
-        (FROM db=qualifiedName)?
-        (WHERE expression)? (ORDER BY sortItem (',' sortItem)*)? (limitElement)?
+        (FROM db=qualifiedName)? showPredicateClauses
     ;
 
 showRoutineLoadTaskStatement
     : SHOW ROUTINE LOAD TASK
-        (FROM db=qualifiedName)?
-        WHERE expression
+        (FROM db=qualifiedName)? showPredicateClauses
     ;
 
 showCreateRoutineLoadStatement
-    : SHOW CREATE ROUTINE LOAD (db=qualifiedName '.')? name=identifier
+    : SHOW CREATE ROUTINE LOAD (db=qualifiedName '.')? name=identifier showPredicateClauses
     ;
 
 showStreamLoadStatement
     : SHOW ALL? STREAM LOAD (FOR (db=qualifiedName '.')? name=identifier)?
-        (FROM db=qualifiedName)?
-        (WHERE expression)? (ORDER BY sortItem (',' sortItem)*)? (limitElement)?
+        (FROM db=qualifiedName)? showPredicateClauses
     ;
 // ------------------------------------------- Analyze Statement -------------------------------------------------------
 
@@ -1458,15 +1457,15 @@ dropAnalyzeJobStatement
     ;
 
 showAnalyzeStatement
-    : SHOW ANALYZE (JOB | STATUS)? (WHERE expression)? (ORDER BY sortItem (',' sortItem)*)? limitElement?
+    : SHOW ANALYZE (JOB | STATUS)? showPredicateClauses
     ;
 
 showStatsMetaStatement
-    : SHOW (MULTIPLE COLUMNS)? STATS META (WHERE expression)? (ORDER BY sortItem (',' sortItem)*)? limitElement?
+    : SHOW (MULTIPLE COLUMNS)? STATS META showPredicateClauses
     ;
 
 showHistogramMetaStatement
-    : SHOW HISTOGRAM META (WHERE expression)? (ORDER BY sortItem (',' sortItem)*)? limitElement?
+    : SHOW HISTOGRAM META showPredicateClauses
     ;
 
 killAnalyzeStatement
@@ -1494,7 +1493,7 @@ dropBaselinePlanStatement
     ;
 
 showBaselinePlanStatement
-    : SHOW BASELINE (WHERE expression)?
+    : SHOW BASELINE showPredicateClauses
     | SHOW BASELINE ON queryRelation
     ;
 
@@ -1525,13 +1524,13 @@ alterResourceGroupStatement
     ;
 
 showResourceGroupStatement
-    : SHOW VERBOSE? RESOURCE GROUP identifier
-    | SHOW VERBOSE? RESOURCE GROUPS ALL?
+    : SHOW VERBOSE? RESOURCE GROUP identifier showPredicateClauses
+    | SHOW VERBOSE? RESOURCE GROUPS ALL? showPredicateClauses
     ;
 
 showResourceGroupUsageStatement
-    : SHOW USAGE RESOURCE GROUP identifier
-    | SHOW USAGE RESOURCE GROUPS
+    : SHOW USAGE RESOURCE GROUP identifier showPredicateClauses
+    | SHOW USAGE RESOURCE GROUPS showPredicateClauses
     ;
 
 createResourceStatement
@@ -1547,7 +1546,7 @@ dropResourceStatement
     ;
 
 showResourceStatement
-    : SHOW RESOURCES
+    : SHOW RESOURCES showPredicateClauses
     ;
 
 classifier
@@ -1557,7 +1556,7 @@ classifier
 // ------------------------------------------- UDF Statement ----------------------------------------------------
 
 showFunctionsStatement
-    : SHOW FULL? (BUILTIN|GLOBAL)? FUNCTIONS ((FROM | IN) db=qualifiedName)? ((LIKE pattern=string) | (WHERE expression))?
+    : SHOW FULL? (BUILTIN|GLOBAL)? FUNCTIONS ((FROM | IN) db=qualifiedName)? (LIKE pattern=string)? showPredicateClauses
     ;
 
 dropFunctionStatement
@@ -1642,12 +1641,12 @@ resourceDesc
     ;
 
 showLoadStatement
-    : SHOW LOAD (ALL)? (FROM identifier)? (WHERE expression)? (ORDER BY sortItem (',' sortItem)*)? limitElement?
+    : SHOW LOAD (ALL)? (FROM identifier)? showPredicateClauses
     ;
 
 showLoadWarningsStatement
-    : SHOW LOAD WARNINGS (FROM identifier)? (WHERE expression)? limitElement?
-    | SHOW LOAD WARNINGS ON string
+    : SHOW LOAD WARNINGS (FROM identifier)? showPredicateClauses
+    | SHOW LOAD WARNINGS ON string showPredicateClauses
     ;
 
 cancelLoadStatement
@@ -1668,62 +1667,62 @@ cancelCompactionStatement
 // ------------------------------------------- Show Statement ----------------------------------------------------------
 
 showAuthorStatement
-    : SHOW AUTHORS
+    : SHOW AUTHORS showPredicateClauses
     ;
 
 showBackendsStatement
-    : SHOW BACKENDS
+    : SHOW BACKENDS showPredicateClauses
     ;
 
 showBrokerStatement
-    : SHOW BROKER
+    : SHOW BROKER showPredicateClauses
     ;
 
 showCharsetStatement
-    : SHOW (CHAR SET | CHARSET | CHARACTER SET) ((LIKE pattern=string) | (WHERE expression))?
+    : SHOW (CHAR SET | CHARSET | CHARACTER SET) (LIKE pattern=string)? showPredicateClauses
     ;
 
 showCollationStatement
-    : SHOW COLLATION ((LIKE pattern=string) | (WHERE expression))?
+    : SHOW COLLATION (LIKE pattern=string)? showPredicateClauses
     ;
 
 showDeleteStatement
-    : SHOW DELETE ((FROM | IN) db=qualifiedName)?
+    : SHOW DELETE ((FROM | IN) db=qualifiedName)? showPredicateClauses
     ;
 
 showDynamicPartitionStatement
-    : SHOW DYNAMIC PARTITION TABLES ((FROM | IN) db=qualifiedName)?
+    : SHOW DYNAMIC PARTITION TABLES ((FROM | IN) db=qualifiedName)? showPredicateClauses
     ;
 
 showEventsStatement
-    : SHOW EVENTS ((FROM | IN) catalog=qualifiedName)? ((LIKE pattern=string) | (WHERE expression))?
+    : SHOW EVENTS ((FROM | IN) catalog=qualifiedName)? (LIKE pattern=string)? showPredicateClauses
     ;
 
 showEnginesStatement
-    : SHOW ENGINES
+    : SHOW ENGINES showPredicateClauses
     ;
 
 showFrontendsStatement
-    : SHOW FRONTENDS
+    : SHOW FRONTENDS showPredicateClauses
     ;
 
 showPluginsStatement
-    : SHOW PLUGINS
+    : SHOW PLUGINS showPredicateClauses
     ;
 
 showRepositoriesStatement
-    : SHOW REPOSITORIES
+    : SHOW REPOSITORIES showPredicateClauses
     ;
 
 showOpenTableStatement
-    : SHOW OPEN TABLES
+    : SHOW OPEN TABLES showPredicateClauses
     ;
 showPrivilegesStatement
-    : SHOW PRIVILEGES
+    : SHOW PRIVILEGES showPredicateClauses
     ;
 
 showProcedureStatement
-    : SHOW (PROCEDURE | FUNCTION) STATUS ((LIKE pattern=string) | (WHERE where=expression))?
+    : SHOW (PROCEDURE | FUNCTION) STATUS (LIKE pattern=string)? showPredicateClauses
     ;
 
 showProcStatement
@@ -1731,45 +1730,45 @@ showProcStatement
     ;
 
 showProcesslistStatement
-    : SHOW FULL? PROCESSLIST (FOR string)?
+    : SHOW FULL? PROCESSLIST (FOR string)? showPredicateClauses
     ;
 
 showProfilelistStatement
-    : SHOW PROFILELIST (LIMIT limit =INTEGER_VALUE)?
+    : SHOW PROFILELIST showPredicateClauses
     ;
 
 showRunningQueriesStatement
-    : SHOW RUNNING QUERIES (LIMIT limit =INTEGER_VALUE)?
+    : SHOW RUNNING QUERIES showPredicateClauses
     ;
 
 showStatusStatement
-    : SHOW varType? STATUS ((LIKE pattern=string) | (WHERE expression))?
+    : SHOW varType? STATUS (LIKE pattern=string)? showPredicateClauses
     ;
 
 showTabletStatement
     : SHOW TABLET INTEGER_VALUE
-    | SHOW (TABLET | TABLETS) FROM qualifiedName partitionNames? (WHERE expression)? (ORDER BY sortItem (',' sortItem)*)? (limitElement)?
+    | SHOW (TABLET | TABLETS) FROM qualifiedName partitionNames? showPredicateClauses
     ;
 
 showTransactionStatement
-    : SHOW TRANSACTION ((FROM | IN) db=qualifiedName)? (WHERE expression)?
+    : SHOW TRANSACTION ((FROM | IN) db=qualifiedName)? showPredicateClauses
     ;
 
 showTriggersStatement
-    : SHOW FULL? TRIGGERS ((FROM | IN) catalog=qualifiedName)? ((LIKE pattern=string) | (WHERE expression))?
+    : SHOW FULL? TRIGGERS ((FROM | IN) catalog=qualifiedName)? (LIKE pattern=string)? showPredicateClauses
     ;
 
 showUserPropertyStatement
-    : SHOW PROPERTY (FOR string)? (LIKE string)?
-    | SHOW PROPERTIES (FOR string)? (LIKE string)?
+    : SHOW PROPERTY (FOR string)? (LIKE string)? showPredicateClauses
+    | SHOW PROPERTIES (FOR string)? (LIKE string)? showPredicateClauses
     ;
 
 showVariablesStatement
-    : SHOW varType? VARIABLES ((LIKE pattern=string) | (WHERE expression))?
+    : SHOW varType? VARIABLES (LIKE pattern=string)? showPredicateClauses
     ;
 
 showWarningStatement
-    : SHOW (WARNINGS | ERRORS) (limitElement)?
+    : SHOW (WARNINGS | ERRORS) showPredicateClauses
     ;
 
 helpStatement
@@ -1793,7 +1792,7 @@ alterUserStatement
     ;
 
 showUserStatement
-    : SHOW (USER | USERS)
+    : SHOW (USER | USERS) showPredicateClauses
     ;
 
 showAuthenticationStatement
@@ -1818,7 +1817,7 @@ dropRoleStatement
     ;
 
 showRolesStatement
-    : SHOW ROLES
+    : SHOW ROLES showPredicateClauses
     ;
 
 grantRoleStatement
@@ -1874,10 +1873,10 @@ revokePrivilegeStatement
     ;
 
 showGrantsStatement
-    : SHOW GRANTS
-    | SHOW GRANTS FOR USER? user
-    | SHOW GRANTS FOR EXTERNAL GROUP identifierOrString
-    | SHOW GRANTS FOR ROLE identifierOrString
+    : SHOW GRANTS showPredicateClauses
+    | SHOW GRANTS FOR USER? user showPredicateClauses
+    | SHOW GRANTS FOR EXTERNAL GROUP identifierOrString showPredicateClauses
+    | SHOW GRANTS FOR ROLE identifierOrString showPredicateClauses
     ;
 
 authOption
@@ -1936,11 +1935,11 @@ dropSecurityIntegrationStatement
     ;
 
 showSecurityIntegrationStatement
-    : SHOW SECURITY INTEGRATIONS
+    : SHOW SECURITY INTEGRATIONS showPredicateClauses
     ;
 
 showCreateSecurityIntegrationStatement
-    : SHOW CREATE SECURITY INTEGRATION identifier
+    : SHOW CREATE SECURITY INTEGRATION identifier showPredicateClauses
     ;
 
 // ------------------------------------------- Group Provider Statement ------------------------------------------
@@ -1954,11 +1953,11 @@ dropGroupProviderStatement
     ;
 
 showGroupProvidersStatement
-    : SHOW GROUP PROVIDERS
+    : SHOW GROUP PROVIDERS showPredicateClauses
     ;
 
 showCreateGroupProviderStatement
-    : SHOW CREATE GROUP PROVIDER identifier
+    : SHOW CREATE GROUP PROVIDER identifier showPredicateClauses
     ;
 
 // ---------------------------------------- Backup Restore Statement ---------------------------------------------------
@@ -1975,7 +1974,7 @@ cancelBackupStatement
     ;
 
 showBackupStatement
-    : SHOW BACKUP ((FROM | IN) identifier)?
+    : SHOW BACKUP ((FROM | IN) identifier)? showPredicateClauses
     ;
 
 restoreStatement
@@ -1992,12 +1991,11 @@ cancelRestoreStatement
     ;
 
 showRestoreStatement
-    : SHOW RESTORE ((FROM | IN) identifier)? (WHERE where=expression)?
+    : SHOW RESTORE ((FROM | IN) identifier)? showPredicateClauses
     ;
 
 showSnapshotStatement
-    : SHOW SNAPSHOT ON identifier
-    (WHERE expression)?
+    : SHOW SNAPSHOT ON identifier showPredicateClauses
     ;
 
 createRepositoryStatement
@@ -2022,11 +2020,11 @@ delSqlBlackListStatement
     ;
 
 showSqlBlackListStatement
-    : SHOW SQLBLACKLIST
+    : SHOW SQLBLACKLIST showPredicateClauses
     ;
 
 showWhiteListStatement
-    : SHOW WHITELIST
+    : SHOW WHITELIST showPredicateClauses
     ;
 
 // ------------------------------------------- Sql Digest BlackList Statement ------------------------------------------
@@ -2040,7 +2038,7 @@ delSqlDigestBlackListStatement
     ;
 
 showSqlDigestBlackListStatement
-    : SHOW SQL DIGEST BLACKLIST
+    : SHOW SQL DIGEST BLACKLIST showPredicateClauses
     ;
 
 
@@ -2055,7 +2053,7 @@ delBackendBlackListStatement
     ;
 
 showBackendBlackListStatement
-    : SHOW BACKEND BLACKLIST
+    : SHOW BACKEND BLACKLIST showPredicateClauses
     ;
 
 // ------------------------------------ Compute Node BlackList Statement ---------------------------------------------------
@@ -2069,7 +2067,7 @@ delComputeNodeBlackListStatement
     ;
 
 showComputeNodeBlackListStatement
-    : SHOW COMPUTE NODE BLACKLIST
+    : SHOW COMPUTE NODE BLACKLIST showPredicateClauses
     ;
 
 // -------------------------------------- DataCache Management Statement --------------------------------------------
@@ -2083,7 +2081,7 @@ createDataCacheRuleStatement
     ;
 
 showDataCacheRulesStatement
-    : SHOW DATACACHE RULES
+    : SHOW DATACACHE RULES showPredicateClauses
     ;
 
 dropDataCacheRuleStatement
@@ -2109,9 +2107,7 @@ cancelExportStatement
     ;
 
 showExportStatement
-    : SHOW EXPORT ((FROM | IN) catalog=qualifiedName)?
-        ((LIKE pattern=string) | (WHERE expression))?
-        (ORDER BY sortItem (',' sortItem)*)? (limitElement)?
+    : SHOW EXPORT ((FROM | IN) catalog=qualifiedName)? (LIKE pattern=string)? showPredicateClauses
     ;
 
 // ------------------------------------------- Plugin Statement --------------------------------------------------------
@@ -2135,7 +2131,7 @@ dropFileStatement
     ;
 
 showSmallFilesStatement
-    : SHOW FILE ((FROM | IN) catalog=qualifiedName)?
+    : SHOW FILE ((FROM | IN) catalog=qualifiedName)? showPredicateClauses
     ;
 
 // -------------------------------------------- Pipe Statement ---------------------------------------------------------
@@ -2167,8 +2163,7 @@ descPipeStatement
     ;
 
 showPipeStatement
-    : SHOW PIPES ((LIKE pattern=string) | (WHERE expression) | (FROM qualifiedName))?
-        (ORDER BY sortItem (',' sortItem)*)? limitElement?
+    : SHOW PIPES ((LIKE pattern=string) | (FROM qualifiedName))? showPredicateClauses
     ;
 
 
@@ -2287,16 +2282,16 @@ setWarehouseStatement
     ;
 
 showWarehousesStatement
-    : SHOW WAREHOUSES (LIKE pattern=string)?
+    : SHOW WAREHOUSES (LIKE pattern=string)? showPredicateClauses
     ;
 
 showClustersStatement
-    : SHOW (CLUSTERS | CNGROUPS) FROM WAREHOUSE identifier
+    : SHOW (CLUSTERS | CNGROUPS) FROM WAREHOUSE identifier showPredicateClauses
     ;
 
 showNodesStatement
-    : SHOW NODES FROM WAREHOUSES (LIKE pattern=string)?
-    | SHOW NODES FROM WAREHOUSE identifier (CNGROUP cngroupName=identifierOrString)?
+    : SHOW NODES FROM WAREHOUSES (LIKE pattern=string)? showPredicateClauses
+    | SHOW NODES FROM WAREHOUSE identifier (CNGROUP cngroupName=identifierOrString)? showPredicateClauses
     ;
 
 alterWarehouseStatement

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ShowProcedureStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ShowProcedureStmt.java
@@ -16,13 +16,11 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.sql.ast.expression.Expr;
-import com.starrocks.sql.ast.expression.Predicate;
 import com.starrocks.sql.parser.NodePosition;
 
 public class ShowProcedureStmt extends ShowStmt {
 
     private String pattern;
-    private Expr where;
 
     public ShowProcedureStmt(String pattern, Expr where) {
         this(pattern, where, NodePosition.ZERO);
@@ -31,7 +29,7 @@ public class ShowProcedureStmt extends ShowStmt {
     public ShowProcedureStmt(String pattern, Expr where, NodePosition pos) {
         super(pos);
         this.pattern = pattern;
-        this.predicate = (Predicate) where;
+        this.predicate = where;
     }
 
     public ShowProcedureStmt() {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SQL grammar and the shared SHOW execution path, so regressions could affect parsing or result ordering/filtering for many SHOW statements; logic is relatively contained and covered by new tests.
> 
> **Overview**
> Many `SHOW` statements now accept a unified `showPredicateClauses` grammar, enabling consistent `WHERE`, `ORDER BY`, and `LIMIT/OFFSET` syntax across the SHOW family.
> 
> Execution is updated so `ShowExecutor.execute()` post-processes `ShowResultSet` rows with predicate evaluation plus optional ordering and limiting (skipping statements that already implement these via new `ShowStmt` self-handling flags), and `ShowStmtAnalyzer` validates/annotates referenced columns and requires constant limit/offset. `ShowStmt` is generalized to store `Expr` predicates (not `Predicate`), and a new unit test (`ShowStmtPredicateTest`) covers several representative SHOW variants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa3a4f03d98a802afc776ea5d20df82b499da9f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->