### PR TITLE
[Enhancement] Implementing dictification for ARRAY_AGG

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -420,6 +420,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String STRUCT_LOW_CARDINALITY_OPTIMIZE = "struct_low_cardinality_optimize";
     public static final String ENABLE_LOW_CARDINALITY_OPTIMIZE_FOR_UNION_ALL =
                     "enable_low_cardinality_optimize_for_union_all";
+    public static final String ARRAY_AGG_LOW_CARDINALITY_OPTIMIZE = "array_agg_low_cardinality_optimize";
     public static final String CBO_USE_NTH_EXEC_PLAN = "cbo_use_nth_exec_plan";
     public static final String CBO_CTE_REUSE = "cbo_cte_reuse";
     public static final String CBO_CTE_REUSE_RATE = "cbo_cte_reuse_rate";
@@ -1763,6 +1764,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = STRUCT_LOW_CARDINALITY_OPTIMIZE)
     private boolean enableStructLowCardinalityOptimize = true;
 
+    @VarAttr(name = ARRAY_AGG_LOW_CARDINALITY_OPTIMIZE)
+    private boolean enableArrayAggLowCardinalityOptimize = true;
+
     @VariableMgr.VarAttr(name = ENABLE_OPTIMIZER_REWRITE_GROUPINGSETS_TO_UNION_ALL)
     private boolean enableRewriteGroupingSetsToUnionAll = false;
 
@@ -2318,6 +2322,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableStructLowCardinalityOptimize;
     }
 
+    public boolean isEnableArrayAggLowCardinalityOptimize() {
+        return enableArrayAggLowCardinalityOptimize;
+    }
+
+    public void setEnableArrayAggLowCardinalityOptimize(boolean enableArrayAggLowCardinalityOptimize) {
+        this.enableArrayAggLowCardinalityOptimize = enableArrayAggLowCardinalityOptimize;
+    }
 
     @VarAttr(name = ENABLE_REWRITE_BITMAP_UNION_TO_BITMAP_AGG)
     private boolean enableRewriteBitmapUnionToBitmapAgg = true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -1003,7 +1003,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                         Preconditions.checkState(structType.getFields().size() == value.getArguments().size());
                         for (int i = 0; i < value.getArguments().size(); i++) {
                             if (value.getArguments().get(i).isColumnRef()
-                                    && context.outputStringColumns.contains(value.getArguments().get(i).cast())) {
+                                    && info.inputStringColumns.contains(value.getArguments().get(i).cast())) {
                                 fieldsData.put(structType.getField(i).getName(), value.getArguments().get(i).cast());
                             }
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.FunctionSet;
@@ -112,7 +113,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
     public static final Set<String> LOW_CARD_AGGREGATE_FUNCTIONS = Sets.newHashSet(FunctionSet.COUNT,
             FunctionSet.MULTI_DISTINCT_COUNT, FunctionSet.MAX, FunctionSet.MIN, FunctionSet.APPROX_COUNT_DISTINCT,
-            FunctionSet.ANY_VALUE);
+            FunctionSet.ANY_VALUE, FunctionSet.ARRAY_AGG);
 
     //TODO(by satanson): it seems that we can support more windows functions in future, at present, we only support
     // LAG/LEAD/FIRST_VALUE/LAST_VALUE and the aggregations functions which can adopt low cardinality optimization
@@ -469,6 +470,10 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             return false;
         }
         ScalarOperator define = stringRefToDefineExprMap.get(cid);
+        if (define instanceof CallOperator && FunctionSet.ARRAY_AGG.equals(((CallOperator) define).getFnName())) {
+            return define.getChild(0).isColumnRef() &&
+                    checkDependOnExpr(((ColumnRefOperator) define.getChild(0)).getId(), checkList);
+        }
         if (define.getType().isStructType()) {
             Map<String, ColumnRefOperator> fieldsMap = getFieldUseStringRefMap(define);
             if (fieldsMap == null) {
@@ -505,12 +510,6 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
     }
 
     void setDefineExpr(ColumnRefOperator col, ScalarOperator define, int counter) {
-        if (define instanceof CallOperator && ((CallOperator) define).getFnName().equals(FunctionSet.ANY_VALUE)) {
-            Map<String, ColumnRefOperator> fieldsMap = getFieldUseStringRefMap(define.getChild(0));
-            if (fieldsMap != null) {
-                structOpToFieldUseStringRef.put(define, fieldsMap);
-            }
-        }
         stringRefToDefineExprMap.putIfAbsent(col.getId(), define);
         Map<String, ColumnRefOperator> fieldsMap = getFieldUseStringRefMap(define);
         if (fieldsMap != null) {
@@ -934,6 +933,25 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         return info;
     }
 
+    private boolean shouldProcessAggFunction(CallOperator agg) {
+        final boolean enableArrayAgg = sessionVariable.isEnableArrayAggLowCardinalityOptimize()
+                && sessionVariable.isEnableArrayLowCardinalityOptimize()
+                && sessionVariable.isEnableStructLowCardinalityOptimize();
+        final boolean isArrayAgg = FunctionSet.ARRAY_AGG.equals(agg.getFnName());
+        if (isArrayAgg && !enableArrayAgg) {
+            return false;
+        }
+        if (!LOW_CARD_AGGREGATE_FUNCTIONS.contains(agg.getFnName())) {
+            return false;
+        }
+        if (isArrayAgg) {
+            // dictify array_agg only when the first child can be dictified.
+            return agg.getChildren().stream().allMatch(c -> c.isColumnRef() || c.isConstantRef())
+                    && agg.getChild(0).isColumnRef() && agg.getFunction().getArgs()[0].isStringType();
+        }
+        return agg.getChildren().size() == 1 && agg.getChildren().get(0).isColumnRef();
+    }
+
     @Override
     public DecodeInfo visitPhysicalHashAggregate(OptExpression optExpression, DecodeInfo context) {
         if (context.outputStringColumns.isEmpty()) {
@@ -945,12 +963,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         ColumnRefSet disableColumns = new ColumnRefSet();
         for (ColumnRefOperator key : aggregate.getAggregations().keySet()) {
             CallOperator agg = aggregate.getAggregations().get(key);
-            if (!LOW_CARD_AGGREGATE_FUNCTIONS.contains(agg.getFnName())) {
-                disableColumns.union(agg.getUsedColumns());
-                disableColumns.union(key);
-                continue;
-            }
-            if (agg.getChildren().size() != 1 || !agg.getChildren().get(0).isColumnRef()) {
+            if (!shouldProcessAggFunction(agg)) {
                 disableColumns.union(agg.getUsedColumns());
                 disableColumns.union(key);
             }
@@ -968,15 +981,41 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 continue;
             }
             CallOperator value = aggregate.getAggregations().get(key);
-            if (!info.inputStringColumns.containsAll(value.getUsedColumns())) {
+            if (FunctionSet.ARRAY_AGG.equals(value.getFnName())) {
+                if (!value.getChild(0).isColumnRef() ||
+                        !info.inputStringColumns.contains(value.getChild(0).cast())) {
+                    continue;
+                }
+            } else if (!info.inputStringColumns.containsAll(value.getUsedColumns())) {
                 continue;
             }
             // aggregate ref -> aggregate expr
             stringAggregateExpressions.computeIfAbsent(key.getId(), x -> Lists.newArrayList()).add(value);
-            // min/max should replace to dict column, count/count distinct don't need
-            if (FunctionSet.MAX.equals(value.getFnName()) || FunctionSet.MIN.equals(value.getFnName())
-                    || FunctionSet.ANY_VALUE.equals(value.getFnName())) {
+            if (supportLowCardinality(value.getType())) {
                 info.outputStringColumns.union(key.getId());
+                AggregateFunction aggFn = (AggregateFunction) value.getFunction();
+                if (aggFn.getIntermediateTypeOrReturnType().isStructType()
+                        && !structRefToFieldUseStringRef.containsKey(key.getId())) {
+                    final Map<String, ColumnRefOperator> fieldsData;
+                    if (FunctionSet.ARRAY_AGG.equals(aggFn.functionName())) {
+                        fieldsData = Maps.newHashMap();
+                        StructType structType = (StructType) aggFn.getIntermediateTypeOrReturnType();
+                        Preconditions.checkState(structType.getFields().size() == value.getArguments().size());
+                        for (int i = 0; i < value.getArguments().size(); i++) {
+                            if (value.getArguments().get(i).isColumnRef()
+                                    && context.outputStringColumns.contains(value.getArguments().get(i).cast())) {
+                                fieldsData.put(structType.getField(i).getName(), value.getArguments().get(i).cast());
+                            }
+                        }
+                    } else if (FunctionSet.ANY_VALUE.equals(aggFn.functionName())) {
+                        fieldsData = getFieldUseStringRefMap(value.getArguments().get(0));
+                    } else {
+                        throw new UnsupportedOperationException(
+                                String.format("Unsupported function: %s with Struct Type", aggFn.functionName()));
+                    }
+                    Preconditions.checkNotNull(fieldsData);
+                    structOpToFieldUseStringRef.put(value, fieldsData);
+                }
                 setDefineExpr(key, value, 1);
             } else if (aggregate.getType().isLocal() || aggregate.getType().isDistinct()) {
                 // count/count distinct, need output dict-set in 1st stage
@@ -1350,7 +1389,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         }
     }
 
-    private static boolean supportLowCardinality(Type type) {
+    static boolean supportLowCardinality(Type type) {
         return type.isVarchar()
                 || (type.isArrayType() && ((ArrayType) type).getItemType().isVarchar())
                 || type.isStructType();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -494,12 +494,14 @@ class DecodeContext {
         }
 
         AggregateFunction buildAggregateFunction(AggregateFunction fn, List<ScalarOperator> newChildren,
-                                                 List<ScalarOperator> originalChildren, boolean isMergeState) {
+                                                 List<ScalarOperator> originalChildren) {
             final List<Type> argTypes;
             final Type intermediateType;
             final Type returnType;
             if (FunctionSet.ARRAY_AGG.equals(fn.functionName())) {
-                if (isMergeState) {
+                ScalarOperator child = originalChildren.get(0);
+                if (child.getType().matchesType(fn.getReturnType())
+                        || child.getType().matchesType(fn.getIntermediateTypeOrReturnType())) {
                     argTypes = Lists.newArrayList();
                     Map<String, ColumnRefOperator> fieldMapping = getFieldUseStringRefMap(originalChildren.get(0));
                     Preconditions.checkNotNull(fieldMapping);
@@ -533,14 +535,18 @@ class DecodeContext {
             List<ScalarOperator> newChildren = visitList(call.getChildren(), hasChange);
 
             if (call.getFunction() instanceof AggregateFunction origFn) {
-                boolean isMergeState = origFn.getIntermediateType() != null
-                        && call.getArguments().size() == 1 && call.getArguments().get(0).isColumnRef()
-                        && call.getArguments().get(0).getType().matchesType(origFn.getIntermediateType());
-                AggregateFunction fn = buildAggregateFunction(origFn, newChildren, call.getArguments(), isMergeState);
-                if (isMergeState) {
-                    ColumnRefOperator input = newChildren.get(0).cast();
-                    newChildren = List.of(new ColumnRefOperator(input.getId(), fn.getIntermediateType(),
-                            input.getName(), input.isNullable()));
+                AggregateFunction fn = buildAggregateFunction(origFn, newChildren, call.getArguments());
+                ColumnRefOperator firstChild = newChildren.get(0).isColumnRef() ? newChildren.get(0).cast() : null;
+                if (firstChild != null && firstChild != call.getArguments().get(0)) {
+                    if (firstChild.getType().matchesType(fn.getReturnType())) {
+                        newChildren.set(0, new ColumnRefOperator(firstChild.getId(), fn.getReturnType(),
+                                firstChild.getName(), firstChild.isNullable()));
+                    }
+                    if (fn.getIntermediateType() != null
+                            && firstChild.getType().matchesType(fn.getIntermediateType())) {
+                        newChildren.set(0, new ColumnRefOperator(firstChild.getId(), fn.getIntermediateType(),
+                                firstChild.getName(), firstChild.isNullable()));
+                    }
                 }
                 Type returnType = call.getType().matchesType(origFn.getReturnType())
                         ? fn.getReturnType() : fn.getIntermediateType();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -47,6 +47,7 @@ import java.util.Set;
 
 import static com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeCollector.LOW_CARD_ARRAY_FUNCTIONS;
 import static com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeCollector.LOW_CARD_STRUCT_FUNCTIONS;
+import static com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeUtil.getDictifiedType;
 
 /*
  * DecodeContext is used to store the information needed for decoding
@@ -490,20 +491,6 @@ class DecodeContext {
         @Override
         public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void ignore) {
             return stringRefToDictRefMap.getOrDefault(variable, variable);
-        }
-
-        private static Type getDictifiedType(Type type) {
-            if (type == null) {
-                return null;
-            }
-            Preconditions.checkState(!type.isStructType());
-            if (type.isStringType()) {
-                return IntegerType.INT;
-            }
-            if (type.isStringArrayType()) {
-                return new ArrayType(IntegerType.INT);
-            }
-            return type;
         }
 
         AggregateFunction buildAggregateFunction(AggregateFunction fn, List<ScalarOperator> newChildren,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -47,7 +47,6 @@ import java.util.Set;
 
 import static com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeCollector.LOW_CARD_ARRAY_FUNCTIONS;
 import static com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeCollector.LOW_CARD_STRUCT_FUNCTIONS;
-import static com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeCollector.LOW_CARD_WINDOW_FUNCTIONS;
 
 /*
  * DecodeContext is used to store the information needed for decoding
@@ -112,6 +111,7 @@ class DecodeContext {
     // STRING or ARRAY<STRING> types. Nested structs are not supported.
     Map<ScalarOperator, Map<String, ColumnRefOperator>> structOpToFieldUseStringRefMap =
             Maps.newIdentityHashMap();
+
     UnionDictionaryManager unionDictionaryManager;
 
     DecodeContext(ColumnRefFactory factory) {
@@ -145,6 +145,9 @@ class DecodeContext {
             Preconditions.checkState(subfieldOperator.getFieldNames().size() == 1
                     && fieldsUseRefMap.containsKey(subfieldOperator.getFieldNames().get(0)));
             return getUseStringRef(fieldsUseRefMap.get(subfieldOperator.getFieldNames().get(0)));
+        }
+        if (operator instanceof CallOperator && FunctionSet.ARRAY_AGG.equals(((CallOperator) operator).getFnName())) {
+            return getUseStringRef(operator.getChild(0));
         }
         List<ColumnRefOperator> columnRefs = Lists.newArrayList();
         for (ScalarOperator child : operator.getChildren()) {
@@ -270,6 +273,21 @@ class DecodeContext {
         }
     }
 
+    private static Function buildFunction(String fnName, List<ScalarOperator> args) {
+        if (fnName.equals(FunctionSet.NAMED_STRUCT)) {
+            Type[] argTypes = args.stream().map(ScalarOperator::getType).toArray(Type[]::new);
+            Function fn = ExprUtils.getBuiltinFunction(fnName, argTypes, Function.CompareMode.IS_SUPERTYPE_OF).copy();
+            List<StructField> fields = Lists.newArrayList();
+            for (int i = 0; i < args.size(); i += 2) {
+                fields.add(new StructField(((ConstantOperator) args.get(i)).getVarchar(), argTypes[i + 1]));
+            }
+            fn.setRetType(new StructType(fields, true));
+            return fn;
+        }
+        Type[] argTypes = args.stream().map(ScalarOperator::getType).toArray(Type[]::new);
+        return ExprUtils.getBuiltinFunction(fnName, argTypes, Function.CompareMode.IS_SUPERTYPE_OF);
+    }
+
     // define mode: means the result column is dict, DictExpr should return int/array<int> type
     // decode mode: means the result column is string, DictExpr should return string/array<string> type
     private class DictExprRewrite extends BaseScalarOperatorShuttle {
@@ -324,7 +342,7 @@ class DecodeContext {
             anchorOp = null;
             anchorUseDictRef = null;
             ScalarOperator result = expression.accept(this, null);
-            if (useStringRef.getType().isVarchar() && anchorOp == null) {
+            if (useStringRef.getType().isVarchar() && anchorUseDictRef == null) {
                 return new DictMappingOperator(useDictRef, expression.clone(), expression.getType());
             }
             if (result.getType().isStructType()) {
@@ -358,7 +376,7 @@ class DecodeContext {
             anchorOp = null;
             anchorUseDictRef = null;
             ScalarOperator result = expression.accept(this, null);
-            if (useStringRef.getType().isVarchar() && anchorOp == null) {
+            if (useStringRef.getType().isVarchar() && anchorUseDictRef == null) {
                 return new DictMappingOperator(useDictRef, expression.clone(), useDictRef.getType());
 
             }
@@ -379,21 +397,6 @@ class DecodeContext {
         @Override
         public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void context) {
             return stringRefToDictRefMap.getOrDefault(variable, variable);
-        }
-
-        private static Function buildFunction(String fnName, List<ScalarOperator> args) {
-            Type[] argTypes = args.stream().map(ScalarOperator::getType).toArray(Type[]::new);
-            Function fn = ExprUtils.getBuiltinFunction(fnName, argTypes, Function.CompareMode.IS_SUPERTYPE_OF);
-            if (!fnName.equals(FunctionSet.NAMED_STRUCT)) {
-                return fn;
-            }
-            fn = fn.copy();
-            List<StructField> fields = Lists.newArrayList();
-            for (int i = 0; i < args.size(); i += 2) {
-                fields.add(new StructField(((ConstantOperator) args.get(i)).getVarchar(), argTypes[i + 1]));
-            }
-            fn.setRetType(new StructType(fields, true));
-            return fn;
         }
 
         @Override
@@ -489,46 +492,82 @@ class DecodeContext {
             return stringRefToDictRefMap.getOrDefault(variable, variable);
         }
 
+        private static Type getDictifiedType(Type type) {
+            if (type == null) {
+                return null;
+            }
+            Preconditions.checkState(!type.isStructType());
+            if (type.isStringType()) {
+                return IntegerType.INT;
+            }
+            if (type.isStringArrayType()) {
+                return new ArrayType(IntegerType.INT);
+            }
+            return type;
+        }
+
+        AggregateFunction buildAggregateFunction(AggregateFunction fn, List<ScalarOperator> newChildren,
+                                                 List<ScalarOperator> originalChildren, boolean isMergeState) {
+            final List<Type> argTypes;
+            final Type intermediateType;
+            final Type returnType;
+            if (FunctionSet.ARRAY_AGG.equals(fn.functionName())) {
+                if (isMergeState) {
+                    argTypes = Lists.newArrayList();
+                    Map<String, ColumnRefOperator> fieldMapping = getFieldUseStringRefMap(originalChildren.get(0));
+                    Preconditions.checkNotNull(fieldMapping);
+                    for (int i = 0; i < fn.getNumArgs(); ++i) {
+                        argTypes.add(fieldMapping.containsKey("col" + (i + 1)) ? getDictifiedType(fn.getArgs()[i])
+                                : fn.getArgs()[i]);
+                    }
+                } else {
+                    argTypes = newChildren.stream().map(ScalarOperator::getType).toList();
+                }
+                intermediateType = new StructType(argTypes.stream().map(t -> (Type) new ArrayType(t)).toList());
+                returnType = new ArrayType(argTypes.get(0));
+            } else if (FunctionSet.ANY_VALUE.equals(fn.functionName())) {
+                returnType = intermediateType = newChildren.get(0).getType();
+                argTypes = List.of(newChildren.get(0).getType());
+            } else {
+                argTypes = List.of(getDictifiedType(fn.getArgs()[0]));
+                returnType = getDictifiedType(fn.getReturnType());
+                intermediateType = getDictifiedType(fn.getIntermediateType());
+            }
+            AggregateFunction newFn = (AggregateFunction) fn.copy();
+            newFn.setArgsType(argTypes.subList(0, fn.getNumArgs()).toArray(Type[]::new));
+            newFn.setIntermediateType(intermediateType);
+            newFn.setRetType(returnType);
+            return newFn;
+        }
+
         @Override
         public ScalarOperator visitCall(CallOperator call, Void ignore) {
             boolean[] hasChange = new boolean[1];
             List<ScalarOperator> newChildren = visitList(call.getChildren(), hasChange);
 
-            if (call.getFunction() instanceof AggregateFunction) {
-                Type argType = newChildren.get(0).getType().isStructType() ? newChildren.get(0).getType()
-                        : newChildren.get(0).getType().isArrayType() ? new ArrayType(IntegerType.INT) : IntegerType.INT;
-                Type[] argTypes = new Type[] {argType};
-                Function fn = ExprUtils.getBuiltinFunction(call.getFnName(), argTypes, Function.CompareMode.IS_SUPERTYPE_OF);
-                // min/max function: will rewrite all stage, return type is dict type
-                if (FunctionSet.MAX.equals(call.getFnName()) || FunctionSet.MIN.equals(call.getFnName())
-                        || FunctionSet.ANY_VALUE.equals((call.getFnName()))) {
-                    return new CallOperator(call.getFnName(), fn.getReturnType(), newChildren, fn,
-                            call.isDistinct(), call.isRemovedDistinct());
-                } else if (FunctionSet.COUNT.equals(call.getFnName()) ||
-                        FunctionSet.MULTI_DISTINCT_COUNT.equals(call.getFnName()) ||
-                        FunctionSet.APPROX_COUNT_DISTINCT.equals(call.getFnName())) {
-                    // count, count_distinct, approx_count_distinct:
-                    // return type don't update
-                    return new CallOperator(call.getFnName(), call.getType(), newChildren, fn,
-                            call.isDistinct(), call.isRemovedDistinct());
-                } else if (LOW_CARD_WINDOW_FUNCTIONS.contains(call.getFnName())) {
-                    CallOperator newCall = new CallOperator(call.getFnName(), fn.getReturnType(), newChildren, fn,
-                            call.isDistinct(), call.isRemovedDistinct());
-                    //encoded window functions should set ignore null flag
-                    newCall.setIgnoreNulls(call.getIgnoreNulls());
-                    return newCall;
+            if (call.getFunction() instanceof AggregateFunction origFn) {
+                boolean isMergeState = origFn.getIntermediateType() != null
+                        && call.getArguments().size() == 1 && call.getArguments().get(0).isColumnRef()
+                        && call.getArguments().get(0).getType().matchesType(origFn.getIntermediateType());
+                AggregateFunction fn = buildAggregateFunction(origFn, newChildren, call.getArguments(), isMergeState);
+                if (isMergeState) {
+                    ColumnRefOperator input = newChildren.get(0).cast();
+                    newChildren = List.of(new ColumnRefOperator(input.getId(), fn.getIntermediateType(),
+                            input.getName(), input.isNullable()));
                 }
+                Type returnType = call.getType().matchesType(origFn.getReturnType())
+                        ? fn.getReturnType() : fn.getIntermediateType();
+                CallOperator newCall = new CallOperator(call.getFnName(), returnType, newChildren, fn,
+                        call.isDistinct(), call.isRemovedDistinct());
+                newCall.setIgnoreNulls(call.getIgnoreNulls());
+                return newCall;
             }
 
             if (!hasChange[0]) {
                 return call;
             }
 
-            Type[] argTypes = new Type[newChildren.size()];
-            for (int i = 0; i < newChildren.size(); i++) {
-                argTypes[i] = newChildren.get(i).getType();
-            }
-            Function fn = ExprUtils.getBuiltinFunction(call.getFnName(), argTypes, Function.CompareMode.IS_SUPERTYPE_OF);
+            Function fn = buildFunction(call.getFnName(), newChildren);
             return new CallOperator(call.getFnName(), fn.getReturnType(), newChildren, fn,
                     call.isDistinct(), call.isRemovedDistinct());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -69,6 +69,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeCollector.supportLowCardinality;
+
 /*
  * Rewrite the whole plan using the dict column by from bottom-up
  */
@@ -336,8 +338,7 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
             }
 
             // merge stage is different from update stage
-            if (FunctionSet.MAX.equals(aggFn.getFnName()) || FunctionSet.MIN.equals(aggFn.getFnName())
-                    || FunctionSet.ANY_VALUE.equals(aggFn.getFnName())) {
+            if (supportLowCardinality(aggFn.getType())) {
                 ColumnRefOperator newAggRef = context.stringRefToDictRefMap.getOrDefault(aggRef, aggRef);
                 aggregations.put(newAggRef, context.stringExprToDictExprMap.get(aggFn).cast());
                 inputStringRefs.union(aggRef.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeUtil.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree.lowcardinality;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.type.ArrayType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.Type;
+
+final class DecodeUtil {
+
+    private DecodeUtil() {}
+
+    static Type getDictifiedType(Type type) {
+        if (type == null) {
+            return null;
+        }
+        Preconditions.checkState(!type.isStructType());
+        if (type.isStringType()) {
+            return IntegerType.INT;
+        }
+        if (type.isStringArrayType()) {
+            return ArrayType.ARRAY_INT;
+        }
+        return type;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
@@ -82,14 +82,17 @@ public class LowCardinalityStructTest extends PlanTestBase {
         connectContext.getSessionVariable().setCboCteReuse(false);
         connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(true);
         connectContext.getSessionVariable().setEnableStructLowCardinalityOptimize(true);
+        connectContext.getSessionVariable().setEnableArrayAggLowCardinalityOptimize(true);
     }
 
     @AfterAll
     public static void afterClass() {
+        FeConstants.USE_MOCK_DICT_MANAGER = false;
         connectContext.getSessionVariable().setSqlMode(0);
         connectContext.getSessionVariable().setEnableLowCardinalityOptimize(false);
         connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(false);
         connectContext.getSessionVariable().setEnableStructLowCardinalityOptimize(false);
+        connectContext.getSessionVariable().setEnableArrayAggLowCardinalityOptimize(false);
     }
 
     @Test
@@ -468,5 +471,111 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 "  |  7 <-> DictDecode([8: VARCHAR_COL, INT, true], [upper[(<place-holder>); args: VARCHAR; " +
                 "result: VARCHAR; args nullable: true; result nullable: true]])\n";
         Assertions.assertTrue(plan.contains(expected), plan);
+    }
+
+    @Test
+    public void testArrayAggString1Stage() throws Exception {
+        String sql = """
+                SELECT /*+ SET_VAR(new_planner_agg_stage='1') */
+                ARRAY_AGG(VARCHAR_COL ORDER BY VARCHAR_COL, INTEGER_COL)
+                FROM T
+                """;
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("  2:Decode\n" +
+                "  |  <dict id 7> : <string id 5>\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update finalize)\n" +
+                "  |  aggregate: array_agg[([6: VARCHAR_COL, INT, true], [6: VARCHAR_COL, INT, true], " +
+                "[4: INTEGER_COL, INT, true]); args: INT,INT,INT; result: ARRAY<INT>; " +
+                "args nullable: true; result nullable: true]\n" +
+                "  |  cardinality: 1"), plan);
+    }
+
+    @Test
+    public void testArrayAggString2Stage() throws Exception {
+        String sql = """
+                SELECT /*+ SET_VAR(new_planner_agg_stage='2') */
+                ARRAY_AGG(VARCHAR_COL ORDER BY VARCHAR_COL, INTEGER_COL)
+                FROM T
+                """;
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("  4:Decode\n" +
+                "  |  <dict id 7> : <string id 5>\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  3:AGGREGATE (merge finalize)\n" +
+                "  |  aggregate: array_agg[([7: array_agg, struct<col1 array<int(11)>, col2 array<int(11)>, " +
+                "col3 array<int(11)>>, true]); args: INT,INT,INT; result: ARRAY<INT>; args nullable: true; " +
+                "result nullable: true]"), plan);
+    }
+
+    @Test
+    public void testArrayAggString3Stage() throws Exception {
+        String sql = """
+                SELECT /*+ SET_VAR(new_planner_agg_stage='3') */
+                ARRAY_AGG(DISTINCT VARCHAR_COL)
+                FROM T
+                GROUP BY KEY_COL 
+                """;
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("Global Dict Exprs:\n" +
+                "    7: DictDefine(6: VARCHAR_COL, [<place-holder>])\n" +
+                "\n" +
+                "  6:Decode\n" +
+                "  |  <dict id 7> : <string id 5>\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  5:Project\n" +
+                "  |  output columns:\n" +
+                "  |  7 <-> [7: array_agg, ARRAY<INT>, true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  4:AGGREGATE (update finalize)\n" +
+                "  |  aggregate: array_agg[([6: VARCHAR_COL, INT, true]); args: INT; result: ARRAY<INT>; " +
+                "args nullable: true; result nullable: true]\n" +
+                "  |  group by: [1: KEY_COL, INT, false]"), plan);
+    }
+
+    @Test
+    public void testArrayAggString4Stage() throws Exception {
+        String sql = """
+                SELECT /*+ SET_VAR(new_planner_agg_stage='4') */
+                ARRAY_AGG(DISTINCT VARCHAR_COL ORDER BY VARCHAR_COL, INTEGER_COL)
+                FROM T
+                """;
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("7:Decode\n" +
+                "  |  <dict id 7> : <string id 5>\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  6:AGGREGATE (merge finalize)\n" +
+                "  |  aggregate: array_agg[([7: array_agg, struct<col1 array<int(11)>, col2 array<int(11)>, " +
+                "col3 array<int(11)>>, true]); args: INT,INT,INT; result: ARRAY<INT>; args nullable: true; " +
+                "result nullable: true]"), plan);
+    }
+
+    @Test
+    public void testArrayAggString4StageGetElement() throws Exception {
+        String sql = """
+                SELECT /*+ SET_VAR(new_planner_agg_stage='4') */
+                UPPER(ARRAY_AGG(DISTINCT VARCHAR_COL ORDER BY VARCHAR_COL, INTEGER_COL)[1])
+                FROM T
+                """;
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("Global Dict Exprs:\n" +
+                "    9: DictDefine(8: VARCHAR_COL, [<place-holder>])\n" +
+                "\n" +
+                "  7:Project\n" +
+                "  |  output columns:\n" +
+                "  |  6 <-> DictDecode([9: array_agg, ARRAY<INT>, true], [upper[(<place-holder>); args: VARCHAR; " +
+                "result: VARCHAR; args nullable: true; result nullable: true]], " +
+                "[9: array_agg, ARRAY<INT>, true][1])\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  6:AGGREGATE (merge finalize)\n" +
+                "  |  aggregate: array_agg[([9: array_agg, struct<col1 array<int(11)>, col2 array<int(11)>, " +
+                "col3 array<int(11)>>, true]); args: INT,INT,INT; result: ARRAY<INT>; args nullable: true;" +
+                " result nullable: true]"), plan);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
@@ -578,4 +578,19 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 "col3 array<int(11)>>, true]); args: INT,INT,INT; result: ARRAY<INT>; args nullable: true;" +
                 " result nullable: true]"), plan);
     }
+
+    @Test
+    public void testArrayAggMultipleStages() throws Exception {
+        String sql = """
+                select array_agg(distinct VARCHAR_COL order by 1 asc), array_agg(VARCHAR_COL order by 1 desc)
+                from T
+                order by 1;
+                """;
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("  6:AGGREGATE (merge finalize)\n" +
+                "  |  aggregate: array_agg[([8: array_agg, struct<col1 array<int(11)>, col2 array<int(11)>>, true]);" +
+                " args: INT,INT; result: ARRAY<INT>; args nullable: true; result nullable: true], " +
+                "array_agg[([9: array_agg, struct<col1 array<int(11)>, col2 array<int(11)>>, true]); args: INT,INT;" +
+                " result: ARRAY<INT>; args nullable: true; result nullable: true]\n"), plan);
+    }
 }

--- a/test/sql/test_global_dict/R/array_agg
+++ b/test/sql/test_global_dict/R/array_agg
@@ -1,0 +1,350 @@
+-- name: test_low_cardinality_array_agg
+CREATE TABLE `t` (
+  `id` int(11) NOT NULL COMMENT "",
+  `grp` int(11) NOT NULL COMMENT "",
+  `str1` varchar(65533) NOT NULL COMMENT "",
+  `str2` varchar(65533) NULL COMMENT "",
+  `val` int(11) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t VALUES
+    (1,  1, 'apple',  'X', 10),
+    (2,  1, 'banana', 'Y', 20),
+    (3,  1, 'apple',  'Z', 15),
+    (4,  1, 'cherry', 'X', 25),
+    (5,  2, 'banana', 'Y', 30),
+    (6,  2, 'cherry', 'Z', 35),
+    (7,  2, 'apple',  'X', 40),
+    (8,  2, 'date',   'Y', 45),
+    (9,  3, 'cherry', 'Z', 50),
+    (10, 3, 'cherry', 'X', 55),
+    (11, 3, 'date',   NULL, 60),
+    (12, 3, 'banana', 'Y', 65);
+-- result:
+-- !result
+[UC] analyze full table t;
+-- result:
+test_db_66e489ab3c1b4d32bb75d4cb9cb7d0ce.t	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('str1', 't')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('str2', 't')
+-- result:
+
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_sort(array_agg(str1)) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","cherry","date"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_sort(array_agg(str1)) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","cherry","date"]
+-- !result
+SELECT grp, array_sort(array_agg(distinct str1)) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","date"]
+-- !result
+SELECT grp, array_agg(distinct str1 ORDER BY str1) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","date"]
+-- !result
+SELECT grp, array_agg(distinct str1 ORDER BY str1, str2) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","date"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY str1) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","cherry","date"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY str1) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","cherry","date"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_sort(array_agg(str1 ORDER BY str2)) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","cherry","date"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_sort(array_agg(str1 ORDER BY str2)) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","cherry","date"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY val) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["banana","cherry","apple","date"]
+3	["cherry","cherry","date","banana"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY val) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["banana","cherry","apple","date"]
+3	["cherry","cherry","date","banana"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY str1, str2) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","cherry","date"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY str1, str2) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","cherry","date"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY val, id) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["banana","cherry","apple","date"]
+3	["cherry","cherry","date","banana"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY val, id) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["banana","cherry","apple","date"]
+3	["cherry","cherry","date","banana"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY str2, val) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","cherry","banana","apple"]
+2	["apple","banana","date","cherry"]
+3	["date","cherry","banana","cherry"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY str2, val) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","cherry","banana","apple"]
+2	["apple","banana","date","cherry"]
+3	["date","cherry","banana","cherry"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY val, str1) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["banana","cherry","apple","date"]
+3	["cherry","cherry","date","banana"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY val, str1) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["banana","cherry","apple","date"]
+3	["cherry","cherry","date","banana"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY str2, val, str1) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","cherry","banana","apple"]
+2	["apple","banana","date","cherry"]
+3	["date","cherry","banana","cherry"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY str2, val, str1) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","cherry","banana","apple"]
+2	["apple","banana","date","cherry"]
+3	["date","cherry","banana","cherry"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY str1 DESC, val ASC) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["cherry","banana","apple","apple"]
+2	["date","cherry","banana","apple"]
+3	["date","cherry","cherry","banana"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY str1 DESC, val ASC) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["cherry","banana","apple","apple"]
+2	["date","cherry","banana","apple"]
+3	["date","cherry","cherry","banana"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(val ORDER BY str1, val) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	[10,15,20,25]
+2	[40,30,35,45]
+3	[65,50,55,60]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(val ORDER BY str1, val) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	[10,15,20,25]
+2	[40,30,35,45]
+3	[65,50,55,60]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_sort(array_agg(val)) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	[10,15,20,25]
+2	[30,35,40,45]
+3	[50,55,60,65]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_sort(array_agg(val)) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	[10,15,20,25]
+2	[30,35,40,45]
+3	[50,55,60,65]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_length(array_agg(str1)) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	4
+2	4
+3	4
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_length(array_agg(str1)) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	4
+2	4
+3	4
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, upper(array_sort(array_agg(str1))[1]) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	APPLE
+2	APPLE
+3	BANANA
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, upper(array_sort(array_agg(str1))[1]) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	APPLE
+2	APPLE
+3	BANANA
+-- !result
+SELECT grp, upper(array_sort(array_agg(distinct str1))[1]) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	APPLE
+2	APPLE
+3	BANANA
+-- !result
+SELECT grp, array_sort(array_distinct(array_agg(str1))) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","date"]
+-- !result
+SELECT grp, array_sort(array_distinct(array_agg(str1))), array_sort(array_distinct(array_agg(str2))) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","banana","cherry"]	["X","Y","Z"]
+2	["apple","banana","cherry","date"]	["X","Y","Z"]
+3	["banana","cherry","date"]	[null,"X","Y","Z"]
+-- !result
+SELECT grp, array_sort(array_agg(str1)) FROM t WHERE str2 = 'X' GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","cherry"]
+2	["apple"]
+3	["cherry"]
+-- !result
+SELECT grp, array_sort(array_agg(str1)) FROM t WHERE str1 IN ('apple', 'banana') GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana"]
+2	["apple","banana"]
+3	["banana"]
+-- !result
+SELECT grp, array_sort(array_distinct(array_agg(str1))) as names FROM t GROUP BY grp HAVING array_length(array_agg(str1)) > 100 ORDER BY grp;
+-- result:
+-- !result
+SELECT grp, array_sort(array_agg(distinct str1)) FROM t WHERE str2 = 'X' GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","cherry"]
+2	["apple"]
+3	["cherry"]
+-- !result
+SELECT grp, names FROM (
+    SELECT grp, array_sort(array_distinct(array_agg(str1))) as names FROM t GROUP BY grp
+) sub WHERE array_length(names) > 2 ORDER BY grp;
+-- result:
+1	["apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","date"]
+-- !result
+SELECT grp, first_val FROM (
+    SELECT grp, array_sort(array_agg(str1 ORDER BY str1))[1] as first_val FROM t GROUP BY grp
+) sub ORDER BY grp;
+-- result:
+1	apple
+2	apple
+3	banana
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_sort(array_distinct(array_agg(str1))), array_length(array_agg(str1)) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","banana","cherry"]	4
+2	["apple","banana","cherry","date"]	4
+3	["banana","cherry","date"]	4
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2, cbo_enable_low_cardinality_optimize=false)*/ grp, array_sort(array_distinct(array_agg(str1))), array_length(array_agg(str1)) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","banana","cherry"]	4
+2	["apple","banana","cherry","date"]	4
+3	["banana","cherry","date"]	4
+-- !result
+SELECT grp, array_sort(array_agg(distinct str1)) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","date"]
+-- !result
+SELECT /*+SET_VAR(cbo_enable_low_cardinality_optimize=false)*/ grp, array_sort(array_agg(distinct str1)) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","banana","cherry"]
+2	["apple","banana","cherry","date"]
+3	["banana","cherry","date"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY val) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["banana","cherry","apple","date"]
+3	["cherry","cherry","date","banana"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1, cbo_enable_low_cardinality_optimize=false)*/ grp, array_agg(str1 ORDER BY val) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["banana","cherry","apple","date"]
+3	["cherry","cherry","date","banana"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY val) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["banana","cherry","apple","date"]
+3	["cherry","cherry","date","banana"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2, cbo_enable_low_cardinality_optimize=false)*/ grp, array_agg(str1 ORDER BY val) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","apple","banana","cherry"]
+2	["banana","cherry","apple","date"]
+3	["cherry","cherry","date","banana"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY str2, val) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","cherry","banana","apple"]
+2	["apple","banana","date","cherry"]
+3	["date","cherry","banana","cherry"]
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2, cbo_enable_low_cardinality_optimize=false)*/ grp, array_agg(str1 ORDER BY str2, val) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["apple","cherry","banana","apple"]
+2	["apple","banana","date","cherry"]
+3	["date","cherry","banana","cherry"]
+-- !result
+drop table t;
+-- result:
+-- !result

--- a/test/sql/test_global_dict/T/array_agg
+++ b/test/sql/test_global_dict/T/array_agg
@@ -1,0 +1,188 @@
+-- name: test_low_cardinality_array_agg
+
+CREATE TABLE `t` (
+  `id` int(11) NOT NULL COMMENT "",
+  `grp` int(11) NOT NULL COMMENT "",
+  `str1` varchar(65533) NOT NULL COMMENT "",
+  `str2` varchar(65533) NULL COMMENT "",
+  `val` int(11) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+INSERT INTO t VALUES
+    (1,  1, 'apple',  'X', 10),
+    (2,  1, 'banana', 'Y', 20),
+    (3,  1, 'apple',  'Z', 15),
+    (4,  1, 'cherry', 'X', 25),
+    (5,  2, 'banana', 'Y', 30),
+    (6,  2, 'cherry', 'Z', 35),
+    (7,  2, 'apple',  'X', 40),
+    (8,  2, 'date',   'Y', 45),
+    (9,  3, 'cherry', 'Z', 50),
+    (10, 3, 'cherry', 'X', 55),
+    (11, 3, 'date',   NULL, 60),
+    (12, 3, 'banana', 'Y', 65);
+
+[UC] analyze full table t;
+function: wait_global_dict_ready('str1', 't')
+function: wait_global_dict_ready('str2', 't')
+
+-- ===== Basic ARRAY_AGG(string) - 1 stage and 2 stage =====
+
+-- 1-stage aggregation
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_sort(array_agg(str1)) FROM t GROUP BY grp ORDER BY grp;
+
+-- 2-stage aggregation (local + merge)
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_sort(array_agg(str1)) FROM t GROUP BY grp ORDER BY grp;
+
+-- ===== ARRAY_AGG(DISTINCT string) =====
+
+-- Basic ARRAY_AGG(DISTINCT)
+SELECT grp, array_sort(array_agg(distinct str1)) FROM t GROUP BY grp ORDER BY grp;
+
+-- ARRAY_AGG(DISTINCT) with ORDER BY
+SELECT grp, array_agg(distinct str1 ORDER BY str1) FROM t GROUP BY grp ORDER BY grp;
+
+-- ARRAY_AGG(DISTINCT) with multi-column ORDER BY
+SELECT grp, array_agg(distinct str1 ORDER BY str1, str2) FROM t GROUP BY grp ORDER BY grp;
+
+-- ===== ARRAY_AGG(string) with single-column ORDER BY =====
+
+-- ORDER BY same string column
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY str1) FROM t GROUP BY grp ORDER BY grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY str1) FROM t GROUP BY grp ORDER BY grp;
+
+-- ORDER BY different string column (non-deterministic ties within str2 groups, use array_sort)
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_sort(array_agg(str1 ORDER BY str2)) FROM t GROUP BY grp ORDER BY grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_sort(array_agg(str1 ORDER BY str2)) FROM t GROUP BY grp ORDER BY grp;
+
+-- ORDER BY non-string column
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY val) FROM t GROUP BY grp ORDER BY grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY val) FROM t GROUP BY grp ORDER BY grp;
+
+-- ===== ARRAY_AGG(string) with multi-column ORDER BY =====
+
+-- Two string columns
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY str1, str2) FROM t GROUP BY grp ORDER BY grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY str1, str2) FROM t GROUP BY grp ORDER BY grp;
+
+-- Two non-string columns
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY val, id) FROM t GROUP BY grp ORDER BY grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY val, id) FROM t GROUP BY grp ORDER BY grp;
+
+-- String + non-string
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY str2, val) FROM t GROUP BY grp ORDER BY grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY str2, val) FROM t GROUP BY grp ORDER BY grp;
+
+-- Non-string + string
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY val, str1) FROM t GROUP BY grp ORDER BY grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY val, str1) FROM t GROUP BY grp ORDER BY grp;
+
+-- Three columns: string, non-string, string
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY str2, val, str1) FROM t GROUP BY grp ORDER BY grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY str2, val, str1) FROM t GROUP BY grp ORDER BY grp;
+
+-- Mixed directions
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY str1 DESC, val ASC) FROM t GROUP BY grp ORDER BY grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY str1 DESC, val ASC) FROM t GROUP BY grp ORDER BY grp;
+
+-- ===== ARRAY_AGG(non-string) - NOT dict-optimized, correctness check =====
+
+-- Non-string value column, string ORDER BY
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(val ORDER BY str1, val) FROM t GROUP BY grp ORDER BY grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(val ORDER BY str1, val) FROM t GROUP BY grp ORDER BY grp;
+
+-- Non-string value column, no ORDER BY
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_sort(array_agg(val)) FROM t GROUP BY grp ORDER BY grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_sort(array_agg(val)) FROM t GROUP BY grp ORDER BY grp;
+
+-- ===== Derived operations on ARRAY_AGG result =====
+
+-- array_length of array_agg
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_length(array_agg(str1)) FROM t GROUP BY grp ORDER BY grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_length(array_agg(str1)) FROM t GROUP BY grp ORDER BY grp;
+
+-- Element access + string function: upper(array_agg(...)[1])
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, upper(array_sort(array_agg(str1))[1]) FROM t GROUP BY grp ORDER BY grp;
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, upper(array_sort(array_agg(str1))[1]) FROM t GROUP BY grp ORDER BY grp;
+
+-- Element access on ARRAY_AGG(DISTINCT)
+SELECT grp, upper(array_sort(array_agg(distinct str1))[1]) FROM t GROUP BY grp ORDER BY grp;
+
+-- array_distinct of array_agg
+SELECT grp, array_sort(array_distinct(array_agg(str1))) FROM t GROUP BY grp ORDER BY grp;
+
+-- ===== Multiple ARRAY_AGGs =====
+
+-- Multiple ARRAY_AGGs in same query
+SELECT grp, array_sort(array_distinct(array_agg(str1))), array_sort(array_distinct(array_agg(str2))) FROM t GROUP BY grp ORDER BY grp;
+
+-- ===== Filtering: WHERE and HAVING =====
+
+-- ARRAY_AGG with WHERE on dict column
+SELECT grp, array_sort(array_agg(str1)) FROM t WHERE str2 = 'X' GROUP BY grp ORDER BY grp;
+
+-- ARRAY_AGG with WHERE using IN on dict column
+SELECT grp, array_sort(array_agg(str1)) FROM t WHERE str1 IN ('apple', 'banana') GROUP BY grp ORDER BY grp;
+
+-- ARRAY_AGG with HAVING clause
+SELECT grp, array_sort(array_distinct(array_agg(str1))) as names FROM t GROUP BY grp HAVING array_length(array_agg(str1)) > 100 ORDER BY grp;
+
+-- ARRAY_AGG(DISTINCT) with WHERE
+SELECT grp, array_sort(array_agg(distinct str1)) FROM t WHERE str2 = 'X' GROUP BY grp ORDER BY grp;
+
+-- ===== Subqueries =====
+
+-- Nested subquery with ARRAY_AGG
+SELECT grp, names FROM (
+    SELECT grp, array_sort(array_distinct(array_agg(str1))) as names FROM t GROUP BY grp
+) sub WHERE array_length(names) > 2 ORDER BY grp;
+
+-- Subquery with element access
+SELECT grp, first_val FROM (
+    SELECT grp, array_sort(array_agg(str1 ORDER BY str1))[1] as first_val FROM t GROUP BY grp
+) sub ORDER BY grp;
+
+-- ===== Correctness: optimized vs non-optimized =====
+
+-- 2-stage: with optimization (default)
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_sort(array_distinct(array_agg(str1))), array_length(array_agg(str1)) FROM t GROUP BY grp ORDER BY grp;
+
+-- 2-stage: without optimization
+SELECT /*+SET_VAR(new_planner_agg_stage=2, cbo_enable_low_cardinality_optimize=false)*/ grp, array_sort(array_distinct(array_agg(str1))), array_length(array_agg(str1)) FROM t GROUP BY grp ORDER BY grp;
+
+-- ARRAY_AGG(DISTINCT): with optimization
+SELECT grp, array_sort(array_agg(distinct str1)) FROM t GROUP BY grp ORDER BY grp;
+
+-- ARRAY_AGG(DISTINCT): without optimization
+SELECT /*+SET_VAR(cbo_enable_low_cardinality_optimize=false)*/ grp, array_sort(array_agg(distinct str1)) FROM t GROUP BY grp ORDER BY grp;
+
+-- 1-stage with ORDER BY: with optimization
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str1 ORDER BY val) FROM t GROUP BY grp ORDER BY grp;
+
+-- 1-stage with ORDER BY: without optimization
+SELECT /*+SET_VAR(new_planner_agg_stage=1, cbo_enable_low_cardinality_optimize=false)*/ grp, array_agg(str1 ORDER BY val) FROM t GROUP BY grp ORDER BY grp;
+
+-- 2-stage with ORDER BY: with optimization
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY val) FROM t GROUP BY grp ORDER BY grp;
+
+-- 2-stage with ORDER BY: without optimization
+SELECT /*+SET_VAR(new_planner_agg_stage=2, cbo_enable_low_cardinality_optimize=false)*/ grp, array_agg(str1 ORDER BY val) FROM t GROUP BY grp ORDER BY grp;
+
+-- 2-stage with multi-column ORDER BY: with optimization
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY str2, val) FROM t GROUP BY grp ORDER BY grp;
+
+-- 2-stage with multi-column ORDER BY: without optimization
+SELECT /*+SET_VAR(new_planner_agg_stage=2, cbo_enable_low_cardinality_optimize=false)*/ grp, array_agg(str1 ORDER BY str2, val) FROM t GROUP BY grp ORDER BY grp;
+
+-- Cleanup
+drop table t;
+


### PR DESCRIPTION
## Why I'm doing:
The Low Cardinality Optimization (LCO) currently does not support ARRAY_AGG. When ARRAY_AGG operates on low-cardinality string columns that have global dictionaries, the aggregation processes full VARCHAR values instead of integer-encoded dictionary IDs. This means ARRAY_AGG misses the performance benefits (reduced memory, faster comparisons)

## What I'm doing:
Extends the Low Cardinality Optimization to support ARRAY_AGG with dict-encoded columns. When the value column (first argument) of ARRAY_AGG has a global dictionary, the optimization:

. Encodes the value and any dict-encodable ORDER BY columns as integer IDs throughout all aggregation stages
. Computes the intermediate struct type with dict-encoded array fields (e.g. struct<ARRAY, ARRAY> instead of struct<ARRAY, ARRAY>)
. Correctly handles multi-stage aggregation by using the struct field mapping to independently determine which fields are dict-encoded in the merge stage
. Supports downstream operations on the dict-encoded result (e.g. UPPER(ARRAY_AGG(...)[1]) applies DictDecode at the projection level)

Key changes:
. DecodeContext.java: Refactored AggregateRewriter to be able to handle functions with different intermediate types.
. DecodeCollector.java:  Adds ARRAY_AGG to supported aggregate functions, gates on value column being a string type with a global dict, builds struct field mapping for intermediate types
. SessionVariable.java: New session variable array_agg_low_cardinality_optimize (default: true).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
