### PR TITLE
Sqlite select 语句生成

### DIFF
--- a/tools/sqlite_select_path_generator.py
+++ b/tools/sqlite_select_path_generator.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generate SELECT statements that cover different grammar paths based on:
+#   https://www.sqlite.org/syntax/select-stmt.html
+#
+# The generator is intentionally bounded to avoid combinatorial explosion.
+# Use --max-outputs and --max-list-items to control the size of output.
+
+import argparse
+import random
+import sys
+from dataclasses import dataclass
+
+
+class Node:
+    def expand(self, ctx):
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class Token(Node):
+    value: str
+
+    def expand(self, ctx):
+        return [[self.value]]
+
+
+class SeqNode(Node):
+    def __init__(self, *nodes):
+        self.nodes = list(nodes)
+
+    def expand(self, ctx):
+        expansions = [[]]
+        for node in self.nodes:
+            next_expansions = []
+            for prefix in expansions:
+                for suffix in node.expand(ctx):
+                    next_expansions.append(prefix + suffix)
+                    if len(next_expansions) >= ctx.node_limit:
+                        break
+                if len(next_expansions) >= ctx.node_limit:
+                    break
+            expansions = next_expansions
+            if not expansions:
+                break
+        return expansions
+
+
+class Choice(Node):
+    def __init__(self, *options):
+        self.options = list(options)
+
+    def expand(self, ctx):
+        expansions = []
+        for opt in self.options:
+            for variant in opt.expand(ctx):
+                expansions.append(variant)
+                if len(expansions) >= ctx.node_limit:
+                    return expansions
+        return expansions
+
+
+class Optional(Node):
+    def __init__(self, node):
+        self.node = node
+
+    def expand(self, ctx):
+        expansions = self.node.expand(ctx)
+        if len(expansions) < ctx.node_limit:
+            expansions.append([])
+        return expansions[:ctx.node_limit]
+
+
+class Repeat(Node):
+    def __init__(self, node, min_rep=0, max_rep=None, sep=None):
+        self.node = node
+        self.min_rep = min_rep
+        self.max_rep = max_rep
+        self.sep = sep
+
+    def expand(self, ctx):
+        max_rep = self.max_rep if self.max_rep is not None else ctx.max_list_items
+        max_rep = max(self.min_rep, min(max_rep, ctx.max_list_items))
+        lengths = [self.min_rep]
+        if max_rep != self.min_rep:
+            lengths = [max_rep, self.min_rep]
+
+        expansions = []
+        for length in lengths:
+            expansions.extend(self._expand_length(length, ctx))
+            if len(expansions) >= ctx.node_limit:
+                break
+        return expansions[:ctx.node_limit]
+
+    def _expand_length(self, length, ctx):
+        if length == 0:
+            return [[]]
+        nodes = []
+        for i in range(length):
+            if i > 0 and self.sep is not None:
+                nodes.append(self.sep)
+            nodes.append(self.node)
+        return SeqNode(*nodes).expand(ctx)
+
+
+@dataclass
+class Context:
+    node_limit: int
+    max_list_items: int
+
+
+def expr():
+    return Choice(
+        Token("1"),
+        Token("c1"),
+        SeqNode(Token("c1"), Token("+"), Token("1")),
+        SeqNode(Token("c1"), Token("*"), Token("2")),
+    )
+
+
+def column_name():
+    return Choice(Token("c1"), Token("c2"), Token("c3"))
+
+
+def expr_list():
+    return Repeat(expr(), min_rep=1, max_rep=None, sep=Token(","))
+
+
+def result_column():
+    return Choice(
+        Token("*"),
+        Token("c1"),
+        Token("t1.c1"),
+        SeqNode(Token("c1"), Token("AS"), Token("alias1")),
+        SeqNode(Token("c1"), Token("+"), Token("1"), Token("AS"), Token("sum1")),
+    )
+
+
+def result_column_list():
+    return Repeat(result_column(), min_rep=1, max_rep=None, sep=Token(","))
+
+
+def ordering_term():
+    return SeqNode(expr(), Optional(Choice(Token("ASC"), Token("DESC"))))
+
+
+def ordering_term_list():
+    return Repeat(ordering_term(), min_rep=1, max_rep=None, sep=Token(","))
+
+
+def table_or_subquery():
+    return Choice(
+        Token("t1"),
+        SeqNode(Token("t1"), Token("AS"), Token("a1")),
+        SeqNode(Token("t1"), Token("INDEXED"), Token("BY"), Token("idx1")),
+        SeqNode(Token("t1"), Token("NOT"), Token("INDEXED")),
+        SeqNode(Token("("), Token("SELECT"), Token("1"), Token(")"), Token("AS"), Token("sub1")),
+    )
+
+
+def join_operator():
+    return Choice(
+        Token("JOIN"),
+        SeqNode(Token("INNER"), Token("JOIN")),
+        SeqNode(Token("LEFT"), Token("JOIN")),
+        SeqNode(Token("LEFT"), Token("OUTER"), Token("JOIN")),
+        SeqNode(Token("CROSS"), Token("JOIN")),
+        SeqNode(Token("NATURAL"), Token("JOIN")),
+    )
+
+
+def join_constraint():
+    return Choice(
+        SeqNode(Token("ON"), expr()),
+        SeqNode(
+            Token("USING"),
+            Token("("),
+            Repeat(column_name(), min_rep=1, max_rep=None, sep=Token(",")),
+            Token(")"),
+        ),
+    )
+
+
+def join_clause():
+    return SeqNode(
+        table_or_subquery(),
+        join_operator(),
+        table_or_subquery(),
+        Optional(join_constraint()),
+    )
+
+
+def from_clause():
+    return SeqNode(
+        Token("FROM"),
+        Choice(
+            Repeat(table_or_subquery(), min_rep=1, max_rep=None, sep=Token(",")),
+            join_clause(),
+        ),
+    )
+
+
+def where_clause():
+    return SeqNode(Token("WHERE"), expr())
+
+
+def group_by_clause():
+    return SeqNode(
+        Token("GROUP"),
+        Token("BY"),
+        expr_list(),
+        Optional(SeqNode(Token("HAVING"), expr())),
+    )
+
+
+def window_def():
+    return SeqNode(
+        Choice(Token("w1"), Token("w2")),
+        Token("AS"),
+        Token("("),
+        Optional(SeqNode(Token("PARTITION"), Token("BY"), expr_list())),
+        Optional(SeqNode(Token("ORDER"), Token("BY"), ordering_term_list())),
+        Token(")"),
+    )
+
+
+def window_clause():
+    return SeqNode(
+        Token("WINDOW"),
+        Repeat(window_def(), min_rep=1, max_rep=2, sep=Token(",")),
+    )
+
+
+def set_quantifier():
+    return Choice(Token("DISTINCT"), Token("ALL"))
+
+
+def values_row():
+    return SeqNode(Token("("), expr_list(), Token(")"))
+
+
+def select_core():
+    select_form = SeqNode(
+        Token("SELECT"),
+        Optional(set_quantifier()),
+        result_column_list(),
+        Optional(from_clause()),
+        Optional(where_clause()),
+        Optional(group_by_clause()),
+        Optional(window_clause()),
+    )
+    values_form = SeqNode(
+        Token("VALUES"),
+        Repeat(values_row(), min_rep=1, max_rep=None, sep=Token(",")),
+    )
+    return Choice(select_form, values_form)
+
+
+def compound_operator():
+    return Choice(
+        Token("UNION"),
+        SeqNode(Token("UNION"), Token("ALL")),
+        Token("INTERSECT"),
+        Token("EXCEPT"),
+    )
+
+
+def compound_clause():
+    return Repeat(
+        SeqNode(compound_operator(), select_core()),
+        min_rep=1,
+        max_rep=1,
+    )
+
+
+def order_by_clause():
+    return SeqNode(Token("ORDER"), Token("BY"), ordering_term_list())
+
+
+def limit_expr():
+    return Choice(Token("1"), Token("10"), Token("100"))
+
+
+def limit_clause():
+    return Choice(
+        SeqNode(
+            Token("LIMIT"),
+            limit_expr(),
+            Optional(SeqNode(Token("OFFSET"), limit_expr())),
+        ),
+        SeqNode(Token("LIMIT"), limit_expr(), Token(","), limit_expr()),
+    )
+
+
+def cte_def():
+    return SeqNode(
+        Choice(Token("cte1"), Token("cte2")),
+        Token("AS"),
+        Token("("),
+        SeqNode(Token("SELECT"), Token("1")),
+        Token(")"),
+    )
+
+
+def with_clause():
+    return SeqNode(
+        Token("WITH"),
+        Optional(Token("RECURSIVE")),
+        Repeat(cte_def(), min_rep=1, max_rep=2, sep=Token(",")),
+    )
+
+
+def select_stmt():
+    return SeqNode(
+        Optional(with_clause()),
+        select_core(),
+        Optional(compound_clause()),
+        Optional(order_by_clause()),
+        Optional(limit_clause()),
+    )
+
+
+def join_tokens(tokens):
+    sql = " ".join(tokens)
+    sql = sql.replace(" ,", ",")
+    sql = sql.replace("( ", "(")
+    sql = sql.replace(" )", ")")
+    sql = sql.replace(" ;", ";")
+    return sql.strip()
+
+
+def dedupe(items):
+    seen = set()
+    result = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        result.append(item)
+    return result
+
+
+def generate_sql(max_outputs, max_list_items, shuffle, seed, with_semicolon):
+    node_limit = min(max_outputs * 10, 5000)
+    ctx = Context(node_limit=node_limit, max_list_items=max_list_items)
+    expansions = select_stmt().expand(ctx)
+    statements = [join_tokens(tokens) for tokens in expansions]
+    statements = dedupe(statements)
+    if shuffle:
+        rng = random.Random(seed)
+        rng.shuffle(statements)
+    statements = statements[:max_outputs]
+    if with_semicolon:
+        statements = [f"{stmt};" for stmt in statements]
+    return statements
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate SQLite SELECT statements across grammar paths."
+    )
+    parser.add_argument(
+        "--max-outputs",
+        type=int,
+        default=200,
+        help="Maximum number of SQL statements to emit.",
+    )
+    parser.add_argument(
+        "--max-list-items",
+        type=int,
+        default=2,
+        help="Maximum items for repeated lists (columns, tables, etc.).",
+    )
+    parser.add_argument(
+        "--shuffle",
+        action="store_true",
+        help="Shuffle output order (use --seed for reproducibility).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed used with --shuffle.",
+    )
+    parser.add_argument(
+        "--with-semicolon",
+        action="store_true",
+        help="Append a semicolon to each statement.",
+    )
+    parser.add_argument(
+        "--output",
+        help="Output file path (default: stdout).",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    statements = generate_sql(
+        max_outputs=args.max_outputs,
+        max_list_items=args.max_list_items,
+        shuffle=args.shuffle,
+        seed=args.seed,
+        with_semicolon=args.with_semicolon,
+    )
+    output = sys.stdout
+    if args.output:
+        output = open(args.output, "w")
+    for stmt in statements:
+        output.write(stmt + "\n")
+    if output is not sys.stdout:
+        output.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/starrocks_table_models_prod_like.sql
+++ b/tools/starrocks_table_models_prod_like.sql
@@ -1,0 +1,187 @@
+-- Production-like table models for StarRocks
+-- Covers: PRIMARY KEY, UNIQUE KEY, AGGREGATE KEY, DUPLICATE KEY
+-- Note: StarRocks does not enforce foreign keys; relations are logical.
+
+CREATE DATABASE IF NOT EXISTS prod_models_demo;
+USE prod_models_demo;
+
+-- ========= Dimension tables (slow-changing, upsert-friendly) =========
+CREATE TABLE IF NOT EXISTS dim_user (
+    user_id BIGINT NOT NULL,
+    user_name VARCHAR(128),
+    phone VARCHAR(32),
+    email VARCHAR(128),
+    city_id INT,
+    register_time DATETIME,
+    status TINYINT,
+    update_time DATETIME
+)
+ENGINE=OLAP
+PRIMARY KEY(user_id)
+DISTRIBUTED BY HASH(user_id) BUCKETS 16
+PROPERTIES (
+    "replication_num" = "3",
+    "enable_persistent_index" = "true"
+);
+
+CREATE TABLE IF NOT EXISTS dim_product (
+    product_id BIGINT NOT NULL,
+    sku_id BIGINT,
+    product_name VARCHAR(256),
+    category_id INT,
+    brand_id INT,
+    list_price DECIMAL(18, 2),
+    is_active BOOLEAN,
+    update_time DATETIME
+)
+ENGINE=OLAP
+UNIQUE KEY(product_id)
+DISTRIBUTED BY HASH(product_id) BUCKETS 16
+PROPERTIES (
+    "replication_num" = "3"
+);
+
+CREATE TABLE IF NOT EXISTS dim_store (
+    store_id BIGINT NOT NULL,
+    store_name VARCHAR(128),
+    region VARCHAR(64),
+    city_id INT,
+    open_date DATE,
+    status TINYINT,
+    update_time DATETIME
+)
+ENGINE=OLAP
+UNIQUE KEY(store_id)
+DISTRIBUTED BY HASH(store_id) BUCKETS 8
+PROPERTIES (
+    "replication_num" = "3"
+);
+
+-- ========= Fact tables (append-heavy, analytics oriented) =========
+-- Relation: fact_order.user_id -> dim_user.user_id
+-- Relation: fact_order.store_id -> dim_store.store_id
+CREATE TABLE IF NOT EXISTS fact_order (
+    order_id BIGINT NOT NULL,
+    order_date DATE NOT NULL,
+    order_time DATETIME,
+    user_id BIGINT,
+    store_id BIGINT,
+    pay_method TINYINT,
+    order_status TINYINT,
+    total_amount DECIMAL(18, 2),
+    total_discount DECIMAL(18, 2),
+    update_time DATETIME
+)
+ENGINE=OLAP
+DUPLICATE KEY(order_id, order_date)
+PARTITION BY RANGE(order_date) (
+    PARTITION p202401 VALUES LESS THAN ("2024-02-01"),
+    PARTITION p202402 VALUES LESS THAN ("2024-03-01"),
+    PARTITION p202403 VALUES LESS THAN ("2024-04-01"),
+    PARTITION pmax VALUES LESS THAN ("9999-12-31")
+)
+DISTRIBUTED BY HASH(order_id) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "3"
+);
+
+-- Relation: fact_order_item.order_id -> fact_order.order_id
+-- Relation: fact_order_item.product_id -> dim_product.product_id
+CREATE TABLE IF NOT EXISTS fact_order_item (
+    order_id BIGINT NOT NULL,
+    order_date DATE NOT NULL,
+    item_id BIGINT NOT NULL,
+    product_id BIGINT,
+    quantity INT,
+    item_price DECIMAL(18, 2),
+    item_discount DECIMAL(18, 2),
+    update_time DATETIME
+)
+ENGINE=OLAP
+DUPLICATE KEY(order_id, order_date, item_id)
+PARTITION BY RANGE(order_date) (
+    PARTITION p202401 VALUES LESS THAN ("2024-02-01"),
+    PARTITION p202402 VALUES LESS THAN ("2024-03-01"),
+    PARTITION p202403 VALUES LESS THAN ("2024-04-01"),
+    PARTITION pmax VALUES LESS THAN ("9999-12-31")
+)
+DISTRIBUTED BY HASH(order_id) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "3"
+);
+
+-- ========= Aggregated model (pre-aggregation) =========
+-- Daily sales summary for reports.
+CREATE TABLE IF NOT EXISTS agg_daily_sales (
+    sales_date DATE NOT NULL,
+    store_id BIGINT NOT NULL,
+    product_id BIGINT NOT NULL,
+    order_cnt BIGINT SUM DEFAULT "0",
+    item_cnt BIGINT SUM DEFAULT "0",
+    gross_amount DECIMAL(18, 2) SUM DEFAULT "0",
+    discount_amount DECIMAL(18, 2) SUM DEFAULT "0",
+    pay_amount DECIMAL(18, 2) SUM DEFAULT "0"
+)
+ENGINE=OLAP
+AGGREGATE KEY(sales_date, store_id, product_id)
+PARTITION BY RANGE(sales_date) (
+    PARTITION p202401 VALUES LESS THAN ("2024-02-01"),
+    PARTITION p202402 VALUES LESS THAN ("2024-03-01"),
+    PARTITION p202403 VALUES LESS THAN ("2024-04-01"),
+    PARTITION pmax VALUES LESS THAN ("9999-12-31")
+)
+DISTRIBUTED BY HASH(store_id) BUCKETS 16
+PROPERTIES (
+    "replication_num" = "3"
+);
+
+-- ========= Event/log model (high volume, append only) =========
+-- Relation: user_activity_log.user_id -> dim_user.user_id
+CREATE TABLE IF NOT EXISTS user_activity_log (
+    event_time DATETIME NOT NULL,
+    user_id BIGINT,
+    session_id VARCHAR(64),
+    page_id VARCHAR(128),
+    event_type VARCHAR(32),
+    event_properties JSON,
+    device_type VARCHAR(32),
+    ip_address VARCHAR(64)
+)
+ENGINE=OLAP
+DUPLICATE KEY(event_time, user_id, session_id)
+PARTITION BY RANGE(event_time) (
+    PARTITION p202401 VALUES LESS THAN ("2024-02-01 00:00:00"),
+    PARTITION p202402 VALUES LESS THAN ("2024-03-01 00:00:00"),
+    PARTITION p202403 VALUES LESS THAN ("2024-04-01 00:00:00"),
+    PARTITION pmax VALUES LESS THAN ("9999-12-31 00:00:00")
+)
+DISTRIBUTED BY HASH(user_id) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "3"
+);
+
+-- ========= Inventory model (upsert latest status) =========
+-- Relation: inventory_snapshot.product_id -> dim_product.product_id
+-- Relation: inventory_snapshot.store_id -> dim_store.store_id
+CREATE TABLE IF NOT EXISTS inventory_snapshot (
+    store_id BIGINT NOT NULL,
+    product_id BIGINT NOT NULL,
+    snapshot_date DATE NOT NULL,
+    on_hand_qty INT,
+    reserved_qty INT,
+    available_qty INT,
+    update_time DATETIME
+)
+ENGINE=OLAP
+PRIMARY KEY(store_id, product_id, snapshot_date)
+PARTITION BY RANGE(snapshot_date) (
+    PARTITION p202401 VALUES LESS THAN ("2024-02-01"),
+    PARTITION p202402 VALUES LESS THAN ("2024-03-01"),
+    PARTITION p202403 VALUES LESS THAN ("2024-04-01"),
+    PARTITION pmax VALUES LESS THAN ("9999-12-31")
+)
+DISTRIBUTED BY HASH(store_id) BUCKETS 16
+PROPERTIES (
+    "replication_num" = "3",
+    "enable_persistent_index" = "true"
+);


### PR DESCRIPTION
## Why I'm doing:

To provide a utility for generating diverse `SELECT` SQL statements based on the SQLite `select-stmt` grammar, useful for testing and analysis.

## What I'm doing:

Adds `tools/sqlite_select_path_generator.py`, a Python script that generates `SELECT` statements covering various grammar paths (e.g., `WITH/CTE`, `compound`, `JOIN`, `GROUP BY`, `WINDOW`). It offers configurable parameters for output quantity and list item lengths.

Fixes #N/A

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

---
<a href="https://cursor.com/background-agent?bcId=bc-dbc90004-459e-4003-b98b-6f12240c7bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dbc90004-459e-4003-b98b-6f12240c7bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

