### PR TITLE
[BugFix] fix the issue of not being able to find LookUpDispatcher

### DIFF
--- a/be/src/exec/fetch_node.cpp
+++ b/be/src/exec/fetch_node.cpp
@@ -55,8 +55,8 @@ Status FetchNode::init(const TPlanNode& tnode, RuntimeState* state) {
         tuple_ids.emplace_back(tuple_id);
     }
 
-    _dispatcher = state->exec_env()->lookup_dispatcher_mgr()->create_dispatcher(state, state->query_id(),
-                                                                                _target_node_id, tuple_ids);
+    _dispatcher = state->exec_env()->lookup_dispatcher_mgr()->create_dispatcher(state->query_id(), _target_node_id,
+                                                                                tuple_ids);
     for (const auto& tuple_id : tuple_ids) {
         const auto& tuple_desc = state->desc_tbl().get_tuple_descriptor(tuple_id);
         for (const auto& slot : tuple_desc->slots()) {

--- a/be/src/exec/lookup_node.cpp
+++ b/be/src/exec/lookup_node.cpp
@@ -47,8 +47,7 @@ Status LookUpNode::init(const TPlanNode& tnode, RuntimeState* state) {
     for (const auto& [tuple_id, row_pos_desc] : _row_pos_descs) {
         tuple_ids.emplace_back(tuple_id);
     }
-    _dispatcher =
-            state->exec_env()->lookup_dispatcher_mgr()->create_dispatcher(state, state->query_id(), id(), tuple_ids);
+    _dispatcher = state->exec_env()->lookup_dispatcher_mgr()->create_dispatcher(state->query_id(), id(), tuple_ids);
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/fetch_processor.h
+++ b/be/src/exec/pipeline/fetch_processor.h
@@ -87,6 +87,7 @@ public:
     bool is_finished() const;
 
     Status set_sink_finishing(RuntimeState* state);
+    void set_source_finishing();
 
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk);
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state);
@@ -138,6 +139,7 @@ private:
     Status _io_task_status;
 
     std::atomic_bool _is_sink_complete = false;
+    std::atomic_bool _is_source_finishing = false;
 
     RuntimeProfile::Counter* _build_row_id_chunk_timer = nullptr;
     RuntimeProfile::Counter* _gen_fetch_tasks_timer = nullptr;

--- a/be/src/exec/pipeline/fetch_source_operator.cpp
+++ b/be/src/exec/pipeline/fetch_source_operator.cpp
@@ -49,6 +49,7 @@ bool FetchSourceOperator::pending_finish() const {
 Status FetchSourceOperator::set_finishing(RuntimeState* state) {
     VLOG_ROW << "[GLM] FetchSourceOperator::set_finishing, processor: " << (void*)_processor.get() << ", "
              << (void*)this;
+    _processor->set_source_finishing();
     return Status::OK();
 }
 

--- a/be/src/runtime/lookup_stream_mgr.cpp
+++ b/be/src/runtime/lookup_stream_mgr.cpp
@@ -25,9 +25,9 @@
 
 namespace starrocks {
 
-LookUpDispatcher::LookUpDispatcher(RuntimeState* state, const TUniqueId& query_id, PlanNodeId lookup_node_id,
+LookUpDispatcher::LookUpDispatcher(const TUniqueId& query_id, PlanNodeId lookup_node_id,
                                    const std::vector<TupleId>& request_tuple_ids)
-        : _state(state), _query_id(query_id), _lookup_node_id(lookup_node_id) {
+        : _query_id(query_id), _lookup_node_id(lookup_node_id) {
     for (const auto& tuple_id : request_tuple_ids) {
         DLOG(INFO) << "create request queue for tuple_id: " << tuple_id;
         _request_queues.emplace(tuple_id, std::make_shared<RequestsQueue>());
@@ -44,8 +44,9 @@ Status LookUpDispatcher::add_request(const pipeline::LookUpRequestContextPtr& ct
     auto notify = this->defer_notify();
     ctx->receive_ts = MonotonicNanos();
     auto request_tuple_id = ctx->request_tuple_id();
-    DCHECK(_request_queues.contains(request_tuple_id)) << "missing tuple_id: " << request_tuple_id;
-    _request_queues.at(request_tuple_id)->enqueue(std::move(ctx));
+    auto it = _request_queues.lazy_emplace(
+            request_tuple_id, [&](const auto& ctor) { ctor(request_tuple_id, std::make_shared<RequestsQueue>()); });
+    it->second->enqueue(std::move(ctx));
     DLOG(INFO) << "[GLM] add request to LookUpDispatcher, "
                << ", query id: " << print_id(_query_id) << ", target node id: " << _lookup_node_id
                << ", tuple id: " << request_tuple_id << ", dispacher: " << (void*)this;
@@ -57,15 +58,16 @@ bool LookUpDispatcher::try_get(int32_t driver_sequence, size_t max_num, pipeline
     // find target_source_slot_id with the largest queue size
     size_t max_cnt = 0;
     SlotId target_tuple_id = 0;
+    RequestsQueuePtr target_queue;
     for (const auto& [tuple_id, queue] : _request_queues) {
         size_t cnt = queue->size_approx();
         if (cnt > max_cnt) {
             max_cnt = cnt;
             target_tuple_id = tuple_id;
+            target_queue = queue;
         }
     }
     if (max_cnt > 0) {
-        auto target_queue = _request_queues.at(target_tuple_id);
         if (size_t num = target_queue->try_dequeue_bulk(ctx->request_ctxs.data(), max_num); num > 0) {
             ctx->request_ctxs.resize(num);
             ctx->request_tuple_id = target_tuple_id;
@@ -87,14 +89,14 @@ bool LookUpDispatcher::has_data(int32_t driver_sequence) const {
     return false;
 }
 
-std::shared_ptr<LookUpDispatcher> LookUpDispatcherMgr::create_dispatcher(RuntimeState* state, const TUniqueId& query_id,
+std::shared_ptr<LookUpDispatcher> LookUpDispatcherMgr::create_dispatcher(const TUniqueId& query_id,
                                                                          PlanNodeId target_node_id,
                                                                          const std::vector<SlotId>& source_id_slots) {
     DispatcherKey key{query_id, target_node_id};
     auto [_, created] = _dispatcher_map.try_emplace(
-            key, std::make_shared<LookUpDispatcher>(state, query_id, target_node_id, source_id_slots));
+            key, std::make_shared<LookUpDispatcher>(query_id, target_node_id, source_id_slots));
     DLOG_IF(INFO, created) << "[GLM] create LookUpDispatcher for query_id=" << print_id(query_id)
-                           << ", target_node_id=" << target_node_id;
+                          << ", target_node_id=" << target_node_id;
     return _dispatcher_map.at(key);
 }
 
@@ -111,22 +113,35 @@ StatusOr<LookUpDispatcherPtr> LookUpDispatcherMgr::get_dispatcher(const TUniqueI
             fmt::format("can't find LookUpDispatcher for query {}, plan_node {}", print_id(query_id), target_node_id));
 }
 
-void LookUpDispatcherMgr::remove_dispatcher(const TUniqueId& query_id, PlanNodeId target_node_id) {
-    DispatcherKey key{query_id, target_node_id};
-    if (_dispatcher_map.contains(key)) {
-        _dispatcher_map.erase(key);
-        DLOG(INFO) << "[GLM] remove LookUpDispatcher for query_id=" << print_id(query_id)
-                   << ", target_node_id=" << target_node_id;
-    }
-}
-
-Status LookUpDispatcherMgr::lookup(const pipeline::RemoteLookUpRequestContextPtr& ctx) {
+LookUpDispatcherPtr LookUpDispatcherMgr::get_or_create_dispatcher(const pipeline::RemoteLookUpRequestContextPtr& ctx) {
     const auto& query_id = ctx->request->query_id();
     TUniqueId t_query_id;
     t_query_id.hi = query_id.hi();
     t_query_id.lo = query_id.lo();
     const auto lookup_node_id = ctx->request->lookup_node_id();
-    ASSIGN_OR_RETURN(auto dispatcher, get_dispatcher(t_query_id, lookup_node_id));
+    const auto request_tuple_id = static_cast<TupleId>(ctx->request->request_tuple_id());
+    DispatcherKey key{t_query_id, lookup_node_id};
+
+    auto it = _dispatcher_map.lazy_emplace(key, [&](const auto& ctor) {
+        DLOG(INFO) << "[GLM] create LookUpDispatcher (lazy) for query_id=" << print_id(t_query_id)
+                  << ", target_node_id=" << lookup_node_id;
+        ctor(key,
+             std::make_shared<LookUpDispatcher>(t_query_id, lookup_node_id, std::vector<TupleId>{request_tuple_id}));
+    });
+    return it->second;
+}
+
+void LookUpDispatcherMgr::remove_dispatcher(const TUniqueId& query_id, PlanNodeId target_node_id) {
+    DispatcherKey key{query_id, target_node_id};
+    if (_dispatcher_map.contains(key)) {
+        _dispatcher_map.erase(key);
+        DLOG(INFO) << "[GLM] remove LookUpDispatcher for query_id=" << print_id(query_id)
+                  << ", target_node_id=" << target_node_id;
+    }
+}
+
+Status LookUpDispatcherMgr::lookup(const pipeline::RemoteLookUpRequestContextPtr& ctx) {
+    auto dispatcher = get_or_create_dispatcher(ctx);
     RETURN_IF_ERROR(dispatcher->add_request(ctx));
     return Status::OK();
 }

--- a/be/src/runtime/lookup_stream_mgr.cpp
+++ b/be/src/runtime/lookup_stream_mgr.cpp
@@ -96,7 +96,7 @@ std::shared_ptr<LookUpDispatcher> LookUpDispatcherMgr::create_dispatcher(const T
     auto [_, created] = _dispatcher_map.try_emplace(
             key, std::make_shared<LookUpDispatcher>(query_id, target_node_id, source_id_slots));
     DLOG_IF(INFO, created) << "[GLM] create LookUpDispatcher for query_id=" << print_id(query_id)
-                          << ", target_node_id=" << target_node_id;
+                           << ", target_node_id=" << target_node_id;
     return _dispatcher_map.at(key);
 }
 
@@ -124,7 +124,7 @@ LookUpDispatcherPtr LookUpDispatcherMgr::get_or_create_dispatcher(const pipeline
 
     auto it = _dispatcher_map.lazy_emplace(key, [&](const auto& ctor) {
         DLOG(INFO) << "[GLM] create LookUpDispatcher (lazy) for query_id=" << print_id(t_query_id)
-                  << ", target_node_id=" << lookup_node_id;
+                   << ", target_node_id=" << lookup_node_id;
         ctor(key,
              std::make_shared<LookUpDispatcher>(t_query_id, lookup_node_id, std::vector<TupleId>{request_tuple_id}));
     });
@@ -136,7 +136,7 @@ void LookUpDispatcherMgr::remove_dispatcher(const TUniqueId& query_id, PlanNodeI
     if (_dispatcher_map.contains(key)) {
         _dispatcher_map.erase(key);
         DLOG(INFO) << "[GLM] remove LookUpDispatcher for query_id=" << print_id(query_id)
-                  << ", target_node_id=" << target_node_id;
+                   << ", target_node_id=" << target_node_id;
     }
 }
 

--- a/test/sql/test_temporary_table/R/temporary_table
+++ b/test/sql/test_temporary_table/R/temporary_table
@@ -347,7 +347,7 @@ WITH BROKER
 -- result:
 E: (5064, 'Getting analyzing error. Detail message: Do not support exporting temporary table.')
 -- !result
--- name: test_sys_temp_tables
+-- name: test_sys_temp_tables @native
 create temporary table `t` (
     `c1` int,
     `c2` int,

--- a/test/sql/test_temporary_table/T/temporary_table
+++ b/test/sql/test_temporary_table/T/temporary_table
@@ -170,7 +170,7 @@ WITH BROKER
     "fs.oss.endpoint" = "${oss_endpoint}"
 );
 
--- name: test_sys_temp_tables
+-- name: test_sys_temp_tables @native
 create temporary table `t` (
     `c1` int,
     `c2` int,


### PR DESCRIPTION
## Why I'm doing:

unstable case: sql/test_global_late_mterialization/R/test_glm_topn@test_glm_topn_iceberg_v3

## What I'm doing:


In multi-BE lookup/fetch execution, remote LookUp RPCs can fail with "can't find LookUpDispatcher" (NotFound), causing queries to fail or retry.

**Phenomenon:**
- Queries with enabling global late materialization send LookUp RPCs from producer BEs to the BE that runs the LookUp/Fetch plan.
- The RPC handler `lookup()` used `get_dispatcher()` and only looked up an existing dispatcher. If the dispatcher did not exist, it returned `Status::NotFound` and the request failed.
- The dispatcher is created in `LookUpNode::init()` / `FetchNode::init()` when the fragment that contains the LookUp/Fetch operator is set up. Due to execution order and parallelism, the first LookUp RPC can arrive **before** that fragment has run `init()` on the target BE, so the dispatcher does not exist yet and the lookup fails.

**Root cause:**
1. **Ordering assumption:** The code assumed the dispatcher was always created locally before any remote LookUp RPC arrived. When RPCs arrived first, `get_dispatcher()` returned NotFound.
2. **Rigid request queues:** `add_request()` used `DCHECK(_request_queues.contains(request_tuple_id))` and `_request_queues.at(request_tuple_id)`, so only pre-registered tuple_ids were allowed. A lazily created dispatcher (created on first RPC) would only have one tuple_id; later requests with other tuple_ids would hit the check or wrong queue.
3. **Unsafe second lookup in try_get:** `try_get()` found `target_tuple_id` by iterating, then did `_request_queues.at(target_tuple_id)` to get the queue. With concurrent updates to `_request_queues`, this second lookup could be inconsistent or race with the map; the map was also not thread-safe for concurrent add/try_get.

## What I'm doing:

1. **Lazy creation of dispatcher on first LookUp RPC**  
   - Add `get_or_create_dispatcher(ctx)` that creates a dispatcher under `(query_id, lookup_node_id)` when it does not exist, using the first request’s `request_tuple_id`.  
   - In `lookup()`, use `get_or_create_dispatcher(ctx)` instead of `get_dispatcher()`, so the first incoming RPC creates the dispatcher if the local fragment has not yet run `init()`.

2. **Dynamic request queues in LookUpDispatcher**  
   - In `add_request()`, use `_request_queues.lazy_emplace(request_tuple_id, ...)` to create a queue for any `request_tuple_id` on demand, instead of DCHECK + `at()`.  
   - This allows both “dispatcher created by init() with full tuple_ids” and “dispatcher created by first RPC with a single tuple_id” to accept subsequent requests for any tuple_id.

3. **Safe use of queue in try_get()**  
   - In `try_get()`, keep the selected queue pointer `target_queue` from the iteration and use it directly for `try_dequeue_bulk()`, instead of calling `_request_queues.at(target_tuple_id)` again.  
   - Switch `_request_queues` to `phmap::parallel_flat_hash_map` with `bthread::Mutex` so concurrent `add_request()` and `try_get()` are safe.

4. **Cleanup**  
   - Remove unused `RuntimeState*` from `LookUpDispatcher` and `create_dispatcher()` (including constructor and call sites).


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
