### PR TITLE
[Enhancement] Add session variable bitmap_max_filter_ratio

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -258,6 +258,9 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
     _params.use_page_cache = _runtime_state->use_page_cache();
     _params.enable_predicate_col_late_materialize =
             _runtime_state->query_options().enable_predicate_col_late_materialize;
+    if (_runtime_state->query_options().__isset.bitmap_max_filter_ratio) {
+        _params.bitmap_max_filter_ratio = _runtime_state->query_options().bitmap_max_filter_ratio;
+    }
     _params.use_pk_index = thrift_olap_scan_node.use_pk_index;
     _params.sample_options = thrift_olap_scan_node.sample_options;
     if (thrift_olap_scan_node.__isset.enable_prune_column_after_index_filter) {

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -148,6 +148,9 @@ Status TabletScanner::_init_reader_params(const std::vector<OlapScanRange*>* key
     _params.use_page_cache = _runtime_state->use_page_cache();
     _params.enable_predicate_col_late_materialize =
             _runtime_state->query_options().enable_predicate_col_late_materialize;
+    if (_runtime_state->query_options().__isset.bitmap_max_filter_ratio) {
+        _params.bitmap_max_filter_ratio = _runtime_state->query_options().bitmap_max_filter_ratio;
+    }
     auto parser = _pool.add(new OlapPredicateParser(_tablet_schema));
 
     ASSIGN_OR_RETURN(auto pred_tree, _parent->_conjuncts_manager->get_predicate_tree(parser, _predicate_free_pool));

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -346,6 +346,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.prune_column_after_index_filter = params.prune_column_after_index_filter;
     rs_opts.enable_gin_filter = params.enable_gin_filter;
     rs_opts.enable_predicate_col_late_materialize = params.enable_predicate_col_late_materialize;
+    rs_opts.bitmap_max_filter_ratio = params.bitmap_max_filter_ratio;
 
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;

--- a/be/src/storage/rowset/bitmap_index_evaluator.cpp
+++ b/be/src/storage/rowset/bitmap_index_evaluator.cpp
@@ -98,6 +98,11 @@ struct BitmapIndexInitializer {
 struct BitmapIndexSeeker {
     enum class ResultType : uint8_t { ALWAYS_FALSE, ALWAYS_TRUE, NOT_USED, OK };
 
+    explicit BitmapIndexSeeker(BitmapIndexEvaluator* parent)
+            : parent(parent),
+              bitmap_max_filter_ratio(parent->_bitmap_max_filter_ratio > 0 ? parent->_bitmap_max_filter_ratio
+                                                                           : config::bitmap_max_filter_ratio) {}
+
     StatusOr<ResultType> operator()(const PredicateAndNode& node) {
         if (!parent->_ctx.is_node_support_bitmap[&node]) {
             return ResultType::NOT_USED;
@@ -180,7 +185,7 @@ struct BitmapIndexSeeker {
         // Estimate the selectivity of the bitmap index.
         // ---------------------------------------------------------
         if (num_always_true_child + num_not_used_children >= num_children ||
-            (need_estimate_selectivity && mul_selected * 1000 > mul_cardinality * config::bitmap_max_filter_ratio)) {
+            (need_estimate_selectivity && mul_selected * 1000 > mul_cardinality * bitmap_max_filter_ratio)) {
             return ResultType::NOT_USED;
         }
 
@@ -273,7 +278,7 @@ struct BitmapIndexSeeker {
         // Estimate the selectivity of the bitmap index.
         // ---------------------------------------------------------
         if (num_always_false_child >= num_children ||
-            (need_estimate_selectivity && mul_selected * 1000 > mul_cardinality * config::bitmap_max_filter_ratio)) {
+            (need_estimate_selectivity && mul_selected * 1000 > mul_cardinality * bitmap_max_filter_ratio)) {
             return ResultType::NOT_USED;
         }
 
@@ -319,6 +324,7 @@ struct BitmapIndexSeeker {
     }
 
     BitmapIndexEvaluator* parent;
+    const int bitmap_max_filter_ratio;
 };
 
 struct BitmapIndexRetriver {

--- a/be/src/storage/rowset/bitmap_index_evaluator.h
+++ b/be/src/storage/rowset/bitmap_index_evaluator.h
@@ -48,8 +48,8 @@ class BitmapIndexEvaluator {
 public:
     using BitmapIndexIteratorSupplier = std::function<StatusOr<BitmapIndexIterator*>(ColumnId)>;
 
-    BitmapIndexEvaluator(const Schema& schema, const PredicateTree& pred_tree)
-            : _schema(schema), _pred_tree(pred_tree) {}
+    BitmapIndexEvaluator(const Schema& schema, const PredicateTree& pred_tree, int bitmap_max_filter_ratio)
+            : _schema(schema), _pred_tree(pred_tree), _bitmap_max_filter_ratio(bitmap_max_filter_ratio) {}
     ~BitmapIndexEvaluator() { close(); }
 
     Status init(BitmapIndexIteratorSupplier&& supplier);
@@ -72,6 +72,7 @@ private:
     BitmapContext _ctx;
     std::vector<BitmapIndexIterator*> _bitmap_index_iterators;
     bool _has_bitmap_index = false;
+    int _bitmap_max_filter_ratio = 0;
 
     bool _closed = false;
 };

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -777,6 +777,7 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
     seg_options.sample_options = options.sample_options;
     seg_options.enable_join_runtime_filter_pushdown = options.enable_join_runtime_filter_pushdown;
     seg_options.enable_predicate_col_late_materialize = options.enable_predicate_col_late_materialize;
+    seg_options.bitmap_max_filter_ratio = options.bitmap_max_filter_ratio;
 
     if (options.delete_predicates != nullptr) {
         seg_options.delete_predicates = options.delete_predicates->get_predicates(end_version());

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -100,6 +100,7 @@ public:
     TTableSampleOptions sample_options;
     bool enable_join_runtime_filter_pushdown = false;
     bool enable_predicate_col_late_materialize = false;
+    int bitmap_max_filter_ratio = 0;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -751,7 +751,7 @@ SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, Schema schema
         : ChunkIterator(std::move(schema), options.chunk_size),
           _segment(std::move(segment)),
           _opts(std::move(options)),
-          _bitmap_index_evaluator(_schema, _opts.pred_tree),
+          _bitmap_index_evaluator(_schema, _opts.pred_tree, _opts.bitmap_max_filter_ratio),
           _predicate_columns(_opts.pred_tree.num_columns()),
           _enable_predicate_col_late_materialize(_opts.enable_predicate_col_late_materialize) {
     // Initialize vector index context only when needed

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -123,6 +123,7 @@ public:
 
     bool enable_join_runtime_filter_pushdown = false;
     bool enable_predicate_col_late_materialize = false;
+    int bitmap_max_filter_ratio = 0;
 
 public:
     Status convert_to(SegmentReadOptions* dst, const std::vector<LogicalType>& new_types, ObjectPool* obj_pool) const;

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -286,6 +286,7 @@ Status TabletReader::_init_collector_for_pk_index_read() {
     rs_opts.global_dictmaps = _reader_params->global_dictmaps;
     rs_opts.unused_output_column_ids = _reader_params->unused_output_column_ids;
     rs_opts.runtime_range_pruner = _reader_params->runtime_range_pruner;
+    rs_opts.bitmap_max_filter_ratio = _reader_params->bitmap_max_filter_ratio;
     // single row fetch, no need to use delvec
     rs_opts.is_primary_keys = false;
     rs_opts.use_vector_index = _reader_params->use_vector_index;
@@ -369,6 +370,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.sample_options = params.sample_options;
     rs_opts.enable_join_runtime_filter_pushdown = params.enable_join_runtime_filter_pushdown;
     rs_opts.enable_predicate_col_late_materialize = params.enable_predicate_col_late_materialize;
+    rs_opts.bitmap_max_filter_ratio = params.bitmap_max_filter_ratio;
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;
         rs_opts.version = _version.second;

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -108,6 +108,7 @@ struct TabletReaderParams {
     TTableSampleOptions sample_options;
     bool enable_join_runtime_filter_pushdown = false;
     bool enable_predicate_col_late_materialize = false;
+    int bitmap_max_filter_ratio = 0;
 
 public:
     std::string to_string() const;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1653,7 +1653,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int maxPushdownConditionsPerColumn = -1;
     // 0 means unset, BE will use its config value
     @VariableMgr.VarAttr(name = BITMAP_MAX_FILTER_RATIO)
-    private int bitmapMaxFilterRatio = 1;
+    private int bitmapMaxFilterRatio = 0;
     @VariableMgr.VarAttr(name = ENABLE_LAMBDA_PUSHDOWN)
     private boolean enableLambdaPushdown = true;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -270,6 +270,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // see comment of `starrocks_max_scan_key_num` and `max_pushdown_conditions_per_column` in BE config
     public static final String MAX_SCAN_KEY_NUM = "max_scan_key_num";
     public static final String MAX_PUSHDOWN_CONDITIONS_PER_COLUMN = "max_pushdown_conditions_per_column";
+    // if set > 0, override BE config::bitmap_max_filter_ratio
+    public static final String BITMAP_MAX_FILTER_RATIO = "bitmap_max_filter_ratio";
 
     public static final String ENABLE_LAMBDA_PUSHDOWN = "enable_lambda_pushdown";
 
@@ -1649,6 +1651,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int maxScanKeyNum = -1;
     @VariableMgr.VarAttr(name = MAX_PUSHDOWN_CONDITIONS_PER_COLUMN)
     private int maxPushdownConditionsPerColumn = -1;
+    // 0 means unset, BE will use its config value
+    @VariableMgr.VarAttr(name = BITMAP_MAX_FILTER_RATIO)
+    private int bitmapMaxFilterRatio = 1;
     @VariableMgr.VarAttr(name = ENABLE_LAMBDA_PUSHDOWN)
     private boolean enableLambdaPushdown = true;
 
@@ -5935,6 +5940,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         }
         if (maxPushdownConditionsPerColumn > -1) {
             tResult.setMax_pushdown_conditions_per_column(maxPushdownConditionsPerColumn);
+        }
+        if (bitmapMaxFilterRatio > 0) {
+            tResult.setBitmap_max_filter_ratio(bitmapMaxFilterRatio);
         }
 
         if (SqlModeHelper.check(sqlMode, SqlModeHelper.MODE_ERROR_IF_OVERFLOW)) {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -362,6 +362,8 @@ struct TQueryOptions {
   201: optional i32 exchange_hash_function_version = 0;
    // whether enable predicate column late materialization
   202: optional bool enable_predicate_col_late_materialize;
+  // if set > 0, override BE config::bitmap_max_filter_ratio
+  203: optional i32 bitmap_max_filter_ratio;
   
   210: optional bool enable_global_late_materialization;
   211: optional bool enable_schedule_log;

--- a/test/sql/test_scan/R/test_bitmap_max_filter_ratio
+++ b/test/sql/test_scan/R/test_bitmap_max_filter_ratio
@@ -1,0 +1,52 @@
+-- name: test_bitmap_max_filter_ratio @sequential
+
+set enable_profile = true;
+-- result:
+-- !result
+set enable_async_profile = false;
+-- result:
+-- !result
+create table t_bitmap_ratio (
+    id int null,
+    v varchar(20) null,
+    index v_bitmap (v) using bitmap
+) engine=olap
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t_bitmap_ratio
+select
+    generate_series as id,
+    case when generate_series <= 20 then 'hot' else concat('v', generate_series) end as v
+from table(generate_series(1, 100));
+-- result:
+-- !result
+create view profile_bitmap_filter_rows as
+select trim(unnest) as line
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%- BitmapIndexFilterRows:%'
+order by unnest;
+-- result:
+-- !result
+select count(*) from t_bitmap_ratio where v = 'hot';
+-- result:
+20
+-- !result
+select cast(regexp_extract(line, ".*- BitmapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as int) = 0
+from profile_bitmap_filter_rows;
+-- result:
+1
+-- !result
+select /*+SET_VAR(bitmap_max_filter_ratio=600)*/ count(*) from t_bitmap_ratio where v = 'hot';
+-- result:
+20
+-- !result
+select cast(regexp_extract(line, ".*- BitmapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as int) > 0
+from profile_bitmap_filter_rows;
+-- result:
+1
+-- !result

--- a/test/sql/test_scan/T/test_bitmap_max_filter_ratio
+++ b/test/sql/test_scan/T/test_bitmap_max_filter_ratio
@@ -17,7 +17,7 @@ PROPERTIES (
 insert into t_bitmap_ratio
 select
     generate_series as id,
-    case when generate_series <= 20 then 'hot' else concat('v', generate_series) end as v
+    case when generate_series % 20 = 0 then 'hot' else concat('v', generate_series) end as v
 from table(generate_series(1, 100));
 
 create view profile_bitmap_filter_rows as

--- a/test/sql/test_scan/T/test_bitmap_max_filter_ratio
+++ b/test/sql/test_scan/T/test_bitmap_max_filter_ratio
@@ -1,0 +1,37 @@
+-- name: test_bitmap_max_filter_ratio @sequential
+
+use db_${uuid0};
+
+set enable_profile = true;
+set enable_async_profile = false;
+
+create table t_bitmap_ratio (
+    id int null,
+    v varchar(20) null,
+    index v_bitmap (v) using bitmap
+) engine=olap
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t_bitmap_ratio
+select
+    generate_series as id,
+    case when generate_series <= 20 then 'hot' else concat('v', generate_series) end as v
+from table(generate_series(1, 100));
+
+create view profile_bitmap_filter_rows as
+select trim(unnest) as line
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%- BitmapIndexFilterRows:%'
+order by unnest;
+
+select count(*) from t_bitmap_ratio where v = 'hot';
+select cast(regexp_extract(line, ".*- BitmapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as int) = 0
+from profile_bitmap_filter_rows;
+
+select /*+SET_VAR(bitmap_max_filter_ratio=600)*/ count(*) from t_bitmap_ratio where v = 'hot';
+select cast(regexp_extract(line, ".*- BitmapIndexFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as int) > 0
+from profile_bitmap_filter_rows;

--- a/test/sql/test_scan/T/test_bitmap_max_filter_ratio
+++ b/test/sql/test_scan/T/test_bitmap_max_filter_ratio
@@ -1,7 +1,5 @@
 -- name: test_bitmap_max_filter_ratio @sequential
 
-use db_${uuid0};
-
 set enable_profile = true;
 set enable_async_profile = false;
 


### PR DESCRIPTION
## Why I'm doing:

Add session variable `bitmap_max_filter_ratio` to give us a chance to modify `bitmap_max_filter_ratio` at runtime.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
