### PR TITLE
[Refactor] Remove unused idToInMemory field and related methods in PartitionInfo

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
@@ -73,9 +73,6 @@ public class PartitionInfo extends JsonWriter implements Cloneable, GsonPreProce
     @SerializedName(value = "isMultiColumnPartition")
     protected boolean isMultiColumnPartition = false;
 
-    @SerializedName(value = "idToInMemory")
-    protected Map<Long, Boolean> idToInMemory;
-
     // partition id -> tablet type
     // Note: currently it's only used for testing, it may change/add more meta field later,
     // so we defer adding meta serialization until memory engine feature is more complete.
@@ -90,7 +87,6 @@ public class PartitionInfo extends JsonWriter implements Cloneable, GsonPreProce
     public PartitionInfo() {
         this.idToDataProperty = new HashMap<>();
         this.idToReplicationNum = new HashMap<>();
-        this.idToInMemory = new HashMap<>();
         this.idToTabletType = new HashMap<>();
         this.idToStorageCacheInfo = new HashMap<>();
     }
@@ -99,7 +95,6 @@ public class PartitionInfo extends JsonWriter implements Cloneable, GsonPreProce
         this.type = type;
         this.idToDataProperty = new HashMap<>();
         this.idToReplicationNum = new HashMap<>();
-        this.idToInMemory = new HashMap<>();
         this.idToTabletType = new HashMap<>();
         this.idToStorageCacheInfo = new HashMap<>();
     }
@@ -171,11 +166,10 @@ public class PartitionInfo extends JsonWriter implements Cloneable, GsonPreProce
     }
 
     public boolean getIsInMemory(long partitionId) {
-        return idToInMemory.get(partitionId);
+        return false;
     }
 
     public void setIsInMemory(long partitionId, boolean isInMemory) {
-        idToInMemory.put(partitionId, isInMemory);
     }
 
     public TTabletType getTabletType(long partitionId) {
@@ -203,7 +197,6 @@ public class PartitionInfo extends JsonWriter implements Cloneable, GsonPreProce
     public void dropPartition(long partitionId) {
         idToDataProperty.remove(partitionId);
         idToReplicationNum.remove(partitionId);
-        idToInMemory.remove(partitionId);
         idToStorageCacheInfo.remove(partitionId);
     }
 
@@ -215,7 +208,6 @@ public class PartitionInfo extends JsonWriter implements Cloneable, GsonPreProce
                              boolean isInMemory) {
         idToDataProperty.put(partitionId, dataProperty);
         idToReplicationNum.put(partitionId, replicationNum);
-        idToInMemory.put(partitionId, isInMemory);
     }
 
     public void addPartition(long partitionId, DataProperty dataProperty,
@@ -292,7 +284,6 @@ public class PartitionInfo extends JsonWriter implements Cloneable, GsonPreProce
                     .append(DataProperty.DATA_PROPERTY_HDD.equals(entry.getValue()));
             buff.append(" data_property: ").append(entry.getValue().toString());
             buff.append(" replica number: ").append(idToReplicationNum.get(entry.getKey()));
-            buff.append(" in memory: ").append(idToInMemory.get(entry.getKey()));
         }
 
         return buff.toString();
@@ -312,7 +303,6 @@ public class PartitionInfo extends JsonWriter implements Cloneable, GsonPreProce
             p.idToDataProperty = new HashMap<>(this.idToDataProperty);
             p.idToReplicationNum = new HashMap<>(this.idToReplicationNum);
             p.isMultiColumnPartition = this.isMultiColumnPartition;
-            p.idToInMemory = new HashMap<>(this.idToInMemory);
             p.idToTabletType = new HashMap<>(this.idToTabletType);
             p.idToStorageCacheInfo = new HashMap<>(this.idToStorageCacheInfo);
             return p;
@@ -324,13 +314,11 @@ public class PartitionInfo extends JsonWriter implements Cloneable, GsonPreProce
     public void setPartitionIdsForRestore(Map<Long, Long> partitionOldIdToNewId) {
         Map<Long, DataProperty> oldIdToDataProperty = this.idToDataProperty;
         Map<Long, Short> oldIdToReplicationNum = this.idToReplicationNum;
-        Map<Long, Boolean> oldIdToInMemory = this.idToInMemory;
         Map<Long, TTabletType> oldIdToTabletType = this.idToTabletType;
         Map<Long, DataCacheInfo> oldIdToStorageCacheInfo = this.idToStorageCacheInfo;
 
         this.idToDataProperty = new HashMap<>();
         this.idToReplicationNum = new HashMap<>();
-        this.idToInMemory = new HashMap<>();
         this.idToTabletType = new HashMap<>();
         this.idToStorageCacheInfo = new HashMap<>();
 
@@ -345,10 +333,6 @@ public class PartitionInfo extends JsonWriter implements Cloneable, GsonPreProce
             Short replicationNum = oldIdToReplicationNum.get(oldId);
             if (replicationNum != null) {
                 this.idToReplicationNum.put(newId, replicationNum);
-            }
-            Boolean inMemory = oldIdToInMemory.get(oldId);
-            if (inMemory != null) {
-                this.idToInMemory.put(newId, inMemory);
             }
             TTabletType tabletType = oldIdToTabletType.get(oldId);
             if (tabletType != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -724,7 +724,7 @@ public class AlterTest {
         }
         alterTableWithNewParser(stmt, false);
         for (Partition partition : partitionList) {
-            Assertions.assertEquals(true, tbl4.getPartitionInfo().getIsInMemory(partition.getId()));
+            Assertions.assertEquals(false, tbl4.getPartitionInfo().getIsInMemory(partition.getId()));
         }
         Assertions.assertEquals(false, tbl4.getPartitionInfo().getIsInMemory(p4.getId()));
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionDescTest.java
@@ -309,7 +309,7 @@ public class ListPartitionDescTest {
 
         Assertions.assertEquals(1, partitionInfo.getReplicationNum(10001L));
         Assertions.assertEquals(TTabletType.TABLET_TYPE_MEMORY, partitionInfo.getTabletType(10001L));
-        Assertions.assertEquals(true, partitionInfo.getIsInMemory(10001L));
+        Assertions.assertEquals(false, partitionInfo.getIsInMemory(10001L));
         Assertions.assertEquals(false, partitionInfo.isMultiColumnPartition());
     }
 
@@ -326,7 +326,7 @@ public class ListPartitionDescTest {
 
         Assertions.assertEquals(1, partitionInfo.getReplicationNum(10001L));
         Assertions.assertEquals(TTabletType.TABLET_TYPE_MEMORY, partitionInfo.getTabletType(10001L));
-        Assertions.assertEquals(true, partitionInfo.getIsInMemory(10001L));
+        Assertions.assertEquals(false, partitionInfo.getIsInMemory(10001L));
         Assertions.assertEquals(true, partitionInfo.isMultiColumnPartition());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TempPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TempPartitionTest.java
@@ -666,10 +666,10 @@ public class TempPartitionTest extends StarRocksTestBase {
         stmtStr = "alter table db2.tbl2 replace partition (p2) with temporary partition (tp4)";
         alterTableWithNewAnalyzer(stmtStr, false);
 
-        // for now, we have 2 partitions: p2, tp3, [min, 20), [20, 30). 0 temp partition. and p2 bucket is 3, 'in_memory' is true.
+        // for now, we have 2 partitions: p2, tp3, [min, 20), [20, 30). 0 temp partition. and p2 bucket is 3, 'in_memory' is ignored.
         p2 = tbl2.getPartition("p2");
         Assertions.assertNotNull(p2);
-        Assertions.assertTrue(tbl2.getPartitionInfo().getIsInMemory(p2.getId()));
+        Assertions.assertFalse(tbl2.getPartitionInfo().getIsInMemory(p2.getId()));
         Assertions.assertEquals(3, p2.getDistributionInfo().getBucketNum());
     }
 


### PR DESCRIPTION
## Why I'm doing:
fix: https://github.com/StarRocks/StarRocksTest/issues/10947
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
