### PR TITLE
[BugFix] Fix use-after-free crash in ConnectorChunkSource::close()

### DIFF
--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -177,7 +177,7 @@ public:
                           RuntimeState* state = nullptr, int connector_scan_node_number = 1);
     std::shared_ptr<MemTracker> mem_tracker() { return _mem_tracker; }
     const std::shared_ptr<MemTracker>& mem_tracker() const { return _mem_tracker; }
-    MemTracker* connector_scan_mem_tracker() { return _connector_scan_mem_tracker.get(); }
+    std::shared_ptr<MemTracker> connector_scan_mem_tracker() { return _connector_scan_mem_tracker; }
 
     Status init_spill_manager(const TQueryOptions& query_options);
     Status init_query_once(workgroup::WorkGroup* wg, bool enable_group_level_query_queue);

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -657,8 +657,9 @@ void ConnectorChunkSource::close(RuntimeState* state) {
     if (_closed) return;
 
     if (_enable_adaptive_io_tasks) {
-        MemTracker* mem_tracker = state->query_ctx()->connector_scan_mem_tracker();
-        mem_tracker->release(_request_mem_tracker_bytes);
+        if (_connector_scan_mem_tracker != nullptr) {
+            _connector_scan_mem_tracker->release(_request_mem_tracker_bytes);
+        }
 
         ConnectorScanOperatorIOTasksMemLimiter* limiter = _get_io_tasks_mem_limiter();
         limiter->update_running_chunk_source_count(-1);
@@ -713,7 +714,8 @@ Status ConnectorChunkSource::_open_data_source(RuntimeState* state, bool* mem_al
     ConnectorScanOperator* scan_op = down_cast<ConnectorScanOperator*>(_scan_op);
     if (scan_op->enable_adaptive_io_tasks()) {
         ConnectorScanOperatorIOTasksMemLimiter* limiter = _get_io_tasks_mem_limiter();
-        MemTracker* mem_tracker = state->query_ctx()->connector_scan_mem_tracker();
+        _connector_scan_mem_tracker = state->query_ctx()->connector_scan_mem_tracker();
+        MemTracker* mem_tracker = _connector_scan_mem_tracker.get();
 
         [[maybe_unused]] auto build_debug_string = [&](const std::string& action) {
             std::stringstream ss;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -182,6 +182,7 @@ private:
     int64_t _request_mem_tracker_bytes = 0;
     int64_t _mem_alloc_failed_count = 0;
     bool _enable_adaptive_io_tasks = true;
+    std::shared_ptr<MemTracker> _connector_scan_mem_tracker = nullptr;
 };
 
 } // namespace pipeline


### PR DESCRIPTION
## Why I'm doing:
When `ScanOperator` destructor is called, it invokes `ConnectorChunkSource::close()`
which accesses `QueryContext::_connector_scan_mem_tracker`. However, in a multi-threaded
environment, the `QueryContext` may have already been destroyed by another thread that
finished the last driver, causing a use-after-free crash.

The crash occurs because:
1. Thread A finishes the last driver and triggers `QueryContext` destruction
2. `QueryContext::~QueryContext()` releases `_connector_scan_mem_tracker` (shared_ptr)
3. Thread B's `ScanOperator` destructor calls `ConnectorChunkSource::close()`
4. `close()` tries to access the already-freed MemTracker, causing crash

Root cause:
`ConnectorChunkSource` was accessing `QueryContext::connector_scan_mem_tracker()` in `close()`,
but `QueryContext`'s lifetime is not guaranteed when `close()` is called from destructor.

## What I'm doing:
- Add `connector_scan_mem_tracker_shared()` method to `QueryContext` to return shared_ptr
- Change `ConnectorChunkSource::_connector_scan_mem_tracker` from raw pointer to shared_ptr
- Cache the shared_ptr in `_open_data_source()` to extend MemTracker's lifetime
- Use the cached shared_ptr in `close()` instead of accessing `QueryContext`

This ensures the MemTracker stays alive as long as any `ConnectorChunkSource` holds
a reference to it, preventing use-after-free.


Fixes #68871

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
