### PR TITLE
[BugFix] Fix ColumnReader::bloom_filter predicates conjunction

### DIFF
--- a/be/src/storage/rowset/cast_column_iterator.h
+++ b/be/src/storage/rowset/cast_column_iterator.h
@@ -48,7 +48,7 @@ public:
     bool has_original_bloom_filter_index() const override { return false; }
     bool has_ngram_bloom_filter_index() const override { return false; }
     Status get_row_ranges_by_bloom_filter(const std::vector<const ColumnPredicate*>& predicates,
-                                          SparseRange<>* row_ranges) override {
+                                          SparseRange<>* row_ranges, bool is_conjunction) override {
         return Status::OK();
     }
 

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -157,7 +157,7 @@ public:
     /// prerequisite:
     /// - if the original relationship between |predicates| is OR, all of them need to support bloom filter.
     virtual Status get_row_ranges_by_bloom_filter(const std::vector<const ColumnPredicate*>& predicates,
-                                                  SparseRange<>* row_ranges) {
+                                                  SparseRange<>* row_ranges, bool is_conjunction) {
         return Status::OK();
     }
 

--- a/be/src/storage/rowset/column_iterator_decorator.h
+++ b/be/src/storage/rowset/column_iterator_decorator.h
@@ -54,8 +54,8 @@ public:
     bool has_original_bloom_filter_index() const override { return _parent->has_original_bloom_filter_index(); }
     bool has_ngram_bloom_filter_index() const override { return _parent->has_ngram_bloom_filter_index(); }
     Status get_row_ranges_by_bloom_filter(const std::vector<const ColumnPredicate*>& predicates,
-                                          SparseRange<>* row_ranges) override {
-        return _parent->get_row_ranges_by_bloom_filter(predicates, row_ranges);
+                                          SparseRange<>* row_ranges, bool is_conjunction) override {
+        return _parent->get_row_ranges_by_bloom_filter(predicates, row_ranges, is_conjunction);
     }
 
     bool all_page_dict_encoded() const override { return _parent->all_page_dict_encoded(); }

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -419,7 +419,7 @@ Status ColumnReader::_parse_zone_map(const TypeInfoPtr& type_info, const ZoneMap
     return Status::OK();
 }
 
-template <bool is_original_bf>
+template <bool is_original_bf, bool is_conjunction>
 Status ColumnReader::bloom_filter(const std::vector<const ColumnPredicate*>& predicates, SparseRange<>* row_ranges,
                                   const IndexReadOptions& opts) {
     RETURN_IF_ERROR(_load_bloom_filter_index(opts));
@@ -440,18 +440,27 @@ Status ColumnReader::bloom_filter(const std::vector<const ColumnPredicate*>& pre
         }
     }
 
+    const auto predicate_satisfied = [&](const auto & pred, const auto & bf) {
+        if constexpr (is_original_bf) {
+            return pred->support_original_bloom_filter() && pred->original_bloom_filter(bf.get());
+        } else {
+            return pred->support_ngram_bloom_filter() &&
+                   pred->ngram_bloom_filter(bf.get(), this->_get_reader_options_for_ngram());
+        }
+    };
+
     for (const auto& pid : page_ids) {
         std::unique_ptr<BloomFilter> bf;
         RETURN_IF_ERROR(bf_iter->read_bloom_filter(pid, &bf));
 
-        const bool satisfy = std::ranges::any_of(predicates, [&](const ColumnPredicate* pred) {
-            if constexpr (is_original_bf) {
-                return pred->support_original_bloom_filter() && pred->original_bloom_filter(bf.get());
-            } else {
-                return pred->support_ngram_bloom_filter() &&
-                       pred->ngram_bloom_filter(bf.get(), _get_reader_options_for_ngram());
+        bool satisfy = false;
+        if constexpr (is_conjunction) {
+            for (const auto& pred : predicates) {
+                if (satisfy = predicate_satisfied(pred, bf); !satisfy) break;
             }
-        });
+        } else {
+            satisfy = std::ranges::any_of(predicates, [&](const auto* pred) { return predicate_satisfied(pred, bf); });
+        }
         if (satisfy) {
             bf_row_ranges.add(
                     Range<>(_ordinal_index->get_first_ordinal(pid), _ordinal_index->get_last_ordinal(pid) + 1));
@@ -462,14 +471,20 @@ Status ColumnReader::bloom_filter(const std::vector<const ColumnPredicate*>& pre
 }
 
 // prerequisite: at least one predicate in |predicates| support bloom filter.
-Status ColumnReader::original_bloom_filter(const std::vector<const ColumnPredicate*>& predicates,
+Status ColumnReader::original_bloom_filter(const std::vector<const ColumnPredicate*>& predicates, bool is_conjunction,
                                            SparseRange<>* row_ranges, const IndexReadOptions& opts) {
-    return bloom_filter<true>(predicates, row_ranges, opts);
+    if (is_conjunction)
+        return bloom_filter<true, true>(predicates, row_ranges, opts);
+    else
+        return bloom_filter<true, false>(predicates, row_ranges, opts);
 }
 
-Status ColumnReader::ngram_bloom_filter(const std::vector<const ::starrocks::ColumnPredicate*>& p,
+Status ColumnReader::ngram_bloom_filter(const std::vector<const ::starrocks::ColumnPredicate*>& p, bool is_conjunction,
                                         SparseRange<>* ranges, const IndexReadOptions& opts) {
-    return bloom_filter<false>(p, ranges, opts);
+    if (is_conjunction)
+        return bloom_filter<false, true>(p, ranges, opts);
+    else
+        return bloom_filter<false, false>(p, ranges, opts);
 }
 
 Status ColumnReader::load_ordinal_index(const IndexReadOptions& opts) {

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -179,11 +179,11 @@ public:
     /// prerequisite:
     /// - if the original relationship between |predicates| is OR, all of them need to support bloom filter.
     /// - if the original relationship between |predicates| is AND, at least one of them need to support bloom filter.
-    Status original_bloom_filter(const std::vector<const ::starrocks::ColumnPredicate*>& p, SparseRange<>* ranges,
-                                 const IndexReadOptions& opts);
+    Status original_bloom_filter(const std::vector<const ::starrocks::ColumnPredicate*>& p, bool is_conjunction,
+                                 SparseRange<>* ranges, const IndexReadOptions& opts);
 
-    Status ngram_bloom_filter(const std::vector<const ::starrocks::ColumnPredicate*>& p, SparseRange<>* ranges,
-                              const IndexReadOptions& opts);
+    Status ngram_bloom_filter(const std::vector<const ::starrocks::ColumnPredicate*>& p, bool is_conjunction,
+                              SparseRange<>* ranges, const IndexReadOptions& opts);
 
     Status load_ordinal_index(const IndexReadOptions& opts);
 
@@ -211,7 +211,7 @@ private:
                                                                  const TabletColumn* column = nullptr);
 
     const std::string& file_name() const { return _segment->file_name(); }
-    template <bool is_original_bf>
+    template <bool is_original_bf, bool is_conjunction>
     Status bloom_filter(const std::vector<const ColumnPredicate*>& predicates, SparseRange<>* row_ranges,
                         const IndexReadOptions& opts);
     struct private_type {

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -737,7 +737,7 @@ public:
     bool has_ngram_bloom_filter_index() const override { return false; }
 
     Status get_row_ranges_by_bloom_filter(const std::vector<const ColumnPredicate*>& predicates,
-                                          SparseRange<>* row_ranges) override {
+                                          SparseRange<>* row_ranges, bool is_conjunction) override {
         return Status::OK();
     }
 

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -471,7 +471,7 @@ bool ScalarColumnIterator::has_ngram_bloom_filter_index() const {
 }
 
 Status ScalarColumnIterator::get_row_ranges_by_bloom_filter(const std::vector<const ColumnPredicate*>& predicates,
-                                                            SparseRange<>* row_ranges) {
+                                                            SparseRange<>* row_ranges, bool is_conjunction) {
     RETURN_IF(!_reader->has_bloom_filter_index(), Status::OK());
 
     bool support_original_bloom_filter = false;
@@ -496,9 +496,9 @@ Status ScalarColumnIterator::get_row_ranges_by_bloom_filter(const std::vector<co
     opts.stats = _opts.stats;
     // filter data using bloom filter or ngram bloom filter
     if (support_original_bloom_filter) {
-        RETURN_IF_ERROR(_reader->original_bloom_filter(predicates, row_ranges, opts));
+        RETURN_IF_ERROR(_reader->original_bloom_filter(predicates, is_conjunction, row_ranges, opts));
     } else {
-        RETURN_IF_ERROR(_reader->ngram_bloom_filter(predicates, row_ranges, opts));
+        RETURN_IF_ERROR(_reader->ngram_bloom_filter(predicates, is_conjunction, row_ranges, opts));
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/scalar_column_iterator.h
+++ b/be/src/storage/rowset/scalar_column_iterator.h
@@ -78,8 +78,8 @@ public:
 
     bool has_original_bloom_filter_index() const override;
     bool has_ngram_bloom_filter_index() const override;
-    Status get_row_ranges_by_bloom_filter(const std::vector<const ColumnPredicate*>& predicates,
-                                          SparseRange<>* range) override;
+    Status get_row_ranges_by_bloom_filter(const std::vector<const ColumnPredicate*>& predicates, SparseRange<>* range,
+                                          bool is_conjunction) override;
 
     bool all_page_dict_encoded() const override { return _all_dict_encoded; }
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -3405,7 +3405,7 @@ struct BloomFilterEvaluator {
         const auto& ctx = pred_tree.compound_node_context(node.id());
         const auto& cid_to_col_preds = ctx.cid_to_col_preds(node);
         for (const auto& [cid, col_preds] : cid_to_col_preds) {
-            RETURN_IF_ERROR(column_iterators[cid]->get_row_ranges_by_bloom_filter(col_preds, &dest_ranges));
+            RETURN_IF_ERROR(column_iterators[cid]->get_row_ranges_by_bloom_filter(col_preds, &dest_ranges, true));
         }
 
         for (const auto& child : node.compound_children()) {
@@ -3424,7 +3424,7 @@ struct BloomFilterEvaluator {
         const auto& cid_to_col_preds = ctx.cid_to_col_preds(node);
         for (const auto& [cid, col_preds] : cid_to_col_preds) {
             auto child_ranges = dest_ranges;
-            RETURN_IF_ERROR(column_iterators[cid]->get_row_ranges_by_bloom_filter(col_preds, &child_ranges));
+            RETURN_IF_ERROR(column_iterators[cid]->get_row_ranges_by_bloom_filter(col_preds, &child_ranges, false));
             cur_dest_ranges |= child_ranges;
         }
 

--- a/test/sql/test_bf_filter/R/test_bf_filter
+++ b/test/sql/test_bf_filter/R/test_bf_filter
@@ -1,0 +1,52 @@
+-- name: test_bf_filter
+DROP TABLE IF EXISTS `test_ngram_bf`;
+CREATE TABLE `test_ngram_bf` (
+  `id` bigint(20) NOT NULL,
+  `content` varchar(200) NOT NULL,
+  INDEX idx_content_ngrambf (`content`) USING NGRAMBF("bloom_filter_fpp" = "0.05", "case_sensitive" = "false", "gram_num" = "4")
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 3 
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO test_ngram_bf VALUES
+(1, 'architecture'),
+(2, 'shared-nothing'),
+(3, 'consistent'),
+(4, 'StarRocks');
+
+INSERT INTO test_ngram_bf (id, content)
+SELECT
+    gs + 100000 AS id,
+    concat('irrelevant1-content1', gs) AS content
+FROM TABLE(generate_series(1, 10000)) AS t(gs);
+
+INSERT INTO test_ngram_bf (id, content)
+SELECT
+    gs + 100000 AS id,
+    concat('irrelevant2-content2', gs) AS content
+FROM TABLE(generate_series(1, 10000)) AS t(gs);
+
+drop view if exists profile_bloom_filter_filtered_rows;
+create view profile_bloom_filter_filtered_rows as
+select trim(unnest) 
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '% BloomFilterFilterRows%'
+order by unnest;
+
+set enable_profile = 1;
+set enable_async_profile = 0;
+
+SELECT count(*) FROM test_ngram_bf WHERE content LIKE '%StarRocks%';
+select * from profile_bloom_filter_filtered_rows;
+-- result:
+- BloomFilterFilterRows: 20.002K (20002)
+-- !result
+
+SELECT count(*) FROM test_ngram_bf WHERE content LIKE '%StarRocks%' AND content LIKE '%irrelevant1-content1%';
+select * from profile_bloom_filter_filtered_rows;
+-- result:
+- BloomFilterFilterRows: 20.004K (20004)
+-- !result

--- a/test/sql/test_bf_filter/T/test_bf_filter
+++ b/test/sql/test_bf_filter/T/test_bf_filter
@@ -1,0 +1,43 @@
+-- name: test_bf_filter
+CREATE TABLE `test_ngram_bf` (
+  `id` bigint(20) NOT NULL,
+  `content` varchar(200) NOT NULL,
+  INDEX idx_content_ngrambf (`content`) USING NGRAMBF("bloom_filter_fpp" = "0.05", "case_sensitive" = "false", "gram_num" = "4")
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 3 
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO test_ngram_bf VALUES
+(1, 'architecture'),
+(2, 'shared-nothing'),
+(3, 'consistent'),
+(4, 'StarRocks');
+
+INSERT INTO test_ngram_bf (id, content)
+SELECT
+    gs + 100000 AS id,
+    concat('irrelevant1-content1', gs) AS content
+FROM TABLE(generate_series(1, 10000)) AS t(gs);
+
+INSERT INTO test_ngram_bf (id, content)
+SELECT
+    gs + 100000 AS id,
+    concat('irrelevant2-content2', gs) AS content
+FROM TABLE(generate_series(1, 10000)) AS t(gs);
+
+create view profile_bloom_filter_filtered_rows as
+select trim(unnest) 
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%BloomFilterFilterRows%'
+order by unnest;
+
+set enable_profile = true;
+
+SELECT count(*) FROM test_ngram_bf WHERE content LIKE '%StarRocks%';
+select * from profile_bloom_filter_filtered_rows;
+
+SELECT count(*) FROM test_ngram_bf WHERE content LIKE '%StarRocks%' AND content LIKE '%irrelevant1-content1%';
+select * from profile_bloom_filter_filtered_rows;


### PR DESCRIPTION
## Why I'm doing:

Currently `ColumnReader::bloom_filter` always treat the passed predicates as disjunctions. So if we do `LIKE '%123%' AND LIKE '%abc%'`, data pages containing '123' **OR** 'abc' will be picked.

## What I'm doing:

Fix ColumnReader::bloom_filter predicates conjunction.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
