### PR TITLE
[BugFix] Fix source partition checking in replication transaction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
@@ -821,8 +821,10 @@ public class ReplicationJob implements GsonPostProcessable {
         Map<Long, PartitionInfo> partitionInfos = Maps.newHashMap();
         for (Partition partition : table.getPartitions()) {
             Partition srcPartition = srcTable.getPartition(partition.getName(), false);
-            Preconditions.checkState(srcPartition != null,
-                    "Partition " + partition.getName() + " in table " + srcTable.getName() + " not found");
+            if (srcPartition == null) {
+                LOG.info("Partition {} in src table {} not found", partition.getName(), srcTable.getName());
+                continue;
+            }
 
             List<PhysicalPartition> physicalPartitions = getOrderedPhysicalPartitions(partition);
             List<PhysicalPartition> srcPhysicalPartitions = getOrderedPhysicalPartitions(srcPartition);


### PR DESCRIPTION
## Why I'm doing:
If target table has extra partitions than source table, it will do not replicate this table. This behavior is bad. This pr allows replication in this situation.

## What I'm doing:
Fix source partition checking in replication transaction

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
