### PR TITLE
[Enhancement] Improve skew join v2 rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -81,7 +81,7 @@ public class HashJoinNode extends JoinNode {
     }
 
     public void setSkewJoin(boolean skewJoin) {
-        isSkewJoin = skewJoin ;
+        this.isSkewJoin = skewJoin;
     }
 
     public boolean isSkewShuffleJoin() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashJoinOperator.java
@@ -30,6 +30,10 @@ public class PhysicalHashJoinOperator extends PhysicalJoinOperator {
     private ScalarOperator skewColumn;
     private List<ScalarOperator> skewValues;
     private Optional<PhysicalHashJoinOperator> skewJoinFriend = Optional.empty();
+
+    // Only meaningful for skew join: 0=left child, 1=right child, -1=unknown/not skew join.
+    // TODO(stephen): Support runtime filters for right-skew joins safely.
+    private int skewSideChildIndex = -1;
     public PhysicalHashJoinOperator(JoinOperator joinType,
                                     ScalarOperator onPredicate,
                                     String joinHint,
@@ -83,6 +87,14 @@ public class PhysicalHashJoinOperator extends PhysicalJoinOperator {
 
     public void setSkewJoinFriend(PhysicalHashJoinOperator skewJoinFriend) {
         this.skewJoinFriend = Optional.ofNullable(skewJoinFriend);
+    }
+
+    public int getSkewSideChildIndex() {
+        return skewSideChildIndex;
+    }
+
+    public void setSkewSideChildIndex(int skewSideChildIndex) {
+        this.skewSideChildIndex = skewSideChildIndex;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -3064,7 +3064,7 @@ public class PlanFragmentBuilder {
             setNullableForJoin(joinOperator, leftFragment, rightFragment, context);
 
             JoinNode joinNode;
-            if (node instanceof PhysicalHashJoinOperator) {
+            if (node instanceof PhysicalHashJoinOperator physicalHashJoinOperator) {
                 joinNode = new HashJoinNode(
                         context.getNextNodeId(),
                         leftFragment.getPlanRoot(), rightFragment.getPlanRoot(),
@@ -3085,11 +3085,11 @@ public class PlanFragmentBuilder {
                 }
                 joinNode.setCommonSlotMap(commonSlotMap);
                 // set skew join, this is used by runtime filter
-                PhysicalHashJoinOperator physicalHashJoinOperator = (PhysicalHashJoinOperator) node;
                 boolean isSkewJoin = physicalHashJoinOperator.getSkewColumn() != null;
                 if (isSkewJoin) {
                     HashJoinNode hashJoinNode = (HashJoinNode) joinNode;
-                    hashJoinNode.setSkewJoin(isSkewJoin);
+                    hashJoinNode.setSkewJoin(true);
+                    hashJoinNode.setSkewSideChildIndex(physicalHashJoinOperator.getSkewSideChildIndex());
                     if (physicalHashJoinOperator.getSkewJoinFriend().isPresent()) {
                         PhysicalHashJoinOperator skewJoinFriend = physicalHashJoinOperator.getSkewJoinFriend().get();
                         if (distributionMode == JoinNode.DistributionMode.BROADCAST &&


### PR DESCRIPTION
## Why I'm doing:
-  Keep shuffle-join input order unchanged for performance: the original PhysicalHashJoin has already gone through join reorder. Preserving the input order in the non-skew (shuffle) branch avoids undoing the optimizer’s chosen build/probe side, which can regress performance.

- Add NULL-only LOJ fast path for performance: when the join is a LEFT OUTER JOIN and the preserved side (left) is the NULL-skew side with NULL-only skew, the skew (broadcast) branch is semantically redundant. We can safely prune the broadcast join and directly return “left NULL rows + right NULL columns” while keeping the output schema/exchange requirements intact.


## What I'm doing:
- **Skew join v2 rewrite refinement**:
  - Keep shuffle branch input order unchanged.
  - Swap inputs only in the broadcast(skew) branch when `skewOnRight`.
- **NULL-only LOJ fast path**:
  - Add `buildNullFastBranch` and fill output columns plus required columns used by upstream output exchange (typed NULLs where necessary).
  - Introduce `OutputExchangeTemplate` + helpers to keep broadcast projection/output distribution consistent when required distribution exists.
- **Runtime filter handling for right-skew**:
  - Propagate `skewSideChildIndex` through `PhysicalHashJoinOperator` → `PlanFragmentBuilder` → `JoinNode`.
  - Disable all RF generation for right-skew skew joins in `JoinNode.buildRuntimeFilters()` (with TODOs to re-enable safely later).


### 1) Keep shuffle order, swap only broadcast when skewOnRight
```text
/*
 * Skew join v2 rewrite (keep shuffle branch input order)
 *
 * Original (after join reorder):
 *
 *              shuffle hash join (PARTITIONED)
 *                     /            \
 *               exchange          exchange
 *                  |                |
 *                child0           child1
 *
 * Rewrite:
 *
 *                           concatenate / union-all
 *                           /                   \
 *            shuffle join (PARTITIONED)      broadcast join (BROADCAST)
 *                 /          \                 /                 \
 *          ex(shuffle)    ex(shuffle)     ex(random/RR)      ex(broadcast)
 *              |              |               |                  |
 *           child0_ns       child1_ns       probe_skew         build_skew
 *
 * Notes:
 * - Shuffle branch input order is unchanged: (child0_ns, child1_ns)
 * - If skewOnLeft:  probe_skew=child0_skew, build_skew=child1_skew
 * - If skewOnRight: probe_skew=child1_skew, build_skew=child0_skew   (swap ONLY here)
 */
```

### 2) NULL-only LOJ fast path (prune broadcast join, project typed NULLs)
```text
/*
 * NULL-only LEFT OUTER JOIN fast path (preserved side NULL skew)
 *
 * Condition:
 * - LEFT OUTER JOIN
 * - skewOnLeft (preserved side)
 * - skew values: only NULL  =>  skew predicate: (left_key IS NULL)
 *
 * Observation:
 * - For LOJ, rows with (left_key IS NULL) never match RHS on equality key,
 *   so skew(broadcast) join branch would output RHS columns as NULL anyway.
 *
 * Rewrite:
 *
 *                           concatenate / union-all
 *                           /                   \
 *            shuffle LOJ (PARTITIONED)          fast path (no broadcast join)
 *                 /          \                        |
 *          ex(shuffle)    ex(shuffle)               project
 *              |              |                      |
 *           left_not_null     right               left_null_rows (ROUND_ROBIN)
 *
 * project output:
 * - keep all left output columns as identity
 * - fill all right output columns as typed NULL
 * - fill any upstream required(exchange-used) columns as typed NULL if missing
 */
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
