### PR TITLE
[Enhancement] Optimize Iceberg partition and file deletion

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -390,4 +390,14 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     public Map<String, String> getCatalogProperties() {
         return normal.getCatalogProperties();
     }
+
+    @Override
+    public boolean canDeleteUsingMetadata(Table table, ScalarOperator predicate) {
+        return normal.canDeleteUsingMetadata(table, predicate);
+    }
+
+    @Override
+    public void executeMetadataDelete(Table table, ScalarOperator predicate, ConnectContext context) {
+        normal.executeMetadataDelete(table, predicate, context);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -375,4 +375,29 @@ public interface ConnectorMetadata {
 
     default void shutdown() {
     }
+
+    /**
+     * Check if the delete can be performed using metadata operations only.
+     * This is connector-specific optimization that allows deleting data by
+     * dropping entire files or partitions without generating position delete files.
+     *
+     * @param table     The table to delete from
+     * @param predicate The delete predicate in ScalarOperator form
+     * @return true if metadata-level delete can be used, false otherwise
+     */
+    default boolean canDeleteUsingMetadata(Table table, ScalarOperator predicate) {
+        return false;
+    }
+
+    /**
+     * Execute metadata-level delete for the given table and predicate.
+     * This method should only be called when canDeleteUsingMetadata returns true.
+     *
+     * @param table     The table to delete from
+     * @param predicate The delete predicate in ScalarOperator form
+     * @param context   The connect context for audit info
+     */
+    default void executeMetadataDelete(Table table, ScalarOperator predicate, ConnectContext context) {
+        throw new UnsupportedOperationException("Metadata delete is not supported by this connector");
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergMetadataDeleteNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergMetadataDeleteNode.java
@@ -1,0 +1,81 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TPlanNode;
+import com.starrocks.thrift.TPlanNodeType;
+
+import java.util.ArrayList;
+
+/**
+ * PlanNode for Iceberg metadata-level delete operation.
+ * This node represents a DELETE that can be performed without generating
+ * position delete files, by using Iceberg's DeleteFiles API directly.
+ */
+public class IcebergMetadataDeleteNode extends PlanNode {
+    private final IcebergTable table;
+    private final ScalarOperator predicate;
+
+    public IcebergMetadataDeleteNode(PlanNodeId id, IcebergTable table,
+                                     ScalarOperator predicate) {
+        super(id, new ArrayList<>(), "ICEBERG_METADATA_DELETE");
+        this.table = table;
+        this.predicate = predicate;
+    }
+
+    @Override
+    public void computeStats() {
+        avgRowSize = 0;
+        cardinality = 0;
+    }
+
+    @Override
+    protected void toThrift(TPlanNode msg) {
+        msg.node_type = TPlanNodeType.EMPTY_SET_NODE;
+    }
+
+    @Override
+    protected String getNodeExplainString(String prefix, TExplainLevel detailLevel) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(prefix).append("ICEBERG METADATA DELETE\n");
+        sb.append(prefix).append("  catalog: ").append(table.getCatalogName()).append("\n");
+        sb.append(prefix).append("  database: ").append(table.getCatalogDBName()).append("\n");
+        sb.append(prefix).append("  table: ").append(table.getCatalogTableName()).append("\n");
+
+        if (predicate != null) {
+            sb.append(prefix).append("  predicate: ").append(predicate.toString()).append("\n");
+        } else {
+            sb.append(prefix).append("  predicate: ALL (delete all rows)\n");
+        }
+
+        return sb.toString();
+    }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return false;
+    }
+
+    public IcebergTable getTable() {
+        return table;
+    }
+
+    public ScalarOperator getPredicate() {
+        return predicate;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -88,6 +88,7 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergMetadata;
 import com.starrocks.failpoint.FailPointExecutor;
 import com.starrocks.http.HttpConnectContext;
@@ -2901,7 +2902,12 @@ public class StmtExecutor {
 
             Optional<ConnectorMetadata> connectorMetadata = GlobalStateMgr.getCurrentState()
                     .getMetadataMgr().getOptionalMetadata(table.getCatalogName());
-            connectorMetadata.ifPresent(metadata -> metadata.executeMetadataDelete(table, predicate, context));
+            if (connectorMetadata.isPresent()) {
+                connectorMetadata.get().executeMetadataDelete(table, predicate, context);
+            } else {
+                throw new StarRocksConnectorException("Can not find {} connector metadata for table: {}",
+                        table.getCatalogName(), table.getName());
+            }
             context.getState().setOk();
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -49,6 +49,7 @@ import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExternalOlapTable;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.ResourceGroup;
@@ -86,6 +87,7 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.iceberg.IcebergMetadata;
 import com.starrocks.failpoint.FailPointExecutor;
 import com.starrocks.http.HttpConnectContext;
@@ -113,6 +115,7 @@ import com.starrocks.planner.DataSink;
 import com.starrocks.planner.FileScanNode;
 import com.starrocks.planner.HiveTableSink;
 import com.starrocks.planner.IcebergDeleteSink;
+import com.starrocks.planner.IcebergMetadataDeleteNode;
 import com.starrocks.planner.IcebergScanNode;
 import com.starrocks.planner.IcebergTableSink;
 import com.starrocks.planner.OlapScanNode;
@@ -2885,6 +2888,21 @@ public class StmtExecutor {
                 }
                 context.setState(e.getQueryState());
             }
+            return;
+        }
+
+        // Handle metadata-level delete for Iceberg
+        // execute the delete operation here
+        if (stmt instanceof DeleteStmt && execPlan != null && execPlan.isIcebergMetadataDelete()) {
+            // Execute metadata-level delete
+            IcebergMetadataDeleteNode node = (IcebergMetadataDeleteNode) execPlan.getTopFragment().getPlanRoot();
+            IcebergTable table = node.getTable();
+            ScalarOperator predicate = node.getPredicate();
+
+            Optional<ConnectorMetadata> connectorMetadata = GlobalStateMgr.getCurrentState()
+                    .getMetadataMgr().getOptionalMetadata(table.getCatalogName());
+            connectorMetadata.ifPresent(metadata -> metadata.executeMetadataDelete(table, predicate, context));
+            context.getState().setOk();
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
@@ -22,6 +22,7 @@ import com.starrocks.common.util.ProfilingExecPlan;
 import com.starrocks.planner.DescriptorTable;
 import com.starrocks.planner.ExecGroup;
 import com.starrocks.planner.HashJoinNode;
+import com.starrocks.planner.IcebergMetadataDeleteNode;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanFragmentId;
 import com.starrocks.planner.PlanNodeId;
@@ -125,6 +126,15 @@ public class ExecPlan {
 
     public PlanFragment getTopFragment() {
         return fragments.get(0);
+    }
+
+    /**
+     * Check if this plan is for Iceberg metadata-level delete operation.
+     * Metadata delete is performed without generating position delete files.
+     */
+    public boolean isIcebergMetadataDelete() {
+        return fragments.size() == 1
+                && fragments.get(0).getPlanRoot() instanceof IcebergMetadataDeleteNode;
     }
 
     public DescriptorTable getDescTbl() {

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/ProfilingExecPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/ProfilingExecPlanTest.java
@@ -75,7 +75,7 @@ public class ProfilingExecPlanTest {
                         "STREAM_LOAD_SCAN", "ANALYTIC_EVAL", "ICEBERG_SCAN", "AGGREGATION", "FILE_SCAN", "EXCHANGE",
                         "META_SCAN", "OLAP_SCAN", "ODPS_SCAN", "ICEBERG_METADATA_SCAN", "KUDU_SCAN",
                         "CAPTURE_VERSION", "ICEBERG_EQUALITY_DELETE_SCAN", "RAW_VALUES", "FETCH", "LOOK_UP",
-                        "BENCHMARK_SCAN");
+                        "BENCHMARK_SCAN", "ICEBERG_METADATA_DELETE");
 
         Method method = ProfilingExecPlan.class.getDeclaredMethod("normalizeNodeName", Class.class);
         method.setAccessible(true);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -56,9 +56,12 @@ import com.starrocks.connector.iceberg.procedure.RemoveOrphanFilesProcedure;
 import com.starrocks.connector.metadata.MetadataCollectJob;
 import com.starrocks.connector.metadata.MetadataTableType;
 import com.starrocks.connector.metadata.iceberg.IcebergMetadataCollectJob;
+import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.WALApplier;
 import com.starrocks.planner.DescriptorTable;
+import com.starrocks.planner.IcebergMetadataDeleteNode;
+import com.starrocks.planner.PlanNodeId;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
@@ -105,6 +108,7 @@ import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.statistic.AnalyzeJob;
 import com.starrocks.statistic.ExternalAnalyzeJob;
 import com.starrocks.statistic.StatsConstants;
+import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TIcebergColumnStats;
 import com.starrocks.thrift.TIcebergDataFile;
 import com.starrocks.thrift.TIcebergFileContent;
@@ -2604,4 +2608,209 @@ public class IcebergMetadataTest extends TableTestBase {
         Assertions.assertTrue(exception.getMessage().contains("checked failure"));
     }
 
+    @Test
+    public void testCanDeleteUsingMetadataWithPartitionLevelDelete() {
+        // Test partition-level delete detection for identity partition spec
+        // When delete expression matches entire partition, canDeleteUsingMetadata should return true
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        // Create predicate: k2 = 2 (which matches entire partition k2=2)
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ,
+                new ColumnRefOperator(1, INT, "k2", true), ConstantOperator.createInt(2));
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT,
+                new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG),
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        // For identity partition, this should return true since k2 is partition column
+        boolean canUseMetadataDelete = metadata.canDeleteUsingMetadata(icebergTable, predicate);
+        Assertions.assertTrue(canUseMetadataDelete,
+                "Partition-level delete should be eligible for metadata delete");
+    }
+
+    @Test
+    public void testCanDeleteUsingMetadataWithPartialMatch() {
+        // Test when delete expression does not match entire partition or file
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_3).commit();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        // Create predicate: k1 = 1 (which only matches some rows, not entire file)
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ,
+                new ColumnRefOperator(0, INT, "k1", true), ConstantOperator.createInt(1));
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT,
+                new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG),
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        // This should return false since expression doesn't match entire file
+        boolean canUseMetadataDelete = metadata.canDeleteUsingMetadata(icebergTable, predicate);
+        Assertions.assertFalse(canUseMetadataDelete,
+                "Partial row match should not be eligible for metadata delete");
+    }
+
+    @Test
+    public void testCanDeleteUsingMetadataWithAlwaysTrue() {
+        // Test delete all rows (no predicate)
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        // Create predicate: null represents delete all (alwaysTrue)
+        ScalarOperator predicate = null;
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT,
+                new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG),
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        // Delete all should be eligible for metadata delete
+        boolean canUseMetadataDelete = metadata.canDeleteUsingMetadata(icebergTable, predicate);
+        Assertions.assertTrue(canUseMetadataDelete,
+                "Delete all should be eligible for metadata delete");
+    }
+
+    @Test
+    public void testExecuteMetadataDelete() throws Exception {
+        // Test metadata delete execution
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        // Create predicate: k2 = 2 (delete entire partition)
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ,
+                new ColumnRefOperator(1, INT, "k2", true), ConstantOperator.createInt(2));
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        // Mock NodeMgr.getMySelf() to return a valid Frontend
+        Frontend frontend = new Frontend(FrontendNodeType.LEADER, "test-fe", "127.0.0.1", 9010);
+        new Expectations(frontend) {
+            {
+                frontend.getFeVersion();
+                minTimes = 0;
+                result = "test-version";
+            }
+        };
+        new Expectations(GlobalStateMgr.getCurrentState().getNodeMgr()) {
+            {
+                GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf();
+                minTimes = 0;
+                result = frontend;
+            }
+        };
+
+        // Execute metadata delete
+        metadata.executeMetadataDelete(icebergTable, predicate, connectContext);
+
+        // Verify the delete was committed
+        mockedNativeTableB.refresh();
+        List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTableB.newScan().planFiles());
+
+        // After deleting partition k2=2, only files with k2=3 should remain
+        Assertions.assertEquals(1, fileScanTasks.size(), "Only one file should remain after partition delete");
+        Assertions.assertEquals("PartitionData{k2=3}", fileScanTasks.get(0).file().partition().toString(),
+                "Remaining file should be from partition k2=3");
+    }
+
+    @Test
+    public void testExecuteMetadataDeleteDeletesAll() throws Exception {
+        // Test metadata delete that removes all data
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        // Create predicate: null represents delete all (alwaysTrue)
+        ScalarOperator predicate = null;
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        // Mock NodeMgr.getMySelf() to return a valid Frontend
+        Frontend frontend = new Frontend(FrontendNodeType.LEADER, "test-fe", "127.0.0.1", 9010);
+        new Expectations(frontend) {
+            {
+                frontend.getFeVersion();
+                minTimes = 0;
+                result = "test-version";
+            }
+        };
+        new Expectations(GlobalStateMgr.getCurrentState().getNodeMgr()) {
+            {
+                GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf();
+                minTimes = 0;
+                result = frontend;
+            }
+        };
+
+        // Execute metadata delete
+        metadata.executeMetadataDelete(icebergTable, predicate, connectContext);
+
+        // Verify all data was deleted
+        mockedNativeTableB.refresh();
+        List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTableB.newScan().planFiles());
+
+        Assertions.assertEquals(0, fileScanTasks.size(), "All files should be deleted");
+    }
+
+    @Test
+    public void testMetadataDeleteNodeExplainString() {
+        // Test that IcebergMetadataDeleteNode generates correct EXPLAIN output
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME,
+                "resource_name", "iceberg_db", "iceberg_table", "",
+                Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        // Create predicate: k2 = 2
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ,
+                new ColumnRefOperator(1, INT, "k2", true), ConstantOperator.createInt(2));
+
+        // Create the metadata delete node
+        IcebergMetadataDeleteNode node = new IcebergMetadataDeleteNode(
+                new PlanNodeId(0), icebergTable, predicate);
+
+        // Verify EXPLAIN output contains expected information
+        String explainString = node.getExplainString();
+        Assertions.assertTrue(explainString.contains("ICEBERG METADATA DELETE"),
+                "EXPLAIN should contain 'ICEBERG METADATA DELETE'");
+        Assertions.assertTrue(explainString.contains("catalog: " + CATALOG_NAME),
+                "EXPLAIN should contain catalog name");
+        Assertions.assertTrue(explainString.contains("database: iceberg_db"),
+                "EXPLAIN should contain database name");
+        Assertions.assertTrue(explainString.contains("table: iceberg_table"),
+                "EXPLAIN should contain table name");
+        Assertions.assertTrue(explainString.contains("predicate:"),
+                "EXPLAIN should contain predicate info");
+    }
+
+    @Test
+    public void testMetadataDeleteNodeExplainStringWithNullPredicate() {
+        // Test EXPLAIN output when predicate is null (delete all)
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).commit();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME,
+                "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        // Create node with null predicate (delete all)
+        IcebergMetadataDeleteNode node = new IcebergMetadataDeleteNode(
+                new PlanNodeId(0), icebergTable, null);
+
+        // Verify EXPLAIN output
+        String explainString = node.getExplainString();
+        Assertions.assertTrue(explainString.contains("ICEBERG METADATA DELETE"),
+                "EXPLAIN should contain 'ICEBERG METADATA DELETE'");
+        Assertions.assertTrue(explainString.contains("predicate: ALL (delete all rows)"),
+                "EXPLAIN should indicate 'delete all rows' when predicate is null");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -66,6 +66,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.MetadataMgr;
+import com.starrocks.server.NodeMgr;
 import com.starrocks.server.TemporaryTableMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
@@ -2690,20 +2691,18 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
 
-        // Mock NodeMgr.getMySelf() to return a valid Frontend
-        Frontend frontend = new Frontend(FrontendNodeType.LEADER, "test-fe", "127.0.0.1", 9010);
-        new Expectations(frontend) {
-            {
-                frontend.getFeVersion();
-                minTimes = 0;
-                result = "test-version";
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getMySelf() {
+                Frontend frontend = new Frontend(FrontendNodeType.LEADER, "test-fe", "127.0.0.1", 9010);
+                return frontend;
             }
         };
-        new Expectations(GlobalStateMgr.getCurrentState().getNodeMgr()) {
-            {
-                GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf();
-                minTimes = 0;
-                result = frontend;
+
+        new MockUp<Frontend>() {
+            @Mock
+            public String getFeVersion() {
+                return "test-version";
             }
         };
 

--- a/test/sql/test_iceberg/R/test_iceberg_metadata_delete_optimization
+++ b/test/sql/test_iceberg/R/test_iceberg_metadata_delete_optimization
@@ -1,0 +1,311 @@
+-- name: test_iceberg_metadata_delete_optimization
+create external catalog iceberg_meta_del_${uuid0}
+PROPERTIES (
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "iceberg.catalog.hive.metastore.uris" = "${hive_metastore_uris}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "enable_iceberg_metadata_cache"="false"
+);
+-- result:
+-- !result
+create database iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}
+properties ("location" = "oss://${oss_bucket}/test_metadata_delete/${uuid0}/db");
+-- result:
+-- !result
+create table iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned (
+    id INT,
+    name STRING,
+    dt STRING,
+    region STRING
+)
+PARTITION BY (dt, region);
+-- result:
+-- !result
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(1, 'Alice', '2023-01-01', 'North'),
+(2, 'Bob', '2023-01-01', 'North'),
+(3, 'Charlie', '2023-01-02', 'South'),
+(4, 'David', '2023-01-02', 'South'),
+(5, 'Eve', '2023-01-03', 'East'),
+(6, 'Frank', '2023-01-03', 'West');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-01' and region = 'North'", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-01' and region = 'North';
+-- result:
+-- !result
+select * from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned order by id;
+-- result:
+3	Charlie	2023-01-02	South
+4	David	2023-01-02	South
+5	Eve	2023-01-03	East
+6	Frank	2023-01-03	West
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-02' and region in ('South', 'East')", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-02' and region in ('South', 'East');
+-- result:
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(5, 'Eve', '2023-01-03', 'East'),
+(6, 'Frank', '2023-01-03', 'West');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-03' or region = 'West'", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-03' or region = 'West';
+-- result:
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	4
+-- !result
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(1, 'Alice', '2023-01-01', 'North'),
+(2, 'Bob', '2023-01-01', 'North'),
+(3, 'Charlie', '2023-01-02', 'South'),
+(4, 'David', '2023-01-02', 'South');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt between '2023-01-01' and '2023-01-02'", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt between '2023-01-01' and '2023-01-02';
+-- result:
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	2
+-- !result
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(5, 'Eve', '2023-01-03', 'East'),
+(6, 'Frank', '2023-01-03', 'West');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-03' and id = 5", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-03' and id = 5;
+-- result:
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(7, 'Grace', '2023-01-01', 'North'),
+(8, 'Henry', '2023-01-02', 'South');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt like '2023-01-%'", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt like '2023-01-%';
+-- result:
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	3
+-- !result
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(9, 'Ivy', null, 'North'),
+(10, 'Jack', null, 'South');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt is null", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt is null;
+-- result:
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	2
+-- !result
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(11, 'Kate', '2023-01-03', 'East'),
+(12, 'Leo', '2023-01-03', 'East');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-03' and region = 'East' and 1 = 1", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-03' and region = 'East' and 1 = 1;
+-- result:
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(13, 'Mike', '2023-01-01', 'North'),
+(14, 'Nancy', '2023-01-02', 'South'),
+(15, 'Oscar', '2023-01-03', 'East'),
+(16, 'Patty', '2023-01-03', 'West');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id > 3", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id > 3;
+-- result:
+-- !result
+select * from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned order by id;
+-- result:
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	4
+-- !result
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(17, 'Quincy', '2023-01-01', 'North'),
+(18, 'Rachel', '2023-01-02', 'South'),
+(19, 'Charlie', '2023-01-03', 'East');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where name = 'Charlie'", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where name = 'Charlie';
+-- result:
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(100, 'Alice', '2023-01-01', 'North'),
+(101, 'Bob', '2023-01-01', 'North'),
+(102, 'Charlie', '2023-01-02', 'South'),
+(103, 'David', '2023-01-02', 'South');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id > 50", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id > 50;
+-- result:
+-- !result
+select * from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned order by id;
+-- result:
+17	Quincy	2023-01-01	North
+18	Rachel	2023-01-02	South
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	2
+-- !result
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(1, 'Alice', '2023-01-01', 'North'),
+(2, 'Bob', '2023-01-01', 'North'),
+(3, 'Charlie', '2023-01-01', 'North'),
+(4, 'David', '2023-01-01', 'North');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id = 2", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id = 2;
+-- result:
+-- !result
+select * from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned order by id;
+-- result:
+1	Alice	2023-01-01	North
+3	Charlie	2023-01-01	North
+4	David	2023-01-01	North
+17	Quincy	2023-01-01	North
+18	Rachel	2023-01-02	South
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(10, 'Eve', '2023-01-01', 'North'),
+(20, 'Frank', '2023-01-01', 'North'),
+(15, 'Grace', '2023-01-02', 'South'),
+(25, 'Henry', '2023-01-02', 'South');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id < 25", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id < 25;
+-- result:
+-- !result
+select * from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned order by id;
+-- result:
+25	Henry	2023-01-02	South
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	8
+-- !result
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(100, 'Test1', '2023-01-01', 'North'),
+(101, 'Test2', '2023-01-01', 'North'),
+(102, 'Test3', '2023-01-02', 'South'),
+(103, 'Test4', '2023-01-02', 'South');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-01' or id = 103", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-01' or id = 103;
+-- result:
+-- !result
+select * from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned order by id;
+-- result:
+25	Henry	2023-01-02	South
+102	Test3	2023-01-02	South
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	3
+-- !result
+drop table iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned force;
+-- result:
+-- !result
+drop database iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog iceberg_meta_del_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_metadata_delete/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/R/test_iceberg_metadata_delete_transform
+++ b/test/sql/test_iceberg/R/test_iceberg_metadata_delete_transform
@@ -1,0 +1,340 @@
+-- name: test_iceberg_metadata_delete_transform
+create external catalog iceberg_transform_${uuid0}
+PROPERTIES (
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "iceberg.catalog.hive.metastore.uris" = "${hive_metastore_uris}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "enable_iceberg_metadata_cache"="false"
+);
+-- result:
+-- !result
+create database iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}
+properties ("location" = "oss://${oss_bucket}/test_transform_delete/${uuid0}/db");
+-- result:
+-- !result
+create table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform (
+    id INT,
+    name STRING,
+    event_time DATETIME
+)
+PARTITION BY year(event_time);
+-- result:
+-- !result
+insert into iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform values
+(1, 'Alice', '2022-06-15 10:00:00'),
+(2, 'Bob', '2022-08-20 14:30:00'),
+(3, 'Charlie', '2023-01-10 09:00:00'),
+(4, 'David', '2023-12-25 16:00:00'),
+(5, 'Eve', '2024-03-05 11:00:00');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform where year(event_time) = 2022", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform where year(event_time) = 2022;
+-- result:
+-- !result
+select * from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform order by id;
+-- result:
+3	Charlie	2023-01-10 09:00:00
+4	David	2023-12-25 16:00:00
+5	Eve	2024-03-05 11:00:00
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform$snapshots order by committed_at desc limit 1;
+-- result:
+delete	2
+-- !result
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform where event_time >= '2023-06-01'", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform where event_time >= '2023-06-01';
+-- result:
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform$snapshots order by committed_at desc limit 1;
+-- result:
+delete	2
+-- !result
+drop table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform force;
+-- result:
+-- !result
+create table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform (
+    id INT,
+    name STRING,
+    event_date DATE
+)
+PARTITION BY month(event_date);
+-- result:
+-- !result
+insert into iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform values
+(1, 'Jan2023', '2023-01-15'),
+(2, 'Jan2023b', '2023-01-25'),
+(3, 'Feb2023', '2023-02-10'),
+(4, 'Feb2023b', '2023-02-20'),
+(5, 'Mar2023', '2023-03-05');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform where month(event_date) = 1", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform where month(event_date) = 1
+
+select * from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform order by id;
+-- result:
+E: (1064, "Getting syntax error at line 3, column 0. Detail message: Unexpected input 'select', the most similar input is {<EOF>, ';'}.")
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform$snapshots order by committed_at desc limit 1;
+-- result:
+append	None
+-- !result
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform where event_date = '2023-02-10'", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform where event_date = '2023-02-10';
+-- result:
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+drop table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform force;
+-- result:
+-- !result
+create table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform (
+    id INT,
+    name STRING,
+    event_date DATE
+)
+PARTITION BY day(event_date);
+-- result:
+-- !result
+insert into iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform values
+(1, 'Day1', '2023-01-01'),
+(2, 'Day1b', '2023-01-01'),
+(3, 'Day2', '2023-01-02'),
+(4, 'Day3', '2023-01-03'),
+(5, 'Day3b', '2023-01-03');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform where day(event_date) = 1", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform where day(event_date) = 1;
+-- result:
+-- !result
+select * from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform order by id;
+-- result:
+3	Day2	2023-01-02
+4	Day3	2023-01-03
+5	Day3b	2023-01-03
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform$snapshots order by committed_at desc limit 1;
+-- result:
+delete	None
+-- !result
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform where event_date = '2023-01-02'", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform where event_date = '2023-01-02';
+-- result:
+-- !result
+select * from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform order by id;
+-- result:
+4	Day3	2023-01-03
+5	Day3b	2023-01-03
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+drop table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform force;
+-- result:
+-- !result
+create table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform (
+    id INT,
+    name STRING,
+    category STRING
+)
+PARTITION BY bucket(category, 4);
+-- result:
+-- !result
+insert into iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform values
+(1, 'A', 'Electronics'),
+(2, 'B', 'Electronics'),
+(3, 'C', 'Clothing'),
+(4, 'D', 'Clothing'),
+(5, 'E', 'Food');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform where category = 'Electronics'", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform where category = 'Electronics';
+-- result:
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform where category in ('Clothing', 'Food')", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform where category in ('Clothing', 'Food');
+-- result:
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform$snapshots order by committed_at desc limit 1;
+-- result:
+delete	3
+-- !result
+drop table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform force;
+-- result:
+-- !result
+create table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform (
+    id INT,
+    name STRING,
+    code STRING
+)
+PARTITION BY truncate(code, 3);
+-- result:
+-- !result
+insert into iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform values
+(1, 'A', 'ABC123'),
+(2, 'B', 'ABC456'),
+(3, 'C', 'DEF789'),
+(4, 'D', 'DEF012'),
+(5, 'E', 'XYZ345');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform where code = 'ABC123'", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform where code = 'ABC123';
+-- result:
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform where code like 'ABC%'", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform where code like 'ABC%';
+-- result:
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+drop table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform force;
+-- result:
+-- !result
+create table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_hour_transform (
+    id INT,
+    name STRING,
+    event_time DATETIME
+)
+PARTITION BY hour(event_time);
+-- result:
+-- !result
+insert into iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_hour_transform values
+(1, 'Hour10', '2023-01-01 10:30:00'),
+(2, 'Hour10b', '2023-01-01 10:45:00'),
+(3, 'Hour14', '2023-01-01 14:00:00'),
+(4, 'Hour14b', '2023-01-01 14:30:00'),
+(5, 'Hour18', '2023-01-01 18:00:00');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_hour_transform where hour(event_time) = 10", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_hour_transform where hour(event_time) = 10;
+-- result:
+-- !result
+select * from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_hour_transform order by id;
+-- result:
+3	Hour14	2023-01-01 14:00:00
+4	Hour14b	2023-01-01 14:30:00
+5	Hour18	2023-01-01 18:00:00
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_hour_transform$snapshots order by committed_at desc limit 1;
+-- result:
+delete	2
+-- !result
+drop table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_hour_transform force;
+-- result:
+-- !result
+create table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform (
+    id INT,
+    name STRING,
+    event_date DATE,
+    region STRING
+)
+PARTITION BY year(event_date), region;
+-- result:
+-- !result
+insert into iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform values
+(1, 'A', '2023-06-15', 'North'),
+(2, 'B', '2023-07-20', 'North'),
+(3, 'C', '2023-08-10', 'South'),
+(4, 'D', '2024-01-05', 'East'),
+(5, 'E', '2024-02-15', 'West');
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform where year(event_date) = 2023 and region = 'North'", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform where year(event_date) = 2023 and region = 'North';
+-- result:
+-- !result
+select * from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform order by id;
+-- result:
+3	C	2023-08-10	South
+4	D	2024-01-05	East
+5	E	2024-02-15	West
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform$snapshots order by committed_at desc limit 1;
+-- result:
+delete	2
+-- !result
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform where event_date = '2024-01-05'", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform where event_date = '2024-01-05';
+-- result:
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+drop table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform force;
+-- result:
+-- !result
+drop database iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog iceberg_transform_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_transform_delete/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/R/test_iceberg_metadata_delete_unpartitioned
+++ b/test/sql/test_iceberg/R/test_iceberg_metadata_delete_unpartitioned
@@ -1,0 +1,249 @@
+-- name: test_iceberg_metadata_delete_unpartitioned
+create external catalog iceberg_unpart_${uuid0}
+PROPERTIES (
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "iceberg.catalog.hive.metastore.uris" = "${hive_metastore_uris}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "enable_iceberg_metadata_cache"="false"
+);
+-- result:
+-- !result
+create database iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}
+properties ("location" = "oss://${oss_bucket}/test_unpart_delete/${uuid0}/db");
+-- result:
+-- !result
+create table iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned (
+    id INT,
+    name STRING,
+    category STRING,
+    amount DECIMAL(10,2)
+);
+-- result:
+-- !result
+insert into iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned values
+(1, 'Alice', 'Electronics', 100.00),
+(2, 'Bob', 'Electronics', 200.00),
+(3, 'Charlie', 'Clothing', 150.00),
+(4, 'David', 'Clothing', 300.00),
+(5, 'Eve', 'Food', 50.00),
+(6, 'Frank', 'Food', 75.00);
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id = 1", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id = 1;
+-- result:
+-- !result
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+-- result:
+2	Bob	Electronics	200.00
+3	Charlie	Clothing	150.00
+4	David	Clothing	300.00
+5	Eve	Food	50.00
+6	Frank	Food	75.00
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id in (2, 3)", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id in (2, 3);
+-- result:
+-- !result
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+-- result:
+4	David	Clothing	300.00
+5	Eve	Food	50.00
+6	Frank	Food	75.00
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	2
+-- !result
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id > 4", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id > 4;
+-- result:
+-- !result
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+-- result:
+4	David	Clothing	300.00
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	2
+-- !result
+insert into iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned values
+(7, 'Grace', 'Electronics', 120.00),
+(8, 'Henry', 'Clothing', 180.00);
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where category = 'Electronics'", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where category = 'Electronics';
+-- result:
+-- !result
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+-- result:
+4	David	Clothing	300.00
+8	Henry	Clothing	180.00
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where name like 'H%'", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where name like 'H%';
+-- result:
+-- !result
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+-- result:
+4	David	Clothing	300.00
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+insert into iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned values
+(10, 'Ivy', 'Food', 60.00),
+(11, 'Jack', 'Food', 90.00),
+(12, 'Kate', 'Food', 110.00);
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id between 10 and 11", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id between 10 and 11;
+-- result:
+-- !result
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+-- result:
+4	David	Clothing	300.00
+12	Kate	Food	110.00
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	2
+-- !result
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where category = 'Food' and amount < 100", "ICEBERG DELETE SINK")
+-- result:
+None
+-- !result
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where category = 'Food' and amount < 100;
+-- result:
+-- !result
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+-- result:
+4	David	Clothing	300.00
+12	Kate	Food	110.00
+-- !result
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	2
+-- !result
+insert into iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned values
+(20, 'Test1', 'Books', 50.00),
+(21, 'Test2', 'Books', 60.00);
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id = 20 or category = 'Books'", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id = 20 or category = 'Books';
+-- result:
+-- !result
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+-- result:
+4	David	Clothing	300.00
+12	Kate	Food	110.00
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+insert into iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned values
+(30, 'NullTest', null, 100.00),
+(31, 'NullTest2', null, 200.00);
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where category is null", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where category is null;
+-- result:
+-- !result
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+-- result:
+4	David	Clothing	300.00
+12	Kate	Food	110.00
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+insert into iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned values
+(100, 'Alice', 'Electronics', 100.00),
+(101, 'Bob', 'Electronics', 200.00),
+(102, 'Charlie', 'Clothing', 150.00),
+(103, 'David', 'Clothing', 300.00);
+-- result:
+-- !result
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id > 50", "ICEBERG METADATA DELETE")
+-- result:
+None
+-- !result
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id > 50;
+-- result:
+-- !result
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+-- result:
+4	David	Clothing	300.00
+12	Kate	Food	110.00
+-- !result
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+-- result:
+delete	1
+-- !result
+select operation from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 5;
+-- result:
+delete
+append
+delete
+append
+delete
+-- !result
+drop table iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned force;
+-- result:
+-- !result
+drop database iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog iceberg_unpart_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_unpart_delete/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_metadata_delete_optimization
+++ b/test/sql/test_iceberg/T/test_iceberg_metadata_delete_optimization
@@ -16,8 +16,6 @@ PROPERTIES (
     "enable_iceberg_metadata_cache"="false"
 );
 
-se
-
 -- Create database
 create database iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}
 properties ("location" = "oss://${oss_bucket}/test_metadata_delete/${uuid0}/db");

--- a/test/sql/test_iceberg/T/test_iceberg_metadata_delete_optimization
+++ b/test/sql/test_iceberg/T/test_iceberg_metadata_delete_optimization
@@ -1,0 +1,314 @@
+-- name: test_iceberg_metadata_delete_optimization
+
+-- ====================================================
+-- SECTION 1: Setup
+-- ====================================================
+
+-- Create external catalog for Iceberg
+create external catalog iceberg_meta_del_${uuid0}
+PROPERTIES (
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "iceberg.catalog.hive.metastore.uris" = "${hive_metastore_uris}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "enable_iceberg_metadata_cache"="false"
+);
+
+se
+
+-- Create database
+create database iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}
+properties ("location" = "oss://${oss_bucket}/test_metadata_delete/${uuid0}/db");
+
+-- Create partitioned table (partitioned by dt and region)
+create table iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned (
+    id INT,
+    name STRING,
+    dt STRING,
+    region STRING
+)
+PARTITION BY (dt, region);
+
+-- Insert test data
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(1, 'Alice', '2023-01-01', 'North'),
+(2, 'Bob', '2023-01-01', 'North'),
+(3, 'Charlie', '2023-01-02', 'South'),
+(4, 'David', '2023-01-02', 'South'),
+(5, 'Eve', '2023-01-03', 'East'),
+(6, 'Frank', '2023-01-03', 'West');
+
+-- ====================================================
+-- SECTION 2: Basic Metadata Delete Tests
+-- ====================================================
+
+-- Test 2.1: Delete single partition - should trigger metadata delete optimization
+-- Verify EXPLAIN contains ICEBERG METADATA DELETE
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-01' and region = 'North'", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-01' and region = 'North';
+
+-- Verify remaining data
+select * from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned order by id;
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+
+-- ====================================================
+-- SECTION 3: Complex Delete Conditions
+-- ====================================================
+
+-- Test 3.1: Delete with IN clause on partition columns - should trigger optimization
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-02' and region in ('South', 'East')", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-02' and region in ('South', 'East');
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 3.2: Delete with OR condition on same partition column - should trigger optimization
+-- (OR condition where all partitions match the predicate)
+-- Re-insert test data for this test
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(5, 'Eve', '2023-01-03', 'East'),
+(6, 'Frank', '2023-01-03', 'West');
+
+-- Delete with dt = '2023-01-03' or region = 'West' - should trigger metadata delete optimization
+-- because all data is in dt='2023-01-03' partition, which matches the first part of the OR condition
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-03' or region = 'West'", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-03' or region = 'West';
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 3.3: Delete with BETWEEN on partition column - should trigger optimization
+-- Re-insert test data for this test
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(1, 'Alice', '2023-01-01', 'North'),
+(2, 'Bob', '2023-01-01', 'North'),
+(3, 'Charlie', '2023-01-02', 'South'),
+(4, 'David', '2023-01-02', 'South');
+
+-- Delete with dt between '2023-01-01' and '2023-01-02' - should trigger metadata delete optimization
+-- because all data is in dt='2023-01-01' and dt='2023-01-02' partitions, which match the BETWEEN condition
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt between '2023-01-01' and '2023-01-02'", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt between '2023-01-01' and '2023-01-02';
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 3.4: Delete with mixed partition and non-partition conditions - should trigger optimization
+-- Re-insert test data for this test
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(5, 'Eve', '2023-01-03', 'East'),
+(6, 'Frank', '2023-01-03', 'West');
+
+-- Delete with dt = '2023-01-03' and id = 5 - should trigger metadata delete optimization
+-- because the table scan will filter out files that don't match the predicate
+-- The file with id=6 will be excluded from scan, and the file with id=5 will match
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-03' and id = 5", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-03' and id = 5;
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 3.5: Delete with LIKE pattern on partition column - should trigger optimization
+-- Re-insert test data for this test
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(7, 'Grace', '2023-01-01', 'North'),
+(8, 'Henry', '2023-01-02', 'South');
+
+-- Delete with dt like '2023-01-%' - should trigger metadata delete optimization
+-- because all data is in dt='2023-01-01' and dt='2023-01-02' partitions, which match the LIKE pattern
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt like '2023-01-%'", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt like '2023-01-%';
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 3.6: Delete with IS NULL on partition column
+-- Re-insert test data for this test
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(9, 'Ivy', null, 'North'),
+(10, 'Jack', null, 'South');
+
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt is null", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt is null;
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 3.7: Delete with compound AND conditions matching single partition
+-- Re-insert test data for this test
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(11, 'Kate', '2023-01-03', 'East'),
+(12, 'Leo', '2023-01-03', 'East');
+
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-03' and region = 'East' and 1 = 1", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-03' and region = 'East' and 1 = 1;
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+
+-- ====================================================
+-- SECTION 4: Non-Partition Column Delete Tests
+-- ====================================================
+
+-- Test 4.1: Delete with only non-partition column conditions - should use position delete
+-- Re-insert test data for this test
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(13, 'Mike', '2023-01-01', 'North'),
+(14, 'Nancy', '2023-01-02', 'South'),
+(15, 'Oscar', '2023-01-03', 'East'),
+(16, 'Patty', '2023-01-03', 'West');
+
+-- Delete with id > 3 - should trigger metadata delete optimization
+-- because file statistics will show that all rows in files have id > 3
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id > 3", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id > 3;
+
+-- Verify remaining data
+select * from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned order by id;
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 4.2: Delete with name condition - should trigger optimization
+-- Re-insert test data for this test
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(17, 'Quincy', '2023-01-01', 'North'),
+(18, 'Rachel', '2023-01-02', 'South'),
+(19, 'Charlie', '2023-01-03', 'East');
+
+-- Delete with name = 'Charlie' - should trigger metadata delete optimization
+-- because table scan will filter out files that don't match the predicate
+-- Only the file with name='Charlie' will be included in scan
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where name = 'Charlie'", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where name = 'Charlie';
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 4.3: Delete with non-partition column condition using file-level statistics
+-- This test verifies that metadata delete can be used when file statistics indicate all rows match
+-- even though the predicate is on a non-partition column
+-- Re-insert test data with high id values to ensure file-level statistics match
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(100, 'Alice', '2023-01-01', 'North'),
+(101, 'Bob', '2023-01-01', 'North'),
+(102, 'Charlie', '2023-01-02', 'South'),
+(103, 'David', '2023-01-02', 'South');
+
+-- Delete with id > 50 - should trigger metadata delete optimization
+-- because file statistics will show that all rows in the files have id > 50
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id > 50", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id > 50;
+
+-- Verify remaining data
+select * from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned order by id;
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 4.4: Delete with non-partition column condition - partial match in same partition
+-- This test verifies that position delete is used when only some rows in a file match
+-- Re-insert test data with mixed id values in same partition
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(1, 'Alice', '2023-01-01', 'North'),
+(2, 'Bob', '2023-01-01', 'North'),
+(3, 'Charlie', '2023-01-01', 'North'),
+(4, 'David', '2023-01-01', 'North');
+
+-- Delete with id = 2 - should use position delete
+-- because the file contains id=1,2,3,4, and only id=2 matches
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id = 2", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id = 2;
+
+-- Verify remaining data
+select * from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned order by id;
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 4.5: Delete with non-partition column condition - partial match across partitions
+-- This test verifies that position delete is used when some rows in each partition don't match
+-- Re-insert test data with mixed id values across partitions
+-- Each partition file contains ids that partially match the condition
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(10, 'Eve', '2023-01-01', 'North'),
+(20, 'Frank', '2023-01-01', 'North'),
+(15, 'Grace', '2023-01-02', 'South'),
+(25, 'Henry', '2023-01-02', 'South');
+
+-- Delete with id < 25 - should use position delete
+-- because each partition file contains ids that both match and don't match the condition
+-- Partition 1: id range [10,20], both 10 and 20 < 25, so metricsMatch=true
+-- Partition 2: id range [15,25], 15 < 25 but 25 not < 25, so metricsMatch=false
+-- Since partition 2 doesn't satisfy metricsMatch, position delete is required
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id < 25", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where id < 25;
+
+-- Verify remaining data
+select * from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned order by id;
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 4.6: Delete with OR condition that cannot be optimized
+-- This test verifies that position delete is used when OR condition causes partial match in scanned files
+-- Re-insert test data
+insert into iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned values
+(100, 'Test1', '2023-01-01', 'North'),
+(101, 'Test2', '2023-01-01', 'North'),
+(102, 'Test3', '2023-01-02', 'South'),
+(103, 'Test4', '2023-01-02', 'South');
+
+-- Delete with dt = '2023-01-01' or id = 103 - should use position delete
+-- Partition 1: dt='2023-01-01' matches, partitionMatches=true, id range [100,101]
+-- Partition 2: dt='2023-01-02' doesn't match, id=103 is in [102,103], so included in scan
+-- Partition 1 file doesn't match id=103, so metricsMatch=false
+-- Since partition 1 doesn't satisfy metricsMatch, position delete is required
+function: assert_explain_contains("delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-01' or id = 103", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned where dt = '2023-01-01' or id = 103;
+
+-- Verify remaining data
+select * from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned order by id;
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned$snapshots order by committed_at desc limit 1;
+
+-- Cleanup
+drop table iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0}.test_partitioned force;
+drop database iceberg_meta_del_${uuid0}.iceberg_meta_db_${uuid0};
+set catalog default_catalog;
+drop catalog iceberg_meta_del_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_metadata_delete/${uuid0} >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_iceberg/T/test_iceberg_metadata_delete_transform
+++ b/test/sql/test_iceberg/T/test_iceberg_metadata_delete_transform
@@ -1,0 +1,331 @@
+-- name: test_iceberg_metadata_delete_transform
+
+-- ====================================================
+-- SECTION 1: Setup
+-- ====================================================
+
+-- Create external catalog for Iceberg
+create external catalog iceberg_transform_${uuid0}
+PROPERTIES (
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "iceberg.catalog.hive.metastore.uris" = "${hive_metastore_uris}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "enable_iceberg_metadata_cache"="false"
+);
+
+-- Create database
+create database iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}
+properties ("location" = "oss://${oss_bucket}/test_transform_delete/${uuid0}/db");
+
+-- ====================================================
+-- SECTION 2: Year Transform Partition Tests
+-- ====================================================
+
+-- Create table with year transform partition
+create table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform (
+    id INT,
+    name STRING,
+    event_time DATETIME
+)
+PARTITION BY year(event_time);
+
+-- Insert test data spanning multiple years
+insert into iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform values
+(1, 'Alice', '2022-06-15 10:00:00'),
+(2, 'Bob', '2022-08-20 14:30:00'),
+(3, 'Charlie', '2023-01-10 09:00:00'),
+(4, 'David', '2023-12-25 16:00:00'),
+(5, 'Eve', '2024-03-05 11:00:00');
+
+-- Test 2.1: Delete with year transform partition - exact year match
+-- Can not trigger metadata delete, because year function can not transform to iceberg expression
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform where year(event_time) = 2022", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform where year(event_time) = 2022;
+
+-- Verify data
+select * from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform order by id;
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform$snapshots order by committed_at desc limit 1;
+
+-- Test 2.2: Delete with date range on year-transformed column
+-- Should use position delete as exact partition match is not simple
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform where event_time >= '2023-06-01'", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform where event_time >= '2023-06-01';
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform$snapshots order by committed_at desc limit 1;
+
+-- Cleanup year transform table
+drop table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_year_transform force;
+
+-- ====================================================
+-- SECTION 3: Month Transform Partition Tests
+-- ====================================================
+
+-- Create table with month transform partition
+create table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform (
+    id INT,
+    name STRING,
+    event_date DATE
+)
+PARTITION BY month(event_date);
+
+-- Insert test data
+insert into iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform values
+(1, 'Jan2023', '2023-01-15'),
+(2, 'Jan2023b', '2023-01-25'),
+(3, 'Feb2023', '2023-02-10'),
+(4, 'Feb2023b', '2023-02-20'),
+(5, 'Mar2023', '2023-03-05');
+
+-- Test 3.1: Delete with month function, should use position delete
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform where month(event_date) = 1", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform where month(event_date) = 1
+
+-- Verify data
+select * from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform order by id;
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform$snapshots order by committed_at desc limit 1;
+
+-- Test 3.2: Delete with date condition on month-transformed column
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform where event_date = '2023-02-10'", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform where event_date = '2023-02-10';
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform$snapshots order by committed_at desc limit 1;
+
+-- Cleanup month transform table
+drop table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_month_transform force;
+
+-- ====================================================
+-- SECTION 4: Day Transform Partition Tests
+-- ====================================================
+
+-- Create table with day transform partition
+create table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform (
+    id INT,
+    name STRING,
+    event_date DATE
+)
+PARTITION BY day(event_date);
+
+-- Insert test data
+insert into iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform values
+(1, 'Day1', '2023-01-01'),
+(2, 'Day1b', '2023-01-01'),
+(3, 'Day2', '2023-01-02'),
+(4, 'Day3', '2023-01-03'),
+(5, 'Day3b', '2023-01-03');
+
+-- Test 4.1: Delete with day function, should use position delete
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform where day(event_date) = 1", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform where day(event_date) = 1;
+
+-- Verify data
+select * from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform order by id;
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform$snapshots order by committed_at desc limit 1;
+
+-- Test 4.2: Delete with date condition on day-transformed column
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform where event_date = '2023-01-02'", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform where event_date = '2023-01-02';
+
+-- Verify data
+select * from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform order by id;
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform$snapshots order by committed_at desc limit 1;
+
+-- Cleanup day transform table
+drop table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_day_transform force;
+
+-- ====================================================
+-- SECTION 5: Bucket Transform Partition Tests
+-- ====================================================
+
+-- Create table with bucket transform partition
+create table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform (
+    id INT,
+    name STRING,
+    category STRING
+)
+PARTITION BY bucket(category, 4);
+
+-- Insert test data
+insert into iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform values
+(1, 'A', 'Electronics'),
+(2, 'B', 'Electronics'),
+(3, 'C', 'Clothing'),
+(4, 'D', 'Clothing'),
+(5, 'E', 'Food');
+
+-- Test 5.1: Delete with bucket transform - exact category value
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform where category = 'Electronics'", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform where category = 'Electronics';
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform$snapshots order by committed_at desc limit 1;
+
+-- Test 5.2: Delete with IN clause on bucket-transformed column
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform where category in ('Clothing', 'Food')", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform where category in ('Clothing', 'Food');
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform$snapshots order by committed_at desc limit 1;
+
+-- Cleanup bucket transform table
+drop table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_bucket_transform force;
+
+-- ====================================================
+-- SECTION 6: Truncate Transform Partition Tests
+-- ====================================================
+
+-- Create table with truncate transform partition
+create table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform (
+    id INT,
+    name STRING,
+    code STRING
+)
+PARTITION BY truncate(code, 3);
+
+-- Insert test data
+insert into iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform values
+(1, 'A', 'ABC123'),
+(2, 'B', 'ABC456'),
+(3, 'C', 'DEF789'),
+(4, 'D', 'DEF012'),
+(5, 'E', 'XYZ345');
+
+-- Test 6.1: Delete with truncate transform
+-- Should use position delete as truncate transform requires prefix matching
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform where code = 'ABC123'", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform where code = 'ABC123';
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform$snapshots order by committed_at desc limit 1;
+
+-- Test 6.2: Delete with LIKE prefix match on truncate-transformed column
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform where code like 'ABC%'", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform where code like 'ABC%';
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform$snapshots order by committed_at desc limit 1;
+
+-- Cleanup truncate transform table
+drop table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_truncate_transform force;
+
+-- ====================================================
+-- SECTION 7: Hour Transform Partition Tests
+-- ====================================================
+
+-- Create table with hour transform partition
+create table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_hour_transform (
+    id INT,
+    name STRING,
+    event_time DATETIME
+)
+PARTITION BY hour(event_time);
+
+-- Insert test data
+insert into iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_hour_transform values
+(1, 'Hour10', '2023-01-01 10:30:00'),
+(2, 'Hour10b', '2023-01-01 10:45:00'),
+(3, 'Hour14', '2023-01-01 14:00:00'),
+(4, 'Hour14b', '2023-01-01 14:30:00'),
+(5, 'Hour18', '2023-01-01 18:00:00');
+
+-- Test 7.1: Delete with hour transform - exact hour match
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_hour_transform where hour(event_time) = 10", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_hour_transform where hour(event_time) = 10;
+
+-- Verify data
+select * from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_hour_transform order by id;
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_hour_transform$snapshots order by committed_at desc limit 1;
+
+-- Cleanup hour transform table
+drop table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_hour_transform force;
+
+-- ====================================================
+-- SECTION 8: Mixed Transform and Identity Partition Tests
+-- ====================================================
+
+-- Create table with mixed partition transforms
+create table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform (
+    id INT,
+    name STRING,
+    event_date DATE,
+    region STRING
+)
+PARTITION BY year(event_date), region;
+
+-- Insert test data
+insert into iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform values
+(1, 'A', '2023-06-15', 'North'),
+(2, 'B', '2023-07-20', 'North'),
+(3, 'C', '2023-08-10', 'South'),
+(4, 'D', '2024-01-05', 'East'),
+(5, 'E', '2024-02-15', 'West');
+
+-- Test 8.1: Delete matching both transform and identity partition columns
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform where year(event_date) = 2023 and region = 'North'", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform where year(event_date) = 2023 and region = 'North';
+
+-- Verify data
+select * from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform order by id;
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform$snapshots order by committed_at desc limit 1;
+
+-- Test 8.2: Delete with partial partition key (only year, not region) - should trigger optimization
+function: assert_explain_contains("delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform where event_date = '2024-01-05'", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform where event_date = '2024-01-05';
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform$snapshots order by committed_at desc limit 1;
+
+-- Cleanup mixed transform table
+drop table iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0}.test_mixed_transform force;
+
+-- ====================================================
+-- SECTION 9: Cleanup
+-- ====================================================
+
+drop database iceberg_transform_${uuid0}.iceberg_transform_db_${uuid0};
+set catalog default_catalog;
+drop catalog iceberg_transform_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_transform_delete/${uuid0} >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_iceberg/T/test_iceberg_metadata_delete_unpartitioned
+++ b/test/sql/test_iceberg/T/test_iceberg_metadata_delete_unpartitioned
@@ -1,0 +1,217 @@
+-- name: test_iceberg_metadata_delete_unpartitioned
+
+-- ====================================================
+-- SECTION 1: Setup
+-- ====================================================
+
+-- Create external catalog for Iceberg
+create external catalog iceberg_unpart_${uuid0}
+PROPERTIES (
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "iceberg.catalog.hive.metastore.uris" = "${hive_metastore_uris}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "enable_iceberg_metadata_cache"="false"
+);
+
+-- Create database
+create database iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}
+properties ("location" = "oss://${oss_bucket}/test_unpart_delete/${uuid0}/db");
+
+-- Create unpartitioned table
+create table iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned (
+    id INT,
+    name STRING,
+    category STRING,
+    amount DECIMAL(10,2)
+);
+
+-- Insert test data
+insert into iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned values
+(1, 'Alice', 'Electronics', 100.00),
+(2, 'Bob', 'Electronics', 200.00),
+(3, 'Charlie', 'Clothing', 150.00),
+(4, 'David', 'Clothing', 300.00),
+(5, 'Eve', 'Food', 50.00),
+(6, 'Frank', 'Food', 75.00);
+
+-- ====================================================
+-- SECTION 2: Unpartitioned Table Delete Tests
+-- ====================================================
+
+-- Test 2.1: Delete with single column condition - should use position delete
+-- For unpartitioned tables, any row-level delete uses position delete
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id = 1", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id = 1;
+
+-- Verify data
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 2.2: Delete with IN clause - should use position delete
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id in (2, 3)", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id in (2, 3);
+
+-- Verify data
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 2.3: Delete with range condition - should use position delete
+-- This test verifies that position delete is used when file statistics don't guarantee all rows match
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id > 4", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id > 4;
+
+-- Verify data
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 2.4: Delete with string column condition
+-- Re-insert data first
+insert into iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned values
+(7, 'Grace', 'Electronics', 120.00),
+(8, 'Henry', 'Clothing', 180.00);
+
+-- Delete by string column
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where category = 'Electronics'", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where category = 'Electronics';
+
+-- Verify data
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 2.5: Delete with LIKE pattern
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where name like 'H%'", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where name like 'H%';
+
+-- Verify data
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 2.6: Delete with BETWEEN condition
+-- Re-insert data
+insert into iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned values
+(10, 'Ivy', 'Food', 60.00),
+(11, 'Jack', 'Food', 90.00),
+(12, 'Kate', 'Food', 110.00);
+
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id between 10 and 11", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id between 10 and 11;
+
+-- Verify data
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 2.7: Delete with compound AND condition
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where category = 'Food' and amount < 100", "ICEBERG DELETE SINK")
+
+-- Execute delete
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where category = 'Food' and amount < 100;
+
+-- Verify data
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+
+-- Query snapshots table to verify operation type and added-position-deletes for POSITION DELETE
+select operation, element_at(summary,'added-position-deletes') as added_position_deletes from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 2.8: Delete with OR condition - should trigger optimization
+-- Re-insert data
+insert into iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned values
+(20, 'Test1', 'Books', 50.00),
+(21, 'Test2', 'Books', 60.00);
+
+-- Delete with id = 20 or category = 'Books' - should trigger metadata delete optimization
+-- because table scan will filter out files that don't match the predicate
+-- Old file (id=10,11,12, category='Food') will be filtered out
+-- New file (id=20,21, category='Books') will be included in scan and fully matches
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id = 20 or category = 'Books'", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id = 20 or category = 'Books';
+
+-- Verify data
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 2.9: Delete with IS NULL condition using file-level statistics
+-- Re-insert data with NULL
+insert into iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned values
+(30, 'NullTest', null, 100.00),
+(31, 'NullTest2', null, 200.00);
+
+-- Delete with category is null - should trigger metadata delete optimization
+-- because file statistics will show that all rows in files have null category
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where category is null", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where category is null;
+
+-- Verify data
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+
+-- Test 2.10: Delete with non-partition column condition using file-level statistics
+-- This test verifies that metadata delete can be used for unpartitioned tables
+-- when file statistics indicate all rows match, even though the table is not partitioned
+-- Re-insert test data with high id values to ensure file-level statistics match
+insert into iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned values
+(100, 'Alice', 'Electronics', 100.00),
+(101, 'Bob', 'Electronics', 200.00),
+(102, 'Charlie', 'Clothing', 150.00),
+(103, 'David', 'Clothing', 300.00);
+
+-- Delete with id > 50 - should trigger metadata delete optimization
+-- because file statistics will show that all rows in files have id > 50
+function: assert_explain_contains("delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id > 50", "ICEBERG METADATA DELETE")
+
+-- Execute delete
+delete from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned where id > 50;
+
+-- Verify data
+select * from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned order by id;
+
+-- Query snapshots table to verify operation type and deleted-data-files for METADATA DELETE
+select operation, element_at(summary,'deleted-data-files') as deleted_data_files from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 1;
+
+-- Query snapshots to verify operation history
+select operation from iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned$snapshots order by committed_at desc limit 5;
+
+-- ====================================================
+-- SECTION 3: Cleanup
+-- ====================================================
+
+drop table iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0}.test_unpartitioned force;
+drop database iceberg_unpart_${uuid0}.iceberg_unpart_db_${uuid0};
+set catalog default_catalog;
+drop catalog iceberg_unpart_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_unpart_delete/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:
#66944
For scenarios involving **Iceberg partition deletion** or cases where **entire files can be removed**, can directly manipulate the Iceberg metadata to avoid writing position delete files.
## What I'm doing:
This pull request introduces a metadata-level delete optimization for Iceberg tables, allowing certain DELETE operations to be performed efficiently by dropping entire files or partitions directly via metadata, without generating position delete files. The changes span the planner, connector interface, and execution logic to support this optimization end-to-end.

Key changes:

**Iceberg metadata delete optimization:**

* Added `canDeleteUsingMetadata` and `executeMetadataDelete` methods to the `ConnectorMetadata` interface, enabling connectors to declare and implement metadata-level delete operations. Default implementations are provided for connectors that do not support this optimization.
* Implemented these methods in `IcebergMetadata`, using Iceberg's APIs to determine if a delete predicate matches entire partitions or all rows in candidate files, and to execute the metadata delete via Iceberg's `DeleteFiles` API.
* Introduced a new `IcebergMetadataDeleteNode` plan node to represent metadata-level delete operations in the planner and explain output.

**Planner and execution integration:**

* Updated the `DeletePlanner` to detect when a metadata-level delete is possible for Iceberg tables, extract the delete predicate from the logical plan, and generate an `IcebergMetadataDeleteNode` plan when applicable. 
* Modified `StmtExecutor` to recognize and execute plans containing `IcebergMetadataDeleteNode`, invoking the connector's `executeMetadataDelete` method directly and marking the statement as successful.

**Supporting utility and refactoring:**

* Enhanced the `ScalarOperatorToIcebergExpr` utility to support strict conversion mode, which is used to ensure that only fully convertible predicates are eligible for metadata-level deletes.
* Added necessary imports and logging for new functionality and error handling. 

These changes collectively enable StarRocks to perform efficient, metadata-only deletes on Iceberg tables when possible, improving performance for qualifying DELETE statements.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
