### PR TITLE
[Enhancement] add arguments for expire_snapshots and remove_orphan_files

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.starrocks.connector.iceberg.IcebergUtil.fileName;
@@ -102,6 +103,9 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
         if (table.currentSnapshot() == null) {
             return;
         }
+        if (table.location() == null || table.location().isEmpty()) {
+            throw new StarRocksConnectorException("table location is empty");
+        }
 
         String location;
         ConstantOperator locationArg = args.get(LOCATION);
@@ -150,7 +154,6 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
 
     /**
      * Validates that the given location is non-empty and is the table root or a subdirectory of it
-     * (path boundary check to avoid accepting sibling paths like table2 when table root is table).
      * Returns the normalized path (no trailing slash) for use in scanning.
      */
     private static String validateAndResolveScanLocation(String location, String tableLocation) {
@@ -158,16 +161,28 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
             throw new StarRocksConnectorException("invalid argument value for %s, expected non-empty string",
                     LOCATION);
         }
-        String tableRoot = normalizePath(tableLocation);
-        String locationNorm = normalizePath(location);
-        if (!locationNorm.equals(tableRoot) && !locationNorm.startsWith(tableRoot + "/")) {
-            throw new StarRocksConnectorException("invalid argument value for %s, location must be a subdirectory of " +
-                    "table location %s, got %s", LOCATION, tableLocation, location);
+
+        if (tableLocation.equals(location)) {
+            return location;
         }
-        return locationNorm;
+
+        URI tableUri = new Path(tableLocation).toUri().normalize();
+        URI locationUri = new Path(location).toUri().normalize();
+        String tablePath = stripTrailingSlash(tableUri.getPath());
+        String locationPath = stripTrailingSlash(locationUri.getPath());
+
+        if (!Objects.equals(tableUri.getScheme(), locationUri.getScheme()) ||
+            !Objects.equals(tableUri.getAuthority(), locationUri.getAuthority()) ||
+            !locationPath.startsWith(tablePath + Path.SEPARATOR)) {
+            throw new StarRocksConnectorException(
+                    "invalid argument value for %s, location must be under table location %s, got %s",
+                    LOCATION, tableLocation, location);
+        }
+
+        return locationPath;
     }
 
-    private static String normalizePath(String path) {
+    private static String stripTrailingSlash(String path) {
         if (path == null || path.isEmpty()) {
             return path;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
@@ -172,11 +172,10 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
         String locationPath = stripTrailingSlash(locationUri.getPath());
 
         if (!Objects.equals(tableUri.getScheme(), locationUri.getScheme()) ||
-            !Objects.equals(tableUri.getAuthority(), locationUri.getAuthority()) ||
-            !locationPath.startsWith(tablePath + Path.SEPARATOR)) {
-            throw new StarRocksConnectorException(
-                    "invalid argument value for %s, location must be under table location %s, got %s",
-                    LOCATION, tableLocation, location);
+                !Objects.equals(tableUri.getAuthority(), locationUri.getAuthority()) ||
+                !locationPath.startsWith(tablePath + Path.SEPARATOR)) {
+            throw new StarRocksConnectorException("invalid argument value for %s, location must be a subdirectory of " +
+                    "table location %s, got %s", LOCATION, tableLocation, location);
         }
 
         return locationPath;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
@@ -21,6 +21,7 @@ import com.starrocks.connector.iceberg.IcebergTableOperation;
 import com.starrocks.connector.iceberg.IcebergUtil;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.type.DateType;
+import com.starrocks.type.VarcharType;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -59,6 +60,7 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
     private static final String PROCEDURE_NAME = "remove_orphan_files";
 
     public static final String OLDER_THAN = "older_than";
+    public static final String LOCATION = "location";
 
     private static final RemoveOrphanFilesProcedure INSTANCE = new RemoveOrphanFilesProcedure();
 
@@ -70,7 +72,8 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
         super(
                 PROCEDURE_NAME,
                 List.of(
-                        new NamedArgument(OLDER_THAN, DateType.DATETIME, false)
+                        new NamedArgument(OLDER_THAN, DateType.DATETIME, false),
+                        new NamedArgument(LOCATION, VarcharType.VARCHAR, false)
                 ),
                 IcebergTableOperation.REMOVE_ORPHAN_FILES
         );
@@ -78,9 +81,9 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
 
     @Override
     public void execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args) {
-        if (args.size() > 1) {
+        if (args.size() > 2) {
             throw new StarRocksConnectorException("invalid args. only support " +
-                    "`older_than` in the remove orphan files operation");
+                    "`older_than` and `location` in the remove orphan files operation");
         }
 
         long olderThanMillis;
@@ -98,6 +101,14 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
         Table table = context.table();
         if (table.currentSnapshot() == null) {
             return;
+        }
+
+        String location;
+        ConstantOperator locationArg = args.get(LOCATION);
+        if (locationArg != null) {
+            location = validateAndResolveScanLocation(locationArg.getVarchar(), table.location());
+        } else {
+            location = table.location();
         }
 
         Set<String> processedManifestFilePaths = new HashSet<>();
@@ -134,7 +145,33 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
 
         validFileNames.add("version-hint.text");
 
-        scanAndDeleteInvalidFiles(table.location(), olderThanMillis, validFileNames, context.hdfsEnvironment());
+        scanAndDeleteInvalidFiles(location, olderThanMillis, validFileNames, context.hdfsEnvironment());
+    }
+
+    /**
+     * Validates that the given location is non-empty and is the table root or a subdirectory of it
+     * (path boundary check to avoid accepting sibling paths like table2 when table root is table).
+     * Returns the normalized path (no trailing slash) for use in scanning.
+     */
+    private static String validateAndResolveScanLocation(String location, String tableLocation) {
+        if (location == null || location.isEmpty()) {
+            throw new StarRocksConnectorException("invalid argument value for %s, expected non-empty string",
+                    LOCATION);
+        }
+        String tableRoot = normalizePath(tableLocation);
+        String locationNorm = normalizePath(location);
+        if (!locationNorm.equals(tableRoot) && !locationNorm.startsWith(tableRoot + "/")) {
+            throw new StarRocksConnectorException("invalid argument value for %s, location must be a subdirectory of " +
+                    "table location %s, got %s", LOCATION, tableLocation, location);
+        }
+        return locationNorm;
+    }
+
+    private static String normalizePath(String path) {
+        if (path == null || path.isEmpty()) {
+            return path;
+        }
+        return path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
     }
 
     private ManifestReader<? extends ContentFile<?>> readerForManifest(Table table, ManifestFile manifest) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
@@ -154,7 +154,7 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
 
     /**
      * Validates that the given location is non-empty and is the table root or a subdirectory of it
-     * Returns the normalized path (no trailing slash) for use in scanning.
+     * Returns the normalized path for use in scanning.
      */
     private static String validateAndResolveScanLocation(String location, String tableLocation) {
         if (location == null || location.isEmpty()) {
@@ -166,8 +166,8 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
             return location;
         }
 
-        URI tableUri = new Path(tableLocation).toUri().normalize();
-        URI locationUri = new Path(location).toUri().normalize();
+        URI tableUri = new Path(tableLocation).toUri();
+        URI locationUri = new Path(location).toUri();
         String tablePath = stripTrailingSlash(tableUri.getPath());
         String locationPath = stripTrailingSlash(locationUri.getPath());
 
@@ -178,7 +178,7 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
                     "table location %s, got %s", LOCATION, tableLocation, location);
         }
 
-        return locationPath;
+        return locationUri.toString();
     }
 
     private static String stripTrailingSlash(String path) {
@@ -218,7 +218,8 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
                 filesToDelete.clear();
             }
         } catch (IOException e) {
-            throw new StarRocksConnectorException("Failed accessing data: ", e);
+            String msg = e.getMessage() != null ? e.getMessage() : e.getClass().getName();
+            throw new StarRocksConnectorException("Failed accessing data: " + msg, e);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterTableOperationStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterTableOperationStmtTest.java
@@ -343,9 +343,11 @@ public class AlterTableOperationStmtTest {
 
         ExpireSnapshotsProcedure expireProc = ExpireSnapshotsProcedure.getInstance();
         Assertions.assertEquals("expire_snapshots", expireProc.getProcedureName());
-        Assertions.assertEquals(1, expireProc.getArguments().size());
+        Assertions.assertEquals(2, expireProc.getArguments().size());
         Assertions.assertEquals("older_than", expireProc.getArguments().get(0).getName());
         Assertions.assertFalse(expireProc.getArguments().get(0).isRequired());
+        Assertions.assertEquals("retain_last", expireProc.getArguments().get(1).getName());
+        Assertions.assertFalse(expireProc.getArguments().get(1).isRequired());
 
         FastForwardProcedure fastForwardProc = FastForwardProcedure.getInstance();
         Assertions.assertEquals("fast_forward", fastForwardProc.getProcedureName());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterTableOperationStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterTableOperationStmtTest.java
@@ -355,7 +355,11 @@ public class AlterTableOperationStmtTest {
 
         RemoveOrphanFilesProcedure removeOrphanProc = RemoveOrphanFilesProcedure.getInstance();
         Assertions.assertEquals("remove_orphan_files", removeOrphanProc.getProcedureName());
-        Assertions.assertEquals(1, removeOrphanProc.getArguments().size());
+        Assertions.assertEquals(2, removeOrphanProc.getArguments().size());
+        Assertions.assertEquals("older_than", removeOrphanProc.getArguments().get(0).getName());
+        Assertions.assertFalse(removeOrphanProc.getArguments().get(0).isRequired());
+        Assertions.assertEquals("location", removeOrphanProc.getArguments().get(1).getName());
+        Assertions.assertFalse(removeOrphanProc.getArguments().get(1).isRequired());
 
         RewriteDataFilesProcedure rewriteProc = RewriteDataFilesProcedure.getInstance();
         Assertions.assertEquals("rewrite_data_files", rewriteProc.getProcedureName());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/ExpireSnapshotsProcedureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/ExpireSnapshotsProcedureTest.java
@@ -1,0 +1,162 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.procedure;
+
+import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.AlterTableOperationClause;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.type.DateType;
+import org.apache.iceberg.ExpireSnapshots;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.Transaction;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ExpireSnapshotsProcedureTest {
+
+    public static final HdfsEnvironment HDFS_ENVIRONMENT = new HdfsEnvironment();
+
+    @Test
+    void testRetainLastInvalidTypeThrows() {
+        ExpireSnapshotsProcedure procedure = ExpireSnapshotsProcedure.getInstance();
+        IcebergTableProcedureContext context = createContextWithTransaction();
+
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put(ExpireSnapshotsProcedure.RETAIN_LAST, ConstantOperator.createVarchar("not_an_int"));
+
+        StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class,
+                () -> procedure.execute(context, args));
+
+        assertTrue(ex.getMessage().contains("invalid argument type"));
+        assertTrue(ex.getMessage().contains(ExpireSnapshotsProcedure.RETAIN_LAST));
+        assertTrue(ex.getMessage().contains("expected INT"));
+    }
+
+    @Test
+    void testRetainLastZeroThrows() {
+        ExpireSnapshotsProcedure procedure = ExpireSnapshotsProcedure.getInstance();
+        IcebergTableProcedureContext context = createContextWithTransaction();
+
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put(ExpireSnapshotsProcedure.RETAIN_LAST, ConstantOperator.createInt(0));
+
+        StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class,
+                () -> procedure.execute(context, args));
+
+        assertTrue(ex.getMessage().contains("invalid argument value"));
+        assertTrue(ex.getMessage().contains(ExpireSnapshotsProcedure.RETAIN_LAST));
+        assertTrue(ex.getMessage().contains("must be >= 1"));
+        assertTrue(ex.getMessage().contains("0"));
+    }
+
+    @Test
+    void testRetainLastValidCallsRetainLastAndCommit() {
+        ExpireSnapshotsProcedure procedure = ExpireSnapshotsProcedure.getInstance();
+        ExpireSnapshots expireSnapshots = Mockito.mock(ExpireSnapshots.class);
+        when(expireSnapshots.retainLast(anyInt())).thenReturn(expireSnapshots);
+        doNothing().when(expireSnapshots).commit();
+
+        Transaction txn = Mockito.mock(Transaction.class);
+        when(txn.expireSnapshots()).thenReturn(expireSnapshots);
+
+        IcebergTableProcedureContext context = createContextWithTransaction(txn);
+
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put(ExpireSnapshotsProcedure.RETAIN_LAST, ConstantOperator.createInt(5));
+
+        assertDoesNotThrow(() -> procedure.execute(context, args));
+
+        verify(txn).expireSnapshots();
+        verify(expireSnapshots).retainLast(5);
+        verify(expireSnapshots, never()).expireOlderThan(anyLong());
+        verify(expireSnapshots).commit();
+    }
+
+    @Test
+    void testRetainLastAbsentNoRetainLastCall() {
+        ExpireSnapshotsProcedure procedure = ExpireSnapshotsProcedure.getInstance();
+        ExpireSnapshots expireSnapshots = Mockito.mock(ExpireSnapshots.class);
+        doNothing().when(expireSnapshots).commit();
+
+        Transaction txn = Mockito.mock(Transaction.class);
+        when(txn.expireSnapshots()).thenReturn(expireSnapshots);
+
+        IcebergTableProcedureContext context = createContextWithTransaction(txn);
+
+        assertDoesNotThrow(() -> procedure.execute(context, Collections.emptyMap()));
+
+        verify(txn).expireSnapshots();
+        verify(expireSnapshots, never()).retainLast(anyInt());
+        verify(expireSnapshots, never()).expireOlderThan(anyLong());
+        verify(expireSnapshots).commit();
+    }
+
+    @Test
+    void testRetainLastWithOlderThanBothApplied() {
+        ExpireSnapshotsProcedure procedure = ExpireSnapshotsProcedure.getInstance();
+        ExpireSnapshots expireSnapshots = Mockito.mock(ExpireSnapshots.class);
+        when(expireSnapshots.expireOlderThan(anyLong())).thenReturn(expireSnapshots);
+        when(expireSnapshots.retainLast(anyInt())).thenReturn(expireSnapshots);
+        doNothing().when(expireSnapshots).commit();
+
+        Transaction txn = Mockito.mock(Transaction.class);
+        when(txn.expireSnapshots()).thenReturn(expireSnapshots);
+
+        IcebergTableProcedureContext context = createContextWithTransaction(txn);
+
+        LocalDateTime olderThan = LocalDateTime.of(2024, 1, 1, 0, 0, 0);
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put(ExpireSnapshotsProcedure.OLDER_THAN, ConstantOperator.createDatetime(olderThan, DateType.DATETIME));
+        args.put(ExpireSnapshotsProcedure.RETAIN_LAST, ConstantOperator.createInt(3));
+
+        assertDoesNotThrow(() -> procedure.execute(context, args));
+
+        verify(expireSnapshots).expireOlderThan(Mockito.anyLong());
+        verify(expireSnapshots).retainLast(3);
+        verify(expireSnapshots).commit();
+    }
+
+    private IcebergTableProcedureContext createContextWithTransaction() {
+        return createContextWithTransaction(Mockito.mock(Transaction.class));
+    }
+
+    private IcebergTableProcedureContext createContextWithTransaction(Transaction transaction) {
+        IcebergHiveCatalog catalog = Mockito.mock(IcebergHiveCatalog.class);
+        Table table = Mockito.mock(Table.class);
+        ConnectContext ctx = Mockito.mock(ConnectContext.class);
+        AlterTableStmt stmt = Mockito.mock(AlterTableStmt.class);
+        AlterTableOperationClause clause = Mockito.mock(AlterTableOperationClause.class);
+        return new IcebergTableProcedureContext(catalog, table, ctx, transaction, HDFS_ENVIRONMENT, stmt, clause);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedureTest.java
@@ -1,0 +1,144 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.procedure;
+
+import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.AlterTableOperationClause;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+public class RemoveOrphanFilesProcedureTest {
+
+    public static final HdfsEnvironment HDFS_ENVIRONMENT = new HdfsEnvironment();
+
+    @Test
+    void testLocationEmptyThrows() {
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+        Table table = Mockito.mock(Table.class);
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+
+        when(table.location()).thenReturn("s3://bucket/table");
+        when(table.currentSnapshot()).thenReturn(snapshot);
+
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put(RemoveOrphanFilesProcedure.LOCATION, ConstantOperator.createVarchar(""));
+
+        IcebergTableProcedureContext context = createContext(table);
+
+        StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class,
+                () -> procedure.execute(context, args));
+
+        assertTrue(ex.getMessage().contains("invalid argument value"));
+        assertTrue(ex.getMessage().contains(RemoveOrphanFilesProcedure.LOCATION));
+        assertTrue(ex.getMessage().contains("expected non-empty string"));
+    }
+
+    @Test
+    void testLocationNotSubdirOfTableThrows() {
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+        Table table = Mockito.mock(Table.class);
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+
+        when(table.location()).thenReturn("s3://bucket/table");
+        when(table.currentSnapshot()).thenReturn(snapshot);
+
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put(RemoveOrphanFilesProcedure.LOCATION, ConstantOperator.createVarchar("s3://other/path"));
+
+        IcebergTableProcedureContext context = createContext(table);
+
+        StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class,
+                () -> procedure.execute(context, args));
+
+        assertTrue(ex.getMessage().contains("invalid argument value"));
+        assertTrue(ex.getMessage().contains(RemoveOrphanFilesProcedure.LOCATION));
+        assertTrue(ex.getMessage().contains("must be a subdirectory of"));
+        assertTrue(ex.getMessage().contains("table location"));
+        assertTrue(ex.getMessage().contains("s3://bucket/table"));
+        assertTrue(ex.getMessage().contains("s3://other/path"));
+    }
+
+    @Test
+    void testLocationSiblingPathRejected() {
+        // location that shares prefix but is not a subdirectory (e.g. table2 vs table) must be rejected
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+        Table table = Mockito.mock(Table.class);
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+
+        when(table.location()).thenReturn("s3://bucket/table");
+        when(table.currentSnapshot()).thenReturn(snapshot);
+
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put(RemoveOrphanFilesProcedure.LOCATION, ConstantOperator.createVarchar("s3://bucket/table2"));
+
+        IcebergTableProcedureContext context = createContext(table);
+
+        StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class,
+                () -> procedure.execute(context, args));
+
+        assertTrue(ex.getMessage().contains("invalid argument value"));
+        assertTrue(ex.getMessage().contains(RemoveOrphanFilesProcedure.LOCATION));
+        assertTrue(ex.getMessage().contains("must be a subdirectory of"));
+        assertTrue(ex.getMessage().contains("s3://bucket/table"));
+        assertTrue(ex.getMessage().contains("s3://bucket/table2"));
+    }
+
+    @Test
+    void testLocationValidSubdirPassesValidation() {
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+        Table table = Mockito.mock(Table.class);
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+
+        when(table.location()).thenReturn("s3://bucket/table");
+        when(table.currentSnapshot()).thenReturn(snapshot);
+        when(table.snapshots()).thenReturn(Collections.emptyList());
+
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put(RemoveOrphanFilesProcedure.LOCATION, ConstantOperator.createVarchar("s3://bucket/table/data"));
+
+        IcebergTableProcedureContext context = createContext(table);
+
+        // Location validation passes; any exception comes from later logic (metadata/filesystem),
+        // not from "expected non-empty string" or "must be a subdirectory".
+        Throwable t = assertThrows(Throwable.class, () -> procedure.execute(context, args));
+        String msg = t.getMessage();
+        assertFalse(msg != null && (msg.contains("expected non-empty string") || msg.contains("must be a subdirectory")),
+                "location validation should pass; got: " + msg);
+    }
+
+    private IcebergTableProcedureContext createContext(Table table) {
+        IcebergHiveCatalog catalog = Mockito.mock(IcebergHiveCatalog.class);
+        ConnectContext ctx = Mockito.mock(ConnectContext.class);
+        AlterTableStmt stmt = Mockito.mock(AlterTableStmt.class);
+        AlterTableOperationClause clause = Mockito.mock(AlterTableOperationClause.class);
+        return new IcebergTableProcedureContext(catalog, table, ctx, null, HDFS_ENVIRONMENT, stmt, clause);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedureTest.java
@@ -40,6 +40,23 @@ public class RemoveOrphanFilesProcedureTest {
     public static final HdfsEnvironment HDFS_ENVIRONMENT = new HdfsEnvironment();
 
     @Test
+    void testTableLocationEmptyThrows() {
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+        Table table = Mockito.mock(Table.class);
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+
+        when(table.location()).thenReturn("");
+        when(table.currentSnapshot()).thenReturn(snapshot);
+
+        IcebergTableProcedureContext context = createContext(table);
+
+        StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class,
+                () -> procedure.execute(context, Collections.emptyMap()));
+
+        assertTrue(ex.getMessage().contains("table location is empty"));
+    }
+
+    @Test
     void testLocationEmptyThrows() {
         RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
         Table table = Mockito.mock(Table.class);
@@ -132,6 +149,96 @@ public class RemoveOrphanFilesProcedureTest {
         String msg = t.getMessage();
         assertFalse(msg != null && (msg.contains("expected non-empty string") || msg.contains("must be a subdirectory")),
                 "location validation should pass; got: " + msg);
+    }
+
+    @Test
+    void testLocationEqualsTableLocationPassesValidation() {
+        // When location exactly equals table location, validateAndResolveScanLocation returns early
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+        Table table = Mockito.mock(Table.class);
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+
+        when(table.location()).thenReturn("oss://bucket/table");
+        when(table.currentSnapshot()).thenReturn(snapshot);
+        when(table.snapshots()).thenReturn(Collections.emptyList());
+
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put(RemoveOrphanFilesProcedure.LOCATION, ConstantOperator.createVarchar("oss://bucket/table"));
+
+        IcebergTableProcedureContext context = createContext(table);
+
+        Throwable t = assertThrows(Throwable.class, () -> procedure.execute(context, args));
+        String msg = t.getMessage();
+        assertFalse(msg != null && (msg.contains("expected non-empty string") || msg.contains("must be a subdirectory")),
+                "location equals table location should pass validation; got: " + msg);
+    }
+
+    @Test
+    void testLocationWithTrailingSlashPassesValidation() {
+        // Trailing slash in location is normalized (stripTrailingSlash); validation still passes
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+        Table table = Mockito.mock(Table.class);
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+
+        when(table.location()).thenReturn("s3://bucket/table");
+        when(table.currentSnapshot()).thenReturn(snapshot);
+        when(table.snapshots()).thenReturn(Collections.emptyList());
+
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put(RemoveOrphanFilesProcedure.LOCATION, ConstantOperator.createVarchar("s3://bucket/table/data/"));
+
+        IcebergTableProcedureContext context = createContext(table);
+
+        Throwable t = assertThrows(Throwable.class, () -> procedure.execute(context, args));
+        String msg = t.getMessage();
+        assertFalse(msg != null && (msg.contains("expected non-empty string") || msg.contains("must be a subdirectory")),
+                "location with trailing slash should pass validation; got: " + msg);
+    }
+
+    @Test
+    void testLocationDifferentSchemeThrows() {
+        // Scheme must match (e.g. s3 vs oss)
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+        Table table = Mockito.mock(Table.class);
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+
+        when(table.location()).thenReturn("s3://bucket/table");
+        when(table.currentSnapshot()).thenReturn(snapshot);
+
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put(RemoveOrphanFilesProcedure.LOCATION, ConstantOperator.createVarchar("oss://bucket/table/data"));
+
+        IcebergTableProcedureContext context = createContext(table);
+
+        StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class,
+                () -> procedure.execute(context, args));
+
+        assertTrue(ex.getMessage().contains("invalid argument value"));
+        assertTrue(ex.getMessage().contains(RemoveOrphanFilesProcedure.LOCATION));
+        assertTrue(ex.getMessage().contains("must be a subdirectory of"));
+    }
+
+    @Test
+    void testLocationDifferentAuthorityThrows() {
+        // Authority (e.g. bucket) must match
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+        Table table = Mockito.mock(Table.class);
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+
+        when(table.location()).thenReturn("s3://bucket-a/table");
+        when(table.currentSnapshot()).thenReturn(snapshot);
+
+        Map<String, ConstantOperator> args = new HashMap<>();
+        args.put(RemoveOrphanFilesProcedure.LOCATION, ConstantOperator.createVarchar("s3://bucket-b/table/data"));
+
+        IcebergTableProcedureContext context = createContext(table);
+
+        StarRocksConnectorException ex = assertThrows(StarRocksConnectorException.class,
+                () -> procedure.execute(context, args));
+
+        assertTrue(ex.getMessage().contains("invalid argument value"));
+        assertTrue(ex.getMessage().contains(RemoveOrphanFilesProcedure.LOCATION));
+        assertTrue(ex.getMessage().contains("must be a subdirectory of"));
     }
 
     private IcebergTableProcedureContext createContext(Table table) {

--- a/test/sql/test_iceberg/R/test_iceberg_expire_snapshots
+++ b/test/sql/test_iceberg/R/test_iceberg_expire_snapshots
@@ -1,0 +1,56 @@
+-- name: test_iceberg_expire_snapshots
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+create table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}(k1 int) properties('location' = 'oss://starrocks-ci-test/iceberg_db_${uuid0}/ice_tbl_${uuid0}');
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 1;
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 2;
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 3;
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 4;
+-- result:
+-- !result
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$snapshots;
+-- result:
+4
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute expire_snapshots(older_than=now(), retain_last=3);
+-- result:
+-- !result
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$snapshots;
+-- result:
+3
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute expire_snapshots(now());
+-- result:
+-- !result
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$snapshots;
+-- result:
+1
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute expire_snapshots(older_than=now(), retain_last=1);
+-- result:
+-- !result
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$snapshots;
+-- result:
+1
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+-- result:
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/R/test_iceberg_remove_orphan_files
+++ b/test/sql/test_iceberg/R/test_iceberg_remove_orphan_files
@@ -44,6 +44,27 @@ select count(1) from files ("path"="oss://starrocks-ci-test/iceberg_db_${uuid0}/
 -- result:
 1
 -- !result
+insert into files (
+    "path" = "oss://starrocks-ci-test/iceberg_db_${uuid0}/ice_tbl_${uuid0}/metadata",
+    "format" = "parquet",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}"
+)
+select 1 as c1;
+-- result:
+-- !result
+select count(1) from files ("path"="oss://starrocks-ci-test/iceberg_db_${uuid0}/ice_tbl_${uuid0}/metadata", "list_files_only" = "true") where IS_DIR=0;
+-- result:
+12
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute remove_orphan_files(older_than=now(),location="oss://starrocks-ci-test/iceberg_db_${uuid0}/ice_tbl_${uuid0}/metadata");
+-- result:
+-- !result
+select count(1) from files ("path"="oss://starrocks-ci-test/iceberg_db_${uuid0}/ice_tbl_${uuid0}/metadata", "list_files_only" = "true") where IS_DIR=0;
+-- result:
+11
+-- !result
 drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
 -- result:
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_expire_snapshots
+++ b/test/sql/test_iceberg/T/test_iceberg_expire_snapshots
@@ -1,0 +1,23 @@
+-- name: test_iceberg_expire_snapshots
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+create table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}(k1 int) properties('location' = 'oss://starrocks-ci-test/iceberg_db_${uuid0}/ice_tbl_${uuid0}');
+
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 1;
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 2;
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 3;
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} select 4;
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$snapshots;
+
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute expire_snapshots(older_than=now(), retain_last=3);
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$snapshots;
+
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute expire_snapshots(now());
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$snapshots;
+
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute expire_snapshots(older_than=now(), retain_last=1);
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$snapshots;
+
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+drop catalog iceberg_sql_test_${uuid0};

--- a/test/sql/test_iceberg/T/test_iceberg_remove_orphan_files
+++ b/test/sql/test_iceberg/T/test_iceberg_remove_orphan_files
@@ -17,6 +17,20 @@ alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execu
 alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute remove_orphan_files(now());
 select count(1) from files ("path"="oss://starrocks-ci-test/iceberg_db_${uuid0}/ice_tbl_${uuid0}/data","list_files_only" = "true") where IS_DIR=0;
 
+insert into files (
+    "path" = "oss://starrocks-ci-test/iceberg_db_${uuid0}/ice_tbl_${uuid0}/metadata",
+    "format" = "parquet",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}"
+)
+select 1 as c1;
+
+select count(1) from files ("path"="oss://starrocks-ci-test/iceberg_db_${uuid0}/ice_tbl_${uuid0}/metadata", "list_files_only" = "true") where IS_DIR=0;
+
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute remove_orphan_files(older_than=now(),location="oss://starrocks-ci-test/iceberg_db_${uuid0}/ice_tbl_${uuid0}/metadata");
+select count(1) from files ("path"="oss://starrocks-ci-test/iceberg_db_${uuid0}/ice_tbl_${uuid0}/metadata", "list_files_only" = "true") where IS_DIR=0;
+
 drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing

Iceberg tables in production often require finer-grained metadata maintenance than a single “expire everything older than X” or “clean the whole table root” operation. Operators commonly want to (1) expire snapshots by time while still retaining the most recent N snapshots for safety/rollback, and (2) run `remove_orphan_files` on a restricted subdirectory (e.g. a partition/data prefix) to avoid touching unrelated data and to reduce the blast radius of a misconfigured cleanup. The existing procedures in StarRocks do not expose these controls, which makes safe and precise Iceberg maintenance harder to automate from StarRocks.

## What I'm doing

- Extend the `expire_snapshots` Iceberg table procedure to accept an additional optional argument `retain_last` (INT):
  - Keep the existing `older_than` (DATETIME) argument.
  - Add validation for `retain_last >= 1` and type checking (must be INT).
  - Wire the argument through to Iceberg `ExpireSnapshots.retainLast(...)` so callers can combine time-based expiry with a minimum number of retained snapshots.
- Extend the `remove_orphan_files` Iceberg table procedure to accept an optional `location` (VARCHAR) argument:
  - Keep the existing `older_than` (DATETIME) argument.
  - Validate that `location` is non-empty and is the table root or a true subdirectory (path-boundary aware, so `…/table2` does not pass when the table root is `…/table`).
  - Scope the orphan-file scan and deletion to the validated `location`, instead of always using the full table root.
- Update `AlterTableOperationStmtTest` to reflect the new procedure signatures and argument metadata for `expire_snapshots` and `remove_orphan_files`.
- Add focused unit tests:
  - `ExpireSnapshotsProcedureTest` to cover typing, value validation (`retain_last`), and the interaction between `older_than` and `retain_last`.
  - `RemoveOrphanFilesProcedureTest` to cover `location` validation (empty, non-subdirectory, valid subdirectory).
- Add and update SQL integration tests under `test/sql/test_iceberg`:
  - New `test_iceberg_expire_snapshots` to exercise `expire_snapshots` with the new arguments.
  - Enhanced `test_iceberg_remove_orphan_files` to cover the new `location` argument and validate that orphan files in a metadata subdirectory can be written, detected, and removed correctly.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [x] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
