### PR TITLE
[Enhancement] Add hash join type validation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/TypeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/TypeChecker.java
@@ -16,15 +16,20 @@ package com.starrocks.sql.optimizer.validate;
 
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ArrayOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -107,6 +112,47 @@ public class TypeChecker implements PlanValidator.Checker {
         public Void visitPhysicalHashAggregate(OptExpression optExpression, Void context) {
             PhysicalHashAggregateOperator operator = (PhysicalHashAggregateOperator) optExpression.getOp();
             checkAggCall(operator.getAggregations(), operator.getType(), operator.isSplit(), operator.hasRemovedDistinctFunc());
+            visit(optExpression, context);
+            return null;
+        }
+
+        @Override
+        public Void visitPhysicalHashJoin(OptExpression optExpression, Void context) {
+            PhysicalHashJoinOperator operator = (PhysicalHashJoinOperator) optExpression.getOp();
+            ScalarOperator onPredicate = operator.getOnPredicate();
+            if (onPredicate != null) {
+                ColumnRefSet leftColumns = optExpression.inputAt(0).getOutputColumns();
+                ColumnRefSet rightColumns = optExpression.inputAt(1).getOutputColumns();
+                List<BinaryPredicateOperator> eqPredicates =
+                        JoinHelper.getEqualsPredicate(leftColumns, rightColumns, Utils.extractConjuncts(onPredicate));
+                for (BinaryPredicateOperator predicate : eqPredicates) {
+                    ScalarOperator left = predicate.getChild(0);
+                    ScalarOperator right = predicate.getChild(1);
+                    ColumnRefSet leftUsed = left.getUsedColumns();
+                    ColumnRefSet rightUsed = right.getUsedColumns();
+                    // Normalize operand order so "left" always belongs to left child and "right" to right child.
+                    // For example, `right.c1 = left.c1` should be swapped to `left.c1 = right.c1`.
+                    if (leftColumns.containsAll(rightUsed) && rightColumns.containsAll(leftUsed)) {
+                        ScalarOperator tmp = left;
+                        left = right;
+                        right = tmp;
+                        ColumnRefSet tmpSet = leftUsed;
+                        leftUsed = rightUsed;
+                        rightUsed = tmpSet;
+                    }
+                    // Skip predicates that still don't map cleanly to left/right children
+                    // (e.g. mixed columns `left.c1+right.c2=right.c3`).
+                    if (!leftColumns.containsAll(leftUsed) || !rightColumns.containsAll(rightUsed)) {
+                        continue;
+                    }
+                    if (!left.getType().matchesType(right.getType())) {
+                        throw new StarRocksPlannerException(
+                                String.format("%s hash join equal predicate type mismatch: left %s, right %s, predicate: %s",
+                                        PREFIX, left.getType(), right.getType(), predicate),
+                                ErrorType.USER_ERROR);
+                    }
+                }
+            }
             visit(optExpression, context);
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/TypeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/TypeChecker.java
@@ -145,7 +145,7 @@ public class TypeChecker implements PlanValidator.Checker {
                     if (!leftColumns.containsAll(leftUsed) || !rightColumns.containsAll(rightUsed)) {
                         continue;
                     }
-                    if (!left.getType().equals(right.getType())) {
+                    if (!left.getType().matchesType(right.getType())) {
                         throw new StarRocksPlannerException(
                                 String.format("%s hash join equal predicate type mismatch: left %s, right %s, predicate: %s",
                                         PREFIX, left.getType(), right.getType(), predicate),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/TypeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/TypeChecker.java
@@ -145,7 +145,7 @@ public class TypeChecker implements PlanValidator.Checker {
                     if (!leftColumns.containsAll(leftUsed) || !rightColumns.containsAll(rightUsed)) {
                         continue;
                     }
-                    if (!left.getType().matchesType(right.getType())) {
+                    if (!left.getType().equals(right.getType())) {
                         throw new StarRocksPlannerException(
                                 String.format("%s hash join equal predicate type mismatch: left %s, right %s, predicate: %s",
                                         PREFIX, left.getType(), right.getType(), predicate),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/validate/TypeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/validate/TypeCheckerTest.java
@@ -27,6 +27,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.Type;
 import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Test;
 
@@ -38,38 +39,31 @@ class TypeCheckerTest {
 
     @Test
     void testHashJoinEqualPredicateTypeMismatch() {
-        ColumnRefOperator leftCol = new ColumnRefOperator(1, IntegerType.BIGINT, "l", true);
-        ColumnRefOperator rightCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "r", true);
-        BinaryPredicateOperator predicate = new BinaryPredicateOperator(BinaryType.EQ, rightCol, leftCol);
+        {
+            OptExpression root = generateHashJoinExpr(IntegerType.BIGINT, VarcharType.VARCHAR);
+            StarRocksPlannerException ex = assertThrows(StarRocksPlannerException.class,
+                    () -> TypeChecker.getInstance().validate(root, null));
+            assertTrue(ex.getMessage().contains("hash join equal predicate type mismatch"),
+                    "Unexpected error: " + ex.getMessage());
+        }
 
-        PhysicalHashJoinOperator join = new PhysicalHashJoinOperator(
-                JoinOperator.INNER_JOIN,
-                predicate,
-                "",
-                Operator.DEFAULT_LIMIT,
-                null,
-                null,
-                null,
-                null);
+        {
+            OptExpression root = generateHashJoinExpr(IntegerType.BIGINT, IntegerType.INT);
+            StarRocksPlannerException ex = assertThrows(StarRocksPlannerException.class,
+                    () -> TypeChecker.getInstance().validate(root, null));
+            assertTrue(ex.getMessage().contains("hash join equal predicate type mismatch"),
+                    "Unexpected error: " + ex.getMessage());
+        }
 
-        OptExpression left = new OptExpression(new MockOperator(OperatorType.LOGICAL_VALUES));
-        left.setLogicalProperty(new LogicalProperty(ColumnRefSet.of(leftCol)));
-
-        OptExpression right = new OptExpression(new MockOperator(OperatorType.LOGICAL_VALUES));
-        right.setLogicalProperty(new LogicalProperty(ColumnRefSet.of(rightCol)));
-
-        OptExpression root = OptExpression.create(join, left, right);
-
-        StarRocksPlannerException ex = assertThrows(StarRocksPlannerException.class,
-                () -> TypeChecker.getInstance().validate(root, null));
-        assertTrue(ex.getMessage().contains("hash join equal predicate type mismatch"),
-                "Unexpected error: " + ex.getMessage());
+        {
+            OptExpression root = generateHashJoinExpr(IntegerType.BIGINT, IntegerType.BIGINT);
+            assertDoesNotThrow(() -> TypeChecker.getInstance().validate(root, null));
+        }
     }
 
-    @Test
-    void testHashJoinEqualPredicateTypeMatch() {
-        ColumnRefOperator leftCol = new ColumnRefOperator(1, VarcharType.VARCHAR, "l", true);
-        ColumnRefOperator rightCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "r", true);
+    private static OptExpression generateHashJoinExpr(Type leftType, Type rightType) {
+        ColumnRefOperator leftCol = new ColumnRefOperator(1, leftType, "l", true);
+        ColumnRefOperator rightCol = new ColumnRefOperator(2, rightType, "r", true);
         BinaryPredicateOperator predicate = new BinaryPredicateOperator(BinaryType.EQ, rightCol, leftCol);
 
         PhysicalHashJoinOperator join = new PhysicalHashJoinOperator(
@@ -88,8 +82,6 @@ class TypeCheckerTest {
         OptExpression right = new OptExpression(new MockOperator(OperatorType.LOGICAL_VALUES));
         right.setLogicalProperty(new LogicalProperty(ColumnRefSet.of(rightCol)));
 
-        OptExpression root = OptExpression.create(join, left, right);
-
-        assertDoesNotThrow(() -> TypeChecker.getInstance().validate(root, null));
+        return OptExpression.create(join, left, right);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/validate/TypeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/validate/TypeCheckerTest.java
@@ -1,0 +1,95 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.validate;
+
+import com.starrocks.sql.ast.JoinOperator;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.LogicalProperty;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.MockOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TypeCheckerTest {
+
+    @Test
+    void testHashJoinEqualPredicateTypeMismatch() {
+        ColumnRefOperator leftCol = new ColumnRefOperator(1, IntegerType.BIGINT, "l", true);
+        ColumnRefOperator rightCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "r", true);
+        BinaryPredicateOperator predicate = new BinaryPredicateOperator(BinaryType.EQ, rightCol, leftCol);
+
+        PhysicalHashJoinOperator join = new PhysicalHashJoinOperator(
+                JoinOperator.INNER_JOIN,
+                predicate,
+                "",
+                Operator.DEFAULT_LIMIT,
+                null,
+                null,
+                null,
+                null);
+
+        OptExpression left = new OptExpression(new MockOperator(OperatorType.LOGICAL_VALUES));
+        left.setLogicalProperty(new LogicalProperty(ColumnRefSet.of(leftCol)));
+
+        OptExpression right = new OptExpression(new MockOperator(OperatorType.LOGICAL_VALUES));
+        right.setLogicalProperty(new LogicalProperty(ColumnRefSet.of(rightCol)));
+
+        OptExpression root = OptExpression.create(join, left, right);
+
+        StarRocksPlannerException ex = assertThrows(StarRocksPlannerException.class,
+                () -> TypeChecker.getInstance().validate(root, null));
+        assertTrue(ex.getMessage().contains("hash join equal predicate type mismatch"),
+                "Unexpected error: " + ex.getMessage());
+    }
+
+    @Test
+    void testHashJoinEqualPredicateTypeMatch() {
+        ColumnRefOperator leftCol = new ColumnRefOperator(1, VarcharType.VARCHAR, "l", true);
+        ColumnRefOperator rightCol = new ColumnRefOperator(2, VarcharType.VARCHAR, "r", true);
+        BinaryPredicateOperator predicate = new BinaryPredicateOperator(BinaryType.EQ, rightCol, leftCol);
+
+        PhysicalHashJoinOperator join = new PhysicalHashJoinOperator(
+                JoinOperator.INNER_JOIN,
+                predicate,
+                "",
+                Operator.DEFAULT_LIMIT,
+                null,
+                null,
+                null,
+                null);
+
+        OptExpression left = new OptExpression(new MockOperator(OperatorType.LOGICAL_VALUES));
+        left.setLogicalProperty(new LogicalProperty(ColumnRefSet.of(leftCol)));
+
+        OptExpression right = new OptExpression(new MockOperator(OperatorType.LOGICAL_VALUES));
+        right.setLogicalProperty(new LogicalProperty(ColumnRefSet.of(rightCol)));
+
+        OptExpression root = OptExpression.create(join, left, right);
+
+        assertDoesNotThrow(() -> TypeChecker.getInstance().validate(root, null));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Add a plan validation check to reject hash join equality predicates when left/right operand types differ.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
