### PR TITLE
[UT] Fix BE UT failure when using Clang

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -665,6 +665,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         # ignore warning from apache-orc
         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unsafe-buffer-usage")
     endif ()
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "18.0.0")
+        # ignore warning from apache-orc
+        set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-switch-default")
+    endif ()
 else ()
     set(CXX_GCC_FLAGS "${CXX_GCC_FLAGS} -fcoroutines")
 endif()

--- a/be/test/exprs/like_test.cpp
+++ b/be/test/exprs/like_test.cpp
@@ -664,7 +664,7 @@ TEST_F(LikeTest, splitLikePatternIntoNgramSet) {
     // pattern contains special characters
     std::string pattern = "abc%_abccc\\%e\\\\\\\\";
     std::vector<std::string> ngram_set;
-    NgramBloomFilterReaderOptions options(4, false);
+    NgramBloomFilterReaderOptions options{4, false};
     VectorizedFunctionCallExpr::split_like_string_to_ngram(pattern, options, ngram_set);
     ASSERT_EQ(6, ngram_set.size());
     ASSERT_EQ("abcc", ngram_set[0]);

--- a/be/test/storage/delta_column_group_test.cpp
+++ b/be/test/storage/delta_column_group_test.cpp
@@ -41,7 +41,7 @@ TEST(TestDeltaColumnGroup, testLoad) {
     }
     DeltaColumnGroup dcg2;
     dcg2.init(100, {{2, 12}}, {"abc1.cols"}, {ep.encryption_meta});
-    dcg.merge_by_version(dcg2, "tmp", RowsetId(100, 100), 100);
+    dcg.merge_by_version(dcg2, "tmp", RowsetId{100, 100}, 100);
     ASSERT_EQ(2, dcg.encryption_metas().size());
 };
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fix BE UT failure when using Clang on branch-3.3.

This was already fixed in PR https://github.com/StarRocks/starrocks/pull/49351 for branch-3.4 and above.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

