### PR TITLE
[Refactor] Ignore fe/target directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ fe/mocked
 fe/ut_ports
 fe/*/target
 fe/*/bin
+fe/target/
 fe/plugin/*/target/
 fe/fe-grammar/gen
 fe/fe-grammar/src/main/antlr/com/starrocks/grammar/gen


### PR DESCRIPTION
## Why I'm doing:

When following instructions from https://github.com/StarRocks/community/blob/main/Contributors/guide/IDEA.md
```
cd fe
mvn install -DskipTests
```
a directory fe/target is created which is not ignored.

## What I'm doing:

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
