### PR TITLE
[BugFix] Fix NPE in Iceberg getPartitions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -348,6 +348,11 @@ public interface IcebergCatalog extends MemoryTrackable {
                             int specId = row.get(1, Integer.class);
                             PartitionSpec spec = nativeTable.specs().get(specId);
 
+                            // Old partition specs may be referenced in metadata even if they have been deleted. Skip them.
+                            if (spec == null) {
+                                continue;
+                            }
+
                             String partitionName =
                                     PartitionUtil.convertIcebergPartitionToPartitionName(nativeTable, spec, partitionData);
                             long lastUpdated =

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergCatalogTest.java
@@ -1,0 +1,81 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.IcebergTable;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.iceberg.DataTask;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionsTable;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.util.StructProjection;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+public class IcebergCatalogTest {
+    @Test
+    public void testGetPartitionsSkipsMissingSpecId() {
+        IcebergCatalog catalog = Mockito.mock(IcebergCatalog.class, Mockito.CALLS_REAL_METHODS);
+        Table nativeTable = Mockito.mock(Table.class);
+        PartitionSpec currentSpec = Mockito.mock(PartitionSpec.class);
+        Mockito.when(currentSpec.isUnpartitioned()).thenReturn(false);
+        Mockito.when(nativeTable.spec()).thenReturn(currentSpec);
+        Mockito.when(nativeTable.specs()).thenReturn(ImmutableMap.of(1, currentSpec));
+        Mockito.when(nativeTable.name()).thenReturn("db.tbl");
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTable", "iceberg_catalog",
+                "resource", "db", "tbl", "", Lists.newArrayList(), nativeTable, Maps.newHashMap());
+
+        PartitionsTable partitionsTable = Mockito.mock(PartitionsTable.class);
+        TableScan scan = Mockito.mock(TableScan.class);
+        Mockito.when(partitionsTable.newScan()).thenReturn(scan);
+
+        FileScanTask task = Mockito.mock(FileScanTask.class);
+        DataTask dataTask = Mockito.mock(DataTask.class);
+        StructLike row = Mockito.mock(StructLike.class);
+        StructProjection partitionData = Mockito.mock(StructProjection.class);
+        Mockito.when(task.asDataTask()).thenReturn(dataTask);
+        Mockito.when(row.get(0, StructProjection.class)).thenReturn(partitionData);
+        Mockito.when(row.get(1, Integer.class)).thenReturn(99);
+        CloseableIterable<StructLike> rowIterable = CloseableIterable.withNoopClose(Lists.newArrayList(row));
+        Mockito.when(dataTask.rows()).thenReturn(rowIterable);
+
+        CloseableIterable<FileScanTask> taskIterable = CloseableIterable.withNoopClose(Lists.newArrayList(task));
+        Mockito.when(scan.planFiles()).thenReturn(taskIterable);
+
+        new MockUp<MetadataTableUtils>() {
+            @Mock
+            public Table createMetadataTableInstance(Table table, MetadataTableType type) {
+                return partitionsTable;
+            }
+        };
+
+        Map<String, Partition> partitions = catalog.getPartitions(icebergTable, -1, null);
+        Assertions.assertTrue(partitions.isEmpty());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Old partitions can sometimes be referenced even if they do not exist when scanning the partitions of an iceberg table. When this happens we attempt to get the associated partition spec by id (which no longer exists). This results in an NPE.

## What I'm doing:

If the partition spec is null we will skip it when scanning partitions. On my test deployment this resolved the issue.

Fixes #64963

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
