### PR TITLE
[BugFix] Fix NPE in IcebergCatalog.getPartitionLastUpdatedTime when snapshot is expired

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -374,7 +374,10 @@ public interface IcebergCatalog extends MemoryTrackable {
         long lastUpdated = -1;
         if (row != null) {
             try {
-                lastUpdated = row.get(columnIndex, Long.class);
+                Long lastUpdatedWrapper = row.get(columnIndex, Long.class);
+                if (lastUpdatedWrapper != null) {
+                    lastUpdated = lastUpdatedWrapper;
+                }
             } catch (Exception e) {
                 logger.error("Failed to get last_updated_at for partition [{}] of table [{}] " +
                                 "under snapshot [{}]", partitionName, nativeTable.name(), snapshotId, e);


### PR DESCRIPTION
## Why I'm doing:

When Iceberg table's snapshot is expired, the `last_updated_at` field in the partitions metadata table returns `null`. The current code directly assigns this nullable `Long` to a primitive `long`, causing `NullPointerException` during Java's auto-unboxing.

Example error logs:
```
ERROR [IcebergCatalog.getPartitionLastUpdatedTime():357] Failed to get last_updated_at for partition [partition_date=2025-01-01] of table [catalog.db.table_name] under snapshot [123456789]
java.lang.NullPointerException: null
WARN [IcebergCatalog.getPartitionLastUpdatedTime():364] The table [catalog.db.table_name] last_updated_at is null (snapshot [123456789] may have been expired), using current snapshot timestamp: ...
```

## What I'm doing:

Add null check before assigning `Long` wrapper to primitive `long` to prevent NPE during auto-unboxing. When `last_updated_at` is null, the code now properly falls back to using the current snapshot timestamp.

**Before:**
```java
lastUpdated = row.get(columnIndex, Long.class);  // NPE when null
```

**After:**
```java
Long lastUpdatedWrapper = row.get(columnIndex, Long.class);
if (lastUpdatedWrapper != null) {
    lastUpdated = lastUpdatedWrapper;
}
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

### Behavior change detail:
Previously, when `last_updated_at` was null due to snapshot expiration, the code would throw an NPE (caught internally) and then fall back to the current snapshot timestamp. This PR changes the behavior to gracefully handle the null value without throwing an exception, still falling back to the current snapshot timestamp. The end result is the same, but the error path is now cleaner.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4