### PR TITLE
[BugFix] Fix public role privilege cache invalidation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationMgr.java
@@ -1088,6 +1088,13 @@ public class AuthorizationMgr {
      * requires role lock
      */
     protected void invalidateRolesInCacheRoleUnlocked(long roleId) throws PrivilegeException {
+        // PUBLIC_ROLE is implicitly granted to all users but is not included in users' explicit roleIds.
+        // When PUBLIC_ROLE privileges change, we must invalidate all cached privilege collections.
+        if (roleId == PrivilegeBuiltinConstants.PUBLIC_ROLE_ID) {
+            ctxToMergedPrivilegeCollections.invalidateAll();
+            return;
+        }
+
         Set<Long> badRoles = getAllDescendantsUnlocked(roleId);
         List<UserPrivKey> badKeys = new ArrayList<>();
         for (UserPrivKey pair : ctxToMergedPrivilegeCollections.asMap().keySet()) {

--- a/fe/fe-core/src/test/java/com/starrocks/authorization/AuthorizationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authorization/AuthorizationMgrTest.java
@@ -1865,4 +1865,36 @@ public class AuthorizationMgrTest {
             Authorizer.checkSystemAction(ctx, PrivilegeType.GRANT);
         });
     }
+
+    @Test
+    public void testPublicRoleCacheInvalidation() throws Exception {
+        // Create a test user
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser("create user cache_test_user", ctx), ctx);
+        UserIdentity cacheTestUser = UserIdentity.createAnalyzedUserIdentWithIp("cache_test_user", "%");
+
+        AuthorizationMgr manager = ctx.getGlobalStateMgr().getAuthorizationMgr();
+
+        // Switch to the test user and populate the privilege cache
+        setCurrentUserAndRoles(ctx, cacheTestUser);
+
+        // Verify the user does NOT have SELECT on tbl0 initially
+        Assertions.assertThrows(AccessDeniedException.class, () ->
+                Authorizer.checkTableAction(ctx, DB_NAME, TABLE_NAME_0, PrivilegeType.SELECT));
+
+        // Grant SELECT on tbl0 to PUBLIC role (as ROOT)
+        setCurrentUserAndRoles(ctx, UserIdentity.ROOT);
+        String grantSql = "GRANT SELECT ON " + DB_NAME + "." + TABLE_NAME_0 + " TO ROLE public";
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(grantSql, ctx), ctx);
+
+        // Switch back to the test user - cache should be invalidated and new privileges should apply
+        setCurrentUserAndRoles(ctx, cacheTestUser);
+
+        // Verify the user now has SELECT on tbl0 through PUBLIC role
+        Authorizer.checkTableAction(ctx, DB_NAME, TABLE_NAME_0, PrivilegeType.SELECT);
+
+        // Cleanup: revoke the privilege from public role
+        setCurrentUserAndRoles(ctx, UserIdentity.ROOT);
+        String revokeSql = "REVOKE SELECT ON " + DB_NAME + "." + TABLE_NAME_0 + " FROM ROLE public";
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(revokeSql, ctx), ctx);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Public role privilege changes are not immediately applied to LDAP (Security Integration) users who are already logged in.

**Problem**
1. Admin grants privilege to `public` role (e.g., `GRANT SELECT ON db.table TO ROLE public`)
2. Already logged-in LDAP users cannot use the new privilege
3. Only works after re-login

**Root Cause**

1. PUBLIC_ROLE handling in privilege loading (`AuthorizationMgr.java:1071-1075`)

```java
// In loadPrivilegeCollection(), PUBLIC_ROLE is always merged separately at the end
RolePrivilegeCollectionV2 rolePrivilegeCollection =
    getRolePrivilegeCollectionUnlocked(PrivilegeBuiltinConstants.PUBLIC_ROLE_ID, false);
if (rolePrivilegeCollection != null) {
    collection.merge(rolePrivilegeCollection);  // Processed separately from user's roleIds
}
```

PUBLIC_ROLE is implicitly granted to all users, but it is NOT included in users' explicit `roleIds`.

2. Bug in cache invalidation logic (`AuthorizationMgr.java:1090-1109`)

```java
protected void invalidateRolesInCacheRoleUnlocked(long roleId) {
    Set<Long> badRoles = getAllDescendantsUnlocked(roleId);
    for (UserPrivKey pair : ctxToMergedPrivilegeCollections.asMap().keySet()) {
        Set<Long> roleIds = pair.roleIds;
        for (long badRoleId : badRoles) {
            if (roleIds.contains(badRoleId)) {  // PUBLIC_ROLE_ID is never in roleIds!
                badKeys.add(pair);
                break;
            }
        }
    }
}
```

`roleIds.contains(PUBLIC_ROLE_ID)` always returns `false`, so the cache is never invalidated.

3. Bug Flow

```
GRANT to PUBLIC_ROLE
       ↓
grantToRole() called
       ↓
invalidateRolesInCacheRoleUnlocked(PUBLIC_ROLE_ID) called
       ↓
for each cached user:
    if (user.roleIds.contains(PUBLIC_ROLE_ID))  ← always false!
       ↓
Cache not invalidated → New privileges not applied to existing sessions
```

## What I'm doing:

Add PUBLIC_ROLE_ID check in `invalidateRolesInCacheRoleUnlocked()` method to invalidate all cached privilege collections when PUBLIC_ROLE privileges change.

```java
protected void invalidateRolesInCacheRoleUnlocked(long roleId) throws PrivilegeException {
    // PUBLIC_ROLE is implicitly granted to all users, so invalidate all caches
    if (roleId == PrivilegeBuiltinConstants.PUBLIC_ROLE_ID) {
        ctxToMergedPrivilegeCollections.invalidateAll();
        return;
    }
    // existing logic...
}
```

**Fixed Flow**

```
GRANT to PUBLIC_ROLE
       ↓
grantToRole() called
       ↓
invalidateRolesInCacheRoleUnlocked(PUBLIC_ROLE_ID) called
       ↓
if (roleId == PUBLIC_ROLE_ID)
    invalidateAll()  ← Invalidate all caches
       ↓
New privileges immediately applied to existing sessions
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
