### PR TITLE
[BugFix] Fix tablet split range selection for range distribution

### DIFF
--- a/be/src/storage/tablet_range.h
+++ b/be/src/storage/tablet_range.h
@@ -52,6 +52,8 @@ public:
     bool greater_than(const VariantTuple& key) const;
 
     bool contains(const VariantTuple& key) const { return !(less_than(key) || greater_than(key)); }
+    // Strictly inside the open interval of this range.
+    bool strictly_contains(const VariantTuple& key) const;
 
     void to_proto(TabletRangePB* tablet_range_pb) const;
 
@@ -80,6 +82,16 @@ inline bool TabletRange::greater_than(const VariantTuple& key) const {
 
     int result = _lower_bound.compare(key);
     return result > 0 || (result == 0 && lower_bound_excluded());
+}
+
+inline bool TabletRange::strictly_contains(const VariantTuple& key) const {
+    if (!is_minimum() && key.compare(_lower_bound) <= 0) {
+        return false;
+    }
+    if (!is_maximum() && key.compare(_upper_bound) >= 0) {
+        return false;
+    }
+    return true;
 }
 
 inline void TabletRange::to_proto(TabletRangePB* tablet_range_pb) const {

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -809,7 +809,7 @@ TEST_F(LakeServiceTest, test_publish_version_transform_batch_to_single) {
 
 TEST_F(LakeServiceTest, test_publish_splitting_tablet) {
     {
-        auto txn_log = generate_write_txn_log(1, 100, 100);
+        auto txn_log = generate_write_txn_log(2, 100, 100);
         ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
 
         PublishVersionRequest publish_request;


### PR DESCRIPTION
## Why I'm doing:
 Ensure tablet splitting only proceeds when there are enough split ranges.
Fix tablet split range generation for range distribution in shared-data mode.

## What I'm doing:
  - Require enough non-empty ranges before splitting to avoid single-segment splits
    and empty split ranges.
  - Ensure split boundaries strictly advance and stay inside tablet range.
  - Skip empty ranges and prefer next non-empty min when there is a gap to avoid
    cutting at segment max.
  - Validate generated split ranges have rows and proper bounds, otherwise fallback.
  - Update/extend tests to cover single-segment and gap-boundary scenarios.

Fixes #64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
