### PR TITLE
[Enhancement] only read iceberg cache when mv refresh and inesert select stmt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1586,6 +1586,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         // analyze expression, because it converts to sql for serialize
         ConnectContext connectContext = ConnectContext.buildInner();
+        connectContext.setOnlyReadIcebergCache(true);
         connectContext.setDatabase(db.getFullName());
         // set privilege
         connectContext.setQualifiedUser(AuthenticationMgr.ROOT_USER);
@@ -2259,6 +2260,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         // analyze partition exprs
         Map<Table, List<Expr>> refBaseTablePartitionExprs = getRefBaseTablePartitionExprs(false);
         ConnectContext connectContext = ConnectContext.buildInner();
+        connectContext.setOnlyReadIcebergCache(true);
         if (refBaseTablePartitionExprs != null) {
             for (BaseTableInfo baseTableInfo : baseTableInfos) {
                 Optional<Table> refBaseTableOpt = MvUtils.getTable(baseTableInfo);
@@ -2710,6 +2712,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         }
         ParseNode defineQueryParseNode = null;
         ConnectContext connectContext = ConnectContext.buildInner();
+        connectContext.setOnlyReadIcebergCache(true);
         if (!Strings.isNullOrEmpty(originalViewDefineSql)) {
             try {
                 String currentDBName = Strings.isNullOrEmpty(originalDBName) ? db.getOriginName() : originalDBName;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -813,8 +813,10 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     @Override
     public List<String> listPartitionNames(String dbName, String tblName, ConnectorMetadatRequestContext requestContext) {
-        Table table = getTable(new ConnectContext(), dbName, tblName);
-        return icebergCatalog.listPartitionNames((IcebergTable) table, requestContext, jobPlanningExecutor);
+        try (ConnectContext.ContextScope scope = ConnectContext.enterOnlyReadIcebergCacheScope(ConnectContext.get())) {
+            Table table = getTable(scope.getContext(), dbName, tblName);
+            return icebergCatalog.listPartitionNames((IcebergTable) table, requestContext, jobPlanningExecutor);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorTableTriggerAnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorTableTriggerAnalyzeMgr.java
@@ -90,8 +90,8 @@ public class ConnectorTableTriggerAnalyzeMgr {
             ConnectorTableColumnKey columnKey = entry.getKey();
             // first check table exist
             if (!tableExist) {
-                try {
-                    tableTriple = StatisticsUtils.getTableTripleByUUID(new ConnectContext(), columnKey.tableUUID);
+                try (ConnectContext.ContextScope scope = ConnectContext.enterOnlyReadIcebergCacheScope(ConnectContext.get())) {
+                    tableTriple = StatisticsUtils.getTableTripleByUUID(scope.getContext(), columnKey.tableUUID);
                     // check table could run analyze
                     if (!tableTriple.getRight().isAnalyzableExternalTable()) {
                         return;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -240,6 +240,9 @@ public class ConnectContext {
 
     private final Map<String, PrepareStmtContext> preparedStmtCtxs = Maps.newHashMap();
 
+    // Control whether to read Iceberg caches without populating/updating them for the current execution.
+    private boolean onlyReadIcebergCache = false;
+
     private UUID sessionId;
 
     private String proxyHostName;
@@ -1286,6 +1289,47 @@ public class ConnectContext {
 
     public void setQuerySource(QuerySource querySource) {
         this.querySource = querySource;
+    }
+
+    public boolean isOnlyReadIcebergCache() {
+        return onlyReadIcebergCache;
+    }
+
+    public void setOnlyReadIcebergCache(boolean onlyReadIcebergCache) {
+        this.onlyReadIcebergCache = onlyReadIcebergCache;
+    }
+
+    /**
+     * Scope helper to enable only-read-iceberg-cache semantics with automatic restore.
+     * Use in try-with-resources to mimic defer behavior.
+     */
+    public static ContextScope enterOnlyReadIcebergCacheScope(ConnectContext ctx) {
+        ConnectContext target = ctx != null ? ctx : new ConnectContext();
+        boolean originOnlyRead = target.isOnlyReadIcebergCache();
+        QuerySource originSource = target.getQuerySource();
+        target.setOnlyReadIcebergCache(true);
+        return new ContextScope(target, originOnlyRead, originSource);
+    }
+
+    public static class ContextScope implements AutoCloseable {
+        private final ConnectContext ctx;
+        private final boolean originOnlyRead;
+        private final QuerySource originSource;
+
+        ContextScope(ConnectContext ctx, boolean originOnlyRead, QuerySource originSource) {
+            this.ctx = ctx;
+            this.originOnlyRead = originOnlyRead;
+            this.originSource = originSource;
+        }
+
+        public ConnectContext getContext() {
+            return ctx;
+        }
+
+        @Override
+        public void close() {
+            ctx.setOnlyReadIcebergCache(originOnlyRead);
+        }
     }
 
     public void startAcceptQuery(ConnectProcessor connectProcessor) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -179,12 +179,13 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         final Tracers.Module mvRefreshTraceModule = queryDebugOptions.getTraceModule();
         Tracers.init(mvRefreshTraceMode, mvRefreshTraceModule, true, false);
 
-        final ConnectContext connectContext = context.getCtx();
+        ConnectContext connectContext = context.getCtx();
         // Set query source to MV for materialized view refresh
         connectContext.setQuerySource(com.starrocks.qe.QueryDetail.QuerySource.MV);
         final QueryMaterializationContext queryMVContext = new QueryMaterializationContext();
         connectContext.setQueryMVContext(queryMVContext);
-        try {
+            
+        try (ConnectContext.ContextScope scope = ConnectContext.enterOnlyReadIcebergCacheScope(connectContext)) {
             // do refresh
             try (Timer ignored = Tracers.watchScope("MVRefreshDoWholeRefresh")) {
                 // refresh mv

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
@@ -42,10 +42,10 @@ public class MvPlanContextBuilder {
 
         // If the caller is not from query (eg. background schema change thread), set thread local info to avoid
         // NPE in the planning.
-        ConnectContext connectContext = ConnectContext.get() == null ? new ConnectContext() : ConnectContext.get();
-
         List<MvPlanContext> results = Lists.newArrayList();
-        try (var guard = connectContext.bindScope()) {
+        ConnectContext.ContextScope scope = ConnectContext.enterOnlyReadIcebergCacheScope(ConnectContext.get());
+        ConnectContext connectContext = scope.getContext();
+        try (scope; var guard = connectContext.bindScope()) {
             Optional.ofNullable(doGetOptimizePlan(() -> mvOptimizer.optimize(mv, connectContext), isThrowException))
                     .map(results::add);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1480,8 +1480,8 @@ public class MvUtils {
     }
 
     public static Optional<Table> getTable(BaseTableInfo baseTableInfo) {
-        try {
-            return GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(new ConnectContext(), baseTableInfo);
+        try (ConnectContext.ContextScope scope = ConnectContext.enterOnlyReadIcebergCacheScope(ConnectContext.get())) {
+            return GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(scope.getContext(), baseTableInfo);
         } catch (Exception e) {
             // For hive catalog, when meets NoSuchObjectException, we should return empty
             //  msg: NoSuchObjectException: hive_db_8b48cd2f_4bfe_11f0_bc1a_00163e09349d.t1 table not found
@@ -1497,9 +1497,9 @@ public class MvUtils {
     }
 
     public static Optional<Table> getTableWithIdentifier(BaseTableInfo baseTableInfo) {
-        try {
+        try (ConnectContext.ContextScope scope = ConnectContext.enterOnlyReadIcebergCacheScope(ConnectContext.get())) {
             return GlobalStateMgr.getCurrentState().getMetadataMgr()
-                    .getTableWithIdentifier(new ConnectContext(), baseTableInfo);
+                    .getTableWithIdentifier(scope.getContext(), baseTableInfo);
         } catch (Exception e) {
             // For hive catalog, when meets NoSuchObjectException, we should return empty
             //  msg: NoSuchObjectException: hive_db_8b48cd2f_4bfe_11f0_bc1a_00163e09349d.t1 table not found
@@ -1516,7 +1516,9 @@ public class MvUtils {
     }
 
     public static Table getTableChecked(BaseTableInfo baseTableInfo) {
-        return GlobalStateMgr.getCurrentState().getMetadataMgr().getTableChecked(new ConnectContext(), baseTableInfo);
+        try (ConnectContext.ContextScope scope = ConnectContext.enterOnlyReadIcebergCacheScope(ConnectContext.get())) {
+            return GlobalStateMgr.getCurrentState().getMetadataMgr().getTableChecked(scope.getContext(), baseTableInfo);
+        }
     }
 
     public static Optional<FunctionCallExpr> getStr2DateExpr(Expr partitionExpr) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IcebergColumnMinMaxMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IcebergColumnMinMaxMgr.java
@@ -118,6 +118,7 @@ public class IcebergColumnMinMaxMgr implements IMinMaxStatsMgr, MemoryTrackable 
                     ConnectContext context = SIMPLE_EXECUTOR.createConnectContext();
                     context.getSessionVariable().setPipelineDop(1);
                     context.getSessionVariable().setIsEnableMinMaxOptimization(true);
+                    context.setOnlyReadIcebergCache(true);
                     List<TResultBatch> result = SIMPLE_EXECUTOR.executeDQL(sql, context);
                     if (result.isEmpty()) {
                         return Optional.empty();

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -142,6 +142,7 @@ public class StatisticUtils {
         context.setCurrentWarehouse(warehouse.getName());
 
         context.setStatisticsContext(true);
+        context.setOnlyReadIcebergCache(true);
         context.setDatabase(StatsConstants.STATISTICS_DB_NAME);
         context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
         context.setCurrentUserIdentity(UserIdentity.ROOT);


### PR DESCRIPTION
## Why I'm doing:
Internal queries or api calls should not populate the cache unless the user explicitly triggers a “Select Query”.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
