### PR TITLE
[Enhancement] Support Partition Transforms with Parentheses When Creating Iceberg Tables

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
@@ -399,8 +399,45 @@ public class AnalyzeCreateTableTest {
                         + "(k1 int, k2 int, k3 int) partition by (k1)");
         analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table" 
                         + "(k1 int, k2 int, k3 int) partition by (k3)");
-        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table" 
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
                         + "(k1 int, k2 int, k3 int, k4 int) partition by (k2, k3)");
+
+        // Test PARTITION BY single column
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                        + "(k1 int, k2 int) partition by k2");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                + "(k1 int, k2 int) partition by (k2)");
+
+        // Test PARTITION BY multiple columns
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                        + "(k1 int, k2 int, k3 int) partition by k2, k3");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                + "(k1 int, k2 int, k3 int) partition by (k2, k3)");
+
+        // Test PARTITION BY three columns
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                        + "(k1 int, k2 int, k3 int, k4 int) partition by k2, k3, k4");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                + "(k1 int, k2 int, k3 int, k4 int) partition by (k2, k3, k4)");
+
+        // Test PARTITION BY with partition transforms
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                        + "(k1 int, k2 date) partition by year(k2)");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                        + "(k1 int, k2 date) partition by month(k2)");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                        + "(k1 int, k2 date) partition by day(k2)");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                        + "(k1 int, k2 datetime) partition by year(k2), bucket(k1, 5)");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                        + "(k1 int, k2 int) partition by bucket(k1, 10), bucket(k2, 10)");
+
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                + "(k1 int, k2 datetime) partition by (year(k2), bucket(k1, 5))");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                + "(k1 int, k2 int) partition by (bucket(k1, 10), bucket(k2, 10))");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                + "(k1 int, k2 int, k3 string) partition by (bucket(k1, 10), bucket(k2, 10), truncate(k3, 3))");
 
         AnalyzeTestUtil.getStarRocksAssert().dropCatalog("iceberg_catalog");
     }

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2916,7 +2916,8 @@ partitionDesc
     | PARTITION BY LIST? identifierList
     | PARTITION BY functionCall '(' (rangePartitionDesc (',' rangePartitionDesc)*)? ')'
     | PARTITION BY functionCall
-    | PARTITION BY '('? partitionExpr (',' partitionExpr)* ')'?
+    | PARTITION BY partitionExpr (',' partitionExpr)*
+    | PARTITION BY '(' partitionExpr (',' partitionExpr)* ')'
     ;
 
 listPartitionDesc

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2916,7 +2916,7 @@ partitionDesc
     | PARTITION BY LIST? identifierList
     | PARTITION BY functionCall '(' (rangePartitionDesc (',' rangePartitionDesc)*)? ')'
     | PARTITION BY functionCall
-    | PARTITION BY partitionExpr (',' partitionExpr)*
+    | PARTITION BY '('? partitionExpr (',' partitionExpr)* ')'?
     ;
 
 listPartitionDesc


### PR DESCRIPTION
## Why I'm doing:
we support create iceberg table like this :
```
create table ice_test (
 k1 int,
 k2 int
) partition by (k1, k2)
```

but do not support create table with partition transform
```
create table ice_test (
 k1 int,
 k2 int
) partition by (bucket(k1, 3), bucket(k2, 3))
```

The standard specified in the document was not followed

## What I'm doing:

This pull request enhances support for the `PARTITION BY` clause in external Iceberg table creation, allowing for more flexible partitioning syntax and additional partition transform options. The changes include both grammar updates and expanded test coverage to ensure the new syntax and features are correctly handled.

**Grammar and Syntax Improvements:**

* Updated the `StarRocks.g4` grammar to allow optional parentheses around the partition expression list in the `PARTITION BY` clause, making the syntax more flexible and user-friendly.

**Test Coverage Enhancements:**

* Expanded the `AnalyzeCreateTableTest.java` test suite to include cases for:
  - Single and multiple column partitioning, with and without parentheses.
  - Partitioning by three columns, with and without parentheses.
  - Partition transforms such as `year()`, `month()`, `day()`, `bucket()`, and `truncate()` in the `PARTITION BY` clause, including combinations and use of parentheses.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
