### PR TITLE
[BugFix] Fix PushDownTopNToPreAggRule bugs

### DIFF
--- a/be/src/exprs/agg/combinator/agg_state_combinator.h
+++ b/be/src/exprs/agg/combinator/agg_state_combinator.h
@@ -32,6 +32,8 @@ public:
 
     ~AggStateCombinator() = default;
 
+    bool support_nullable_immediate_input() const override { return _function->support_nullable_immediate_input(); }
+
     // get the agg state desc
     const AggStateDesc* get_agg_state_desc() const { return &_agg_state_desc; }
 

--- a/be/src/exprs/agg/maxmin_by.h
+++ b/be/src/exprs/agg/maxmin_by.h
@@ -401,6 +401,8 @@ public:
         }
     }
 
+    bool support_nullable_immediate_input() const override { return true; }
+
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         Slice src;
         if (column->only_null() || column->is_null(row_num)) {
@@ -668,6 +670,8 @@ public:
             update(ctx, columns, state, i);
         }
     }
+
+    bool support_nullable_immediate_input() const override { return true; }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         if (column->only_null() || column->is_null(row_num)) {

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -135,7 +135,7 @@ public:
     }
 
     // only nullable aggregate can support nullable immediate input.
-    bool support_nullable_immediate_input() const { return true; }
+    bool support_nullable_immediate_input() const override { return true; }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         // Scalar function compute will return non-nullable column

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -134,6 +134,9 @@ public:
         nested_function->reset(ctx, args, this->data(state).mutable_nest_state());
     }
 
+    // only nullable aggregate can support nullable immediate input.
+    bool support_nullable_immediate_input() const { return true; }
+
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         // Scalar function compute will return non-nullable column
         // for nullable column when the real whole chunk data all not-null.

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -77,6 +77,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static com.starrocks.qe.SessionVariableConstants.AUTO;
 import static com.starrocks.qe.SessionVariableConstants.FORCE_PREAGGREGATION;
 import static com.starrocks.qe.SessionVariableConstants.FORCE_STREAMING;
 import static com.starrocks.qe.SessionVariableConstants.LIMITED;
@@ -390,6 +391,10 @@ public class AggregationNode extends PlanNode implements RuntimeFilterBuildNode 
         }
         if (useSortAgg) {
             output.append(detailPrefix).append("sorted streaming: true\n");
+        }
+        if (detailLevel == TExplainLevel.VERBOSE && !AUTO.equalsIgnoreCase(streamingPreaggregationMode)) {
+            output.append(detailPrefix).append("streaming preaggregation mode: ")
+                    .append(streamingPreaggregationMode).append("\n");
         }
 
         if (withLocalShuffle) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
@@ -86,6 +86,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.starrocks.qe.SessionVariableConstants.AUTO;
+
 public class Explain {
     public static final Explain DEFAULT_EXPLAIN = new Explain(true, false, "    ", "    ");
 
@@ -456,6 +458,10 @@ public class Explain {
             sb.append("\n");
 
             buildCostEstimate(sb, optExpression, context.step);
+            if (enableCosts && !AUTO.equalsIgnoreCase(aggregate.getNeededPreaggregationMode())) {
+                buildOperatorProperty(sb,
+                        "streaming_preaggregation_mode: " + aggregate.getNeededPreaggregationMode(), context.step);
+            }
 
             for (Map.Entry<ColumnRefOperator, CallOperator> entry : aggregate.getAggregations().entrySet()) {
                 String analyticCallString =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
@@ -121,6 +121,7 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
         this.withoutColocateRequirement = aggregateOperator.withoutColocateRequirement;
         this.distinctColumnDataSkew = aggregateOperator.distinctColumnDataSkew;
         this.groupByMinMaxStatistic = aggregateOperator.groupByMinMaxStatistic;
+        this.forcePreAggregation = aggregateOperator.forcePreAggregation;
         this.withLocalShuffle = aggregateOperator.withLocalShuffle;
         this.localLimit = aggregateOperator.localLimit;
     }
@@ -260,6 +261,10 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
 
     public void setForcePreAggregation(boolean forcePreAggregation) {
         this.forcePreAggregation = forcePreAggregation;
+    }
+
+    public boolean isForcePreAggregation() {
+        return forcePreAggregation;
     }
 
     public boolean isWithLocalShuffle() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownTopNToPreAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownTopNToPreAggRule.java
@@ -145,7 +145,6 @@ public class PushDownTopNToPreAggRule extends TransformationRule {
             localTopNSortInfo = new LogicalTopNOperator.TopNSortInfo(
                     topn.getOrderByElements(), topn.getSortPhase(), topn.getTopNType(),
                     topn.getLimit(), topn.getOffset());
-            localTopNOp.setTopNPushDownAgg();
         }
         // Create new local aggregation with TopN information for filtering during aggregation
         OptExpression newLocalAgg = OptExpression.create(new LogicalAggregationOperator.Builder()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -38,6 +38,7 @@ import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
+import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDecodeOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
@@ -377,11 +378,35 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
                         projection);
         op.setWithLocalShuffle(aggregate.isWithLocalShuffle());
         op.setMergedLocalAgg(aggregate.isMergedLocalAgg());
+        op.setTopNLocalAgg(aggregate.isTopNLocalAgg());
+        op.setTopNSortInfo(rewriteTopNSortInfo(aggregate.getTopNSortInfo(), inputStringRefs));
         op.setUseSortAgg(aggregate.isUseSortAgg());
         op.setUsePerBucketOptmize(aggregate.isUsePerBucketOptmize());
         op.setWithoutColocateRequirement(aggregate.isWithoutColocateRequirement());
+        op.setDistinctColumnDataSkew(aggregate.getDistinctColumnDataSkew());
+        op.setForcePreAggregation(aggregate.isForcePreAggregation());
         op.setLocalLimit(aggregate.getLocalLimit());
+        op.setGroupByMinMaxStatistic(aggregate.getGroupByMinMaxStatistic());
         return rewriteOptExpression(optExpression, op, info.outputStringColumns);
+    }
+
+    private LogicalTopNOperator.TopNSortInfo rewriteTopNSortInfo(LogicalTopNOperator.TopNSortInfo sortInfo,
+                                                                 ColumnRefSet inputStringRefs) {
+        if (sortInfo == null) {
+            return null;
+        }
+        List<Ordering> newOrderByElements = sortInfo.orderByElements().stream().map(ordering -> {
+            ColumnRefOperator columnRef = ordering.getColumnRef();
+            if (inputStringRefs.contains(columnRef)) {
+                ColumnRefOperator dictRef = context.stringRefToDictRefMap.get(columnRef);
+                if (dictRef != null) {
+                    return new Ordering(dictRef, ordering.isAscending(), ordering.isNullsFirst());
+                }
+            }
+            return ordering;
+        }).collect(Collectors.toList());
+        return new LogicalTopNOperator.TopNSortInfo(newOrderByElements, sortInfo.sortPhase(),
+                sortInfo.topNType(), sortInfo.limit(), sortInfo.offset());
     }
 
     @Override

--- a/test/sql/test_skew_join/R/test_skew_join_with_pre_topn
+++ b/test/sql/test_skew_join/R/test_skew_join_with_pre_topn
@@ -1,0 +1,249 @@
+-- name: test_skew_join_with_pre_topn
+CREATE TABLE IF NOT EXISTS skew_customer (
+    c_custkey     INT NOT NULL,
+    c_name        VARCHAR(25) NOT NULL,
+    c_address     VARCHAR(40) NOT NULL,
+    c_nationkey   INT NOT NULL,
+    c_phone       CHAR(15) NOT NULL,
+    c_acctbal     DECIMAL(15,2)   NOT NULL,
+    c_mktsegment  CHAR(10) NOT NULL,
+    c_comment     VARCHAR(117) NOT NULL
+)
+DUPLICATE KEY(c_custkey)
+DISTRIBUTED BY HASH(c_custkey) BUCKETS 3
+PROPERTIES (
+    "replication_num"="1"
+);
+-- result:
+-- !result
+CREATE TABLE IF NOT EXISTS nation (
+    n_nationkey INT NOT NULL,
+    n_name      CHAR(25) NOT NULL,
+    n_regionkey INT NOT NULL,
+    n_comment   VARCHAR(256)
+)
+DUPLICATE KEY(n_nationkey)
+DISTRIBUTED BY HASH(n_nationkey) BUCKETS 3
+PROPERTIES (
+    "replication_num"="1"
+);
+-- result:
+-- !result
+INSERT INTO nation VALUES
+(0, 'ALGERIA', 0, 'haggle. carefully final deposits detect slyly ag'),
+(1, 'ARGENTINA', 1, 'al foxes promise slyly according to the regular accounts. bold requests alon'),
+(2, 'BRAZIL', 1, 'y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special'),
+(3, 'CANADA', 1, 'eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold'),
+(4, 'EGYPT', 4, 'y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d'),
+(5, 'ETHIOPIA', 0, 'ven packages wake quickly. regu'),
+(6, 'FRANCE', 3, 'refully final requests. regular, ironi'),
+(7, 'GERMANY', 3, 'l platelets. regular accounts x-ray: unusual, regular acco'),
+(8, 'INDIA', 2, 'ss excuses cajole slyly across the packages. deposits print aroun'),
+(9, 'INDONESIA', 2, ' slyly express asymptotes. regular deposits haggle. slyly regular accounts across the expedited theodolite'),
+(10, 'IRAN', 4, 'efully alongside of the slyly final dependence'),
+(11, 'IRAQ', 4, 'nic deposits boost atop the quickly final requests? quickly regula'),
+(12, 'JAPAN', 2, 'ously. final, express gifts cajole a'),
+(13, 'JORDAN', 4, 'ic deposits are blithely about the carefully regular pa'),
+(14, 'KENYA', 0, ' pending excuses haggle furiously deposits. pending, express pinto beans wake fluffily past t'),
+(15, 'MOROCCO', 0, 'rns. blithely bold courts among the closely regular packages use furiously bold platelets?'),
+(16, 'MOZAMBIQUE', 0, 's. ironic, unusual asymptotes wake blithely r'),
+(17, 'PERU', 1, 'platelets. blithely pending dependencies use fluffily across the even pinto beans. carefully silent accoun'),
+(18, 'CHINA', 2, 'c dependencies. furiously careful notornis and slyly final packages. slyly bold accounts sleep a'),
+(19, 'ROMANIA', 3, 'ular asymptotes are about the furious multipliers. express dependencies nag above the ironically ironic account'),
+(20, 'SAUDI ARABIA', 4, 'ts. silent requests haggle. closely express packages sleep across the blithely'),
+(21, 'VIETNAM', 2, 'hely enticingly express accounts. even, final'),
+(22, 'RUSSIA', 3, ' requests against the platelets use never according to the quickly regular pint'),
+(23, 'UNITED KINGDOM', 3, 'eans boost carefully special requests. accounts are. carefull'),
+(24, 'UNITED STATES', 1, 'y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be');
+-- result:
+-- !result
+INSERT INTO skew_customer 
+SELECT 1, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment 
+FROM (
+    SELECT 'Customer#Skew001' as c_name, 'SkewAddr001' as c_address, 1 as c_nationkey, 
+           '11-111-111-1111' as c_phone, 1000.00 as c_acctbal, 'BUILDING' as c_mktsegment, 'skew data' as c_comment
+    UNION ALL
+    SELECT 'Customer#Skew002', 'SkewAddr002', 2, '22-222-222-2222', 2000.00, 'AUTOMOBILE', 'skew data'
+    UNION ALL
+    SELECT 'Customer#Skew003', 'SkewAddr003', 3, '33-333-333-3333', 3000.00, 'MACHINERY', 'skew data'
+    UNION ALL
+    SELECT 'Customer#Skew004', 'SkewAddr004', 4, '44-444-444-4444', 4000.00, 'HOUSEHOLD', 'skew data'
+    UNION ALL
+    SELECT 'Customer#Skew005', 'SkewAddr005', 5, '55-555-555-5555', 5000.00, 'FURNITURE', 'skew data'
+) t;
+-- result:
+-- !result
+SELECT COUNT(*) as total_customers FROM skew_customer;
+-- result:
+5
+-- !result
+set topn_push_down_agg_mode=1;
+-- result:
+-- !result
+set enable_optimize_skew_join_v1=false;
+-- result:
+-- !result
+set enable_optimize_skew_join_v2=false;
+-- result:
+-- !result
+SELECT c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, SUM(c_custkey) as sum_custkey FROM nation JOIN [skew|nation.n_nationkey(1,2,8)] skew_customer ON c_custkey = n_nationkey GROUP BY c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey LIMIT 3;
+-- result:
+1	Customer#Skew001	1000.00	ARGENTINA	SkewAddr001	11-111-111-1111	1	1
+1	Customer#Skew002	2000.00	ARGENTINA	SkewAddr002	22-222-222-2222	1	1
+1	Customer#Skew003	3000.00	ARGENTINA	SkewAddr003	33-333-333-3333	1	1
+-- !result
+SELECT c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, SUM(c_custkey) as sum_custkey FROM nation JOIN skew_customer ON c_custkey = n_nationkey GROUP BY c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey LIMIT 3;
+-- result:
+1	Customer#Skew001	1000.00	ARGENTINA	SkewAddr001	11-111-111-1111	1	1
+1	Customer#Skew002	2000.00	ARGENTINA	SkewAddr002	22-222-222-2222	1	1
+1	Customer#Skew003	3000.00	ARGENTINA	SkewAddr003	33-333-333-3333	1	1
+-- !result
+SELECT n_nationkey, COUNT(*) as cnt FROM nation JOIN [skew|nation.n_nationkey(1,2,8)] skew_customer ON c_custkey = n_nationkey GROUP BY n_nationkey ORDER BY n_nationkey;
+-- result:
+1	5
+-- !result
+SELECT n_name, COUNT(*) as cnt, SUM(c_acctbal) as total_bal, AVG(c_acctbal) as avg_bal, MAX(c_acctbal) as max_bal, MIN(c_acctbal) as min_bal FROM nation JOIN [skew|nation.n_nationkey(1,2,8)] skew_customer ON c_custkey = n_nationkey GROUP BY n_name ORDER BY n_name;
+-- result:
+ARGENTINA	5	15000.00	3000.00000000	5000.00	1000.00
+-- !result
+SELECT n_nationkey, n_name, COUNT(c_custkey) as customer_count FROM nation LEFT JOIN [skew|nation.n_nationkey(1,2,8)] skew_customer ON c_nationkey = n_nationkey GROUP BY n_nationkey, n_name ORDER BY n_nationkey, n_name LIMIT 10;
+-- result:
+0	ALGERIA	0
+1	ARGENTINA	1
+2	BRAZIL	1
+3	CANADA	1
+4	EGYPT	1
+5	ETHIOPIA	1
+6	FRANCE	0
+7	GERMANY	0
+8	INDIA	0
+9	INDONESIA	0
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation join [skew|nation.n_nationkey(1,2,8)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+1	Customer#Skew001	1000.00	ARGENTINA	SkewAddr001	11-111-111-1111	1	1
+1	Customer#Skew002	2000.00	ARGENTINA	SkewAddr002	22-222-222-2222	1	1
+1	Customer#Skew003	3000.00	ARGENTINA	SkewAddr003	33-333-333-3333	1	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation left join [skew|nation.n_nationkey(1,2,8)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+None	None	None	ALGERIA	None	None	0	1
+None	None	None	BRAZIL	None	None	2	1
+None	None	None	CANADA	None	None	3	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation join [skew|nation.n_nationkey(1)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+1	Customer#Skew001	1000.00	ARGENTINA	SkewAddr001	11-111-111-1111	1	1
+1	Customer#Skew002	2000.00	ARGENTINA	SkewAddr002	22-222-222-2222	1	1
+1	Customer#Skew003	3000.00	ARGENTINA	SkewAddr003	33-333-333-3333	1	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation left join [skew|nation.n_nationkey(1, NULL)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+None	None	None	ALGERIA	None	None	0	1
+None	None	None	BRAZIL	None	None	2	1
+None	None	None	CANADA	None	None	3	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer join [skew|nation.n_nationkey(1,2,8)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+1	Customer#Skew001	1000.00	ARGENTINA	SkewAddr001	11-111-111-1111	1	1
+1	Customer#Skew002	2000.00	ARGENTINA	SkewAddr002	22-222-222-2222	1	1
+1	Customer#Skew003	3000.00	ARGENTINA	SkewAddr003	33-333-333-3333	1	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer left join [skew|nation.n_nationkey(1,2,8)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+1	Customer#Skew001	1000.00	ARGENTINA	SkewAddr001	11-111-111-1111	1	1
+1	Customer#Skew002	2000.00	ARGENTINA	SkewAddr002	22-222-222-2222	1	1
+1	Customer#Skew003	3000.00	ARGENTINA	SkewAddr003	33-333-333-3333	1	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer join [skew|nation.n_nationkey(1)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+1	Customer#Skew001	1000.00	ARGENTINA	SkewAddr001	11-111-111-1111	1	1
+1	Customer#Skew002	2000.00	ARGENTINA	SkewAddr002	22-222-222-2222	1	1
+1	Customer#Skew003	3000.00	ARGENTINA	SkewAddr003	33-333-333-3333	1	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer left join [skew|nation.n_nationkey(1, NULL)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+1	Customer#Skew001	1000.00	ARGENTINA	SkewAddr001	11-111-111-1111	1	1
+1	Customer#Skew002	2000.00	ARGENTINA	SkewAddr002	22-222-222-2222	1	1
+1	Customer#Skew003	3000.00	ARGENTINA	SkewAddr003	33-333-333-3333	1	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation join [skew|skew_customer.c_custkey(1,2,8)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+1	Customer#Skew001	1000.00	ARGENTINA	SkewAddr001	11-111-111-1111	1	1
+1	Customer#Skew002	2000.00	ARGENTINA	SkewAddr002	22-222-222-2222	1	1
+1	Customer#Skew003	3000.00	ARGENTINA	SkewAddr003	33-333-333-3333	1	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation left join [skew|skew_customer.c_custkey(1,2,8)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+None	None	None	ALGERIA	None	None	0	1
+None	None	None	BRAZIL	None	None	2	1
+None	None	None	CANADA	None	None	3	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation join [skew|skew_customer.c_custkey(1)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+1	Customer#Skew001	1000.00	ARGENTINA	SkewAddr001	11-111-111-1111	1	1
+1	Customer#Skew002	2000.00	ARGENTINA	SkewAddr002	22-222-222-2222	1	1
+1	Customer#Skew003	3000.00	ARGENTINA	SkewAddr003	33-333-333-3333	1	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation left join [skew|skew_customer.c_custkey(1, NULL)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+None	None	None	ALGERIA	None	None	0	1
+None	None	None	BRAZIL	None	None	2	1
+None	None	None	CANADA	None	None	3	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer join [skew|skew_customer.c_custkey(1,2,8)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+1	Customer#Skew001	1000.00	ARGENTINA	SkewAddr001	11-111-111-1111	1	1
+1	Customer#Skew002	2000.00	ARGENTINA	SkewAddr002	22-222-222-2222	1	1
+1	Customer#Skew003	3000.00	ARGENTINA	SkewAddr003	33-333-333-3333	1	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer left join [skew|skew_customer.c_custkey(1,2,8)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+1	Customer#Skew001	1000.00	ARGENTINA	SkewAddr001	11-111-111-1111	1	1
+1	Customer#Skew002	2000.00	ARGENTINA	SkewAddr002	22-222-222-2222	1	1
+1	Customer#Skew003	3000.00	ARGENTINA	SkewAddr003	33-333-333-3333	1	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer join [skew|skew_customer.c_custkey(1)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+1	Customer#Skew001	1000.00	ARGENTINA	SkewAddr001	11-111-111-1111	1	1
+1	Customer#Skew002	2000.00	ARGENTINA	SkewAddr002	22-222-222-2222	1	1
+1	Customer#Skew003	3000.00	ARGENTINA	SkewAddr003	33-333-333-3333	1	1
+-- !result
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer left join [skew|skew_customer.c_custkey(1, NULL)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+-- result:
+1	Customer#Skew001	1000.00	ARGENTINA	SkewAddr001	11-111-111-1111	1	1
+1	Customer#Skew002	2000.00	ARGENTINA	SkewAddr002	22-222-222-2222	1	1
+1	Customer#Skew003	3000.00	ARGENTINA	SkewAddr003	33-333-333-3333	1	1
+-- !result
+SELECT n_nationkey, BOOL_OR(c_custkey), MIN_BY(c_name, c_acctbal), MAX_BY(c_name, c_acctbal) FROM nation LEFT JOIN [skew|nation.n_nationkey(1,2,8)] skew_customer ON c_custkey = n_nationkey GROUP BY n_nationkey ORDER BY n_nationkey LIMIT 10;
+-- result:
+0	0	None	None
+1	1	Customer#Skew001	Customer#Skew005
+2	0	None	None
+3	0	None	None
+4	0	None	None
+5	0	None	None
+6	0	None	None
+7	0	None	None
+8	0	None	None
+9	0	None	None
+-- !result
+SELECT n_nationkey, BOOL_OR(c_custkey), MIN_BY(c_name, c_acctbal), MAX_BY(c_name, c_acctbal), MAP_SIZE(MAP_AGG(n_nationkey, c_name)) FROM nation LEFT JOIN [skew|nation.n_nationkey(1,2,8)] skew_customer ON c_custkey = n_nationkey GROUP BY n_nationkey ORDER BY n_nationkey LIMIT 10;
+-- result:
+0	0	None	None	1
+1	1	Customer#Skew001	Customer#Skew005	1
+2	0	None	None	1
+3	0	None	None	1
+4	0	None	None	1
+5	0	None	None	1
+6	0	None	None	1
+7	0	None	None	1
+8	0	None	None	1
+9	0	None	None	1
+-- !result
+drop table skew_customer;
+-- result:
+-- !result
+drop table nation;
+-- result:
+-- !result

--- a/test/sql/test_skew_join/T/test_skew_join_with_pre_topn
+++ b/test/sql/test_skew_join/T/test_skew_join_with_pre_topn
@@ -1,0 +1,115 @@
+-- name: test_skew_join_with_pre_topn
+
+CREATE TABLE IF NOT EXISTS skew_customer (
+    c_custkey     INT NOT NULL,
+    c_name        VARCHAR(25) NOT NULL,
+    c_address     VARCHAR(40) NOT NULL,
+    c_nationkey   INT NOT NULL,
+    c_phone       CHAR(15) NOT NULL,
+    c_acctbal     DECIMAL(15,2)   NOT NULL,
+    c_mktsegment  CHAR(10) NOT NULL,
+    c_comment     VARCHAR(117) NOT NULL
+)
+DUPLICATE KEY(c_custkey)
+DISTRIBUTED BY HASH(c_custkey) BUCKETS 3
+PROPERTIES (
+    "replication_num"="1"
+);
+
+CREATE TABLE IF NOT EXISTS nation (
+    n_nationkey INT NOT NULL,
+    n_name      CHAR(25) NOT NULL,
+    n_regionkey INT NOT NULL,
+    n_comment   VARCHAR(256)
+)
+DUPLICATE KEY(n_nationkey)
+DISTRIBUTED BY HASH(n_nationkey) BUCKETS 3
+PROPERTIES (
+    "replication_num"="1"
+);
+
+INSERT INTO nation VALUES
+(0, 'ALGERIA', 0, 'haggle. carefully final deposits detect slyly ag'),
+(1, 'ARGENTINA', 1, 'al foxes promise slyly according to the regular accounts. bold requests alon'),
+(2, 'BRAZIL', 1, 'y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special'),
+(3, 'CANADA', 1, 'eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold'),
+(4, 'EGYPT', 4, 'y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d'),
+(5, 'ETHIOPIA', 0, 'ven packages wake quickly. regu'),
+(6, 'FRANCE', 3, 'refully final requests. regular, ironi'),
+(7, 'GERMANY', 3, 'l platelets. regular accounts x-ray: unusual, regular acco'),
+(8, 'INDIA', 2, 'ss excuses cajole slyly across the packages. deposits print aroun'),
+(9, 'INDONESIA', 2, ' slyly express asymptotes. regular deposits haggle. slyly regular accounts across the expedited theodolite'),
+(10, 'IRAN', 4, 'efully alongside of the slyly final dependence'),
+(11, 'IRAQ', 4, 'nic deposits boost atop the quickly final requests? quickly regula'),
+(12, 'JAPAN', 2, 'ously. final, express gifts cajole a'),
+(13, 'JORDAN', 4, 'ic deposits are blithely about the carefully regular pa'),
+(14, 'KENYA', 0, ' pending excuses haggle furiously deposits. pending, express pinto beans wake fluffily past t'),
+(15, 'MOROCCO', 0, 'rns. blithely bold courts among the closely regular packages use furiously bold platelets?'),
+(16, 'MOZAMBIQUE', 0, 's. ironic, unusual asymptotes wake blithely r'),
+(17, 'PERU', 1, 'platelets. blithely pending dependencies use fluffily across the even pinto beans. carefully silent accoun'),
+(18, 'CHINA', 2, 'c dependencies. furiously careful notornis and slyly final packages. slyly bold accounts sleep a'),
+(19, 'ROMANIA', 3, 'ular asymptotes are about the furious multipliers. express dependencies nag above the ironically ironic account'),
+(20, 'SAUDI ARABIA', 4, 'ts. silent requests haggle. closely express packages sleep across the blithely'),
+(21, 'VIETNAM', 2, 'hely enticingly express accounts. even, final'),
+(22, 'RUSSIA', 3, ' requests against the platelets use never according to the quickly regular pint'),
+(23, 'UNITED KINGDOM', 3, 'eans boost carefully special requests. accounts are. carefull'),
+(24, 'UNITED STATES', 1, 'y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be');
+
+INSERT INTO skew_customer 
+SELECT 1, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment 
+FROM (
+    SELECT 'Customer#Skew001' as c_name, 'SkewAddr001' as c_address, 1 as c_nationkey, 
+           '11-111-111-1111' as c_phone, 1000.00 as c_acctbal, 'BUILDING' as c_mktsegment, 'skew data' as c_comment
+    UNION ALL
+    SELECT 'Customer#Skew002', 'SkewAddr002', 2, '22-222-222-2222', 2000.00, 'AUTOMOBILE', 'skew data'
+    UNION ALL
+    SELECT 'Customer#Skew003', 'SkewAddr003', 3, '33-333-333-3333', 3000.00, 'MACHINERY', 'skew data'
+    UNION ALL
+    SELECT 'Customer#Skew004', 'SkewAddr004', 4, '44-444-444-4444', 4000.00, 'HOUSEHOLD', 'skew data'
+    UNION ALL
+    SELECT 'Customer#Skew005', 'SkewAddr005', 5, '55-555-555-5555', 5000.00, 'FURNITURE', 'skew data'
+) t;
+
+SELECT COUNT(*) as total_customers FROM skew_customer;
+
+set topn_push_down_agg_mode=1;
+set enable_optimize_skew_join_v1=false;
+set enable_optimize_skew_join_v2=false;
+
+SELECT c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, SUM(c_custkey) as sum_custkey FROM nation JOIN [skew|nation.n_nationkey(1,2,8)] skew_customer ON c_custkey = n_nationkey GROUP BY c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey LIMIT 3;
+
+SELECT c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, SUM(c_custkey) as sum_custkey FROM nation JOIN skew_customer ON c_custkey = n_nationkey GROUP BY c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey LIMIT 3;
+
+SELECT n_nationkey, COUNT(*) as cnt FROM nation JOIN [skew|nation.n_nationkey(1,2,8)] skew_customer ON c_custkey = n_nationkey GROUP BY n_nationkey ORDER BY n_nationkey;
+
+SELECT n_name, COUNT(*) as cnt, SUM(c_acctbal) as total_bal, AVG(c_acctbal) as avg_bal, MAX(c_acctbal) as max_bal, MIN(c_acctbal) as min_bal FROM nation JOIN [skew|nation.n_nationkey(1,2,8)] skew_customer ON c_custkey = n_nationkey GROUP BY n_name ORDER BY n_name;
+
+SELECT n_nationkey, n_name, COUNT(c_custkey) as customer_count FROM nation LEFT JOIN [skew|nation.n_nationkey(1,2,8)] skew_customer ON c_nationkey = n_nationkey GROUP BY n_nationkey, n_name ORDER BY n_nationkey, n_name LIMIT 10;
+
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation join [skew|nation.n_nationkey(1,2,8)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation left join [skew|nation.n_nationkey(1,2,8)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation join [skew|nation.n_nationkey(1)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation left join [skew|nation.n_nationkey(1, NULL)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer join [skew|nation.n_nationkey(1,2,8)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer left join [skew|nation.n_nationkey(1,2,8)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer join [skew|nation.n_nationkey(1)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer left join [skew|nation.n_nationkey(1, NULL)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation join [skew|skew_customer.c_custkey(1,2,8)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation left join [skew|skew_customer.c_custkey(1,2,8)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation join [skew|skew_customer.c_custkey(1)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from nation left join [skew|skew_customer.c_custkey(1, NULL)] skew_customer on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer join [skew|skew_customer.c_custkey(1,2,8)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer left join [skew|skew_customer.c_custkey(1,2,8)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer join [skew|skew_customer.c_custkey(1)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+select c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, n_nationkey, count(1) from skew_customer left join [skew|skew_customer.c_custkey(1, NULL)] nation on c_custkey = n_nationkey group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, n_nationkey order by all limit 3;
+
+SELECT n_nationkey, BOOL_OR(c_custkey), MIN_BY(c_name, c_acctbal), MAX_BY(c_name, c_acctbal) FROM nation LEFT JOIN [skew|nation.n_nationkey(1,2,8)] skew_customer ON c_custkey = n_nationkey GROUP BY n_nationkey ORDER BY n_nationkey LIMIT 10;
+
+SELECT n_nationkey, BOOL_OR(c_custkey), MIN_BY(c_name, c_acctbal), MAX_BY(c_name, c_acctbal), MAP_SIZE(MAP_AGG(n_nationkey, c_name)) FROM nation LEFT JOIN [skew|nation.n_nationkey(1,2,8)] skew_customer ON c_custkey = n_nationkey GROUP BY n_nationkey ORDER BY n_nationkey LIMIT 10;
+
+-- Cleanup
+drop table skew_customer;
+drop table nation;


### PR DESCRIPTION
## Why I'm doing:

1. After PushDownTopNToPreAggRule, there may be a TopN operator between multi-stage aggregates, which may convert a non-nullable aggregate immediate state into a nullable one because of `has_outer_join_child`. So for aggregate functions that expect non-nullable immediate input, we should convert the nullable column into a non-nullable column.
2. PushDownTopNToPreAggRule has some conflicts with AddDecodeNodeForDictStringRule which will cause AggregateNode's property lose.

## What I'm doing:
- Ensure non-nullable aggregate immediate state as input for non-nullable aggregate functions.
- Several operator properties (forcePreAggregation, topNLocalAgg, distinctColumnDataSkew, etc.) were not being properly preserved during plan transformations, specifically in AddDecodeNodeForDictStringRule and DecodeRewriter.
- Added `streaming_preaggregation_mode` to the explain output for better debugging and observability of aggregation execution strategies.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
