### PR TITLE
[Enhancement] Optimize the performance of find_best_tablet_to_do_update_compaction

### DIFF
--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -77,21 +77,19 @@ TabletSharedPtr Tablet::create_tablet_from_meta(const TabletMetaSharedPtr& table
 
 Tablet::Tablet(const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir)
         : BaseTablet(tablet_meta, data_dir),
-          _last_cumu_compaction_failure_millis(0),
-          _last_base_compaction_failure_millis(0),
-          _last_cumu_compaction_success_millis(0),
-          _last_base_compaction_success_millis(0),
           _cumulative_point(kInvalidCumulativePoint) {
     // change _rs_graph to _timestamped_version_tracker
     _timestamped_version_tracker.construct_versioned_tracker(_tablet_meta->all_rs_metas());
     _max_version_schema = BaseTablet::tablet_schema();
+    _keys_type = _max_version_schema->keys_type();
     MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
 #ifndef BE_TEST
     StarRocksMetrics::instance()->table_metrics_mgr()->register_table(_tablet_meta->table_id());
 #endif
 }
 
-Tablet::Tablet() {
+Tablet::Tablet(KeysType keys_type) {
+    _keys_type = keys_type;
     MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
 }
 

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -76,8 +76,7 @@ TabletSharedPtr Tablet::create_tablet_from_meta(const TabletMetaSharedPtr& table
 }
 
 Tablet::Tablet(const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir)
-        : BaseTablet(tablet_meta, data_dir),
-          _cumulative_point(kInvalidCumulativePoint) {
+        : BaseTablet(tablet_meta, data_dir), _cumulative_point(kInvalidCumulativePoint) {
     // change _rs_graph to _timestamped_version_tracker
     _timestamped_version_tracker.construct_versioned_tracker(_tablet_meta->all_rs_metas());
     _max_version_schema = BaseTablet::tablet_schema();

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -85,11 +85,12 @@ public:
 
     Tablet(const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir);
 
+    Tablet() = delete;
     Tablet(const Tablet&) = delete;
     const Tablet& operator=(const Tablet&) = delete;
 
     // for ut
-    Tablet();
+    Tablet(KeysType keys_type);
 
     ~Tablet() override;
 
@@ -117,8 +118,8 @@ public:
 
     bool belonged_to_cloud_native() const override { return false; }
 
-    // propreties encapsulated in TabletSchema
-    KeysType keys_type() const;
+    // properties encapsulated in TabletSchema
+    KeysType keys_type() const { return _keys_type; }
     size_t num_columns_with_max_version() const;
     size_t num_key_columns_with_max_version() const;
     size_t num_rows_per_row_block_with_max_version() const;
@@ -483,6 +484,9 @@ private:
 
     std::atomic<bool> _is_dropping{false};
     std::atomic<bool> _update_schema_running{false};
+    // The KeysType of a Tablet cannot be changed after creation. It is retrieved from the TabletSchema,
+    // and the redundant storage is designed to avoid unnecessary locking and reduce performance overhead.
+    KeysType _keys_type;
 };
 
 inline bool Tablet::init_succeeded() {
@@ -507,10 +511,6 @@ inline const int64_t Tablet::cumulative_layer_point() const {
 
 inline void Tablet::set_cumulative_layer_point(int64_t new_point) {
     _cumulative_point = new_point;
-}
-
-inline KeysType Tablet::keys_type() const {
-    return tablet_schema()->keys_type();
 }
 
 inline size_t Tablet::num_columns_with_max_version() const {

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -280,6 +280,7 @@ private:
     void sweep_shutdown_tablet(const DroppedTabletInfo& info, std::vector<DroppedTabletInfo>& finished_tablets);
 
     std::vector<TabletSharedPtr> _get_all_tablets_from_shard(const TabletsShard& shard);
+    std::vector<TabletSharedPtr> _get_all_tablets_from_shard(const TabletsShard& shard, KeysType keys_type);
 
     static Status _remove_tablet_meta(const TabletSharedPtr& tablet);
     static Status _remove_tablet_directories(const TabletSharedPtr& tablet);

--- a/be/test/storage/base_compaction_test.cpp
+++ b/be/test/storage/base_compaction_test.cpp
@@ -301,7 +301,9 @@ protected:
 };
 
 TEST_F(BaseCompactionTest, test_init_succeeded) {
+    create_tablet_schema(DUP_KEYS);
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
+    tablet_meta->set_tablet_schema(_tablet_schema);
     TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, _engine->get_stores()[0]);
     BaseCompaction base_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(base_compaction.compact().ok());
@@ -309,7 +311,7 @@ TEST_F(BaseCompactionTest, test_init_succeeded) {
 
 TEST_F(BaseCompactionTest, test_input_rowsets_LE_1) {
     TabletSchemaPB schema_pb;
-    schema_pb.set_keys_type(KeysType::DUP_KEYS);
+    schema_pb.set_keys_type(DUP_KEYS);
     auto schema = std::make_shared<const TabletSchema>(schema_pb);
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
     tablet_meta->set_tablet_schema(schema);

--- a/be/test/storage/compaction_manager_test.cpp
+++ b/be/test/storage/compaction_manager_test.cpp
@@ -105,7 +105,7 @@ TEST_F(CompactionManagerTest, test_candidates) {
     std::vector<CompactionCandidate> candidates;
     DataDir data_dir("./data_dir");
     for (int i = 0; i <= 10; i++) {
-        TabletSharedPtr tablet = std::make_shared<Tablet>();
+        TabletSharedPtr tablet = std::make_shared<Tablet>(DUP_KEYS);
         TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
         tablet_meta->set_tablet_id(i);
         tablet->set_tablet_meta(tablet_meta);
@@ -156,7 +156,7 @@ TEST_F(CompactionManagerTest, test_candidates_exceede) {
     std::vector<CompactionCandidate> candidates;
     DataDir data_dir("./data_dir");
     for (int i = 0; i < 20; i++) {
-        TabletSharedPtr tablet = std::make_shared<Tablet>();
+        TabletSharedPtr tablet = std::make_shared<Tablet>(DUP_KEYS);
         TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
         tablet_meta->set_tablet_id(i);
         tablet->set_tablet_meta(tablet_meta);
@@ -188,7 +188,7 @@ TEST_F(CompactionManagerTest, test_disable_compaction) {
     std::vector<CompactionCandidate> candidates;
     DataDir data_dir("./data_dir");
     for (int i = 0; i < 10; i++) {
-        TabletSharedPtr tablet = std::make_shared<Tablet>();
+        TabletSharedPtr tablet = std::make_shared<Tablet>(DUP_KEYS);
         TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
         tablet_meta->set_tablet_id(i);
         tablet_meta->TEST_set_table_id(1);
@@ -260,6 +260,7 @@ private:
 
 class MockTablet : public Tablet {
 public:
+    MockTablet() : Tablet(DUP_KEYS) {}
     MOCK_METHOD(std::shared_ptr<CompactionTask>, create_compaction_task, (), (override));
 };
 
@@ -353,7 +354,7 @@ TEST_F(CompactionManagerTest, test_remove_disable_compaction) {
     std::vector<CompactionCandidate> candidates;
     DataDir data_dir("./data_dir");
     for (int i = 0; i < 10; i++) {
-        TabletSharedPtr tablet = std::make_shared<Tablet>();
+        TabletSharedPtr tablet = std::make_shared<Tablet>(DUP_KEYS);
         TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
         tablet_meta->set_tablet_id(i);
         tablet_meta->TEST_set_table_id(2);
@@ -400,7 +401,7 @@ TEST_F(CompactionManagerTest, test_compaction_tasks) {
     config::max_compaction_concurrency = 2;
     config::cumulative_compaction_num_threads_per_disk = config::max_compaction_concurrency;
     for (int i = 0; i < config::max_compaction_concurrency + 1; i++) {
-        TabletSharedPtr tablet = std::make_shared<Tablet>();
+        TabletSharedPtr tablet = std::make_shared<Tablet>(DUP_KEYS);
         TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
         tablet_meta->set_tablet_id(i);
         tablet->set_tablet_meta(tablet_meta);
@@ -468,7 +469,7 @@ TEST_F(CompactionManagerTest, test_compaction_parallel) {
     int task_id = 0;
     // each tablet has 3 compaction tasks
     for (int i = 0; i < tablet_num; i++) {
-        TabletSharedPtr tablet = std::make_shared<Tablet>();
+        TabletSharedPtr tablet = std::make_shared<Tablet>(DUP_KEYS);
         TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
         tablet_meta->set_tablet_id(i);
         tablet->set_tablet_meta(tablet_meta);

--- a/be/test/storage/cumulative_compaction_test.cpp
+++ b/be/test/storage/cumulative_compaction_test.cpp
@@ -326,7 +326,9 @@ protected:
 };
 
 TEST_F(CumulativeCompactionTest, test_init_succeeded) {
+    create_tablet_schema(DUP_KEYS);
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
+    tablet_meta->set_tablet_schema(_tablet_schema);
     TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
     CumulativeCompaction cumulative_compaction(_compaction_mem_tracker.get(), tablet);
     ASSERT_FALSE(cumulative_compaction.compact().ok());

--- a/be/test/storage/default_compaction_policy_test.cpp
+++ b/be/test/storage/default_compaction_policy_test.cpp
@@ -294,7 +294,9 @@ protected:
 };
 
 TEST_F(DefaultCompactionPolicyTest, test_init_succeeded) {
+    create_tablet_schema(DUP_KEYS);
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
+    tablet_meta->set_tablet_schema(_tablet_schema);
     TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, nullptr);
     init_compaction_context(tablet);
     ASSERT_FALSE(compact(tablet).ok());

--- a/be/test/storage/persistent_index_load_executor_test.cpp
+++ b/be/test/storage/persistent_index_load_executor_test.cpp
@@ -241,7 +241,7 @@ TEST_F(PersistentIndexLoadExecutorTest, test_submit_task_many_times) {
 
 TEST_F(PersistentIndexLoadExecutorTest, test_non_pk_tablet) {
     // non pk tablet
-    auto tablet = std::make_shared<Tablet>();
+    auto tablet = std::make_shared<Tablet>(PRIMARY_KEYS);
     auto tablet_meta = std::make_shared<TabletMeta>();
     tablet_meta->set_tablet_id(10000);
     tablet->set_tablet_meta(tablet_meta);

--- a/be/test/storage/persistent_index_load_executor_test.cpp
+++ b/be/test/storage/persistent_index_load_executor_test.cpp
@@ -241,7 +241,7 @@ TEST_F(PersistentIndexLoadExecutorTest, test_submit_task_many_times) {
 
 TEST_F(PersistentIndexLoadExecutorTest, test_non_pk_tablet) {
     // non pk tablet
-    auto tablet = std::make_shared<Tablet>(PRIMARY_KEYS);
+    auto tablet = std::make_shared<Tablet>(DUP_KEYS);
     auto tablet_meta = std::make_shared<TabletMeta>();
     tablet_meta->set_tablet_id(10000);
     tablet->set_tablet_meta(tablet_meta);


### PR DESCRIPTION
## Why I'm doing:

The Compaction of the Primary Key model requires scanning all Tablets, which consumes a significant amount of CPU resources.

<img width="2668" height="688" alt="image" src="https://github.com/user-attachments/assets/b8f3fdbc-8130-403f-a534-dccd0f87f5af" />


* The KeysType of a Tablet will not change once created, so we can store the KeysType redundantly to avoid unnecessary locking.
* _get_all_tablets_from_shard takes the type parameter to prevent acquiring non-primary-key Tablets.


for 70,000 tablets (half duplicate key, half primary key), scan costs: 

Before Optimization: 266 ms
After Optimization: 132ms

## What I'm doing:

Optimize the performance of find_best_tablet_to_do_update_compaction

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
