### PR TITLE
[Refactor] Disallow Column copy constructor and assignment

### DIFF
--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -19,7 +19,6 @@
 #include "base/simd/simd.h"
 #include "column/column.h"
 #include "column/nullable_column.h"
-
 namespace starrocks {
 
 // NullableColumn has two columns: data column and null column. Based on the data, we classify null column into four types:
@@ -84,15 +83,9 @@ public:
 
     State state() { return _state; }
 
-    AdaptiveNullableColumn(const AdaptiveNullableColumn& rhs) { CHECK(false) << "unimplemented"; }
+    DISALLOW_COPY(AdaptiveNullableColumn);
 
     AdaptiveNullableColumn(AdaptiveNullableColumn&& rhs) noexcept { CHECK(false) << "unimplemented"; }
-
-    AdaptiveNullableColumn& operator=(const AdaptiveNullableColumn& rhs) {
-        AdaptiveNullableColumn tmp(rhs);
-        this->swap_column(tmp);
-        return *this;
-    }
 
     AdaptiveNullableColumn& operator=(AdaptiveNullableColumn&& rhs) noexcept {
         AdaptiveNullableColumn tmp(std::move(rhs));
@@ -361,6 +354,11 @@ public:
 
     MutableColumnPtr clone_empty() const override {
         return NullableColumn::create(_data_column->clone_empty(), _null_column->clone_empty());
+    }
+
+    MutableColumnPtr clone() const override {
+        materialized_nullable();
+        return create(_data_column->clone(), _null_column->clone());
     }
 
     size_t serialize_batch_at_interval(uint8_t* dst, size_t byte_offset, size_t byte_interval, uint32_t max_row_size,

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -77,9 +77,7 @@ public:
         }
     }
 
-    // NOTE: do *NOT* copy |_slices|
-    BinaryColumnBase(const BinaryColumnBase<T>& rhs)
-            : _bytes(rhs._bytes), _offsets(rhs._offsets), _resource(rhs._resource), _immuable_container(*this) {}
+    DISALLOW_COPY(BinaryColumnBase<T>);
 
     // NOTE: do *NOT* copy |_slices|
     BinaryColumnBase(BinaryColumnBase<T>&& rhs) noexcept
@@ -87,12 +85,6 @@ public:
               _offsets(std::move(rhs._offsets)),
               _resource(std::move(rhs._resource)),
               _immuable_container(*this) {}
-
-    BinaryColumnBase<T>& operator=(const BinaryColumnBase<T>& rhs) {
-        BinaryColumnBase<T> tmp(rhs);
-        this->swap_column(tmp);
-        return *this;
-    }
 
     BinaryColumnBase<T>& operator=(BinaryColumnBase<T>&& rhs) noexcept {
         BinaryColumnBase<T> tmp(std::move(rhs));
@@ -300,6 +292,12 @@ public:
     }
 
     MutableColumnPtr clone_empty() const override { return BinaryColumnBase<T>::create(); }
+
+    MutableColumnPtr clone() const override {
+        auto p = clone_empty();
+        p->append(*this, 0, size());
+        return p;
+    }
 
     MutableColumnPtr cut(size_t start, size_t length) const;
     size_t filter_range(const Filter& filter, size_t start, size_t to) override;

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -77,7 +77,7 @@ public:
         }
     }
 
-    DISALLOW_COPY(BinaryColumnBase<T>);
+    DISALLOW_COPY_TEMPLATE(BinaryColumnBase, BinaryColumnBase<T>);
 
     // NOTE: do *NOT* copy |_slices|
     BinaryColumnBase(BinaryColumnBase<T>&& rhs) noexcept

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -26,6 +26,7 @@
 #include "common/config.h"
 #include "common/statusor.h"
 #include "gutil/casts.h"
+#include "gutil/macros.h"
 #include "runtime/memory/column_allocator.h"
 #include "storage/delete_condition.h" // for DelCondSatisfied
 #include "util/cow.h"

--- a/be/src/column/column_view/column_view.h
+++ b/be/src/column/column_view/column_view.h
@@ -28,8 +28,6 @@ public:
     DISALLOW_COPY(ColumnView);
     ColumnView(ColumnView&& column_view) = delete;
 
-    MutableColumnPtr clone() const override { NOT_SUPPORT(); }
-
     bool is_view() const override { return true; }
     bool is_json_view() const override { return ColumnHelper::get_data_column(_default_column.get())->is_json(); }
     bool is_variant_view() const override { return ColumnHelper::get_data_column(_default_column.get())->is_variant(); }
@@ -37,5 +35,7 @@ public:
     bool is_array_view() const override { return ColumnHelper::get_data_column(_default_column.get())->is_array(); }
     bool is_binary_view() const override { return ColumnHelper::get_data_column(_default_column.get())->is_binary(); }
     bool is_struct_view() const override { return ColumnHelper::get_data_column(_default_column.get())->is_struct(); }
+
+    MutableColumnPtr clone() const override { return ColumnViewBase::clone(); }
 };
 } // namespace starrocks

--- a/be/src/column/column_view/column_view.h
+++ b/be/src/column/column_view/column_view.h
@@ -25,8 +25,11 @@ public:
     using Super = CowFactory<ColumnFactory<ColumnViewBase, ColumnView>, ColumnView, Column>;
     explicit ColumnView(ColumnPtr&& default_column, long concat_rows_limit, long concat_bytes_limit)
             : Super(std::move(default_column), concat_rows_limit, concat_bytes_limit) {}
-    ColumnView(const ColumnView& column_view) : Super(column_view) {}
+    DISALLOW_COPY(ColumnView);
     ColumnView(ColumnView&& column_view) = delete;
+
+    MutableColumnPtr clone() const override { NOT_SUPPORT(); }
+
     bool is_view() const override { return true; }
     bool is_json_view() const override { return ColumnHelper::get_data_column(_default_column.get())->is_json(); }
     bool is_variant_view() const override { return ColumnHelper::get_data_column(_default_column.get())->is_variant(); }

--- a/be/src/column/column_view/column_view_base.cpp
+++ b/be/src/column/column_view/column_view_base.cpp
@@ -15,9 +15,23 @@
 #include <base/simd/gather.h>
 #include <column/column.h>
 #include <column/column_helper.h>
+#include <column/column_view/column_view.h>
 #include <column/column_view/column_view_base.h>
 
 namespace starrocks {
+
+MutableColumnPtr ColumnViewBase::clone() const {
+    auto copy = ColumnView::create(ColumnPtr(_default_column->clone()), _concat_rows_limit, _concat_bytes_limit);
+    auto* c = static_cast<ColumnViewBase*>(copy.get());
+    c->_habitats = _habitats;
+    c->_num_rows = _num_rows;
+    c->_tasks = _tasks;
+    c->_habitat_idx = _habitat_idx;
+    c->_row_idx = _row_idx;
+    c->_concat_column = _concat_column;
+    return copy;
+}
+
 size_t ColumnViewBase::container_memory_usage() const {
     if (_concat_column) {
         return _concat_column->container_memory_usage();

--- a/be/src/column/column_view/column_view_base.h
+++ b/be/src/column/column_view/column_view_base.h
@@ -64,16 +64,7 @@ public:
               _concat_rows_limit(concat_rows_limit),
               _concat_bytes_limit(concat_bytes_limit) {}
 
-    ColumnViewBase(const ColumnViewBase& that)
-            : _default_column(that._default_column->clone()),
-              _concat_rows_limit(that._concat_rows_limit),
-              _concat_bytes_limit(that._concat_bytes_limit),
-              _habitats(that._habitats),
-              _num_rows(that._num_rows),
-              _tasks(that._tasks),
-              _habitat_idx(that._habitat_idx),
-              _row_idx(that._row_idx),
-              _concat_column(that._concat_column) {}
+    DISALLOW_COPY(ColumnViewBase);
 
     ColumnViewBase(ColumnViewBase&&) = delete;
     void append_default() override;

--- a/be/src/column/column_view/column_view_base.h
+++ b/be/src/column/column_view/column_view_base.h
@@ -103,7 +103,7 @@ public:
                                                bool& has_null) override {
         NOT_SUPPORT();
     }
-    MutablePtr clone() const override { NOT_SUPPORT(); }
+    MutablePtr clone() const override;
     uint32_t serialize_size(size_t idx) const override { NOT_SUPPORT(); }
     size_t filter_range(const Filter& filter, size_t from, size_t to) override { NOT_SUPPORT(); }
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override {

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -31,15 +31,9 @@ public:
     explicit ConstColumn(ColumnPtr data_column);
     ConstColumn(ColumnPtr data_column, size_t size);
 
-    ConstColumn(const ConstColumn& rhs) : _data(rhs._data->clone()), _size(rhs._size) {}
+    DISALLOW_COPY(ConstColumn);
 
     ConstColumn(ConstColumn&& rhs) noexcept : _data(std::move(rhs._data)), _size(rhs._size) {}
-
-    ConstColumn& operator=(const ConstColumn& rhs) {
-        ConstColumn tmp(rhs);
-        this->swap_column(tmp);
-        return *this;
-    }
 
     ConstColumn& operator=(ConstColumn&& rhs) noexcept {
         ConstColumn tmp(std::move(rhs));
@@ -202,6 +196,8 @@ public:
     uint32_t serialize_size(size_t idx) const override { return _data->serialize_size(0); }
 
     MutableColumnPtr clone_empty() const override { return create(_data->clone_empty(), 0); }
+
+    MutableColumnPtr clone() const override { return create(_data->clone(), _size); }
 
     size_t filter_range(const Filter& filter, size_t from, size_t to) override;
 

--- a/be/src/column/decimalv3_column.h
+++ b/be/src/column/decimalv3_column.h
@@ -36,7 +36,7 @@ public:
     DecimalV3Column(int precision, int scale);
     DecimalV3Column(int precision, int scale, size_t num_rows);
 
-    DISALLOW_COPY(DecimalV3Column<DecimalType<T>>);
+    DISALLOW_COPY_TEMPLATE(DecimalV3Column, DecimalV3Column<DecimalType<T>>);
 
     bool is_decimal() const override;
     bool is_numeric() const override;

--- a/be/src/column/decimalv3_column.h
+++ b/be/src/column/decimalv3_column.h
@@ -36,8 +36,7 @@ public:
     DecimalV3Column(int precision, int scale);
     DecimalV3Column(int precision, int scale, size_t num_rows);
 
-    DecimalV3Column(DecimalV3Column const&) = default;
-    DecimalV3Column& operator=(DecimalV3Column const&) = default;
+    DISALLOW_COPY(DecimalV3Column<DecimalType<T>>);
 
     bool is_decimal() const override;
     bool is_numeric() const override;
@@ -47,6 +46,12 @@ public:
     int scale() const;
 
     MutableColumnPtr clone_empty() const override { return this->create(_precision, _scale); }
+
+    MutableColumnPtr clone() const override {
+        auto p = clone_empty();
+        p->append(*this, 0, this->size());
+        return p;
+    }
 
     void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx, bool is_binary_protocol = false) const override;
     std::string debug_item(size_t idx) const override;

--- a/be/src/column/fixed_length_column.h
+++ b/be/src/column/fixed_length_column.h
@@ -33,7 +33,14 @@ public:
 
     FixedLengthColumn(const size_t n, const ValueType x) : SuperClass(n, x) {}
 
-    FixedLengthColumn(const FixedLengthColumn& src) : SuperClass((const FixedLengthColumnBase<T>&)(src)) {}
+    DISALLOW_COPY(FixedLengthColumn<T>);
+
     MutableColumnPtr clone_empty() const override { return this->create(); }
+
+    MutableColumnPtr clone() const override {
+        auto p = clone_empty();
+        p->append(*this, 0, this->size());
+        return p;
+    }
 };
 } // namespace starrocks

--- a/be/src/column/fixed_length_column.h
+++ b/be/src/column/fixed_length_column.h
@@ -33,7 +33,7 @@ public:
 
     FixedLengthColumn(const size_t n, const ValueType x) : SuperClass(n, x) {}
 
-    DISALLOW_COPY(FixedLengthColumn<T>);
+    DISALLOW_COPY_TEMPLATE(FixedLengthColumn, FixedLengthColumn<T>);
 
     MutableColumnPtr clone_empty() const override { return this->create(); }
 

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -23,7 +23,6 @@
 #include "column/datum.h"
 #include "column/vectorized_fwd.h"
 #include "common/statusor.h"
-
 namespace starrocks {
 
 template <typename T>
@@ -59,8 +58,7 @@ public:
 
     FixedLengthColumnBase(const size_t n, const ValueType x) : _data(n, x) {}
 
-    FixedLengthColumnBase(const FixedLengthColumnBase& src)
-            : _resource(src._resource), _data(src.immutable_data().begin(), src.immutable_data().end()) {}
+    DISALLOW_COPY(FixedLengthColumnBase<T>);
 
     // Only used as a underlying type for other column type(i.e. DecimalV3Column), C++
     // is weak to implement delegation for composite type like golang, so we have to use

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -58,7 +58,7 @@ public:
 
     FixedLengthColumnBase(const size_t n, const ValueType x) : _data(n, x) {}
 
-    DISALLOW_COPY(FixedLengthColumnBase<T>);
+    DISALLOW_COPY_TEMPLATE(FixedLengthColumnBase, FixedLengthColumnBase<T>);
 
     // Only used as a underlying type for other column type(i.e. DecimalV3Column), C++
     // is weak to implement delegation for composite type like golang, so we have to use

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -38,7 +38,7 @@ public:
 
     JsonColumn() = default;
     explicit JsonColumn(size_t size) : SuperClass(size) {}
-    JsonColumn(const JsonColumn& rhs) : SuperClass(rhs) {}
+    DISALLOW_COPY(JsonColumn);
 
     JsonColumn(JsonColumn&& rhs) noexcept : SuperClass(std::move(rhs)) {
         _flat_columns = std::move(rhs._flat_columns);

--- a/be/src/column/struct_column.h
+++ b/be/src/column/struct_column.h
@@ -17,7 +17,6 @@
 #include "column/binary_column.h"
 #include "column/column.h"
 #include "column/fixed_length_column.h"
-
 namespace starrocks {
 class StructColumn final : public CowFactory<ColumnFactory<Column, StructColumn>, StructColumn> {
     friend class CowFactory<ColumnFactory<Column, StructColumn>, StructColumn>;
@@ -32,12 +31,8 @@ public:
     StructColumn(MutableColumns&& fields, std::vector<std::string> field_names);
     StructColumn(const Columns& fields);
     StructColumn(const Columns& fields, std::vector<std::string> field_names);
-    StructColumn(const StructColumn& rhs) {
-        for (const auto& field : rhs._fields) {
-            _fields.emplace_back(field->clone());
-        }
-        _field_names = rhs._field_names;
-    }
+    DISALLOW_COPY(StructColumn);
+
     StructColumn(StructColumn&& rhs) noexcept
             : _fields(std::move(rhs._fields)), _field_names(std::move(rhs._field_names)) {}
 
@@ -121,6 +116,12 @@ public:
     uint32_t serialize_size(size_t idx) const override;
 
     MutableColumnPtr clone_empty() const override;
+
+    MutableColumnPtr clone() const override {
+        auto p = clone_empty();
+        p->append(*this, 0, size());
+        return p;
+    }
 
     size_t filter_range(const Filter& filter, size_t from, size_t to) override;
 

--- a/be/src/column/variant_column.h
+++ b/be/src/column/variant_column.h
@@ -33,7 +33,7 @@ public:
 
     VariantColumn() = default;
     explicit VariantColumn(size_t size) : SuperClass(size) {}
-    VariantColumn(const VariantColumn& rhs) : SuperClass(rhs) {}
+    DISALLOW_COPY(VariantColumn);
 
     VariantColumn(VariantColumn&& rhs) noexcept : SuperClass(std::move(rhs)) {}
 

--- a/be/src/exprs/agg/percentile_cont.h
+++ b/be/src/exprs/agg/percentile_cont.h
@@ -270,7 +270,7 @@ public:
         auto* dst_column = down_cast<BinaryColumn*>(dst.get());
         Bytes& bytes = dst_column->get_bytes();
         double rate = ColumnHelper::get_const_value<TYPE_DOUBLE>(src[1]);
-        auto src_column = *down_cast<const InputColumnType*>(src[0].get());
+        const auto& src_column = *down_cast<const InputColumnType*>(src[0].get());
         const InputCppType* src_data = src_column.immutable_data().data();
         for (auto i = 0; i < chunk_size; ++i) {
             size_t old_size = bytes.size();
@@ -393,7 +393,7 @@ public:
         Bytes& bytes = dst_column->get_bytes();
         double rate = ColumnHelper::get_const_value<TYPE_DOUBLE>(src[1]);
 
-        auto src_column = *down_cast<const BinaryColumn*>(src[0].get());
+        const auto& src_column = *down_cast<const BinaryColumn*>(src[0].get());
         const auto& src_data = src_column.get_proxy_data();
         for (auto i = 0; i < chunk_size; ++i) {
             size_t old_size = bytes.size();
@@ -671,7 +671,7 @@ public:
         bytes.resize(new_size);
         unsigned char* cur = bytes.data() + old_size;
 
-        auto src_column = *down_cast<const InputColumnType*>(src[0].get());
+        const auto& src_column = *down_cast<const InputColumnType*>(src[0].get());
         const InputCppType* src_data = src_column.immutable_data().data();
 
         size_t cur_size = old_size;

--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -335,7 +335,7 @@ private:
 
         // element: [1,2]; target: NULL
         if (targets->only_null() && !nullable_element) {
-            return ArrayColumn::create(array);
+            return array.clone();
         }
 
         // Expand Only-Null column.
@@ -1249,7 +1249,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_slice(FunctionContext* ctx, const Colu
 
         const auto* src_nullable_column = down_cast<const NullableColumn*>(columns[0].get());
         array_column = down_cast<const ArrayColumn*>(src_nullable_column->data_column().get());
-        null_result = NullColumn::create(*src_nullable_column->null_column());
+        null_result = NullColumn::static_pointer_cast(src_nullable_column->null_column()->clone());
     } else {
         array_column = down_cast<const ArrayColumn*>(src_column.get());
     }
@@ -1264,7 +1264,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_slice(FunctionContext* ctx, const Colu
         if (null_result) {
             null_result = FunctionHelper::union_null_column(null_result, src_nullable_column->null_column());
         } else {
-            null_result = NullColumn::create(*src_nullable_column->null_column());
+            null_result = NullColumn::static_pointer_cast(src_nullable_column->null_column()->clone());
         }
     } else {
         offset_column = down_cast<const Int64Column*>(
@@ -1283,7 +1283,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_slice(FunctionContext* ctx, const Colu
             if (null_result) {
                 null_result = FunctionHelper::union_null_column(null_result, src_nullable_column->null_column());
             } else {
-                null_result = NullColumn::create(*src_nullable_column->null_column());
+                null_result = NullColumn::static_pointer_cast(src_nullable_column->null_column()->clone());
             }
         } else {
             length_column = down_cast<const Int64Column*>(
@@ -1724,7 +1724,7 @@ StatusOr<ColumnPtr> ArrayFunctions::repeat(FunctionContext* ctx, const Columns& 
     NullColumnPtr null_result = nullptr;
     if (repeat_count_column->is_nullable()) {
         const auto* nullable_repeat_count_column = down_cast<const NullableColumn*>(repeat_count_column.get());
-        null_result = NullColumn::create(*nullable_repeat_count_column->null_column());
+        null_result = NullColumn::static_pointer_cast(nullable_repeat_count_column->null_column()->clone());
     }
 
     if (null_result) {
@@ -1754,7 +1754,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_top_n(FunctionContext* ctx, const Colu
 
         const auto* src_nullable_column = down_cast<const NullableColumn*>(columns[0].get());
         array_column = down_cast<const ArrayColumn*>(src_nullable_column->data_column().get());
-        null_result = NullColumn::create(*src_nullable_column->null_column());
+        null_result = NullColumn::static_pointer_cast(src_nullable_column->null_column()->clone());
     } else {
         array_column = down_cast<const ArrayColumn*>(src_column.get());
     }
@@ -1770,7 +1770,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_top_n(FunctionContext* ctx, const Colu
         if (null_result) {
             null_result = FunctionHelper::union_null_column(null_result, src_nullable_column->null_column());
         } else {
-            null_result = NullColumn::create(*src_nullable_column->null_column());
+            null_result = NullColumn::static_pointer_cast(src_nullable_column->null_column()->clone());
         }
     } else {
         count_column = down_cast<const Int32Column*>(

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -178,7 +178,8 @@ private:
             const auto* src_data_column = down_cast<const ArrayColumn*>(src_nullable_column->data_column_raw_ptr());
             auto src_null_data = src_nullable_column->immutable_null_column_data();
             auto dest_column_mut = NullableColumn::create(
-                    ArrayColumn::create(std::move(dest_column_data), UInt32Column::create(src_data_column->offsets())),
+                    ArrayColumn::create(std::move(dest_column_data),
+                                        UInt32Column::static_pointer_cast(src_data_column->offsets_column()->clone())),
                     NullColumn::create());
 
             auto& dest_nullable_column = down_cast<NullableColumn&>(*dest_column_mut.get());
@@ -203,7 +204,8 @@ private:
         } else {
             const auto* src_data_column = down_cast<const ArrayColumn*>(src_column.get());
             auto dest_column_mut =
-                    ArrayColumn::create(std::move(dest_column_data), UInt32Column::create(src_data_column->offsets()));
+                    ArrayColumn::create(std::move(dest_column_data),
+                                        UInt32Column::static_pointer_cast(src_data_column->offsets_column()->clone()));
 
             auto* dest_data_column = down_cast<ArrayColumn*>(dest_column_mut.get());
             for (size_t i = 0; i < chunk_size; i++) {
@@ -1607,7 +1609,7 @@ private:
             auto nullable = down_cast<NullableColumn*>(array_column->as_mutable_raw_ptr());
 
             array_col = down_cast<ArrayColumn*>(nullable->data_column_raw_ptr());
-            array_null = NullColumn::create(*nullable->null_column());
+            array_null = NullColumn::static_pointer_cast(nullable->null_column()->clone());
         } else {
             array_col = down_cast<ArrayColumn*>(array_column->as_mutable_raw_ptr());
             array_null = NullColumn::create(array_column->size(), 0);

--- a/be/src/exprs/binary_predicate.cpp
+++ b/be/src/exprs/binary_predicate.cpp
@@ -259,8 +259,8 @@ public:
 
         DCHECK(data1->is_array());
         DCHECK(data2->is_array());
-        auto lhs_arr = down_cast<const ArrayColumn&>(*data1);
-        auto rhs_arr = down_cast<const ArrayColumn&>(*data2);
+        const auto& lhs_arr = down_cast<const ArrayColumn&>(*data1);
+        const auto& rhs_arr = down_cast<const ArrayColumn&>(*data2);
 
         ColumnBuilder<TYPE_BOOLEAN> builder(l->size());
         std::vector<int8_t> cmp_result;

--- a/be/src/exprs/bitmap_functions.cpp
+++ b/be/src/exprs/bitmap_functions.cpp
@@ -409,7 +409,8 @@ StatusOr<ColumnPtr> BitmapFunctions::bitmap_to_array(FunctionContext* context, c
                 ArrayColumn::create(
                         NullableColumn::create(std::move(array_bigint_column), NullColumn::create(offset, 0)),
                         std::move(array_offsets)),
-                NullColumn::create(*ColumnHelper::as_raw_column<NullableColumn>(columns[0])->null_column()));
+                NullColumn::static_pointer_cast(
+                        ColumnHelper::as_raw_column<NullableColumn>(columns[0])->null_column()->clone()));
     }
 }
 

--- a/be/src/exprs/map_functions.cpp
+++ b/be/src/exprs/map_functions.cpp
@@ -158,7 +158,8 @@ StatusOr<ColumnPtr> MapFunctions::map_keys(FunctionContext* context, const Colum
     auto arg0 = ColumnHelper::unpack_and_duplicate_const_column(columns[0]->size(), columns[0]);
     const auto* col_map = down_cast<const MapColumn*>(ColumnHelper::get_data_column(arg0.get()));
     const auto& map_keys = col_map->keys_column();
-    auto map_keys_array = ArrayColumn::create(std::move(*map_keys).mutate(), UInt32Column::create(col_map->offsets()));
+    auto map_keys_array = ArrayColumn::create(std::move(*map_keys).mutate(),
+                                              UInt32Column::static_pointer_cast(col_map->offsets_column()->clone()));
 
     if (arg0->has_null()) {
         return NullableColumn::create(
@@ -177,8 +178,8 @@ StatusOr<ColumnPtr> MapFunctions::map_values(FunctionContext* context, const Col
 
     const auto* col_map = down_cast<const MapColumn*>(ColumnHelper::get_data_column(arg0.get()));
     const auto& map_values = col_map->values_column();
-    auto map_values_array =
-            ArrayColumn::create(std::move(*map_values).mutate(), UInt32Column::create(col_map->offsets()));
+    auto map_values_array = ArrayColumn::create(std::move(*map_values).mutate(),
+                                                UInt32Column::static_pointer_cast(col_map->offsets_column()->clone()));
 
     if (arg0->has_null()) {
         return NullableColumn::create(
@@ -214,7 +215,8 @@ StatusOr<ColumnPtr> MapFunctions::map_entries(FunctionContext* context, const Co
 
     auto null_column = NullColumn::create(struct_column->size(), 0);
     auto nullable_struct = NullableColumn::create(std::move(struct_column), std::move(null_column));
-    auto result_array = ArrayColumn::create(std::move(nullable_struct), UInt32Column::create(col_map->offsets()));
+    auto result_array = ArrayColumn::create(std::move(nullable_struct),
+                                            UInt32Column::static_pointer_cast(col_map->offsets_column()->clone()));
 
     if (arg0->has_null()) {
         return NullableColumn::create(

--- a/be/src/exprs/split.cpp
+++ b/be/src/exprs/split.cpp
@@ -190,7 +190,8 @@ StatusOr<ColumnPtr> StringFunctions::split(FunctionContext* context, const starr
                     ArrayColumn::create(NullableColumn::create(std::move(array_binary_column),
                                                                NullColumn::create(std::move(offset), 0)),
                                         std::move(array_offsets)),
-                    NullColumn::create(*ColumnHelper::as_raw_column<NullableColumn>(columns[0])->null_column()));
+                    NullColumn::static_pointer_cast(
+                            ColumnHelper::as_raw_column<NullableColumn>(columns[0])->null_column()->clone()));
         }
     } else {
         array_binary_column->reserve(row_nums * 5, haystack_columns->get_immutable_bytes().size() * sizeof(uint8_t));

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -520,7 +520,7 @@ ColumnPtr string_func_const(StringConstFuncType func, const Columns& columns, Ar
         if (src_nullable->has_null()) {
             auto* src_binary = down_cast<const BinaryColumn*>(src_nullable->data_column().get());
             ColumnPtr binary = func(columns, src_binary, std::forward<Args>(args)...);
-            NullColumn::MutablePtr src_null = NullColumn::create(*(src_nullable->null_column()));
+            NullColumn::MutablePtr src_null = NullColumn::static_pointer_cast(src_nullable->null_column()->clone());
 
             // - if binary is null ConstColumn, just return it.
             // - if binary is non-null ConstColumn, unfold it and wrap with src_null.

--- a/be/src/gutil/macros.h
+++ b/be/src/gutil/macros.h
@@ -99,6 +99,14 @@ struct CompileAssert {};
     TypeName(const TypeName&) = delete; \
     void operator=(const TypeName&) = delete
 
+// For class templates: use ClassName (no template-id) for constructor/operator=,
+// and FullTypeName (e.g. ClassName<T>) for the parameter. Avoids C++20
+// -Wtemplate-id-cdtor (template-id not allowed for constructor).
+#undef DISALLOW_COPY_TEMPLATE
+#define DISALLOW_COPY_TEMPLATE(ClassName, FullTypeName) \
+    ClassName(const FullTypeName&) = delete;            \
+    void operator=(const FullTypeName&) = delete
+
 #undef DISALLOW_MOVE
 #define DISALLOW_MOVE(TypeName)    \
     TypeName(TypeName&&) = delete; \

--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -200,7 +200,7 @@ private:
             array_col = down_cast<const ArrayColumn*>(const_column->data_column().get());
 
             auto element = array_col->elements_column();
-            auto offsets = UInt32Column::create(array_col->offsets());
+            auto offsets = UInt32Column::static_pointer_cast(array_col->offsets_column()->clone());
 
             ASSIGN_OR_RETURN(ColumnPtr string_col, _translate_string(element, element->size()));
             string_col = ColumnHelper::unfold_const_column(stringType, element->size(), std::move(string_col));
@@ -208,10 +208,10 @@ private:
         } else if (array->is_nullable()) {
             const auto* nullable = down_cast<const NullableColumn*>(array.get());
             array_col = down_cast<const ArrayColumn*>(nullable->data_column_raw_ptr());
-            NullColumnPtr array_null = NullColumn::create(*nullable->null_column());
+            NullColumnPtr array_null = NullColumn::static_pointer_cast(nullable->null_column()->clone());
 
             auto element = array_col->elements_column();
-            auto offsets = UInt32Column::create(array_col->offsets());
+            auto offsets = UInt32Column::static_pointer_cast(array_col->offsets_column()->clone());
 
             ASSIGN_OR_RETURN(ColumnPtr string_col, _translate_string(element, element->size()));
             string_col = ColumnHelper::unfold_const_column(stringType, element->size(), std::move(string_col));
@@ -219,7 +219,7 @@ private:
         } else {
             array_col = down_cast<const ArrayColumn*>(array.get());
             auto element = array_col->elements_column();
-            auto offsets = UInt32Column::create(array_col->offsets());
+            auto offsets = UInt32Column::static_pointer_cast(array_col->offsets_column()->clone());
 
             ASSIGN_OR_RETURN(ColumnPtr string_col, _translate_string(element, element->size()));
             string_col = ColumnHelper::unfold_const_column(stringType, element->size(), std::move(string_col));

--- a/be/src/util/cow.h
+++ b/be/src/util/cow.h
@@ -354,9 +354,7 @@ public:
         return MutablePtr(new Derived(std::forward<std::initializer_list<T>>(arg)));
     }
 
-    typename AncestorBaseType::MutablePtr clone() const override {
-        return typename AncestorBaseType::MutablePtr(new Derived(down_cast<const Derived&>(*this)));
-    }
+    typename AncestorBaseType::MutablePtr clone() const override = 0;
 
     // cast base ptr to derived ptr statically, like std::static_pointer_cast; if failed, return nullptr.
     static Ptr static_pointer_cast(const BasePtr& ptr) {

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -719,12 +719,12 @@ PARALLEL_TEST(ArrayColumnTest, test_copy_constructor) {
     c0->elements_column_raw_ptr()->append_datum(6);
     c0->offsets_column_raw_ptr()->append(6);
 
-    ArrayColumn c1(*c0);
+    auto c1 = ArrayColumn::static_pointer_cast(c0->clone());
     c0->reset_column();
-    ASSERT_EQ("[1,2,3]", c1.debug_item(0));
-    ASSERT_EQ("[4,5,6]", c1.debug_item(1));
-    ASSERT_TRUE(c1.elements_column()->use_count() == 1);
-    ASSERT_TRUE(c1.offsets_column()->use_count() == 1);
+    ASSERT_EQ("[1,2,3]", c1->debug_item(0));
+    ASSERT_EQ("[4,5,6]", c1->debug_item(1));
+    ASSERT_TRUE(c1->elements_column()->use_count() == 1);
+    ASSERT_TRUE(c1->offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE
@@ -766,13 +766,12 @@ PARALLEL_TEST(ArrayColumnTest, test_copy_assignment) {
     c0->elements_column_raw_ptr()->append_datum(6);
     c0->offsets_column_raw_ptr()->append(6);
 
-    ArrayColumn c1(NullableColumn::create(Int32Column::create(), NullColumn::create()), UInt32Column::create());
-    c1 = *c0;
+    auto c1 = ArrayColumn::static_pointer_cast(c0->clone());
     c0->reset_column();
-    ASSERT_EQ("[1,2,3]", c1.debug_item(0));
-    ASSERT_EQ("[4,5,6]", c1.debug_item(1));
-    ASSERT_TRUE(c1.elements_column()->use_count() == 1);
-    ASSERT_TRUE(c1.offsets_column()->use_count() == 1);
+    ASSERT_EQ("[1,2,3]", c1->debug_item(0));
+    ASSERT_EQ("[4,5,6]", c1->debug_item(1));
+    ASSERT_TRUE(c1->elements_column()->use_count() == 1);
+    ASSERT_TRUE(c1->offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -430,11 +430,11 @@ PARALLEL_TEST(BinaryColumnTest, test_copy_constructor) {
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
 
-    auto c2(*c1);
+    auto c2 = BinaryColumn::static_pointer_cast(c1->clone());
 
     c1.reset();
-    slices = c2.get_data();
-    ASSERT_EQ(2, c2.size());
+    slices = c2->get_data();
+    ASSERT_EQ(2, c2->size());
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
 }
@@ -470,12 +470,11 @@ PARALLEL_TEST(BinaryColumnTest, test_copy_assignment) {
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
 
-    BinaryColumn c2;
-    c2 = *c1;
+    auto c2 = BinaryColumn::static_pointer_cast(c1->clone());
 
     c1.reset();
-    slices = c2.get_data();
-    ASSERT_EQ(2, c2.size());
+    slices = c2->get_data();
+    ASSERT_EQ(2, c2->size());
     ASSERT_EQ("abc", slices[0]);
     ASSERT_EQ("def", slices[1]);
 }

--- a/be/test/column/const_column_test.cpp
+++ b/be/test/column/const_column_test.cpp
@@ -170,18 +170,18 @@ PARALLEL_TEST(ConstColumnTest, test_copy_constructor) {
 
     ASSERT_EQ(100, c1->size());
 
-    auto c2(*c1);
-    ASSERT_EQ(100, c2.size());
-    ASSERT_EQ(1, c2.data_column()->use_count());
+    auto c2 = ConstColumn::static_pointer_cast(c1->clone());
+    ASSERT_EQ(100, c2->size());
+    ASSERT_EQ(1, c2->data_column()->use_count());
     for (int i = 0; i < 100; i++) {
-        ASSERT_EQ(1, c2.get(i).get_int32());
+        ASSERT_EQ(1, c2->get(i).get_int32());
     }
 
     c1->reset_column();
-    ASSERT_EQ(100, c2.size());
-    ASSERT_EQ(1, c2.data_column()->use_count());
+    ASSERT_EQ(100, c2->size());
+    ASSERT_EQ(1, c2->data_column()->use_count());
     for (int i = 0; i < 100; i++) {
-        ASSERT_EQ(1, c2.get(i).get_int32());
+        ASSERT_EQ(1, c2->get(i).get_int32());
     }
 }
 
@@ -217,8 +217,7 @@ PARALLEL_TEST(ConstColumnTest, test_copy_assignment) {
 
     ASSERT_EQ(100, c1->size());
 
-    auto c2 = create_const_column(100, 1);
-    *c2 = *c1;
+    auto c2 = ConstColumn::static_pointer_cast(c1->clone());
 
     ASSERT_EQ(100, c2->size());
     ASSERT_EQ(1, c2->data_column()->use_count());

--- a/be/test/column/map_column_test.cpp
+++ b/be/test/column/map_column_test.cpp
@@ -809,13 +809,13 @@ PARALLEL_TEST(MapColumnTest, test_copy_constructor) {
     map1[(int32_t)6] = (int32_t)66;
     c0->append_datum(map1);
 
-    MapColumn c1(*c0);
+    auto c1 = MapColumn::static_pointer_cast(c0->clone());
     c0->reset_column();
-    ASSERT_EQ("{1:11,2:22,3:33}", c1.debug_item(0));
-    ASSERT_EQ("{4:44,5:55,6:66}", c1.debug_item(1));
-    ASSERT_TRUE(c1.keys_column()->use_count() == 1);
-    ASSERT_TRUE(c1.values_column()->use_count() == 1);
-    ASSERT_TRUE(c1.offsets_column()->use_count() == 1);
+    ASSERT_EQ("{1:11,2:22,3:33}", c1->debug_item(0));
+    ASSERT_EQ("{4:44,5:55,6:66}", c1->debug_item(1));
+    ASSERT_TRUE(c1->keys_column()->use_count() == 1);
+    ASSERT_TRUE(c1->values_column()->use_count() == 1);
+    ASSERT_TRUE(c1->offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE
@@ -864,15 +864,13 @@ PARALLEL_TEST(MapColumnTest, test_copy_assignment) {
     map1[(int32_t)6] = (int32_t)66;
     c0->append_datum(map1);
 
-    MapColumn c1(NullableColumn::create(Int32Column::create(), NullColumn::create()),
-                 NullableColumn::create(Int32Column::create(), NullColumn::create()), UInt32Column::create());
-    c1 = *c0;
+    auto c1 = MapColumn::static_pointer_cast(c0->clone());
     c0->reset_column();
-    ASSERT_EQ("{1:11,2:22,3:33}", c1.debug_item(0));
-    ASSERT_EQ("{4:44,5:55,6:66}", c1.debug_item(1));
-    ASSERT_TRUE(c1.keys_column()->use_count() == 1);
-    ASSERT_TRUE(c1.values_column()->use_count() == 1);
-    ASSERT_TRUE(c1.offsets_column()->use_count() == 1);
+    ASSERT_EQ("{1:11,2:22,3:33}", c1->debug_item(0));
+    ASSERT_EQ("{4:44,5:55,6:66}", c1->debug_item(1));
+    ASSERT_TRUE(c1->keys_column()->use_count() == 1);
+    ASSERT_TRUE(c1->values_column()->use_count() == 1);
+    ASSERT_TRUE(c1->offsets_column()->use_count() == 1);
 }
 
 // NOLINTNEXTLINE

--- a/be/test/column/nullable_column_test.cpp
+++ b/be/test/column/nullable_column_test.cpp
@@ -65,18 +65,18 @@ PARALLEL_TEST(NullableColumnTest, test_copy_constructor) {
     c0->append_datum((int32_t)2);
     c0->append_datum((int32_t)3);
 
-    NullableColumn c1(*c0);
+    auto c1 = NullableColumn::static_pointer_cast(c0->clone());
     c0->reset_column();
 
-    ASSERT_EQ(4, c1.size());
-    ASSERT_TRUE(c1.data_column()->use_count() == 1);
-    ASSERT_TRUE(c1.null_column()->use_count() == 1);
-    ASSERT_EQ(4, c1.data_column()->size());
-    ASSERT_EQ(4, c1.null_column()->size());
-    ASSERT_TRUE(c1.get(0).is_null());
-    ASSERT_EQ(1, c1.get(1).get_int32());
-    ASSERT_EQ(2, c1.get(2).get_int32());
-    ASSERT_EQ(3, c1.get(3).get_int32());
+    ASSERT_EQ(4, c1->size());
+    ASSERT_TRUE(c1->data_column()->use_count() == 1);
+    ASSERT_TRUE(c1->null_column()->use_count() == 1);
+    ASSERT_EQ(4, c1->data_column()->size());
+    ASSERT_EQ(4, c1->null_column()->size());
+    ASSERT_TRUE(c1->get(0).is_null());
+    ASSERT_EQ(1, c1->get(1).get_int32());
+    ASSERT_EQ(2, c1->get(2).get_int32());
+    ASSERT_EQ(3, c1->get(3).get_int32());
 }
 
 // NOLINTNEXTLINE
@@ -110,19 +110,18 @@ PARALLEL_TEST(NullableColumnTest, test_copy_assignment) {
     c0->append_datum((int32_t)2);
     c0->append_datum((int32_t)3);
 
-    NullableColumn c1(Int32Column::create(), NullColumn::create());
-    c1 = *c0;
+    auto c1 = NullableColumn::static_pointer_cast(c0->clone());
     c0->reset_column();
 
-    ASSERT_EQ(4, c1.size());
-    ASSERT_TRUE(c1.data_column()->use_count() == 1);
-    ASSERT_TRUE(c1.null_column()->use_count() == 1);
-    ASSERT_EQ(4, c1.data_column()->size());
-    ASSERT_EQ(4, c1.null_column()->size());
-    ASSERT_TRUE(c1.get(0).is_null());
-    ASSERT_EQ(1, c1.get(1).get_int32());
-    ASSERT_EQ(2, c1.get(2).get_int32());
-    ASSERT_EQ(3, c1.get(3).get_int32());
+    ASSERT_EQ(4, c1->size());
+    ASSERT_TRUE(c1->data_column()->use_count() == 1);
+    ASSERT_TRUE(c1->null_column()->use_count() == 1);
+    ASSERT_EQ(4, c1->data_column()->size());
+    ASSERT_EQ(4, c1->null_column()->size());
+    ASSERT_TRUE(c1->get(0).is_null());
+    ASSERT_EQ(1, c1->get(1).get_int32());
+    ASSERT_EQ(2, c1->get(2).get_int32());
+    ASSERT_EQ(3, c1->get(3).get_int32());
 }
 
 // NOLINTNEXTLINE
@@ -134,18 +133,17 @@ PARALLEL_TEST(NullableColumnTest, test_move_assignment) {
     c0->append_datum((int32_t)2);
     c0->append_datum((int32_t)3);
 
-    NullableColumn c1(Int32Column::create(), NullColumn::create());
-    c1 = *c0;
+    auto c1 = NullableColumn::static_pointer_cast(c0->clone());
 
-    ASSERT_EQ(4, c1.size());
-    ASSERT_TRUE(c1.data_column()->use_count() == 1);
-    ASSERT_TRUE(c1.null_column()->use_count() == 1);
-    ASSERT_EQ(4, c1.data_column()->size());
-    ASSERT_EQ(4, c1.null_column()->size());
-    ASSERT_TRUE(c1.get(0).is_null());
-    ASSERT_EQ(1, c1.get(1).get_int32());
-    ASSERT_EQ(2, c1.get(2).get_int32());
-    ASSERT_EQ(3, c1.get(3).get_int32());
+    ASSERT_EQ(4, c1->size());
+    ASSERT_TRUE(c1->data_column()->use_count() == 1);
+    ASSERT_TRUE(c1->null_column()->use_count() == 1);
+    ASSERT_EQ(4, c1->data_column()->size());
+    ASSERT_EQ(4, c1->null_column()->size());
+    ASSERT_TRUE(c1->get(0).is_null());
+    ASSERT_EQ(1, c1->get(1).get_int32());
+    ASSERT_EQ(2, c1->get(2).get_int32());
+    ASSERT_EQ(3, c1->get(3).get_int32());
 }
 
 // NOLINTNEXTLINE

--- a/be/test/column/struct_column_test.cpp
+++ b/be/test/column/struct_column_test.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "column/binary_column.h"
+#include "column/column_helper.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
@@ -285,15 +286,16 @@ TEST(StructColumnTest, test_copy_construtor) {
     ASSERT_EQ("{id:1,name:'smith'}", col->debug_item(0));
     ASSERT_EQ("{id:2,name:'cruise'}", col->debug_item(1));
 
-    StructColumn copy(*col);
+    auto copy_ptr = col->clone();
+    auto* copy = down_cast<StructColumn*>(copy_ptr.get());
     col->reset_column();
     ASSERT_EQ(0, col->size());
-    ASSERT_EQ(2, copy.size());
-    ASSERT_EQ("{id:1,name:'smith'}", copy.debug_item(0));
-    ASSERT_EQ("{id:2,name:'cruise'}", copy.debug_item(1));
+    ASSERT_EQ(2, copy->size());
+    ASSERT_EQ("{id:1,name:'smith'}", copy->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", copy->debug_item(1));
 
-    ASSERT_TRUE(copy.get_column_by_idx(0)->use_count() == 1);
-    ASSERT_TRUE(copy.get_column_by_idx(1)->use_count() == 1);
+    ASSERT_TRUE(copy->get_column_by_idx(0)->use_count() == 1);
+    ASSERT_TRUE(copy->get_column_by_idx(1)->use_count() == 1);
 }
 
 TEST(StructColumnTest, test_move_construtor) {

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -1670,7 +1670,7 @@ void test_non_deterministic_agg_function(FunctionContext* ctx, const AggregateFu
     func->update_batch_single_state(ctx, row_column->size(), &row_column, state->state());
     func->finalize_to_column(ctx, state->state(), result_column1.get());
 
-    auto expected_column1 = down_cast<const ExpeactedResultColumnType&>(row_column[0]);
+    const auto& expected_column1 = down_cast<const ExpeactedResultColumnType&>(row_column[0]);
     ASSERT_EQ(expected_column1.get_data()[0], result_column1->get_data()[0]);
 
     // update input column 2
@@ -1681,7 +1681,7 @@ void test_non_deterministic_agg_function(FunctionContext* ctx, const AggregateFu
     func->update_batch_single_state(ctx, row_column->size(), &row_column, state2->state());
     func->finalize_to_column(ctx, state2->state(), result_column2.get());
 
-    auto expected_column2 = down_cast<const ExpeactedResultColumnType&>(row_column[0]);
+    const auto& expected_column2 = down_cast<const ExpeactedResultColumnType&>(row_column[0]);
     ASSERT_EQ(expected_column2.get_data()[0], result_column2->get_data()[0]);
 
     // merge column 1 and column 2

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -3502,9 +3502,10 @@ PARALLEL_TEST(VecStringFunctionsTest, strposInstanceTest) {
         instance->append(1);
         nulls->append(1);
 
-        auto haystack_nullable = NullableColumn::create(haystack, NullColumn::create(*nulls));
-        auto needle_nullable = NullableColumn::create(needle->clone(), NullColumn::create(*nulls));
-        auto instance_nullable = NullableColumn::create(instance->clone(), NullColumn::create(*nulls));
+        auto haystack_nullable = NullableColumn::create(haystack, NullColumn::static_pointer_cast(nulls->clone()));
+        auto needle_nullable = NullableColumn::create(needle->clone(), NullColumn::static_pointer_cast(nulls->clone()));
+        auto instance_nullable =
+                NullableColumn::create(instance->clone(), NullColumn::static_pointer_cast(nulls->clone()));
 
         columns.emplace_back(haystack_nullable);
         columns.emplace_back(needle_nullable);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Disable the copy constructor and assign operator for Columns to avoid the overhead of implicit copying. 
Where copying is necessary, explicitly use the clone method.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
