### PR TITLE
[BugFix] Handle join skew hint in OptExpressionDuplicator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -401,7 +401,12 @@ public class OptExpressionDuplicator {
                 ScalarOperator newOnPredicate = rewriter.rewrite(onpredicate);
                 LogicalJoinOperator.Builder joinBuilder = (LogicalJoinOperator.Builder) opBuilder;
                 joinBuilder.setOnPredicate(newOnPredicate);
+
+                if (joinOperator.getSkewColumn() != null) {
+                    joinBuilder.setSkewColumn(rewriter.rewrite(joinOperator.getSkewColumn()));
+                }
             }
+
             return OptExpression.create(opBuilder.build(), inputs);
         }
 


### PR DESCRIPTION
## Why I'm doing:
Consider the following query:
```sql
select a.p, a.s, b.val, sum(a.x) over (partition by a.p order by a.s) 
from window_skew_table a 
join [skew|b.id(NULL)] window_skew_table_join b on a.p = b.id
```
Currently `OptExpressionDuplicator` does not rewrite the columns of a skew hint. 
If a optimizer rule like `SplitWindowSkewToUnionRule` rewrites the child expression, the column in skew hint points to the old ColumnRef. 
This leads to "Can't find skew column" exception ([link](https://github.com/martinr0x/starrocks/blob/61e7922924008167839b3731134229c6d125b751/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java#L247))
## What I'm doing:
Adding support to rewrite skew hint column in the `OptExpressionDuplicator`.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
