### PR TITLE
[BugFix] Fix struct field names not being escaped

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ParseUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ParseUtil.java
@@ -151,6 +151,6 @@ public class ParseUtil {
         if (StringUtils.isEmpty(str)) {
             return str;
         }
-        return "`" + str + "`";
+        return "`" + str.replace("`", "``") + "`";
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
@@ -220,7 +220,7 @@ public class AST2SQLVisitor extends AST2StringVisitor {
                                 columnName));
                     }
                 } else if (columnName != null) {
-                    selectListString.add(visit(expr) + " AS `" + columnName + "`");
+                    selectListString.add(visit(expr) + " AS " + ParseUtil.backquote(columnName));
                 } else {
                     selectListString.add(visit(expr));
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableWithAggStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableWithAggStateTest.java
@@ -257,15 +257,15 @@ public class CreateTableWithAggStateTest {
                             .getTable("test_agg_tbl1");
                     String columns = table.getColumns().toString();
                     String expect = "[`k1` varchar(10) NULL COMMENT \"\", " +
-                            "`k10` struct<col1 array<largeint(40)>> array_agg(largeint(40)) NULL COMMENT \"\", " +
-                            "`k11` struct<col1 array<float>> array_agg(float) NULL COMMENT \"\", " +
-                            "`k12` struct<col1 array<double>> array_agg(double) NULL COMMENT \"\", " +
-                            "`k13` struct<col1 array<DECIMAL128(38,1)>> array_agg(decimal(38, 1)) NULL COMMENT \"\", " +
-                            "`k2` struct<col1 array<datetime>> array_agg(datetime) NULL COMMENT \"\", " +
-                            "`k6` struct<col1 array<tinyint(4)>> array_agg(tinyint(4)) NULL COMMENT \"\", " +
-                            "`k7` struct<col1 array<smallint(6)>> array_agg(smallint(6)) NULL COMMENT \"\", " +
-                            "`k8` struct<col1 array<int(11)>> array_agg(int(11)) NULL COMMENT \"\", " +
-                            "`k9` struct<col1 array<bigint(20)>> array_agg(bigint(20)) NULL COMMENT \"\"]";
+                            "`k10` struct<`col1` array<largeint(40)>> array_agg(largeint(40)) NULL COMMENT \"\", " +
+                            "`k11` struct<`col1` array<float>> array_agg(float) NULL COMMENT \"\", " +
+                            "`k12` struct<`col1` array<double>> array_agg(double) NULL COMMENT \"\", " +
+                            "`k13` struct<`col1` array<DECIMAL128(38,1)>> array_agg(decimal(38, 1)) NULL COMMENT \"\", " +
+                            "`k2` struct<`col1` array<datetime>> array_agg(datetime) NULL COMMENT \"\", " +
+                            "`k6` struct<`col1` array<tinyint(4)>> array_agg(tinyint(4)) NULL COMMENT \"\", " +
+                            "`k7` struct<`col1` array<smallint(6)>> array_agg(smallint(6)) NULL COMMENT \"\", " +
+                            "`k8` struct<`col1` array<int(11)>> array_agg(int(11)) NULL COMMENT \"\", " +
+                            "`k9` struct<`col1` array<bigint(20)>> array_agg(bigint(20)) NULL COMMENT \"\"]";
                     Assertions.assertEquals(expect, columns);
                 });
     }
@@ -294,15 +294,15 @@ public class CreateTableWithAggStateTest {
                             .getTable("test_agg_tbl1");
                     String columns = table.getColumns().toString();
                     String expect = "[`k1` varchar(10) NULL COMMENT \"\", " +
-                            "`k10` struct<col1 array<varchar(1048576)>> group_concat(largeint(40)) NULL COMMENT \"\", " +
-                            "`k11` struct<col1 array<varchar(1048576)>> group_concat(float) NULL COMMENT \"\", " +
-                            "`k12` struct<col1 array<varchar(1048576)>> group_concat(double) NULL COMMENT \"\", " +
-                            "`k13` struct<col1 array<varchar(1048576)>> group_concat(decimal(21, 10)) NULL COMMENT \"\", " +
-                            "`k2` struct<col1 array<varchar(1048576)>> group_concat(datetime) NULL COMMENT \"\", " +
-                            "`k6` struct<col1 array<varchar(1048576)>> group_concat(tinyint(4)) NULL COMMENT \"\", " +
-                            "`k7` struct<col1 array<varchar(1048576)>> group_concat(smallint(6)) NULL COMMENT \"\", " +
-                            "`k8` struct<col1 array<varchar(1048576)>> group_concat(int(11)) NULL COMMENT \"\", " +
-                            "`k9` struct<col1 array<varchar(1048576)>> group_concat(bigint(20)) NULL COMMENT \"\"]";
+                            "`k10` struct<`col1` array<varchar(1048576)>> group_concat(largeint(40)) NULL COMMENT \"\", " +
+                            "`k11` struct<`col1` array<varchar(1048576)>> group_concat(float) NULL COMMENT \"\", " +
+                            "`k12` struct<`col1` array<varchar(1048576)>> group_concat(double) NULL COMMENT \"\", " +
+                            "`k13` struct<`col1` array<varchar(1048576)>> group_concat(decimal(21, 10)) NULL COMMENT \"\", " +
+                            "`k2` struct<`col1` array<varchar(1048576)>> group_concat(datetime) NULL COMMENT \"\", " +
+                            "`k6` struct<`col1` array<varchar(1048576)>> group_concat(tinyint(4)) NULL COMMENT \"\", " +
+                            "`k7` struct<`col1` array<varchar(1048576)>> group_concat(smallint(6)) NULL COMMENT \"\", " +
+                            "`k8` struct<`col1` array<varchar(1048576)>> group_concat(int(11)) NULL COMMENT \"\", " +
+                            "`k9` struct<`col1` array<varchar(1048576)>> group_concat(bigint(20)) NULL COMMENT \"\"]";
                     Assertions.assertEquals(expect, columns);
                 });
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -258,7 +258,7 @@ public class TypeTest {
                 {TypeFactory.createDecimalV3NarrowestType(18, 4), "decimal(18, 4)"},
                 {new ArrayType(IntegerType.INT), "array<int(11)>"},
                 {new MapType(IntegerType.INT, IntegerType.INT), "map<int(11),int(11)>"},
-                {new StructType(Lists.newArrayList(IntegerType.INT)), "struct<col1 int(11)>"},
+                {new StructType(Lists.newArrayList(IntegerType.INT)), "struct<`col1` int(11)>"},
         };
 
         for (Object[] tc : testCases) {
@@ -280,7 +280,7 @@ public class TypeTest {
         String json = GsonUtils.GSON.toJson(mapType);
         Type deType = GsonUtils.GSON.fromJson(json, Type.class);
         Assertions.assertTrue(deType.isMapType());
-        Assertions.assertEquals("MAP<INT,struct<c1 int(11), cc1 varchar(1073741824)>>", deType.toString());
+        Assertions.assertEquals("MAP<INT,struct<`c1` int(11), `cc1` varchar(1073741824)>>", deType.toString());
         // Make sure select fields are false when initialized
         Assertions.assertFalse(deType.getSelectedFields()[0]);
         Assertions.assertFalse(deType.getSelectedFields()[1]);
@@ -301,7 +301,8 @@ public class TypeTest {
         Type deType = GsonUtils.GSON.fromJson(json, Type.class);
         Assertions.assertTrue(deType.isStructType());
         Assertions.assertEquals(
-                "struct<struct_test int(11) COMMENT 'comment test', c1 struct<c1 int(11), cc1 varchar(1073741824)>>",
+                "struct<`struct_test` int(11) COMMENT 'comment test', `c1` struct<`c1` int(11), `cc1` " +
+                        "varchar(1073741824)>>",
                 deType.toString());
         // test initialed fieldMap by ctor in deserializer.
         Assertions.assertEquals(1, ((StructType) deType).getFieldPos("c1"));

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
@@ -293,7 +293,7 @@ public class AggStateCombinatorTest extends MVTestBase {
                 "c25 json,\n" +
                 "c26 varbinary,\n" +
                 "c27 map<varchar(1048576),varchar(1048576)>,\n" +
-                "c28 struct<col1 array<varchar(1048576)>>,\n" +
+                "c28 struct<`col1` array<varchar(1048576)>>,\n" +
                 "c29 array<varchar(100)>,\n" +
                 "c30 variant";
         String[] splits = define.split(",\n");
@@ -919,7 +919,7 @@ public class AggStateCombinatorTest extends MVTestBase {
             String sql1 = "select k1, " + Joiner.on(", ").join(stateColumns) + " from t1;";
             String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql1);
             PlanTestBase.assertContains(plan, "33 <-> array_agg_state[([26: c24, VARCHAR, true]); args: VARCHAR; " +
-                    "result: struct<col1 array<varchar(100)>>; args nullable: true; result nullable: true]");
+                    "result: struct<`col1` array<varchar(100)>>; args nullable: true; result nullable: true]");
             PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
                     "     table: t1, rollup: t1");
         }
@@ -930,8 +930,8 @@ public class AggStateCombinatorTest extends MVTestBase {
                     + " from test_agg_state_table group by k1;";
             String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql1);
             PlanTestBase.assertContains(plan, "|  aggregate: array_agg_union[([2: v0, " +
-                    "struct<col1 array<varchar(1048576)>>, true]); args: INVALID_TYPE; " +
-                    "result: struct<col1 array<varchar(100)>>; args nullable: true; result nullable: true]");
+                    "struct<`col1` array<varchar(1048576)>>, true]); args: INVALID_TYPE; " +
+                    "result: struct<`col1` array<varchar(100)>>; args nullable: true; result nullable: true]");
             PlanTestBase.assertContains(plan, " 0:OlapScanNode\n" +
                     "     table: test_agg_state_table, rollup: test_agg_state_table");
         }
@@ -942,7 +942,7 @@ public class AggStateCombinatorTest extends MVTestBase {
                     + " from test_agg_state_table group by k1;";
             String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql1);
             PlanTestBase.assertContains(plan, "|  aggregate: array_agg_merge[([2: v0, " +
-                    "struct<col1 array<varchar(1048576)>>, true]); args: INVALID_TYPE; " +
+                    "struct<`col1` array<varchar(1048576)>>, true]); args: INVALID_TYPE; " +
                     "result: ARRAY<VARCHAR(100)>; args nullable: true; result nullable: true]");
             PlanTestBase.assertContains(plan, " 0:OlapScanNode\n" +
                     "     table: test_agg_state_table, rollup: test_agg_state_table");

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/ParseUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/ParseUtilTest.java
@@ -41,4 +41,11 @@ public class ParseUtilTest {
         assertThat(exception.getMessage(),
                 containsString("Invalid var: 'tru'. Expected values should be 1, 0, on, off, true, or false (case insensitive)"));
     }
+
+    @Test
+    public void testBackquoteEscapesInnerBackticks() {
+        Assertions.assertEquals("`a``b`", ParseUtil.backquote("a`b"));
+        Assertions.assertEquals("```ab```", ParseUtil.backquote("`ab`"));
+        Assertions.assertEquals("`ab`", ParseUtil.backquote("ab"));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -1229,7 +1229,7 @@ public class TrinoQueryTest extends TrinoTestBase {
     @Test
     public void testCastRowDataType() throws Exception {
         String sql = "select CAST(ROW(1, 2e0) AS ROW(x BIGINT, y DOUBLE))";
-        assertPlanContains(sql, "CAST(row(1, 2.0) AS struct<X bigint(20), Y double>)");
+        assertPlanContains(sql, "CAST(row(1, 2.0) AS struct<`X` bigint(20), `Y` double>)");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AST2StringBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AST2StringBuilderTest.java
@@ -193,4 +193,22 @@ public class AST2StringBuilderTest {
 
         Assertions.assertEquals(expected, actual);
     }
+
+    @Test
+    public void testCastStructInArrayEscapesFieldNames() throws Exception {
+        String sql = "SELECT cast(PARSE_JSON('{}') as array<struct<`a b` int>>)";
+        List<StatementBase> statementBase =
+                SqlParser.parse(sql, AnalyzeTestUtil.getConnectContext().getSessionVariable().getSqlMode());
+        Assertions.assertEquals(1, statementBase.size());
+        StatementBase baseStmt = statementBase.get(0);
+        Assertions.assertTrue(baseStmt instanceof QueryStatement);
+
+        QueryStatement queryStmt = (QueryStatement) baseStmt;
+        Analyzer.analyze(queryStmt, AnalyzeTestUtil.getConnectContext());
+
+        String expected = "SELECT CAST((parse_json('{}')) AS ARRAY<struct<`a b` int(11)>>)";
+        String actual = AstToStringBuilder.toString(queryStmt);
+
+        Assertions.assertEquals(expected, actual);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStructTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStructTest.java
@@ -114,8 +114,10 @@ public class AnalyzeStructTest {
         ShowCreateTableStmt stmt = (ShowCreateTableStmt) analyzeSuccess("SHOW CREATE TABLE deeper_table");
         ShowResultSet resultSet = ShowExecutor.execute(stmt, ctx);
         String res = resultSet.getResultRows().get(0).get(1);
-        Assertions.assertTrue(res.contains("`b` struct<b struct<c struct<d struct<e int(11)>>>> NULL COMMENT \"\""));
+        Assertions.assertTrue(res.contains(
+                "`b` struct<`b` struct<`c` struct<`d` struct<`e` int(11)>>>> NULL COMMENT \"\""));
         Assertions.assertTrue(
-                res.contains("`struct_a` struct<struct_a struct<struct_a int(11)>, other int(11)> NULL COMMENT \"\""));
+                res.contains("`struct_a` struct<`struct_a` struct<`struct_a` int(11)>, `other` int(11)> " +
+                        "NULL COMMENT \"\""));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
@@ -461,8 +461,9 @@ public class CreateTableAnalyzerTest {
 
         testInvalidComplexDefault(
                 "c4 STRUCT<id INT, name STRING> DEFAULT row('not_int', 123, 456)",
-                "Invalid default value for 'c4': Default value type struct<col1 varchar, col2 tinyint(4), col3 smallint(6)> " +
-                        "cannot be cast to column type struct<id int(11), name varchar(65533)>");
+                "Invalid default value for 'c4': Default value type struct<`col1` varchar, `col2` tinyint(4), " +
+                        "`col3` smallint(6)> cannot be cast to column type struct<`id` int(11), `name` " +
+                        "varchar(65533)>");
 
         testInvalidComplexDefault("c1 ARRAY<STRUCT<id INT>> DEFAULT [row(1, 'extra_field')]", "");
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/ScanPredicateExprReuseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/ScanPredicateExprReuseTest.java
@@ -212,7 +212,7 @@ public class ScanPredicateExprReuseTest extends PlanTestBase {
                     + "  1:Project\n"
                     + "  |  output columns:\n"
                     + "  |  1 <-> [1: k, BIGINT, false]\n"
-                    + "  |  12 <-> [6: v5, struct<a int(11), b struct<a array<bigint(20)>>>, true].b.a[false]\n"
+                    + "  |  12 <-> [6: v5, struct<`a` int(11), `b` struct<`a` array<bigint(20)>>>, true].b.a[false]\n"
                     + "  |  cardinality: 1");
             assertContains(plan, "ColumnAccessPath: [/v5/b/a]");
         }
@@ -305,13 +305,14 @@ public class ScanPredicateExprReuseTest extends PlanTestBase {
                     + "  |  1 <-> [1: k, BIGINT, false]\n"
                     + "  |  11 <-> cardinality[([2: v1, ARRAY<BIGINT>, true]); args: INVALID_TYPE; result: INT; args nullable: "
                     + "true; result nullable: true]\n"
-                    + "  |  12 <-> cardinality[([6: v5, struct<a int(11), b struct<a array<bigint(20)>>>, true].b.a[true]); "
+                    + "  |  12 <-> cardinality[([6: v5, struct<`a` int(11), `b` "
+                    + "struct<`a` array<bigint(20)>>>, true].b.a[true]); "
                     + "args: INVALID_TYPE; result: INT; args nullable: true; result nullable: true]\n"
                     + "  |  13 <-> cardinality[([7: v6, MAP<INT,INT>, true]); args: INVALID_TYPE; result: INT; args nullable: "
                     + "true; result nullable: true]\n"
                     + "  |  cardinality: 1");
             assertContains(plan, "     Pruned type: 2 <-> [ARRAY<BIGINT>]\n" +
-                    "     Pruned type: 6 <-> [struct<a int(11), b struct<a array<bigint(20)>>>]\n" +
+                    "     Pruned type: 6 <-> [struct<`a` int(11), `b` struct<`a` array<bigint(20)>>>]\n" +
                     "     Pruned type: 7 <-> [MAP<INT,INT>]\n" +
                     "     ColumnAccessPath: [/v1/OFFSET, /v5/b/a/OFFSET, /v6/OFFSET]");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
@@ -70,7 +70,7 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
                 "  2:EXCHANGE");
         sql = "select c2 from test1 union all select c2_0 from test1";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "CAST(3: c2 AS struct<a int(11), b varchar>)");
+        assertContains(plan, "CAST(3: c2 AS struct<`a` int(11), `b` varchar>)");
 
         sql = "select index_struct[1].`index` from index_struct_nest";
         plan = getFragmentPlan(sql);
@@ -84,13 +84,14 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
         assertVerbosePlanContains(sql, "[/c1/a]");
 
         connectContext.getSessionVariable().setEnablePruneComplexTypes(false);
-        assertVerbosePlanContains(sql, "Pruned type: 2 <-> [STRUCT<a int(11), b ARRAY<STRUCT<a int(11), b int(11)>>>]");
+        assertVerbosePlanContains(sql,
+                "Pruned type: 2 <-> [struct<`a` int(11), `b` array<struct<`a` int(11), `b` int(11)>>>]");
     }
 
     @Test
     public void testStructMultiSelect() throws Exception {
         String sql = "select c2.a, c2.b from test";
-        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [STRUCT<a int(11), b int(11)>]");
+        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [struct<`a` int(11), `b` int(11)>]");
     }
 
     @Test
@@ -117,7 +118,7 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
         assertVerbosePlanContains(sql, "[/c2/a]");
 
         sql = "select sum(c2.b) as t from test group by c2.a";
-        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [STRUCT<a int(11), b int(11)>]");
+        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [struct<`a` int(11), `b` int(11)>]");
 
         sql = "select count(c1.b[10].a) from test";
         assertVerbosePlanContains(sql, "[/c1/b/INDEX/a]");
@@ -132,21 +133,23 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
     @Test
     public void testSelectPredicate() throws Exception {
         String sql = "select c0 from test where (c0+c2.a)>5";
-        assertVerbosePlanContains(sql, "[struct<a int(11), b int(11)>]");
+        assertVerbosePlanContains(sql, "[struct<`a` int(11), `b` int(11)>]");
     }
 
     @Test
     public void testSelectStar() throws Exception {
         FeConstants.runningUnitTest = true;
         String sql = "select *, c1.b[10].a from test";
-        assertVerbosePlanContains(sql, "Pruned type: 2 <-> [STRUCT<a int(11), b ARRAY<STRUCT<a int(11), b int(11)>>>]");
-        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [STRUCT<a int(11), b int(11)>]");
         assertVerbosePlanContains(sql,
-                "Pruned type: 4 <-> [STRUCT<a int(11), b int(11), c STRUCT<a int(11), b int(11)>, d ARRAY<int(11)>>]");
+                "Pruned type: 2 <-> [struct<`a` int(11), `b` array<struct<`a` int(11), `b` int(11)>>>]");
+        assertVerbosePlanContains(sql, "Pruned type: 3 <-> [struct<`a` int(11), `b` int(11)>]");
+        assertVerbosePlanContains(sql,
+                "Pruned type: 4 <-> [struct<`a` int(11), `b` int(11), `c` struct<`a` int(11), `b` int(11)>, " +
+                        "`d` array<int(11)>>]");
         sql = "select * from index_struct_nest where index_struct[1].`index` = 5";
-        assertVerbosePlanContains(sql, "2 <-> [ARRAY<struct<index bigint(20), char_col varchar(1048576)>>]");
+        assertVerbosePlanContains(sql, "2 <-> [ARRAY<struct<`index` bigint(20), `char_col` varchar(1048576)>>]");
         sql = "select index_struct from index_struct_nest where index_struct[1].`index` = 5";
-        assertVerbosePlanContains(sql, "2 <-> [ARRAY<struct<index bigint(20), char_col varchar(1048576)>>]");
+        assertVerbosePlanContains(sql, "2 <-> [ARRAY<struct<`index` bigint(20), `char_col` varchar(1048576)>>]");
         FeConstants.runningUnitTest = false;
     }
 
@@ -155,7 +158,7 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
         FeConstants.runningUnitTest = true;
         // test for CommonSubOperator
         String sql = "select abs(index_struct[1].`index`) + abs(index_struct[1].`index`) from index_struct_nest";
-        assertVerbosePlanContains(sql, "Pruned type: 2 <-> [ARRAY<struct<index bigint(20)>>]");
+        assertVerbosePlanContains(sql, "Pruned type: 2 <-> [ARRAY<struct<`index` bigint(20)>>]");
         FeConstants.runningUnitTest = false;
     }
 
@@ -222,11 +225,11 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
 
     @Test
     public void testCast() throws Exception {
-        String sql = "select cast(row(null, null, null) as STRUCT<a int, b MAP<int, int>, c ARRAY<INT>>); ";
+        String sql = "select cast(row(null, null, null) as STRUCT<a int, b MAP<int, int>, c ARRAY<INT>>)";
         String plan = getVerboseExplain(sql);
         assertContains(plan, "cast(row[(NULL, NULL, NULL); args: BOOLEAN,BOOLEAN,BOOLEAN; " +
-                "result: struct<col1 boolean, col2 boolean, col3 boolean>; args nullable: true; result nullable: true] " +
-                "as struct<a int(11), b map<int(11),int(11)>, c array<int(11)>>)");
+                "result: struct<`col1` boolean, `col2` boolean, `col3` boolean>; args nullable: true; " +
+                "result nullable: true] as struct<`a` int(11), `b` map<int(11),int(11)>, `c` array<int(11)>>)");
     }
 
     @Test
@@ -235,8 +238,9 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
         String plan = getVerboseExplain(sql);
         assertCContains(plan, "1:Project\n" +
                         "  |  output columns:\n" +
-                        "  |  5 <-> [2: c1, struct<a int(11), b array<struct<a int(11), b int(11)>>>, true].b[true][111]",
-                "Pruned type: 2 <-> [struct<a int(11), b array<struct<a int(11), b int(11)>>>]");
+                        "  |  5 <-> [2: c1, struct<`a` int(11), `b` array<struct<`a` int(11), `b` int(11)>>>, " +
+                        "true].b[true][111]",
+                "Pruned type: 2 <-> [struct<`a` int(11), `b` array<struct<`a` int(11), `b` int(11)>>>]");
     }
 
     @Test
@@ -244,21 +248,22 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
         FeConstants.runningUnitTest = true;
         // no project on input, and no project on tf, no prune
         String sql = "select c2_struct from array_struct_nest, unnest(c2) as t(c2_struct);";
-        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11), `c2_sub2` int(11)>>]");
         sql = "select c2 from array_struct_nest, unnest(c2) as t(c2_struct);";
-        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11), `c2_sub2` int(11)>>]");
         sql = "select c2, c2_struct from array_struct_nest, unnest(c2) as t(c2_struct);";
-        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11), `c2_sub2` int(11)>>]");
         // project on input, no project on tf, prune
         sql = "select c3_struct from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";
-        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), c3_sub1_sub2 int(11)>>>]");
+        assertVerbosePlanContains(sql,
+                "[struct<`c3_sub1` array<struct<`c3_sub1_sub1` int(11), `c3_sub1_sub2` int(11)>>>]");
         // output contains the complete column, no prune
         sql = "select c3 from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";
-        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), " +
-                "c3_sub1_sub2 int(11)>>, c3_sub2 int(11)>]");
+        assertVerbosePlanContains(sql, "[struct<`c3_sub1` array<struct<`c3_sub1_sub1` int(11), " +
+                "`c3_sub1_sub2` int(11)>>, `c3_sub2` int(11)>]");
         sql = "select c3, c3_struct from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";
-        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), " +
-                "c3_sub1_sub2 int(11)>>, c3_sub2 int(11)>]");
+        assertVerbosePlanContains(sql, "[struct<`c3_sub1` array<struct<`c3_sub1_sub1` int(11), " +
+                "`c3_sub1_sub2` int(11)>>, `c3_sub2` int(11)>]");
         FeConstants.runningUnitTest = false;
     }
 
@@ -267,20 +272,22 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
         FeConstants.runningUnitTest = true;
         // no project on input, and project on tf, prune
         String sql = "select c2_struct.c2_sub1 from array_struct_nest, unnest(c2) as t(c2_struct);";
-        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11)>>]");
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11)>>]");
         // no project on input, and project on tf all subfiled, no prune
         sql = "select c2_struct.c2_sub1, c2_struct.c2_sub2 from array_struct_nest, unnest(c2) as t(c2_struct);";
-        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11), `c2_sub2` int(11)>>]");
         sql = "select c2_struct, c2_struct.c2_sub2 from array_struct_nest, unnest(c2) as t(c2_struct);";
-        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11), `c2_sub2` int(11)>>]");
         // project on input, project on tf, prune
         sql = "select c3_struct.c3_sub1_sub1 from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";
-        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11)>>>]");
+        assertVerbosePlanContains(sql, "[struct<`c3_sub1` array<struct<`c3_sub1_sub1` int(11)>>>]");
         // project on input, project on tf but all subfiled, prune
         sql = "select c3_struct.c3_sub1_sub1, c3_struct.c3_sub1_sub2 from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";
-        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), c3_sub1_sub2 int(11)>>>]");
+        assertVerbosePlanContains(sql, "[struct<`c3_sub1` array<struct<`c3_sub1_sub1` int(11), `c3_sub1_sub2` " +
+                "int(11)>>>]");
         sql = "select c3_struct.c3_sub1_sub1, c3_struct from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";
-        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), c3_sub1_sub2 int(11)>>>]");
+        assertVerbosePlanContains(sql, "[struct<`c3_sub1` array<struct<`c3_sub1_sub1` int(11), `c3_sub1_sub2` " +
+                "int(11)>>>]");
         FeConstants.runningUnitTest = false;
     }
 
@@ -288,9 +295,9 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
     public void testNoOutputOnTF() throws Exception {
         FeConstants.runningUnitTest = true;
         String sql = "select c1 from array_struct_nest, unnest(c2) as t(c2_struct) where c2_struct.c2_sub1 > 0;";
-        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11)>>]");
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11)>>]");
         sql = "select c1 from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct) where c3_struct.c3_sub1_sub1 > 0;";
-        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11)>>>]");
+        assertVerbosePlanContains(sql, "[struct<`c3_sub1` array<struct<`c3_sub1_sub1` int(11)>>>]");
         FeConstants.runningUnitTest = false;
     }
 
@@ -299,8 +306,8 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
         FeConstants.runningUnitTest = true;
         String sql = "select c3_struct.c3_sub1_sub1 from array_struct_nest, unnest(c2) as t(c_struct), " +
                 "unnest(c3.c3_sub1) as tt(c3_struct) where c_struct.c2_sub1 > 10";
-        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11)>>]");
-        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11)>>>]");
+        assertVerbosePlanContains(sql, "[ARRAY<struct<`c2_sub1` int(11)>>]");
+        assertVerbosePlanContains(sql, "[struct<`c3_sub1` array<struct<`c3_sub1_sub1` int(11)>>>]");
         FeConstants.runningUnitTest = false;
     }
 
@@ -309,7 +316,7 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
         FeConstants.runningUnitTest = true;
         String sql = "select c3_struct.c3_sub1_sub1 from array_struct_nest cross join " +
                 "unnest(c3.c3_sub1) as t(c3_struct) where c1 > 0;";
-        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11)>>>]");
+        assertVerbosePlanContains(sql, "[struct<`c3_sub1` array<struct<`c3_sub1_sub1` int(11)>>>]");
         FeConstants.runningUnitTest = false;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
@@ -193,10 +193,10 @@ public class DecimalTypeTest extends PlanTestBase {
         try {
             String sql = "select array_agg(c_0_0) from tab0";
             String plan = getVerboseExplain(sql);
-            assertContains(plan, "array_agg[([16: array_agg, struct<col1 array<DECIMAL128(26,2)>>, true]); " +
+            assertContains(plan, "array_agg[([16: array_agg, struct<`col1` array<DECIMAL128(26,2)>>, true]); " +
                     "args: DECIMAL128; result: ARRAY<DECIMAL128(26,2)>;");
             assertContains(plan, "array_agg[([1: c_0_0, DECIMAL128(26,2), false]); " +
-                    "args: DECIMAL128; result: struct<col1 array<DECIMAL128(26,2)>>;");
+                    "args: DECIMAL128; result: struct<`col1` array<DECIMAL128(26,2)>>;");
         } finally {
             connectContext.getSessionVariable().setNewPlanerAggStage(stage);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggregationOverWindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggregationOverWindowTest.java
@@ -418,7 +418,7 @@ public class DistinctAggregationOverWindowTest extends PlanTestBase {
 
         assertCContains(plan, "  3:ANALYTIC\n" +
                 "  |  functions: [, fused_multi_distinct_count_sum_avg[([7: cast, DECIMAL128(19,2), true]); args: " +
-                "DECIMAL128; result: struct<count bigint(20), sum decimal(38, 2), avg decimal(38, 8)>; " +
+                "DECIMAL128; result: struct<`count` bigint(20), `sum` decimal(38, 2), `avg` decimal(38, 8)>; " +
                 "args nullable: true; result nullable: true], ]\n" +
                 "  |  partition by: [1: v1, BIGINT, true]\n" +
                 "  |  order by: [2: v2, BIGINT, true] ASC\n" +
@@ -429,12 +429,12 @@ public class DistinctAggregationOverWindowTest extends PlanTestBase {
                 "  |  1 <-> [1: v1, BIGINT, true]\n" +
                 "  |  2 <-> [2: v2, BIGINT, true]\n" +
                 "  |  3 <-> [3: v3, BIGINT, true]\n" +
-                "  |  4 <-> [8: fused_multi_distinct_count_sum_avg, struct<count bigint(20), sum decimal(38, 2), " +
-                "avg decimal(38, 8)>, true].count[false]\n" +
-                "  |  5 <-> [8: fused_multi_distinct_count_sum_avg, struct<count bigint(20), sum decimal(38, 2), " +
-                "avg decimal(38, 8)>, true].sum[false]\n" +
-                "  |  6 <-> [8: fused_multi_distinct_count_sum_avg, struct<count bigint(20), sum decimal(38, 2), " +
-                "avg decimal(38, 8)>, true].avg[false]");
+                "  |  4 <-> [8: fused_multi_distinct_count_sum_avg, struct<`count` bigint(20), `sum` decimal(38, 2), " +
+                "`avg` decimal(38, 8)>, true].count[false]\n" +
+                "  |  5 <-> [8: fused_multi_distinct_count_sum_avg, struct<`count` bigint(20), `sum` decimal(38, 2), " +
+                "`avg` decimal(38, 8)>, true].sum[false]\n" +
+                "  |  6 <-> [8: fused_multi_distinct_count_sum_avg, struct<`count` bigint(20), `sum` decimal(38, 2), " +
+                "`avg` decimal(38, 8)>, true].avg[false]");
     }
 
     private Type getAggregateFunctionReturnType(String sql, String... functionNames) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1628,16 +1628,16 @@ public class ExpressionTest extends PlanTestBase {
     public void testStructExpression() throws Exception {
         String sql = "select struct('a', 1, 2, 10000)";
         String plan = getVerboseExplain(sql);
-        assertCContains(plan, "struct<col1 varchar, col2 tinyint(4), col3 tinyint(4), col4 smallint(6)>");
+        assertCContains(plan, "struct<`col1` varchar, `col2` tinyint(4), `col3` tinyint(4), `col4` smallint(6)>");
 
         sql = "select row('a', 1, 2, 10000, [1, 2, 3], NULL, map{'a': 1, 'b': 2})";
         plan = getVerboseExplain(sql);
-        assertCContains(plan, "struct<col1 varchar, col2 tinyint(4), col3 tinyint(4), col4 smallint(6), " +
-                "col5 array<tinyint(4)>, col6 boolean, col7 map<varchar,tinyint(4)>>");
+        assertCContains(plan, "struct<`col1` varchar, `col2` tinyint(4), `col3` tinyint(4), `col4` smallint(6), " +
+                "`col5` array<tinyint(4)>, `col6` boolean, `col7` map<varchar,tinyint(4)>>");
 
         sql = "select named_struct('a', 1, 'b', 2)";
         plan = getVerboseExplain(sql);
-        assertCContains(plan, "struct<a tinyint(4), b tinyint(4)>");
+        assertCContains(plan, "struct<`a` tinyint(4), `b` tinyint(4)>");
 
         try {
             sql = "select named_struct('a', 1, 'b', 2, 3, 6)";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveSubfieldPrunePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveSubfieldPrunePlanTest.java
@@ -30,6 +30,6 @@ public class HiveSubfieldPrunePlanTest extends PlanTestBase {
         String sql = "with stream as (select array_agg(col_struct.c0) as t1 from hive0.subfield_db.subfield group by " +
                 "col_int) select t1 from stream";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "Pruned type: 2 [col_struct] <-> [struct<c0 int(11)>]");
+        assertContains(plan, "Pruned type: 2 [col_struct] <-> [struct<`c0` int(11)>]");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
@@ -116,7 +116,7 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 """;
         String plan = getVerboseExplain(sql);
         String expected = "5 <-> row[([2: VARCHAR_COL, VARCHAR, true], [4: INTEGER_COL, INT, true]); " +
-                "args: VARCHAR,INT; result: struct<col1 varchar(25), col2 int(11)>; args nullable: true; " +
+                "args: VARCHAR,INT; result: struct<`col1` varchar(25), `col2` int(11)>; args nullable: true; " +
                 "result nullable: true].col2[true";
         Assertions.assertTrue(plan.contains(expected), plan);
     }
@@ -135,15 +135,15 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 "  |  output columns:\n" +
                 "  |  6 <-> DictDecode([9: VARCHAR_COL, INT, true], [<place-holder>], row[([9: VARCHAR_COL, INT, " +
                 "true], [10: ARRAY_VARCHAR_COL, ARRAY<INT>, true], [4: INTEGER_COL, INT, true]); args: " +
-                "INT,INVALID_TYPE,INT; result: struct<col1 int(11), col2 array<int(11)>, col3 int(11)>; args " +
+                "INT,INVALID_TYPE,INT; result: struct<`col1` int(11), `col2` array<int(11)>, `col3` int(11)>; args " +
                 "nullable: true; result nullable: true].col1[true])\n" +
                 "  |  7 <-> DictDecode([10: ARRAY_VARCHAR_COL, ARRAY<INT>, true], [<place-holder>], row[([9: " +
                 "VARCHAR_COL, INT, true], [10: ARRAY_VARCHAR_COL, ARRAY<INT>, true], [4: INTEGER_COL, INT, true]); " +
-                "args: INT,INVALID_TYPE,INT; result: struct<col1 int(11), col2 array<int(11)>, col3 int(11)>; args " +
+                "args: INT,INVALID_TYPE,INT; result: struct<`col1` int(11), `col2` array<int(11)>, `col3` int(11)>; args " +
                 "nullable: true; result nullable: true].col2[true])\n" +
                 "  |  8 <-> row[(DictDecode([9: VARCHAR_COL, INT, true], [<place-holder>]), DictDecode([10: " +
                 "ARRAY_VARCHAR_COL, ARRAY<INT>, true], [<place-holder>]), [4: INTEGER_COL, INT, true]); args: " +
-                "VARCHAR,INVALID_TYPE,INT; result: struct<col1 varchar(25), col2 array<varchar(40)>, col3 int(11)>;" +
+                "VARCHAR,INVALID_TYPE,INT; result: struct<`col1` varchar(25), `col2` array<varchar(40)>, `col3` int(11)>;" +
                 " args nullable: true; result nullable: true].col3[true]\n";
         Assertions.assertTrue(plan.contains(expected), plan);
     }
@@ -157,7 +157,7 @@ public class LowCardinalityStructTest extends PlanTestBase {
         String plan = getVerboseExplain(sql);
         String expected = "5 <-> to_json[(row[([2: VARCHAR_COL, VARCHAR, true], [4: INTEGER_COL, INT, true], " +
                 "[3: ARRAY_VARCHAR_COL, ARRAY<VARCHAR(40)>, true]); args: VARCHAR,INT,INVALID_TYPE; result: " +
-                "struct<col1 varchar(25), col2 int(11), col3 array<varchar(40)>>; args nullable: true; result " +
+                "struct<`col1` varchar(25), `col2` int(11), `col3` array<varchar(40)>>; args nullable: true; result " +
                 "nullable: true]); args: INVALID_TYPE; result: JSON; args nullable: true; result nullable: true]";
         Assertions.assertTrue(plan.contains(expected), plan);
     }
@@ -180,12 +180,12 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 """;
         String plan = getVerboseExplain(sql);
         String expected = "5 <-> named_struct[('c1', DictDecode([6: VARCHAR_COL, INT, true], [<place-holder>], " +
-                "[8: named_struct, struct<c1 int(11), c2 array<int(11)>, c3 int(11)>, true].c1[true]), 'c2', " +
+                "[8: named_struct, struct<`c1` int(11), `c2` array<int(11)>, `c3` int(11)>, true].c1[true]), 'c2', " +
                 "DictDecode([7: ARRAY_VARCHAR_COL, ARRAY<INT>, true], [<place-holder>], [8: named_struct, " +
-                "struct<c1 int(11), c2 array<int(11)>, c3 int(11)>, true].c2[true]), 'c3', [8: named_struct, " +
-                "struct<c1 int(11), c2 array<int(11)>, c3 int(11)>, true].c3[true]); args: " +
-                "VARCHAR,VARCHAR,VARCHAR,INVALID_TYPE,VARCHAR,INT; result: struct<c1 varchar(25), c2 " +
-                "array<varchar(40)>, c3 int(11)>; args nullable: true; result nullable: true]";
+                "struct<`c1` int(11), `c2` array<int(11)>, `c3` int(11)>, true].c2[true]), 'c3', [8: named_struct, " +
+                "struct<`c1` int(11), `c2` array<int(11)>, `c3` int(11)>, true].c3[true]); args: " +
+                "VARCHAR,VARCHAR,VARCHAR,INVALID_TYPE,VARCHAR,INT; result: struct<`c1` varchar(25), `c2` " +
+                "array<varchar(40)>, `c3` int(11)>; args nullable: true; result nullable: true]";
         Assertions.assertTrue(plan.contains(expected), plan);
     }
 
@@ -203,16 +203,16 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 "  |  output columns:\n" +
                 "  |  6 <-> DictDecode([9: VARCHAR_COL, INT, true], [<place-holder>], named_struct[('c1', [9: " +
                 "VARCHAR_COL, INT, true], 'c2', [10: ARRAY_VARCHAR_COL, ARRAY<INT>, true], 'c3', [4: INTEGER_COL, " +
-                "INT, true]); args: VARCHAR,INT,VARCHAR,INVALID_TYPE,VARCHAR,INT; result: struct<c1 int(11), c2 " +
-                "array<int(11)>, c3 int(11)>; args nullable: true; result nullable: true].c1[true])\n" +
+                "INT, true]); args: VARCHAR,INT,VARCHAR,INVALID_TYPE,VARCHAR,INT; result: struct<`c1` int(11), `c2` " +
+                "array<int(11)>, `c3` int(11)>; args nullable: true; result nullable: true].c1[true])\n" +
                 "  |  7 <-> DictDecode([10: ARRAY_VARCHAR_COL, ARRAY<INT>, true], [<place-holder>], named_struct[('c1'" +
                 ", [9: VARCHAR_COL, INT, true], 'c2', [10: ARRAY_VARCHAR_COL, ARRAY<INT>, true], 'c3', [4: " +
-                "INTEGER_COL, INT, true]); args: VARCHAR,INT,VARCHAR,INVALID_TYPE,VARCHAR,INT; result: struct<c1 " +
-                "int(11), c2 array<int(11)>, c3 int(11)>; args nullable: true; result nullable: true].c2[true])\n" +
+                "INTEGER_COL, INT, true]); args: VARCHAR,INT,VARCHAR,INVALID_TYPE,VARCHAR,INT; result: struct<`c1` " +
+                "int(11), `c2` array<int(11)>, `c3` int(11)>; args nullable: true; result nullable: true].c2[true])\n" +
                 "  |  8 <-> named_struct[('c1', DictDecode([9: VARCHAR_COL, INT, true], [<place-holder>]), 'c2', " +
                 "DictDecode([10: ARRAY_VARCHAR_COL, ARRAY<INT>, true], [<place-holder>]), 'c3', [4: INTEGER_COL, INT," +
-                " true]); args: VARCHAR,VARCHAR,VARCHAR,INVALID_TYPE,VARCHAR,INT; result: struct<c1 varchar(25), c2" +
-                " array<varchar(40)>, c3 int(11)>; args nullable: true; result nullable: true].c3[true]\n";
+                " true]); args: VARCHAR,VARCHAR,VARCHAR,INVALID_TYPE,VARCHAR,INT; result: struct<`c1` varchar(25), `c2`" +
+                " array<varchar(40)>, `c3` int(11)>; args nullable: true; result nullable: true].c3[true]\n";
         Assertions.assertTrue(plan.contains(expected), plan);
     }
 
@@ -246,7 +246,7 @@ public class LowCardinalityStructTest extends PlanTestBase {
         String plan = getVerboseExplain(sql);
         String expected = "5 <-> DictDecode([6: ARRAY_VARCHAR_COL, ARRAY<INT>, true], [<place-holder>], " +
                 "row[([6: ARRAY_VARCHAR_COL, ARRAY<INT>, true], [2: VARCHAR_COL, VARCHAR, true]); args: " +
-                "INVALID_TYPE,VARCHAR; result: struct<col1 array<int(11)>, col2 varchar(25)>; args nullable: true; " +
+                "INVALID_TYPE,VARCHAR; result: struct<`col1` array<int(11)>, `col2` varchar(25)>; args nullable: true; " +
                 "result nullable: true].col1[true][1])";
         Assertions.assertTrue(plan.contains(expected), plan);
     }
@@ -263,9 +263,9 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 "  |  output columns:\n" +
                 "  |  4 <-> [4: INTEGER_COL, INT, true]\n" +
                 "  |  5 <-> row[(row[(DictDecode([7: VARCHAR_COL, INT, true], [<place-holder>])); args: VARCHAR; " +
-                "result: struct<col1 varchar(25)>; args nullable: true; result nullable: true], [3: " +
+                "result: struct<`col1` varchar(25)>; args nullable: true; result nullable: true], [3: " +
                 "ARRAY_VARCHAR_COL, ARRAY<VARCHAR(40)>, true]); args: INVALID_TYPE,INVALID_TYPE; result: " +
-                "struct<col1 struct<col1 varchar(25)>, col2 array<varchar(40)>>; args nullable: true;" +
+                "struct<`col1` struct<`col1` varchar(25)>, `col2` array<varchar(40)>>; args nullable: true;" +
                 " result nullable: true]\n" +
                 "  |  8 <-> DictDefine([7: VARCHAR_COL, INT, true], [upper[(<place-holder>); args: VARCHAR; result:" +
                 " VARCHAR; args nullable: true; result nullable: true]])";
@@ -294,10 +294,10 @@ public class LowCardinalityStructTest extends PlanTestBase {
         String expected = "  10:Project\n" +
                 "  |  output columns:\n" +
                 "  |  5 <-> named_struct[('col1', DictDecode([11: VARCHAR_COL, INT, true], [<place-holder>], [13: " +
-                "row, struct<col1 int(11)>, true].col1[true])); args: VARCHAR,VARCHAR; result: struct<col1 " +
+                "row, struct<`col1` int(11)>, true].col1[true])); args: VARCHAR,VARCHAR; result: struct<`col1` " +
                 "varchar(25)>; args nullable: true; result nullable: true]\n" +
                 "  |  10 <-> named_struct[('col1', DictDecode([12: VARCHAR_COL2, INT, true], [<place-holder>], [14:" +
-                " row, struct<col1 int(11)>, true].col1[true])); args: VARCHAR,VARCHAR; result: struct<col1 " +
+                " row, struct<`col1` int(11)>, true].col1[true])); args: VARCHAR,VARCHAR; result: struct<`col1` " +
                 "varchar(25)>; args nullable: true; result nullable: true]\n";
         Assertions.assertTrue(plan.contains(expected), plan);
     }
@@ -318,7 +318,7 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 "  |  output columns:\n" +
                 "  |  4 <-> [4: INTEGER_COL, INT, true]\n" +
                 "  |  5 <-> named_struct[('col1', DictDecode([6: VARCHAR_COL, INT, true], [<place-holder>], [8: row," +
-                " struct<col1 int(11)>, true].col1[true])); args: VARCHAR,VARCHAR; result: struct<col1 varchar(25)>; " +
+                " struct<`col1` int(11)>, true].col1[true])); args: VARCHAR,VARCHAR; result: struct<`col1` varchar(25)>; " +
                 "args nullable: true; result nullable: true]\n" +
                 "  |  7 <-> [7: ARRAY_VARCHAR_COL, ARRAY<INT>, true]";
         Assertions.assertTrue(plan.contains(expected), plan);
@@ -344,9 +344,9 @@ public class LowCardinalityStructTest extends PlanTestBase {
         String expected = "  3:Project\n" +
                 "  |  output columns:\n" +
                 "  |  6 <-> named_struct[('col1', DictDecode([7: VARCHAR_COL, INT, true], [<place-holder>], [9: " +
-                "any_value, struct<col1 int(11), col2 int(11)>, true].col1[true]), 'col2', [9: any_value, struct<col1" +
-                " int(11), col2 int(11)>, true].col2[true]); args: VARCHAR,VARCHAR,VARCHAR,INT; result: struct<col1" +
-                " varchar(25), col2 int(11)>; args nullable: true; result nullable: true]\n";
+                "any_value, struct<`col1` int(11), `col2` int(11)>, true].col1[true]), 'col2', [9: any_value, struct<`col1`" +
+                " int(11), `col2` int(11)>, true].col2[true]); args: VARCHAR,VARCHAR,VARCHAR,INT; result: struct<`col1`" +
+                " varchar(25), `col2` int(11)>; args nullable: true; result nullable: true]\n";
         Assertions.assertTrue(plan.contains(expected), plan);
     }
 
@@ -369,12 +369,12 @@ public class LowCardinalityStructTest extends PlanTestBase {
         String plan = getVerboseExplain(sql);
         String expected = "  3:Project\n" +
                 "  |  output columns:\n" +
-                "  |  7 <-> DictDecode([13: VARCHAR_COL, INT, true], [<place-holder>], [16: any_value, struct<col1 " +
-                "int(11), col2 int(11), col3 array<int(11)>>, true].col1[true])\n" +
-                "  |  8 <-> [16: any_value, struct<col1 int(11), col2 int(11), col3 array<int(11)>>, true].col2" +
+                "  |  7 <-> DictDecode([13: VARCHAR_COL, INT, true], [<place-holder>], [16: any_value, struct<`col1` " +
+                "int(11), `col2` int(11), `col3` array<int(11)>>, true].col1[true])\n" +
+                "  |  8 <-> [16: any_value, struct<`col1` int(11), `col2` int(11), `col3` array<int(11)>>, true].col2" +
                 "[false]\n" +
                 "  |  9 <-> DictDecode([14: ARRAY_VARCHAR_COL, ARRAY<INT>, true], [<place-holder>], [16: any_value, " +
-                "struct<col1 int(11), col2 int(11), col3 array<int(11)>>, true].col3[true])\n";
+                "struct<`col1` int(11), `col2` int(11), `col3` array<int(11)>>, true].col3[true])\n";
         Assertions.assertTrue(plan.contains(expected), plan);
     }
 
@@ -404,13 +404,13 @@ public class LowCardinalityStructTest extends PlanTestBase {
         String expected = "  8:Project\n" +
                 "  |  output columns:\n" +
                 "  |  6 <-> named_struct[('col1', DictDecode([13: VARCHAR_COL, INT, true], [<place-holder>], [16: " +
-                "any_value, struct<col1 int(11), col2 int(11)>, true].col1[true]), 'col2', [16: any_value, struct" +
-                "<col1 int(11), col2 int(11)>, true].col2[true]); args: VARCHAR,VARCHAR,VARCHAR,INT; result: struct" +
-                "<col1 varchar(25), col2 int(11)>; args nullable: true; result nullable: true]\n" +
+                "any_value, struct<`col1` int(11), `col2` int(11)>, true].col1[true]), 'col2', [16: any_value, struct" +
+                "<`col1` int(11), `col2` int(11)>, true].col2[true]); args: VARCHAR,VARCHAR,VARCHAR,INT; result: struct" +
+                "<`col1` varchar(25), `col2` int(11)>; args nullable: true; result nullable: true]\n" +
                 "  |  12 <-> named_struct[('col1', DictDecode([14: VARCHAR_COL2, INT, true], [<place-holder>], [18: " +
-                "any_value, struct<col1 int(11), col2 int(11)>, true].col1[true]), 'col2', [18: any_value, struct" +
-                "<col1 int(11), col2 int(11)>, true].col2[true]); args: VARCHAR,VARCHAR,VARCHAR,INT; result: struct" +
-                "<col1 varchar(25), col2 int(11)>; args nullable: true; result nullable: true]\n";
+                "any_value, struct<`col1` int(11), `col2` int(11)>, true].col1[true]), 'col2', [18: any_value, struct" +
+                "<`col1` int(11), `col2` int(11)>, true].col2[true]); args: VARCHAR,VARCHAR,VARCHAR,INT; result: struct" +
+                "<`col1` varchar(25), `col2` int(11)>; args nullable: true; result nullable: true]\n";
         Assertions.assertTrue(plan.contains(expected), plan);
     }
 
@@ -423,12 +423,12 @@ public class LowCardinalityStructTest extends PlanTestBase {
         String plan = getVerboseExplain(sql);
         Assertions.assertTrue(plan.contains("  1:Project\n" +
                 "  |  output columns:\n" +
-                "  |  5 <-> [10: row, struct<col1 int(11)>, true]\n" +
+                "  |  5 <-> [10: row, struct<`col1` int(11)>, true]\n" +
                 "  |  6 <-> DictDecode([9: VARCHAR_COL, INT, true], [upper[(<place-holder>); args: VARCHAR; result: " +
                 "VARCHAR; args nullable: true; result nullable: true]])\n" +
-                "  |  7 <-> row[([4: INTEGER_COL, INT, true]); args: INT; result: struct<col1 int(11)>; args " +
+                "  |  7 <-> row[([4: INTEGER_COL, INT, true]); args: INT; result: struct<`col1` int(11)>; args " +
                 "nullable: true; result nullable: true].col1[true]\n" +
-                "  |  8 <-> row[(1); args: TINYINT; result: struct<col1 tinyint(4)>; args nullable: false; " +
+                "  |  8 <-> row[(1); args: TINYINT; result: struct<`col1` tinyint(4)>; args nullable: false; " +
                 "result nullable: true].col1[true]"), plan);
     }
 
@@ -450,9 +450,9 @@ public class LowCardinalityStructTest extends PlanTestBase {
         Assertions.assertTrue(plan.contains("  3:Project\n" +
                 "  |  output columns:\n" +
                 "  |  7 <-> to_json[(named_struct[('col1', DictDecode([8: VARCHAR_COL, INT, true], [<place-holder>], " +
-                "[10: any_value, struct<col1 int(11), col2 int(11)>, true].col1[true]), 'col2', [10: any_value, " +
-                "struct<col1 int(11), col2 int(11)>, true].col2[true]); args: VARCHAR,VARCHAR,VARCHAR,INT; result: " +
-                "struct<col1 varchar(25), col2 int(11)>; args nullable: true; result nullable: true]); args: " +
+                "[10: any_value, struct<`col1` int(11), `col2` int(11)>, true].col1[true]), 'col2', [10: any_value, " +
+                "struct<`col1` int(11), `col2` int(11)>, true].col2[true]); args: VARCHAR,VARCHAR,VARCHAR,INT; result: " +
+                "struct<`col1` varchar(25), `col2` int(11)>; args nullable: true; result nullable: true]); args: " +
                 "INVALID_TYPE; result: JSON; args nullable: true; result nullable: true]\n"), plan);
     }
 
@@ -465,8 +465,8 @@ public class LowCardinalityStructTest extends PlanTestBase {
         String plan = getVerboseExplain(sql);
         String expected = "  1:Project\n" +
                 "  |  output columns:\n" +
-                "  |  5 <-> [5: STRUCT_COL, struct<VARCHAR_FIELD varchar(50), INTEGER_FIELD int(11)>, true]\n" +
-                "  |  6 <-> upper[([5: STRUCT_COL, struct<VARCHAR_FIELD varchar(50), INTEGER_FIELD int(11)>, true]." +
+                "  |  5 <-> [5: STRUCT_COL, struct<`VARCHAR_FIELD` varchar(50), `INTEGER_FIELD` int(11)>, true]\n" +
+                "  |  6 <-> upper[([5: STRUCT_COL, struct<`VARCHAR_FIELD` varchar(50), `INTEGER_FIELD` int(11)>, true]." +
                 "VARCHAR_FIELD[true]); args: VARCHAR; result: VARCHAR; args nullable: true; result nullable: true]\n" +
                 "  |  7 <-> DictDecode([8: VARCHAR_COL, INT, true], [upper[(<place-holder>); args: VARCHAR; " +
                 "result: VARCHAR; args nullable: true; result nullable: true]])\n";
@@ -505,8 +505,8 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 "  |  cardinality: 1\n" +
                 "  |  \n" +
                 "  3:AGGREGATE (merge finalize)\n" +
-                "  |  aggregate: array_agg[([7: array_agg, struct<col1 array<int(11)>, col2 array<int(11)>, " +
-                "col3 array<int(11)>>, true]); args: INT,INT,INT; result: ARRAY<INT>; args nullable: true; " +
+                "  |  aggregate: array_agg[([7: array_agg, struct<`col1` array<int(11)>, `col2` array<int(11)>, " +
+                "`col3` array<int(11)>>, true]); args: INT,INT,INT; result: ARRAY<INT>; args nullable: true; " +
                 "result nullable: true]"), plan);
     }
 
@@ -550,8 +550,8 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 "  |  cardinality: 1\n" +
                 "  |  \n" +
                 "  6:AGGREGATE (merge finalize)\n" +
-                "  |  aggregate: array_agg[([7: array_agg, struct<col1 array<int(11)>, col2 array<int(11)>, " +
-                "col3 array<int(11)>>, true]); args: INT,INT,INT; result: ARRAY<INT>; args nullable: true; " +
+                "  |  aggregate: array_agg[([7: array_agg, struct<`col1` array<int(11)>, `col2` array<int(11)>, " +
+                "`col3` array<int(11)>>, true]); args: INT,INT,INT; result: ARRAY<INT>; args nullable: true; " +
                 "result nullable: true]"), plan);
     }
 
@@ -574,8 +574,8 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 "  |  cardinality: 1\n" +
                 "  |  \n" +
                 "  6:AGGREGATE (merge finalize)\n" +
-                "  |  aggregate: array_agg[([9: array_agg, struct<col1 array<int(11)>, col2 array<int(11)>, " +
-                "col3 array<int(11)>>, true]); args: INT,INT,INT; result: ARRAY<INT>; args nullable: true;" +
+                "  |  aggregate: array_agg[([9: array_agg, struct<`col1` array<int(11)>, `col2` array<int(11)>, " +
+                "`col3` array<int(11)>>, true]); args: INT,INT,INT; result: ARRAY<INT>; args nullable: true;" +
                 " result nullable: true]"), plan);
     }
 
@@ -588,9 +588,9 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 """;
         String plan = getVerboseExplain(sql);
         Assertions.assertTrue(plan.contains("  6:AGGREGATE (merge finalize)\n" +
-                "  |  aggregate: array_agg[([8: array_agg, struct<col1 array<int(11)>, col2 array<int(11)>>, true]);" +
+                "  |  aggregate: array_agg[([8: array_agg, struct<`col1` array<int(11)>, `col2` array<int(11)>>, true]);" +
                 " args: INT,INT; result: ARRAY<INT>; args nullable: true; result nullable: true], " +
-                "array_agg[([9: array_agg, struct<col1 array<int(11)>, col2 array<int(11)>>, true]); args: INT,INT;" +
+                "array_agg[([9: array_agg, struct<`col1` array<int(11)>, `col2` array<int(11)>>, true]); args: INT,INT;" +
                 " result: ARRAY<INT>; args nullable: true; result nullable: true]\n"), plan);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -150,8 +150,8 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "  1:Project\n"
                 + "  |  output columns:\n"
                 + "  |  3 <-> [3: v1, BIGINT, true]\n"
-                + "  |  12 <-> [4: st1, struct<s1 int(11), s2 int(11)>, true].s1[false]\n"
-                + "  |  13 <-> [4: st1, struct<s1 int(11), s2 int(11)>, true].s2[false]\n"
+                + "  |  12 <-> [4: st1, struct<`s1` int(11), `s2` int(11)>, true].s1[false]\n"
+                + "  |  13 <-> [4: st1, struct<`s1` int(11), `s2` int(11)>, true].s2[false]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  0:OlapScanNode");
@@ -167,13 +167,13 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "[/st1/s1]");
         assertContains(plan, "  5:Project\n"
                 + "  |  output columns:\n"
-                + "  |  22 <-> [9: st1, struct<s1 int(11), s2 int(11)>, true].s1[false]\n"
+                + "  |  22 <-> [9: st1, struct<`s1` int(11), `s2` int(11)>, true].s1[false]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  4:OlapScanNode");
         assertContains(plan, "  2:Project\n"
                 + "  |  output columns:\n"
-                + "  |  21 <-> [2: st1, struct<s1 int(11), s2 int(11)>, true].s1[false]\n"
+                + "  |  21 <-> [2: st1, struct<`s1` int(11), `s2` int(11)>, true].s1[false]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  1:OlapScanNode");
@@ -187,8 +187,8 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "  1:Project\n"
                 + "  |  output columns:\n"
                 + "  |  1 <-> [1: v1, BIGINT, true]\n"
-                + "  |  26 <-> [2: st1, struct<s1 int(11), s2 int(11)>, true].s1[false]\n"
-                + "  |  27 <-> [3: st2, struct<s1 int(11), s2 int(11), sm3 map<int(11),int(11)>>, true].s2[false]\n"
+                + "  |  26 <-> [2: st1, struct<`s1` int(11), `s2` int(11)>, true].s1[false]\n"
+                + "  |  27 <-> [3: st2, struct<`s1` int(11), `s2` int(11), `sm3` map<int(11),int(11)>>, true].s2[false]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  0:OlapScanNode");
@@ -414,14 +414,14 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "  4:Project\n"
                 + "  |  output columns:\n"
                 + "  |  15 <-> [15: v1, BIGINT, true]\n"
-                + "  |  25 <-> [17: st2, struct<s1 int(11), s2 int(11), sm3 map<int(11),int(11)>>, true].s2[false]\n"
+                + "  |  25 <-> [17: st2, struct<`s1` int(11), `s2` int(11), `sm3` map<int(11),int(11)>>, true].s2[false]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  3:OlapScanNode");
         assertContains(plan, "1:Project\n"
                 + "  |  output columns:\n"
                 + "  |  8 <-> [8: v1, BIGINT, true]\n"
-                + "  |  24 <-> [9: st1, struct<s1 int(11), s2 int(11)>, true].s1[false]\n"
+                + "  |  24 <-> [9: st1, struct<`s1` int(11), `s2` int(11)>, true].s1[false]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  0:OlapScanNode");
@@ -439,25 +439,26 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "  9:Project\n"
                 + "  |  output columns:\n"
                 + "  |  22 <-> [22: v1, BIGINT, true]\n"
-                + "  |  33 <-> [24: st2, struct<s1 int(11), s2 int(11), sm3 map<int(11),int(11)>>, true].sm3[true][1]\n"
+                + "  |  33 <-> [24: st2, struct<`s1` int(11), `s2` int(11), `sm3` map<int(11),int(11)>>, true].sm3[true][1]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  8:OlapScanNode");
         assertContains(plan, "ColumnAccessPath: [/st2/sm3/INDEX]");
         assertContains(plan, "  0:UNION\n" +
                 "  |  output exprs:\n" +
-                "  |      [15, BIGINT, true] | [34, struct<s31 int(11), s32 int(11)>, true] | " +
+                "  |      [15, BIGINT, true] | [34, struct<`s31` int(11), `s32` int(11)>, true] | " +
                 "[32, ARRAY<INT>, true]\n" +
                 "  |  child exprs:\n" +
-                "  |      [1: v1, BIGINT, true] | [35: expr, struct<s31 int(11), s32 int(11)>, true] | " +
+                "  |      [1: v1, BIGINT, true] | [35: expr, struct<`s31` int(11), `s32` int(11)>, true] | " +
                 "[36: expr, ARRAY<INT>, true]\n" +
-                "  |      [8: v1, BIGINT, true] | [37: expr, struct<s31 int(11), s32 int(11)>, true] | " +
+                "  |      [8: v1, BIGINT, true] | [37: expr, struct<`s31` int(11), `s32` int(11)>, true] | " +
                 "[38: expr, ARRAY<INT>, true]");
         assertContains(plan, "  5:Project\n"
                 + "  |  output columns:\n"
                 + "  |  8 <-> [8: v1, BIGINT, true]\n"
-                + "  |  37 <-> [12: st4, struct<s1 int(11), s2 int(11), ss3 struct<s31 int(11), s32 int(11)>>, true].ss3[false]\n"
-                + "  |  38 <-> [11: st3, struct<s1 int(11), s2 int(11), sa3 array<int(11)>>, true].sa3[false]\n"
+                + "  |  37 <-> [12: st4, struct<`s1` int(11), `s2` int(11), `ss3` struct<`s31` int(11), "
+                + "`s32` int(11)>>, true].ss3[false]\n"
+                + "  |  38 <-> [11: st3, struct<`s1` int(11), `s2` int(11), `sa3` array<int(11)>>, true].sa3[false]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  4:OlapScanNode");
@@ -465,8 +466,9 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "  2:Project\n"
                 + "  |  output columns:\n"
                 + "  |  1 <-> [1: v1, BIGINT, true]\n"
-                + "  |  35 <-> [5: st4, struct<s1 int(11), s2 int(11), ss3 struct<s31 int(11), s32 int(11)>>, true].ss3[false]\n"
-                + "  |  36 <-> [4: st3, struct<s1 int(11), s2 int(11), sa3 array<int(11)>>, true].sa3[false]\n"
+                + "  |  35 <-> [5: st4, struct<`s1` int(11), `s2` int(11), "
+                + "`ss3` struct<`s31` int(11), `s32` int(11)>>, true].ss3[false]\n"
+                + "  |  36 <-> [4: st3, struct<`s1` int(11), `s2` int(11), `sa3` array<int(11)>>, true].sa3[false]\n"
                 + "  |  cardinality: 1");
         assertContains(plan, "ColumnAccessPath: [/st3/sa3, /st4/ss3]");
     }
@@ -478,30 +480,33 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "union all " +
                 "select v1, st1, st3, st4 from sc0 group by v1, st1, st3, st4) x1 join sc0 x2 on x1.v1 = x2.v1";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "30 <-> [21: st2, struct<s1 int(11), s2 int(11), sm3 map<int(11),int(11)>>, true].sm3[true][1]");
+        assertContains(plan, "30 <-> [21: st2, struct<`s1` int(11), `s2` int(11), "
+                + "`sm3` map<int(11),int(11)>>, true].sm3[true][1]");
         assertContains(plan, "ColumnAccessPath: [/st2/sm3/INDEX]");
         assertContains(plan, "  0:UNION\n" +
                 "  |  output exprs:\n" +
                 "  |      [15, BIGINT, true] | [29, ARRAY<INT>, true] | " +
-                "[31, struct<s31 int(11), s32 int(11)>, true]\n" +
+                "[31, struct<`s31` int(11), `s32` int(11)>, true]\n" +
                 "  |  child exprs:\n" +
                 "  |      [1: v1, BIGINT, true] | [32: expr, ARRAY<INT>, true] | " +
-                "[33: expr, struct<s31 int(11), s32 int(11)>, true]\n" +
+                "[33: expr, struct<`s31` int(11), `s32` int(11)>, true]\n" +
                 "  |      [8: v1, BIGINT, true] | [34: expr, ARRAY<INT>, true] | " +
-                "[35: expr, struct<s31 int(11), s32 int(11)>, true]");
+                "[35: expr, struct<`s31` int(11), `s32` int(11)>, true]");
         assertContains(plan, "  6:Project\n"
                 + "  |  output columns:\n"
                 + "  |  8 <-> [8: v1, BIGINT, true]\n"
-                + "  |  34 <-> [11: st3, struct<s1 int(11), s2 int(11), sa3 array<int(11)>>, true].sa3[false]\n"
-                + "  |  35 <-> [12: st4, struct<s1 int(11), s2 int(11), ss3 struct<s31 int(11), s32 int(11)>>, true].ss3[false]\n"
+                + "  |  34 <-> [11: st3, struct<`s1` int(11), `s2` int(11), `sa3` array<int(11)>>, true].sa3[false]\n"
+                + "  |  35 <-> [12: st4, struct<`s1` int(11), `s2` int(11), "
+                + "`ss3` struct<`s31` int(11), `s32` int(11)>>, true].ss3[false]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  5:AGGREGATE");
         assertContains(plan, "  2:Project\n"
                 + "  |  output columns:\n"
                 + "  |  1 <-> [1: v1, BIGINT, true]\n"
-                + "  |  32 <-> [4: st3, struct<s1 int(11), s2 int(11), sa3 array<int(11)>>, true].sa3[false]\n"
-                + "  |  33 <-> [5: st4, struct<s1 int(11), s2 int(11), ss3 struct<s31 int(11), s32 int(11)>>, true].ss3[false]\n"
+                + "  |  32 <-> [4: st3, struct<`s1` int(11), `s2` int(11), `sa3` array<int(11)>>, true].sa3[false]\n"
+                + "  |  33 <-> [5: st4, struct<`s1` int(11), `s2` int(11), "
+                + "`ss3` struct<`s31` int(11), `s32` int(11)>>, true].ss3[false]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  1:OlapScanNode");
@@ -518,8 +523,8 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "  2:Project\n"
                 + "  |  output columns:\n"
                 + "  |  3 <-> [3: v1, BIGINT, true]\n"
-                + "  |  12 <-> [4: st1, struct<s1 int(11), s2 int(11)>, true].s1[false]\n"
-                + "  |  13 <-> [4: st1, struct<s1 int(11), s2 int(11)>, true].s2[false]\n");
+                + "  |  12 <-> [4: st1, struct<`s1` int(11), `s2` int(11)>, true].s1[false]\n"
+                + "  |  13 <-> [4: st1, struct<`s1` int(11), `s2` int(11)>, true].s2[false]\n");
     }
 
     @Test
@@ -532,13 +537,13 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "  1:Project\n"
                 + "  |  output columns:\n"
                 + "  |  3 <-> [3: v1, BIGINT, true]\n"
-                + "  |  4 <-> [4: st1, struct<s1 int(11), s2 int(11)>, true]\n"
-                + "  |  10 <-> [4: st1, struct<s1 int(11), s2 int(11)>, true].s1[true]");
+                + "  |  4 <-> [4: st1, struct<`s1` int(11), `s2` int(11)>, true]\n"
+                + "  |  10 <-> [4: st1, struct<`s1` int(11), `s2` int(11)>, true].s1[true]");
         assertContains(plan, "  3:Project\n"
                 + "  |  output columns:\n"
                 + "  |  3 <-> [3: v1, BIGINT, true]\n"
-                + "  |  13 <-> [4: st1, struct<s1 int(11), s2 int(11)>, true].s1[false]\n"
-                + "  |  14 <-> [4: st1, struct<s1 int(11), s2 int(11)>, true].s2[false]");
+                + "  |  13 <-> [4: st1, struct<`s1` int(11), `s2` int(11)>, true].s1[false]\n"
+                + "  |  14 <-> [4: st1, struct<`s1` int(11), `s2` int(11)>, true].s2[false]");
     }
 
     @Test
@@ -564,14 +569,14 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "  7:Project\n"
                 + "  |  output columns:\n"
                 + "  |  15 <-> [15: v1, BIGINT, true]\n"
-                + "  |  25 <-> [17: st2, struct<s1 int(11), s2 int(11), sm3 map<int(11),int(11)>>, true].s2[false]\n"
+                + "  |  25 <-> [17: st2, struct<`s1` int(11), `s2` int(11), `sm3` map<int(11),int(11)>>, true].s2[false]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  6:AGGREGATE");
         assertContains(plan, "  1:Project\n"
                 + "  |  output columns:\n"
                 + "  |  8 <-> [8: v1, BIGINT, true]\n"
-                + "  |  24 <-> [9: st1, struct<s1 int(11), s2 int(11)>, true].s1[false]\n"
+                + "  |  24 <-> [9: st1, struct<`s1` int(11), `s2` int(11)>, true].s1[false]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  0:OlapScanNode");
@@ -589,7 +594,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "  12:Project\n"
                 + "  |  output columns:\n"
                 + "  |  15 <-> [15: v1, BIGINT, true]\n"
-                + "  |  25 <-> [17: st2, struct<s1 int(11), s2 int(11), sm3 map<int(11),int(11)>>, true].s2[false]\n"
+                + "  |  25 <-> [17: st2, struct<`s1` int(11), `s2` int(11), `sm3` map<int(11),int(11)>>, true].s2[false]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  11:AGGREGATE");
@@ -599,9 +604,9 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "  1:Project\n"
                 + "  |  output columns:\n"
                 + "  |  1 <-> [1: v1, BIGINT, true]\n"
-                + "  |  2 <-> [2: st1, struct<s1 int(11), s2 int(11)>, true]\n"
-                + "  |  3 <-> [3: st2, struct<s1 int(11), s2 int(11), sm3 map<int(11),int(11)>>, true]\n"
-                + "  |  26 <-> [2: st1, struct<s1 int(11), s2 int(11)>, true].s1[true]\n"
+                + "  |  2 <-> [2: st1, struct<`s1` int(11), `s2` int(11)>, true]\n"
+                + "  |  3 <-> [3: st2, struct<`s1` int(11), `s2` int(11), `sm3` map<int(11),int(11)>>, true]\n"
+                + "  |  26 <-> [2: st1, struct<`s1` int(11), `s2` int(11)>, true].s1[true]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  0:OlapScanNode");
@@ -617,7 +622,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "  6:Project\n"
                 + "  |  output columns:\n"
                 + "  |  10 <-> [12: expr, INT, true]\n"
-                + "  |  11 <-> [6: st3, struct<s1 int(11), s2 int(11), sa3 array<int(11)>>, true] IS NULL\n"
+                + "  |  11 <-> [6: st3, struct<`s1` int(11), `s2` int(11), `sa3` array<int(11)>>, true] IS NULL\n"
                 + "  |  hasNullableGenerateChild: true\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
@@ -625,8 +630,8 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "  1:Project\n"
                 + "  |  output columns:\n"
                 + "  |  3 <-> [3: v1, BIGINT, true]\n"
-                + "  |  6 <-> [6: st3, struct<s1 int(11), s2 int(11), sa3 array<int(11)>>, true]\n"
-                + "  |  12 <-> [4: st1, struct<s1 int(11), s2 int(11)>, true].s1[false]\n"
+                + "  |  6 <-> [6: st3, struct<`s1` int(11), `s2` int(11), `sa3` array<int(11)>>, true]\n"
+                + "  |  12 <-> [4: st1, struct<`s1` int(11), `s2` int(11)>, true].s1[false]\n"
                 + "  |  cardinality: 1\n"
                 + "  |  \n"
                 + "  0:OlapScanNode");
@@ -695,7 +700,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                     + "     partitionsRatio=0/1, tabletsRatio=0/0\n"
                     + "     tabletList=\n"
                     + "     actualRows=0, avgRowSize=3.0\n"
-                    + "     Pruned type: 4 <-> [struct<s1 int(11), s2 int(11), sa3 array<int(11)>>]\n"
+                    + "     Pruned type: 4 <-> [struct<`s1` int(11), `s2` int(11), `sa3` array<int(11)>>]\n"
                     + "     ColumnAccessPath: [/st3/sa3]\n"
                     + "     cardinality: 1");
         }
@@ -719,7 +724,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         {
             String sql = "select st3.sa3[0], array_length(st3.sa3) from sc0 where (([1,2,3]) is NOT NULL)";
             String plan = getVerboseExplain(sql);
-            assertContains(plan, "     Pruned type: 4 <-> [struct<s1 int(11), s2 int(11), sa3 array<int(11)>>]\n" +
+            assertContains(plan, "     Pruned type: 4 <-> [struct<`s1` int(11), `s2` int(11), `sa3` array<int(11)>>]\n" +
                     "     ColumnAccessPath: [/st3/sa3/ALL]\n" +
                     "     cardinality: 1\n");
         }

--- a/fe/fe-type/src/main/java/com/starrocks/type/StructField.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/StructField.java
@@ -99,7 +99,7 @@ public class StructField {
         String typeSql = (depth < Type.MAX_NESTING_DEPTH) ? type.toSql(depth) : "...";
         StringBuilder sb = new StringBuilder();
         if (printName) {
-            sb.append(name).append(' ');
+            sb.append(backquoteName(name)).append(' ');
         }
         sb.append(typeSql);
         if (comment != null) {
@@ -111,7 +111,7 @@ public class StructField {
     public String toTypeString(int depth) {
         String typeSql = (depth < Type.MAX_NESTING_DEPTH) ? type.toTypeString(depth) : "...";
         StringBuilder sb = new StringBuilder();
-        sb.append(name).append(' ');
+        sb.append(backquoteName(name)).append(' ');
         sb.append(typeSql);
         return sb.toString();
     }
@@ -124,7 +124,7 @@ public class StructField {
         String leftPadding = Strings.repeat(" ", lpad);
         StringBuilder sb = new StringBuilder(leftPadding);
         if (printName) {
-            sb.append(name).append(' ');
+            sb.append(backquoteName(name)).append(' ');
         }
 
         // Pass in the padding to make sure nested fields are aligned properly,
@@ -137,6 +137,15 @@ public class StructField {
             sb.append(String.format(" COMMENT '%s'", comment));
         }
         return sb.toString();
+    }
+
+    private static String backquoteName(String value) {
+        if (StringUtils.isEmpty(value)) {
+            return value;
+        }
+        // Escape embedded backticks by doubling them so the resulting identifier is always parseable.
+        String escaped = value.replace("`", "``");
+        return "`" + escaped + "`";
     }
 
     @Override

--- a/fe/fe-type/src/test/java/com/starrocks/type/StructTypeTest.java
+++ b/fe/fe-type/src/test/java/com/starrocks/type/StructTypeTest.java
@@ -32,7 +32,7 @@ public class StructTypeTest {
     @Test
     public void testUnnamedStruct() {
         StructType type = new StructType(Lists.newArrayList(IntegerType.INT, DateType.DATETIME));
-        Assertions.assertEquals("struct<col1 int(11), col2 datetime>", type.toSql());
+        Assertions.assertEquals("struct<`col1` int(11), `col2` datetime>", type.toSql());
     }
 
     @Test

--- a/test/sql/test_create_table/R/test_create_table_with_time
+++ b/test/sql/test_create_table/R/test_create_table_with_time
@@ -44,7 +44,7 @@ E: (1064, 'Getting analyzing error. Detail message: Type:MAP<BIGINT,TIME> of col
 CREATE TABLE dup_test (
     id bigint,
     city varchar(100) not null,
-    time struct<c1 bigint, c2 TIME> not null
+    time struct<`c1` bigint, `c2` TIME> not null
 )
 DUPLICATE KEY(id)
 PARTITION BY (city)
@@ -53,5 +53,5 @@ PROPERTIES (
 "replication_num" = "1"
 );
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Type:struct<c1 bigint(20), c2 TIME> of column:time does not support.')
+E: (1064, 'Getting analyzing error. Detail message: Type:struct<`c1` bigint(20), `c2` TIME> of column:time does not support.')
 -- !result

--- a/test/sql/test_files/R/test_avro_complex_nest_type
+++ b/test/sql/test_files/R/test_avro_complex_nest_type
@@ -19,19 +19,19 @@ desc files(
     "aws.s3.secret_key" = "${oss_sk}",
     "aws.s3.endpoint" = "${oss_endpoint}");
 -- result:
-record_of_record	struct<inner struct<val int(11)>>	YES
-record_of_array	struct<list array<int(11)>>	YES
-record_of_map	struct<dict map<varchar(1048576),varchar(1048576)>>	YES
-array_of_record	array<struct<value varchar(1048576)>>	YES
+record_of_record	struct<`inner` struct<`val` int(11)>>	YES
+record_of_array	struct<`list` array<int(11)>>	YES
+record_of_map	struct<`dict` map<varchar(1048576),varchar(1048576)>>	YES
+array_of_record	array<struct<`value` varchar(1048576)>>	YES
 array_of_array	array<array<int>>	YES
 array_of_map	array<map<varchar(1048576),int>>	YES
-map_of_record	map<varchar(1048576),struct<id int(11)>>	YES
+map_of_record	map<varchar(1048576),struct<`id` int(11)>>	YES
 map_of_array	map<varchar(1048576),array<int>>	YES
 map_of_map	map<varchar(1048576),map<varchar(1048576),varchar(1048576)>>	YES
-record_array_of_record	struct<entries array<struct<flag boolean>>>	YES
-record_array_of_map	struct<entries array<map<varchar(1048576),varchar(1048576)>>>	YES
-array_map_record	array<map<varchar(1048576),struct<ok boolean>>>	YES
-map_array_record	map<varchar(1048576),array<struct<score float>>>	YES
+record_array_of_record	struct<`entries` array<struct<`flag` boolean>>>	YES
+record_array_of_map	struct<`entries` array<map<varchar(1048576),varchar(1048576)>>>	YES
+array_map_record	array<map<varchar(1048576),struct<`ok` boolean>>>	YES
+map_array_record	map<varchar(1048576),array<struct<`score` float>>>	YES
 -- !result
 
 select * from files(

--- a/test/sql/test_files/R/test_avro_complex_type
+++ b/test/sql/test_files/R/test_avro_complex_type
@@ -19,7 +19,7 @@ desc files(
     "aws.s3.secret_key" = "${oss_sk}",
     "aws.s3.endpoint" = "${oss_endpoint}");
 -- result:
-record_field	struct<id int(11), name varchar(1048576)>	YES
+record_field	struct<`id` int(11), `name` varchar(1048576)>	YES
 enum_field	varchar(1048576)	YES
 array_field	array<varchar(1048576)>	YES
 map_field	map<varchar(1048576),int>	YES

--- a/test/sql/test_files/R/test_avro_files_merge
+++ b/test/sql/test_files/R/test_avro_files_merge
@@ -28,7 +28,7 @@ desc files(
 -- result:
 id	int	YES
 name	varchar(1048576)	YES
-info	struct<address varchar(1048576), email varchar(1048576)>	YES
+info	struct<`address` varchar(1048576), `email` varchar(1048576)>	YES
 extra	varchar(1048576)	YES
 -- !result
 
@@ -53,7 +53,7 @@ desc files(
 -- result:
 id	bigint	YES
 name	varchar(1048576)	YES
-info	struct<age int(11), email varchar(1048576)>	YES
+info	struct<`age` int(11), `email` varchar(1048576)>	YES
 -- !result
 
 select * from files(

--- a/test/sql/test_files/R/test_orc_struct
+++ b/test/sql/test_files/R/test_orc_struct
@@ -34,7 +34,7 @@ create table t1 as select col_int, col_struct, col_struct.c_date from files("pat
 desc t1;
 -- result:
 col_int	int	YES	true	None	
-col_struct	struct<c_int int(11), c_float decimal(38, 9), c_double decimal(38, 9), c_char varchar(1048576), c_varchar varchar(1048576), c_date date, c_timestamp datetime, c_boolean boolean>	YES	false	None	
+col_struct	struct<`c_int` int(11), `c_float` decimal(38, 9), `c_double` decimal(38, 9), `c_char` varchar(1048576), `c_varchar` varchar(1048576), `c_date` date, `c_timestamp` datetime, `c_boolean` boolean>	YES	false	None	
 c_date	date	YES	false	None	
 -- !result
 select count(*) from t1;

--- a/test/sql/test_files/R/test_parquet_list_legacy_encoding
+++ b/test/sql/test_files/R/test_parquet_list_legacy_encoding
@@ -34,7 +34,7 @@ desc files(
     "aws.s3.secret_key" = "${oss_sk}",
     "aws.s3.endpoint" = "${oss_endpoint}");
 -- result:
-field1	struct<list1 array<varchar(1048576)>>	YES
+field1	struct<`list1` array<varchar(1048576)>>	YES
 -- !result
 
 select count(*) from files(
@@ -76,7 +76,7 @@ desc files(
     "aws.s3.secret_key" = "${oss_sk}",
     "aws.s3.endpoint" = "${oss_endpoint}");
 -- result:
-field1	struct<list1 array<varchar(1048576)>, list2 array<array<varchar(1048576)>>, map1 map<varchar(1048576),array<varchar(1048576)>>>	YES
+field1	struct<`list1` array<varchar(1048576)>, `list2` array<array<varchar(1048576)>>, `map1` map<varchar(1048576),array<varchar(1048576)>>>	YES
 -- !result
 
 select count(*) from files(

--- a/test/sql/test_function/R/test_typeof
+++ b/test/sql/test_function/R/test_typeof
@@ -73,7 +73,7 @@ map<tinyint,varchar>
 -- !result
 select typeof(struct(1, 2, 3, 4));
 -- result:
-struct<col1 tinyint, col2 tinyint, col3 tinyint, col4 tinyint>
+struct<`col1` tinyint, `col2` tinyint, `col3` tinyint, `col4` tinyint>
 -- !result
 select typeof(bitmap_empty());
 -- result:
@@ -137,7 +137,7 @@ select typeof(c1)
   ,typeof(c20)
   from t1;
 -- result:
-tinyint	smallint	int	bigint	largeint	decimal128(19, 2)	decimal128(38, 9)	decimal128(38, 9)	boolean	varchar	varchar	varchar	varbinary	date	datetime	array<tinyint>	varchar	map<tinyint,varchar>	struct<col1 tinyint, col2 tinyint, col3 tinyint, col4 tinyint>	json
+tinyint	smallint	int	bigint	largeint	decimal128(19, 2)	decimal128(38, 9)	decimal128(38, 9)	boolean	varchar	varchar	varchar	varbinary	date	datetime	array<tinyint>	varchar	map<tinyint,varchar>	struct<`col1` tinyint, `col2` tinyint, `col3` tinyint, `col4` tinyint>	json
 -- !result
 -- name: test_typeof_table_bitmap
 CREATE TABLE pv_bitmap (

--- a/test/sql/test_http_sql/R/test_http_semi
+++ b/test/sql/test_http_sql/R/test_http_semi
@@ -83,7 +83,7 @@ insert into sc2 values (5, map{5: map{50:map{500: 505}}}, row(5, map{50: 505}, m
 shell: curl -X POST '${url}/api/v1/catalogs/default_catalog/databases/${db[0]}/sql' -u 'root:' -d '{"query": "select * from sc2 order by v1;", "onlyOutputResultRaw":true}' --header "Content-Type: application/json"
 -- result:
 0
-{"meta":[{"name":"v1","type":"bigint(20)"},{"name":"map1","type":"map<int(11),map<int(11),map<int(11),int(11)>>>"},{"name":"st1","type":"struct<s1 int(11), sm2 map<int(11),int(11)>, sm3 map<int(11),map<int(11),int(11)>>>"},{"name":"st2","type":"struct<s1 int(11), sa2 array<int(11)>, ss3 struct<sss1 int(11), sss2 struct<ssss1 int(11), ssss2 int(11)>>>"}]}
+{"meta":[{"name":"v1","type":"bigint(20)"},{"name":"map1","type":"map<int(11),map<int(11),map<int(11),int(11)>>>"},{"name":"st1","type":"struct<`s1` int(11), `sm2` map<int(11),int(11)>, `sm3` map<int(11),map<int(11),int(11)>>>"},{"name":"st2","type":"struct<`s1` int(11), `sa2` array<int(11)>, `ss3` struct<`sss1` int(11), `sss2` struct<`ssss1` int(11), `ssss2` int(11)>>>"}]}
 {"data":[1,{"1": {"10": {"100": 101}}},{"s1": 1, "sm2": {"10": 101}, "sm3": {"10": {"100": 101}}},{"s1": 1, "sa2": [1, 10, 101], "ss3": {"sss1": 1, "sss2": {"ssss1": 10, "ssss2": 11}}}]}
 {"data":[2,{"2": {"20": {"200": 202}}},{"s1": 2, "sm2": {"20": 202}, "sm3": {"20": {"200": 202}}},{"s1": 2, "sa2": [2, 20, 202], "ss3": {"sss1": 2, "sss2": {"ssss1": 20, "ssss2": 22}}}]}
 {"data":[3,{"3": {"30": {"300": 303}}},{"s1": 3, "sm2": {"30": 303}, "sm3": {"30": {"300": 303}}},{"s1": 3, "sa2": [3, 30, 303], "ss3": {"sss1": 3, "sss2": {"ssss1": 30, "ssss2": 33}}}]}

--- a/test/sql/test_iceberg/R/test_iceberg_catalog_complex_type
+++ b/test/sql/test_iceberg/R/test_iceberg_catalog_complex_type
@@ -35,7 +35,7 @@ select array_filter(x->x.`user` = 'official', name)[1].family from ice_cat_${uui
 -- result:
 Glover433
 -- !result
-function: assert_explain_verbose_contains("select array_filter(x->x.`user` = 'official', name)[1].family from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0}", "Pruned type: 1 <-> [ARRAY<struct<user varchar(1073741824), family varchar(1073741824), given array<varchar(1073741824)>, prefix array<varchar(1073741824)>, suffix array<varchar(1073741824)>>>]")
+function: assert_explain_verbose_contains("select array_filter(x->x.`user` = 'official', name)[1].family from ice_cat_${uuid0}.ice_db_${uuid0}.ice_tbl_${uuid0}", "Pruned type: 1 <-> [ARRAY<struct<`user` varchar(1073741824), `family` varchar(1073741824), `given` array<varchar(1073741824)>, `prefix` array<varchar(1073741824)>, `suffix` array<varchar(1073741824)>>>]")
 -- result:
 None
 -- !result

--- a/test/sql/test_iceberg/R/test_metadata_table
+++ b/test/sql/test_iceberg/R/test_metadata_table
@@ -95,7 +95,7 @@ select partition_value,record_count,file_count from iceberg_sql_test_${uuid0}.ic
 -- !result
 desc iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}_${uuid0}$partitions;
 -- result:
-partition_value	struct<p1 int(11), p2 int(11)>	Yes	false	None		
+partition_value	struct<`p1` int(11), `p2` int(11)>	Yes	false	None		
 spec_id	INT	Yes	false	None		
 record_count	BIGINT	Yes	false	None		
 file_count	BIGINT	Yes	false	None		

--- a/test/sql/test_join/R/test_join_map
+++ b/test/sql/test_join/R/test_join_map
@@ -77,7 +77,7 @@ select t.map0, s.map4 from map_test t join map_test s where s.map0 = t.map4 orde
 -- !result
 select t.map0, s.map5 from map_test t join map_test s where s.map0 = t.map5 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 71. Detail message: Column type map<int(11),varchar(65533)> does not support binary predicate operation with type map<int(11),struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 71. Detail message: Column type map<int(11),varchar(65533)> does not support binary predicate operation with type map<int(11),struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select t.map1, s.map2 from map_test t join map_test s where s.map1 = t.map2 order by t.pk;
 -- result:
@@ -93,7 +93,7 @@ select t.map1, s.map4 from map_test t join map_test s where s.map1 = t.map4 orde
 -- !result
 select t.map1, s.map5 from map_test t join map_test s where s.map1 = t.map5 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 71. Detail message: Column type map<decimal(16, 3),varchar(30)> does not support binary predicate operation with type map<int(11),struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 71. Detail message: Column type map<decimal(16, 3),varchar(30)> does not support binary predicate operation with type map<int(11),struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select t.map2, s.map3 from map_test t join map_test s where s.map2 = t.map3 order by t.pk;
 -- result:
@@ -105,7 +105,7 @@ E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 71. 
 -- !result
 select t.map2, s.map5 from map_test t join map_test s where s.map2 = t.map5 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 71. Detail message: Column type map<int(11),array<varchar(65533)>> does not support binary predicate operation with type map<int(11),struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 71. Detail message: Column type map<int(11),array<varchar(65533)>> does not support binary predicate operation with type map<int(11),struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select t.map3, s.map4 from map_test t join map_test s where s.map3 = t.map4 order by t.pk;
 -- result:
@@ -113,11 +113,11 @@ E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 71. 
 -- !result
 select t.map3, s.map5 from map_test t join map_test s where s.map3 = t.map5 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 71. Detail message: Column type map<varchar(65533),map<int(11),varchar(30)>> does not support binary predicate operation with type map<int(11),struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 71. Detail message: Column type map<varchar(65533),map<int(11),varchar(30)>> does not support binary predicate operation with type map<int(11),struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select t.map4, s.map5 from map_test t join map_test s where s.map4 = t.map5 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 71. Detail message: Column type map<int(11),json> does not support binary predicate operation with type map<int(11),struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 71. Detail message: Column type map<int(11),json> does not support binary predicate operation with type map<int(11),struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select t.map3, s.map3 from map_test t join map_test s on s.map3 <=> t.map3 order by t.pk;
 -- result:
@@ -137,7 +137,7 @@ E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 73. 
 -- !result
 select t.map2, s.map5 from map_test t join map_test s where s.map2 <=> t.map5 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 73. Detail message: Column type map<int(11),array<varchar(65533)>> does not support binary predicate operation with type map<int(11),struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 73. Detail message: Column type map<int(11),array<varchar(65533)>> does not support binary predicate operation with type map<int(11),struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select t.map3, s.map4 from map_test t join map_test s where s.map3 <=> t.map4 order by t.pk;
 -- result:
@@ -145,11 +145,11 @@ E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 73. 
 -- !result
 select t.map3, s.map5 from map_test t join map_test s where s.map3 <=> t.map5 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 73. Detail message: Column type map<varchar(65533),map<int(11),varchar(30)>> does not support binary predicate operation with type map<int(11),struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 73. Detail message: Column type map<varchar(65533),map<int(11),varchar(30)>> does not support binary predicate operation with type map<int(11),struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select t.map4, s.map5 from map_test t join map_test s where s.map4 <=> t.map5 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 73. Detail message: Column type map<int(11),json> does not support binary predicate operation with type map<int(11),struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 73. Detail message: Column type map<int(11),json> does not support binary predicate operation with type map<int(11),struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select t.map0, s.map0 from map_test t join map_test s on s.map0 < t.map0 order by t.pk;
 -- result:
@@ -184,7 +184,7 @@ select map3 from map_test t where exists (select 1 from map_test s where t.map3 
 -- !result
 select map5 from map_test t where exists (select 1 from map_test s where t.map5 < s.map3) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 73 to line 1, column 84. Detail message: Column type map<int(11),struct<c int(11), b varchar(65533)>> does not support binary predicate operation with type map<varchar(65533),map<int(11),varchar(30)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 73 to line 1, column 84. Detail message: Column type map<int(11),struct<`c` int(11), `b` varchar(65533)>> does not support binary predicate operation with type map<varchar(65533),map<int(11),varchar(30)>>.')
 -- !result
 select map0 from map_test t where not exists (select 1 from map_test s where t.map0 = s.map0) order by t.pk;
 -- result:
@@ -197,11 +197,11 @@ None
 -- !result
 select map0 from map_test t where not exists (select 1 from map_test s where t.map0 = s.map5) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type map<int(11),varchar(65533)> does not support binary predicate operation with type map<int(11),struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type map<int(11),varchar(65533)> does not support binary predicate operation with type map<int(11),struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select map5 from map_test t where not exists (select 1 from map_test s where t.map5 < s.map5) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type map<int(11),struct<c int(11), b varchar(65533)>> does not support binary predicate operation with type map<int(11),struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type map<int(11),struct<`c` int(11), `b` varchar(65533)>> does not support binary predicate operation with type map<int(11),struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select map3 from map_test t where map3 in (select map3 from map_test s) order by t.pk;
 -- result:
@@ -212,7 +212,7 @@ select map3 from map_test t where map3 in (select map3 from map_test s) order by
 -- !result
 select map4 from map_test t where map4 in (select map5 from map_test s) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 39 to line 1, column 70. Detail message: The input types (map<int(11),json>,map<int(11),struct<c int(11), b varchar(65533)>>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 39 to line 1, column 70. Detail message: The input types (map<int(11),json>,map<int(11),struct<`c` int(11), `b` varchar(65533)>>) of in predict are not compatible.')
 -- !result
 select map5 from map_test t where map5 in (select map5 from map_test s) order by t.pk;
 -- result:
@@ -238,7 +238,7 @@ None
 -- !result
 select map3 in (select map5 from map_test s) from map_test order by 1;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 43. Detail message: The input types (map<varchar(65533),map<int(11),varchar(30)>>,map<int(11),struct<c int(11), b varchar(65533)>>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 43. Detail message: The input types (map<varchar(65533),map<int(11),varchar(30)>>,map<int(11),struct<`c` int(11), `b` varchar(65533)>>) of in predict are not compatible.')
 -- !result
 select map5 in (select map5 from map_test s) from map_test order by 1;
 -- result:
@@ -266,7 +266,7 @@ None
 -- !result
 select map4 not in (select map5 from map_test s) from map_test order by 1;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 47. Detail message: The input types (map<int(11),json>,map<int(11),struct<c int(11), b varchar(65533)>>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 47. Detail message: The input types (map<int(11),json>,map<int(11),struct<`c` int(11), `b` varchar(65533)>>) of in predict are not compatible.')
 -- !result
 select map5 not in (select map5 from map_test s) from map_test order by 1;
 -- result:
@@ -286,7 +286,7 @@ E: (1064, "Getting syntax error at line 1, column 59. Detail message: Unexpected
 -- !result
 select t.map2, s.map5 from map_test t left join map_test s on s.map2 = t.map5 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 73. Detail message: Column type map<int(11),array<varchar(65533)>> does not support binary predicate operation with type map<int(11),struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 73. Detail message: Column type map<int(11),array<varchar(65533)>> does not support binary predicate operation with type map<int(11),struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select t.map3, s.map4 from map_test t left join map_test s on s.map3 <=> t.map4 order by t.pk;
 -- result:
@@ -346,7 +346,7 @@ E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 73. 
 -- !result
 select t.map2, s.map5 from map_test t full join map_test s on s.map2 = t.map5 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 73. Detail message: Column type map<int(11),array<varchar(65533)>> does not support binary predicate operation with type map<int(11),struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 73. Detail message: Column type map<int(11),array<varchar(65533)>> does not support binary predicate operation with type map<int(11),struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select t.map3, s.map4 from map_test t full join map_test s on s.map3 <=> t.map4 order by t.pk;
 -- result:

--- a/test/sql/test_join/R/test_join_struct
+++ b/test/sql/test_join/R/test_join_struct
@@ -1,12 +1,12 @@
 -- name: test_join_struct @no_arrow_flight_sql
 CREATE TABLE struct_test (
 pk bigint not null,
-s0  struct<c0 int,c1 string>,
-s1  struct<c0 DECIMAL(16, 3),c1 varchar(30)>,
-s2  struct<c0 int,c1 array<string>>,
-s3  struct<c0 string,c1 map<int, varchar(30)>>,
-s4  struct<c0 int,c1 json>,
-s5  struct<c0 INT,c1 STRUCT<c INT, b string>>
+s0  struct<`c0` int,`c1` string>,
+s1  struct<`c0` DECIMAL(16, 3),`c1` varchar(30)>,
+s2  struct<`c0` int,`c1` array<string>>,
+s3  struct<`c0` string,`c1` map<int, varchar(30)>>,
+s4  struct<`c0` int,`c1` json>,
+s5  struct<`c0` INT,`c1` STRUCT<`c` INT, `b` string>>
 ) ENGINE=OLAP
 DUPLICATE KEY(pk)
 DISTRIBUTED BY HASH(pk) BUCKETS 3
@@ -17,7 +17,7 @@ PROPERTIES (
 -- !result
 insert into struct_test (pk,s0) values (7,row(3,'',null,null));
 -- result:
-E: (1064, "Getting analyzing error. Detail message: Cannot cast 'row(3, '', NULL, NULL)' from struct<col1 tinyint(4), col2 varchar, col3 boolean, col4 boolean> to struct<c0 int(11), c1 varchar(65533)>.")
+E: (1064, "Getting analyzing error. Detail message: Cannot cast 'row(3, '', NULL, NULL)' from struct<`col1` tinyint(4), `col2` varchar, `col3` boolean, `col4` boolean> to struct<`c0` int(11), `c1` varchar(65533)>.")
 -- !result
 insert into struct_test values (0, row(0,'ab'),row(0,'ab'),row(0,['1','2']),row('1',map(1,'abc')),row(1,json_object('name','abc','age',23)),row(0, row(1,'a')));
 -- result:
@@ -94,7 +94,7 @@ select t.s3, s.s3 from struct_test t join struct_test s where s.s3 = t.s3 order 
 -- !result
 select t.s2, s.s3 from struct_test t join struct_test s where s.s2 = t.s3 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 71. Detail message: Column type struct<c0 int(11), c1 array<varchar(65533)>> does not support binary predicate operation with type struct<c0 varchar(65533), c1 map<int(11),varchar(30)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 71. Detail message: Column type struct<`c0` int(11), `c1` array<varchar(65533)>> does not support binary predicate operation with type struct<`c0` varchar(65533), `c1` map<int(11),varchar(30)>>.')
 -- !result
 select t.s0, s.s0 from struct_test t join struct_test s on s.s0 <=> t.s0 order by t.pk;
 -- result:
@@ -156,35 +156,35 @@ None	None
 -- !result
 select t.s4, s.s5 from struct_test t join struct_test s where s.s4 <=> t.s5 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 73. Detail message: Column type struct<c0 int(11), c1 json> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 73. Detail message: Column type struct<`c0` int(11), `c1` json> does not support binary predicate operation with type struct<`c0` int(11), `c1` struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select t.s0, s.s0 from struct_test t join struct_test s on s.s0 < t.s0 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 59 to line 1, column 68. Detail message: Column type struct<c0 int(11), c1 varchar(65533)> does not support binary predicate operation with type struct<c0 int(11), c1 varchar(65533)>.')
+E: (1064, 'Getting analyzing error from line 1, column 59 to line 1, column 68. Detail message: Column type struct<`c0` int(11), `c1` varchar(65533)> does not support binary predicate operation with type struct<`c0` int(11), `c1` varchar(65533)>.')
 -- !result
 select t.s4, s.s4 from struct_test t join struct_test s where s.s4 > t.s4 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 71. Detail message: Column type struct<c0 int(11), c1 json> does not support binary predicate operation with type struct<c0 int(11), c1 json>.')
+E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 71. Detail message: Column type struct<`c0` int(11), `c1` json> does not support binary predicate operation with type struct<`c0` int(11), `c1` json>.')
 -- !result
 select t.s0, s.s0 from struct_test t join struct_test s on s.s0 >= t.s0 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 59 to line 1, column 69. Detail message: Column type struct<c0 int(11), c1 varchar(65533)> does not support binary predicate operation with type struct<c0 int(11), c1 varchar(65533)>.')
+E: (1064, 'Getting analyzing error from line 1, column 59 to line 1, column 69. Detail message: Column type struct<`c0` int(11), `c1` varchar(65533)> does not support binary predicate operation with type struct<`c0` int(11), `c1` varchar(65533)>.')
 -- !result
 select t.s4, s.s5 from struct_test t join struct_test s where s.s4 >= t.s5 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 72. Detail message: Column type struct<c0 int(11), c1 json> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 72. Detail message: Column type struct<`c0` int(11), `c1` json> does not support binary predicate operation with type struct<`c0` int(11), `c1` struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select s0 from struct_test t where exists (select 1 from struct_test s where t.s0 = s.s5) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<c0 int(11), c1 varchar(65533)> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<`c0` int(11), `c1` varchar(65533)> does not support binary predicate operation with type struct<`c0` int(11), `c1` struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select s1 from struct_test t where exists (select 1 from struct_test s where t.s1 = s.s5) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<c0 decimal(16, 3), c1 varchar(30)> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<`c0` decimal(16, 3), `c1` varchar(30)> does not support binary predicate operation with type struct<`c0` int(11), `c1` struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 = s.s5) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<c0 int(11), c1 array<varchar(65533)>> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<`c0` int(11), `c1` array<varchar(65533)>> does not support binary predicate operation with type struct<`c0` int(11), `c1` struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 <=> s.s2) order by t.pk;
 -- result:
@@ -192,39 +192,39 @@ E: (1064, 'Getting analyzing error. Detail message: Not support exists correlati
 -- !result
 select s3 from struct_test t where exists (select 1 from struct_test s where t.s3 <=> s.s2) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type struct<c0 varchar(65533), c1 map<int(11),varchar(30)>> does not support binary predicate operation with type struct<c0 int(11), c1 array<varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type struct<`c0` varchar(65533), `c1` map<int(11),varchar(30)>> does not support binary predicate operation with type struct<`c0` int(11), `c1` array<varchar(65533)>>.')
 -- !result
 select s4 from struct_test t where exists (select 1 from struct_test s where t.s4 <=> s.s2) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type struct<c0 int(11), c1 json> does not support binary predicate operation with type struct<c0 int(11), c1 array<varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type struct<`c0` int(11), `c1` json> does not support binary predicate operation with type struct<`c0` int(11), `c1` array<varchar(65533)>>.')
 -- !result
 select s5 from struct_test t where exists (select 1 from struct_test s where t.s5 <=> s.s2) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>> does not support binary predicate operation with type struct<c0 int(11), c1 array<varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type struct<`c0` int(11), `c1` struct<`c` int(11), `b` varchar(65533)>> does not support binary predicate operation with type struct<`c0` int(11), `c1` array<varchar(65533)>>.')
 -- !result
 select s0 from struct_test t where exists (select 1 from struct_test s where t.s0 < s.s1) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<c0 int(11), c1 varchar(65533)> does not support binary predicate operation with type struct<c0 decimal(16, 3), c1 varchar(30)>.')
+E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<`c0` int(11), `c1` varchar(65533)> does not support binary predicate operation with type struct<`c0` decimal(16, 3), `c1` varchar(30)>.')
 -- !result
 select s1 from struct_test t where exists (select 1 from struct_test s where t.s1 < s.s1) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<c0 decimal(16, 3), c1 varchar(30)> does not support binary predicate operation with type struct<c0 decimal(16, 3), c1 varchar(30)>.')
+E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<`c0` decimal(16, 3), `c1` varchar(30)> does not support binary predicate operation with type struct<`c0` decimal(16, 3), `c1` varchar(30)>.')
 -- !result
 select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 < s.s1) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<c0 int(11), c1 array<varchar(65533)>> does not support binary predicate operation with type struct<c0 decimal(16, 3), c1 varchar(30)>.')
+E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<`c0` int(11), `c1` array<varchar(65533)>> does not support binary predicate operation with type struct<`c0` decimal(16, 3), `c1` varchar(30)>.')
 -- !result
 select s2 from struct_test t where not exists (select 1 from struct_test s where t.s2 <=> s.s5) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 81 to line 1, column 92. Detail message: Column type struct<c0 int(11), c1 array<varchar(65533)>> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 81 to line 1, column 92. Detail message: Column type struct<`c0` int(11), `c1` array<varchar(65533)>> does not support binary predicate operation with type struct<`c0` int(11), `c1` struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select s3 from struct_test t where not exists (select 1 from struct_test s where t.s3 <=> s.s5) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 81 to line 1, column 92. Detail message: Column type struct<c0 varchar(65533), c1 map<int(11),varchar(30)>> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 81 to line 1, column 92. Detail message: Column type struct<`c0` varchar(65533), `c1` map<int(11),varchar(30)>> does not support binary predicate operation with type struct<`c0` int(11), `c1` struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select s4 from struct_test t where not exists (select 1 from struct_test s where t.s4 <=> s.s5) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 81 to line 1, column 92. Detail message: Column type struct<c0 int(11), c1 json> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 81 to line 1, column 92. Detail message: Column type struct<`c0` int(11), `c1` json> does not support binary predicate operation with type struct<`c0` int(11), `c1` struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select s5 from struct_test t where not exists (select 1 from struct_test s where t.s5 <=> s.s5) order by t.pk;
 -- result:
@@ -232,7 +232,7 @@ E: (1064, 'Getting analyzing error. Detail message: Not support exists correlati
 -- !result
 select s2 from struct_test t where s2 in (select s0 from struct_test s) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 38 to line 1, column 70. Detail message: The input types (struct<c0 int(11), c1 array<varchar(65533)>>,struct<c0 int(11), c1 varchar(65533)>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 38 to line 1, column 70. Detail message: The input types (struct<`c0` int(11), `c1` array<varchar(65533)>>,struct<`c0` int(11), `c1` varchar(65533)>) of in predict are not compatible.')
 -- !result
 select s4 from struct_test t where s4 in (select s1 from struct_test s) order by t.pk;
 -- result:
@@ -240,14 +240,14 @@ select s4 from struct_test t where s4 in (select s1 from struct_test s) order by
 -- !result
 select s0 from struct_test t where s0 in (select s5 from struct_test s) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 38 to line 1, column 70. Detail message: The input types (struct<c0 int(11), c1 varchar(65533)>,struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 38 to line 1, column 70. Detail message: The input types (struct<`c0` int(11), `c1` varchar(65533)>,struct<`c0` int(11), `c1` struct<`c` int(11), `b` varchar(65533)>>) of in predict are not compatible.')
 -- !result
 select s5 from struct_test t where s5 not in (select s5 from struct_test s) order by t.pk;
 -- result:
 -- !result
 select s0 from struct_test t where s0 not in (select s5 from struct_test s) order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 38 to line 1, column 74. Detail message: The input types (struct<c0 int(11), c1 varchar(65533)>,struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 38 to line 1, column 74. Detail message: The input types (struct<`c0` int(11), `c1` varchar(65533)>,struct<`c0` int(11), `c1` struct<`c` int(11), `b` varchar(65533)>>) of in predict are not compatible.')
 -- !result
 select s0 in (select s0 from struct_test s) from struct_test order by t.pk;
 -- result:
@@ -267,11 +267,11 @@ E: (1064, "Getting analyzing error. Detail message: Column '`t`.`pk`' cannot be 
 -- !result
 select s0 not in (select s2 from struct_test s) from struct_test order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 10 to line 1, column 46. Detail message: The input types (struct<c0 int(11), c1 varchar(65533)>,struct<c0 int(11), c1 array<varchar(65533)>>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 10 to line 1, column 46. Detail message: The input types (struct<`c0` int(11), `c1` varchar(65533)>,struct<`c0` int(11), `c1` array<varchar(65533)>>) of in predict are not compatible.')
 -- !result
 select s0 not in (select s5 from struct_test s) from struct_test order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 10 to line 1, column 46. Detail message: The input types (struct<c0 int(11), c1 varchar(65533)>,struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 10 to line 1, column 46. Detail message: The input types (struct<`c0` int(11), `c1` varchar(65533)>,struct<`c0` int(11), `c1` struct<`c` int(11), `b` varchar(65533)>>) of in predict are not compatible.')
 -- !result
 select t.s4, s.s5 from struct_test t left join struct_test s where s.s4 <=> t.s5 order by t.pk;
 -- result:
@@ -287,11 +287,11 @@ None	None
 -- !result
 select t.s1, s.s2 from struct_test t left join struct_test s on s.s1 = t.s2 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 64 to line 1, column 73. Detail message: Column type struct<c0 decimal(16, 3), c1 varchar(30)> does not support binary predicate operation with type struct<c0 int(11), c1 array<varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 64 to line 1, column 73. Detail message: Column type struct<`c0` decimal(16, 3), `c1` varchar(30)> does not support binary predicate operation with type struct<`c0` int(11), `c1` array<varchar(65533)>>.')
 -- !result
 select t.s1, s.s3 from struct_test t left join struct_test s on s.s1 < t.s3 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 64 to line 1, column 73. Detail message: Column type struct<c0 decimal(16, 3), c1 varchar(30)> does not support binary predicate operation with type struct<c0 varchar(65533), c1 map<int(11),varchar(30)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 64 to line 1, column 73. Detail message: Column type struct<`c0` decimal(16, 3), `c1` varchar(30)> does not support binary predicate operation with type struct<`c0` varchar(65533), `c1` map<int(11),varchar(30)>>.')
 -- !result
 select t.s0, s.s0 from struct_test t left join struct_test s where s.s0 = t.s0 order by t.pk;
 -- result:
@@ -315,11 +315,11 @@ None	None
 -- !result
 select t.s1, s.s2 from struct_test t right join struct_test s on s.s1 = t.s2 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 65 to line 1, column 74. Detail message: Column type struct<c0 decimal(16, 3), c1 varchar(30)> does not support binary predicate operation with type struct<c0 int(11), c1 array<varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 65 to line 1, column 74. Detail message: Column type struct<`c0` decimal(16, 3), `c1` varchar(30)> does not support binary predicate operation with type struct<`c0` int(11), `c1` array<varchar(65533)>>.')
 -- !result
 select t.s1, s.s3 from struct_test t right join struct_test s on s.s1 < t.s3 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 65 to line 1, column 74. Detail message: Column type struct<c0 decimal(16, 3), c1 varchar(30)> does not support binary predicate operation with type struct<c0 varchar(65533), c1 map<int(11),varchar(30)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 65 to line 1, column 74. Detail message: Column type struct<`c0` decimal(16, 3), `c1` varchar(30)> does not support binary predicate operation with type struct<`c0` varchar(65533), `c1` map<int(11),varchar(30)>>.')
 -- !result
 select t.s0, s.s0 from struct_test t right join struct_test s on s.s0 = t.s0 order by t.pk;
 -- result:
@@ -335,7 +335,7 @@ E: (1064, "Getting syntax error at line 1, column 62. Detail message: Unexpected
 -- !result
 select t.s4, s.s5 from struct_test t full join struct_test s on s.s4 <=> t.s5 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 64 to line 1, column 75. Detail message: Column type struct<c0 int(11), c1 json> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 64 to line 1, column 75. Detail message: Column type struct<`c0` int(11), `c1` json> does not support binary predicate operation with type struct<`c0` int(11), `c1` struct<`c` int(11), `b` varchar(65533)>>.')
 -- !result
 select t.s0, s.s0 from struct_test t full join struct_test s on s.s0 = t.s0 order by t.pk;
 -- result:
@@ -348,11 +348,11 @@ None	None
 -- !result
 select t.s1, s.s2 from struct_test t full join struct_test s on s.s1 = t.s2 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 64 to line 1, column 73. Detail message: Column type struct<c0 decimal(16, 3), c1 varchar(30)> does not support binary predicate operation with type struct<c0 int(11), c1 array<varchar(65533)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 64 to line 1, column 73. Detail message: Column type struct<`c0` decimal(16, 3), `c1` varchar(30)> does not support binary predicate operation with type struct<`c0` int(11), `c1` array<varchar(65533)>>.')
 -- !result
 select t.s1, s.s3 from struct_test t full join struct_test s on s.s1 < t.s3 order by t.pk;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 64 to line 1, column 73. Detail message: Column type struct<c0 decimal(16, 3), c1 varchar(30)> does not support binary predicate operation with type struct<c0 varchar(65533), c1 map<int(11),varchar(30)>>.')
+E: (1064, 'Getting analyzing error from line 1, column 64 to line 1, column 73. Detail message: Column type struct<`c0` decimal(16, 3), `c1` varchar(30)> does not support binary predicate operation with type struct<`c0` varchar(65533), `c1` map<int(11),varchar(30)>>.')
 -- !result
 select t.s0, s.s0 from struct_test t full join struct_test s where s.s0 = t.s0 order by t.pk;
 -- result:

--- a/test/sql/test_map/R/test_map
+++ b/test/sql/test_map/R/test_map
@@ -150,7 +150,7 @@ E: (1064, "Getting analyzing error from line 2, column 29 to line 2, column 41. 
 select map_concat(c1, map(named_struct('1',2), named_struct('A', [map()])))
 from (select c1 from (values(map())) as t(c1)) t;
 -- result:
-E: (1064, "Getting analyzing error from line 1, column 22 to line 1, column 73. Detail message: Map key don't supported type: struct<1 tinyint(4)>.")
+E: (1064, "Getting analyzing error from line 1, column 22 to line 1, column 73. Detail message: Map key don't supported type: struct<`1` tinyint(4)>.")
 -- !result
 select map_concat(c1, map(named_struct('1',2), named_struct('A', [map([],[[named_struct('C', [[map()]])]])])))
 from (select c1 from (values(map())) as t(c1)) t;

--- a/test/sql/test_pipe/R/basic
+++ b/test/sql/test_pipe/R/basic
@@ -38,7 +38,7 @@ desc t1;
 -- result:
 col_int	int	YES	true	None	
 col_map	map<varchar(1048576),int>	YES	false	None	
-col_struct	struct<a varchar(1048576), b int(11)>	YES	false	None	
+col_struct	struct<`a` varchar(1048576), `b` int(11)>	YES	false	None	
 -- !result
 select count(*) from t1;
 -- result:

--- a/test/sql/test_semi/R/test_in_predict
+++ b/test/sql/test_semi/R/test_in_predict
@@ -533,15 +533,15 @@ E: (1064, 'Getting analyzing error from line 1, column 14 to line 1, column 23. 
 -- !result
 select array2 not in (row(2,3)) from sc2 order by 1;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 14 to line 1, column 30. Detail message: The input types (array<map<int(11),int(11)>>,struct<col1 tinyint(4), col2 tinyint(4)>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 14 to line 1, column 30. Detail message: The input types (array<map<int(11),int(11)>>,struct<`col1` tinyint(4), `col2` tinyint(4)>) of in predict are not compatible.')
 -- !result
 select array3 in (33,1) from sc2 order by 1;
 -- result:
-E: (1064, 'Getting analyzing error at line 1, column 7. Detail message: in predicate type array<struct<a int(11), b int(11)>> with type double is invalid.')
+E: (1064, 'Getting analyzing error at line 1, column 7. Detail message: in predicate type array<struct<`a` int(11), `b` int(11)>> with type double is invalid.')
 -- !result
 select array3 not in (2,3) from sc2 order by 1;
 -- result:
-E: (1064, 'Getting analyzing error at line 1, column 7. Detail message: in predicate type array<struct<a int(11), b int(11)>> with type double is invalid.')
+E: (1064, 'Getting analyzing error at line 1, column 7. Detail message: in predicate type array<struct<`a` int(11), `b` int(11)>> with type double is invalid.')
 -- !result
 select map1 in (map{}), map1 not in (map{}), map2 in (map{}), map2 not in (map{}), map3 in (map{}), map3 not in (map{}) from sc2 order by 1;
 -- result:
@@ -725,11 +725,11 @@ E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 34. 
 -- !result
 select map3 in ([map{}]) from sc2 order by 1;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 23. Detail message: The input types (map<int(11),struct<c int(11), b int(11)>>,array<map<NULL_TYPE,NULL_TYPE>>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 23. Detail message: The input types (map<int(11),struct<`c` int(11), `b` int(11)>>,array<map<NULL_TYPE,NULL_TYPE>>) of in predict are not compatible.')
 -- !result
 select map3 not in (map{null:2}) from sc2 order by 1;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 31. Detail message: The input types (map<int(11),struct<c int(11), b int(11)>>,map<NULL_TYPE,tinyint(4)>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 31. Detail message: The input types (map<int(11),struct<`c` int(11), `b` int(11)>>,map<NULL_TYPE,tinyint(4)>) of in predict are not compatible.')
 -- !result
 select map1 in (2,3) from sc2 order by 1;
 -- result:
@@ -773,19 +773,19 @@ None	None
 -- !result
 select st1 in (row(null, null)), st1 not in (row(null,null)) from sc2 order by 1;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 11 to line 1, column 30. Detail message: The input types (struct<s1 int(11), s2 array<int(11)>, s3 map<int(11),int(11)>, s4 struct<e int(11), f int(11)>>,struct<col1 boolean, col2 boolean>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 11 to line 1, column 30. Detail message: The input types (struct<`s1` int(11), `s2` array<int(11)>, `s3` map<int(11),int(11)>, `s4` struct<`e` int(11), `f` int(11)>>,struct<`col1` boolean, `col2` boolean>) of in predict are not compatible.')
 -- !result
 select row(null,null) in (st1), row(null,null) not in (st1) from sc2 order by 1;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 22 to line 1, column 29. Detail message: The input types (struct<col1 boolean, col2 boolean>,struct<s1 int(11), s2 array<int(11)>, s3 map<int(11),int(11)>, s4 struct<e int(11), f int(11)>>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 22 to line 1, column 29. Detail message: The input types (struct<`col1` boolean, `col2` boolean>,struct<`s1` int(11), `s2` array<int(11)>, `s3` map<int(11),int(11)>, `s4` struct<`e` int(11), `f` int(11)>>) of in predict are not compatible.')
 -- !result
 select st1 in (row(null)), st1 not in (row(null)) from sc2 order by 1;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 11 to line 1, column 24. Detail message: The input types (struct<s1 int(11), s2 array<int(11)>, s3 map<int(11),int(11)>, s4 struct<e int(11), f int(11)>>,struct<col1 boolean>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 11 to line 1, column 24. Detail message: The input types (struct<`s1` int(11), `s2` array<int(11)>, `s3` map<int(11),int(11)>, `s4` struct<`e` int(11), `f` int(11)>>,struct<`col1` boolean>) of in predict are not compatible.')
 -- !result
 select row(null) in (st1), row(null) not in (st1) from sc2 order by 1;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 17 to line 1, column 24. Detail message: The input types (struct<col1 boolean>,struct<s1 int(11), s2 array<int(11)>, s3 map<int(11),int(11)>, s4 struct<e int(11), f int(11)>>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 17 to line 1, column 24. Detail message: The input types (struct<`col1` boolean>,struct<`s1` int(11), `s2` array<int(11)>, `s3` map<int(11),int(11)>, `s4` struct<`e` int(11), `f` int(11)>>) of in predict are not compatible.')
 -- !result
 select st1 in (row(1, [2,1,3], map{1:1, 2:2}, row(3, 2)), row(12, [2,null,3], map{11:1, 2:2}, row(31, 2))) from sc2 order by 1;
 -- result:
@@ -853,9 +853,9 @@ None
 -- !result
 select st1 in (map{}) from sc2 order by 1;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 11 to line 1, column 20. Detail message: The input types (struct<s1 int(11), s2 array<int(11)>, s3 map<int(11),int(11)>, s4 struct<e int(11), f int(11)>>,map<NULL_TYPE,NULL_TYPE>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 11 to line 1, column 20. Detail message: The input types (struct<`s1` int(11), `s2` array<int(11)>, `s3` map<int(11),int(11)>, `s4` struct<`e` int(11), `f` int(11)>>,map<NULL_TYPE,NULL_TYPE>) of in predict are not compatible.')
 -- !result
 select st1 not in (map{}) from sc2 order by 1;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 11 to line 1, column 24. Detail message: The input types (struct<s1 int(11), s2 array<int(11)>, s3 map<int(11),int(11)>, s4 struct<e int(11), f int(11)>>,map<NULL_TYPE,NULL_TYPE>) of in predict are not compatible.')
+E: (1064, 'Getting analyzing error from line 1, column 11 to line 1, column 24. Detail message: The input types (struct<`s1` int(11), `s2` array<int(11)>, `s3` map<int(11),int(11)>, `s4` struct<`e` int(11), `f` int(11)>>,map<NULL_TYPE,NULL_TYPE>) of in predict are not compatible.')
 -- !result

--- a/test/sql/test_sort/R/test_order_by_struct_comprehensive.sql
+++ b/test/sql/test_sort/R/test_order_by_struct_comprehensive.sql
@@ -725,7 +725,7 @@ SELECT s FROM t20_where
 WHERE s > row(1, 1) 
 ORDER BY s;
 -- result:
-E: (1064, 'Getting analyzing error from line 2, column 6 to line 2, column 18. Detail message: Column type struct<a int(11), b int(11)> does not support binary predicate operation with type struct<col1 tinyint(4), col2 tinyint(4)>.')
+E: (1064, 'Getting analyzing error from line 2, column 6 to line 2, column 18. Detail message: Column type struct<`a` int(11), `b` int(11)> does not support binary predicate operation with type struct<`col1` tinyint(4), `col2` tinyint(4)>.')
 -- !result
 SELECT s FROM t20_where 
 WHERE s = row(2, 1)

--- a/test/sql/test_sort/R/test_struct_order_by_edge_cases.sql
+++ b/test/sql/test_sort/R/test_struct_order_by_edge_cases.sql
@@ -165,7 +165,7 @@ FROM test_struct_edge
 GROUP BY category
 ORDER BY min_info;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 17 to line 1, column 25. Detail message: No matching function with signature: min(struct<name varchar(65533), score int(11)>).')
+E: (1064, 'Getting analyzing error from line 1, column 17 to line 1, column 25. Detail message: No matching function with signature: min(struct<`name` varchar(65533), `score` int(11)>).')
 -- !result
 SELECT id, 
        CASE WHEN id % 2 = 0 
@@ -186,7 +186,7 @@ SELECT * FROM (
 WHERE info > named_struct('name', 'Alice', 'age', 20)
 ORDER BY info;
 -- result:
-E: (1064, 'Getting analyzing error from line 7, column 6 to line 7, column 52. Detail message: Column type struct<name varchar, age tinyint(4)> does not support binary predicate operation with type struct<name varchar, age tinyint(4)>.')
+E: (1064, 'Getting analyzing error from line 7, column 6 to line 7, column 52. Detail message: Column type struct<`name` varchar, `age` tinyint(4)> does not support binary predicate operation with type struct<`name` varchar, `age` tinyint(4)>.')
 -- !result
 SELECT DISTINCT info FROM (
     VALUES 


### PR DESCRIPTION
## Why I'm doing:
Struct field names are not escaped in some cases even if the user escapes them on the input. This leads to errors.

## What I'm doing:

Fixes #68965

I updated StructField to always backtick field names in the toSQL() function. 
Back ticks are stripped on parsing when we assign the `name` field here so we don't have to worry about double backticks, that same functionality is also the source of this bug. 

I added a test case that reproduced the issue, confirmed it failed, then implemented my fix and confirmed the test case now passes.

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
