### PR TITLE
[Enhancement] Let skew join v2 ignore global dict distribution marking

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -1054,15 +1054,12 @@ public class QueryOptimizer extends Optimizer {
 
     private OptExpression dynamicRewrite(ConnectContext connectContext, TaskContext rootTaskContext,
                                          OptExpression result) {
-        // update the existRequiredDistribution value in optExpression. The next rules need it to determine
-        // if we can change the distribution to adjust the plan because of skew data, bad statistics or something else.
-        result = new MarkParentRequiredDistributionRule().rewrite(result, rootTaskContext);
-
-        // this rule must be put after MarkParentRequiredDistributionRule
         if (rootTaskContext.getOptimizerContext().getSessionVariable().isEnableOptimizerSkewJoinOptimizeV2()) {
+            result = new MarkParentRequiredDistributionRule(false).rewrite(result, rootTaskContext);
             result = new SkewShuffleJoinEliminationRule().rewrite(result, rootTaskContext);
         }
 
+        result = new MarkParentRequiredDistributionRule(true).rewrite(result, rootTaskContext);
         result = new ApplyTuningGuideRule(connectContext).rewrite(result, rootTaskContext);
 
         OperatorTuningGuides.OptimizedRecord optimizedRecord = PlanTuningAdvisor.getInstance()


### PR DESCRIPTION
### Why I'm doing:
- `MarkParentRequiredDistributionRule` marks `existRequiredDistribution` so later components (especially **query feedback / tuning guide**, e.g. PlanTuningAdvisor) can understand which subtrees should not freely change distribution.
- When **low-cardinality/global dict** is enabled, scan operators may carry global dict info, which can make `existRequiredDistribution` become true even when the parent does not truly require a specific distribution for the skew-join rewrite.
- For **skew join v2**, `existRequiredDistribution=true` forces the rewrite to keep the broadcast-branch output distribution aligned with the original shuffle join output, which can introduce an extra **`EXCHANGE` (PhysicalDistribution)** *above the broadcast join branch*:
  - `CONCATENATE/UNION -> EXCHANGE -> broadcast HASH JOIN`
- That extra `EXCHANGE` is expensive (repartition/shuffle + network/serialization + pipeline scheduling), and can add noticeable latency, reducing the benefit of skew join v2.

### What I'm doing:
- Make `MarkParentRequiredDistributionRule` configurable: it can optionally **ignore global dict** when marking `existRequiredDistribution`.
- In `QueryOptimizer.dynamicRewrite()`:
  - Run `MarkParentRequiredDistributionRule(false)` **before** `SkewShuffleJoinEliminationRule` so skew join v2 rewrite is not forced into adding the alignment `EXCHANGE` just because of global dict.
  - Run `MarkParentRequiredDistributionRule(true)` **after** skew join v2 rewrite so the final plan still carries correct distribution-marking for **query feedback / tuning guide**.

### Sketch (before/after)
```
Before (global dict causes existRequiredDistribution=true):
            CONCATENATE / UNION
               /            \
    shuffle-join branch    EXCHANGE (align output dist)   <-- extra cost
           |                  |
        HASH JOIN          HASH JOIN (BROADCAST)
           |                  |
          ...                ...

After (ignore global dict only during skew rewrite):
            CONCATENATE / UNION
               /            \
    shuffle-join branch    HASH JOIN (BROADCAST)
           |                  |
        HASH JOIN             ...
           |
          ...
    local exchange type: DIRECT
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
