### PR TITLE
[Refactor] Remove unnecessary build code from TableProperty 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -35,9 +35,9 @@
 package com.starrocks.catalog;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -358,20 +358,84 @@ public class TableProperty implements Writable, GsonPostProcessable {
         this.properties = properties;
     }
 
+    public TableProperty(TableProperty other) {
+        this.properties = Maps.newLinkedHashMap();
+        if (other.properties != null) {
+            this.properties.putAll(other.properties);
+        }
+        this.flatJsonConfig = other.flatJsonConfig == null ? null : new FlatJsonConfig(other.flatJsonConfig);
+        this.dynamicPartitionProperty = copyDynamicPartitionProperty(other.dynamicPartitionProperty);
+        this.replicationNum = other.replicationNum;
+        this.partitionTTLNumber = other.partitionTTLNumber;
+        this.partitionTTL = other.partitionTTL;
+        this.partitionRetentionCondition = other.partitionRetentionCondition;
+        this.timeDriftConstraintSpec = other.timeDriftConstraintSpec;
+        this.partitionRefreshNumber = other.partitionRefreshNumber;
+        this.partitionRefreshStrategy = other.partitionRefreshStrategy;
+        this.mvRefreshMode = other.mvRefreshMode;
+        this.autoRefreshPartitionsLimit = other.autoRefreshPartitionsLimit;
+        this.excludedTriggerTables = other.excludedTriggerTables == null ? null : Lists.newArrayList(other.excludedTriggerTables);
+        this.excludedRefreshTables = other.excludedRefreshTables == null ? null : Lists.newArrayList(other.excludedRefreshTables);
+        this.mvSortKeys = other.mvSortKeys == null ? null : Lists.newArrayList(other.mvSortKeys);
+        this.forceExternalTableQueryRewrite = other.forceExternalTableQueryRewrite;
+        this.queryRewriteConsistencyMode = other.queryRewriteConsistencyMode;
+        this.mvQueryRewriteSwitch = other.mvQueryRewriteSwitch;
+        this.mvTransparentRewriteMode = other.mvTransparentRewriteMode;
+        this.enablePersistentIndex = other.enablePersistentIndex;
+        this.persistentIndexType = other.persistentIndexType;
+        this.primaryIndexCacheExpireSec = other.primaryIndexCacheExpireSec;
+        this.storageVolume = other.storageVolume;
+        this.storageCoolDownTTL = other.storageCoolDownTTL;
+        this.resourceGroup = other.resourceGroup;
+        this.compressionType = other.compressionType;
+        this.compressionLevel = other.compressionLevel;
+        this.writeQuorum = other.writeQuorum;
+        this.enableReplicatedStorage = other.enableReplicatedStorage;
+        this.storageType = other.storageType;
+        this.bucketSize = other.bucketSize;
+        this.mutableBucketNum = other.mutableBucketNum;
+        this.enableLoadProfile = other.enableLoadProfile;
+        this.baseCompactionForbiddenTimeRanges = other.baseCompactionForbiddenTimeRanges;
+        this.hasDelete = other.hasDelete;
+        this.hasForbiddenGlobalDict = other.hasForbiddenGlobalDict;
+        if (other.storageInfo != null) {
+            this.storageInfo = new StorageInfo(other.storageInfo.getFilePathInfo(), other.storageInfo.getCacheInfo());
+        }
+        this.binlogAvailableVersions = other.binlogAvailableVersions == null
+                ? new HashMap<>()
+                : new HashMap<>(other.binlogAvailableVersions);
+        this.binlogConfig = other.binlogConfig == null ? null : new BinlogConfig(other.binlogConfig);
+        this.uniqueConstraints = other.uniqueConstraints == null ? null : Lists.newArrayList(other.uniqueConstraints);
+        this.foreignKeyConstraints = other.foreignKeyConstraints == null ? null : Lists.newArrayList(other.foreignKeyConstraints);
+        this.useFastSchemaEvolution = other.useFastSchemaEvolution;
+        this.dataCachePartitionDuration = other.dataCachePartitionDuration;
+        this.location = copyLocation(other.location);
+        this.fileBundling = other.fileBundling;
+        this.compactionStrategy = other.compactionStrategy;
+        this.lakeCompactionMaxParallel = other.lakeCompactionMaxParallel;
+        this.enableStatisticCollectOnFirstLoad = other.enableStatisticCollectOnFirstLoad;
+        this.tableQueryTimeout = other.tableQueryTimeout;
+        this.cloudNativeFastSchemaEvolutionV2 = other.cloudNativeFastSchemaEvolutionV2;
+    }
+
     public TableProperty copy() {
-        TableProperty newTableProperty = new TableProperty(Maps.newHashMap(this.properties));
-        try {
-            newTableProperty.gsonPostProcess();
-        } catch (IOException e) {
-            Preconditions.checkState(false, "gsonPostProcess shouldn't fail");
+        return new TableProperty(this);
+    }
+
+    private static DynamicPartitionProperty copyDynamicPartitionProperty(DynamicPartitionProperty other) {
+        if (other == null || !other.isExists()) {
+            return new DynamicPartitionProperty(Maps.newHashMap());
         }
-        newTableProperty.hasDelete = this.hasDelete;
-        newTableProperty.hasForbiddenGlobalDict = this.hasForbiddenGlobalDict;
-        if (this.storageInfo != null) {
-            newTableProperty.storageInfo =
-                    new StorageInfo(this.storageInfo.getFilePathInfo(), this.storageInfo.getCacheInfo());
+        return new DynamicPartitionProperty(Maps.newHashMap(other.getProperties()));
+    }
+
+    private static Multimap<String, String> copyLocation(Multimap<String, String> location) {
+        if (location == null) {
+            return null;
         }
-        return newTableProperty;
+        Multimap<String, String> copied = HashMultimap.create();
+        copied.putAll(location);
+        return copied;
     }
 
     public static boolean isSamePrefixProperties(Map<String, String> properties, String prefix) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -1375,8 +1375,6 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildFileBundling();
         buildMutableBucketNum();
         buildCompactionStrategy();
-        buildLakeCompactionMaxParallel();
-        buildEnableStatisticCollectOnFirstLoad();
-        buildTableQueryTimeout();
+        // NOTE: new properties should not be built here, just add SerializedName to the field.
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/FlatJsonConfigValidationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/FlatJsonConfigValidationTest.java
@@ -241,7 +241,7 @@ public class FlatJsonConfigValidationTest {
         // Test the bug fix scenario:
         // 1. Table has flat JSON enabled with other properties set
         // 2. User sets flat_json.enable = false (properties may contain residual flat JSON properties)
-        // 3. TableProperty.copy() -> gsonPostProcess() -> buildFlatJsonConfig() should not throw exception
+        // 3. TableProperty.copy() should preserve a valid FlatJsonConfig and should not throw exception
         
         // Step 1: Create TableProperty with flat JSON enabled and other properties
         Map<String, String> initialProperties = new HashMap<>();
@@ -290,7 +290,7 @@ public class FlatJsonConfigValidationTest {
         Assertions.assertEquals(Config.flat_json_sparsity_factory, configWithResidual.getFlatJsonSparsityFactor(), 0.001);
         Assertions.assertEquals(Config.flat_json_column_max, configWithResidual.getFlatJsonColumnMax());
         
-        // Step 4: Test TableProperty.copy() which calls gsonPostProcess()
+        // Step 4: Test TableProperty.copy()
         // This simulates what happens during SELECT query when table is copied
         TableProperty copiedProperty = propertyWithResidual.copy();
         Assertions.assertNotNull(copiedProperty);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TablePropertyCopyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TablePropertyCopyTest.java
@@ -1,0 +1,95 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Lists;
+import com.starrocks.binlog.BinlogConfig;
+import com.starrocks.catalog.constraint.ForeignKeyConstraint;
+import com.starrocks.catalog.constraint.UniqueConstraint;
+import com.starrocks.common.Pair;
+import com.starrocks.common.util.PropertyAnalyzer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TablePropertyCopyTest {
+    @Test
+    public void testCopyShouldCopyMutableContainers() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("k1", "v1");
+        properties.put(PropertyAnalyzer.PROPERTIES_LABELS_LOCATION, "rack:r1,rack:r2");
+        properties.put(TableProperty.BINLOG_PARTITION + "1", "10");
+
+        TableProperty original = new TableProperty(properties);
+        original.buildLocation();
+        original.buildBinlogAvailableVersion();
+        original.setFlatJsonConfig(new FlatJsonConfig(true, 0.1, 0.8, 50));
+        original.setBinlogConfig(new BinlogConfig(1, true, 60, 100));
+        original.setExcludedTriggerTables(Lists.newArrayList(new TableName("ext_catalog", "db1", "t1")));
+        original.setMvSortKeys(Lists.newArrayList("k1", "k2"));
+        original.setUniqueConstraints(Lists.newArrayList(new UniqueConstraint("ext_catalog", "db1", "t1",
+                Lists.newArrayList(ColumnId.create("c1")))));
+        original.setForeignKeyConstraints(Lists.newArrayList(new ForeignKeyConstraint(
+                new BaseTableInfo("ext_catalog", "db1", "parent_table", "parent_identifier"),
+                new BaseTableInfo("ext_catalog", "db1", "child_table", "child_identifier"),
+                Lists.newArrayList(Pair.create(ColumnId.create("child_col"), ColumnId.create("parent_col"))))));
+        original.setHasDelete(true);
+        original.setHasForbiddenGlobalDict(true);
+
+        TableProperty copied = original.copy();
+
+        Assertions.assertNotSame(original, copied);
+        Assertions.assertNotSame(original.getProperties(), copied.getProperties());
+        Assertions.assertNotSame(original.getFlatJsonConfig(), copied.getFlatJsonConfig());
+        Assertions.assertNotSame(original.getBinlogConfig(), copied.getBinlogConfig());
+        Assertions.assertNotSame(original.getExcludedTriggerTables(), copied.getExcludedTriggerTables());
+        Assertions.assertSame(original.getExcludedTriggerTables().get(0), copied.getExcludedTriggerTables().get(0));
+        Assertions.assertNotSame(original.getMvSortKeys(), copied.getMvSortKeys());
+        Assertions.assertNotSame(original.getUniqueConstraints(), copied.getUniqueConstraints());
+        Assertions.assertNotSame(original.getForeignKeyConstraints(), copied.getForeignKeyConstraints());
+        Assertions.assertSame(original.getUniqueConstraints().get(0), copied.getUniqueConstraints().get(0));
+        Assertions.assertSame(original.getForeignKeyConstraints().get(0), copied.getForeignKeyConstraints().get(0));
+        Assertions.assertNotSame(original.getBinlogAvailableVersions(), copied.getBinlogAvailableVersions());
+        Assertions.assertNotSame(original.getLocation(), copied.getLocation());
+
+        original.getProperties().put("k1", "changed");
+        original.getFlatJsonConfig().setFlatJsonEnable(false);
+        original.getBinlogConfig().setBinlogEnable(false);
+        original.getExcludedTriggerTables().add(new TableName("ext_catalog", "db2", "t2"));
+        original.getMvSortKeys().add("k3");
+        original.getUniqueConstraints().clear();
+        original.getForeignKeyConstraints().clear();
+        original.getBinlogAvailableVersions().put(2L, 20L);
+        original.getLocation().put("rack", "r3");
+        original.setHasDelete(false);
+        original.setHasForbiddenGlobalDict(false);
+
+        Assertions.assertEquals("v1", copied.getProperties().get("k1"));
+        Assertions.assertTrue(copied.getFlatJsonConfig().getFlatJsonEnable());
+        Assertions.assertTrue(copied.getBinlogConfig().getBinlogEnable());
+        Assertions.assertEquals(1, copied.getExcludedTriggerTables().size());
+        Assertions.assertEquals("t1", copied.getExcludedTriggerTables().get(0).getTbl());
+        Assertions.assertEquals(2, copied.getMvSortKeys().size());
+        Assertions.assertEquals(1, copied.getUniqueConstraints().size());
+        Assertions.assertEquals(1, copied.getForeignKeyConstraints().size());
+        Assertions.assertEquals(1, copied.getBinlogAvailableVersions().size());
+        Assertions.assertFalse(copied.getBinlogAvailableVersions().containsKey(2L));
+        Assertions.assertFalse(copied.getLocation().containsEntry("rack", "r3"));
+        Assertions.assertTrue(copied.hasDelete());
+        Assertions.assertTrue(copied.hasForbiddenGlobalDict());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

New properties should not be built in the GsonPostHook, just add SerializedName to the field.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
