### PR TITLE
[Enhancement] Support sparse segment idx in shared-data storage metadata

### DIFF
--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -499,9 +499,9 @@ bool CompactionUpdateConflictChecker::conflict_check(const TxnLogPB_OpCompaction
     // 1. find all segments that have been compacted
     for (const auto& rowset : metadata.rowsets()) {
         if (input_rowsets.count(rowset.id()) > 0 && rowset.segments_size() > 0) {
-            std::vector<int> temp(rowset.segments_size());
-            std::iota(temp.begin(), temp.end(), rowset.id());
-            input_segments.insert(input_segments.end(), temp.begin(), temp.end());
+            for (int i = 0; i < rowset.segments_size(); ++i) {
+                input_segments.push_back(get_rssid(rowset, i));
+            }
         }
     }
     // 2. find out if these segments have been updated

--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -78,6 +78,7 @@ Status CompactionTask::fill_compaction_segment_info(TxnLogPB_OpCompaction* op_co
     } else {
         op_compaction->set_new_segment_offset(0);
         for (const auto& file : writer->segments()) {
+            uint32_t segment_idx = op_compaction->output_rowset().segments_size();
             op_compaction->mutable_output_rowset()->add_segments(file.path);
             op_compaction->mutable_output_rowset()->add_segment_size(file.size.value());
             op_compaction->mutable_output_rowset()->add_segment_encryption_metas(file.encryption_meta);
@@ -85,6 +86,7 @@ Status CompactionTask::fill_compaction_segment_info(TxnLogPB_OpCompaction* op_co
             file.sort_key_min.to_proto(segment_meta->mutable_sort_key_min());
             file.sort_key_max.to_proto(segment_meta->mutable_sort_key_max());
             segment_meta->set_num_rows(file.num_rows);
+            segment_meta->set_segment_idx(segment_idx);
         }
         op_compaction->set_new_segment_count(writer->segments().size());
         op_compaction->mutable_output_rowset()->set_num_rows(writer->num_rows());

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -740,6 +740,7 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
     table_schema_key->set_schema_id(_tablet_schema->id());
 
     for (const auto& f : _tablet_writer->segments()) {
+        uint32_t segment_idx = op_write->mutable_rowset()->segments_size();
         op_write->mutable_rowset()->add_segments(f.path);
         op_write->mutable_rowset()->add_segment_size(f.size.value());
         op_write->mutable_rowset()->add_segment_encryption_metas(f.encryption_meta);
@@ -750,6 +751,7 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
         f.sort_key_min.to_proto(segment_meta->mutable_sort_key_min());
         f.sort_key_max.to_proto(segment_meta->mutable_sort_key_max());
         segment_meta->set_num_rows(f.num_rows);
+        segment_meta->set_segment_idx(segment_idx);
     }
     for (const auto& f : _tablet_writer->dels()) {
         op_write->add_dels(f.path);

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -21,6 +21,7 @@
 #include "storage/lake/lake_local_persistent_index.h"
 #include "storage/lake/lake_persistent_index.h"
 #include "storage/lake/local_pk_index_manager.h"
+#include "storage/lake/meta_file.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/rowset_update_state.h"
 #include "storage/lake/tablet.h"
@@ -168,7 +169,8 @@ Status LakePrimaryIndex::_do_lake_load(TabletManager* tablet_mgr, const TabletMe
                     } else {
                         pkc = chunk->columns()[0].get();
                     }
-                    RETURN_IF_ERROR(insert(rowset->id() + i, rowids, *pkc));
+                    uint32_t rssid = rowset->id() + get_segment_idx(rowset->metadata(), static_cast<int32_t>(i));
+                    RETURN_IF_ERROR(insert(rssid, rowids, *pkc));
                 }
             }
             itr->close();

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -24,6 +24,7 @@
 #include "storage/delete_predicates.h"
 #include "storage/lake/column_mode_partial_update_handler.h"
 #include "storage/lake/lake_delvec_loader.h"
+#include "storage/lake/meta_file.h"
 #include "storage/lake/segment_metadata_filter.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_range_helper.h"
@@ -149,6 +150,10 @@ Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_co
 
     // 2. add compacted segments in this round
     op_compaction->set_new_segment_offset(op_compaction->output_rowset().segments_size());
+    // For rowsets with sparse segment_idx, new compacted segments must use fresh ids that do not
+    // collide with any remaining old segments copied into output_rowset.
+    uint32_t next_segment_id = metadata().segments_size() > 0 ? get_max_segment_idx(metadata()) + 1
+                                                              : op_compaction->output_rowset().segments_size();
     for (const auto& file : writer->segments()) {
         op_compaction->mutable_output_rowset()->add_segments(file.path);
         op_compaction->mutable_output_rowset()->add_segment_size(file.size.value());
@@ -161,6 +166,7 @@ Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_co
             file.sort_key_min.to_proto(segment_meta->mutable_sort_key_min());
             file.sort_key_max.to_proto(segment_meta->mutable_sort_key_max());
             segment_meta->set_num_rows(file.num_rows);
+            segment_meta->set_segment_idx(next_segment_id++);
         }
     }
     op_compaction->set_new_segment_count(writer->segments().size());
@@ -522,7 +528,7 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, SegmentReadOptio
     segments->reserve(segments->size() + metadata().segments_size());
 
     size_t footer_size_hint = 16 * 1024;
-    uint32_t seg_id = 0;
+    int32_t seg_idx = 0;
     bool ignore_lost_segment = config::experimental_lake_ignore_lost_segment;
 
     // RowsetMetaData upgrade from old version may not have the field of segment_size
@@ -546,7 +552,12 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, SegmentReadOptio
     // When parallel loading is enabled, we need to preserve the index mapping between
     // segments vector and metadata. We use a vector of (index, future) pairs to track
     // which index each loaded segment should be placed at.
-    std::vector<std::pair<int, std::future<std::pair<StatusOr<SegmentPtr>, std::string>>>> segment_futures;
+    struct SegmentLoadFuture {
+        int target_idx;
+        uint32_t segment_id;
+        std::future<std::pair<StatusOr<SegmentPtr>, std::string>> future;
+    };
+    std::vector<SegmentLoadFuture> segment_futures;
 
     // Pre-allocate segments vector to maintain correct index mapping.
     // This is necessary because when parallel loading is enabled with skip_segment_idxs,
@@ -575,16 +586,17 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, SegmentReadOptio
     };
 
     for (const auto& seg_name : metadata().segments()) {
-        int current_idx = base_idx + seg_id;
+        int current_idx = base_idx + seg_idx;
+        uint32_t segment_id = get_segment_idx(metadata(), seg_idx);
 
         // Skip segments that are filtered by metadata filter
-        if (skip_segment_idxs != nullptr && skip_segment_idxs->count(seg_id) > 0) {
+        if (skip_segment_idxs != nullptr && skip_segment_idxs->count(seg_idx) > 0) {
             if (!use_index_mapping) {
                 segments->emplace_back(nullptr);
             }
             // When use_index_mapping is true, the slot is already nullptr from resize
             index++;
-            seg_id++;
+            seg_idx++;
             continue;
         }
 
@@ -617,7 +629,7 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, SegmentReadOptio
         if (_parallel_load) {
             int captured_idx = current_idx;
             auto task = std::make_shared<std::packaged_task<std::pair<StatusOr<SegmentPtr>, std::string>()>>([=]() {
-                auto result = _tablet_mgr->load_segment(segment_info, seg_id, lake_io_opts,
+                auto result = _tablet_mgr->load_segment(segment_info, segment_id, lake_io_opts,
                                                         lake_io_opts.fill_metadata_cache, _tablet_schema);
                 return std::make_pair(std::move(result), seg_name);
             });
@@ -627,30 +639,30 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, SegmentReadOptio
                 !st.ok()) {
                 // try load segment serially
                 LOG(WARNING) << "sumbit_func failed: " << st.code_as_string()
-                             << ", try to load segment serially, seg_id: " << seg_id;
-                auto segment_or = _tablet_mgr->load_segment(segment_info, seg_id, &footer_size_hint, lake_io_opts,
+                             << ", try to load segment serially, seg_id: " << segment_id;
+                auto segment_or = _tablet_mgr->load_segment(segment_info, segment_id, &footer_size_hint, lake_io_opts,
                                                             lake_io_opts.fill_metadata_cache, _tablet_schema);
-                if (auto status = check_status_at_index(segment_or, seg_name, seg_id, captured_idx); !status.ok()) {
+                if (auto status = check_status_at_index(segment_or, seg_name, segment_id, captured_idx); !status.ok()) {
                     return status;
                 }
             } else {
-                segment_futures.emplace_back(captured_idx, task->get_future());
+                segment_futures.push_back({captured_idx, segment_id, task->get_future()});
             }
-            seg_id++;
+            seg_idx++;
         } else {
-            auto segment_or = _tablet_mgr->load_segment(segment_info, seg_id, &footer_size_hint, lake_io_opts,
+            auto segment_or = _tablet_mgr->load_segment(segment_info, segment_id, &footer_size_hint, lake_io_opts,
                                                         lake_io_opts.fill_metadata_cache, _tablet_schema);
-            if (auto status = check_status_at_index(segment_or, seg_name, seg_id, current_idx); !status.ok()) {
+            if (auto status = check_status_at_index(segment_or, seg_name, segment_id, current_idx); !status.ok()) {
                 return status;
             }
-            seg_id++;
+            seg_idx++;
         }
     }
 
-    for (auto& [target_idx, future] : segment_futures) {
-        auto result_pair = future.get();
+    for (auto& f : segment_futures) {
+        auto result_pair = f.future.get();
         auto segment_or = result_pair.first;
-        if (auto status = check_status_at_index(segment_or, result_pair.second, target_idx - base_idx, target_idx);
+        if (auto status = check_status_at_index(segment_or, result_pair.second, f.segment_id, f.target_idx);
             !status.ok()) {
             return status;
         }

--- a/be/src/storage/lake/spark_load.cpp
+++ b/be/src/storage/lake/spark_load.cpp
@@ -113,6 +113,7 @@ Status SparkLoadHandler::_load_convert(VersionedTablet& cur_tablet) {
     txn_log->set_txn_id(_request.transaction_id);
     auto op_write = txn_log->mutable_op_write();
     for (const auto& f : writer->segments()) {
+        uint32_t segment_idx = op_write->mutable_rowset()->segments_size();
         op_write->mutable_rowset()->add_segments(f.path);
         op_write->mutable_rowset()->add_segment_size(f.size.value());
         op_write->mutable_rowset()->add_segment_encryption_metas(f.encryption_meta);
@@ -120,6 +121,7 @@ Status SparkLoadHandler::_load_convert(VersionedTablet& cur_tablet) {
         f.sort_key_min.to_proto(segment_meta->mutable_sort_key_min());
         f.sort_key_max.to_proto(segment_meta->mutable_sort_key_max());
         segment_meta->set_num_rows(f.num_rows);
+        segment_meta->set_segment_idx(segment_idx);
     }
     op_write->mutable_rowset()->set_num_rows(writer->num_rows());
     op_write->mutable_rowset()->set_data_size(writer->data_size());

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -295,7 +295,7 @@ static Status get_tablet_split_ranges(TabletManager* tablet_manager, const Table
             segment_info.stat.num_rows = segment_meta.num_rows();
             segment_info.stat.data_size = rowset.segment_size(i);
             if (use_delvec) {
-                const uint32_t segment_id = rowset.id() + i;
+                const uint32_t segment_id = rowset.id() + get_segment_idx(rowset, i);
                 DelVector delvec;
                 LakeIOOptions lake_io_opts{.fill_data_cache = false};
                 auto st = lake::get_del_vec(tablet_manager, *tablet_metadata, segment_id, false, lake_io_opts, &delvec);
@@ -796,7 +796,7 @@ CONTINUE_HANDLE_MERGING_TABLET:
 
         uint32_t max_end = 0;
         for (const auto& rowset : merge_infos[i].metadata->rowsets()) {
-            max_end = std::max(max_end, rowset.id() + std::max(1, rowset.segments_size()));
+            max_end = std::max(max_end, rowset.id() + get_rowset_id_step(rowset));
         }
         if (max_end > 0) {
             next_rowset_id = std::max(next_rowset_id, static_cast<uint32_t>(static_cast<int64_t>(max_end) + offset));

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -64,7 +64,7 @@ private:
 class RssidFileInfoContainer {
 public:
     void add_rssid_to_file(const TabletMetadata& metadata);
-    void add_rssid_to_file(const RowsetMetadataPB& meta, uint32_t rowset_id, uint32_t segment_id,
+    void add_rssid_to_file(const RowsetMetadataPB& meta, uint32_t rowset_id, uint32_t segment_idx,
                            const std::map<int, FileInfo>& replace_segments);
 
     const std::unordered_map<uint32_t, FileInfo>& rssid_to_file() const { return _rssid_to_file_info; }

--- a/be/src/storage/lake_meta_reader.cpp
+++ b/be/src/storage/lake_meta_reader.cpp
@@ -23,6 +23,7 @@
 #include "runtime/exec_env.h"
 #include "runtime/global_dict/config.h"
 #include "storage/lake/column_mode_partial_update_handler.h"
+#include "storage/lake/meta_file.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/table_schema_service.h"
 #include "storage/rowset/column_iterator.h"
@@ -162,7 +163,7 @@ Status LakeMetaReader::_get_segments(const lake::VersionedTablet& tablet, std::v
             if (options.is_primary_keys) {
                 options.tablet_id = tablet.metadata()->id();
                 options.version = tablet.version();
-                options.segment_id = seg_id;
+                options.segment_id = lake::get_segment_idx(rowset->metadata(), seg_id);
                 options.pk_rowsetid = rowset->id();
                 options.dcg_loader = std::make_shared<lake::LakeDeltaColumnGroupLoader>(tablet.metadata());
             }

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -112,7 +112,7 @@ message DelfileWithRowsetId {
     // origin rowset that generate this del file.
     optional uint32 origin_rowset_id = 2;
     // Because of historical reason, DELETE don't have its own segment id, we only use
-    // `rowset_id + segment_id` for UPSERT.
+    // `rowset_id + segment_idx` for UPSERT.
     // So if there is a UPSERT and DELETE mix transaction, we use
     // `op_offset` to identify the order of deletes, and rssid of DELETE will be
     // just same as previous UPSERT. And if the Rowset don't have UPSERT, DELETE's rssid
@@ -134,6 +134,11 @@ message SegmentMetadataPB {
     optional TuplePB sort_key_min = 1;
     optional TuplePB sort_key_max = 2;
     optional int64 num_rows = 3;
+    // Segment index inside the rowset. The global rssid is `rowset_id + segment_idx`.
+    // Initially assigned as a contiguous positional index at write time, but may become
+    // non-contiguous after operations such as partial compaction or batch merge.
+    // Backward compatibility: if absent, consumers should fallback to positional index.
+    optional uint32 segment_idx = 4;
 }
 
 message RowsetMetadataPB {


### PR DESCRIPTION
  ## Why I'm doing:

  Previously, the rssid (rowset-segment-id) was always computed as
  `rowset_id + segment_index`, which implicitly assumed segment IDs are
  contiguous (0, 1, 2, ...). This assumption prevents future optimizations
  such as segment-level partial compaction or segment reuse across rowsets,
  where segment IDs within a rowset may become sparse or non-contiguous.

  ## What I'm doing:

  Add an explicit `segment_idx` field to `SegmentMetadataPB` in the protobuf
  definition, and update all lake storage code paths to use it instead of
  deriving segment ID from the positional index.

  Key changes:
  - Add `optional uint32 segment_idx = 4` to `SegmentMetadataPB` with
    backward-compatible fallback to segment index when the field is absent.
  - Introduce helper functions (`get_segment_idx`, `get_max_segment_idx`,
    `get_rowset_id_step`, `get_rssid`) in `meta_file.h/cpp` to centralize
    segment ID and rssid computation.
  - Update all rssid computation sites: primary index rebuild, persistent
    index loading, compaction publish, delta writer, schema change, spark
    load, tablet reshard, and meta reader.
  - Convert `next_rowset_id` advancement from `std::max(1, segments_size())`
    to `get_rowset_id_step()` which accounts for sparse segment IDs.
  - Update batch merge logic in `txn_log_applier` and `meta_file` to remap
    segment IDs into the merged rowset's local ID space.
  - Replace range-based delvec/dcg deletion in `apply_opcompaction` with
    set-based lookup using `unordered_set` for correctness with sparse IDs.
  - Replace `std::iota` in compaction conflict checker with explicit
    `get_rssid` loop.
  - Add comprehensive unit tests covering sparse segment ID scenarios.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
