### PR TITLE
[Feature] Support dynamic modification of datacache.enable property for cloud-native table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -931,6 +931,12 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable, Memor
                         ((RecyclePartitionInfoV2) partitionInfo).getDataCacheInfo());
             }
 
+            // Corner case: The user may have dropped the partition (non-force), then changed
+            // the table's datacache.enable property while the partition was in the recycle bin.
+            // When the partition is recovered (including replay), its DataCacheInfo should be
+            // updated to match the table's current datacache.enable value.
+            partitionInfo.syncDataCacheInfoWithTable(table, rangePartitionInfo, partitionId);
+
             iterator.remove();
             idToRecycleTime.remove(partitionId);
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2333,6 +2333,15 @@ public class OlapTable extends Table {
         tableProperty.buildFileBundling();
     }
 
+    public void setDataCacheEnable(boolean isEnable) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE,
+                Boolean.valueOf(isEnable).toString());
+        tableProperty.buildDataCacheEnable();
+    }
+
     public void setStorageCoolDownTTL(PeriodDuration duration) {
         tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL,
                 TimeUtils.toHumanReadableString(duration));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -503,6 +503,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 buildCloudNativeFastSchemaEvolutionV2();
                 buildLakeCompactionMaxParallel();
                 buildTableQueryTimeout();
+                buildDataCacheEnable();
                 break;
             case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY:
                 buildConstraint();
@@ -946,6 +947,19 @@ public class TableProperty implements Writable, GsonPostProcessable {
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FILE_BUNDLING)) {
             fileBundling = Boolean.parseBoolean(
                     properties.getOrDefault(PropertyAnalyzer.PROPERTIES_FILE_BUNDLING, "false"));
+        }
+        return this;
+    }
+
+    public TableProperty buildDataCacheEnable() {
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+            boolean dataCacheEnable = Boolean.parseBoolean(
+                    properties.getOrDefault(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "false"));
+            if (this.storageInfo != null) {
+                this.storageInfo.setDataCacheEnable(dataCacheEnable);
+            } else {
+                LOG.warn("Setting datacache.enable to {} while storage info is null", dataCacheEnable);
+            }
         }
         return this;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1627,6 +1627,10 @@ public class PropertyAnalyzer {
         }
     }
 
+    public static boolean analyzeDataCacheEnable(Map<String, String> properties) throws AnalysisException {
+        return analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, true);
+    }
+
     public static TPersistentIndexType analyzePersistentIndexType(Map<String, String> properties) throws AnalysisException {
         if (properties != null && properties.containsKey(PROPERTIES_PERSISTENT_INDEX_TYPE)) {
             String type = properties.get(PROPERTIES_PERSISTENT_INDEX_TYPE);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StorageInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StorageInfo.java
@@ -63,6 +63,10 @@ public class StorageInfo implements GsonPreProcessable, GsonPostProcessable {
         return new DataCacheInfo(getCacheInfo());
     }
 
+    public void setDataCacheEnable(boolean isEnable) {
+        this.cacheInfo = this.cacheInfo.toBuilder().setEnableCache(isEnable).build();
+    }
+
     @Override
     public void gsonPreProcess() throws IOException {
         if (storeInfo != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3957,12 +3957,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     private void alterDataCacheEnable(Database db, OlapTable table,
                                       Map<String, String> properties,
                                       List<Runnable> appliers) throws DdlException {
-        // The caller (AlterJobExecutor.visitModifyTablePropertiesClause) must hold
-        // the db write lock to prevent concurrent partition additions/drops while
-        // we iterate over the partition list and update DataCacheInfo.
-        Locker locker = new Locker();
-        Preconditions.checkArgument(locker.isDbWriteLockHeldByCurrentThread(db));
-
+        // We need hole lock to prevent concurrent partition additions/drops while we iterate over the partition list
+        // and update DataCacheInfo.
+        // However since the caller in AlterJobExecutor have already locked the database, we don't need to lock again here.
         boolean isEnable;
         try {
             isEnable = PropertyAnalyzer.analyzeDataCacheEnable(properties);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3954,6 +3954,62 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
     }
 
+    private void alterDataCacheEnable(Database db, OlapTable table,
+                                      Map<String, String> properties,
+                                      List<Runnable> appliers) throws DdlException {
+        // The caller (AlterJobExecutor.visitModifyTablePropertiesClause) must hold
+        // the db write lock to prevent concurrent partition additions/drops while
+        // we iterate over the partition list and update DataCacheInfo.
+        Locker locker = new Locker();
+        Preconditions.checkArgument(locker.isDbWriteLockHeldByCurrentThread(db));
+
+        boolean isEnable;
+        try {
+            isEnable = PropertyAnalyzer.analyzeDataCacheEnable(properties);
+        } catch (AnalysisException ex) {
+            throw new DdlException(ex.getMessage());
+        }
+
+        if (!table.isCloudNativeTableOrMaterializedView()) {
+            throw new DdlException("Property 'datacache.enable' is only supported for cloud native tables");
+        }
+
+        // Collect partitions that need shard group update
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        Collection<Partition> partitions = table.getPartitions();
+        List<Partition> partitionsToUpdateShardGroup = new ArrayList<>();
+
+        for (Partition partition : partitions) {
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+            if (dataCacheInfo == null || isEnable != dataCacheInfo.isEnabled()) {
+                partitionsToUpdateShardGroup.add(partition);
+            }
+        }
+
+        // Call StarOS to update shard groups BEFORE persisting
+        if (!partitionsToUpdateShardGroup.isEmpty()) {
+            GlobalStateMgr.getCurrentState().getStarOSAgent()
+                    .updateShardGroup(partitionsToUpdateShardGroup, isEnable);
+        }
+
+        // Add applier for table property + partition DataCacheInfo updates.
+        // Note: We do NOT write a separate OP_BATCH_MODIFY_PARTITION log here.
+        // The partition-level DataCacheInfo is derived from the table property during
+        // replay of OP_ALTER_TABLE_PROPERTIES (see replayModifyTableProperty), ensuring
+        // atomicity — a single edit log entry covers both table and partition state.
+        appliers.add(() -> {
+            // Update table property
+            table.setDataCacheEnable(isEnable);
+
+            // Update partition DataCacheInfo in memory
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                boolean asyncWriteBack = dataCacheInfo != null && dataCacheInfo.isAsyncWriteBack();
+                partitionInfo.setDataCacheInfo(partition.getId(), new DataCacheInfo(isEnable, asyncWriteBack));
+            }
+        });
+    }
+
     public void alterTableProperties(Database db, OlapTable table, Map<String, String> properties)
             throws DdlException {
         Map<String, String> propertiesToPersist = new HashMap<>(properties);
@@ -3993,6 +4049,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
         if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_TABLE_QUERY_TIMEOUT)) {
             alterTableQueryTimeout(table, properties, appliers);
+        }
+        if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+            alterDataCacheEnable(db, table, properties, appliers);
         }
         if (!properties.isEmpty()) {
             throw new DdlException("Modify failed because unknown properties: " + properties);
@@ -4437,6 +4496,22 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 } else if (opCode == OperationType.OP_MODIFY_BASE_COMPACTION_FORBIDDEN_TIME_RANGES) {
                     GlobalStateMgr.getCurrentState().getCompactionControlScheduler().updateTableForbiddenTimeRanges(
                             tableId, tableProperty.getBaseCompactionForbiddenTimeRanges());
+                } else if (opCode == OperationType.OP_ALTER_TABLE_PROPERTIES) {
+                    // When datacache.enable is changed at the table level, also update all
+                    // partition-level DataCacheInfo to match. This ensures atomicity: a single
+                    // OP_ALTER_TABLE_PROPERTIES log entry covers both table and partition state.
+                    if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)
+                            && olapTable.isCloudNativeTableOrMaterializedView()) {
+                        boolean dataCacheEnable = Boolean.parseBoolean(
+                                properties.get(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE));
+                        PartitionInfo partitionInfo = olapTable.getPartitionInfo();
+                        for (Partition partition : olapTable.getPartitions()) {
+                            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                            boolean asyncWriteBack = dataCacheInfo != null && dataCacheInfo.isAsyncWriteBack();
+                            partitionInfo.setDataCacheInfo(partition.getId(),
+                                    new DataCacheInfo(dataCacheEnable, asyncWriteBack));
+                        }
+                    }
                 }
             }
         } catch (Exception ex) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3957,7 +3957,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     private void alterDataCacheEnable(Database db, OlapTable table,
                                       Map<String, String> properties,
                                       List<Runnable> appliers) throws DdlException {
-        // We need hole lock to prevent concurrent partition additions/drops while we iterate over the partition list
+        // We need hold lock to prevent concurrent partition additions/drops while we iterate over the partition list
         // and update DataCacheInfo.
         // However since the caller in AlterJobExecutor have already locked the database, we don't need to lock again here.
         boolean isEnable;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -486,6 +486,13 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
             } catch (AnalysisException e) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, e.getMessage());
             }
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+            if (!properties.get(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE).equalsIgnoreCase("true") &&
+                    !properties.get(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE).equalsIgnoreCase("false")) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Property " + PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE +
+                                " must be bool type(false/true)");
+            }
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);
         }
@@ -1097,6 +1104,7 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
     // 2. storage_medium && storage_cooldown_time
     // 3. in_memory
     // 4. tablet type
+    // 5. datacache.enable
     private void checkProperties(Map<String, String> properties) throws AnalysisException {
         // 1. data property
         DataProperty newDataProperty = null;
@@ -1114,6 +1122,15 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
 
         // 4. tablet type
         PropertyAnalyzer.analyzeTabletType(properties);
+
+        // 5. datacache.enable (validate bool value if present)
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+            String value = properties.get(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE);
+            if (!value.equalsIgnoreCase("true") && !value.equalsIgnoreCase("false")) {
+                throw new AnalysisException("Property " + PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE
+                        + " must be bool type(false/true)");
+            }
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterDataCacheEnableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterDataCacheEnableTest.java
@@ -1,0 +1,740 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.common.collect.Lists;
+import com.staros.proto.FileCacheInfo;
+import com.staros.proto.FilePathInfo;
+import com.staros.proto.FileStoreInfo;
+import com.staros.proto.FileStoreType;
+import com.staros.proto.S3FileStoreInfo;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableName;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.StarOSAgent;
+import com.starrocks.persist.BatchModifyPartitionsInfo;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.ModifyPartitionInfo;
+import com.starrocks.persist.ModifyTablePropertyOperationLog;
+import com.starrocks.persist.NextIdLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.WALApplier;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.ModifyPartitionClause;
+import com.starrocks.sql.ast.ModifyTablePropertiesClause;
+import com.starrocks.sql.ast.QualifiedName;
+import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class LakeTableAlterDataCacheEnableTest {
+    private static final int NUM_BUCKETS = 4;
+    private ConnectContext connectContext;
+    private Database db;
+    private LakeTable table;
+    private long partitionId;
+    private final List<Long> shadowTabletIds = new ArrayList<>();
+    private final AtomicBoolean updateShardGroupCalled = new AtomicBoolean(false);
+    private final AtomicBoolean updateShardGroupEnableCache = new AtomicBoolean(false);
+    private final List<BatchModifyPartitionsInfo> loggedBatchModifyPartitions = new ArrayList<>();
+
+    public LakeTableAlterDataCacheEnableTest() {
+        connectContext = new ConnectContext(null);
+        connectContext.setStartTime();
+        connectContext.setThreadLocalInfo();
+    }
+
+    @BeforeEach
+    public void before() throws Exception {
+        FeConstants.runningUnitTest = true;
+        updateShardGroupCalled.set(false);
+        updateShardGroupEnableCache.set(false);
+        loggedBatchModifyPartitions.clear();
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> createShards(int shardCount, FilePathInfo path, FileCacheInfo cache, long groupId,
+                                           List<Long> matchShardIds, Map<String, String> properties)
+                    throws DdlException {
+                for (int i = 0; i < shardCount; i++) {
+                    shadowTabletIds.add(GlobalStateMgr.getCurrentState().getNextId());
+                }
+                return shadowTabletIds;
+            }
+
+            @Mock
+            public void updateShardGroup(List<Partition> partitionsList, boolean enableCache) throws DdlException {
+                updateShardGroupCalled.set(true);
+                updateShardGroupEnableCache.set(enableCache);
+            }
+        };
+
+        new MockUp<EditLog>() {
+            @Mock
+            public void logAlterTableProperties(ModifyTablePropertyOperationLog info, WALApplier walApplier) {
+                walApplier.apply(info);
+            }
+
+            @Mock
+            public void logSaveNextId(long nextId, WALApplier applier) {
+                applier.apply(new NextIdLog(nextId));
+            }
+
+            @Mock
+            public void logBatchModifyPartition(BatchModifyPartitionsInfo info) {
+                loggedBatchModifyPartitions.add(info);
+            }
+        };
+
+        GlobalStateMgr.getCurrentState().setEditLog(new EditLog(new ArrayBlockingQueue<>(100)));
+        final long dbId = GlobalStateMgr.getCurrentState().getNextId();
+        partitionId = GlobalStateMgr.getCurrentState().getNextId();
+        final long tableId = GlobalStateMgr.getCurrentState().getNextId();
+        final long indexId = GlobalStateMgr.getCurrentState().getNextId();
+
+        GlobalStateMgr.getCurrentState().setStarOSAgent(new StarOSAgent());
+
+        KeysType keysType = KeysType.DUP_KEYS;
+        db = new Database(dbId, "db_datacache_enable");
+
+        Database oldDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getIdToDb().putIfAbsent(db.getId(), db);
+        Assertions.assertNull(oldDb);
+
+        Column c0 = new Column("c0", IntegerType.INT, true);
+        DistributionInfo dist = new HashDistributionInfo(NUM_BUCKETS, Collections.singletonList(c0));
+        PartitionInfo partitionInfo = new RangePartitionInfo(Collections.singletonList(c0));
+        partitionInfo.setDataProperty(partitionId, DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(partitionId, (short) 1);
+
+        table = new LakeTable(tableId, "t0", Collections.singletonList(c0), keysType, partitionInfo, dist);
+        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        Partition partition = new Partition(partitionId, partitionId + 100, "t0", index, dist);
+        TStorageMedium storage = TStorageMedium.HDD;
+        TabletMeta tabletMeta = new TabletMeta(db.getId(), table.getId(), partition.getId(), index.getId(), storage, true);
+        for (int i = 0; i < NUM_BUCKETS; i++) {
+            Tablet tablet = new LakeTablet(GlobalStateMgr.getCurrentState().getNextId());
+            index.addTablet(tablet, tabletMeta);
+        }
+        table.addPartition(partition);
+
+        table.setIndexMeta(index.getMetaId(), "t0", Collections.singletonList(c0), 0, 0, (short) 1, TStorageType.COLUMN,
+                keysType);
+        table.setBaseIndexMetaId(index.getMetaId());
+
+        FilePathInfo.Builder builder = FilePathInfo.newBuilder();
+        FileStoreInfo.Builder fsBuilder = builder.getFsInfoBuilder();
+        S3FileStoreInfo.Builder s3FsBuilder = fsBuilder.getS3FsInfoBuilder();
+        s3FsBuilder.setBucket("test-bucket");
+        s3FsBuilder.setRegion("test-region");
+        S3FileStoreInfo s3FsInfo = s3FsBuilder.build();
+        fsBuilder.setFsType(FileStoreType.S3);
+        fsBuilder.setFsKey("test-bucket");
+        fsBuilder.setS3FsInfo(s3FsInfo);
+        FileStoreInfo fsInfo = fsBuilder.build();
+        builder.setFsInfo(fsInfo);
+        builder.setFullPath("s3://test-bucket/datacache-enable-test");
+        FilePathInfo pathInfo = builder.build();
+
+        // Set table property first, then storage info (setStorageInfo writes to the table property)
+        table.setTableProperty(new TableProperty(new HashMap<>()));
+
+        // Initialize with datacache disabled
+        table.setStorageInfo(pathInfo, new DataCacheInfo(false, false));
+        DataCacheInfo dataCacheInfo = new DataCacheInfo(false, false);
+        partitionInfo.setDataCacheInfo(partitionId, dataCacheInfo);
+
+        db.registerTableUnlocked(table);
+    }
+
+    @AfterEach
+    public void after() throws Exception {
+        db.dropTable(table.getName());
+    }
+
+    private void executeAlterTable(Map<String, String> properties) throws Exception {
+        ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
+
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public Database getDb(String dbName) {
+                return db;
+            }
+
+            @Mock
+            public Table getTable(String dbName, String tblName) {
+                return table;
+            }
+        };
+
+        connectContext.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        TableName tableName = new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, db.getFullName(), table.getName());
+        new AlterJobExecutor().process(new AlterTableStmt(
+                new TableRef(QualifiedName.of(Lists.newArrayList(
+                        tableName.getCatalog(), tableName.getDb(), tableName.getTbl())),
+                        null, NodePosition.ZERO),
+                Lists.newArrayList(modify)
+        ), connectContext);
+    }
+
+    private void executeModifyPartition(String partitionName, Map<String, String> properties) throws Exception {
+        ModifyPartitionClause modify = new ModifyPartitionClause(
+                Collections.singletonList(partitionName), properties, NodePosition.ZERO);
+
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public Database getDb(String dbName) {
+                return db;
+            }
+
+            @Mock
+            public Table getTable(String dbName, String tblName) {
+                return table;
+            }
+        };
+
+        connectContext.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        TableName tableName = new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, db.getFullName(), table.getName());
+        new AlterJobExecutor().process(new AlterTableStmt(
+                new TableRef(QualifiedName.of(Lists.newArrayList(
+                        tableName.getCatalog(), tableName.getDb(), tableName.getTbl())),
+                        null, NodePosition.ZERO),
+                Lists.newArrayList(modify)
+        ), connectContext);
+    }
+
+    // ==================== Table-level ALTER TABLE SET tests ====================
+
+    @Test
+    public void testEnableDataCacheOnTable() throws Exception {
+        // Initially disabled
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        DataCacheInfo initialInfo = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertNotNull(initialInfo);
+        Assertions.assertFalse(initialInfo.isEnabled());
+
+        // Enable datacache
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+        executeAlterTable(properties);
+
+        // Verify table property
+        Assertions.assertTrue(table.getTableProperty().getStorageInfo().getDataCacheInfo().isEnabled());
+
+        // Verify partition DataCacheInfo updated
+        DataCacheInfo updatedInfo = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertNotNull(updatedInfo);
+        Assertions.assertTrue(updatedInfo.isEnabled());
+
+        // Verify StarOS updateShardGroup was called
+        Assertions.assertTrue(updateShardGroupCalled.get());
+        Assertions.assertTrue(updateShardGroupEnableCache.get());
+
+        // Table-level ALTER TABLE SET does NOT write a separate OP_BATCH_MODIFY_PARTITION log.
+        // The partition DataCacheInfo is persisted atomically as part of OP_ALTER_TABLE_PROPERTIES
+        // and recovered during replay via replayModifyTableProperty.
+        Assertions.assertEquals(0, loggedBatchModifyPartitions.size());
+    }
+
+    @Test
+    public void testDisableDataCacheOnTable() throws Exception {
+        // First enable
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        partitionInfo.setDataCacheInfo(partitionId, new DataCacheInfo(true, false));
+
+        // Disable datacache
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "false");
+        executeAlterTable(properties);
+
+        // Verify partition DataCacheInfo updated
+        DataCacheInfo updatedInfo = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertNotNull(updatedInfo);
+        Assertions.assertFalse(updatedInfo.isEnabled());
+
+        // Verify StarOS updateShardGroup was called with false
+        Assertions.assertTrue(updateShardGroupCalled.get());
+        Assertions.assertFalse(updateShardGroupEnableCache.get());
+
+        // Table-level: no separate batch modify partition log
+        Assertions.assertEquals(0, loggedBatchModifyPartitions.size());
+    }
+
+    @Test
+    public void testEnableDataCacheWhenAlreadyEnabled() throws Exception {
+        // Set datacache already enabled
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        partitionInfo.setDataCacheInfo(partitionId, new DataCacheInfo(true, false));
+
+        // Try to enable again
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+        executeAlterTable(properties);
+
+        // updateShardGroup should NOT be called (no partition needs update)
+        Assertions.assertFalse(updateShardGroupCalled.get());
+
+        // Table-level: no separate batch modify partition log
+        Assertions.assertEquals(0, loggedBatchModifyPartitions.size());
+    }
+
+    @Test
+    public void testDataCacheEnablePreservesAsyncWriteBack() throws Exception {
+        // Set datacache with asyncWriteBack=true (though it's disabled by default in newer versions)
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        DataCacheInfo originalInfo = new DataCacheInfo(false, false);
+        partitionInfo.setDataCacheInfo(partitionId, originalInfo);
+
+        // Enable datacache
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+        executeAlterTable(properties);
+
+        // asyncWriteBack should be preserved (false)
+        DataCacheInfo updatedInfo = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertFalse(updatedInfo.isAsyncWriteBack());
+    }
+
+    @Test
+    public void testDataCacheEnableOnNonCloudNativeTableFails() throws Exception {
+        // Create a non-cloud-native OlapTable
+        final long dbId2 = GlobalStateMgr.getCurrentState().getNextId();
+        final long tableId2 = GlobalStateMgr.getCurrentState().getNextId();
+        final long indexId2 = GlobalStateMgr.getCurrentState().getNextId();
+        final long partitionId2 = GlobalStateMgr.getCurrentState().getNextId();
+
+        Database db2 = new Database(dbId2, "db_non_cloud");
+        GlobalStateMgr.getCurrentState().getLocalMetastore().getIdToDb().putIfAbsent(db2.getId(), db2);
+
+        Column c0 = new Column("c0", IntegerType.INT, true);
+        DistributionInfo dist = new HashDistributionInfo(NUM_BUCKETS, Collections.singletonList(c0));
+        PartitionInfo partInfo = new RangePartitionInfo(Collections.singletonList(c0));
+        partInfo.setDataProperty(partitionId2, DataProperty.DEFAULT_DATA_PROPERTY);
+        partInfo.setReplicationNum(partitionId2, (short) 1);
+
+        OlapTable olapTable = new OlapTable(tableId2, "t_olap", Collections.singletonList(c0),
+                KeysType.DUP_KEYS, partInfo, dist);
+        MaterializedIndex idx = new MaterializedIndex(indexId2, MaterializedIndex.IndexState.NORMAL);
+        Partition p = new Partition(partitionId2, partitionId2 + 100, "t_olap", idx, dist);
+        olapTable.addPartition(p);
+        olapTable.setIndexMeta(indexId2, "t_olap", Collections.singletonList(c0), 0, 0, (short) 1,
+                TStorageType.COLUMN, KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(indexId2);
+        olapTable.setTableProperty(new TableProperty(new HashMap<>()));
+        db2.registerTableUnlocked(olapTable);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public Database getDb(String dbName) {
+                return db2;
+            }
+
+            @Mock
+            public Table getTable(String dbName, String tblName) {
+                return olapTable;
+            }
+        };
+
+        connectContext.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        TableName tableName = new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                db2.getFullName(), olapTable.getName());
+        ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
+
+        Assertions.assertThrows(AlterJobException.class, () -> {
+            new AlterJobExecutor().process(new AlterTableStmt(
+                    new TableRef(QualifiedName.of(Lists.newArrayList(
+                            tableName.getCatalog(), tableName.getDb(), tableName.getTbl())),
+                            null, NodePosition.ZERO),
+                    Lists.newArrayList(modify)
+            ), connectContext);
+        });
+    }
+
+    // ==================== Partition-level MODIFY PARTITION tests ====================
+
+    @Test
+    public void testEnableDataCacheOnPartition() throws Exception {
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+
+        // Initially disabled
+        Assertions.assertFalse(partitionInfo.getDataCacheInfo(partitionId).isEnabled());
+
+        // Modify partition to enable datacache
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+        executeModifyPartition("t0", properties);
+
+        // Verify partition DataCacheInfo updated
+        DataCacheInfo updatedInfo = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertNotNull(updatedInfo);
+        Assertions.assertTrue(updatedInfo.isEnabled());
+
+        // Verify StarOS updateShardGroup was called
+        Assertions.assertTrue(updateShardGroupCalled.get());
+        Assertions.assertTrue(updateShardGroupEnableCache.get());
+
+        // Verify batch modify partition was logged
+        Assertions.assertEquals(1, loggedBatchModifyPartitions.size());
+    }
+
+    @Test
+    public void testDisableDataCacheOnPartition() throws Exception {
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+
+        // First enable
+        partitionInfo.setDataCacheInfo(partitionId, new DataCacheInfo(true, false));
+
+        // Modify partition to disable datacache
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "false");
+        executeModifyPartition("t0", properties);
+
+        // Verify partition DataCacheInfo updated
+        DataCacheInfo updatedInfo = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertNotNull(updatedInfo);
+        Assertions.assertFalse(updatedInfo.isEnabled());
+
+        // Verify StarOS updateShardGroup was called with false
+        Assertions.assertTrue(updateShardGroupCalled.get());
+        Assertions.assertFalse(updateShardGroupEnableCache.get());
+    }
+
+    @Test
+    public void testModifyPartitionDataCacheOnNonCloudNativeTableFails() throws Exception {
+        // Create non-cloud-native table
+        final long dbId2 = GlobalStateMgr.getCurrentState().getNextId();
+        final long tableId2 = GlobalStateMgr.getCurrentState().getNextId();
+        final long indexId2 = GlobalStateMgr.getCurrentState().getNextId();
+        final long partitionId2 = GlobalStateMgr.getCurrentState().getNextId();
+
+        Database db2 = new Database(dbId2, "db_non_cloud_part");
+        GlobalStateMgr.getCurrentState().getLocalMetastore().getIdToDb().putIfAbsent(db2.getId(), db2);
+
+        Column c0 = new Column("c0", IntegerType.INT, true);
+        DistributionInfo dist = new HashDistributionInfo(NUM_BUCKETS, Collections.singletonList(c0));
+        PartitionInfo partInfo = new RangePartitionInfo(Collections.singletonList(c0));
+        partInfo.setDataProperty(partitionId2, DataProperty.DEFAULT_DATA_PROPERTY);
+        partInfo.setReplicationNum(partitionId2, (short) 1);
+
+        OlapTable olapTable = new OlapTable(tableId2, "t_olap2", Collections.singletonList(c0),
+                KeysType.DUP_KEYS, partInfo, dist);
+        MaterializedIndex idx = new MaterializedIndex(indexId2, MaterializedIndex.IndexState.NORMAL);
+        Partition p = new Partition(partitionId2, partitionId2 + 100, "t_olap2", idx, dist);
+        olapTable.addPartition(p);
+        olapTable.setIndexMeta(indexId2, "t_olap2", Collections.singletonList(c0), 0, 0, (short) 1,
+                TStorageType.COLUMN, KeysType.DUP_KEYS);
+        olapTable.setBaseIndexMetaId(indexId2);
+        olapTable.setTableProperty(new TableProperty(new HashMap<>()));
+        db2.registerTableUnlocked(olapTable);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public Database getDb(String dbName) {
+                return db2;
+            }
+
+            @Mock
+            public Table getTable(String dbName, String tblName) {
+                return olapTable;
+            }
+        };
+
+        connectContext.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        TableName tableName = new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                db2.getFullName(), olapTable.getName());
+        ModifyPartitionClause modify = new ModifyPartitionClause(
+                Collections.singletonList("t_olap2"), properties, NodePosition.ZERO);
+
+        Assertions.assertThrows(AlterJobException.class, () -> {
+            new AlterJobExecutor().process(new AlterTableStmt(
+                    new TableRef(QualifiedName.of(Lists.newArrayList(
+                            tableName.getCatalog(), tableName.getDb(), tableName.getTbl())),
+                            null, NodePosition.ZERO),
+                    Lists.newArrayList(modify)
+            ), connectContext);
+        });
+    }
+
+    @Test
+    public void testUpdateShardGroupFailureThrowsException() throws Exception {
+        // Mock StarOSAgent to throw exception on updateShardGroup
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> createShards(int shardCount, FilePathInfo path, FileCacheInfo cache, long groupId,
+                                           List<Long> matchShardIds, Map<String, String> properties)
+                    throws DdlException {
+                return shadowTabletIds;
+            }
+
+            @Mock
+            public void updateShardGroup(List<Partition> partitionsList, boolean enableCache) throws DdlException {
+                throw new DdlException("StarOS update failed");
+            }
+        };
+
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        Assertions.assertFalse(partitionInfo.getDataCacheInfo(partitionId).isEnabled());
+
+        // Try to enable — partition-level should throw exception (consistent with table-level)
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+
+        Assertions.assertThrows(AlterJobException.class, () -> {
+            executeModifyPartition("t0", properties);
+        });
+
+        // Verify in-memory datacache state was reverted to false
+        DataCacheInfo info = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertFalse(info.isEnabled());
+
+        // Verify no batch modify partition was logged (exception prevented persistence)
+        Assertions.assertEquals(0, loggedBatchModifyPartitions.size());
+    }
+
+    @Test
+    public void testUpdateShardGroupFailureOnTableLevel() throws Exception {
+        // Mock StarOSAgent to throw exception on updateShardGroup
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> createShards(int shardCount, FilePathInfo path, FileCacheInfo cache, long groupId,
+                                           List<Long> matchShardIds, Map<String, String> properties)
+                    throws DdlException {
+                return shadowTabletIds;
+            }
+
+            @Mock
+            public void updateShardGroup(List<Partition> partitionsList, boolean enableCache) throws DdlException {
+                throw new DdlException("StarOS update failed");
+            }
+        };
+
+        // Table-level: the error propagates
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+
+        Assertions.assertThrows(AlterJobException.class, () -> {
+            executeAlterTable(properties);
+        });
+
+        // Partition should remain unchanged (not enabled)
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        DataCacheInfo info = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertFalse(info.isEnabled());
+    }
+
+    @Test
+    public void testEnableDataCacheWhenDataCacheInfoIsNull() throws Exception {
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        // Set DataCacheInfo to null to test the null check path
+        partitionInfo.setDataCacheInfo(partitionId, null);
+
+        // Enable datacache
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+        executeAlterTable(properties);
+
+        // Verify partition DataCacheInfo is now set and enabled
+        DataCacheInfo updatedInfo = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertNotNull(updatedInfo);
+        Assertions.assertTrue(updatedInfo.isEnabled());
+
+        // updateShardGroup should be called since DataCacheInfo was null
+        Assertions.assertTrue(updateShardGroupCalled.get());
+    }
+
+    @Test
+    public void testModifyPartitionOtherPropertyDoesNotChangeDatacache() throws Exception {
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        // Set datacache to enabled with asyncWriteBack=true
+        partitionInfo.setDataCacheInfo(partitionId, new DataCacheInfo(true, true));
+
+        // Mock analyzeReplicationNum to avoid backend availability check in unit test
+        new MockUp<PropertyAnalyzer>() {
+            @Mock
+            public Short analyzeReplicationNum(Map<String, String> properties, short oldReplicationNum) {
+                short replicationNum = oldReplicationNum;
+                if (properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
+                    replicationNum = Short.parseShort(properties.get(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM));
+                    properties.remove(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM);
+                }
+                return replicationNum;
+            }
+        };
+
+        // Modify only replication_num, NOT datacache.enable
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, "1");
+        executeModifyPartition("t0", properties);
+
+        // Verify datacache state is unchanged (still enabled with asyncWriteBack)
+        DataCacheInfo info = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertTrue(info.isEnabled());
+        Assertions.assertTrue(info.isAsyncWriteBack());
+
+        // Verify updateShardGroup was NOT called
+        Assertions.assertFalse(updateShardGroupCalled.get());
+
+        // Verify the logged ModifyPartitionInfo has null dataCacheEnable
+        Assertions.assertEquals(1, loggedBatchModifyPartitions.size());
+        ModifyPartitionInfo modInfo = loggedBatchModifyPartitions.get(0).getModifyPartitionInfos().get(0);
+        Assertions.assertNull(modInfo.getDataCacheEnable());
+    }
+
+    @Test
+    public void testEnableDataCacheOnPartitionWhenAlreadyEnabled() throws Exception {
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        // Set datacache already enabled
+        partitionInfo.setDataCacheInfo(partitionId, new DataCacheInfo(true, false));
+
+        // Try to enable again
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+        executeModifyPartition("t0", properties);
+
+        // Datacache should still be enabled
+        DataCacheInfo info = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertTrue(info.isEnabled());
+
+        // updateShardGroup should NOT be called (no change needed)
+        Assertions.assertFalse(updateShardGroupCalled.get());
+    }
+
+    @Test
+    public void testModifyPartitionDataCachePreservesAsyncWriteBack() throws Exception {
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        // Set asyncWriteBack=true (represents a legacy configuration)
+        partitionInfo.setDataCacheInfo(partitionId, new DataCacheInfo(true, true));
+
+        // Disable datacache
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "false");
+        executeModifyPartition("t0", properties);
+
+        // Verify asyncWriteBack is preserved even after datacache state change
+        DataCacheInfo info = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertFalse(info.isEnabled());
+        Assertions.assertTrue(info.isAsyncWriteBack());
+    }
+
+    @Test
+    public void testReplayModifyPartitionWithDataCacheEnable() {
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        // Initially datacache disabled, asyncWriteBack=true
+        partitionInfo.setDataCacheInfo(partitionId, new DataCacheInfo(false, true));
+
+        // Create a ModifyPartitionInfo with dataCacheEnable=true
+        ModifyPartitionInfo modInfo = new ModifyPartitionInfo(
+                db.getId(), table.getId(), partitionId,
+                DataProperty.DEFAULT_DATA_PROPERTY, (short) -1, true);
+
+        // Replay
+        GlobalStateMgr.getCurrentState().getAlterJobMgr().replayModifyPartition(modInfo);
+
+        // Verify datacache is now enabled
+        DataCacheInfo info = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertTrue(info.isEnabled());
+        // asyncWriteBack should be preserved from the original DataCacheInfo
+        Assertions.assertTrue(info.isAsyncWriteBack());
+    }
+
+    @Test
+    public void testReplayModifyPartitionWithoutDataCacheField() {
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        // Set datacache to enabled
+        partitionInfo.setDataCacheInfo(partitionId, new DataCacheInfo(true, false));
+
+        // Create a ModifyPartitionInfo WITHOUT dataCacheEnable (old format, backward compat)
+        ModifyPartitionInfo modInfo = new ModifyPartitionInfo(
+                db.getId(), table.getId(), partitionId,
+                DataProperty.DEFAULT_DATA_PROPERTY, (short) -1);
+
+        // Replay
+        GlobalStateMgr.getCurrentState().getAlterJobMgr().replayModifyPartition(modInfo);
+
+        // Verify datacache state is UNCHANGED (still enabled) — backward compatibility
+        DataCacheInfo info = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertTrue(info.isEnabled());
+    }
+
+    @Test
+    public void testReplayModifyTablePropertyWithDataCacheEnable() {
+        PartitionInfo partitionInfo = table.getPartitionInfo();
+        // Initially datacache disabled, asyncWriteBack=true
+        partitionInfo.setDataCacheInfo(partitionId, new DataCacheInfo(false, true));
+
+        // Create ModifyTablePropertyOperationLog with datacache.enable=true
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+        ModifyTablePropertyOperationLog log = new ModifyTablePropertyOperationLog(
+                db.getId(), table.getId(), properties);
+
+        // Replay via replayModifyTableProperty with OP_ALTER_TABLE_PROPERTIES
+        GlobalStateMgr.getCurrentState().getLocalMetastore().replayModifyTableProperty(
+                OperationType.OP_ALTER_TABLE_PROPERTIES, log);
+
+        // Verify table-level property updated
+        Assertions.assertTrue(table.getTableProperty().getStorageInfo().isEnableDataCache());
+
+        // Verify partition-level DataCacheInfo updated
+        DataCacheInfo info = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertTrue(info.isEnabled());
+        // asyncWriteBack should be preserved
+        Assertions.assertTrue(info.isAsyncWriteBack());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/RecyclePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/RecyclePartitionInfoTest.java
@@ -1,0 +1,387 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Range;
+import com.staros.proto.FileCacheInfo;
+import com.staros.proto.FilePathInfo;
+import com.starrocks.common.DdlException;
+import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.lake.StorageInfo;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link RecyclePartitionInfo#syncDataCacheInfoWithTable}.
+ * Tests all branches of the protected method directly via a concrete subclass.
+ */
+public class RecyclePartitionInfoTest {
+
+    /**
+     * A concrete test-only subclass of RecyclePartitionInfo that exposes the
+     * protected syncDataCacheInfoWithTable method for direct testing.
+     */
+    private static class TestRecyclePartitionInfo extends RecyclePartitionInfo {
+        private final DataCacheInfo dataCacheInfo;
+
+        TestRecyclePartitionInfo(long dbId, long tableId, Partition partition,
+                                 DataProperty dataProperty, short replicationNum,
+                                 DataCacheInfo dataCacheInfo) {
+            super(dbId, tableId, partition, dataProperty, replicationNum);
+            this.dataCacheInfo = dataCacheInfo;
+        }
+
+        @Override
+        Range<PartitionKey> getRange() {
+            return null;
+        }
+
+        @Override
+        DataCacheInfo getDataCacheInfo() {
+            return dataCacheInfo;
+        }
+
+        @Override
+        void checkRecoverable(OlapTable table) throws DdlException {
+        }
+
+        @Override
+        void recover(OlapTable table) {
+        }
+
+        // Expose the protected method for testing
+        public void testSyncDataCacheInfoWithTable(OlapTable table, PartitionInfo partitionInfo, long partitionId) {
+            syncDataCacheInfoWithTable(table, partitionInfo, partitionId);
+        }
+    }
+
+    @Test
+    public void testSyncSkipsNonCloudNativeTable(@Mocked OlapTable table, @Mocked RangePartitionInfo partitionInfo) {
+        new Expectations() {
+            {
+                table.isCloudNativeTableOrMaterializedView();
+                result = false;
+                // Should NOT access tableProperty since it returns early
+                table.getTableProperty();
+                times = 0;
+            }
+        };
+
+        TestRecyclePartitionInfo info = new TestRecyclePartitionInfo(
+                1L, 2L, null, DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        // Should return early without any error for non-cloud-native table
+        info.testSyncDataCacheInfoWithTable(table, partitionInfo, 100L);
+    }
+
+    @Test
+    public void testSyncSkipsWhenTablePropertyIsNull(@Mocked OlapTable table, @Mocked RangePartitionInfo partitionInfo) {
+        new Expectations() {
+            {
+                table.isCloudNativeTableOrMaterializedView();
+                result = true;
+                table.getTableProperty();
+                result = null;
+                // Should NOT access partitionInfo since it returns early
+                partitionInfo.getDataCacheInfo(anyLong);
+                times = 0;
+            }
+        };
+
+        TestRecyclePartitionInfo info = new TestRecyclePartitionInfo(
+                1L, 2L, null, DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        info.testSyncDataCacheInfoWithTable(table, partitionInfo, 100L);
+    }
+
+    @Test
+    public void testSyncSkipsWhenStorageInfoIsNull(
+            @Mocked OlapTable table, @Mocked RangePartitionInfo partitionInfo, @Mocked TableProperty tableProperty) {
+        new Expectations() {
+            {
+                table.isCloudNativeTableOrMaterializedView();
+                result = true;
+                table.getTableProperty();
+                result = tableProperty;
+                tableProperty.getStorageInfo();
+                result = null;
+                // Should NOT access partitionInfo since it returns early
+                partitionInfo.getDataCacheInfo(anyLong);
+                times = 0;
+            }
+        };
+
+        TestRecyclePartitionInfo info = new TestRecyclePartitionInfo(
+                1L, 2L, null, DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        info.testSyncDataCacheInfoWithTable(table, partitionInfo, 100L);
+    }
+
+    @Test
+    public void testSyncCreatesNewDataCacheInfoWhenCurrentIsNull(
+            @Mocked OlapTable table, @Mocked TableProperty tableProperty) {
+        StorageInfo storageInfo = new StorageInfo(
+                FilePathInfo.newBuilder().build(),
+                FileCacheInfo.newBuilder().setEnableCache(true).build());
+
+        // Use a real RangePartitionInfo-like approach: track what gets set
+        RangePartitionInfo partitionInfo = new RangePartitionInfo();
+
+        new Expectations() {
+            {
+                table.isCloudNativeTableOrMaterializedView();
+                result = true;
+                table.getTableProperty();
+                result = tableProperty;
+                tableProperty.getStorageInfo();
+                result = storageInfo;
+            }
+        };
+
+        long partitionId = 100L;
+        // Ensure no DataCacheInfo exists initially for this partitionId
+        Assertions.assertNull(partitionInfo.getDataCacheInfo(partitionId));
+
+        TestRecyclePartitionInfo info = new TestRecyclePartitionInfo(
+                1L, 2L, null, DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        info.testSyncDataCacheInfoWithTable(table, partitionInfo, partitionId);
+
+        // Verify that DataCacheInfo was created with table's enableCache=true and asyncWriteBack=false
+        DataCacheInfo newDataCacheInfo = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertNotNull(newDataCacheInfo, "DataCacheInfo should be created when current is null");
+        Assertions.assertTrue(newDataCacheInfo.isEnabled(), "DataCacheInfo should inherit table's enableCache=true");
+        Assertions.assertFalse(newDataCacheInfo.isAsyncWriteBack(),
+                "asyncWriteBack should default to false when currentDataCacheInfo is null");
+    }
+
+    @Test
+    public void testSyncUpdatesWhenDataCacheMismatch_EnableToDisable(
+            @Mocked OlapTable table, @Mocked TableProperty tableProperty) {
+        // Table has datacache disabled
+        StorageInfo storageInfo = new StorageInfo(
+                FilePathInfo.newBuilder().build(),
+                FileCacheInfo.newBuilder().setEnableCache(false).build());
+
+        RangePartitionInfo partitionInfo = new RangePartitionInfo();
+        long partitionId = 200L;
+        // Partition has datacache enabled (mismatch)
+        partitionInfo.setDataCacheInfo(partitionId, new DataCacheInfo(true, true));
+
+        new Expectations() {
+            {
+                table.isCloudNativeTableOrMaterializedView();
+                result = true;
+                table.getTableProperty();
+                result = tableProperty;
+                tableProperty.getStorageInfo();
+                result = storageInfo;
+            }
+        };
+
+        TestRecyclePartitionInfo info = new TestRecyclePartitionInfo(
+                1L, 2L, null, DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        info.testSyncDataCacheInfoWithTable(table, partitionInfo, partitionId);
+
+        DataCacheInfo updatedDataCacheInfo = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertNotNull(updatedDataCacheInfo);
+        Assertions.assertFalse(updatedDataCacheInfo.isEnabled(),
+                "DataCacheInfo should match table's datacache.enable=false");
+        // asyncWriteBack should be preserved from the old value
+        Assertions.assertTrue(updatedDataCacheInfo.isAsyncWriteBack(),
+                "asyncWriteBack should be preserved from original DataCacheInfo");
+    }
+
+    @Test
+    public void testSyncUpdatesWhenDataCacheMismatch_DisableToEnable(
+            @Mocked OlapTable table, @Mocked TableProperty tableProperty) {
+        // Table has datacache enabled
+        StorageInfo storageInfo = new StorageInfo(
+                FilePathInfo.newBuilder().build(),
+                FileCacheInfo.newBuilder().setEnableCache(true).build());
+
+        RangePartitionInfo partitionInfo = new RangePartitionInfo();
+        long partitionId = 300L;
+        // Partition has datacache disabled (mismatch)
+        partitionInfo.setDataCacheInfo(partitionId, new DataCacheInfo(false, false));
+
+        new Expectations() {
+            {
+                table.isCloudNativeTableOrMaterializedView();
+                result = true;
+                table.getTableProperty();
+                result = tableProperty;
+                tableProperty.getStorageInfo();
+                result = storageInfo;
+            }
+        };
+
+        TestRecyclePartitionInfo info = new TestRecyclePartitionInfo(
+                1L, 2L, null, DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        info.testSyncDataCacheInfoWithTable(table, partitionInfo, partitionId);
+
+        DataCacheInfo updatedDataCacheInfo = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertNotNull(updatedDataCacheInfo);
+        Assertions.assertTrue(updatedDataCacheInfo.isEnabled(),
+                "DataCacheInfo should match table's datacache.enable=true");
+        Assertions.assertFalse(updatedDataCacheInfo.isAsyncWriteBack(),
+                "asyncWriteBack should be preserved from original DataCacheInfo");
+    }
+
+    @Test
+    public void testSyncNoOpWhenAlreadyInSync(
+            @Mocked OlapTable table, @Mocked TableProperty tableProperty) {
+        // Table has datacache enabled
+        StorageInfo storageInfo = new StorageInfo(
+                FilePathInfo.newBuilder().build(),
+                FileCacheInfo.newBuilder().setEnableCache(true).build());
+
+        RangePartitionInfo partitionInfo = new RangePartitionInfo();
+        long partitionId = 400L;
+        // Partition also has datacache enabled (in sync)
+        DataCacheInfo originalDataCacheInfo = new DataCacheInfo(true, true);
+        partitionInfo.setDataCacheInfo(partitionId, originalDataCacheInfo);
+
+        new Expectations() {
+            {
+                table.isCloudNativeTableOrMaterializedView();
+                result = true;
+                table.getTableProperty();
+                result = tableProperty;
+                tableProperty.getStorageInfo();
+                result = storageInfo;
+            }
+        };
+
+        TestRecyclePartitionInfo info = new TestRecyclePartitionInfo(
+                1L, 2L, null, DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        info.testSyncDataCacheInfoWithTable(table, partitionInfo, partitionId);
+
+        // DataCacheInfo should remain unchanged (same object or equivalent)
+        DataCacheInfo resultDataCacheInfo = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertNotNull(resultDataCacheInfo);
+        Assertions.assertTrue(resultDataCacheInfo.isEnabled());
+        // The object should be the same since no update was needed
+        Assertions.assertSame(originalDataCacheInfo, resultDataCacheInfo,
+                "DataCacheInfo should not be replaced when already in sync");
+    }
+
+    @Test
+    public void testSyncNoOpWhenBothDisabled(
+            @Mocked OlapTable table, @Mocked TableProperty tableProperty) {
+        // Table has datacache disabled
+        StorageInfo storageInfo = new StorageInfo(
+                FilePathInfo.newBuilder().build(),
+                FileCacheInfo.newBuilder().setEnableCache(false).build());
+
+        RangePartitionInfo partitionInfo = new RangePartitionInfo();
+        long partitionId = 500L;
+        // Partition also has datacache disabled (in sync)
+        DataCacheInfo originalDataCacheInfo = new DataCacheInfo(false, false);
+        partitionInfo.setDataCacheInfo(partitionId, originalDataCacheInfo);
+
+        new Expectations() {
+            {
+                table.isCloudNativeTableOrMaterializedView();
+                result = true;
+                table.getTableProperty();
+                result = tableProperty;
+                tableProperty.getStorageInfo();
+                result = storageInfo;
+            }
+        };
+
+        TestRecyclePartitionInfo info = new TestRecyclePartitionInfo(
+                1L, 2L, null, DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        info.testSyncDataCacheInfoWithTable(table, partitionInfo, partitionId);
+
+        // DataCacheInfo should remain unchanged
+        DataCacheInfo resultDataCacheInfo = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertNotNull(resultDataCacheInfo);
+        Assertions.assertFalse(resultDataCacheInfo.isEnabled());
+        Assertions.assertSame(originalDataCacheInfo, resultDataCacheInfo,
+                "DataCacheInfo should not be replaced when both disabled (in sync)");
+    }
+
+    @Test
+    public void testSyncPreservesAsyncWriteBackTrue(
+            @Mocked OlapTable table, @Mocked TableProperty tableProperty) {
+        // Table has datacache enabled
+        StorageInfo storageInfo = new StorageInfo(
+                FilePathInfo.newBuilder().build(),
+                FileCacheInfo.newBuilder().setEnableCache(true).build());
+
+        RangePartitionInfo partitionInfo = new RangePartitionInfo();
+        long partitionId = 600L;
+        // Partition has datacache disabled but asyncWriteBack=true
+        partitionInfo.setDataCacheInfo(partitionId, new DataCacheInfo(false, true));
+
+        new Expectations() {
+            {
+                table.isCloudNativeTableOrMaterializedView();
+                result = true;
+                table.getTableProperty();
+                result = tableProperty;
+                tableProperty.getStorageInfo();
+                result = storageInfo;
+            }
+        };
+
+        TestRecyclePartitionInfo info = new TestRecyclePartitionInfo(
+                1L, 2L, null, DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        info.testSyncDataCacheInfoWithTable(table, partitionInfo, partitionId);
+
+        DataCacheInfo updatedDataCacheInfo = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertNotNull(updatedDataCacheInfo);
+        Assertions.assertTrue(updatedDataCacheInfo.isEnabled(),
+                "DataCacheInfo should match table's datacache.enable=true");
+        Assertions.assertTrue(updatedDataCacheInfo.isAsyncWriteBack(),
+                "asyncWriteBack=true should be preserved from original DataCacheInfo");
+    }
+
+    @Test
+    public void testSyncPreservesAsyncWriteBackFalse(
+            @Mocked OlapTable table, @Mocked TableProperty tableProperty) {
+        // Table has datacache disabled
+        StorageInfo storageInfo = new StorageInfo(
+                FilePathInfo.newBuilder().build(),
+                FileCacheInfo.newBuilder().setEnableCache(false).build());
+
+        RangePartitionInfo partitionInfo = new RangePartitionInfo();
+        long partitionId = 700L;
+        // Partition has datacache enabled but asyncWriteBack=false
+        partitionInfo.setDataCacheInfo(partitionId, new DataCacheInfo(true, false));
+
+        new Expectations() {
+            {
+                table.isCloudNativeTableOrMaterializedView();
+                result = true;
+                table.getTableProperty();
+                result = tableProperty;
+                tableProperty.getStorageInfo();
+                result = storageInfo;
+            }
+        };
+
+        TestRecyclePartitionInfo info = new TestRecyclePartitionInfo(
+                1L, 2L, null, DataProperty.DEFAULT_DATA_PROPERTY, (short) 1, null);
+        info.testSyncDataCacheInfoWithTable(table, partitionInfo, partitionId);
+
+        DataCacheInfo updatedDataCacheInfo = partitionInfo.getDataCacheInfo(partitionId);
+        Assertions.assertNotNull(updatedDataCacheInfo);
+        Assertions.assertFalse(updatedDataCacheInfo.isEnabled(),
+                "DataCacheInfo should match table's datacache.enable=false");
+        Assertions.assertFalse(updatedDataCacheInfo.isAsyncWriteBack(),
+                "asyncWriteBack=false should be preserved from original DataCacheInfo");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/PropertyAnalyzerTest.java
@@ -119,4 +119,33 @@ public class PropertyAnalyzerTest {
         int result2 = PropertyAnalyzer.analyzeTableQueryTimeout(properties6);
         Assertions.assertEquals(600, result2);
     }
+
+    @Test
+    public void testAnalyzeDataCacheEnable() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+
+        try {
+            Assertions.assertTrue(PropertyAnalyzer.analyzeDataCacheEnable(properties));
+        } catch (AnalysisException e) {
+            Assertions.fail("Should not throw exception");
+        }
+
+        Assertions.assertEquals(0, properties.size());
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "false");
+        try {
+            Assertions.assertFalse(PropertyAnalyzer.analyzeDataCacheEnable(properties));
+        } catch (AnalysisException e) {
+            Assertions.fail("Should not throw exception");
+        }
+
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "abcd");
+        // If the string passed in is not "true" (ignoring case),
+        // analyzeDataCacheEnable will return false instead of throwing an exception
+        try {
+            Assertions.assertFalse(PropertyAnalyzer.analyzeDataCacheEnable(properties));
+        } catch (AnalysisException e) {
+            Assertions.fail("Should not throw exception");
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StorageInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StorageInfoTest.java
@@ -1,0 +1,101 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.staros.proto.FileCacheInfo;
+import com.staros.proto.FilePathInfo;
+import com.staros.proto.FileStoreInfo;
+import com.staros.proto.FileStoreType;
+import com.staros.proto.S3FileStoreInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StorageInfoTest {
+
+    private FilePathInfo createTestFilePathInfo() {
+        FilePathInfo.Builder builder = FilePathInfo.newBuilder();
+        FileStoreInfo.Builder fsBuilder = builder.getFsInfoBuilder();
+        S3FileStoreInfo.Builder s3FsBuilder = fsBuilder.getS3FsInfoBuilder();
+        s3FsBuilder.setBucket("test-bucket");
+        s3FsBuilder.setRegion("test-region");
+        fsBuilder.setFsType(FileStoreType.S3);
+        fsBuilder.setFsKey("test-bucket");
+        fsBuilder.setS3FsInfo(s3FsBuilder.build());
+        builder.setFsInfo(fsBuilder.build());
+        builder.setFullPath("s3://test-bucket/test-path");
+        return builder.build();
+    }
+
+    @Test
+    public void testSetDataCacheEnableFromFalseToTrue() {
+        FileCacheInfo cacheInfo = FileCacheInfo.newBuilder()
+                .setEnableCache(false)
+                .setTtlSeconds(0)
+                .setAsyncWriteBack(false)
+                .build();
+        StorageInfo storageInfo = new StorageInfo(createTestFilePathInfo(), cacheInfo);
+
+        Assertions.assertFalse(storageInfo.isEnableDataCache());
+
+        storageInfo.setDataCacheEnable(true);
+        Assertions.assertTrue(storageInfo.isEnableDataCache());
+    }
+
+    @Test
+    public void testSetDataCacheEnableFromTrueToFalse() {
+        FileCacheInfo cacheInfo = FileCacheInfo.newBuilder()
+                .setEnableCache(true)
+                .setTtlSeconds(-1)
+                .setAsyncWriteBack(false)
+                .build();
+        StorageInfo storageInfo = new StorageInfo(createTestFilePathInfo(), cacheInfo);
+
+        Assertions.assertTrue(storageInfo.isEnableDataCache());
+
+        storageInfo.setDataCacheEnable(false);
+        Assertions.assertFalse(storageInfo.isEnableDataCache());
+    }
+
+    @Test
+    public void testSetDataCacheEnablePreservesOtherFields() {
+        FileCacheInfo cacheInfo = FileCacheInfo.newBuilder()
+                .setEnableCache(false)
+                .setTtlSeconds(3600)
+                .setAsyncWriteBack(false)
+                .build();
+        StorageInfo storageInfo = new StorageInfo(createTestFilePathInfo(), cacheInfo);
+
+        storageInfo.setDataCacheEnable(true);
+
+        // Other fields should be preserved
+        Assertions.assertTrue(storageInfo.isEnableDataCache());
+        Assertions.assertFalse(storageInfo.isEnableAsyncWriteBack());
+    }
+
+    @Test
+    public void testGetDataCacheInfo() {
+        FileCacheInfo cacheInfo = FileCacheInfo.newBuilder()
+                .setEnableCache(true)
+                .setTtlSeconds(-1)
+                .setAsyncWriteBack(false)
+                .build();
+        StorageInfo storageInfo = new StorageInfo(createTestFilePathInfo(), cacheInfo);
+
+        DataCacheInfo dataCacheInfo = storageInfo.getDataCacheInfo();
+        Assertions.assertNotNull(dataCacheInfo);
+        Assertions.assertTrue(dataCacheInfo.isEnabled());
+        Assertions.assertFalse(dataCacheInfo.isAsyncWriteBack());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/persist/ModifyPartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/ModifyPartitionInfoTest.java
@@ -1,0 +1,143 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.Gson;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.thrift.TStorageMedium;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ModifyPartitionInfoTest {
+
+    @Test
+    public void testConstructorWithDataCacheEnable() {
+        DataProperty dataProperty = new DataProperty(TStorageMedium.HDD, DataProperty.MAX_COOLDOWN_TIME_MS);
+        ModifyPartitionInfo info = new ModifyPartitionInfo(1L, 2L, 3L, dataProperty, (short) 1, true);
+
+        Assertions.assertEquals(1L, info.getDbId());
+        Assertions.assertEquals(2L, info.getTableId());
+        Assertions.assertEquals(3L, info.getPartitionId());
+        Assertions.assertEquals(dataProperty, info.getDataProperty());
+        Assertions.assertEquals((short) 1, info.getReplicationNum());
+        Assertions.assertTrue(info.getDataCacheEnable());
+    }
+
+    @Test
+    public void testConstructorWithoutDataCacheEnableDefaultsNull() {
+        DataProperty dataProperty = new DataProperty(TStorageMedium.SSD, DataProperty.MAX_COOLDOWN_TIME_MS);
+        ModifyPartitionInfo info = new ModifyPartitionInfo(1L, 2L, 3L, dataProperty, (short) 3);
+
+        Assertions.assertNull(info.getDataCacheEnable());
+    }
+
+    @Test
+    public void testSetDataCacheEnable() {
+        DataProperty dataProperty = new DataProperty(TStorageMedium.HDD, DataProperty.MAX_COOLDOWN_TIME_MS);
+        ModifyPartitionInfo info = new ModifyPartitionInfo(1L, 2L, 3L, dataProperty, (short) 1, false);
+
+        Assertions.assertFalse(info.getDataCacheEnable());
+        info.setDataCacheEnable(true);
+        Assertions.assertTrue(info.getDataCacheEnable());
+        info.setDataCacheEnable(false);
+        Assertions.assertFalse(info.getDataCacheEnable());
+    }
+
+    @Test
+    public void testEqualsWithDataCacheEnable() {
+        DataProperty dataProperty = new DataProperty(TStorageMedium.HDD, DataProperty.MAX_COOLDOWN_TIME_MS);
+
+        ModifyPartitionInfo info1 = new ModifyPartitionInfo(1L, 2L, 3L, dataProperty, (short) 1, true);
+        ModifyPartitionInfo info2 = new ModifyPartitionInfo(1L, 2L, 3L, dataProperty, (short) 1, true);
+        ModifyPartitionInfo info3 = new ModifyPartitionInfo(1L, 2L, 3L, dataProperty, (short) 1, false);
+
+        Assertions.assertEquals(info1, info2);
+        Assertions.assertNotEquals(info1, info3);
+    }
+
+    @Test
+    public void testEqualsSameObject() {
+        DataProperty dataProperty = new DataProperty(TStorageMedium.HDD, DataProperty.MAX_COOLDOWN_TIME_MS);
+        ModifyPartitionInfo info = new ModifyPartitionInfo(1L, 2L, 3L, dataProperty, (short) 1, true);
+        Assertions.assertEquals(info, info);
+    }
+
+    @Test
+    public void testEqualsNull() {
+        DataProperty dataProperty = new DataProperty(TStorageMedium.HDD, DataProperty.MAX_COOLDOWN_TIME_MS);
+        ModifyPartitionInfo info = new ModifyPartitionInfo(1L, 2L, 3L, dataProperty, (short) 1, true);
+        Assertions.assertNotEquals(info, null);
+    }
+
+    @Test
+    public void testEqualsWrongType() {
+        DataProperty dataProperty = new DataProperty(TStorageMedium.HDD, DataProperty.MAX_COOLDOWN_TIME_MS);
+        ModifyPartitionInfo info = new ModifyPartitionInfo(1L, 2L, 3L, dataProperty, (short) 1, true);
+        Assertions.assertNotEquals(info, "not a ModifyPartitionInfo");
+    }
+
+    @Test
+    public void testGsonSerialization() {
+        DataProperty dataProperty = new DataProperty(TStorageMedium.HDD, DataProperty.MAX_COOLDOWN_TIME_MS);
+        ModifyPartitionInfo info = new ModifyPartitionInfo(1L, 2L, 3L, dataProperty, (short) 1, true);
+
+        Gson gson = new Gson();
+        String json = gson.toJson(info);
+
+        // Verify the json contains dataCacheEnable
+        Assertions.assertTrue(json.contains("\"dataCacheEnable\":true"));
+
+        ModifyPartitionInfo deserialized = gson.fromJson(json, ModifyPartitionInfo.class);
+        Assertions.assertEquals(info.getDbId(), deserialized.getDbId());
+        Assertions.assertEquals(info.getTableId(), deserialized.getTableId());
+        Assertions.assertEquals(info.getPartitionId(), deserialized.getPartitionId());
+        Assertions.assertEquals(info.getReplicationNum(), deserialized.getReplicationNum());
+        Assertions.assertEquals(info.getDataCacheEnable(), deserialized.getDataCacheEnable());
+    }
+
+    @Test
+    public void testGsonSerializationWithDataCacheDisabled() {
+        DataProperty dataProperty = new DataProperty(TStorageMedium.SSD, DataProperty.MAX_COOLDOWN_TIME_MS);
+        ModifyPartitionInfo info = new ModifyPartitionInfo(1L, 2L, 3L, dataProperty, (short) 3, false);
+
+        Gson gson = new Gson();
+        String json = gson.toJson(info);
+        ModifyPartitionInfo deserialized = gson.fromJson(json, ModifyPartitionInfo.class);
+
+        Assertions.assertFalse(deserialized.getDataCacheEnable());
+    }
+
+    @Test
+    public void testDefaultConstructor() {
+        ModifyPartitionInfo info = new ModifyPartitionInfo();
+        // Default values
+        Assertions.assertEquals(0L, info.getDbId());
+        Assertions.assertEquals(0L, info.getTableId());
+        Assertions.assertEquals(0L, info.getPartitionId());
+        Assertions.assertNull(info.getDataCacheEnable());
+    }
+
+    @Test
+    public void testGsonDeserializationWithoutDataCacheEnableField() {
+        // Simulate an old edit log entry created before dataCacheEnable was added.
+        // Gson should deserialize the missing field as null (not false).
+        String oldJson = "{\"dbId\":1,\"tableId\":2,\"partitionId\":3,\"replicationNum\":1}";
+        Gson gson = new Gson();
+        ModifyPartitionInfo deserialized = gson.fromJson(oldJson, ModifyPartitionInfo.class);
+
+        Assertions.assertNull(deserialized.getDataCacheEnable(),
+                "Old entries without dataCacheEnable should deserialize as null, not false");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -158,6 +158,9 @@ public class AnalyzeAlterTableStatementTest {
         analyzeSuccess("ALTER TABLE test.t0 SET (\"default.replication_num\" = \"2\");");
         analyzeSuccess("ALTER TABLE test.t0 SET (\"datacache.partition_duration\" = \"10 days\");");
         analyzeFail("ALTER TABLE test.t0 SET (\"datacache.partition_duration\" = \"abcd\");", "Cannot parse text to Duration");
+        analyzeSuccess("ALTER TABLE test.t0 SET (\"datacache.enable\" = \"true\");");
+        analyzeSuccess("ALTER TABLE test.t0 SET (\"datacache.enable\" = \"false\");");
+        analyzeFail("ALTER TABLE test.t0 SET (\"datacache.enable\" = \"abcd\");", "must be bool type(false/true)");
         analyzeFail("ALTER TABLE test.t0 SET (\"default.replication_num\" = \"2\", \"dynamic_partition.enable\" = \"true\");",
                 "Can only set one table property at a time");
         analyzeFail("ALTER TABLE test.t0 SET (\"abc\" = \"2\");",


### PR DESCRIPTION
## Why I'm doing:

Currently, the datacache.enable property for shared-data (cloud-native) tables can only be set during table creation. Users have no way to dynamically enable or disable data caching on existing tables or individual partitions. This makes it difficult to manage caching strategies in production — for example, disabling cache for cold historical partitions while keeping it enabled for hot recent partitions.

## What I'm doing:

Fixes #69012

Add support for dynamically modifying the datacache.enable property at both the table level and partition level:

- Table level: ALTER TABLE <tblSET ("datacache.enable" = "true/false") — Updates the table property and propagates the change to all existing partitions' DataCacheInfo, then calls StarOSAgent.updateShardGroup to sync the cache setting with StarOS.
- Partition level: ALTER TABLE <tblMODIFY PARTITION (<partitions) SET ("datacache.enable" = "true/false") — Updates DataCacheInfo for specified partitions only.

Key changes:
- Analyzer (AlterTableClauseAnalyzer): Validate datacache.enable is a boolean value.
- Executor (AlterJobExecutor): Route datacache.enable to alterTableProperties; handle partition-level modification in modifyPartitionsProperty.
- Metastore (LocalMetastore): Add alterDataCacheEnable helper following the appliers pattern to update table property, partition DataCacheInfo, and call StarOS.
- Persistence (ModifyPartitionInfo): Add dataCacheEnable field for edit log replay.
- Replay (AlterJobMgr): Restore DataCacheInfo from ModifyPartitionInfo during log replay.
- StarOS (StarOSAgent): Add updateShardGroup to update cache settings in StarOS.
- Model (OlapTable, TableProperty, StorageInfo): Add setDataCacheEnable / buildDataCacheEnable methods.


Demo: 

`datacache.enable` is set to false at the beginning, change its value to true. We can validate the behavior by `IORemoteCount` metric in the query profile. Note, if you want to change property value from true to false, you may need to restart CN nodes to prevent memory cache affect the validation. 

```sql

MySQL [test]> show create table Employees\G
*************************** 1. row ***************************
       Table: Employees
Create Table: CREATE TABLE `Employees` (
  `EmployeeID` int(11) NOT NULL COMMENT "",
  `Name` varchar(50) NULL COMMENT "",
  `Salary` decimal(10, 2) NULL COMMENT ""
) ENGINE=OLAP
PRIMARY KEY(`EmployeeID`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`EmployeeID`)
PROPERTIES (
"cloud_native_fast_schema_evolution_v2" = "true",
"compression" = "LZ4",
"datacache.enable" = "false",
"enable_async_write_back" = "false",
"enable_persistent_index" = "true",
"file_bundling" = "true",
"persistent_index_type" = "CLOUD_NATIVE",
"replication_num" = "3",
"storage_volume" = "def_volume"
);
1 row in set (0.003 sec)

MySQL [test]> select * from Employees; select last_query_id();
+------------+----------------+---------+
| EmployeeID | Name           | Salary  |
+------------+----------------+---------+
|          2 | Jane Smith     | 6600.00 |
|          3 | Robert Johnson | 6050.00 |
|          5 | Michael Brown  | 7700.00 |
|          4 | Emily Williams | 4950.00 |
|          1 | John Doe       | 5500.00 |
+------------+----------------+---------+
5 rows in set (0.111 sec)

+--------------------------------------+
| last_query_id()                      |
+--------------------------------------+
| 019c546e-cf7a-7747-bbdc-981bef75b850 |
+--------------------------------------+
1 row in set (0.002 sec)

MySQL [test]> SELECT regexp_extract(
    ->     get_query_profile('019c546e-cf7a-7747-bbdc-981bef75b850'),
    ->     'IOCountRemote: [0-9\\.]+', 0
    -> );
+----------------------------------------------------------------------------------------------------------+
| regexp_extract(get_query_profile('019c546e-cf7a-7747-bbdc-981bef75b850'), 'IOCountRemote: [0-9\\.]+', 0) |
+----------------------------------------------------------------------------------------------------------+
| IOCountRemote: 20                                                                                        |
+----------------------------------------------------------------------------------------------------------+
1 row in set (0.007 sec)

MySQL [test]> ALTER TABLE test.Employees
    -> SET ("datacache.enable" = "true");
Query OK, 0 rows affected (0.006 sec)

MySQL [test]> select * from Employees; select last_query_id();
+------------+----------------+---------+
| EmployeeID | Name           | Salary  |
+------------+----------------+---------+
|          2 | Jane Smith     | 6600.00 |
|          4 | Emily Williams | 4950.00 |
|          1 | John Doe       | 5500.00 |
|          3 | Robert Johnson | 6050.00 |
|          5 | Michael Brown  | 7700.00 |
+------------+----------------+---------+
5 rows in set (0.011 sec)

+--------------------------------------+
| last_query_id()                      |
+--------------------------------------+
| 019c546f-51fd-7e68-96b1-290a41388c17 |
+--------------------------------------+
1 row in set (0.003 sec)

MySQL [test]> SELECT regexp_extract(
    ->     get_query_profile('019c546f-51fd-7e68-96b1-290a41388c17'),
    ->     'IOCountRemote: [0-9\\.]+', 0
    -> );
+----------------------------------------------------------------------------------------------------------+
| regexp_extract(get_query_profile('019c546f-51fd-7e68-96b1-290a41388c17'), 'IOCountRemote: [0-9\\.]+', 0) |
+----------------------------------------------------------------------------------------------------------+
| IOCountRemote: 0                                                                                         |
+----------------------------------------------------------------------------------------------------------+
1 row in set (0.007 sec)

```

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
