### PR TITLE
[BugFix] Fix DISTINCT ORDER BY alias resolution for duplicated constants

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -136,7 +136,7 @@ public class QueryTransformer {
             }
         }
 
-        builder = distinct(builder, queryBlock.isDistinct(), queryBlock.getOutputExpression());
+        builder = distinct(builder, queryBlock, queryBlock.isDistinct(), queryBlock.getOutputExpression());
         // add project to express order by expression
         builder = project(builder, Iterables.concat(queryBlock.getOrderByExpressions(), queryBlock.getOutputExpression()));
         List<ColumnRefOperator> orderByColumns = Lists.newArrayList();
@@ -181,9 +181,10 @@ public class QueryTransformer {
         Scope scope = queryBlock.getOrderScope();
         ExpressionMapping outputTranslations = new ExpressionMapping(scope);
         Map<ColumnRefOperator, ScalarOperator> projections = Maps.newHashMap();
+        List<Expr> outputExprList = Lists.newArrayList(outputExpression);
 
         int outputExprIdx = 0;
-        for (Expr expression : outputExpression) {
+        for (Expr expression : outputExprList) {
             Map<ScalarOperator, SubqueryOperator> subqueryPlaceholders = Maps.newHashMap();
             ScalarOperator scalarOperator = SqlToScalarOperatorTranslator.translate(expression,
                     subOpt.getExpressionMapping(), columnRefFactory,
@@ -653,10 +654,37 @@ public class QueryTransformer {
         return subOpt.withNewRoot(sortOperator);
     }
 
-    private OptExprBuilder distinct(OptExprBuilder subOpt, boolean isDistinct, List<Expr> outputExpressions) {
+    private OptExprBuilder distinct(OptExprBuilder subOpt, SelectRelation queryBlock,
+                                    boolean isDistinct, List<Expr> outputExpressions) {
         if (isDistinct) {
             // Add project before DISTINCT to express select item
             subOpt = project(subOpt, outputExpressions);
+
+            // For duplicated output expressions under DISTINCT, bind their aliases to a single canonical column
+            // to keep ORDER BY keys consistent with DISTINCT output.
+            List<String> outputNames = queryBlock.getColumnOutputNames();
+            Map<Expr, Integer> outputExprCounts = Maps.newHashMap();
+            for (Expr expr : outputExpressions) {
+                outputExprCounts.put(expr, outputExprCounts.getOrDefault(expr, 0) + 1);
+            }
+            for (int i = 0; i < outputExpressions.size() && i < outputNames.size(); i++) {
+                Expr expr = outputExpressions.get(i);
+                if (outputExprCounts.getOrDefault(expr, 0) <= 1) {
+                    continue;
+                }
+                ColumnRefOperator canonicalColumn = (ColumnRefOperator) SqlToScalarOperatorTranslator
+                        .translate(expr, subOpt.getExpressionMapping(), columnRefFactory);
+
+                TableName resolveTableName = queryBlock.getResolveTableName();
+                if (expr instanceof SlotRef) {
+                    resolveTableName = queryBlock.getRelation().getResolveTableName();
+                }
+                SlotRef qualifiedAlias = new SlotRef(resolveTableName, outputNames.get(i));
+                SlotRef unqualifiedAlias = new SlotRef(null, outputNames.get(i));
+                subOpt.getExpressionMapping().getExpressionToColumns().put(unqualifiedAlias, canonicalColumn);
+                subOpt.getExpressionMapping().getExpressionToColumns().put(qualifiedAlias, canonicalColumn);
+            }
+
             List<ColumnRefOperator> groupByColumns = Lists.newArrayList();
             for (Expr expr : outputExpressions) {
                 ColumnRefOperator column = (ColumnRefOperator) SqlToScalarOperatorTranslator


### PR DESCRIPTION
## Why I'm doing:
Fix invalid logical plans for `SELECT DISTINCT ... ORDER BY <select-item-alias>` when the select list contains duplicated expressions with different aliases (e.g. `'Current' AS ext_period, 'Current' AS int_period`).  
Previously, alias resolution could bind to a stale `ColumnRef`, making `TopN` require a column not produced by the DISTINCT aggregation and causing plan validation/statistics failures.

## What I'm doing:
Rebind select-item aliases to the canonical `ColumnRef` produced by the pre-DISTINCT project so `ORDER BY <alias>` always targets columns that survive DISTINCT.

fix sql like this:
```
select distinct v1, 'Current' as ext_period, 'Current' as int_period from t0 order by ext_period, v1;
```
error stack:
```
com.starrocks.sql.common.StarRocksPlannerException: only found column statistics: {1: v1}, but missing statistic of col: 4: expr.

	at com.starrocks.sql.optimizer.statistics.Statistics.getColumnStatistic(Statistics.java:134)
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitVariableReference(ExpressionStatisticCalculator.java:88)
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitVariableReference(ExpressionStatisticCalculator.java:67)
	at com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator.accept(ColumnRefOperator.java:131)
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator.calculate(ExpressionStatisticCalculator.java:64)
	at com.starrocks.sql.optimizer.statistics.ExpressionStatisticCalculator.calculate(ExpressionStatisticCalculator.java:56)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitOperator(StatisticsCalculator.java:293)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.computeAggregateNode(StatisticsCalculator.java:1090)
```
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
