### PR TITLE
[Enhancement] Fix gcc compile warning

### DIFF
--- a/be/src/exprs/agg/minmax_n.h
+++ b/be/src/exprs/agg/minmax_n.h
@@ -64,6 +64,9 @@ struct MinMaxNAggregateState {
 
     template <bool IsDeepCopy>
     void process(MemPool* mem_pool, const CppType& value) {
+        if (UNLIKELY(n <= 0)) {
+            return;
+        }
         if (heap.size() < static_cast<size_t>(n)) {
             // Heap not full, add directly
             auto copied_value = _copy<IsDeepCopy>(mem_pool, value);


### PR DESCRIPTION
## Why I'm doing:

### Warning1
```
oot/work/dev2/be/src/exprs/agg/percentile_cont.h:225:15: warning: ‘void* memcpy(void*, const void*, size_t)’ specified bound 18446744073709551600 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
  225 |         memcpy(vec.data() + 1, data_ptr, items_size * sizeof(InputCppType));
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/root/work/dev2/be/src/exprs/agg/percentile_cont.h: In member function ‘void starrocks::PercentileContDiscAggregateFunction<LT, <template-parameter-1-2> >::merge(starrocks::FunctionContext*, const starrocks::Column*, starrocks::AggDataPtr, std::size_t) const [with starrocks::LogicalType LT = starrocks::TYPE_DOUBLE; <template-parameter-1-2> = int]’:
/root/work/dev2/be/src/exprs/agg/percentile_cont.h:225:15: warning: ‘void* memcpy(void*, const void*, size_t)’ specified bound 18446744073709551600 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
  225 |         memcpy(vec.data() + 1, data_ptr, items_size * sizeof(InputCppType));
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/root/work/dev2/be/src/exprs/agg/percentile_cont.h: In member function ‘void starrocks::PercentileContDiscAggregateFunction<LT, <template-parameter-1-2> >::merge(starrocks::FunctionContext*, const starrocks::Column*, starrocks::AggDataPtr, std::size_t) const [with starrocks::LogicalType LT = starrocks::TYPE_DECIMAL128; <template-parameter-1-2> = int]’:
/root/work/dev2/be/src/exprs/agg/percentile_cont.h:225:15: warning: ‘void* memcpy(void*, const void*, size_t)’ specified bound 18446744073709551584 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
  225 |         memcpy(vec.data() + 1, data_ptr, items_size * sizeof(InputCppType));
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/root/work/dev2/be/src/exprs/agg/percentile_cont.h: In member function ‘void starrocks::PercentileContDiscAggregateFunction<LT, <template-parameter-1-2> >::merge(starrocks::FunctionContext*, const starrocks::Column*, starrocks::AggDataPtr, std::size_t) const [with starrocks::LogicalType LT = starrocks::TYPE_LARGEINT; <template-parameter-1-2> = int]’:
/root/work/dev2/be/src/exprs/agg/percentile_cont.h:225:15: warning: ‘void* memcpy(void*, const void*, size_t)’ specified bound 18446744073709551584 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
  225 |         memcpy(vec.data() + 1, data_ptr, items_size * sizeof(InputCppType));
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/root/work/dev2/be/src/exprs/agg/percentile_cont.h: In member function ‘void starrocks::PercentileContDiscAggregateFunction<LT, <template-parameter-1-2> >::merge(starrocks::FunctionContext*, const starrocks::Column*, starrocks::AggDataPtr, std::size_t) const [with starrocks::LogicalType LT = starrocks::TYPE_DATETIME; <template-parameter-1-2> = int]’:
/root/work/dev2/be/src/exprs/agg/percentile_cont.h:225:15: warning: ‘void* memcpy(void*, const void*, size_t)’ specified bound 18446744073709551600 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
  225 |         memcpy(vec.data() + 1, data_ptr, items_size * sizeof(InputCppType));
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/root/work/dev2/be/src/exprs/agg/percentile_cont.h: In member function ‘void starrocks::PercentileContDiscAggregateFunction<LT, <template-parameter-1-2> >::merge(starrocks::FunctionContext*, const starrocks::Column*, starrocks::AggDataPtr, std::size_t) const [with starrocks::LogicalType LT = starrocks::TYPE_DATE; <template-parameter-1-2> = int]’:
/root/work/dev2/be/src/exprs/agg/percentile_cont.h:225:15: warning: ‘void* memcpy(void*, const void*, size_t)’ specified bound 18446744073709551608 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
  225 |         memcpy(vec.data() + 1, data_ptr, items_size * sizeof(InputCppType));
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/root/work/dev2/be/src/exprs/agg/percentile_cont.h: In member function ‘void starrocks::PercentileContDiscAggregateFunction<LT, <template-parameter-1-2> >::merge(starrocks::FunctionContext*, const starrocks::Column*, starrocks::AggDataPtr, std::size_t) const [with starrocks::LogicalType LT = starrocks::TYPE_DECIMALV2; <template-parameter-1-2> = int]’:
/root/work/dev2/be/src/exprs/agg/percentile_cont.h:225:15: warning: ‘void* memcpy(void*, const void*, size_t)’ specified bound 18446744073709551584 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
  225 |         memcpy(vec.data() + 1, data_ptr, items_size * sizeof(InputCppType));
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
### Warning2
```
inlined from ‘void std::priority_queue<_Tp, _Sequence, _Compare>::push(const value_type&) [with _Tp = float; _Sequence = std::vector<float>; _Compare = starrocks::MinMaxNAggregateState<starrocks::TYPE_FLOAT, false>::Comparator]’ at /opt/gcc-toolset-14/include/c++/14.3.0/bits/stl_queue.h:739:16,
    inlined from ‘void starrocks::MinMaxNAggregateState<LT, IsMin>::process(starrocks::MemPool*, const CppType&) [with bool IsDeepCopy = false; starrocks::LogicalType LT = starrocks::TYPE_FLOAT; bool IsMin = false]’ at /root/work/dev2/be/src/exprs/agg/minmax_n.h:75:22,
    inlined from ‘void starrocks::MinMaxNAggregateFunction<LT, IsMin>::convert_to_serialize_format(starrocks::FunctionContext*, const starrocks::Columns&, std::size_t, starrocks::MutableColumnPtr&) const [with starrocks::LogicalType LT = starrocks::TYPE_FLOAT; bool IsMin = false]’ at /root/work/dev2/be/src/exprs/agg/minmax_n.h:249:42:
/opt/gcc-toolset-14/include/c++/14.3.0/bits/stl_heap.h:215:18: warning: array subscript -1 is outside array bounds of ‘float [2305843009213693951]’ [-Warray-bounds=]
  215 |       _ValueType __value = _GLIBCXX_MOVE(*(__last - 1));
      |                  ^~~~~~~
In function ‘constexpr void std::destroy_at(_Tp*) [with _Tp = short int]’,
    inlined from ‘static constexpr void std::allocator_traits<std::allocator<_Up> >::destroy(allocator_type&, _Up*) [with _Up = short int; _Tp = short int]’ at /opt/gcc-toolset-14/include/c++/14.3.0/bits/alloc_traits.h:599:19,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::pop_back() [with _Tp = short int; _Alloc = std::allocator<short int>]’ at /opt/gcc-toolset-14/include/c++/14.3.0/bits/stl_vector.h:1341:24,
    inlined from ‘void std::priority_queue<_Tp, _Sequence, _Compare>::pop() [with _Tp = short int; _Sequence = std::vector<short int, std::allocator<short int> >; _Compare = starrocks::MinMaxNAggregateState<starrocks::TYPE_SMALLINT, true>::Comparator]’ at /opt/gcc-toolset-14/include/c++/14.3.0/bits/stl_queue.h:775:12,
    inlined from ‘void starrocks::MinMaxNAggregateState<LT, IsMin>::process(starrocks::MemPool*, const CppType&) [with bool IsDeepCopy = false; starrocks::LogicalType LT = starrocks::TYPE_SMALLINT; bool IsMin = true]’ at /root/work/dev2/be/src/exprs/agg/minmax_n.h:73:21,
    inlined from ‘void starrocks::MinMaxNAggregateFunction<LT, IsMin>::convert_to_serialize_format(starrocks::FunctionContext*, const starrocks::Columns&, std::size_t, starrocks::MutableColumnPtr&) const [with starrocks::LogicalType LT = starrocks::TYPE_SMALLINT; bool IsMin = true]’ at /root/work/dev2/be/src/exprs/agg/minmax_n.h:249:42:
/opt/gcc-toolset-14/include/c++/14.3.0/bits/stl_construct.h:88:9: warning: array subscript -1 is outside array bounds of ‘short int [4611686018427387903]’ [-Warray-bounds=]
   88 |         __location->~_Tp();
      |         ^~~~~~~~~~
In function ‘constexpr void std::push_heap(_RAIter, _RAIter, _Compare) [with _RAIter = __gnu_cxx::__normal_iterator<short int*, vector<short int, allocator<short int> > >; _Compare = starrocks::MinMaxNAggregateState<starrocks::TYPE_SMALLINT, true>::Comparator]’,
    inlined from ‘void std::priority_queue<_Tp, _Sequence, _Compare>::push(const value_type&) [with _Tp = short int; _Sequence = std::vector<short int, std::allocator<short int> >; _Compare = starrocks::MinMaxNAggregateState<starrocks::TYPE_SMALLINT, true>::Comparator]’ at /opt/gcc-toolset-14/include/c++/14.3.0/bits/stl_queue.h:739:16,
    inlined from ‘void starrocks::MinMaxNAggregateState<LT, IsMin>::process(starrocks::MemPool*, const CppType&) [with bool IsDeepCopy = false; starrocks::LogicalType LT = starrocks::TYPE_SMALLINT; bool IsMin = true]’ at /root/work/dev2/be/src/exprs/agg/minmax_n.h:75:22,
    inlined from ‘void starrocks::MinMaxNAggregateFunction<LT, IsMin>::convert_to_serialize_format(starrocks::FunctionContext*, const starrocks::Columns&, std::size_t, starrocks::MutableColumnPtr&) const [with starrocks::LogicalType LT = starrocks::TYPE_SMALLINT; bool IsMin = true]’ at /root/work/dev2/be/src/exprs/agg/minmax_n.h:249:42:
/opt/gcc-toolset-14/include/c++/14.3.0/bits/stl_heap.h:215:18: warning: array subscript -1 is outside array bounds of ‘short int [4611686018427387903]’ [-Warray-bounds=]
  215 |       _ValueType __value = _GLIBCXX_MOVE(*(__last - 1));
      |                  ^~~~~~~
In function ‘constexpr void std::destroy_at(_Tp*) [with _Tp = short int]’,
    inlined from ‘static constexpr void std::allocator_traits<std::allocator<_Up> >::destroy(allocator_type&, _Up*) [with _Up = short int; _Tp = short int]’ at /opt/gcc-toolset-14/include/c++/14.3.0/bits/alloc_traits.h:599:19,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::pop_back() [with _Tp = short int; _Alloc = std::allocator<short int>]’ at /opt/gcc-toolset-14/include/c++/14.3.0/bits/stl_vector.h:1341:24,
    inlined from ‘void std::priority_queue<_Tp, _Sequence, _Compare>::pop() [with _Tp = short int; _Sequence = std::vector<short int, std::allocator<short int> >; _Compare = starrocks::MinMaxNAggregateState<starrocks::TYPE_SMALLINT, false>::Comparator]’ at /opt/gcc-toolset-14/include/c++/14.3.0/bits/stl_queue.h:775:12,
    inlined from ‘void starrocks::MinMaxNAggregateState<LT, IsMin>::process(starrocks::MemPool*, const CppType&) [with bool IsDeepCopy = false; starrocks::LogicalType LT = starrocks::TYPE_SMALLINT; bool IsMin = false]’ at /root/work/dev2/be/src/exprs/agg/minmax_n.h:73:21,
    inlined from ‘void starrocks::MinMaxNAggregateFunction<LT, IsMin>::convert_to_serialize_format(starrocks::FunctionContext*, const starrocks::Columns&, std::size_t, starrocks::MutableColumnPtr&) const [with starrocks::LogicalType LT = starrocks::TYPE_SMALLINT; bool IsMin = false]’ at /root/work/dev2/be/src/exprs/agg/minmax_n.h:249:42:
/opt/gcc-toolset-14/include/c++/14.3.0/bits/stl_construct.h:88:9: warning: array subscript -1 is outside array bounds of ‘short int [4611686018427387903]’ [-Warray-bounds=]
   88 |         __location->~_Tp();
      |         ^~~~~~~~~~
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
