### PR TITLE
[BugFix] Fix JSON path parsing for quoted field names with dots and brackets

### DIFF
--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -293,18 +293,36 @@ double estimate_filter_fpp(uint64_t element_nums) {
 }
 
 std::pair<std::string_view, std::string_view> JsonFlatPath::split_path(const std::string_view& path) {
-    size_t pos = 0;
-    pos = path.find('.', pos);
-    std::string_view key;
-    std::string_view next;
-    if (pos == std::string::npos) {
-        key = path;
-    } else {
-        key = path.substr(0, pos);
-        next = path.substr(pos + 1);
+    if (path.empty()) {
+        return {path, {}};
     }
 
-    return {key, next};
+    if (path[0] == '"') {
+        // Quoted key: find the matching closing quote.
+        // The entire quoted segment (including quotes) is the key.
+        // e.g. "my.inner.term".baz -> key="my.inner.term", next=baz
+        size_t end_quote = path.find('"', 1);
+        if (end_quote == std::string_view::npos) {
+            // Unmatched quote, treat the whole thing as the key
+            return {path, {}};
+        }
+        std::string_view key = path.substr(0, end_quote + 1);
+        if (end_quote + 1 >= path.size()) {
+            return {key, {}};
+        }
+        // Skip the '.' separator after the closing quote
+        if (path[end_quote + 1] == '.') {
+            return {key, path.substr(end_quote + 2)};
+        }
+        return {key, path.substr(end_quote + 1)};
+    }
+
+    // Unquoted key: find the first '.'
+    size_t pos = path.find('.');
+    if (pos == std::string_view::npos) {
+        return {path, {}};
+    }
+    return {path.substr(0, pos), path.substr(pos + 1)};
 }
 
 JsonFlatPath* JsonFlatPath::normalize_from_path(const std::string_view& path, JsonFlatPath* root) {

--- a/be/test/util/json_flattener_test.cpp
+++ b/be/test/util/json_flattener_test.cpp
@@ -645,4 +645,153 @@ INSTANTIATE_TEST_SUITE_P(JsonBoolExtractionCases, JsonBoolExtractionTest,
                                            std::make_tuple(R"({"bool_field": "1"})", true),
                                            std::make_tuple(R"({"bool_field": "0"})", false)));
 
+TEST(JsonFlatPathTest, SplitPathQuoted) {
+    // Normal unquoted path
+    {
+        auto [k, n] = JsonFlatPath::split_path("a.b.c");
+        EXPECT_EQ(k, "a");
+        EXPECT_EQ(n, "b.c");
+    }
+
+    // Quoted key containing dots
+    {
+        auto [k, n] = JsonFlatPath::split_path("\"my.inner.term\".baz");
+        EXPECT_EQ(k, "\"my.inner.term\"");
+        EXPECT_EQ(n, "baz");
+    }
+
+    // Quoted key containing brackets
+    {
+        auto [k, n] = JsonFlatPath::split_path("\"bar[0]\".next");
+        EXPECT_EQ(k, "\"bar[0]\"");
+        EXPECT_EQ(n, "next");
+    }
+
+    // Quoted key only, no remainder
+    {
+        auto [k, n] = JsonFlatPath::split_path("\"a.b\"");
+        EXPECT_EQ(k, "\"a.b\"");
+        EXPECT_TRUE(n.empty());
+    }
+
+    // Multiple quoted segments
+    {
+        auto [k, n] = JsonFlatPath::split_path("\"x.y\".\"p.q\".r");
+        EXPECT_EQ(k, "\"x.y\"");
+        EXPECT_EQ(n, "\"p.q\".r");
+    }
+
+    // Empty path
+    {
+        auto [k, n] = JsonFlatPath::split_path("");
+        EXPECT_TRUE(k.empty());
+        EXPECT_TRUE(n.empty());
+    }
+
+    // Simple path without dots
+    {
+        auto [k, n] = JsonFlatPath::split_path("simple");
+        EXPECT_EQ(k, "simple");
+        EXPECT_TRUE(n.empty());
+    }
+
+    // Quoted key followed by unquoted path
+    {
+        auto [k, n] = JsonFlatPath::split_path("\"a.b\".c.d");
+        EXPECT_EQ(k, "\"a.b\"");
+        EXPECT_EQ(n, "c.d");
+    }
+
+    // Unquoted prefix followed by quoted key
+    {
+        auto [k, n] = JsonFlatPath::split_path("foo.\"bar.baz\"");
+        EXPECT_EQ(k, "foo");
+        EXPECT_EQ(n, "\"bar.baz\"");
+    }
+
+    // Unmatched quote: treat whole path as key
+    {
+        auto [k, n] = JsonFlatPath::split_path("\"unclosed");
+        EXPECT_EQ(k, "\"unclosed");
+        EXPECT_TRUE(n.empty());
+    }
+}
+
+TEST(JsonFlatPathTest, NormalizeFromPathQuoted) {
+    // Verify that normalize_from_path correctly builds the path tree
+    // when paths contain quoted segments (as produced by FE).
+
+    // Simple unquoted path
+    {
+        auto root = std::make_shared<JsonFlatPath>();
+        auto* leaf = JsonFlatPath::normalize_from_path("a.b.c", root.get());
+        EXPECT_NE(leaf, nullptr);
+        // root -> a -> b -> c
+        EXPECT_EQ(root->children.size(), 1);
+        EXPECT_TRUE(root->children.count("a"));
+        auto* a = root->children["a"].get();
+        EXPECT_EQ(a->children.size(), 1);
+        EXPECT_TRUE(a->children.count("b"));
+        auto* b = a->children["b"].get();
+        EXPECT_EQ(b->children.size(), 1);
+        EXPECT_TRUE(b->children.count("c"));
+        EXPECT_EQ(leaf, b->children["c"].get());
+    }
+
+    // Quoted key with dots: foo."my.inner.term".baz
+    // Should create: root -> foo -> "my.inner.term" -> baz
+    // NOT: root -> foo -> my -> inner -> term -> baz
+    {
+        auto root = std::make_shared<JsonFlatPath>();
+        auto* leaf = JsonFlatPath::normalize_from_path("foo.\"my.inner.term\".baz", root.get());
+        EXPECT_NE(leaf, nullptr);
+        EXPECT_EQ(root->children.size(), 1);
+        EXPECT_TRUE(root->children.count("foo"));
+        auto* foo = root->children["foo"].get();
+        EXPECT_EQ(foo->children.size(), 1);
+        // The key in the map should be the quoted form
+        EXPECT_TRUE(foo->children.count("\"my.inner.term\""));
+        auto* inner = foo->children["\"my.inner.term\""].get();
+        EXPECT_EQ(inner->children.size(), 1);
+        EXPECT_TRUE(inner->children.count("baz"));
+        EXPECT_EQ(leaf, inner->children["baz"].get());
+    }
+
+    // Quoted key with brackets: foo."bar[0]".next
+    // Should create: root -> foo -> "bar[0]" -> next
+    {
+        auto root = std::make_shared<JsonFlatPath>();
+        auto* leaf = JsonFlatPath::normalize_from_path("foo.\"bar[0]\".next", root.get());
+        EXPECT_NE(leaf, nullptr);
+        EXPECT_EQ(root->children.size(), 1);
+        auto* foo = root->children["foo"].get();
+        EXPECT_EQ(foo->children.size(), 1);
+        EXPECT_TRUE(foo->children.count("\"bar[0]\""));
+        auto* bar = foo->children["\"bar[0]\""].get();
+        EXPECT_EQ(bar->children.size(), 1);
+        EXPECT_TRUE(bar->children.count("next"));
+        EXPECT_EQ(leaf, bar->children["next"].get());
+    }
+
+    // Multiple quoted segments
+    {
+        auto root = std::make_shared<JsonFlatPath>();
+        auto* leaf = JsonFlatPath::normalize_from_path("\"a.b\".\"c.d\"", root.get());
+        EXPECT_NE(leaf, nullptr);
+        EXPECT_EQ(root->children.size(), 1);
+        EXPECT_TRUE(root->children.count("\"a.b\""));
+        auto* ab = root->children["\"a.b\""].get();
+        EXPECT_EQ(ab->children.size(), 1);
+        EXPECT_TRUE(ab->children.count("\"c.d\""));
+        EXPECT_EQ(leaf, ab->children["\"c.d\""].get());
+    }
+
+    // Empty path returns root
+    {
+        auto root = std::make_shared<JsonFlatPath>();
+        auto* result = JsonFlatPath::normalize_from_path("", root.get());
+        EXPECT_EQ(result, root.get());
+    }
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -30,9 +30,10 @@ import com.starrocks.type.InvalidType;
 import com.starrocks.type.JsonType;
 import com.starrocks.type.Type;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.text.StrTokenizer;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +47,51 @@ import java.util.stream.Collectors;
 public class SubfieldAccessPathNormalizer {
     // simple json patten, same as BE's JsonPathPiece, match: abc[1][2], group: (abc)([1][2])
     private static final Pattern JSON_ARRAY_PATTEN = Pattern.compile("^([\\w#.]+)((?:\\[[\\d:*]+])*)");
+
+    static class PathToken {
+        final String value;
+        final boolean wasQuoted;
+
+        PathToken(String value, boolean wasQuoted) {
+            this.value = value;
+            this.wasQuoted = wasQuoted;
+        }
+    }
+
+    // Tokenize a JSON path by '.', respecting '"' as quoting character.
+    // Preserves whether each token was originally quoted.
+    // e.g.:
+    //   $.foo."bar[0]".baz  ->  [$, foo, "bar[0]"(quoted), baz]
+    //   $."a.b".c           ->  [$, "a.b"(quoted), c]
+    static List<PathToken> tokenizeJsonPath(String path) {
+        List<PathToken> tokens = new ArrayList<>();
+        int i = 0;
+        int len = path.length();
+        while (i < len) {
+            if (path.charAt(i) == '"') {
+                int end = path.indexOf('"', i + 1);
+                if (end == -1) {
+                    return Collections.emptyList();
+                }
+                tokens.add(new PathToken(path.substring(i + 1, end), true));
+                i = end + 1;
+                if (i < len && path.charAt(i) == '.') {
+                    i++;
+                }
+            } else {
+                int end = path.indexOf('.', i);
+                if (end == -1) {
+                    end = len;
+                }
+                String token = path.substring(i, end);
+                if (!token.isEmpty()) {
+                    tokens.add(new PathToken(token, false));
+                }
+                i = end + 1;
+            }
+        }
+        return tokens;
+    }
 
     private final Deque<AccessPath> allAccessPaths = Lists.newLinkedList();
 
@@ -239,6 +285,7 @@ public class SubfieldAccessPathNormalizer {
         //  $.a.b -> [a, b]
         //  $.a[0].b -> [a] -- don't support array index
         //  $."a.b".c -> ["a.b", c]
+        //  $."bar[0]".c -> ["bar[0]", c] -- quoted brackets are literal field names
         //  $.a#b.c -> [a#b, c]
         //  $.a.b.c.d.e.f -> [a, b] -- don't support overflown JSON_FLATTEN_DEPTH
         //  a.b.c -> [a, b, c]
@@ -252,41 +299,45 @@ public class SubfieldAccessPathNormalizer {
                 return false;
             }
 
-            StrTokenizer tokenizer = new StrTokenizer(path, '.', '"');
-            String[] tokens = tokenizer.getTokenArray();
-
-            if (tokens.length < 1) {
+            List<PathToken> tokens = tokenizeJsonPath(path);
+            if (tokens.isEmpty()) {
                 return false;
             }
+
             int size = jsonFlattenDepth;
             int i = 0;
-            if (tokens[0].equals("$")) {
+            if (tokens.get(0).value.equals("$")) {
                 size++;
                 i++;
             }
-            size = Math.min(tokens.length, size);
+            size = Math.min(tokens.size(), size);
+
             for (; i < size; i++) {
-                if (tokens[i].contains(".")) {
-                    result.add("\"" + tokens[i] + "\"");
+                PathToken token = tokens.get(i);
+
+                if (token.wasQuoted) {
+                    // Quoted token is a literal field name, no array pattern matching needed.
+                    // This handles cases like "bar[0]" and "my.inner.term" correctly.
+                    result.add("\"" + token.value + "\"");
                     continue;
                 }
-                // unsupported path, should stop match
-                Matcher matcher = JSON_ARRAY_PATTEN.matcher(tokens[i]);
+
+                // For unquoted tokens, apply the original regex logic
+                Matcher matcher = JSON_ARRAY_PATTEN.matcher(token.value);
                 if (!matcher.matches()) {
                     return true;
                 }
-                // only extract name, don't needed index
                 String name = matcher.group(1);
                 if (StringUtils.isBlank(name)) {
                     return true;
                 }
                 result.add(name);
-                if (tokens[i].replaceFirst(name, "").contains("[")) {
+                if (token.value.replaceFirst(Pattern.quote(name), "").contains("[")) {
                     // can't support flatten array index
                     return true;
                 }
             }
-            return size < tokens.length;
+            return size < tokens.size();
         }
 
         private Optional<AccessPath> process(ScalarOperator scalarOperator, Deque<AccessPath> accessPaths) {
@@ -316,6 +367,7 @@ public class SubfieldAccessPathNormalizer {
     //  $.a.b -> [a, b]
     //  $.a[0].b -> [a[0], b] -- don't support array index
     //  $."a.b".c -> ["a.b", c]
+    //  $."bar[0]".c -> ["bar[0]", c] -- quoted brackets are literal field names
     //  $.a#b.c -> [a#b, c]
     //  $.a.b.c.d.e.f -> [a, b] -- don't support overflown JSON_FLATTEN_DEPTH
     //  a.b.c -> [a, b, c]
@@ -329,22 +381,21 @@ public class SubfieldAccessPathNormalizer {
             return result;
         }
 
-        StrTokenizer tokenizer = new StrTokenizer(path, '.', '"');
-        String[] tokens = tokenizer.getTokenArray();
-
-        if (tokens.length < 1) {
+        List<PathToken> tokens = tokenizeJsonPath(path);
+        if (tokens.isEmpty()) {
             return result;
         }
+
         int i = 0;
-        if (tokens[0].equals("$")) {
+        if (tokens.get(0).value.equals("$")) {
             i++;
         }
-        for (; i < tokens.length; i++) {
-            if (tokens[i].contains(".")) {
-                result.add("\"" + tokens[i] + "\"");
-                continue;
+        for (; i < tokens.size(); i++) {
+            PathToken token = tokens.get(i);
+            if (token.wasQuoted || token.value.contains(".")) {
+                result.add("\"" + token.value + "\"");
             } else {
-                result.add(tokens[i]);
+                result.add(token.value);
             }
         }
         return result;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizerTest.java
@@ -1,0 +1,219 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree.prunesubfield;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SubfieldAccessPathNormalizerTest {
+
+    // ============================================================
+    // Tests for tokenizeJsonPath
+    // ============================================================
+
+    @Test
+    public void testTokenizeSimplePath() {
+        var tokens = SubfieldAccessPathNormalizer.tokenizeJsonPath("$.a.b.c");
+        assertEquals(4, tokens.size());
+        assertEquals("$", tokens.get(0).value);
+        assertFalse(tokens.get(0).wasQuoted);
+        assertEquals("a", tokens.get(1).value);
+        assertFalse(tokens.get(1).wasQuoted);
+        assertEquals("b", tokens.get(2).value);
+        assertEquals("c", tokens.get(3).value);
+    }
+
+    @Test
+    public void testTokenizeQuotedDotField() {
+        var tokens = SubfieldAccessPathNormalizer.tokenizeJsonPath("$.\"a.b\".c");
+        assertEquals(3, tokens.size());
+        assertEquals("$", tokens.get(0).value);
+        assertFalse(tokens.get(0).wasQuoted);
+        assertEquals("a.b", tokens.get(1).value);
+        assertTrue(tokens.get(1).wasQuoted);
+        assertEquals("c", tokens.get(2).value);
+        assertFalse(tokens.get(2).wasQuoted);
+    }
+
+    @Test
+    public void testTokenizeQuotedBracketField() {
+        var tokens = SubfieldAccessPathNormalizer.tokenizeJsonPath("$.foo.\"bar[0]\".baz");
+        assertEquals(4, tokens.size());
+        assertEquals("$", tokens.get(0).value);
+        assertEquals("foo", tokens.get(1).value);
+        assertFalse(tokens.get(1).wasQuoted);
+        assertEquals("bar[0]", tokens.get(2).value);
+        assertTrue(tokens.get(2).wasQuoted);
+        assertEquals("baz", tokens.get(3).value);
+        assertFalse(tokens.get(3).wasQuoted);
+    }
+
+    @Test
+    public void testTokenizeMultipleQuotedSegments() {
+        var tokens = SubfieldAccessPathNormalizer.tokenizeJsonPath("$.\"a.b\".\"c[1]\".d");
+        assertEquals(4, tokens.size());
+        assertEquals("$", tokens.get(0).value);
+        assertEquals("a.b", tokens.get(1).value);
+        assertTrue(tokens.get(1).wasQuoted);
+        assertEquals("c[1]", tokens.get(2).value);
+        assertTrue(tokens.get(2).wasQuoted);
+        assertEquals("d", tokens.get(3).value);
+        assertFalse(tokens.get(3).wasQuoted);
+    }
+
+    @Test
+    public void testTokenizeAdjacentQuotedSegments() {
+        // Two quoted segments next to each other separated by dot
+        var tokens = SubfieldAccessPathNormalizer.tokenizeJsonPath("\"a.b\".\"c.d\"");
+        assertEquals(2, tokens.size());
+        assertEquals("a.b", tokens.get(0).value);
+        assertTrue(tokens.get(0).wasQuoted);
+        assertEquals("c.d", tokens.get(1).value);
+        assertTrue(tokens.get(1).wasQuoted);
+    }
+
+    @Test
+    public void testTokenizeUnmatchedQuote() {
+        // Unmatched quote should return empty list
+        var tokens = SubfieldAccessPathNormalizer.tokenizeJsonPath("$.\"abc");
+        assertTrue(tokens.isEmpty());
+    }
+
+    @Test
+    public void testTokenizeEmptyString() {
+        var tokens = SubfieldAccessPathNormalizer.tokenizeJsonPath("");
+        assertTrue(tokens.isEmpty());
+    }
+
+    @Test
+    public void testTokenizeWithoutRoot() {
+        var tokens = SubfieldAccessPathNormalizer.tokenizeJsonPath("a.b.c");
+        assertEquals(3, tokens.size());
+        assertEquals("a", tokens.get(0).value);
+        assertEquals("b", tokens.get(1).value);
+        assertEquals("c", tokens.get(2).value);
+    }
+
+    @Test
+    public void testTokenizeSingleToken() {
+        var tokens = SubfieldAccessPathNormalizer.tokenizeJsonPath("abc");
+        assertEquals(1, tokens.size());
+        assertEquals("abc", tokens.get(0).value);
+        assertFalse(tokens.get(0).wasQuoted);
+    }
+
+    @Test
+    public void testTokenizeSingleQuotedToken() {
+        var tokens = SubfieldAccessPathNormalizer.tokenizeJsonPath("\"a.b\"");
+        assertEquals(1, tokens.size());
+        assertEquals("a.b", tokens.get(0).value);
+        assertTrue(tokens.get(0).wasQuoted);
+    }
+
+    @Test
+    public void testTokenizeQuotedWithSpecialChars() {
+        // Quoted field with mixed special characters
+        var tokens = SubfieldAccessPathNormalizer.tokenizeJsonPath("$.\"a.b[*]\".c");
+        assertEquals(3, tokens.size());
+        assertEquals("a.b[*]", tokens.get(1).value);
+        assertTrue(tokens.get(1).wasQuoted);
+    }
+
+    // ============================================================
+    // Tests for parseSimpleJsonPath
+    // ============================================================
+
+    @Test
+    public void testParseSimplePath() {
+        List<String> result = SubfieldAccessPathNormalizer.parseSimpleJsonPath("$.a.b.c");
+        assertEquals(List.of("a", "b", "c"), result);
+    }
+
+    @Test
+    public void testParseQuotedDotField() {
+        List<String> result = SubfieldAccessPathNormalizer.parseSimpleJsonPath("$.\"a.b\".c");
+        assertEquals(List.of("\"a.b\"", "c"), result);
+    }
+
+    @Test
+    public void testParseQuotedBracketField() {
+        // Key bug fix: previously "bar[0]" lost its quoting and was incorrectly
+        // parsed as array access instead of literal field name
+        List<String> result = SubfieldAccessPathNormalizer.parseSimpleJsonPath("$.foo.\"bar[0]\".baz");
+        assertEquals(List.of("foo", "\"bar[0]\"", "baz"), result);
+    }
+
+    @Test
+    public void testParseQuotedComplexBracketField() {
+        List<String> result = SubfieldAccessPathNormalizer.parseSimpleJsonPath("$.foo.\"arr[1][2]\".next");
+        assertEquals(List.of("foo", "\"arr[1][2]\"", "next"), result);
+    }
+
+    @Test
+    public void testParseQuotedDotAndBracketMixed() {
+        // "my.inner.term" should be kept as a single quoted field
+        List<String> result = SubfieldAccessPathNormalizer.parseSimpleJsonPath("$.foo.\"my.inner.term\".baz");
+        assertEquals(List.of("foo", "\"my.inner.term\"", "baz"), result);
+    }
+
+    @Test
+    public void testParseWithoutRoot() {
+        List<String> result = SubfieldAccessPathNormalizer.parseSimpleJsonPath("a.b.c");
+        assertEquals(List.of("a", "b", "c"), result);
+    }
+
+    @Test
+    public void testParseEmptyPath() {
+        List<String> result = SubfieldAccessPathNormalizer.parseSimpleJsonPath("");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testParseDollarOnly() {
+        List<String> result = SubfieldAccessPathNormalizer.parseSimpleJsonPath("$");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testParseRecursivePath() {
+        // ".." is not supported
+        List<String> result = SubfieldAccessPathNormalizer.parseSimpleJsonPath("$.a..b");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testParseUnpairedQuote() {
+        List<String> result = SubfieldAccessPathNormalizer.parseSimpleJsonPath("$.\"abc");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testParseUnquotedArrayPath() {
+        // Unquoted array access should be preserved as-is (no special handling in parseSimpleJsonPath)
+        List<String> result = SubfieldAccessPathNormalizer.parseSimpleJsonPath("$.a[0].b");
+        assertEquals(List.of("a[0]", "b"), result);
+    }
+
+    @Test
+    public void testParseMultipleQuotedSegments() {
+        List<String> result = SubfieldAccessPathNormalizer.parseSimpleJsonPath("$.\"a.b\".\"c[0]\".d");
+        assertEquals(List.of("\"a.b\"", "\"c[0]\"", "d"), result);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -1294,4 +1294,40 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         connectContext.getSessionVariable().setEnablePruneComplexTypes(false);
         connectContext.getSessionVariable().setEnablePruneComplexTypesInUnnest(false);
     }
+
+    @Test
+    public void testJsonQuotedBracketPath() throws Exception {
+        // Quoted field names containing brackets should be treated as literal field names,
+        // not as array indexing. Previously, "bar[0]" was incorrectly parsed as field "bar"
+        // with array index [0], causing path truncation and performance regression.
+        String sql = "select get_json_int(j1, '$.foo.\"bar[0]\".baz') from js0;";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "/j1/foo/\"bar[0]\"/baz");
+
+        sql = "select get_json_string(j1, '$.foo.\"arr[1][2]\".next') from js0;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "/j1/foo/\"arr[1][2]\"/next");
+    }
+
+    @Test
+    public void testJsonQuotedDotPath() throws Exception {
+        // Quoted field names containing dots should be treated as literal field names.
+        // Previously, "my.inner.term" was correctly extracted but then incorrectly
+        // flagged as "invalid json path" during query execution.
+        String sql = "select get_json_string(j1, '$.foo.\"my.inner.term\".baz') from js0;";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "/j1/foo/\"my.inner.term\"/baz");
+    }
+
+    @Test
+    public void testJsonMixedQuotedAndUnquotedPaths() throws Exception {
+        // Test that quoted and unquoted paths can coexist in the same query
+        String sql = "select " +
+                "get_json_int(j1, '$.a.\"b.c\".d'), " +
+                "get_json_string(j1, '$.a.\"b[0]\".e') " +
+                "from js0;";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "/j1/a/\"b.c\"");
+        assertContains(plan, "/j1/a/\"b[0]\"");
+    }
 }


### PR DESCRIPTION
Quoted JSON field names like "bar[0]" and "my.inner.term" were incorrectly parsed: brackets were treated as array indexing and dots as path separators, causing path truncation and query errors. Replace StrTokenizer with a custom tokenizer that respects double-quote quoting, and update BE's split_path to handle quoted segments so the flat path tree is built correctly.

Fixes #69021

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [X] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
- [ ] 4.1
- [ ] 4.0
- [ ] 3.5
- [ ] 3.4
