### PR TITLE
[BugFix] Fix FULL OUTER JOIN USING with constant subqueries

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -441,6 +441,16 @@ public class JoinTest extends PlanTestBase {
                 "  |  equal join conjunct: 1: v1 = 4: v1\n" +
                 "  |  other predicates: coalesce(1: v1, 4: v1) = 3");
 
+        sql = "select v1 from t0 full outer join (select 1 as v1 from t1) t1 using(v1)";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "coalesce(1: v1, CAST(7: expr AS BIGINT)");
+
+        sql = "select v1 from t0 full outer join (select 1 as v1 from t1) t1 using(v1) " +
+                "full outer join (select 9 as v1 from t1) t2 using(v1)";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "join op: FULL OUTER JOIN");
+        assertContains(plan, "coalesce(8: v1, CAST(12: expr AS BIGINT)");
+
         sql = "select v5, v6 from t1 full outer join test_using a using(v5, v6) full outer join test_using b using(v5, v6)";
         plan = getFragmentPlan(sql);
         assertContains(plan, "9:Project\n" +

--- a/test/sql/test_join/R/test_join_using_comprehensive.sql
+++ b/test/sql/test_join/R/test_join_using_comprehensive.sql
@@ -165,6 +165,32 @@ INSERT INTO t8 VALUES
 (80, 't8_80');
 -- result:
 -- !result
+SELECT id, v1
+FROM t1 FULL OUTER JOIN (SELECT 1 AS id) s1 USING(id)
+ORDER BY id, v1;
+-- result:
+None	t1_null
+1	t1_1
+2	t1_2
+3	t1_3
+10	t1_10
+-- !result
+SELECT id, v1, v2
+FROM t1 FULL OUTER JOIN (SELECT 1 AS id) s1 USING(id)
+        FULL OUTER JOIN t2 USING(id)
+        FULL OUTER JOIN (SELECT 9 AS id) s2 USING(id)
+ORDER BY id, v1, v2;
+-- result:
+None	None	t2_null
+None	t1_null	None
+1	t1_1	t2_1
+2	t1_2	t2_2
+3	t1_3	None
+4	None	t2_4
+9	None	None
+10	t1_10	None
+20	None	t2_20
+-- !result
 SELECT id, v1, v2, v3, v4, v5, v6
 FROM t1 FULL OUTER JOIN t2 USING(id)
         FULL OUTER JOIN t3 USING(id)

--- a/test/sql/test_join/T/test_join_using_comprehensive.sql
+++ b/test/sql/test_join/T/test_join_using_comprehensive.sql
@@ -156,6 +156,22 @@ INSERT INTO t8 VALUES
 -- 6-table JOIN combinations
 -- ===============================================
 
+-- ===============================================
+-- Test 1c: FULL OUTER JOIN with constant subquery (single join)
+-- ===============================================
+SELECT id, v1
+FROM t1 FULL OUTER JOIN (SELECT 1 AS id) s1 USING(id)
+ORDER BY id, v1;
+
+-- ===============================================
+-- Test 1d: FULL OUTER JOIN with constant subqueries (multi-join)
+-- ===============================================
+SELECT id, v1, v2
+FROM t1 FULL OUTER JOIN (SELECT 1 AS id) s1 USING(id)
+        FULL OUTER JOIN t2 USING(id)
+        FULL OUTER JOIN (SELECT 9 AS id) s2 USING(id)
+ORDER BY id, v1, v2;
+
 -- Test 2: 6-table all FULL OUTER
 SELECT id, v1, v2, v3, v4, v5, v6
 FROM t1 FULL OUTER JOIN t2 USING(id)


### PR DESCRIPTION
## Why I'm doing:
Fix a planning crash for FULL OUTER JOIN ... USING when one side is a constant subquery (e.g. `SELECT 1 AS id`).  
The USING key can be rewritten into casts and lose its base column name, causing the coalesce projection builder to miss the USING column and throw `IndexOutOfBounds`.

## What I'm doing:
Add a fallback in `buildFullOuterJoinUsingPlan` to pick the join predicate pair when name-based lookup fails, ensuring the COALESCE projection is built correctly.  

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
