### PR TITLE
[Enhancement] Make sys_log_verbose_modules and sys_log_verbose_level mutable

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -223,9 +223,9 @@ CONF_String(sys_log_roll_mode, "SIZE-MB-1024");
 // The log roll num.
 CONF_Int32(sys_log_roll_num, "10");
 // Verbose log.
-CONF_Strings(sys_log_verbose_modules, "");
+CONF_mStrings(sys_log_verbose_modules, "");
 // Verbose log level.
-CONF_Int32(sys_log_verbose_level, "10");
+CONF_mInt32(sys_log_verbose_level, "10");
 // The log buffer level.
 CONF_String(log_buffer_level, "");
 // Whether to show timezone in log prefix.

--- a/be/src/common/configbase.cpp
+++ b/be/src/common/configbase.cpp
@@ -121,6 +121,20 @@ bool strtox(const std::string& valstr, MutableString& retval) {
     return true;
 }
 
+bool strtox(const std::string& valstr, MutableStrings& retval) {
+    std::vector<std::string> tmp;
+    std::vector<std::string> parts = strings::Split(valstr, ",");
+    for (auto& part : parts) {
+        StripWhiteSpace(&part);
+        if (part.empty()) {
+            continue;
+        }
+        tmp.emplace_back(std::move(part));
+    }
+    retval = std::move(tmp);
+    return true;
+}
+
 inline bool parse_key_value_pairs(std::istream& input) {
     std::string line;
     std::string key;

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -97,6 +97,53 @@ inline std::ostream& operator<<(std::ostream& os, const MutableString& s) {
     return os << s.value();
 }
 
+// A wrapper on std::vector<std::string>, it's safe to read/write MutableStrings concurrently.
+class MutableStrings {
+public:
+    MutableStrings() = default;
+    ~MutableStrings() = default;
+
+    // Disallow copy and move, because no usage now.
+    MutableStrings(const MutableStrings&) = delete;
+    void operator=(const MutableStrings&) = delete;
+    MutableStrings(MutableStrings&&) = delete;
+    void operator=(MutableStrings&&) = delete;
+
+    std::vector<std::string> value() const;
+
+    operator std::vector<std::string>() const { return value(); }
+
+    MutableStrings& operator=(std::vector<std::string> v);
+
+private:
+    static bool update_value(std::vector<std::string>& bg, std::vector<std::string> new_value) {
+        bg = std::move(new_value);
+        return true;
+    }
+
+    mutable butil::DoublyBufferedData<std::vector<std::string>> _data;
+};
+
+inline std::vector<std::string> MutableStrings::value() const {
+    butil::DoublyBufferedData<std::vector<std::string>>::ScopedPtr ptr;
+    _data.Read(&ptr);
+    return *ptr;
+}
+
+inline MutableStrings& MutableStrings::operator=(std::vector<std::string> v) {
+    _data.Modify(update_value, std::move(v));
+    return *this;
+}
+
+inline std::ostream& operator<<(std::ostream& os, const MutableStrings& s) {
+    auto v = s.value();
+    for (size_t i = 0; i < v.size(); i++) {
+        if (i > 0) os << ",";
+        os << v[i];
+    }
+    return os;
+}
+
 #define DECLARE_FIELD(FIELD_TYPE, FIELD_NAME) extern FIELD_TYPE FIELD_NAME;
 
 // NOTE: alias configs must be defined after the true config, otherwise there will be a compile error
@@ -120,6 +167,7 @@ inline std::ostream& operator<<(std::ostream& os, const MutableString& s) {
 #define CONF_mInt64(name, defaultstr) DECLARE_FIELD(int64_t, name)
 #define CONF_mDouble(name, defaultstr) DECLARE_FIELD(double, name)
 #define CONF_mString(name, defaultstr) DECLARE_FIELD(MutableString, name)
+#define CONF_mStrings(name, defaultstr) DECLARE_FIELD(MutableStrings, name)
 
 // Initialize configurations from a config file.
 bool init(const char* filename);
@@ -142,5 +190,18 @@ template <>
 struct fmt::formatter<starrocks::config::MutableString> : formatter<std::string> {
     auto format(const starrocks::config::MutableString& s, format_context& ctx) const {
         return formatter<std::string>::format(s.value(), ctx);
+    }
+};
+
+template <>
+struct fmt::formatter<starrocks::config::MutableStrings> : formatter<std::string> {
+    auto format(const starrocks::config::MutableStrings& s, format_context& ctx) const {
+        auto v = s.value();
+        std::string result;
+        for (size_t i = 0; i < v.size(); i++) {
+            if (i > 0) result += ",";
+            result += v[i];
+        }
+        return formatter<std::string>::format(result, ctx);
     }
 };

--- a/be/src/common/configbase_impl.h
+++ b/be/src/common/configbase_impl.h
@@ -44,6 +44,7 @@ bool strtox(const std::string& valstr, int64_t& retval);
 bool strtox(const std::string& valstr, double& retval);
 bool strtox(const std::string& valstr, std::string& retval);
 bool strtox(const std::string& valstr, MutableString& retval);
+bool strtox(const std::string& valstr, MutableStrings& retval);
 
 class Field {
 public:
@@ -209,6 +210,7 @@ private:
 #undef CONF_mInt64
 #undef CONF_mDouble
 #undef CONF_mString
+#undef CONF_mStrings
 
 // NOTE: alias configs must be defined after the true config, otherwise there will be a compile error
 #define CONF_Alias(name, alias) DEFINE_ALIAS(name, alias)
@@ -232,5 +234,6 @@ private:
 #define CONF_mInt64(name, defaultstr) DEFINE_FIELD(int64_t, name, defaultstr, true, "int64")
 #define CONF_mDouble(name, defaultstr) DEFINE_FIELD(double, name, defaultstr, true, "double")
 #define CONF_mString(name, defaultstr) DEFINE_FIELD(MutableString, name, defaultstr, true, "string")
+#define CONF_mStrings(name, defaultstr) DEFINE_FIELD(MutableStrings, name, defaultstr, true, "list<string>")
 
 } // namespace starrocks::config

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -71,6 +71,7 @@
 #include "storage/storage_engine.h"
 #include "storage/update_manager.h"
 #include "util/bthreads/executor.h"
+#include "util/logging.h"
 #include "util/priority_thread_pool.hpp"
 
 #ifdef USE_STAROS
@@ -414,6 +415,14 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             if (batch_write_mgr) {
                 batch_write_mgr->txn_state_cache()->set_capacity(config::merge_commit_txn_state_cache_capacity);
             }
+            return Status::OK();
+        });
+        _config_callback.emplace("sys_log_verbose_modules", [&]() -> Status {
+            update_verbose_modules();
+            return Status::OK();
+        });
+        _config_callback.emplace("sys_log_verbose_level", [&]() -> Status {
+            update_verbose_modules();
             return Status::OK();
         });
 

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -418,11 +418,11 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             return Status::OK();
         });
         _config_callback.emplace("sys_log_verbose_modules", [&]() -> Status {
-            update_verbose_modules();
+            update_vlog_conf();
             return Status::OK();
         });
         _config_callback.emplace("sys_log_verbose_level", [&]() -> Status {
-            update_verbose_modules();
+            update_vlog_conf();
             return Status::OK();
         });
 

--- a/be/src/runtime/logconfig.cpp
+++ b/be/src/runtime/logconfig.cpp
@@ -436,7 +436,7 @@ bool init_glog(const char* basename, bool install_signal_handler) {
             google::SetVLOGLevel(verbose_module.c_str(), vlog_level);
         }
     }
-    // Initialize s_previous_verbose_modules so update_verbose_modules can clean up properly
+    // Initialize s_previous_verbose_modules so update_vlog_conf can clean up properly
     s_previous_verbose_modules = verbose_modules;
 
     google::InitGoogleLogging(basename);
@@ -493,7 +493,7 @@ void update_logging() {
     }
 }
 
-void update_verbose_modules() {
+void update_vlog_conf() {
     std::lock_guard<std::mutex> lock(s_verbose_modules_mutex);
 
     // Clear previous verbose module settings first

--- a/be/src/runtime/logconfig.cpp
+++ b/be/src/runtime/logconfig.cpp
@@ -525,7 +525,7 @@ void update_verbose_modules() {
     // Save current modules for future cleanup
     s_previous_verbose_modules = verbose_modules;
 
-    LOG(INFO) << "Updated sys_log_verbose_modules, " << verbose_modules.size()
+    LOG(INFO) << "Updated verbose logging configuration: " << verbose_modules.size()
               << " file patterns configured with verbose level " << vlog_level;
 }
 

--- a/be/src/runtime/logconfig.cpp
+++ b/be/src/runtime/logconfig.cpp
@@ -60,6 +60,11 @@ static bool logging_initialized = false;
 
 static std::mutex logging_mutex;
 
+// Store previously configured verbose modules for cleanup
+static std::vector<std::string> s_previous_verbose_modules;
+static std::mutex s_verbose_modules_mutex;
+static constexpr int32_t kMinVlogLevel = 0;
+
 static bool iequals(const std::string& a, const std::string& b) {
     size_t sz = a.size();
     if (b.size() != sz) {
@@ -420,13 +425,19 @@ bool init_glog(const char* basename, bool install_signal_handler) {
 
     // Set verbose modules.
     FLAGS_v = -1;
-    std::vector<std::string>& verbose_modules = config::sys_log_verbose_modules;
+    std::vector<std::string> verbose_modules = config::sys_log_verbose_modules;
     int32_t vlog_level = config::sys_log_verbose_level;
+    if (vlog_level < kMinVlogLevel) {
+        vlog_level = kMinVlogLevel;
+        config::sys_log_verbose_level = vlog_level;
+    }
     for (auto& verbose_module : verbose_modules) {
         if (verbose_module.size() != 0) {
             google::SetVLOGLevel(verbose_module.c_str(), vlog_level);
         }
     }
+    // Initialize s_previous_verbose_modules so update_verbose_modules can clean up properly
+    s_previous_verbose_modules = verbose_modules;
 
     google::InitGoogleLogging(basename);
 
@@ -480,6 +491,42 @@ void update_logging() {
     } else {
         LOG(WARNING) << "update sys_log_level failed, need to be INFO, WARNING, ERROR, FATAL";
     }
+}
+
+void update_verbose_modules() {
+    std::lock_guard<std::mutex> lock(s_verbose_modules_mutex);
+
+    // Clear previous verbose module settings first
+    for (const auto& prev_module : s_previous_verbose_modules) {
+        if (!prev_module.empty()) {
+            google::SetVLOGLevel(prev_module.c_str(), 0);
+        }
+    }
+
+    // Get new verbose module settings (use value copy for thread safety)
+    std::vector<std::string> verbose_modules = config::sys_log_verbose_modules;
+    int32_t vlog_level = config::sys_log_verbose_level;
+
+    // Clamp vlog_level: must not be negative
+    if (vlog_level < kMinVlogLevel) {
+        LOG(WARNING) << "sys_log_verbose_level " << vlog_level << " is below minimum " << kMinVlogLevel
+                     << ", clamping to " << kMinVlogLevel;
+        vlog_level = kMinVlogLevel;
+        config::sys_log_verbose_level = vlog_level;
+    }
+
+    // Apply new verbose module settings
+    for (const auto& verbose_module : verbose_modules) {
+        if (!verbose_module.empty()) {
+            google::SetVLOGLevel(verbose_module.c_str(), vlog_level);
+        }
+    }
+
+    // Save current modules for future cleanup
+    s_previous_verbose_modules = verbose_modules;
+
+    LOG(INFO) << "Updated sys_log_verbose_modules, " << verbose_modules.size()
+              << " file patterns configured with verbose level " << vlog_level;
 }
 
 } // namespace starrocks

--- a/be/src/util/logging.h
+++ b/be/src/util/logging.h
@@ -37,4 +37,6 @@ std::string FormatTimestampForLog(MicrosecondsInt64 micros_since_epoch);
 
 void update_logging();
 
+void update_verbose_modules();
+
 } // namespace starrocks

--- a/be/src/util/logging.h
+++ b/be/src/util/logging.h
@@ -37,6 +37,6 @@ std::string FormatTimestampForLog(MicrosecondsInt64 micros_since_epoch);
 
 void update_logging();
 
-void update_verbose_modules();
+void update_vlog_conf();
 
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -400,6 +400,7 @@ set(EXEC_FILES
         ./util/jvm_metrics_test.cpp
         ./util/llm_cache_test.cpp
         ./util/llm_query_service_test.cpp
+        ./util/logging_test.cpp
         )
 
 if (USE_AVX2)

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -532,4 +532,142 @@ TEST_F(ConfigTest, test_alias04) {
     EXPECT_EQ(8080, cfg_int32);
 }
 
+TEST_F(ConfigTest, test_mstrings_init_and_list) {
+    CONF_mStrings(cfg_mstrings, "a,b,c");
+
+    ASSERT_TRUE(config::init(nullptr));
+
+    // Verify default value parsed correctly
+    std::vector<std::string> val = cfg_mstrings;
+    EXPECT_THAT(val, ElementsAre("a", "b", "c"));
+
+    // Verify list_configs shows correct type and value
+    auto configs = config::list_configs();
+    for (const auto& c : configs) {
+        if (c.name == "cfg_mstrings") {
+            EXPECT_EQ("list<string>", c.type);
+            EXPECT_EQ("a,b,c", c.value);
+            EXPECT_TRUE(c.valmutable);
+        }
+    }
+}
+
+TEST_F(ConfigTest, test_mstrings_set_and_rollback) {
+    CONF_mStrings(cfg_mstrings_rw, "x,y");
+
+    ASSERT_TRUE(config::init(nullptr));
+
+    // Verify default
+    std::vector<std::string> val = cfg_mstrings_rw;
+    EXPECT_THAT(val, ElementsAre("x", "y"));
+
+    // set_config with new value
+    ASSERT_TRUE(config::set_config("cfg_mstrings_rw", "s1,s2,s3").ok());
+    val = cfg_mstrings_rw;
+    EXPECT_THAT(val, ElementsAre("s1", "s2", "s3"));
+
+    // rollback to previous value
+    ASSERT_TRUE(config::rollback_config("cfg_mstrings_rw").ok());
+    val = cfg_mstrings_rw;
+    EXPECT_THAT(val, ElementsAre("x", "y"));
+
+    // set again and verify
+    ASSERT_TRUE(config::set_config("cfg_mstrings_rw", "only_one").ok());
+    val = cfg_mstrings_rw;
+    EXPECT_THAT(val, ElementsAre("only_one"));
+}
+
+TEST_F(ConfigTest, test_mstrings_strtox_parsing) {
+    CONF_mStrings(cfg_mstrings_parse, "");
+
+    ASSERT_TRUE(config::init(nullptr));
+
+    // Empty default → empty vector
+    std::vector<std::string> val = cfg_mstrings_parse;
+    EXPECT_TRUE(val.empty());
+
+    // Normal comma-separated
+    ASSERT_TRUE(config::set_config("cfg_mstrings_parse", "a,b,c").ok());
+    val = cfg_mstrings_parse;
+    EXPECT_THAT(val, ElementsAre("a", "b", "c"));
+
+    // Leading/trailing spaces stripped
+    ASSERT_TRUE(config::set_config("cfg_mstrings_parse", " s1 , s2 , s3 ").ok());
+    val = cfg_mstrings_parse;
+    EXPECT_THAT(val, ElementsAre("s1", "s2", "s3"));
+
+    // Empty parts skipped (leading comma, trailing comma, double comma)
+    ASSERT_TRUE(config::set_config("cfg_mstrings_parse", ",a,,b,").ok());
+    val = cfg_mstrings_parse;
+    EXPECT_THAT(val, ElementsAre("a", "b"));
+
+    // Single value
+    ASSERT_TRUE(config::set_config("cfg_mstrings_parse", "single").ok());
+    val = cfg_mstrings_parse;
+    EXPECT_THAT(val, ElementsAre("single"));
+
+    // All-empty input → empty vector
+    ASSERT_TRUE(config::set_config("cfg_mstrings_parse", ",,").ok());
+    val = cfg_mstrings_parse;
+    EXPECT_TRUE(val.empty());
+
+    // Empty string input → empty vector
+    ASSERT_TRUE(config::set_config("cfg_mstrings_parse", "").ok());
+    val = cfg_mstrings_parse;
+    EXPECT_TRUE(val.empty());
+}
+
+TEST_F(ConfigTest, test_mstrings_fmt_formatter) {
+    CONF_mStrings(cfg_fmt_mstrings, "mod1,mod2,mod3");
+
+    ASSERT_TRUE(config::init(nullptr));
+
+    // Multiple elements: should produce comma-separated string
+    std::string result = fmt::format("{}", cfg_fmt_mstrings);
+    EXPECT_EQ("mod1,mod2,mod3", result);
+
+    // Single element
+    ASSERT_TRUE(config::set_config("cfg_fmt_mstrings", "single").ok());
+    result = fmt::format("{}", cfg_fmt_mstrings);
+    EXPECT_EQ("single", result);
+
+    // Empty
+    ASSERT_TRUE(config::set_config("cfg_fmt_mstrings", "").ok());
+    result = fmt::format("{}", cfg_fmt_mstrings);
+    EXPECT_EQ("", result);
+}
+
+TEST_F(ConfigTest, test_read_write_mutable_strings_concurrently) {
+    CONF_mStrings(cfg_test_mstrings_conc, "default_val");
+
+    ASSERT_TRUE(config::init(nullptr));
+
+    std::vector<std::string> init_val = cfg_test_mstrings_conc;
+    EXPECT_THAT(init_val, ElementsAre("default_val"));
+
+    std::vector<std::thread> threads;
+    threads.reserve(5);
+    for (int i = 0; i < 5; i++) {
+        threads.emplace_back([&, id = i]() {
+            if (id < 2) { // writer
+                for (int j = 0; j < 200; j++) {
+                    std::string csv = std::to_string(id) + "_" + std::to_string(j);
+                    auto st = set_config("cfg_test_mstrings_conc", csv);
+                    ASSERT_TRUE(st.ok()) << st;
+                }
+            } else { // reader
+                for (int j = 0; j < 1000; j++) {
+                    std::vector<std::string> val = cfg_test_mstrings_conc;
+                    // Should never crash or produce corrupted data
+                    // Value should be either default or a valid single-element vector
+                    ASSERT_LE(val.size(), 1u);
+                }
+            }
+        });
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+}
+
 } // namespace starrocks

--- a/be/test/http/action/update_config_action_test.cpp
+++ b/be/test/http/action/update_config_action_test.cpp
@@ -120,4 +120,30 @@ TEST_F(UpdateConfigActionTest, test_update_tablet_meta_info_worker_count) {
     ASSERT_EQ(1, thread_pool->max_threads());
 }
 
+TEST_F(UpdateConfigActionTest, test_update_sys_log_verbose_modules) {
+    UpdateConfigAction action(ExecEnv::GetInstance());
+
+    ASSERT_OK(action.update_config("sys_log_verbose_modules", "storage_engine,tablet_manager"));
+
+    std::vector<std::string> modules = config::sys_log_verbose_modules;
+    ASSERT_EQ(2, modules.size());
+    EXPECT_EQ("storage_engine", modules[0]);
+    EXPECT_EQ("tablet_manager", modules[1]);
+
+    // Update to empty
+    ASSERT_OK(action.update_config("sys_log_verbose_modules", ""));
+}
+
+TEST_F(UpdateConfigActionTest, test_update_sys_log_verbose_level) {
+    UpdateConfigAction action(ExecEnv::GetInstance());
+
+    auto original_level = static_cast<int32_t>(config::sys_log_verbose_level);
+
+    ASSERT_OK(action.update_config("sys_log_verbose_level", "5"));
+    EXPECT_EQ(5, static_cast<int32_t>(config::sys_log_verbose_level));
+
+    // Restore original level
+    ASSERT_OK(action.update_config("sys_log_verbose_level", std::to_string(original_level)));
+}
+
 } // namespace starrocks

--- a/be/test/util/logging_test.cpp
+++ b/be/test/util/logging_test.cpp
@@ -1,0 +1,172 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/logging.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "common/config.h"
+
+namespace starrocks {
+
+class LoggingTest : public testing::Test {
+protected:
+    void SetUp() override {
+        // Save original config values
+        _original_verbose_modules = config::sys_log_verbose_modules;
+        _original_verbose_level = config::sys_log_verbose_level;
+    }
+
+    void TearDown() override {
+        // Restore original config values
+        config::sys_log_verbose_modules = _original_verbose_modules;
+        config::sys_log_verbose_level = _original_verbose_level;
+        // Restore glog VLOG level settings
+        update_verbose_modules();
+    }
+
+private:
+    std::vector<std::string> _original_verbose_modules;
+    int32_t _original_verbose_level;
+};
+
+// Test update_verbose_modules with empty config
+TEST_F(LoggingTest, UpdateVerboseModulesEmpty) {
+    config::sys_log_verbose_modules = std::vector<std::string>{};
+    config::sys_log_verbose_level = 2;
+
+    // Should not crash with empty config
+    ASSERT_NO_THROW(update_verbose_modules());
+}
+
+// Test update_verbose_modules with single module
+TEST_F(LoggingTest, UpdateVerboseModulesSingle) {
+    config::sys_log_verbose_modules = std::vector<std::string>{"storage_engine"};
+    config::sys_log_verbose_level = 2;
+
+    ASSERT_NO_THROW(update_verbose_modules());
+}
+
+// Test update_verbose_modules with multiple modules
+TEST_F(LoggingTest, UpdateVerboseModulesMultiple) {
+    config::sys_log_verbose_modules = std::vector<std::string>{"storage_engine", "tablet_manager"};
+    config::sys_log_verbose_level = 3;
+
+    ASSERT_NO_THROW(update_verbose_modules());
+}
+
+// Test update_verbose_modules with wildcard patterns
+TEST_F(LoggingTest, UpdateVerboseModulesWildcard) {
+    config::sys_log_verbose_modules = std::vector<std::string>{"*"};
+    config::sys_log_verbose_level = 2;
+
+    ASSERT_NO_THROW(update_verbose_modules());
+}
+
+// Test update_verbose_modules handles empty strings in config
+TEST_F(LoggingTest, UpdateVerboseModulesSkipsEmpty) {
+    config::sys_log_verbose_modules = std::vector<std::string>{"storage_engine", "", "tablet_manager"};
+    config::sys_log_verbose_level = 2;
+
+    // Should skip empty strings without error
+    ASSERT_NO_THROW(update_verbose_modules());
+}
+
+// Test update_verbose_modules with different verbose levels
+TEST_F(LoggingTest, UpdateVerboseLevelOnly) {
+    config::sys_log_verbose_modules = std::vector<std::string>{"storage_engine"};
+
+    // Test with different verbose levels
+    for (int level = 0; level <= 10; ++level) {
+        config::sys_log_verbose_level = level;
+        ASSERT_NO_THROW(update_verbose_modules());
+    }
+}
+
+// Test dynamic update of verbose level without changing modules
+TEST_F(LoggingTest, UpdateVerboseLevelDynamic) {
+    config::sys_log_verbose_modules = std::vector<std::string>{"*"};
+    config::sys_log_verbose_level = 1;
+    ASSERT_NO_THROW(update_verbose_modules());
+
+    // Change only the level
+    config::sys_log_verbose_level = 5;
+    ASSERT_NO_THROW(update_verbose_modules());
+
+    // Change to higher level
+    config::sys_log_verbose_level = 10;
+    ASSERT_NO_THROW(update_verbose_modules());
+
+    // Change to lower level
+    config::sys_log_verbose_level = 0;
+    ASSERT_NO_THROW(update_verbose_modules());
+}
+
+// Test verbose level clamping: negative values should be clamped to 0
+TEST_F(LoggingTest, UpdateVerboseLevelClamp) {
+    config::sys_log_verbose_modules = std::vector<std::string>{"storage_engine"};
+
+    // Negative value should be clamped to 0
+    config::sys_log_verbose_level = -5;
+    ASSERT_NO_THROW(update_verbose_modules());
+    EXPECT_EQ(static_cast<int32_t>(config::sys_log_verbose_level), 0);
+
+    // Zero (boundary) should remain unchanged
+    config::sys_log_verbose_level = 0;
+    ASSERT_NO_THROW(update_verbose_modules());
+    EXPECT_EQ(static_cast<int32_t>(config::sys_log_verbose_level), 0);
+
+    // Positive values should remain unchanged
+    config::sys_log_verbose_level = 10;
+    ASSERT_NO_THROW(update_verbose_modules());
+    EXPECT_EQ(static_cast<int32_t>(config::sys_log_verbose_level), 10);
+
+    // Large positive value should remain unchanged (no max limit)
+    config::sys_log_verbose_level = 200;
+    ASSERT_NO_THROW(update_verbose_modules());
+    EXPECT_EQ(static_cast<int32_t>(config::sys_log_verbose_level), 200);
+}
+
+// Test thread safety of update_verbose_modules
+TEST_F(LoggingTest, UpdateVerboseModulesThreadSafety) {
+    std::vector<std::thread> threads;
+    const int num_threads = 10;
+    const int iterations = 100;
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([i, iterations]() {
+            for (int j = 0; j < iterations; ++j) {
+                // Alternate between different configs
+                if (j % 2 == 0) {
+                    config::sys_log_verbose_modules = std::vector<std::string>{"storage_engine", "tablet_manager"};
+                } else {
+                    config::sys_log_verbose_modules = std::vector<std::string>{"*query*", "*compaction*"};
+                }
+                config::sys_log_verbose_level = (i + j) % 5;
+                update_verbose_modules();
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+    // Should complete without crash or data corruption
+}
+
+} // namespace starrocks

--- a/be/test/util/logging_test.cpp
+++ b/be/test/util/logging_test.cpp
@@ -37,7 +37,7 @@ protected:
         config::sys_log_verbose_modules = _original_verbose_modules;
         config::sys_log_verbose_level = _original_verbose_level;
         // Restore glog VLOG level settings
-        update_verbose_modules();
+        update_vlog_conf();
     }
 
 private:
@@ -45,56 +45,56 @@ private:
     int32_t _original_verbose_level;
 };
 
-// Test update_verbose_modules with empty config
+// Test update_vlog_conf with empty config
 TEST_F(LoggingTest, UpdateVerboseModulesEmpty) {
     config::sys_log_verbose_modules = std::vector<std::string>{};
     config::sys_log_verbose_level = 2;
 
     // Should not crash with empty config
-    ASSERT_NO_THROW(update_verbose_modules());
+    ASSERT_NO_THROW(update_vlog_conf());
 }
 
-// Test update_verbose_modules with single module
+// Test update_vlog_conf with single module
 TEST_F(LoggingTest, UpdateVerboseModulesSingle) {
     config::sys_log_verbose_modules = std::vector<std::string>{"storage_engine"};
     config::sys_log_verbose_level = 2;
 
-    ASSERT_NO_THROW(update_verbose_modules());
+    ASSERT_NO_THROW(update_vlog_conf());
 }
 
-// Test update_verbose_modules with multiple modules
+// Test update_vlog_conf with multiple modules
 TEST_F(LoggingTest, UpdateVerboseModulesMultiple) {
     config::sys_log_verbose_modules = std::vector<std::string>{"storage_engine", "tablet_manager"};
     config::sys_log_verbose_level = 3;
 
-    ASSERT_NO_THROW(update_verbose_modules());
+    ASSERT_NO_THROW(update_vlog_conf());
 }
 
-// Test update_verbose_modules with wildcard patterns
+// Test update_vlog_conf with wildcard patterns
 TEST_F(LoggingTest, UpdateVerboseModulesWildcard) {
     config::sys_log_verbose_modules = std::vector<std::string>{"*"};
     config::sys_log_verbose_level = 2;
 
-    ASSERT_NO_THROW(update_verbose_modules());
+    ASSERT_NO_THROW(update_vlog_conf());
 }
 
-// Test update_verbose_modules handles empty strings in config
+// Test update_vlog_conf handles empty strings in config
 TEST_F(LoggingTest, UpdateVerboseModulesSkipsEmpty) {
     config::sys_log_verbose_modules = std::vector<std::string>{"storage_engine", "", "tablet_manager"};
     config::sys_log_verbose_level = 2;
 
     // Should skip empty strings without error
-    ASSERT_NO_THROW(update_verbose_modules());
+    ASSERT_NO_THROW(update_vlog_conf());
 }
 
-// Test update_verbose_modules with different verbose levels
+// Test update_vlog_conf with different verbose levels
 TEST_F(LoggingTest, UpdateVerboseLevelOnly) {
     config::sys_log_verbose_modules = std::vector<std::string>{"storage_engine"};
 
     // Test with different verbose levels
     for (int level = 0; level <= 10; ++level) {
         config::sys_log_verbose_level = level;
-        ASSERT_NO_THROW(update_verbose_modules());
+        ASSERT_NO_THROW(update_vlog_conf());
     }
 }
 
@@ -102,19 +102,19 @@ TEST_F(LoggingTest, UpdateVerboseLevelOnly) {
 TEST_F(LoggingTest, UpdateVerboseLevelDynamic) {
     config::sys_log_verbose_modules = std::vector<std::string>{"*"};
     config::sys_log_verbose_level = 1;
-    ASSERT_NO_THROW(update_verbose_modules());
+    ASSERT_NO_THROW(update_vlog_conf());
 
     // Change only the level
     config::sys_log_verbose_level = 5;
-    ASSERT_NO_THROW(update_verbose_modules());
+    ASSERT_NO_THROW(update_vlog_conf());
 
     // Change to higher level
     config::sys_log_verbose_level = 10;
-    ASSERT_NO_THROW(update_verbose_modules());
+    ASSERT_NO_THROW(update_vlog_conf());
 
     // Change to lower level
     config::sys_log_verbose_level = 0;
-    ASSERT_NO_THROW(update_verbose_modules());
+    ASSERT_NO_THROW(update_vlog_conf());
 }
 
 // Test verbose level clamping: negative values should be clamped to 0
@@ -123,26 +123,26 @@ TEST_F(LoggingTest, UpdateVerboseLevelClamp) {
 
     // Negative value should be clamped to 0
     config::sys_log_verbose_level = -5;
-    ASSERT_NO_THROW(update_verbose_modules());
+    ASSERT_NO_THROW(update_vlog_conf());
     EXPECT_EQ(static_cast<int32_t>(config::sys_log_verbose_level), 0);
 
     // Zero (boundary) should remain unchanged
     config::sys_log_verbose_level = 0;
-    ASSERT_NO_THROW(update_verbose_modules());
+    ASSERT_NO_THROW(update_vlog_conf());
     EXPECT_EQ(static_cast<int32_t>(config::sys_log_verbose_level), 0);
 
     // Positive values should remain unchanged
     config::sys_log_verbose_level = 10;
-    ASSERT_NO_THROW(update_verbose_modules());
+    ASSERT_NO_THROW(update_vlog_conf());
     EXPECT_EQ(static_cast<int32_t>(config::sys_log_verbose_level), 10);
 
     // Large positive value should remain unchanged (no max limit)
     config::sys_log_verbose_level = 200;
-    ASSERT_NO_THROW(update_verbose_modules());
+    ASSERT_NO_THROW(update_vlog_conf());
     EXPECT_EQ(static_cast<int32_t>(config::sys_log_verbose_level), 200);
 }
 
-// Test thread safety of update_verbose_modules
+// Test thread safety of update_vlog_conf
 TEST_F(LoggingTest, UpdateVerboseModulesThreadSafety) {
     std::vector<std::thread> threads;
     const int num_threads = 10;
@@ -158,7 +158,7 @@ TEST_F(LoggingTest, UpdateVerboseModulesThreadSafety) {
                     config::sys_log_verbose_modules = std::vector<std::string>{"*query*", "*compaction*"};
                 }
                 config::sys_log_verbose_level = (i + j) % 5;
-                update_verbose_modules();
+                update_vlog_conf();
             }
         });
     }

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -130,8 +130,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Default: 10
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: The level of the logs to be printed. This configuration item is used to control the output of logs initiated with VLOG in codes.
+- Is mutable: Yes
+- Description: The level of the logs to be printed. This configuration item is used to control the output of logs initiated with VLOG in codes. When this parameter is dynamically updated, the VLOG level for the modules specified by `sys_log_verbose_modules` will be updated accordingly.
 - Introduced in: -
 
 ##### sys_log_verbose_modules
@@ -139,8 +139,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Default: 
 - Type: Strings
 - Unit: -
-- Is mutable: No
-- Description: The module of the logs to be printed. For example, if you set this configuration item to OLAP, StarRocks only prints the logs of the OLAP module. Valid values are namespaces in BE, including `starrocks`, `starrocks::debug`, `starrocks::fs`, `starrocks::io`, `starrocks::lake`, `starrocks::pipeline`, `starrocks::query_cache`, `starrocks::stream`, and `starrocks::workgroup`.
+- Is mutable: Yes
+- Description: The file names (without extension) or file name wildcards for which VLOG logs should be printed. You can specify multiple file names separated by commas. For example, if you set this configuration item to `storage_engine,tablet_manager`, StarRocks only prints VLOG logs for those specific files. You can also use wildcards like `*` to print VLOG logs for all files. The VLOG log level is controlled by the `sys_log_verbose_level` parameter.
 - Introduced in: -
 
 ### Server

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -102,8 +102,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - デフォルト: 10
 - タイプ: Int
 - 単位: -
-- 可変: いいえ
-- 説明: 印刷するログのレベル。この設定項目は、コード内で VLOG で開始されたログの出力を制御するために使用されます。
+- 可変: はい
+- 説明: 印刷するログのレベル。この設定項目は、コード内で VLOG で開始されたログの出力を制御するために使用されます。このパラメータを動的に更新すると、`sys_log_verbose_modules` で指定されたモジュールの VLOG ログレベルが同時に更新されます。
 - 導入バージョン: -
 
 ##### sys_log_verbose_modules
@@ -111,8 +111,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - デフォルト: 
 - タイプ: Strings
 - 単位: -
-- 可変: いいえ
-- 説明: 印刷するログのモジュール。たとえば、この設定項目を OLAP に設定すると、StarRocks は OLAP モジュールのログのみを印刷します。有効な値は BE の名前空間であり、`starrocks`、`starrocks::debug`、`starrocks::fs`、`starrocks::io`、`starrocks::lake`、`starrocks::pipeline`、`starrocks::query_cache`、`starrocks::stream`、`starrocks::workgroup` などがあります。
+- 可変: はい
+- 説明: VLOGログを出力するファイル名（拡張子なし）またはファイル名ワイルドカードを設定します。複数のファイル名をカンマで区切って指定できます。たとえば、この設定項目を `storage_engine,tablet_manager` に設定すると、StarRocks はこれらの特定ファイルのVLOGログのみを出力します。`*` のようなワイルドカードを使用して、すべてのファイルのVLOGログを出力することもできます。VLOGログの出力レベルは `sys_log_verbose_level` パラメータで制御されます。
 - 導入バージョン: -
 
 ### サーバー

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -108,8 +108,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值：10
 - 类型：Int
 - 单位：-
-- 是否动态：否
-- 描述：日志显示的级别，用于控制代码中 VLOG 开头的日志输出。
+- 是否动态：是
+- 描述：日志显示的级别，用于控制代码中 VLOG 开头的日志输出。动态更新此参数时，将同步更新 `sys_log_verbose_modules` 中指定模块的 VLOG 日志级别。
 - 引入版本：-
 
 ##### sys_log_verbose_modules
@@ -117,8 +117,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值：
 - 类型：Strings
 - 单位：-
-- 是否动态：否
-- 描述：日志打印的模块。有效值为 BE 的 namespace，包括 `starrocks`、`starrocks::debug`、`starrocks::fs`、`starrocks::io`、`starrocks::lake`、`starrocks::pipeline`、`starrocks::query_cache`、`starrocks::stream` 以及 `starrocks::workgroup`。
+- 是否动态：是
+- 描述：设置需要输出 VLOG 日志的文件名（去掉文件扩展名）或文件名通配符。可以指定多个文件名，用逗号分隔。例如，如果将此配置项设置为 `storage_engine,tablet_manager`，StarRocks 将只打印这些特定文件的 VLOG 日志。您也可以使用通配符，如设置为 `*` 表示打印所有文件的 VLOG 日志。VLOG 日志打印级别通过 `sys_log_verbose_level` 参数控制
 - 引入版本：-
 
 ### 服务器


### PR DESCRIPTION
## Why I'm doing:
- Currently, modifying sys_log_verbose_modules and sys_log_verbose_level requires restarting the service. 
- This change allows these parameters to be updated dynamically, enabling more detailed logs to be collected without a restart.
- This is especially useful for troubleshooting live issues in production environments.

## What I'm doing:
- This change allows these parameters to be updated dynamically, enabling more detailed logs to be collected without a restart.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4