### PR TITLE
[Enhancement] add ByteBuffer Estimator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.ProfileManager;
+import com.starrocks.memory.estimate.ByteBufferEstimator;
 import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.memory.estimate.StringEstimator;
 import com.starrocks.monitor.jvm.JvmStats;
@@ -36,6 +37,7 @@ import com.starrocks.sql.optimizer.statistics.IRelaxDictManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
 
@@ -235,6 +237,8 @@ public class MemoryUsageTracker extends FrontendDaemon {
 
     private void registerCustomEstimators() {
         Estimator.registerCustomEstimator(String.class, new StringEstimator());
+        Estimator.registerCustomEstimator(ByteBuffer.class, new ByteBufferEstimator());
+        Estimator.registerCustomEstimator("java.nio.HeapByteBuffer", new ByteBufferEstimator());
     }
 
     private void registerShallowMemoryClasses() {

--- a/fe/fe-core/src/main/java/com/starrocks/memory/estimate/ByteBufferEstimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/estimate/ByteBufferEstimator.java
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.memory.estimate;
+
+import com.google.common.base.Preconditions;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Custom estimator for heap-based ByteBuffer instances.
+ */
+public class ByteBufferEstimator implements CustomEstimator {
+    @Override
+    public long estimate(Object obj) {
+        Preconditions.checkArgument(obj instanceof ByteBuffer);
+        ByteBuffer buffer = (ByteBuffer) obj;
+        long size = Estimator.shallow(buffer);
+
+        if (buffer.isDirect()) {
+            // Direct buffers are off-heap; only count the wrapper itself.
+            return size;
+        }
+
+        try {
+            if (buffer.hasArray()) {
+                byte[] array = buffer.array();
+                return size + Estimator.ARRAY_HEADER_SIZE + array.length;
+            }
+        } catch (UnsupportedOperationException ignore) {
+            // fall through to shallow size
+        }
+
+        return size;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/memory/estimate/Estimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/estimate/Estimator.java
@@ -76,7 +76,7 @@ public class Estimator {
     };
 
     // Registry for custom estimators
-    protected static final Map<Class<?>, CustomEstimator> CUSTOM_ESTIMATORS = new HashMap<>();
+    protected static final Map<String, CustomEstimator> CUSTOM_ESTIMATORS = new HashMap<>();
 
     // Registry for classes that should only calculate shallow memory
     // Store class names instead of Class<?> to avoid pinning Class/ClassLoader.
@@ -156,7 +156,17 @@ public class Estimator {
      * @param estimator the custom estimator
      */
     public static void registerCustomEstimator(Class<?> clazz, CustomEstimator estimator) {
-        CUSTOM_ESTIMATORS.put(clazz, estimator);
+        CUSTOM_ESTIMATORS.put(clazz.getName(), estimator);
+    }
+
+    /**
+     * Register a custom estimator for a specific class.
+     *
+     * @param clazzName     the class name to register estimator for
+     * @param estimator the custom estimator
+     */
+    public static void registerCustomEstimator(String clazzName, CustomEstimator estimator) {
+        CUSTOM_ESTIMATORS.put(clazzName, estimator);
     }
 
     /**
@@ -166,7 +176,7 @@ public class Estimator {
      * @return the custom estimator, or null if not registered
      */
     public static CustomEstimator getCustomEstimator(Class<?> clazz) {
-        return CUSTOM_ESTIMATORS.get(clazz);
+        return CUSTOM_ESTIMATORS.get(clazz.getName());
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:

ByteBuffer's array is inaccessible, and the field visited here will throw an exception and exit without counting the byte array size.

## What I'm doing:
This pull request introduces support for custom memory estimation of `ByteBuffer` instances, improving the accuracy of memory usage tracking for heap-based and read-only buffers. It also refactors the custom estimator registry in the `Estimator` class to use class names as keys, allowing more flexible registration and lookup. Comprehensive unit tests are added to verify the new estimator's behavior.

### Memory estimation enhancements

* Added a new `ByteBufferEstimator` class to provide custom memory estimation for heap-based `ByteBuffer` instances, including proper handling of direct and read-only buffers. (`fe/fe-core/src/main/java/com/starrocks/memory/estimate/ByteBufferEstimator.java`)
* Registered `ByteBufferEstimator` for both `ByteBuffer.class` and `"java.nio.HeapByteBuffer"` in the `MemoryUsageTracker`, ensuring it covers relevant buffer types. (`fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java`)

### Refactoring and API improvements

* Refactored the custom estimator registry in `Estimator` to use class names (`String`) instead of `Class<?>` as keys, and updated registration and lookup methods accordingly. (`fe/fe-core/src/main/java/com/starrocks/memory/estimate/Estimator.java`) [[1]](diffhunk://#diff-73379f8ba941fd6dec287b10b6f5b1626037ee1ce64dc929b29760f5bc70247cL79-R79) [[2]](diffhunk://#diff-73379f8ba941fd6dec287b10b6f5b1626037ee1ce64dc929b29760f5bc70247cL159-R169) [[3]](diffhunk://#diff-73379f8ba941fd6dec287b10b6f5b1626037ee1ce64dc929b29760f5bc70247cL169-R179)

### Testing

* Added unit tests to verify custom estimation for heap-based and read-only `ByteBuffer` instances, ensuring the estimator is registered and works as expected. (`fe/fe-core/src/test/java/com/starrocks/memory/estimate/EstimatorTest.java`)

### Dependency updates

* Added necessary imports for `ByteBuffer` and `ByteBufferEstimator` in relevant files. (`fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java`, `fe/fe-core/src/test/java/com/starrocks/memory/estimate/EstimatorTest.java`) [[1]](diffhunk://#diff-a6be6952d2293a50a6545df0f7f30994a6f3a1ce256efd44dc90c967887fd915R22) [[2]](diffhunk://#diff-a6be6952d2293a50a6545df0f7f30994a6f3a1ce256efd44dc90c967887fd915R40) [[3]](diffhunk://#diff-9503a1de04c0407d2ec230920309fe0d515fe53bdf75b6cc29f0583a8e6dde8bR22)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
