### PR TITLE
[BugFix] fix PK key column fail to check generated column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -644,7 +644,8 @@ public class CreateTableAnalyzer {
                         partitionDesc instanceof SingleItemListPartitionDesc ||
                         partitionDesc instanceof SingleRangePartitionDesc) {
                     try {
-                        PartitionDescAnalyzer.analyze(partitionDesc, stmt.getColumnDefs(), stmt.getProperties());
+                        PartitionDescAnalyzer.analyze(partitionDesc, stmt.getColumnDefs(), stmt.getProperties(),
+                                stmt.getKeysDesc().getKeysType());
                     } catch (AnalysisException e) {
                         throw new SemanticException(e.getMessage());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionDescAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionDescAnalyzer.java
@@ -39,6 +39,7 @@ import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.ExpressionPartitionDesc;
+import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.MultiItemListPartitionDesc;
 import com.starrocks.sql.ast.MultiRangePartitionDesc;
@@ -90,8 +91,14 @@ public class PartitionDescAnalyzer {
      */
     public static void analyze(PartitionDesc partitionDesc, List<ColumnDef> columnDefs, Map<String, String> otherProperties)
             throws AnalysisException {
+        analyze(partitionDesc, columnDefs, otherProperties, null);
+    }
+
+    public static void analyze(PartitionDesc partitionDesc, List<ColumnDef> columnDefs,
+                               Map<String, String> otherProperties, KeysType keysType)
+            throws AnalysisException {
         if (partitionDesc instanceof ListPartitionDesc) {
-            analyzeListPartitionDesc((ListPartitionDesc) partitionDesc, columnDefs, otherProperties);
+            analyzeListPartitionDesc((ListPartitionDesc) partitionDesc, columnDefs, otherProperties, keysType);
         } else if (partitionDesc instanceof RangePartitionDesc) {
             analyzeRangePartitionDesc((RangePartitionDesc) partitionDesc, columnDefs, otherProperties);
         } else if (partitionDesc instanceof ExpressionPartitionDesc) {
@@ -345,11 +352,12 @@ public class PartitionDescAnalyzer {
     // Analyze methods for different partition types
 
     public static void analyzeListPartitionDesc(ListPartitionDesc desc, List<ColumnDef> columnDefs,
-                                                Map<String, String> tableProperties) throws AnalysisException {
+                                                Map<String, String> tableProperties, KeysType keysType)
+            throws AnalysisException {
         // analyze partition columns
         List<ColumnDef> columnDefList = analyzeListPartitionColumns(desc, columnDefs);
         // analyze partition expr
-        analyzeListPartitionExprs(desc, columnDefs);
+        analyzeListPartitionExprs(desc, columnDefs, keysType);
         // analyze single list property
         analyzeSingleListPartitions(desc, tableProperties, columnDefList);
         // analyze multi list partition
@@ -583,19 +591,48 @@ public class PartitionDescAnalyzer {
         return partitionColumns;
     }
 
-    private static void analyzeListPartitionExprs(ListPartitionDesc desc, List<ColumnDef> columnDefs) throws AnalysisException {
-        if (desc.getPartitionExprs() == null) {
-            return;
+    private static void analyzeListPartitionExprs(ListPartitionDesc desc, List<ColumnDef> columnDefs, KeysType keysType)
+            throws AnalysisException {
+        List<String> slotRefs = Lists.newArrayList();
+        if (desc.getPartitionExprs() != null) {
+            slotRefs.addAll(desc.getPartitionExprs().stream()
+                    .flatMap(e -> ExprUtils.collectAllSlotRefs(e).stream())
+                    .map(SlotRef::getColumnName)
+                    .collect(Collectors.toList()));
         }
-        List<String> slotRefs = desc.getPartitionExprs().stream()
-                .flatMap(e -> ExprUtils.collectAllSlotRefs(e).stream())
-                .map(SlotRef::getColumnName)
-                .collect(Collectors.toList());
-        
+        Map<String, ColumnDef> columnDefMap = columnDefs.stream()
+                .collect(Collectors.toMap(ColumnDef::getName, c -> c, (a, b) -> a,
+                        () -> Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER)));
+        for (String partitionCol : desc.getPartitionColNames()) {
+            ColumnDef partitionColumnDef = columnDefMap.get(partitionCol);
+            if (partitionColumnDef == null) {
+                continue;
+            }
+            if (partitionColumnDef.isGeneratedColumn()) {
+                slotRefs.addAll(ExprUtils.collectAllSlotRefs(partitionColumnDef.getGeneratedColumnExpr())
+                        .stream().map(SlotRef::getColumnName).collect(Collectors.toList()));
+            } else {
+                slotRefs.add(partitionColumnDef.getName());
+            }
+        }
+
         for (ColumnDef columnDef : columnDefs) {
-            if ((slotRefs.isEmpty() || slotRefs.contains(columnDef.getName())) && !columnDef.isKey()
+            if ((slotRefs.isEmpty() || slotRefs.contains(columnDef.getName()))
+                    && !columnDef.isKey()
                     && columnDef.getAggregateType() != AggregateType.NONE) {
                 throw new AnalysisException("The partition expr should base on key column");
+            }
+        }
+
+        if (keysType == KeysType.PRIMARY_KEYS) {
+            Set<String> keyColumnNames = columnDefs.stream()
+                    .filter(ColumnDef::isKey)
+                    .map(ColumnDef::getName)
+                    .collect(Collectors.toCollection(() -> Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER)));
+            for (String slotRef : slotRefs) {
+                if (!keyColumnNames.contains(slotRef)) {
+                    throw new AnalysisException("The partition expr should base on key column");
+                }
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionDescTest.java
@@ -222,7 +222,7 @@ public class ListPartitionDescTest {
             dt.setAggregateType(AggregateType.NONE);
             List<ColumnDef> columnDefList = Lists.newArrayList(province, dt);
             ListPartitionDesc listSinglePartitionDesc = this.findListSinglePartitionDesc("province", "p1", "p2", null);
-            PartitionDescAnalyzer.analyzeListPartitionDesc(listSinglePartitionDesc, columnDefList, null);
+            PartitionDescAnalyzer.analyzeListPartitionDesc(listSinglePartitionDesc, columnDefList, null, null);
         });
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
@@ -127,6 +127,43 @@ public class CreateTableAnalyzerTest {
         Config.max_column_number_per_table = 10000;
     }
 
+    @Test
+    public void testPrimaryKeyTablePartitionSourceColumnsMustBePrimaryKeys() {
+        String nonKeyGeneratedPartitionColumnSql = "CREATE TABLE test_create_table_db.t_pk_partition_non_key (\n" +
+                "  `id` bigint NOT NULL AUTO_INCREMENT,\n" +
+                "  `transaction_time` datetime NOT NULL,\n" +
+                "  `transaction_date` date NULL AS date(transaction_time)\n" +
+                ") ENGINE=OLAP\n" +
+                "PRIMARY KEY(`id`)\n" +
+                "PARTITION BY (`transaction_date`)\n" +
+                "DISTRIBUTED BY HASH(`id`)\n" +
+                "PROPERTIES(\"replication_num\" = \"1\")";
+        analyzeFail(nonKeyGeneratedPartitionColumnSql,
+                "The partition expr should base on key column");
+
+        String nonKeyPartitionExprSourceSql = "CREATE TABLE test_create_table_db.t_pk_partition_expr_non_key_source (\n" +
+                "  `id` bigint NOT NULL,\n" +
+                "  `transaction_time` bigint NOT NULL,\n" +
+                "  `v1` int\n" +
+                ") ENGINE=OLAP\n" +
+                "PRIMARY KEY(`id`)\n" +
+                "PARTITION BY from_unixtime(transaction_time)\n" +
+                "DISTRIBUTED BY HASH(`id`)\n" +
+                "PROPERTIES(\"replication_num\" = \"1\")";
+        analyzeFail(nonKeyPartitionExprSourceSql,
+                "The partition expr should base on key column");
+
+        String keyPartitionExprSourceSql = "CREATE TABLE test_create_table_db.t_pk_partition_on_key_expr (\n" +
+                "  `id` bigint NOT NULL,\n" +
+                "  `v1` int\n" +
+                ") ENGINE=OLAP\n" +
+                "PRIMARY KEY(`id`)\n" +
+                "PARTITION BY from_unixtime(id)\n" +
+                "DISTRIBUTED BY HASH(`id`)\n" +
+                "PROPERTIES(\"replication_num\" = \"1\")";
+        analyzeSuccess(keyPartitionExprSourceSql);
+    }
+
     private void testValidComplexDefault(String columnDef) {
         String sql = "CREATE TABLE test_create_table_db.test_complex_default (\n" +
                 "    id INT,\n" +


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
```
mysql> CREATE TABLE `t` (
    ->   `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT "",
    ->   `transaction_time` datetime NOT NULL COMMENT "",
    ->   `transaction_date` date NULL AS date(transaction_time) COMMENT ""
    -> ) ENGINE=OLAP
    -> PRIMARY KEY(`id`)
    -> COMMENT "OLAP"
    -> PARTITION BY (`transaction_date`)
    -> DISTRIBUTED BY HASH(`id`)
    -> ORDER BY(`transaction_time`)
    -> PROPERTIES (
    -> "compression" = "LZ4",
    -> "datacache.enable" = "true",
    -> "enable_async_write_back" = "false",
    -> "enable_persistent_index" = "true",
    -> "persistent_index_type" = "CLOUD_NATIVE",
    -> "replication_num" = "1"
    -> );
ERROR 1064 (HY000): Getting analyzing error. Detail message: The partition column could not be aggregated column and unique table's partition column must be key column.
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
