### PR TITLE
[Enhancement] Add resource share type support for AWS Glue GetDatabases API

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/DefaultAWSGlueMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/DefaultAWSGlueMetastore.java
@@ -81,6 +81,7 @@ import software.amazon.awssdk.services.glue.model.Partition;
 import software.amazon.awssdk.services.glue.model.PartitionError;
 import software.amazon.awssdk.services.glue.model.PartitionInput;
 import software.amazon.awssdk.services.glue.model.PartitionValueList;
+import software.amazon.awssdk.services.glue.model.ResourceShareType;
 import software.amazon.awssdk.services.glue.model.Segment;
 import software.amazon.awssdk.services.glue.model.StringColumnStatisticsData;
 import software.amazon.awssdk.services.glue.model.Table;
@@ -134,6 +135,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
     private final HiveConf conf;
     private final GlueClient glueClient;
     private final String catalogId;
+    private final ResourceShareType resourceShareType;
     private final ExecutorService executorService;
     private final int numPartitionSegments;
 
@@ -156,6 +158,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
         this.conf = conf;
         this.glueClient = glueClient;
         this.catalogId = MetastoreClientUtils.getCatalogId(conf);
+        this.resourceShareType = MetastoreClientUtils.getResourceShareType(conf);
         this.executorService = getExecutorService(conf);
     }
 
@@ -182,8 +185,10 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
         String nextToken = null;
         do {
             GetDatabasesRequest.Builder getDatabasesRequest =
-                    GetDatabasesRequest.builder().nextToken(nextToken).catalogId(
-                    catalogId);
+                    GetDatabasesRequest.builder()
+                            .nextToken(nextToken)
+                            .catalogId(catalogId)
+                            .resourceShareType(resourceShareType);
             GetDatabasesResponse result = glueClient.getDatabases(getDatabasesRequest.build());
             nextToken = result.nextToken();
             ret.addAll(result.databaseList());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/DefaultAWSGlueMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/DefaultAWSGlueMetastore.java
@@ -97,6 +97,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -135,7 +136,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
     private final HiveConf conf;
     private final GlueClient glueClient;
     private final String catalogId;
-    private final ResourceShareType resourceShareType;
+    private final Optional<ResourceShareType> resourceShareType;
     private final ExecutorService executorService;
     private final int numPartitionSegments;
 
@@ -187,8 +188,10 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
             GetDatabasesRequest.Builder getDatabasesRequest =
                     GetDatabasesRequest.builder()
                             .nextToken(nextToken)
-                            .catalogId(catalogId)
-                            .resourceShareType(resourceShareType);
+                            .catalogId(catalogId);
+            // Only set ResourceShareType when explicitly specified
+            // When not set, AWS Glue defaults to returning only local databases
+            resourceShareType.ifPresent(getDatabasesRequest::resourceShareType);
             GetDatabasesResponse result = glueClient.getDatabases(getDatabasesRequest.build());
             nextToken = result.nextToken();
             ret.addAll(result.databaseList());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtils.java
@@ -27,6 +27,9 @@ import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.services.glue.model.ResourceShareType;
 
 import java.util.Map;
 
@@ -34,6 +37,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
 
 public final class MetastoreClientUtils {
+    private static final Logger LOG = LogManager.getLogger(MetastoreClientUtils.class);
+
     private MetastoreClientUtils() {
         // static util class should not be instantiated
     }
@@ -135,5 +140,28 @@ public final class MetastoreClientUtils {
         }
         // This case defaults to using the caller's account Id as Catalog Id.
         return null;
+    }
+
+    /**
+     * Gets the ResourceShareType for AWS Glue GetDatabases API.
+     * Valid values: ALL, FOREIGN, FEDERATED
+     * Default: ALL (returns both local and shared databases)
+     *
+     * @param conf Hadoop configuration
+     * @return ResourceShareType enum value, defaults to ALL if not specified or invalid
+     * @see <a href="https://docs.aws.amazon.com/glue/latest/webapi/API_GetDatabases.html">AWS Glue GetDatabases API</a>
+     */
+    public static ResourceShareType getResourceShareType(Configuration conf) {
+        String resourceShareType = conf.get(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE);
+        if (StringUtils.isNotEmpty(resourceShareType)) {
+            try {
+                return ResourceShareType.valueOf(resourceShareType.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                LOG.warn("Invalid aws.glue.resource_share_type value: '{}'. Valid values are: ALL, FOREIGN, FEDERATED. " +
+                        "Using default value: ALL", resourceShareType);
+            }
+        }
+        // Default to ALL to include both local and shared databases
+        return ResourceShareType.ALL;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtils.java
@@ -32,6 +32,7 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.services.glue.model.ResourceShareType;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
@@ -145,23 +146,25 @@ public final class MetastoreClientUtils {
     /**
      * Gets the ResourceShareType for AWS Glue GetDatabases API.
      * Valid values: ALL, FOREIGN, FEDERATED
-     * Default: ALL (returns both local and shared databases)
+     * <p>
+     * When not specified (null or empty), AWS Glue defaults to returning only local databases.
+     * To include shared databases, explicitly set this to ALL.
      *
      * @param conf Hadoop configuration
-     * @return ResourceShareType enum value, defaults to ALL if not specified or invalid
+     * @return Optional containing ResourceShareType if specified and valid, empty Optional otherwise
      * @see <a href="https://docs.aws.amazon.com/glue/latest/webapi/API_GetDatabases.html">AWS Glue GetDatabases API</a>
      */
-    public static ResourceShareType getResourceShareType(Configuration conf) {
+    public static Optional<ResourceShareType> getResourceShareType(Configuration conf) {
         String resourceShareType = conf.get(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE);
         if (StringUtils.isNotEmpty(resourceShareType)) {
             try {
-                return ResourceShareType.valueOf(resourceShareType.toUpperCase());
+                return Optional.of(ResourceShareType.valueOf(resourceShareType.toUpperCase()));
             } catch (IllegalArgumentException e) {
                 LOG.warn("Invalid aws.glue.resource_share_type value: '{}'. Valid values are: ALL, FOREIGN, FEDERATED. " +
-                        "Using default value: ALL", resourceShareType);
+                        "AWS default behavior will be used (local databases only).", resourceShareType);
             }
         }
-        // Default to ALL to include both local and shared databases
-        return ResourceShareType.ALL;
+        // Return empty Optional when not specified - AWS Glue defaults to local databases only
+        return Optional.empty();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtilsTest.java
@@ -21,6 +21,7 @@ import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.glue.model.ResourceShareType;
 import software.amazon.awssdk.services.glue.model.StorageDescriptor;
 
 import java.util.Map;
@@ -64,5 +65,68 @@ public class MetastoreClientUtilsTest {
         } catch (Exception e) {
             Assertions.fail("Partition projection table should be valid: " + e.getMessage());
         }
+    }
+
+    @Test
+    public void testGetResourceShareTypeDefaultValue() {
+        Configuration conf = new Configuration();
+        // When not set, should default to ALL
+        Assertions.assertEquals(ResourceShareType.ALL, MetastoreClientUtils.getResourceShareType(conf));
+    }
+
+    @Test
+    public void testGetResourceShareTypeValidValues() {
+        Configuration conf = new Configuration();
+
+        // Test ALL
+        conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "ALL");
+        Assertions.assertEquals(ResourceShareType.ALL, MetastoreClientUtils.getResourceShareType(conf));
+
+        // Test FOREIGN
+        conf = new Configuration();
+        conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "FOREIGN");
+        Assertions.assertEquals(ResourceShareType.FOREIGN, MetastoreClientUtils.getResourceShareType(conf));
+
+        // Test FEDERATED
+        conf = new Configuration();
+        conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "FEDERATED");
+        Assertions.assertEquals(ResourceShareType.FEDERATED, MetastoreClientUtils.getResourceShareType(conf));
+    }
+
+    @Test
+    public void testGetResourceShareTypeCaseInsensitive() {
+        Configuration conf = new Configuration();
+
+        // Test lowercase
+        conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "all");
+        Assertions.assertEquals(ResourceShareType.ALL, MetastoreClientUtils.getResourceShareType(conf));
+
+        // Test mixed case
+        conf = new Configuration();
+        conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "Foreign");
+        Assertions.assertEquals(ResourceShareType.FOREIGN, MetastoreClientUtils.getResourceShareType(conf));
+
+        conf = new Configuration();
+        conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "federated");
+        Assertions.assertEquals(ResourceShareType.FEDERATED, MetastoreClientUtils.getResourceShareType(conf));
+    }
+
+    @Test
+    public void testGetResourceShareTypeInvalidValue() {
+        Configuration conf = new Configuration();
+
+        // Test invalid value - should return default (ALL)
+        conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "INVALID");
+        Assertions.assertEquals(ResourceShareType.ALL, MetastoreClientUtils.getResourceShareType(conf));
+
+        // Test empty string - should return default (ALL)
+        conf = new Configuration();
+        conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "");
+        Assertions.assertEquals(ResourceShareType.ALL, MetastoreClientUtils.getResourceShareType(conf));
+
+        // Test whitespace - should return default (ALL)
+        conf = new Configuration();
+        conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "   ");
+        Assertions.assertEquals(ResourceShareType.ALL, MetastoreClientUtils.getResourceShareType(conf));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/util/MetastoreClientUtilsTest.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.services.glue.model.ResourceShareType;
 import software.amazon.awssdk.services.glue.model.StorageDescriptor;
 
 import java.util.Map;
+import java.util.Optional;
 
 
 public class MetastoreClientUtilsTest {
@@ -70,8 +71,9 @@ public class MetastoreClientUtilsTest {
     @Test
     public void testGetResourceShareTypeDefaultValue() {
         Configuration conf = new Configuration();
-        // When not set, should default to ALL
-        Assertions.assertEquals(ResourceShareType.ALL, MetastoreClientUtils.getResourceShareType(conf));
+        // When not set, should return empty Optional (AWS defaults to local databases only)
+        Optional<ResourceShareType> result = MetastoreClientUtils.getResourceShareType(conf);
+        Assertions.assertFalse(result.isPresent(), "When not set, should return empty Optional");
     }
 
     @Test
@@ -80,17 +82,23 @@ public class MetastoreClientUtilsTest {
 
         // Test ALL
         conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "ALL");
-        Assertions.assertEquals(ResourceShareType.ALL, MetastoreClientUtils.getResourceShareType(conf));
+        Optional<ResourceShareType> result = MetastoreClientUtils.getResourceShareType(conf);
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(ResourceShareType.ALL, result.get());
 
         // Test FOREIGN
         conf = new Configuration();
         conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "FOREIGN");
-        Assertions.assertEquals(ResourceShareType.FOREIGN, MetastoreClientUtils.getResourceShareType(conf));
+        result = MetastoreClientUtils.getResourceShareType(conf);
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(ResourceShareType.FOREIGN, result.get());
 
         // Test FEDERATED
         conf = new Configuration();
         conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "FEDERATED");
-        Assertions.assertEquals(ResourceShareType.FEDERATED, MetastoreClientUtils.getResourceShareType(conf));
+        result = MetastoreClientUtils.getResourceShareType(conf);
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(ResourceShareType.FEDERATED, result.get());
     }
 
     @Test
@@ -99,34 +107,43 @@ public class MetastoreClientUtilsTest {
 
         // Test lowercase
         conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "all");
-        Assertions.assertEquals(ResourceShareType.ALL, MetastoreClientUtils.getResourceShareType(conf));
+        Optional<ResourceShareType> result = MetastoreClientUtils.getResourceShareType(conf);
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(ResourceShareType.ALL, result.get());
 
         // Test mixed case
         conf = new Configuration();
         conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "Foreign");
-        Assertions.assertEquals(ResourceShareType.FOREIGN, MetastoreClientUtils.getResourceShareType(conf));
+        result = MetastoreClientUtils.getResourceShareType(conf);
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(ResourceShareType.FOREIGN, result.get());
 
         conf = new Configuration();
         conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "federated");
-        Assertions.assertEquals(ResourceShareType.FEDERATED, MetastoreClientUtils.getResourceShareType(conf));
+        result = MetastoreClientUtils.getResourceShareType(conf);
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(ResourceShareType.FEDERATED, result.get());
     }
 
     @Test
     public void testGetResourceShareTypeInvalidValue() {
         Configuration conf = new Configuration();
 
-        // Test invalid value - should return default (ALL)
+        // Test invalid value - should return empty Optional (AWS defaults to local databases)
         conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "INVALID");
-        Assertions.assertEquals(ResourceShareType.ALL, MetastoreClientUtils.getResourceShareType(conf));
+        Optional<ResourceShareType> result = MetastoreClientUtils.getResourceShareType(conf);
+        Assertions.assertFalse(result.isPresent(), "Invalid value should return empty Optional");
 
-        // Test empty string - should return default (ALL)
+        // Test empty string - should return empty Optional
         conf = new Configuration();
         conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "");
-        Assertions.assertEquals(ResourceShareType.ALL, MetastoreClientUtils.getResourceShareType(conf));
+        result = MetastoreClientUtils.getResourceShareType(conf);
+        Assertions.assertFalse(result.isPresent(), "Empty string should return empty Optional");
 
-        // Test whitespace - should return default (ALL)
+        // Test whitespace - should return empty Optional
         conf = new Configuration();
         conf.set(CloudConfigurationConstants.AWS_GLUE_RESOURCE_SHARE_TYPE, "   ");
-        Assertions.assertEquals(ResourceShareType.ALL, MetastoreClientUtils.getResourceShareType(conf));
+        result = MetastoreClientUtils.getResourceShareType(conf);
+        Assertions.assertFalse(result.isPresent(), "Whitespace should return empty Optional");
     }
 }

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/credential/CloudConfigurationConstants.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/credential/CloudConfigurationConstants.java
@@ -77,6 +77,10 @@ public class CloudConfigurationConstants {
     public static final String AWS_GLUE_ENDPOINT = "aws.glue.endpoint";
     // https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-databases.html
     public static final String AWS_GLUE_CATALOG_ID = "aws.glue.catalog_id";
+    // Resource share type for GetDatabases API: ALL, FOREIGN, FEDERATED
+    // Default is ALL to include both local and shared databases
+    // https://docs.aws.amazon.com/glue/latest/webapi/API_GetDatabases.html
+    public static final String AWS_GLUE_RESOURCE_SHARE_TYPE = "aws.glue.resource_share_type";
 
     // Credential for Azure storage
     // For Azure Blob Storage


### PR DESCRIPTION
## Why I'm doing:
adds support for configuring the AWS Glue resource share type when retrieving databases
## What I'm doing:
This pull request adds support for configuring the AWS Glue resource share type when retrieving databases, allowing more flexible control over whether local, shared, or federated databases are returned. The change introduces a new configuration option, integrates it into the metastore logic, and provides comprehensive unit tests to ensure correct behavior.

Configuration and API integration:

* Added the `aws.glue.resource_share_type` configuration key to `CloudConfigurationConstants` to allow users to specify the resource share type for AWS Glue's `GetDatabases` API.
* Implemented logic in `MetastoreClientUtils.getResourceShareType` to parse the configuration value, handle invalid values gracefully, and default to `ALL` if not specified. This ensures robust and predictable behavior.
* Updated `DefaultAWSGlueMetastore` to store the resource share type and pass it to the `GetDatabasesRequest`, enabling the feature in the actual Glue API calls. 

Testing and validation:

* Added unit tests in `MetastoreClientUtilsTest` to verify default, valid, case-insensitive, and invalid values for the new resource share type configuration, ensuring correctness and resilience.

Logging and diagnostics:

* Introduced logging in `MetastoreClientUtils` to warn when an invalid resource share type is provided, improving diagnostics for misconfiguration.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
