### PR TITLE
[BugFix] Fix projection loss in MV rewrite due to shared mutable state.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -783,6 +783,8 @@ public class QueryOptimizer extends Optimizer {
             OptimizerTraceUtil.logMVRewriteRule("VIEW_BASED_MV_REWRITE", "try VIEW_BASED_MV_REWRITE");
             // Clone the tree to avoid modifying the original tree stored in QueryMaterializationContext
             OptExpression treeWithView = MvUtils.cloneExpression(queryMaterializationContext.getQueryOptPlanWithView());
+            // Derive logical property for the cloned tree to ensure it has complete metadata
+            MvUtils.deriveLogicalProperty(treeWithView);
             OptimizerTraceUtil.logOptExpression("before ViewBasedMvRuleRewrite:\n%s", tree);
             // should add a LogicalTreeAnchorOperator for rewrite
             treeWithView = OptExpression.create(new LogicalTreeAnchorOperator(), treeWithView);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -781,7 +781,8 @@ public class QueryOptimizer extends Optimizer {
         boolean isRewrittenSuccess = false;
         try (Timer ignored = Tracers.watchScope("MVViewRewrite")) {
             OptimizerTraceUtil.logMVRewriteRule("VIEW_BASED_MV_REWRITE", "try VIEW_BASED_MV_REWRITE");
-            OptExpression treeWithView = queryMaterializationContext.getQueryOptPlanWithView();
+            // Clone the tree to avoid modifying the original tree stored in QueryMaterializationContext
+            OptExpression treeWithView = MvUtils.cloneExpression(queryMaterializationContext.getQueryOptPlanWithView());
             OptimizerTraceUtil.logOptExpression("before ViewBasedMvRuleRewrite:\n%s", tree);
             // should add a LogicalTreeAnchorOperator for rewrite
             treeWithView = OptExpression.create(new LogicalTreeAnchorOperator(), treeWithView);


### PR DESCRIPTION
## Why I'm doing:
Side effect issue caused by Java object reference passing. The QueryMaterializationContext stores a reference to the original object. During the Stage1 optimization process, SeparateProjectRule directly modifies the projection field of this original object, causing Stage2 to retrieve an already-modified object, which leads to the loss of the projection field.
```
prepareMvRewrite (Preparation Phase)
  ↓
Save original object reference: setQueryOptPlanWithView(logicOperatorTree)
  ↓
ruleBasedMaterializedViewRewriteStage1 (Stage 1)
  ↓
SeparateProjectRule modifies original object(getQueryOptPlanWithView()): operator.setProjection(null)
  ↓
ruleBasedMaterializedViewRewriteStage2 (Stage 2)
  ↓
Retrieve modified object: getQueryOptPlanWithView() returns object with projection=null
  ↓
Problem occurs: projection field is null, causing column reference not found

```
```
LOGICAL

->  LogicalAggregation {type=GLOBAL ,aggregations={260: sum=sum(259: if)} ,groupKeys=[] ,projection=[if(ifnull(260: sum, 0) = 0, 0, null)] ,predicate=null}

    ->  LogicalUnionOperator{output=[121: dt, 122: attr_new_act, 123: delivery_type, 124: delivery_team], 1: dt, 41: attr_new_act, 53: delivery_type, 54: delivery_team, 61: dt, 101: attr_new_act, 113: delivery_type, 114: delivery_team}

        ->  LogicalOlapScanOperator {table=2957681, selectedPartitionId=[3643822, 3643883, 3643944, 3644005, 3644066, 3644127, 3644188, 3644249, 3644310, 3644371, 3644432, 3644493, 3644554, 3644615, 3644676, 3644737, 3644798, 3644859, 3644920, 3644981, 3645042, 3645103, 3645164, 3645225, 3645286, 3645347, 3645408, 3645469, 3645530, 3645591, 3645652, 3645713, 3645774, 3645835, 3645896, 3645957, 3646018, 3646079, 3646140, 3646201, 3646262, 3646323, 3646384, 3968036, 5516637, 17136435, 20452438, 39845030, 55605205], selectedIndexId=75456507, outputColumns=[1: dt, 53: delivery_type, 54: delivery_team, 41: attr_new_act], predicate=null, prunedPartitionPredicates=[], limit=-1}
        ->  LogicalOlapScanOperator {table=156713056, selectedPartitionId=[156713005, 156713006, 156713007, 156713008, 156713009, 156713010, 156713011, 156713012, 156713013, 156713014, 156713015, 156713016, 156713017, 156713018, 156713019, 156713020, 156713021, 156713022, 156713023, 156713024, 156713025, 156713026, 156713027, 156713028, 156713029, 156713030, 156713031, 156713032, 156713033, 156713034, 156713035, 156713036, 156713037, 156713038, 156713039, 156713040, 156713041, 156713042, 156713043, 156713044, 156713045, 156713046, 156713047, 156713048, 156713049, 156713050, 156713051, 156713052, 156713053], selectedIndexId=156713057, outputColumns=[113: delivery_type, 114: delivery_team, 101: attr_new_act, 61: dt], predicate=null, prunedPartitionPredicates=[], limit=-1}

```
```
LOGICAL

->  LogicalProjectOperator {projection=[if(ifnull(260: sum, 0) = 0, 0, null)]}

    ->  LogicalAggregation {type=GLOBAL ,aggregations={260: sum=sum(259: if)} ,groupKeys=[] ,projection=null ,predicate=null}

        ->  LogicalProjectOperator {projection=[if(123: delivery_type = install, 122: attr_new_act, 0)]}

            ->  LogicalUnionOperator{output=[121: dt, 122: attr_new_act, 123: delivery_type, 124: delivery_team], 1: dt, 41: attr_new_act, 53: delivery_type, 54: delivery_team, 61: dt, 101: attr_new_act, 113: delivery_type, 114: delivery_team}

                ->  LogicalOlapScanOperator {table=2957681, selectedPartitionId=[3643822, 3643883, 3643944, 3644005, 3644066, 3644127, 3644188, 3644249, 3644310, 3644371, 3644432, 3644493, 3644554, 3644615, 3644676, 3644737, 3644798, 3644859, 3644920, 3644981, 3645042, 3645103, 3645164, 3645225, 3645286, 3645347, 3645408, 3645469, 3645530, 3645591, 3645652, 3645713, 3645774, 3645835, 3645896, 3645957, 3646018, 3646079, 3646140, 3646201, 3646262, 3646323, 3646384, 3968036, 5516637, 17136435, 20452438, 39845030, 55605205], selectedIndexId=75456507, outputColumns=[1: dt, 53: delivery_type, 54: delivery_team, 41: attr_new_act], predicate=null, prunedPartitionPredicates=[], limit=-1}
                ->  LogicalOlapScanOperator {table=156713056, selectedPartitionId=[156713005, 156713006, 156713007, 156713008, 156713009, 156713010, 156713011, 156713012, 156713013, 156713014, 156713015, 156713016, 156713017, 156713018, 156713019, 156713020, 156713021, 156713022, 156713023, 156713024, 156713025, 156713026, 156713027, 156713028, 156713029, 156713030, 156713031, 156713032, 156713033, 156713034, 156713035, 156713036, 156713037, 156713038, 156713039, 156713040, 156713041, 156713042, 156713043, 156713044, 156713045, 156713046, 156713047, 156713048, 156713049, 156713050, 156713051, 156713052, 156713053], selectedIndexId=156713057, outputColumns=[113: delivery_type, 114: delivery_team, 101: attr_new_act, 61: dt], predicate=null, prunedPartitionPredicates=[], limit=-1}

```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
