### PR TITLE
[BugFix] Support inserting array type to hive table with CSV format (backport #67355)

### DIFF
--- a/be/src/formats/csv/csv_file_writer.h
+++ b/be/src/formats/csv/csv_file_writer.h
@@ -24,10 +24,16 @@ struct CSVWriterOptions : FileWriterOptions {
     std::string column_terminated_by = ",";
     std::string line_terminated_by = "\n";
     bool include_header = false;
+    std::string collection_delim = ",";
+    std::string mapkey_delim = ",";
+    bool is_hive = false;
 
     inline static std::string COLUMN_TERMINATED_BY = "column_terminated_by";
     inline static std::string LINE_TERMINATED_BY = "line_terminated_by";
     inline static std::string INCLUDE_HEADER = "include_header";
+    inline static std::string COLLECTION_DELIM = "collection_delim";
+    inline static std::string MAPKEY_DELIM = "mapkey_delim";
+    inline static std::string IS_HIVE = "is_hive";
 };
 
 // The primary purpose of this class is to support hive + csv. Use with caution in other cases.
@@ -61,6 +67,7 @@ private:
     std::vector<std::unique_ptr<ColumnEvaluator>> _column_evaluators;
     std::shared_ptr<CSVWriterOptions> _writer_options;
     const std::function<void()> _rollback_action;
+    std::shared_ptr<csv::Converter::Options> _converter_options;
 
     int64_t _num_rows = 0;
     bool _header_written = false;

--- a/be/src/runtime/hive_table_sink.cpp
+++ b/be/src/runtime/hive_table_sink.cpp
@@ -82,6 +82,9 @@ Status HiveTableSink::decompose_to_pipeline(pipeline::OpFactories prev_operators
         DCHECK(boost::iequals(t_hive_sink.file_format, formats::TEXTFILE));
         sink_ctx->options[formats::CSVWriterOptions::COLUMN_TERMINATED_BY] = DEFAULT_FIELD_DELIM;
         sink_ctx->options[formats::CSVWriterOptions::LINE_TERMINATED_BY] = DEFAULT_LINE_DELIM;
+        sink_ctx->options[formats::CSVWriterOptions::COLLECTION_DELIM] = DEFAULT_COLLECTION_DELIM;
+        sink_ctx->options[formats::CSVWriterOptions::MAPKEY_DELIM] = DEFAULT_MAPKEY_DELIM;
+        sink_ctx->options[formats::CSVWriterOptions::IS_HIVE] = "true";
 
         // use customized value if specified
         if (t_hive_sink.text_file_desc.__isset.field_delim) {
@@ -89,6 +92,13 @@ Status HiveTableSink::decompose_to_pipeline(pipeline::OpFactories prev_operators
         }
         if (t_hive_sink.text_file_desc.__isset.line_delim) {
             sink_ctx->options[formats::CSVWriterOptions::LINE_TERMINATED_BY] = t_hive_sink.text_file_desc.line_delim;
+        }
+        if (t_hive_sink.text_file_desc.__isset.collection_delim) {
+            sink_ctx->options[formats::CSVWriterOptions::COLLECTION_DELIM] =
+                    t_hive_sink.text_file_desc.collection_delim;
+        }
+        if (t_hive_sink.text_file_desc.__isset.mapkey_delim) {
+            sink_ctx->options[formats::CSVWriterOptions::MAPKEY_DELIM] = t_hive_sink.text_file_desc.mapkey_delim;
         }
     }
     sink_ctx->fragment_context = fragment_ctx;

--- a/test/sql/test_hive/R/test_write_csv_array
+++ b/test/sql/test_hive/R/test_write_csv_array
@@ -1,0 +1,35 @@
+-- name: test_write_csv_array
+create external catalog hive_sink_test_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+-- result:
+-- !result
+set catalog hive_sink_test_${uuid0};
+-- result:
+-- !result
+create database hive_db_${uuid0};
+-- result:
+-- !result
+use hive_db_${uuid0};
+-- result:
+-- !result
+create table t1(c1 string, c2 array<integer>) properties("file_format"="textfile");
+-- result:
+-- !result
+insert into t1(c1,c2) values('hello', [123456,0,-128,0]);
+-- result:
+-- !result
+select * from t1;
+-- result:
+hello	[123456,0,-128,0]
+-- !result
+drop table t1 force;
+-- result:
+-- !result
+drop database hive_db_${uuid0};
+-- result:
+-- !result
+drop catalog hive_sink_test_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result

--- a/test/sql/test_hive/T/test_write_csv_array
+++ b/test/sql/test_hive/T/test_write_csv_array
@@ -1,0 +1,16 @@
+-- name: test_write_csv_array
+
+create external catalog hive_sink_test_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+set catalog hive_sink_test_${uuid0};
+create database hive_db_${uuid0};
+use hive_db_${uuid0};
+
+create table t1(c1 string, c2 array<integer>) properties("file_format"="textfile");
+insert into t1(c1,c2) values('hello', [123456,0,-128,0]);
+
+select * from t1;
+drop table t1 force;
+
+drop database hive_db_${uuid0};
+drop catalog hive_sink_test_${uuid0};
+set catalog default_catalog;


### PR DESCRIPTION
## Why I'm doing:
Now StarRocks doesn't handle the case that inserting array types to hive table with cvs format.

When writing array type to hive table with cvs format, cvs writer ignores the hive options (such as collection delimiter) and write the array to a file using a format that is incompatible with Hive, which cause the result array data cannot be read correctly using hive catalog.

## What I'm doing:

Support inserting array type to hive table with CVS format and write the array data based on hive table file description.

Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/10793)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

