### PR TITLE
[Enhancement] fix cloud scan dop and data skew compared with olap scan

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -1127,19 +1127,20 @@ StatusOr<pipeline::MorselQueuePtr> LakeDataSourceProvider::convert_scan_range_to
         }
     }
 
-    return DataSourceProvider::convert_scan_range_to_morsel_queue(
-            scan_ranges, node_id, pipeline_dop, enable_tablet_internal_parallel, tablet_internal_parallel_mode,
-            num_total_scan_ranges, (size_t)lake_scan_parallelism);
+    ASSIGN_OR_RETURN(auto morsel_queue,
+                     DataSourceProvider::convert_scan_range_to_morsel_queue(
+                             scan_ranges, node_id, pipeline_dop, enable_tablet_internal_parallel,
+                             tablet_internal_parallel_mode, num_total_scan_ranges, (size_t)lake_scan_parallelism));
+    if (_could_split) {
+        morsel_queue->set_has_more_from_split(true);
+    }
+    return morsel_queue;
 }
 
 StatusOr<bool> LakeDataSourceProvider::_could_tablet_internal_parallel(
         const std::vector<TScanRangeParams>& scan_ranges, int32_t pipeline_dop, size_t num_total_scan_ranges,
         TTabletInternalParallelMode::type tablet_internal_parallel_mode, int64_t* scan_parallelism,
         int64_t* splitted_scan_rows) const {
-    //if (_t_lake_scan_node.use_pk_index) {
-    //    return false;
-    //}
-
     bool force_split = tablet_internal_parallel_mode == TTabletInternalParallelMode::type::FORCE_SPLIT;
     // The enough number of tablets shouldn't use tablet internal parallel.
     if (!force_split && num_total_scan_ranges >= pipeline_dop) {
@@ -1176,6 +1177,12 @@ StatusOr<bool> LakeDataSourceProvider::_could_tablet_internal_parallel(
 
     bool could =
             *scan_parallelism >= pipeline_dop || *scan_parallelism >= config::tablet_internal_parallel_min_scan_dop;
+    // if don't use tablet internal parallel scan, we choose the number of tablets as the dop of scan node
+    // which is the same as olap scan
+    if (!could) {
+        *scan_parallelism = scan_ranges.size();
+    }
+
     return could;
 }
 

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -223,8 +223,7 @@ public:
     Status init(ObjectPool* pool, RuntimeState* state) override;
     const TupleDescriptor* tuple_descriptor(RuntimeState* state) const override;
 
-    // always enable shared scan for cloud native table
-    bool always_shared_scan() const override { return true; }
+    bool always_shared_scan() const override { return false; }
 
     StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
             const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -576,7 +576,7 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
                                  scan_ranges, scan_ranges_per_driver_seq, scan_node->id(), group_execution_scan_dop,
                                  _is_in_colocate_exec_group(scan_node->id()), enable_tablet_internal_parallel,
                                  tablet_internal_parallel_mode, enable_shared_scan));
-        morsel_queue_factory->set_has_more(has_more_morsel);
+        morsel_queue_factory->set_has_more_scan_ranges(has_more_morsel);
         scan_node->enable_shared_scan(enable_shared_scan && morsel_queue_factory->is_shared());
         morsel_queue_factories.emplace(scan_node->id(), std::move(morsel_queue_factory));
     }
@@ -1066,7 +1066,7 @@ Status FragmentExecutor::append_incremental_scan_ranges(ExecEnv* exec_env, const
         bool has_more_morsel = false;
         pipeline::ScanMorsel::build_scan_morsels(node_id, scan_ranges, true, &morsels, &has_more_morsel);
         RETURN_IF_ERROR(morsel_queue_factory->append_morsels(0, std::move(morsels)));
-        morsel_queue_factory->set_has_more(has_more_morsel);
+        morsel_queue_factory->set_has_more_scan_ranges(has_more_morsel);
         notify_ids.insert(node_id);
 
         if (morsel_queue_factory->reach_limit()) {
@@ -1098,7 +1098,7 @@ Status FragmentExecutor::append_incremental_scan_ranges(ExecEnv* exec_env, const
                 pipeline::ScanMorsel::build_scan_morsels(node_id, scan_ranges, true, &morsels, &local_has_more);
                 RETURN_IF_ERROR(morsel_queue_factory->append_morsels(driver_seq, std::move(morsels)));
             }
-            morsel_queue_factory->set_has_more(has_more_morsel);
+            morsel_queue_factory->set_has_more_scan_ranges(has_more_morsel);
             notify_ids.insert(node_id);
 
             if (morsel_queue_factory->reach_limit()) {

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -204,6 +204,10 @@ void ConnectorScanOperatorFactory::detach_shared_input(int32_t operator_seq, int
     }
 }
 
+void ConnectorScanOperatorFactory::mark_split_source_morsel_finished() {
+    morsel_queue_factory()->mark_split_source_morsel_finished();
+}
+
 // ===============================================================
 struct ConnectorScanOperatorAdaptiveProcessor {
     // ----------------------
@@ -580,8 +584,27 @@ Status ConnectorScanOperator::append_morsels(std::vector<MorselPtr>&& morsels) {
             }
         }
     }
+
+    auto* morsel_queue_factory = _source_factory()->morsel_queue_factory();
+    if (morsel_queue_factory != nullptr && morsel_queue_factory->size() > 1 &&
+        morsel_queue_factory->enable_random_append_split_morsel()) {
+        auto notify = defer_notify([&]() { return true; });
+        for (auto& morsel : morsels) {
+            Morsels one;
+            one.emplace_back(std::move(morsel));
+            ASSIGN_OR_RETURN(int driver_seq, morsel_queue_factory->next_driver_seq());
+            RETURN_IF_ERROR(morsel_queue_factory->append_morsels(driver_seq, std::move(one)));
+        }
+        return Status::OK();
+    }
+
     RETURN_IF_ERROR(_morsel_queue->append_morsels(std::move(morsels)));
     return Status::OK();
+}
+
+void ConnectorScanOperator::mark_split_source_morsel_finished() {
+    auto* factory = down_cast<ConnectorScanOperatorFactory*>(_factory);
+    factory->mark_split_source_morsel_finished();
 }
 
 int64_t ConnectorScanOperator::get_scan_table_id() const {
@@ -620,6 +643,11 @@ ConnectorChunkSource::ConnectorChunkSource(ScanOperator* op, RuntimeProfile* run
     auto* scan_morsel = (ScanMorsel*)_morsel.get();
     TScanRange* scan_range = scan_morsel->get_scan_range();
     ScanSplitContext* split_context = scan_morsel->get_split_context();
+    // A split source morsel means this morsel can potentially produce split tasks.
+    // `split_context == nullptr` identifies root morsels, and `has_more_from_split()`
+    // indicates split mode is enabled for this scan node.
+    _is_split_source_morsel =
+            (split_context == nullptr) && (op->morsel_queue() != nullptr) && op->morsel_queue()->has_more_from_split();
 
     _data_source = scan_node->data_source_provider()->create_data_source(*scan_range);
     _data_source->set_driver_sequence(op->get_driver_sequence());
@@ -653,6 +681,16 @@ const std::string ConnectorChunkSource::get_custom_coredump_msg() const {
 ConnectorScanOperatorIOTasksMemLimiter* ConnectorChunkSource::_get_io_tasks_mem_limiter() const {
     auto* f = down_cast<ConnectorScanOperatorFactory*>(_scan_op->get_factory());
     return f->_io_tasks_mem_limiter;
+}
+
+void ConnectorChunkSource::_report_split_source_morsel_finished_once() {
+    if (!_is_split_source_morsel || _split_source_morsel_reported) {
+        return;
+    }
+
+    auto* scan_op = down_cast<ConnectorScanOperator*>(_scan_op);
+    scan_op->mark_split_source_morsel_finished();
+    _split_source_morsel_reported = true;
 }
 
 void ConnectorChunkSource::close(RuntimeState* state) {
@@ -845,13 +883,13 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
     {
         std::vector<ScanSplitContextPtr> split_tasks;
         _data_source->get_split_tasks(&split_tasks);
+        auto* current_morsel = down_cast<ScanMorsel*>(_morsel.get());
         if (split_tasks.size() != 0) {
             VLOG_OPERATOR << "get_split_tasks. query_id = " << print_id(state->query_id())
                           << ", op_id = " << _scan_op->get_plan_node_id() << "/" << _scan_op->get_driver_sequence()
                           << ", split_tasks = " << split_tasks.size();
 
             std::vector<MorselPtr> split_morsels;
-            ScanMorsel* current_morsel = down_cast<ScanMorsel*>(_morsel.get());
 
             if (current_morsel->is_last_split()) {
                 split_tasks.back()->set_last_split(true);
@@ -866,6 +904,8 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
 
             RETURN_IF_ERROR(scan_op->append_morsels(std::move(split_morsels)));
         }
+
+        _report_split_source_morsel_finished_once();
     }
     return Status::EndOfFile("");
 }

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -204,8 +204,8 @@ void ConnectorScanOperatorFactory::detach_shared_input(int32_t operator_seq, int
     }
 }
 
-void ConnectorScanOperatorFactory::mark_split_source_morsel_finished() {
-    morsel_queue_factory()->mark_split_source_morsel_finished();
+Status ConnectorScanOperatorFactory::mark_split_source_morsel_finished() {
+    return morsel_queue_factory()->mark_split_source_morsel_finished();
 }
 
 // ===============================================================
@@ -602,9 +602,9 @@ Status ConnectorScanOperator::append_morsels(std::vector<MorselPtr>&& morsels) {
     return Status::OK();
 }
 
-void ConnectorScanOperator::mark_split_source_morsel_finished() {
+Status ConnectorScanOperator::mark_split_source_morsel_finished() {
     auto* factory = down_cast<ConnectorScanOperatorFactory*>(_factory);
-    factory->mark_split_source_morsel_finished();
+    return factory->mark_split_source_morsel_finished();
 }
 
 int64_t ConnectorScanOperator::get_scan_table_id() const {
@@ -683,18 +683,26 @@ ConnectorScanOperatorIOTasksMemLimiter* ConnectorChunkSource::_get_io_tasks_mem_
     return f->_io_tasks_mem_limiter;
 }
 
-void ConnectorChunkSource::_report_split_source_morsel_finished_once() {
+Status ConnectorChunkSource::_report_split_source_morsel_finished_once() {
     if (!_is_split_source_morsel || _split_source_morsel_reported) {
-        return;
+        return Status::OK();
     }
 
     auto* scan_op = down_cast<ConnectorScanOperator*>(_scan_op);
-    scan_op->mark_split_source_morsel_finished();
+    RETURN_IF_ERROR(scan_op->mark_split_source_morsel_finished());
     _split_source_morsel_reported = true;
+    return Status::OK();
 }
 
 void ConnectorChunkSource::close(RuntimeState* state) {
     if (_closed) return;
+
+    // Ensure split-source completion is reported even when this chunk source
+    // exits through non-EOF paths (cancel/close/error/limit reach).
+    Status report_status = _report_split_source_morsel_finished_once();
+    LOG_IF(WARNING, !report_status.ok()) << "mark split source morsel finished failed, fragment_instance_id="
+                                         << print_id(state->fragment_instance_id())
+                                         << ", error=" << report_status.to_string();
 
     if (_enable_adaptive_io_tasks) {
         MemTracker* mem_tracker = state->query_ctx()->connector_scan_mem_tracker();
@@ -812,75 +820,78 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
     ConnectorScanOperatorAdaptiveProcessor& P = *(scan_op->adaptive_processor());
 
     DeferOp defer_op([&]() { P.last_chunk_souce_finish_timestamp = GetCurrentTimeMicros(); });
+    auto is_terminal_status = [](const Status& st) {
+        return st.is_end_of_file() || st.is_cancelled() || (!st.ok() && !st.is_time_out() && !st.is_eagain());
+    };
 
-    int64_t total_time_ns = 0;
-    int64_t delta_io_time_ns = 0;
-    int64_t delta_scan_bytes = 0;
-    {
-        SCOPED_RAW_TIMER(&total_time_ns);
-        int64_t prev_io_time_ns = get_io_time_spent();
-        int64_t prev_scan_bytes = get_scan_bytes();
+    Status ret = [&]() -> Status {
+        int64_t total_time_ns = 0;
+        int64_t delta_io_time_ns = 0;
+        int64_t delta_scan_bytes = 0;
+        {
+            SCOPED_RAW_TIMER(&total_time_ns);
+            int64_t prev_io_time_ns = get_io_time_spent();
+            int64_t prev_scan_bytes = get_scan_bytes();
 
-        bool mem_alloc_failed = false;
-        RETURN_IF_ERROR(_open_data_source(state, &mem_alloc_failed));
-        if (mem_alloc_failed) {
-            _mem_alloc_failed_count += 1;
-            return Status::EAgain("");
-        }
-        if (state->is_cancelled()) {
-            return Status::Cancelled("canceled state");
-        }
-
-        // Improve for select * from table limit x, x is small
-        if (_reach_eof()) {
-            _reach_limit.store(true);
-            return Status::EndOfFile("limit reach");
-        }
-
-        while (_status.ok()) {
-            ChunkPtr tmp;
-            _status = _data_source->get_next(state, &tmp);
-            if (_status.ok()) {
-                if (tmp->num_rows() == 0) continue;
-                _ck_acc.push(tmp);
-                if (_ck_acc.has_output()) break;
-            } else if (!_status.is_end_of_file()) {
-                if (_status.is_time_out()) {
-                    Status t = _status;
-                    _status = Status::OK();
-                    return t;
-                } else {
-                    return _status;
-                }
-            } else {
-                _ck_acc.finalize();
-                DCHECK(_status.is_end_of_file());
+            bool mem_alloc_failed = false;
+            RETURN_IF_ERROR(_open_data_source(state, &mem_alloc_failed));
+            if (mem_alloc_failed) {
+                _mem_alloc_failed_count += 1;
+                return Status::EAgain("");
             }
+            if (state->is_cancelled()) {
+                return Status::Cancelled("canceled state");
+            }
+
+            // Improve for select * from table limit x, x is small
+            if (_reach_eof()) {
+                _reach_limit.store(true);
+                return Status::EndOfFile("limit reach");
+            }
+
+            while (_status.ok()) {
+                ChunkPtr tmp;
+                _status = _data_source->get_next(state, &tmp);
+                if (_status.ok()) {
+                    if (tmp->num_rows() == 0) continue;
+                    _ck_acc.push(tmp);
+                    if (_ck_acc.has_output()) break;
+                } else if (!_status.is_end_of_file()) {
+                    if (_status.is_time_out()) {
+                        Status t = _status;
+                        _status = Status::OK();
+                        return t;
+                    } else {
+                        return _status;
+                    }
+                } else {
+                    _ck_acc.finalize();
+                    DCHECK(_status.is_end_of_file());
+                }
+            }
+
+            DCHECK(_status.ok() || _status.is_end_of_file());
+            _scan_rows_num = _data_source->raw_rows_read();
+            _scan_bytes = _data_source->num_bytes_read();
+            _cpu_time_spent_ns = _data_source->cpu_time_spent();
+            _io_time_spent_ns = _data_source->io_time_spent();
+            delta_io_time_ns = _io_time_spent_ns - prev_io_time_ns;
+            delta_scan_bytes = _scan_bytes - prev_scan_bytes;
         }
 
-        DCHECK(_status.ok() || _status.is_end_of_file());
-        _scan_rows_num = _data_source->raw_rows_read();
-        _scan_bytes = _data_source->num_bytes_read();
-        _cpu_time_spent_ns = _data_source->cpu_time_spent();
-        _io_time_spent_ns = _data_source->io_time_spent();
-        delta_io_time_ns = _io_time_spent_ns - prev_io_time_ns;
-        delta_scan_bytes = _scan_bytes - prev_scan_bytes;
-    }
+        if (_ck_acc.has_output()) {
+            *chunk = std::move(_ck_acc.pull());
+            P.cs_total_running_time += total_time_ns;
+            P.cs_total_io_time += delta_io_time_ns;
+            P.cs_total_scan_bytes += delta_scan_bytes;
+            _chunk_rows_read += (*chunk)->num_rows();
+            _chunk_mem_bytes += (*chunk)->memory_usage();
+            _chunk_buffer.update_limiter(chunk->get());
+            return Status::OK();
+        }
+        _ck_acc.reset();
 
-    if (_ck_acc.has_output()) {
-        *chunk = std::move(_ck_acc.pull());
-        P.cs_total_running_time += total_time_ns;
-        P.cs_total_io_time += delta_io_time_ns;
-        P.cs_total_scan_bytes += delta_scan_bytes;
-        _chunk_rows_read += (*chunk)->num_rows();
-        _chunk_mem_bytes += (*chunk)->memory_usage();
-        _chunk_buffer.update_limiter(chunk->get());
-        return Status::OK();
-    }
-    _ck_acc.reset();
-
-    // before returning eof, we can check if this chunk source generates splits.
-    {
+        // before returning eof, we can check if this chunk source generates splits.
         std::vector<ScanSplitContextPtr> split_tasks;
         _data_source->get_split_tasks(&split_tasks);
         auto* current_morsel = down_cast<ScanMorsel*>(_morsel.get());
@@ -904,10 +915,13 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
 
             RETURN_IF_ERROR(scan_op->append_morsels(std::move(split_morsels)));
         }
+        return Status::EndOfFile("");
+    }();
 
-        _report_split_source_morsel_finished_once();
+    if (is_terminal_status(ret)) {
+        RETURN_IF_ERROR(_report_split_source_morsel_finished_once());
     }
-    return Status::EndOfFile("");
+    return ret;
 }
 
 uint64_t ConnectorChunkSource::avg_row_mem_bytes() const {

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -72,6 +72,7 @@ public:
     void set_scan_mem_limit(int64_t scan_mem_limit);
     void set_mem_share_arb(ConnectorScanOperatorMemShareArbitrator* arb);
     void set_data_source_mem_bytes(int64_t value);
+    void mark_split_source_morsel_finished();
 
     void attach_shared_input(int32_t operator_seq, int32_t source_index);
     void detach_shared_input(int32_t operator_seq, int32_t source_index);
@@ -120,6 +121,7 @@ public:
     bool is_running_all_io_tasks() const override;
 
     Status append_morsels(std::vector<MorselPtr>&& morsels);
+    void mark_split_source_morsel_finished();
     ConnectorScanOperatorAdaptiveProcessor* adaptive_processor() const { return _adaptive_processor; }
     bool enable_adaptive_io_tasks() const { return _enable_adaptive_io_tasks; }
 
@@ -162,6 +164,7 @@ protected:
 
 private:
     Status _read_chunk(RuntimeState* state, ChunkPtr* chunk) override;
+    void _report_split_source_morsel_finished_once();
 
     ConnectorScanOperatorIOTasksMemLimiter* _get_io_tasks_mem_limiter() const;
 
@@ -177,6 +180,8 @@ private:
     ChunkPipelineAccumulator _ck_acc;
     bool _opened = false;
     bool _closed = false;
+    bool _is_split_source_morsel = false;
+    bool _split_source_morsel_reported = false;
     uint64_t _chunk_rows_read = 0;
     uint64_t _chunk_mem_bytes = 0;
     int64_t _request_mem_tracker_bytes = 0;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -72,7 +72,7 @@ public:
     void set_scan_mem_limit(int64_t scan_mem_limit);
     void set_mem_share_arb(ConnectorScanOperatorMemShareArbitrator* arb);
     void set_data_source_mem_bytes(int64_t value);
-    void mark_split_source_morsel_finished();
+    Status mark_split_source_morsel_finished();
 
     void attach_shared_input(int32_t operator_seq, int32_t source_index);
     void detach_shared_input(int32_t operator_seq, int32_t source_index);
@@ -121,7 +121,7 @@ public:
     bool is_running_all_io_tasks() const override;
 
     Status append_morsels(std::vector<MorselPtr>&& morsels);
-    void mark_split_source_morsel_finished();
+    Status mark_split_source_morsel_finished();
     ConnectorScanOperatorAdaptiveProcessor* adaptive_processor() const { return _adaptive_processor; }
     bool enable_adaptive_io_tasks() const { return _enable_adaptive_io_tasks; }
 
@@ -164,7 +164,7 @@ protected:
 
 private:
     Status _read_chunk(RuntimeState* state, ChunkPtr* chunk) override;
-    void _report_split_source_morsel_finished_once();
+    Status _report_split_source_morsel_finished_once();
 
     ConnectorScanOperatorIOTasksMemLimiter* _get_io_tasks_mem_limiter() const;
 

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -77,6 +77,10 @@ void LogicalSplitScanMorsel::init_tablet_reader_params(TabletReaderParams* param
 }
 
 /// MorselQueueFactory.
+
+SharedMorselQueueFactory::SharedMorselQueueFactory(MorselQueuePtr queue, int size)
+        : _queue(std::move(queue)), _size(size), _num_original_morsels(_queue->num_original_morsels()) {}
+
 size_t SharedMorselQueueFactory::num_original_morsels() const {
     return _queue->num_original_morsels();
 }
@@ -86,8 +90,21 @@ Status SharedMorselQueueFactory::append_morsels([[maybe_unused]] int driver_seq,
     return Status::OK();
 }
 
-void SharedMorselQueueFactory::set_has_more(bool v) {
-    _queue->set_has_more(v);
+void SharedMorselQueueFactory::set_has_more_scan_ranges(bool v) {
+    _queue->set_has_more_scan_ranges(v);
+}
+
+void SharedMorselQueueFactory::mark_split_source_morsel_finished() {
+    int64_t remain = _num_original_morsels.load(std::memory_order_relaxed);
+    while (remain > 0) {
+        if (_num_original_morsels.compare_exchange_weak(remain, remain - 1, std::memory_order_relaxed,
+                                                        std::memory_order_relaxed)) {
+            if (remain == 1) {
+                _queue->set_has_more_from_split(false);
+            }
+            return;
+        }
+    }
 }
 
 bool SharedMorselQueueFactory::reach_limit() const {
@@ -106,9 +123,15 @@ Status MorselQueueFactory::append_morsels(int driver_seq, Morsels&& morsels) {
     return Status::NotSupported("MorselQueueFactory::append_morsels not supported");
 }
 
+StatusOr<int> MorselQueueFactory::next_driver_seq() {
+    return Status::NotSupported("MorselQueueFactory::next_driver_seq not supported");
+}
+
 IndividualMorselQueueFactory::IndividualMorselQueueFactory(std::map<int, MorselQueuePtr>&& queue_per_driver_seq,
-                                                           bool could_local_shuffle)
-        : _could_local_shuffle(could_local_shuffle) {
+                                                           bool could_local_shuffle,
+                                                           bool enable_random_append_split_morsel)
+        : _could_local_shuffle(could_local_shuffle),
+          _enable_random_append_split_morsel(enable_random_append_split_morsel) {
     if (queue_per_driver_seq.empty()) {
         _queue_per_driver_seq.emplace_back(pipeline::create_empty_morsel_queue());
         return;
@@ -123,6 +146,11 @@ IndividualMorselQueueFactory::IndividualMorselQueueFactory(std::map<int, MorselQ
         } else {
             _queue_per_driver_seq.emplace_back(std::move(it->second));
         }
+    }
+
+    if (_enable_random_append_split_morsel) {
+        int64_t total = static_cast<int64_t>(num_original_morsels());
+        _remaining_split_source_morsels.store(total, std::memory_order_relaxed);
     }
 }
 
@@ -140,13 +168,57 @@ static void ensure_size_of_queue_per_drive_seq(std::vector<MorselQueuePtr>& _que
 
 Status IndividualMorselQueueFactory::append_morsels(int driver_seq, Morsels&& morsels) {
     ensure_size_of_queue_per_drive_seq(_queue_per_driver_seq, driver_seq);
+
+    if (_enable_random_append_split_morsel) {
+        int64_t added_root_morsels = 0;
+        for (const auto& morsel : morsels) {
+            auto* scan_morsel = down_cast<ScanMorsel*>(morsel.get());
+            if (scan_morsel != nullptr && scan_morsel->get_split_context() == nullptr) {
+                added_root_morsels += 1;
+            }
+        }
+        if (added_root_morsels > 0) {
+            int64_t remain = _remaining_split_source_morsels.fetch_add(added_root_morsels, std::memory_order_relaxed);
+            if (remain == 0) {
+                for (auto& q : _queue_per_driver_seq) {
+                    q->set_has_more_from_split(true);
+                }
+            }
+        }
+    }
+
     RETURN_IF_ERROR(_queue_per_driver_seq[driver_seq]->append_morsels(std::move(morsels)));
     return Status::OK();
 }
 
-void IndividualMorselQueueFactory::set_has_more(bool v) {
+StatusOr<int> IndividualMorselQueueFactory::next_driver_seq() {
+    int size = _queue_per_driver_seq.size();
+    if (size == 0) {
+        return Status::NotSupported("IndividualMorselQueueFactory::next_driver_seq empty");
+    }
+    int seq = _random_cursor.fetch_add(1, std::memory_order_relaxed);
+    return seq % size;
+}
+
+void IndividualMorselQueueFactory::set_has_more_scan_ranges(bool v) {
     for (auto& q : _queue_per_driver_seq) {
-        q->set_has_more(v);
+        q->set_has_more_scan_ranges(v);
+    }
+}
+
+void IndividualMorselQueueFactory::mark_split_source_morsel_finished() {
+    DCHECK(_enable_random_append_split_morsel);
+    int64_t remain = _remaining_split_source_morsels.load(std::memory_order_relaxed);
+    while (remain > 0) {
+        if (_remaining_split_source_morsels.compare_exchange_weak(remain, remain - 1, std::memory_order_relaxed,
+                                                                  std::memory_order_relaxed)) {
+            if (remain == 1) {
+                for (auto& q : _queue_per_driver_seq) {
+                    q->set_has_more_from_split(false);
+                }
+            }
+            return;
+        }
     }
 }
 
@@ -185,9 +257,9 @@ Status BucketSequenceMorselQueueFactory::append_morsels(int driver_seq, Morsels&
     return Status::OK();
 }
 
-void BucketSequenceMorselQueueFactory::set_has_more(bool v) {
+void BucketSequenceMorselQueueFactory::set_has_more_scan_ranges(bool v) {
     for (auto& q : _queue_per_driver_seq) {
-        q->set_has_more(v);
+        q->set_has_more_scan_ranges(v);
     }
 }
 

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -79,7 +79,7 @@ void LogicalSplitScanMorsel::init_tablet_reader_params(TabletReaderParams* param
 /// MorselQueueFactory.
 
 SharedMorselQueueFactory::SharedMorselQueueFactory(MorselQueuePtr queue, int size)
-        : _queue(std::move(queue)), _size(size), _num_original_morsels(_queue->num_original_morsels()) {}
+        : _queue(std::move(queue)), _size(size) {}
 
 size_t SharedMorselQueueFactory::num_original_morsels() const {
     return _queue->num_original_morsels();
@@ -92,19 +92,6 @@ Status SharedMorselQueueFactory::append_morsels([[maybe_unused]] int driver_seq,
 
 void SharedMorselQueueFactory::set_has_more_scan_ranges(bool v) {
     _queue->set_has_more_scan_ranges(v);
-}
-
-void SharedMorselQueueFactory::mark_split_source_morsel_finished() {
-    int64_t remain = _num_original_morsels.load(std::memory_order_relaxed);
-    while (remain > 0) {
-        if (_num_original_morsels.compare_exchange_weak(remain, remain - 1, std::memory_order_relaxed,
-                                                        std::memory_order_relaxed)) {
-            if (remain == 1) {
-                _queue->set_has_more_from_split(false);
-            }
-            return;
-        }
-    }
 }
 
 bool SharedMorselQueueFactory::reach_limit() const {
@@ -125,6 +112,10 @@ Status MorselQueueFactory::append_morsels(int driver_seq, Morsels&& morsels) {
 
 StatusOr<int> MorselQueueFactory::next_driver_seq() {
     return Status::NotSupported("MorselQueueFactory::next_driver_seq not supported");
+}
+
+Status MorselQueueFactory::mark_split_source_morsel_finished() {
+    return Status::NotSupported("MorselQueueFactory::mark_split_source_morsel_finished not supported");
 }
 
 IndividualMorselQueueFactory::IndividualMorselQueueFactory(std::map<int, MorselQueuePtr>&& queue_per_driver_seq,
@@ -169,23 +160,16 @@ static void ensure_size_of_queue_per_drive_seq(std::vector<MorselQueuePtr>& _que
 Status IndividualMorselQueueFactory::append_morsels(int driver_seq, Morsels&& morsels) {
     ensure_size_of_queue_per_drive_seq(_queue_per_driver_seq, driver_seq);
 
+#ifndef NDEBUG
+    // only append splitted morsel
     if (_enable_random_append_split_morsel) {
-        int64_t added_root_morsels = 0;
         for (const auto& morsel : morsels) {
             auto* scan_morsel = down_cast<ScanMorsel*>(morsel.get());
-            if (scan_morsel != nullptr && scan_morsel->get_split_context() == nullptr) {
-                added_root_morsels += 1;
-            }
-        }
-        if (added_root_morsels > 0) {
-            int64_t remain = _remaining_split_source_morsels.fetch_add(added_root_morsels, std::memory_order_relaxed);
-            if (remain == 0) {
-                for (auto& q : _queue_per_driver_seq) {
-                    q->set_has_more_from_split(true);
-                }
-            }
+            DCHECK(scan_morsel != nullptr);
+            DCHECK(scan_morsel->get_split_context() != nullptr);
         }
     }
+#endif
 
     RETURN_IF_ERROR(_queue_per_driver_seq[driver_seq]->append_morsels(std::move(morsels)));
     return Status::OK();
@@ -206,7 +190,7 @@ void IndividualMorselQueueFactory::set_has_more_scan_ranges(bool v) {
     }
 }
 
-void IndividualMorselQueueFactory::mark_split_source_morsel_finished() {
+Status IndividualMorselQueueFactory::mark_split_source_morsel_finished() {
     DCHECK(_enable_random_append_split_morsel);
     int64_t remain = _remaining_split_source_morsels.load(std::memory_order_relaxed);
     while (remain > 0) {
@@ -217,9 +201,10 @@ void IndividualMorselQueueFactory::mark_split_source_morsel_finished() {
                     q->set_has_more_from_split(false);
                 }
             }
-            return;
+            return Status::OK();
         }
     }
+    return Status::OK();
 }
 
 bool IndividualMorselQueueFactory::reach_limit() const {

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <mutex>
 #include <optional>
 
@@ -251,13 +252,16 @@ public:
     virtual bool could_local_shuffle() const = 0;
 
     virtual Status append_morsels(int driver_seq, Morsels&& morsels);
-    virtual void set_has_more(bool v) {}
+    virtual StatusOr<int> next_driver_seq();
+    virtual bool enable_random_append_split_morsel() const { return false; }
+    virtual void set_has_more_scan_ranges(bool v) {}
+    virtual void mark_split_source_morsel_finished() {}
     virtual bool reach_limit() const { return false; }
 };
 
 class SharedMorselQueueFactory final : public MorselQueueFactory {
 public:
-    SharedMorselQueueFactory(MorselQueuePtr queue, int size) : _queue(std::move(queue)), _size(size) {}
+    SharedMorselQueueFactory(MorselQueuePtr queue, int size);
     ~SharedMorselQueueFactory() override = default;
 
     MorselQueue* create(int driver_sequence) override { return _queue.get(); }
@@ -268,17 +272,20 @@ public:
     bool could_local_shuffle() const override { return true; }
 
     Status append_morsels(int driver_seq, Morsels&& morsels) override;
-    void set_has_more(bool v) override;
+    void set_has_more_scan_ranges(bool v) override;
+    void mark_split_source_morsel_finished() override;
     bool reach_limit() const override;
 
 private:
     MorselQueuePtr _queue;
     const int _size;
+    std::atomic<int64_t> _num_original_morsels{0};
 };
 
 class IndividualMorselQueueFactory final : public MorselQueueFactory {
 public:
-    IndividualMorselQueueFactory(std::map<int, MorselQueuePtr>&& queue_per_driver_seq, bool could_local_shuffle);
+    IndividualMorselQueueFactory(std::map<int, MorselQueuePtr>&& queue_per_driver_seq, bool could_local_shuffle,
+                                 bool enable_random_append_split_morsel);
     ~IndividualMorselQueueFactory() override = default;
 
     MorselQueue* create(int driver_sequence) override {
@@ -294,12 +301,21 @@ public:
     bool could_local_shuffle() const override { return _could_local_shuffle; }
 
     Status append_morsels(int driver_seq, Morsels&& morsels) override;
-    void set_has_more(bool v) override;
+    StatusOr<int> next_driver_seq() override;
+    bool enable_random_append_split_morsel() const override {
+        DCHECK(_could_local_shuffle);
+        return _enable_random_append_split_morsel;
+    }
+    void set_has_more_scan_ranges(bool v) override;
+    void mark_split_source_morsel_finished() override;
     bool reach_limit() const override;
 
 private:
     std::vector<MorselQueuePtr> _queue_per_driver_seq;
+    std::atomic<int> _random_cursor{0};
+    std::atomic<int64_t> _remaining_split_source_morsels{0};
     const bool _could_local_shuffle;
+    const bool _enable_random_append_split_morsel;
 };
 
 class BucketSequenceMorselQueueFactory final : public MorselQueueFactory {
@@ -321,7 +337,7 @@ public:
     bool could_local_shuffle() const override { return _could_local_shuffle; }
 
     Status append_morsels(int driver_seq, Morsels&& morsels) override;
-    void set_has_more(bool v) override;
+    void set_has_more_scan_ranges(bool v) override;
 
 private:
     std::vector<MorselQueuePtr> _queue_per_driver_seq;
@@ -373,14 +389,18 @@ public:
         _tablet_schema = tablet_schema;
     }
     // is there any more scan ranges delivered from FE to be processed?
-    bool has_more() const { return _has_more; }
-    void set_has_more(bool v) { _has_more = v; }
+    bool has_more() const { return _has_more_scan_ranges || _has_more_from_split; }
+    bool has_more_scan_ranges() const { return _has_more_scan_ranges; }
+    bool has_more_from_split() const { return _has_more_from_split; }
+    void set_has_more_scan_ranges(bool v) { _has_more_scan_ranges = v; }
+    void set_has_more_from_split(bool v) { _has_more_from_split = v; }
     // do scan operator emit enough rows that we can stop processing scan ranges?
     void set_reach_limit(bool v) { _reach_limit = v; }
     bool reach_limit() const { return _reach_limit; }
 
 protected:
-    std::atomic<bool> _has_more = false;
+    std::atomic<bool> _has_more_scan_ranges = false;
+    std::atomic<bool> _has_more_from_split = false;
     std::atomic<bool> _reach_limit = false;
     Morsels _morsels;
     size_t _num_morsels = 0;
@@ -611,7 +631,7 @@ public:
         (void)append_morsels(std::move(morsels));
         _size = _num_morsels = _queue.size();
         _degree_of_parallelism = _num_morsels;
-        _has_more = has_more;
+        _has_more_scan_ranges = has_more;
     }
 
     ~DynamicMorselQueue() override = default;

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -255,7 +255,7 @@ public:
     virtual StatusOr<int> next_driver_seq();
     virtual bool enable_random_append_split_morsel() const { return false; }
     virtual void set_has_more_scan_ranges(bool v) {}
-    virtual void mark_split_source_morsel_finished() {}
+    virtual Status mark_split_source_morsel_finished();
     virtual bool reach_limit() const { return false; }
 };
 
@@ -273,13 +273,11 @@ public:
 
     Status append_morsels(int driver_seq, Morsels&& morsels) override;
     void set_has_more_scan_ranges(bool v) override;
-    void mark_split_source_morsel_finished() override;
     bool reach_limit() const override;
 
 private:
     MorselQueuePtr _queue;
     const int _size;
-    std::atomic<int64_t> _num_original_morsels{0};
 };
 
 class IndividualMorselQueueFactory final : public MorselQueueFactory {
@@ -307,7 +305,7 @@ public:
         return _enable_random_append_split_morsel;
     }
     void set_has_more_scan_ranges(bool v) override;
-    void mark_split_source_morsel_finished() override;
+    Status mark_split_source_morsel_finished() override;
     bool reach_limit() const override;
 
 private:

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -122,6 +122,8 @@ static StatusOr<std::map<int, pipeline::MorselQueuePtr>> uniform_distribute_mors
     }
 
     auto morsel_queue_type = morsel_queue->type();
+    bool has_more_scan_ranges = morsel_queue->has_more_scan_ranges();
+    bool has_more_from_split = morsel_queue->has_more_from_split();
     DCHECK(morsel_queue_type == pipeline::MorselQueue::Type::FIXED ||
            morsel_queue_type == pipeline::MorselQueue::Type::DYNAMIC);
 
@@ -132,7 +134,18 @@ static StatusOr<std::map<int, pipeline::MorselQueuePtr>> uniform_distribute_mors
     } else {
         for (auto& [operator_seq, morsels] : morsels_per_driver) {
             queue_per_driver.emplace(operator_seq, std::make_unique<pipeline::DynamicMorselQueue>(
-                                                           std::move(morsels), morsel_queue->has_more()));
+                                                           std::move(morsels), has_more_scan_ranges));
+        }
+
+        if (has_more_from_split) {
+            for (; driver_seq < dop; driver_seq++) {
+                queue_per_driver.emplace(driver_seq, std::make_unique<pipeline::DynamicMorselQueue>(
+                                                             pipeline::Morsels(), has_more_scan_ranges));
+            }
+            DCHECK_EQ(queue_per_driver.size(), dop);
+            for (auto& [_, queue] : queue_per_driver) {
+                queue->set_has_more_from_split(has_more_from_split);
+            }
         }
     }
 
@@ -157,12 +170,19 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
                                                  morsel_queue_type == pipeline::MorselQueue::Type::DYNAMIC);
 
         // If not so much morsels, try to assign morsel uniformly among operators to avoid data skew
-        if (!always_shared_scan() && scan_dop > 1 && is_fixed_or_dynamic_morsel_queue &&
+        // for Lake, always use SharedMorselQueueFactory
+        // for cloud, if enable_shared_scan, then always use SharedMorselQueueFactory
+        // else it will consider the morsel numbers and io_parallelism to choose individual or shared morsel queue factory
+        if (!always_shared_scan() && !enable_shared_scan && scan_dop > 1 && is_fixed_or_dynamic_morsel_queue &&
             morsel_queue->num_original_morsels() <= io_parallelism) {
+            bool enable_random_append_split_morsel = morsel_queue->has_more_from_split();
+            DCHECK(!enable_random_append_split_morsel || morsel_queue_type == pipeline::MorselQueue::Type::DYNAMIC);
             ASSIGN_OR_RETURN(auto morsel_queue_map, uniform_distribute_morsels(std::move(morsel_queue), scan_dop));
             return std::make_unique<pipeline::IndividualMorselQueueFactory>(std::move(morsel_queue_map),
-                                                                            /*could_local_shuffle*/ true);
+                                                                            /*could_local_shuffle*/ true,
+                                                                            enable_random_append_split_morsel);
         } else {
+            morsel_queue->set_has_more_from_split(false);
             if (config::use_default_dop_when_shared_scan && enable_shared_scan && is_fixed_or_dynamic_morsel_queue) {
                 scan_dop = pipeline_dop;
             }
@@ -179,6 +199,7 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
             ASSIGN_OR_RETURN(auto queue, convert_scan_range_to_morsel_queue(
                                                  scan_ranges, node_id, pipeline_dop, enable_tablet_internal_parallel,
                                                  tablet_internal_parallel_mode, num_total_scan_ranges));
+            queue->set_has_more_from_split(false);
             queue_per_driver_seq.emplace(dop, std::move(queue));
         }
 
@@ -192,7 +213,7 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
                                                                                 /*could_local_shuffle*/ false);
         } else {
             return std::make_unique<pipeline::IndividualMorselQueueFactory>(std::move(queue_per_driver_seq),
-                                                                            /*could_local_shuffle*/ false);
+                                                                            /*could_local_shuffle*/ false, false);
         }
     }
 }

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -137,8 +137,10 @@ static StatusOr<std::map<int, pipeline::MorselQueuePtr>> uniform_distribute_mors
                                                            std::move(morsels), has_more_scan_ranges));
         }
 
+        // queue_per_driver's size determines the scan's dop
+        // if morsels can be split, then we hope scan's dop is the same as pipeline dop
         if (has_more_from_split) {
-            for (; driver_seq < dop; driver_seq++) {
+            for (driver_seq = queue_per_driver.size(); driver_seq < dop; driver_seq++) {
                 queue_per_driver.emplace(driver_seq, std::make_unique<pipeline::DynamicMorselQueue>(
                                                              pipeline::Morsels(), has_more_scan_ranges));
             }

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -170,7 +170,7 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
                                                  morsel_queue_type == pipeline::MorselQueue::Type::DYNAMIC);
 
         // If not so much morsels, try to assign morsel uniformly among operators to avoid data skew
-        // for Lake, always use SharedMorselQueueFactory
+        // for DLA, always use SharedMorselQueueFactory
         // for cloud, if enable_shared_scan, then always use SharedMorselQueueFactory
         // else it will consider the morsel numbers and io_parallelism to choose individual or shared morsel queue factory
         if (!always_shared_scan() && !enable_shared_scan && scan_dop > 1 && is_fixed_or_dynamic_morsel_queue &&

--- a/be/test/exec/connector_scan_node_test.cpp
+++ b/be/test/exec/connector_scan_node_test.cpp
@@ -165,7 +165,14 @@ TEST_F(ConnectorScanNodeTest, test_convert_scan_range_to_morsel_queue_factory_cl
     ASSIGN_OR_ABORT(morsel_queue_factory,
                     scan_node->convert_scan_range_to_morsel_queue_factory(
                             scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop, false,
-                            enable_tablet_internal_parallel, tablet_internal_parallel_mode));
+                            enable_tablet_internal_parallel, tablet_internal_parallel_mode, false));
+    ASSERT_FALSE(morsel_queue_factory->is_shared());
+
+    // dop is 2 and not so much morsels but enable shared scan
+    ASSIGN_OR_ABORT(morsel_queue_factory,
+                    scan_node->convert_scan_range_to_morsel_queue_factory(
+                            scan_ranges, no_scan_ranges_per_driver_seq, scan_node->id(), pipeline_dop, false,
+                            enable_tablet_internal_parallel, tablet_internal_parallel_mode, true));
     ASSERT_TRUE(morsel_queue_factory->is_shared());
 
     // dop is 2 and so much morsels

--- a/be/test/storage/lake/lake_data_source_test.cpp
+++ b/be/test/storage/lake/lake_data_source_test.cpp
@@ -224,8 +224,8 @@ TEST_F(LakeDataSourceTest, test_convert_scan_range_to_morsel_queue) {
     ASSERT_TRUE(data_source_provider->could_split_physically());
 
     ASSERT_FALSE(morsel_queue_factory->is_shared());
-    auto morsel_queue = morsel_queue_factory->create(1);
-    ASSERT_TRUE(morsel_queue->max_degree_of_parallelism() > 1);
+    auto morsel_queue = morsel_queue_factory->create(0);
+    ASSERT_TRUE(morsel_queue->max_degree_of_parallelism() == 1);
 }
 
 TEST_F(LakeDataSourceTest, get_tablet_schema) {

--- a/be/test/storage/lake/lake_data_source_test.cpp
+++ b/be/test/storage/lake/lake_data_source_test.cpp
@@ -204,7 +204,7 @@ TEST_F(LakeDataSourceTest, test_convert_scan_range_to_morsel_queue) {
     auto data_source_provider = dynamic_cast<connector::LakeDataSourceProvider*>(scan_node->data_source_provider());
     data_source_provider->set_lake_tablet_manager(_tablet_mgr);
 
-    ASSERT_TRUE(data_source_provider->always_shared_scan());
+    ASSERT_FALSE(data_source_provider->always_shared_scan());
 
     config::tablet_internal_parallel_max_splitted_scan_bytes = 32;
     config::tablet_internal_parallel_min_splitted_scan_rows = 4;

--- a/be/test/storage/lake/lake_data_source_test.cpp
+++ b/be/test/storage/lake/lake_data_source_test.cpp
@@ -223,7 +223,7 @@ TEST_F(LakeDataSourceTest, test_convert_scan_range_to_morsel_queue) {
     ASSERT_TRUE(data_source_provider->could_split());
     ASSERT_TRUE(data_source_provider->could_split_physically());
 
-    ASSERT_TRUE(morsel_queue_factory->is_shared());
+    ASSERT_FALSE(morsel_queue_factory->is_shared());
     auto morsel_queue = morsel_queue_factory->create(1);
     ASSERT_TRUE(morsel_queue->max_degree_of_parallelism() > 1);
 }

--- a/be/test/storage/lake/lake_scan_node_test.cpp
+++ b/be/test/storage/lake/lake_scan_node_test.cpp
@@ -196,6 +196,7 @@ TEST_F(LakeScanNodeTest, test_could_split) {
                             enable_tablet_internal_parallel, tablet_internal_parallel_mode));
     ASSERT_TRUE(data_source_provider->could_split());
     ASSERT_TRUE(data_source_provider->could_split_physically());
+    ASSERT_TRUE(morsel_queue_factory->create(0)->has_more_from_split());
 }
 
 // test issue https://github.com/StarRocks/starrocks/pull/44386


### PR DESCRIPTION
## Why I'm doing:
1. if don't use tablet internal parallel scan,cloud native table still adjust scan dop which can be less then pipeline_dop, which cause Not enough parallelism
2. if The number of morsels is small, for example:3,  currently only at most 3 drivers will get morsel, ohter drivers found morsel queue is empty and closed directly, however, these 3 morsels can be split into 30 morsels, so only three drivers have input, which cause data skew.

## What I'm doing:
1.  if don't use tablet internal parallel scan, we choose the number of tablets as the dop of scan node which is the same as olap scan
2. for morsels less then dop*io tasks per scan and trigger tablet internal parallel scan, use individual morsel queue, and append the splitted mosel into next morsel queue in round robin way. And scan operator's has_output can be false only when there won't be any new morsel from splitting

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
