### PR TITLE
[Enhancement] adaptive choose whether to batch chunks when have topn rf

### DIFF
--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -32,6 +32,7 @@ namespace starrocks {
 class ExprContext;
 class ConnectorScanNode;
 class RuntimeFilterProbeCollector;
+class TopnRuntimeFilterUpdateContext;
 
 namespace connector {
 
@@ -56,6 +57,8 @@ public:
     virtual int64_t num_bytes_read() const = 0;
     // CPU time of this data source
     virtual int64_t cpu_time_spent() const = 0;
+    // rows filtered by runtime zone map filter
+    virtual int64_t runtime_stats_filtered() const { return 0; }
     // IO time of this data source
     virtual int64_t io_time_spent() const { return 0; }
     virtual bool can_estimate_mem_usage() const { return false; }
@@ -75,6 +78,7 @@ public:
     void set_runtime_filters(RuntimeFilterProbeCollector* runtime_filters) { _runtime_filters = runtime_filters; }
     void set_read_limit(const uint64_t limit) { _read_limit = limit; }
     void set_split_context(pipeline::ScanSplitContext* split_context) { _split_context = split_context; }
+    void set_topn_rf_update_ctx(TopnRuntimeFilterUpdateContext* ctx) { _topn_rf_update_ctx = ctx; }
     virtual Status parse_runtime_filters(RuntimeState* state);
     void update_has_any_predicate();
     // Called frequently, don't do heavy work
@@ -100,6 +104,7 @@ protected:
     RuntimeProfile* _runtime_profile = nullptr;
     TupleDescriptor* _tuple_desc = nullptr;
     pipeline::ScanSplitContext* _split_context = nullptr;
+    TopnRuntimeFilterUpdateContext* _topn_rf_update_ctx = nullptr;
 
     virtual Status _init_chunk_if_needed(ChunkPtr* chunk, size_t n) {
         ASSIGN_OR_RETURN(*chunk, ChunkHelper::new_chunk_checked(*_tuple_desc, n));

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -330,6 +330,7 @@ Status LakeDataSource::init_reader_params(const std::vector<OlapScanRange*>& key
     if (thrift_lake_scan_node.__isset.enable_gin_filter) {
         _params.enable_gin_filter = thrift_lake_scan_node.enable_gin_filter;
     }
+    _params.topn_rf_update_ctx = _topn_rf_update_ctx;
 
     ASSIGN_OR_RETURN(auto pred_tree, _conjuncts_manager->get_predicate_tree(parser, _predicate_free_pool));
     _params.enable_join_runtime_filter_pushdown = _runtime_state->enable_join_runtime_filter_pushdown();
@@ -863,6 +864,7 @@ void LakeDataSource::update_realtime_counter(Chunk* chunk) {
     _num_rows_read += chunk->num_rows();
     auto& stats = _reader->stats();
     _raw_rows_read = stats.raw_rows_read;
+    _runtime_stats_filtered = stats.runtime_stats_filtered;
     _bytes_read = stats.bytes_read;
     _cpu_time_spent_ns = stats.decompress_ns + stats.vec_cond_ns + stats.del_filter_ns;
 }

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -50,6 +50,7 @@ public:
     int64_t num_rows_read() const override { return _num_rows_read; }
     int64_t num_bytes_read() const override { return _bytes_read; }
     int64_t cpu_time_spent() const override { return _cpu_time_spent_ns; }
+    int64_t runtime_stats_filtered() const override { return _runtime_stats_filtered; }
 
     void get_split_tasks(std::vector<pipeline::ScanSplitContextPtr>* split_tasks) override {
         _reader->get_split_tasks(split_tasks);
@@ -119,6 +120,7 @@ private:
     // The following are profile meatures
     int64_t _num_rows_read = 0;
     int64_t _raw_rows_read = 0;
+    int64_t _runtime_stats_filtered = 0;
     int64_t _bytes_read = 0;
     int64_t _cpu_time_spent_ns = 0;
 

--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -84,6 +84,9 @@ Status ConnectorScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
             _back_pressure_throttle_time = tnode.lake_scan_node.back_pressure_throttle_time;
             _back_pressure_throttle_time_upper_bound = tnode.lake_scan_node.back_pressure_throttle_time_upper_bound;
         }
+        if (tnode.lake_scan_node.__isset.topn_filter_on_sort_key) {
+            _topn_filter_on_sort_key = tnode.lake_scan_node.topn_filter_on_sort_key;
+        }
     }
 
     return Status::OK();

--- a/be/src/exec/connector_scan_node.h
+++ b/be/src/exec/connector_scan_node.h
@@ -68,6 +68,7 @@ public:
     bool output_chunk_by_bucket() const override { return _data_source_provider->output_chunk_by_bucket(); }
     bool is_asc_hint() const override { return _data_source_provider->is_asc_hint(); }
     std::optional<bool> partition_order_hint() const override { return _data_source_provider->partition_order_hint(); }
+    bool topn_filter_on_sort_key() const override { return _topn_filter_on_sort_key; }
 
 private:
     // non-pipeline methods.
@@ -146,6 +147,7 @@ private:
     int64_t _scan_mem_limit = 0;
     size_t _estimated_scan_row_bytes = 0;
     size_t _estimated_data_source_mem_bytes = 0;
+    bool _topn_filter_on_sort_key = false;
 
 #ifdef BE_TEST
     std::atomic_bool _use_stream_load_thread_pool = false;

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -122,6 +122,10 @@ Status OlapScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _back_pressure_throttle_time_upper_bound = tnode.olap_scan_node.back_pressure_throttle_time_upper_bound;
     }
 
+    if (tnode.olap_scan_node.__isset.topn_filter_on_sort_key) {
+        _topn_filter_on_sort_key = tnode.olap_scan_node.topn_filter_on_sort_key;
+    }
+
     _estimate_scan_and_output_row_bytes();
 
     return Status::OK();

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -102,6 +102,7 @@ public:
     bool output_chunk_by_bucket() const override { return _output_chunk_by_bucket; }
     bool is_asc_hint() const override { return _output_asc_hint; }
     std::optional<bool> partition_order_hint() const override { return _partition_order_hint; }
+    bool topn_filter_on_sort_key() const override { return _topn_filter_on_sort_key; }
 
     const std::vector<ExprContext*>& bucket_exprs() const { return _bucket_exprs; }
 
@@ -180,6 +181,7 @@ private:
     size_t _estimated_scan_row_bytes = 0;
     size_t _estimated_output_row_bytes = 0;
     bool _start = false;
+    bool _topn_filter_on_sort_key = false;
 
     mutable SpinLock _status_mutex;
     Status _status;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -849,7 +849,8 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
     ConnectorScanOperatorAdaptiveProcessor& P = *(scan_op->adaptive_processor());
 
     DeferOp defer_op([&]() { P.last_chunk_souce_finish_timestamp = GetCurrentTimeMicros(); });
-    bool skip_chunk_accumulate = _should_skip_chunk_accumulate();
+    // Direct output is only safe when the accumulator is empty; otherwise we would use accumulator
+    bool skip_chunk_accumulate = _should_skip_chunk_accumulate() && _ck_acc.empty();
     auto is_terminal_status = [](const Status& st) {
         return st.is_end_of_file() || st.is_cancelled() || (!st.ok() && !st.is_time_out() && !st.is_eagain());
     };
@@ -858,6 +859,7 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
         int64_t total_time_ns = 0;
         int64_t delta_io_time_ns = 0;
         int64_t delta_scan_bytes = 0;
+        ChunkPtr direct_chunk;
         {
             SCOPED_RAW_TIMER(&total_time_ns);
             int64_t prev_io_time_ns = get_io_time_spent();
@@ -884,8 +886,12 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
                 _status = _data_source->get_next(state, &tmp);
                 if (_status.ok()) {
                     if (tmp->num_rows() == 0) continue;
+                    if (skip_chunk_accumulate) {
+                        direct_chunk = std::move(tmp);
+                        break;
+                    }
                     _ck_acc.push(tmp);
-                    if (_ck_acc.has_output() || skip_chunk_accumulate) break;
+                    if (_ck_acc.has_output()) break;
                 } else if (!_status.is_end_of_file()) {
                     if (_status.is_time_out()) {
                         Status t = _status;
@@ -909,8 +915,8 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
             delta_scan_bytes = _scan_bytes - prev_scan_bytes;
         }
 
-        if (_ck_acc.has_output() || skip_chunk_accumulate) {
-            *chunk = std::move(_ck_acc.pull());
+        if (direct_chunk != nullptr || _ck_acc.has_output()) {
+            *chunk = direct_chunk != nullptr ? std::move(direct_chunk) : std::move(_ck_acc.pull());
             P.cs_total_running_time += total_time_ns;
             P.cs_total_io_time += delta_io_time_ns;
             P.cs_total_scan_bytes += delta_scan_bytes;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -652,6 +652,7 @@ ConnectorChunkSource::ConnectorChunkSource(ScanOperator* op, RuntimeProfile* run
     _data_source = scan_node->data_source_provider()->create_data_source(*scan_range);
     _data_source->set_driver_sequence(op->get_driver_sequence());
     _data_source->set_split_context(split_context);
+    _data_source->set_topn_rf_update_ctx(op->topn_rf_update_ctx());
 
     _data_source->set_morsel(scan_morsel);
     _data_source->set_predicates(_conjunct_ctxs);
@@ -659,6 +660,7 @@ ConnectorChunkSource::ConnectorChunkSource(ScanOperator* op, RuntimeProfile* run
     _data_source->set_read_limit(_limit);
     _data_source->set_runtime_profile(runtime_profile);
     _data_source->update_has_any_predicate();
+    _topn_rf_update_ctx = op->topn_rf_update_ctx();
 }
 
 ConnectorChunkSource::~ConnectorChunkSource() {
@@ -692,6 +694,33 @@ Status ConnectorChunkSource::_report_split_source_morsel_finished_once() {
     RETURN_IF_ERROR(scan_op->mark_split_source_morsel_finished());
     _split_source_morsel_reported = true;
     return Status::OK();
+}
+
+bool ConnectorChunkSource::_should_skip_chunk_accumulate() const {
+    if (_topn_rf_update_ctx != nullptr) {
+        return _topn_rf_update_ctx->should_skip_chunk_accumulate();
+    }
+    return false;
+}
+
+void ConnectorChunkSource::_update_topn_rf_update_ctx() {
+    if (_topn_rf_update_ctx == nullptr) {
+        return;
+    }
+    const int64_t raw_rows = _data_source->raw_rows_read();
+    const int64_t runtime_filtered = _data_source->runtime_stats_filtered();
+    int64_t raw_delta = raw_rows - _prev_raw_rows_read;
+    int64_t runtime_delta = runtime_filtered - _prev_runtime_filtered;
+    if (raw_delta < 0) {
+        raw_delta = raw_rows;
+    }
+    if (runtime_delta < 0) {
+        runtime_delta = runtime_filtered;
+    }
+    _topn_rf_update_ctx->update_stats(raw_delta, runtime_delta);
+    _prev_raw_rows_read = raw_rows;
+    _prev_runtime_filtered = runtime_filtered;
+    _topn_rf_update_ctx->on_chunk_output();
 }
 
 void ConnectorChunkSource::close(RuntimeState* state) {
@@ -820,6 +849,7 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
     ConnectorScanOperatorAdaptiveProcessor& P = *(scan_op->adaptive_processor());
 
     DeferOp defer_op([&]() { P.last_chunk_souce_finish_timestamp = GetCurrentTimeMicros(); });
+    bool skip_chunk_accumulate = _should_skip_chunk_accumulate();
     auto is_terminal_status = [](const Status& st) {
         return st.is_end_of_file() || st.is_cancelled() || (!st.ok() && !st.is_time_out() && !st.is_eagain());
     };
@@ -855,7 +885,7 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
                 if (_status.ok()) {
                     if (tmp->num_rows() == 0) continue;
                     _ck_acc.push(tmp);
-                    if (_ck_acc.has_output()) break;
+                    if (_ck_acc.has_output() || skip_chunk_accumulate) break;
                 } else if (!_status.is_end_of_file()) {
                     if (_status.is_time_out()) {
                         Status t = _status;
@@ -879,7 +909,7 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
             delta_scan_bytes = _scan_bytes - prev_scan_bytes;
         }
 
-        if (_ck_acc.has_output()) {
+        if (_ck_acc.has_output() || skip_chunk_accumulate) {
             *chunk = std::move(_ck_acc.pull());
             P.cs_total_running_time += total_time_ns;
             P.cs_total_io_time += delta_io_time_ns;
@@ -887,6 +917,7 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
             _chunk_rows_read += (*chunk)->num_rows();
             _chunk_mem_bytes += (*chunk)->memory_usage();
             _chunk_buffer.update_limiter(chunk->get());
+            _update_topn_rf_update_ctx();
             return Status::OK();
         }
         _ck_acc.reset();

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -165,6 +165,8 @@ protected:
 private:
     Status _read_chunk(RuntimeState* state, ChunkPtr* chunk) override;
     Status _report_split_source_morsel_finished_once();
+    bool _should_skip_chunk_accumulate() const;
+    void _update_topn_rf_update_ctx();
 
     ConnectorScanOperatorIOTasksMemLimiter* _get_io_tasks_mem_limiter() const;
 
@@ -187,6 +189,9 @@ private:
     int64_t _request_mem_tracker_bytes = 0;
     int64_t _mem_alloc_failed_count = 0;
     bool _enable_adaptive_io_tasks = true;
+    TopnRuntimeFilterUpdateContext* _topn_rf_update_ctx = nullptr;
+    int64_t _prev_raw_rows_read = 0;
+    int64_t _prev_runtime_filtered = 0;
 };
 
 } // namespace pipeline

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -52,6 +52,7 @@
 #include "storage/projection_iterator.h"
 #include "storage/runtime_range_pruner.hpp"
 #include "storage/storage_engine.h"
+#include "storage/topn_runtime_filter_update_context.h"
 #include "storage/virtual_column_utils.h"
 #include "types/json_value.h"
 #include "types/logical_type.h"
@@ -65,7 +66,9 @@ OlapChunkSource::OlapChunkSource(ScanOperator* op, RuntimeProfile* runtime_profi
           _scan_node(scan_node),
           _scan_ctx(scan_ctx),
           _limit(scan_node->limit()),
-          _scan_range(down_cast<ScanMorsel*>(_morsel.get())->get_olap_scan_range()) {}
+          _scan_range(down_cast<ScanMorsel*>(_morsel.get())->get_olap_scan_range()) {
+    _topn_rf_update_ctx = op->topn_rf_update_ctx();
+}
 
 OlapChunkSource::~OlapChunkSource() {
     _reader.reset();
@@ -274,6 +277,7 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
     if (thrift_olap_scan_node.__isset.enable_gin_filter) {
         _params.enable_gin_filter = thrift_olap_scan_node.enable_gin_filter;
     }
+    _params.topn_rf_update_ctx = _topn_rf_update_ctx;
     _params.use_vector_index = _use_vector_index;
     if (_use_vector_index) {
         const TVectorSearchOptions& vector_options = thrift_olap_scan_node.vector_search_options;
@@ -861,6 +865,20 @@ void OlapChunkSource::_update_realtime_counter(Chunk* chunk) {
     if (chunk != nullptr && num_rows > 0) {
         _chunk_buffer.update_limiter(chunk);
     }
+    _update_topn_rf_update_ctx();
+}
+
+void OlapChunkSource::_update_topn_rf_update_ctx() {
+    if (_topn_rf_update_ctx == nullptr) {
+        return;
+    }
+    const auto& stats = _reader->stats();
+    const int64_t raw_rows = stats.raw_rows_read;
+    const int64_t runtime_filtered = stats.runtime_stats_filtered;
+    _topn_rf_update_ctx->update_stats(raw_rows - _prev_raw_rows_read, runtime_filtered - _prev_runtime_filtered);
+    _prev_raw_rows_read = raw_rows;
+    _prev_runtime_filtered = runtime_filtered;
+    _topn_rf_update_ctx->on_chunk_output();
 }
 
 void OlapChunkSource::_update_counter() {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -35,6 +35,7 @@ namespace starrocks {
 
 class SlotDescriptor;
 class TableMetrics;
+class TopnRuntimeFilterUpdateContext;
 
 namespace pipeline {
 
@@ -72,6 +73,7 @@ private:
     Status _extend_schema_by_access_paths();
     void _inherit_default_value_from_json(TabletColumn* column, const TabletColumn& root_column,
                                           const ColumnAccessPath* path);
+    void _update_topn_rf_update_ctx();
 
 private:
     TabletReaderParams _params{};
@@ -107,6 +109,9 @@ private:
     std::vector<SlotDescriptor*> _query_slots;
 
     std::vector<ColumnAccessPathPtr> _column_access_paths;
+    TopnRuntimeFilterUpdateContext* _topn_rf_update_ctx = nullptr;
+    int64_t _prev_raw_rows_read = 0;
+    int64_t _prev_runtime_filtered = 0;
 
     bool _use_vector_index = false;
     bool _use_ivfpq = false;

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -93,6 +93,15 @@ Status ScanOperator::prepare(RuntimeState* state) {
     _prepare_chunk_source_timer = ADD_TIMER(_unique_metrics, "PrepareChunkSourceTime");
     _submit_io_task_timer = ADD_TIMER(_unique_metrics, "SubmitTaskTime");
 
+    if (_scan_node->topn_filter_on_sort_key()) {
+        int32_t mode = TopnRuntimeFilterUpdateContext::AUTO;
+        const auto& query_options = state->query_options();
+        if (query_options.__isset.topn_runtime_filter_update_mode) {
+            mode = query_options.topn_runtime_filter_update_mode;
+        }
+        _topn_rf_update_ctx = std::make_unique<TopnRuntimeFilterUpdateContext>(mode);
+    }
+
     if (_scan_node->is_enable_topn_filter_back_pressure()) {
         if (auto* runtime_filters = runtime_bloom_filters(); runtime_filters != nullptr) {
             auto has_topn_filters =

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -24,6 +24,7 @@
 #include "exec/query_cache/lane_arbiter.h"
 #include "exec/workgroup/work_group_fwd.h"
 #include "exprs/chunk_predicate_evaluator.h"
+#include "storage/topn_runtime_filter_update_context.h"
 
 namespace starrocks {
 
@@ -92,6 +93,7 @@ public:
         _op_pull_rows += res->num_rows();
     }
     bool is_asc() const { return _is_asc; }
+    TopnRuntimeFilterUpdateContext* topn_rf_update_ctx() const { return _topn_rf_update_ctx.get(); }
     void end_pull_chunk(int64_t time) { _op_running_time_ns += time; }
     virtual void begin_driver_process() {}
     virtual void end_driver_process(PipelineDriver* driver) {}
@@ -289,6 +291,7 @@ private:
 
     RuntimeMembershipFilterEvalContext _topn_filter_eval_context;
     std::unique_ptr<TopnRfBackPressure> _topn_filter_back_pressure = nullptr;
+    std::unique_ptr<TopnRuntimeFilterUpdateContext> _topn_rf_update_ctx = nullptr;
 
     DECLARE_RACE_DETECTOR(race_pull_chunk)
 };

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -124,6 +124,7 @@ public:
     virtual bool output_chunk_by_bucket() const { return false; }
     virtual bool is_asc_hint() const { return true; }
     virtual std::optional<bool> partition_order_hint() const { return std::nullopt; }
+    virtual bool topn_filter_on_sort_key() const { return false; }
 
     // TODO: support more share_scan strategy
     void enable_shared_scan(bool enable);

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -317,8 +317,9 @@ void TabletScanner::_update_realtime_counter(Chunk* chunk) {
     _compressed_bytes_read += _reader->stats().compressed_bytes_read;
     _reader->mutable_stats()->compressed_bytes_read = 0;
 
-    COUNTER_UPDATE(_parent->_raw_rows_counter, _reader->stats().raw_rows_read);
-    _raw_rows_read += _reader->stats().raw_rows_read;
+    int64_t raw_rows_read = _reader->stats().raw_rows_read;
+    COUNTER_UPDATE(_parent->_raw_rows_counter, raw_rows_read);
+    _raw_rows_read += raw_rows_read;
     _reader->mutable_stats()->raw_rows_read = 0;
     _num_rows_read += num_rows;
 }

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -145,6 +145,7 @@ public:
     bool has_output() const;
     bool need_input() const;
     bool is_finished() const;
+    bool empty() const { return _in_chunk == nullptr && _out_chunk == nullptr; }
 
 private:
     static bool _check_json_schema_equallity(const Chunk* one, const Chunk* two);

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -347,6 +347,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.prune_column_after_index_filter = params.prune_column_after_index_filter;
     rs_opts.enable_gin_filter = params.enable_gin_filter;
     rs_opts.enable_predicate_col_late_materialize = params.enable_predicate_col_late_materialize;
+    rs_opts.topn_rf_update_ctx = params.topn_rf_update_ctx;
 
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -778,6 +778,7 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
     seg_options.sample_options = options.sample_options;
     seg_options.enable_join_runtime_filter_pushdown = options.enable_join_runtime_filter_pushdown;
     seg_options.enable_predicate_col_late_materialize = options.enable_predicate_col_late_materialize;
+    seg_options.topn_rf_update_ctx = options.topn_rf_update_ctx;
 
     if (options.delete_predicates != nullptr) {
         seg_options.delete_predicates = options.delete_predicates->get_predicates(end_version());

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -27,6 +27,7 @@
 #include "storage/runtime_range_pruner.h"
 #include "storage/seek_range.h"
 #include "storage/tablet_schema.h"
+#include "storage/topn_runtime_filter_update_context.h"
 
 namespace starrocks {
 class Conditions;
@@ -100,6 +101,7 @@ public:
     TTableSampleOptions sample_options;
     bool enable_join_runtime_filter_pushdown = false;
     bool enable_predicate_col_late_materialize = false;
+    TopnRuntimeFilterUpdateContext* topn_rf_update_ctx = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -454,6 +454,7 @@ private:
     // Build column-specific RuntimeFilterPredicates for late materialization
     // Group runtime filter predicates by ColumnId
     void _build_column_oriented_rf(ScanContext* ctx);
+    bool _use_small_chunk_threshold() const;
 
 private:
     using RawColumnIterators = std::vector<std::unique_ptr<ColumnIterator>>;
@@ -2190,10 +2191,18 @@ StatusOr<size_t> SegmentIterator::_predicate_evaluate(vector<rowid_t>* rowid) {
     }
 }
 
+bool SegmentIterator::_use_small_chunk_threshold() const {
+    if (_opts.topn_rf_update_ctx == nullptr) {
+        return false;
+    }
+    return _opts.topn_rf_update_ctx->should_use_small_chunk_threshold();
+}
+
 StatusOr<size_t> SegmentIterator::_predicate_evaluate_late_materialize_read_first_column(
         vector<rowid_t>* rowid, std::vector<Column*>& current_columns) {
     const uint32_t chunk_capacity = _reserve_chunk_size;
-    const uint32_t return_chunk_threshold = std::max<uint32_t>(chunk_capacity - chunk_capacity / 4, 1);
+    const uint32_t return_chunk_threshold =
+            _use_small_chunk_threshold() ? 1 : std::max<uint32_t>(chunk_capacity - chunk_capacity / 4, 1);
     const bool has_non_expr_predicate = !_non_expr_pred_tree.empty();
     const bool scan_range_normalized = _scan_range.is_sorted();
     Chunk* chunk = _context->_read_chunk.get();
@@ -2216,7 +2225,6 @@ StatusOr<size_t> SegmentIterator::_predicate_evaluate_late_materialize_read_firs
     size_t original_chunk_size = chunk_start;
     while ((chunk_start < return_chunk_threshold) && _range_iter.has_more()) {
         RETURN_IF_ERROR(_read(chunk, rowid, chunk_capacity - chunk_start, true));
-        // chunk->check_or_die();
         size_t next_start = first_col->size();
 
         // Count how many rowids were read by this _read() call
@@ -2324,7 +2332,8 @@ StatusOr<size_t> SegmentIterator::_predicate_evaluate_late_materialize(vector<ro
 
 StatusOr<size_t> SegmentIterator::_predicate_evaluate_without_late_materialize(vector<rowid_t>* rowid) {
     const uint32_t chunk_capacity = _reserve_chunk_size;
-    const uint32_t return_chunk_threshold = std::max<uint32_t>(chunk_capacity - chunk_capacity / 4, 1);
+    const uint32_t return_chunk_threshold =
+            _use_small_chunk_threshold() ? 1 : std::max<uint32_t>(chunk_capacity - chunk_capacity / 4, 1);
     const bool has_non_expr_predicate = !_non_expr_pred_tree.empty();
     const bool scan_range_normalized = _scan_range.is_sorted();
 

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -29,6 +29,7 @@
 #include "storage/runtime_filter_predicate.h"
 #include "storage/runtime_range_pruner.h"
 #include "storage/seek_range.h"
+#include "storage/topn_runtime_filter_update_context.h"
 
 namespace starrocks {
 class ColumnAccessPath;
@@ -120,6 +121,7 @@ public:
 
     bool enable_join_runtime_filter_pushdown = false;
     bool enable_predicate_col_late_materialize = false;
+    TopnRuntimeFilterUpdateContext* topn_rf_update_ctx = nullptr;
 
 public:
     Status convert_to(SegmentReadOptions* dst, const std::vector<LogicalType>& new_types, ObjectPool* obj_pool) const;

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -372,6 +372,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.sample_options = params.sample_options;
     rs_opts.enable_join_runtime_filter_pushdown = params.enable_join_runtime_filter_pushdown;
     rs_opts.enable_predicate_col_late_materialize = params.enable_predicate_col_late_materialize;
+    rs_opts.topn_rf_update_ctx = params.topn_rf_update_ctx;
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;
         rs_opts.version = _version.second;

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -27,6 +27,7 @@
 #include "storage/predicate_tree/predicate_tree.hpp"
 #include "storage/runtime_filter_predicate.h"
 #include "storage/runtime_range_pruner.h"
+#include "storage/topn_runtime_filter_update_context.h"
 
 namespace starrocks {
 
@@ -108,6 +109,7 @@ struct TabletReaderParams {
     TTableSampleOptions sample_options;
     bool enable_join_runtime_filter_pushdown = false;
     bool enable_predicate_col_late_materialize = false;
+    TopnRuntimeFilterUpdateContext* topn_rf_update_ctx = nullptr;
 
 public:
     std::string to_string() const;

--- a/be/src/storage/topn_runtime_filter_update_context.h
+++ b/be/src/storage/topn_runtime_filter_update_context.h
@@ -1,0 +1,79 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+
+namespace starrocks {
+
+class TopnRuntimeFilterUpdateContext {
+public:
+    enum Mode : int32_t {
+        OFF = 0,
+        AUTO = 1,
+        FORCE = 2,
+    };
+
+    explicit TopnRuntimeFilterUpdateContext(int32_t mode) : _mode(mode) {}
+
+    void update_stats(int64_t raw_rows_delta, int64_t runtime_filtered_delta) {
+        if (raw_rows_delta > 0) {
+            _raw_rows.fetch_add(raw_rows_delta, std::memory_order_relaxed);
+        }
+        if (runtime_filtered_delta > 0) {
+            _runtime_filtered.fetch_add(runtime_filtered_delta, std::memory_order_relaxed);
+        }
+    }
+
+    void on_chunk_output() { _chunks.fetch_add(1, std::memory_order_relaxed); }
+
+    bool should_skip_chunk_accumulate() const {
+        if (_mode == FORCE) {
+            return true;
+        }
+        if (_mode == OFF) {
+            return false;
+        }
+        // first 10 chunks skip accumulating, then depends on topn filter rate, this context is per operator
+        // since if topn rf on sort key, we want to have a good topn filter asap to skip data by index
+        // but if topn can't filter much data after 10 chunks, then it's better to accumulate chunk to decrease push_chunk times
+        // TODO: find a better strategy
+        return _is_in_warmup() || _is_filtered_over_half();
+    }
+
+    bool should_use_small_chunk_threshold() const { return should_skip_chunk_accumulate(); }
+
+private:
+    static constexpr int64_t kWarmupChunks = 10;
+
+    bool _is_in_warmup() const { return _chunks.load(std::memory_order_relaxed) < kWarmupChunks; }
+
+    bool _is_filtered_over_half() const {
+        const int64_t raw = _raw_rows.load(std::memory_order_relaxed);
+        const int64_t filtered = _runtime_filtered.load(std::memory_order_relaxed);
+        const int64_t denom = raw + filtered;
+        if (denom <= 0) {
+            return false;
+        }
+        return filtered * 2 > denom;
+    }
+
+    const int32_t _mode;
+    std::atomic<int64_t> _chunks{0};
+    std::atomic<int64_t> _raw_rows{0};
+    std::atomic<int64_t> _runtime_filtered{0};
+};
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -179,6 +179,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
     private boolean withoutColocateRequirement = false;
     private boolean outputAscHint = true;
     private boolean sortKeyAscHint = true;
+    private boolean topnFilterOnSortKey = false;
     private Optional<Boolean> partitionKeyAscHint = Optional.empty();
 
     private Map<Long, Integer> tabletId2BucketSeq = Maps.newHashMap();
@@ -998,6 +999,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
     }
 
     private void assignOrderByHints(List<String> keyColumnNames) {
+        topnFilterOnSortKey = false;
         // assign order by hint
         for (RuntimeFilterDescription probeRuntimeFilter : probeRuntimeFilters) {
             if (RuntimeFilterDescription.RuntimeFilterType.TOPN_FILTER.equals(
@@ -1007,8 +1009,11 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                     // check key columns
                     SlotId cid = ((SlotRef) expr).getSlotId();
                     String columnName = desc.getSlot(cid.asInt()).getColumn().getName();
-                    if (!keyColumnNames.isEmpty() && keyColumnNames.get(0).equals(columnName)) {
-                        sortKeyAscHint = outputAscHint;
+                    if (!keyColumnNames.isEmpty() && keyColumnNames.contains(columnName)) {
+                        if (keyColumnNames.get(0).equals(columnName)) {
+                            sortKeyAscHint = outputAscHint;
+                        }
+                        topnFilterOnSortKey = true;
                     }
                     // check partition column
                     PartitionInfo partitionInfo = olapTable.getPartitionInfo();
@@ -1120,6 +1125,9 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             }
 
             msg.lake_scan_node.setOutput_asc_hint(sortKeyAscHint);
+            if (topnFilterOnSortKey) {
+                msg.lake_scan_node.setTopn_filter_on_sort_key(true);
+            }
             msg.lake_scan_node.setSchema_key(getSchemaKey());
         } else { // If you find yourself changing this code block, see also the above code block
             msg.node_type = TPlanNodeType.OLAP_SCAN_NODE;
@@ -1164,6 +1172,9 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             }
 
             msg.olap_scan_node.setOutput_asc_hint(sortKeyAscHint);
+            if (topnFilterOnSortKey) {
+                msg.olap_scan_node.setTopn_filter_on_sort_key(true);
+            }
             partitionKeyAscHint.ifPresent(aBoolean -> msg.olap_scan_node.setPartition_order_hint(aBoolean));
             if (!bucketExprs.isEmpty()) {
                 msg.olap_scan_node.setBucket_exprs(ExprToThrift.treesToThrift(bucketExprs));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1047,6 +1047,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     // 0 for disable, 1 for too many data; 2 for force
     public static final String TOPN_FILTER_BACK_PRESSURE_MODE = "topn_filter_back_pressure_mode";
+    public static final String TOPN_RUNTIME_FILTER_UPDATE_MODE = "topn_runtime_filter_update_mode";
     public static final String BACK_PRESSURE_MAX_ROUNDS = "back_pressure_back_rounds";
     public static final String BACK_PRESSURE_THROTTLE_TIME_UPPER_BOUND = "back_pressure_throttle_time_upper_bound";
 
@@ -2122,6 +2123,31 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = TOPN_FILTER_BACK_PRESSURE_MODE)
     private int topnFilterBackPressureMode = 0;
+    @VarAttr(name = TOPN_RUNTIME_FILTER_UPDATE_MODE)
+    private String topnRuntimeFilterUpdateMode = SessionVariableConstants.AUTO;
+
+    public void setTopnRuntimeFilterUpdateMode(String mode) {
+        if (mode == null) {
+            this.topnRuntimeFilterUpdateMode = SessionVariableConstants.AUTO;
+            return;
+        }
+        String normalized = StringUtils.lowerCase(mode.trim());
+        switch (normalized) {
+            case "auto":
+                this.topnRuntimeFilterUpdateMode = SessionVariableConstants.AUTO;
+                break;
+            case "off":
+                this.topnRuntimeFilterUpdateMode = SessionVariableConstants.OFF;
+                break;
+            case "force":
+                this.topnRuntimeFilterUpdateMode = SessionVariableConstants.FORCE;
+                break;
+            default:
+                throw new SemanticException(
+                        "Invalid value for " + TOPN_RUNTIME_FILTER_UPDATE_MODE + ": " + mode
+                                + ". Valid values are: off, auto, force");
+        }
+    }
     @VarAttr(name = BACK_PRESSURE_MAX_ROUNDS)
     private int backPressureMaxRounds = 3;
     @VarAttr(name = BACK_PRESSURE_THROTTLE_TIME_UPPER_BOUND)
@@ -5813,6 +5839,20 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.topnFilterBackPressureMode = value;
     }
 
+    public int getTopnRuntimeFilterUpdateMode() {
+        if (topnRuntimeFilterUpdateMode == null) {
+            return 1;
+        }
+        String mode = topnRuntimeFilterUpdateMode.toLowerCase();
+        if (SessionVariableConstants.OFF.equals(mode)) {
+            return 0;
+        }
+        if (SessionVariableConstants.FORCE.equals(mode)) {
+            return 2;
+        }
+        return 1;
+    }
+
     public int getBackPressureMaxRounds() {
         return this.backPressureMaxRounds;
     }
@@ -6146,6 +6186,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setEnable_query_debug_trace(enableQueryDebugTrace);
         tResult.setEnable_pipeline_query_statistic(true);
         tResult.setRuntime_filter_early_return_selectivity(runtimeFilterEarlyReturnSelectivity);
+        tResult.setTopn_runtime_filter_update_mode(getTopnRuntimeFilterUpdateMode());
 
         tResult.setAllow_throw_exception((sqlMode & SqlModeHelper.MODE_ALLOW_THROW_EXCEPTION) != 0);
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -21,6 +21,8 @@ public class SessionVariableConstants {
     private SessionVariableConstants() {}
 
     public static final String AUTO = "auto";
+    public static final String OFF = "off";
+    public static final String FORCE = "force";
 
     public static final String FORCE_STREAMING = "force_streaming";
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -365,6 +365,8 @@ struct TQueryOptions {
   
   210: optional bool enable_global_late_materialization;
   211: optional bool enable_schedule_log;
+  // 0: off, 1: auto, 2: force
+  212: optional i32 topn_runtime_filter_update_mode = 1;
 
 }
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -660,6 +660,8 @@ struct TOlapScanNode {
 
   // This field is only used for flat json to provide a uniq id
   55: optional i32 next_uniq_id
+  // true if there is a TopN runtime filter on any sort key
+  56: optional bool topn_filter_on_sort_key
 }
 
 struct TJDBCScanNode {
@@ -708,6 +710,8 @@ struct TLakeScanNode {
   45: optional bool enable_gin_filter
 
   46: optional i32 next_uniq_id
+  // true if there is a TopN runtime filter on any sort key
+  47: optional bool topn_filter_on_sort_key
 }
 
 struct TEqJoinCondition {


### PR DESCRIPTION
## Why I'm doing:
TopN runtime filters can prune data much earlier when the scan side updates them quickly, especially if the filter is applied to a table’s sort key. The current chunk batching behavior may delay those updates especially when predicates have good selectivity, which reduces the benefit of TopN runtime filtering. This PR makes scan batching adaptive so the engine can expose useful TopN filter information earlier and improve pruning efficiency.

## What I'm doing:
This PR adds an adaptive chunk-batching mechanism for scan operators when a TopN runtime filter is present on sort keys. It  introduces FE-to-BE plumbing to mark whether a TopN filter targets sort keys, adds a new session variable  topn_runtime_filter_update_mode with modes like off, auto, and force, and passes that setting through thrift. On the BE side, it  adds a shared update context that tracks filtering effectiveness and uses it to decide whether to bypass chunk accumulation or use  smaller output thresholds.

if mode is OFF: the logic is same as before. accumulate chunks
if mode is FORCE: don't  accumulate at all
if mode is AUTO: don't accumulate for the first ten chunks, so they can update topn rf, then depends on topn rf's selectivity, if topn rf works well then don't accumulate, otherwise accumulate.

This  update context is per scan operator.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
