### PR TITLE
[BugFix] Fix all-null value handling bug in sync MV

### DIFF
--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -293,15 +293,8 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
                 return false;
             }
 
-            if (new_col->only_null()) {
-                // unfold only null columns to avoid no default values.
-                auto unfold_col = new_col->clone_empty();
-                unfold_col->append_nulls(new_col->size());
-                new_col = std::move(unfold_col);
-            } else {
-                // NOTE: Unpack const column first to avoid generating NullColumn<ConstColumn> result.
-                new_col = ColumnHelper::unpack_and_duplicate_const_column(new_col->size(), new_col);
-            }
+            const auto& type_desc = _schema_mapping[i].mv_expr_ctx->root()->type();
+            new_col = ColumnHelper::unfold_const_column(type_desc, new_col->size(), new_col);
 
             if (new_schema.field(i)->is_nullable()) {
                 new_col = ColumnHelper::cast_to_nullable_column(std::move(new_col));

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view_only_null
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view_only_null
@@ -1,0 +1,42 @@
+-- name: test_sync_materialized_view_only_null
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `c1` varchar(300) NOT NULL COMMENT "",
+  `c2` json NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`)
+PROPERTIES (
+"compression" = "LZ4",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO t1 (c1, c2) VALUES  ('key1', '{"res_id":"RES10033_001","status":"active","value":123.45}');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW MV_1
+AS
+SELECT
+    c1,
+    CAST(
+        get_json_string(c1, '$.expiresAt')
+        AS DATETIME
+    ) AS expires_at
+FROM t1;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+select * from MV_1 [_SYNC_MV_];
+-- result:
+key1	None
+-- !result
+drop materialized view MV_1;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_only_null
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_only_null
@@ -1,0 +1,33 @@
+-- name: test_sync_materialized_view_only_null
+
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+
+CREATE TABLE `t1` (
+  `c1` varchar(300) NOT NULL COMMENT "",
+  `c2` json NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`)
+PROPERTIES (
+"compression" = "LZ4",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+INSERT INTO t1 (c1, c2) VALUES  ('key1', '{"res_id":"RES10033_001","status":"active","value":123.45}');
+
+CREATE MATERIALIZED VIEW MV_1
+AS
+SELECT
+    c1,
+    CAST(
+        get_json_string(c1, '$.expiresAt')
+        AS DATETIME
+    ) AS expires_at
+FROM t1;
+
+function: wait_materialized_view_finish()
+
+select * from MV_1 [_SYNC_MV_];
+
+drop materialized view MV_1;


### PR DESCRIPTION
## Why I'm doing:

The `ColumnWriter` requires the input to be a non-const column, so the const column must be expanded here. If an only-null column is expanded using `unpack_and_duplicate_const_column`, it will be of type FixedLengthColumn<uint8_t>, so the `TypeDesc` needs to be passed in to expand it to the actual type.

This pr: https://github.com/StarRocks/starrocks/pull/34672 does not fundamentally resolve the issue; instead, it introduces new problems.

```
*** Aborted at 1770689188 (unix time) try "date -d @1770689188" if you are using GNU date ***
PC: @          0x97cfe8c starrocks::ScalarColumnWriter::append(starrocks::Column const&)
*** SIGSEGV (@0x11) received by PID 9202 (TID 0x154ae3f71640) LWP(13831) from PID 17; stack trace: ***
    @     0x154b4e17eee8 (/usr/lib/x86_64-linux-gnu/libc.so.6 (deleted)+0x99ee7)
    @          0xffe6189 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x154b4e127520 (/usr/lib/x86_64-linux-gnu/libc.so.6 (deleted)+0x4251f)
    @          0x97cfe8c starrocks::ScalarColumnWriter::append(starrocks::Column const&)
    @          0x97bc041 starrocks::SegmentWriter::append_chunk(starrocks::Chunk const&)
    @          0xa56ab7f starrocks::HorizontalRowsetWriter::add_chunk(starrocks::Chunk const&, std::vector<unsigned long, std::allocator<unsigned long> > const&)
    @          0xa56af0a starrocks::HorizontalRowsetWriter::add_chunk(starrocks::Chunk const&)
    @          0xa70fd58 starrocks::SchemaChangeDirectly::process(starrocks::TabletReader*, starrocks::RowsetWriter*, std::shared_ptr<starrocks::Tablet>, std::shared_ptr<starrocks::Tablet>, std::shared_ptr<starrocks::Rowset>, std::shared_ptr<starrocks::TabletSchema const>)
    @          0xa717343 starrocks::SchemaChangeHandler::_convert_historical_rowsets(starrocks::SchemaChangeParams&)
    @          0xa71b34a starrocks::SchemaChangeHandler::_do_process_alter_tablet_normal(starrocks::TAlterTabletReqV2 const&, starrocks::SchemaChangeParams&, std::shared_ptr<starrocks::Tablet> const&, std::shared_ptr<starrocks::Tablet> const&)
    @          0xa71d200 starrocks::SchemaChangeHandler::_do_process_alter_tablet(starrocks::TAlterTabletReqV2 const&)
    @          0xa71e18f starrocks::SchemaChangeHandler::process_alter_tablet(starrocks::TAlterTabletReqV2 const&)
    @          0xbc4eeab starrocks::EngineAlterTabletTask::execute()
    @          0x95d44a6 starrocks::StorageEngine::execute_task(starrocks::EngineTask*)
    @          0xbc32872 starrocks::run_alter_tablet_task(std::shared_ptr<starrocks::AgentTaskRequestWithReqBody<starrocks::TAlterTabletReqV2> > const&, starrocks::ExecEnv*)
    @          0xc0f245b starrocks::ThreadPool::dispatch_thread()
    @          0xc0e8c49 starrocks::Thread::supervise_thread(void*)
```

## What I'm doing:

Fix all-null value handling bug in sync MV

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
