### PR TITLE
[Enhancement] Support dynamic configuration for exec state report thread pool sizes

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1371,6 +1371,11 @@ CONF_mDouble(spill_max_dir_bytes_ratio, "0.8"); // 80%
 CONF_Int64(spill_read_buffer_min_bytes, "1048576");
 CONF_mInt64(mem_limited_chunk_queue_block_size, "8388608");
 
+// The max number of threads for exec_state_report thread pool.
+CONF_mInt32(exec_state_report_max_threads, "2");
+// The max number of threads for priority_exec_state_report thread pool.
+CONF_mInt32(priority_exec_state_report_max_threads, "2");
+
 CONF_Int32(internal_service_query_rpc_thread_num, "-1");
 CONF_Int32(internal_service_datacache_rpc_thread_num, "-1");
 // The retry times of rpc request to report exec rpc request to FE. The default value is 10,

--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -21,6 +21,7 @@
 
 #include "agent/master_info.h"
 #include "base/network/network_util.h"
+#include "common/config.h"
 #include "common/system/backend_options.h"
 #include "exec/pipeline/pipeline_metrics.h"
 #include "runtime/client_cache.h"
@@ -253,9 +254,10 @@ Status ExecStateReporter::report_epoch(const TMVMaintenanceTasks& params, ExecEn
 }
 
 ExecStateReporter::ExecStateReporter(const CpuUtil::CpuIds& cpuids, ExecStateReporterMetrics* metrics) {
+    int exec_state_report_threads = std::max(1, config::exec_state_report_max_threads);
     auto status = ThreadPoolBuilder("exec_state_report") // exec state reporter
                           .set_min_threads(1)
-                          .set_max_threads(2)
+                          .set_max_threads(exec_state_report_threads)
                           .set_max_queue_size(1000)
                           .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
                           .set_cpuids(cpuids)
@@ -264,9 +266,10 @@ ExecStateReporter::ExecStateReporter(const CpuUtil::CpuIds& cpuids, ExecStateRep
         LOG(FATAL) << "Cannot create thread pool for ExecStateReport: error=" << status.to_string();
     }
 
+    int priority_exec_state_report_threads = std::max(1, config::priority_exec_state_report_max_threads);
     status = ThreadPoolBuilder("priority_exec_state_report") // priority exec state reporter with infinite queue
                      .set_min_threads(1)
-                     .set_max_threads(2)
+                     .set_max_threads(priority_exec_state_report_threads)
                      .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
                      .set_cpuids(cpuids)
                      .build(&_priority_thread_pool);
@@ -296,6 +299,14 @@ void ExecStateReporter::submit(std::function<void()>&& report_task, bool priorit
 void ExecStateReporter::bind_cpus(const CpuUtil::CpuIds& cpuids) const {
     _thread_pool->bind_cpus(cpuids, {});
     _priority_thread_pool->bind_cpus(cpuids, {});
+}
+
+Status ExecStateReporter::update_max_threads(int max_threads) {
+    return _thread_pool->update_max_threads(std::max(1, max_threads));
+}
+
+Status ExecStateReporter::update_priority_max_threads(int max_threads) {
+    return _priority_thread_pool->update_max_threads(std::max(1, max_threads));
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exec_state_reporter.h
+++ b/be/src/exec/pipeline/exec_state_reporter.h
@@ -44,11 +44,20 @@ public:
 
     void bind_cpus(const CpuUtil::CpuIds& cpuids) const;
 
+    Status update_max_threads(int max_threads);
+    Status update_priority_max_threads(int max_threads);
+
     // STREAM MV
     static TMVMaintenanceTasks create_report_epoch_params(const QueryContext* query_ctx,
                                                           const std::vector<FragmentContext*>& fragment_ctxs);
 
     static Status report_epoch(const TMVMaintenanceTasks& params, ExecEnv* exec_env, const TNetworkAddress& fe_addr);
+
+public:
+    // Accessors exposed only for unit tests (via the friend declaration above).
+    // Normal code paths must not call these methods.
+    int TEST_pool_max_threads() const { return _thread_pool->max_threads(); }
+    int TEST_priority_pool_max_threads() const { return _priority_thread_pool->max_threads(); }
 
 private:
     ExecStateReporterMetrics* _metrics;

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -95,6 +95,8 @@ public:
 
     void bind_cpus(const CpuUtil::CpuIds& cpuids, const std::vector<CpuUtil::CpuIds>& borrowed_cpuids) override;
 
+    ExecStateReporter* exec_state_reporter() { return _exec_state_reporter.get(); }
+
 private:
     using Base = FactoryMethod<DriverExecutor, GlobalDriverExecutor>;
     void _worker_thread();

--- a/be/src/exec/workgroup/pipeline_executor_set.cpp
+++ b/be/src/exec/workgroup/pipeline_executor_set.cpp
@@ -186,6 +186,22 @@ void PipelineExecutorSet::notify_config_changed() const {
     LOG(INFO) << "[WORKGROUP] change cpus and threads of executors " << to_string();
 }
 
+Status PipelineExecutorSet::update_exec_state_report_max_threads(int max_threads) const {
+    auto* executor = dynamic_cast<pipeline::GlobalDriverExecutor*>(_driver_executor.get());
+    if (executor != nullptr && executor->exec_state_reporter() != nullptr) {
+        return executor->exec_state_reporter()->update_max_threads(max_threads);
+    }
+    return Status::OK();
+}
+
+Status PipelineExecutorSet::update_priority_exec_state_report_max_threads(int max_threads) const {
+    auto* executor = dynamic_cast<pipeline::GlobalDriverExecutor*>(_driver_executor.get());
+    if (executor != nullptr && executor->exec_state_reporter() != nullptr) {
+        return executor->exec_state_reporter()->update_priority_max_threads(max_threads);
+    }
+    return Status::OK();
+}
+
 uint32_t PipelineExecutorSet::calculate_num_threads(uint32_t num_total_threads) const {
     if (!_borrowed_cpu_ids.empty()) {
         return num_total_threads;

--- a/be/src/exec/workgroup/pipeline_executor_set.h
+++ b/be/src/exec/workgroup/pipeline_executor_set.h
@@ -58,6 +58,9 @@ public:
     void notify_num_total_connector_scan_threads_changed() const;
     void notify_config_changed() const;
 
+    Status update_exec_state_report_max_threads(int max_threads) const;
+    Status update_priority_exec_state_report_max_threads(int max_threads) const;
+
     pipeline::DriverExecutor* driver_executor() const { return _driver_executor.get(); }
     ScanExecutor* scan_executor() const { return _scan_executor.get(); }
     ScanExecutor* connector_scan_executor() const { return _connector_scan_executor.get(); }

--- a/be/src/exec/workgroup/pipeline_executor_set_manager.cpp
+++ b/be/src/exec/workgroup/pipeline_executor_set_manager.cpp
@@ -157,6 +157,20 @@ void ExecutorsManager::change_enable_resource_group_cpu_borrowing(bool val) {
     update_shared_executors();
 }
 
+void ExecutorsManager::change_exec_state_report_max_threads(int max_threads) {
+    for_each_executors([max_threads](const auto& executors) {
+        auto st = executors.update_exec_state_report_max_threads(max_threads);
+        LOG_IF(WARNING, !st.ok()) << "[WORKGROUP] change exec_state_report_max_threads failed: " << st;
+    });
+}
+
+void ExecutorsManager::change_priority_exec_state_report_max_threads(int max_threads) {
+    for_each_executors([max_threads](const auto& executors) {
+        auto st = executors.update_priority_exec_state_report_max_threads(max_threads);
+        LOG_IF(WARNING, !st.ok()) << "[WORKGROUP] change priority_exec_state_report_max_threads failed: " << st;
+    });
+}
+
 void ExecutorsManager::for_each_executors(const ExecutorsConsumer& consumer) const {
     for (const auto& [_, wg] : _parent->_workgroups) {
         if (wg != nullptr && wg->exclusive_executors() != nullptr) {

--- a/be/src/exec/workgroup/pipeline_executor_set_manager.h
+++ b/be/src/exec/workgroup/pipeline_executor_set_manager.h
@@ -60,6 +60,8 @@ public:
 
     void change_num_connector_scan_threads(uint32_t num_connector_scan_threads);
     void change_enable_resource_group_cpu_borrowing(bool val);
+    void change_exec_state_report_max_threads(int max_threads);
+    void change_priority_exec_state_report_max_threads(int max_threads);
 
     using ExecutorsConsumer = std::function<void(PipelineExecutorSet&)>;
     void for_each_executors(const ExecutorsConsumer& consumer) const;

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -693,6 +693,16 @@ void WorkGroupManager::change_enable_resource_group_cpu_borrowing(const bool val
     _executors_manager.change_enable_resource_group_cpu_borrowing(val);
 }
 
+void WorkGroupManager::change_exec_state_report_max_threads(int max_threads) {
+    std::shared_lock read_lock(_mutex);
+    _executors_manager.change_exec_state_report_max_threads(max_threads);
+}
+
+void WorkGroupManager::change_priority_exec_state_report_max_threads(int max_threads) {
+    std::shared_lock read_lock(_mutex);
+    _executors_manager.change_priority_exec_state_report_max_threads(max_threads);
+}
+
 void WorkGroupManager::set_workgroup_expiration_time(const std::chrono::seconds value) {
     std::unique_lock write_lock(_mutex);
     _workgroup_expiration_time = value;

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -310,6 +310,8 @@ public:
     void for_each_executors(const ExecutorsManager::ExecutorsConsumer& consumer) const;
     void change_num_connector_scan_threads(uint32_t num_connector_scan_threads);
     void change_enable_resource_group_cpu_borrowing(bool val);
+    void change_exec_state_report_max_threads(int max_threads);
+    void change_priority_exec_state_report_max_threads(int max_threads);
     void set_workgroup_expiration_time(std::chrono::seconds value);
 
 private:

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -385,6 +385,19 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             return ExecEnv::GetInstance()->load_channel_mgr()->async_rpc_pool()->update_max_threads(
                     config::load_channel_rpc_thread_pool_num);
         });
+        _config_callback.emplace("exec_state_report_max_threads", [&]() -> Status {
+            LOG(INFO) << "set exec_state_report_max_threads:" << config::exec_state_report_max_threads;
+            ExecEnv::GetInstance()->workgroup_manager()->change_exec_state_report_max_threads(
+                    config::exec_state_report_max_threads);
+            return Status::OK();
+        });
+        _config_callback.emplace("priority_exec_state_report_max_threads", [&]() -> Status {
+            LOG(INFO) << "set priority_exec_state_report_max_threads:"
+                      << config::priority_exec_state_report_max_threads;
+            ExecEnv::GetInstance()->workgroup_manager()->change_priority_exec_state_report_max_threads(
+                    config::priority_exec_state_report_max_threads);
+            return Status::OK();
+        });
         _config_callback.emplace("number_tablet_writer_threads", [&]() -> Status {
             int max_delta_writer_thread_num = caculate_delta_writer_thread_num(config::number_tablet_writer_threads);
             LOG(INFO) << "set max delta writer thread num: " << max_delta_writer_thread_num;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -55,6 +55,7 @@ set(EXEC_FILES
         ./exec/paimon/paimon_delete_file_builder_test.cpp
         ./exec/workgroup/scan_task_queue_test.cpp
         ./exec/workgroup/pipeline_executor_set_test.cpp
+        ./exec/workgroup/pipeline_executor_set_manager_test.cpp
         ./exec/workgroup/work_group_manager_test.cpp
         ./exec/workgroup/mem_tracker_manager_test.cpp
         ./exec/pipeline/schedule/observer_test.cpp

--- a/be/test/exec/workgroup/pipeline_executor_set_manager_test.cpp
+++ b/be/test/exec/workgroup/pipeline_executor_set_manager_test.cpp
@@ -1,0 +1,374 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "base/testutil/assert.h"
+#include "base/testutil/parallel_test.h"
+#include "exec/pipeline/pipeline_driver_executor.h"
+#include "exec/pipeline/pipeline_metrics.h"
+#include "exec/workgroup/pipeline_executor_set.h"
+#include "exec/workgroup/work_group.h"
+
+namespace starrocks::workgroup {
+
+// ---------------------------------------------------------------------------
+// Helper utilities
+// ---------------------------------------------------------------------------
+
+static TWorkGroup make_exclusive_twg(int64_t id, int32_t exclusive_cpu_cores) {
+    TWorkGroup twg;
+    twg.__set_id(id);
+    twg.__set_version(1);
+    twg.__set_name("exclusive_wg_" + std::to_string(id));
+    twg.__set_exclusive_cpu_cores(exclusive_cpu_cores);
+    twg.__set_mem_limit(0.5);
+    return twg;
+}
+
+static TWorkGroupOp make_create_op(const TWorkGroup& twg) {
+    TWorkGroupOp op;
+    op.__set_workgroup(twg);
+    op.__set_op_type(TWorkGroupOpType::WORKGROUP_OP_CREATE);
+    return op;
+}
+
+// ---------------------------------------------------------------------------
+// ExecutorsManagerTest
+//
+// Tests that do NOT require executor threads to be running.  The manager is
+// constructed with null metrics and empty CPUIDs so start() is never called.
+// The lambdas passed to for_each_executors only count visits and never
+// dereference sub-executor members (which would be null in un-started sets).
+// ---------------------------------------------------------------------------
+
+TEST(ExecutorsManagerTest, for_each_executors_visits_only_shared_when_no_exclusive_workgroups) {
+    // With null metrics and empty CPUIDs, no exclusive executor can be created,
+    // so for_each_executors should visit exactly the one shared executor set.
+    PipelineExecutorSetConfig config(8, 2, 2, 4, CpuUtil::CpuIds{}, false, false, nullptr);
+    auto manager = std::make_unique<WorkGroupManager>(config);
+
+    int visit_count = 0;
+    manager->for_each_executors([&visit_count](PipelineExecutorSet&) { ++visit_count; });
+
+    ASSERT_EQ(1, visit_count);
+
+    manager->destroy();
+}
+
+TEST(ExecutorsManagerTest, for_each_executors_still_one_when_shared_workgroups_exist) {
+    // Workgroups that cannot obtain exclusive CPUs (empty total_cpuids) use the
+    // shared executor set, so the visit count stays 1.
+    PipelineExecutorSetConfig config(8, 2, 2, 4, CpuUtil::CpuIds{}, false, false, nullptr);
+    auto manager = std::make_unique<WorkGroupManager>(config);
+
+    // Add two workgroups that would request exclusive cores but cannot get them.
+    TWorkGroup twg1 = make_exclusive_twg(10, 4);
+    TWorkGroup twg2 = make_exclusive_twg(11, 2);
+    manager->apply({make_create_op(twg1), make_create_op(twg2)});
+
+    int visit_count = 0;
+    manager->for_each_executors([&visit_count](PipelineExecutorSet&) { ++visit_count; });
+
+    // Both workgroups fall back to the shared executor because total_cpuids is
+    // empty, so still only 1 executor set is visited.
+    ASSERT_EQ(1, visit_count);
+
+    manager->destroy();
+}
+
+// ---------------------------------------------------------------------------
+// ExecutorsManagerIntegrationTest
+//
+// Tests that require fully started executor sets, including real thread pools.
+// Using 8 total cores with actual CPUIDs and a real PipelineExecutorMetrics so
+// that start() and exclusive-executor creation succeed.
+//
+// Config layout:
+//   total_cores = 8, cpuids = {0..7}
+//   initial num_total_connector_scan_threads = 4
+//
+// After applying an exclusive workgroup with exclusive_cpu_cores = 4:
+//   exclusive executor: cpuids = {0,1,2,3}
+//   shared executor  : cpuids = {4,5,6,7}
+//   num_connector_scan_threads per set = max(1, 4 * 4/8) = 2 (before any change)
+// ---------------------------------------------------------------------------
+
+class ExecutorsManagerIntegrationTest : public ::testing::Test {
+protected:
+    static constexpr uint32_t kTotalCores = 8;
+    static constexpr uint32_t kInitConnScanThreads = 4;
+
+    void SetUp() override {
+        _metrics = std::make_unique<pipeline::PipelineExecutorMetrics>();
+        CpuUtil::CpuIds cpuids{0, 1, 2, 3, 4, 5, 6, 7};
+        // enable_bind_cpus=false → thread pools are created without CPU pinning,
+        // which avoids requiring actual core-binding privileges in CI.
+        _config = std::make_unique<PipelineExecutorSetConfig>(kTotalCores, 2, 2, kInitConnScanThreads, cpuids, false,
+                                                              false, _metrics.get());
+        _manager = std::make_unique<WorkGroupManager>(*_config);
+        ASSERT_OK(_manager->start());
+    }
+
+    void TearDown() override {
+        _manager->close();
+        _manager->destroy();
+        // _manager and _config must die before _metrics so that thread pools
+        // (and their executor-metric references) are fully cleaned up first.
+        _manager.reset();
+        _config.reset();
+        _metrics.reset();
+    }
+
+    // Apply a CREATE op for a workgroup with the given number of exclusive cores.
+    void apply_exclusive_workgroup(int64_t id, int32_t exclusive_cores) {
+        _manager->apply({make_create_op(make_exclusive_twg(id, exclusive_cores))});
+    }
+
+    // Return the exclusive PipelineExecutorSet for any workgroup that has one,
+    // or nullptr if none exists.
+    PipelineExecutorSet* find_exclusive_executor() const {
+        PipelineExecutorSet* result = nullptr;
+        _manager->for_each_workgroup([&result](const WorkGroup& wg) {
+            if (wg.exclusive_executors() != nullptr) {
+                result = wg.exclusive_executors();
+            }
+        });
+        return result;
+    }
+
+    // Return the max_threads of the normal exec_state_report thread pool owned by the executor set.
+    // Only for unit tests: accesses ExecStateReporter::TEST_pool_max_threads() via friend.
+    static int TEST_exec_state_report_pool_max_threads(const PipelineExecutorSet* exec_set) {
+        auto* driver_exec = dynamic_cast<pipeline::GlobalDriverExecutor*>(exec_set->driver_executor());
+        EXPECT_NE(nullptr, driver_exec);
+        if (driver_exec == nullptr || driver_exec->exec_state_reporter() == nullptr) return -1;
+        return driver_exec->exec_state_reporter()->TEST_pool_max_threads();
+    }
+
+    // Return the max_threads of the priority exec_state_report thread pool owned by the executor set.
+    // Only for unit tests: accesses ExecStateReporter::TEST_priority_pool_max_threads() via friend.
+    static int TEST_priority_exec_state_report_pool_max_threads(const PipelineExecutorSet* exec_set) {
+        auto* driver_exec = dynamic_cast<pipeline::GlobalDriverExecutor*>(exec_set->driver_executor());
+        EXPECT_NE(nullptr, driver_exec);
+        if (driver_exec == nullptr || driver_exec->exec_state_reporter() == nullptr) return -1;
+        return driver_exec->exec_state_reporter()->TEST_priority_pool_max_threads();
+    }
+
+    std::unique_ptr<pipeline::PipelineExecutorMetrics> _metrics;
+    std::unique_ptr<PipelineExecutorSetConfig> _config;
+    std::unique_ptr<WorkGroupManager> _manager;
+};
+
+// With no workgroups, only the shared executor set exists → 1 visit.
+TEST_F(ExecutorsManagerIntegrationTest, for_each_executors_visits_only_shared_by_default) {
+    int visit_count = 0;
+    _manager->for_each_executors([&visit_count](PipelineExecutorSet&) { ++visit_count; });
+    ASSERT_EQ(1, visit_count);
+}
+
+// After adding an exclusive workgroup (which successfully obtains dedicated CPUs
+// because total_cpuids is non-empty), for_each_executors should visit both the
+// exclusive and the shared executor set.
+TEST_F(ExecutorsManagerIntegrationTest, for_each_executors_visits_both_shared_and_exclusive) {
+    apply_exclusive_workgroup(200, 4);
+
+    int visit_count = 0;
+    _manager->for_each_executors([&visit_count](PipelineExecutorSet&) { ++visit_count; });
+
+    // 1 exclusive + 1 shared
+    ASSERT_EQ(2, visit_count);
+    ASSERT_NE(nullptr, find_exclusive_executor());
+}
+
+// change_num_connector_scan_threads propagates the new thread-count to the
+// shared executor set when no exclusive workgroup exists.
+TEST_F(ExecutorsManagerIntegrationTest, change_num_connector_scan_threads_updates_shared_executor) {
+    // All 8 CPUs belong to shared initially: max(1, 4 * 8/8) = 4.
+    ASSERT_EQ(4u, _manager->shared_executors()->num_connector_scan_threads());
+
+    _manager->change_num_connector_scan_threads(8);
+
+    // Shared still holds all 8 CPUs: max(1, 8 * 8/8) = 8.
+    ASSERT_EQ(8u, _manager->shared_executors()->num_connector_scan_threads());
+}
+
+// After change_num_connector_scan_threads, the new thread-count is reflected
+// both by the shared executor set and by every exclusive executor set.
+TEST_F(ExecutorsManagerIntegrationTest, change_num_connector_scan_threads_propagates_to_exclusive_executor) {
+    apply_exclusive_workgroup(201, 4);
+    // exclusive: cpuids={0..3}, shared: cpuids={4..7}
+    // Before change: max(1, 4 * 4/8) = 2 for both.
+    ASSERT_EQ(2u, _manager->shared_executors()->num_connector_scan_threads());
+
+    PipelineExecutorSet* excl_exec = find_exclusive_executor();
+    ASSERT_NE(nullptr, excl_exec);
+    ASSERT_EQ(2u, excl_exec->num_connector_scan_threads());
+
+    _manager->change_num_connector_scan_threads(8);
+
+    // After change: max(1, 8 * 4/8) = 4 for both executor sets.
+    ASSERT_EQ(4u, _manager->shared_executors()->num_connector_scan_threads());
+    ASSERT_EQ(4u, excl_exec->num_connector_scan_threads());
+}
+
+// Calling change_num_connector_scan_threads with the same value as the current
+// config is a no-op (the guard in change_num_connector_scan_threads prevents
+// unnecessary notifications).  Subsequent calls with a different value still
+// take effect.
+TEST_F(ExecutorsManagerIntegrationTest, change_num_connector_scan_threads_no_op_when_same_value) {
+    // All 8 CPUs belong to shared: max(1, 4 * 8/8) = 4.
+    ASSERT_EQ(4u, _manager->shared_executors()->num_connector_scan_threads());
+
+    // Call with the same initial value — should not change anything.
+    _manager->change_num_connector_scan_threads(kInitConnScanThreads);
+    ASSERT_EQ(4u, _manager->shared_executors()->num_connector_scan_threads());
+
+    // A subsequent call with a new value must still take effect.
+    _manager->change_num_connector_scan_threads(8);
+    ASSERT_EQ(8u, _manager->shared_executors()->num_connector_scan_threads());
+
+    // Calling again with the same new value remains a no-op.
+    _manager->change_num_connector_scan_threads(8);
+    ASSERT_EQ(8u, _manager->shared_executors()->num_connector_scan_threads());
+}
+
+// ---------------------------------------------------------------------------
+// exec_state_report thread-pool size tests
+//
+// These tests mirror the SQL integration test in
+// test/sql/test_exec_state_report_threadpool_size/T/test_exec_state_report_threadpool_size
+// and verify that change_exec_state_report_max_threads /
+// change_priority_exec_state_report_max_threads propagate to the correct
+// thread pools in both the shared and exclusive executor sets.
+//
+// Key difference from connector-scan thread tests: exec_state_reporter pools
+// use the raw config value directly (no proportional-to-cpu-cores scaling),
+// so shared and exclusive executor sets always get the same per-pool value.
+// ---------------------------------------------------------------------------
+
+// change_exec_state_report_max_threads updates the shared executor's normal
+// pool when no exclusive workgroup exists.
+TEST_F(ExecutorsManagerIntegrationTest, change_exec_state_report_max_threads_updates_shared_executor) {
+    // Establish a known baseline (config default is 2).
+    _manager->change_exec_state_report_max_threads(2);
+    ASSERT_EQ(2, TEST_exec_state_report_pool_max_threads(_manager->shared_executors()));
+
+    _manager->change_exec_state_report_max_threads(4);
+
+    ASSERT_EQ(4, TEST_exec_state_report_pool_max_threads(_manager->shared_executors()));
+}
+
+// change_exec_state_report_max_threads propagates to both the shared and the
+// exclusive executor set.  Unlike connector-scan threads there is no
+// proportional-to-cpu-cores scaling: both sets receive the raw config value.
+TEST_F(ExecutorsManagerIntegrationTest, change_exec_state_report_max_threads_propagates_to_exclusive_executor) {
+    apply_exclusive_workgroup(300, 4);
+    // exclusive: cpuids={0..3}, shared: cpuids={4..7}
+
+    _manager->change_exec_state_report_max_threads(2);
+    ASSERT_EQ(2, TEST_exec_state_report_pool_max_threads(_manager->shared_executors()));
+
+    PipelineExecutorSet* excl_exec = find_exclusive_executor();
+    ASSERT_NE(nullptr, excl_exec);
+    ASSERT_EQ(2, TEST_exec_state_report_pool_max_threads(excl_exec));
+
+    _manager->change_exec_state_report_max_threads(4);
+
+    // Both shared and exclusive receive the full config value — no cpu-fraction scaling.
+    ASSERT_EQ(4, TEST_exec_state_report_pool_max_threads(_manager->shared_executors()));
+    ASSERT_EQ(4, TEST_exec_state_report_pool_max_threads(excl_exec));
+}
+
+// change_priority_exec_state_report_max_threads updates the shared executor's
+// priority pool when no exclusive workgroup exists.
+TEST_F(ExecutorsManagerIntegrationTest, change_priority_exec_state_report_max_threads_updates_shared_executor) {
+    _manager->change_priority_exec_state_report_max_threads(2);
+    ASSERT_EQ(2, TEST_priority_exec_state_report_pool_max_threads(_manager->shared_executors()));
+
+    _manager->change_priority_exec_state_report_max_threads(6);
+
+    ASSERT_EQ(6, TEST_priority_exec_state_report_pool_max_threads(_manager->shared_executors()));
+}
+
+// change_priority_exec_state_report_max_threads propagates to both the shared
+// and the exclusive executor set with the raw config value.
+TEST_F(ExecutorsManagerIntegrationTest,
+       change_priority_exec_state_report_max_threads_propagates_to_exclusive_executor) {
+    apply_exclusive_workgroup(301, 4);
+
+    _manager->change_priority_exec_state_report_max_threads(2);
+    ASSERT_EQ(2, TEST_priority_exec_state_report_pool_max_threads(_manager->shared_executors()));
+
+    PipelineExecutorSet* excl_exec = find_exclusive_executor();
+    ASSERT_NE(nullptr, excl_exec);
+    ASSERT_EQ(2, TEST_priority_exec_state_report_pool_max_threads(excl_exec));
+
+    _manager->change_priority_exec_state_report_max_threads(6);
+
+    ASSERT_EQ(6, TEST_priority_exec_state_report_pool_max_threads(_manager->shared_executors()));
+    ASSERT_EQ(6, TEST_priority_exec_state_report_pool_max_threads(excl_exec));
+}
+
+// Mirrors the SQL test's three-phase scenario (default→enlarge→shrink) for
+// the normal exec_state_report pool with both shared and exclusive executor
+// sets present.
+TEST_F(ExecutorsManagerIntegrationTest, change_exec_state_report_max_threads_enlarge_then_shrink) {
+    apply_exclusive_workgroup(302, 4);
+    PipelineExecutorSet* excl_exec = find_exclusive_executor();
+    ASSERT_NE(nullptr, excl_exec);
+
+    // Phase 1 – default (2 per pool, matching config default).
+    _manager->change_exec_state_report_max_threads(2);
+    ASSERT_EQ(2, TEST_exec_state_report_pool_max_threads(_manager->shared_executors()));
+    ASSERT_EQ(2, TEST_exec_state_report_pool_max_threads(excl_exec));
+
+    // Phase 2 – enlarge to 4.
+    _manager->change_exec_state_report_max_threads(4);
+    ASSERT_EQ(4, TEST_exec_state_report_pool_max_threads(_manager->shared_executors()));
+    ASSERT_EQ(4, TEST_exec_state_report_pool_max_threads(excl_exec));
+
+    // Phase 3 – shrink back to 2.
+    _manager->change_exec_state_report_max_threads(2);
+    ASSERT_EQ(2, TEST_exec_state_report_pool_max_threads(_manager->shared_executors()));
+    ASSERT_EQ(2, TEST_exec_state_report_pool_max_threads(excl_exec));
+}
+
+// Mirrors the SQL test's three-phase scenario for the priority
+// exec_state_report pool with both shared and exclusive executor sets present.
+TEST_F(ExecutorsManagerIntegrationTest, change_priority_exec_state_report_max_threads_enlarge_then_shrink) {
+    apply_exclusive_workgroup(303, 4);
+    PipelineExecutorSet* excl_exec = find_exclusive_executor();
+    ASSERT_NE(nullptr, excl_exec);
+
+    // Phase 1 – default (2 per pool).
+    _manager->change_priority_exec_state_report_max_threads(2);
+    ASSERT_EQ(2, TEST_priority_exec_state_report_pool_max_threads(_manager->shared_executors()));
+    ASSERT_EQ(2, TEST_priority_exec_state_report_pool_max_threads(excl_exec));
+
+    // Phase 2 – enlarge to 6 (matching the SQL test's priority_exec_state_report_max_threads = 6).
+    _manager->change_priority_exec_state_report_max_threads(6);
+    ASSERT_EQ(6, TEST_priority_exec_state_report_pool_max_threads(_manager->shared_executors()));
+    ASSERT_EQ(6, TEST_priority_exec_state_report_pool_max_threads(excl_exec));
+
+    // Phase 3 – shrink back to 2.
+    _manager->change_priority_exec_state_report_max_threads(2);
+    ASSERT_EQ(2, TEST_priority_exec_state_report_pool_max_threads(_manager->shared_executors()));
+    ASSERT_EQ(2, TEST_priority_exec_state_report_pool_max_threads(excl_exec));
+}
+
+} // namespace starrocks::workgroup

--- a/be/test/exec/workgroup/pipeline_executor_set_test.cpp
+++ b/be/test/exec/workgroup/pipeline_executor_set_test.cpp
@@ -76,4 +76,69 @@ PARALLEL_TEST(PipelineExecutorSetConfigTest, test_constructor) {
     }
 }
 
+// Tests for PipelineExecutorSet::calculate_num_threads and the thread-count accessors.
+// These tests create a PipelineExecutorSet without calling start() to verify the
+// thread-count scaling logic in isolation.
+
+// Shared executor (no borrowed CPUs): thread count is scaled proportionally
+// to the fraction of total cores assigned to this executor set.
+TEST(PipelineExecutorSetTest, test_calculate_num_threads_proportional) {
+    CpuUtil::CpuIds all_cpuids{0, 1, 2, 3, 4, 5, 6, 7};
+    // 8 total cores, 16 total connector-scan threads.
+    PipelineExecutorSetConfig conf(8, 8, 8, 16, all_cpuids, false, false, nullptr);
+
+    // Executor covering 2 out of 8 CPUs, no borrowed CPUs → 8 * 2/8 = 2 for driver/scan, 16 * 2/8 = 4 for connector scan
+    PipelineExecutorSet exec(conf, "test_shared", CpuUtil::CpuIds{0, 1}, /*borrowed=*/{});
+    EXPECT_EQ(4u, exec.num_connector_scan_threads());
+    EXPECT_EQ(2u, exec.num_driver_threads());
+    EXPECT_EQ(2u, exec.num_scan_threads());
+}
+
+// Exclusive executor (shared with CPU borrowing): when borrowed_cpuids is non-empty
+// the executor will use borrowed CPUs and should receive the full thread count so
+// it can fully utilise those extra cores.
+TEST(PipelineExecutorSetTest, test_calculate_num_threads_full_when_borrowed) {
+    CpuUtil::CpuIds all_cpuids{0, 1, 2, 3, 4, 5, 6, 7};
+    // 8 total cores, 16 total connector-scan threads.
+    PipelineExecutorSetConfig conf(8, 8, 8, 16, all_cpuids, false, false, nullptr);
+
+    // Executor with 2 own CPUs but also borrows {2,3,4,5} → returns num_total_driver_threads -> 8.
+    PipelineExecutorSet exec(conf, "test_borrowed", CpuUtil::CpuIds{0, 1},
+                             /*borrowed=*/{{2, 3, 4, 5}});
+    EXPECT_EQ(16u, exec.num_connector_scan_threads());
+    EXPECT_EQ(8u, exec.num_driver_threads());
+    EXPECT_EQ(8u, exec.num_scan_threads());
+}
+
+// The result is floored at 1 even when num_total_threads is very small relative
+// to the total core count.
+TEST(PipelineExecutorSetTest, test_calculate_num_threads_minimum_one) {
+    CpuUtil::CpuIds all_cpuids{0, 1, 2, 3, 4, 5, 6, 7};
+    // 8 total cores, only 1 total connector-scan thread configured.
+    PipelineExecutorSetConfig conf(8, 1, 1, 1, all_cpuids, false, false, nullptr);
+
+    // 1 out of 8 CPUs → 1 * 1/8 = 0, but floor is 1.
+    PipelineExecutorSet exec(conf, "test_min", CpuUtil::CpuIds{0}, /*borrowed=*/{});
+    EXPECT_EQ(1u, exec.num_connector_scan_threads());
+    EXPECT_EQ(1u, exec.num_driver_threads());
+    EXPECT_EQ(1u, exec.num_scan_threads());
+}
+
+// After the total-thread-count configuration is updated (simulating
+// change_num_connector_scan_threads), the accessor reflects the new value.
+TEST(PipelineExecutorSetTest, test_calculate_num_threads_reflects_config_update) {
+    CpuUtil::CpuIds all_cpuids{0, 1, 2, 3, 4, 5, 6, 7};
+    // Mutable config: num_total_connector_scan_threads starts at 4.
+    PipelineExecutorSetConfig conf(8, 4, 4, 4, all_cpuids, false, false, nullptr);
+
+    PipelineExecutorSet exec(conf, "test_update", CpuUtil::CpuIds{0, 1, 2, 3}, /*borrowed=*/{});
+    // 4 * 4/8 = 2 initially.
+    EXPECT_EQ(2u, exec.num_connector_scan_threads());
+
+    // Simulate the config update performed by change_num_connector_scan_threads.
+    conf.num_total_connector_scan_threads = 8;
+    // The accessor now returns the updated proportional value: 8 * 4/8 = 4.
+    EXPECT_EQ(4u, exec.num_connector_scan_threads());
+}
+
 } // namespace starrocks::workgroup

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -773,6 +773,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Description: The maximum buffer size on the receiver end of an exchange node for each query. This configuration item is a soft limit. A backpressure is triggered when data is sent to the receiver end with an excessive speed.
 - Introduced in: -
 
+##### exec_state_report_max_threads
+
+- Default: 2
+- Type: Int
+- Unit: Threads
+- Is mutable: Yes
+- Description: Maximum number of threads for the exec-state-report thread pool. This pool is used by `ExecStateReporter` to asynchronously send non-priority execution status reports (such as fragment completion and error status) from BE to FE via RPC. The actual pool size at startup is `max(1, exec_state_report_max_threads)`. Changing this config at runtime triggers `update_max_threads` on the pool in every executor set (shared and exclusive). The pool has a fixed task queue size of 1000; report submissions are silently dropped when all threads are busy and the queue is full. Paired with `priority_exec_state_report_max_threads` for the high-priority pool. Increase this value when delayed or dropped exec-state reports are observed under high query concurrency.
+- Introduced in: v4.1.0, v4.0.8, v3.5.15
+
 ##### file_descriptor_cache_capacity
 
 - Default: 16384
@@ -1105,6 +1114,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Is mutable: Yes
 - Description: Sets the maximum queue size (number of pending tasks) for the "cloud_native_pk_index_get" thread pool used by PK index parallel get operations in shared-data (cloud-native/lake) mode. The actual thread count for that pool is controlled by `pk_index_parallel_get_threadpool_max_threads`; this setting only limits how many tasks may be queued awaiting execution. The very large default (2^20) effectively makes the queue unbounded; lowering it prevents excessive memory growth from queued tasks but may cause task submissions to block or fail when the queue is full. Tune together with `pk_index_parallel_get_threadpool_max_threads` based on workload concurrency and memory constraints.
 - Introduced in: -
+
+##### priority_exec_state_report_max_threads
+
+- Default: 2
+- Type: Int
+- Unit: Threads
+- Is mutable: Yes
+- Description: Maximum number of threads for the high-priority exec-state-report thread pool. This pool is used by `ExecStateReporter` to asynchronously send high-priority execution status reports (such as urgent fragment failures) from BE to FE via RPC. Unlike the normal exec-state-report pool, this pool has an unbounded task queue. The actual pool size at startup is `max(1, priority_exec_state_report_max_threads)`. Changing this config at runtime triggers `update_max_threads` on the priority pool in every executor set (shared and exclusive). Paired with `exec_state_report_max_threads` for the normal pool. Increase this value when high-priority reports are delayed under heavy concurrent query loads.
+- Introduced in: v4.1.0, v4.0.8, v3.5.15
 
 ##### priority_queue_remaining_tasks_increased_frequency
 

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -596,6 +596,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: 各クエリの交換ノードの受信側の最大バッファサイズ。この設定項目はソフトリミットです。データが過剰な速度で受信側に送信されると、バックプレッシャーがトリガーされます。
 - 導入バージョン: -
 
+##### exec_state_report_max_threads
+
+- デフォルト: 2
+- タイプ: Int
+- 単位: スレッド
+- 可変: はい
+- 説明: exec-state-report スレッドプールの最大スレッド数。このプールは `ExecStateReporter` が通常優先度の実行状態レポート（フラグメント完了やエラーステータスなど）を BE から FE へ非同期で RPC 送信するために使用されます。起動時の実際のプールサイズは `max(1, exec_state_report_max_threads)` になります。このコンフィグを実行時に変更すると、全エグゼキュータセット（共有・専有）のプールに対して `update_max_threads` が呼び出されます。プールのタスクキューサイズは 1000 固定です。高並行クエリ実行時に実行状態レポートが遅延または消失する場合は値を増やしてください。対応する高優先度プールは `priority_exec_state_report_max_threads` で制御します。
+- 導入バージョン: v4.1.0, v4.0.8, v3.5.15
+
 ##### file_descriptor_cache_capacity
 
 - デフォルト: 16384
@@ -900,6 +909,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 可変: いいえ
 - 説明: Pipeline 実行エンジンの SCAN スレッドプールの最大タスクキュー長。
 - 導入バージョン: -
+
+##### priority_exec_state_report_max_threads
+
+- デフォルト: 2
+- タイプ: Int
+- 単位: スレッド
+- 可変: はい
+- 説明: 高優先度 exec-state-report スレッドプールの最大スレッド数。このプールは `ExecStateReporter` が高優先度の実行状態レポート（緊急なフラグメント失敗など）を BE から FE へ非同期で RPC 送信するために使用されます。通常のプールとは異なり、このプールのタスクキューはサイズ無制限です。起動時の実際のプールサイズは `max(1, priority_exec_state_report_max_threads)` になります。このコンフィグを実行時に変更すると、全エグゼキュータセット（共有・専有）の優先度プールに対して `update_max_threads` が呼び出されます。通常プールは `exec_state_report_max_threads` で制御します。
+- 導入バージョン: v4.1.0, v4.0.8, v3.5.15
 
 ##### query_cache_capacity
 

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -764,6 +764,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：Exchange 算子中，单个查询在接收端的 Buffer 容量。这是一个软限制，如果数据的发送速度过快，接收端会触发反压来限制发送速度。
 - 引入版本：-
 
+##### exec_state_report_max_threads
+
+- 默认值：2
+- 类型：Int
+- 单位：Threads
+- 是否动态：是
+- 描述：exec-state-report 线程池的最大线程数。该线程池由 `ExecStateReporter` 用于将普通优先级的执行状态报告（如 Fragment 完成状态、错误状态等）从 BE 异步地通过 RPC 上报给 FE。启动时实际使用的线程数为 `max(1, exec_state_report_max_threads)`。运行时修改此配置会触发对所有 Executor Set（共享和独占）中线程池调用 `update_max_threads`。该线程池的任务队列大小固定为 1000，当所有线程繁忙且队列已满时，新的上报任务将被静默丢弃。高优先级线程池由 `priority_exec_state_report_max_threads` 控制。若在高并发查询场景下观察到执行状态上报延迟或丢失，可适当增大此值。
+- 引入版本：v4.1.0, v4.0.8, v3.5.15
+
 ##### file_descriptor_cache_capacity
 
 - 默认值：16384
@@ -1087,6 +1096,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：是
 - 描述: 设置用于 shared-data（cloud-native / lake）模式下 PK 索引并行获取操作的 "cloud_native_pk_index_get" 线程池的最大队列大小（待处理任务数量）。该池的实际线程数由 `pk_index_parallel_get_threadpool_max_threads` 控制；此设置仅限制可排队等待执行的任务数量。非常大的默认值（2^20）实际上使队列近似无界；降低此值可以防止排队任务导致的内存过度增长，但在队列已满时可能导致任务提交阻塞或失败。应根据工作负载并发性和内存约束与 `pk_index_parallel_get_threadpool_max_threads` 一起调优。
 - 引入版本: -
+
+##### priority_exec_state_report_max_threads
+
+- 默认值：2
+- 类型：Int
+- 单位：Threads
+- 是否动态：是
+- 描述：高优先级 exec-state-report 线程池的最大线程数。该线程池由 `ExecStateReporter` 用于将高优先级执行状态报告（如紧急 Fragment 失败）从 BE 异步地通过 RPC 上报给 FE。与普通线程池不同，该线程池的任务队列无上限。启动时实际使用的线程数为 `max(1, priority_exec_state_report_max_threads)`。运行时修改此配置会触发对所有 Executor Set（共享和独占）中优先级线程池调用 `update_max_threads`。普通线程池由 `exec_state_report_max_threads` 控制。
+- 引入版本：v4.1.0, v4.0.8, v3.5.15
 
 ##### query_cache_capacity
 

--- a/test/sql/test_exec_state_report_threadpool_size/R/test_exec_state_report_threadpool_size
+++ b/test/sql/test_exec_state_report_threadpool_size/R/test_exec_state_report_threadpool_size
@@ -1,0 +1,28 @@
+-- name: test_exec_state_report_threadpool_size
+SELECT NAME, VALUE, `DEFAULT`, MUTABLE FROM information_schema.be_configs WHERE NAME LIKE '%exec_state_report_max_threads' ORDER BY BE_ID, NAME limit 2;
+-- result:
+exec_state_report_max_threads	2	2	1
+priority_exec_state_report_max_threads	2	2	1
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '4' WHERE NAME = 'exec_state_report_max_threads';
+-- result:
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '6' WHERE NAME = 'priority_exec_state_report_max_threads';
+-- result:
+-- !result
+SELECT NAME, VALUE, `DEFAULT`, MUTABLE FROM information_schema.be_configs WHERE NAME LIKE '%exec_state_report_max_threads' ORDER BY BE_ID, NAME limit 2;
+-- result:
+exec_state_report_max_threads	4	2	1
+priority_exec_state_report_max_threads	6	2	1
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '2' WHERE NAME = 'exec_state_report_max_threads';
+-- result:
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '2' WHERE NAME = 'priority_exec_state_report_max_threads';
+-- result:
+-- !result
+SELECT NAME, VALUE, `DEFAULT`, MUTABLE FROM information_schema.be_configs WHERE NAME LIKE '%exec_state_report_max_threads' ORDER BY BE_ID, NAME limit 2;
+-- result:
+exec_state_report_max_threads	2	2	1
+priority_exec_state_report_max_threads	2	2	1
+-- !result

--- a/test/sql/test_exec_state_report_threadpool_size/T/test_exec_state_report_threadpool_size
+++ b/test/sql/test_exec_state_report_threadpool_size/T/test_exec_state_report_threadpool_size
@@ -1,0 +1,18 @@
+-- name: test_exec_state_report_threadpool_size
+
+-- take the config and metric snapshot before making changes
+SELECT NAME, VALUE, `DEFAULT`, MUTABLE FROM information_schema.be_configs WHERE NAME LIKE '%exec_state_report_max_threads' ORDER BY BE_ID, NAME limit 2;
+
+-- make changes, enlarge both thread pools
+UPDATE information_schema.be_configs SET VALUE = '4' WHERE NAME = 'exec_state_report_max_threads';
+UPDATE information_schema.be_configs SET VALUE = '6' WHERE NAME = 'priority_exec_state_report_max_threads';
+
+-- confirm the change takes effect
+SELECT NAME, VALUE, `DEFAULT`, MUTABLE FROM information_schema.be_configs WHERE NAME LIKE '%exec_state_report_max_threads' ORDER BY BE_ID, NAME limit 2;
+
+-- make changes, shrink to its original size
+UPDATE information_schema.be_configs SET VALUE = '2' WHERE NAME = 'exec_state_report_max_threads';
+UPDATE information_schema.be_configs SET VALUE = '2' WHERE NAME = 'priority_exec_state_report_max_threads';
+
+-- confirm the change takes effect
+SELECT NAME, VALUE, `DEFAULT`, MUTABLE FROM information_schema.be_configs WHERE NAME LIKE '%exec_state_report_max_threads' ORDER BY BE_ID, NAME limit 2;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Add two new mutable BE configs, `exec_state_report_max_threads` and
`priority_exec_state_report_max_threads` (both default to 2), that allow
the size of the two exec-state reporter thread pools to be adjusted at
runtime without restarting the BE process.

Changes:
- Add CONF_mInt32 entries to config.h for both configs.
- ExecStateReporter: initialise thread pools from the new configs and
  expose update_max_threads / update_priority_max_threads methods.
- Propagate config changes down the PipelineExecutorSet →
  PipelineExecutorSetManager → WorkGroupManager call chain, covering
  both shared and exclusive executor sets.
- Register callbacks in UpdateConfigAction so HTTP-based config updates
  take effect immediately.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
