### PR TITLE
[BugFix] fix missing agg function when min/max stats rewrite failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
@@ -334,15 +334,9 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
             CallOperator call = entry.getValue();
             if (call.getFnName().equals(FunctionSet.MAX) || call.getFnName().equals(FunctionSet.MIN)) {
                 List<ColumnRefOperator> minMaxRefs = call.getUsedColumns().getColumnRefOperators(factory);
-                if (minMaxRefs.size() != 1) {
-                    continue;
-                }
                 ColumnRefOperator ref = minMaxRefs.get(0);
                 if (!ref.getType().isNumericType() && !ref.getType().isDate()) {
-                    continue;
-                }
-
-                if (!scanOperator.getColRefToColumnMetaMap().containsKey(ref)) {
+                    newAggCalls.put(entry.getKey(), entry.getValue());
                     continue;
                 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateMetaTest.java
@@ -16,11 +16,13 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TabletStatMgr;
 import com.starrocks.sql.optimizer.base.ColumnIdentifier;
 import com.starrocks.sql.optimizer.statistics.ColumnMinMaxMgr;
 import com.starrocks.sql.optimizer.statistics.IMinMaxStatsMgr;
 import com.starrocks.sql.optimizer.statistics.StatsVersion;
+import com.starrocks.statistic.StatisticUtils;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
@@ -69,6 +71,39 @@ public class AggregateMetaTest extends PlanTestBase {
                 "  1:AGGREGATE (update finalize)\n" +
                 "  |  output: max(2: v2)\n" +
                 "  |  group by:");
+    }
+
+    @Test
+    public void testAggregateMinMaxMetaDatetimeTypeFallback() throws Exception {
+        new MockUp<StatisticUtils>() {
+            @Mock
+            public LocalDateTime getTableLastUpdateTime(Table table) {
+                return LocalDateTime.now();
+            }
+        };
+        new MockUp<ColumnMinMaxMgr>() {
+            @Mock
+            public Optional<IMinMaxStatsMgr.ColumnMinMax> getStats(ColumnIdentifier identifier, StatsVersion version) {
+                if ("t1b".equals(identifier.getColumnName().getId())) {
+                    return Optional.of(new IMinMaxStatsMgr.ColumnMinMax("0", "100"));
+                }
+                return Optional.empty();
+            }
+        };
+
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(true);
+        connectContext.getSessionVariable().setScanOlapPartitionNumLimit(0);
+        String sql = "SELECT min(id_datetime), max(t1b) FROM test_all_type_not_null";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:Project\n" +
+                "  |  <slot 11> : 11: min\n" +
+                "  |  <slot 12> : 100\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: min(8: id_datetime)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/CelerData/celerdata-enterprise/pull/49510

agg functions that cannot be modified by min/max stats should be retained. Additionally, some redundant conditional logic should be removed, as it has already been checked in the check method.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
