### PR TITLE
[BugFix] Fix large SST missing start_key in parallel compaction task splitting

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -581,9 +581,10 @@ StatusOr<AsyncCompactCBPtr> LakePersistentIndex::early_sst_compact(
     ASSIGN_OR_RETURN(auto result,
                      LakePersistentIndexSizeTieredCompactionStrategy::pick_compaction_candidates(sstable_meta));
     // 3. Do parallel compaction for each candidate set.
+    bool is_merge_base_level = fileset_start_idx == 0 ? result.merge_base_level : false;
     ASSIGN_OR_RETURN(auto cb,
                      compact_mgr->async_compact(
-                             result.candidate_filesets, metadata, fileset_start_idx == 0 /* merge_base_level */,
+                             result.candidate_filesets, metadata, is_merge_base_level,
                              [&, result](const std::vector<PersistentIndexSstablePB>& sstables) {
                                  // 4. Merge output sstables into current index.
                                  //    reuse `apply_opcompaction` to do this.

--- a/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
+++ b/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
@@ -195,11 +195,10 @@ StatusOr<CompactionCandidateResult> LakePersistentIndexSizeTieredCompactionStrat
         }
 
         result.candidate_filesets.push_back(std::move(fileset_sstables));
-    }
-    // Limit max sstable filesets that can do merge, to avoid cost too much memory.
-    const int32_t max_limit = config::lake_pk_index_sst_max_compaction_versions;
-    if (result.candidate_filesets.size() > max_limit) {
-        result.candidate_filesets.resize(max_limit);
+        if (result.candidate_filesets.size() >= config::lake_pk_index_sst_max_compaction_versions) {
+            // Already reach max compaction versions, stop picking more filesets.
+            break;
+        }
     }
     result.merge_base_level = merge_base_level;
     result.max_max_rss_rowid = max_max_rss_rowid;

--- a/be/src/storage/sstable/table.cpp
+++ b/be/src/storage/sstable/table.cpp
@@ -96,7 +96,7 @@ Status Table::sample_keys(std::vector<std::string>* keys, size_t sample_interval
     // skip interval_step keys per sample
     DCHECK(rep_->options.block_size > 0);
     size_t interval_step = sample_interval_bytes / rep_->options.block_size + 1;
-    size_t index = 0;
+    size_t index = 1; // First key is already included, so start with 1 to skip it.
     // If the key is last key in index block, it's a short successor key.
     // E.g.
     //      index block may contains ["key_0001", "key_0005", "l"]


### PR DESCRIPTION
## Why I'm doing:

When sampling keys from large SST files for parallel compaction task splitting, the `start_key` was omitted from the boundary keys. Since index block entries correspond to the **last key** of each data block (via `FindShortestSeparator`), the first sampled key was always greater than the actual `start_key`. This caused the first compaction task's `seek_range` to skip keys at the beginning of the SST, leading to potential data loss during parallel compaction.

## What I'm doing:

- **Always include `start_key` first** in `sample_keys_from_sstable` (for both small and large SSTs), ensuring the first task's seek range starts from the correct position.
- **Adjust `Table::sample_keys`** to start iteration from `index = 1` to avoid duplicating the first index block entry when `start_key` is already prepended.
- **Fix `merge_base_level` propagation** in `early_sst_compact`: use the actual `result.merge_base_level` from the compaction strategy instead of hardcoding based on `fileset_start_idx == 0`.
- **Early-break compaction version limit** in `pick_compaction_candidates`: break out of the loop when reaching `lake_pk_index_sst_max_compaction_versions` instead of truncating after the loop, which could incorrectly discard the `merge_base_level` determination.
- **Add unit tests** covering the fix:
  - Verify large SST sample keys always start with `start_key` and contain no duplicates
  - Verify generated parallel tasks' seek ranges cover the SST's start_key
  - End-to-end test verifying no key gaps after parallel compaction of large SSTs

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4