### PR TITLE
[Enhancement] Introduce rowset range in tablet splitting and merging for range-distribution table

### DIFF
--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -101,9 +101,31 @@ Rowset::~Rowset() {
     }
 }
 
+StatusOr<std::optional<SeekRange>> Rowset::get_seek_range() const {
+    const TabletRangePB* range_pb = nullptr;
+    if (_metadata->has_range()) {
+        range_pb = &_metadata->range();
+    } else if (_tablet_metadata != nullptr && _tablet_metadata->has_range()) {
+        range_pb = &_tablet_metadata->range();
+    }
+
+    if (range_pb == nullptr) {
+        return std::optional<SeekRange>{};
+    }
+
+    // Do not use mem_pool here. SeekRange will reference the data owned by protobuf metadata,
+    // and metadata lifetime is guaranteed to outlive rowset iterators.
+    ASSIGN_OR_RETURN(auto range, TabletRangeHelper::create_seek_range_from(*range_pb, _tablet_schema, nullptr));
+    return std::optional<SeekRange>(std::move(range));
+}
+
 Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_compaction, TabletWriter* writer,
                                                     uint64_t& uncompacted_num_rows, uint64_t& uncompacted_data_size) {
     DCHECK(partial_segments_compaction());
+
+    if (metadata().has_range()) {
+        op_compaction->mutable_output_rowset()->mutable_range()->CopyFrom(metadata().range());
+    }
 
     std::vector<SegmentPtr> segments;
     LakeIOOptions lake_io_opts{.fill_data_cache = true};
@@ -276,13 +298,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
 
     std::vector<ChunkIteratorPtr> segment_iterators;
 
-    SeekRange tablet_range;
-    if (_tablet_metadata != nullptr && _tablet_metadata->has_range()) {
-        // do not use mem_pool here which means SeekRange is the reference of the data in tablet_metadata->range()
-        // and the data in tablet_metadata->range() has the same lifetime as the rowset
-        ASSIGN_OR_RETURN(tablet_range,
-                         TabletRangeHelper::create_seek_range_from(_tablet_metadata->range(), _tablet_schema, nullptr));
-    }
+    ASSIGN_OR_RETURN(auto shared_segment_range, get_seek_range());
 
     // Check if segment metadata filter can be used.
     // Apply metadata filter BEFORE loading segments to avoid loading unnecessary segment footers.
@@ -327,8 +343,9 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
         }
 
         seg_options.tablet_range = std::nullopt;
-        if (i < _metadata->shared_segments_size() && _metadata->shared_segments(i)) {
-            seg_options.tablet_range = tablet_range;
+        if (i < _metadata->shared_segments_size() && _metadata->shared_segments(i) &&
+            shared_segment_range.has_value()) {
+            seg_options.tablet_range = *shared_segment_range;
         }
 
         if (options.rowid_range_option != nullptr) { // physical split.
@@ -398,19 +415,14 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
     ASSIGN_OR_RETURN(seg_options.fs, FileSystem::CreateSharedFromString(root_loc));
     seg_options.stats = stats;
 
-    SeekRange tablet_range;
-    if (_tablet_metadata != nullptr && _tablet_metadata->has_range()) {
-        // do not use mem_pool here which means SeekRange is the reference of the data in tablet_metadata->range()
-        // and the data in tablet_metadata->range() has the same lifetime as the rowset
-        ASSIGN_OR_RETURN(tablet_range,
-                         TabletRangeHelper::create_seek_range_from(_tablet_metadata->range(), _tablet_schema, nullptr));
-    }
+    ASSIGN_OR_RETURN(auto shared_segment_range, get_seek_range());
 
     for (int i = 0; i < segments.size(); i++) {
         auto& seg_ptr = segments[i];
         seg_options.tablet_range = std::nullopt;
-        if (i < _metadata->shared_segments_size() && _metadata->shared_segments(i)) {
-            seg_options.tablet_range = tablet_range;
+        if (i < _metadata->shared_segments_size() && _metadata->shared_segments(i) &&
+            shared_segment_range.has_value()) {
+            seg_options.tablet_range = *shared_segment_range;
         }
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {
@@ -446,19 +458,14 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
     seg_options.tablet_id = tablet_id();
     seg_options.rowset_id = metadata().id();
 
-    SeekRange tablet_range;
-    if (_tablet_metadata != nullptr && _tablet_metadata->has_range()) {
-        // do not use mem_pool here which means SeekRange is the reference of the data in tablet_metadata->range()
-        // and the data in tablet_metadata->range() has the same lifetime as the rowset
-        ASSIGN_OR_RETURN(tablet_range,
-                         TabletRangeHelper::create_seek_range_from(_tablet_metadata->range(), _tablet_schema, nullptr));
-    }
+    ASSIGN_OR_RETURN(auto shared_segment_range, get_seek_range());
 
     for (int i = 0; i < segments.size(); i++) {
         auto& seg_ptr = segments[i];
         seg_options.tablet_range = std::nullopt;
-        if (i < _metadata->shared_segments_size() && _metadata->shared_segments(i)) {
-            seg_options.tablet_range = tablet_range;
+        if (i < _metadata->shared_segments_size() && _metadata->shared_segments(i) &&
+            shared_segment_range.has_value()) {
+            seg_options.tablet_range = *shared_segment_range;
         }
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <optional>
 #include <unordered_set>
 
 #include "common/statusor.h"
@@ -23,6 +24,7 @@
 #include "storage/olap_common.h"
 #include "storage/options.h"
 #include "storage/rowset/base_rowset.h"
+#include "storage/seek_range.h"
 
 namespace starrocks::lake {
 
@@ -136,6 +138,8 @@ public:
     int64_t end_version() const override { return 0; }
 
 private:
+    StatusOr<std::optional<SeekRange>> get_seek_range() const;
+
     TabletManager* _tablet_mgr;
     int64_t _tablet_id;
     const RowsetMetadataPB* _metadata;

--- a/be/src/storage/lake/tablet_reshard.h
+++ b/be/src/storage/lake/tablet_reshard.h
@@ -69,8 +69,8 @@ private:
 
 std::ostream& operator<<(std::ostream& out, const PublishTabletInfo& tablet_info);
 
-TxnLogPtr convert_txn_log(const TxnLogPtr& txn_log, const TabletMetadataPtr& base_tablet_metadata,
-                          const PublishTabletInfo& publish_tablet_info);
+StatusOr<TxnLogPtr> convert_txn_log(const TxnLogPtr& txn_log, const TabletMetadataPtr& base_tablet_metadata,
+                                    const PublishTabletInfo& publish_tablet_info);
 
 Status publish_resharding_tablet(TabletManager* tablet_manager, const ReshardingTabletInfoPB& resharding_tablet,
                                  int64_t base_version, int64_t new_version, const TxnInfoPB& txn_info,

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1354,12 +1354,10 @@ TEST_F(LakeServiceTest, test_publish_merging_tablet) {
             ASSERT_EQ(3, old_metadata_1->version());
             ASSERT_EQ(old_metadata_1->rowsets(0).segments_size(), old_metadata_1->rowsets(0).shared_segments_size());
             EXPECT_TRUE(old_metadata_1->rowsets(0).shared_segments(0));
-
             ASSIGN_OR_ABORT(auto old_metadata_2, _tablet_mgr->get_tablet_metadata(old_tablet_id_2, 3));
             ASSERT_EQ(3, old_metadata_2->version());
             ASSERT_EQ(old_metadata_2->rowsets(0).segments_size(), old_metadata_2->rowsets(0).shared_segments_size());
             EXPECT_TRUE(old_metadata_2->rowsets(0).shared_segments(0));
-
             ASSIGN_OR_ABORT(auto new_metadata, _tablet_mgr->get_tablet_metadata(new_tablet_id, 3));
             ASSERT_EQ(new_tablet_id, new_metadata->id());
             ASSERT_EQ(2, new_metadata->rowsets_size());
@@ -1371,6 +1369,12 @@ TEST_F(LakeServiceTest, test_publish_merging_tablet) {
                       generate_sort_key(0).SerializeAsString());
             EXPECT_EQ(new_metadata->range().upper_bound().SerializeAsString(),
                       generate_sort_key(100).SerializeAsString());
+            ASSERT_TRUE(new_metadata->rowsets(0).has_range());
+            ASSERT_TRUE(new_metadata->rowsets(1).has_range());
+            EXPECT_EQ(new_metadata->rowsets(0).range().SerializeAsString(),
+                      old_metadata_1->range().SerializeAsString());
+            EXPECT_EQ(new_metadata->rowsets(1).range().SerializeAsString(),
+                      old_metadata_2->range().SerializeAsString());
         }
 
         {

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -329,6 +329,22 @@ static void set_rowset_shared_segments(RowsetMetadataPB* rowset_meta, bool share
     }
 }
 
+static void set_rowset_range_int(RowsetMetadataPB* rowset_meta, std::optional<int32_t> lower, bool lower_included,
+                                 std::optional<int32_t> upper, bool upper_included) {
+    auto* range = rowset_meta->mutable_range();
+    range->Clear();
+    if (lower.has_value()) {
+        auto* tuple = range->mutable_lower_bound();
+        *tuple->add_values() = make_int_variant_pb(lower.value());
+        range->set_lower_bound_included(lower_included);
+    }
+    if (upper.has_value()) {
+        auto* tuple = range->mutable_upper_bound();
+        *tuple->add_values() = make_int_variant_pb(upper.value());
+        range->set_upper_bound_included(upper_included);
+    }
+}
+
 static size_t count_rows_from_iters(const std::vector<ChunkIteratorPtr>& iters, int chunk_size = 1024) {
     size_t rows = 0;
     for (const auto& it : iters) {
@@ -400,6 +416,28 @@ TEST_F(LakeRowsetTest, test_tablet_range_pruning_inclusive_exclusive) {
     // Per segment keys include 10,11,12. Total segments = 3.
     // With tablet range [10, 12) (closed-open), each segment contributes keys {10, 11}.
     ASSERT_EQ(make_rowset_and_count(10, true, 12, false), 3 * 2);
+}
+
+TEST_F(LakeRowsetTest, test_rowset_range_overrides_tablet_range) {
+    create_rowsets_for_testing();
+
+    // tablet range [10, 12), rowset range [11, 13)
+    set_tablet_range_int(_tablet_metadata.get(), 10, true, 12, false);
+    auto* rs_meta = _tablet_metadata->mutable_rowsets(0);
+    set_rowset_shared_segments(rs_meta, true);
+    set_rowset_range_int(rs_meta, 11, true, 13, false);
+
+    auto rowset =
+            std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 0 /* compaction_segment_limit */);
+    RowsetReadOptions rs_opts;
+    OlapReaderStatistics stats;
+    rs_opts.stats = &stats;
+    rs_opts.tablet_schema = std::make_shared<const TabletSchema>(_tablet_metadata->schema());
+    auto input_schema = ChunkHelper::convert_schema(_tablet_schema, std::vector<ColumnId>{0});
+    ASSIGN_OR_ABORT(auto iters, rowset->read(input_schema, rs_opts));
+
+    // If rowset range takes precedence, keep keys [11,13) => each segment contributes 11,12
+    ASSERT_EQ(count_rows_from_iters(iters), 3 * 2);
 }
 
 TEST_F(LakeRowsetTest, test_tablet_range_pb_invalid_bounds) {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -161,6 +161,8 @@ message RowsetMetadataPB {
     // Whether segments are shared by multiple tablets
     repeated bool shared_segments = 15;
     repeated SegmentMetadataPB segment_metas = 17;
+    // Indicates the effective sort key range of this rowset for range distribution table.
+    optional TabletRangePB range = 18;
 }
 
 // At present, the lake persistent index reuses the logic of the persistent index,


### PR DESCRIPTION
## Why I'm doing:
  Range-distribution tables can hit duplicate-read risks after split-then-merge flows when rowset range semantics are not preserved consistently.
 
## What I'm doing:
  - Added `range` to `RowsetMetadataPB` to persist effective rowset range.
  - Added `TabletRange::intersect()` and `TabletRange::is_empty()` utilities.
  - Refined rowset range rewrite flow during split/merge:
    - normalize rowset range update logic,
    - ensure merged rowsets are updated with old-tablet range semantics.
  - Renamed and cleaned helper APIs in `tablet_reshard`:
    - `update_txn_log_rowset_ranges` -> `update_rowset_ranges` with `Status` return.
  - Changed `convert_txn_log` to return `StatusOr<TxnLogPtr>` and propagated failures to upper layers.
  - Refactored seek-range resolution into `Rowset::get_seek_range()` and removed redundant parameters.
  - Removed redundant range-consistency check in `MetaFileBuilder::add_rowset`.
  - Added/updated BE tests for split/merge/cross-publish rowset range behavior.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
