### PR TITLE
[BugFix] Fix low-cardinality rewrite crash for LEAD/LAG window functions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -518,12 +518,18 @@ class DecodeContext {
                 returnType = intermediateType = newChildren.get(0).getType();
                 argTypes = List.of(newChildren.get(0).getType());
             } else {
-                argTypes = List.of(getDictifiedType(fn.getArgs()[0]));
+                argTypes = Lists.newArrayListWithCapacity(fn.getNumArgs());
+                for (int i = 0; i < fn.getNumArgs(); ++i) {
+                    argTypes.add(getDictifiedType(fn.getArgs()[i]));
+                }
                 returnType = getDictifiedType(fn.getReturnType());
                 intermediateType = getDictifiedType(fn.getIntermediateType());
             }
             AggregateFunction newFn = (AggregateFunction) fn.copy();
-            newFn.setArgsType(argTypes.subList(0, fn.getNumArgs()).toArray(Type[]::new));
+            Preconditions.checkState(argTypes.size() == fn.getNumArgs(),
+                    "argTypes size %s doesn't match numArgs %s for function %s",
+                    argTypes.size(), fn.getNumArgs(), fn.functionName());
+            newFn.setArgsType(argTypes.toArray(Type[]::new));
             newFn.setIntermediateType(intermediateType);
             newFn.setRetType(returnType);
             return newFn;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2803,6 +2803,20 @@ public class LowCardinalityTest2 extends PlanTestBase {
     }
 
     @Test
+    public void testLeadWindowFunctionLowCardinalityRewrite() throws Exception {
+        String sql = "select S_SUPPKEY, S_ADDRESS, lead(S_ADDRESS, 1) over(order by S_SUPPKEY) from supplier";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "4:Decode\n" +
+                "  |  <dict id 10> : <string id 3>\n" +
+                "  |  <dict id 11> : <string id 9>\n" +
+                "  |  \n" +
+                "  3:ANALYTIC\n" +
+                "  |  functions: [, lead(10: S_ADDRESS, 1, NULL), ]\n" +
+                "  |  order by: 1: S_SUPPKEY ASC\n" +
+                "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING");
+    }
+
+    @Test
     public void testCreateDecodeInfoDoesNotReturnSharedMutableSingleton() {
         DecodeInfo empty1 = DecodeInfo.create();
         DecodeInfo empty2 = DecodeInfo.create();


### PR DESCRIPTION
## Why I'm doing:
Low-cardinality optimization  rewrites some window/analytic functions (e.g. `LEAD`/`LAG`) as `AggregateFunction`s. For multi-argument analytic signatures like `lead(v, offset)`, the rewrite path built an argument type list with the wrong length and then sliced it by `numArgs`, which can trigger `IndexOutOfBoundsException` during plan generation.

## What I'm doing:
Fix the low-cardinality aggregate/analytic function rewriter to correctly handle multi-argument `AggregateFunction` signatures by dictifying **all** argument types and keeping the rewritten function signature consistent with `numArgs`. Add a regression unit test to cover `LEAD` window function under low-cardinality rewrite and ensure planning no longer crashes.

Fixes #issue
fix https://github.com/StarRocks/StarRocksTest/issues/10990

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
