### PR TITLE
[BugFix] Align CAST(... AS SIGNED) to BIGINT in TypeParser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/TypeParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/TypeParser.java
@@ -76,7 +76,8 @@ public class TypeParser {
         } else if (context.CHAR() != null) {
             return TypeFactory.createCharType(length);
         } else if (context.SIGNED() != null) {
-            return IntegerType.INT;
+            // Align with MySQL semantics: CAST(... AS SIGNED) returns a 64-bit signed integer (BIGINT).
+            return IntegerType.BIGINT;
         } else if (context.HLL() != null) {
             return HLLType.HLL;
         } else if (context.BINARY() != null || context.VARBINARY() != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MySQLTableCastTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MySQLTableCastTest.java
@@ -65,6 +65,10 @@ public class MySQLTableCastTest extends PlanTestBase {
         sqls.add(Pair.create("select * from ods_order where cast(org_order_no as int)",
                 "predicates: CAST(CAST(org_order_no AS INT) AS BOOLEAN)"));
 
+        // MySQL-compatible SIGNED cast should return BIGINT.
+        sqls.add(Pair.create("select cast(2147483648 as signed)", "<slot 2> : 2147483648"));
+        sqls.add(Pair.create("select cast(1 as signed integer)", "<slot 2> : 1"));
+
         return sqls.stream().map(e -> Arguments.of(e));
     }
 


### PR DESCRIPTION
## Why I'm doing:
`CAST(expr AS SIGNED)` is a MySQL-compatible syntax that should cast to a **64-bit signed integer (BIGINT)**. In StarRocks FE, `SIGNED` was parsed as `INT`, so values beyond the 32-bit range (e.g. `2147483648`) could overflow during execution and produce `NULL`, which is inconsistent with MySQL semantics and can break pushed-down SQL using `SIGNED`.

## What I'm doing:
Update `TypeParser` to map `SIGNED` to `BIGINT` to align with MySQL behavior and avoid 32-bit overflow in `CAST(... AS SIGNED)`. Add plan regression tests in `MySQLTableCastTest` to verify `CAST(... AS SIGNED [INTEGER])` is rewritten as `CAST(... AS BIGINT)`.

Fixes #issue_number

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
