### PR TITLE
[BugFix] Fix ineffective retries in cross publish for tablet merging

### DIFF
--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -30,6 +30,18 @@
 
 namespace starrocks::lake {
 
+static std::ostream& operator<<(std::ostream& out, const std::vector<int64_t>& tablet_ids) {
+    out << '[';
+    for (size_t i = 0; i < tablet_ids.size(); ++i) {
+        if (i > 0) {
+            out << ", ";
+        }
+        out << tablet_ids[i];
+    }
+    out << ']';
+    return out;
+}
+
 std::ostream& operator<<(std::ostream& out, const PublishTabletInfo& tablet_info) {
     if (tablet_info.get_publish_tablet_type() == PublishTabletInfo::PUBLISH_NORMAL) {
         return out << "{tablet_id: " << tablet_info.get_tablet_id_in_metadata() << '}';
@@ -37,7 +49,7 @@ std::ostream& operator<<(std::ostream& out, const PublishTabletInfo& tablet_info
 
     return out << "{publish_tablet_type: " << (int)tablet_info.get_publish_tablet_type()
                << ", tablet_id_in_metadata: " << tablet_info.get_tablet_id_in_metadata()
-               << ", tablet_id_in_txn_log: " << tablet_info.get_tablet_id_in_txn_log() << '}';
+               << ", tablet_id_in_txn_log: " << tablet_info.get_tablet_ids_in_txn_logs() << '}';
 }
 
 static void set_all_data_files_shared(RowsetMetadataPB* rowset_metadata) {

--- a/be/test/storage/lake/transactions_test.cpp
+++ b/be/test/storage/lake/transactions_test.cpp
@@ -1,7 +1,6 @@
 #include "storage/lake/transactions.h"
 
 #include <fmt/format.h>
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <filesystem>
@@ -18,14 +17,10 @@
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/txn_log.h"
 
-using ::testing::_;
-using ::testing::Invoke;
-using ::testing::Return;
-
 namespace starrocks::lake {
 
-// Forward declaration: only declare the original interface
-StatusOr<TxnLogVectorPtr> load_txn_log(TabletManager* tablet_mgr, int64_t tablet_id, const TxnInfoPB& txn_info);
+StatusOr<std::vector<TxnLogVector>> load_txn_log(TabletManager* tablet_mgr, std::vector<int64_t> tablet_ids,
+                                                 const TxnInfoPB& txn_info);
 
 // Helper: build a minimal TxnLogPB.
 static std::shared_ptr<TxnLogPB> make_txn_log(int64_t tablet_id, int64_t txn_id) {
@@ -75,9 +70,11 @@ TEST(TransactionsLoadIdsTest, AllLoadIdsPresent_RealApiWithMockMgr) {
     }
 
     auto info = make_txn_info(txn_id, load_ids);
-    auto st = load_txn_log(&mgr, tablet_id, info);
+    auto st = load_txn_log(&mgr, {tablet_id}, info);
     ASSERT_TRUE(st.ok()) << st.status();
-    ASSERT_EQ(st.value()->size(), load_ids.size());
+    ASSERT_EQ(st->size(), 1);
+    const auto& txn_logs = (*st)[0];
+    ASSERT_EQ(txn_logs.size(), load_ids.size());
 }
 
 TEST(TransactionsLoadIdsTest, SomeLoadIdsMissingAreSkipped_RealApiWithMockMgr) {
@@ -103,9 +100,11 @@ TEST(TransactionsLoadIdsTest, SomeLoadIdsMissingAreSkipped_RealApiWithMockMgr) {
     }
 
     auto info = make_txn_info(txn_id, load_ids);
-    auto st = load_txn_log(&mgr, tablet_id, info);
+    auto st = load_txn_log(&mgr, {tablet_id}, info);
     ASSERT_TRUE(st.ok()) << st.status();
-    ASSERT_EQ(st.value()->size(), 2); // Only 2 files exist
+    ASSERT_EQ(st->size(), 1);
+    const auto& txn_logs = (*st)[0];
+    ASSERT_EQ(txn_logs.size(), 2); // Only 2 files exist
 }
 
 TEST(TransactionsLoadIdsTest, AnyOtherErrorShouldFail_RealApiWithMockMgr) {
@@ -117,11 +116,12 @@ TEST(TransactionsLoadIdsTest, AnyOtherErrorShouldFail_RealApiWithMockMgr) {
 
     // Don't create any files, but have load_ids, should return error
     auto info = make_txn_info(txn_id, load_ids);
-    auto st = load_txn_log(&mgr, tablet_id, info);
+    auto st = load_txn_log(&mgr, {tablet_id}, info);
     // Based on actual behavior, if all files are missing and have load_ids, may return success but empty list
     // or return error, need to adjust expectation based on actual implementation
     if (st.ok()) {
-        ASSERT_EQ(st.value()->size(), 0); // If successful, should be empty list
+        ASSERT_EQ(st->size(), 1);
+        ASSERT_EQ((*st)[0].size(), 0);
     } else {
         ASSERT_FALSE(st.ok()); // If failed, that's expected
     }
@@ -136,9 +136,10 @@ TEST(TransactionsLoadIdsTest, AllMissingReturnsEmptyVectorOk_RealApiWithMockMgr)
 
     // Don't create any files, all missing
     auto info = make_txn_info(txn_id, load_ids);
-    auto st = load_txn_log(&mgr, tablet_id, info);
+    auto st = load_txn_log(&mgr, {tablet_id}, info);
     ASSERT_TRUE(st.ok()) << st.status();
-    ASSERT_EQ(st.value()->size(), 0);
+    ASSERT_EQ(st->size(), 1);
+    ASSERT_EQ((*st)[0].size(), 0);
 }
 
 TEST(TransactionsLoadIdsTest, SingleTxnLogWithoutLoadIds_RealApiWithMockMgr) {
@@ -158,9 +159,111 @@ TEST(TransactionsLoadIdsTest, SingleTxnLogWithoutLoadIds_RealApiWithMockMgr) {
     info.set_txn_id(txn_id);
     info.set_combined_txn_log(false);
 
-    auto st = load_txn_log(&mgr, tablet_id, info);
+    auto st = load_txn_log(&mgr, {tablet_id}, info);
     ASSERT_TRUE(st.ok()) << st.status();
-    ASSERT_EQ(st.value()->size(), 1);
+    ASSERT_EQ(st->size(), 1);
+    ASSERT_EQ((*st)[0].size(), 1);
+}
+
+TEST(TransactionsLoadIdsTest, MultiTabletLoadIdsPresent_RealApiWithMockMgr) {
+    auto location_provider = std::make_shared<FixedLocationProvider>("/tmp/test_lake");
+    TabletManager mgr(location_provider, 1);
+    const int64_t tablet_id_1 = 1006;
+    const int64_t tablet_id_2 = 1007;
+    const int64_t txn_id = 2007;
+    std::vector<std::pair<int64_t, int64_t>> load_ids = {{1, 101}, {2, 202}};
+
+    for (int64_t tablet_id : {tablet_id_1, tablet_id_2}) {
+        for (const auto& [hi, lo] : load_ids) {
+            PUniqueId load_id;
+            load_id.set_hi(hi);
+            load_id.set_lo(lo);
+            auto log = make_txn_log(tablet_id, txn_id);
+            log->mutable_load_id()->CopyFrom(load_id);
+            auto path = mgr.txn_log_location(tablet_id, txn_id, load_id);
+            ensure_directory_exists(path);
+            auto st = mgr.put_txn_log(log, path);
+            ASSERT_TRUE(st.ok()) << "Failed to put txn log: " << st.to_string();
+        }
+    }
+
+    auto info = make_txn_info(txn_id, load_ids);
+    auto st = load_txn_log(&mgr, {tablet_id_1, tablet_id_2}, info);
+    ASSERT_TRUE(st.ok()) << st.status();
+    ASSERT_EQ(st->size(), 2);
+    const auto& txn_logs_1 = (*st)[0];
+    ASSERT_EQ(txn_logs_1.size(), load_ids.size());
+    ASSERT_EQ(txn_logs_1[0]->tablet_id(), tablet_id_1);
+    const auto& txn_logs_2 = (*st)[1];
+    ASSERT_EQ(txn_logs_2.size(), load_ids.size());
+    ASSERT_EQ(txn_logs_2[0]->tablet_id(), tablet_id_2);
+}
+
+TEST(TransactionsLoadIdsTest, CombinedTxnLogForMultipleTablets_RealApiWithMockMgr) {
+    auto location_provider = std::make_shared<FixedLocationProvider>("/tmp/test_lake");
+    TabletManager mgr(location_provider, 1);
+    const int64_t partition_id = 3001;
+    const int64_t tablet_id_1 = 1008;
+    const int64_t tablet_id_2 = 1009;
+    const int64_t txn_id = 2008;
+
+    CombinedTxnLogPB combined_txn_log;
+    for (auto tablet_id : {tablet_id_1, tablet_id_2}) {
+        auto* log = combined_txn_log.add_txn_logs();
+        log->set_partition_id(partition_id);
+        log->set_tablet_id(tablet_id);
+        log->set_txn_id(txn_id);
+    }
+    auto put_st = mgr.put_combined_txn_log(combined_txn_log);
+    ASSERT_TRUE(put_st.ok()) << "Failed to put combined txn log: " << put_st.to_string();
+
+    TxnInfoPB info;
+    info.set_txn_id(txn_id);
+    info.set_combined_txn_log(true);
+
+    auto st = load_txn_log(&mgr, {tablet_id_1, tablet_id_2}, info);
+    ASSERT_TRUE(st.ok()) << st.status();
+    ASSERT_EQ(st->size(), 2);
+
+    const auto& txn_logs_1 = (*st)[0];
+    ASSERT_EQ(txn_logs_1.size(), 1);
+    ASSERT_EQ(txn_logs_1[0]->tablet_id(), tablet_id_1);
+    ASSERT_EQ(txn_logs_1[0]->txn_id(), txn_id);
+
+    const auto& txn_logs_2 = (*st)[1];
+    ASSERT_EQ(txn_logs_2.size(), 1);
+    ASSERT_EQ(txn_logs_2[0]->tablet_id(), tablet_id_2);
+    ASSERT_EQ(txn_logs_2[0]->txn_id(), txn_id);
+}
+
+TEST(TransactionsLoadIdsTest, PreserveInputTabletIdsOrder_RealApiWithMockMgr) {
+    auto location_provider = std::make_shared<FixedLocationProvider>("/tmp/test_lake");
+    TabletManager mgr(location_provider, 1);
+    const int64_t partition_id = 3002;
+    const int64_t tablet_id_1 = 1010;
+    const int64_t tablet_id_2 = 1011;
+    const int64_t txn_id = 2009;
+
+    CombinedTxnLogPB combined_txn_log;
+    for (auto tablet_id : {tablet_id_1, tablet_id_2}) {
+        auto* log = combined_txn_log.add_txn_logs();
+        log->set_partition_id(partition_id);
+        log->set_tablet_id(tablet_id);
+        log->set_txn_id(txn_id);
+    }
+    auto put_st = mgr.put_combined_txn_log(combined_txn_log);
+    ASSERT_TRUE(put_st.ok()) << "Failed to put combined txn log: " << put_st.to_string();
+
+    TxnInfoPB info;
+    info.set_txn_id(txn_id);
+    info.set_combined_txn_log(true);
+
+    // Intentionally reverse the input order and verify output follows the same order.
+    auto st = load_txn_log(&mgr, {tablet_id_2, tablet_id_1}, info);
+    ASSERT_TRUE(st.ok()) << st.status();
+    ASSERT_EQ(st->size(), 2);
+    ASSERT_EQ((*st)[0][0]->tablet_id(), tablet_id_2);
+    ASSERT_EQ((*st)[1][0]->tablet_id(), tablet_id_1);
 }
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:
  In cross publish with merge tablet, FE may trigger multiple `publish_version` calls serially.
  After the first call writes new metadata, later calls can return early due to metadata cache hit, which may cause expected follow-up effects to be skipped.

## What I'm doing:
  1. Update merge cross-publish modeling so one publish task carries all source tablet ids for the merged tablet.
  2. Adapt publish/apply/cleanup paths to process txn logs.

Fixes #64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
