### PR TITLE
[BugFix] Fix MV index properties lost during materialized view creation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -750,7 +750,7 @@ public class MaterializedViewAnalyzer {
                         }
                     }
                     indexes.add(new Index(indexDef.getIndexName(), columnIds, indexDef.getIndexType(),
-                            indexDef.getComment()));
+                            indexDef.getComment(), indexDef.getProperties()));
                     indexMultiMap.put(indexDef.getIndexName().toLowerCase(), 1);
                     colMultiMap.put(String.join(",", indexDef.getColumns()), 1);
                 }


### PR DESCRIPTION
## Why I'm doing:

When creating a materialized view with GIN (inverted) index, the MV refresh fails with error:
<img width="2288" height="1148" alt="image" src="https://github.com/user-attachments/assets/3b623c8d-24a1-44ea-8bb5-6930a6230511" />
The root cause is that `MaterializedViewAnalyzer.genMaterializedViewIndexes()` uses a 4-parameter `Index` constructor that does not accept `properties`, effectively discarding all index properties (including default values like `imp_lib=clucene`, `parser=none`) that were correctly populated by `IndexAnalyzer.checkColumn()` → `addDefaultProperties()` during semantic analysis.

In contrast, `CreateTableAnalyzer.analyzeIndexDefs()` correctly passes `indexDef.getProperties()` to the `Index` constructor, so this issue only affects materialized views.

When `Index.toThrift()` serializes the index metadata to BE, the `common_properties` map is empty (no `imp_lib` key), causing BE's `get_inverted_imp_type()` to fail with `"Can not get inverted imp type"`.

This bug affects all property-dependent index types (GIN, NGRAMBF, VECTOR) on materialized views.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
