### PR TITLE
[BugFix] Fix a bug that Hive varchar type MV can not be inserted due to varchar length

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
@@ -187,7 +187,7 @@ public class ColumnTypeConverterTest {
         resType = fromHiveTypeToMapType(typeStr);
         Assertions.assertEquals(mapType, resType);
 
-        keyType = TypeFactory.createVarcharType(10);
+        keyType = TypeFactory.createVarcharType(40);
         valueType = TypeFactory.createCharType(5);
         mapType = new MapType(keyType, valueType);
         typeStr = "map<varchar(10),char(5)>";
@@ -195,7 +195,7 @@ public class ColumnTypeConverterTest {
         Assertions.assertEquals(mapType, resType);
 
         keyType = BooleanType.BOOLEAN;
-        valueType = TypeFactory.createVarcharType(10);
+        valueType = TypeFactory.createVarcharType(40);
         mapType = new MapType(keyType, valueType);
         typeStr = "map<boolean,varchar(10)>";
         resType = fromHiveTypeToMapType(typeStr);
@@ -299,7 +299,7 @@ public class ColumnTypeConverterTest {
 
     @Test
     public void testVarcharString() {
-        Type varcharType = TypeFactory.createVarcharType(100);
+        Type varcharType = TypeFactory.createVarcharType(400);
         String typeStr = "varchar(100)";
         Type resType = ColumnTypeConverter.fromHiveType(typeStr);
         Assertions.assertEquals(resType, varcharType);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/trino/TrinoViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/trino/TrinoViewTest.java
@@ -137,7 +137,7 @@ public class TrinoViewTest {
         Assertions.assertEquals(hiveView.getFullSchema().get(5).getName(), "double_col");
         Assertions.assertEquals(hiveView.getFullSchema().get(5).getType(), FloatType.DOUBLE);
         Assertions.assertEquals(hiveView.getFullSchema().get(9).getName(), "varchar_col");
-        Assertions.assertEquals(hiveView.getFullSchema().get(9).getType(), TypeFactory.createVarcharType(20));
+        Assertions.assertEquals(hiveView.getFullSchema().get(9).getType(), TypeFactory.createVarcharType(80));
         Assertions.assertEquals(hiveView.getFullSchema().get(10).getName(), "binary_col");
         Assertions.assertEquals(hiveView.getFullSchema().get(10).getType(), VarbinaryType.VARBINARY);
         Assertions.assertEquals(hiveView.getFullSchema().get(13).getName(), "timestamp_col");
@@ -184,7 +184,7 @@ public class TrinoViewTest {
         Assertions.assertEquals(columnList.get(4).getType(), FloatType.FLOAT);
         Assertions.assertEquals(columnList.get(5).getType(), FloatType.DOUBLE);
         Assertions.assertEquals(columnList.get(6).getType(), TypeFactory.createDecimalV3NarrowestType(10, 2));
-        Assertions.assertEquals(columnList.get(7).getType(), TypeFactory.createVarcharType(20));
+        Assertions.assertEquals(columnList.get(7).getType(), TypeFactory.createVarcharType(80));
         Assertions.assertEquals(columnList.get(8).getType(), TypeFactory.createCharType(10));
         Assertions.assertEquals(columnList.get(9).getType(), TypeFactory.createDefaultCatalogString());
         Assertions.assertEquals(columnList.get(10).getType(), BooleanType.BOOLEAN);


### PR DESCRIPTION
Fix a bug that Hive varchar type in MV may can not be inserted into StarRocks due to varchar length
## Why I'm doing:
For Hive table that have columns like following.
<img width="1442" height="1424" alt="image" src="https://github.com/user-attachments/assets/8141206d-4670-4ea9-a259-a7b42fe8c388" />
And the error will be as following:
<img width="1546" height="1500" alt="image" src="https://github.com/user-attachments/assets/1eaefe9d-f2b2-470e-a7f2-6d5f4593be5b" />
It is because Hive will use character length for the varchar length.
But StarRocks will use byte length.
So the error came.
## What I'm doing:
Here we can remain the minimum of 4 * hive_varchar_length and MAX_CATALOG_STRING_LENGTH.
As 4 will be the maximum for UTF-8 encoding.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
