### PR TITLE
[BugFix] Fix Java UDTF/UDAF crashes when method parameters use generic types

### DIFF
--- a/be/src/exprs/table_function/java_udtf_function.cpp
+++ b/be/src/exprs/table_function/java_udtf_function.cpp
@@ -164,6 +164,15 @@ std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* ru
     });
     env->PushLocalFrame(num_cols * num_rows + 16);
 
+    // Boundary check: method_desc must have at least num_cols + 1 elements
+    // (index 0 is return type, indices 1..num_cols are parameter types)
+    if (stateUDTF->method_process()->method_desc.size() < num_cols + 1) {
+        state->set_status(
+                Status::InternalError(fmt::format("method_desc size mismatch: need at least {}, got {}", num_cols + 1,
+                                                  stateUDTF->method_process()->method_desc.size())));
+        return {};
+    }
+
     for (int i = 0; i < num_rows; ++i) {
         DeferOp defer = DeferOp([&]() {
             for (int j = 0; j < num_cols; ++j) {

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -790,6 +790,22 @@ Status ClassAnalyzer::has_method(jclass clazz, const std::string& method, bool* 
     return Status::OK();
 }
 
+void ClassAnalyzer::strip_jni_generic_types(std::string* sign) {
+    std::string cleaned;
+    cleaned.reserve(sign->size());
+    int depth = 0;
+    for (char c : *sign) {
+        if (c == '<') {
+            depth++;
+        } else if (c == '>') {
+            depth--;
+        } else if (depth == 0) {
+            cleaned += c;
+        }
+    }
+    *sign = std::move(cleaned);
+}
+
 Status ClassAnalyzer::get_signature(jclass clazz, const std::string& method, std::string* sign) {
     DCHECK(clazz != nullptr);
     DCHECK(sign != nullptr);
@@ -820,6 +836,14 @@ Status ClassAnalyzer::get_signature(jclass clazz, const std::string& method, std
         return Status::InternalError(fmt::format("couldn't found method:{}", method));
     }
     *sign = helper.to_string(result_sign);
+    // Strip generic type parameters from signature to produce standard JNI method descriptor.
+    // Java's getGenericParameterTypes() may produce signatures with generic info that:
+    // 1. JNI GetMethodID cannot match against the erased method descriptor, returning NULL.
+    // 2. get_udaf_method_desc() uses exact string matching (e.g. type == "java/util/List")
+    //    to populate method_desc. Generic signatures like "java/util/List<java/lang/String>"
+    //    would fail to match, causing missing MethodTypeDescriptor entries and subsequent
+    //    out-of-bounds access in process()/update()/merge() when indexing method_desc[j+1].
+    strip_jni_generic_types(sign);
     return Status::OK();
 }
 
@@ -876,16 +900,42 @@ Status ClassAnalyzer::get_udaf_method_desc(const std::string& sign, std::vector<
         if (sign[i] == '(' || sign[i] == ')') {
             continue;
         }
+        // Handle array types
         if (sign[i] == '[') {
-            while (sign[i] != ';') {
-                i++;
+            // Consume all leading '[' (for multi-dimensional arrays)
+            while (i < sign.size() && sign[i] == '[') {
+                ++i;
             }
+
+            if (i >= sign.size()) {
+                return Status::InternalError(fmt::format("Invalid array descriptor '{}': missing element type", sign));
+            }
+
+            // Handle element type: object array 'L...;' or primitive type (single char)
+            if (sign[i] == 'L') {
+                // Object array: [L<classname>;
+                ++i; // Skip 'L'
+                while (i < sign.size() && sign[i] != ';') {
+                    ++i;
+                }
+                if (i >= sign.size()) {
+                    return Status::InternalError(
+                            fmt::format("Invalid object array descriptor '{}': missing ';'", sign));
+                }
+                // i now points to ';', loop will increment it
+            }
+            // For primitive arrays ([I, [J, etc.), the single char is already at the right position
+
             desc->emplace_back(MethodTypeDescriptor{TYPE_UNKNOWN, true});
+            continue;
         }
         if (sign[i] == 'L') {
             int st = i + 1;
-            while (sign[i] != ';') {
+            while (i < sign.size() && sign[i] != ';') {
                 i++;
+            }
+            if (i >= sign.size()) {
+                return Status::InternalError(fmt::format("Invalid object type descriptor '{}': missing ';'", sign));
             }
             std::string type = sign.substr(st, i - st);
             if (false) {

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -504,6 +504,11 @@ class ClassAnalyzer {
 public:
     ClassAnalyzer() = default;
     ~ClassAnalyzer() = default;
+
+    // Strip generic type parameters from a JNI method signature.
+    // e.g. "(Ljava/util/List<java/lang/String>;)V" -> "(Ljava/util/List;)V"
+    static void strip_jni_generic_types(std::string* sign);
+
     Status has_method(jclass clazz, const std::string& method, bool* has);
     Status get_signature(jclass clazz, const std::string& method, std::string* sign);
     Status get_method_desc(const std::string& sign, std::vector<MethodTypeDescriptor>* desc);

--- a/be/test/udf/java/java_udf_test.cpp
+++ b/be/test/udf/java/java_udf_test.cpp
@@ -115,4 +115,117 @@ TEST_F(JavaUDFTest, test_time_convert) {
     _env->DeleteLocalRef(time_array);
     _env->DeleteLocalRef(time_class);
 }
+
+// ============================================================================
+// Tests for strip_jni_generic_types():
+//   Strips generic type parameters from JNI method signatures.
+// ============================================================================
+
+TEST(StripJniGenericTypesTest, NoGenerics) {
+    std::string sign = "(Ljava/lang/String;I)V";
+    ClassAnalyzer::strip_jni_generic_types(&sign);
+    EXPECT_EQ(sign, "(Ljava/lang/String;I)V");
+}
+
+TEST(StripJniGenericTypesTest, SimpleGeneric) {
+    std::string sign = "(Ljava/util/List<Ljava/lang/String;>;)V";
+    ClassAnalyzer::strip_jni_generic_types(&sign);
+    EXPECT_EQ(sign, "(Ljava/util/List;)V");
+}
+
+TEST(StripJniGenericTypesTest, MultipleGenericParams) {
+    std::string sign = "(Ljava/lang/String;Ljava/util/List<Ljava/lang/String;>;Ljava/util/List<Ljava/lang/Integer;>;)V";
+    ClassAnalyzer::strip_jni_generic_types(&sign);
+    EXPECT_EQ(sign, "(Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V");
+}
+
+TEST(StripJniGenericTypesTest, NestedGenerics) {
+    std::string sign = "(Ljava/util/Map<Ljava/lang/String;Ljava/util/List<Ljava/lang/Integer;>;>;)V";
+    ClassAnalyzer::strip_jni_generic_types(&sign);
+    EXPECT_EQ(sign, "(Ljava/util/Map;)V");
+}
+
+TEST(StripJniGenericTypesTest, EmptyString) {
+    std::string sign;
+    ClassAnalyzer::strip_jni_generic_types(&sign);
+    EXPECT_EQ(sign, "");
+}
+
+// ============================================================================
+// Tests for ClassAnalyzer::get_udaf_method_desc bug fixes:
+//   1. '[' branch missing continue — caused spurious method_desc entries
+//   2. List<> generic in signature — caused type matching failure
+//   3. Combined: UDTF with List params + String[] return — the crash scenario
+// ============================================================================
+
+// Test: '[' branch continue fix — array param must not produce spurious entries.
+// Before fix, processing "[Ljava/lang/String;" left i on ';', which fell through
+// to the else branch and added an extra {TYPE_UNKNOWN, false} entry.
+TEST(GetUdafMethodDescTest, ArrayBranchContinueFix) {
+    ClassAnalyzer analyzer;
+    std::vector<MethodTypeDescriptor> desc;
+    // Signature: process(String[] arr, int n) -> void
+    ASSERT_OK(analyzer.get_udaf_method_desc("([Ljava/lang/String;I)V", &desc));
+    // Must be exactly 3: [return=V, param1=[String, param2=I]
+    // Before fix: 4 entries (spurious {TYPE_UNKNOWN,false} from ';')
+    ASSERT_EQ(desc.size(), 3);
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
+    EXPECT_EQ(desc[1].type, TYPE_UNKNOWN); // [String array
+    EXPECT_EQ(desc[2].type, TYPE_INT);     // int
+}
+
+// Test: List type matching — after get_signature strips generics,
+// "Ljava/util/List;" must be recognized as TYPE_ARRAY.
+// Before fix, generic signature "Ljava/util/List<java/lang/String>;" caused
+// type == "java/util/List<java/lang/String>" which didn't match "java/util/List".
+TEST(GetUdafMethodDescTest, ListTypeMatchAfterGenericStrip) {
+    ClassAnalyzer analyzer;
+    std::vector<MethodTypeDescriptor> desc;
+    // Clean signature (generics already stripped by get_signature)
+    ASSERT_OK(analyzer.get_udaf_method_desc("(Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V", &desc));
+    ASSERT_EQ(desc.size(), 4);
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
+    EXPECT_EQ(desc[1].type, TYPE_VARCHAR); // String
+    EXPECT_EQ(desc[2].type, TYPE_ARRAY);   // List → TYPE_ARRAY
+    EXPECT_EQ(desc[3].type, TYPE_ARRAY);   // List → TYPE_ARRAY
+}
+
+// Test: realistic UDTF crash scenario — process(String, List, List) -> String[]
+// This is the exact signature pattern that caused the CN crash.
+// Verifies method_desc.size() == num_cols + 1 so process() won't OOB access.
+TEST(GetUdafMethodDescTest, UDTFCrashScenarioSignature) {
+    ClassAnalyzer analyzer;
+    std::vector<MethodTypeDescriptor> desc;
+    std::string sign = "(Ljava/lang/String;Ljava/util/List;Ljava/util/List;)[Ljava/lang/String;";
+    ASSERT_OK(analyzer.get_udaf_method_desc(sign, &desc));
+    // 1 return + 3 params = 4
+    ASSERT_EQ(desc.size(), 4);
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return [String
+    EXPECT_EQ(desc[1].type, TYPE_VARCHAR); // param String
+    EXPECT_EQ(desc[2].type, TYPE_ARRAY);   // param List
+    EXPECT_EQ(desc[3].type, TYPE_ARRAY);   // param List
+}
+
+// Test: Primitive array parsing — [I, [J, etc. don't end with ';'.
+TEST(GetUdafMethodDescTest, PrimitiveIntArray) {
+    ClassAnalyzer analyzer;
+    std::vector<MethodTypeDescriptor> desc;
+    // Signature: process(int, int[]) -> void
+    ASSERT_OK(analyzer.get_udaf_method_desc("(I[I)V", &desc));
+    ASSERT_EQ(desc.size(), 3);
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
+    EXPECT_EQ(desc[1].type, TYPE_INT);     // param int
+    EXPECT_EQ(desc[2].type, TYPE_UNKNOWN); // param int[] (array)
+}
+
+// Test: Multi-dimensional primitive array — [[J (long[][])
+TEST(GetUdafMethodDescTest, MultiDimensionalPrimitiveArray) {
+    ClassAnalyzer analyzer;
+    std::vector<MethodTypeDescriptor> desc;
+    ASSERT_OK(analyzer.get_udaf_method_desc("([[J)V", &desc));
+    ASSERT_EQ(desc.size(), 2);
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
+    EXPECT_EQ(desc[1].type, TYPE_UNKNOWN); // param long[][] (array)
+}
+
 } // namespace starrocks

--- a/java-extensions/udf-extensions/src/test/java/com/starrocks/udf/UDFClassAnalyzerTest.java
+++ b/java-extensions/udf-extensions/src/test/java/com/starrocks/udf/UDFClassAnalyzerTest.java
@@ -1,0 +1,54 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.udf;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class UDFClassAnalyzerTest {
+
+    // UDTF with generic List<String> parameters
+    public static class GenericListUDTF {
+        public String[] process(String input, List<String> tags, List<String> values) {
+            return new String[]{input};
+        }
+    }
+
+    // UDTF with raw List parameters
+    @SuppressWarnings("rawtypes")
+    public static class RawListUDTF {
+        public String[] process(String input, List tags, List values) {
+            return new String[]{input};
+        }
+    }
+
+    @Test
+    public void testGenericListSignatureContainsAngleBrackets() throws NoSuchMethodException {
+        String signature = UDFClassAnalyzer.getSignature("process", GenericListUDTF.class);
+        Assertions.assertNotNull(signature);
+        Assertions.assertTrue(signature.contains("<"),
+                "Generic List signature should contain '<' due to getGenericParameterTypes(): " + signature);
+    }
+
+    // Raw List params produce standard JNI signature without generics.
+    @Test
+    public void testRawListSignatureIsStandardJNI() throws NoSuchMethodException {
+        String signature = UDFClassAnalyzer.getSignature("process", RawListUDTF.class);
+        String expected = "(Ljava/lang/String;Ljava/util/List;Ljava/util/List;)[Ljava/lang/String;";
+        Assertions.assertEquals(expected, signature);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
Fixes #69195

## What I'm doing:

Fixes #69195

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
