### PR TITLE
[Enhancement] Add commit audit information to Iceberg insert/delete operations

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -293,6 +293,12 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public void finishSink(String dbName, String table, List<TSinkCommitInfo> commitInfos, String branch, Object extra,
+                           ConnectContext context) {
+        normal.finishSink(dbName, table, commitInfos, branch, extra, context);
+    }
+
+    @Override
     public void abortSink(String dbName, String table, List<TSinkCommitInfo> commitInfos) {
         normal.abortSink(dbName, table, commitInfos);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -295,6 +295,11 @@ public interface ConnectorMetadata {
         throw new StarRocksConnectorException("This connector doesn't support sink");
     }
 
+    default void finishSink(String dbName, String table, List<TSinkCommitInfo> commitInfos, String branch, Object extra,
+                            ConnectContext context) {
+        finishSink(dbName, table, commitInfos, branch, extra);
+    }
+
     default void abortSink(String dbName, String table, List<TSinkCommitInfo> commitInfos) {
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -451,11 +451,17 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
     }
 
-    private void updateCommitInfo(SnapshotUpdate update, ConnectContext context) {
-        update.set(ENGINE_NAME, "StarRocks");
-        update.set(ENGINE_VERSION, GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getFeVersion());
-        update.set(STARROCKS_USER, context.getCurrentUserIdentity() != null ?
-                context.getCurrentUserIdentity().getUser() : "None");
+    public static void updateCommitInfo(SnapshotUpdate update, ConnectContext context) {
+        updateCommitInfo(update, "StarRocks",
+                GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getFeVersion(),
+                context.getCurrentUserIdentity() != null ?
+                        context.getCurrentUserIdentity().getUser() : "None");
+    }
+
+    public static void updateCommitInfo(SnapshotUpdate update, String engineName, String engineVersion, String user) {
+        update.set(ENGINE_NAME, engineName);
+        update.set(ENGINE_VERSION, engineVersion);
+        update.set(STARROCKS_USER, user);
     }
 
     /**
@@ -1160,10 +1166,10 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     private CloseableIterator<FileScanTask> buildFileScanTaskIterator(IcebergTable icebergTable,
-                                                             Expression icebergPredicate,
-                                                             TvrVersionRange tvrVersionRange,
-                                                             ConnectContext connectContext,
-                                                             boolean enableCollectColumnStats) {
+                                                                      Expression icebergPredicate,
+                                                                      TvrVersionRange tvrVersionRange,
+                                                                      ConnectContext connectContext,
+                                                                      boolean enableCollectColumnStats) {
         if (tvrVersionRange.isEmpty()) {
             return new CloseableIterator<>() {
                 @Override
@@ -1595,7 +1601,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                 // Commit state is unknown - the commit may have succeeded, failed, or still be in progress
                 // Do NOT delete the data files as they may have been committed
                 LOG.warn("Commit state unknown for {}.{}.{}, data files may have been committed. " +
-                        "Do NOT retry without verification to avoid duplicate data ingestion.",
+                                "Do NOT retry without verification to avoid duplicate data ingestion.",
                         catalogName, dbName, tableName);
             }
             LOG.error("Failed to commit iceberg transaction on {}.{}", dbName, tableName, e);
@@ -1835,9 +1841,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         default void setAuditInfo(String engineName, String engineVersion, String user) {
             SnapshotUpdate<?> update = getSnapshotUpdate();
             if (update != null) {
-                update.set(ENGINE_NAME, engineName);
-                update.set(ENGINE_VERSION, engineVersion);
-                update.set(STARROCKS_USER, user);
+                IcebergMetadata.updateCommitInfo(update, engineName, engineVersion, user);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1498,6 +1498,12 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     @Override
     public void finishSink(String dbName, String tableName, List<TSinkCommitInfo> commitInfos, String branch, Object extra) {
+        finishSink(dbName, tableName, commitInfos, branch, extra, null);
+    }
+
+    @Override
+    public void finishSink(String dbName, String tableName, List<TSinkCommitInfo> commitInfos, String branch, Object extra,
+                           ConnectContext context) {
         // Normalize db name and table name to lower case for commit queue key
         // because some catalogs are case-insensitive (e.g., Hive, Glue)
         //
@@ -1542,10 +1548,10 @@ public class IcebergMetadata implements ConnectorMetadata {
                     dataFile.isSetFile_content() &&
                             (dataFile.getFile_content() == TIcebergFileContent.POSITION_DELETES));
             if (isDeleteOperation) {
-                commitDeleteOperation(transaction, nativeTbl, dataFiles, branch, dbName, tableName, extra);
+                commitDeleteOperation(transaction, nativeTbl, dataFiles, branch, dbName, tableName, extra, context);
             } else {
                 commitDataOperation(transaction, nativeTbl, dataFiles, branch, isOverwrite, isRewrite, extra,
-                        dbName, tableName);
+                        dbName, tableName, context);
             }
         };
 
@@ -1608,7 +1614,8 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     private void commitDeleteOperation(Transaction transaction, org.apache.iceberg.Table nativeTbl,
                                        List<TIcebergDataFile> dataFiles, String branch,
-                                       String dbName, String tableName, Object extra) {
+                                       String dbName, String tableName, Object extra,
+                                       ConnectContext context) {
         // DELETE operations - use RowDelta
         RowDelta rowDelta = transaction.newRowDelta();
         if (branch != null) {
@@ -1673,6 +1680,11 @@ public class IcebergMetadata implements ConnectorMetadata {
             rowDelta.validateNoConflictingDataFiles();
         }
 
+        // Set audit info for the commit
+        if (context != null) {
+            updateCommitInfo(rowDelta, context);
+        }
+
         commitWithCleanup(() -> {
             rowDelta.commit();
             transaction.commitTransaction();
@@ -1683,7 +1695,8 @@ public class IcebergMetadata implements ConnectorMetadata {
     private void commitDataOperation(Transaction transaction, org.apache.iceberg.Table nativeTbl,
                                      List<TIcebergDataFile> dataFiles, String branch,
                                      boolean isOverwrite, boolean isRewrite, Object extra,
-                                     String dbName, String tableName) {
+                                     String dbName, String tableName,
+                                     ConnectContext context) {
         BatchWrite batchWrite = getBatchWrite(transaction, isOverwrite, isRewrite);
 
         if (branch != null) {
@@ -1721,6 +1734,13 @@ public class IcebergMetadata implements ConnectorMetadata {
             ((IcebergSinkExtra) extra).getScannedDataFiles().forEach(batchWrite::deleteFile);
             ((IcebergSinkExtra) extra).getAppliedDeleteFiles().forEach(batchWrite::deleteFile);
             ((RewriteData) batchWrite).setSnapshotId(nativeTbl.currentSnapshot().snapshotId());
+        }
+
+        // Set audit info for the commit
+        if (context != null) {
+            batchWrite.setAuditInfo("StarRocks",
+                    GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getFeVersion(),
+                    context.getCurrentUserIdentity() != null ? context.getCurrentUserIdentity().getUser() : "None");
         }
 
         commitWithCleanup(() -> {
@@ -1809,6 +1829,17 @@ public class IcebergMetadata implements ConnectorMetadata {
         void commit();
 
         void toBranch(String targetBranch);
+
+        SnapshotUpdate<?> getSnapshotUpdate();
+
+        default void setAuditInfo(String engineName, String engineVersion, String user) {
+            SnapshotUpdate<?> update = getSnapshotUpdate();
+            if (update != null) {
+                update.set(ENGINE_NAME, engineName);
+                update.set(ENGINE_VERSION, engineVersion);
+                update.set(STARROCKS_USER, user);
+            }
+        }
     }
 
     public static class Append implements BatchWrite {
@@ -1841,6 +1872,11 @@ public class IcebergMetadata implements ConnectorMetadata {
         @Override
         public void toBranch(String targetBranch) {
             append = append.toBranch(targetBranch);
+        }
+
+        @Override
+        public SnapshotUpdate<?> getSnapshotUpdate() {
+            return append;
         }
     }
 
@@ -1910,6 +1946,11 @@ public class IcebergMetadata implements ConnectorMetadata {
         public void toBranch(String targetBranch) {
             replace = replace.toBranch(targetBranch);
         }
+
+        @Override
+        public SnapshotUpdate<?> getSnapshotUpdate() {
+            return replace;
+        }
     }
 
     public static class RewriteData implements BatchWrite {
@@ -1946,6 +1987,11 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         public void setSnapshotId(long snapshotId) {
             rewriteFiles.validateFromSnapshot(snapshotId);
+        }
+
+        @Override
+        public SnapshotUpdate<?> getSnapshotUpdate() {
+            return rewriteFiles;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRewriteDataJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergRewriteDataJob.java
@@ -261,7 +261,7 @@ public class IcebergRewriteDataJob {
             try {
                 context.getGlobalStateMgr().getMetadataMgr().finishSink(
                         collected.peek().getCatalog(), collected.peek().getDb(), collected.peek().getTable(),
-                        faList, collected.peek().getBranch(), extra);
+                        faList, collected.peek().getBranch(), extra, context);
             } catch (Exception e) {
                 LOG.error("Failed to commit iceberg rewrite on [{}]", originAlterStmt.getTableName(), e);
                 throw new StarRocksConnectorException("Failed to commit iceberg rewrite", e);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -287,6 +287,13 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public void finishSink(String dbName, String table, List<TSinkCommitInfo> commitInfos, String branch, Object extra,
+                           ConnectContext context) {
+        ConnectorMetadata metadata = metadataOfTable(dbName, table);
+        metadata.finishSink(dbName, table, commitInfos, branch, extra, context);
+    }
+
+    @Override
     public CloudConfiguration getCloudConfiguration() {
         return hiveMetadata.getCloudConfiguration();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -3193,7 +3193,7 @@ public class StmtExecutor {
                     // This is a DELETE operation, use IcebergDeleteSink
                     IcebergMetadata.IcebergSinkExtra extra = deleteSink.getSinkExtraInfo();
                     context.getGlobalStateMgr().getMetadataMgr().finishSink(
-                            catalogName, dbName, tableName, commitInfos, null, extra);
+                            catalogName, dbName, tableName, commitInfos, null, extra, context);
                 } else if (dataSink instanceof IcebergTableSink) {
                     // This is an INSERT/OVERWRITE operation, use IcebergTableSink
                     IcebergTableSink sink = (IcebergTableSink) dataSink;
@@ -3210,7 +3210,7 @@ public class StmtExecutor {
                                 .finish(catalogName, dbName, tableName, commitInfos, sink.getTargetBranch(), (Object) extra);
                     } else {
                         context.getGlobalStateMgr().getMetadataMgr().finishSink(
-                                catalogName, dbName, tableName, commitInfos, sink.getTargetBranch(), (Object) extra);
+                                catalogName, dbName, tableName, commitInfos, sink.getTargetBranch(), (Object) extra, context);
                     }
                 } else {
                     throw new RuntimeException("Unsupported sink type for Iceberg table: " + dataSink.getClass().getName());

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -910,10 +910,16 @@ public class MetadataMgr {
 
     public void finishSink(String catalogName, String dbName, String tableName,
                            List<TSinkCommitInfo> sinkCommitInfos, String branch, Object extra) {
+        finishSink(catalogName, dbName, tableName, sinkCommitInfos, branch, extra, null);
+    }
+
+    public void finishSink(String catalogName, String dbName, String tableName,
+                           List<TSinkCommitInfo> sinkCommitInfos, String branch, Object extra,
+                           ConnectContext context) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
         connectorMetadata.ifPresent(metadata -> {
             try {
-                metadata.finishSink(dbName, tableName, sinkCommitInfos, branch, extra);
+                metadata.finishSink(dbName, tableName, sinkCommitInfos, branch, extra, context);
             } catch (StarRocksConnectorException e) {
                 LOG.error("table sink commit failed", e);
                 throw new StarRocksConnectorException(e.getMessage());

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -688,7 +688,7 @@ public class IcebergScanNodeTest {
             result = Optional.of(connectorMetadata);
             minTimes = 0;
 
-            connectorMetadata.finishSink("db", "tbl", sinkCommitInfos, "branch", extra);
+            connectorMetadata.finishSink("db", "tbl", sinkCommitInfos, "branch", extra, null);
         }};
 
         metadataMgr.finishSink("testCatalog", "db", "tbl", sinkCommitInfos, "branch", extra);
@@ -712,7 +712,7 @@ public class IcebergScanNodeTest {
             result = Optional.of(connectorMetadata);
             minTimes = 0;
 
-            connectorMetadata.finishSink("db", "tbl", sinkCommitInfos, "branch", extra);
+            connectorMetadata.finishSink("db", "tbl", sinkCommitInfos, "branch", extra, null);
             result = new StarRocksConnectorException("fail!");
             minTimes = 0;
         }};


### PR DESCRIPTION
## Why I'm doing:
Iceberg insert/delete operations do not have audit information
## What I'm doing:
This pull request adds audit information (such as engine name, engine version, and user) to Iceberg table snapshot commits during sink operations. It does so by extending the `finishSink` method signatures throughout the codebase to accept a `ConnectContext`, propagating this context through the call stack, and updating the commit logic to include audit info in the snapshot summary. Comprehensive tests are also added to verify that the audit information is correctly recorded for various operations.

**API and Method Signature Updates:**

* Extended the `finishSink` method in `ConnectorMetadata`, `CatalogConnectorMetadata`, `UnifiedMetadata`, `IcebergMetadata`, and `MetadataMgr` to accept an additional `ConnectContext` parameter, ensuring that context is available during commit operations. 
* Updated all relevant call sites (including DML statement handling and rewrite jobs) to pass the `ConnectContext` argument when invoking `finishSink`. 

**Iceberg Commit Logic Enhancements:**

* Modified Iceberg commit operations (`commitDeleteOperation`, `commitDataOperation`) to set audit info (engine name, version, and user) on the snapshot update if a `ConnectContext` is provided, using a new `setAuditInfo` method in the `BatchWrite` interface and its implementations. 

**Testing and Verification:**

* Enhanced and added tests in `IcebergMetadataTest` to mock the context and verify that the snapshot summary contains the correct audit information for different types of sink operations (insert, overwrite, delete), including scenarios with and without commit queues.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
