### PR TITLE
[BugFix] Normalize add_files parquet stats to Iceberg logical bounds

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/AddFilesProcedureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/AddFilesProcedureTest.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.VarcharType;
+import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
@@ -31,18 +32,40 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.UUIDUtil;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -300,6 +323,279 @@ public class AddFilesProcedureTest {
             assertFalse(exception.getMessage().contains("Unsupported file format"),
                     "Format " + format + " should be supported");
         }
+    }
+
+    @Test
+    public void testTryConvertDecimalStatValue() {
+        Types.DecimalType decimalType = Types.DecimalType.of(7, 2);
+
+        BigDecimal fromNull = AddFilesProcedure.tryConvertDecimalStatValue(decimalType, null);
+        Assertions.assertNull(fromNull);
+
+        BigDecimal fromInt = AddFilesProcedure.tryConvertDecimalStatValue(decimalType, 123);
+        assertEquals(new BigDecimal("1.23"), fromInt);
+
+        BigDecimal fromLong = AddFilesProcedure.tryConvertDecimalStatValue(decimalType, 123L);
+        assertEquals(new BigDecimal("1.23"), fromLong);
+
+        BigDecimal fromBinary = AddFilesProcedure.tryConvertDecimalStatValue(
+                decimalType, Binary.fromConstantByteArray(new byte[] {0x00, 0x7B}));
+        assertEquals(new BigDecimal("1.23"), fromBinary);
+
+        BigDecimal fromBytes = AddFilesProcedure.tryConvertDecimalStatValue(decimalType, new byte[] {0x00, 0x7B});
+        assertEquals(new BigDecimal("1.23"), fromBytes);
+
+        BigDecimal fromByteBuffer = AddFilesProcedure.tryConvertDecimalStatValue(
+                decimalType, ByteBuffer.wrap(new byte[] {0x00, 0x7B}));
+        assertEquals(new BigDecimal("1.23"), fromByteBuffer);
+
+        BigDecimal passthrough = AddFilesProcedure.tryConvertDecimalStatValue(
+                decimalType, new BigDecimal("12.34"));
+        assertEquals(new BigDecimal("12.34"), passthrough);
+
+        BigDecimal unsupported = AddFilesProcedure.tryConvertDecimalStatValue(decimalType, "12.34");
+        Assertions.assertNull(unsupported);
+    }
+
+    @Test
+    public void testTryConvertStatValue() {
+        Object nullFieldType = AddFilesProcedure.tryConvertStatValue(null, 123);
+        Assertions.assertNull(nullFieldType);
+
+        Object nullStatValue = AddFilesProcedure.tryConvertStatValue(Types.IntegerType.get(), null);
+        Assertions.assertNull(nullStatValue);
+
+        Object intFromLong = AddFilesProcedure.tryConvertStatValue(Types.IntegerType.get(), 123L);
+        assertEquals(123, intFromLong);
+
+        Object longValue = AddFilesProcedure.tryConvertStatValue(Types.LongType.get(), 123);
+        assertEquals(123L, longValue);
+
+        Object longUnsupported = AddFilesProcedure.tryConvertStatValue(Types.LongType.get(), "123");
+        Assertions.assertNull(longUnsupported);
+
+        Object floatFromDouble = AddFilesProcedure.tryConvertStatValue(Types.FloatType.get(), 1.25D);
+        assertEquals(1.25F, floatFromDouble);
+
+        Object floatUnsupported = AddFilesProcedure.tryConvertStatValue(Types.FloatType.get(), "1.25");
+        Assertions.assertNull(floatUnsupported);
+
+        Object doubleFromFloat = AddFilesProcedure.tryConvertStatValue(Types.DoubleType.get(), 1.25F);
+        assertEquals(1.25D, doubleFromFloat);
+
+        Object doubleUnsupported = AddFilesProcedure.tryConvertStatValue(Types.DoubleType.get(), "1.25");
+        Assertions.assertNull(doubleUnsupported);
+
+        Object stringFromCharSequence = AddFilesProcedure.tryConvertStatValue(Types.StringType.get(), new StringBuilder("abc"));
+        assertEquals("abc", stringFromCharSequence);
+
+        Object stringValue = AddFilesProcedure.tryConvertStatValue(
+                Types.StringType.get(), Binary.fromConstantByteArray("abc".getBytes(StandardCharsets.UTF_8)));
+        assertEquals("abc", stringValue);
+
+        Object stringFromBytes = AddFilesProcedure.tryConvertStatValue(
+                Types.StringType.get(), "abc".getBytes(StandardCharsets.UTF_8));
+        assertEquals("abc", stringFromBytes);
+
+        Object stringUnsupported = AddFilesProcedure.tryConvertStatValue(Types.StringType.get(), 123);
+        Assertions.assertNull(stringUnsupported);
+
+        UUID uuid = UUID.randomUUID();
+        Object uuidFromUuid = AddFilesProcedure.tryConvertStatValue(Types.UUIDType.get(), uuid);
+        assertEquals(uuid, uuidFromUuid);
+
+        byte[] uuidBytes = UUIDUtil.convert(uuid);
+        Object uuidFromBinary = AddFilesProcedure.tryConvertStatValue(
+                Types.UUIDType.get(), Binary.fromConstantByteArray(uuidBytes));
+        assertEquals(uuid, uuidFromBinary);
+
+        Object uuidFromBytes = AddFilesProcedure.tryConvertStatValue(Types.UUIDType.get(), uuidBytes);
+        assertEquals(uuid, uuidFromBytes);
+
+        Object uuidFromByteBuffer = AddFilesProcedure.tryConvertStatValue(
+                Types.UUIDType.get(), UUIDUtil.convertToByteBuffer(uuid));
+        assertEquals(uuid, uuidFromByteBuffer);
+
+        Object uuidUnsupported = AddFilesProcedure.tryConvertStatValue(Types.UUIDType.get(), 123);
+        Assertions.assertNull(uuidUnsupported);
+
+        ByteBuffer fixedBuffer = ByteBuffer.wrap(new byte[] {0x01, 0x02});
+        Object fixedFromBuffer = AddFilesProcedure.tryConvertStatValue(Types.FixedType.ofLength(2), fixedBuffer);
+        assertEquals(ByteBuffer.wrap(new byte[] {0x01, 0x02}), fixedFromBuffer);
+
+        Object fixedValue = AddFilesProcedure.tryConvertStatValue(
+                Types.FixedType.ofLength(2), Binary.fromConstantByteArray(new byte[] {0x01, 0x02}));
+        assertEquals(ByteBuffer.wrap(new byte[] {0x01, 0x02}), fixedValue);
+
+        Object fixedFromBytes = AddFilesProcedure.tryConvertStatValue(
+                Types.FixedType.ofLength(2), new byte[] {0x01, 0x02});
+        assertEquals(ByteBuffer.wrap(new byte[] {0x01, 0x02}), fixedFromBytes);
+
+        Object fixedUnsupported = AddFilesProcedure.tryConvertStatValue(Types.FixedType.ofLength(2), 123);
+        Assertions.assertNull(fixedUnsupported);
+
+        Type fakeDecimalType = new Type() {
+            @Override
+            public Type.TypeID typeId() {
+                return Type.TypeID.DECIMAL;
+            }
+        };
+        Object decimalUnsupported = AddFilesProcedure.tryConvertStatValue(fakeDecimalType, 123);
+        Assertions.assertNull(decimalUnsupported);
+
+        Object defaultUnsupported = AddFilesProcedure.tryConvertStatValue(
+                Types.StructType.of(Types.NestedField.optional(99, "x", Types.IntegerType.get())), 123);
+        Assertions.assertNull(defaultUnsupported);
+
+        Object unsupported = AddFilesProcedure.tryConvertStatValue(Types.IntegerType.get(), "123");
+        Assertions.assertNull(unsupported);
+    }
+
+    @Test
+    public void testTryGetComparator() {
+        Assertions.assertNull(AddFilesProcedure.tryGetComparator(null));
+        Assertions.assertNull(AddFilesProcedure.tryGetComparator(
+                Types.StructType.of(Types.NestedField.optional(1, "x", Types.IntegerType.get()))));
+
+        Type badType = new Type() {
+            @Override
+            public Type.TypeID typeId() {
+                return Type.TypeID.BOOLEAN;
+            }
+
+            @Override
+            public boolean isPrimitiveType() {
+                return true;
+            }
+
+            @Override
+            public Type.PrimitiveType asPrimitiveType() {
+                throw new RuntimeException("mocked comparator failure");
+            }
+        };
+        Assertions.assertNull(AddFilesProcedure.tryGetComparator(badType));
+    }
+
+    @Test
+    public void testExtractParquetMetricsWithMissingStatsCleanup(@Mocked Table table,
+                                                                 @Mocked IcebergHiveCatalog catalog,
+                                                                 @Mocked ParquetFileReader reader,
+                                                                 @Mocked HadoopInputFile inputFile) throws Exception {
+        AddFilesProcedure procedure = AddFilesProcedure.getInstance();
+        IcebergTableProcedureContext context =
+                new IcebergTableProcedureContext(catalog, table, null, null, HDFS_ENVIRONMENT, null, null);
+
+        Schema schema = new Schema(
+                Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+                Types.NestedField.optional(2, "struct_col", Types.StructType.of(
+                        Types.NestedField.optional(3, "nested_id", Types.IntegerType.get())))
+        );
+        FileStatus fileStatus = new FileStatus(1024L, false, 1, 0L, 0L, new Path("/tmp/data.parquet"));
+
+        Statistics<?> validStats = Statistics.getStatsBasedOnType(PrimitiveType.PrimitiveTypeName.INT32);
+        validStats.updateStats(10);
+        validStats.updateStats(20);
+        validStats.setNumNulls(0L);
+
+        Statistics<?> invalidConversionStats = Statistics.getStatsBasedOnType(PrimitiveType.PrimitiveTypeName.BINARY);
+        invalidConversionStats.updateStats(Binary.fromString("invalid_min"));
+        invalidConversionStats.updateStats(Binary.fromString("invalid_max"));
+        invalidConversionStats.setNumNulls(0L);
+
+        Statistics<?> nonPrimitiveStats = Statistics.getStatsBasedOnType(PrimitiveType.PrimitiveTypeName.INT32);
+        nonPrimitiveStats.updateStats(1);
+        nonPrimitiveStats.setNumNulls(0L);
+
+        Set<Encoding> encodings = Set.of(Encoding.PLAIN);
+
+        ColumnChunkMetaData validColumn = ColumnChunkMetaData.get(
+                ColumnPath.fromDotString("id"),
+                PrimitiveType.PrimitiveTypeName.INT32,
+                CompressionCodecName.UNCOMPRESSED,
+                encodings,
+                validStats,
+                0L,
+                0L,
+                10L,
+                100L,
+                100L);
+
+        ColumnChunkMetaData invalidConversionColumn = ColumnChunkMetaData.get(
+                ColumnPath.fromDotString("id"),
+                PrimitiveType.PrimitiveTypeName.BINARY,
+                CompressionCodecName.UNCOMPRESSED,
+                encodings,
+                invalidConversionStats,
+                0L,
+                0L,
+                20L,
+                200L,
+                200L);
+
+        ColumnChunkMetaData nonPrimitiveColumn = ColumnChunkMetaData.get(
+                ColumnPath.fromDotString("struct_col"),
+                PrimitiveType.PrimitiveTypeName.INT32,
+                CompressionCodecName.UNCOMPRESSED,
+                encodings,
+                nonPrimitiveStats,
+                0L,
+                0L,
+                5L,
+                50L,
+                50L);
+
+        BlockMetaData block1 = new BlockMetaData();
+        block1.setRowCount(10L);
+        block1.addColumn(validColumn);
+        block1.addColumn(nonPrimitiveColumn);
+
+        BlockMetaData block2 = new BlockMetaData();
+        block2.setRowCount(20L);
+        block2.addColumn(invalidConversionColumn);
+
+        ParquetMetadata metadata = new ParquetMetadata(
+                new FileMetaData(new MessageType("test"), new HashMap<>(), "test"),
+                List.of(block1, block2));
+
+        new Expectations() {
+            {
+                table.schema();
+                result = schema;
+
+                reader.getFooter();
+                result = metadata;
+            }
+        };
+
+        new MockUp<HadoopInputFile>() {
+            @Mock
+            public HadoopInputFile fromStatus(FileStatus ignored, org.apache.hadoop.conf.Configuration conf) {
+                return inputFile;
+            }
+        };
+
+        new MockUp<ParquetFileReader>() {
+            @Mock
+            public ParquetFileReader open(HadoopInputFile ignored) {
+                return reader;
+            }
+        };
+
+        java.lang.reflect.Method method = AddFilesProcedure.class.getDeclaredMethod("extractParquetMetrics",
+                IcebergTableProcedureContext.class, Table.class, FileStatus.class);
+        method.setAccessible(true);
+        Metrics metrics = (Metrics) method.invoke(procedure, context, table, fileStatus);
+
+        assertEquals(30L, metrics.recordCount());
+        assertEquals(300L, metrics.columnSizes().get(1));
+        assertEquals(50L, metrics.columnSizes().get(2));
+        assertEquals(30L, metrics.valueCounts().get(1));
+        assertEquals(5L, metrics.valueCounts().get(2));
+
+        assertFalse(metrics.nullValueCounts().containsKey(1));
+        assertFalse(metrics.nullValueCounts().containsKey(2));
+        assertTrue(metrics.lowerBounds().isEmpty());
+        assertTrue(metrics.upperBounds().isEmpty());
     }
 
     private IcebergTableProcedureContext createMockContext(@Mocked Table table, @Mocked IcebergHiveCatalog catalog) {


### PR DESCRIPTION
## Why I'm doing:
- add_files populated Metrics.lowerBounds/upperBounds from parquet getMinBytes/getMaxBytes.
- Those bytes are parquet physical encodings and are not guaranteed to match Iceberg logical encodings.
- This could produce wrong file bounds and over-prune data files (for example, TPC-DS q21 on item.i_current_price DECIMAL(7,2))
## What I'm doing:
- Refactor extractParquetMetrics to aggregate row-group min/max as typed logical values.
- Read stats via genericGetMin/genericGetMax, convert by Iceberg field type (tryConvertStatValue),
  compare with Comparators.forType, and serialize bounds with Conversions.toByteBuffer.
- Apply the same logical path to all supported primitive types, not only DECIMAL.
- Keep missing-stats handling by dropping unreliable bounds/null-count entries.
- Add helper methods tryGetComparator and tryConvertStatValue, and extend decimal conversion for ByteBuffer input.
- Add unit tests in AddFilesProcedureTest for decimal/stat value conversion paths.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
