### PR TITLE
[Enhancement] [starrocks-sqlalchemy] Optimize run_mode resolution by lazy fetch and add tests

### DIFF
--- a/contrib/starrocks-python-client/CHANGES.md
+++ b/contrib/starrocks-python-client/CHANGES.md
@@ -1,6 +1,10 @@
 Version history
 ===============
 
+**1.3.4**
+
+- Optimize StarRocks `run_mode` resolution by making it lazy and cached, avoiding unnecessary `run_mode` lookups on common table read/write and reflection paths.
+
 **1.3.3**
 
 - Add back support for SQLAlchemy 1.4 (#65976 by @rad-pat)

--- a/contrib/starrocks-python-client/pyproject.toml
+++ b/contrib/starrocks-python-client/pyproject.toml
@@ -106,7 +106,7 @@ include = '\.pyi?$'
 
 
 [tool.pytest.ini_options]
-addopts = "--tb native -n4 -v -r fxX --maxfail=500 -p no:warnings"
+addopts = "--tb native -v -r fxX --maxfail=500 -p no:warnings"
 #python_files = "test/*test_*.py test/**/*test_*.py"
 python_files = "test/**/*test_*.py"
 #python_functions = "test_engine_and_comment"

--- a/contrib/starrocks-python-client/test/integration/test_run_mode_lazy_table_paths.py
+++ b/contrib/starrocks-python-client/test/integration/test_run_mode_lazy_table_paths.py
@@ -1,0 +1,163 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine, exc, inspect, select, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.testing import fixtures
+from sqlalchemy.testing.assertions import eq_, is_true
+
+from starrocks.common.types import SystemRunMode
+
+
+class _RunModeLookupForbidder:
+    def __init__(self, engine: Engine, message: str):
+        self.engine = engine
+        self.message = message
+        self.call_count = 0
+        self._dialect = engine.dialect
+        self._original_get_run_mode = None
+
+    def __enter__(self):
+        self._original_get_run_mode = self._dialect._get_run_mode
+        self._dialect._run_mode = None
+
+        def _forbid_get_run_mode(*args, **kwargs):
+            self.call_count += 1
+            raise AssertionError(self.message)
+
+        self._dialect._get_run_mode = _forbid_get_run_mode
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._dialect._get_run_mode = self._original_get_run_mode
+
+
+@pytest.mark.integration
+class TestRunModeLazyForCommonTablePaths(fixtures.TablesTest):
+    __only_on__ = "starrocks"
+    run_define_tables = "each"
+    run_create_tables = "each"
+    run_inserts = None
+    run_deletes = None
+
+    @classmethod
+    def define_tables(cls, metadata):
+        Table(
+            "test_run_mode_lazy_common_ops",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("name", String(32)),
+            starrocks_distributed_by="HASH(id) BUCKETS 8",
+            starrocks_properties={"replication_num": "1"},
+        )
+        Table(
+            "test_run_mode_lazy_autoload",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("name", String(32)),
+            starrocks_distributed_by="HASH(id) BUCKETS 8",
+            starrocks_properties={"replication_num": "1"},
+        )
+
+    def test_insert_select_and_inspect_do_not_require_run_mode(self, connection) -> None:
+        table = self.tables.test_run_mode_lazy_common_ops
+
+        with _RunModeLookupForbidder(
+            self.bind,
+            "common table read/write paths should not query run_mode",
+        ) as forbidder:
+            connection.execute(table.insert().values(id=1, name="alice"))
+            rows = connection.execute(select(table.c.name).where(table.c.id == 1)).fetchall()
+            is_true(rows and rows[0][0] == "alice")
+
+            inspector = inspect(self.bind)
+            is_true(inspector.has_table(table.name))
+            columns = inspector.get_columns(table.name)
+            is_true(any(col["name"].lower() == "id" for col in columns))
+            is_true(any(col["name"].lower() == "name" for col in columns))
+            inspector.get_table_options(table.name)
+
+        eq_(forbidder.call_count, 0)
+
+    def test_autoload_table_does_not_require_run_mode(self) -> None:
+        table_name = self.tables.test_run_mode_lazy_autoload.name
+
+        with _RunModeLookupForbidder(
+            self.bind,
+            "table autoload should not query run_mode",
+        ) as forbidder:
+            reflected = Table(table_name, MetaData(), autoload_with=self.bind)
+            eq_(reflected.name, table_name)
+            is_true("id" in reflected.c)
+            is_true("name" in reflected.c)
+
+        eq_(forbidder.call_count, 0)
+
+
+@pytest.mark.integration
+class TestRunModeLimitedUser(fixtures.TestBase):
+    __only_on__ = "starrocks"
+
+    def test_limited_table_rw_user_can_resolve_run_mode(self, connection) -> None:
+        table_name = "test_run_mode_limited_user_table"
+        database = connection.engine.url.database
+        username = f"run_mode_u_{uuid4().hex[:10]}"
+        password = f"P_{uuid4().hex[:14]}"
+        user_spec = f"'{username}'@'%'"
+        user_engine = None
+
+        try:
+            connection.execute(text(f"DROP TABLE IF EXISTS {table_name}"))
+            connection.execute(
+                text(
+                    f"""
+                        CREATE TABLE {table_name} (
+                            id INT,
+                            name VARCHAR(32)
+                        )
+                        DISTRIBUTED BY HASH(id) BUCKETS 8
+                        PROPERTIES("replication_num" = "1")
+                        """
+                )
+            )
+
+            try:
+                connection.execute(text(f"CREATE USER {user_spec} IDENTIFIED BY '{password}'"))
+                connection.execute(text(f"GRANT SELECT, INSERT, UPDATE, DELETE ON {database}.{table_name} TO {user_spec}"))
+            except exc.DBAPIError as create_user_exc:
+                pytest.skip(
+                    f"Unable to create/grant limited test user in this environment: {create_user_exc}"
+                )
+
+            user_url = connection.engine.url.set(username=username, password=password)
+            user_engine = create_engine(user_url, pool_pre_ping=True)
+
+            with user_engine.begin() as conn:
+                conn.execute(text(f"INSERT INTO {table_name} (id, name) VALUES (1, 'alice')"))
+                rows = conn.execute(text(f"SELECT name FROM {table_name} WHERE id = 1")).fetchall()
+                is_true(rows and rows[0][0] == "alice")
+
+            run_mode = user_engine.dialect.run_mode
+            is_true(run_mode in (SystemRunMode.SHARED_DATA, SystemRunMode.SHARED_NOTHING))
+        finally:
+            if user_engine is not None:
+                user_engine.dispose()
+            try:
+                connection.execute(text(f"DROP TABLE IF EXISTS {table_name}"))
+                connection.execute(text(f"DROP USER {user_spec}"))
+            except exc.DBAPIError:
+                pass

--- a/contrib/starrocks-python-client/test/unit/test_dialect_run_mode.py
+++ b/contrib/starrocks-python-client/test/unit/test_dialect_run_mode.py
@@ -1,0 +1,110 @@
+#! /usr/bin/python3
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, Mock
+
+from sqlalchemy import exc
+from sqlalchemy.testing import fixtures
+from sqlalchemy.testing.assertions import eq_, is_
+
+from starrocks.common.types import SystemRunMode
+from starrocks.dialect import MySQLDialect_pymysql, StarRocksDialect
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+
+class TestRunModeUnit(fixtures.TestBase):
+    __only_on__ = "starrocks"
+
+    def test_initialize_does_not_fetch_run_mode(self, monkeypatch):
+        # Keep the parent initialize behavior out of this unit test.
+        monkeypatch.setattr(MySQLDialect_pymysql, "initialize", lambda self, conn: None)
+
+        dialect = StarRocksDialect()
+        dialect._get_run_mode = Mock(side_effect=AssertionError("run_mode should not be queried in initialize"))
+
+        conn = Mock()
+        conn.engine = Mock()
+
+        dialect.initialize(conn)
+
+        dialect._get_run_mode.assert_not_called()
+        is_(dialect._run_mode, None)
+        is_(dialect._bind_engine, conn.engine)
+
+    def test_run_mode_property_is_lazy_and_cached(self):
+        dialect = StarRocksDialect()
+        fake_conn = Mock()
+        fake_engine = MagicMock()
+        fake_engine.connect.return_value.__enter__.return_value = fake_conn
+        fake_engine.connect.return_value.__exit__.return_value = None
+
+        dialect._bind_engine = fake_engine
+        dialect._get_run_mode = Mock(return_value=SystemRunMode.SHARED_DATA)
+
+        eq_(dialect.run_mode, SystemRunMode.SHARED_DATA)
+        eq_(dialect.run_mode, SystemRunMode.SHARED_DATA)
+        dialect._get_run_mode.assert_called_once_with(fake_conn)
+
+    def test_get_run_mode_fallback_to_storage_volumes(self):
+        dialect = StarRocksDialect()
+        conn = Mock()
+
+        def _execute(stmt):
+            sql = str(stmt)
+            if "ADMIN SHOW FRONTEND CONFIG LIKE 'run_mode'" in sql:
+                return _FakeResult([])
+            if "SHOW STORAGE VOLUMES" in sql:
+                return _FakeResult([("builtin_storage_volume",)])
+            raise AssertionError(f"Unexpected SQL: {sql}")
+
+        conn.execute.side_effect = _execute
+
+        eq_(dialect._get_run_mode(conn), SystemRunMode.SHARED_DATA)
+
+    def test_get_run_mode_defaults_to_shared_data_on_query_failures(self):
+        dialect = StarRocksDialect()
+        conn = Mock()
+
+        def _execute(stmt):
+            sql = str(stmt)
+            if "ADMIN SHOW FRONTEND CONFIG LIKE 'run_mode'" in sql:
+                raise exc.OperationalError(sql, {}, Exception("access denied"))
+            if "SHOW STORAGE VOLUMES" in sql:
+                raise exc.OperationalError(sql, {}, Exception("access denied"))
+            raise AssertionError(f"Unexpected SQL: {sql}")
+
+        conn.execute.side_effect = _execute
+
+        eq_(dialect._get_run_mode(conn), SystemRunMode.SHARED_NOTHING)
+
+    def test_common_table_sql_compile_does_not_access_run_mode(self):
+        from sqlalchemy import Column, Integer, MetaData, Table, insert, select
+        from sqlalchemy.schema import CreateTable
+
+        dialect = StarRocksDialect()
+        dialect._get_run_mode = Mock(side_effect=AssertionError("run_mode should not be used for normal table sql compile"))
+
+        table = Table("t_compile", MetaData(), Column("id", Integer))
+
+        str(CreateTable(table).compile(dialect=dialect))
+        str(select(table).compile(dialect=dialect))
+        str(insert(table).values(id=1).compile(dialect=dialect))


### PR DESCRIPTION
## Why I'm doing:
It need OPERATE privilege to get run_mode info, which is a high level privilege.
Simple table read and write won't need run_mode, and most of time, users only have low level privileges.

## What I'm doing:
This PR improves StarRocks `run_mode` handling to lazily get it when needed.
And, it will use "SHOW STORAGE VOLUMNES" to detect the run_mode when it can't be gotten directly.

Fixes #issue

### Changes

- Optimize `run_mode` lookup in dialect:
  - lazy + cached access
  - fallback logic for config query failures
- Add run_mode unit tests:
- Add/adjust run_mode integration tests in SQLAlchemy style

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4