### PR TITLE
[Doc] Fix incorrect description of sys_log_verbose_modules BE conf

### DIFF
--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -140,7 +140,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Type: Strings
 - Unit: -
 - Is mutable: No
-- Description: The module of the logs to be printed. For example, if you set this configuration item to OLAP, StarRocks only prints the logs of the OLAP module. Valid values are namespaces in BE, including `starrocks`, `starrocks::debug`, `starrocks::fs`, `starrocks::io`, `starrocks::lake`, `starrocks::pipeline`, `starrocks::query_cache`, `starrocks::stream`, and `starrocks::workgroup`.
+- Description: Specifies the file names (without extensions) or file name wildcards for which VLOG logs should be printed. Multiple file names can be separated by commas. For example, if you set this configuration item to `storage_engine,tablet_manager`, StarRocks prints VLOG logs from the storage_engine.cpp and tablet_manager.cpp files. You can also use wildcards, e.g., set to `*` to print VLOG logs from all files. The VLOG log printing level is controlled by the `sys_log_verbose_level` parameter.
 - Introduced in: -
 
 ### Server

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -112,7 +112,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - タイプ: Strings
 - 単位: -
 - 可変: いいえ
-- 説明: 印刷するログのモジュール。たとえば、この設定項目を OLAP に設定すると、StarRocks は OLAP モジュールのログのみを印刷します。有効な値は BE の名前空間であり、`starrocks`、`starrocks::debug`、`starrocks::fs`、`starrocks::io`、`starrocks::lake`、`starrocks::pipeline`、`starrocks::query_cache`、`starrocks::stream`、`starrocks::workgroup` などがあります。
+- 説明: VLOGログを出力するファイル名（拡張子を除く）またはファイル名のワイルドカードを指定します。複数のファイル名はカンマで区切ることができます。たとえば、この設定項目を `storage_engine,tablet_manager` に設定すると、StarRocks は storage_engine.cpp および tablet_manager.cpp ファイルの VLOG ログを出力します。ワイルドカードも使用可能で、`*` に設定するとすべてのファイルの VLOG ログを出力します。VLOG ログの出力レベルは `sys_log_verbose_level` パラメータで制御されます。
 - 導入バージョン: -
 
 ### サーバー

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -118,7 +118,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Strings
 - 单位：-
 - 是否动态：否
-- 描述：日志打印的模块。有效值为 BE 的 namespace，包括 `starrocks`、`starrocks::debug`、`starrocks::fs`、`starrocks::io`、`starrocks::lake`、`starrocks::pipeline`、`starrocks::query_cache`、`starrocks::stream` 以及 `starrocks::workgroup`。
+- 描述：设置需要输出 VLOG 日志的文件名（去掉文件扩展名）或文件名通配符。可以指定多个文件名，用逗号分隔。例如，如果将此配置项设置为 `storage_engine,tablet_manager`，StarRocks 将打印 storage_engine.cpp、tablet_manager.cpp 文件的 VLOG 日志。您也可以使用通配符，如设置为 `*` 表示打印所有文件的 VLOG 日志。VLOG 日志打印级别通过 `sys_log_verbose_level` 参数控制。
 - 引入版本：-
 
 ### 服务器


### PR DESCRIPTION
## Why I'm doing:
The current documentation for the `sys_log_verbose_modules` BE configuration parameter is incorrect. The description states that this parameter controls logging by **BE namespace modules** (e.g., `starrocks`, `starrocks::debug`, `starrocks::pipeline`), but this is wrong.

In reality, `sys_log_verbose_modules` specifies **source file names** (without file extensions) or file name wildcards to control which files' VLOG output is enabled. This can be verified by examining the BE source code where glog's `--vmodule` flag is used:

```cpp
// be/src/common/logging.cpp
FLAGS_vmodule = config::sys_log_verbose_modules;
```

The glog `--vmodule` flag documentation clearly states:
> Per-module verbose level. Argument is a comma-separated list of `<module name>=<log level>`. `<module name>` is a glob pattern, matched against the **filename base** (that is, name ignoring .cc/.h./-inl.h).

For example:
- Setting `sys_log_verbose_modules=storage_engine,tablet_manager` enables VLOG output from `storage_engine.cpp` and `tablet_manager.cpp`
- Setting `sys_log_verbose_modules=*` enables VLOG output from all source files
- The old documentation incorrectly suggested using values like `starrocks::pipeline` which are C++ namespaces, not file names.

## What I'm doing:
Update the `sys_log_verbose_modules` parameter description in BE_configuration.md

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
