### PR TITLE
[BugFix] Fix SET ROLE not propagating to information_schema queries

### DIFF
--- a/docs/en/sql-reference/sql-statements/account-management/SET_ROLE.md
+++ b/docs/en/sql-reference/sql-statements/account-management/SET_ROLE.md
@@ -19,6 +19,8 @@ You can query the roles of a user using [SHOW GRANTS](./SHOW_GRANTS.md).
 
 You can query the active roles of the current user using `SELECT CURRENT_ROLE()`. For more information, see [current_role](../../sql-functions/utility-functions/current_role.md).
 
+The activated role affects all authorization checks, including queries against `information_schema` system views. For example, after executing `SET ROLE role1`, queries like `SELECT * FROM information_schema.tables` will only return tables accessible through `role1`. This ensures that role-based access control is consistently applied across all system catalogs and metadata queries.
+
 ## Syntax
 
 ```SQL

--- a/docs/ja/sql-reference/sql-statements/account-management/SET_ROLE.md
+++ b/docs/ja/sql-reference/sql-statements/account-management/SET_ROLE.md
@@ -4,28 +4,28 @@ displayed_sidebar: docs
 
 # SET ROLE
 
-## 説明
+SET ROLE は、現在のセッションに対して、ロールとそれに関連するすべての権限およびネストされたロールをアクティブにします。ロールがアクティブ化されると、ユーザーはこのロールを使用して操作を実行できます。
 
-現在のセッションで、ロールとその関連するすべての権限およびネストされたロールをアクティブにします。ロールがアクティブ化された後、ユーザーはこのロールを使用して操作を実行できます。
+このコマンドを実行した後、`select is_role_in_session("<role_name>");` を実行して、このロールが現在のセッションでアクティブであるかどうかを確認できます。
 
-このコマンドを実行した後、`select is_role_in_session("<role_name>");` を実行して、このロールが現在のセッションでアクティブかどうかを確認できます。
-
-このコマンドは v3.0 からサポートされています。
+このコマンドは v3.0 以降でサポートされています。
 
 ## 使用上の注意
 
-ユーザーは、自分に割り当てられたロールのみをアクティブにできます。
+ユーザーは、自分に割り当てられているロールのみをアクティブにできます。
 
-ユーザーのロールを照会するには、[SHOW GRANTS](./SHOW_GRANTS.md) を使用します。
+[SHOW GRANTS](./SHOW_GRANTS.md) を使用して、ユーザーのロールをクエリできます。
 
-現在のユーザーのアクティブなロールを照会するには、`SELECT CURRENT_ROLE()` を使用します。詳細については、[current_role](../../sql-functions/utility-functions/current_role.md) を参照してください。
+`SELECT CURRENT_ROLE()` を使用して、現在のユーザーのアクティブなロールをクエリできます。詳細については、[current_role](../../sql-functions/utility-functions/current_role.md) を参照してください。
+
+アクティブ化されたロールは、`information_schema` システムビューに対するクエリを含む、すべての承認チェックに影響します。例えば、`SET ROLE role1` を実行した後、`SELECT * FROM information_schema.tables` のようなクエリは、`role1` を通じてアクセス可能なテーブルのみを返します。これにより、ロールベースのアクセス制御が、すべてのシステムカタログおよびメタデータクエリ全体で一貫して適用されます。
 
 ## 構文
 
 ```SQL
 -- 特定のロールをアクティブにし、このロールとして操作を実行します。
 SET ROLE <role_name>[,<role_name>,..];
--- 特定のロールを除いて、ユーザーのすべてのロールをアクティブにします。
+-- 特定のロールを除く、ユーザーのすべてのロールをアクティブにします。
 SET ROLE ALL EXCEPT <role_name>[,<role_name>,..]; 
 -- ユーザーのすべてのロールをアクティブにします。
 SET ROLE ALL;
@@ -37,7 +37,7 @@ SET ROLE ALL;
 
 ## 例
 
-現在のユーザーのすべてのロールを照会します。
+現在のユーザーのすべてのロールをクエリします。
 
 ```SQL
 SHOW GRANTS;
@@ -54,7 +54,7 @@ SHOW GRANTS;
 SET ROLE db_admin;
 ```
 
-現在のユーザーのアクティブなロールを照会します。
+現在のユーザーのアクティブなロールをクエリします。
 
 ```SQL
 SELECT CURRENT_ROLE();
@@ -65,12 +65,12 @@ SELECT CURRENT_ROLE();
 +--------------------+
 ```
 
-## 参考
+## 参照
 
 - [CREATE ROLE](CREATE_ROLE.md): ロールを作成します。
 - [GRANT](GRANT.md): ユーザーまたは他のロールにロールを割り当てます。
 - [ALTER USER](ALTER_USER.md): ロールを変更します。
 - [SHOW ROLES](SHOW_ROLES.md): システム内のすべてのロールを表示します。
 - [current_role](../../sql-functions/utility-functions/current_role.md): 現在のユーザーのロールを表示します。
-- [is_role_in_session](../../sql-functions/utility-functions/is_role_in_session.md): ロール（またはネストされたロール）が現在のセッションでアクティブかどうかを確認します。
+- [is_role_in_session](../../sql-functions/utility-functions/is_role_in_session.md): ロール（またはネストされたロール）が現在のセッションでアクティブであるかどうかを確認します。
 - [DROP ROLE](DROP_ROLE.md): ロールを削除します。

--- a/docs/zh/sql-reference/sql-statements/account-management/SET_ROLE.md
+++ b/docs/zh/sql-reference/sql-statements/account-management/SET_ROLE.md
@@ -18,6 +18,8 @@ displayed_sidebar: docs
 
 - 用户可以通过 [SHOW GRANTS](SHOW_GRANTS.md) 查看拥有的角色，可以通过[SELECT CURRENT_ROLE](../../sql-functions/utility-functions/current_role.md) 查看当前激活的角色。
 
+- 激活的角色会影响所有权限检查,包括对 `information_schema` 系统视图的查询。例如,执行 `SET ROLE role1` 后,查询 `SELECT * FROM information_schema.tables` 将只返回通过 `role1` 可访问的表。这确保了基于角色的访问控制在所有系统目录和元数据查询中得到一致应用。
+
 ## 语法
 
 ```SQL

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/UserIdentityUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/UserIdentityUtils.java
@@ -15,15 +15,22 @@
 package com.starrocks.authentication;
 
 import com.google.common.base.Strings;
+import com.starrocks.authorization.PrivilegeException;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TAuthInfo;
 import com.starrocks.thrift.TUserIdentity;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class UserIdentityUtils {
-    
+    private static final Logger LOG = LogManager.getLogger(UserIdentityUtils.class);
+
     public static UserIdentity fromString(String userIdentStr) {
         if (Strings.isNullOrEmpty(userIdentStr)) {
             return null;
@@ -79,7 +86,16 @@ public class UserIdentityUtils {
         UserIdentity userIdentity = UserIdentityUtils.fromThrift(tUserIdent);
         context.setCurrentUserIdentity(userIdentity);
         if (tUserIdent.isSetCurrent_role_ids()) {
-            context.setCurrentRoleIds(new HashSet<>(tUserIdent.current_role_ids.getRole_id_list()));
+            List<Long> roleIdList = tUserIdent.current_role_ids.getRole_id_list();
+            Set<Long> requestedRoleIds = roleIdList != null ? new HashSet<>(roleIdList) : new HashSet<>();
+            try {
+                Set<Long> actualRoleIds =
+                        GlobalStateMgr.getCurrentState().getAuthorizationMgr().getRoleIdsByUser(userIdentity);
+                requestedRoleIds.retainAll(actualRoleIds);
+            } catch (PrivilegeException e) {
+                LOG.warn("Failed to validate role IDs for user {}: {}", userIdentity, e.getMessage());
+            }
+            context.setCurrentRoleIds(requestedRoleIds);
         } else {
             context.setCurrentRoleIds(userIdentity);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -44,6 +44,7 @@ import com.starrocks.thrift.TListMaterializedViewStatusResult;
 import com.starrocks.thrift.TMaterializedViewStatus;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.thrift.TUserIdentity;
+import com.starrocks.thrift.TUserRoles;
 import com.starrocks.type.DateType;
 import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
@@ -56,6 +57,7 @@ import org.apache.thrift.TException;
 import org.apache.thrift.meta_data.FieldValueMetaData;
 import org.sparkproject.guava.base.Strings;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -137,6 +139,11 @@ public class MaterializedViewsSystemTable extends SystemTable {
 
         ConnectContext context = Preconditions.checkNotNull(ConnectContext.get(), "not a valid connection");
         TUserIdentity userIdentity = UserIdentityUtils.toThrift(context.getCurrentUserIdentity());
+        if (context.getCurrentRoleIds() != null) {
+            TUserRoles userRoles = new TUserRoles();
+            userRoles.setRole_id_list(new ArrayList<>(context.getCurrentRoleIds()));
+            userIdentity.setCurrent_role_ids(userRoles);
+        }
         TGetTablesParams params = new TGetTablesParams();
         params.setCurrent_user_ident(userIdentity);
         params.setType(MATERIALIZED_VIEW);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
@@ -34,6 +34,7 @@ import com.starrocks.thrift.TGetTablesInfoResponse;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.thrift.TTableInfo;
 import com.starrocks.thrift.TUserIdentity;
+import com.starrocks.thrift.TUserRoles;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 import org.apache.commons.lang3.NotImplementedException;
@@ -42,6 +43,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 import org.apache.thrift.meta_data.FieldValueMetaData;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -152,6 +154,11 @@ public class TablesSystemTable extends SystemTable {
         final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
         ConnectContext context = Preconditions.checkNotNull(ConnectContext.get(), "not a valid connection");
         TUserIdentity userIdentity = UserIdentityUtils.toThrift(context.getCurrentUserIdentity());
+        if (context.getCurrentRoleIds() != null) {
+            TUserRoles userRoles = new TUserRoles();
+            userRoles.setRole_id_list(new ArrayList<>(context.getCurrentRoleIds()));
+            userIdentity.setCurrent_role_ids(userRoles);
+        }
         TGetTablesInfoRequest params = new TGetTablesInfoRequest();
         TAuthInfo authInfo = new TAuthInfo();
         authInfo.setCurrent_user_ident(userIdentity);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
@@ -20,7 +20,6 @@ import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.Table;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.cluster.ClusterNamespace;
@@ -42,6 +41,7 @@ import com.starrocks.thrift.TGetTasksParams;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.thrift.TTaskRunInfo;
 import com.starrocks.thrift.TUserIdentity;
+import com.starrocks.thrift.TUserRoles;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 import org.apache.commons.lang3.NotImplementedException;
@@ -50,6 +50,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.thrift.meta_data.FieldValueMetaData;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -142,6 +143,11 @@ public class TaskRunsSystemTable extends SystemTable {
 
         ConnectContext context = Preconditions.checkNotNull(ConnectContext.get(), "not a valid connection");
         TUserIdentity userIdentity = UserIdentityUtils.toThrift(context.getCurrentUserIdentity());
+        if (context.getCurrentRoleIds() != null) {
+            TUserRoles userRoles = new TUserRoles();
+            userRoles.setRole_id_list(new ArrayList<>(context.getCurrentRoleIds()));
+            userIdentity.setCurrent_role_ids(userRoles);
+        }
         params.setCurrent_user_ident(userIdentity);
         // Evaluate result
         TGetTaskRunInfoResult info = query(params);
@@ -168,9 +174,9 @@ public class TaskRunsSystemTable extends SystemTable {
         List<TTaskRunInfo> tasksResult = Lists.newArrayList();
         result.setTask_runs(tasksResult);
 
-        UserIdentity currentUser = null;
+        ConnectContext context = new ConnectContext();
         if (params.isSetCurrent_user_ident()) {
-            currentUser = UserIdentityUtils.fromThrift(params.current_user_ident);
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.current_user_ident);
         }
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         TaskManager taskManager = globalStateMgr.getTaskManager();
@@ -183,9 +189,6 @@ public class TaskRunsSystemTable extends SystemTable {
             }
 
             try {
-                ConnectContext context = new ConnectContext();
-                context.setCurrentUserIdentity(currentUser);
-                context.setCurrentRoleIds(currentUser);
                 Authorizer.checkAnyActionOnOrInDb(context, InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
                         status.getDbName());
             } catch (AccessDeniedException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TasksSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TasksSystemTable.java
@@ -18,7 +18,6 @@ import com.starrocks.authentication.UserIdentityUtils;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.Table;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.cluster.ClusterNamespace;
@@ -70,9 +69,9 @@ public class TasksSystemTable {
         TaskManager taskManager = globalStateMgr.getTaskManager();
         List<Task> taskList = taskManager.filterTasks(params);
         List<TTaskInfo> result = Lists.newArrayList();
-        UserIdentity currentUser = null;
+        ConnectContext context = new ConnectContext();
         if (params.isSetCurrent_user_ident()) {
-            currentUser = UserIdentityUtils.fromThrift(params.current_user_ident);
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.current_user_ident);
         }
 
         for (Task task : taskList) {
@@ -82,9 +81,6 @@ public class TasksSystemTable {
             }
 
             try {
-                ConnectContext context = new ConnectContext();
-                context.setCurrentUserIdentity(currentUser);
-                context.setCurrentRoleIds(currentUser);
                 Authorizer.checkAnyActionOnOrInDb(context, InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
                         task.getDbName());
             } catch (AccessDeniedException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
@@ -48,6 +48,7 @@ import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.thrift.TTableStatus;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.thrift.TUserIdentity;
+import com.starrocks.thrift.TUserRoles;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 import org.apache.commons.lang3.NotImplementedException;
@@ -57,6 +58,7 @@ import org.apache.parquet.Strings;
 import org.apache.thrift.TException;
 import org.apache.thrift.meta_data.FieldValueMetaData;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -129,6 +131,11 @@ public class ViewsSystemTable extends SystemTable {
         final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
         ConnectContext context = Preconditions.checkNotNull(ConnectContext.get(), "not a valid connection");
         TUserIdentity userIdentity = UserIdentityUtils.toThrift(context.getCurrentUserIdentity());
+        if (context.getCurrentRoleIds() != null) {
+            TUserRoles userRoles = new TUserRoles();
+            userRoles.setRole_id_list(new ArrayList<>(context.getCurrentRoleIds()));
+            userIdentity.setCurrent_role_ids(userRoles);
+        }
         TGetTablesParams params = new TGetTablesParams();
         params.setCurrent_user_ident(userIdentity);
         params.setType(VIEW);
@@ -241,11 +248,12 @@ public class ViewsSystemTable extends SystemTable {
                 throw new TException("Pattern is in bad format " + params.getPattern());
             }
         }
-        UserIdentity currentUser;
         if (params.isSetCurrent_user_ident()) {
-            currentUser = UserIdentityUtils.fromThrift(params.current_user_ident);
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.getCurrent_user_ident());
         } else {
-            currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
+            UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
+            context.setCurrentUserIdentity(currentUser);
+            context.setCurrentRoleIds(currentUser);
         }
         String tableNameParam = params.isSetTable_name() ? params.getTable_name() : null;
         boolean listingViews = params.isSetType() && TTableType.VIEW.equals(params.getType());
@@ -261,7 +269,7 @@ public class ViewsSystemTable extends SystemTable {
         long limit = params.isSetLimit() ? params.getLimit() : -1;
         List<GetViewResult> result = Lists.newArrayList();
         for (Database db : databases) {
-            if (!collectViewsInDb(context, db, currentUser, tableNameParam, pattern, matcher,
+            if (!collectViewsInDb(context, db, tableNameParam, pattern, matcher,
                     limit, listingViews, caseSensitive, result)) {
                 break;
             }
@@ -272,7 +280,7 @@ public class ViewsSystemTable extends SystemTable {
     /**
      * if the limit is reached, false is returned, otherwise true will be returned.
      */
-    private static boolean collectViewsInDb(ConnectContext context, Database db, UserIdentity currentUser,
+    private static boolean collectViewsInDb(ConnectContext context, Database db,
                                             String paramTableName, String paramPattern, PatternMatcher matcher,
                                             long limit, boolean listingViews, boolean caseSensitive,
                                             List<GetViewResult> result) {
@@ -288,8 +296,6 @@ public class ViewsSystemTable extends SystemTable {
             OUTER:
             for (Table table : tables) {
                 try {
-                    context.setCurrentUserIdentity(currentUser);
-                    context.setCurrentRoleIds(currentUser);
                     Authorizer.checkAnyActionOnTableLikeObject(context, dbName, table);
                 } catch (AccessDeniedException e) {
                     continue;
@@ -326,8 +332,6 @@ public class ViewsSystemTable extends SystemTable {
                                     .getTable(db.getFullName(), tableName.getTbl());
                             if (tbl != null) {
                                 try {
-                                    context.setCurrentUserIdentity(currentUser);
-                                    context.setCurrentRoleIds(currentUser);
                                     Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), tbl);
                                 } catch (AccessDeniedException e) {
                                     continue OUTER;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
@@ -55,10 +55,12 @@ import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TSchemaScanNode;
 import com.starrocks.thrift.TUserIdentity;
+import com.starrocks.thrift.TUserRoles;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -206,7 +208,13 @@ public class SchemaScanNode extends ScanNode {
         msg.schema_scan_node.setIp(frontendIP);
         msg.schema_scan_node.setPort(frontendPort);
 
-        TUserIdentity tCurrentUser = UserIdentityUtils.toThrift(ConnectContext.get().getCurrentUserIdentity());
+        ConnectContext currentCtx = ConnectContext.get();
+        TUserIdentity tCurrentUser = UserIdentityUtils.toThrift(currentCtx.getCurrentUserIdentity());
+        if (currentCtx.getCurrentRoleIds() != null) {
+            TUserRoles userRoles = new TUserRoles();
+            userRoles.setRole_id_list(new ArrayList<>(currentCtx.getCurrentRoleIds()));
+            tCurrentUser.setCurrent_role_ids(userRoles);
+        }
         msg.schema_scan_node.setCurrent_user_ident(tCurrentUser);
 
         if (tableId != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -460,15 +460,14 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             catalogName = params.getCatalog_name();
         }
 
-        UserIdentity currentUser;
-        if (params.isSetCurrent_user_ident()) {
-            currentUser = UserIdentityUtils.fromThrift(params.current_user_ident);
-        } else {
-            currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
-        }
         ConnectContext context = new ConnectContext();
-        context.setCurrentUserIdentity(currentUser);
-        context.setCurrentRoleIds(currentUser);
+        if (params.isSetCurrent_user_ident()) {
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.current_user_ident);
+        } else {
+            UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
+            context.setCurrentUserIdentity(currentUser);
+            context.setCurrentRoleIds(currentUser);
+        }
 
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
         List<String> dbNames = metadataMgr.listDbNames(context, catalogName);
@@ -516,16 +515,14 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             catalogName = params.getCatalog_name();
         }
 
-        UserIdentity currentUser = null;
-        if (params.isSetCurrent_user_ident()) {
-            currentUser = UserIdentityUtils.fromThrift(params.current_user_ident);
-        } else {
-            currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
-        }
-
         ConnectContext context = new ConnectContext();
-        context.setCurrentUserIdentity(currentUser);
-        context.setCurrentRoleIds(currentUser);
+        if (params.isSetCurrent_user_ident()) {
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.current_user_ident);
+        } else {
+            UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
+            context.setCurrentUserIdentity(currentUser);
+            context.setCurrentRoleIds(currentUser);
+        }
 
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
         Database db = metadataMgr.getDb(context, catalogName, params.db);
@@ -805,15 +802,14 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         result.setColumns(columns);
 
         // database privs should be checked in analysis phrase
-        UserIdentity currentUser = null;
-        if (params.isSetCurrent_user_ident()) {
-            currentUser = UserIdentityUtils.fromThrift(params.current_user_ident);
-        } else {
-            currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
-        }
         ConnectContext context = new ConnectContext();
-        context.setCurrentUserIdentity(currentUser);
-        context.setCurrentRoleIds(currentUser);
+        if (params.isSetCurrent_user_ident()) {
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.current_user_ident);
+        } else {
+            UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
+            context.setCurrentUserIdentity(currentUser);
+            context.setCurrentRoleIds(currentUser);
+        }
 
         long limit = params.isSetLimit() ? params.getLimit() : -1;
 
@@ -822,7 +818,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         // describe_table interface only once, which can reduce RPC time from BE to FE, and
         // the amount of data. In additional,we need add db_name & table_name values to TColumnDesc.
         if (!params.isSetDb() && StringUtils.isBlank(params.getTable_name())) {
-            describeWithoutDbAndTable(currentUser, columns, limit);
+            describeWithoutDbAndTable(context, columns, limit);
             return result;
         }
 
@@ -857,11 +853,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
     // get describeTable without db name and table name parameter, so we need iterate over
     // dbs and tables, when reach limit, we break;
-    private void describeWithoutDbAndTable(UserIdentity currentUser, List<TColumnDef> columns, long limit) {
+    private void describeWithoutDbAndTable(ConnectContext context, List<TColumnDef> columns, long limit) {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        ConnectContext context = new ConnectContext();
-        context.setCurrentUserIdentity(currentUser);
-        context.setCurrentRoleIds(currentUser);
 
         List<String> dbNames = globalStateMgr.getLocalMetastore().listDbNames(context);
         boolean reachLimit;

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -117,15 +117,14 @@ public class InformationSchemaDataSource {
             catalogName = authInfo.getCatalog_name();
         }
 
-        UserIdentity currentUser;
-        if (authInfo.isSetCurrent_user_ident()) {
-            currentUser = UserIdentityUtils.fromThrift(authInfo.current_user_ident);
-        } else {
-            currentUser = UserIdentity.createAnalyzedUserIdentWithIp(authInfo.user, authInfo.user_ip);
-        }
         ConnectContext context = new ConnectContext();
-        context.setCurrentUserIdentity(currentUser);
-        context.setCurrentRoleIds(currentUser);
+        if (authInfo.isSetCurrent_user_ident()) {
+            UserIdentityUtils.setAuthInfoFromThrift(context, authInfo.getCurrent_user_ident());
+        } else {
+            UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp(authInfo.user, authInfo.user_ip);
+            context.setCurrentUserIdentity(currentUser);
+            context.setCurrentRoleIds(currentUser);
+        }
 
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
         List<String> dbNames = metadataMgr.listDbNames(context, catalogName);
@@ -146,7 +145,7 @@ public class InformationSchemaDataSource {
             }
             authorizedDbs.add(fullName);
         }
-        return new AuthDbRequestResult(authorizedDbs, currentUser);
+        return new AuthDbRequestResult(authorizedDbs, context);
     }
 
     // keywords
@@ -218,10 +217,19 @@ public class InformationSchemaDataSource {
     private static class AuthDbRequestResult {
         public final List<String> authorizedDbs;
         public final UserIdentity currentUser;
+        private final ConnectContext authContext;
 
-        public AuthDbRequestResult(List<String> authorizedDbs, UserIdentity currentUser) {
+        public AuthDbRequestResult(List<String> authorizedDbs, ConnectContext authContext) {
             this.authorizedDbs = authorizedDbs;
-            this.currentUser = currentUser;
+            this.currentUser = authContext.getCurrentUserIdentity();
+            this.authContext = authContext;
+        }
+
+        public ConnectContext buildConnectContext() {
+            ConnectContext context = new ConnectContext();
+            context.setCurrentUserIdentity(authContext.getCurrentUserIdentity());
+            context.setCurrentRoleIds(authContext.getCurrentRoleIds());
+            return context;
         }
     }
 
@@ -242,9 +250,7 @@ public class InformationSchemaDataSource {
                     List<Table> allTables = GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
                     for (Table table : allTables) {
                         try {
-                            ConnectContext context = new ConnectContext();
-                            context.setCurrentUserIdentity(result.currentUser);
-                            context.setCurrentRoleIds(result.currentUser);
+                            ConnectContext context = result.buildConnectContext();
                             Authorizer.checkAnyActionOnTableLikeObject(context, dbName, table);
                         } catch (AccessDeniedException e) {
                             LOG.warn("failed to check db: {} table: {} authorization", dbName, table, e);
@@ -380,9 +386,7 @@ public class InformationSchemaDataSource {
                 continue;
             }
             try {
-                ConnectContext context = new ConnectContext();
-                context.setCurrentUserIdentity(result.currentUser);
-                context.setCurrentRoleIds(result.currentUser);
+                ConnectContext context = result.buildConnectContext();
                 Authorizer.checkAnyActionOnTableLikeObject(context, ele.dbName, table);
             } catch (AccessDeniedException e) {
                 LOG.warn("failed to check db: {} table: {} authorization", ele.dbName, table, e);
@@ -512,9 +516,7 @@ public class InformationSchemaDataSource {
 
         TAuthInfo authInfo = request.getAuth_info();
         AuthDbRequestResult result = getAuthDbRequestResult(authInfo);
-        ConnectContext context = new ConnectContext();
-        context.setCurrentUserIdentity(result.currentUser);
-        context.setCurrentRoleIds(result.currentUser);
+        ConnectContext context = result.buildConnectContext();
 
         PatternMatcher matcher = null;
         boolean caseSensitive = CaseSensibility.DATABASE.getCaseSensibility();
@@ -680,9 +682,7 @@ public class InformationSchemaDataSource {
         TemporaryTableMgr temporaryTableMgr = GlobalStateMgr.getCurrentState().getTemporaryTableMgr();
         TAuthInfo authInfo = request.getAuth_info();
         AuthDbRequestResult result = getAuthDbRequestResult(authInfo);
-        ConnectContext context = new ConnectContext();
-        context.setCurrentUserIdentity(result.currentUser);
-        context.setCurrentRoleIds(result.currentUser);
+        ConnectContext context = result.buildConnectContext();
 
         String catalogName = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
         if (authInfo.isSetCatalog_name()) {

--- a/fe/fe-core/src/test/java/com/starrocks/authorization/SetRoleInformationSchemaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authorization/SetRoleInformationSchemaTest.java
@@ -1,0 +1,517 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authorization;
+
+import com.starrocks.authentication.AuthenticationMgr;
+import com.starrocks.authentication.UserIdentityUtils;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
+import com.starrocks.qe.GlobalVariable;
+import com.starrocks.qe.SetRoleExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.FrontendServiceImpl;
+import com.starrocks.sql.ast.CreateUserStmt;
+import com.starrocks.sql.ast.GrantPrivilegeStmt;
+import com.starrocks.sql.ast.GrantRoleStmt;
+import com.starrocks.sql.ast.SetRoleStmt;
+import com.starrocks.thrift.TDescribeTableParams;
+import com.starrocks.thrift.TDescribeTableResult;
+import com.starrocks.thrift.TGetDbsParams;
+import com.starrocks.thrift.TGetDbsResult;
+import com.starrocks.thrift.TGetTablesParams;
+import com.starrocks.thrift.TGetTablesResult;
+import com.starrocks.thrift.TListTableStatusResult;
+import com.starrocks.thrift.TTableStatus;
+import com.starrocks.thrift.TUserIdentity;
+import com.starrocks.thrift.TUserRoles;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Integration tests for SET ROLE propagation to information_schema queries.
+ *
+ * Tests the bugfix: SET ROLE not propagating to all information_schema paths.
+ *
+ * When activate_all_roles_on_login=OFF, SET ROLE updates the session's active
+ * role IDs. These tests verify the role IDs are correctly propagated through
+ * all thrift handlers and system table query methods, so that authorization
+ * checks reflect the active role rather than all granted roles.
+ *
+ * Tested paths:
+ * - FrontendServiceImpl.getDbNames() — DB visibility
+ * - FrontendServiceImpl.getTableNames() — table visibility
+ * - FrontendServiceImpl.describeTable() — column visibility
+ * - FrontendServiceImpl.listTableStatus() → ViewsSystemTable.query() — table listing
+ */
+public class SetRoleInformationSchemaTest {
+    private static ConnectContext ctx;
+    private static StarRocksAssert starRocksAssert;
+    private static final String DB_1 = "test_set_role_db1";
+    private static final String DB_2 = "test_set_role_db2";
+    private static final String TABLE_1 = "tbl1";
+    private static final String TABLE_2 = "tbl2";
+    private static final String ROLE_1 = "test_sr_role_1";
+    private static final String ROLE_2 = "test_sr_role_2";
+    private static final String TEST_USER = "test_set_role_user";
+    private static FrontendServiceImpl frontendService;
+    private static long role1Id;
+    private static long role2Id;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+        ctx = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        ctx.setThreadLocalInfo();
+        starRocksAssert = new StarRocksAssert(ctx);
+        frontendService = new FrontendServiceImpl(null);
+
+        // Disable activate_all_roles_on_login — this is the scenario where the bug manifests
+        GlobalVariable.setActivateAllRolesOnLogin(false);
+
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        globalStateMgr.setAuthenticationMgr(new AuthenticationMgr());
+        globalStateMgr.setAuthorizationMgr(new AuthorizationMgr(new DefaultAuthorizationProvider()));
+
+        // Create two databases, each with one table
+        starRocksAssert.withDatabase(DB_1).useDatabase(DB_1);
+        starRocksAssert.withTable("create table " + TABLE_1 + " (id int) properties('replication_num'='1')");
+
+        starRocksAssert.withDatabase(DB_2).useDatabase(DB_2);
+        starRocksAssert.withTable("create table " + TABLE_2 + " (id int) properties('replication_num'='1')");
+
+        // Create test user
+        CreateUserStmt createUserStmt = (CreateUserStmt) UtFrameUtils.parseStmtWithNewParser(
+                "create user " + TEST_USER, ctx);
+        globalStateMgr.getAuthenticationMgr().createUser(createUserStmt);
+
+        // Create roles
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "create role " + ROLE_1, ctx), ctx);
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(
+                "create role " + ROLE_2, ctx), ctx);
+
+        // Grant role1: access to db1.tbl1
+        GrantPrivilegeStmt grantStmt1 = (GrantPrivilegeStmt) UtFrameUtils.parseStmtWithNewParser(
+                "grant select on " + DB_1 + "." + TABLE_1 + " to role " + ROLE_1, ctx);
+        globalStateMgr.getAuthorizationMgr().grant(grantStmt1);
+
+        // Grant role2: access to db2.tbl2
+        GrantPrivilegeStmt grantStmt2 = (GrantPrivilegeStmt) UtFrameUtils.parseStmtWithNewParser(
+                "grant select on " + DB_2 + "." + TABLE_2 + " to role " + ROLE_2, ctx);
+        globalStateMgr.getAuthorizationMgr().grant(grantStmt2);
+
+        // Grant both roles to test user
+        GrantRoleStmt grantRoleStmt = (GrantRoleStmt) UtFrameUtils.parseStmtWithNewParser(
+                "grant " + ROLE_1 + ", " + ROLE_2 + " to " + TEST_USER, ctx);
+        globalStateMgr.getAuthorizationMgr().grantRole(grantRoleStmt);
+
+        // Cache role IDs
+        role1Id = globalStateMgr.getAuthorizationMgr().getRoleIdByNameNoLock(ROLE_1);
+        role2Id = globalStateMgr.getAuthorizationMgr().getRoleIdByNameNoLock(ROLE_2);
+    }
+
+    @AfterAll
+    public static void tearDown() throws Exception {
+        starRocksAssert.dropDatabase(DB_1);
+        starRocksAssert.dropDatabase(DB_2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper methods
+    // -----------------------------------------------------------------------
+
+    private static TUserIdentity buildUserIdentityWithRoles(UserIdentity user, Set<Long> roleIds) {
+        TUserIdentity tUserIdentity = UserIdentityUtils.toThrift(user);
+        if (roleIds != null) {
+            TUserRoles tUserRoles = new TUserRoles();
+            tUserRoles.setRole_id_list(new ArrayList<>(roleIds));
+            tUserIdentity.setCurrent_role_ids(tUserRoles);
+        }
+        return tUserIdentity;
+    }
+
+    private static UserIdentity getTestUserIdentity() {
+        return UserIdentity.createAnalyzedUserIdentWithIp(TEST_USER, "%");
+    }
+
+    // -----------------------------------------------------------------------
+    // Unit tests: SET ROLE mechanics
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSetRoleUpdatesContextRoleIds() throws Exception {
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        ctx.setCurrentRoleIds(UserIdentity.ROOT);
+
+        // Switch to test user
+        UserIdentity testUser = getTestUserIdentity();
+        ctx.setCurrentUserIdentity(testUser);
+        ctx.setCurrentRoleIds(testUser);
+
+        // SET ROLE role1
+        SetRoleStmt setRoleStmt = (SetRoleStmt) UtFrameUtils.parseStmtWithNewParser(
+                "set role " + ROLE_1, ctx);
+        SetRoleExecutor.execute(setRoleStmt, ctx);
+
+        Assertions.assertTrue(ctx.getCurrentRoleIds().contains(role1Id),
+                "Context should contain role1 ID after SET ROLE role1");
+        Assertions.assertEquals(1, ctx.getCurrentRoleIds().size(),
+                "Context should have exactly 1 role ID after SET ROLE role1");
+
+        // SET ROLE role2
+        setRoleStmt = (SetRoleStmt) UtFrameUtils.parseStmtWithNewParser(
+                "set role " + ROLE_2, ctx);
+        SetRoleExecutor.execute(setRoleStmt, ctx);
+
+        Assertions.assertTrue(ctx.getCurrentRoleIds().contains(role2Id),
+                "Context should contain role2 ID after SET ROLE role2");
+        Assertions.assertEquals(1, ctx.getCurrentRoleIds().size(),
+                "Context should have exactly 1 role ID after SET ROLE role2");
+
+        // SET ROLE ALL
+        setRoleStmt = (SetRoleStmt) UtFrameUtils.parseStmtWithNewParser(
+                "set role all", ctx);
+        SetRoleExecutor.execute(setRoleStmt, ctx);
+
+        Assertions.assertTrue(ctx.getCurrentRoleIds().contains(role1Id) &&
+                        ctx.getCurrentRoleIds().contains(role2Id),
+                "Context should contain both role IDs after SET ROLE ALL");
+    }
+
+    @Test
+    public void testSetRoleNoneProducesEmptyRoleIds() throws Exception {
+        UserIdentity testUser = getTestUserIdentity();
+        ctx.setCurrentUserIdentity(testUser);
+        ctx.setCurrentRoleIds(testUser);
+
+        // SET ROLE NONE
+        SetRoleStmt setRoleStmt = (SetRoleStmt) UtFrameUtils.parseStmtWithNewParser(
+                "set role none", ctx);
+        SetRoleExecutor.execute(setRoleStmt, ctx);
+
+        Assertions.assertNotNull(ctx.getCurrentRoleIds(),
+                "SET ROLE NONE should produce non-null role set");
+        Assertions.assertTrue(ctx.getCurrentRoleIds().isEmpty(),
+                "SET ROLE NONE should produce empty role set");
+    }
+
+    @Test
+    public void testSetRoleNoneSerializationRoundTrip() throws Exception {
+        UserIdentity testUser = getTestUserIdentity();
+
+        // Build TUserIdentity with empty role set (SET ROLE NONE)
+        TUserIdentity tUserIdentity = buildUserIdentityWithRoles(testUser, Set.of());
+
+        Assertions.assertTrue(tUserIdentity.isSetCurrent_role_ids(),
+                "Empty role set should still be serialized as current_role_ids");
+
+        // Deserialize and verify
+        ConnectContext tempCtx = new ConnectContext();
+        UserIdentityUtils.setAuthInfoFromThrift(tempCtx, tUserIdentity);
+
+        Assertions.assertNotNull(tempCtx.getCurrentRoleIds(),
+                "Deserialized role IDs should not be null");
+        Assertions.assertTrue(tempCtx.getCurrentRoleIds().isEmpty(),
+                "Deserialized role IDs should be empty for SET ROLE NONE");
+    }
+
+    @Test
+    public void testRoleIdPropagation() throws Exception {
+        UserIdentity testUser = getTestUserIdentity();
+        ctx.setCurrentUserIdentity(testUser);
+        ctx.setCurrentRoleIds(testUser);
+
+        SetRoleStmt setRoleStmt = (SetRoleStmt) UtFrameUtils.parseStmtWithNewParser(
+                "set role " + ROLE_1, ctx);
+        SetRoleExecutor.execute(setRoleStmt, ctx);
+
+        Assertions.assertFalse(ctx.getCurrentRoleIds().isEmpty(),
+                "ConnectContext should have role IDs after SET ROLE");
+
+        TUserIdentity tUserIdentity = buildUserIdentityWithRoles(
+                ctx.getCurrentUserIdentity(), ctx.getCurrentRoleIds());
+
+        Assertions.assertTrue(tUserIdentity.isSetCurrent_role_ids(),
+                "TUserIdentity should have current_role_ids set");
+        Assertions.assertFalse(tUserIdentity.getCurrent_role_ids().getRole_id_list().isEmpty(),
+                "TUserIdentity role_id_list should not be empty");
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration tests: getDbNames
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testGetDbNamesRespectsSetRole() throws Exception {
+        UserIdentity testUser = getTestUserIdentity();
+
+        // With role1 only: should see db1 but not db2
+        TGetDbsParams params1 = new TGetDbsParams();
+        params1.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role1Id)));
+        TGetDbsResult result1 = frontendService.getDbNames(params1);
+        List<String> dbs1 = result1.getDbs();
+
+        Assertions.assertTrue(dbs1.contains(DB_1),
+                "With role1, should see " + DB_1 + ", got: " + dbs1);
+        Assertions.assertFalse(dbs1.contains(DB_2),
+                "With role1, should NOT see " + DB_2 + ", got: " + dbs1);
+
+        // With role2 only: should see db2 but not db1
+        TGetDbsParams params2 = new TGetDbsParams();
+        params2.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role2Id)));
+        TGetDbsResult result2 = frontendService.getDbNames(params2);
+        List<String> dbs2 = result2.getDbs();
+
+        Assertions.assertTrue(dbs2.contains(DB_2),
+                "With role2, should see " + DB_2 + ", got: " + dbs2);
+        Assertions.assertFalse(dbs2.contains(DB_1),
+                "With role2, should NOT see " + DB_1 + ", got: " + dbs2);
+
+        // With both roles: should see both
+        TGetDbsParams params3 = new TGetDbsParams();
+        params3.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role1Id, role2Id)));
+        TGetDbsResult result3 = frontendService.getDbNames(params3);
+        List<String> dbs3 = result3.getDbs();
+
+        Assertions.assertTrue(dbs3.contains(DB_1) && dbs3.contains(DB_2),
+                "With both roles, should see both databases, got: " + dbs3);
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration tests: getTableNames
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testGetTableNamesRespectsSetRole() throws Exception {
+        UserIdentity testUser = getTestUserIdentity();
+
+        // With role1: should see tbl1 in db1
+        TGetTablesParams params1 = new TGetTablesParams();
+        params1.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role1Id)));
+        params1.setDb(DB_1);
+        TGetTablesResult result1 = frontendService.getTableNames(params1);
+
+        Assertions.assertTrue(result1.getTables().contains(TABLE_1),
+                "With role1, should see " + TABLE_1 + " in " + DB_1);
+
+        // With role2: should NOT see tbl1 in db1
+        TGetTablesParams params2 = new TGetTablesParams();
+        params2.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role2Id)));
+        params2.setDb(DB_1);
+        TGetTablesResult result2 = frontendService.getTableNames(params2);
+
+        Assertions.assertFalse(result2.getTables().contains(TABLE_1),
+                "With role2, should NOT see " + TABLE_1 + " in " + DB_1 + ", got: " + result2.getTables());
+
+        // With role2: should see tbl2 in db2
+        TGetTablesParams params3 = new TGetTablesParams();
+        params3.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role2Id)));
+        params3.setDb(DB_2);
+        TGetTablesResult result3 = frontendService.getTableNames(params3);
+
+        Assertions.assertTrue(result3.getTables().contains(TABLE_2),
+                "With role2, should see " + TABLE_2 + " in " + DB_2);
+
+        // With role1: should NOT see tbl2 in db2
+        TGetTablesParams params4 = new TGetTablesParams();
+        params4.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role1Id)));
+        params4.setDb(DB_2);
+        TGetTablesResult result4 = frontendService.getTableNames(params4);
+
+        Assertions.assertFalse(result4.getTables().contains(TABLE_2),
+                "With role1, should NOT see " + TABLE_2 + " in " + DB_2 + ", got: " + result4.getTables());
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration tests: describeTable
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testDescribeTableRespectsSetRole() throws Exception {
+        UserIdentity testUser = getTestUserIdentity();
+
+        // With role1: should see columns of tbl1 in db1
+        TDescribeTableParams params1 = new TDescribeTableParams();
+        params1.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role1Id)));
+        params1.setDb(DB_1);
+        params1.setTable_name(TABLE_1);
+        TDescribeTableResult result1 = frontendService.describeTable(params1);
+
+        Assertions.assertFalse(result1.getColumns().isEmpty(),
+                "With role1, should see columns of " + TABLE_1 + " in " + DB_1);
+
+        // With role2: should NOT see columns of tbl1 in db1
+        TDescribeTableParams params2 = new TDescribeTableParams();
+        params2.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role2Id)));
+        params2.setDb(DB_1);
+        params2.setTable_name(TABLE_1);
+        TDescribeTableResult result2 = frontendService.describeTable(params2);
+
+        Assertions.assertTrue(result2.getColumns().isEmpty(),
+                "With role2, should NOT see columns of " + TABLE_1 + " in " + DB_1);
+
+        // With role2: should see columns of tbl2 in db2
+        TDescribeTableParams params3 = new TDescribeTableParams();
+        params3.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role2Id)));
+        params3.setDb(DB_2);
+        params3.setTable_name(TABLE_2);
+        TDescribeTableResult result3 = frontendService.describeTable(params3);
+
+        Assertions.assertFalse(result3.getColumns().isEmpty(),
+                "With role2, should see columns of " + TABLE_2 + " in " + DB_2);
+
+        // With role1: should NOT see columns of tbl2 in db2
+        TDescribeTableParams params4 = new TDescribeTableParams();
+        params4.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role1Id)));
+        params4.setDb(DB_2);
+        params4.setTable_name(TABLE_2);
+        TDescribeTableResult result4 = frontendService.describeTable(params4);
+
+        Assertions.assertTrue(result4.getColumns().isEmpty(),
+                "With role1, should NOT see columns of " + TABLE_2 + " in " + DB_2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration tests: listTableStatus (ViewsSystemTable.query path)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testListTableStatusRespectsSetRole() throws Exception {
+        UserIdentity testUser = getTestUserIdentity();
+
+        // With role1: should see tbl1 in db1
+        TGetTablesParams params1 = new TGetTablesParams();
+        params1.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role1Id)));
+        params1.setDb(DB_1);
+        TListTableStatusResult result1 = frontendService.listTableStatus(params1);
+        List<String> tables1 = result1.getTables().stream()
+                .map(TTableStatus::getName).collect(Collectors.toList());
+
+        Assertions.assertTrue(tables1.contains(TABLE_1),
+                "With role1, should see " + TABLE_1 + " in " + DB_1 + ", got: " + tables1);
+
+        // With role2: should NOT see tbl1 in db1
+        TGetTablesParams params2 = new TGetTablesParams();
+        params2.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role2Id)));
+        params2.setDb(DB_1);
+        TListTableStatusResult result2 = frontendService.listTableStatus(params2);
+        List<String> tables2 = result2.getTables().stream()
+                .map(TTableStatus::getName).collect(Collectors.toList());
+
+        Assertions.assertFalse(tables2.contains(TABLE_1),
+                "With role2, should NOT see " + TABLE_1 + " in " + DB_1 + ", got: " + tables2);
+
+        // With role2: should see tbl2 in db2
+        TGetTablesParams params3 = new TGetTablesParams();
+        params3.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role2Id)));
+        params3.setDb(DB_2);
+        TListTableStatusResult result3 = frontendService.listTableStatus(params3);
+        List<String> tables3 = result3.getTables().stream()
+                .map(TTableStatus::getName).collect(Collectors.toList());
+
+        Assertions.assertTrue(tables3.contains(TABLE_2),
+                "With role2, should see " + TABLE_2 + " in " + DB_2 + ", got: " + tables3);
+
+        // With role1: should NOT see tbl2 in db2
+        TGetTablesParams params4 = new TGetTablesParams();
+        params4.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role1Id)));
+        params4.setDb(DB_2);
+        TListTableStatusResult result4 = frontendService.listTableStatus(params4);
+        List<String> tables4 = result4.getTables().stream()
+                .map(TTableStatus::getName).collect(Collectors.toList());
+
+        Assertions.assertFalse(tables4.contains(TABLE_2),
+                "With role1, should NOT see " + TABLE_2 + " in " + DB_2 + ", got: " + tables4);
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration test: SET ROLE NONE hides all metadata
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSetRoleNoneHidesAllDatabases() throws Exception {
+        UserIdentity testUser = getTestUserIdentity();
+
+        // SET ROLE NONE: empty role set — should see neither db1 nor db2
+        TGetDbsParams params = new TGetDbsParams();
+        params.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of()));
+        TGetDbsResult result = frontendService.getDbNames(params);
+        List<String> dbs = result.getDbs();
+
+        Assertions.assertFalse(dbs.contains(DB_1),
+                "With SET ROLE NONE, should NOT see " + DB_1 + ", got: " + dbs);
+        Assertions.assertFalse(dbs.contains(DB_2),
+                "With SET ROLE NONE, should NOT see " + DB_2 + ", got: " + dbs);
+    }
+
+    @Test
+    public void testSetRoleNoneHidesAllTables() throws Exception {
+        UserIdentity testUser = getTestUserIdentity();
+
+        // SET ROLE NONE: should not see tbl1 in db1
+        TGetTablesParams params1 = new TGetTablesParams();
+        params1.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of()));
+        params1.setDb(DB_1);
+        TGetTablesResult result1 = frontendService.getTableNames(params1);
+
+        Assertions.assertFalse(result1.getTables().contains(TABLE_1),
+                "With SET ROLE NONE, should NOT see " + TABLE_1 + " in " + DB_1);
+
+        // SET ROLE NONE: should not see tbl2 in db2
+        TGetTablesParams params2 = new TGetTablesParams();
+        params2.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of()));
+        params2.setDb(DB_2);
+        TGetTablesResult result2 = frontendService.getTableNames(params2);
+
+        Assertions.assertFalse(result2.getTables().contains(TABLE_2),
+                "With SET ROLE NONE, should NOT see " + TABLE_2 + " in " + DB_2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration test: SET ROLE ALL with both roles shows everything
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testSetRoleAllShowsAllDatabases() throws Exception {
+        UserIdentity testUser = getTestUserIdentity();
+
+        // Single role: limited visibility
+        TGetDbsParams params1 = new TGetDbsParams();
+        params1.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role1Id)));
+        TGetDbsResult result1 = frontendService.getDbNames(params1);
+
+        // Both roles: full visibility
+        TGetDbsParams params2 = new TGetDbsParams();
+        params2.setCurrent_user_ident(buildUserIdentityWithRoles(testUser, Set.of(role1Id, role2Id)));
+        TGetDbsResult result2 = frontendService.getDbNames(params2);
+
+        Assertions.assertTrue(result2.getDbs().size() >= result1.getDbs().size(),
+                "SET ROLE ALL (both roles) should show at least as many databases as single role");
+        Assertions.assertTrue(result2.getDbs().contains(DB_1) && result2.getDbs().contains(DB_2),
+                "With both roles, should see both databases");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

When privileges are granted to a role and that role is granted to a user, objects are not visible in `information_schema` tables — even after executing `SET ROLE`.    
This breaks RBAC workflows where users need to activate specific roles to access certain databases or tables.

The root cause is that the information_schema code path (`TablesSystemTable` → `InformationSchemaDataSource`) serializes only the user identity into `TAuthInfo`, then creates a brand-new `ConnectContext` that recalculates roles from defaults. The session's `SET ROLE` state is completely discarded.

## What I'm doing:

Fix the issue by propagating the session's active role IDs through the thrift layer:

1. **TablesSystemTable**: When building `TAuthInfo`, populate `TUserIdentity.current_role_ids` with the session context's active roles (from `getCurrentRoleIds()`).

2. **InformationSchemaDataSource**:
   - Extract role IDs from `TAuthInfo.current_user_ident.current_role_ids`
   - Validate them against the user's actual roles (defense-in-depth via `retainAll`)
   - Add `roleIds` field to `AuthDbRequestResult` with a `buildConnectContext()` helper
   - Replace all 4 manual context creation sites with `buildConnectContext()` for consistency

No thrift schema changes required — `TUserIdentity.current_role_ids` already exists.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

**Behavior change details**: After `SET ROLE role_name`, information_schema queries will now correctly respect the activated role's privileges. Previously, only default roles were used, causing objects to be invisible even when the role granting access was explicitly activated.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
