### PR TITLE
[Enhancement] add @@run_mode global readonly variable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -99,6 +99,8 @@ public final class GlobalVariable {
 
     public static final String ENABLE_TABLE_NAME_CASE_INSENSITIVE = "enable_table_name_case_insensitive";
 
+    public static final String RUN_MODE = "run_mode";
+
 
     @VariableMgr.VarAttr(name = VERSION_COMMENT, flag = VariableMgr.READ_ONLY)
     public static String versionComment = Version.STARROCKS_VERSION + "-" + Version.STARROCKS_COMMIT_HASH;
@@ -163,6 +165,9 @@ public final class GlobalVariable {
      */
     @VariableMgr.VarAttr(name = ENABLE_TABLE_NAME_CASE_INSENSITIVE, flag = VariableMgr.READ_ONLY)
     public static boolean enableTableNameCaseInsensitive = false;
+
+    @VariableMgr.VarAttr(name = RUN_MODE, flag = VariableMgr.READ_ONLY)
+    public static String runMode = Config.run_mode;
 
     /**
      * Query will be pending when BE is overloaded, if `enableQueryQueueXxx` is true.

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -659,6 +659,8 @@ public class GlobalStateMgr {
     private GlobalStateMgr(boolean isCkptGlobalState, NodeMgr nodeMgr) {
         if (!isCkptGlobalState) {
             RunMode.detectRunMode();
+            // set the global read-only variable again, avoid static variable initialization order chaos
+            GlobalVariable.runMode = Config.run_mode;
         }
 
         if (RunMode.isSharedDataMode()) {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrRunModeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrRunModeTest.java
@@ -1,0 +1,67 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.sql.analyzer.SetStmtAnalyzer;
+import com.starrocks.sql.ast.SetStmt;
+import com.starrocks.sql.ast.SetType;
+import com.starrocks.sql.ast.SystemVariable;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.sql.ast.expression.VariableExpr;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class VariableMgrRunModeTest {
+
+    @BeforeEach
+    public void setUp() {
+        // Initialize test environment
+        UtFrameUtils.setUpForPersistTest();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testRunModeReadOnly() {
+        VariableMgr variableMgr = new VariableMgr();
+        SessionVariable var = variableMgr.newSessionVariable();
+        VariableExpr desc = new VariableExpr("run_mode");
+
+        // Check default value
+        String runMode = variableMgr.getValue(var, desc);
+        Assertions.assertEquals(Config.run_mode, runMode);
+
+        // Try to set run_mode (should fail as it is read-only)
+        SystemVariable setVar = new SystemVariable(SetType.GLOBAL, "run_mode", new StringLiteral("shared_data"));
+        try {
+            SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), null);
+            variableMgr.setSystemVariable(var, setVar, false);
+            Assertions.fail("No exception throws.");
+        } catch (Exception e) {
+            Assertions.assertTrue(e instanceof DdlException);
+            Assertions.assertEquals("Variable 'run_mode' is a read only variable", e.getMessage());
+        }
+    }
+}
+

--- a/test/sql/test_run_mode/R/test_shared_data
+++ b/test/sql/test_run_mode/R/test_shared_data
@@ -1,0 +1,6 @@
+-- name: test_shared_data @cloud
+select @@run_mode;
+-- result:
+shared_data
+-- !result
+

--- a/test/sql/test_run_mode/R/test_shared_nothing
+++ b/test/sql/test_run_mode/R/test_shared_nothing
@@ -1,0 +1,6 @@
+-- name: test_shared_nothing @native
+select @@run_mode;
+-- result:
+shared_nothing
+-- !result
+

--- a/test/sql/test_run_mode/T/test_shared_data
+++ b/test/sql/test_run_mode/T/test_shared_data
@@ -1,0 +1,3 @@
+-- name: test_shared_data @cloud
+select @@run_mode;
+

--- a/test/sql/test_run_mode/T/test_shared_nothing
+++ b/test/sql/test_run_mode/T/test_shared_nothing
@@ -1,0 +1,3 @@
+-- name: test_shared_nothing @native
+select @@run_mode;
+


### PR DESCRIPTION
* allow `select @@run_mode` to get the current cluster run mode, its value is `shared_nothing` or `shared_data`

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
