### PR TITLE
[UT] fix case test_short_circuit run failed

### DIFF
--- a/test/sql/test_short_circuit/R/test_short_circuit
+++ b/test/sql/test_short_circuit/R/test_short_circuit
@@ -5,6 +5,9 @@ set enable_short_circuit=true;
 set enable_profile=true;
 -- result:
 -- !result
+set sql_mode='ONLY_FULL_GROUP_BY,PIPES_AS_CONCAT';
+-- result:
+-- !result
 CREATE TABLE short_circuit
     (c1 int,
     c2  int)
@@ -72,13 +75,13 @@ select * from short_circuit_bool where k1 = 6 and k2=true;
 -- result:
 6	1	6
 -- !result
-explain analyze select * from short_circuit_bool where k1 = 6 and k2=true;
--- result:
-E: (1064, "short circuit point query doesn't suppot explain analyze stmt, you can set it off by using  set enable_short_circuit=false")
--- !result
+[UC]explain analyze select * from short_circuit_bool where k1 = 6 and k2=true;
 set enable_short_circuit=false;
 -- result:
 -- !result
 set enable_profile=false;
+-- result:
+-- !result
+set sql_mode='ONLY_FULL_GROUP_BY';
 -- result:
 -- !result

--- a/test/sql/test_short_circuit/T/test_short_circuit
+++ b/test/sql/test_short_circuit/T/test_short_circuit
@@ -1,6 +1,7 @@
 -- name: testShortCircuit @no_arrow_flight_sql
 set enable_short_circuit=true;
 set enable_profile=true;
+set sql_mode='ONLY_FULL_GROUP_BY,PIPES_AS_CONCAT';
 
 CREATE TABLE short_circuit
     (c1 int,
@@ -47,7 +48,8 @@ insert into short_circuit_bool values
 (9, true, 9),
 (10, true, 10);
 select * from short_circuit_bool where k1 = 6 and k2=true;
-explain analyze select * from short_circuit_bool where k1 = 6 and k2=true;
+[UC]explain analyze select * from short_circuit_bool where k1 = 6 and k2=true;
 
 set enable_short_circuit=false;
 set enable_profile=false;
+set sql_mode='ONLY_FULL_GROUP_BY';


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

we should use sql_mode PIPES_AS_CONCAT:
```
======================================================================
FAIL: 591  : sql/test_short_circuit/R/test_short_circuit:testShortCircuit
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/nose/case.py", line 170, in runTest
    self.test(*self.arg)
  File "/usr/local/lib/python3.10/dist-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/root/starrocks/test/lib/sql_annotation.py", line 48, in wrapper
    raise e
  File "/root/starrocks/test/lib/sql_annotation.py", line 43, in wrapper
    res = func(*args, **kwargs)
  File "/root/starrocks/test/test_sql_cases.py", line 384, in test_sql_basic
    self.check(sql_id, sql, expect_res, actual_res, order, ori_sql)
  File "/root/starrocks/test/lib/sr_sql_lib.py", line 1486, in check
    tools.assert_count_equal(
AssertionError: Element counts were not equal:
First has 1, Second has 0:  '66'
First has 0, Second has 1:  '1' : sql result not match:
- [SQL]: select c1||c2 from short_circuit where c1 = 6;
- [exp]: ['66']
- [act]: ['1']
---
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
