### PR TITLE
[BugFix] Fix lock leak in addPartitions caused by name-based table lookup after concurrent SWAP

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1383,7 +1383,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             }
             Set<String> existPartitionNameSet = Sets.newHashSet();
             try {
-                olapTable = checkTable(db, tableName);
+                // Use ID-based lookup to ensure we get the same table we locked,
+                // avoiding lock leak when a concurrent SWAP changes the name-to-table mapping.
+                olapTable = checkTable(db, olapTable.getId());
                 existPartitionNameSet = CatalogUtils.checkPartitionNameExistForAddPartitions(olapTable,
                         partitionDescs);
                 if (existPartitionNameSet.size() > 0) {


### PR DESCRIPTION
## Why I'm doing:

`LocalMetastore.addPartitions()` has a two-phase locking pattern: acquire READ lock, do validation,
release READ lock, then acquire WRITE lock and apply changes. Between the READ unlock and WRITE lock,
there is an unlocked gap where concurrent DDL can execute.

If a SWAP operation (`ALTER TABLE/MATERIALIZED VIEW ... SWAP WITH`) executes during this gap, the
table name is remapped to a different table ID. In the WRITE phase:

1. WRITE lock is acquired on the original table's ID (e.g. 308183)
2. `checkTable(db, tableName)` looks up the table by name → returns a different table after SWAP
3. `olapTable` variable is reassigned to the swapped table (different ID)
4. `finally` calls `unLockTableWithIntensiveDbLock(db.getId(), olapTable.getId(), WRITE)`
   → tries to unlock the swapped table's ID, but the lock was on the original table's ID
5. `LockManager.release()` throws `IllegalMonitorStateException: Attempt to unlock lock, not locked
   by current locker` (swapped table was never locked)
6. The original table's WRITE lock is permanently leaked

Since `unLockTablesWithIntensiveDbLock` releases the DB intention lock before the table lock,
the DB intention lock is successfully released, but the table WRITE lock release fails and is skipped.
The leaked WRITE lock permanently blocks all subsequent operations that require any lock on the
affected table — including queries (READ lock), DDL (WRITE lock), transaction publish, compaction,
and schema change. In production, the leaked lock blocked `publish-version-daemon` (a single-threaded
daemon responsible for ALL databases), causing a global transaction publish stall lasting 14+ hours.

## What I'm doing:

Change `checkTable(db, tableName)` (name-based lookup) to `checkTable(db, olapTable.getId())`
(ID-based lookup) in the WRITE lock phase of `addPartitions`. ID-based lookup always returns the
same table that was locked, regardless of concurrent SWAP. This guarantees `olapTable.getId()` in
`finally` matches the locked table ID.

Fix https://github.com/StarRocks/StarRocksTest/issues/11007

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.1
  - [X] 4.0
  - [X] 3.5
  - [X] 3.4