### PR TITLE
[Doc] Add ColumnCore module boundary rules to BE AGENTS.md

### DIFF
--- a/be/AGENTS.md
+++ b/be/AGENTS.md
@@ -189,6 +189,17 @@ Use `#pragma once` instead of traditional include guards:
 - **No higher-level BE deps**: do not include headers from `runtime/*`, `util/*`, `storage/*`, `exec/*`, `service/*`, `http/*`, `connector/*`, etc.
 - **UT constraint**: keep `TypesCore` unit tests in `types_test` and avoid introducing `Util`/`Runtime` link requirements unless a dedicated integration test is used.
 
+### columncore (`ColumnCore` target)
+- **Allowed deps only**: code compiled into `ColumnCore` (the `be/src/column` module) may only depend on `TypesCore`, `Common`, `Base`, `Gutils`, `gen_cpp/*`, system headers, and third-party libraries.
+- **No circular deps**: do **not** introduce dependencies from `ColumnCore` to `Util`, `Runtime`, `Storage`, `Exec`, or any other higher-level module. Circular dependencies between modules are strictly forbidden.
+- **Goal**: `ColumnCore` should be buildable with minimal dependencies so that `column_test` can be compiled and run without building the entire codebase. This enables fast AI-agent iteration loops.
+- **UT constraint**: keep `ColumnCore` unit tests in `column_test`. To verify changes quickly, run:
+  ```bash
+  STARROCKS_LINKER=lld STARROCKS_THIRDPARTY=/var/local/thirdparty \
+  ./run-be-ut.sh --clean --with-dynamic --build-target column_test
+  ```
+  This builds only `column_test` and its minimal dependencies, making it extremely fast for iterative development.
+
 ### runtimecore (`RuntimeCore` target)
 - **Allowed deps only**: code compiled into `RuntimeCore` (currently selected files under `be/src/runtime`, starting with `mem_tracker.cpp`) may only depend on `chunkcore` (`ChunkCore`), `columncore` (`ColumnCore`), `typecore` (`TypesCore`), `common/*`, `base/*`, `gutil/*`, `gen_cpp/*`, system headers, and third-party libraries.
 - **No higher-level BE deps**: do not include headers from `runtime/*` components that require full `Runtime`, `util/*`, `storage/*`, `exec/*`, `service/*`, `http/*`, `connector/*`, `exprs/*`, etc.


### PR DESCRIPTION
## Why I'm doing:

The `ColumnCore` module boundary rules were not documented in `be/AGENTS.md`. Without clear documentation, AI agents (and developers) may accidentally introduce dependencies from `ColumnCore` to higher-level modules like `Util`, breaking the minimal-dependency design and slowing down incremental builds.

## What I'm doing:

Add a `columncore` section to the Module Boundaries in `be/AGENTS.md` that documents:
- **Allowed dependencies**: only `TypesCore`, `Common`, `Base`, `Gutils`, `gen_cpp/*`, system headers, and third-party libraries
- **No circular dependencies**: explicitly forbids deps on `Util`, `Runtime`, `Storage`, `Exec`, etc.
- **Design goal**: `column_test` should build without compiling the entire codebase, enabling fast AI-agent iteration
- **Fast verification command**: `STARROCKS_LINKER=lld STARROCKS_THIRDPARTY=/var/local/thirdparty ./run-be-ut.sh --clean --with-dynamic --build-target column_test`

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4