### PR TITLE
[BugFix] Fix struct type sub-column name missed and datetime type missing

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/odps/EntityConvertUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/odps/EntityConvertUtils.java
@@ -29,6 +29,7 @@ import com.starrocks.type.DateType;
 import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.MapType;
+import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
@@ -90,10 +91,13 @@ public class EntityConvertUtils {
                 return new ArrayType(convertType(arrayTypeInfo.getElementTypeInfo()));
             case STRUCT:
                 StructTypeInfo structTypeInfo = (StructTypeInfo) typeInfo;
-                List<Type> fieldTypeList =
-                        structTypeInfo.getFieldTypeInfos().stream().map(EntityConvertUtils::convertType)
-                                .collect(Collectors.toList());
-                return new StructType(fieldTypeList);
+                List<StructField> structFields = new ArrayList<>();
+                for (int i = 0; i < structTypeInfo.getFieldCount(); i++) {
+                    String name = structTypeInfo.getFieldNames().get(i);
+                    Type t = convertType(structTypeInfo.getFieldTypeInfos().get(i));
+                    structFields.add(new StructField(name, t));
+                }
+                return new StructType(structFields, true);
             default:
                 return VarcharType.VARCHAR;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/odps/EntityConvertUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/odps/EntityConvertUtilsTest.java
@@ -31,6 +31,7 @@ import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
@@ -190,7 +191,9 @@ public class EntityConvertUtilsTest {
         Type result = EntityConvertUtils.convertType(structTypeInfo);
         Type expectedType1 = TypeFactory.createDefaultCatalogString();
         Type expectedType2 = IntegerType.INT;
-        Type expectedType = new StructType(ImmutableList.of(expectedType1, expectedType2));
+        StructField field1 = new StructField("fieldTypeInfo1", expectedType1);
+        StructField field2 = new StructField("fieldTypeInfo2", expectedType2);
+        Type expectedType = new StructType(ImmutableList.of(field1, field2), true);
         assertEquals(expectedType, result);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/odps/EntityConvertUtilsTests.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/odps/EntityConvertUtilsTests.java
@@ -31,6 +31,7 @@ import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
@@ -192,7 +193,9 @@ public class EntityConvertUtilsTests {
         Type result = EntityConvertUtils.convertType(structTypeInfo);
         Type expectedType1 = TypeFactory.createDefaultCatalogString();
         Type expectedType2 = IntegerType.INT;
-        Type expectedType = new StructType(ImmutableList.of(expectedType1, expectedType2));
+        StructField field1 = new StructField("fieldTypeInfo1", expectedType1);
+        StructField field2 = new StructField("fieldTypeInfo2", expectedType2);
+        Type expectedType = new StructType(ImmutableList.of(field1, field2), true);
         assertEquals(expectedType, result);
     }
 

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
@@ -84,6 +84,7 @@ public class ColumnType {
         PRIMITIVE_TYPE_VALUE_MAPPING.put("date", TypeValue.DATE);
         PRIMITIVE_TYPE_VALUE_MAPPING.put("time", TypeValue.TIME);
         PRIMITIVE_TYPE_VALUE_MAPPING.put("timestamp", TypeValue.DATETIME);
+        PRIMITIVE_TYPE_VALUE_MAPPING.put("datetime", TypeValue.DATETIME);
         PRIMITIVE_TYPE_VALUE_MAPPING.put("timestamp-micros", TypeValue.DATETIME_MICROS);
         PRIMITIVE_TYPE_VALUE_MAPPING.put("timestamp-millis", TypeValue.DATETIME_MILLIS);
         PRIMITIVE_TYPE_VALUE_MAPPING.put("decimalv2", TypeValue.DECIMALV2);


### PR DESCRIPTION
## Why I'm doing:
Currently, subfield name of odps struct type is ignored and is replaced by default name like 'col1'、'col2'. And Datetime type is missed in type mapping.

## What I'm doing:
Using correct odps struct subfield name to initialize starrocks struct type, and add datetime type mapping.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
