### PR TITLE
[Doc] Update SQL queries to use sys.fe_locks

### DIFF
--- a/docs/en/sql-reference/sys/fe_locks.md
+++ b/docs/en/sql-reference/sys/fe_locks.md
@@ -42,7 +42,7 @@ The behavior of `fe_locks` depends on the `lock_manager_enabled` configuration p
 
 ```sql
 SELECT lock_object, lock_mode, hold_time_ms, thread_info
-FROM information_schema.fe_locks 
+FROM sys.fe_locks 
 WHERE hold_time_ms > 10000  -- Locks held for more than 10 seconds
 ORDER BY hold_time_ms DESC;
 ```
@@ -51,7 +51,7 @@ ORDER BY hold_time_ms DESC;
 
 ```sql
 SELECT lock_object, COUNT(*) as lock_count
-FROM information_schema.fe_locks 
+FROM sys.fe_locks 
 WHERE granted = true
 GROUP BY lock_object
 HAVING COUNT(*) > 1;
@@ -61,7 +61,7 @@ HAVING COUNT(*) > 1;
 
 ```sql
 SELECT lock_object, waiter_list
-FROM information_schema.fe_locks 
+FROM sys.fe_locks 
 WHERE waiter_list != '';
 ```
 

--- a/docs/ja/sql-reference/sys/fe_locks.md
+++ b/docs/ja/sql-reference/sys/fe_locks.md
@@ -42,7 +42,7 @@ displayed_sidebar: docs
 
 ```sql
 SELECT lock_object, lock_mode, hold_time_ms, thread_info
-FROM information_schema.fe_locks 
+FROM sys.fe_locks 
 WHERE hold_time_ms > 10000  -- 10秒以上保持されているロック
 ORDER BY hold_time_ms DESC;
 ```
@@ -51,7 +51,7 @@ ORDER BY hold_time_ms DESC;
 
 ```sql
 SELECT lock_object, COUNT(*) as lock_count
-FROM information_schema.fe_locks 
+FROM sys.fe_locks 
 WHERE granted = true
 GROUP BY lock_object
 HAVING COUNT(*) > 1;
@@ -61,7 +61,7 @@ HAVING COUNT(*) > 1;
 
 ```sql
 SELECT lock_object, waiter_list
-FROM information_schema.fe_locks 
+FROM sys.fe_locks 
 WHERE waiter_list != '';
 ```
 

--- a/docs/zh/sql-reference/sys/fe_locks.md
+++ b/docs/zh/sql-reference/sys/fe_locks.md
@@ -42,7 +42,7 @@ displayed_sidebar: docs
 
 ```sql
 SELECT lock_object, lock_mode, hold_time_ms, thread_info
-FROM information_schema.fe_locks 
+FROM sys.fe_locks 
 WHERE hold_time_ms > 10000  -- 持有超过10秒的锁
 ORDER BY hold_time_ms DESC;
 ```
@@ -51,7 +51,7 @@ ORDER BY hold_time_ms DESC;
 
 ```sql
 SELECT lock_object, COUNT(*) as lock_count
-FROM information_schema.fe_locks 
+FROM sys.fe_locks 
 WHERE granted = true
 GROUP BY lock_object
 HAVING COUNT(*) > 1;
@@ -61,7 +61,7 @@ HAVING COUNT(*) > 1;
 
 ```sql
 SELECT lock_object, waiter_list
-FROM information_schema.fe_locks 
+FROM sys.fe_locks 
 WHERE waiter_list != '';
 ```
 


### PR DESCRIPTION
Updated the examples to work for me without throwing ERROR 5502 -  Unknown table 'information_schema.fe_locks. 

This page says fe_locks is in the sys schema -> 

https://docs.starrocks.io/docs/sql-reference/sys/#views-in-sys

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
