### PR TITLE
[Doc] Fix syntax for ADMIN CHECK TABLET command

### DIFF
--- a/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_CHECK_TABLET.md
+++ b/docs/en/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_CHECK_TABLET.md
@@ -15,7 +15,7 @@ This operation requires the SYSTEM-level OPERATE privilege. You can follow the i
 ## Syntax
 
 ```sql
-ADMIN CHECK TABLE (tablet_id1, tablet_id2, ...)
+ADMIN CHECK TABLET (tablet_id1, tablet_id2, ...)
 PROPERTIES("type" = "...")
 ```
 

--- a/docs/ja/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_CHECK_TABLET.md
+++ b/docs/ja/sql-reference/sql-statements/cluster-management/tablet_replica/ADMIN_CHECK_TABLET.md
@@ -17,7 +17,7 @@ displayed_sidebar: docs
 ## 構文
 
 ```sql
-ADMIN CHECK TABLE (tablet_id1, tablet_id2, ...)
+ADMIN CHECK TABLET (tablet_id1, tablet_id2, ...)
 PROPERTIES("type" = "...")
 ```
 


### PR DESCRIPTION
The ADMIN CHECK TABLE command gets an error:

ERROR 1064 (HY000): Getting syntax error at line 1, column 12. Detail message: Unexpected input 'TABLE', the most similar input is {'TABLET', 'TABLETS'}.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
