### PR TITLE
[Doc] fix typos and update start commands for shell compatibility in Upgrade and Downgrade

### DIFF
--- a/docs/en/deployment/downgrade.md
+++ b/docs/en/deployment/downgrade.md
@@ -99,13 +99,13 @@ After the compatibility configuration and the availability test, you can downgra
 
 1. Create a metadata snapshot.
 
-   a. Run [ALTER SYSTEM CREATE IMAGE](../sql-reference/sql-statements/cluster-management/nodes_processes/ALTER_SYSTEM.md) to create a meatedata snapshot.
+   a. Run [ALTER SYSTEM CREATE IMAGE](../sql-reference/sql-statements/cluster-management/nodes_processes/ALTER_SYSTEM.md) to create a metadata snapshot.
 
    b. You can check whether the image file has been synchronized by viewing the log file **fe.log** of the Leader FE. A record of log like "push image.* from subdir [] to other nodes. totally xx nodes, push successful xx nodes" suggests that the image file has been successfully synchronized. 
 
    > **CAUTION**
    >
-   > The ALTER SYSTEM CREATE IMAGE statement is supported in v2.5.3 and later. In earlier versions, you need to create a meatadata snapshot by restarting the Leader FE.
+   > The ALTER SYSTEM CREATE IMAGE statement is supported in v2.5.3 and later. In earlier versions, you need to create a metadata snapshot by restarting the Leader FE.
 
 2. Navigate to the working directory of the FE node and stop the node.
 
@@ -136,7 +136,7 @@ After the compatibility configuration and the availability test, you can downgra
 4. Start the FE node.
 
    ```Bash
-   sh bin/start_fe.sh --daemon
+   ./bin/start_fe.sh --daemon
    ```
 
 5. Check if the FE node is started successfully.
@@ -175,7 +175,7 @@ Having downgraded the FE nodes, you can then downgrade the BE nodes in the clust
 3. Start the BE node.
 
    ```Bash
-   sh bin/start_be.sh --daemon
+   ./bin/start_be.sh --daemon
    ```
 
 4. Check if the BE node is started successfully.
@@ -208,7 +208,7 @@ Having downgraded the FE nodes, you can then downgrade the BE nodes in the clust
 3. Start the CN node.
 
    ```Bash
-   sh bin/start_cn.sh --daemon
+   ./bin/start_cn.sh --daemon
    ```
 
 4. Check if the CN node is started successfully.

--- a/docs/en/deployment/upgrade.md
+++ b/docs/en/deployment/upgrade.md
@@ -121,7 +121,7 @@ Having passed the upgrade availability test, you can first upgrade the BE nodes 
 3. Start the BE node.
 
    ```Bash
-   sh bin/start_be.sh --daemon
+   ./bin/start_be.sh --daemon
    ```
 
 4. Check if the BE node is started successfully.
@@ -156,7 +156,7 @@ Having passed the upgrade availability test, you can first upgrade the BE nodes 
 3. Start the CN node.
 
    ```Bash
-   sh bin/start_cn.sh --daemon
+   ./bin/start_cn.sh --daemon
    ```
 
 4. Check if the CN node is started successfully.
@@ -193,7 +193,7 @@ After upgrading all BE and CN nodes, you can then upgrade the FE nodes. You must
 3. Start the FE node.
 
    ```Bash
-   sh bin/start_fe.sh --daemon
+   ./bin/start_fe.sh --daemon
    ```
 
 4. Check if the FE node is started successfully.

--- a/docs/ja/deployment/downgrade.md
+++ b/docs/ja/deployment/downgrade.md
@@ -136,7 +136,7 @@ v3.3.0 以降から v3.2 にクラスターをダウングレードするには�
 4. FE ノードを起動します。
 
    ```Bash
-   sh bin/start_fe.sh --daemon
+   ./bin/start_fe.sh --daemon
    ```
 
 5. FE ノードが正常に起動したかどうかを確認します。
@@ -175,7 +175,7 @@ FE ノードをダウングレードした後、クラスター内の BE ノー�
 3. BE ノードを起動します。
 
    ```Bash
-   sh bin/start_be.sh --daemon
+   ./bin/start_be.sh --daemon
    ```
 
 4. BE ノードが正常に起動したかどうかを確認します。
@@ -208,7 +208,7 @@ FE ノードをダウングレードした後、クラスター内の BE ノー�
 3. CN ノードを起動します。
 
    ```Bash
-   sh bin/start_cn.sh --daemon
+   ./bin/start_cn.sh --daemon
    ```
 
 4. CN ノードが正常に起動したかどうかを確認します。

--- a/docs/ja/deployment/upgrade.md
+++ b/docs/ja/deployment/upgrade.md
@@ -121,7 +121,7 @@ StarRocks v2.0 クラスタをアップグレードする前に、次の BE 設�
 3. BE ノードを起動します。
 
    ```Bash
-   sh bin/start_be.sh --daemon
+   ./bin/start_be.sh --daemon
    ```
 
 4. BE ノードが正常に起動したかどうかを確認します。
@@ -156,7 +156,7 @@ StarRocks v2.0 クラスタをアップグレードする前に、次の BE 設�
 3. CN ノードを起動します。
 
    ```Bash
-   sh bin/start_cn.sh --daemon
+   ./bin/start_cn.sh --daemon
    ```
 
 4. CN ノードが正常に起動したかどうかを確認します。
@@ -193,7 +193,7 @@ StarRocks v2.0 クラスタをアップグレードする前に、次の BE 設�
 3. FE ノードを起動します。
 
    ```Bash
-   sh bin/start_fe.sh --daemon
+   ./bin/start_fe.sh --daemon
    ```
 
 4. FE ノードが正常に起動したかどうかを確認します。

--- a/docs/zh/deployment/downgrade.md
+++ b/docs/zh/deployment/downgrade.md
@@ -140,7 +140,7 @@ ADMIN SET FRONTEND CONFIG ("disable_colocate_balance"="false");
 4. 启动该 FE 节点。
 
    ```Bash
-   sh bin/start_fe.sh --daemon
+   ./bin/start_fe.sh --daemon
    ```
 
 5. 查看节点是否启动成功。
@@ -179,7 +179,7 @@ ADMIN SET FRONTEND CONFIG ("disable_colocate_balance"="false");
 3. 启动该 BE 节点。
 
    ```Bash
-   sh bin/start_be.sh --daemon
+   ./bin/start_be.sh --daemon
    ```
 
 4. 查看节点是否启动成功。
@@ -212,7 +212,7 @@ ADMIN SET FRONTEND CONFIG ("disable_colocate_balance"="false");
 3. 启动该 CN 节点。
 
    ```Bash
-   sh bin/start_cn.sh --daemon
+   ./bin/start_cn.sh --daemon
    ```
 
 4. 查看节点是否启动成功。

--- a/docs/zh/deployment/upgrade.md
+++ b/docs/zh/deployment/upgrade.md
@@ -123,7 +123,7 @@ ADMIN SET FRONTEND CONFIG ("disable_colocate_balance"="false");
 3. 启动该 BE 节点。
 
    ```Bash
-   sh bin/start_be.sh --daemon
+   ./bin/start_be.sh --daemon
    ```
 
 4. 查看节点是否启动成功。
@@ -158,7 +158,7 @@ ADMIN SET FRONTEND CONFIG ("disable_colocate_balance"="false");
 3. 启动该 CN 节点。
 
    ```Bash
-   sh bin/start_cn.sh --daemon
+   ./bin/start_cn.sh --daemon
    ```
 
 4. 查看节点是否启动成功。
@@ -195,7 +195,7 @@ ADMIN SET FRONTEND CONFIG ("disable_colocate_balance"="false");
 3. 启动该 FE 节点。
 
    ```Bash
-   sh bin/start_fe.sh --daemon
+   ./bin/start_fe.sh --daemon
    ```
 
 4. 查看节点是否启动成功。


### PR DESCRIPTION
## Why I'm doing:
On Ubuntu and Debian systems, `/bin/sh` acts as a symlink to `dash`. Dash does not support Bash-specific syntax (such as `source` and `[[`) which are used inside the StarRocks startup scripts. Consequently, following the documentation commands `sh bin/start_fe.sh` results in "source: not found" errors and startup failure.

Additionally, a typo ("meatedata") was found in the English downgrade documentation.

## What I'm doing:
1. Updated start commands from `sh bin/...` to `./bin/...` in `upgrade.md` and `downgrade.md`. This change was applied to English, Japanese, and Chinese documentation. Using `./` forces the system to respect the script's shebang (`#!/usr/bin/env bash`) and load the correct interpreter.
2. Fixed spelling errors ("meatedata" -> "metadata") in `docs/en/deployment/downgrade.md`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
