### PR TITLE
[Enhancement] Update thrift to 0.22 and mockito to 5.21

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -212,7 +212,7 @@ subprojects {
             implementation("org.apache.spark:spark-core_2.12:${project.ext["spark.version"]}")
             implementation("org.apache.spark:spark-launcher_2.12:${project.ext["spark.version"]}")
             implementation("org.apache.spark:spark-sql_2.12:${project.ext["spark.version"]}")
-            implementation("org.apache.thrift:libthrift:0.20.0")
+            implementation("org.apache.thrift:libthrift:0.22.0")
             implementation("org.apache.velocity:velocity-engine-core:2.4.1")
             implementation("org.eclipse.jetty:jetty-client:${project.ext["jetty.version"]}")
             implementation("org.eclipse.jetty:jetty-io:${project.ext["jetty.version"]}")

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -787,8 +787,22 @@ under the License.
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>4.11.0</version>
+            <artifactId>mockito-core</artifactId>
+            <version>5.21.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.18.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>1.18.4</version>
             <scope>test</scope>
         </dependency>
 
@@ -1068,11 +1082,13 @@ under the License.
 
                     <argLine>
                         -javaagent:${settings.localRepository}/com/github/hazendaz/jmockit/jmockit/1.49.4/jmockit-1.49.4.jar
+                        -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/1.18.4/byte-buddy-agent-1.18.4.jar
                         ${async.profiler.arg}
                         -Xmx4096m
                         -XX:TieredStopAtLevel=1 -XX:CICompilerCount=1 -XX:-BackgroundCompilation -XX:+UseSerialGC
                         -Duser.timezone=Asia/Shanghai
                         -Djacoco-agent.destfile=${project.build.directory}/jacoco.exec
+                        -XX:+EnableDynamicAgentLoading
                     </argLine>
                     <!-- Set maven to use independent class loading to avoid unit test failure due to the early shutdown of the JVM -->
                     <useSystemClassLoader>false</useSystemClassLoader>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -494,7 +494,7 @@ under the License.
             <dependency>
                 <groupId>org.apache.thrift</groupId>
                 <artifactId>libthrift</artifactId>
-                <version>0.20.0</version>
+                <version>0.22.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.tomcat.embed</groupId>

--- a/fs_brokers/apache_hdfs_broker/src/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/src/pom.xml
@@ -44,7 +44,7 @@ under the License.
         <guava.version>32.0.1-jre</guava.version>
         <zookeeper.version>3.9.3</zookeeper.version>
         <protobuf.version>3.25.5</protobuf.version>
-        <thrift.version>0.14.1</thrift.version>
+        <thrift.version>0.22.0</thrift.version>
         <tomcat.version>9.0.106</tomcat.version>
         <log4j.version>2.17.1</log4j.version>
         <jackson.version>2.18.3</jackson.version>

--- a/java-extensions/paimon-reader/pom.xml
+++ b/java-extensions/paimon-reader/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.20.0</version>
+            <version>0.22.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java -->

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -97,10 +97,10 @@ OPENSSL_SOURCE=openssl-OpenSSL_1_1_1m
 OPENSSL_MD5SUM="710c2368d28f1a25ab92e25b5b9b11ec"
 
 # thrift
-THRIFT_DOWNLOAD="http://archive.apache.org/dist/thrift/0.20.0/thrift-0.20.0.tar.gz"
-THRIFT_NAME=thrift-0.20.0.tar.gz
-THRIFT_SOURCE=thrift-0.20.0
-THRIFT_MD5SUM="aadebde599e1f5235acd3c730721b873"
+THRIFT_DOWNLOAD="http://archive.apache.org/dist/thrift/0.22.0/thrift-0.22.0.tar.gz"
+THRIFT_NAME=thrift-0.22.0.tar.gz
+THRIFT_SOURCE=thrift-0.22.0
+THRIFT_MD5SUM="29f4ef82e6ebc336c69ef4f26fb4d2a1"
 
 # protobuf
 PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.14.0.tar.gz"


### PR DESCRIPTION
This is needed to support testing in newer jdk versions

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
