### PR TITLE
[Enhancement] Migrate some tests that depend on jmockit to mockito

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/proc/FrontendsProcNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/proc/FrontendsProcNodeTest.java
@@ -17,10 +17,11 @@ package com.starrocks.proc;
 import com.starrocks.common.proc.FrontendsProcNode;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.system.Frontend;
-import mockit.Expectations;
-import mockit.Injectable;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -29,38 +30,25 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.Mockito.when;
+
 public class FrontendsProcNodeTest {
 
-    @Injectable
+    @Mock
     InetSocketAddress socketAddr1;
-    @Injectable
+    @Mock
     InetAddress addr1;
 
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
     private void mockAddress() {
-        new Expectations() {
-            {
-                socketAddr1.getAddress();
-                result = addr1;
-            }
-        };
-        new Expectations() {
-            {
-                socketAddr1.getPort();
-                result = 1000;
-            }
-        };
-        new Expectations() {
-            {
-                addr1.getHostAddress();
-                result = "127.0.0.1";
-            }
-        };
-        new Expectations() {
-            {
-                addr1.getHostName();
-                result = "sandbox";
-            }
-        };
+        when(socketAddr1.getAddress()).thenReturn(addr1);
+        when(socketAddr1.getPort()).thenReturn(1000);
+        when(addr1.getHostAddress()).thenReturn("127.0.0.1");
+        when(addr1.getHostName()).thenReturn("sandbox");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -68,18 +68,13 @@ import com.starrocks.thrift.TMasterOpResult;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TUserIdentity;
 import com.starrocks.utframe.UtFrameUtils;
-import com.starrocks.warehouse.DefaultWarehouse;
-import com.starrocks.warehouse.cngroup.ComputeResource;
-import com.starrocks.warehouse.cngroup.WarehouseComputeResourceProvider;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
 import org.xnio.StreamConnection;
+import org.xnio.conduits.ConduitStreamSourceChannel;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -88,6 +83,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class ConnectProcessorTest extends DDLTestBase {
     private static ByteBuffer initDbPacket;
@@ -101,13 +107,13 @@ public class ConnectProcessorTest extends DDLTestBase {
     private static AuditEventBuilder auditBuilder = new AuditEventBuilder();
     private static ConnectContext myContext;
 
-    @Mocked
     private static StreamConnection connection;
 
     private static PQueryStatistics statistics = new PQueryStatistics();
 
     @BeforeAll
     public static void setUpClass() {
+        connection = mock(StreamConnection.class);
         FeConstants.runningUnitTest = false;
         // Init Database packet
         {
@@ -192,6 +198,7 @@ public class ConnectProcessorTest extends DDLTestBase {
 
     @BeforeEach
     public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
         initDbPacket.clear();
         initWarehousePacket.clear();
         pingPacket.clear();
@@ -200,15 +207,13 @@ public class ConnectProcessorTest extends DDLTestBase {
         fieldListPacket.clear();
         changeUserPacket.clear();
         resetConnectionPacket.clear();
+        // Mock connection to return a valid InetSocketAddress
+        java.net.InetSocketAddress mockAddress = new java.net.InetSocketAddress("127.0.0.1", 12345);
+        when(connection.getPeerAddress()).thenReturn(mockAddress);
         // Mock
-        MysqlChannel channel = new MysqlChannel(connection);
-        new Expectations(channel) {
-            {
-                channel.getRemoteHostPortString();
-                minTimes = 0;
-                result = "127.0.0.1:12345";
-            }
-        };
+        MysqlChannel channel = spy(new MysqlChannel(connection));
+        when(channel.getRemoteHostPortString()).thenReturn("127.0.0.1:12345");
+
         myContext = new ConnectContext(connection);
         Deencapsulation.setField(myContext, "mysqlChannel", channel);
         super.setUp();
@@ -216,27 +221,24 @@ public class ConnectProcessorTest extends DDLTestBase {
 
     private static MysqlChannel mockChannel(ByteBuffer packet) {
         try {
-            MysqlChannel channel = new MysqlChannel(connection);
-            new Expectations(channel) {
-                {
-                    // Mock receive
-                    channel.fetchOnePacket();
-                    minTimes = 0;
-                    result = packet;
+            // Mock connection to return a valid InetSocketAddress
+            java.net.InetSocketAddress mockAddress = new java.net.InetSocketAddress("127.0.0.1", 12345);
+            when(connection.getPeerAddress()).thenReturn(mockAddress);
 
-                    // Mock reset
-                    channel.setSequenceId(0);
-                    times = 1;
+            // Mock source channel for reading
+            ConduitStreamSourceChannel mockSourceChannel =
+                    mock(org.xnio.conduits.ConduitStreamSourceChannel.class);
+            when(connection.getSourceChannel()).thenReturn(mockSourceChannel);
 
-                    // Mock send
-                    channel.sendAndFlush((ByteBuffer) any);
-                    minTimes = 0;
+            MysqlChannel channel = spy(new MysqlChannel(connection));
+            // Mock receive
+            when(channel.fetchOnePacket()).thenReturn(packet);
+            // Mock reset
+            doNothing().when(channel).setSequenceId(0);
+            // Mock send
+            doNothing().when(channel).sendAndFlush(any(ByteBuffer.class));
+            when(channel.getRemoteHostPortString()).thenReturn("127.0.0.1:12345");
 
-                    channel.getRemoteHostPortString();
-                    minTimes = 0;
-                    result = "127.0.0.1:12345";
-                }
-            };
             return channel;
         } catch (IOException e) {
             return null;
@@ -244,7 +246,7 @@ public class ConnectProcessorTest extends DDLTestBase {
     }
 
     private static ConnectContext initMockContext(MysqlChannel channel, GlobalStateMgr globalStateMgr) {
-        ConnectContext context = new ConnectContext(connection) {
+        ConnectContext context = spy(new ConnectContext(connection) {
             private boolean firstTimeToSetCommand = true;
 
             @Override
@@ -281,67 +283,20 @@ public class ConnectProcessorTest extends DDLTestBase {
                     super.setCommand(command);
                 }
             }
-        };
+        });
 
-        new Expectations(context) {
-            {
-                context.getMysqlChannel();
-                minTimes = 0;
-                result = channel;
-
-                context.isKilled();
-                minTimes = 0;
-                maxTimes = 3;
-                returns(false, true, false);
-
-                context.getGlobalStateMgr();
-                minTimes = 0;
-                result = globalStateMgr;
-
-                context.getAuditEventBuilder();
-                minTimes = 0;
-                result = auditBuilder;
-
-                context.getQualifiedUser();
-                minTimes = 0;
-                result = "testCluster:user";
-
-                context.getCurrentUserIdentity();
-                minTimes = 0;
-                result = UserIdentity.ROOT;
-
-                context.getStartTime();
-                minTimes = 0;
-                result = 0L;
-
-                context.getReturnRows();
-                minTimes = 0;
-                result = 1L;
-
-                context.setStmtId(anyLong);
-                minTimes = 0;
-
-                context.getStmtId();
-                minTimes = 0;
-                result = 1L;
-
-                context.getExecutionId();
-                minTimes = 0;
-                result = new TUniqueId();
-
-                context.getCapability();
-                minTimes = 0;
-                result = MysqlCapability.DEFAULT_CAPABILITY;
-
-                context.getAccessControlContext();
-                minTimes = 0;
-                result = new AccessControlContext();
-
-                context.getAuthenticationProvider();
-                minTimes = 0;
-                result = new PlainPasswordAuthenticationProvider(MysqlPassword.EMPTY_PASSWORD);
-            }
-        };
+        when(context.getMysqlChannel()).thenReturn(channel);
+        when(context.isKilled()).thenReturn(false, true, false);
+        when(context.getGlobalStateMgr()).thenReturn(globalStateMgr);
+        when(context.getAuditEventBuilder()).thenReturn(auditBuilder);
+        when(context.getQualifiedUser()).thenReturn("testCluster:user");
+        when(context.getCurrentUserIdentity()).thenReturn(UserIdentity.ROOT);
+        when(context.getStartTime()).thenReturn(0L);
+        when(context.getReturnRows()).thenReturn(1L);
+        doNothing().when(context).setStmtId(anyLong());
+        when(context.getStmtId()).thenReturn(1L);
+        when(context.getExecutionId()).thenReturn(new TUniqueId());
+        when(context.getCapability()).thenReturn(MysqlCapability.DEFAULT_CAPABILITY);
 
         return context;
     }
@@ -441,17 +396,15 @@ public class ConnectProcessorTest extends DDLTestBase {
         ConnectContext ctx = initMockContext(mockChannel(queryPacket), GlobalStateMgr.getCurrentState());
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
-        // Mock statement executor
-        // Create mock for StmtExecutor using MockUp instead of @Mocked parameter
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return statistics;
-            }
-        };
+        // Mock statement executor using MockedConstruction
+        try (var mockedStmtExecutor = mockConstruction(StmtExecutor.class,
+                (mock, context) -> {
+                    when(mock.getQueryStatisticsForAuditLog()).thenReturn(statistics);
+                })) {
 
-        processor.processOnce();
-        Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
+            processor.processOnce();
+            Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
+        }
     }
 
     @Test
@@ -569,21 +522,16 @@ public class ConnectProcessorTest extends DDLTestBase {
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
 
-        // Mock statement executor using MockUp
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute() throws Exception {
-                throw new IOException("Fail");
-            }
+        // Mock statement executor using MockedConstruction
+        try (var mockedStmtExecutor = mockConstruction(StmtExecutor.class,
+                (mock, context) -> {
+                    when(mock.getQueryStatisticsForAuditLog()).thenReturn(statistics);
+                    doThrow(new IOException("Fail")).when(mock).execute();
+                })) {
 
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return statistics;
-            }
-        };
-
-        processor.processOnce();
-        Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
+            processor.processOnce();
+            Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
+        }
     }
 
     @Test
@@ -592,22 +540,17 @@ public class ConnectProcessorTest extends DDLTestBase {
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
 
-        // Mock statement executor using MockUp
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute() throws Exception {
-                throw new NullPointerException("Fail");
-            }
+        // Mock statement executor using MockedConstruction
+        try (var mockedStmtExecutor = mockConstruction(StmtExecutor.class,
+                (mock, context) -> {
+                    when(mock.getQueryStatisticsForAuditLog()).thenReturn(statistics);
+                    doThrow(new NullPointerException("Fail")).when(mock).execute();
+                })) {
 
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return statistics;
-            }
-        };
-
-        processor.processOnce();
-        Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
-        Assertions.assertTrue(myContext.getState().toResponsePacket() instanceof MysqlErrPacket);
+            processor.processOnce();
+            Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
+            Assertions.assertTrue(myContext.getState().toResponsePacket() instanceof MysqlErrPacket);
+        }
     }
 
     @Test
@@ -618,24 +561,23 @@ public class ConnectProcessorTest extends DDLTestBase {
         ConnectProcessor processor = new ConnectProcessor(ctx);
 
         AtomicReference<String> customQueryId = new AtomicReference<>();
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute() throws Exception {
-                customQueryId.set(ctx.getCustomQueryId());
-            }
+        try (var mockedStmtExecutor = mockConstruction(StmtExecutor.class,
+                (mock, context) -> {
+                    when(mock.getQueryStatisticsForAuditLog()).thenReturn(null);
+                    doAnswer(invocation -> {
+                        customQueryId.set(ctx.getCustomQueryId());
+                        return null;
+                    }).when(mock).execute();
+                })) {
 
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
-        processor.processOnce();
-        Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
-        // verify customQueryId is set during query execution
-        Assertions.assertEquals("a_custom_query_id", customQueryId.get());
-        // customQueryId is cleared after query finished
-        Assertions.assertEquals("", ctx.getCustomQueryId());
-        Assertions.assertEquals("", ctx.getSessionVariable().getCustomQueryId());
+            processor.processOnce();
+            Assertions.assertEquals(MysqlCommand.COM_QUERY, myContext.getCommand());
+            // verify customQueryId is set during query execution
+            Assertions.assertEquals("a_custom_query_id", customQueryId.get());
+            // customQueryId is cleared after query finished
+            Assertions.assertEquals("", ctx.getCustomQueryId());
+            Assertions.assertEquals("", ctx.getSessionVariable().getCustomQueryId());
+        }
     }
 
     @Test
@@ -651,7 +593,7 @@ public class ConnectProcessorTest extends DDLTestBase {
             public void execute() throws Exception {
                 customSessionName.set(ctx.getCustomSessionName());
             }
-            
+
             @Mock
             public PQueryStatistics getQueryStatisticsForAuditLog() {
                 return null;
@@ -815,17 +757,15 @@ public class ConnectProcessorTest extends DDLTestBase {
         ctx.setThreadLocalInfo();
 
         ConnectProcessor processor = new ConnectProcessor(ctx);
-        new mockit.MockUp<StmtExecutor>() {
-            @mockit.Mock
-            public void execute() {}
-            @mockit.Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
+        try (var mockedStmtExecutor = mockConstruction(StmtExecutor.class,
+                (mock, context) -> {
+                    when(mock.getQueryStatisticsForAuditLog()).thenReturn(null);
+                    doNothing().when(mock).execute();
+                })) {
 
-        TMasterOpResult result = processor.proxyExecute(request, null);
-        Assertions.assertNotNull(result);
+            TMasterOpResult result = processor.proxyExecute(request);
+            Assertions.assertNotNull(result);
+        }
     }
 
     @Test
@@ -843,18 +783,16 @@ public class ConnectProcessorTest extends DDLTestBase {
 
         ConnectContext context = new ConnectContext();
         ConnectProcessor processor = new ConnectProcessor(context);
-        new mockit.MockUp<StmtExecutor>() {
-            @mockit.Mock
-            public void execute() {}
-            @mockit.Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return null;
-            }
-        };
+        try (var mockedStmtExecutor = mockConstruction(StmtExecutor.class,
+                (mock, mockContext) -> {
+                    when(mock.getQueryStatisticsForAuditLog()).thenReturn(null);
+                    doNothing().when(mock).execute();
+                })) {
 
-        TMasterOpResult result = processor.proxyExecute(request, null);
-        Assertions.assertNotNull(result);
-        Assertions.assertTrue(context.getState().isError());
+            TMasterOpResult result = processor.proxyExecute(request);
+            Assertions.assertNotNull(result);
+            Assertions.assertTrue(context.getState().isError());
+        }
     }
 
     /**
@@ -878,43 +816,33 @@ public class ConnectProcessorTest extends DDLTestBase {
         AtomicReference<Boolean> tracersInitialized = new AtomicReference<>(false);
 
         // Mock Tracers
-        new MockUp<Tracers>() {
-            @Mock
-            public void register(ConnectContext context) {
+        try (var mockedTracers = mockStatic(Tracers.class);
+                var mockedStmtExecutor = mockConstruction(StmtExecutor.class,
+                        (mock, context) -> {
+                            when(mock.getQueryStatisticsForAuditLog()).thenReturn(statistics);
+                            when(mock.getParsedStmt()).thenReturn(prepareStmt);
+                            doNothing().when(mock).execute();
+                        })) {
+
+            mockedTracers.when(() -> Tracers.register(ctx)).thenAnswer(invocation -> {
                 tracersRegistered.set(true);
-            }
+                return null;
+            });
 
-            @Mock
-            public void init(ConnectContext context, String traceMode, String traceModule) {
-                tracersInitialized.set(true);
-            }
-        };
+            mockedTracers.when(() -> Tracers.init(any(ConnectContext.class), any(Tracers.Mode.class), any(String.class)))
+                    .thenAnswer(invocation -> {
+                        tracersInitialized.set(true);
+                        return null;
+                    });
 
-        // Mock StmtExecutor
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void execute() throws Exception {
-                // Do nothing for test
-            }
+            processor.processOnce();
 
-            @Mock
-            public PQueryStatistics getQueryStatisticsForAuditLog() {
-                return statistics;
-            }
-
-            @Mock
-            public StatementBase getParsedStmt() {
-                return prepareStmt;
-            }
-        };
-
-        processor.processOnce();
-
-        // Verify that tracers are properly initialized for query statements
-        Assertions.assertTrue(tracersRegistered.get(), "Tracers should be registered for query statements");
-        Assertions.assertTrue(tracersInitialized.get(), "Tracers should be initialized for query statements");
-        Assertions.assertEquals(MysqlCommand.COM_STMT_EXECUTE, myContext.getCommand());
-        Assertions.assertEquals("SELECT 1 + 2 AS `1 + 2`", processor.executor.getOriginStmtInString());
+            // Verify that tracers are properly initialized for query statements
+            Assertions.assertTrue(tracersRegistered.get(), "Tracers should be registered for query statements");
+            Assertions.assertTrue(tracersInitialized.get(), "Tracers should be initialized for query statements");
+            Assertions.assertEquals(MysqlCommand.COM_STMT_EXECUTE, myContext.getCommand());
+            Assertions.assertEquals("SELECT 1 + 2 AS `1 + 2`", processor.executor.getOriginStmtInString());
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
@@ -17,20 +17,17 @@ package com.starrocks.qe.scheduler;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.starrocks.common.Reference;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.qe.SessionVariableConstants.ComputationFragmentSchedulingPolicy;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.warehouse.cngroup.ComputeResource;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -48,6 +45,11 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 public class DefaultWorkerProviderTest {
     private final ImmutableMap<Long, ComputeNode> id2Backend = genWorkers(0, 10, Backend::new, false);
@@ -95,60 +97,58 @@ public class DefaultWorkerProviderTest {
         Set<Long> nonAvailableWorkerId = ImmutableSet.of(deadBEId, deadCNId, inBlacklistBEId, inBlacklistCNId);
         id2Backend.get(deadBEId).setAlive(false);
         id2ComputeNode.get(deadCNId).setAlive(false);
-        new MockUp<SimpleScheduler>() {
-            @Mock
-            public boolean isInBlocklist(long backendId) {
-                return backendId == inBlacklistBEId || backendId == inBlacklistCNId;
-            }
-        };
 
-        Reference<Integer> nextComputeNodeIndex = new Reference<>(0);
-        new MockUp<DefaultWorkerProvider>() {
-            @Mock
-            int getNextComputeNodeIndex(ComputeResource computeResource) {
-                int next = nextComputeNodeIndex.getRef();
-                nextComputeNodeIndex.setRef(next + 1);
-                return next;
-            }
-        };
+        // Create mock SystemInfoService
+        SystemInfoService mockSystemInfoService = mock(SystemInfoService.class);
+        when(mockSystemInfoService.getIdToBackend()).thenReturn((ImmutableMap) id2Backend);
+        when(mockSystemInfoService.getIdComputeNode()).thenReturn((ImmutableMap) id2ComputeNode);
 
-        new MockUp<SystemInfoService>() {
-            @Mock
-            public ImmutableMap<Long, ComputeNode> getIdToBackend() {
-                return id2Backend;
-            }
+        try (var mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class);
+                var mockedSimpleScheduler = mockStatic(SimpleScheduler.class)) {
 
-            @Mock
-            public ImmutableMap<Long, ComputeNode> getIdComputeNode() {
-                return id2ComputeNode;
-            }
-        };
+            // Mock GlobalStateMgr chain
+            GlobalStateMgr mockState = mock(GlobalStateMgr.class);
+            NodeMgr mockNodeMgr = mock(NodeMgr.class);
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(mockState);
+            when(mockState.getNodeMgr()).thenReturn(mockNodeMgr);
+            when(mockNodeMgr.getClusterInfo()).thenReturn(mockSystemInfoService);
 
-        DefaultWorkerProvider.Factory workerProviderFactory = new DefaultWorkerProvider.Factory();
-        DefaultWorkerProvider workerProvider;
-        List<Integer> numUsedComputeNodesList = ImmutableList.of(100, 0, -1, 1, 2, 3, 4, 5, 6);
-        for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
-            // Reset nextComputeNodeIndex.
-            nextComputeNodeIndex.setRef(0);
+            mockedSimpleScheduler.when(() -> SimpleScheduler.isInBlocklist(anyLong()))
+                    .thenAnswer(invocation -> {
+                        long backendId = invocation.getArgument(0);
+                        return backendId == inBlacklistBEId || backendId == inBlacklistCNId;
+                    });
 
-            workerProvider =
-                    workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
-                            true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY,
-                            WarehouseManager.DEFAULT_RESOURCE);
+            // Mock getNextComputeNodeIndex to return incrementing values
+            DefaultWorkerProvider.getNextComputeNodeIndexer().set(0);
 
-            int numAvailableComputeNodes = 0;
-            for (long id = 0; id < 15; id++) {
-                ComputeNode worker = workerProvider.getWorkerById(id);
-                if (nonAvailableWorkerId.contains(id)
-                        // Exceed the limitation of numUsedComputeNodes.
-                        || (numUsedComputeNodes > 0 && numAvailableComputeNodes >= numUsedComputeNodes)) {
-                    Assertions.assertNull(worker);
-                } else {
-                    Assertions.assertNotNull(worker, "numUsedComputeNodes=" + numUsedComputeNodes + ",id=" + id);
-                    Assertions.assertEquals(id, worker.getId());
+            DefaultWorkerProvider.Factory workerProviderFactory = new DefaultWorkerProvider.Factory();
+            DefaultWorkerProvider workerProvider;
+            List<Integer> numUsedComputeNodesList = ImmutableList.of(100, 0, -1, 1, 2, 3, 4, 5, 6);
+            for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
+                // Reset nextComputeNodeIndex.
+                DefaultWorkerProvider.getNextComputeNodeIndexer().set(0);
 
-                    if (id2ComputeNode.containsKey(id)) {
-                        numAvailableComputeNodes++;
+                workerProvider =
+                        workerProviderFactory.captureAvailableWorkers(
+                                mockSystemInfoService,
+                                true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY,
+                                WarehouseManager.DEFAULT_RESOURCE);
+
+                int numAvailableComputeNodes = 0;
+                for (long id = 0; id < 15; id++) {
+                    ComputeNode worker = workerProvider.getWorkerById(id);
+                    if (nonAvailableWorkerId.contains(id)
+                            // Exceed the limitation of numUsedComputeNodes.
+                            || (numUsedComputeNodes > 0 && numAvailableComputeNodes >= numUsedComputeNodes)) {
+                        Assertions.assertNull(worker);
+                    } else {
+                        Assertions.assertNotNull(worker, "numUsedComputeNodes=" + numUsedComputeNodes + ",id=" + id);
+                        Assertions.assertEquals(id, worker.getId());
+
+                        if (id2ComputeNode.containsKey(id)) {
+                            numAvailableComputeNodes++;
+                        }
                     }
                 }
             }
@@ -160,64 +160,70 @@ public class DefaultWorkerProviderTest {
      */
     @Test
     public void testSelectBackendAndComputeNode() {
-        new MockUp<SystemInfoService>() {
-            @Mock
-            public ImmutableMap<Long, ComputeNode> getIdToBackend() {
-                return availableId2Backend;
-            }
+        // Create mock SystemInfoService
+        SystemInfoService mockSystemInfoService = mock(SystemInfoService.class);
+        when(mockSystemInfoService.getIdToBackend()).thenReturn((ImmutableMap) availableId2Backend);
+        when(mockSystemInfoService.getIdComputeNode()).thenReturn((ImmutableMap) availableId2ComputeNode);
 
-            @Mock
-            public ImmutableMap<Long, ComputeNode> getIdComputeNode() {
-                return availableId2ComputeNode;
-            }
-        };
+        try (var mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class)) {
 
-        DefaultWorkerProvider.Factory workerProviderFactory = new DefaultWorkerProvider.Factory();
-        DefaultWorkerProvider workerProvider;
-        List<Integer> numUsedComputeNodesList = ImmutableList.of(-1, 0, 2, 3, 5, 8, 10);
+            // Mock GlobalStateMgr chain
+            GlobalStateMgr mockState = mock(GlobalStateMgr.class);
+            NodeMgr mockNodeMgr = mock(NodeMgr.class);
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(mockState);
+            when(mockState.getNodeMgr()).thenReturn(mockNodeMgr);
+            when(mockNodeMgr.getClusterInfo()).thenReturn(mockSystemInfoService);
 
-        // test ComputeNode only
-        for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
-            workerProvider =
-                    workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
-                            true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY,
-                            WarehouseManager.DEFAULT_RESOURCE);
-            List<Long> selectedWorkerIdsList = workerProvider.getAllAvailableNodes();
-            for (Long selectedWorkerId : selectedWorkerIdsList) {
-                Assertions.assertTrue(availableId2ComputeNode.containsKey(selectedWorkerId),
-                        "selectedWorkerId:" + selectedWorkerId);
+            DefaultWorkerProvider.Factory workerProviderFactory = new DefaultWorkerProvider.Factory();
+            DefaultWorkerProvider workerProvider;
+            List<Integer> numUsedComputeNodesList = ImmutableList.of(-1, 0, 2, 3, 5, 8, 10);
+
+            // test ComputeNode only
+            for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
+                workerProvider =
+                        workerProviderFactory.captureAvailableWorkers(
+                                mockSystemInfoService,
+                                true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY,
+                                WarehouseManager.DEFAULT_RESOURCE);
+                List<Long> selectedWorkerIdsList = workerProvider.getAllAvailableNodes();
+                for (Long selectedWorkerId : selectedWorkerIdsList) {
+                    Assertions.assertTrue(availableId2ComputeNode.containsKey(selectedWorkerId),
+                            "selectedWorkerId:" + selectedWorkerId);
+                }
             }
-        }
-        // test Backend only
-        for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
-            workerProvider =
-                    workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
-                            false, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY,
-                            WarehouseManager.DEFAULT_RESOURCE);
-            List<Long> selectedWorkerIdsList = workerProvider.getAllAvailableNodes();
-            Assertions.assertEquals(availableId2Backend.size(), selectedWorkerIdsList.size());
-            for (Long selectedWorkerId : selectedWorkerIdsList) {
-                Assertions.assertTrue(availableId2Backend.containsKey(selectedWorkerId),
-                        "selectedWorkerId:" + selectedWorkerId);
+            // test Backend only
+            for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
+                workerProvider =
+                        workerProviderFactory.captureAvailableWorkers(
+                                mockSystemInfoService,
+                                false, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.COMPUTE_NODES_ONLY,
+                                WarehouseManager.DEFAULT_RESOURCE);
+                List<Long> selectedWorkerIdsList = workerProvider.getAllAvailableNodes();
+                Assertions.assertEquals(availableId2Backend.size(), selectedWorkerIdsList.size());
+                for (Long selectedWorkerId : selectedWorkerIdsList) {
+                    Assertions.assertTrue(availableId2Backend.containsKey(selectedWorkerId),
+                            "selectedWorkerId:" + selectedWorkerId);
+                }
             }
-        }
-        // test Backend and ComputeNode
-        for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
-            workerProvider =
-                    workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo(),
-                            true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.ALL_NODES,
-                            WarehouseManager.DEFAULT_RESOURCE);
-            List<Long> selectedWorkerIdsList = workerProvider.getAllAvailableNodes();
-            Collections.reverse(selectedWorkerIdsList); //put ComputeNode id to the front,Backend id to the back
-            //test ComputeNode
-            for (int i = 0; i < availableId2ComputeNode.size() && i < selectedWorkerIdsList.size(); i++) {
-                Assertions.assertTrue(availableId2ComputeNode.containsKey(selectedWorkerIdsList.get(i)),
-                        "selectedWorkerId:" + selectedWorkerIdsList.get(i));
-            }
-            //test Backend
-            for (int i = availableId2ComputeNode.size(); i < selectedWorkerIdsList.size(); i++) {
-                Assertions.assertTrue(availableId2Backend.containsKey(selectedWorkerIdsList.get(i)),
-                        "selectedWorkerId:" + selectedWorkerIdsList.get(i));
+            // test Backend and ComputeNode
+            for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
+                workerProvider =
+                        workerProviderFactory.captureAvailableWorkers(
+                                mockSystemInfoService,
+                                true, numUsedComputeNodes, ComputationFragmentSchedulingPolicy.ALL_NODES,
+                                WarehouseManager.DEFAULT_RESOURCE);
+                List<Long> selectedWorkerIdsList = workerProvider.getAllAvailableNodes();
+                Collections.reverse(selectedWorkerIdsList); //put ComputeNode id to the front,Backend id to the back
+                //test ComputeNode
+                for (int i = 0; i < availableId2ComputeNode.size() && i < selectedWorkerIdsList.size(); i++) {
+                    Assertions.assertTrue(availableId2ComputeNode.containsKey(selectedWorkerIdsList.get(i)),
+                            "selectedWorkerId:" + selectedWorkerIdsList.get(i));
+                }
+                //test Backend
+                for (int i = availableId2ComputeNode.size(); i < selectedWorkerIdsList.size(); i++) {
+                    Assertions.assertTrue(availableId2Backend.containsKey(selectedWorkerIdsList.get(i)),
+                            "selectedWorkerId:" + selectedWorkerIdsList.get(i));
+                }
             }
         }
     }
@@ -405,39 +411,45 @@ public class DefaultWorkerProviderTest {
     }
 
     @Test
-    public void getNextComputeNodeIndex_returnsIncrementedValueInSharedDataMode(@Mocked ComputeResource computeResource) {
-        new MockUp<RunMode>() {
-            @Mock
-            public RunMode getCurrentRunMode() {
-                return RunMode.SHARED_DATA;
-            }
-        };
+    public void getNextComputeNodeIndex_returnsIncrementedValueInSharedDataMode() {
         AtomicInteger mockIndex = new AtomicInteger(5);
-        new MockUp<WarehouseManager>() {
-            @Mock
-            public AtomicInteger getNextComputeNodeIndexFromWarehouse(ComputeResource resource) {
-                return mockIndex;
-            }
-        };
 
-        int result = DefaultWorkerProvider.getNextComputeNodeIndex(computeResource);
-        Assertions.assertEquals(5, result);
-        Assertions.assertEquals(6, mockIndex.get());
+        // Create mock ComputeResource
+        ComputeResource mockComputeResource = mock(ComputeResource.class);
+        when(mockComputeResource.getWarehouseId()).thenReturn(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+
+        // Create mock WarehouseManager
+        WarehouseManager mockWarehouseManager = mock(WarehouseManager.class);
+        when(mockWarehouseManager.getNextComputeNodeIndexFromWarehouse(any(ComputeResource.class)))
+                .thenReturn(mockIndex);
+
+        try (var mockedRunMode = mockStatic(RunMode.class);
+                var mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class)) {
+
+            GlobalStateMgr mockState = mock(GlobalStateMgr.class);
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(mockState);
+            when(mockState.getWarehouseMgr()).thenReturn(mockWarehouseManager);
+
+            mockedRunMode.when(RunMode::getCurrentRunMode)
+                    .thenReturn(RunMode.SHARED_DATA);
+
+            int result = DefaultWorkerProvider.getNextComputeNodeIndex(mockComputeResource);
+            Assertions.assertEquals(5, result);
+            Assertions.assertEquals(6, mockIndex.get());
+        }
     }
 
     @Test
-    public void getNextComputeNodeIndex_returnsIncrementedValueInSharedNothingMode(@Mocked ComputeResource computeResource) {
-        new MockUp<RunMode>() {
-            @Mock
-            public RunMode getCurrentRunMode() {
-                return RunMode.SHARED_NOTHING;
-            }
-        };
+    public void getNextComputeNodeIndex_returnsIncrementedValueInSharedNothingMode() {
+        try (var mockedRunMode = mockStatic(RunMode.class)) {
+            mockedRunMode.when(RunMode::getCurrentRunMode)
+                    .thenReturn(RunMode.SHARED_NOTHING);
 
-        int initialIndex = DefaultWorkerProvider.getNextComputeNodeIndexer().get();
-        int result = DefaultWorkerProvider.getNextComputeNodeIndex(computeResource);
-        Assertions.assertEquals(initialIndex, result);
-        Assertions.assertEquals(initialIndex + 1, DefaultWorkerProvider.getNextComputeNodeIndexer().get());
+            int initialIndex = DefaultWorkerProvider.getNextComputeNodeIndexer().get();
+            int result = DefaultWorkerProvider.getNextComputeNodeIndex(null);
+            Assertions.assertEquals(initialIndex, result);
+            Assertions.assertEquals(initialIndex + 1, DefaultWorkerProvider.getNextComputeNodeIndexer().get());
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendOptionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendOptionsTest.java
@@ -16,11 +16,11 @@ package com.starrocks.service;
 
 import com.starrocks.common.Config;
 import com.starrocks.common.util.NetUtils;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -36,19 +36,30 @@ import java.util.List;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 public class FrontendOptionsTest {
 
-    @Mocked
-    Inet4Address addr;
-
+    private Inet4Address addr;
     private boolean useFqdn = true;
     private boolean useFqdnFile = true;
 
+    @BeforeEach
+    public void setUp() {
+        addr = mock(Inet4Address.class);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        FrontendOptions.PRIORITY_CIDRS.clear();
+    }
+
     @Test
     public void cidrTest() {
-
         List<String> priorityCidrs = FrontendOptions.PRIORITY_CIDRS;
         priorityCidrs.add("192.168.5.136/32");
         priorityCidrs.add("2001:db8::/32");
@@ -59,7 +70,7 @@ public class FrontendOptionsTest {
 
         inPriorNetwork = frontendOptions.isInPriorNetwork("192.168.5.136");
         Assertions.assertEquals(true, inPriorNetwork);
-        
+
         inPriorNetwork = frontendOptions.isInPriorNetwork("2001:db8::1");
         Assertions.assertTrue(inPriorNetwork);
     }
@@ -74,51 +85,15 @@ public class FrontendOptionsTest {
         Assertions.assertEquals(true, inPriorNetwork);
     }
 
-    private void mockNet() {
-        new MockUp<Inet4Address>() {
-            @Mock
-            public InetAddress getLocalHost() throws UnknownHostException {
-                return addr;
-            }
-            @Mock
-            public String getHostAddress() {
-                return "127.0.0.10";
-            }
-            @Mock
-            public String getCanonicalHostName() {
-                return "sandbox";
-            }
-        };
-        new MockUp<NetUtils>() {
-            @Mock
-            public List<InetAddress> getHosts() {
-                List<InetAddress> hosts = new ArrayList<>();
-                hosts.add(addr);
-                return hosts;
-            }
-        };
-
-        new MockUp<FrontendOptions>() {
-            @Mock
-            public void initAddrUseFqdn(List<InetAddress> hosts) throws UnknownHostException {
-                useFqdn = true;
-                useFqdnFile = true;
-            }
-            @Mock
-            public void initAddrUseIp(List<InetAddress> hosts) {
-                useFqdn = false;
-                useFqdnFile = false;
-            }
-        };
-    }
-
     @Test
     public void enableFQDNTest() throws UnknownHostException,
-                                        NoSuchFieldException,
-                                        SecurityException,
-                                        IllegalArgumentException,
-                                        IllegalAccessException {
-        mockNet();
+            NoSuchFieldException,
+            SecurityException,
+            IllegalArgumentException,
+            IllegalAccessException {
+        when(addr.getHostAddress()).thenReturn("127.0.0.10");
+        when(addr.getCanonicalHostName()).thenReturn("sandbox");
+
         Field field = FrontendOptions.class.getDeclaredField("localAddr");
         field.setAccessible(true);
         field.set(null, addr);
@@ -133,33 +108,41 @@ public class FrontendOptionsTest {
 
     @Test
     public void testChooseHostType() throws UnknownHostException {
-        mockNet();
-        useFqdn = true;
-        FrontendOptions.init("ip");
-        Assertions.assertTrue(!useFqdn);
-        useFqdn = false;
-        FrontendOptions.init("fqdn");
-        Assertions.assertTrue(useFqdn);
-        useFqdn = false;
-        FrontendOptions.init(null);
-        Assertions.assertTrue(!useFqdn);
-    }
+        when(addr.getHostAddress()).thenReturn("127.0.0.10");
+        when(addr.getCanonicalHostName()).thenReturn("sandbox");
 
-    private void testInitAddrUseFqdnCommonMock() {
-        new MockUp<System>() {
-            @Mock
-            public void exit(int status) throws IllegalAccessException {
-                throw new IllegalAccessException();
-            }
-        };
-        new MockUp<NetUtils>() {
-            @Mock
-            public List<InetAddress> getHosts() {
-                List<InetAddress> hosts = new ArrayList<>();
-                hosts.add(addr);
-                return hosts;
-            }
-        };
+        List<InetAddress> hosts = new ArrayList<>();
+        hosts.add(addr);
+
+        try (MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class);
+                MockedStatic<NetUtils> mockedNetUtils = mockStatic(NetUtils.class);
+                MockedStatic<FrontendOptions> mockedFrontendOptions = mockStatic(FrontendOptions.class)) {
+
+            mockedInetAddress.when(InetAddress::getLocalHost).thenReturn(addr);
+            mockedNetUtils.when(NetUtils::getHosts).thenReturn(hosts);
+
+            mockedFrontendOptions.when(() -> FrontendOptions.init(any())).thenCallRealMethod();
+            mockedFrontendOptions.when(() -> FrontendOptions.initAddrUseFqdn(any())).thenAnswer(invocation -> {
+                useFqdn = true;
+                useFqdnFile = true;
+                return null;
+            });
+            mockedFrontendOptions.when(() -> FrontendOptions.initAddrUseIp(any())).thenAnswer(invocation -> {
+                useFqdn = false;
+                useFqdnFile = false;
+                return null;
+            });
+
+            useFqdn = true;
+            FrontendOptions.init("ip");
+            Assertions.assertTrue(!useFqdn);
+            useFqdn = false;
+            FrontendOptions.init("fqdn");
+            Assertions.assertTrue(useFqdn);
+            useFqdn = false;
+            FrontendOptions.init(null);
+            Assertions.assertTrue(!useFqdn);
+        }
     }
 
     @Test
@@ -167,168 +150,140 @@ public class FrontendOptionsTest {
         assertThrows(IllegalAccessException.class, () -> {
             String oldVal = Config.priority_networks;
             Config.priority_networks = "";
-            testInitAddrUseFqdnCommonMock();
-            List<InetAddress> hosts = NetUtils.getHosts();
-            new MockUp<InetAddress>() {
-                @Mock
-                public InetAddress getLocalHost() throws UnknownHostException {
-                    throw new UnknownHostException();
-                }
-            };
-            FrontendOptions.initAddrUseFqdn(hosts);
-            Config.priority_networks = oldVal;
+
+            List<InetAddress> hosts = new ArrayList<>();
+            hosts.add(addr);
+
+            try (MockedStatic<System> mockedSystem = mockStatic(System.class);
+                    MockedStatic<NetUtils> mockedNetUtils = mockStatic(NetUtils.class);
+                    MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class)) {
+
+                mockedSystem.when(() -> System.exit(org.mockito.ArgumentMatchers.anyInt()))
+                        .thenThrow(new IllegalAccessException());
+                mockedNetUtils.when(NetUtils::getHosts).thenReturn(hosts);
+                mockedInetAddress.when(InetAddress::getLocalHost).thenThrow(new UnknownHostException());
+
+                FrontendOptions.initAddrUseFqdn(hosts);
+            } finally {
+                Config.priority_networks = oldVal;
+            }
         });
     }
 
     @Test
     public void testGetStartWithFQDNGetNullCanonicalHostName() {
         assertThrows(IllegalAccessException.class, () -> {
-            testInitAddrUseFqdnCommonMock();
-            List<InetAddress> hosts = NetUtils.getHosts();
-            new MockUp<InetAddress>() {
-                @Mock
-                public InetAddress getLocalHost() throws UnknownHostException {
-                    return addr;
-                }
+            List<InetAddress> hosts = new ArrayList<>();
+            hosts.add(addr);
 
-                @Mock
-                public String getHostAddress() {
-                    return "127.0.0.10";
-                }
+            when(addr.getHostAddress()).thenReturn("127.0.0.10");
+            when(addr.getCanonicalHostName()).thenReturn(null);
 
-                @Mock
-                public String getCanonicalHostName() {
-                    return null;
-                }
-            };
-            FrontendOptions.initAddrUseFqdn(hosts);
+            try (MockedStatic<System> mockedSystem = mockStatic(System.class);
+                    MockedStatic<NetUtils> mockedNetUtils = mockStatic(NetUtils.class);
+                    MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class)) {
+
+                mockedSystem.when(() -> System.exit(org.mockito.ArgumentMatchers.anyInt()))
+                        .thenThrow(new IllegalAccessException());
+                mockedNetUtils.when(NetUtils::getHosts).thenReturn(hosts);
+                mockedInetAddress.when(InetAddress::getLocalHost).thenReturn(addr);
+
+                FrontendOptions.initAddrUseFqdn(hosts);
+            }
         });
     }
 
     @Test
     public void testGetStartWithFQDNGetNameThrowUnknownHostException() {
         assertThrows(IllegalAccessException.class, () -> {
-            testInitAddrUseFqdnCommonMock();
-            List<InetAddress> hosts = NetUtils.getHosts();
-            new MockUp<InetAddress>() {
-                @Mock
-                public InetAddress getLocalHost() throws UnknownHostException {
-                    return addr;
-                }
+            List<InetAddress> hosts = new ArrayList<>();
+            hosts.add(addr);
 
-                @Mock
-                public String getHostAddress() {
-                    return "127.0.0.10";
-                }
+            when(addr.getHostAddress()).thenReturn("127.0.0.10");
+            when(addr.getCanonicalHostName()).thenReturn("sandbox");
 
-                @Mock
-                public String getCanonicalHostName() {
-                    return "sandbox";
-                }
+            try (MockedStatic<System> mockedSystem = mockStatic(System.class);
+                    MockedStatic<NetUtils> mockedNetUtils = mockStatic(NetUtils.class);
+                    MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class)) {
 
-                @Mock
-                public InetAddress getByName(String host) throws UnknownHostException {
-                    throw new UnknownHostException();
-                }
-            };
-            FrontendOptions.initAddrUseFqdn(hosts);
+                mockedSystem.when(() -> System.exit(org.mockito.ArgumentMatchers.anyInt()))
+                        .thenThrow(new IllegalAccessException());
+                mockedNetUtils.when(NetUtils::getHosts).thenReturn(hosts);
+                mockedInetAddress.when(InetAddress::getLocalHost).thenReturn(addr);
+                mockedInetAddress.when(() -> InetAddress.getByName(anyString()))
+                        .thenThrow(new UnknownHostException());
+
+                FrontendOptions.initAddrUseFqdn(hosts);
+            }
         });
     }
 
     @Test
     public void testGetStartWithFQDNGetNameGetNull() {
         assertThrows(IllegalAccessException.class, () -> {
-            testInitAddrUseFqdnCommonMock();
-            List<InetAddress> hosts = NetUtils.getHosts();
-            new MockUp<InetAddress>() {
-                @Mock
-                public InetAddress getLocalHost() throws UnknownHostException {
-                    return addr;
-                }
+            List<InetAddress> hosts = new ArrayList<>();
+            hosts.add(addr);
 
-                @Mock
-                public String getHostAddress() {
-                    return "127.0.0.10";
-                }
+            when(addr.getHostAddress()).thenReturn("127.0.0.10");
+            when(addr.getCanonicalHostName()).thenReturn("sandbox");
 
-                @Mock
-                public String getCanonicalHostName() {
-                    return "sandbox";
-                }
+            try (MockedStatic<System> mockedSystem = mockStatic(System.class);
+                    MockedStatic<NetUtils> mockedNetUtils = mockStatic(NetUtils.class);
+                    MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class)) {
 
-                @Mock
-                public InetAddress getByName(String host) throws UnknownHostException {
-                    return null;
-                }
-            };
-            FrontendOptions.initAddrUseFqdn(hosts);
+                mockedSystem.when(() -> System.exit(org.mockito.ArgumentMatchers.anyInt()))
+                        .thenThrow(new IllegalAccessException());
+                mockedNetUtils.when(NetUtils::getHosts).thenReturn(hosts);
+                mockedInetAddress.when(InetAddress::getLocalHost).thenReturn(addr);
+                mockedInetAddress.when(() -> InetAddress.getByName(anyString())).thenReturn(null);
+
+                FrontendOptions.initAddrUseFqdn(hosts);
+            }
         });
     }
 
     @Test
     public void testGetStartWithFQDN() {
-        testInitAddrUseFqdnCommonMock();
-        List<InetAddress> hosts = NetUtils.getHosts();
-        new MockUp<InetAddress>() {
-            @Mock
-            public InetAddress getLocalHost() throws UnknownHostException {
-                return addr;
-            }
-            @Mock
-            public String getHostAddress() {
-                return "127.0.0.10";
-            }
-            @Mock
-            public String getCanonicalHostName() {
-                return "sandbox";
-            }
-            @Mock
-            public InetAddress getByName(String host) throws UnknownHostException {
-                return addr;
-            }
-        };
-        FrontendOptions.initAddrUseFqdn(hosts);
+        List<InetAddress> hosts = new ArrayList<>();
+        hosts.add(addr);
+
+        when(addr.getHostAddress()).thenReturn("127.0.0.10");
+        when(addr.getCanonicalHostName()).thenReturn("sandbox");
+
+        try (MockedStatic<System> mockedSystem = mockStatic(System.class);
+                MockedStatic<NetUtils> mockedNetUtils = mockStatic(NetUtils.class);
+                MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class)) {
+
+            mockedSystem.when(() -> System.exit(org.mockito.ArgumentMatchers.anyInt()))
+                    .thenThrow(new IllegalAccessException());
+            mockedNetUtils.when(NetUtils::getHosts).thenReturn(hosts);
+            mockedInetAddress.when(InetAddress::getLocalHost).thenReturn(addr);
+            mockedInetAddress.when(() -> InetAddress.getByName(anyString())).thenReturn(addr);
+
+            FrontendOptions.initAddrUseFqdn(hosts);
+        }
     }
 
     @Test
     public void testGetStartWithFQDNNotFindAddr() {
         assertThrows(IllegalAccessException.class, () -> {
-            new MockUp<System>() {
-                @Mock
-                public void exit(int status) throws IllegalAccessException {
-                    throw new IllegalAccessException();
-                }
-            };
-            new MockUp<NetUtils>() {
-                @Mock
-                public List<InetAddress> getHosts() {
-                    List<InetAddress> hosts = new ArrayList<>();
-                    return hosts;
-                }
-            };
-            List<InetAddress> hosts = NetUtils.getHosts();
-            new MockUp<InetAddress>() {
-                @Mock
-                public InetAddress getLocalHost() throws UnknownHostException {
-                    return addr;
-                }
+            List<InetAddress> hosts = new ArrayList<>();
 
-                @Mock
-                public String getHostAddress() {
-                    return "127.0.0.10";
-                }
+            when(addr.getHostAddress()).thenReturn("127.0.0.10");
+            when(addr.getCanonicalHostName()).thenReturn("sandbox");
 
-                @Mock
-                public String getCanonicalHostName() {
-                    return "sandbox";
-                }
+            try (MockedStatic<System> mockedSystem = mockStatic(System.class);
+                    MockedStatic<NetUtils> mockedNetUtils = mockStatic(NetUtils.class);
+                    MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class)) {
 
-                @Mock
-                public InetAddress getByName(String host) throws UnknownHostException {
-                    return addr;
-                }
-            };
-            FrontendOptions.initAddrUseFqdn(hosts);
+                mockedSystem.when(() -> System.exit(org.mockito.ArgumentMatchers.anyInt()))
+                        .thenThrow(new IllegalAccessException());
+                mockedNetUtils.when(NetUtils::getHosts).thenReturn(hosts);
+                mockedInetAddress.when(InetAddress::getLocalHost).thenReturn(addr);
+                mockedInetAddress.when(() -> InetAddress.getByName(anyString())).thenReturn(addr);
+
+                FrontendOptions.initAddrUseFqdn(hosts);
+            }
         });
     }
 
@@ -379,23 +334,49 @@ public class FrontendOptionsTest {
 
     @Test
     public void testChooseHostTypeByFile() throws UnknownHostException {
-        mockNet();
+        when(addr.getHostAddress()).thenReturn("127.0.0.10");
+        when(addr.getCanonicalHostName()).thenReturn("sandbox");
+
+        List<InetAddress> hosts = new ArrayList<>();
+        hosts.add(addr);
+
         Config.meta_dir = "feOpTestDir1";
         String metaPath = Config.meta_dir + "/";
-        // fqdn
-        mkdir(true, metaPath);
-        useFqdnFile = false;
-        FrontendOptions.init(null);
-        Assertions.assertTrue(useFqdnFile);
-        File dir = new File(metaPath);
-        deleteDir(dir);
-        // ip
-        mkdir(false, metaPath);
-        useFqdnFile = true;
-        FrontendOptions.init(null);
-        Assertions.assertTrue(!useFqdnFile);
-        dir = new File(metaPath);
-        deleteDir(dir);
+
+        try (MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class);
+                MockedStatic<NetUtils> mockedNetUtils = mockStatic(NetUtils.class);
+                MockedStatic<FrontendOptions> mockedFrontendOptions = mockStatic(FrontendOptions.class)) {
+
+            mockedInetAddress.when(InetAddress::getLocalHost).thenReturn(addr);
+            mockedNetUtils.when(NetUtils::getHosts).thenReturn(hosts);
+
+            mockedFrontendOptions.when(() -> FrontendOptions.init(any())).thenCallRealMethod();
+            mockedFrontendOptions.when(() -> FrontendOptions.initAddrUseFqdn(any())).thenAnswer(invocation -> {
+                useFqdn = true;
+                useFqdnFile = true;
+                return null;
+            });
+            mockedFrontendOptions.when(() -> FrontendOptions.initAddrUseIp(any())).thenAnswer(invocation -> {
+                useFqdn = false;
+                useFqdnFile = false;
+                return null;
+            });
+
+            // fqdn
+            mkdir(true, metaPath);
+            useFqdnFile = false;
+            FrontendOptions.init(null);
+            Assertions.assertTrue(useFqdnFile);
+            File dir = new File(metaPath);
+            deleteDir(dir);
+            // ip
+            mkdir(false, metaPath);
+            useFqdnFile = true;
+            FrontendOptions.init(null);
+            Assertions.assertTrue(!useFqdnFile);
+            dir = new File(metaPath);
+            deleteDir(dir);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AlterSystemStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AlterSystemStmtAnalyzerTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.analyzer;
 
 import com.starrocks.catalog.UserIdentity;
@@ -34,23 +33,23 @@ import com.starrocks.system.SystemInfoService;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import java.net.InetAddress;
 import java.util.List;
 
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
 
 public class AlterSystemStmtAnalyzerTest extends StarRocksTestBase {
     private static StarRocksAssert starRocksAssert;
     private static ConnectContext connectContext;
-
 
     @BeforeAll
     public static void beforeClass() throws Exception {
@@ -60,34 +59,32 @@ public class AlterSystemStmtAnalyzerTest extends StarRocksTestBase {
         AnalyzeTestUtil.init();
 
         UtFrameUtils.setUpForPersistTest();
+        MockitoAnnotations.openMocks(AlterSystemStmtAnalyzerTest.class);
     }
 
-    @Mocked
+    @Mock
     InetAddress addr1;
-
-    private void mockNet() {
-        new MockUp<InetAddress>() {
-            @Mock
-            public InetAddress getByName(String host) {
-                return addr1;
-            }
-        };
-    }
 
     @Test
     public void testVisitModifyBackendClause() {
-        mockNet();
-        AlterSystemStmtAnalyzer visitor = new AlterSystemStmtAnalyzer();
-        ModifyBackendClause clause = new ModifyBackendClause("test", "fqdn");
-        Void result = visitor.visitModifyBackendClause(clause, null);
+        try (var mockedInetAddress = mockStatic(InetAddress.class)) {
+            mockedInetAddress.when(() -> InetAddress.getByName(anyString())).thenReturn(addr1);
+
+            AlterSystemStmtAnalyzer visitor = new AlterSystemStmtAnalyzer();
+            ModifyBackendClause clause = new ModifyBackendClause("test", "fqdn");
+            visitor.visitModifyBackendClause(clause, null);
+        }
     }
 
     @Test
     public void testVisitModifyFrontendHostClause() {
-        mockNet();
-        AlterSystemStmtAnalyzer visitor = new AlterSystemStmtAnalyzer();
-        ModifyFrontendAddressClause clause = new ModifyFrontendAddressClause("test", "fqdn");
-        Void result = visitor.visitModifyFrontendHostClause(clause, null);
+        try (var mockedInetAddress = mockStatic(InetAddress.class)) {
+            mockedInetAddress.when(() -> InetAddress.getByName(anyString())).thenReturn(addr1);
+
+            AlterSystemStmtAnalyzer visitor = new AlterSystemStmtAnalyzer();
+            ModifyFrontendAddressClause clause = new ModifyFrontendAddressClause("test", "fqdn");
+            visitor.visitModifyFrontendHostClause(clause, null);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateFunctionStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateFunctionStmtAnalyzerTest.java
@@ -22,16 +22,22 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.CreateFunctionStmt;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 public class CreateFunctionStmtAnalyzerTest {
     private static StarRocksAssert starRocksAssert;
@@ -118,26 +124,27 @@ public class CreateFunctionStmtAnalyzerTest {
 
     @Test
     public void testJScalarUDF() {
-        try {
-            Config.enable_udf = true;
-            new MockUp<CreateFunctionAnalyzer>() {
-                @Mock
-                public String computeMd5(CreateFunctionStmt stmt) {
-                    return "0xff";
-                }
-            };
-            new MockUp<UDFInternalClassLoader>() {
-                @Mock
-                public final Class<?> loadClass(String name, boolean resolve)
-                        throws ClassNotFoundException {
-                    return NormalEval.class;
-                }
-            };
-            CreateFunctionStmt stmt = createStmt("symbol", "");
-            new CreateFunctionAnalyzer().analyze(stmt, connectContext);
-            Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
-        } finally {
-            Config.enable_udf = false;
+        try (MockedConstruction<CreateFunctionAnalyzer> mockedAnalyzerConstruction =
+                mockConstruction(CreateFunctionAnalyzer.class,
+                        withSettings().defaultAnswer(CALLS_REAL_METHODS),
+                        (mock, context) -> {
+                            doReturn("0xff").when(mock).computeMd5(any());
+                        });
+                MockedConstruction<UDFInternalClassLoader> mockedLoaderConstruction =
+                        mockConstruction(UDFInternalClassLoader.class,
+                                (mock, context) -> {
+                                    when(mock.loadClass(anyString()))
+                                            .thenReturn((Class) NormalEval.class);
+                                })) {
+
+            try {
+                Config.enable_udf = true;
+                CreateFunctionStmt stmt = createStmt("symbol", "");
+                new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+                Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
+            } finally {
+                Config.enable_udf = false;
+            }
         }
     }
 
@@ -149,36 +156,36 @@ public class CreateFunctionStmtAnalyzerTest {
 
     @Test
     public void testJScalarUDFNoScalarInputs() {
-        try {
-            Config.enable_udf = true;
-            new MockUp<CreateFunctionAnalyzer>() {
-                @Mock
-                public String computeMd5(CreateFunctionStmt stmt) {
-                    return "0xff";
-                }
-            };
-            new MockUp<UDFInternalClassLoader>() {
-                @Mock
-                public final Class<?> loadClass(String name, boolean resolve)
-                        throws ClassNotFoundException {
-                    return ComplexEval.class;
-                }
-            };
+        try (MockedConstruction<CreateFunctionAnalyzer> mockedAnalyzerConstruction =
+                mockConstruction(CreateFunctionAnalyzer.class,
+                        withSettings().defaultAnswer(CALLS_REAL_METHODS),
+                        (mock, context) -> {
+                            doReturn("0xff").when(mock).computeMd5(any());
+                        });
+                MockedConstruction<UDFInternalClassLoader> mockedLoaderConstruction =
+                        mockConstruction(UDFInternalClassLoader.class,
+                                (mock, context) -> {
+                                    when(mock.loadClass(anyString()))
+                                            .thenReturn((Class) ComplexEval.class);
+                                })) {
 
-            String createFunctionSql = String.format("CREATE %s FUNCTION ABC.Echo(array<string>,map<int, string>) \n"
-                    + "RETURNS array<int> \n"
-                    + "properties (\n"
-                    + "    \"symbol\" = \"%s\",\n"
-                    + "    \"type\" = \"StarrocksJar\",\n"
-                    + "    \"file\" = \"http://localhost:8080/\"\n"
-                    + ");", "", "symbol");
+            try {
+                Config.enable_udf = true;
+                String createFunctionSql = String.format("CREATE %s FUNCTION ABC.Echo(array<string>,map<int, string>) \n"
+                        + "RETURNS array<int> \n"
+                        + "properties (\n"
+                        + "    \"symbol\" = \"%s\",\n"
+                        + "    \"type\" = \"StarrocksJar\",\n"
+                        + "    \"file\" = \"http://localhost:8080/\"\n"
+                        + ");", "", "symbol");
 
-            CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
-                    createFunctionSql, 32).get(0);
-            new CreateFunctionAnalyzer().analyze(stmt, connectContext);
-            Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
-        } finally {
-            Config.enable_udf = false;
+                CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
+                        createFunctionSql, 32).get(0);
+                new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+                Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
+            } finally {
+                Config.enable_udf = false;
+            }
         }
     }
 
@@ -193,35 +200,32 @@ public class CreateFunctionStmtAnalyzerTest {
         return sql;
     }
 
-    void mockClazz(Class<?> clazz) {
-        new MockUp<CreateFunctionAnalyzer>() {
-            @Mock
-            public String computeMd5(CreateFunctionStmt stmt) {
-                return "0xff";
-            }
-        };
-        new MockUp<UDFInternalClassLoader>() {
-            @Mock
-            public final Class<?> loadClass(String name, boolean resolve)
-                    throws ClassNotFoundException {
-                return clazz;
-            }
-        };
-    }
-
     @Test
     public void testJScalarUDFNoScalarUnmatchedArgs() {
         assertThrows(SemanticException.class, () -> {
-            try {
-                Config.enable_udf = true;
-                mockClazz(ComplexEval.class);
-                String createFunctionSql = buildFunction("array<string>", "array<int>, array<string>");
-                CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
-                        createFunctionSql, 32).get(0);
-                new CreateFunctionAnalyzer().analyze(stmt, connectContext);
-                Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
-            } finally {
-                Config.enable_udf = false;
+            try (MockedConstruction<CreateFunctionAnalyzer> mockedAnalyzerConstruction =
+                    mockConstruction(CreateFunctionAnalyzer.class,
+                            withSettings().defaultAnswer(CALLS_REAL_METHODS),
+                            (mock, context) -> {
+                                doReturn("0xff").when(mock).computeMd5(any());
+                            });
+                    MockedConstruction<UDFInternalClassLoader> mockedLoaderConstruction =
+                            mockConstruction(UDFInternalClassLoader.class,
+                                    (mock, context) -> {
+                                        when(mock.loadClass(anyString()))
+                                                .thenReturn((Class) ComplexEval.class);
+                                    })) {
+
+                try {
+                    Config.enable_udf = true;
+                    String createFunctionSql = buildFunction("array<string>", "array<int>, array<string>");
+                    CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
+                            createFunctionSql, 32).get(0);
+                    new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+                    Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
+                } finally {
+                    Config.enable_udf = false;
+                }
             }
         });
     }
@@ -229,16 +233,29 @@ public class CreateFunctionStmtAnalyzerTest {
     @Test
     public void testJScalarUDFNoScalarUnmatchedRetTypes() {
         assertThrows(SemanticException.class, () -> {
-            try {
-                Config.enable_udf = true;
-                mockClazz(ComplexEval.class);
-                String createFunctionSql = buildFunction("string", "array<int>, map<string,string>");
-                CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
-                        createFunctionSql, 32).get(0);
-                new CreateFunctionAnalyzer().analyze(stmt, connectContext);
-                Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
-            } finally {
-                Config.enable_udf = false;
+            try (MockedConstruction<CreateFunctionAnalyzer> mockedAnalyzerConstruction =
+                    mockConstruction(CreateFunctionAnalyzer.class,
+                            withSettings().defaultAnswer(CALLS_REAL_METHODS),
+                            (mock, context) -> {
+                                doReturn("0xff").when(mock).computeMd5(any());
+                            });
+                    MockedConstruction<UDFInternalClassLoader> mockedLoaderConstruction =
+                            mockConstruction(UDFInternalClassLoader.class,
+                                    (mock, context) -> {
+                                        when(mock.loadClass(anyString()))
+                                                .thenReturn((Class) ComplexEval.class);
+                                    })) {
+
+                try {
+                    Config.enable_udf = true;
+                    String createFunctionSql = buildFunction("string", "array<int>, map<string,string>");
+                    CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
+                            createFunctionSql, 32).get(0);
+                    new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+                    Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
+                } finally {
+                    Config.enable_udf = false;
+                }
             }
         });
     }
@@ -336,85 +353,94 @@ public class CreateFunctionStmtAnalyzerTest {
 
     @Test
     public void testJUDAF() {
-        try {
-            Config.enable_udf = true;
-            new MockUp<CreateFunctionAnalyzer>() {
-                @Mock
-                public String computeMd5(CreateFunctionStmt stmt) {
-                    return "0xff";
-                }
-            };
-            new MockUp<UDFInternalClassLoader>() {
-                @Mock
-                public final Class<?> loadClass(String name, boolean resolve)
-                        throws ClassNotFoundException {
-                    if (name.contains("$")) {
-                        return EmptyAggEval.State.class;
-                    }
-                    return EmptyAggEval.class;
-                }
-            };
-            CreateFunctionStmt stmt = createStmt("symbol", "AGGREGATE");
-            new CreateFunctionAnalyzer().analyze(stmt, connectContext);
-            Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
-        } finally {
-            Config.enable_udf = false;
+        try (MockedConstruction<CreateFunctionAnalyzer> mockedAnalyzerConstruction =
+                mockConstruction(CreateFunctionAnalyzer.class,
+                        withSettings().defaultAnswer(CALLS_REAL_METHODS),
+                        (mock, context) -> {
+                            doReturn("0xff").when(mock).computeMd5(any());
+                        });
+                MockedConstruction<UDFInternalClassLoader> mockedLoaderConstruction =
+                        mockConstruction(UDFInternalClassLoader.class,
+                                (mock, context) -> {
+                                    when(mock.loadClass(anyString())).thenAnswer(invocation -> {
+                                        String name = invocation.getArgument(0);
+                                        if (name.contains("$")) {
+                                            return EmptyAggEval.State.class;
+                                        }
+                                        return EmptyAggEval.class;
+                                    });
+                                })) {
+
+            try {
+                Config.enable_udf = true;
+                CreateFunctionStmt stmt = createStmt("symbol", "AGGREGATE");
+                new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+                Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
+            } finally {
+                Config.enable_udf = false;
+            }
         }
     }
 
     @Test
     public void testJUDAFMap() {
-        try {
-            Config.enable_udf = true;
-            new MockUp<CreateFunctionAnalyzer>() {
-                @Mock
-                public String computeMd5(CreateFunctionStmt stmt) {
-                    return "0xff";
-                }
-            };
-            new MockUp<UDFInternalClassLoader>() {
-                @Mock
-                public final Class<?> loadClass(String name, boolean resolve)
-                        throws ClassNotFoundException {
-                    if (name.contains("$")) {
-                        return EmptyAggMapEval.State.class;
-                    }
-                    return EmptyAggMapEval.class;
-                }
-            };
-            CreateFunctionStmt stmt = createMapStmt("symbol", "AGGREGATE");
-            new CreateFunctionAnalyzer().analyze(stmt, connectContext);
-            Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
-        } finally {
-            Config.enable_udf = false;
+        try (MockedConstruction<CreateFunctionAnalyzer> mockedAnalyzerConstruction =
+                mockConstruction(CreateFunctionAnalyzer.class,
+                        withSettings().defaultAnswer(CALLS_REAL_METHODS),
+                        (mock, context) -> {
+                            doReturn("0xff").when(mock).computeMd5(any());
+                        });
+                MockedConstruction<UDFInternalClassLoader> mockedLoaderConstruction =
+                        mockConstruction(UDFInternalClassLoader.class,
+                                (mock, context) -> {
+                                    when(mock.loadClass(anyString())).thenAnswer(invocation -> {
+                                        String name = invocation.getArgument(0);
+                                        if (name.contains("$")) {
+                                            return EmptyAggMapEval.State.class;
+                                        }
+                                        return EmptyAggMapEval.class;
+                                    });
+                                })) {
+
+            try {
+                Config.enable_udf = true;
+                CreateFunctionStmt stmt = createMapStmt("symbol", "AGGREGATE");
+                new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+                Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
+            } finally {
+                Config.enable_udf = false;
+            }
         }
     }
 
     @Test
     public void testJUDAFList() {
-        try {
-            Config.enable_udf = true;
-            new MockUp<CreateFunctionAnalyzer>() {
-                @Mock
-                public String computeMd5(CreateFunctionStmt stmt) {
-                    return "0xff";
-                }
-            };
-            new MockUp<UDFInternalClassLoader>() {
-                @Mock
-                public final Class<?> loadClass(String name, boolean resolve)
-                        throws ClassNotFoundException {
-                    if (name.contains("$")) {
-                        return EmptyAggListEval.State.class;
-                    }
-                    return EmptyAggListEval.class;
-                }
-            };
-            CreateFunctionStmt stmt = createListStmt("symbol", "AGGREGATE");
-            new CreateFunctionAnalyzer().analyze(stmt, connectContext);
-            Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
-        } finally {
-            Config.enable_udf = false;
+        try (MockedConstruction<CreateFunctionAnalyzer> mockedAnalyzerConstruction =
+                mockConstruction(CreateFunctionAnalyzer.class,
+                        withSettings().defaultAnswer(CALLS_REAL_METHODS),
+                        (mock, context) -> {
+                            doReturn("0xff").when(mock).computeMd5(any());
+                        });
+                MockedConstruction<UDFInternalClassLoader> mockedLoaderConstruction =
+                        mockConstruction(UDFInternalClassLoader.class,
+                                (mock, context) -> {
+                                    when(mock.loadClass(anyString())).thenAnswer(invocation -> {
+                                        String name = invocation.getArgument(0);
+                                        if (name.contains("$")) {
+                                            return EmptyAggListEval.State.class;
+                                        }
+                                        return EmptyAggListEval.class;
+                                    });
+                                })) {
+
+            try {
+                Config.enable_udf = true;
+                CreateFunctionStmt stmt = createListStmt("symbol", "AGGREGATE");
+                new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+                Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
+            } finally {
+                Config.enable_udf = false;
+            }
         }
     }
 
@@ -426,26 +452,27 @@ public class CreateFunctionStmtAnalyzerTest {
 
     @Test
     public void testJUDTF() {
-        try {
-            Config.enable_udf = true;
-            new MockUp<CreateFunctionAnalyzer>() {
-                @Mock
-                public String computeMd5(CreateFunctionStmt stmt) {
-                    return "0xff";
-                }
-            };
-            new MockUp<UDFInternalClassLoader>() {
-                @Mock
-                public final Class<?> loadClass(String name, boolean resolve)
-                        throws ClassNotFoundException {
-                    return JUDTF.class;
-                }
-            };
-            CreateFunctionStmt stmt = createStmt("symbol", "TABLE");
-            new CreateFunctionAnalyzer().analyze(stmt, connectContext);
-            Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
-        } finally {
-            Config.enable_udf = false;
+        try (MockedConstruction<CreateFunctionAnalyzer> mockedAnalyzerConstruction =
+                mockConstruction(CreateFunctionAnalyzer.class,
+                        withSettings().defaultAnswer(CALLS_REAL_METHODS),
+                        (mock, context) -> {
+                            doReturn("0xff").when(mock).computeMd5(any());
+                        });
+                MockedConstruction<UDFInternalClassLoader> mockedLoaderConstruction =
+                        mockConstruction(UDFInternalClassLoader.class,
+                                (mock, context) -> {
+                                    when(mock.loadClass(anyString()))
+                                            .thenReturn((Class) JUDTF.class);
+                                })) {
+
+            try {
+                Config.enable_udf = true;
+                CreateFunctionStmt stmt = createStmt("symbol", "TABLE");
+                new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+                Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
+            } finally {
+                Config.enable_udf = false;
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
@@ -28,25 +28,22 @@ import com.starrocks.persist.UpdateHistoricalNodeLog;
 import com.starrocks.persist.WALApplier;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
+import com.starrocks.server.NodeMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.analyzer.AlterSystemStmtAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.ModifyBackendClause;
+import com.starrocks.system.HistoricalNodeMgr;
 import com.starrocks.warehouse.cngroup.CRAcquireContext;
-import com.starrocks.warehouse.cngroup.ComputeResource;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import java.lang.reflect.Field;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -55,16 +52,21 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 public class SystemInfoServiceTest {
 
     SystemInfoService service;
 
-    @Mocked
     GlobalStateMgr globalStateMgr;
 
-    @Mocked
     EditLog editLog;
+
+    InetAddress addr;
 
     @BeforeEach
     public void setUp() throws NoSuchFieldException,
@@ -72,59 +74,44 @@ public class SystemInfoServiceTest {
             IllegalArgumentException,
             IllegalAccessException {
         service = new SystemInfoService();
+        globalStateMgr = mock(GlobalStateMgr.class);
+        editLog = mock(EditLog.class);
+        addr = mock(InetAddress.class);
         Field field = FrontendOptions.class.getDeclaredField("useFqdn");
         field.setAccessible(true);
         field.set(null, true);
     }
 
-    private void mockFunc() {
-        new MockUp<GlobalStateMgr>() {
-            @Mock
-            public GlobalStateMgr getCurrentState() {
-                return globalStateMgr;
-            }
-        };
-        new Expectations() {
-            {
-                globalStateMgr.getEditLog();
-                result = editLog;
-            }
-        };
-        new MockUp<EditLog>() {
-            @Mock
-            public void logBackendStateChange(UpdateBackendInfo info, WALApplier walApplier) {
-                walApplier.apply(info);
-            }
-
-            @Mock
-            public void logDropBackend(DropBackendInfo info, WALApplier applier) {
-                applier.apply(info);
-            }
-        };
-    }
-
     @Test
     public void testUpdateBackendHostWithOneBe() throws Exception {
-        mockFunc();
-        Backend be = new Backend(100, "127.0.0.1", 1000);
-        service.addBackend(be);
-        ModifyBackendClause clause = new ModifyBackendClause("127.0.0.1", "sandbox");
-        service.modifyBackendHost(clause);
-        Backend backend = service.getBackendWithHeartbeatPort("sandbox", 1000);
-        Assertions.assertNotNull(backend);
+        try (MockedStatic<GlobalStateMgr> mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class)) {
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            when(globalStateMgr.getEditLog()).thenReturn(editLog);
+
+            Backend be = new Backend(100, "127.0.0.1", 1000);
+            service.addBackend(be);
+            ModifyBackendClause clause = new ModifyBackendClause("127.0.0.1", "sandbox");
+            service.modifyBackendHost(clause);
+            Backend backend = service.getBackendWithHeartbeatPort("sandbox", 1000);
+            Assertions.assertNotNull(backend);
+        }
     }
 
     @Test
     public void testUpdateBackendHostWithMoreBe() throws Exception {
-        mockFunc();
-        Backend be1 = new Backend(100, "127.0.0.1", 1000);
-        Backend be2 = new Backend(101, "127.0.0.1", 1001);
-        service.addBackend(be1);
-        service.addBackend(be2);
-        ModifyBackendClause clause = new ModifyBackendClause("127.0.0.1", "sandbox");
-        service.modifyBackendHost(clause);
-        Backend backend = service.getBackendWithHeartbeatPort("sandbox", 1000);
-        Assertions.assertNotNull(backend);
+        try (MockedStatic<GlobalStateMgr> mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class)) {
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            when(globalStateMgr.getEditLog()).thenReturn(editLog);
+
+            Backend be1 = new Backend(100, "127.0.0.1", 1000);
+            Backend be2 = new Backend(101, "127.0.0.1", 1001);
+            service.addBackend(be1);
+            service.addBackend(be2);
+            ModifyBackendClause clause = new ModifyBackendClause("127.0.0.1", "sandbox");
+            service.modifyBackendHost(clause);
+            Backend backend = service.getBackendWithHeartbeatPort("sandbox", 1000);
+            Assertions.assertNotNull(backend);
+        }
     }
 
     @Test
@@ -143,154 +130,126 @@ public class SystemInfoServiceTest {
      */
     @Test
     public void testModifyBackendProperty() throws DdlException {
-        Backend be = new Backend(100, "originalHost", 1000);
-        service.addBackend(be);
-        Map<String, String> properties = Maps.newHashMap();
-        String location = "rack:rack1";
-        properties.put(AlterSystemStmtAnalyzer.PROP_KEY_LOCATION, location);
-        ModifyBackendClause clause = new ModifyBackendClause("originalHost:1000", properties);
-        new MockUp<EditLog>() {
-            @Mock
-            public void logBackendStateChange(UpdateBackendInfo info, WALApplier walApplier) {
-                walApplier.apply(info);
-            }
-        };
-        service.modifyBackendProperty(clause);
-        Backend backend = service.getBackendWithHeartbeatPort("originalHost", 1000);
-        Assertions.assertNotNull(backend);
-        Assertions.assertEquals("{rack=rack1}", backend.getLocation().toString());
+        try (MockedStatic<GlobalStateMgr> mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class)) {
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            when(globalStateMgr.getEditLog()).thenReturn(editLog);
+
+            Backend be = new Backend(100, "originalHost", 1000);
+            service.addBackend(be);
+            Map<String, String> properties = Maps.newHashMap();
+            String location = "rack:rack1";
+            properties.put(AlterSystemStmtAnalyzer.PROP_KEY_LOCATION, location);
+            ModifyBackendClause clause = new ModifyBackendClause("originalHost:1000", properties);
+            service.modifyBackendProperty(clause);
+            Backend backend = service.getBackendWithHeartbeatPort("originalHost", 1000);
+            Assertions.assertNotNull(backend);
+            Assertions.assertEquals("{rack=rack1}", backend.getLocation().toString());
+        }
     }
 
     @Test
     public void testGetBackendOrComputeNode() {
-        mockNet();
+        try (MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class)) {
+            mockedInetAddress.when(() -> InetAddress.getByName(anyString())).thenReturn(addr);
+            when(addr.getHostAddress()).thenReturn("127.0.0.1");
 
-        Backend be = new Backend(10001, "host1", 1000);
-        service.addBackend(be);
-        ComputeNode cn = new ComputeNode(10002, "host2", 1000);
-        cn.setBePort(1001);
-        service.addComputeNode(cn);
+            Backend be = new Backend(10001, "host1", 1000);
+            service.addBackend(be);
+            ComputeNode cn = new ComputeNode(10002, "host2", 1000);
+            cn.setBePort(1001);
+            service.addComputeNode(cn);
 
-        Assertions.assertEquals(be, service.getBackendOrComputeNode(be.getId()));
-        Assertions.assertEquals(cn, service.getBackendOrComputeNode(cn.getId()));
-        Assertions.assertNull(service.getBackendOrComputeNode(/* Not Exist */ 100));
+            Assertions.assertEquals(be, service.getBackendOrComputeNode(be.getId()));
+            Assertions.assertEquals(cn, service.getBackendOrComputeNode(cn.getId()));
+            Assertions.assertNull(service.getBackendOrComputeNode(/* Not Exist */ 100));
 
-        Assertions.assertEquals(cn, service.getBackendOrComputeNodeWithBePort("host2", 1001));
-        Assertions.assertFalse(service.checkNodeAvailable(cn));
-        Assertions.assertFalse(service.checkNodeAvailable(be));
+            Assertions.assertEquals(cn, service.getBackendOrComputeNodeWithBePort("host2", 1001));
+            Assertions.assertFalse(service.checkNodeAvailable(cn));
+            Assertions.assertFalse(service.checkNodeAvailable(be));
 
-        List<ComputeNode> nodes = service.backendAndComputeNodeStream().collect(Collectors.toList());
-        Assertions.assertEquals(2, nodes.size());
-        Assertions.assertEquals(be, nodes.get(0));
-        Assertions.assertEquals(cn, nodes.get(1));
+            List<ComputeNode> nodes = service.backendAndComputeNodeStream().collect(Collectors.toList());
+            Assertions.assertEquals(2, nodes.size());
+            Assertions.assertEquals(be, nodes.get(0));
+            Assertions.assertEquals(cn, nodes.get(1));
+        }
     }
 
     @Test
     public void testDropBackend() throws Exception {
-        new MockUp<RunMode>() {
-            @Mock
-            public RunMode getCurrentRunMode() {
-                return RunMode.SHARED_DATA;
-            }
-        };
+        try (MockedStatic<RunMode> mockedRunMode = mockStatic(RunMode.class);
+                MockedStatic<GlobalStateMgr> mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class)) {
 
-        Boolean savedConfig = Config.enable_trace_historical_node;
-        Config.enable_trace_historical_node = true;
+            mockedRunMode.when(RunMode::getCurrentRunMode).thenReturn(RunMode.SHARED_DATA);
 
-        Backend be = new Backend(10001, "newHost", 1000);
-        service.addBackend(be);
+            Boolean savedConfig = Config.enable_trace_historical_node;
+            Config.enable_trace_historical_node = true;
 
-        LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
+            Backend be = new Backend(10001, "newHost", 1000);
+            service.addBackend(be);
 
-        WarehouseManager warehouseManager = new WarehouseManager();
-        warehouseManager.initDefaultWarehouse();
+            LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
 
-        new Expectations() {
-            {
-                globalStateMgr.getLocalMetastore();
-                minTimes = 0;
-                result = localMetastore;
+            WarehouseManager warehouseManager = new WarehouseManager();
+            warehouseManager.initDefaultWarehouse();
 
-                globalStateMgr.getWarehouseMgr();
-                minTimes = 0;
-                result = warehouseManager;
-            }
-        };
+            HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
 
-        new MockUp<WarehouseManager>() {
-            @Mock
-            public ComputeResource acquireComputeResource(CRAcquireContext acquireContext) {
-                return WarehouseManager.DEFAULT_RESOURCE;
-            }
-        };
-        new MockUp<EditLog>() {
-            @Mock
-            public void logDropBackend(DropBackendInfo info, WALApplier applier) {
-                applier.apply(info);
-            }
-        };
-        service.addBackend(be);
-        be.setStarletPort(1001);
-        service.dropBackend("newHost", 1000, WarehouseManager.DEFAULT_WAREHOUSE_NAME, "", false);
-        Backend beIP = service.getBackendWithHeartbeatPort("newHost", 1000);
-        Assertions.assertNull(beIP);
+            NodeMgr nodeMgr = mock(NodeMgr.class);
+            when(nodeMgr.getClusterInfo()).thenReturn(service);
 
-        Config.enable_trace_historical_node = savedConfig;
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            when(globalStateMgr.getLocalMetastore()).thenReturn(localMetastore);
+            when(globalStateMgr.getWarehouseMgr()).thenReturn(warehouseManager);
+            when(globalStateMgr.getHistoricalNodeMgr()).thenReturn(historicalNodeMgr);
+            when(globalStateMgr.getEditLog()).thenReturn(editLog);
+            when(globalStateMgr.getNodeMgr()).thenReturn(nodeMgr);
+
+            service.addBackend(be);
+            be.setStarletPort(1001);
+            service.dropBackend("newHost", 1000, WarehouseManager.DEFAULT_WAREHOUSE_NAME, "", false);
+            Backend beIP = service.getBackendWithHeartbeatPort("newHost", 1000);
+            Assertions.assertTrue(beIP == null);
+
+            Config.enable_trace_historical_node = savedConfig;
+        }
     }
 
     @Test
     public void testDropComputeNode() throws Exception {
-        new MockUp<RunMode>() {
-            @Mock
-            public RunMode getCurrentRunMode() {
-                return RunMode.SHARED_DATA;
-            }
-        };
+        try (MockedStatic<RunMode> mockedRunMode = mockStatic(RunMode.class);
+                MockedStatic<GlobalStateMgr> mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class)) {
 
-        Boolean savedConfig = Config.enable_trace_historical_node;
-        Config.enable_trace_historical_node = true;
+            mockedRunMode.when(RunMode::getCurrentRunMode).thenReturn(RunMode.SHARED_DATA);
 
-        ComputeNode cn = new ComputeNode(10001, "newHost", 1000);
-        service.addComputeNode(cn);
+            Boolean savedConfig = Config.enable_trace_historical_node;
+            Config.enable_trace_historical_node = true;
 
-        LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
+            ComputeNode cn = new ComputeNode(10001, "newHost", 1000);
+            service.addComputeNode(cn);
 
-        WarehouseManager warehouseManager = new WarehouseManager();
-        warehouseManager.initDefaultWarehouse();
+            LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
 
-        new Expectations() {
-            {
-                globalStateMgr.getLocalMetastore();
-                minTimes = 0;
-                result = localMetastore;
+            WarehouseManager warehouseManager = new WarehouseManager();
+            warehouseManager.initDefaultWarehouse();
 
-                globalStateMgr.getWarehouseMgr();
-                minTimes = 0;
-                result = warehouseManager;
-            }
-        };
+            HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
 
-        new MockUp<WarehouseManager>() {
-            @Mock
-            public ComputeResource acquireComputeResource(CRAcquireContext acquireContext) {
-                return WarehouseManager.DEFAULT_RESOURCE;
-            }
-        };
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            when(globalStateMgr.getLocalMetastore()).thenReturn(localMetastore);
+            when(globalStateMgr.getWarehouseMgr()).thenReturn(warehouseManager);
+            when(globalStateMgr.getHistoricalNodeMgr()).thenReturn(historicalNodeMgr);
+            when(globalStateMgr.getEditLog()).thenReturn(editLog);
 
-        new MockUp<EditLog>() {
-            @Mock
-            public void logDropComputeNode(DropComputeNodeLog log, WALApplier applier) {
-                applier.apply(log);
-            }
-        };
-        service.addComputeNode(cn);
-        cn.setStarletPort(1001);
-        service.dropComputeNode("newHost", 1000, WarehouseManager.DEFAULT_WAREHOUSE_NAME, "");
-        ComputeNode cnIP = service.getComputeNodeWithHeartbeatPort("newHost", 1000);
-        Assertions.assertTrue(cnIP == null);
+            service.addComputeNode(cn);
+            cn.setStarletPort(1001);
+            service.dropComputeNode("newHost", 1000, WarehouseManager.DEFAULT_WAREHOUSE_NAME, "");
+            ComputeNode cnIP = service.getComputeNodeWithHeartbeatPort("newHost", 1000);
+            Assertions.assertTrue(cnIP == null);
 
-        Config.enable_trace_historical_node = savedConfig;
+            Config.enable_trace_historical_node = savedConfig;
+        }
     }
+
     @Test
     public void testDropComputeNode2() throws Exception {
         new MockUp<RunMode>() {
@@ -326,7 +285,7 @@ public class SystemInfoServiceTest {
 
         {
             Assertions.assertThrows(DdlException.class, () ->
-                    service.dropComputeNode("newHost", 1000, "warehousename-cn-not-exists", ""),
+                            service.dropComputeNode("newHost", 1000, "warehousename-cn-not-exists", ""),
                     ErrorCode.ERR_UNKNOWN_WAREHOUSE.formatErrorMsg("name: warehousename-cn-not-exists"));
         }
 
@@ -334,365 +293,273 @@ public class SystemInfoServiceTest {
         ComputeNode cnIP = service.getComputeNodeWithHeartbeatPort("newHost", 1000);
         Assertions.assertNull(cnIP);
 
-
         Config.enable_trace_historical_node = savedConfig;
     }
 
     @Test
     public void testDropBackendWithoutWarehouse() throws Exception {
-        new MockUp<RunMode>() {
-            @Mock
-            public RunMode getCurrentRunMode() {
-                return RunMode.SHARED_DATA;
+        try (MockedStatic<RunMode> mockedRunMode = mockStatic(RunMode.class);
+                MockedStatic<GlobalStateMgr> mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class)) {
+
+            mockedRunMode.when(RunMode::getCurrentRunMode).thenReturn(RunMode.SHARED_DATA);
+
+            Boolean savedConfig = Config.enable_trace_historical_node;
+            Config.enable_trace_historical_node = true;
+
+            Backend be = new Backend(10001, "newHost", 1000);
+            service.addBackend(be);
+
+            LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
+
+            WarehouseManager warehouseManager = new WarehouseManager();
+            warehouseManager.initDefaultWarehouse();
+
+            HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
+
+            NodeMgr nodeMgr = mock(NodeMgr.class);
+            when(nodeMgr.getClusterInfo()).thenReturn(service);
+
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            when(globalStateMgr.getLocalMetastore()).thenReturn(localMetastore);
+            when(globalStateMgr.getHistoricalNodeMgr()).thenReturn(historicalNodeMgr);
+            when(globalStateMgr.getEditLog()).thenReturn(editLog);
+            when(globalStateMgr.getNodeMgr()).thenReturn(nodeMgr);
+
+            WarehouseManager spyWarehouseManager = mock(WarehouseManager.class);
+            when(spyWarehouseManager.acquireComputeResource(any(CRAcquireContext.class)))
+                    .thenReturn(WarehouseManager.DEFAULT_RESOURCE);
+            when(globalStateMgr.getWarehouseMgr()).thenReturn(spyWarehouseManager);
+
+            service.addBackend(be);
+            be.setStarletPort(1001);
+
+            {
+                Assertions.assertThrows(DdlException.class, () ->
+                                service.dropBackend("newHost", 1000, "warehousename-cn-not-exists",
+                                        "", false),
+                        ErrorCode.ERR_UNKNOWN_WAREHOUSE.formatErrorMsg("name: warehousename-cn-not-exists"));
             }
-        };
 
-        Boolean savedConfig = Config.enable_trace_historical_node;
-        Config.enable_trace_historical_node = true;
+            service.dropBackend("newHost", 1000, null, null, false);
+            Backend beIP = service.getBackendWithHeartbeatPort("newHost", 1000);
+            Assertions.assertNull(beIP);
 
-        Backend be = new Backend(10001, "newHost", 1000);
-        service.addBackend(be);
-
-        LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
-
-        WarehouseManager warehouseManager = new WarehouseManager();
-        warehouseManager.initDefaultWarehouse();
-
-        new MockUp<GlobalStateMgr>() {
-            @Mock
-            public LocalMetastore getLocalMetastore() {
-                return localMetastore;
-            }
-
-            @Mock
-            public WarehouseManager getWarehouseMgr() {
-                return warehouseManager;
-            }
-        };
-
-        new MockUp<WarehouseManager>() {
-            @Mock
-            public ComputeResource acquireComputeResource(CRAcquireContext acquireContext) {
-                return WarehouseManager.DEFAULT_RESOURCE;
-            }
-        };
-        new MockUp<EditLog>() {
-            @Mock
-            public void logDropBackend(DropBackendInfo info, WALApplier applier) {
-                applier.apply(info);
-            }
-        };
-        service.addBackend(be);
-        be.setStarletPort(1001);
-
-        {
-            Assertions.assertThrows(DdlException.class, () ->
-                            service.dropBackend("newHost", 1000, "warehousename-cn-not-exists",
-                                    "", false),
-                    ErrorCode.ERR_UNKNOWN_WAREHOUSE.formatErrorMsg("name: warehousename-cn-not-exists"));
+            Config.enable_trace_historical_node = savedConfig;
         }
-
-        service.dropBackend("newHost", 1000, null, null, false);
-        Backend beIP = service.getBackendWithHeartbeatPort("newHost", 1000);
-        Assertions.assertNull(beIP);
-
-        Config.enable_trace_historical_node = savedConfig;
     }
 
     @Test
     public void testDropComputeNodeWithoutWarehouse() throws Exception {
-        new MockUp<RunMode>() {
-            @Mock
-            public RunMode getCurrentRunMode() {
-                return RunMode.SHARED_DATA;
-            }
-        };
+        try (MockedStatic<RunMode> mockedRunMode = mockStatic(RunMode.class);
+                MockedStatic<GlobalStateMgr> mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class)) {
 
-        Boolean savedConfig = Config.enable_trace_historical_node;
-        Config.enable_trace_historical_node = true;
+            mockedRunMode.when(RunMode::getCurrentRunMode).thenReturn(RunMode.SHARED_DATA);
 
-        ComputeNode cn = new ComputeNode(10001, "newHost", 1000);
-        service.addComputeNode(cn);
+            Boolean savedConfig = Config.enable_trace_historical_node;
+            Config.enable_trace_historical_node = true;
 
-        LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
+            ComputeNode cn = new ComputeNode(10001, "newHost", 1000);
+            service.addComputeNode(cn);
 
-        WarehouseManager warehouseManager = new WarehouseManager();
-        warehouseManager.initDefaultWarehouse();
+            LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
 
-        new MockUp<GlobalStateMgr>() {
-            @Mock
-            public LocalMetastore getLocalMetastore() {
-                return localMetastore;
-            }
+            WarehouseManager warehouseManager = new WarehouseManager();
+            warehouseManager.initDefaultWarehouse();
 
-            @Mock
-            public WarehouseManager getWarehouseMgr() {
-                return warehouseManager;
-            }
-        };
+            HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
 
-        new MockUp<WarehouseManager>() {
-            @Mock
-            public ComputeResource acquireComputeResource(CRAcquireContext acquireContext) {
-                return WarehouseManager.DEFAULT_RESOURCE;
-            }
-        };
-        new MockUp<EditLog>() {
-            @Mock
-            public void logDropComputeNode(DropComputeNodeLog log, WALApplier applier) {
-                applier.apply(log);
-            }
-        };
-        service.addComputeNode(cn);
-        cn.setStarletPort(1001);
-        service.dropComputeNode("newHost", 1000, null, null);
-        ComputeNode cnIP = service.getComputeNodeWithHeartbeatPort("newHost", 1000);
-        Assertions.assertNull(cnIP);
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            when(globalStateMgr.getLocalMetastore()).thenReturn(localMetastore);
+            when(globalStateMgr.getHistoricalNodeMgr()).thenReturn(historicalNodeMgr);
+            when(globalStateMgr.getEditLog()).thenReturn(editLog);
 
-        Config.enable_trace_historical_node = savedConfig;
+            WarehouseManager spyWarehouseManager = mock(WarehouseManager.class);
+            when(spyWarehouseManager.acquireComputeResource(any(CRAcquireContext.class)))
+                    .thenReturn(WarehouseManager.DEFAULT_RESOURCE);
+            when(globalStateMgr.getWarehouseMgr()).thenReturn(spyWarehouseManager);
+
+            service.addComputeNode(cn);
+            cn.setStarletPort(1001);
+            service.dropComputeNode("newHost", 1000, null, null);
+            ComputeNode cnIP = service.getComputeNodeWithHeartbeatPort("newHost", 1000);
+            Assertions.assertNull(cnIP);
+
+            Config.enable_trace_historical_node = savedConfig;
+        }
     }
 
     @Test
     public void testDropBackendWithInvalidWarehouse() throws Exception {
-        new MockUp<RunMode>() {
-            @Mock
-            public RunMode getCurrentRunMode() {
-                return RunMode.SHARED_DATA;
-            }
-        };
+        try (MockedStatic<RunMode> mockedRunMode = mockStatic(RunMode.class);
+                MockedStatic<GlobalStateMgr> mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class)) {
 
-        Boolean savedConfig = Config.enable_trace_historical_node;
-        Config.enable_trace_historical_node = true;
+            mockedRunMode.when(RunMode::getCurrentRunMode).thenReturn(RunMode.SHARED_DATA);
 
-        Backend be = new Backend(10001, "newHost", 1000);
-        service.addBackend(be);
+            Boolean savedConfig = Config.enable_trace_historical_node;
+            Config.enable_trace_historical_node = true;
 
-        LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
+            Backend be = new Backend(10001, "newHost", 1000);
+            service.addBackend(be);
 
-        WarehouseManager warehouseManager = new WarehouseManager();
-        warehouseManager.initDefaultWarehouse();
+            LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
 
-        new MockUp<GlobalStateMgr>() {
-            @Mock
-            public LocalMetastore getLocalMetastore() {
-                return localMetastore;
-            }
+            WarehouseManager warehouseManager = new WarehouseManager();
+            warehouseManager.initDefaultWarehouse();
 
-            @Mock
-            public WarehouseManager getWarehouseMgr() {
-                return warehouseManager;
-            }
-        };
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            when(globalStateMgr.getLocalMetastore()).thenReturn(localMetastore);
 
-        new MockUp<WarehouseManager>() {
-            @Mock
-            public ComputeResource acquireComputeResource(CRAcquireContext acquireContext) {
-                return WarehouseManager.DEFAULT_RESOURCE;
-            }
-        };
-        service.addBackend(be);
-        be.setStarletPort(1001);
-        Assertions.assertThrows(DdlException.class,
-                () -> service.dropBackend("newHost", 1000, "not_existed_warehouse", null, false));
+            WarehouseManager spyWarehouseManager = mock(WarehouseManager.class);
+            when(spyWarehouseManager.acquireComputeResource(any(CRAcquireContext.class)))
+                    .thenReturn(WarehouseManager.DEFAULT_RESOURCE);
+            when(globalStateMgr.getWarehouseMgr()).thenReturn(spyWarehouseManager);
 
-        Config.enable_trace_historical_node = savedConfig;
+            service.addBackend(be);
+            be.setStarletPort(1001);
+            Assertions.assertThrows(DdlException.class,
+                    () -> service.dropBackend("newHost", 1000, "not_existed_warehouse", null, false));
+
+            Config.enable_trace_historical_node = savedConfig;
+        }
     }
 
     @Test
     public void testDropComputeNodeWithInvalidWarehouse() throws Exception {
-        new MockUp<RunMode>() {
-            @Mock
-            public RunMode getCurrentRunMode() {
-                return RunMode.SHARED_DATA;
-            }
-        };
+        try (MockedStatic<RunMode> mockedRunMode = mockStatic(RunMode.class);
+                MockedStatic<GlobalStateMgr> mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class)) {
 
-        Boolean savedConfig = Config.enable_trace_historical_node;
-        Config.enable_trace_historical_node = true;
+            mockedRunMode.when(RunMode::getCurrentRunMode).thenReturn(RunMode.SHARED_DATA);
 
-        ComputeNode cn = new ComputeNode(10001, "newHost", 1000);
-        service.addComputeNode(cn);
+            Boolean savedConfig = Config.enable_trace_historical_node;
+            Config.enable_trace_historical_node = true;
 
-        LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
+            ComputeNode cn = new ComputeNode(10001, "newHost", 1000);
+            service.addComputeNode(cn);
 
-        WarehouseManager warehouseManager = new WarehouseManager();
-        warehouseManager.initDefaultWarehouse();
+            LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
 
-        new MockUp<GlobalStateMgr>() {
-            @Mock
-            public LocalMetastore getLocalMetastore() {
-                return localMetastore;
-            }
+            WarehouseManager warehouseManager = new WarehouseManager();
+            warehouseManager.initDefaultWarehouse();
 
-            @Mock
-            public WarehouseManager getWarehouseMgr() {
-                return warehouseManager;
-            }
-        };
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            when(globalStateMgr.getLocalMetastore()).thenReturn(localMetastore);
 
-        new MockUp<WarehouseManager>() {
-            @Mock
-            public ComputeResource acquireComputeResource(CRAcquireContext acquireContext) {
-                return WarehouseManager.DEFAULT_RESOURCE;
-            }
-        };
-        service.addComputeNode(cn);
-        cn.setStarletPort(1001);
-        Assertions.assertThrows(DdlException.class,
-                () -> service.dropComputeNode("newHost", 1000, "not_existed_warehouse", null));
+            WarehouseManager spyWarehouseManager = mock(WarehouseManager.class);
+            when(spyWarehouseManager.acquireComputeResource(any(CRAcquireContext.class)))
+                    .thenReturn(WarehouseManager.DEFAULT_RESOURCE);
+            when(globalStateMgr.getWarehouseMgr()).thenReturn(spyWarehouseManager);
 
-        Config.enable_trace_historical_node = savedConfig;
+            service.addComputeNode(cn);
+            cn.setStarletPort(1001);
+            Assertions.assertThrows(DdlException.class,
+                    () -> service.dropComputeNode("newHost", 1000, "not_existed_warehouse", null));
+
+            Config.enable_trace_historical_node = savedConfig;
+        }
     }
 
     @Test
     public void testReplayUpdateHistoricalNode() throws Exception {
-        new MockUp<RunMode>() {
-            @Mock
-            public RunMode getCurrentRunMode() {
-                return RunMode.SHARED_DATA;
-            }
-        };
+        try (MockedStatic<RunMode> mockedRunMode = mockStatic(RunMode.class);
+                MockedStatic<GlobalStateMgr> mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class)) {
 
-        HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
+            mockedRunMode.when(RunMode::getCurrentRunMode).thenReturn(RunMode.SHARED_DATA);
 
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                result = globalStateMgr;
+            HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
 
-                globalStateMgr.getHistoricalNodeMgr();
-                result = historicalNodeMgr;
-            }
-        };
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            when(globalStateMgr.getHistoricalNodeMgr()).thenReturn(historicalNodeMgr);
 
-        List<Long> backendIds = Arrays.asList(101L, 102L);
-        List<Long> computeNodeIds = Arrays.asList(201L, 202L, 203L);
-        long updateTime = System.currentTimeMillis();
-        long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
-        long workerGroupId = StarOSAgent.DEFAULT_WORKER_GROUP_ID;
-        UpdateHistoricalNodeLog log = new UpdateHistoricalNodeLog(warehouseId, workerGroupId, updateTime, backendIds,
-                computeNodeIds);
+            List<Long> backendIds = Arrays.asList(101L, 102L);
+            List<Long> computeNodeIds = Arrays.asList(201L, 202L, 203L);
+            long updateTime = System.currentTimeMillis();
+            long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
+            long workerGroupId = StarOSAgent.DEFAULT_WORKER_GROUP_ID;
+            UpdateHistoricalNodeLog log = new UpdateHistoricalNodeLog(warehouseId, workerGroupId, updateTime, backendIds,
+                    computeNodeIds);
 
-        service.replayUpdateHistoricalNode(log);
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(warehouseId, workerGroupId).size(), 2);
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouseId, workerGroupId).size(), 3);
+            service.replayUpdateHistoricalNode(log);
+            Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(warehouseId, workerGroupId).size(), 2);
+            Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouseId, workerGroupId).size(), 3);
+        }
     }
 
     @Test
     public void testReplayOldFormatOfUpdateHistoricalNode() throws Exception {
-        new MockUp<RunMode>() {
-            @Mock
-            public RunMode getCurrentRunMode() {
-                return RunMode.SHARED_DATA;
-            }
-        };
+        try (MockedStatic<RunMode> mockedRunMode = mockStatic(RunMode.class);
+                MockedStatic<GlobalStateMgr> mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class)) {
 
-        new MockUp<UpdateHistoricalNodeLog>() {
-            @Mock
-            public String getWarehouse() {
-                return WarehouseManager.DEFAULT_WAREHOUSE_NAME;
-            }
-        };
+            mockedRunMode.when(RunMode::getCurrentRunMode).thenReturn(RunMode.SHARED_DATA);
 
-        HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                result = globalStateMgr;
+            HistoricalNodeMgr historicalNodeMgr = new HistoricalNodeMgr();
 
-                globalStateMgr.getHistoricalNodeMgr();
-                result = historicalNodeMgr;
-            }
-        };
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            when(globalStateMgr.getHistoricalNodeMgr()).thenReturn(historicalNodeMgr);
 
-        List<Long> backendIds = Arrays.asList(101L, 102L);
-        List<Long> computeNodeIds = Arrays.asList(201L, 202L, 203L);
-        long updateTime = System.currentTimeMillis();
-        long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
-        long workerGroupId = StarOSAgent.DEFAULT_WORKER_GROUP_ID;
-        UpdateHistoricalNodeLog log = new UpdateHistoricalNodeLog(warehouseId, workerGroupId, updateTime, backendIds,
-                computeNodeIds);
+            List<Long> backendIds = Arrays.asList(101L, 102L);
+            List<Long> computeNodeIds = Arrays.asList(201L, 202L, 203L);
+            long updateTime = System.currentTimeMillis();
+            long warehouseId = WarehouseManager.DEFAULT_WAREHOUSE_ID;
+            long workerGroupId = StarOSAgent.DEFAULT_WORKER_GROUP_ID;
+            UpdateHistoricalNodeLog log = new UpdateHistoricalNodeLog(warehouseId, workerGroupId, updateTime, backendIds,
+                    computeNodeIds);
 
-        service.replayUpdateHistoricalNode(log);
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(warehouseId, workerGroupId).size(), 2);
-        Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouseId, workerGroupId).size(), 3);
+            service.replayUpdateHistoricalNode(log);
+            Assertions.assertEquals(historicalNodeMgr.getHistoricalBackendIds(warehouseId, workerGroupId).size(), 2);
+            Assertions.assertEquals(historicalNodeMgr.getHistoricalComputeNodeIds(warehouseId, workerGroupId).size(), 3);
+        }
     }
 
     @Test
     public void testReplayDropBackend() throws Exception {
-        new MockUp<RunMode>() {
-            @Mock
-            public RunMode getCurrentRunMode() {
-                return RunMode.SHARED_DATA;
-            }
-        };
+        try (MockedStatic<RunMode> mockedRunMode = mockStatic(RunMode.class);
+                MockedStatic<GlobalStateMgr> mockedGlobalStateMgr = mockStatic(GlobalStateMgr.class)) {
 
-        Backend be = new Backend(10001, "newHost", 1000);
-        be.setStarletPort(1001);
+            mockedRunMode.when(RunMode::getCurrentRunMode).thenReturn(RunMode.SHARED_DATA);
 
-        LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
-        new Expectations() {
-            {
-                service.getBackendWithHeartbeatPort("newHost", 1000);
-                minTimes = 0;
-                result = be;
+            Backend be = new Backend(10001, "newHost", 1000);
+            be.setStarletPort(1001);
 
-                globalStateMgr.getLocalMetastore();
-                minTimes = 0;
-                result = localMetastore;
-            }
-        };
+            LocalMetastore localMetastore = new LocalMetastore(globalStateMgr, null, null);
 
-        service.addBackend(be);
-        service.replayDropBackend(new DropBackendInfo(be.getId()));
-        Backend beIP = service.getBackendWithHeartbeatPort("newHost", 1000);
-        Assertions.assertTrue(beIP == null);
-    }
+            mockedGlobalStateMgr.when(GlobalStateMgr::getCurrentState).thenReturn(globalStateMgr);
+            when(globalStateMgr.getLocalMetastore()).thenReturn(localMetastore);
 
-    @Mocked
-    InetAddress addr;
-
-    private void mockNet() {
-        new MockUp<InetAddress>() {
-            @Mock
-            public InetAddress getByName(String host) throws UnknownHostException {
-                return addr;
-            }
-        };
-        new Expectations() {
-            {
-                addr.getHostAddress();
-                result = "127.0.0.1";
-            }
-        };
+            service.addBackend(be);
+            service.replayDropBackend(be);
+            Backend beIP = service.getBackendWithHeartbeatPort("newHost", 1000);
+            Assertions.assertTrue(beIP == null);
+        }
     }
 
     @Test
     public void testGetBackendWithBePort() throws Exception {
+        try (MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class)) {
+            mockedInetAddress.when(() -> InetAddress.getByName(anyString())).thenReturn(addr);
+            when(addr.getHostAddress()).thenReturn("127.0.0.1");
 
-        mockNet();
+            Backend be1 = new Backend(10001, "127.0.0.1", 1000);
+            be1.setBePort(1001);
+            service.addBackend(be1);
+            Backend beIP1 = service.getBackendWithBePort("127.0.0.1", 1001);
 
-        Backend be1 = new Backend(10001, "127.0.0.1", 1000);
-        be1.setBePort(1001);
-        service.addBackend(be1);
-        Backend beIP1 = service.getBackendWithBePort("127.0.0.1", 1001);
+            service.dropAllBackend();
 
-        service.dropAllBackend();
+            Backend be2 = new Backend(10001, "newHost-1", 1000);
+            be2.setBePort(1001);
+            service.addBackend(be2);
+            Backend beFqdn = service.getBackendWithBePort("127.0.0.1", 1001);
 
-        Backend be2 = new Backend(10001, "newHost-1", 1000);
-        be2.setBePort(1001);
-        service.addBackend(be2);
-        Backend beFqdn = service.getBackendWithBePort("127.0.0.1", 1001);
+            Assertions.assertTrue(beFqdn != null && beIP1 != null);
 
-        Assertions.assertTrue(beFqdn != null && beIP1 != null);
+            service.dropAllBackend();
 
-        service.dropAllBackend();
-
-        Backend be3 = new Backend(10001, "127.0.0.1", 1000);
-        be3.setBePort(1001);
-        service.addBackend(be3);
-        Backend beIP3 = service.getBackendWithBePort("127.0.0.2", 1001);
-        Assertions.assertTrue(beIP3 == null);
+            Backend be3 = new Backend(10001, "127.0.0.1", 1000);
+            be3.setBePort(1001);
+            service.addBackend(be3);
+            Backend beIP3 = service.getBackendWithBePort("127.0.0.2", 1001);
+            Assertions.assertTrue(beIP3 == null);
+        }
     }
 
     @Test
@@ -766,45 +633,46 @@ public class SystemInfoServiceTest {
 
     @Test
     public void testGetComputeNodeWithBePort() throws Exception {
-        mockNet();
+        try (MockedStatic<InetAddress> mockedInetAddress = mockStatic(InetAddress.class)) {
+            mockedInetAddress.when(() -> InetAddress.getByName(anyString())).thenReturn(addr);
+            when(addr.getHostAddress()).thenReturn("127.0.0.1");
 
-        ComputeNode be1 = new ComputeNode(10001, "127.0.0.1", 1000);
-        be1.setBePort(1001);
-        service.addComputeNode(be1);
-        ComputeNode beIP1 = service.getComputeNodeWithBePort("127.0.0.1", 1001);
+            ComputeNode be1 = new ComputeNode(10001, "127.0.0.1", 1000);
+            be1.setBePort(1001);
+            service.addComputeNode(be1);
+            ComputeNode beIP1 = service.getComputeNodeWithBePort("127.0.0.1", 1001);
 
-        service.dropAllComputeNode();
+            service.dropAllComputeNode();
 
-        ComputeNode be2 = new ComputeNode(10001, "newHost-1", 1000);
-        be2.setBePort(1001);
-        service.addComputeNode(be2);
-        ComputeNode beFqdn = service.getComputeNodeWithBePort("127.0.0.1", 1001);
+            ComputeNode be2 = new ComputeNode(10001, "newHost-1", 1000);
+            be2.setBePort(1001);
+            service.addComputeNode(be2);
+            ComputeNode beFqdn = service.getComputeNodeWithBePort("127.0.0.1", 1001);
 
-        Assertions.assertTrue(beFqdn != null && beIP1 != null);
+            Assertions.assertTrue(beFqdn != null && beIP1 != null);
 
-        service.dropAllComputeNode();
+            service.dropAllComputeNode();
 
-        ComputeNode be3 = new ComputeNode(10001, "127.0.0.1", 1000);
-        be3.setBePort(1001);
-        service.addComputeNode(be3);
-        ComputeNode beIP3 = service.getComputeNodeWithBePort("127.0.0.2", 1001);
-        Assertions.assertTrue(beIP3 == null);
+            ComputeNode be3 = new ComputeNode(10001, "127.0.0.1", 1000);
+            be3.setBePort(1001);
+            service.addComputeNode(be3);
+            ComputeNode beIP3 = service.getComputeNodeWithBePort("127.0.0.2", 1001);
+            Assertions.assertTrue(beIP3 == null);
+        }
     }
 
     @Test
     public void testUpdateBackendAddressInSharedDataMode() {
         assertThrows(DdlException.class, () -> {
-            new MockUp<RunMode>() {
-                @Mock
-                public boolean isSharedDataMode() {
-                    return true;
-                }
-            };
-            Backend be = new Backend(100, "originalHost", 1000);
-            service.addBackend(be);
-            ModifyBackendClause clause = new ModifyBackendClause("originalHost-test", "sandbox");
-            // throw not support exception
-            service.modifyBackendHost(clause);
+            try (MockedStatic<RunMode> mockedRunMode = mockStatic(RunMode.class)) {
+                mockedRunMode.when(RunMode::isSharedDataMode).thenReturn(true);
+
+                Backend be = new Backend(100, "originalHost", 1000);
+                service.addBackend(be);
+                ModifyBackendClause clause = new ModifyBackendClause("originalHost-test", "sandbox");
+                // throw not support exception
+                service.modifyBackendHost(clause);
+            }
         });
     }
 }


### PR DESCRIPTION
Jmockit tries to mock system classes, e.g:
System - System.exit()
InetAddress / Inet4Address - getLocalHost(), getByName(), getHostAddress(), getCanonicalHostName()

while mockito uses mockStatic, which is allowed in newer JDKs

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
