### PR TITLE
[Enhancement] Support DCG files synchronization during shared-nothing to shared-data replication

### DIFF
--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -41,6 +41,7 @@
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "storage/delete_handler.h"
+#include "storage/delta_column_group.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/tablet.h"
@@ -281,6 +282,37 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
             auto* op_write = txn_log->mutable_op_replication()->add_op_writes();
             RETURN_IF_ERROR(convert_rowset_meta(*rowset_meta, request.transaction_id, op_write, &filename_map));
         }
+
+        // Handle delta column groups for non-PK tables.
+        // The .dcgs_snapshot file only exists when the source table uses partial update or generated columns.
+        // A NotFound error means the source has no DCGs (expected for most tables).
+        // Any other download failure (network, timeout) should be treated as a real error to prevent
+        // data inconsistency where rowsets are replicated but their DCG metadata is lost.
+        std::string remote_dcgs_snapshot_file_name = std::to_string(request.src_tablet_id) + ".dcgs_snapshot";
+        auto dcgs_snapshot_content_or = ReplicationUtils::download_remote_snapshot_file(
+                src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
+                src_snapshot_info.snapshot_path, request.src_tablet_id, request.src_schema_hash,
+                remote_dcgs_snapshot_file_name, config::download_low_speed_time);
+        if (dcgs_snapshot_content_or.ok()) {
+            DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
+            RETURN_IF_ERROR(ProtobufFileWithHeader::load(&dcg_snapshot_pb, dcgs_snapshot_content_or.value()));
+
+            std::unordered_map<std::string, uint32_t> rowset_id_to_seg_id;
+            for (const auto& rowset_meta : rowset_metas) {
+                rowset_id_to_seg_id[rowset_meta->rowset_id().to_string()] = rowset_meta->get_rowset_seg_id();
+            }
+
+            RETURN_IF_ERROR(convert_dcg_snapshot_for_non_pk(
+                    dcg_snapshot_pb, rowset_id_to_seg_id, request.transaction_id,
+                    txn_log->mutable_op_replication()->mutable_dcg_meta(), &filename_map));
+        } else if (!dcgs_snapshot_content_or.status().is_not_found()) {
+            // NotFound means the source has no DCGs (expected for most tables).
+            LOG(WARNING) << "Failed to download dcgs_snapshot file: " << remote_dcgs_snapshot_file_name
+                         << ", status: " << dcgs_snapshot_content_or.status();
+            return dcgs_snapshot_content_or.status().clone_and_prepend("Failed to download dcgs_snapshot file: " +
+                                                                       remote_dcgs_snapshot_file_name);
+        }
+
         // None-pk table always has tablet schema in tablet meta
         tablet_meta.tablet_schema_ptr()->to_schema_pb(txn_log->mutable_op_replication()->mutable_source_schema());
         source_schema_pb = &txn_log->op_replication().source_schema();
@@ -323,6 +355,10 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
             delvec.save_to(delvec_data.mutable_data());
         }
 
+        // Handle delta column groups for PK tables
+        RETURN_IF_ERROR(convert_dcg_for_pk(snapshot_meta.delta_column_groups(), request.transaction_id,
+                                           txn_log->mutable_op_replication()->mutable_dcg_meta(), &filename_map));
+
         if (snapshot_meta.tablet_meta().has_schema()) {
             // Try to get source schema from tablet meta, only full snapshot has tablet meta
             txn_log->mutable_op_replication()->mutable_source_schema()->CopyFrom(snapshot_meta.tablet_meta().schema());
@@ -348,6 +384,12 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
     std::unordered_map<uint32_t, uint32_t> column_unique_id_map;
     ReplicationUtils::calc_column_unique_id_map(source_schema_pb->column(), tablet_metadata->schema().column(),
                                                 &column_unique_id_map);
+
+    // Convert column unique IDs in DCG metadata
+    if (txn_log->op_replication().has_dcg_meta()) {
+        RETURN_IF_ERROR(convert_dcg_column_unique_ids(txn_log->mutable_op_replication()->mutable_dcg_meta(),
+                                                      column_unique_id_map));
+    }
 
     std::vector<std::string> files_to_delete;
     CancelableDefer clean_files([&files_to_delete]() { lake::delete_files_async(std::move(files_to_delete)); });
@@ -390,10 +432,6 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
 Status ReplicationTxnManager::convert_rowset_meta(
         const RowsetMeta& rowset_meta, TTransactionId transaction_id, TxnLogPB::OpWrite* op_write,
         std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>* filename_map) {
-    if (rowset_meta.is_column_mode_partial_update()) {
-        return Status::NotSupported("Column mode partial update is not supported in shared-data mode");
-    }
-
     // Convert rowset metadata
     auto* rowset_metadata = op_write->mutable_rowset();
     rowset_metadata->set_id(rowset_meta.get_rowset_seg_id());
@@ -486,6 +524,115 @@ Status ReplicationTxnManager::convert_delete_predicate_pb(DeletePredicatePB* del
     return Status::OK();
 }
 
+Status ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(
+        const DeltaColumnGroupSnapshotPB& dcg_snapshot_pb,
+        const std::unordered_map<std::string, uint32_t>& rowset_id_to_seg_id, TTransactionId transaction_id,
+        DeltaColumnGroupMetadataPB* dcg_meta,
+        std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>* filename_map) {
+    for (int i = 0; i < dcg_snapshot_pb.dcg_lists_size(); i++) {
+        auto it = rowset_id_to_seg_id.find(dcg_snapshot_pb.rowset_id(i));
+        if (it == rowset_id_to_seg_id.end()) {
+            continue;
+        }
+        uint32_t rssid = it->second + dcg_snapshot_pb.segment_id(i);
+        const auto& dcg_list_pb = dcg_snapshot_pb.dcg_lists(i);
+        auto& dcg_ver = (*dcg_meta->mutable_dcgs())[rssid];
+
+        if (dcg_list_pb.versions_size() != dcg_list_pb.dcgs_size()) {
+            return Status::Corruption(fmt::format(
+                    "Mismatch between versions_size ({}) and dcgs_size ({}) in DeltaColumnGroup list for rowset {}, "
+                    "segment {}",
+                    dcg_list_pb.versions_size(), dcg_list_pb.dcgs_size(), dcg_snapshot_pb.rowset_id(i),
+                    dcg_snapshot_pb.segment_id(i)));
+        }
+        for (int j = 0; j < dcg_list_pb.dcgs_size(); j++) {
+            const auto& dcg_pb = dcg_list_pb.dcgs(j);
+            int64_t version = dcg_list_pb.versions(j);
+            if (dcg_pb.column_ids_size() != dcg_pb.column_files_size()) {
+                return Status::Corruption(fmt::format(
+                        "Mismatch between column_ids_size ({}) and column_files_size ({}) in DeltaColumnGroup for "
+                        "rowset {}, segment {}, dcg index {}",
+                        dcg_pb.column_ids_size(), dcg_pb.column_files_size(), dcg_snapshot_pb.rowset_id(i),
+                        dcg_snapshot_pb.segment_id(i), j));
+            }
+            for (int k = 0; k < dcg_pb.column_files_size(); k++) {
+                const auto& old_cols_filename = dcg_pb.column_files(k);
+                std::string new_cols_filename = gen_cols_filename(transaction_id);
+
+                dcg_ver.add_column_files(new_cols_filename);
+                dcg_ver.add_versions(version);
+
+                dcg_ver.add_unique_column_ids()->CopyFrom(dcg_pb.column_ids(k));
+
+                FileEncryptionPair encryption_pair;
+                if (config::enable_transparent_data_encryption) {
+                    ASSIGN_OR_RETURN(encryption_pair,
+                                     KeyCache::instance().create_encryption_meta_pair_using_current_kek());
+                    dcg_ver.add_encryption_metas(encryption_pair.encryption_meta);
+                }
+
+                auto result = filename_map->emplace(
+                        old_cols_filename, std::pair(std::move(new_cols_filename), std::move(encryption_pair)));
+                if (!result.second) {
+                    return Status::Corruption("Duplicated cols file: " + result.first->first);
+                }
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status ReplicationTxnManager::convert_dcg_for_pk(
+        const std::unordered_map<uint32_t, DeltaColumnGroupList>& delta_column_groups, TTransactionId transaction_id,
+        DeltaColumnGroupMetadataPB* dcg_meta,
+        std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>* filename_map) {
+    for (const auto& [segment_id, dcg_list] : delta_column_groups) {
+        auto& dcg_ver = (*dcg_meta->mutable_dcgs())[segment_id];
+
+        for (const auto& dcg : dcg_list) {
+            for (size_t i = 0; i < dcg->relative_column_files().size(); i++) {
+                const auto& old_cols_filename = dcg->relative_column_files()[i];
+                std::string new_cols_filename = gen_cols_filename(transaction_id);
+
+                dcg_ver.add_column_files(new_cols_filename);
+                dcg_ver.add_versions(dcg->version());
+
+                if (i < dcg->column_ids().size()) {
+                    auto* ucids = dcg_ver.add_unique_column_ids();
+                    for (auto cid : dcg->column_ids()[i]) {
+                        ucids->add_column_ids(cid);
+                    }
+                }
+
+                FileEncryptionPair encryption_pair;
+                if (config::enable_transparent_data_encryption) {
+                    ASSIGN_OR_RETURN(encryption_pair,
+                                     KeyCache::instance().create_encryption_meta_pair_using_current_kek());
+                    dcg_ver.add_encryption_metas(encryption_pair.encryption_meta);
+                }
+
+                auto result = filename_map->emplace(
+                        old_cols_filename, std::pair(std::move(new_cols_filename), std::move(encryption_pair)));
+                if (!result.second) {
+                    return Status::Corruption("Duplicated cols file: " + result.first->first);
+                }
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status ReplicationTxnManager::convert_dcg_column_unique_ids(
+        DeltaColumnGroupMetadataPB* dcg_meta, const std::unordered_map<uint32_t, uint32_t>& column_unique_id_map) {
+    for (auto& [seg_id, dcg_ver] : *dcg_meta->mutable_dcgs()) {
+        for (int i = 0; i < dcg_ver.unique_column_ids_size(); i++) {
+            RETURN_IF_ERROR(ReplicationUtils::convert_column_unique_ids(
+                    dcg_ver.mutable_unique_column_ids(i)->mutable_column_ids(), column_unique_id_map));
+        }
+    }
+    return Status::OK();
+}
+
 // Helper function to create replication txn log with converted metadata
 FileConverterCreatorFunc ReplicationTxnManager::build_file_converters(
         const TabletManager* tablet_manager, const TReplicateSnapshotRequest& request,
@@ -517,7 +664,7 @@ FileConverterCreatorFunc ReplicationTxnManager::build_file_converters(
 
         files_to_delete.push_back(std::move(segment_location));
 
-        if (is_segment(file_name) && !column_unique_id_map.empty()) {
+        if ((is_segment(file_name) || is_cols(file_name)) && !column_unique_id_map.empty()) {
             return std::make_unique<SegmentStreamConverter>(file_name, file_size, std::move(output_file),
                                                             &column_unique_id_map);
         }

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -302,9 +302,9 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
                 rowset_id_to_seg_id[rowset_meta->rowset_id().to_string()] = rowset_meta->get_rowset_seg_id();
             }
 
-            RETURN_IF_ERROR(convert_dcg_snapshot_for_non_pk(
-                    dcg_snapshot_pb, rowset_id_to_seg_id, request.transaction_id,
-                    txn_log->mutable_op_replication()->mutable_dcg_meta(), &filename_map));
+            RETURN_IF_ERROR(convert_dcg_meta_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, request.transaction_id,
+                                                        txn_log->mutable_op_replication()->mutable_dcg_meta(),
+                                                        &filename_map));
         } else if (!dcgs_snapshot_content_or.status().is_not_found()) {
             // NotFound means the source has no DCGs (expected for most tables).
             LOG(WARNING) << "Failed to download dcgs_snapshot file: " << remote_dcgs_snapshot_file_name
@@ -356,8 +356,8 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
         }
 
         // Handle delta column groups for PK tables
-        RETURN_IF_ERROR(convert_dcg_for_pk(snapshot_meta.delta_column_groups(), request.transaction_id,
-                                           txn_log->mutable_op_replication()->mutable_dcg_meta(), &filename_map));
+        RETURN_IF_ERROR(convert_dcg_meta_for_pk(snapshot_meta.delta_column_groups(), request.transaction_id,
+                                                txn_log->mutable_op_replication()->mutable_dcg_meta(), &filename_map));
 
         if (snapshot_meta.tablet_meta().has_schema()) {
             // Try to get source schema from tablet meta, only full snapshot has tablet meta
@@ -524,7 +524,7 @@ Status ReplicationTxnManager::convert_delete_predicate_pb(DeletePredicatePB* del
     return Status::OK();
 }
 
-Status ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(
+Status ReplicationTxnManager::convert_dcg_meta_for_non_pk(
         const DeltaColumnGroupSnapshotPB& dcg_snapshot_pb,
         const std::unordered_map<std::string, uint32_t>& rowset_id_to_seg_id, TTransactionId transaction_id,
         DeltaColumnGroupMetadataPB* dcg_meta,
@@ -582,7 +582,7 @@ Status ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(
     return Status::OK();
 }
 
-Status ReplicationTxnManager::convert_dcg_for_pk(
+Status ReplicationTxnManager::convert_dcg_meta_for_pk(
         const std::unordered_map<uint32_t, DeltaColumnGroupList>& delta_column_groups, TTransactionId transaction_id,
         DeltaColumnGroupMetadataPB* dcg_meta,
         std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>* filename_map) {
@@ -597,8 +597,8 @@ Status ReplicationTxnManager::convert_dcg_for_pk(
                 dcg_ver.add_column_files(new_cols_filename);
                 dcg_ver.add_versions(dcg->version());
 
+                auto* ucids = dcg_ver.add_unique_column_ids();
                 if (i < dcg->column_ids().size()) {
-                    auto* ucids = dcg_ver.add_unique_column_ids();
                     for (auto cid : dcg->column_ids()[i]) {
                         ucids->add_column_ids(cid);
                     }

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -593,6 +593,12 @@ Status ReplicationTxnManager::convert_dcg_meta_for_pk(
         auto& dcg_ver = (*dcg_meta->mutable_dcgs())[segment_id];
 
         for (const auto& dcg : dcg_list) {
+            if (dcg->column_ids().size() != dcg->relative_column_files().size()) {
+                return Status::Corruption(fmt::format(
+                        "Mismatch between column_ids size ({}) and column_files size ({}) in DeltaColumnGroup for "
+                        "segment {}",
+                        dcg->column_ids().size(), dcg->relative_column_files().size(), segment_id));
+            }
             for (size_t i = 0; i < dcg->relative_column_files().size(); i++) {
                 const auto& old_cols_filename = dcg->relative_column_files()[i];
                 std::string new_cols_filename = gen_cols_filename(transaction_id);
@@ -601,10 +607,8 @@ Status ReplicationTxnManager::convert_dcg_meta_for_pk(
                 dcg_ver.add_versions(dcg->version());
 
                 auto* ucids = dcg_ver.add_unique_column_ids();
-                if (i < dcg->column_ids().size()) {
-                    for (auto cid : dcg->column_ids()[i]) {
-                        ucids->add_column_ids(cid);
-                    }
+                for (auto cid : dcg->column_ids()[i]) {
+                    ucids->add_column_ids(cid);
                 }
 
                 FileEncryptionPair encryption_pair;

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -283,34 +283,37 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
             RETURN_IF_ERROR(convert_rowset_meta(*rowset_meta, request.transaction_id, op_write, &filename_map));
         }
 
-        // Handle delta column groups for non-PK tables.
-        // The .dcgs_snapshot file only exists when the source table uses partial update or generated columns.
-        // A NotFound error means the source has no DCGs (expected for most tables).
-        // Any other download failure (network, timeout) should be treated as a real error to prevent
-        // data inconsistency where rowsets are replicated but their DCG metadata is lost.
-        std::string remote_dcgs_snapshot_file_name = std::to_string(request.src_tablet_id) + ".dcgs_snapshot";
-        auto dcgs_snapshot_content_or = ReplicationUtils::download_remote_snapshot_file(
-                src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
-                src_snapshot_info.snapshot_path, request.src_tablet_id, request.src_schema_hash,
-                remote_dcgs_snapshot_file_name, config::download_low_speed_time);
-        if (dcgs_snapshot_content_or.ok()) {
-            DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
-            RETURN_IF_ERROR(ProtobufFileWithHeader::load(&dcg_snapshot_pb, dcgs_snapshot_content_or.value()));
+        // Handle delta column groups (DCGs) for non-PK tables.
+        // Skip .dcgs_snapshot download for incremental snapshots -- snapshot_incremental() never creates
+        // this file, so the download would always get NotFound. Only attempt download for full snapshots.
+        // Note: we cannot add a has_dcg flag to TSnapshotInfo or embed DCG in .hdr because cross-cluster
+        // replication must not depend on the source cluster upgrading its code version, so for full
+        // snapshots of tables without DCGs, the target still makes one NotFound request (acceptable since
+        // full replication is rare -- only initial sync or fallback).
+        if (!src_snapshot_info.incremental_snapshot) {
+            std::string remote_dcgs_snapshot_file_name = std::to_string(request.src_tablet_id) + ".dcgs_snapshot";
+            auto dcgs_snapshot_content_or = ReplicationUtils::download_remote_snapshot_file(
+                    src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
+                    src_snapshot_info.snapshot_path, request.src_tablet_id, request.src_schema_hash,
+                    remote_dcgs_snapshot_file_name, config::download_low_speed_time);
+            if (dcgs_snapshot_content_or.ok()) {
+                DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
+                RETURN_IF_ERROR(ProtobufFileWithHeader::load(&dcg_snapshot_pb, dcgs_snapshot_content_or.value()));
 
-            std::unordered_map<std::string, uint32_t> rowset_id_to_seg_id;
-            for (const auto& rowset_meta : rowset_metas) {
-                rowset_id_to_seg_id[rowset_meta->rowset_id().to_string()] = rowset_meta->get_rowset_seg_id();
+                std::unordered_map<std::string, uint32_t> rowset_id_to_seg_id;
+                for (const auto& rowset_meta : rowset_metas) {
+                    rowset_id_to_seg_id[rowset_meta->rowset_id().to_string()] = rowset_meta->get_rowset_seg_id();
+                }
+
+                RETURN_IF_ERROR(convert_dcg_meta_for_non_pk(
+                        dcg_snapshot_pb, rowset_id_to_seg_id, request.transaction_id,
+                        txn_log->mutable_op_replication()->mutable_dcg_meta(), &filename_map));
+            } else if (!dcgs_snapshot_content_or.status().is_not_found()) {
+                LOG(WARNING) << "Failed to download dcgs_snapshot file: " << remote_dcgs_snapshot_file_name
+                             << ", status: " << dcgs_snapshot_content_or.status();
+                return dcgs_snapshot_content_or.status().clone_and_prepend("Failed to download dcgs_snapshot file: " +
+                                                                           remote_dcgs_snapshot_file_name);
             }
-
-            RETURN_IF_ERROR(convert_dcg_meta_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, request.transaction_id,
-                                                        txn_log->mutable_op_replication()->mutable_dcg_meta(),
-                                                        &filename_map));
-        } else if (!dcgs_snapshot_content_or.status().is_not_found()) {
-            // NotFound means the source has no DCGs (expected for most tables).
-            LOG(WARNING) << "Failed to download dcgs_snapshot file: " << remote_dcgs_snapshot_file_name
-                         << ", status: " << dcgs_snapshot_content_or.status();
-            return dcgs_snapshot_content_or.status().clone_and_prepend("Failed to download dcgs_snapshot file: " +
-                                                                       remote_dcgs_snapshot_file_name);
         }
 
         // None-pk table always has tablet schema in tablet meta

--- a/be/src/storage/lake/replication_txn_manager.h
+++ b/be/src/storage/lake/replication_txn_manager.h
@@ -52,19 +52,19 @@ public:
             const std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map,
             std::unordered_map<uint32_t, uint32_t>& column_unique_id_map, std::vector<std::string>& files_to_delete);
 
-    // Convert DeltaColumnGroupSnapshotPB from shared-nothing non-PK table snapshot into
-    // DeltaColumnGroupMetadataPB for shared-data replication. Also populates filename_map
-    // with old->new .cols filename mappings.
-    static Status convert_dcg_snapshot_for_non_pk(
+    // Convert DeltaColumnGroupSnapshotPB from shared-nothing non-PK table snapshot
+    // into DeltaColumnGroupMetadataPB for shared-data replication.
+    // Also populates filename_map with old->new .cols filename mappings.
+    static Status convert_dcg_meta_for_non_pk(
             const DeltaColumnGroupSnapshotPB& dcg_snapshot_pb,
             const std::unordered_map<std::string, uint32_t>& rowset_id_to_seg_id, TTransactionId transaction_id,
             DeltaColumnGroupMetadataPB* dcg_meta,
             std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>* filename_map);
 
-    // Convert DeltaColumnGroupList from shared-nothing PK table snapshot into
-    // DeltaColumnGroupMetadataPB for shared-data replication. Also populates filename_map
-    // with old->new .cols filename mappings.
-    static Status convert_dcg_for_pk(
+    // Convert DeltaColumnGroupList from shared-nothing PK table snapshot
+    // into DeltaColumnGroupMetadataPB for shared-data replication.
+    // Also populates filename_map with old->new .cols filename mappings.
+    static Status convert_dcg_meta_for_pk(
             const std::unordered_map<uint32_t, DeltaColumnGroupList>& delta_column_groups,
             TTransactionId transaction_id, DeltaColumnGroupMetadataPB* dcg_meta,
             std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>* filename_map);

--- a/be/src/storage/lake/replication_txn_manager.h
+++ b/be/src/storage/lake/replication_txn_manager.h
@@ -19,6 +19,7 @@
 #include "gen_cpp/AgentService_types.h"
 #include "gutil/macros.h"
 #include "lake_replication_txn_manager.h"
+#include "storage/delta_column_group.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/txn_log.h"
 #include "storage/lake/types_fwd.h"
@@ -50,6 +51,27 @@ public:
             const TabletManager* tablet_manager, const TReplicateSnapshotRequest& request,
             const std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>& filename_map,
             std::unordered_map<uint32_t, uint32_t>& column_unique_id_map, std::vector<std::string>& files_to_delete);
+
+    // Convert DeltaColumnGroupSnapshotPB from shared-nothing non-PK table snapshot into
+    // DeltaColumnGroupMetadataPB for shared-data replication. Also populates filename_map
+    // with old->new .cols filename mappings.
+    static Status convert_dcg_snapshot_for_non_pk(
+            const DeltaColumnGroupSnapshotPB& dcg_snapshot_pb,
+            const std::unordered_map<std::string, uint32_t>& rowset_id_to_seg_id, TTransactionId transaction_id,
+            DeltaColumnGroupMetadataPB* dcg_meta,
+            std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>* filename_map);
+
+    // Convert DeltaColumnGroupList from shared-nothing PK table snapshot into
+    // DeltaColumnGroupMetadataPB for shared-data replication. Also populates filename_map
+    // with old->new .cols filename mappings.
+    static Status convert_dcg_for_pk(
+            const std::unordered_map<uint32_t, DeltaColumnGroupList>& delta_column_groups,
+            TTransactionId transaction_id, DeltaColumnGroupMetadataPB* dcg_meta,
+            std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>>* filename_map);
+
+    // Convert column unique IDs in DCG metadata using the provided column_unique_id_map.
+    static Status convert_dcg_column_unique_ids(DeltaColumnGroupMetadataPB* dcg_meta,
+                                                const std::unordered_map<uint32_t, uint32_t>& column_unique_id_map);
 
 private:
     Status make_remote_snapshot(const TRemoteSnapshotRequest& request, const std::vector<Version>* missed_versions,

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -160,6 +160,35 @@ Status update_metadata_schema(const TxnLogPB_OpWrite& op_write, int64_t txn_id,
     return Status::OK();
 }
 
+// Build rssid_remap for DCG application during replication.
+// Maps source rssid to target rssid based on which op_writes will actually be applied.
+// For PK tables: an op_write is applied when dels_size > 0 || num_rows > 0 || has_delete_predicate.
+// For Non-PK tables: an op_write is applied when has_rowset && (num_rows > 0 || has_delete_predicate).
+std::unordered_map<uint32_t, uint32_t> build_rssid_remap(const TxnLogPB_OpReplication& op_replication,
+                                                         uint32_t start_target_id, bool is_pk) {
+    std::unordered_map<uint32_t, uint32_t> rssid_remap;
+    uint32_t target_id = start_target_id;
+    for (const auto& op_write : op_replication.op_writes()) {
+        bool included = false;
+        if (is_pk) {
+            included = op_write.dels_size() > 0 || op_write.rowset().num_rows() > 0 ||
+                       op_write.rowset().has_delete_predicate();
+        } else {
+            included = op_write.has_rowset() &&
+                       (op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate());
+        }
+        if (included) {
+            uint32_t source_id = op_write.rowset().id();
+            uint32_t step = get_rowset_id_step(op_write.rowset());
+            for (uint32_t i = 0; i < step; i++) {
+                rssid_remap[source_id + i] = target_id + i;
+            }
+            target_id += step;
+        }
+    }
+    return rssid_remap;
+}
+
 void apply_replication_dcg_meta(const TxnLogPB_OpReplication& op_replication,
                                 const std::unordered_map<uint32_t, uint32_t>& rssid_remap, TabletMetadataPB* metadata) {
     if (!op_replication.has_dcg_meta()) return;
@@ -613,24 +642,7 @@ private:
         }
 
         if (txn_meta.incremental_snapshot()) {
-            // Pre-compute source rssid -> target rssid mapping for DCG application.
-            // Each op_write's rowset gets assigned a new ID starting from next_rowset_id.
-            // We simulate this mapping before applying writes so DCG keys can be remapped.
-            std::unordered_map<uint32_t, uint32_t> rssid_remap;
-            {
-                uint32_t target_id = _metadata->next_rowset_id();
-                for (const auto& op_write : op_replication.op_writes()) {
-                    if (op_write.dels_size() > 0 || op_write.rowset().num_rows() > 0 ||
-                        op_write.rowset().has_delete_predicate()) {
-                        uint32_t source_id = op_write.rowset().id();
-                        uint32_t step = get_rowset_id_step(op_write.rowset());
-                        for (uint32_t i = 0; i < step; i++) {
-                            rssid_remap[source_id + i] = target_id + i;
-                        }
-                        target_id += step;
-                    }
-                }
-            }
+            auto rssid_remap = build_rssid_remap(op_replication, _metadata->next_rowset_id(), /*is_pk=*/true);
 
             for (const auto& op_write : op_replication.op_writes()) {
                 RETURN_IF_ERROR(apply_write_log(op_write, txn_id));
@@ -1181,23 +1193,7 @@ private:
 
         int64_t base_version = _metadata->version();
         if (txn_meta.incremental_snapshot()) {
-            // Pre-compute source rssid -> target rssid mapping for DCG application.
-            // Non-PK apply_write_log assigns new IDs from next_rowset_id to each rowset.
-            std::unordered_map<uint32_t, uint32_t> rssid_remap;
-            {
-                uint32_t target_id = _metadata->next_rowset_id();
-                for (const auto& op_write : op_replication.op_writes()) {
-                    if (op_write.has_rowset() &&
-                        (op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate())) {
-                        uint32_t source_id = op_write.rowset().id();
-                        uint32_t step = get_rowset_id_step(op_write.rowset());
-                        for (uint32_t i = 0; i < step; i++) {
-                            rssid_remap[source_id + i] = target_id + i;
-                        }
-                        target_id += step;
-                    }
-                }
-            }
+            auto rssid_remap = build_rssid_remap(op_replication, _metadata->next_rowset_id(), /*is_pk=*/false);
 
             for (const auto& op_write : op_replication.op_writes()) {
                 RETURN_IF_ERROR(apply_write_log(op_write, txn_meta.txn_id()));
@@ -1235,23 +1231,7 @@ private:
                 }
             } else {
                 // Non-Lake replication (replication from shared-nothing cluster).
-                // Build rssid remapping: source rssid -> target rssid.
-                // Use the same condition as apply_write_log to ensure current_next_id advances
-                // in lockstep with the actual next_rowset_id updates.
-                std::unordered_map<uint32_t, uint32_t> rssid_remap;
-                uint32_t current_next_id = _metadata->next_rowset_id();
-                for (const auto& op_write : op_replication.op_writes()) {
-                    if (op_write.has_rowset() &&
-                        (op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate())) {
-                        const auto& rowset = op_write.rowset();
-                        uint32_t source_id = rowset.id();
-                        uint32_t step = get_rowset_id_step(rowset);
-                        for (uint32_t i = 0; i < step; i++) {
-                            rssid_remap[source_id + i] = current_next_id + i;
-                        }
-                        current_next_id += step;
-                    }
-                }
+                auto rssid_remap = build_rssid_remap(op_replication, _metadata->next_rowset_id(), /*is_pk=*/false);
                 for (const auto& op_write : op_replication.op_writes()) {
                     RETURN_IF_ERROR(apply_write_log(op_write, txn_meta.txn_id()));
                 }

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -160,6 +160,44 @@ Status update_metadata_schema(const TxnLogPB_OpWrite& op_write, int64_t txn_id,
     return Status::OK();
 }
 
+void apply_replication_dcg_meta(const TxnLogPB_OpReplication& op_replication,
+                                const std::unordered_map<uint32_t, uint32_t>& rssid_remap, TabletMetadataPB* metadata) {
+    if (!op_replication.has_dcg_meta()) return;
+    // Remapping source rssid to target rssid using the provided map.
+    // Keys not found in the map are kept unchanged.
+    for (const auto& [src_rssid, dcg_ver] : op_replication.dcg_meta().dcgs()) {
+        auto it = rssid_remap.find(src_rssid);
+        uint32_t target_rssid = (it != rssid_remap.end()) ? it->second : src_rssid;
+        (*metadata->mutable_dcg_meta()->mutable_dcgs())[target_rssid].CopyFrom(dcg_ver);
+    }
+}
+
+void apply_replication_dcg_meta(const TxnLogPB_OpReplication& op_replication, uint32_t rssid_offset,
+                                TabletMetadataPB* metadata) {
+    if (!op_replication.has_dcg_meta()) return;
+    // Adding a fixed offset to each source rssid.
+    for (const auto& [src_rssid, dcg_ver] : op_replication.dcg_meta().dcgs()) {
+        (*metadata->mutable_dcg_meta()->mutable_dcgs())[src_rssid + rssid_offset].CopyFrom(dcg_ver);
+    }
+}
+
+void collect_dcg_orphan_files(const DeltaColumnGroupMetadataPB& old_dcg_meta,
+                              const std::unordered_set<std::string>& new_referenced_files, TabletMetadataPB* metadata) {
+    // Move old delta column group files to orphan files list for later cleanup.
+    // Files still referenced by new metadata (in new_referenced_files) are skipped.
+    for (const auto& [_, dcg_ver] : old_dcg_meta.dcgs()) {
+        for (int i = 0; i < dcg_ver.column_files_size(); ++i) {
+            if (new_referenced_files.count(dcg_ver.column_files(i)) > 0) continue;
+            FileMetaPB file_meta;
+            file_meta.set_name(dcg_ver.column_files(i));
+            if (dcg_ver.shared_files_size() > 0 && i < dcg_ver.shared_files_size()) {
+                file_meta.set_shared(dcg_ver.shared_files(i));
+            }
+            metadata->mutable_orphan_files()->Add(std::move(file_meta));
+        }
+    }
+}
+
 } // namespace
 
 class PrimaryKeyTxnLogApplier : public TxnLogApplier {
@@ -575,9 +613,31 @@ private:
         }
 
         if (txn_meta.incremental_snapshot()) {
+            // Pre-compute source rssid -> target rssid mapping for DCG application.
+            // Each op_write's rowset gets assigned a new ID starting from next_rowset_id.
+            // We simulate this mapping before applying writes so DCG keys can be remapped.
+            std::unordered_map<uint32_t, uint32_t> rssid_remap;
+            {
+                uint32_t target_id = _metadata->next_rowset_id();
+                for (const auto& op_write : op_replication.op_writes()) {
+                    if (op_write.dels_size() > 0 || op_write.rowset().num_rows() > 0 ||
+                        op_write.rowset().has_delete_predicate()) {
+                        uint32_t source_id = op_write.rowset().id();
+                        uint32_t step = get_rowset_id_step(op_write.rowset());
+                        for (uint32_t i = 0; i < step; i++) {
+                            rssid_remap[source_id + i] = target_id + i;
+                        }
+                        target_id += step;
+                    }
+                }
+            }
+
             for (const auto& op_write : op_replication.op_writes()) {
                 RETURN_IF_ERROR(apply_write_log(op_write, txn_id));
             }
+
+            apply_replication_dcg_meta(op_replication, rssid_remap, _metadata.get());
+
             LOG(INFO) << "Apply pk incremental replication log finish. tablet_id: " << _tablet.id()
                       << ", base_version: " << _base_version << ", new_version: " << _new_version
                       << ", txn_id: " << txn_id;
@@ -624,6 +684,7 @@ private:
                         << ", rowsets size: " << _metadata->rowsets_size();
             } else {
                 // Non-Lake replication (replication from shared-nothing cluster).
+                auto old_next_rowset_id = _metadata->next_rowset_id();
                 auto new_next_rowset_id = _metadata->next_rowset_id();
                 for (const auto& op_write : op_replication.op_writes()) {
                     auto rowset = _metadata->add_rowsets();
@@ -637,8 +698,9 @@ private:
                 for (const auto& [segment_id, delvec_data] : op_replication.delvecs()) {
                     auto delvec = std::make_shared<DelVector>();
                     RETURN_IF_ERROR(delvec->load(_new_version, delvec_data.data().data(), delvec_data.data().size()));
-                    _builder.append_delvec(delvec, segment_id + _metadata->next_rowset_id());
+                    _builder.append_delvec(delvec, segment_id + old_next_rowset_id);
                 }
+                apply_replication_dcg_meta(op_replication, old_next_rowset_id, _metadata.get());
                 _metadata->set_next_rowset_id(new_next_rowset_id);
                 old_rowsets.Swap(_metadata->mutable_compaction_inputs());
             }
@@ -680,18 +742,7 @@ private:
                 file_meta.set_shared(sstable.shared());
                 _metadata->mutable_orphan_files()->Add(std::move(file_meta));
             }
-            // Clear dcg_meta and add to orphan files.
-            for (const auto& [_, dcg_ver] : old_dcg_meta.dcgs()) {
-                for (int i = 0; i < dcg_ver.column_files_size(); ++i) {
-                    if (new_referenced_files.count(dcg_ver.column_files(i)) > 0) continue;
-                    FileMetaPB file_meta;
-                    file_meta.set_name(dcg_ver.column_files(i));
-                    if (dcg_ver.shared_files_size() > 0 && i < dcg_ver.shared_files_size()) {
-                        file_meta.set_shared(dcg_ver.shared_files(i));
-                    }
-                    _metadata->mutable_orphan_files()->Add(std::move(file_meta));
-                }
-            }
+            collect_dcg_orphan_files(old_dcg_meta, new_referenced_files, _metadata.get());
 
             _tablet.update_mgr()->unload_primary_index(_tablet.id());
             LOG(INFO) << "Apply pk full replication log finish. tablet_id: " << _tablet.id()
@@ -1130,19 +1181,43 @@ private:
 
         int64_t base_version = _metadata->version();
         if (txn_meta.incremental_snapshot()) {
+            // Pre-compute source rssid -> target rssid mapping for DCG application.
+            // Non-PK apply_write_log assigns new IDs from next_rowset_id to each rowset.
+            std::unordered_map<uint32_t, uint32_t> rssid_remap;
+            {
+                uint32_t target_id = _metadata->next_rowset_id();
+                for (const auto& op_write : op_replication.op_writes()) {
+                    if (op_write.has_rowset() &&
+                        (op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate())) {
+                        uint32_t source_id = op_write.rowset().id();
+                        uint32_t step = get_rowset_id_step(op_write.rowset());
+                        for (uint32_t i = 0; i < step; i++) {
+                            rssid_remap[source_id + i] = target_id + i;
+                        }
+                        target_id += step;
+                    }
+                }
+            }
+
             for (const auto& op_write : op_replication.op_writes()) {
                 RETURN_IF_ERROR(apply_write_log(op_write, txn_meta.txn_id()));
             }
+
+            apply_replication_dcg_meta(op_replication, rssid_remap, _metadata.get());
+
             LOG(INFO) << "Apply incremental replication log finish. tablet_id: " << _tablet.id()
                       << ", base_version: " << base_version << ", new_version: " << _new_version
                       << ", txn_id: " << txn_meta.txn_id();
         } else {
             auto old_rowsets = std::move(*_metadata->mutable_rowsets());
+            auto old_dcg_meta = std::move(*_metadata->mutable_dcg_meta());
             _metadata->mutable_rowsets()->Clear();
+            _metadata->mutable_dcg_meta()->Clear();
             if (op_replication.has_tablet_metadata()) {
                 // Lake replication (replication from shared-data cluster) with tablet metadata provided.
                 const auto& copied_tablet_meta = op_replication.tablet_metadata();
                 _metadata->mutable_rowsets()->CopyFrom(copied_tablet_meta.rowsets());
+                _metadata->mutable_dcg_meta()->CopyFrom(copied_tablet_meta.dcg_meta());
 
                 _metadata->set_next_rowset_id(copied_tablet_meta.next_rowset_id());
                 // In lake replication scenario, we need to carefully handle compaction_inputs.
@@ -1160,11 +1235,37 @@ private:
                 }
             } else {
                 // Non-Lake replication (replication from shared-nothing cluster).
+                // Build rssid remapping: source rssid -> target rssid.
+                // Use the same condition as apply_write_log to ensure current_next_id advances
+                // in lockstep with the actual next_rowset_id updates.
+                std::unordered_map<uint32_t, uint32_t> rssid_remap;
+                uint32_t current_next_id = _metadata->next_rowset_id();
+                for (const auto& op_write : op_replication.op_writes()) {
+                    if (op_write.has_rowset() &&
+                        (op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate())) {
+                        const auto& rowset = op_write.rowset();
+                        uint32_t source_id = rowset.id();
+                        uint32_t step = get_rowset_id_step(rowset);
+                        for (uint32_t i = 0; i < step; i++) {
+                            rssid_remap[source_id + i] = current_next_id + i;
+                        }
+                        current_next_id += step;
+                    }
+                }
                 for (const auto& op_write : op_replication.op_writes()) {
                     RETURN_IF_ERROR(apply_write_log(op_write, txn_meta.txn_id()));
                 }
+                apply_replication_dcg_meta(op_replication, rssid_remap, _metadata.get());
                 old_rowsets.Swap(_metadata->mutable_compaction_inputs());
             }
+            std::unordered_set<std::string> new_referenced_files;
+            for (const auto& [_, dcg] : _metadata->dcg_meta().dcgs()) {
+                for (const auto& cf : dcg.column_files()) {
+                    new_referenced_files.insert(cf);
+                }
+            }
+            // Clear dcg_meta and add to orphan files.
+            collect_dcg_orphan_files(old_dcg_meta, new_referenced_files, _metadata.get());
             _metadata->set_cumulative_point(0);
             LOG(INFO) << "Apply full replication log finish. tablet_id: " << _tablet.id()
                       << ", base_version: " << base_version << ", new_version: " << _new_version

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -169,13 +169,15 @@ std::unordered_map<uint32_t, uint32_t> build_rssid_remap(const TxnLogPB_OpReplic
     std::unordered_map<uint32_t, uint32_t> rssid_remap;
     uint32_t target_id = start_target_id;
     for (const auto& op_write : op_replication.op_writes()) {
+        if (!op_write.has_rowset()) {
+            continue;
+        }
         bool included = false;
         if (is_pk) {
             included = op_write.dels_size() > 0 || op_write.rowset().num_rows() > 0 ||
                        op_write.rowset().has_delete_predicate();
         } else {
-            included = op_write.has_rowset() &&
-                       (op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate());
+            included = op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate();
         }
         if (included) {
             uint32_t source_id = op_write.rowset().id();

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -547,9 +547,19 @@ StatusOr<std::string> SnapshotManager::snapshot_full(const TabletSharedPtr& tabl
         }
     }
 
-    std::stringstream dcg_snapshot_path;
-    dcg_snapshot_path << snapshot_dir << "/" << tablet->tablet_id() << ".dcgs_snapshot";
-    RETURN_IF_ERROR(DeltaColumnGroupListHelper::save_snapshot(dcg_snapshot_path.str(), dcg_snapshot_pb));
+    // Only save .dcgs_snapshot when non-empty DCGs exist. The target side handles NotFound gracefully.
+    bool has_non_empty_dcgs = false;
+    for (int i = 0; i < dcg_snapshot_pb.dcg_lists_size(); i++) {
+        if (dcg_snapshot_pb.dcg_lists(i).dcgs_size() > 0) {
+            has_non_empty_dcgs = true;
+            break;
+        }
+    }
+    if (has_non_empty_dcgs) {
+        std::stringstream dcg_snapshot_path;
+        dcg_snapshot_path << snapshot_dir << "/" << tablet->tablet_id() << ".dcgs_snapshot";
+        RETURN_IF_ERROR(DeltaColumnGroupListHelper::save_snapshot(dcg_snapshot_path.str(), dcg_snapshot_pb));
+    }
 
     // handle inverted index files
     std::vector<std::string> all_files;

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -547,19 +547,9 @@ StatusOr<std::string> SnapshotManager::snapshot_full(const TabletSharedPtr& tabl
         }
     }
 
-    // Only save .dcgs_snapshot when non-empty DCGs exist. The target side handles NotFound gracefully.
-    bool has_non_empty_dcgs = false;
-    for (int i = 0; i < dcg_snapshot_pb.dcg_lists_size(); i++) {
-        if (dcg_snapshot_pb.dcg_lists(i).dcgs_size() > 0) {
-            has_non_empty_dcgs = true;
-            break;
-        }
-    }
-    if (has_non_empty_dcgs) {
-        std::stringstream dcg_snapshot_path;
-        dcg_snapshot_path << snapshot_dir << "/" << tablet->tablet_id() << ".dcgs_snapshot";
-        RETURN_IF_ERROR(DeltaColumnGroupListHelper::save_snapshot(dcg_snapshot_path.str(), dcg_snapshot_pb));
-    }
+    std::stringstream dcg_snapshot_path;
+    dcg_snapshot_path << snapshot_dir << "/" << tablet->tablet_id() << ".dcgs_snapshot";
+    RETURN_IF_ERROR(DeltaColumnGroupListHelper::save_snapshot(dcg_snapshot_path.str(), dcg_snapshot_pb));
 
     // handle inverted index files
     std::vector<std::string> all_files;

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -642,8 +642,8 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_build_file_converters_h
     EXPECT_TRUE(lake::is_del(new_del));
 }
 
-// Test convert_dcg_for_pk: converts DeltaColumnGroupList from snapshot into DeltaColumnGroupMetadataPB
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_for_pk) {
+// Test convert_dcg_meta_for_pk: converts DeltaColumnGroupList from snapshot into DeltaColumnGroupMetadataPB
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_meta_for_pk) {
     // Build DeltaColumnGroupList in the same format as shared-nothing PK snapshot
     std::unordered_map<uint32_t, DeltaColumnGroupList> delta_column_groups;
 
@@ -670,7 +670,8 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_for_pk) {
 
     // Call the extracted function
     ASSERT_TRUE(
-            lake::ReplicationTxnManager::convert_dcg_for_pk(delta_column_groups, 12345, &dcg_meta, &filename_map).ok());
+            lake::ReplicationTxnManager::convert_dcg_meta_for_pk(delta_column_groups, 12345, &dcg_meta, &filename_map)
+                    .ok());
 
     // Verify structure
     EXPECT_EQ(2, dcg_meta.dcgs_size());
@@ -886,8 +887,8 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_dcg_apply_replication_n
     EXPECT_EQ(5, result_dcg.unique_column_ids(0).column_ids(0));
 }
 
-// Test convert_dcg_snapshot_for_non_pk: converts DeltaColumnGroupSnapshotPB into DeltaColumnGroupMetadataPB
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_for_non_pk) {
+// Test convert_dcg_meta_for_non_pk: converts DeltaColumnGroupSnapshotPB into DeltaColumnGroupMetadataPB
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_meta_for_non_pk) {
     DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
 
     // Add entry: rowset_id="rs_001", segment_id=0
@@ -923,8 +924,8 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_fo
     std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
 
     // Call the extracted function
-    ASSERT_TRUE(lake::ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
-                                                                             &dcg_meta, &filename_map)
+    ASSERT_TRUE(lake::ReplicationTxnManager::convert_dcg_meta_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
+                                                                         &dcg_meta, &filename_map)
                         .ok());
 
     // Verify: rssid 7 (rowset_seg_id=7 + segment_id=0) and rssid 8 (7+1)
@@ -953,8 +954,8 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_fo
     EXPECT_TRUE(filename_map.count("rs_001_1_5_0.cols"));
 }
 
-// Test convert_dcg_snapshot_for_non_pk with unknown rowset_id (should skip)
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_for_non_pk_unknown_rowset) {
+// Test convert_dcg_meta_for_non_pk with unknown rowset_id (should skip)
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_meta_for_non_pk_unknown_rowset) {
     DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
 
     dcg_snapshot_pb.add_tablet_id(100);
@@ -972,8 +973,8 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_fo
     DeltaColumnGroupMetadataPB dcg_meta;
     std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
 
-    ASSERT_TRUE(lake::ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
-                                                                             &dcg_meta, &filename_map)
+    ASSERT_TRUE(lake::ReplicationTxnManager::convert_dcg_meta_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
+                                                                         &dcg_meta, &filename_map)
                         .ok());
 
     // Unknown rowset should be skipped
@@ -981,8 +982,8 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_fo
     EXPECT_EQ(0, filename_map.size());
 }
 
-// Test that duplicate .cols filenames in convert_dcg_for_pk are detected
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_for_pk_duplicate_cols) {
+// Test that duplicate .cols filenames in convert_dcg_meta_for_pk are detected
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_meta_for_pk_duplicate_cols) {
     std::unordered_map<uint32_t, DeltaColumnGroupList> delta_column_groups;
 
     // Two DCGs for the same segment with the SAME column file name → duplicate
@@ -1005,13 +1006,13 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_for_pk_dupl
     std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
 
     Status status =
-            lake::ReplicationTxnManager::convert_dcg_for_pk(delta_column_groups, 12345, &dcg_meta, &filename_map);
+            lake::ReplicationTxnManager::convert_dcg_meta_for_pk(delta_column_groups, 12345, &dcg_meta, &filename_map);
     EXPECT_TRUE(status.is_corruption()) << status;
     EXPECT_TRUE(status.message().find("Duplicated cols file") != std::string::npos) << status;
 }
 
-// Test that duplicate .cols filenames in convert_dcg_snapshot_for_non_pk are detected
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_for_non_pk_duplicate_cols) {
+// Test that duplicate .cols filenames in convert_dcg_meta_for_non_pk are detected
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_meta_for_non_pk_duplicate_cols) {
     DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
 
     // Two entries with the same column file name → duplicate
@@ -1043,14 +1044,14 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_fo
     DeltaColumnGroupMetadataPB dcg_meta;
     std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
 
-    Status status = lake::ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id,
-                                                                                 9999, &dcg_meta, &filename_map);
+    Status status = lake::ReplicationTxnManager::convert_dcg_meta_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
+                                                                             &dcg_meta, &filename_map);
     EXPECT_TRUE(status.is_corruption()) << status;
     EXPECT_TRUE(status.message().find("Duplicated cols file") != std::string::npos) << status;
 }
 
-// Test convert_dcg_snapshot_for_non_pk: versions_size != dcgs_size mismatch
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_for_non_pk_versions_dcgs_mismatch) {
+// Test convert_dcg_meta_for_non_pk: versions_size != dcgs_size mismatch
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_meta_for_non_pk_versions_dcgs_mismatch) {
     DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
 
     dcg_snapshot_pb.add_tablet_id(100);
@@ -1072,14 +1073,14 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_fo
     DeltaColumnGroupMetadataPB dcg_meta;
     std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
 
-    Status status = lake::ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id,
-                                                                                 9999, &dcg_meta, &filename_map);
+    Status status = lake::ReplicationTxnManager::convert_dcg_meta_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
+                                                                             &dcg_meta, &filename_map);
     EXPECT_TRUE(status.is_corruption()) << status;
     EXPECT_TRUE(status.message().find("Mismatch between versions_size") != std::string::npos) << status;
 }
 
-// Test convert_dcg_snapshot_for_non_pk: column_ids_size != column_files_size mismatch
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_for_non_pk_column_ids_files_mismatch) {
+// Test convert_dcg_meta_for_non_pk: column_ids_size != column_files_size mismatch
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_meta_for_non_pk_column_ids_files_mismatch) {
     DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
 
     dcg_snapshot_pb.add_tablet_id(100);
@@ -1101,14 +1102,14 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_fo
     DeltaColumnGroupMetadataPB dcg_meta;
     std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
 
-    Status status = lake::ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id,
-                                                                                 9999, &dcg_meta, &filename_map);
+    Status status = lake::ReplicationTxnManager::convert_dcg_meta_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
+                                                                             &dcg_meta, &filename_map);
     EXPECT_TRUE(status.is_corruption()) << status;
     EXPECT_TRUE(status.message().find("Mismatch between column_ids_size") != std::string::npos) << status;
 }
 
-// Test convert_dcg_snapshot_for_non_pk with empty snapshot (no entries)
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_for_non_pk_empty) {
+// Test convert_dcg_meta_for_non_pk with empty snapshot (no entries)
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_meta_for_non_pk_empty) {
     DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
 
     std::unordered_map<std::string, uint32_t> rowset_id_to_seg_id;
@@ -1117,16 +1118,16 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_fo
     DeltaColumnGroupMetadataPB dcg_meta;
     std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
 
-    ASSERT_TRUE(lake::ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
-                                                                             &dcg_meta, &filename_map)
+    ASSERT_TRUE(lake::ReplicationTxnManager::convert_dcg_meta_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
+                                                                         &dcg_meta, &filename_map)
                         .ok());
 
     EXPECT_EQ(0, dcg_meta.dcgs_size());
     EXPECT_EQ(0, filename_map.size());
 }
 
-// Test convert_dcg_snapshot_for_non_pk with multiple DCGs per segment (different versions)
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_for_non_pk_multiple_dcgs_per_segment) {
+// Test convert_dcg_meta_for_non_pk with multiple DCGs per segment (different versions)
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_meta_for_non_pk_multiple_dcgs_per_segment) {
     DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
 
     // Single entry with multiple DCGs (different versions) for one segment
@@ -1155,8 +1156,8 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_fo
     DeltaColumnGroupMetadataPB dcg_meta;
     std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
 
-    ASSERT_TRUE(lake::ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
-                                                                             &dcg_meta, &filename_map)
+    ASSERT_TRUE(lake::ReplicationTxnManager::convert_dcg_meta_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
+                                                                         &dcg_meta, &filename_map)
                         .ok());
 
     // rssid = 10 + 0 = 10
@@ -1181,15 +1182,16 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_fo
     EXPECT_TRUE(filename_map.count("file_v5.cols"));
 }
 
-// Test convert_dcg_for_pk with empty delta_column_groups
-TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_for_pk_empty) {
+// Test convert_dcg_meta_for_pk with empty delta_column_groups
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_meta_for_pk_empty) {
     std::unordered_map<uint32_t, DeltaColumnGroupList> delta_column_groups;
 
     DeltaColumnGroupMetadataPB dcg_meta;
     std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
 
     ASSERT_TRUE(
-            lake::ReplicationTxnManager::convert_dcg_for_pk(delta_column_groups, 12345, &dcg_meta, &filename_map).ok());
+            lake::ReplicationTxnManager::convert_dcg_meta_for_pk(delta_column_groups, 12345, &dcg_meta, &filename_map)
+                    .ok());
 
     EXPECT_EQ(0, dcg_meta.dcgs_size());
     EXPECT_EQ(0, filename_map.size());

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -30,6 +30,8 @@
 #include "fs/key_cache.h"
 #include "runtime/exec_env.h"
 #include "storage/chunk_helper.h"
+#include "storage/delta_column_group.h"
+#include "storage/lake/filenames.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/location_provider.h"
@@ -39,6 +41,7 @@
 #include "storage/lake/update_manager.h"
 #include "storage/olap_define.h"
 #include "storage/options.h"
+#include "storage/replication_utils.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_options.h"
 #include "storage/rowset/rowset_writer.h"
@@ -579,6 +582,850 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_delete_predicat
     EXPECT_FALSE(delete_predicate.in_predicates(0).is_not_in());
     EXPECT_EQ(1, delete_predicate.in_predicates(0).values_size());
     EXPECT_EQ("1", delete_predicate.in_predicates(0).values(0));
+}
+
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_rowset_meta_column_mode_partial_update) {
+    // Create a RowsetMetaPB with num_update_files > 0 (column mode partial update)
+    RowsetMetaPB rowset_meta_pb;
+    rowset_meta_pb.set_rowset_id("0");
+    rowset_meta_pb.set_partition_id(1);
+    rowset_meta_pb.set_tablet_id(100);
+    rowset_meta_pb.set_num_rows(10);
+    rowset_meta_pb.set_total_disk_size(1024);
+    rowset_meta_pb.set_data_disk_size(1024);
+    rowset_meta_pb.set_num_segments(2);
+    rowset_meta_pb.set_num_update_files(1); // column mode partial update
+    rowset_meta_pb.set_rowset_seg_id(5);
+    RowsetMeta rowset_meta(rowset_meta_pb);
+    EXPECT_TRUE(rowset_meta.is_column_mode_partial_update());
+
+    TxnLogPB::OpWrite op_write;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    // Previously this would return NotSupported, now it should succeed
+    Status status = lake::ReplicationTxnManager::convert_rowset_meta(rowset_meta, 12345, &op_write, &filename_map);
+    EXPECT_TRUE(status.ok()) << status;
+
+    // Verify segments are properly converted
+    EXPECT_EQ(2, op_write.rowset().segments_size());
+    EXPECT_EQ(2, filename_map.size());
+
+    // Verify all segment files are .dat files
+    for (const auto& segment : op_write.rowset().segments()) {
+        EXPECT_TRUE(lake::is_segment(segment));
+    }
+}
+
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_build_file_converters_handles_cols_files) {
+    // Verify that build_file_converters handles .cols files alongside .dat files
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    std::string old_segment = "test_rowset_0.dat";
+    std::string new_segment = lake::gen_segment_filename(100);
+    filename_map[old_segment] = {new_segment, FileEncryptionPair()};
+
+    std::string old_cols = "test_rowset_0_1_0.cols";
+    std::string new_cols = lake::gen_cols_filename(100);
+    filename_map[old_cols] = {new_cols, FileEncryptionPair()};
+
+    std::string old_del = "test_rowset_0.del";
+    std::string new_del = lake::gen_del_filename(100);
+    filename_map[old_del] = {new_del, FileEncryptionPair()};
+
+    // .cols files should be in the filename map and handled correctly
+    EXPECT_TRUE(filename_map.count(old_cols) > 0);
+    EXPECT_TRUE(lake::is_cols(old_cols));
+    EXPECT_TRUE(lake::is_cols(new_cols));
+    EXPECT_TRUE(lake::is_segment(old_segment));
+    EXPECT_TRUE(lake::is_segment(new_segment));
+    EXPECT_TRUE(lake::is_del(old_del));
+    EXPECT_TRUE(lake::is_del(new_del));
+}
+
+// Test convert_dcg_for_pk: converts DeltaColumnGroupList from snapshot into DeltaColumnGroupMetadataPB
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_for_pk) {
+    // Build DeltaColumnGroupList in the same format as shared-nothing PK snapshot
+    std::unordered_map<uint32_t, DeltaColumnGroupList> delta_column_groups;
+
+    // Segment 5: one DCG with version 3, two column files
+    {
+        auto dcg = std::make_shared<DeltaColumnGroup>();
+        std::vector<std::string> column_files = {"old_file_1.cols", "old_file_2.cols"};
+        std::vector<std::vector<int32_t>> column_ids = {{1, 2}, {3}};
+        dcg->init(3, column_ids, column_files);
+        delta_column_groups[5].push_back(dcg);
+    }
+
+    // Segment 6: one DCG with version 5, one column file
+    {
+        auto dcg = std::make_shared<DeltaColumnGroup>();
+        std::vector<std::string> column_files = {"old_file_3.cols"};
+        std::vector<std::vector<int32_t>> column_ids = {{4}};
+        dcg->init(5, column_ids, column_files);
+        delta_column_groups[6].push_back(dcg);
+    }
+
+    DeltaColumnGroupMetadataPB dcg_meta;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    // Call the extracted function
+    ASSERT_TRUE(
+            lake::ReplicationTxnManager::convert_dcg_for_pk(delta_column_groups, 12345, &dcg_meta, &filename_map).ok());
+
+    // Verify structure
+    EXPECT_EQ(2, dcg_meta.dcgs_size());
+    EXPECT_TRUE(dcg_meta.dcgs().count(5));
+    EXPECT_TRUE(dcg_meta.dcgs().count(6));
+
+    const auto& ver1 = dcg_meta.dcgs().at(5);
+    EXPECT_EQ(2, ver1.column_files_size());
+    EXPECT_EQ(2, ver1.versions_size());
+    EXPECT_EQ(2, ver1.unique_column_ids_size());
+    EXPECT_EQ(3, ver1.versions(0));
+    EXPECT_EQ(3, ver1.versions(1));
+    EXPECT_EQ(2, ver1.unique_column_ids(0).column_ids_size());
+    EXPECT_EQ(1, ver1.unique_column_ids(0).column_ids(0));
+    EXPECT_EQ(2, ver1.unique_column_ids(0).column_ids(1));
+    EXPECT_EQ(1, ver1.unique_column_ids(1).column_ids_size());
+    EXPECT_EQ(3, ver1.unique_column_ids(1).column_ids(0));
+
+    const auto& ver2 = dcg_meta.dcgs().at(6);
+    EXPECT_EQ(1, ver2.column_files_size());
+    EXPECT_EQ(1, ver2.versions_size());
+    EXPECT_EQ(5, ver2.versions(0));
+    EXPECT_EQ(1, ver2.unique_column_ids(0).column_ids_size());
+    EXPECT_EQ(4, ver2.unique_column_ids(0).column_ids(0));
+
+    // Verify filename_map has old->new mappings for 3 .cols files
+    EXPECT_EQ(3, filename_map.size());
+    EXPECT_TRUE(filename_map.count("old_file_1.cols"));
+    EXPECT_TRUE(filename_map.count("old_file_2.cols"));
+    EXPECT_TRUE(filename_map.count("old_file_3.cols"));
+    for (const auto& [old_name, pair] : filename_map) {
+        EXPECT_TRUE(lake::is_cols(pair.first));
+    }
+}
+
+// Test convert_dcg_column_unique_ids
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_column_unique_ids) {
+    DeltaColumnGroupMetadataPB dcg_meta;
+
+    // Build DCG metadata with original column IDs
+    auto& dcg_ver1 = (*dcg_meta.mutable_dcgs())[5];
+    dcg_ver1.add_column_files("file1.cols");
+    dcg_ver1.add_versions(3);
+    auto* ucids1 = dcg_ver1.add_unique_column_ids();
+    ucids1->add_column_ids(1);
+    ucids1->add_column_ids(2);
+
+    dcg_ver1.add_column_files("file2.cols");
+    dcg_ver1.add_versions(3);
+    auto* ucids2 = dcg_ver1.add_unique_column_ids();
+    ucids2->add_column_ids(3);
+
+    auto& dcg_ver2 = (*dcg_meta.mutable_dcgs())[6];
+    dcg_ver2.add_column_files("file3.cols");
+    dcg_ver2.add_versions(5);
+    auto* ucids3 = dcg_ver2.add_unique_column_ids();
+    ucids3->add_column_ids(4);
+
+    std::unordered_map<uint32_t, uint32_t> column_unique_id_map;
+    column_unique_id_map[1] = 10;
+    column_unique_id_map[2] = 20;
+    column_unique_id_map[3] = 30;
+    column_unique_id_map[4] = 40;
+
+    ASSERT_TRUE(lake::ReplicationTxnManager::convert_dcg_column_unique_ids(&dcg_meta, column_unique_id_map).ok());
+
+    // Verify converted IDs
+    EXPECT_EQ(10, dcg_meta.dcgs().at(5).unique_column_ids(0).column_ids(0));
+    EXPECT_EQ(20, dcg_meta.dcgs().at(5).unique_column_ids(0).column_ids(1));
+    EXPECT_EQ(30, dcg_meta.dcgs().at(5).unique_column_ids(1).column_ids(0));
+    EXPECT_EQ(40, dcg_meta.dcgs().at(6).unique_column_ids(0).column_ids(0));
+}
+
+// Test DCG metadata apply for PK table replication
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_dcg_apply_replication_pk) {
+    // Simulate PK table apply_replication_log with DCG metadata
+    // Build a tablet metadata
+    TabletMetadataPB metadata;
+    metadata.set_id(100);
+    metadata.set_version(1);
+    metadata.set_next_rowset_id(10);
+    auto* schema = metadata.mutable_schema();
+    schema->set_keys_type(PRIMARY_KEYS);
+    schema->set_id(1);
+
+    // Build op_replication with DCG metadata
+    TxnLogPB_OpReplication op_replication;
+    auto* txn_meta = op_replication.mutable_txn_meta();
+    txn_meta->set_txn_id(1);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_tablet_id(100);
+    txn_meta->set_visible_version(1);
+    txn_meta->set_data_version(0);
+    txn_meta->set_snapshot_version(2);
+    txn_meta->set_incremental_snapshot(false);
+
+    // Add a rowset with 2 segments
+    auto* op_write = op_replication.add_op_writes();
+    auto* rowset = op_write->mutable_rowset();
+    rowset->set_id(5); // source rowset seg id
+    rowset->set_num_rows(100);
+    rowset->set_data_size(4096);
+    rowset->add_segments("seg1.dat");
+    rowset->add_segments("seg2.dat");
+
+    // Add DCG metadata - segment 5 has DCG with version 3
+    auto* dcg_meta = op_replication.mutable_dcg_meta();
+    auto& dcg_ver = (*dcg_meta->mutable_dcgs())[5]; // source rssid = 5
+    dcg_ver.add_column_files("test.cols");
+    dcg_ver.add_versions(3);
+    auto* ucids = dcg_ver.add_unique_column_ids();
+    ucids->add_column_ids(1);
+    ucids->add_column_ids(2);
+
+    // Simulate applying the replication log for PK tables
+    // For PK non-lake replication: new_rssid = source_rssid + old_next_rowset_id
+    uint32_t old_next_rowset_id = metadata.next_rowset_id(); // 10
+
+    // Apply DCG with offset
+    for (const auto& [src_rssid, src_dcg_ver] : op_replication.dcg_meta().dcgs()) {
+        (*metadata.mutable_dcg_meta()->mutable_dcgs())[src_rssid + old_next_rowset_id].CopyFrom(src_dcg_ver);
+    }
+
+    // Verify result
+    EXPECT_EQ(1, metadata.dcg_meta().dcgs_size());
+    EXPECT_TRUE(metadata.dcg_meta().dcgs().count(15)); // 5 + 10
+    const auto& result_dcg = metadata.dcg_meta().dcgs().at(15);
+    EXPECT_EQ(1, result_dcg.column_files_size());
+    EXPECT_EQ("test.cols", result_dcg.column_files(0));
+    EXPECT_EQ(3, result_dcg.versions(0));
+    EXPECT_EQ(2, result_dcg.unique_column_ids(0).column_ids_size());
+    EXPECT_EQ(1, result_dcg.unique_column_ids(0).column_ids(0));
+    EXPECT_EQ(2, result_dcg.unique_column_ids(0).column_ids(1));
+}
+
+// Test DCG metadata apply for non-PK table replication with rssid remapping
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_dcg_apply_replication_non_pk) {
+    // Build op_replication with two rowsets and DCG metadata
+    TxnLogPB_OpReplication op_replication;
+    auto* txn_meta = op_replication.mutable_txn_meta();
+    txn_meta->set_txn_id(1);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_tablet_id(200);
+    txn_meta->set_visible_version(1);
+    txn_meta->set_data_version(0);
+    txn_meta->set_snapshot_version(2);
+    txn_meta->set_incremental_snapshot(false);
+
+    // Rowset 1: source id=3, 2 segments
+    auto* op_write1 = op_replication.add_op_writes();
+    auto* rowset1 = op_write1->mutable_rowset();
+    rowset1->set_id(3);
+    rowset1->set_num_rows(50);
+    rowset1->set_data_size(2048);
+    rowset1->add_segments("seg1.dat");
+    rowset1->add_segments("seg2.dat");
+
+    // Rowset 2: source id=10, 1 segment
+    auto* op_write2 = op_replication.add_op_writes();
+    auto* rowset2 = op_write2->mutable_rowset();
+    rowset2->set_id(10);
+    rowset2->set_num_rows(30);
+    rowset2->set_data_size(1024);
+    rowset2->add_segments("seg3.dat");
+
+    // DCG on segment (source rssid=4, which is rowset1.id + segment_index 1)
+    auto* dcg_meta = op_replication.mutable_dcg_meta();
+    auto& dcg_ver = (*dcg_meta->mutable_dcgs())[4]; // rssid 4 = rowset1(3) + segment 1
+    dcg_ver.add_column_files("cols1.cols");
+    dcg_ver.add_versions(2);
+    auto* ucids = dcg_ver.add_unique_column_ids();
+    ucids->add_column_ids(5);
+
+    // Simulate non-PK rssid remapping
+    // Assume target next_rowset_id starts at 20
+    uint32_t current_next_id = 20;
+    std::unordered_map<uint32_t, uint32_t> rssid_remap;
+
+    for (const auto& ow : op_replication.op_writes()) {
+        if (ow.has_rowset()) {
+            uint32_t source_id = ow.rowset().id();
+            uint32_t num_segments = ow.rowset().segments_size();
+            for (uint32_t i = 0; i < num_segments; i++) {
+                rssid_remap[source_id + i] = current_next_id + i;
+            }
+            current_next_id += std::max<uint32_t>(1, num_segments);
+        }
+    }
+
+    // Verify remap: source 3->20, 4->21, 10->22
+    EXPECT_EQ(20, rssid_remap[3]);
+    EXPECT_EQ(21, rssid_remap[4]);
+    EXPECT_EQ(22, rssid_remap[10]);
+
+    // Apply DCG with remapping
+    TabletMetadataPB metadata;
+    metadata.set_id(200);
+    metadata.set_version(1);
+
+    for (const auto& [src_rssid, src_dcg_ver] : op_replication.dcg_meta().dcgs()) {
+        auto it = rssid_remap.find(src_rssid);
+        uint32_t target_rssid = (it != rssid_remap.end()) ? it->second : src_rssid;
+        (*metadata.mutable_dcg_meta()->mutable_dcgs())[target_rssid].CopyFrom(src_dcg_ver);
+    }
+
+    // Verify: source rssid 4 -> target rssid 21
+    EXPECT_EQ(1, metadata.dcg_meta().dcgs_size());
+    EXPECT_TRUE(metadata.dcg_meta().dcgs().count(21));
+    const auto& result_dcg = metadata.dcg_meta().dcgs().at(21);
+    EXPECT_EQ(1, result_dcg.column_files_size());
+    EXPECT_EQ("cols1.cols", result_dcg.column_files(0));
+    EXPECT_EQ(2, result_dcg.versions(0));
+    EXPECT_EQ(5, result_dcg.unique_column_ids(0).column_ids(0));
+}
+
+// Test convert_dcg_snapshot_for_non_pk: converts DeltaColumnGroupSnapshotPB into DeltaColumnGroupMetadataPB
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_for_non_pk) {
+    DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
+
+    // Add entry: rowset_id="rs_001", segment_id=0
+    dcg_snapshot_pb.add_tablet_id(100);
+    dcg_snapshot_pb.add_rowset_id("rs_001");
+    dcg_snapshot_pb.add_segment_id(0);
+
+    auto* dcg_list_pb = dcg_snapshot_pb.add_dcg_lists();
+    dcg_list_pb->add_versions(5);
+    auto* dcg_pb = dcg_list_pb->add_dcgs();
+    dcg_pb->add_column_files("rs_001_0_5_0.cols");
+    auto* col_ids = dcg_pb->add_column_ids();
+    col_ids->add_column_ids(1);
+    col_ids->add_column_ids(2);
+
+    // Add second entry: same rowset, segment 1
+    dcg_snapshot_pb.add_tablet_id(100);
+    dcg_snapshot_pb.add_rowset_id("rs_001");
+    dcg_snapshot_pb.add_segment_id(1);
+
+    auto* dcg_list_pb2 = dcg_snapshot_pb.add_dcg_lists();
+    dcg_list_pb2->add_versions(5);
+    auto* dcg_pb2 = dcg_list_pb2->add_dcgs();
+    dcg_pb2->add_column_files("rs_001_1_5_0.cols");
+    auto* col_ids2 = dcg_pb2->add_column_ids();
+    col_ids2->add_column_ids(3);
+
+    // Build rowset_id -> seg_id mapping
+    std::unordered_map<std::string, uint32_t> rowset_id_to_seg_id;
+    rowset_id_to_seg_id["rs_001"] = 7;
+
+    DeltaColumnGroupMetadataPB dcg_meta;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    // Call the extracted function
+    ASSERT_TRUE(lake::ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
+                                                                             &dcg_meta, &filename_map)
+                        .ok());
+
+    // Verify: rssid 7 (rowset_seg_id=7 + segment_id=0) and rssid 8 (7+1)
+    EXPECT_EQ(2, dcg_meta.dcgs_size());
+    EXPECT_TRUE(dcg_meta.dcgs().count(7));
+    EXPECT_TRUE(dcg_meta.dcgs().count(8));
+
+    const auto& dcg7 = dcg_meta.dcgs().at(7);
+    EXPECT_EQ(1, dcg7.column_files_size());
+    EXPECT_TRUE(lake::is_cols(dcg7.column_files(0)));
+    EXPECT_EQ(5, dcg7.versions(0));
+    EXPECT_EQ(2, dcg7.unique_column_ids(0).column_ids_size());
+    EXPECT_EQ(1, dcg7.unique_column_ids(0).column_ids(0));
+    EXPECT_EQ(2, dcg7.unique_column_ids(0).column_ids(1));
+
+    const auto& dcg8 = dcg_meta.dcgs().at(8);
+    EXPECT_EQ(1, dcg8.column_files_size());
+    EXPECT_TRUE(lake::is_cols(dcg8.column_files(0)));
+    EXPECT_EQ(5, dcg8.versions(0));
+    EXPECT_EQ(1, dcg8.unique_column_ids(0).column_ids_size());
+    EXPECT_EQ(3, dcg8.unique_column_ids(0).column_ids(0));
+
+    // Verify filename_map
+    EXPECT_EQ(2, filename_map.size());
+    EXPECT_TRUE(filename_map.count("rs_001_0_5_0.cols"));
+    EXPECT_TRUE(filename_map.count("rs_001_1_5_0.cols"));
+}
+
+// Test convert_dcg_snapshot_for_non_pk with unknown rowset_id (should skip)
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_for_non_pk_unknown_rowset) {
+    DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
+
+    dcg_snapshot_pb.add_tablet_id(100);
+    dcg_snapshot_pb.add_rowset_id("unknown_rs");
+    dcg_snapshot_pb.add_segment_id(0);
+
+    auto* dcg_list_pb = dcg_snapshot_pb.add_dcg_lists();
+    dcg_list_pb->add_versions(1);
+    auto* dcg_pb = dcg_list_pb->add_dcgs();
+    dcg_pb->add_column_files("unknown_file.cols");
+
+    std::unordered_map<std::string, uint32_t> rowset_id_to_seg_id;
+    rowset_id_to_seg_id["rs_001"] = 7; // Only rs_001, not "unknown_rs"
+
+    DeltaColumnGroupMetadataPB dcg_meta;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    ASSERT_TRUE(lake::ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
+                                                                             &dcg_meta, &filename_map)
+                        .ok());
+
+    // Unknown rowset should be skipped
+    EXPECT_EQ(0, dcg_meta.dcgs_size());
+    EXPECT_EQ(0, filename_map.size());
+}
+
+// Test that duplicate .cols filenames in convert_dcg_for_pk are detected
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_for_pk_duplicate_cols) {
+    std::unordered_map<uint32_t, DeltaColumnGroupList> delta_column_groups;
+
+    // Two DCGs for the same segment with the SAME column file name → duplicate
+    {
+        auto dcg1 = std::make_shared<DeltaColumnGroup>();
+        std::vector<std::string> column_files = {"same_file.cols"};
+        std::vector<std::vector<int32_t>> column_ids = {{1}};
+        dcg1->init(1, column_ids, column_files);
+
+        auto dcg2 = std::make_shared<DeltaColumnGroup>();
+        std::vector<std::string> column_files2 = {"same_file.cols"};
+        std::vector<std::vector<int32_t>> column_ids2 = {{2}};
+        dcg2->init(2, column_ids2, column_files2);
+
+        delta_column_groups[5].push_back(dcg1);
+        delta_column_groups[5].push_back(dcg2);
+    }
+
+    DeltaColumnGroupMetadataPB dcg_meta;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    Status status =
+            lake::ReplicationTxnManager::convert_dcg_for_pk(delta_column_groups, 12345, &dcg_meta, &filename_map);
+    EXPECT_TRUE(status.is_corruption()) << status;
+    EXPECT_TRUE(status.message().find("Duplicated cols file") != std::string::npos) << status;
+}
+
+// Test that duplicate .cols filenames in convert_dcg_snapshot_for_non_pk are detected
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_for_non_pk_duplicate_cols) {
+    DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
+
+    // Two entries with the same column file name → duplicate
+    dcg_snapshot_pb.add_tablet_id(100);
+    dcg_snapshot_pb.add_rowset_id("rs_001");
+    dcg_snapshot_pb.add_segment_id(0);
+
+    auto* dcg_list_pb1 = dcg_snapshot_pb.add_dcg_lists();
+    dcg_list_pb1->add_versions(1);
+    auto* dcg_pb1 = dcg_list_pb1->add_dcgs();
+    dcg_pb1->add_column_files("same_file.cols");
+    auto* col_ids1 = dcg_pb1->add_column_ids();
+    col_ids1->add_column_ids(1);
+
+    dcg_snapshot_pb.add_tablet_id(100);
+    dcg_snapshot_pb.add_rowset_id("rs_001");
+    dcg_snapshot_pb.add_segment_id(0);
+
+    auto* dcg_list_pb2 = dcg_snapshot_pb.add_dcg_lists();
+    dcg_list_pb2->add_versions(2);
+    auto* dcg_pb2 = dcg_list_pb2->add_dcgs();
+    dcg_pb2->add_column_files("same_file.cols");
+    auto* col_ids2 = dcg_pb2->add_column_ids();
+    col_ids2->add_column_ids(2);
+
+    std::unordered_map<std::string, uint32_t> rowset_id_to_seg_id;
+    rowset_id_to_seg_id["rs_001"] = 7;
+
+    DeltaColumnGroupMetadataPB dcg_meta;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    Status status = lake::ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id,
+                                                                                 9999, &dcg_meta, &filename_map);
+    EXPECT_TRUE(status.is_corruption()) << status;
+    EXPECT_TRUE(status.message().find("Duplicated cols file") != std::string::npos) << status;
+}
+
+// Test convert_dcg_snapshot_for_non_pk: versions_size != dcgs_size mismatch
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_for_non_pk_versions_dcgs_mismatch) {
+    DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
+
+    dcg_snapshot_pb.add_tablet_id(100);
+    dcg_snapshot_pb.add_rowset_id("rs_001");
+    dcg_snapshot_pb.add_segment_id(0);
+
+    auto* dcg_list_pb = dcg_snapshot_pb.add_dcg_lists();
+    // Add 2 versions but only 1 dcg → mismatch
+    dcg_list_pb->add_versions(1);
+    dcg_list_pb->add_versions(2);
+    auto* dcg_pb = dcg_list_pb->add_dcgs();
+    dcg_pb->add_column_files("file.cols");
+    auto* col_ids = dcg_pb->add_column_ids();
+    col_ids->add_column_ids(1);
+
+    std::unordered_map<std::string, uint32_t> rowset_id_to_seg_id;
+    rowset_id_to_seg_id["rs_001"] = 7;
+
+    DeltaColumnGroupMetadataPB dcg_meta;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    Status status = lake::ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id,
+                                                                                 9999, &dcg_meta, &filename_map);
+    EXPECT_TRUE(status.is_corruption()) << status;
+    EXPECT_TRUE(status.message().find("Mismatch between versions_size") != std::string::npos) << status;
+}
+
+// Test convert_dcg_snapshot_for_non_pk: column_ids_size != column_files_size mismatch
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_for_non_pk_column_ids_files_mismatch) {
+    DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
+
+    dcg_snapshot_pb.add_tablet_id(100);
+    dcg_snapshot_pb.add_rowset_id("rs_001");
+    dcg_snapshot_pb.add_segment_id(0);
+
+    auto* dcg_list_pb = dcg_snapshot_pb.add_dcg_lists();
+    dcg_list_pb->add_versions(1);
+    auto* dcg_pb = dcg_list_pb->add_dcgs();
+    // Add 2 column_files but only 1 column_ids → mismatch
+    dcg_pb->add_column_files("file1.cols");
+    dcg_pb->add_column_files("file2.cols");
+    auto* col_ids = dcg_pb->add_column_ids();
+    col_ids->add_column_ids(1);
+
+    std::unordered_map<std::string, uint32_t> rowset_id_to_seg_id;
+    rowset_id_to_seg_id["rs_001"] = 7;
+
+    DeltaColumnGroupMetadataPB dcg_meta;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    Status status = lake::ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id,
+                                                                                 9999, &dcg_meta, &filename_map);
+    EXPECT_TRUE(status.is_corruption()) << status;
+    EXPECT_TRUE(status.message().find("Mismatch between column_ids_size") != std::string::npos) << status;
+}
+
+// Test convert_dcg_snapshot_for_non_pk with empty snapshot (no entries)
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_for_non_pk_empty) {
+    DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
+
+    std::unordered_map<std::string, uint32_t> rowset_id_to_seg_id;
+    rowset_id_to_seg_id["rs_001"] = 7;
+
+    DeltaColumnGroupMetadataPB dcg_meta;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    ASSERT_TRUE(lake::ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
+                                                                             &dcg_meta, &filename_map)
+                        .ok());
+
+    EXPECT_EQ(0, dcg_meta.dcgs_size());
+    EXPECT_EQ(0, filename_map.size());
+}
+
+// Test convert_dcg_snapshot_for_non_pk with multiple DCGs per segment (different versions)
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_snapshot_for_non_pk_multiple_dcgs_per_segment) {
+    DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
+
+    // Single entry with multiple DCGs (different versions) for one segment
+    dcg_snapshot_pb.add_tablet_id(100);
+    dcg_snapshot_pb.add_rowset_id("rs_001");
+    dcg_snapshot_pb.add_segment_id(0);
+
+    auto* dcg_list_pb = dcg_snapshot_pb.add_dcg_lists();
+    dcg_list_pb->add_versions(3);
+    dcg_list_pb->add_versions(5);
+
+    auto* dcg_pb1 = dcg_list_pb->add_dcgs();
+    dcg_pb1->add_column_files("file_v3.cols");
+    auto* col_ids1 = dcg_pb1->add_column_ids();
+    col_ids1->add_column_ids(1);
+    col_ids1->add_column_ids(2);
+
+    auto* dcg_pb2 = dcg_list_pb->add_dcgs();
+    dcg_pb2->add_column_files("file_v5.cols");
+    auto* col_ids2 = dcg_pb2->add_column_ids();
+    col_ids2->add_column_ids(3);
+
+    std::unordered_map<std::string, uint32_t> rowset_id_to_seg_id;
+    rowset_id_to_seg_id["rs_001"] = 10;
+
+    DeltaColumnGroupMetadataPB dcg_meta;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    ASSERT_TRUE(lake::ReplicationTxnManager::convert_dcg_snapshot_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
+                                                                             &dcg_meta, &filename_map)
+                        .ok());
+
+    // rssid = 10 + 0 = 10
+    EXPECT_EQ(1, dcg_meta.dcgs_size());
+    EXPECT_TRUE(dcg_meta.dcgs().count(10));
+
+    const auto& dcg_ver = dcg_meta.dcgs().at(10);
+    // Two DCGs → two column_files, two versions, two unique_column_ids
+    EXPECT_EQ(2, dcg_ver.column_files_size());
+    EXPECT_EQ(2, dcg_ver.versions_size());
+    EXPECT_EQ(2, dcg_ver.unique_column_ids_size());
+    EXPECT_EQ(3, dcg_ver.versions(0));
+    EXPECT_EQ(5, dcg_ver.versions(1));
+    EXPECT_EQ(2, dcg_ver.unique_column_ids(0).column_ids_size());
+    EXPECT_EQ(1, dcg_ver.unique_column_ids(0).column_ids(0));
+    EXPECT_EQ(2, dcg_ver.unique_column_ids(0).column_ids(1));
+    EXPECT_EQ(1, dcg_ver.unique_column_ids(1).column_ids_size());
+    EXPECT_EQ(3, dcg_ver.unique_column_ids(1).column_ids(0));
+
+    EXPECT_EQ(2, filename_map.size());
+    EXPECT_TRUE(filename_map.count("file_v3.cols"));
+    EXPECT_TRUE(filename_map.count("file_v5.cols"));
+}
+
+// Test convert_dcg_for_pk with empty delta_column_groups
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_for_pk_empty) {
+    std::unordered_map<uint32_t, DeltaColumnGroupList> delta_column_groups;
+
+    DeltaColumnGroupMetadataPB dcg_meta;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    ASSERT_TRUE(
+            lake::ReplicationTxnManager::convert_dcg_for_pk(delta_column_groups, 12345, &dcg_meta, &filename_map).ok());
+
+    EXPECT_EQ(0, dcg_meta.dcgs_size());
+    EXPECT_EQ(0, filename_map.size());
+}
+
+// Test convert_dcg_column_unique_ids with missing column ID in map
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_column_unique_ids_missing_column) {
+    DeltaColumnGroupMetadataPB dcg_meta;
+
+    auto& dcg_ver = (*dcg_meta.mutable_dcgs())[5];
+    dcg_ver.add_column_files("file.cols");
+    dcg_ver.add_versions(1);
+    auto* ucids = dcg_ver.add_unique_column_ids();
+    ucids->add_column_ids(999); // This column ID is not in the map
+
+    std::unordered_map<uint32_t, uint32_t> column_unique_id_map;
+    column_unique_id_map[1] = 10;
+    column_unique_id_map[2] = 20;
+
+    Status status = lake::ReplicationTxnManager::convert_dcg_column_unique_ids(&dcg_meta, column_unique_id_map);
+    EXPECT_TRUE(!status.ok()) << status;
+    EXPECT_TRUE(status.message().find("Column not found") != std::string::npos) << status;
+}
+
+// Test convert_dcg_column_unique_ids with empty map (no-op)
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_column_unique_ids_empty_map) {
+    DeltaColumnGroupMetadataPB dcg_meta;
+
+    auto& dcg_ver = (*dcg_meta.mutable_dcgs())[5];
+    dcg_ver.add_column_files("file.cols");
+    dcg_ver.add_versions(1);
+    auto* ucids = dcg_ver.add_unique_column_ids();
+    ucids->add_column_ids(1);
+
+    std::unordered_map<uint32_t, uint32_t> empty_map;
+
+    Status status = lake::ReplicationTxnManager::convert_dcg_column_unique_ids(&dcg_meta, empty_map);
+    EXPECT_TRUE(status.ok()) << status;
+
+    // Column IDs should remain unchanged when map is empty
+    EXPECT_EQ(1, dcg_meta.dcgs().at(5).unique_column_ids(0).column_ids(0));
+}
+
+// Test PK incremental replication DCG apply with rssid remap
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_dcg_apply_incremental_pk) {
+    // Simulate PK incremental replication with DCG metadata
+    TabletMetadataPB metadata;
+    metadata.set_id(100);
+    metadata.set_version(5);
+    metadata.set_next_rowset_id(20); // existing next_rowset_id
+
+    // Build op_replication with incremental snapshot
+    TxnLogPB_OpReplication op_replication;
+    auto* txn_meta = op_replication.mutable_txn_meta();
+    txn_meta->set_txn_id(1);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_tablet_id(100);
+    txn_meta->set_visible_version(5);
+    txn_meta->set_data_version(0);
+    txn_meta->set_snapshot_version(7);
+    txn_meta->set_incremental_snapshot(true);
+
+    // Rowset 1: source id=3, 2 segments, 50 rows
+    auto* op_write1 = op_replication.add_op_writes();
+    auto* rowset1 = op_write1->mutable_rowset();
+    rowset1->set_id(3);
+    rowset1->set_num_rows(50);
+    rowset1->set_data_size(2048);
+    rowset1->add_segments("seg1.dat");
+    rowset1->add_segments("seg2.dat");
+
+    // Rowset 2: source id=8, 1 segment, 30 rows
+    auto* op_write2 = op_replication.add_op_writes();
+    auto* rowset2 = op_write2->mutable_rowset();
+    rowset2->set_id(8);
+    rowset2->set_num_rows(30);
+    rowset2->set_data_size(1024);
+    rowset2->add_segments("seg3.dat");
+
+    // DCG on source segment 4 (rowset1.id=3, segment index 1)
+    auto* dcg_meta_pb = op_replication.mutable_dcg_meta();
+    auto& dcg_ver = (*dcg_meta_pb->mutable_dcgs())[4];
+    dcg_ver.add_column_files("test.cols");
+    dcg_ver.add_versions(3);
+    auto* ucids = dcg_ver.add_unique_column_ids();
+    ucids->add_column_ids(10);
+
+    // Simulate PK incremental apply: build rssid_remap
+    // PK skip condition: dels_size>0 || num_rows>0 || has_delete_predicate
+    std::unordered_map<uint32_t, uint32_t> rssid_remap;
+    {
+        uint32_t target_id = metadata.next_rowset_id(); // 20
+        for (const auto& ow : op_replication.op_writes()) {
+            if (ow.dels_size() > 0 || ow.rowset().num_rows() > 0 || ow.rowset().has_delete_predicate()) {
+                uint32_t source_id = ow.rowset().id();
+                uint32_t step = std::max<uint32_t>(1, ow.rowset().segments_size());
+                for (uint32_t i = 0; i < step; i++) {
+                    rssid_remap[source_id + i] = target_id + i;
+                }
+                target_id += step;
+            }
+        }
+    }
+
+    // Verify remap: source 3->20, 4->21, 8->22
+    EXPECT_EQ(20, rssid_remap[3]);
+    EXPECT_EQ(21, rssid_remap[4]);
+    EXPECT_EQ(22, rssid_remap[8]);
+
+    // Apply DCG with rssid remap
+    for (const auto& [src_rssid, src_dcg_ver] : op_replication.dcg_meta().dcgs()) {
+        auto it = rssid_remap.find(src_rssid);
+        uint32_t target_rssid = (it != rssid_remap.end()) ? it->second : src_rssid;
+        (*metadata.mutable_dcg_meta()->mutable_dcgs())[target_rssid].CopyFrom(src_dcg_ver);
+    }
+
+    // Source rssid 4 → target rssid 21
+    EXPECT_EQ(1, metadata.dcg_meta().dcgs_size());
+    EXPECT_TRUE(metadata.dcg_meta().dcgs().count(21));
+    const auto& result = metadata.dcg_meta().dcgs().at(21);
+    EXPECT_EQ("test.cols", result.column_files(0));
+    EXPECT_EQ(3, result.versions(0));
+    EXPECT_EQ(10, result.unique_column_ids(0).column_ids(0));
+}
+
+// Test non-PK incremental replication DCG apply with rssid remap
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_dcg_apply_incremental_non_pk) {
+    TabletMetadataPB metadata;
+    metadata.set_id(200);
+    metadata.set_version(3);
+    metadata.set_next_rowset_id(15);
+
+    TxnLogPB_OpReplication op_replication;
+    auto* txn_meta = op_replication.mutable_txn_meta();
+    txn_meta->set_txn_id(2);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_tablet_id(200);
+    txn_meta->set_visible_version(3);
+    txn_meta->set_data_version(0);
+    txn_meta->set_snapshot_version(5);
+    txn_meta->set_incremental_snapshot(true);
+
+    // Rowset: source id=5, 3 segments, 100 rows
+    auto* op_write = op_replication.add_op_writes();
+    auto* rowset = op_write->mutable_rowset();
+    rowset->set_id(5);
+    rowset->set_num_rows(100);
+    rowset->set_data_size(4096);
+    rowset->add_segments("s1.dat");
+    rowset->add_segments("s2.dat");
+    rowset->add_segments("s3.dat");
+
+    // DCG on source segment 6 (rowset.id=5, segment index 1)
+    auto* dcg_meta_pb = op_replication.mutable_dcg_meta();
+    auto& dcg_ver = (*dcg_meta_pb->mutable_dcgs())[6];
+    dcg_ver.add_column_files("inc.cols");
+    dcg_ver.add_versions(4);
+    auto* ucids = dcg_ver.add_unique_column_ids();
+    ucids->add_column_ids(7);
+
+    // Non-PK skip condition: has_rowset && (num_rows>0 || has_delete_predicate)
+    std::unordered_map<uint32_t, uint32_t> rssid_remap;
+    {
+        uint32_t target_id = metadata.next_rowset_id(); // 15
+        for (const auto& ow : op_replication.op_writes()) {
+            if (ow.has_rowset() && (ow.rowset().num_rows() > 0 || ow.rowset().has_delete_predicate())) {
+                uint32_t source_id = ow.rowset().id();
+                uint32_t step = std::max<uint32_t>(1, ow.rowset().segments_size());
+                for (uint32_t i = 0; i < step; i++) {
+                    rssid_remap[source_id + i] = target_id + i;
+                }
+                target_id += step;
+            }
+        }
+    }
+
+    // Verify remap: source 5->15, 6->16, 7->17
+    EXPECT_EQ(15, rssid_remap[5]);
+    EXPECT_EQ(16, rssid_remap[6]);
+    EXPECT_EQ(17, rssid_remap[7]);
+
+    // Apply DCG with rssid remap
+    for (const auto& [src_rssid, src_dcg_ver] : op_replication.dcg_meta().dcgs()) {
+        auto it = rssid_remap.find(src_rssid);
+        uint32_t target_rssid = (it != rssid_remap.end()) ? it->second : src_rssid;
+        (*metadata.mutable_dcg_meta()->mutable_dcgs())[target_rssid].CopyFrom(src_dcg_ver);
+    }
+
+    // Source rssid 6 → target rssid 16
+    EXPECT_EQ(1, metadata.dcg_meta().dcgs_size());
+    EXPECT_TRUE(metadata.dcg_meta().dcgs().count(16));
+    const auto& result = metadata.dcg_meta().dcgs().at(16);
+    EXPECT_EQ("inc.cols", result.column_files(0));
+    EXPECT_EQ(4, result.versions(0));
+    EXPECT_EQ(7, result.unique_column_ids(0).column_ids(0));
+}
+
+// Test OpReplication protobuf correctly carries DCG metadata
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_op_replication_dcg_meta_serialization) {
+    TxnLogPB txn_log;
+    txn_log.set_tablet_id(100);
+    txn_log.set_txn_id(200);
+
+    auto* op_replication = txn_log.mutable_op_replication();
+    auto* txn_meta = op_replication->mutable_txn_meta();
+    txn_meta->set_txn_id(200);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+
+    // Add DCG metadata
+    auto* dcg_meta = op_replication->mutable_dcg_meta();
+    auto& dcg_ver = (*dcg_meta->mutable_dcgs())[10];
+    dcg_ver.add_column_files("test_file.cols");
+    dcg_ver.add_versions(42);
+    auto* ucids = dcg_ver.add_unique_column_ids();
+    ucids->add_column_ids(100);
+    ucids->add_column_ids(200);
+
+    // Serialize and deserialize
+    std::string serialized;
+    EXPECT_TRUE(txn_log.SerializeToString(&serialized));
+
+    TxnLogPB deserialized;
+    EXPECT_TRUE(deserialized.ParseFromString(serialized));
+
+    // Verify deserialized DCG metadata
+    EXPECT_TRUE(deserialized.op_replication().has_dcg_meta());
+    EXPECT_EQ(1, deserialized.op_replication().dcg_meta().dcgs_size());
+    EXPECT_TRUE(deserialized.op_replication().dcg_meta().dcgs().count(10));
+
+    const auto& result = deserialized.op_replication().dcg_meta().dcgs().at(10);
+    EXPECT_EQ(1, result.column_files_size());
+    EXPECT_EQ("test_file.cols", result.column_files(0));
+    EXPECT_EQ(42, result.versions(0));
+    EXPECT_EQ(2, result.unique_column_ids(0).column_ids_size());
+    EXPECT_EQ(100, result.unique_column_ids(0).column_ids(0));
+    EXPECT_EQ(200, result.unique_column_ids(0).column_ids(1));
 }
 
 } // namespace starrocks

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -1389,6 +1389,142 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_dcg_apply_incremental_n
     EXPECT_EQ(7, result.unique_column_ids(0).column_ids(0));
 }
 
+// Test end-to-end non-PK DCG replication for generated columns produced by linked schema change.
+// Simulates: source non-PK table had linked schema change adding generated columns, which produced
+// .cols files (DCGs) at multiple schema versions. The replication must:
+// 1. Convert DeltaColumnGroupSnapshotPB -> DeltaColumnGroupMetadataPB (with rssid mapping)
+// 2. Remap column unique IDs from source schema to target schema
+// 3. Apply the DCG metadata during publish with correct rssid remapping
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_non_pk_generated_column_dcg_replication_e2e) {
+    // --- Step 1: Build DeltaColumnGroupSnapshotPB simulating generated columns ---
+    // Scenario: source non-PK table (e.g., DUP_KEYS) had two linked schema changes:
+    //   - Version 3: added generated column gc1 (unique_id=10, stored in .cols file)
+    //   - Version 5: added generated column gc2 (unique_id=11, stored in another .cols file)
+    // The table has one rowset "rs_100" with 2 segments.
+    DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
+
+    // Segment 0 of rs_100: has DCGs from both schema changes
+    dcg_snapshot_pb.add_tablet_id(500);
+    dcg_snapshot_pb.add_rowset_id("rs_100");
+    dcg_snapshot_pb.add_segment_id(0);
+
+    auto* dcg_list_seg0 = dcg_snapshot_pb.add_dcg_lists();
+    // DCG at version 3: generated column gc1
+    dcg_list_seg0->add_versions(3);
+    auto* dcg_v3_seg0 = dcg_list_seg0->add_dcgs();
+    dcg_v3_seg0->add_column_files("rs_100_0_3_0.cols");
+    auto* col_ids_v3_seg0 = dcg_v3_seg0->add_column_ids();
+    col_ids_v3_seg0->add_column_ids(10); // source unique_id for gc1
+
+    // DCG at version 5: generated column gc2
+    dcg_list_seg0->add_versions(5);
+    auto* dcg_v5_seg0 = dcg_list_seg0->add_dcgs();
+    dcg_v5_seg0->add_column_files("rs_100_0_5_0.cols");
+    auto* col_ids_v5_seg0 = dcg_v5_seg0->add_column_ids();
+    col_ids_v5_seg0->add_column_ids(11); // source unique_id for gc2
+
+    // Segment 1 of rs_100: also has DCGs from both schema changes
+    dcg_snapshot_pb.add_tablet_id(500);
+    dcg_snapshot_pb.add_rowset_id("rs_100");
+    dcg_snapshot_pb.add_segment_id(1);
+
+    auto* dcg_list_seg1 = dcg_snapshot_pb.add_dcg_lists();
+    dcg_list_seg1->add_versions(3);
+    auto* dcg_v3_seg1 = dcg_list_seg1->add_dcgs();
+    dcg_v3_seg1->add_column_files("rs_100_1_3_0.cols");
+    auto* col_ids_v3_seg1 = dcg_v3_seg1->add_column_ids();
+    col_ids_v3_seg1->add_column_ids(10);
+
+    dcg_list_seg1->add_versions(5);
+    auto* dcg_v5_seg1 = dcg_list_seg1->add_dcgs();
+    dcg_v5_seg1->add_column_files("rs_100_1_5_0.cols");
+    auto* col_ids_v5_seg1 = dcg_v5_seg1->add_column_ids();
+    col_ids_v5_seg1->add_column_ids(11);
+
+    // --- Step 2: Convert snapshot to DCG metadata (simulates convert_dcg_meta_for_non_pk) ---
+    std::unordered_map<std::string, uint32_t> rowset_id_to_seg_id;
+    rowset_id_to_seg_id["rs_100"] = 20; // source rowset_seg_id
+
+    DeltaColumnGroupMetadataPB dcg_meta;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    ASSERT_OK(lake::ReplicationTxnManager::convert_dcg_meta_for_non_pk(dcg_snapshot_pb, rowset_id_to_seg_id, 9999,
+                                                                       &dcg_meta, &filename_map));
+
+    // Verify: rssid 20 (seg_id=20 + segment_id=0) and rssid 21 (20+1)
+    EXPECT_EQ(2, dcg_meta.dcgs_size());
+    EXPECT_TRUE(dcg_meta.dcgs().count(20));
+    EXPECT_TRUE(dcg_meta.dcgs().count(21));
+    EXPECT_EQ(4, filename_map.size()); // 4 .cols files total
+
+    // Each segment has 2 DCGs (version 3 and 5)
+    EXPECT_EQ(2, dcg_meta.dcgs().at(20).versions_size());
+    EXPECT_EQ(3, dcg_meta.dcgs().at(20).versions(0));
+    EXPECT_EQ(5, dcg_meta.dcgs().at(20).versions(1));
+    EXPECT_EQ(2, dcg_meta.dcgs().at(21).versions_size());
+
+    // Column IDs are still source IDs at this point
+    EXPECT_EQ(10, dcg_meta.dcgs().at(20).unique_column_ids(0).column_ids(0));
+    EXPECT_EQ(11, dcg_meta.dcgs().at(20).unique_column_ids(1).column_ids(0));
+
+    // --- Step 3: Remap column unique IDs (simulates convert_dcg_column_unique_ids) ---
+    // In target cluster, gc1 has unique_id=100, gc2 has unique_id=101
+    std::unordered_map<uint32_t, uint32_t> column_unique_id_map;
+    column_unique_id_map[10] = 100; // source gc1(10) -> target gc1(100)
+    column_unique_id_map[11] = 101; // source gc2(11) -> target gc2(101)
+
+    ASSERT_OK(lake::ReplicationTxnManager::convert_dcg_column_unique_ids(&dcg_meta, column_unique_id_map));
+
+    // Verify column IDs are now target IDs
+    EXPECT_EQ(100, dcg_meta.dcgs().at(20).unique_column_ids(0).column_ids(0));
+    EXPECT_EQ(101, dcg_meta.dcgs().at(20).unique_column_ids(1).column_ids(0));
+    EXPECT_EQ(100, dcg_meta.dcgs().at(21).unique_column_ids(0).column_ids(0));
+    EXPECT_EQ(101, dcg_meta.dcgs().at(21).unique_column_ids(1).column_ids(0));
+
+    // --- Step 4: Apply DCG during publish with rssid remapping ---
+    // Simulate non-PK full replication apply: source rssid + offset
+    TabletMetadataPB metadata;
+    metadata.set_id(600);
+    metadata.set_version(1);
+    metadata.set_next_rowset_id(50);
+
+    // Build rssid_remap: source 20->50, 21->51
+    std::unordered_map<uint32_t, uint32_t> rssid_remap;
+    rssid_remap[20] = 50;
+    rssid_remap[21] = 51;
+
+    for (const auto& [src_rssid, src_dcg_ver] : dcg_meta.dcgs()) {
+        auto it = rssid_remap.find(src_rssid);
+        uint32_t target_rssid = (it != rssid_remap.end()) ? it->second : src_rssid;
+        (*metadata.mutable_dcg_meta()->mutable_dcgs())[target_rssid].CopyFrom(src_dcg_ver);
+    }
+
+    // Verify final result: target rssids 50 and 51 have correct DCG metadata
+    EXPECT_EQ(2, metadata.dcg_meta().dcgs_size());
+    EXPECT_TRUE(metadata.dcg_meta().dcgs().count(50));
+    EXPECT_TRUE(metadata.dcg_meta().dcgs().count(51));
+
+    // Segment 0 (rssid 50): 2 DCGs with remapped column IDs
+    const auto& final_seg0 = metadata.dcg_meta().dcgs().at(50);
+    EXPECT_EQ(2, final_seg0.column_files_size());
+    EXPECT_EQ(2, final_seg0.versions_size());
+    EXPECT_EQ(3, final_seg0.versions(0));
+    EXPECT_EQ(5, final_seg0.versions(1));
+    EXPECT_EQ(100, final_seg0.unique_column_ids(0).column_ids(0)); // gc1 remapped
+    EXPECT_EQ(101, final_seg0.unique_column_ids(1).column_ids(0)); // gc2 remapped
+
+    // Segment 1 (rssid 51): same structure
+    const auto& final_seg1 = metadata.dcg_meta().dcgs().at(51);
+    EXPECT_EQ(2, final_seg1.column_files_size());
+    EXPECT_EQ(100, final_seg1.unique_column_ids(0).column_ids(0));
+    EXPECT_EQ(101, final_seg1.unique_column_ids(1).column_ids(0));
+
+    // All .cols filenames should be new lake-format names
+    for (const auto& [_, pair] : filename_map) {
+        EXPECT_TRUE(lake::is_cols(pair.first));
+    }
+}
+
 // Test OpReplication protobuf correctly carries DCG metadata
 TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_op_replication_dcg_meta_serialization) {
     TxnLogPB txn_log;

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -557,8 +557,11 @@ TEST_P(LakeReplicationTxnManagerTest, test_incremental_non_pk_skips_dcg_download
             << "Incremental replication should not load DCG metadata";
 }
 
-// Verify full snapshot skips creating .dcgs_snapshot file when all DCG lists are empty.
-TEST_P(LakeReplicationTxnManagerTest, test_full_snapshot_skips_empty_dcg_file) {
+// Verify full snapshot always creates .dcgs_snapshot file (even when empty).
+// The target side must handle both empty and non-empty .dcgs_snapshot files correctly.
+// We do NOT skip writing on the source side because replication must not depend on
+// the source cluster upgrading its code version.
+TEST_P(LakeReplicationTxnManagerTest, test_full_snapshot_creates_dcg_file_even_when_empty) {
     if (GetParam() == TKeysType::type::PRIMARY_KEYS) {
         return;
     }
@@ -585,13 +588,12 @@ TEST_P(LakeReplicationTxnManagerTest, test_full_snapshot_skips_empty_dcg_file) {
     ASSERT_TRUE(status.ok()) << status;
     ASSERT_FALSE(remote_snapshot_info.incremental_snapshot) << "data_version=1 should trigger full snapshot";
 
-    // Verify the .dcgs_snapshot file was NOT created (all DCG lists are empty)
+    // Verify the .dcgs_snapshot file IS created (source always writes it)
     std::string dcg_file_path = remote_snapshot_info.snapshot_path + "/" + std::to_string(_src_tablet_id) + "/" +
                                 std::to_string(_schema_hash) + "/" + std::to_string(_src_tablet_id) + ".dcgs_snapshot";
-    EXPECT_FALSE(fs::path_exist(dcg_file_path))
-            << "Empty .dcgs_snapshot file should not be created for tables without DCGs";
+    EXPECT_TRUE(fs::path_exist(dcg_file_path)) << ".dcgs_snapshot file should always be created by source cluster";
 
-    // Verify replicate_snapshot() still succeeds (handles NotFound gracefully)
+    // Verify replicate_snapshot() succeeds with the empty .dcgs_snapshot file
     TReplicateSnapshotRequest replicate_snapshot_request;
     replicate_snapshot_request.__set_transaction_id(_transaction_id);
     replicate_snapshot_request.__set_table_id(_table_id);
@@ -610,6 +612,15 @@ TEST_P(LakeReplicationTxnManagerTest, test_full_snapshot_skips_empty_dcg_file) {
 
     status = _replication_txn_manager->replicate_snapshot(replicate_snapshot_request);
     EXPECT_TRUE(status.ok()) << status;
+
+    // Verify txn_log has no DCG metadata (empty .dcgs_snapshot produces no DCGs)
+    auto txn_log_path = _tablet_manager->txn_log_location(_tablet_id, _transaction_id);
+    auto txn_log_or = _tablet_manager->get_txn_log(txn_log_path, false);
+    ASSERT_TRUE(txn_log_or.ok()) << txn_log_or.status();
+    // Empty DCG snapshot should result in no DCG metadata in txn log
+    if (txn_log_or.value()->op_replication().has_dcg_meta()) {
+        EXPECT_EQ(0, txn_log_or.value()->op_replication().dcg_meta().dcgs_size());
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(LakeReplicationTxnManagerTest, LakeReplicationTxnManagerTest,
@@ -1140,6 +1151,29 @@ TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_meta_for_pk
             lake::ReplicationTxnManager::convert_dcg_meta_for_pk(delta_column_groups, 12345, &dcg_meta, &filename_map);
     EXPECT_TRUE(status.is_corruption()) << status;
     EXPECT_TRUE(status.message().find("Duplicated cols file") != std::string::npos) << status;
+}
+
+// Test convert_dcg_meta_for_pk: column_ids size != column_files size → Corruption
+TEST_F(LakeReplicationTxnManagerStaticFunctionTest, test_convert_dcg_meta_for_pk_column_ids_files_mismatch) {
+    std::unordered_map<uint32_t, DeltaColumnGroupList> delta_column_groups;
+
+    // Create a DCG with mismatched column_ids and column_files sizes
+    {
+        auto dcg = std::make_shared<DeltaColumnGroup>();
+        // 2 column files but only 1 column_ids entry → mismatch
+        std::vector<std::string> column_files = {"file1.cols", "file2.cols"};
+        std::vector<std::vector<int32_t>> column_ids = {{1}};
+        dcg->init(1, column_ids, column_files);
+        delta_column_groups[5].push_back(dcg);
+    }
+
+    DeltaColumnGroupMetadataPB dcg_meta;
+    std::unordered_map<std::string, std::pair<std::string, FileEncryptionPair>> filename_map;
+
+    Status status =
+            lake::ReplicationTxnManager::convert_dcg_meta_for_pk(delta_column_groups, 12345, &dcg_meta, &filename_map);
+    EXPECT_TRUE(status.is_corruption()) << status;
+    EXPECT_TRUE(status.message().find("Mismatch between column_ids size") != std::string::npos) << status;
 }
 
 // Test that duplicate .cols filenames in convert_dcg_meta_for_non_pk are detected

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -481,6 +481,137 @@ TEST_P(LakeReplicationTxnManagerTest, test_run_normal_encrypted) {
     EXPECT_EQ(_src_version, status_or.value()->version());
 }
 
+// Verify incremental non-PK replication skips .dcgs_snapshot download (the file is never created
+// by snapshot_incremental, so downloading it would be a wasted HTTP round-trip).
+TEST_P(LakeReplicationTxnManagerTest, test_incremental_non_pk_skips_dcg_download) {
+    if (GetParam() == TKeysType::type::PRIMARY_KEYS) {
+        return;
+    }
+
+    // Create a full snapshot via remote_snapshot()
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_data_version(_version);
+    remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_visible_version(_src_version);
+    remote_snapshot_request.__set_src_backends({TBackend()});
+
+    TSnapshotInfo remote_snapshot_info;
+    Status status = _replication_txn_manager->remote_snapshot(remote_snapshot_request, &remote_snapshot_info);
+    ASSERT_TRUE(status.ok()) << status;
+
+    // Place a .dcgs_snapshot file with real DCG data in the snapshot directory.
+    // With incremental_snapshot=true, this file should be completely ignored.
+    std::string dcg_file_path = remote_snapshot_info.snapshot_path + "/" + std::to_string(_src_tablet_id) + "/" +
+                                std::to_string(_schema_hash) + "/" + std::to_string(_src_tablet_id) + ".dcgs_snapshot";
+
+    DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
+    dcg_snapshot_pb.add_tablet_id(_src_tablet_id);
+    dcg_snapshot_pb.add_rowset_id("dummy_rowset");
+    dcg_snapshot_pb.add_segment_id(0);
+    auto* dcg_list_pb = dcg_snapshot_pb.add_dcg_lists();
+    dcg_list_pb->add_versions(5);
+    auto* dcg_pb = dcg_list_pb->add_dcgs();
+    dcg_pb->add_column_files("dummy.cols");
+    auto* col_ids = dcg_pb->add_column_ids();
+    col_ids->add_column_ids(1);
+    ASSERT_TRUE(DeltaColumnGroupListHelper::save_snapshot(dcg_file_path, dcg_snapshot_pb).ok());
+
+    // Override incremental_snapshot to true
+    remote_snapshot_info.__set_incremental_snapshot(true);
+
+    // replicate_snapshot() should skip .dcgs_snapshot download for incremental snapshots
+    TReplicateSnapshotRequest replicate_snapshot_request;
+    replicate_snapshot_request.__set_transaction_id(_transaction_id);
+    replicate_snapshot_request.__set_table_id(_table_id);
+    replicate_snapshot_request.__set_partition_id(_partition_id);
+    replicate_snapshot_request.__set_tablet_id(_tablet_id);
+    replicate_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    replicate_snapshot_request.__set_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_visible_version(_version);
+    replicate_snapshot_request.__set_data_version(_version);
+    replicate_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    replicate_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    replicate_snapshot_request.__set_src_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_src_visible_version(_src_version);
+    replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
+
+    status = _replication_txn_manager->replicate_snapshot(replicate_snapshot_request);
+    EXPECT_TRUE(status.ok()) << status;
+
+    // Verify txn_log has no DCG metadata (the .dcgs_snapshot file was skipped)
+    auto txn_log_path = _tablet_manager->txn_log_location(_tablet_id, _transaction_id);
+    auto txn_log_or = _tablet_manager->get_txn_log(txn_log_path, false);
+    ASSERT_TRUE(txn_log_or.ok()) << txn_log_or.status();
+    EXPECT_FALSE(txn_log_or.value()->op_replication().has_dcg_meta())
+            << "Incremental replication should not load DCG metadata";
+}
+
+// Verify full snapshot skips creating .dcgs_snapshot file when all DCG lists are empty.
+TEST_P(LakeReplicationTxnManagerTest, test_full_snapshot_skips_empty_dcg_file) {
+    if (GetParam() == TKeysType::type::PRIMARY_KEYS) {
+        return;
+    }
+
+    // Create a full snapshot for a non-PK table without DCGs
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_data_version(_version);
+    remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_visible_version(_src_version);
+    remote_snapshot_request.__set_src_backends({TBackend()});
+
+    TSnapshotInfo remote_snapshot_info;
+    Status status = _replication_txn_manager->remote_snapshot(remote_snapshot_request, &remote_snapshot_info);
+    ASSERT_TRUE(status.ok()) << status;
+    ASSERT_FALSE(remote_snapshot_info.incremental_snapshot) << "data_version=1 should trigger full snapshot";
+
+    // Verify the .dcgs_snapshot file was NOT created (all DCG lists are empty)
+    std::string dcg_file_path = remote_snapshot_info.snapshot_path + "/" + std::to_string(_src_tablet_id) + "/" +
+                                std::to_string(_schema_hash) + "/" + std::to_string(_src_tablet_id) + ".dcgs_snapshot";
+    EXPECT_FALSE(fs::path_exist(dcg_file_path))
+            << "Empty .dcgs_snapshot file should not be created for tables without DCGs";
+
+    // Verify replicate_snapshot() still succeeds (handles NotFound gracefully)
+    TReplicateSnapshotRequest replicate_snapshot_request;
+    replicate_snapshot_request.__set_transaction_id(_transaction_id);
+    replicate_snapshot_request.__set_table_id(_table_id);
+    replicate_snapshot_request.__set_partition_id(_partition_id);
+    replicate_snapshot_request.__set_tablet_id(_tablet_id);
+    replicate_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    replicate_snapshot_request.__set_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_visible_version(_version);
+    replicate_snapshot_request.__set_data_version(_version);
+    replicate_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    replicate_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    replicate_snapshot_request.__set_src_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_src_visible_version(_src_version);
+    replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
+
+    status = _replication_txn_manager->replicate_snapshot(replicate_snapshot_request);
+    EXPECT_TRUE(status.ok()) << status;
+}
+
 INSTANTIATE_TEST_SUITE_P(LakeReplicationTxnManagerTest, LakeReplicationTxnManagerTest,
                          testing::Values(TKeysType::type::AGG_KEYS, TKeysType::type::PRIMARY_KEYS));
 

--- a/be/test/storage/lake/txn_log_applier_test.cpp
+++ b/be/test/storage/lake/txn_log_applier_test.cpp
@@ -575,6 +575,13 @@ TEST(TxnLogApplierBatchTest, PKFullReplicationWithDcg) {
 }
 
 TEST(TxnLogApplierBatchTest, PKIncrementalReplicationWithDcg) {
+    // NOTE: PK incremental replication calls apply_write_log which requires prepare_primary_index
+    // for non-empty op_writes. In this lightweight test environment (no real data files),
+    // prepare_primary_index would fail. Therefore we use empty op_writes (num_rows=0, no dels,
+    // no delete_predicate) which are skipped by apply_write_log, and verify that DCG entries
+    // from op_replication are correctly applied to metadata (pass-through without remapping).
+    // The full DCG rssid remapping logic is tested by NonPKIncrementalReplicationWithDcg,
+    // which uses the same shared apply_replication_dcg_meta function.
     Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 50005);
     auto meta = build_pk_metadata(50005);
     meta->set_next_rowset_id(10);
@@ -591,35 +598,21 @@ TEST(TxnLogApplierBatchTest, PKIncrementalReplicationWithDcg) {
     txn_meta->set_data_version(3);
     txn_meta->set_incremental_snapshot(true);
 
-    // op_write 1: num_rows=50, 2 segments → included, remap {5→10, 6→11}, target→12
+    // All op_writes are empty (num_rows=0, no dels, no delete_pred) → skipped by apply_write_log.
+    // rssid_remap will be empty, so DCG keys are preserved as-is.
     auto* op_write1 = op_rep->add_op_writes();
     auto* rowset1 = op_write1->mutable_rowset();
     rowset1->set_id(5);
-    rowset1->set_num_rows(50);
-    rowset1->set_data_size(200);
-    rowset1->add_segments("pk_seg1");
-    rowset1->add_segments("pk_seg2");
-    rowset1->add_segment_size(100);
-    rowset1->add_segment_size(100);
+    rowset1->set_num_rows(0);
+    rowset1->set_data_size(0);
 
-    // op_write 2: empty (num_rows=0, no dels, no delete_pred) → skipped
     auto* op_write2 = op_rep->add_op_writes();
     auto* rowset2 = op_write2->mutable_rowset();
     rowset2->set_id(20);
     rowset2->set_num_rows(0);
     rowset2->set_data_size(0);
 
-    // op_write 3: has dels → included, remap {30→12}, target→13
-    auto* op_write3 = op_rep->add_op_writes();
-    auto* rowset3 = op_write3->mutable_rowset();
-    rowset3->set_id(30);
-    rowset3->set_num_rows(0);
-    rowset3->set_data_size(50);
-    rowset3->add_segments("pk_seg3");
-    rowset3->add_segment_size(50);
-    op_write3->add_dels("pk_del1");
-
-    // DCG entries: 6→11, 30→12, 99 not in remap → kept as 99
+    // DCG entries: no remapping (rssid_remap is empty), all keys preserved as-is
     auto* dcg_meta = op_rep->mutable_dcg_meta();
     (*dcg_meta->mutable_dcgs())[6].add_column_files("pk_dcg_6.cols");
     (*dcg_meta->mutable_dcgs())[30].add_column_files("pk_dcg_30.cols");
@@ -627,16 +620,16 @@ TEST(TxnLogApplierBatchTest, PKIncrementalReplicationWithDcg) {
 
     ASSERT_TRUE(applier->apply(*log).ok());
 
-    // Verify DCG remap: 6→11, 30→12, 99→99
+    // Verify DCG entries preserved with original keys (no remapping since all op_writes are empty)
     ASSERT_EQ(3, meta->dcg_meta().dcgs_size());
-    EXPECT_TRUE(meta->dcg_meta().dcgs().count(11));
-    EXPECT_EQ("pk_dcg_6.cols", meta->dcg_meta().dcgs().at(11).column_files(0));
-    EXPECT_TRUE(meta->dcg_meta().dcgs().count(12));
-    EXPECT_EQ("pk_dcg_30.cols", meta->dcg_meta().dcgs().at(12).column_files(0));
+    EXPECT_TRUE(meta->dcg_meta().dcgs().count(6));
+    EXPECT_EQ("pk_dcg_6.cols", meta->dcg_meta().dcgs().at(6).column_files(0));
+    EXPECT_TRUE(meta->dcg_meta().dcgs().count(30));
+    EXPECT_EQ("pk_dcg_30.cols", meta->dcg_meta().dcgs().at(30).column_files(0));
     EXPECT_TRUE(meta->dcg_meta().dcgs().count(99));
     EXPECT_EQ("pk_dcg_99.cols", meta->dcg_meta().dcgs().at(99).column_files(0));
-    // next_rowset_id: 10 + 2 (op1 step) + 1 (op3 step) = 13
-    EXPECT_EQ(13u, meta->next_rowset_id());
+    // next_rowset_id unchanged since all op_writes were skipped
+    EXPECT_EQ(10u, meta->next_rowset_id());
 }
 
 TEST(TxnLogApplierBatchTest, NonPKFullReplicationWithDcg) {

--- a/be/test/storage/lake/txn_log_applier_test.cpp
+++ b/be/test/storage/lake/txn_log_applier_test.cpp
@@ -404,5 +404,408 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeyReplicationWithoutTabletMetaSparseSegm
     EXPECT_EQ(7u, meta->next_rowset_id());
 }
 
+TEST(TxnLogApplierBatchTest, NonPrimaryKeyFullReplicationWithoutTabletMetaClearsStaleDcgMeta) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 30004);
+    auto meta = build_non_pk_metadata(30004);
+    meta->set_next_rowset_id(10);
+    auto& stale_dcg = (*meta->mutable_dcg_meta()->mutable_dcgs())[123];
+    stale_dcg.add_column_files("stale_dcg_file1.cols");
+    stale_dcg.add_column_files("stale_dcg_file2.cols");
+    stale_dcg.add_shared_files(false);
+    stale_dcg.add_shared_files(true);
+
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(30004);
+    log->set_txn_id(62);
+    auto* op_replication = log->mutable_op_replication();
+    auto* txn_meta = op_replication->mutable_txn_meta();
+    txn_meta->set_txn_id(62);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_snapshot_version(2);
+    txn_meta->set_data_version(0);
+
+    auto* op_write = op_replication->add_op_writes();
+    auto* rowset = op_write->mutable_rowset();
+    rowset->set_id(5); // source rssid base
+    rowset->set_num_rows(10);
+    rowset->set_data_size(100);
+    rowset->add_segments("rep_seg1");
+    rowset->add_segment_size(100);
+
+    auto& incoming_dcg = (*op_replication->mutable_dcg_meta()->mutable_dcgs())[5];
+    incoming_dcg.add_column_files("new_dcg_file.cols");
+    incoming_dcg.add_shared_files(false);
+
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+    Status st = applier->apply(*log);
+    EXPECT_TRUE(st.ok()) << st.to_string();
+
+    ASSERT_EQ(1, meta->dcg_meta().dcgs_size());
+    EXPECT_TRUE(meta->dcg_meta().dcgs().count(10));
+    EXPECT_FALSE(meta->dcg_meta().dcgs().count(123));
+    EXPECT_EQ("new_dcg_file.cols", meta->dcg_meta().dcgs().at(10).column_files(0));
+
+    bool found_stale1 = false;
+    bool found_stale2 = false;
+    for (int i = 0; i < meta->orphan_files_size(); i++) {
+        const auto& orphan = meta->orphan_files(i);
+        if (orphan.name() == "stale_dcg_file1.cols") {
+            found_stale1 = true;
+            EXPECT_FALSE(orphan.shared());
+        }
+        if (orphan.name() == "stale_dcg_file2.cols") {
+            found_stale2 = true;
+            EXPECT_TRUE(orphan.shared());
+        }
+    }
+    EXPECT_TRUE(found_stale1);
+    EXPECT_TRUE(found_stale2);
+}
+
+TEST(TxnLogApplierBatchTest, PKFullReplicationWithDcg) {
+    // --- Sub-case 1: Non-lake path (offset-based DCG remap) ---
+    {
+        Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 50001);
+        auto meta = build_pk_metadata(50001);
+        meta->set_next_rowset_id(10);
+        // Pre-existing stale DCG
+        auto& stale_dcg = (*meta->mutable_dcg_meta()->mutable_dcgs())[99];
+        stale_dcg.add_column_files("stale_pk.cols");
+        stale_dcg.add_shared_files(true);
+        auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+        auto log = std::make_shared<TxnLogPB>();
+        log->set_tablet_id(50001);
+        log->set_txn_id(200);
+        auto* op_rep = log->mutable_op_replication();
+        auto* txn_meta = op_rep->mutable_txn_meta();
+        txn_meta->set_txn_id(200);
+        txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+        txn_meta->set_snapshot_version(2);
+        txn_meta->set_data_version(0);
+
+        // Rowset: source id=3, 2 segments
+        auto* op_write = op_rep->add_op_writes();
+        auto* rowset = op_write->mutable_rowset();
+        rowset->set_id(3);
+        rowset->set_num_rows(50);
+        rowset->set_data_size(2048);
+        rowset->add_segments("pk_full_seg1.dat");
+        rowset->add_segments("pk_full_seg2.dat");
+        rowset->add_segment_size(1024);
+        rowset->add_segment_size(1024);
+
+        // DCG on source rssid 4 → offset to 4 + 10 = 14
+        auto& dcg = (*op_rep->mutable_dcg_meta()->mutable_dcgs())[4];
+        dcg.add_column_files("pk_full_dcg.cols");
+        dcg.add_versions(1);
+        auto* ucids = dcg.add_unique_column_ids();
+        ucids->add_column_ids(5);
+
+        ASSERT_TRUE(applier->apply(*log).ok());
+
+        // Rowset offset: id = 3 + 10 = 13
+        ASSERT_EQ(1, meta->rowsets_size());
+        EXPECT_EQ(13u, meta->rowsets(0).id());
+        // DCG offset: 4 + 10 = 14
+        ASSERT_EQ(1, meta->dcg_meta().dcgs_size());
+        EXPECT_TRUE(meta->dcg_meta().dcgs().count(14));
+        EXPECT_EQ("pk_full_dcg.cols", meta->dcg_meta().dcgs().at(14).column_files(0));
+        EXPECT_EQ(5, meta->dcg_meta().dcgs().at(14).unique_column_ids(0).column_ids(0));
+        // Stale DCG → orphan files
+        EXPECT_FALSE(meta->dcg_meta().dcgs().count(99));
+        bool found_stale = false;
+        for (int i = 0; i < meta->orphan_files_size(); i++) {
+            if (meta->orphan_files(i).name() == "stale_pk.cols") {
+                found_stale = true;
+                EXPECT_TRUE(meta->orphan_files(i).shared());
+            }
+        }
+        EXPECT_TRUE(found_stale);
+    }
+
+    // --- Sub-case 2: Lake path (tablet_metadata copy) ---
+    {
+        Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 50002);
+        auto meta = build_pk_metadata(50002);
+        meta->set_next_rowset_id(5);
+        auto& stale_dcg = (*meta->mutable_dcg_meta()->mutable_dcgs())[88];
+        stale_dcg.add_column_files("stale_lake_pk.cols");
+        auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+        auto log = std::make_shared<TxnLogPB>();
+        log->set_tablet_id(50002);
+        log->set_txn_id(201);
+        auto* op_rep = log->mutable_op_replication();
+        auto* txn_meta = op_rep->mutable_txn_meta();
+        txn_meta->set_txn_id(201);
+        txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+        txn_meta->set_snapshot_version(2);
+        txn_meta->set_data_version(0);
+
+        auto* tablet_metadata = op_rep->mutable_tablet_metadata();
+        tablet_metadata->set_id(50002);
+        tablet_metadata->set_next_rowset_id(20);
+        auto* rep_rowset = tablet_metadata->add_rowsets();
+        rep_rowset->set_id(0);
+        rep_rowset->set_num_rows(100);
+        rep_rowset->set_data_size(4096);
+        rep_rowset->add_segments("lake_pk_seg1.dat");
+        rep_rowset->add_segment_size(4096);
+        auto& lake_dcg = (*tablet_metadata->mutable_dcg_meta()->mutable_dcgs())[5];
+        lake_dcg.add_column_files("lake_pk_dcg.cols");
+        lake_dcg.add_versions(2);
+
+        ASSERT_TRUE(applier->apply(*log).ok());
+
+        ASSERT_EQ(1, meta->rowsets_size());
+        EXPECT_EQ(0u, meta->rowsets(0).id());
+        EXPECT_EQ(20u, meta->next_rowset_id());
+        // DCG directly copied from tablet_metadata
+        ASSERT_EQ(1, meta->dcg_meta().dcgs_size());
+        EXPECT_TRUE(meta->dcg_meta().dcgs().count(5));
+        EXPECT_FALSE(meta->dcg_meta().dcgs().count(88));
+        // Stale DCG → orphan files
+        bool found = false;
+        for (int i = 0; i < meta->orphan_files_size(); i++) {
+            if (meta->orphan_files(i).name() == "stale_lake_pk.cols") found = true;
+        }
+        EXPECT_TRUE(found);
+    }
+}
+
+TEST(TxnLogApplierBatchTest, PKIncrementalReplicationWithDcg) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 50005);
+    auto meta = build_pk_metadata(50005);
+    meta->set_next_rowset_id(10);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(50005);
+    log->set_txn_id(204);
+    auto* op_rep = log->mutable_op_replication();
+    auto* txn_meta = op_rep->mutable_txn_meta();
+    txn_meta->set_txn_id(204);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_snapshot_version(4);
+    txn_meta->set_data_version(3);
+    txn_meta->set_incremental_snapshot(true);
+
+    // op_write 1: num_rows=50, 2 segments → included, remap {5→10, 6→11}, target→12
+    auto* op_write1 = op_rep->add_op_writes();
+    auto* rowset1 = op_write1->mutable_rowset();
+    rowset1->set_id(5);
+    rowset1->set_num_rows(50);
+    rowset1->set_data_size(200);
+    rowset1->add_segments("pk_seg1");
+    rowset1->add_segments("pk_seg2");
+    rowset1->add_segment_size(100);
+    rowset1->add_segment_size(100);
+
+    // op_write 2: empty (num_rows=0, no dels, no delete_pred) → skipped
+    auto* op_write2 = op_rep->add_op_writes();
+    auto* rowset2 = op_write2->mutable_rowset();
+    rowset2->set_id(20);
+    rowset2->set_num_rows(0);
+    rowset2->set_data_size(0);
+
+    // op_write 3: has dels → included, remap {30→12}, target→13
+    auto* op_write3 = op_rep->add_op_writes();
+    auto* rowset3 = op_write3->mutable_rowset();
+    rowset3->set_id(30);
+    rowset3->set_num_rows(0);
+    rowset3->set_data_size(50);
+    rowset3->add_segments("pk_seg3");
+    rowset3->add_segment_size(50);
+    op_write3->add_dels("pk_del1");
+
+    // DCG entries: 6→11, 30→12, 99 not in remap → kept as 99
+    auto* dcg_meta = op_rep->mutable_dcg_meta();
+    (*dcg_meta->mutable_dcgs())[6].add_column_files("pk_dcg_6.cols");
+    (*dcg_meta->mutable_dcgs())[30].add_column_files("pk_dcg_30.cols");
+    (*dcg_meta->mutable_dcgs())[99].add_column_files("pk_dcg_99.cols");
+
+    ASSERT_TRUE(applier->apply(*log).ok());
+
+    // Verify DCG remap: 6→11, 30→12, 99→99
+    ASSERT_EQ(3, meta->dcg_meta().dcgs_size());
+    EXPECT_TRUE(meta->dcg_meta().dcgs().count(11));
+    EXPECT_EQ("pk_dcg_6.cols", meta->dcg_meta().dcgs().at(11).column_files(0));
+    EXPECT_TRUE(meta->dcg_meta().dcgs().count(12));
+    EXPECT_EQ("pk_dcg_30.cols", meta->dcg_meta().dcgs().at(12).column_files(0));
+    EXPECT_TRUE(meta->dcg_meta().dcgs().count(99));
+    EXPECT_EQ("pk_dcg_99.cols", meta->dcg_meta().dcgs().at(99).column_files(0));
+    // next_rowset_id: 10 + 2 (op1 step) + 1 (op3 step) = 13
+    EXPECT_EQ(13u, meta->next_rowset_id());
+}
+
+TEST(TxnLogApplierBatchTest, NonPKFullReplicationWithDcg) {
+    // --- Sub-case 1: Non-lake path (rssid_remap) ---
+    {
+        Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 50003);
+        auto meta = build_non_pk_metadata(50003);
+        meta->set_next_rowset_id(10);
+        auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+        auto log = std::make_shared<TxnLogPB>();
+        log->set_tablet_id(50003);
+        log->set_txn_id(202);
+        auto* op_rep = log->mutable_op_replication();
+        auto* txn_meta = op_rep->mutable_txn_meta();
+        txn_meta->set_txn_id(202);
+        txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+        txn_meta->set_snapshot_version(2);
+        txn_meta->set_data_version(0);
+
+        // Rowset 1: source id=5, 2 segs → remap {5→10, 6→11}, target→12
+        auto* op_write1 = op_rep->add_op_writes();
+        auto* rowset1 = op_write1->mutable_rowset();
+        rowset1->set_id(5);
+        rowset1->set_num_rows(50);
+        rowset1->set_data_size(200);
+        rowset1->add_segments("full_seg1");
+        rowset1->add_segments("full_seg2");
+        rowset1->add_segment_size(100);
+        rowset1->add_segment_size(100);
+
+        // Rowset 2: source id=8, 1 seg → remap {8→12}, target→13
+        auto* op_write2 = op_rep->add_op_writes();
+        auto* rowset2 = op_write2->mutable_rowset();
+        rowset2->set_id(8);
+        rowset2->set_num_rows(30);
+        rowset2->set_data_size(100);
+        rowset2->add_segments("full_seg3");
+        rowset2->add_segment_size(100);
+
+        // DCG on source rssid 6 → remap to 11
+        (*op_rep->mutable_dcg_meta()->mutable_dcgs())[6].add_column_files("nonpk_full_dcg.cols");
+
+        ASSERT_TRUE(applier->apply(*log).ok());
+
+        ASSERT_EQ(2, meta->rowsets_size());
+        EXPECT_EQ(10u, meta->rowsets(0).id());
+        EXPECT_EQ(12u, meta->rowsets(1).id());
+        ASSERT_EQ(1, meta->dcg_meta().dcgs_size());
+        EXPECT_TRUE(meta->dcg_meta().dcgs().count(11));
+        EXPECT_EQ("nonpk_full_dcg.cols", meta->dcg_meta().dcgs().at(11).column_files(0));
+    }
+
+    // --- Sub-case 2: Lake path (tablet_metadata copy + stale DCG cleanup) ---
+    {
+        Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 50004);
+        auto meta = build_non_pk_metadata(50004);
+        meta->set_next_rowset_id(10);
+        auto& stale_dcg = (*meta->mutable_dcg_meta()->mutable_dcgs())[88];
+        stale_dcg.add_column_files("stale_nonpk.cols");
+        auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+        auto log = std::make_shared<TxnLogPB>();
+        log->set_tablet_id(50004);
+        log->set_txn_id(203);
+        auto* op_rep = log->mutable_op_replication();
+        auto* txn_meta = op_rep->mutable_txn_meta();
+        txn_meta->set_txn_id(203);
+        txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+        txn_meta->set_snapshot_version(2);
+        txn_meta->set_data_version(0);
+
+        auto* tablet_metadata = op_rep->mutable_tablet_metadata();
+        tablet_metadata->set_id(50004);
+        tablet_metadata->set_next_rowset_id(25);
+        auto* rep_rowset = tablet_metadata->add_rowsets();
+        rep_rowset->set_id(0);
+        rep_rowset->set_num_rows(200);
+        rep_rowset->set_data_size(8192);
+        rep_rowset->add_segments("lake_nonpk_seg1.dat");
+        rep_rowset->add_segment_size(8192);
+        (*tablet_metadata->mutable_dcg_meta()->mutable_dcgs())[3].add_column_files("lake_nonpk_dcg.cols");
+
+        ASSERT_TRUE(applier->apply(*log).ok());
+
+        ASSERT_EQ(1, meta->rowsets_size());
+        EXPECT_EQ(200, meta->rowsets(0).num_rows());
+        EXPECT_EQ(25u, meta->next_rowset_id());
+        ASSERT_EQ(1, meta->dcg_meta().dcgs_size());
+        EXPECT_TRUE(meta->dcg_meta().dcgs().count(3));
+        EXPECT_FALSE(meta->dcg_meta().dcgs().count(88));
+        bool found = false;
+        for (int i = 0; i < meta->orphan_files_size(); i++) {
+            if (meta->orphan_files(i).name() == "stale_nonpk.cols") found = true;
+        }
+        EXPECT_TRUE(found);
+    }
+}
+
+TEST(TxnLogApplierBatchTest, NonPKIncrementalReplicationWithDcg) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 40001);
+    auto meta = build_non_pk_metadata(40001);
+    meta->set_next_rowset_id(10);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(40001);
+    log->set_txn_id(100);
+    auto* op_rep = log->mutable_op_replication();
+    auto* txn_meta = op_rep->mutable_txn_meta();
+    txn_meta->set_txn_id(100);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_snapshot_version(4);
+    txn_meta->set_data_version(3);
+    txn_meta->set_incremental_snapshot(true);
+
+    // op_write 1: num_rows=50, 2 segs → included, remap {5→10, 6→11}, target→12
+    auto* op_write1 = op_rep->add_op_writes();
+    auto* rowset1 = op_write1->mutable_rowset();
+    rowset1->set_id(5);
+    rowset1->set_num_rows(50);
+    rowset1->set_data_size(200);
+    rowset1->add_segments("seg1");
+    rowset1->add_segments("seg2");
+    rowset1->add_segment_size(100);
+    rowset1->add_segment_size(100);
+
+    // op_write 2: empty (num_rows=0, no delete_pred) → skipped
+    auto* op_write2 = op_rep->add_op_writes();
+    auto* rowset2 = op_write2->mutable_rowset();
+    rowset2->set_id(100);
+    rowset2->set_num_rows(0);
+    rowset2->set_data_size(0);
+
+    // op_write 3: has delete_predicate, num_rows=0 → included, remap {20→12}, target→13
+    auto* op_write3 = op_rep->add_op_writes();
+    auto* rowset3 = op_write3->mutable_rowset();
+    rowset3->set_id(20);
+    rowset3->set_num_rows(0);
+    rowset3->set_data_size(50);
+    rowset3->add_segments("seg3");
+    rowset3->add_segment_size(50);
+    rowset3->mutable_delete_predicate()->set_version(1);
+
+    // op_write 4: no rowset → skipped
+    op_rep->add_op_writes();
+
+    // DCG: 6→11, 20→12, 77 not in remap → kept as 77
+    auto* dcg_meta = op_rep->mutable_dcg_meta();
+    (*dcg_meta->mutable_dcgs())[6].add_column_files("dcg_6.cols");
+    (*dcg_meta->mutable_dcgs())[20].add_column_files("dcg_20.cols");
+    (*dcg_meta->mutable_dcgs())[77].add_column_files("dcg_77.cols");
+
+    ASSERT_TRUE(applier->apply(*log).ok());
+
+    // Rowsets: op1 (50 rows) + op3 (delete_pred), op2/op4 skipped
+    ASSERT_EQ(2, meta->rowsets_size());
+    EXPECT_EQ(10u, meta->rowsets(0).id());
+    EXPECT_EQ(50, meta->rowsets(0).num_rows());
+    EXPECT_EQ(12u, meta->rowsets(1).id());
+    EXPECT_TRUE(meta->rowsets(1).has_delete_predicate());
+    // next_rowset_id: 10 + 2 + 1 = 13
+    EXPECT_EQ(13u, meta->next_rowset_id());
+    // DCG remap: 6→11, 20→12, 77→77
+    ASSERT_EQ(3, meta->dcg_meta().dcgs_size());
+    EXPECT_EQ("dcg_6.cols", meta->dcg_meta().dcgs().at(11).column_files(0));
+    EXPECT_EQ("dcg_20.cols", meta->dcg_meta().dcgs().at(12).column_files(0));
+    EXPECT_EQ("dcg_77.cols", meta->dcg_meta().dcgs().at(77).column_files(0));
+}
+
 } // namespace lake
 } // namespace starrocks

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -344,6 +344,8 @@ message TxnLogPB {
         optional TabletSchemaPB source_schema = 4;
         // used for shared-data replication to store the tablet meta replicated
         optional TabletMetadataPB tablet_metadata = 5;
+        // delta column group metadata for partial update and generated column replication
+        optional DeltaColumnGroupMetadataPB dcg_meta = 6;
     }
 
     optional int64 tablet_id = 1;


### PR DESCRIPTION
## Why I'm doing:

Tables using Partial Update or Generated Column features fail to replicate from shared-nothing to shared-data clusters because DeltaColumnGroup (.cols) files are not synchronized during replication.

## What I'm doing:

Add DeltaColumnGroup file synchronization to the shared-nothing → shared-data replication path.

Fixes #69334

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
