### PR TITLE
[Doc] fix broken code blocks and comment typo in Data_recovery

### DIFF
--- a/docs/en/administration/Data_recovery.md
+++ b/docs/en/administration/Data_recovery.md
@@ -10,14 +10,14 @@ StarRocks supports data recovery for mistakenly deleted databases/tables/partiti
 
 Syntax:
 
-~~~sql
+```sql
 -- 1) Recover database
 RECOVER DATABASE db_name;
--- 2) Restore table
+-- 2) Recover table
 RECOVER TABLE [db_name.]table_name;
 -- 3) Recover partition
 RECOVER PARTITION partition_name FROM [db_name.]table_name;
-~~~
+```
 
 ## Notes
 
@@ -28,18 +28,18 @@ RECOVER PARTITION partition_name FROM [db_name.]table_name;
 
 1. Recover the database named `example_db`
 
-    ~~~sql
+    ```sql
     RECOVER DATABASE example_db;
-    ~~~ 2.
+    ```
 
 2. Recover the table named `example_tbl`
 
-    ~~~sql
+    ```sql
     RECOVER TABLE example_db.example_tbl;
-    ~~~ 3.
+    ```
 
 3. Recover the partition named `p1` in the table `example_tbl`
 
-    ~~~sql
+    ```sql
     RECOVER PARTITION p1 FROM example_tbl;
-    ~~~
+    ```

--- a/docs/ja/administration/Data_recovery.md
+++ b/docs/ja/administration/Data_recovery.md
@@ -10,14 +10,14 @@ StarRocks は、誤って削除されたデータベース/テーブル/パー�
 
 構文:
 
-~~~sql
+```sql
 -- 1) データベースを復元
 RECOVER DATABASE db_name;
 -- 2) テーブルを復元
 RECOVER TABLE [db_name.]table_name;
 -- 3) パーティションを復元
 RECOVER PARTITION partition_name FROM [db_name.]table_name;
-~~~
+```
 
 ## 注意事項
 
@@ -28,18 +28,18 @@ RECOVER PARTITION partition_name FROM [db_name.]table_name;
 
 1. `example_db` という名前のデータベースを復元
 
-    ~~~sql
+    ```sql
     RECOVER DATABASE example_db;
-    ~~~
+    ```
 
 2. `example_tbl` という名前のテーブルを復元
 
-    ~~~sql
+    ```sql
     RECOVER TABLE example_db.example_tbl;
-    ~~~
+    ```
 
 3. テーブル `example_tbl` のパーティション `p1` を復元
 
-    ~~~sql
+    ```sql
     RECOVER PARTITION p1 FROM example_tbl;
-    ~~~
+    ```


### PR DESCRIPTION
## Why I'm doing:
The Examples section in `docs/en/administration/Data_recovery.md` had malformed 
code block closings (`~~~ 2.` and `~~~ 3.`) which caused the SQL examples and 
list numbers to bleed into the same code block, breaking the rendered output on 
the docs site.

## What I'm doing:
- Fix broken code block fences in Examples 1 and 2 (`~~~ 2.` → ` ``` `, `~~~ 3.` → ` ``` `)
- Change all `~~~sql` fences to  ` ```sql `  for consistency with the rest of the doc
- Fix comment typo in Related commands: `-- 2) Restore table` → `-- 2) Recover table`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
