### PR TITLE
[Enhancement] Make date function in Trino dialect will have same behavior with Trino

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/ComplexFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/ComplexFunctionCallTransformer.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.ast.expression.TimestampArithmeticExpr;
 import com.starrocks.type.AnyMapType;
+import com.starrocks.type.DateType;
 import com.starrocks.type.VarcharType;
 
 import java.util.Collections;
@@ -131,6 +132,11 @@ public class ComplexFunctionCallTransformer {
             FunctionCallExpr key = new FunctionCallExpr("array_agg", ImmutableList.of(args[0]));
             FunctionCallExpr value = new FunctionCallExpr("array_agg", ImmutableList.of(args[1]));
             return new FunctionCallExpr("map_from_arrays", ImmutableList.of(key, value));
+        } else if (functionName.equalsIgnoreCase(FunctionSet.DATE)) {
+            if (args.length != 1) {
+                throw new SemanticException("date function must have 1 argument");
+            }
+            return new CastExpr(DateType.DATE, args[0]);
         }
         return null;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -211,6 +211,12 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         sql = "select date_diff('month', timestamp '2023-07-31')";
         analyzeFail(sql, "date_diff function must have 3 arguments");
 
+        sql = "select date('2026-02-20')";
+        assertPlanContains(sql, "cast");
+
+        sql = "select date('2026-02-20', 1)";
+        analyzeFail(sql, "date function must have 1 argument");
+
         sql = "select to_date('2022-02-02', 'yyyy-mm-dd')";
         assertPlanContains(sql, "to_tera_date('2022-02-02', 'yyyy-mm-dd')");
 


### PR DESCRIPTION
## Why I'm doing:
For the query like select xxx from table where date(grass_date) = '2026-02-19';
From the plan we can see
before:
<img width="1972" height="1096" alt="image" src="https://github.com/user-attachments/assets/6b157ab5-4ac0-49ec-91f3-0b320280d8d8" />
The partition did not pushed down because of the date function will cast the expr as dateTime.
after:
<img width="2528" height="1258" alt="image" src="https://github.com/user-attachments/assets/f4095717-286a-4fda-91b2-ac461c0f49b2" />
We can see that in the pic, the partition prued.
## What I'm doing:
Here I make the date function have same behavior with Trino.
<img width="1224" height="224" alt="image" src="https://github.com/user-attachments/assets/a72350f4-626d-45ce-a3d3-ae1cc238c9c9" />
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
