### PR TITLE
[Enhancement] Add thread name into the print all thread stack util

### DIFF
--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -23,6 +23,10 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <sys/syscall.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <sstream>
 
 #ifdef __APPLE__
 #include <signal.h>
@@ -289,14 +293,18 @@ std::string get_stack_trace_for_threads_with_pattern(const std::vector<int>& tid
             continue;
         }
         if (e.second.size() == 1) {
-            ret += strings::Substitute("$0tid: $1\n", line_prefix, e.second[0]);
+            int tid = e.second[0];
+            ret += strings::Substitute("$0tid: $1:$2\n", line_prefix, tid, get_thread_name(tid));
         } else {
             ret += strings::Substitute("$0$1 tids: ", line_prefix, e.second.size());
             for (size_t i = 0; i < e.second.size(); i++) {
+                int tid = e.second[i];
                 if (i > 0) {
-                    ret += ",";
+                    ret += ", ";
                 }
-                ret += std::to_string(e.second[i]);
+                ret += std::to_string(tid);
+                ret += ":";
+                ret += get_thread_name(tid);
             }
             ret += "\n";
         }
@@ -352,6 +360,19 @@ std::vector<int> get_thread_id_list() {
     }
     closedir(dir);
     return thread_id_list;
+}
+
+std::string get_thread_name(int tid) {
+    std::string self_path = "/proc/self/task/" + std::to_string(tid) + "/comm";
+    std::ifstream self_file(self_path);
+    if (self_file.is_open()) {
+        std::string name;
+        std::getline(self_file, name);
+        if (!name.empty()) {
+            return name;
+        }
+    }
+    return "unknown";
 }
 
 class ExceptionStackContext {

--- a/be/src/util/stack_util.h
+++ b/be/src/util/stack_util.h
@@ -26,6 +26,7 @@
 namespace starrocks {
 
 std::vector<int> get_thread_id_list();
+std::string get_thread_name(int tid);
 bool install_stack_trace_sighandler();
 std::string get_stack_trace_for_thread(int tid, int timeout_ms);
 std::string get_stack_trace_for_threads(const std::vector<int>& tids, int timeout_ms);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
After changed the we can not only see the thread stack but also see the thread name
<img width="3454" height="918" alt="image" src="https://github.com/user-attachments/assets/1ed7e3e0-54db-4bbf-a133-f0b88c38efa7" />
When execute SQL:
admin execute on 280449 'System.print(ExecEnv.get_stack_trace_for_all_threads())';
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
