### PR TITLE
[BugFix] fix stale vended credentials returned by iceberg table cache reload

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -125,11 +125,18 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                     @Override
                     public Table reload(IcebergTableName key, Table oldValue) {
                         try {
-                            BaseTable updateTable = 
+                            BaseTable updateTable =
                                     (BaseTable) delegate.getTable(new ConnectContext(), key.dbName, key.tableName);
+                            // REST catalogs may vend temporary credentials (STS tokens) embedded in the
+                            // Table object. Always return the freshly loaded table so callers get valid
+                            // credentials, even when the metadata-file location has not changed.
+                            if (delegate instanceof IcebergRESTCatalog) {
+                                return updateTable;
+                            }
                             TableOperations newOps = updateTable.operations();
                             TableOperations oldOps = ((BaseTable) oldValue).operations();
-                            if (oldOps.current().metadataFileLocation().equals(newOps.current().metadataFileLocation())) {
+                            if (oldOps.current().metadataFileLocation().equals(
+                                    newOps.current().metadataFileLocation())) {
                                 return oldValue;
                             }
                             return updateTable;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -743,4 +743,153 @@ public class CachingIcebergCatalogTest {
             System.out.println("===== test reload async end =====");
         }
     }
+
+    @Test
+    public void testReloadAlwaysReturnsFreshTable(@Mocked IcebergRESTCatalog delegate,
+                                                   @Mocked IcebergCatalogProperties props,
+                                                   @Mocked ConnectContext ctx) throws Exception {
+        // Two tables with SAME metadataFileLocation but different identity,
+        // simulating a REST catalog returning fresh vended credentials on each loadTable call.
+        Table oldTable = createBaseTableWithManifests(1, 1);
+        Table freshTable = createBaseTableWithManifests(1, 1);
+        String sharedMetadataLocation = "s3://bucket/metadata/v1.metadata.json";
+        Mockito.when(((BaseTable) oldTable).operations().current().metadataFileLocation())
+                .thenReturn(sharedMetadataLocation);
+        Mockito.when(((BaseTable) freshTable).operations().current().metadataFileLocation())
+                .thenReturn(sharedMetadataLocation);
+
+        AtomicLong callCount = new AtomicLong(0);
+
+        new Expectations() {
+            {
+                props.isEnableIcebergMetadataCache();
+                result = true;
+                props.isEnableIcebergTableCache();
+                result = true;
+                props.getIcebergMetaCacheTtlSec();
+                result = 60L;
+                props.getIcebergTableCacheRefreshIntervalSec();
+                result = 1L;
+                props.getIcebergTableCacheMemoryUsageRatio();
+                result = 1;
+                props.getIcebergDataFileCacheMemoryUsageRatio();
+                result = 0.0;
+                props.getIcebergDeleteFileCacheMemoryUsageRatio();
+                result = 0.0;
+
+                delegate.getTable((ConnectContext) any, "db1", "t1");
+                result = new Delegate<Table>() {
+                    Table capture(ConnectContext c, String db, String tbl) {
+                        long idx = callCount.incrementAndGet();
+                        if (idx == 1) {
+                            return oldTable;
+                        }
+                        return freshTable;
+                    }
+                };
+            }
+        };
+
+        ExecutorService es = Executors.newSingleThreadExecutor();
+        try {
+            CachingIcebergCatalog catalog =
+                    new CachingIcebergCatalog("iceberg0", delegate, props, es);
+            IcebergTableName key = new IcebergTableName("db1", "t1");
+
+            // Initial load returns oldTable
+            Table cached = catalog.getTable(ctx, "db1", "t1");
+            Assertions.assertSame(oldTable, cached, "initial load should return oldTable");
+            Assertions.assertEquals(1, callCount.get());
+
+            // Wait for refresh interval to elapse, then trigger async reload
+            LoadingCache<IcebergTableName, Table> tableCache = Deencapsulation.getField(catalog, "tables");
+            Thread.sleep(1100);
+            tableCache.get(key); // triggers async reload
+            Thread.sleep(300);   // allow async reload to complete
+
+            // After reload, cache must hold freshTable (not oldTable),
+            // even though metadataFileLocation is identical.
+            Assertions.assertEquals(2, callCount.get(), "delegate should have been called twice");
+            Table reloaded = tableCache.get(key);
+            Assertions.assertSame(freshTable, reloaded,
+                    "reload must return freshly loaded table even when metadata location is unchanged");
+            Assertions.assertNotSame(oldTable, reloaded,
+                    "reload must NOT return stale oldTable when metadata location is unchanged");
+        } finally {
+            es.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testReloadReturnsOldTableForNonRestWhenMetadataUnchanged(@Mocked IcebergCatalog delegate,
+                                                                          @Mocked IcebergCatalogProperties props,
+                                                                          @Mocked ConnectContext ctx) throws Exception {
+        // Non-REST catalog with SAME metadataFileLocation should return oldValue (optimization preserved).
+        Table oldTable = createBaseTableWithManifests(1, 1);
+        Table freshTable = createBaseTableWithManifests(1, 1);
+        String sharedMetadataLocation = "s3://bucket/metadata/v1.metadata.json";
+        Mockito.when(((BaseTable) oldTable).operations().current().metadataFileLocation())
+                .thenReturn(sharedMetadataLocation);
+        Mockito.when(((BaseTable) freshTable).operations().current().metadataFileLocation())
+                .thenReturn(sharedMetadataLocation);
+
+        AtomicLong callCount = new AtomicLong(0);
+
+        new Expectations() {
+            {
+                props.isEnableIcebergMetadataCache();
+                result = true;
+                props.isEnableIcebergTableCache();
+                result = true;
+                props.getIcebergMetaCacheTtlSec();
+                result = 60L;
+                props.getIcebergTableCacheRefreshIntervalSec();
+                result = 1L;
+                props.getIcebergTableCacheMemoryUsageRatio();
+                result = 1;
+                props.getIcebergDataFileCacheMemoryUsageRatio();
+                result = 0.0;
+                props.getIcebergDeleteFileCacheMemoryUsageRatio();
+                result = 0.0;
+
+                delegate.getTable((ConnectContext) any, "db1", "t1");
+                result = new Delegate<Table>() {
+                    Table capture(ConnectContext c, String db, String tbl) {
+                        long idx = callCount.incrementAndGet();
+                        if (idx == 1) {
+                            return oldTable;
+                        }
+                        return freshTable;
+                    }
+                };
+            }
+        };
+
+        ExecutorService es = Executors.newSingleThreadExecutor();
+        try {
+            CachingIcebergCatalog catalog =
+                    new CachingIcebergCatalog("iceberg0", delegate, props, es);
+            IcebergTableName key = new IcebergTableName("db1", "t1");
+
+            // Initial load returns oldTable
+            Table cached = catalog.getTable(ctx, "db1", "t1");
+            Assertions.assertSame(oldTable, cached, "initial load should return oldTable");
+            Assertions.assertEquals(1, callCount.get());
+
+            // Wait for refresh interval to elapse, then trigger async reload
+            LoadingCache<IcebergTableName, Table> tableCache = Deencapsulation.getField(catalog, "tables");
+            Thread.sleep(1100);
+            tableCache.get(key); // triggers async reload
+            Thread.sleep(300);   // allow async reload to complete
+
+            // After reload with non-REST delegate, cache must hold oldTable
+            // because metadataFileLocation is unchanged (optimization preserved).
+            Assertions.assertEquals(2, callCount.get(), "delegate should have been called twice");
+            Table reloaded = tableCache.get(key);
+            Assertions.assertSame(oldTable, reloaded,
+                    "non-REST reload must return old table when metadata location is unchanged");
+        } finally {
+            es.shutdownNow();
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

`CachingIcebergCatalog.reload()` returns the old cached `Table` object when `metadataFileLocation` hasn't changed. This breaks REST catalogs with **vended credentials**, where each `loadTable` response embeds fresh short-lived STS tokens in the `Table` object. After the tokens expire, queries fail with authentication errors because the cache keeps serving the stale `Table`.

## What I'm doing:

Add an `instanceof IcebergRESTCatalog` guard in `reload()` to always return the freshly loaded `Table` for REST catalogs, bypassing the `metadataFileLocation` equality optimization. Non-REST catalogs retain the existing optimization unchanged.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4