### PR TITLE
[Enhancement] Make set catalog = xxx will also use setCatalogStatement

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/TableObjectCaseInsensitiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/TableObjectCaseInsensitiveTest.java
@@ -335,6 +335,9 @@ public class TableObjectCaseInsensitiveTest {
         analyzeSuccess("SET CATALOG Test_Catalog");
         analyzeSuccess("set catalog TEST_catalog");
 
+        analyzeSuccess("SET CATALOG = Test_Catalog");
+        analyzeSuccess("set catalog = TEST_catalog");
+
         analyzeSuccess("DROP CATALOG IF EXISTS Test_Catalog");
         analyzeSuccess("drop catalog TEST_catalog");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetVarTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetVarTest.java
@@ -189,6 +189,11 @@ public class SetVarTest extends PlanTestBase {
             if (attr == null) {
                 continue;
             }
+            // Skip set catalog = xxx;
+            // As it will set database empty.
+            if (SessionVariable.CATALOG.equals(attr.name())) {
+                continue;
+            }
             field.setAccessible(true);
             Object value = field.get(sessionVariable);
 

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -395,7 +395,7 @@ useCatalogStatement
     ;
 
 setCatalogStatement
-    : SET CATALOG identifierOrString
+    : SET CATALOG EQ? identifierOrString
     ;
 
 showDatabasesStatement


### PR DESCRIPTION
## Why I'm doing:
Currently when user execute `set catalog = xxx;`
It will be setStatement. 
That means the permission check for catalog will be miss.
Then users can use catalog that they do not have permission.

## What I'm doing:
Make set catalog = xxx will also use setCatalogStatement.
So that it will use the permission for the setCatalogStatement.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
