### PR TITLE
[Refactor] Move Expr into ExprCore

### DIFF
--- a/be/src/exprs/CMakeLists.txt
+++ b/be/src/exprs/CMakeLists.txt
@@ -19,6 +19,8 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/exprs")
 
 set(EXPR_CORE_FILES
   function_context.cpp
+  expr_context.cpp
+  expr.cpp
 )
 
 ADD_BE_LIB(ExprCore ${EXPR_CORE_FILES})
@@ -44,8 +46,6 @@ set(EXPR_FILES
   binary_functions.cpp
   expr_factory.cpp
   expr_executor.cpp
-  expr_context.cpp
-  expr.cpp
   table_function/table_function_factory.cpp
   table_function/json_each.cpp
   table_function/list_rowsets.cpp

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -43,7 +43,6 @@
 
 #include "base/failpoint/fail_point.h"
 #include "exprs/expr_context.h"
-#include "runtime/runtime_state.h"
 
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "EndlessLoop"

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -35,20 +35,29 @@
 #include "exprs/expr_context.h"
 
 #include <fmt/format.h>
-#include <storage/chunk_helper.h>
 
 #include <memory>
-#include <sstream>
 #include <stdexcept>
 
 #include "column/chunk.h"
+#include "column/column_helper.h"
 #include "common/statusor.h"
-#include "exprs/column_ref.h"
 #include "exprs/expr.h"
 #include "runtime/mem_pool.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks {
+
+namespace {
+
+ChunkPtr create_dummy_chunk() {
+    auto dummy_chunk = std::make_shared<Chunk>();
+    auto column = ColumnHelper::create_const_column<TYPE_INT>(1, 1);
+    dummy_chunk->append_column(std::move(column), 0);
+    return dummy_chunk;
+}
+
+} // namespace
 
 ExprContext::ExprContext(Expr* root) : _root(root) {}
 
@@ -166,7 +175,7 @@ StatusOr<ColumnPtr> ExprContext::evaluate(Expr* e, Chunk* chunk, uint8_t* filter
     // but some expr can not handle situation that input chunk is nullptr or empty correctly
     // so we create chunk with one column and one raw
     if (chunk == nullptr) {
-        dummy_chunk = ChunkHelper::createDummyChunk();
+        dummy_chunk = create_dummy_chunk();
         chunk = dummy_chunk.get();
     }
 #ifndef NDEBUG

--- a/be/test/exprs/CMakeLists.txt
+++ b/be/test/exprs/CMakeLists.txt
@@ -15,6 +15,8 @@
 set(EXPR_CORE_TEST_FILES
     ../base/cxa_throw_wrap.cpp
     function_context_core_test.cpp
+    expr_core_test.cpp
+    expr_context_core_test.cpp
 )
 
 set(EXPR_CORE_TEST_LINK_LIBS
@@ -41,4 +43,3 @@ target_link_libraries(starrocks_expr_core_test_objs PRIVATE StarRocksPCH)
 set_target_properties(starrocks_expr_core_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control")
 add_executable(expr_core_test $<TARGET_OBJECTS:starrocks_expr_core_test_objs>)
 target_link_libraries(expr_core_test ${EXPR_CORE_TEST_LINK_LIBS} gtest_main)
-

--- a/be/test/exprs/expr_context_core_test.cpp
+++ b/be/test/exprs/expr_context_core_test.cpp
@@ -1,0 +1,130 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "common/object_pool.h"
+#include "exprs/expr.h"
+#include "exprs/expr_context.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+
+namespace {
+
+class ExprContextTestExpr final : public Expr {
+public:
+    explicit ExprContextTestExpr(bool register_fn_ctx = false)
+            : Expr(TypeDescriptor(TYPE_INT)), _register_fn_ctx(register_fn_ctx) {}
+
+    Expr* clone(ObjectPool* pool) const override { return pool->add(new ExprContextTestExpr(*this)); }
+
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext*, Chunk*) override {
+        ++_evaluate_calls;
+        return ColumnHelper::create_const_column<TYPE_INT>(7, 1);
+    }
+
+    Status prepare(RuntimeState* state, ExprContext* context) override {
+        RETURN_IF_ERROR(Expr::prepare(state, context));
+        if (_register_fn_ctx) {
+            _fn_ctx_idx = context->register_func(state, FunctionContext::TypeDesc(TypeDescriptor(TYPE_INT)), {});
+        }
+        return Status::OK();
+    }
+
+    void close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override {
+        ++_close_calls;
+        Expr::close(state, context, scope);
+    }
+
+    int fn_ctx_idx() const { return _fn_ctx_idx; }
+    int close_calls() const { return _close_calls; }
+    int evaluate_calls() const { return _evaluate_calls; }
+
+private:
+    bool _register_fn_ctx = false;
+    int _fn_ctx_idx = -1;
+    int _close_calls = 0;
+    int _evaluate_calls = 0;
+};
+
+} // namespace
+
+TEST(ExprContextCoreTest, EvaluateResizesConstToInputRows) {
+    ExprContextTestExpr expr;
+    RuntimeState state;
+    ExprContext context(&expr);
+    ASSERT_TRUE(context.prepare(&state).ok());
+    ASSERT_TRUE(context.open(&state).ok());
+
+    constexpr size_t num_rows = 4;
+    Chunk chunk;
+    auto input_column = ColumnHelper::create_const_column<TYPE_INT>(1, num_rows);
+    chunk.append_column(std::move(input_column), 0);
+
+    auto result = context.evaluate(&chunk);
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(num_rows, result.value()->size());
+}
+
+TEST(ExprContextCoreTest, EvaluateWithNullChunkUsesDummyChunk) {
+    ExprContextTestExpr expr;
+    RuntimeState state;
+    ExprContext context(&expr);
+    ASSERT_TRUE(context.prepare(&state).ok());
+    ASSERT_TRUE(context.open(&state).ok());
+
+    auto result = context.evaluate(nullptr);
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(1, result.value()->size());
+    EXPECT_EQ(1, expr.evaluate_calls());
+}
+
+TEST(ExprContextCoreTest, CloneCopiesFunctionContexts) {
+    ExprContextTestExpr expr(true);
+    RuntimeState state;
+    ExprContext context(&expr);
+    ASSERT_TRUE(context.prepare(&state).ok());
+    ASSERT_TRUE(context.open(&state).ok());
+    ASSERT_GE(expr.fn_ctx_idx(), 0);
+
+    int fragment_local_state = 123;
+    context.fn_context(expr.fn_ctx_idx())->set_function_state(FunctionContext::FRAGMENT_LOCAL, &fragment_local_state);
+
+    ObjectPool pool;
+    ExprContext* cloned = nullptr;
+    ASSERT_TRUE(context.clone(&state, &pool, &cloned).ok());
+    ASSERT_NE(nullptr, cloned);
+
+    auto* original_fn_ctx = context.fn_context(expr.fn_ctx_idx());
+    auto* cloned_fn_ctx = cloned->fn_context(expr.fn_ctx_idx());
+    EXPECT_NE(original_fn_ctx, cloned_fn_ctx);
+    EXPECT_EQ(&fragment_local_state, cloned_fn_ctx->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+}
+
+TEST(ExprContextCoreTest, CloseIsIdempotent) {
+    ExprContextTestExpr expr;
+    RuntimeState state;
+    ExprContext context(&expr);
+    ASSERT_TRUE(context.prepare(&state).ok());
+    ASSERT_TRUE(context.open(&state).ok());
+
+    context.close(&state);
+    context.close(&state);
+    EXPECT_EQ(1, expr.close_calls());
+}
+
+} // namespace starrocks

--- a/be/test/exprs/expr_core_test.cpp
+++ b/be/test/exprs/expr_core_test.cpp
@@ -1,0 +1,98 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/column_helper.h"
+#include "common/object_pool.h"
+#include "exprs/expr.h"
+#include "exprs/expr_context.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+
+namespace {
+
+class SimpleExpr final : public Expr {
+public:
+    explicit SimpleExpr(TypeDescriptor type, bool is_constant = true)
+            : Expr(std::move(type)), _is_constant(is_constant) {}
+
+    SimpleExpr(TypeDescriptor type, TExprNodeType::type node_type, TExprOpcode::type opcode) : Expr(std::move(type)) {
+        _node_type = node_type;
+        _opcode = opcode;
+    }
+
+    Expr* clone(ObjectPool* pool) const override { return pool->add(new SimpleExpr(*this)); }
+
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext*, Chunk*) override {
+        ++evaluate_calls;
+        return ColumnHelper::create_const_column<TYPE_INT>(42, 1);
+    }
+
+    bool is_constant() const override { return _is_constant; }
+
+    int evaluate_calls = 0;
+
+private:
+    bool _is_constant = true;
+};
+
+} // namespace
+
+TEST(ExprCoreTest, CopyDeepCopiesChildren) {
+    ObjectPool pool;
+    auto* root = pool.add(new SimpleExpr(TypeDescriptor(TYPE_INT)));
+    auto* child = pool.add(new SimpleExpr(TypeDescriptor(TYPE_INT)));
+    auto* grandchild = pool.add(new SimpleExpr(TypeDescriptor(TYPE_INT)));
+    child->add_child(grandchild);
+    root->add_child(child);
+
+    auto* copied_root = Expr::copy(&pool, root);
+    ASSERT_NE(root, copied_root);
+    ASSERT_EQ(1, copied_root->get_num_children());
+
+    auto* copied_child = copied_root->get_child(0);
+    ASSERT_NE(child, copied_child);
+    ASSERT_EQ(1, copied_child->get_num_children());
+
+    auto* copied_grandchild = copied_child->get_child(0);
+    EXPECT_NE(grandchild, copied_grandchild);
+}
+
+TEST(ExprCoreTest, TypeWithoutCastSkipsCastOpcode) {
+    SimpleExpr child(TypeDescriptor(TYPE_INT), TExprNodeType::INT_LITERAL, TExprOpcode::INVALID_OPCODE);
+    SimpleExpr cast(TypeDescriptor(TYPE_INT), TExprNodeType::CAST_EXPR, TExprOpcode::CAST);
+    cast.add_child(&child);
+
+    EXPECT_EQ(TExprNodeType::INT_LITERAL, Expr::type_without_cast(&cast));
+    EXPECT_EQ(&child, Expr::expr_without_cast(&cast));
+}
+
+TEST(ExprCoreTest, EvaluateConstCachesResult) {
+    SimpleExpr expr{TypeDescriptor(TYPE_INT)};
+    RuntimeState state;
+    ExprContext context(&expr);
+    ASSERT_TRUE(context.prepare(&state).ok());
+    ASSERT_TRUE(context.open(&state).ok());
+
+    auto first = expr.evaluate_const(&context);
+    auto second = expr.evaluate_const(&context);
+    ASSERT_TRUE(first.ok());
+    ASSERT_TRUE(second.ok());
+    EXPECT_EQ(1, expr.evaluate_calls);
+    EXPECT_EQ(first.value().get(), second.value().get());
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
