### PR TITLE
[Refactor] Move more into ExprCore

### DIFF
--- a/be/src/exprs/CMakeLists.txt
+++ b/be/src/exprs/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/exprs")
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/exprs")
 
 set(EXPR_CORE_FILES
+  arithmetic_expr.cpp
   function_context.cpp
   expr_context.cpp
   expr.cpp
@@ -25,19 +26,31 @@ set(EXPR_CORE_FILES
   array_expr.cpp
   base64.cpp
   bit_functions.cpp
+  bitmap_functions.cpp
   cast_nested.cpp
+  case_expr.cpp
+  cast_expr_json.cpp
+  cast_expr_map.cpp
   chunk_predicate_evaluator.cpp
   column_ref.cpp
   compound_predicate.cpp
+  encryption_functions.cpp
   es_functions.cpp
   expr_executor.cpp
   function_helper.cpp
   gin_functions.cpp
   grouping_sets_functions.cpp
+  hash_functions.cpp
+  hyperloglog_functions.cpp
   info_func.cpp
+  in_const_predicate.cpp
+  in_predicate.cpp
+  is_null_predicate.cpp
   jsonpath.cpp
   lambda_function.cpp
+  like_predicate.cpp
   literal.cpp
+  math_functions.cpp
   map_expr.cpp
   map_element_expr.cpp
   map_functions.cpp
@@ -48,6 +61,7 @@ set(EXPR_CORE_FILES
   struct_functions.cpp
   subfield_expr.cpp
   table_function/json_each.cpp
+  time_functions.cpp
   variant_path_parser.cpp
 )
 
@@ -80,33 +94,21 @@ set(EXPR_FILES
   expr_factory.cpp
   table_function/table_function_factory.cpp
   table_function/list_rowsets.cpp
-  arithmetic_expr.cpp
   array_functions.cpp
   arrow_function_call.cpp
   binary_predicate.cpp
-  bitmap_functions.cpp
-  case_expr.cpp
   cast_expr.cpp
   cast_expr_array.cpp
-  cast_expr_json.cpp
   cast_expr_struct.cpp
-  cast_expr_map.cpp
   dictmapping_expr.cpp
   condition_expr.cpp
-  encryption_functions.cpp
   find_in_set.cpp
   function_call_expr.cpp
   geo_functions.cpp
-  hyperloglog_functions.cpp
-  in_const_predicate.cpp
   inet_aton.cpp
-  in_predicate.cpp
-  is_null_predicate.cpp
   json_functions.cpp
   variant_functions.cpp
-  like_predicate.cpp
   locate.cpp
-  math_functions.cpp
   percentile_functions.cpp
   runtime_filter_bank.cpp
   runtime_filter.cpp
@@ -114,7 +116,6 @@ set(EXPR_FILES
   split_part.cpp
   str_to_map.cpp
   string_functions.cpp
-  time_functions.cpp
   utility_functions.cpp
   agg/java_udaf_function.cpp
   agg/java_window_function.cpp
@@ -127,7 +128,6 @@ set(EXPR_FILES
   dict_query_expr.cpp
   dictionary_get_expr.cpp
   ngram.cpp
-  hash_functions.cpp
   ai_functions.cpp
 )
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -132,7 +132,6 @@ set(EXEC_FILES
         ./exprs/agg/agg_compressed_key_test.cpp
         ./exprs/agg/agg_state_functions_test.cpp
         ./exprs/ai_functions_test.cpp
-        ./exprs/arithmetic_expr_test.cpp
         ./exprs/arithmetic_operation_test.cpp
         ./exprs/decimal_binary_function_test.cpp
         ./exprs/array_functions_test.cpp
@@ -140,7 +139,6 @@ set(EXEC_FILES
         ./exprs/binary_functions_test.cpp
         ./exprs/binary_predicate_test.cpp
         ./exprs/bitmap_functions_test.cpp
-        ./exprs/case_expr_test.cpp
         ./exprs/cast_expr_test.cpp
         ./exprs/decimal_cast_expr_decimal_test.cpp
         ./exprs/decimal_cast_expr_integer_test.cpp
@@ -153,11 +151,7 @@ set(EXEC_FILES
         ./exprs/encryption_functions_test.cpp
         ./exprs/function_call_expr_test.cpp
         ./exprs/geography_functions_test.cpp
-        ./exprs/hash_functions_test.cpp
-        ./exprs/hyperloglog_functions_test.cpp
         ./exprs/if_expr_test.cpp
-        ./exprs/in_predicate_test.cpp
-        ./exprs/is_null_predicate_test.cpp
         ./exprs/jit_cache_test.cpp
         ./exprs/json_functions_test.cpp
         ./exprs/flat_json_functions_test.cpp
@@ -187,7 +181,6 @@ set(EXEC_FILES
         ./exprs/runtime_filter_test.cpp
         ./exprs/variant_functions_test.cpp
         ./exprs/min_max_predicate_test.cpp
-        ./exprs/in_const_predicate_test.cpp
         ./exprs/table_function/test_list_rowsets.cpp
         ./exprs/dict_expr_test.cpp
         ./formats/csv/array_converter_test.cpp

--- a/be/test/exprs/CMakeLists.txt
+++ b/be/test/exprs/CMakeLists.txt
@@ -14,10 +14,17 @@
 
 set(EXPR_CORE_TEST_FILES
     ../base/cxa_throw_wrap.cpp
+    arithmetic_expr_test.cpp
     array_expr_test.cpp
+    case_expr_test.cpp
     function_context_core_test.cpp
     expr_core_test.cpp
     expr_context_core_test.cpp
+    hash_functions_test.cpp
+    hyperloglog_functions_test.cpp
+    in_const_predicate_test.cpp
+    in_predicate_test.cpp
+    is_null_predicate_test.cpp
     array_element_expr_test.cpp
     es_functions_test.cpp
     function_helper_test.cpp
@@ -54,6 +61,7 @@ set(EXPR_CORE_TEST_LINK_LIBS
 
 add_library(starrocks_expr_core_test_objs OBJECT ${EXPR_CORE_TEST_FILES})
 target_link_libraries(starrocks_expr_core_test_objs PRIVATE StarRocksPCH)
-set_target_properties(starrocks_expr_core_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control")
+set_target_properties(starrocks_expr_core_test_objs PROPERTIES
+    COMPILE_FLAGS "-fno-access-control -DSTARROCKS_EXPR_CORE_TEST_NO_JIT")
 add_executable(expr_core_test $<TARGET_OBJECTS:starrocks_expr_core_test_objs>)
 target_link_libraries(expr_core_test ${EXPR_CORE_TEST_LINK_LIBS} gtest_main)

--- a/be/test/exprs/exprs_test_helper.h
+++ b/be/test/exprs/exprs_test_helper.h
@@ -20,7 +20,9 @@
 #include "column/chunk.h"
 #include "exprs/array_expr.h"
 #include "exprs/expr_executor.h"
+#ifndef STARROCKS_EXPR_CORE_TEST_NO_JIT
 #include "exprs/jit/jit_expr.h"
+#endif
 #include "gen_cpp/Descriptors_types.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
@@ -158,6 +160,12 @@ public:
         // Verify the original result.
         test_func(ptr);
 
+#ifdef STARROCKS_EXPR_CORE_TEST_NO_JIT
+        (void)expr;
+        (void)runtime_state;
+        (void)need_jit;
+        return;
+#else
         if (!need_jit) {
             return;
         }
@@ -182,9 +190,16 @@ public:
         test_func(ptr);
 
         ExprExecutor::close(expr_ctxs, runtime_state);
+#endif
     }
 
     static void verify_result_with_jit(const ColumnPtr& ptr, Expr* expr, RuntimeState* runtime_state) {
+#ifdef STARROCKS_EXPR_CORE_TEST_NO_JIT
+        (void)ptr;
+        (void)expr;
+        (void)runtime_state;
+        return;
+#else
         auto jit_engine = JITEngine::get_instance();
         if (!jit_engine->support_jit()) {
             return;
@@ -215,6 +230,7 @@ public:
         }
 
         ExprExecutor::close(expr_ctxs, runtime_state);
+#endif
     }
 };
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-system refactor that mostly relocates sources/tests between targets; main risk is missing symbols or CI breakage due to incorrect CMake/test wiring.
> 
> **Overview**
> Moves a set of expression implementations (e.g., arithmetic/case, bitmap/hash/hll, predicates like `in`/`like`/`is_null`, JSON/map casts, and time/math/encryption functions) from the `Exprs` library into `ExprCore` by updating `be/src/exprs/CMakeLists.txt`.
> 
> Refactors unit test build wiring to match: several expr tests are moved from the main `starrocks_test` target into `expr_core_test`, and `expr_core_test` is now built with `-DSTARROCKS_EXPR_CORE_TEST_NO_JIT`, with `exprs_test_helper.h` conditionally excluding JIT headers/verification code when that flag is set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c7e4b26bc6a560639eec75cbb854d9ffff97244. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->