### PR TITLE
[Refactor] Extract create_tree from ExecNode

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -28,6 +28,7 @@ set(EXEC_FILES
     empty_set_node.cpp
     exec_factory.cpp
     exec_node.cpp
+    exec_node_executor.cpp
     exchange_node.cpp
     scan_node.cpp
     select_node.cpp

--- a/be/src/exec/exec_factory.h
+++ b/be/src/exec/exec_factory.h
@@ -22,10 +22,14 @@ class DescriptorTbl;
 class ExecNode;
 class ObjectPool;
 class RuntimeState;
+class TPlan;
 class TPlanNode;
 
 class ExecFactory {
 public:
+    static Status create_tree(RuntimeState* state, ObjectPool* pool, const TPlan& plan, const DescriptorTbl& descs,
+                              ExecNode** root);
+
     static Status create_vectorized_node(RuntimeState* state, ObjectPool* pool, const TPlanNode& tnode,
                                          const DescriptorTbl& descs, ExecNode** node);
 };

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -56,7 +56,6 @@ class ExprContext;
 class ObjectPool;
 class RuntimeState;
 class SlotRef;
-class TPlan;
 class DataSink;
 
 namespace pipeline {
@@ -146,12 +145,6 @@ public:
     // close() on the children. To ensure that close() is called on the entire plan tree,
     // each implementation should start out by calling the default implementation.
     virtual void close(RuntimeState* state);
-
-    // Creates exec node tree from list of nodes contained in plan via depth-first
-    // traversal. All nodes are placed in pool.
-    // Returns error if 'plan' is corrupted, otherwise success.
-    static Status create_tree(RuntimeState* state, ObjectPool* pool, const TPlan& plan, const DescriptorTbl& descs,
-                              ExecNode** root);
 
     // Collect all nodes of given 'node_type' that are part of this subtree, and return in
     // 'nodes'.
@@ -284,9 +277,6 @@ protected:
     /// Valid to call in or after Prepare().
     bool is_in_subplan() const { return false; }
 
-    static Status create_tree_helper(RuntimeState* state, ObjectPool* pool, const std::vector<TPlanNode>& tnodes,
-                                     const DescriptorTbl& descs, ExecNode* parent, int* node_idx, ExecNode** root);
-
     virtual bool is_scan_node() const { return false; }
 
     void init_runtime_profile(const std::string& name);
@@ -299,8 +289,6 @@ protected:
     Status exec_debug_action(TExecNodePhase::type phase);
 
 private:
-    // TODO: delete this function if removed tupleId
-    Status static checkTupleIdsInDescs(const DescriptorTbl& descs, const TPlanNode& planNode);
     RuntimeState* _runtime_state;
     bool _is_closed;
 };

--- a/be/src/exec/exec_node_executor.cpp
+++ b/be/src/exec/exec_node_executor.cpp
@@ -1,0 +1,37 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/exec_node.h"
+#include "exec/pipeline/chunk_accumulate_operator.h"
+#include "exec/pipeline/pipeline_builder.h"
+
+namespace starrocks {
+
+void ExecNode::init_runtime_filter_for_operator(OperatorFactory* op, pipeline::PipelineBuilderContext* context,
+                                                const RcRfProbeCollectorPtr& rc_rf_probe_collector) {
+    op->init_runtime_filter(context->fragment_context()->runtime_filter_hub(), this->get_tuple_ids(),
+                            this->local_rf_waiting_set(), this->row_desc(), rc_rf_probe_collector,
+                            _filter_null_value_columns, _tuple_slot_mappings);
+}
+
+void ExecNode::may_add_chunk_accumulate_operator(OpFactories& ops, pipeline::PipelineBuilderContext* context, int id) {
+    // TODO(later): Need to rewrite ChunkAccumulateOperator to support StreamPipelines,
+    // for now just disable it in stream pipelines:
+    // - make sure UPDATE_BEFORE/UPDATE_AFTER are in the same chunk.
+    if (!context->is_stream_pipeline()) {
+        ops.emplace_back(std::make_shared<pipeline::ChunkAccumulateOperatorFactory>(context->next_operator_id(), id));
+    }
+}
+
+} // namespace starrocks

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -26,6 +26,7 @@
 #include "exec/capture_version_node.h"
 #include "exec/cross_join_node.h"
 #include "exec/exchange_node.h"
+#include "exec/exec_factory.h"
 #include "exec/exec_node.h"
 #include "exec/hash_join_node.h"
 #include "exec/olap_scan_node.h"
@@ -464,8 +465,8 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
 
     // Set up plan
     _fragment_ctx->move_tplan(*const_cast<TPlan*>(&fragment.plan));
-    RETURN_IF_ERROR(
-            ExecNode::create_tree(runtime_state, obj_pool, _fragment_ctx->tplan(), desc_tbl, &_fragment_ctx->plan()));
+    RETURN_IF_ERROR(ExecFactory::create_tree(runtime_state, obj_pool, _fragment_ctx->tplan(), desc_tbl,
+                                             &_fragment_ctx->plan()));
     ExecNode* plan = _fragment_ctx->plan();
     std::unordered_set<int32_t> filter_ids;
     collect_non_broadcast_rf_ids(plan, filter_ids);

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -43,6 +43,7 @@
 #include "common/object_pool.h"
 #include "exec/data_sink.h"
 #include "exec/exchange_node.h"
+#include "exec/exec_factory.h"
 #include "exec/exec_node.h"
 #include "exec/scan_node.h"
 #include "gutil/map_util.h"
@@ -105,7 +106,7 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
 
     // set up plan
     DCHECK(request.__isset.fragment);
-    RETURN_IF_ERROR(ExecNode::create_tree(_runtime_state, obj_pool(), request.fragment.plan, *desc_tbl, &_plan));
+    RETURN_IF_ERROR(ExecFactory::create_tree(_runtime_state, obj_pool(), request.fragment.plan, *desc_tbl, &_plan));
     _runtime_state->set_fragment_root_id(_plan->id());
 
     auto* fragment_dict_state = _runtime_state->fragment_dict_state();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core query setup by changing where and how the `ExecNode` plan tree is built, so any subtle mismatch in child wiring or error handling could break fragment execution despite being a refactor; added unit tests reduce risk.
> 
> **Overview**
> Refactors plan reconstruction by moving `create_tree` (and tuple-id validation/logging) out of `ExecNode` into `ExecFactory`, and updates both pipeline (`pipeline/fragment_executor.cpp`) and non-pipeline (`runtime/plan_fragment_executor.cpp`) executors to call `ExecFactory::create_tree`.
> 
> Splits `ExecNode` implementation by extracting pipeline-only helpers (`init_runtime_filter_for_operator`, `may_add_chunk_accumulate_operator`) into a new `exec_node_executor.cpp` compilation unit, and adds focused tests in `exec_factory_test.cpp` for empty plans, valid simple trees, invalid tuple ids, and malformed/partial thrift trees.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90c6b65d448c3f019057725d3113649459e39c6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->