### PR TITLE
[BugFix] Disable the iceberg v3 features to avoid reading and writing incorrect data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -254,6 +254,35 @@ public class IcebergTable extends Table {
     }
 
     /**
+     * Check if the Iceberg table format version is supported.
+     * Currently, only Iceberg V1 and V2 are supported. V3 and higher versions are not supported.
+     *
+     * @throws StarRocksConnectorException if the table format version is V3 or higher
+     */
+    public void checkSupportedFormat() {
+        org.apache.iceberg.Table nativeTable = getNativeTable();
+        if (!(nativeTable instanceof BaseTable)) {
+            return;
+        }
+        BaseTable baseTable = (BaseTable) nativeTable;
+        org.apache.iceberg.TableOperations operations = baseTable.operations();
+        if (operations == null) {
+            return;
+        }
+        org.apache.iceberg.TableMetadata metadata = operations.current();
+        if (metadata == null) {
+            return;
+        }
+        int formatVersion = metadata.formatVersion();
+        if (formatVersion >= 3) {
+            throw new StarRocksConnectorException(String.format(
+                    "Iceberg table %s uses format version %d which is not supported. " +
+                    "Currently only Iceberg V1 and V2 are supported.",
+                    getTableIdentifier(), formatVersion));
+        }
+    }
+
+    /**
      * <p>
      *     In the Iceberg Partition Evolution scenario, 'org.apache.iceberg.PartitionField#name' only represents the
      *     name of a partition in the Iceberg table's Partition Spec. This name is used when trying to obtain the

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergMetadataScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergMetadataScanNode.java
@@ -17,11 +17,14 @@ package com.starrocks.planner;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.connector.RemoteMetaSplit;
 import com.starrocks.connector.TableVersionRange;
 import com.starrocks.connector.iceberg.IcebergMetaSpec;
 import com.starrocks.connector.metadata.MetadataTable;
 import com.starrocks.connector.metadata.MetadataTableType;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.HDFSScanNodePredicates;
 import com.starrocks.thrift.THdfsScanNode;
@@ -86,6 +89,12 @@ public class IcebergMetadataScanNode extends ScanNode {
         String catalogName = table.getCatalogName();
         String originDbName = table.getOriginDb();
         String originTableName = table.getOriginTable();
+        ConnectContext connectContext = ConnectContext.get() == null ? new ConnectContext() : ConnectContext.get();
+        Table originTable = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(connectContext, catalogName, originDbName, originTableName);
+        if (originTable instanceof IcebergTable) {
+            ((IcebergTable) originTable).checkSupportedFormat();
+        }
 
         long snapshotId = version.end().isPresent() ? version.end().get() : -1;
         IcebergMetaSpec serializedMetaSpec = GlobalStateMgr.getCurrentState().getMetadataMgr().getSerializedMetaSpec(

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -85,6 +85,7 @@ public class IcebergScanNode extends ScanNode {
                            PartitionIdGenerator partitionIdGenerator) {
         super(id, desc, planNodeName);
         this.icebergTable = (IcebergTable) desc.getTable();
+        this.icebergTable.checkSupportedFormat();
         this.tableFullMORParams = tableFullMORParams;
         this.morParams = morParams;
         this.icebergScanMetricsReporter = new IcebergMetricsReporter();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
@@ -53,6 +53,7 @@ public class IcebergTableSink extends DataSink {
 
     public IcebergTableSink(IcebergTable icebergTable, TupleDescriptor desc, boolean isStaticPartitionSink,
                             SessionVariable sessionVariable, String targetBranch) {
+        icebergTable.checkSupportedFormat();
         Table nativeTable = icebergTable.getNativeTable();
         this.desc = desc;
         this.tableLocation = nativeTable.location();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -2185,4 +2185,45 @@ public class IcebergMetadataTest extends TableTestBase {
                 HDFS_ENVIRONMENT);
         executor.execute();
     }
+
+    @Test
+    public void testIcebergV1FormatVersionSupported() {
+        // mockedNativeTableB is created with formatVersion=1
+        IcebergTable icebergTable = new IcebergTable(1, "test_table_v1", CATALOG_NAME, "resource_name",
+                "test_db", "test_table_v1", "s3://bucket/tbl_v1", Lists.newArrayList(),
+                mockedNativeTableB, Maps.newHashMap());
+
+        // V1 format should not throw exception
+        Assertions.assertDoesNotThrow(icebergTable::checkSupportedFormat);
+    }
+
+    @Test
+    public void testIcebergV2FormatVersionSupported() {
+        // mockedNativeTableA is created with formatVersion=2
+        IcebergTable icebergTable = new IcebergTable(1, "test_table_v2", CATALOG_NAME, "resource_name",
+                "test_db", "test_table_v2", "s3://bucket/tbl_v2", Lists.newArrayList(),
+                mockedNativeTableA, Maps.newHashMap());
+
+        // V2 format should not throw exception
+        Assertions.assertDoesNotThrow(icebergTable::checkSupportedFormat);
+    }
+
+    @Test
+    public void testIcebergV3FormatVersionThrowsException() {
+        // Use MockUp to change mockedNativeTableA to return V3 format version
+        new MockUp<TableMetadata>() {
+            @Mock
+            public int formatVersion() {
+                return 3;  // V3 format version
+            }
+        };
+
+        // Use existing mockedNativeTableA which has V2 format by default
+        IcebergTable icebergTable = new IcebergTable(1, "test_table", CATALOG_NAME, "resource_name",
+                "test_db", "test_table", "s3://bucket/tbl", Lists.newArrayList(),
+                mockedNativeTableA, Maps.newHashMap());
+
+        // Verify V3 table throws exception when checking format
+        Assertions.assertThrows(StarRocksConnectorException.class, icebergTable::checkSupportedFormat);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
Apache Iceberg format version 3 introduced some new features that are currently not supported by StarRocks. To prevent users from encountering unexpected errors or data inconsistencies when working with V3 tables, we need to explicitly check and reject operations on unsupported Iceberg format versions. This provides a clear error message upfront rather than failing with cryptic errors during query execution or data ingestion.

## What I'm doing:
 We add a `checkSupportedFormat()` method to the `IcebergTable` class that validates the Iceberg table's format version before performing read/write operations. This method is called in key data operation nodes (`IcebergScanNode`, `IcebergMetadataScanNode`, `IcebergTableSink`) to ensure V3+ tables are blocked early with a descriptive exception message. The check is intentionally placed only in data operation paths, allowing metadata-only operations like `DESC TABLE`, `SHOW CREATE TABLE`, and other schema inspection commands to continue working normally. This approach prevents data access failures while still enabling users to inspect the table structure and metadata of unsupported V3 tables.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

