### PR TITLE
[Enhancement] Use tryLock with timeout in canTxnFinished to reduce lock contention

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -645,8 +645,20 @@ public class GlobalTransactionMgr implements MemoryTrackable {
 
     public boolean canTxnFinished(TransactionState txn, Set<Long> errReplicas,
                                   Set<Long> unfinishedBackends) throws StarRocksException {
+        try {
+            return canTxnFinished(txn, errReplicas, unfinishedBackends, 0L);
+        } catch (LockTimeoutException exception) {
+            // Should not happen, since lockTimeoutMs=0
+            LOG.warn("canTxnFinished failed due to lock timeout, but lock timeout is set to 0, so just return false",
+                    exception);
+            return false;
+        }
+    }
+
+    public boolean canTxnFinished(TransactionState txn, Set<Long> errReplicas, Set<Long> unfinishedBackends,
+                                  long lockTimeoutMs) throws StarRocksException, LockTimeoutException {
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(txn.getDbId());
-        return dbTransactionMgr.canTxnFinished(txn, errReplicas, unfinishedBackends);
+        return dbTransactionMgr.canTxnFinished(txn, errReplicas, unfinishedBackends, lockTimeoutMs);
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:

The `canTxnFinished()` method previously acquired the intensive DB read lock unconditionally (blocking), which could be highly contended under heavy publish workloads and stall the publish daemon.


## What I'm doing:

This change mirrors the pattern already applied to `finishTransaction()` (ref: 450477ac7b):

- Add a `lockTimeoutMs` parameter to `DatabaseTransactionMgr.canTxnFinished()` and replace the blocking `lockTablesWithIntensiveDbLock` call with `tryLockTablesWithIntensiveDbLock`. When the tryLock fails, a `LockTimeoutException` is thrown.
- Add an overloaded 4-arg variant to `GlobalTransactionMgr.canTxnFinished()`; the existing 3-arg overload delegates to it with `lockTimeoutMs=0` (blocking) for full backward compatibility.
- Update `PublishVersionDaemon.tryFinishTransaction()` to pass `Config.finish_transaction_default_lock_timeout_ms` (the same config item already used for `finishTransaction`) and handle `LockTimeoutException` by logging a warning and returning early, allowing a retry on the next daemon cycle.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
