### PR TITLE
[BugFix] Fix INSERT failure when auto-partition range is enclosed by existing merged partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -415,6 +415,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -2270,8 +2271,25 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                         " already create partition failed");
             }
 
+            // Run analyzer first so that system partitions enclosed by existing partitions
+            // are removed from the resolved list before we decide whether new partitions
+            // will actually be created.
+            ConnectContext ctx = Util.getOrCreateInnerContext();
+            if (txnState.getWarehouseId() != WarehouseManager.DEFAULT_WAREHOUSE_ID) {
+                ctx.setCurrentWarehouseId(txnState.getWarehouseId());
+            }
+            try (AutoCloseableLock ignore = new AutoCloseableLock(new Locker(), db.getId(),
+                    Lists.newArrayList(table.getId()), LockType.READ)) {
+                AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(olapTable);
+                analyzer.analyze(ctx, addPartitionClause);
+            }
+
+            Set<String> resolvedPartitionNames = new TreeSet<>();
+            for (PartitionDesc desc : addPartitionClause.getResolvedPartitionDescList()) {
+                resolvedPartitionNames.add(desc.getPartitionName());
+            }
             boolean willCreateNewPartition =
-                    CatalogUtils.checkIfNewPartitionExists(olapTable, creatingPartitionNames);
+                    CatalogUtils.checkIfNewPartitionExists(olapTable, resolvedPartitionNames);
 
             // ingestion is top priority, if schema change or rollup is running, cancel it
             try {
@@ -2299,17 +2317,12 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 LOG.warn("cancel schema change or rollup failed. error: {}", e.getMessage());
             }
 
-            // If a create partition request is from BE or CN, the warehouse information may be lost, we can get it from txn state.
-            ConnectContext ctx = Util.getOrCreateInnerContext();
-            if (txnState.getWarehouseId() != WarehouseManager.DEFAULT_WAREHOUSE_ID) {
-                ctx.setCurrentWarehouseId(txnState.getWarehouseId());
+            if (willCreateNewPartition) {
+                state.getLocalMetastore().addPartitions(ctx, db, olapTable.getName(), addPartitionClause);
+            } else {
+                LOG.info("skip addPartitions for automatic create partition txn_id={}, no new partition after analyze",
+                        request.getTxn_id());
             }
-            try (AutoCloseableLock ignore = new AutoCloseableLock(new Locker(), db.getId(), Lists.newArrayList(table.getId()),
-                    LockType.READ)) {
-                AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(olapTable);
-                analyzer.analyze(ctx, addPartitionClause);
-            }
-            state.getLocalMetastore().addPartitions(ctx, db, olapTable.getName(), addPartitionClause);
         } catch (Exception e) {
             LOG.warn("failed to add partitions", e);
             errorStatus.setError_msgs(Lists.newArrayList(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -132,7 +132,9 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1465,7 +1467,15 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
             properties.putAll(clauseProperties);
         }
 
-        for (PartitionDesc partitionDesc : partitionDescs) {
+        List<String> rangePartitionColNames = null;
+        if (addPartitionClause.getPartitionDesc() instanceof RangePartitionDesc) {
+            rangePartitionColNames =
+                    ((RangePartitionDesc) addPartitionClause.getPartitionDesc()).getPartitionColNames();
+        }
+
+        Iterator<PartitionDesc> iterator = partitionDescs.iterator();
+        while (iterator.hasNext()) {
+            PartitionDesc partitionDesc = iterator.next();
             Map<String, String> cloneProperties = Maps.newHashMap(properties);
             Map<String, String> sourceProperties = partitionDesc.getProperties();
             if (sourceProperties != null && !sourceProperties.isEmpty()) {
@@ -1484,6 +1494,23 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                 PartitionDescAnalyzer.analyzeSingleRangePartitionDesc(singleRangePartitionDesc,
                         rangePartitionInfo.getPartitionColumnsSize(), cloneProperties);
                 if (!existPartitionNameSet.contains(singleRangePartitionDesc.getPartitionName())) {
+                    if (singleRangePartitionDesc.isSystem()) {
+                        long enclosingId = rangePartitionInfo.getEnclosingPartitionId(
+                                table.getIdToColumn(), singleRangePartitionDesc,
+                                addPartitionClause.isTempPartition());
+                        if (enclosingId >= 0) {
+                            Partition enclosingPartition = olapTable.getPartition(enclosingId);
+                            if (enclosingPartition != null && rangePartitionColNames != null) {
+                                int idx = rangePartitionColNames.indexOf(
+                                        singleRangePartitionDesc.getPartitionName());
+                                if (idx >= 0) {
+                                    rangePartitionColNames.set(idx, enclosingPartition.getName());
+                                }
+                            }
+                            iterator.remove();
+                            continue;
+                        }
+                    }
                     rangePartitionInfo.checkAndCreateRange(table.getIdToColumn(), singleRangePartitionDesc,
                             addPartitionClause.isTempPartition());
                 }
@@ -1511,6 +1538,12 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
             } else {
                 throw new DdlException("Only support adding partition to range/list partitioned table");
             }
+        }
+
+        if (rangePartitionColNames != null) {
+            LinkedHashSet<String> deduped = new LinkedHashSet<>(rangePartitionColNames);
+            rangePartitionColNames.clear();
+            rangePartitionColNames.addAll(deduped);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -519,7 +519,7 @@ public class FrontendServiceImplTest {
         request.setPartition_values(partitionValues);
         TCreatePartitionResult partition = impl.createPartition(request);
 
-        Assertions.assertEquals(TStatusCode.RUNTIME_ERROR, partition.getStatus().getStatus_code());
+        Assertions.assertEquals(TStatusCode.OK, partition.getStatus().getStatus_code());
         ((OlapTable) table).setState(OlapTable.OlapTableState.NORMAL);
     }
 

--- a/test/sql/test_optimize_table/R/test_merge_partition_insert
+++ b/test/sql/test_optimize_table/R/test_merge_partition_insert
@@ -1,0 +1,221 @@
+-- name: test_insert_into_merged_partition
+create database test_merge_insert_${uuid0};
+-- result:
+-- !result
+use test_merge_insert_${uuid0};
+-- result:
+-- !result
+create table t(k datetime, v int) partition by date_trunc('month', k) distributed by hash(k) buckets 3 properties("replication_num"="1");
+-- result:
+-- !result
+insert into t values ('2022-03-01', 1),('2022-06-15', 2),('2022-09-20', 3),('2023-01-10', 4),('2023-05-05', 5);
+-- result:
+-- !result
+select * from t order by k;
+-- result:
+2022-03-01 00:00:00	1
+2022-06-15 00:00:00	2
+2022-09-20 00:00:00	3
+2023-01-10 00:00:00	4
+2023-05-05 00:00:00	5
+-- !result
+show partitions from t;
+-- result:
+[REGEX].*p202203.*
+.*p202206.*
+.*p202209.*
+.*p202301.*
+.*p202305.*
+-- !result
+alter table t partition by date_trunc('year', k) between '2022-01-01' and '2022-12-31';
+-- result:
+-- !result
+function: wait_optimize_table_finish()
+-- result:
+None
+-- !result
+show partitions from t;
+-- result:
+[REGEX].*p2022.*
+.*p202301.*
+.*p202305.*
+-- !result
+insert into t values ('2022-04-01', 6),('2022-11-11', 7);
+-- result:
+-- !result
+select * from t order by k;
+-- result:
+2022-03-01 00:00:00	1
+2022-04-01 00:00:00	6
+2022-06-15 00:00:00	2
+2022-09-20 00:00:00	3
+2022-11-11 00:00:00	7
+2023-01-10 00:00:00	4
+2023-05-05 00:00:00	5
+-- !result
+insert into t values ('2023-02-14', 8),('2022-07-07', 9),('2024-01-01', 10);
+-- result:
+-- !result
+select * from t order by k;
+-- result:
+2022-03-01 00:00:00	1
+2022-04-01 00:00:00	6
+2022-06-15 00:00:00	2
+2022-07-07 00:00:00	9
+2022-09-20 00:00:00	3
+2022-11-11 00:00:00	7
+2023-01-10 00:00:00	4
+2023-02-14 00:00:00	8
+2023-05-05 00:00:00	5
+2024-01-01 00:00:00	10
+-- !result
+show partitions from t;
+-- result:
+[REGEX].*p2022.*
+.*p202301.*
+.*p202302.*
+.*p202305.*
+.*p202401.*
+-- !result
+drop database test_merge_insert_${uuid0};
+-- result:
+-- !result
+-- name: test_insert_into_merged_partition_low_open_partitions
+create database test_merge_low_${uuid0};
+-- result:
+-- !result
+use test_merge_low_${uuid0};
+-- result:
+-- !result
+admin set frontend config ("max_load_initial_open_partition_number"="1");
+-- result:
+-- !result
+create table t(k datetime, v int) partition by date_trunc('month', k) distributed by hash(k) buckets 3 properties("replication_num"="1");
+-- result:
+-- !result
+insert into t values ('2022-03-01', 1),('2022-06-15', 2),('2023-01-10', 3);
+-- result:
+-- !result
+select * from t order by k;
+-- result:
+2022-03-01 00:00:00	1
+2022-06-15 00:00:00	2
+2023-01-10 00:00:00	3
+-- !result
+alter table t partition by date_trunc('year', k) between '2022-01-01' and '2022-12-31';
+-- result:
+-- !result
+function: wait_optimize_table_finish()
+-- result:
+None
+-- !result
+show partitions from t;
+-- result:
+[REGEX].*p2022.*
+.*p202301.*
+-- !result
+insert into t values ('2022-04-01', 4),('2022-09-01', 5),('2023-02-01', 6),('2024-01-01', 7);
+-- result:
+-- !result
+select * from t order by k;
+-- result:
+2022-03-01 00:00:00	1
+2022-04-01 00:00:00	4
+2022-06-15 00:00:00	2
+2022-09-01 00:00:00	5
+2023-01-10 00:00:00	3
+2023-02-01 00:00:00	6
+2024-01-01 00:00:00	7
+-- !result
+insert into t values ('2022-01-15', 8),('2022-12-25', 9),('2022-06-30', 10),('2023-06-01', 11);
+-- result:
+-- !result
+select * from t order by k;
+-- result:
+2022-01-15 00:00:00	8
+2022-03-01 00:00:00	1
+2022-04-01 00:00:00	4
+2022-06-15 00:00:00	2
+2022-06-30 00:00:00	10
+2022-09-01 00:00:00	5
+2022-12-25 00:00:00	9
+2023-01-10 00:00:00	3
+2023-02-01 00:00:00	6
+2023-06-01 00:00:00	11
+2024-01-01 00:00:00	7
+-- !result
+show partitions from t;
+-- result:
+[REGEX].*p2022.*
+.*p202301.*
+.*p202302.*
+.*p202306.*
+.*p202401.*
+-- !result
+admin set frontend config ("max_load_initial_open_partition_number"="64");
+-- result:
+-- !result
+drop database test_merge_low_${uuid0};
+-- result:
+-- !result
+-- name: test_insert_into_multi_year_merged_partitions
+create database test_merge_multi_${uuid0};
+-- result:
+-- !result
+use test_merge_multi_${uuid0};
+-- result:
+-- !result
+admin set frontend config ("max_load_initial_open_partition_number"="1");
+-- result:
+-- !result
+create table t(k datetime, v int) partition by date_trunc('month', k) distributed by hash(k) buckets 3 properties("replication_num"="1");
+-- result:
+-- !result
+insert into t values ('2020-05-01',1),('2021-05-01',2),('2022-05-01',3),('2023-05-01',4);
+-- result:
+-- !result
+alter table t partition by date_trunc('year', k) between '2020-01-01' and '2022-12-31';
+-- result:
+-- !result
+function: wait_optimize_table_finish()
+-- result:
+None
+-- !result
+show partitions from t;
+-- result:
+[REGEX].*p2020.*
+.*p2021.*
+.*p2022.*
+.*p202305.*
+-- !result
+insert into t values ('2020-01-15',5),('2020-11-20',6),('2021-03-10',7),('2021-09-25',8),('2022-02-14',9),('2022-12-31',10),('2023-07-04',11);
+-- result:
+-- !result
+select * from t order by k;
+-- result:
+2020-01-15 00:00:00	5
+2020-05-01 00:00:00	1
+2020-11-20 00:00:00	6
+2021-03-10 00:00:00	7
+2021-05-01 00:00:00	2
+2021-09-25 00:00:00	8
+2022-02-14 00:00:00	9
+2022-05-01 00:00:00	3
+2022-12-31 00:00:00	10
+2023-05-01 00:00:00	4
+2023-07-04 00:00:00	11
+-- !result
+show partitions from t;
+-- result:
+[REGEX].*p2020.*
+.*p2021.*
+.*p2022.*
+.*p202305.*
+.*p202307.*
+-- !result
+admin set frontend config ("max_load_initial_open_partition_number"="64");
+-- result:
+-- !result
+drop database test_merge_multi_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_optimize_table/T/test_merge_partition_insert
+++ b/test/sql/test_optimize_table/T/test_merge_partition_insert
@@ -1,0 +1,70 @@
+-- name: test_insert_into_merged_partition
+create database test_merge_insert_${uuid0};
+use test_merge_insert_${uuid0};
+
+create table t(k datetime, v int) partition by date_trunc('month', k) distributed by hash(k) buckets 3 properties("replication_num"="1");
+
+insert into t values ('2022-03-01', 1),('2022-06-15', 2),('2022-09-20', 3),('2023-01-10', 4),('2023-05-05', 5);
+select * from t order by k;
+show partitions from t;
+
+alter table t partition by date_trunc('year', k) between '2022-01-01' and '2022-12-31';
+function: wait_optimize_table_finish()
+show partitions from t;
+
+insert into t values ('2022-04-01', 6),('2022-11-11', 7);
+select * from t order by k;
+
+insert into t values ('2023-02-14', 8),('2022-07-07', 9),('2024-01-01', 10);
+select * from t order by k;
+show partitions from t;
+
+drop database test_merge_insert_${uuid0};
+
+-- name: test_insert_into_merged_partition_low_open_partitions
+create database test_merge_low_${uuid0};
+use test_merge_low_${uuid0};
+
+admin set frontend config ("max_load_initial_open_partition_number"="1");
+
+create table t(k datetime, v int) partition by date_trunc('month', k) distributed by hash(k) buckets 3 properties("replication_num"="1");
+
+insert into t values ('2022-03-01', 1),('2022-06-15', 2),('2023-01-10', 3);
+select * from t order by k;
+
+alter table t partition by date_trunc('year', k) between '2022-01-01' and '2022-12-31';
+function: wait_optimize_table_finish()
+show partitions from t;
+
+insert into t values ('2022-04-01', 4),('2022-09-01', 5),('2023-02-01', 6),('2024-01-01', 7);
+select * from t order by k;
+
+insert into t values ('2022-01-15', 8),('2022-12-25', 9),('2022-06-30', 10),('2023-06-01', 11);
+select * from t order by k;
+show partitions from t;
+
+admin set frontend config ("max_load_initial_open_partition_number"="64");
+
+drop database test_merge_low_${uuid0};
+
+-- name: test_insert_into_multi_year_merged_partitions
+create database test_merge_multi_${uuid0};
+use test_merge_multi_${uuid0};
+
+admin set frontend config ("max_load_initial_open_partition_number"="1");
+
+create table t(k datetime, v int) partition by date_trunc('month', k) distributed by hash(k) buckets 3 properties("replication_num"="1");
+
+insert into t values ('2020-05-01',1),('2021-05-01',2),('2022-05-01',3),('2023-05-01',4);
+
+alter table t partition by date_trunc('year', k) between '2020-01-01' and '2022-12-31';
+function: wait_optimize_table_finish()
+show partitions from t;
+
+insert into t values ('2020-01-15',5),('2020-11-20',6),('2021-03-10',7),('2021-09-25',8),('2022-02-14',9),('2022-12-31',10),('2023-07-04',11);
+select * from t order by k;
+show partitions from t;
+
+admin set frontend config ("max_load_initial_open_partition_number"="64");
+
+drop database test_merge_multi_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
When a table uses monthly auto-partitioning and some monthly partitions have been merged into yearly partitions via OPTIMIZE TABLE, subsequent stream loads / INSERT operations fail. The failure occurs because BE triggers a `createPartition` RPC to create a monthly auto-partition whose range is already fully enclosed by the merged yearly partition, causing a range intersection error.


## What I'm doing:
- Add `getEnclosingPartitionId()` to `RangePartitionInfo` to detect whether a given partition range is fully enclosed by any existing partition range.
- In `AlterTableClauseAnalyzer.analyzeAddPartition`, for system-created (auto) partitions only: if the new partition range is enclosed by an existing partition, skip creating it and replace its name in `rangePartitionColNames` with the enclosing partition's name, so that `buildCreatePartitionResponse()` can correctly look up and return the enclosing partition info to BE.
- Deduplicate `rangePartitionColNames` to avoid returning duplicate partition info to BE.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
