### PR TITLE
[Enhancement] Bypass caching in CachingIcebergCatalog when vended credentials are enabled

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -232,10 +232,6 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     public Table getTable(ConnectContext connectContext, String dbName, String tableName) throws StarRocksConnectorException {
         IcebergTableName icebergTableName = new IcebergTableName(dbName, tableName);
 
-        if (ConnectContext.get() == null || ConnectContext.get().getCommand() == MysqlCommand.COM_QUERY) {
-            tableLatestAccessTime.put(icebergTableName, System.currentTimeMillis());
-        }
-
         // do not cache if jwt or oauth2 is used AND it is a REST Catalog.
         // do not cache if vended credentials are enabled, because credentials may expire before cache TTL.
         boolean cacheAllowed = icebergProperties.isEnableIcebergTableCache() &&
@@ -243,6 +239,10 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                 !delegate.isVendedCredentialsEnabled();
         if (!cacheAllowed) {
             return delegate.getTable(connectContext, dbName, tableName);
+        }
+
+        if (ConnectContext.get() == null || ConnectContext.get().getCommand() == MysqlCommand.COM_QUERY) {
+            tableLatestAccessTime.put(icebergTableName, System.currentTimeMillis());
         }
         try {
             TABLE_LOAD_CONTEXT.set(connectContext);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -236,9 +236,11 @@ public class CachingIcebergCatalog implements IcebergCatalog {
             tableLatestAccessTime.put(icebergTableName, System.currentTimeMillis());
         }
 
-        // do not cache if jwt or oauth2 is not used OR if it is not a REST Catalog.
-        boolean cacheAllowed = icebergProperties.isEnableIcebergTableCache() && 
-                (Strings.isNullOrEmpty(connectContext.getAuthToken()) || !(delegate instanceof IcebergRESTCatalog));
+        // do not cache if jwt or oauth2 is used AND it is a REST Catalog.
+        // do not cache if vended credentials are enabled, because credentials may expire before cache TTL.
+        boolean cacheAllowed = icebergProperties.isEnableIcebergTableCache() &&
+                (Strings.isNullOrEmpty(connectContext.getAuthToken()) || !(delegate instanceof IcebergRESTCatalog)) &&
+                !delegate.isVendedCredentialsEnabled();
         if (!cacheAllowed) {
             return delegate.getTable(connectContext, dbName, tableName);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -247,6 +247,17 @@ public interface IcebergCatalog extends MemoryTrackable {
         return new HashMap<>();
     }
 
+    /**
+     * Check if this catalog uses vended credentials for table access.
+     * When vended credentials are used, caching tables may cause issues
+     * because credentials expire before the cache TTL.
+     *
+     * @return true if vended credentials are enabled
+     */
+    default boolean isVendedCredentialsEnabled() {
+        return false;
+    }
+
     default String defaultTableLocation(ConnectContext context, Namespace ns, String tableName) {
         Map<String, String> properties = loadNamespaceMetadata(context, ns);
         String databaseLocation = properties.get(LOCATION_PROPERTY);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -87,6 +87,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     private Map<String, String> restCatalogProperties;
     private final boolean nestedNamespaceEnabled;
     private final boolean viewEndpointsEnabled;
+    private final boolean enableVendedCredentials;
 
 
     public IcebergRESTCatalog(String name, Configuration conf, Map<String, String> properties) {
@@ -104,7 +105,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         restCatalogProperties.put(CatalogProperties.FILE_IO_IMPL, IcebergCachingFileIO.class.getName());
         restCatalogProperties.put(CatalogProperties.METRICS_REPORTER_IMPL, IcebergMetricsReporter.class.getName());
 
-        boolean enableVendedCredentials =
+        this.enableVendedCredentials =
                 Boolean.parseBoolean(restCatalogProperties.getOrDefault(KEY_VENDED_CREDENTIALS_ENABLED, "true"));
         if (enableVendedCredentials) {
             restCatalogProperties.put("header.X-Iceberg-Access-Delegation", "vended-credentials");
@@ -139,6 +140,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         this.nestedNamespaceEnabled = false;
         this.viewEndpointsEnabled = true;
         this.restCatalogProperties = Maps.newHashMap();
+        this.enableVendedCredentials = false;
     }
 
     @Override
@@ -464,5 +466,10 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
         return new SessionCatalog.SessionContext(sessionId, context.getQualifiedUser(), credentials, ImmutableMap.of(),
                 context.getCurrentUserIdentity());
+    }
+
+    @Override
+    public boolean isVendedCredentialsEnabled() {
+        return enableVendedCredentials;
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request introduces improvements to the caching logic for Iceberg REST catalogs, specifically addressing scenarios where vended credentials are used. The main goal is to ensure that table caching is bypassed when vended credentials are enabled, preventing issues with expired credentials. The changes include updates to caching logic, interface extensions, and new tests to verify correct behavior.

Caching logic enhancements:

* Updated `CachingIcebergCatalog.getTable` to bypass caching when vended credentials are enabled, ensuring that credentials do not expire before cache TTL.

Iceberg catalog interface updates:

* Added the `isVendedCredentialsEnabled` method to the `IcebergCatalog` interface, allowing catalogs to indicate whether vended credentials are used.
* Implemented `isVendedCredentialsEnabled` in `IcebergRESTCatalog`, with proper initialization and handling in constructors. 

Testing improvements:

* Added unit tests in `CachingIcebergCatalogTest` to verify that caching is bypassed when vended credentials are enabled and that caching works normally when vended credentials are disabled.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
