### PR TITLE
[BugFix] Fix Arrow Flight Proxy with Multiple FE (backport #68300)

### DIFF
--- a/docs/en/unloading/arrow_flight.md
+++ b/docs/en/unloading/arrow_flight.md
@@ -176,6 +176,8 @@ SET GLOBAL arrow_flight_proxy = 'your-proxy-hostname:Port';
 
 - The proxy feature is enabled by default, which may result in 8-10% lower throughput compared to direct BE connections. If your clients have direct network access to BE nodes, you can disable the proxy to achieve optimal performance: `SET GLOBAL arrow_flight_proxy_enabled = false;`
 - When `arrow_flight_proxy` is empty, tickets will automatically route through the FE node that the client initially connected to.
+- **Important**: The `arrow_flight_proxy` and `arrow_flight_proxy_enabled` settings should be configured globally using `SET GLOBAL`. Session-level settings are not supported.
+- **Session restart required**: Changing the proxy settings only affects new sessions. Existing Arrow Flight SQL sessions will continue using their original settings until they reconnect.
 
 :::
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -77,6 +77,8 @@ public final class GlobalVariable {
     public static final String ACTIVATE_ALL_ROLES_ON_LOGIN = "activate_all_roles_on_login";
     public static final String ACTIVATE_ALL_ROLES_ON_LOGIN_V2 = "activate_all_roles_on_login_v2";
     public static final String ENABLE_TDE = "enable_tde";
+    public static final String ARROW_FLIGHT_PROXY = "arrow_flight_proxy";
+    public static final String ARROW_FLIGHT_PROXY_ENABLED = "arrow_flight_proxy_enabled";
     public static final String MAX_UNKNOWN_STRING_META_LENGTH = "max_unknown_string_meta_length";
 
 
@@ -179,6 +181,14 @@ public final class GlobalVariable {
 
     @VariableMgr.VarAttr(name = ENABLE_TDE, flag = VariableMgr.GLOBAL | VariableMgr.READ_ONLY)
     public static boolean enableTde = KeyMgr.isEncrypted();
+
+    // Arrow Flight SQL proxy endpoint. Format: "hostname:port" or "grpcs://hostname:port" for TLS.
+    @VariableMgr.VarAttr(name = ARROW_FLIGHT_PROXY, flag = VariableMgr.GLOBAL)
+    private static volatile String arrowFlightProxy = "";
+
+    // Enable Arrow Flight SQL proxy mode.
+    @VariableMgr.VarAttr(name = ARROW_FLIGHT_PROXY_ENABLED, flag = VariableMgr.GLOBAL)
+    private static volatile boolean arrowFlightProxyEnabled = true;
 
     @VariableMgr.VarAttr(name = MAX_UNKNOWN_STRING_META_LENGTH, flag = VariableMgr.GLOBAL)
     private static int maxUnknownStringMetaLength = 64;
@@ -315,6 +325,22 @@ public final class GlobalVariable {
 
     public static void setActivateAllRolesOnLogin(boolean activateAllRolesOnLogin) {
         GlobalVariable.activateAllRolesOnLogin = activateAllRolesOnLogin;
+    }
+
+    public static String getArrowFlightProxy() {
+        return arrowFlightProxy;
+    }
+
+    public static void setArrowFlightProxy(String arrowFlightProxy) {
+        GlobalVariable.arrowFlightProxy = arrowFlightProxy;
+    }
+
+    public static boolean isArrowFlightProxyEnabled() {
+        return arrowFlightProxyEnabled;
+    }
+
+    public static void setArrowFlightProxyEnabled(boolean arrowFlightProxyEnabled) {
+        GlobalVariable.arrowFlightProxyEnabled = arrowFlightProxyEnabled;
     }
 
     public static int getMaxUnknownStringMetaLength() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -947,9 +947,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH = "enable_insert_select_external_auto_refresh";
 
-    public static final String ARROW_FLIGHT_PROXY = "arrow_flight_proxy";
-    public static final String ARROW_FLIGHT_PROXY_ENABLED = "arrow_flight_proxy_enabled";
-
     public static final String TOPN_PUSH_DOWN_AGG_MODE = "topn_push_down_agg_mode";
 
     public static final String ENABLE_LABELED_COLUMN_STATISTIC_OUTPUT = "enable_labeled_column_statistic_output";
@@ -1940,11 +1937,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH)
     private boolean enableInsertSelectExternalAutoRefresh = true;
-
-    @VarAttr(name = ARROW_FLIGHT_PROXY)
-    private String arrowFlightProxy = "";
-    @VarAttr(name = ARROW_FLIGHT_PROXY_ENABLED)
-    private boolean arrowFlightProxyEnabled = true;
 
     @VarAttr(name = TOPN_PUSH_DOWN_AGG_MODE, flag = VariableMgr.INVISIBLE)
     private int topNPushDownAggMode = 1;
@@ -5241,22 +5233,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableInsertSelectExternalAutoRefresh(boolean enableInsertSelectExternalAutoRefresh) {
         this.enableInsertSelectExternalAutoRefresh = enableInsertSelectExternalAutoRefresh;
-    }
-
-    public void setArrowFlightProxy(String proxy) {
-        this.arrowFlightProxy = proxy;
-    }
-
-    public String getArrowFlightProxy() {
-        return this.arrowFlightProxy;
-    }
-
-    public void setArrowFlightProxyEnabled(boolean flag) {
-        this.arrowFlightProxyEnabled = flag;
-    }
-
-    public boolean isArrowFlightProxyEnabled() {
-        return this.arrowFlightProxyEnabled;
     }
 
     public void setEnablePreAggTopNPushDown(int  topNPushDownAggMode) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -947,9 +947,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH = "enable_insert_select_external_auto_refresh";
 
+<<<<<<< HEAD
     public static final String ARROW_FLIGHT_PROXY = "arrow_flight_proxy";
     public static final String ARROW_FLIGHT_PROXY_ENABLED = "arrow_flight_proxy_enabled";
 
+=======
+    public static final String TOPN_PUSH_DOWN_AGG_MODE = "topn_push_down_agg_mode";
+
+    public static final String ENABLE_LABELED_COLUMN_STATISTIC_OUTPUT = "enable_labeled_column_statistic_output";
+>>>>>>> 0662e9c8a9 ([BugFix] Fix Arrow Flight Proxy with Multiple FE (#68300))
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
@@ -1938,11 +1944,19 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH)
     private boolean enableInsertSelectExternalAutoRefresh = true;
 
+<<<<<<< HEAD
     @VarAttr(name = ARROW_FLIGHT_PROXY)
     private String arrowFlightProxy = "";
     @VarAttr(name = ARROW_FLIGHT_PROXY_ENABLED)
     private boolean arrowFlightProxyEnabled = true;
 
+=======
+    @VarAttr(name = TOPN_PUSH_DOWN_AGG_MODE, flag = VariableMgr.INVISIBLE)
+    private int topNPushDownAggMode = 1;
+
+    @VarAttr(name = ENABLE_LABELED_COLUMN_STATISTIC_OUTPUT)
+    private boolean enableLabeledColumnStatisticOutput = false;
+>>>>>>> 0662e9c8a9 ([BugFix] Fix Arrow Flight Proxy with Multiple FE (#68300))
 
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
@@ -5235,6 +5249,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableInsertSelectExternalAutoRefresh = enableInsertSelectExternalAutoRefresh;
     }
 
+<<<<<<< HEAD
     public void setArrowFlightProxy(String proxy) {
         this.arrowFlightProxy = proxy;
     }
@@ -5251,6 +5266,23 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return this.arrowFlightProxyEnabled;
     }
 
+=======
+    public void setEnablePreAggTopNPushDown(int  topNPushDownAggMode) {
+        this.topNPushDownAggMode = topNPushDownAggMode;
+    }
+
+    public int getTopNPushDownAggMode() {
+        return topNPushDownAggMode;
+    }
+
+    public void setEnableLabeledColumnStatisticOutput(boolean flag) {
+        this.enableLabeledColumnStatisticOutput = flag;
+    }
+
+    public boolean isEnableLabeledColumnStatisticOutput() {
+        return this.enableLabeledColumnStatisticOutput;
+    }
+>>>>>>> 0662e9c8a9 ([BugFix] Fix Arrow Flight Proxy with Multiple FE (#68300))
 
     // Serialize to thrift object
     // used for rest api

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -947,15 +947,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH = "enable_insert_select_external_auto_refresh";
 
-<<<<<<< HEAD
     public static final String ARROW_FLIGHT_PROXY = "arrow_flight_proxy";
     public static final String ARROW_FLIGHT_PROXY_ENABLED = "arrow_flight_proxy_enabled";
 
-=======
     public static final String TOPN_PUSH_DOWN_AGG_MODE = "topn_push_down_agg_mode";
 
     public static final String ENABLE_LABELED_COLUMN_STATISTIC_OUTPUT = "enable_labeled_column_statistic_output";
->>>>>>> 0662e9c8a9 ([BugFix] Fix Arrow Flight Proxy with Multiple FE (#68300))
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
@@ -1944,19 +1941,16 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH)
     private boolean enableInsertSelectExternalAutoRefresh = true;
 
-<<<<<<< HEAD
     @VarAttr(name = ARROW_FLIGHT_PROXY)
     private String arrowFlightProxy = "";
     @VarAttr(name = ARROW_FLIGHT_PROXY_ENABLED)
     private boolean arrowFlightProxyEnabled = true;
 
-=======
     @VarAttr(name = TOPN_PUSH_DOWN_AGG_MODE, flag = VariableMgr.INVISIBLE)
     private int topNPushDownAggMode = 1;
 
     @VarAttr(name = ENABLE_LABELED_COLUMN_STATISTIC_OUTPUT)
     private boolean enableLabeledColumnStatisticOutput = false;
->>>>>>> 0662e9c8a9 ([BugFix] Fix Arrow Flight Proxy with Multiple FE (#68300))
 
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
@@ -5249,7 +5243,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableInsertSelectExternalAutoRefresh = enableInsertSelectExternalAutoRefresh;
     }
 
-<<<<<<< HEAD
     public void setArrowFlightProxy(String proxy) {
         this.arrowFlightProxy = proxy;
     }
@@ -5266,7 +5259,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return this.arrowFlightProxyEnabled;
     }
 
-=======
     public void setEnablePreAggTopNPushDown(int  topNPushDownAggMode) {
         this.topNPushDownAggMode = topNPushDownAggMode;
     }
@@ -5282,7 +5274,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public boolean isEnableLabeledColumnStatisticOutput() {
         return this.enableLabeledColumnStatisticOutput;
     }
->>>>>>> 0662e9c8a9 ([BugFix] Fix Arrow Flight Proxy with Multiple FE (#68300))
 
     // Serialize to thrift object
     // used for rest api

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -30,7 +30,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.util.ArrowUtil;
 import com.starrocks.common.util.DebugUtil;
-import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.GlobalVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.arrow.flight.sql.session.ArrowFlightSqlSessionManager;
 import com.starrocks.sql.plan.ExecPlan;
@@ -55,6 +55,8 @@ import org.apache.arrow.flight.SchemaResult;
 import org.apache.arrow.flight.SetSessionOptionsRequest;
 import org.apache.arrow.flight.SetSessionOptionsResult;
 import org.apache.arrow.flight.Ticket;
+import org.apache.arrow.flight.auth2.BearerCredentialWriter;
+import org.apache.arrow.flight.grpc.CredentialCallOption;
 import org.apache.arrow.flight.sql.FlightSqlProducer;
 import org.apache.arrow.flight.sql.SqlInfoBuilder;
 import org.apache.arrow.flight.sql.impl.FlightSql;
@@ -76,6 +78,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -85,10 +88,10 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
     private static final Logger LOG = LogManager.getLogger(ArrowFlightSqlServiceImpl.class);
     private final BufferAllocator rootAllocator = new RootAllocator();
     private final ArrowFlightSqlSessionManager sessionManager;
-    private final Location feEndpoint;
+    private final ArrowFlightSqlTicketManager ticketManager;
     private final SqlInfoBuilder sqlInfoBuilder;
-    private final Cache<String, FlightClient> beClientCache = CacheBuilder.newBuilder()
-            .maximumSize(128)
+    private final Cache<String, FlightClient> clientCache = CacheBuilder.newBuilder()
+            .maximumSize(256)
             .expireAfterAccess(10, TimeUnit.MINUTES)
             .removalListener((RemovalNotification<String, FlightClient> notification) -> {
                 FlightClient client = notification.getValue();
@@ -110,7 +113,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
 
     public ArrowFlightSqlServiceImpl(final ArrowFlightSqlSessionManager sessionManager, final Location feEndpoint) {
         this.sessionManager = sessionManager;
-        this.feEndpoint = feEndpoint;
+        this.ticketManager = createTicketManager(feEndpoint);
         this.sqlInfoBuilder = new SqlInfoBuilder();
         this.sqlInfoBuilder.withFlightSqlServerName("StarRocks")
                 .withFlightSqlServerVersion("1.0.0")
@@ -129,7 +132,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
 
     @Override
     public void close() throws Exception {
-        beClientCache.invalidateAll();
+        clientCache.invalidateAll();
         AutoCloseables.close(rootAllocator);
     }
 
@@ -141,9 +144,20 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
      */
     @Override
     public void closeSession(CloseSessionRequest request, CallContext context, StreamListener<CloseSessionResult> listener) {
-        ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(context.peerIdentity());
+        String token = context.peerIdentity();
+
+        // When proxy is enabled and token is from another FE, forward the request
+        if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
+            forwardCloseSessionToRemoteFE(token, listener);
+            return;
+        }
+
+        ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(token);
         ctx.kill(true, "Close Arrow Flight SQL session via RPC request");
         sessionManager.closeSession(ctx.getArrowFlightSqlToken());
+
+        CloseSessionResult result = new CloseSessionResult(CloseSessionResult.Status.CLOSED);
+        listener.onNext(result);
         listener.onCompleted();
     }
 
@@ -169,6 +183,13 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
         EXECUTOR.submit(() -> {
             try {
                 String token = context.peerIdentity();
+
+                // When proxy is enabled and token is from another FE, forward the request
+                if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
+                    forwardActionToRemoteFE(token, request, listener);
+                    return;
+                }
+
                 ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(token);
 
                 String preparedStmtId = ctx.addPreparedStatement(request.getQuery());
@@ -204,6 +225,15 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
     public void closePreparedStatement(FlightSql.ActionClosePreparedStatementRequest request, CallContext context,
                                        StreamListener<Result> listener) {
         String token = context.peerIdentity();
+
+        // When proxy is enabled and token is from another FE, forward the request
+        if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
+            EXECUTOR.submit(() -> {
+                forwardActionToRemoteFE(token, request, listener);
+            });
+            return;
+        }
+
         ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(token);
 
         String preparedStmtId = request.getPreparedStatementHandle().toStringUtf8();
@@ -213,14 +243,22 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
     }
 
     /**
-     * Execute the prepared statement and return the endpoint of the result stream.
+     * Execute a prepared statement query and return the endpoint of the result stream.
      *
-     * <p> Planner and coordinator will be executed in this method.
+     * <p> When proxy is enabled and the token is from another FE, the request is forwarded
+     * to the FE that issued the token, since the prepared statement state exists only on that FE.
      */
     @Override
     public FlightInfo getFlightInfoPreparedStatement(FlightSql.CommandPreparedStatementQuery command, CallContext context,
                                                      FlightDescriptor descriptor) {
         String token = context.peerIdentity();
+
+        // When proxy is enabled and token is from another FE, forward the request
+        // The prepared statement state exists only on the FE that created it
+        if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
+            return forwardGetFlightInfoToRemoteFE(token, command);
+        }
+
         ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(token);
         String database = context.getMiddleware(FlightConstants.HEADER_KEY).headers().get("database");
         if (!StringUtils.isEmpty(database)) {
@@ -244,11 +282,20 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
      *
      * <p> This is for the native Arrow Flight Client, such as FlightSqlClient in Java.
      * The RPC sequence is getFlightInfoStatement -> getStreamStatement.
+     *
+     * <p> When proxy is enabled and the token is from another FE, the request is forwarded
+     * to the FE that issued the token.
      */
     @Override
     public FlightInfo getFlightInfoStatement(FlightSql.CommandStatementQuery command, CallContext context,
                                              FlightDescriptor descriptor) {
         String token = context.peerIdentity();
+
+        // When proxy is enabled and token is from another FE, forward the request
+        if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
+            return forwardGetFlightInfoToRemoteFE(token, command);
+        }
+
         ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(token);
         String query = command.getQuery();
         return getFlightInfoFromQuery(ctx, descriptor, query);
@@ -256,13 +303,15 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
 
     @Override
     public void getStreamStatement(FlightSql.TicketStatementQuery ticket, CallContext context, ServerStreamListener listener) {
-        getStreamResult(ticket.getStatementHandle().toStringUtf8(), listener);
+        String token = context.peerIdentity();
+        getStreamResult(ticket.getStatementHandle().toStringUtf8(), token, listener);
     }
 
     @Override
     public void getStreamPreparedStatement(FlightSql.CommandPreparedStatementQuery command, CallContext context,
                                            ServerStreamListener listener) {
-        getStreamResult(command.getPreparedStatementHandle().toStringUtf8(), listener);
+        String token = context.peerIdentity();
+        getStreamResult(command.getPreparedStatementHandle().toStringUtf8(), token, listener);
     }
 
     /**
@@ -272,13 +321,21 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
     public void setSessionOptions(SetSessionOptionsRequest request, CallContext context,
                                   StreamListener<SetSessionOptionsResult> listener) {
         EXECUTOR.submit(() -> {
+            String token = context.peerIdentity();
+
+            // When proxy is enabled and token is from another FE, forward the request
+            if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
+                forwardSetSessionOptionsToRemoteFE(token, request, listener);
+                return;
+            }
+
             Map<String, SetSessionOptionsResult.Error> errors = Maps.newHashMap();
             request.getSessionOptions().forEach((key, value) -> {
                 // Only support set `catalog` for now.
                 if (!key.equalsIgnoreCase("catalog")) {
                     errors.put(key, new SetSessionOptionsResult.Error(SetSessionOptionsResult.ErrorValue.INVALID_NAME));
                 } else {
-                    ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(context.peerIdentity());
+                    ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(token);
                     String catalog = value.acceptVisitor(new NoOpSessionOptionValueVisitor<>() {
                         @Override
                         public String visit(String value) {
@@ -470,103 +527,136 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
         }
     }
 
-    private void getStreamResult(String ticket, ServerStreamListener listener) {
-        String[] ticketParts = ticket.split("\\|");
+    private void getStreamResult(String ticketString, String bearerToken, ServerStreamListener listener) {
+        ArrowFlightSqlTicketManager.ParsedTicket parsedTicket = ticketManager.parseTicket(ticketString);
 
-        if (ticketParts.length != 2 && ticketParts.length != 4) {
-            throw CallStatus.INVALID_ARGUMENT.withDescription(
-                            String.format("Invalid ticket format: expected 2 or 4 parts, got [%d]", ticketParts.length))
-                    .toRuntimeException();
-        }
-
-        if (ticketParts.length == 2) {
-            getStreamResultFromFE(ticketParts[0], ticketParts[1], listener); 
-            return;
-        }
-
-        try {
-            getStreamResultFromBE(ticketParts[0], ticketParts[1], ticketParts[2],
-                             Integer.parseInt(ticketParts[3]), listener);
-        } catch (NumberFormatException e) {
-            throw CallStatus.INVALID_ARGUMENT.withDescription(
-                            String.format("Invalid ticket format: expected numerical port, received [%s]", ticketParts[3]))
-                    .toRuntimeException();
+        switch (parsedTicket.getType()) {
+            case FE_LOCAL:
+                // Use bearer token from auth header for session lookup
+                getStreamResultFromFE(bearerToken, parsedTicket.getQueryId(), listener);
+                break;
+            case FE_PROXY:
+                getStreamResultFromRemoteFE(parsedTicket, bearerToken, listener);
+                break;
+            case BE_PROXY:
+                getStreamResultFromBE(parsedTicket, listener);
+                break;
+            default:
+                throw CallStatus.INVALID_ARGUMENT.withDescription(
+                        "Unknown ticket type: " + parsedTicket.getType()).toRuntimeException();
         }
     }
 
-    private void getStreamResultFromBE(String queryId, String fragmentInstanceId,
-                                    String beHost, int bePort, ServerStreamListener listener) {
-        FlightStream beStream = null;
-        String beKey = beHost + ":" + bePort;
+    /**
+     * Proxies the result stream from a remote BE to the client.
+     *
+     * <p>The queryId in the ticket serves as a validation token between FE, BE, and client,
+     * since it's a random UUID that was generated during query execution. This allows the BE
+     * to validate that the request is legitimate without requiring a separate bearer token.
+     */
+    private void getStreamResultFromBE(ArrowFlightSqlTicketManager.ParsedTicket ticket,
+                                        ServerStreamListener listener) {
+        ByteString ticketHandle = ticketManager.buildBETicket(ticket.getQueryId(), ticket.getFragmentInstanceId());
+        // bearerToken is null for BE connections because the queryId in the ticket serves as the validation token
+        getStreamResultFromRemoteNode(ticket.getHost(), ticket.getPort(), ticketHandle, null, "BE", listener);
+    }
+
+    private void getStreamResultFromRemoteFE(ArrowFlightSqlTicketManager.ParsedTicket ticket,
+                                              String bearerToken,
+                                              ServerStreamListener listener) {
+        // Check if this is the local FE - if so, handle locally to avoid unnecessary network hop
+        if (ticketManager.isLocalFE(ticket)) {
+            getStreamResultFromFE(bearerToken, ticket.getQueryId(), listener);
+            return;
+        }
+
+        String uuid = extractUuidFromToken(bearerToken);
+        ByteString ticketHandle = ByteString.copyFromUtf8(uuid + "|" + ticket.getQueryId());
+        getStreamResultFromRemoteNode(ticket.getHost(), ticket.getPort(), ticketHandle, bearerToken, "FE", listener);
+    }
+
+    private void getStreamResultFromRemoteNode(String host, int port,
+                                                ByteString ticketHandle,
+                                                String bearerToken,
+                                                String targetType,
+                                                ServerStreamListener listener) {
+        FlightStream stream = null;
+        String nodeKey = host + ":" + port;
 
         try {
-            FlightClient beClient = getOrCreateBeClient(beKey, beHost, bePort);
-            // Reconstruct the original BE ticket (without BE host/port)
+            FlightClient client = getOrCreateClient(nodeKey, host, port);
             FlightSql.TicketStatementQuery ticketStatement = FlightSql.TicketStatementQuery.newBuilder()
-                    .setStatementHandle(buildBETicket(queryId, fragmentInstanceId))
+                    .setStatementHandle(ticketHandle)
                     .build();
             Ticket ticket = new Ticket(Any.pack(ticketStatement).toByteArray());
 
-            beStream = getStreamWithRetry(beClient, ticket, beKey, beHost, bePort);
-            final FlightStream streamToCancel = beStream;
+            stream = getStreamWithRetry(client, ticket, nodeKey, host, port, bearerToken);
+            final FlightStream streamToCancel = stream;
 
             listener.setOnCancelHandler(() -> {
                 try {
                     streamToCancel.cancel("Client cancelled request", null);
                 } catch (Exception e) {
-                    LOG.warn("[ARROW] Error cancelling BE stream", e);
+                    LOG.warn("[ARROW] Error cancelling {} stream", targetType, e);
                 }
             });
 
-            VectorSchemaRoot root = beStream.getRoot();
-            // Start streaming to client
+            VectorSchemaRoot root = stream.getRoot();
             listener.start(root);
-            while (beStream.next()) {
+            while (stream.next()) {
                 listener.putNext();
             }
             listener.completed();
         } catch (Exception e) {
-            LOG.warn("[ARROW] Error proxying result from BE {}:{}", beHost, bePort, e);
+            LOG.warn("[ARROW] Error proxying result from {} {}:{}", targetType, host, port, e);
 
-            if (beStream != null) {
+            if (stream != null) {
                 try {
-                    beStream.cancel("Error during streaming", e);
+                    stream.cancel("Error during streaming", e);
                 } catch (Exception cancelStreamEx) {
-                    LOG.warn("[ARROW] Error cancelling stream", cancelStreamEx);
+                    LOG.warn("[ARROW] Error cancelling {} stream", targetType, cancelStreamEx);
                 }
             }
 
             listener.error(CallStatus.INTERNAL
-                    .withDescription("Failed to proxy result from BE: " + e.getMessage())
+                    .withDescription("Failed to proxy result from " + targetType + ": " + e.getMessage())
                     .toRuntimeException());
         } finally {
             try {
-                if (beStream != null) {
-                    beStream.close();
+                if (stream != null) {
+                    stream.close();
                 }
             } catch (Exception e) {
-                LOG.warn("[ARROW] Error closing BE stream", e);
+                LOG.warn("[ARROW] Error closing {} stream", targetType, e);
             }
         }
     }
 
-    private FlightClient getOrCreateBeClient(String beKey, String beHost, int bePort) throws Exception {
-        return beClientCache.get(beKey, () -> {
-            Location beLocation = Location.forGrpcInsecure(beHost, bePort);
-            return FlightClient.builder().allocator(rootAllocator).location(beLocation).build();
+    private FlightClient getOrCreateClient(String key, String host, int port) throws Exception {
+        return clientCache.get(key, () -> {
+            Location location = Location.forGrpcInsecure(host, port);
+            return FlightClient.builder().allocator(rootAllocator).location(location).build();
         });
     }
 
-    private FlightStream getStreamWithRetry(FlightClient beClient, Ticket ticket,
-                                            String beKey, String beHost, int bePort) throws Exception {
+    private FlightStream getStreamWithRetry(FlightClient client, Ticket ticket,
+                                            String key, String host, int port,
+                                            String bearerToken) throws Exception {
         try {
-            return beClient.getStream(ticket);
+            if (bearerToken != null) {
+                CredentialCallOption authOption = new CredentialCallOption(new BearerCredentialWriter(bearerToken));
+                return client.getStream(ticket, authOption);
+            }
+            return client.getStream(ticket);
         } catch (Exception e) {
-            LOG.warn("[ARROW] Failed to get stream from BE {}:{}, retrying with new client",
-                    beHost, bePort, e);
+            LOG.warn("[ARROW] Failed to get stream from {}:{}, retrying with new client", host, port, e);
 
-            beClientCache.invalidate(beKey);
-            FlightClient freshClient = getOrCreateBeClient(beKey, beHost, bePort);
+            clientCache.invalidate(key);
+            FlightClient freshClient = getOrCreateClient(key, host, port);
+            if (bearerToken != null) {
+                CredentialCallOption authOption = new CredentialCallOption(new BearerCredentialWriter(bearerToken));
+                return freshClient.getStream(ticket, authOption);
+            }
             return freshClient.getStream(ticket);
         }
     }
@@ -587,6 +677,156 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
     }
 
     /**
+     * Forward a getFlightInfo request to the FE that issued the token.
+     * Used when proxy is enabled and a request arrives at a different FE than the one that authenticated the client.
+     *
+     * @param token The bearer token containing the FE host
+     * @param command The protobuf command to forward (e.g., CommandStatementQuery, CommandPreparedStatementQuery)
+     */
+    private FlightInfo forwardGetFlightInfoToRemoteFE(String token, Message command) {
+        String feHost = ArrowFlightSqlSessionManager.extractFeHost(token);
+        if (feHost == null) {
+            throw CallStatus.INVALID_ARGUMENT
+                    .withDescription("Invalid token format: cannot extract FE host from token")
+                    .toRuntimeException();
+        }
+
+        int fePort = Config.arrow_flight_port;
+        String nodeKey = feHost + ":" + fePort;
+
+        try {
+            FlightClient client = getOrCreateClient(nodeKey, feHost, fePort);
+            FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(command).toByteArray());
+            CredentialCallOption authOption = new CredentialCallOption(new BearerCredentialWriter(token));
+
+            FlightInfo remoteInfo = client.getInfo(descriptor, authOption);
+            LOG.info("[ARROW] Forwarded getFlightInfo to remote FE {}:{}", feHost, fePort);
+            return remoteInfo;
+
+        } catch (Exception e) {
+            LOG.warn("[ARROW] Failed to forward getFlightInfo to remote FE {}:{}", feHost, fePort, e);
+            throw CallStatus.UNAVAILABLE
+                    .withDescription("Failed to forward request to FE " + feHost + ": " + e.getMessage())
+                    .withCause(e)
+                    .toRuntimeException();
+        }
+    }
+
+    /**
+     * Forward an action to the FE that issued the token.
+     *
+     * @param token The bearer token containing the FE host
+     * @param request The protobuf action request to forward
+     * @param listener The listener to receive results
+     */
+    private void forwardActionToRemoteFE(String token, Message request, StreamListener<Result> listener) {
+        String feHost = ArrowFlightSqlSessionManager.extractFeHost(token);
+        if (feHost == null) {
+            listener.onError(CallStatus.INVALID_ARGUMENT
+                    .withDescription("Invalid token format: cannot extract FE host from token")
+                    .toRuntimeException());
+            return;
+        }
+
+        int fePort = Config.arrow_flight_port;
+        String nodeKey = feHost + ":" + fePort;
+
+        try {
+            FlightClient client = getOrCreateClient(nodeKey, feHost, fePort);
+            CredentialCallOption authOption = new CredentialCallOption(new BearerCredentialWriter(token));
+
+            org.apache.arrow.flight.Action action = new org.apache.arrow.flight.Action(
+                    request.getDescriptorForType().getFullName(),
+                    Any.pack(request).toByteArray());
+
+            Iterator<Result> results = client.doAction(action, authOption);
+            while (results.hasNext()) {
+                listener.onNext(results.next());
+            }
+            listener.onCompleted();
+
+            LOG.info("[ARROW] Forwarded action {} to remote FE {}:{}",
+                    request.getDescriptorForType().getName(), feHost, fePort);
+
+        } catch (Exception e) {
+            LOG.warn("[ARROW] Failed to forward action to remote FE {}:{}", feHost, fePort, e);
+            listener.onError(CallStatus.UNAVAILABLE
+                    .withDescription("Failed to forward action to FE " + feHost + ": " + e.getMessage())
+                    .withCause(e)
+                    .toRuntimeException());
+        }
+    }
+
+    /**
+     * Forward a setSessionOptions request to the FE that issued the token.
+     */
+    private void forwardSetSessionOptionsToRemoteFE(String token, SetSessionOptionsRequest request,
+                                                     StreamListener<SetSessionOptionsResult> listener) {
+        String feHost = ArrowFlightSqlSessionManager.extractFeHost(token);
+        if (feHost == null) {
+            listener.onError(CallStatus.INVALID_ARGUMENT
+                    .withDescription("Invalid token format: cannot extract FE host from token")
+                    .toRuntimeException());
+            return;
+        }
+
+        int fePort = Config.arrow_flight_port;
+        String nodeKey = feHost + ":" + fePort;
+
+        try {
+            FlightClient client = getOrCreateClient(nodeKey, feHost, fePort);
+            CredentialCallOption authOption = new CredentialCallOption(new BearerCredentialWriter(token));
+
+            SetSessionOptionsResult result = client.setSessionOptions(request, authOption);
+            listener.onNext(result);
+            listener.onCompleted();
+
+            LOG.info("[ARROW] Forwarded setSessionOptions to remote FE {}:{}", feHost, fePort);
+
+        } catch (Exception e) {
+            LOG.warn("[ARROW] Failed to forward setSessionOptions to remote FE {}:{}", feHost, fePort, e);
+            listener.onError(CallStatus.UNAVAILABLE
+                    .withDescription("Failed to forward setSessionOptions to FE " + feHost + ": " + e.getMessage())
+                    .withCause(e)
+                    .toRuntimeException());
+        }
+    }
+
+    /**
+     * Forward a closeSession request to the FE that issued the token.
+     */
+    private void forwardCloseSessionToRemoteFE(String token, StreamListener<CloseSessionResult> listener) {
+        String feHost = ArrowFlightSqlSessionManager.extractFeHost(token);
+        if (feHost == null) {
+            listener.onError(CallStatus.INVALID_ARGUMENT
+                    .withDescription("Invalid token format: cannot extract FE host from token")
+                    .toRuntimeException());
+            return;
+        }
+
+        int fePort = Config.arrow_flight_port;
+        String nodeKey = feHost + ":" + fePort;
+
+        try {
+            FlightClient client = getOrCreateClient(nodeKey, feHost, fePort);
+            CredentialCallOption authOption = new CredentialCallOption(new BearerCredentialWriter(token));
+
+            CloseSessionResult result = client.closeSession(new CloseSessionRequest(), authOption);
+            listener.onNext(result);
+            listener.onCompleted();
+
+            LOG.info("[ARROW] Forwarded closeSession to remote FE {}:{}", feHost, fePort);
+
+        } catch (Exception e) {
+            LOG.warn("[ARROW] Failed to forward closeSession to remote FE {}:{}", feHost, fePort, e);
+            listener.onError(CallStatus.UNAVAILABLE
+                    .withDescription("Failed to forward closeSession to FE " + feHost + ": " + e.getMessage())
+                    .withCause(e)
+                    .toRuntimeException());
+        }
+    }
+
+    /**
      * In ADBC, a single connection can execute multiple statements concurrently, but since ConnectContext is not thread-safe,
      * we currently cannot support this behavior.
      * Therefore, use {@link ArrowFlightSqlConnectContext#acquireRunningToken(long)} to ensure that only one statement is
@@ -601,11 +841,12 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
 
             // FE task will return FE (or proxy) as endpoint.
             if (!result.isBackendResultDescriptor()) {
-                final ByteString handle = buildFETicket(ctx);
+                Pair<Location, ByteString> feEndpoint = getFEEndpoint(ctx);
+                Location endpoint = feEndpoint.first;
+                ByteString handle = feEndpoint.second;
+
                 FlightSql.TicketStatementQuery ticketStatement =
                         FlightSql.TicketStatementQuery.newBuilder().setStatementHandle(handle).build();
-                SessionVariable sv = ctx.getSessionVariable();
-                Location endpoint = getFEEndpoint(sv);
                 return buildFlightInfo(ticketStatement, descriptor, result.getSchema(), endpoint);
             }
 
@@ -617,8 +858,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
             SystemInfoService clusterInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
             ComputeNode worker = clusterInfoService.getBackendOrComputeNode(workerId);
 
-            SessionVariable sv = ctx.getSessionVariable();
-            Pair<Location, ByteString> beEndpoint = getBEEndpoint(sv, ctx.getExecutionId(), worker, rootFragmentInstanceId);
+            Pair<Location, ByteString> beEndpoint = getBEEndpoint(ctx.getExecutionId(), worker, rootFragmentInstanceId);
             Location endpoint = beEndpoint.first;
             ByteString handle = beEndpoint.second;
 
@@ -631,33 +871,22 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
         }
     }
 
-    private static ByteString buildFETicket(ArrowFlightSqlConnectContext ctx) {
-        // FETicket: <Token> : <QueryId>
-        return ByteString.copyFromUtf8(ctx.getArrowFlightSqlToken() + "|" + DebugUtil.printId(ctx.getExecutionId()));
-    }
-
-    private static ByteString buildBETicket(String queryId, String rootFragmentInstanceId) {
-        return ByteString.copyFromUtf8(queryId + ":" + rootFragmentInstanceId);
-    }
-
-    private static ByteString buildBETicket(TUniqueId queryId, TUniqueId rootFragmentInstanceId) {
-        // BETicket: <QueryId> : <FragmentInstanceId>
-        return buildBETicket(hexStringFromUniqueId(queryId), hexStringFromUniqueId(rootFragmentInstanceId));
-    }
-
-    private static ByteString buildFEProxyTicket(TUniqueId queryId, TUniqueId rootFragmentInstanceId, ComputeNode worker) {
-        // Proxy Ticket: <QueryId> : <FragmentInstanceId> : Worker Hostname : Port
-        return ByteString.copyFromUtf8(hexStringFromUniqueId(queryId) + "|" 
-                        + hexStringFromUniqueId(rootFragmentInstanceId) + "|" 
-                        + worker.getHost() + "|" 
-                        + worker.getArrowFlightPort());
+    protected Pair<Location, ByteString> getFEEndpoint(ArrowFlightSqlConnectContext ctx) throws InvalidConfException {
+        return ticketManager.getFEEndpoint(ctx);
     }
 
     private <T extends Message> FlightInfo buildFlightInfoFromFE(T request, FlightDescriptor descriptor,
                                                                  Schema schema, CallContext context) {
+        String token = context.peerIdentity();
+
+        // When proxy is enabled and token is from another FE, forward the request
+        if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
+            return forwardGetFlightInfoToRemoteFE(token, request);
+        }
+
         try {
-            ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(context.peerIdentity());
-            Location endpoint = getFEEndpoint(ctx.getSessionVariable());
+            sessionManager.validateAndGetConnectContext(token);
+            Location endpoint = getFELocation();
             return buildFlightInfo(request, descriptor, schema, endpoint);
         } catch (InvalidConfException e) {
             throw CallStatus.INTERNAL.withDescription(e.getMessage()).toRuntimeException();
@@ -685,85 +914,56 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
         return new Schema(arrowFields);
     }
 
-    private static String hexStringFromUniqueId(final TUniqueId id) {
-        if (id == null) {
-            return "";
-        }
-        return Long.toHexString(id.hi) + "-" + Long.toHexString(id.lo);
+    /**
+     * Factory method to create the TicketManager. Override in tests to provide custom behavior.
+     */
+    @VisibleForTesting
+    protected ArrowFlightSqlTicketManager createTicketManager(Location feEndpoint) {
+        return new ArrowFlightSqlTicketManager(feEndpoint);
     }
 
-    private static void validateProxyFormat(String arrowFlightProxy) throws InvalidConfException {
-        if (arrowFlightProxy.isEmpty()) {
-            return;
-        }
-
-        String[] split = arrowFlightProxy.split(":");
-        if (split.length != 2) {
-            throw new InvalidConfException(
-                    String.format("Expected format 'hostname:port', got '%s'", arrowFlightProxy));
-        }
-
-        if (split[0].isEmpty()) {
-            throw new InvalidConfException(
-                    String.format("Hostname cannot be empty, got '%s'", arrowFlightProxy));
-        }
-
-        try {
-            int port = Integer.parseInt(split[1]);
-            if (port < 1 || port > 65535) {
-                throw new InvalidConfException(
-                        String.format("Port must be between 1 and 65535, got '%d'", port));
-            }
-        } catch (NumberFormatException e) {
-            throw new InvalidConfException(
-                    String.format("Port must be a valid integer, got '%s'", split[1]));
-        }
+    protected Location getFELocation() throws InvalidConfException {
+        return ticketManager.getFELocation();
     }
 
-    private Location getProxyLocation(String arrowFlightProxy) throws InvalidConfException {
-        validateProxyFormat(arrowFlightProxy);
-        String[] split = arrowFlightProxy.split(":");
-        return Location.forGrpcInsecure(split[0], Integer.parseInt(split[1]));
-    }
-
-    protected Location getFEEndpoint(SessionVariable sv) throws InvalidConfException {
-        if (sv.isArrowFlightProxyEnabled()) {
-            String arrowFlightProxy = sv.getArrowFlightProxy();
-            if (!arrowFlightProxy.isEmpty()) {
-                return getProxyLocation(arrowFlightProxy);
-            }
-        }
-        return feEndpoint;
-    }
-
-    protected Pair<Location, ByteString> getBEEndpoint(SessionVariable sv, TUniqueId queryId,
-                                                  ComputeNode worker, TUniqueId rootFragmentInstanceId)
-                                                  throws InvalidConfException {
-        ByteString handle;
-        Location endpoint;
-        if (sv.isArrowFlightProxyEnabled()) {
-            String arrowFlightProxy = sv.getArrowFlightProxy();
-            handle = buildFEProxyTicket(queryId, rootFragmentInstanceId, worker);
-            if (arrowFlightProxy.isEmpty()) { // route to FE
-                endpoint = feEndpoint;
-            } else { // route to defined proxy
-                endpoint = getProxyLocation(arrowFlightProxy);
-            }
-        } else { // route directly to BE
-            handle = buildBETicket(queryId, rootFragmentInstanceId);
-            endpoint = Location.forGrpcInsecure(worker.getHost(), worker.getArrowFlightPort());
-        }
-
-        return new Pair<>(endpoint, handle);
+    protected Pair<Location, ByteString> getBEEndpoint(TUniqueId queryId, ComputeNode worker,
+                                                       TUniqueId rootFragmentInstanceId)
+                                                       throws InvalidConfException {
+        return ticketManager.getBEEndpoint(queryId, worker, rootFragmentInstanceId);
     }
 
     @VisibleForTesting
     protected void addToCacheForTesting(String key, FlightClient client) {
-        this.beClientCache.put(key, client);
+        this.clientCache.put(key, client);
     }
 
     @VisibleForTesting
     protected FlightClient getClientFromCacheForTesting(String key) {
-        return this.beClientCache.getIfPresent(key);
+        return this.clientCache.getIfPresent(key);
+    }
+
+    /**
+     * Extracts the UUID portion from a bearer token.
+     * When proxy is enabled, tokens have format "FE_HOST|UUID", otherwise just "UUID".
+     */
+    private static String extractUuidFromToken(String token) {
+        if (token == null || token.isEmpty()) {
+            return token;
+        }
+        int lastDelimiter = token.lastIndexOf('|');
+        if (lastDelimiter > 0) {
+            // Token contains delimiter, extract UUID after last '|'
+            return token.substring(lastDelimiter + 1);
+        }
+        // Token doesn't contain delimiter, return as-is
+        return token;
+    }
+
+    /**
+     * Check if Arrow Flight proxy is enabled. Override in tests to control behavior.
+     */
+    @VisibleForTesting
+    protected boolean isProxyEnabled() {
+        return GlobalVariable.isArrowFlightProxyEnabled();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManager.java
@@ -1,0 +1,408 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.service.arrow.flight.sql;
+
+import com.google.protobuf.ByteString;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.InvalidConfException;
+import com.starrocks.common.Pair;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.NetUtils;
+import com.starrocks.qe.GlobalVariable;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TUniqueId;
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.Location;
+import org.apache.arrow.util.VisibleForTesting;
+
+import java.net.URI;
+
+
+/**
+ * Manages Arrow Flight SQL ticket creation, parsing, and endpoint resolution.
+ *
+ * <p>Ticket formats:
+ * <ul>
+ *   <li>FE Local: {@code <Token>|<QueryId>} - 2 parts, handled by this FE</li>
+ *   <li>FE Proxy: {@code <Token>|<QueryId>|<FEHost>:<FEPort>} - 3 parts, proxied through FE</li>
+ *   <li>BE Proxy: {@code <QueryId>|<FragmentInstanceId>|<BEHost>|<BEPort>} - 4 parts, proxied to BE</li>
+ *   <li>BE Direct: {@code <QueryId>:<FragmentInstanceId>} - used for direct BE connection</li>
+ * </ul>
+ */
+public class ArrowFlightSqlTicketManager {
+
+    private static final String TICKET_DELIMITER = "\\|"; // regexp
+    private static final String BE_TICKET_DELIMITER = ":";
+    private static final String FE_TICKET_DELIMITER = "|";
+    private static final String GRPCS_SCHEME = "grpcs://";
+    private static final String GRPC_SCHEME = "grpc://";
+
+    private final Location feEndpoint;
+
+    public enum TicketType {
+        // FE local ticket: Token|QueryId
+        FE_LOCAL,
+        // FE proxy ticket: Token|QueryId|FEHost:FEPort
+        FE_PROXY,
+        //BE proxy ticket: QueryId|FragmentInstanceId|BEHost|BEPort
+        BE_PROXY
+    }
+
+    public static class ParsedTicket {
+        private final TicketType type;
+        private final String token;
+        private final String queryId;
+        private final String fragmentInstanceId;
+        private final String host;
+        private final int port;
+
+        private ParsedTicket(TicketType type, String token, String queryId,
+                             String fragmentInstanceId, String host, int port) {
+            this.type = type;
+            this.token = token;
+            this.queryId = queryId;
+            this.fragmentInstanceId = fragmentInstanceId;
+            this.host = host;
+            this.port = port;
+        }
+
+        public TicketType getType() {
+            return type;
+        }
+
+        public String getToken() {
+            return token;
+        }
+
+        public String getQueryId() {
+            return queryId;
+        }
+
+        public String getFragmentInstanceId() {
+            return fragmentInstanceId;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        static ParsedTicket feLocal(String token, String queryId) {
+            return new ParsedTicket(TicketType.FE_LOCAL, token, queryId, null, null, 0);
+        }
+
+        static ParsedTicket feProxy(String token, String queryId, String host, int port) {
+            return new ParsedTicket(TicketType.FE_PROXY, token, queryId, null, host, port);
+        }
+
+        static ParsedTicket beProxy(String queryId, String fragmentInstanceId, String host, int port) {
+            return new ParsedTicket(TicketType.BE_PROXY, null, queryId, fragmentInstanceId, host, port);
+        }
+    }
+
+    public ArrowFlightSqlTicketManager(Location feEndpoint) {
+        this.feEndpoint = feEndpoint;
+    }
+
+    /**
+     * Parses a ticket string and returns the parsed ticket data.
+     *
+     * Ticket formats:
+     * - FE_LOCAL (2 parts):  token|queryId
+     * - FE_PROXY (3 parts):  token|queryId|feHost:fePort
+     * - BE_PROXY (4 parts):  queryId|fragmentInstanceId|beHost|bePort
+     *
+     * @param ticket the ticket string to parse
+     * @return parsed ticket data
+     * @throws org.apache.arrow.flight.FlightRuntimeException if the ticket format is invalid
+     */
+    public ParsedTicket parseTicket(String ticket) {
+        String[] ticketParts = ticket.split(TICKET_DELIMITER);
+
+        switch (ticketParts.length) {
+            case 2:
+                // FE_LOCAL: token|queryId
+                return ParsedTicket.feLocal(ticketParts[0], ticketParts[1]);
+            case 3:
+                return parseFEProxyTicket(ticketParts);
+            case 4:
+                return parseBEProxyTicket(ticketParts);
+            default:
+                throw CallStatus.INVALID_ARGUMENT.withDescription(
+                        String.format("Invalid ticket format: expected 2, 3, or 4 parts, got [%d]",
+                                ticketParts.length)).toRuntimeException();
+        }
+    }
+
+    /**
+     * Parses FE proxy ticket format: token|queryId|feHost:fePort
+     * ticketParts[0] = token
+     * ticketParts[1] = queryId
+     * ticketParts[2] = feHost:fePort (or [ipv6]:fePort)
+     */
+    private ParsedTicket parseFEProxyTicket(String[] ticketParts) {
+        String[] hostPort;
+        try {
+            hostPort = NetUtils.resolveHostInfoFromHostPort(ticketParts[2]);
+        } catch (AnalysisException e) { // deprecated, but NetUtils uses
+            throw CallStatus.INVALID_ARGUMENT.withDescription(
+                    "Invalid FE host:port format: " + ticketParts[2]).toRuntimeException();
+        }
+
+        int port;
+        try {
+            port = Integer.parseInt(hostPort[1]);
+        } catch (NumberFormatException e) {
+            throw CallStatus.INVALID_ARGUMENT.withDescription(
+                    "Invalid FE port: " + hostPort[1]).toRuntimeException();
+        }
+
+        return ParsedTicket.feProxy(ticketParts[0], ticketParts[1], hostPort[0], port);
+    }
+
+    /**
+     * Parses BE proxy ticket format: queryId|fragmentInstanceId|beHost|bePort
+     * ticketParts[0] = queryId
+     * ticketParts[1] = fragmentInstanceId
+     * ticketParts[2] = beHost
+     * ticketParts[3] = bePort
+     */
+    private ParsedTicket parseBEProxyTicket(String[] ticketParts) {
+        int port;
+        try {
+            port = Integer.parseInt(ticketParts[3]);
+        } catch (NumberFormatException e) {
+            throw CallStatus.INVALID_ARGUMENT.withDescription(
+                    String.format("Invalid ticket format: expected numerical port, received [%s]",
+                            ticketParts[3])).toRuntimeException();
+        }
+
+        return ParsedTicket.beProxy(ticketParts[0], ticketParts[1], ticketParts[2], port);
+    }
+
+    public boolean isLocalFE(ParsedTicket ticket) {
+        if (ticket.getType() != TicketType.FE_PROXY) {
+            return false;
+        }
+
+        URI feUri = feEndpoint.getUri(); 
+        return ticket.getHost().equals(feUri.getHost()) && ticket.getPort() == feUri.getPort();
+    }
+
+    public ByteString buildBETicket(TUniqueId queryId, TUniqueId fragmentInstanceId) {
+        return ByteString.copyFromUtf8(
+                hexStringFromUniqueId(queryId) + BE_TICKET_DELIMITER + hexStringFromUniqueId(fragmentInstanceId));
+    }
+
+    public ByteString buildBETicket(String queryId, String fragmentInstanceId) {
+        return ByteString.copyFromUtf8(queryId + BE_TICKET_DELIMITER + fragmentInstanceId);
+    }
+
+    public ByteString buildFEProxyTicketForBE(TUniqueId queryId, TUniqueId fragmentInstanceId,
+                                               ComputeNode worker) {
+        return ByteString.copyFromUtf8(
+                hexStringFromUniqueId(queryId) + "|"
+                        + hexStringFromUniqueId(fragmentInstanceId) + "|"
+                        + worker.getHost() + "|"
+                        + worker.getArrowFlightPort());
+    }
+
+    public ByteString buildFELocalTicket(String token, TUniqueId queryId) {
+        // Extract UUID from token (token may be "host|uuid" or just "uuid")
+        String uuid = extractUuidFromToken(token);
+        return ByteString.copyFromUtf8(uuid + FE_TICKET_DELIMITER + DebugUtil.printId(queryId));
+    }
+
+    public ByteString buildFEProxyTicket(String token, TUniqueId queryId) {
+        // Extract UUID from token (token may be "host|uuid" or just "uuid")
+        String uuid = extractUuidFromToken(token);
+        String feHost = feEndpoint.getUri().getHost();
+        int fePort = feEndpoint.getUri().getPort();
+        String hostPort = NetUtils.getHostPortInAccessibleFormat(feHost, fePort);
+        return ByteString.copyFromUtf8(uuid + FE_TICKET_DELIMITER + DebugUtil.printId(queryId) + FE_TICKET_DELIMITER + hostPort);
+    }
+
+    /**
+     * Gets the FE endpoint and ticket handle for FE tasks.
+     *
+     * @return a pair of (endpoint location, ticket handle)
+     */
+    public Pair<Location, ByteString> getFEEndpoint(ArrowFlightSqlConnectContext ctx)
+            throws InvalidConfException {
+        ByteString handle;
+        Location endpoint;
+
+        if (isProxyEnabled()) {
+            String arrowFlightProxy = getProxyAddress();
+            handle = buildFEProxyTicket(ctx.getArrowFlightSqlToken(), ctx.getExecutionId());
+
+            if (!arrowFlightProxy.isEmpty()) {
+                endpoint = getProxyLocation(arrowFlightProxy);
+            } else {
+                endpoint = feEndpoint;
+            }
+        } else {
+            handle = buildFELocalTicket(ctx.getArrowFlightSqlToken(), ctx.getExecutionId());
+            endpoint = feEndpoint;
+        }
+
+        return new Pair<>(endpoint, handle);
+    }
+
+    /**
+     * Gets the BE endpoint and ticket handle for BE tasks.
+     *
+     * @return a pair of (endpoint location, ticket handle)
+     */
+    public Pair<Location, ByteString> getBEEndpoint(TUniqueId queryId, ComputeNode worker,
+                                                     TUniqueId rootFragmentInstanceId)
+            throws InvalidConfException {
+        ByteString handle;
+        Location endpoint;
+
+        if (isProxyEnabled()) {
+            String arrowFlightProxy = getProxyAddress();
+            handle = buildFEProxyTicketForBE(queryId, rootFragmentInstanceId, worker);
+            if (arrowFlightProxy.isEmpty()) {
+                endpoint = feEndpoint;
+            } else {
+                endpoint = getProxyLocation(arrowFlightProxy);
+            }
+        } else {
+            handle = buildBETicket(queryId, rootFragmentInstanceId);
+            endpoint = Location.forGrpcInsecure(worker.getHost(), worker.getArrowFlightPort());
+        }
+
+        return new Pair<>(endpoint, handle);
+    }
+
+    public Location getFELocation() throws InvalidConfException {
+        if (isProxyEnabled()) {
+            String arrowFlightProxy = getProxyAddress();
+            if (!arrowFlightProxy.isEmpty()) {
+                return getProxyLocation(arrowFlightProxy);
+            }
+        }
+        return feEndpoint;
+    }
+
+    public Location getProxyLocation(String arrowFlightProxy) throws InvalidConfException {
+        validateProxyFormat(arrowFlightProxy);
+
+        boolean useTls = arrowFlightProxy.startsWith(GRPCS_SCHEME);
+        String hostPortStr = arrowFlightProxy;
+
+        // Strip scheme if present
+        if (arrowFlightProxy.startsWith(GRPCS_SCHEME)) {
+            hostPortStr = arrowFlightProxy.substring(GRPCS_SCHEME.length());
+        } else if (arrowFlightProxy.startsWith(GRPC_SCHEME)) {
+            hostPortStr = arrowFlightProxy.substring(GRPC_SCHEME.length());
+        }
+
+        String[] hostPort;
+        try {
+            hostPort = NetUtils.resolveHostInfoFromHostPort(hostPortStr);
+        } catch (AnalysisException e) { // deprecated, but NetUtils uses
+            throw new InvalidConfException(e.getMessage());
+        }
+        int port = Integer.parseInt(hostPort[1]);
+
+        if (useTls) {
+            return Location.forGrpcTls(hostPort[0], port);
+        }
+        return Location.forGrpcInsecure(hostPort[0], port);
+    }
+
+    public void validateProxyFormat(String arrowFlightProxy) throws InvalidConfException {
+        if (arrowFlightProxy.isEmpty()) {
+            return;
+        }
+
+        String hostPortStr = arrowFlightProxy;
+        // Strip scheme if present (grpcs:// or grpc://)
+        if (arrowFlightProxy.startsWith(GRPCS_SCHEME)) {
+            hostPortStr = arrowFlightProxy.substring(GRPCS_SCHEME.length());
+        } else if (arrowFlightProxy.startsWith(GRPC_SCHEME)) {
+            hostPortStr = arrowFlightProxy.substring(GRPC_SCHEME.length());
+        }
+
+        String[] hostPort;
+        try {
+            hostPort = NetUtils.resolveHostInfoFromHostPort(hostPortStr);
+        } catch (AnalysisException e) { // deprecated, but NetUtils uses
+            throw new InvalidConfException(
+                    String.format("Expected format 'hostname:port' or 'grpcs://hostname:port', got '%s'",
+                            arrowFlightProxy));
+        }
+
+        if (hostPort[0].isEmpty()) {
+            throw new InvalidConfException(
+                    String.format("Hostname cannot be empty, got '%s'", arrowFlightProxy));
+        }
+
+        try {
+            int port = Integer.parseInt(hostPort[1]);
+            if (port < 1 || port > 65535) {
+                throw new InvalidConfException(
+                        String.format("Port must be between 1 and 65535, got '%d'", port));
+            }
+        } catch (NumberFormatException e) {
+            throw new InvalidConfException(
+                    String.format("Port must be a valid integer, got '%s'", hostPort[1]));
+        }
+    }
+
+    public Location getInternalFEEndpoint() {
+        return feEndpoint;
+    }
+
+    @VisibleForTesting
+    protected boolean isProxyEnabled() {
+        return GlobalVariable.isArrowFlightProxyEnabled();
+    }
+
+    @VisibleForTesting
+    protected String getProxyAddress() {
+        return GlobalVariable.getArrowFlightProxy();
+    }
+
+    /**
+     * Extracts the UUID portion from a token.
+     * When proxy is enabled, tokens have format "FE_HOST|UUID", otherwise just "UUID".
+     * This method returns just the UUID part to avoid delimiter conflicts in tickets.
+     */
+    private static String extractUuidFromToken(String token) {
+        if (token == null || token.isEmpty()) {
+            return token;
+        }
+        int lastDelimiter = token.lastIndexOf('|');
+        if (lastDelimiter > 0) {
+            // Token contains delimiter, extract UUID after last '|'
+            return token.substring(lastDelimiter + 1);
+        }
+        // Token doesn't contain delimiter, return as-is
+        return token;
+    }
+
+    private static String hexStringFromUniqueId(TUniqueId id) {
+        if (id == null) {
+            return "";
+        }
+        return Long.toHexString(id.hi) + "-" + Long.toHexString(id.lo);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/auth2/ArrowFlightSqlAuthenticator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/auth2/ArrowFlightSqlAuthenticator.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.service.arrow.flight.sql.auth2;
 
+import com.starrocks.qe.GlobalVariable;
 import com.starrocks.service.arrow.flight.sql.session.ArrowFlightSqlSessionManager;
 import org.apache.arrow.flight.CallHeaders;
 import org.apache.arrow.flight.CallStatus;
@@ -62,10 +63,21 @@ public class ArrowFlightSqlAuthenticator implements CallHeaderAuthenticator {
         try {
             sessionManager.validateToken(token);
         } catch (IllegalArgumentException e) {
+            // Token not found locally - if proxy is enabled and token is from a valid FE, allow through.
+            if (isProxyEnabled()) {
+                String feHost = ArrowFlightSqlSessionManager.extractFeHost(token);
+                if (feHost != null && ArrowFlightSqlSessionManager.isValidFeHost(feHost)) {
+                    return createAuthResult(token);
+                }
+            }
             throw CallStatus.UNAUTHENTICATED.withCause(e).withDescription(e.getMessage()).toRuntimeException();
         }
 
         return createAuthResult(token);
+    }
+
+    private boolean isProxyEnabled() {
+        return GlobalVariable.isArrowFlightProxyEnabled();
     }
 
     private AuthResult createAuthResult(String token) {

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -16,21 +16,15 @@ package com.starrocks.service.arrow.flight.sql;
 
 import com.google.common.cache.Cache;
 import com.google.protobuf.ByteString;
-<<<<<<< HEAD
 import com.starrocks.analysis.ParseNode;
-=======
 import com.starrocks.common.Config;
->>>>>>> 0662e9c8a9 ([BugFix] Fix Arrow Flight Proxy with Multiple FE (#68300))
 import com.starrocks.common.DdlException;
 import com.starrocks.common.util.ArrowUtil;
 import com.starrocks.metric.LongCounterMetric;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.plugin.AuditEvent;
-<<<<<<< HEAD
-import com.starrocks.qe.OriginStatement;
-=======
 import com.starrocks.qe.GlobalVariable;
->>>>>>> 0662e9c8a9 ([BugFix] Fix Arrow Flight Proxy with Multiple FE (#68300))
+import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.service.arrow.flight.sql.session.ArrowFlightSqlSessionManager;

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -16,24 +16,26 @@ package com.starrocks.service.arrow.flight.sql;
 
 import com.google.common.cache.Cache;
 import com.google.protobuf.ByteString;
+<<<<<<< HEAD
 import com.starrocks.analysis.ParseNode;
+=======
+import com.starrocks.common.Config;
+>>>>>>> 0662e9c8a9 ([BugFix] Fix Arrow Flight Proxy with Multiple FE (#68300))
 import com.starrocks.common.DdlException;
-import com.starrocks.common.InvalidConfException;
-import com.starrocks.common.Pair;
-import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.ArrowUtil;
 import com.starrocks.metric.LongCounterMetric;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.plugin.AuditEvent;
+<<<<<<< HEAD
 import com.starrocks.qe.OriginStatement;
+=======
+import com.starrocks.qe.GlobalVariable;
+>>>>>>> 0662e9c8a9 ([BugFix] Fix Arrow Flight Proxy with Multiple FE (#68300))
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlConnectProcessor;
-import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlResultDescriptor;
 import com.starrocks.service.arrow.flight.sql.session.ArrowFlightSqlSessionManager;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.AuditEncryptionChecker;
-import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TUniqueId;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -64,7 +66,6 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 
 import java.lang.reflect.Field;
@@ -101,6 +102,26 @@ public class ArrowFlightSqlServiceImplTest {
     @Mocked
     AuditEncryptionChecker mockChecker;
 
+    /**
+     * Testable subclass that allows controlling isProxyEnabled() without MockedStatic.
+     */
+    private static class TestableArrowFlightSqlServiceImpl extends ArrowFlightSqlServiceImpl {
+        private boolean proxyEnabled = false;
+
+        public TestableArrowFlightSqlServiceImpl(ArrowFlightSqlSessionManager sessionManager, Location feEndpoint) {
+            super(sessionManager, feEndpoint);
+        }
+
+        public void setProxyEnabled(boolean enabled) {
+            this.proxyEnabled = enabled;
+        }
+
+        @Override
+        protected boolean isProxyEnabled() {
+            return proxyEnabled;
+        }
+    }
+
     @BeforeEach
     public void setUp() throws IllegalAccessException, NoSuchFieldException, InterruptedException {
         sessionManager = mock(ArrowFlightSqlSessionManager.class);
@@ -108,6 +129,7 @@ public class ArrowFlightSqlServiceImplTest {
         mockCallContext = mock(FlightProducer.CallContext.class);
         when(mockCallContext.peerIdentity()).thenReturn("token123");
         when(sessionManager.validateAndGetConnectContext("token123")).thenReturn(mockContext);
+        when(sessionManager.isLocalToken("token123")).thenReturn(true);
         when(mockContext.getState()).thenReturn(mock(QueryState.class));
         when(mockContext.getResult(anyString())).thenReturn(mock(VectorSchemaRoot.class));
         when(mockContext.getExecutionId()).thenReturn(new com.starrocks.thrift.TUniqueId(1, 1));
@@ -119,7 +141,6 @@ public class ArrowFlightSqlServiceImplTest {
         when(mockSessionVariable.getQueryTimeoutS()).thenReturn(10);
         when(mockSessionVariable.getQueryDeliveryTimeoutS()).thenReturn(10);
         when(mockSessionVariable.getSqlDialect()).thenReturn("mysql");
-        when(mockSessionVariable.isArrowFlightProxyEnabled()).thenReturn(false);
 
         CallHeaders mockHeaders = mock(CallHeaders.class);
         when(mockHeaders.get("database")).thenReturn("test_db");
@@ -150,7 +171,8 @@ public class ArrowFlightSqlServiceImplTest {
         StatementBase mockStmtBase = mock(StatementBase.class);
         when(mockStmtBase.getOrigStmt()).thenReturn(new OriginStatement("SELECT 1", 0));
 
-        service = new ArrowFlightSqlServiceImpl(sessionManager, Location.forGrpcInsecure("localhost", 1234));
+        service = new ArrowFlightSqlServiceImpl(sessionManager,
+                Location.forGrpcInsecure("localhost", 1234));
     }
 
     @Test
@@ -167,8 +189,17 @@ public class ArrowFlightSqlServiceImplTest {
         doNothing().when(mockContext).kill(anyBoolean(), anyString());
         doNothing().when(sessionManager).closeSession(anyString());
         FlightSqlProducer.StreamListener<CloseSessionResult> listener = mock(FlightSqlProducer.StreamListener.class);
+
         service.closeSession(new CloseSessionRequest(), mockCallContext, listener);
+
         verify(sessionManager).closeSession("token123");
+
+        ArgumentCaptor<CloseSessionResult> resultCaptor = ArgumentCaptor.forClass(CloseSessionResult.class);
+        verify(listener).onNext(resultCaptor.capture());
+        verify(listener).onCompleted();
+
+        CloseSessionResult result = resultCaptor.getValue();
+        assertEquals(CloseSessionResult.Status.CLOSED, result.getStatus());
     }
 
     @Test
@@ -194,48 +225,59 @@ public class ArrowFlightSqlServiceImplTest {
 
     @Test
     public void testGetFlightInfoCatalogsWithProxy() {
-        // Configure proxy enabled with proxy endpoint
-        SessionVariable mockSv = mock(SessionVariable.class);
-        when(mockContext.getSessionVariable()).thenReturn(mockSv);
-        when(mockSv.isArrowFlightProxyEnabled()).thenReturn(true);
-        when(mockSv.getArrowFlightProxy()).thenReturn("proxy.example.com:9408");
+        try (MockedStatic<GlobalVariable> mockedGlobal = mockStatic(GlobalVariable.class)) {
+            mockedGlobal.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mockedGlobal.when(GlobalVariable::getArrowFlightProxy).thenReturn("proxy.example.com:9408");
 
-        FlightSql.CommandGetCatalogs command = FlightSql.CommandGetCatalogs.newBuilder().build();
-        FlightInfo info = service.getFlightInfoCatalogs(command, mockCallContext, FlightDescriptor.command("".getBytes()));
+            ArrowFlightSqlServiceImpl proxyService = new ArrowFlightSqlServiceImpl(sessionManager,
+                    Location.forGrpcInsecure("localhost", 1234));
 
-        assertNotNull(info);
-        assertEquals(1, info.getEndpoints().size());
-        assertEquals(Location.forGrpcInsecure("proxy.example.com", 9408),
-                info.getEndpoints().get(0).getLocations().get(0));
+            FlightSql.CommandGetCatalogs command = FlightSql.CommandGetCatalogs.newBuilder().build();
+            FlightDescriptor descriptor = FlightDescriptor.command("".getBytes());
+            FlightInfo info = proxyService.getFlightInfoCatalogs(command, mockCallContext, descriptor);
+
+            assertNotNull(info);
+            assertEquals(1, info.getEndpoints().size());
+            assertEquals(Location.forGrpcInsecure("proxy.example.com", 9408),
+                    info.getEndpoints().get(0).getLocations().get(0));
+        }
     }
 
     @Test
     public void testGetFlightInfoCatalogsWithProxyEnabledButEmpty() {
-        SessionVariable mockSv = mock(SessionVariable.class);
-        when(mockContext.getSessionVariable()).thenReturn(mockSv);
-        when(mockSv.isArrowFlightProxyEnabled()).thenReturn(true);
-        when(mockSv.getArrowFlightProxy()).thenReturn("");
+        try (MockedStatic<GlobalVariable> mockedGlobal = mockStatic(GlobalVariable.class)) {
+            mockedGlobal.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mockedGlobal.when(GlobalVariable::getArrowFlightProxy).thenReturn("");
 
-        FlightSql.CommandGetCatalogs command = FlightSql.CommandGetCatalogs.newBuilder().build();
-        FlightInfo info = service.getFlightInfoCatalogs(command, mockCallContext, FlightDescriptor.command("".getBytes()));
+            ArrowFlightSqlServiceImpl proxyService = new ArrowFlightSqlServiceImpl(sessionManager,
+                    Location.forGrpcInsecure("localhost", 1234));
 
-        assertNotNull(info);
-        assertEquals(1, info.getEndpoints().size());
-        assertEquals(Location.forGrpcInsecure("localhost", 1234),
-                info.getEndpoints().get(0).getLocations().get(0));
+            FlightSql.CommandGetCatalogs command = FlightSql.CommandGetCatalogs.newBuilder().build();
+            FlightDescriptor descriptor = FlightDescriptor.command("".getBytes());
+            FlightInfo info = proxyService.getFlightInfoCatalogs(command, mockCallContext, descriptor);
+
+            assertNotNull(info);
+            assertEquals(1, info.getEndpoints().size());
+            assertEquals(Location.forGrpcInsecure("localhost", 1234),
+                    info.getEndpoints().get(0).getLocations().get(0));
+        }
     }
 
     @Test
     public void testGetFlightInfoCatalogsWithInvalidProxy() {
-        SessionVariable mockSv = mock(SessionVariable.class);
-        when(mockContext.getSessionVariable()).thenReturn(mockSv);
-        when(mockSv.isArrowFlightProxyEnabled()).thenReturn(true);
-        when(mockSv.getArrowFlightProxy()).thenReturn("invalid-proxy-format");
+        try (MockedStatic<GlobalVariable> mockedGlobal = mockStatic(GlobalVariable.class)) {
+            mockedGlobal.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mockedGlobal.when(GlobalVariable::getArrowFlightProxy).thenReturn("invalid-proxy-format");
 
-        FlightSql.CommandGetCatalogs command = FlightSql.CommandGetCatalogs.newBuilder().build();
-        FlightRuntimeException ex = assertThrows(FlightRuntimeException.class, () ->
-                service.getFlightInfoCatalogs(command, mockCallContext, FlightDescriptor.command("".getBytes())));
-        assertTrue(ex.getMessage().contains("Expected format 'hostname:port'"));
+            ArrowFlightSqlServiceImpl proxyService = new ArrowFlightSqlServiceImpl(sessionManager,
+                    Location.forGrpcInsecure("localhost", 1234));
+
+            FlightSql.CommandGetCatalogs command = FlightSql.CommandGetCatalogs.newBuilder().build();
+            FlightDescriptor descriptor = FlightDescriptor.command("".getBytes());
+            FlightRuntimeException ex = assertThrows(FlightRuntimeException.class, () ->
+                    proxyService.getFlightInfoCatalogs(command, mockCallContext, descriptor));
+            assertTrue(ex.getMessage().contains("Expected format 'hostname:port'"));
+        }
     }
 
     @Test
@@ -400,7 +442,7 @@ public class ArrowFlightSqlServiceImplTest {
         // Mock the cache to always return our mock client
         Cache<String, FlightClient> mockCache = mock(Cache.class);
         when(mockCache.get(anyString(), any())).thenReturn(mockBeClient);
-        setFinalField(service, "beClientCache", mockCache);
+        setFinalField(service, "clientCache", mockCache);
 
         // First call throws exception, second call succeeds
         when(mockBeClient.getStream(any(Ticket.class)))
@@ -428,21 +470,38 @@ public class ArrowFlightSqlServiceImplTest {
     }
 
     @Test
-    public void testGetStreamStatementInvalid() {
-        FlightSql.TicketStatementQuery threeSections = FlightSql.TicketStatementQuery.newBuilder()
-                .setStatementHandle(ByteString.copyFromUtf8("token123|queryId|invalid_section")).build();
+    public void testGetStreamStatementInvalidTicketFormats() {
         FlightProducer.ServerStreamListener listener = mock(FlightProducer.ServerStreamListener.class);
 
+        // 3-part ticket with invalid host:port format (missing port)
+        FlightSql.TicketStatementQuery invalidFeProxy = FlightSql.TicketStatementQuery.newBuilder()
+                .setStatementHandle(ByteString.copyFromUtf8("token123|queryId|invalid_section")).build();
         assertThrows(FlightRuntimeException.class, () ->
-                    service.getStreamStatement(threeSections, mockCallContext, listener
-        ));
+                service.getStreamStatement(invalidFeProxy, mockCallContext, listener));
 
-        FlightSql.TicketStatementQuery nonZeroPort = FlightSql.TicketStatementQuery.newBuilder()
-                .setStatementHandle(ByteString.copyFromUtf8("token123|queryId|hostname|non-zero-port")).build();
-
+        // 3-part ticket with non-numeric port
+        FlightSql.TicketStatementQuery invalidFeProxyPort = FlightSql.TicketStatementQuery.newBuilder()
+                .setStatementHandle(ByteString.copyFromUtf8("token123|queryId|hostname:abc")).build();
         assertThrows(FlightRuntimeException.class, () ->
-                service.getStreamStatement(nonZeroPort, mockCallContext, listener
-                ));
+                service.getStreamStatement(invalidFeProxyPort, mockCallContext, listener));
+
+        // 4-part BE ticket with non-numeric port
+        FlightSql.TicketStatementQuery invalidBePort = FlightSql.TicketStatementQuery.newBuilder()
+                .setStatementHandle(ByteString.copyFromUtf8("queryId|fragmentId|hostname|non-zero-port")).build();
+        assertThrows(FlightRuntimeException.class, () ->
+                service.getStreamStatement(invalidBePort, mockCallContext, listener));
+
+        // 1-part ticket (invalid)
+        FlightSql.TicketStatementQuery onePart = FlightSql.TicketStatementQuery.newBuilder()
+                .setStatementHandle(ByteString.copyFromUtf8("just-one-part")).build();
+        assertThrows(FlightRuntimeException.class, () ->
+                service.getStreamStatement(onePart, mockCallContext, listener));
+
+        // 5-part ticket (invalid)
+        FlightSql.TicketStatementQuery fiveParts = FlightSql.TicketStatementQuery.newBuilder()
+                .setStatementHandle(ByteString.copyFromUtf8("a|b|c|d|e")).build();
+        assertThrows(FlightRuntimeException.class, () ->
+                service.getStreamStatement(fiveParts, mockCallContext, listener));
     }
 
     @Test
@@ -552,8 +611,10 @@ public class ArrowFlightSqlServiceImplTest {
         service.setSessionOptions(request, context, listener);
     }
 
-    private void setFinalField(Object target, String fieldName, Object value) {
-        Deencapsulation.setField(target, fieldName, value);
+    private void setFinalField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
     }
 
     @Test
@@ -571,150 +632,6 @@ public class ArrowFlightSqlServiceImplTest {
         } catch (Exception ignored) {
 
         }
-    }
-
-    @Test
-    public void testGetBEEndpointAllPaths() throws Exception {
-        // Setup common mocks
-        SessionVariable mockSv = mock(SessionVariable.class);
-        ComputeNode mockWorker = mock(ComputeNode.class);
-        TUniqueId mockFragmentInstanceId = new TUniqueId(1L, 2L);
-        TUniqueId mockQueryId = new TUniqueId(3L, 4L);
-
-        when(mockWorker.getHost()).thenReturn("be-host");
-        when(mockWorker.getArrowFlightPort()).thenReturn(8815);
-
-        when(mockSv.isArrowFlightProxyEnabled()).thenReturn(false);
-        Pair<Location, ByteString> result = service.getBEEndpoint(mockSv, mockQueryId, mockWorker, mockFragmentInstanceId);
-        assertEquals(Location.forGrpcInsecure("be-host", 8815), result.first);
-        String beTicket = result.second.toStringUtf8();
-        assertEquals("3-4:1-2", beTicket);
-
-        when(mockSv.isArrowFlightProxyEnabled()).thenReturn(true);
-        when(mockSv.getArrowFlightProxy()).thenReturn("");
-        result = service.getBEEndpoint(mockSv, mockQueryId, mockWorker, mockFragmentInstanceId);
-        assertEquals(Location.forGrpcInsecure("localhost", 1234), result.first);
-        String feProxyTicket = result.second.toStringUtf8();
-        assertEquals("3-4|1-2|be-host|8815", feProxyTicket);
-
-        when(mockSv.getArrowFlightProxy()).thenReturn("proxy-host:9400");
-        result = service.getBEEndpoint(mockSv, mockQueryId, mockWorker, mockFragmentInstanceId);
-        assertEquals(Location.forGrpcInsecure("proxy-host", 9400), result.first);
-        // Ticket should still be FE proxy ticket format
-        assertEquals("3-4|1-2|be-host|8815", result.second.toStringUtf8());
-
-        when(mockSv.getArrowFlightProxy()).thenReturn("invalidproxy");
-        InvalidConfException ex = assertThrows(InvalidConfException.class, () ->
-                service.getBEEndpoint(mockSv, mockQueryId, mockWorker, mockFragmentInstanceId));
-        assertEquals("Expected format 'hostname:port', got 'invalidproxy'", ex.getMessage());
-
-        when(mockSv.getArrowFlightProxy()).thenReturn(":9400");
-        ex = assertThrows(InvalidConfException.class, () ->
-                service.getBEEndpoint(mockSv, mockQueryId, mockWorker, mockFragmentInstanceId));
-        assertEquals("Hostname cannot be empty, got ':9400'", ex.getMessage());
-
-        when(mockSv.getArrowFlightProxy()).thenReturn("hostname:abc");
-        ex = assertThrows(InvalidConfException.class, () ->
-                service.getBEEndpoint(mockSv, mockQueryId, mockWorker, mockFragmentInstanceId));
-        assertEquals("Port must be a valid integer, got 'abc'", ex.getMessage());
-
-        when(mockSv.getArrowFlightProxy()).thenReturn("hostname:99999");
-        ex = assertThrows(InvalidConfException.class, () ->
-                service.getBEEndpoint(mockSv, mockQueryId, mockWorker, mockFragmentInstanceId));
-        assertEquals("Port must be between 1 and 65535, got '99999'", ex.getMessage());
-
-        when(mockSv.getArrowFlightProxy()).thenReturn("hostname:0");
-        ex = assertThrows(InvalidConfException.class, () ->
-                service.getBEEndpoint(mockSv, mockQueryId, mockWorker, mockFragmentInstanceId));
-        assertEquals("Port must be between 1 and 65535, got '0'", ex.getMessage());
-
-        when(mockSv.getArrowFlightProxy()).thenReturn("host:port:extra");
-        ex = assertThrows(InvalidConfException.class, () ->
-                service.getBEEndpoint(mockSv, mockQueryId, mockWorker, mockFragmentInstanceId));
-        assertEquals("Expected format 'hostname:port', got 'host:port:extra'", ex.getMessage());
-
-        when(mockSv.getArrowFlightProxy()).thenReturn("hostname:65535");
-        result = service.getBEEndpoint(mockSv, mockQueryId, mockWorker, mockFragmentInstanceId);
-        assertEquals(Location.forGrpcInsecure("hostname", 65535), result.first);
-
-        when(mockSv.getArrowFlightProxy()).thenReturn("hostname:1");
-        result = service.getBEEndpoint(mockSv, mockQueryId, mockWorker, mockFragmentInstanceId);
-        assertEquals(Location.forGrpcInsecure("hostname", 1), result.first);
-    }
-
-    @Test
-    public void testGetFlightInfoFromQueryFETaskWithProxy() throws Exception {
-        // Test that FE-handled queries respect the proxy setting
-        SessionVariable mockSv = mock(SessionVariable.class);
-        when(mockContext.getSessionVariable()).thenReturn(mockSv);
-
-        ArrowFlightSqlResultDescriptor mockResult = mock(ArrowFlightSqlResultDescriptor.class);
-        when(mockResult.isBackendResultDescriptor()).thenReturn(false); // FE task
-        when(mockResult.getSchema()).thenReturn(mock(Schema.class));
-
-        try (MockedConstruction<ArrowFlightSqlConnectProcessor> mockedProcessor =
-                     org.mockito.Mockito.mockConstruction(ArrowFlightSqlConnectProcessor.class,
-                             (mock, context) -> when(mock.execute()).thenReturn(mockResult))) {
-
-            FlightSql.CommandStatementQuery command = FlightSql.CommandStatementQuery.newBuilder()
-                    .setQuery("SHOW VARIABLES").build();
-            FlightDescriptor descriptor = FlightDescriptor.command(command.toByteArray());
-
-            // Test 1: Proxy disabled - should return internal FE endpoint (localhost:1234)
-            when(mockSv.isArrowFlightProxyEnabled()).thenReturn(false);
-            FlightInfo info = service.getFlightInfoStatement(command, mockCallContext, descriptor);
-            assertNotNull(info);
-            assertEquals(1, info.getEndpoints().size());
-            assertEquals(Location.forGrpcInsecure("localhost", 1234), info.getEndpoints().get(0).getLocations().get(0));
-
-            // Test 2: Proxy enabled with proxy configured - should return proxy endpoint
-            when(mockSv.isArrowFlightProxyEnabled()).thenReturn(true);
-            when(mockSv.getArrowFlightProxy()).thenReturn("proxy.example.com:443");
-            info = service.getFlightInfoStatement(command, mockCallContext, descriptor);
-            assertNotNull(info);
-            assertEquals(1, info.getEndpoints().size());
-            assertEquals(Location.forGrpcInsecure("proxy.example.com", 443), info.getEndpoints().get(0).getLocations().get(0));
-
-            // Test 3: Proxy enabled but empty - should return internal FE endpoint
-            when(mockSv.getArrowFlightProxy()).thenReturn("");
-            info = service.getFlightInfoStatement(command, mockCallContext, descriptor);
-            assertNotNull(info);
-            assertEquals(1, info.getEndpoints().size());
-            assertEquals(Location.forGrpcInsecure("localhost", 1234), info.getEndpoints().get(0).getLocations().get(0));
-        }
-    }
-
-    @Test
-    public void testGetFEEndpointAllPaths() throws Exception {
-        SessionVariable mockSv = mock(SessionVariable.class);
-
-        when(mockSv.isArrowFlightProxyEnabled()).thenReturn(false);
-        Location result = service.getFEEndpoint(mockSv);
-        assertEquals(Location.forGrpcInsecure("localhost", 1234), result);
-
-        when(mockSv.isArrowFlightProxyEnabled()).thenReturn(true);
-        when(mockSv.getArrowFlightProxy()).thenReturn("");
-        result = service.getFEEndpoint(mockSv);
-        assertEquals(Location.forGrpcInsecure("localhost", 1234), result);
-
-        when(mockSv.getArrowFlightProxy()).thenReturn("proxy-host:9408");
-        result = service.getFEEndpoint(mockSv);
-        assertEquals(Location.forGrpcInsecure("proxy-host", 9408), result);
-
-        when(mockSv.getArrowFlightProxy()).thenReturn("invalidproxy");
-        InvalidConfException ex = assertThrows(InvalidConfException.class, () ->
-                service.getFEEndpoint(mockSv));
-        assertEquals("Expected format 'hostname:port', got 'invalidproxy'", ex.getMessage());
-
-        when(mockSv.getArrowFlightProxy()).thenReturn(":9408");
-        ex = assertThrows(InvalidConfException.class, () ->
-                service.getFEEndpoint(mockSv));
-        assertEquals("Hostname cannot be empty, got ':9408'", ex.getMessage());
-
-        when(mockSv.getArrowFlightProxy()).thenReturn("hostname:abc");
-        ex = assertThrows(InvalidConfException.class, () ->
-                service.getFEEndpoint(mockSv));
-        assertEquals("Port must be a valid integer, got 'abc'", ex.getMessage());
     }
 
     @Test
@@ -768,4 +685,513 @@ public class ArrowFlightSqlServiceImplTest {
         assertThrows(FlightRuntimeException.class,
                 () -> service.listFlights(mockCallContext, mockCriteria, mock(FlightProducer.StreamListener.class)));
     }
+
+    @Test
+    public void testGetStreamResultFromRemoteFE_shortCircuitLocalFE() {
+        String localFeTicket = "token123|queryId|localhost:1234";
+        FlightSql.TicketStatementQuery ticket = FlightSql.TicketStatementQuery.newBuilder()
+                .setStatementHandle(ByteString.copyFromUtf8(localFeTicket)).build();
+        FlightProducer.ServerStreamListener listener = mock(FlightProducer.ServerStreamListener.class);
+
+        when(mockContext.getResult("queryId")).thenReturn(mock(VectorSchemaRoot.class));
+
+        service.getStreamStatement(ticket, mockCallContext, listener);
+
+        verify(listener).start(any());
+        verify(listener).putNext();
+        verify(listener).completed();
+    }
+
+    @Test
+    public void testGetStreamResultFromRemoteFE_forwardToRemote() throws Exception {
+        // When the 3-part ticket points to a remote FE, it should forward the request
+        FlightClient mockFeClient = mock(FlightClient.class);
+        FlightStream mockFeStream = mock(FlightStream.class);
+        VectorSchemaRoot mockRoot = mock(VectorSchemaRoot.class);
+
+        Cache<String, FlightClient> mockCache = mock(Cache.class);
+        when(mockCache.get(anyString(), any())).thenReturn(mockFeClient);
+        setFinalField(service, "clientCache", mockCache);
+
+        when(mockFeClient.getStream(any(Ticket.class), any())).thenReturn(mockFeStream);
+        when(mockFeStream.getRoot()).thenReturn(mockRoot);
+        when(mockFeStream.next()).thenReturn(true).thenReturn(false);
+
+        // Remote FE ticket - different host than local (localhost:1234)
+        String remoteFeTicket = "token123|queryId|remote-fe:9408";
+        FlightSql.TicketStatementQuery ticket = FlightSql.TicketStatementQuery.newBuilder()
+                .setStatementHandle(ByteString.copyFromUtf8(remoteFeTicket)).build();
+        FlightProducer.ServerStreamListener listener = mock(FlightProducer.ServerStreamListener.class);
+
+        service.getStreamStatement(ticket, mockCallContext, listener);
+
+        // Should have forwarded to remote FE
+        verify(mockFeClient).getStream(any(Ticket.class), any());
+        verify(listener).start(mockRoot);
+        verify(listener).putNext();
+        verify(listener).completed();
+        verify(mockFeStream).close();
+    }
+
+    @Test
+    public void testProxyForwarding_closeSession_allScenarios() throws Exception {
+        try (MockedStatic<GlobalVariable> mockedGlobal = mockStatic(GlobalVariable.class);
+                MockedStatic<ArrowFlightSqlSessionManager> mockedSessionMgr =
+                        mockStatic(ArrowFlightSqlSessionManager.class)) {
+            mockedGlobal.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+
+            String remoteToken = "remote-fe|some-uuid-token";
+            when(mockCallContext.peerIdentity()).thenReturn(remoteToken);
+            when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
+            mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost(remoteToken))
+                    .thenReturn("remote-fe");
+
+            FlightClient mockFeClient = mock(FlightClient.class);
+            Cache<String, FlightClient> mockCache = mock(Cache.class);
+            when(mockCache.get(anyString(), any())).thenReturn(mockFeClient);
+            setFinalField(service, "clientCache", mockCache);
+
+            // Test 1: Success case
+            CloseSessionResult mockResult = mock(CloseSessionResult.class);
+            when(mockFeClient.closeSession(any(CloseSessionRequest.class), any())).thenReturn(mockResult);
+
+            FlightSqlProducer.StreamListener<CloseSessionResult> listener1 = mock(FlightSqlProducer.StreamListener.class);
+            service.closeSession(new CloseSessionRequest(), mockCallContext, listener1);
+            verify(listener1).onNext(mockResult);
+            verify(listener1).onCompleted();
+
+            // Test 2: Invalid token
+            mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost("invalid-token"))
+                    .thenReturn(null);
+            when(mockCallContext.peerIdentity()).thenReturn("invalid-token");
+            when(sessionManager.isLocalToken("invalid-token")).thenReturn(false);
+
+            FlightSqlProducer.StreamListener<CloseSessionResult> listener2 = mock(FlightSqlProducer.StreamListener.class);
+            service.closeSession(new CloseSessionRequest(), mockCallContext, listener2);
+            verify(listener2).onError(any(FlightRuntimeException.class));
+
+            // Test 3: Remote exception
+            when(mockCallContext.peerIdentity()).thenReturn(remoteToken);
+            when(mockFeClient.closeSession(any(CloseSessionRequest.class), any()))
+                    .thenThrow(new RuntimeException("Connection refused"));
+
+            FlightSqlProducer.StreamListener<CloseSessionResult> listener3 = mock(FlightSqlProducer.StreamListener.class);
+            service.closeSession(new CloseSessionRequest(), mockCallContext, listener3);
+            verify(listener3).onError(any(FlightRuntimeException.class));
+        }
+    }
+
+    @Test
+    public void testProxyForwarding_getFlightInfoPreparedStatement() throws Exception {
+        try (MockedStatic<GlobalVariable> mockedGlobal = mockStatic(GlobalVariable.class);
+                MockedStatic<ArrowFlightSqlSessionManager> mockedSessionMgr =
+                        mockStatic(ArrowFlightSqlSessionManager.class)) {
+            mockedGlobal.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+
+            String remoteToken = "remote-fe|some-uuid-token";
+            FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
+            when(callContext.peerIdentity()).thenReturn(remoteToken);
+            when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
+            mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost(remoteToken))
+                    .thenReturn("remote-fe");
+
+            FlightClient mockFeClient = mock(FlightClient.class);
+            Cache<String, FlightClient> mockCache = mock(Cache.class);
+            when(mockCache.get(anyString(), any())).thenReturn(mockFeClient);
+            setFinalField(service, "clientCache", mockCache);
+
+            FlightInfo mockFlightInfo = mock(FlightInfo.class);
+            when(mockFeClient.getInfo(any(FlightDescriptor.class), any())).thenReturn(mockFlightInfo);
+
+            FlightSql.CommandPreparedStatementQuery getInfoCmd = FlightSql.CommandPreparedStatementQuery.newBuilder()
+                    .setPreparedStatementHandle(ByteString.copyFromUtf8("stmt-id")).build();
+            FlightDescriptor descriptor = FlightDescriptor.command("".getBytes());
+            FlightInfo result = service.getFlightInfoPreparedStatement(getInfoCmd, callContext, descriptor);
+            assertEquals(mockFlightInfo, result);
+
+            mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost("invalid-token"))
+                    .thenReturn(null);
+            when(callContext.peerIdentity()).thenReturn("invalid-token");
+            when(sessionManager.isLocalToken("invalid-token")).thenReturn(false);
+            assertThrows(FlightRuntimeException.class, () ->
+                    service.getFlightInfoPreparedStatement(getInfoCmd, callContext, descriptor));
+
+            when(callContext.peerIdentity()).thenReturn(remoteToken);
+            when(mockFeClient.getInfo(any(FlightDescriptor.class), any()))
+                    .thenThrow(new RuntimeException("Connection timeout"));
+            assertThrows(FlightRuntimeException.class, () ->
+                    service.getFlightInfoPreparedStatement(getInfoCmd, callContext, descriptor));
+        }
+    }
+
+    @Test
+    public void testProxyForwarding_getFlightInfoStatement() throws Exception {
+        try (MockedStatic<GlobalVariable> mockedGlobal = mockStatic(GlobalVariable.class);
+                MockedStatic<ArrowFlightSqlSessionManager> mockedSessionMgr =
+                        mockStatic(ArrowFlightSqlSessionManager.class)) {
+            mockedGlobal.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+
+            String remoteToken = "remote-fe|some-uuid-token";
+            FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
+            when(callContext.peerIdentity()).thenReturn(remoteToken);
+            when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
+            mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost(remoteToken))
+                    .thenReturn("remote-fe");
+
+            FlightClient mockFeClient = mock(FlightClient.class);
+            Cache<String, FlightClient> mockCache = mock(Cache.class);
+            when(mockCache.get(anyString(), any())).thenReturn(mockFeClient);
+            setFinalField(service, "clientCache", mockCache);
+
+            FlightInfo mockFlightInfo = mock(FlightInfo.class);
+            when(mockFeClient.getInfo(any(FlightDescriptor.class), any())).thenReturn(mockFlightInfo);
+
+            FlightSql.CommandStatementQuery stmtCmd = FlightSql.CommandStatementQuery.newBuilder()
+                    .setQuery("SELECT 1").build();
+            FlightDescriptor descriptor = FlightDescriptor.command("".getBytes());
+            FlightInfo stmtResult = service.getFlightInfoStatement(stmtCmd, callContext, descriptor);
+            assertEquals(mockFlightInfo, stmtResult);
+        }
+    }
+
+    @Test
+    public void testStreamErrorHandling_cancelAndCloseErrors() throws Exception {
+        FlightClient mockBeClient = mock(FlightClient.class);
+        FlightStream mockBeStream = mock(FlightStream.class);
+        VectorSchemaRoot mockRoot = mock(VectorSchemaRoot.class);
+
+        service.addToCacheForTesting("127.0.0.1:9400", mockBeClient);
+
+        when(mockBeClient.getStream(any(Ticket.class))).thenReturn(mockBeStream);
+        when(mockBeStream.getRoot()).thenReturn(mockRoot);
+
+        when(mockBeStream.next()).thenReturn(true).thenReturn(false);
+        doThrow(new RuntimeException("Cancel failed")).when(mockBeStream).cancel(anyString(), any());
+        doNothing().when(mockBeStream).close();
+
+        String proxyTicket = "19abc7b87307530-9965dc19f22a94a8|19abc7b87307530-9965dc19f22a94a9|127.0.0.1|9400";
+        FlightSql.TicketStatementQuery ticket = FlightSql.TicketStatementQuery.newBuilder()
+                .setStatementHandle(ByteString.copyFromUtf8(proxyTicket)).build();
+
+        FlightProducer.ServerStreamListener listener1 = mock(FlightProducer.ServerStreamListener.class);
+        ArgumentCaptor<Runnable> cancelCaptor = ArgumentCaptor.forClass(Runnable.class);
+
+        service.getStreamStatement(ticket, mockCallContext, listener1);
+        verify(listener1).setOnCancelHandler(cancelCaptor.capture());
+        cancelCaptor.getValue().run(); // Should handle exception gracefully
+
+        doThrow(new RuntimeException("Close failed")).when(mockBeStream).close();
+        when(mockBeStream.next()).thenReturn(true).thenReturn(false);
+
+        FlightProducer.ServerStreamListener listener2 = mock(FlightProducer.ServerStreamListener.class);
+        service.getStreamStatement(ticket, mockCallContext, listener2);
+        verify(listener2).completed();
+
+        RuntimeException streamError = new RuntimeException("Connection lost");
+        when(mockBeStream.next()).thenThrow(streamError);
+        doThrow(new RuntimeException("Cancel also failed")).when(mockBeStream).cancel(anyString(), any(Throwable.class));
+
+        FlightProducer.ServerStreamListener listener3 = mock(FlightProducer.ServerStreamListener.class);
+        service.getStreamStatement(ticket, mockCallContext, listener3);
+        verify(listener3).error(any(FlightRuntimeException.class));
+    }
+
+    @Test
+    public void testGetStreamWithRetry_withBearerToken() throws Exception {
+        FlightClient mockFeClient = mock(FlightClient.class);
+        FlightStream mockFeStream = mock(FlightStream.class);
+        VectorSchemaRoot mockRoot = mock(VectorSchemaRoot.class);
+
+        Cache<String, FlightClient> mockCache = mock(Cache.class);
+        when(mockCache.get(anyString(), any())).thenReturn(mockFeClient);
+        setFinalField(service, "clientCache", mockCache);
+
+        // First call fails, retry with bearer token succeeds
+        when(mockFeClient.getStream(any(Ticket.class), any()))
+                .thenThrow(new RuntimeException("First attempt failed"))
+                .thenReturn(mockFeStream);
+        when(mockFeStream.getRoot()).thenReturn(mockRoot);
+        when(mockFeStream.next()).thenReturn(true).thenReturn(false);
+
+        String remoteFeTicket = "token-with-bearer|queryId|remote-fe:9408";
+        FlightSql.TicketStatementQuery ticket = FlightSql.TicketStatementQuery.newBuilder()
+                .setStatementHandle(ByteString.copyFromUtf8(remoteFeTicket)).build();
+        FlightProducer.ServerStreamListener listener = mock(FlightProducer.ServerStreamListener.class);
+
+        service.getStreamStatement(ticket, mockCallContext, listener);
+
+        verify(mockFeClient, org.mockito.Mockito.times(2)).getStream(any(Ticket.class), any());
+        verify(mockCache).invalidate(anyString());
+        verify(listener).completed();
+    }
+
+    @Test
+    public void testGetStreamResultNotFound() {
+        when(mockContext.getResult("nonexistent-query")).thenReturn(null);
+
+        FlightSql.TicketStatementQuery ticket = FlightSql.TicketStatementQuery.newBuilder()
+                .setStatementHandle(ByteString.copyFromUtf8("token123|nonexistent-query")).build();
+        FlightProducer.ServerStreamListener listener = mock(FlightProducer.ServerStreamListener.class);
+
+        assertThrows(FlightRuntimeException.class, () ->
+                service.getStreamStatement(ticket, mockCallContext, listener));
+    }
+
+    @Test
+    public void testProxyForwarding_createPreparedStatement_withTestableService() throws Exception {
+        try (MockedStatic<ArrowFlightSqlSessionManager> mockedSessionMgr =
+                     mockStatic(ArrowFlightSqlSessionManager.class)) {
+            TestableArrowFlightSqlServiceImpl testService =
+                    new TestableArrowFlightSqlServiceImpl(sessionManager,
+                            Location.forGrpcInsecure("localhost", 1234));
+            testService.setProxyEnabled(true);
+
+            String remoteToken = "remote-fe|some-uuid-token";
+            FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
+            when(callContext.peerIdentity()).thenReturn(remoteToken);
+            when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
+            mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost(remoteToken))
+                    .thenReturn("remote-fe");
+
+            FlightClient mockFeClient = mock(FlightClient.class);
+            Config.arrow_flight_port = 9408;
+            testService.addToCacheForTesting("remote-fe:9408", mockFeClient);
+
+            Result mockResult = mock(Result.class);
+            java.util.Iterator<Result> mockIter = mock(java.util.Iterator.class);
+            when(mockIter.hasNext()).thenReturn(true).thenReturn(false);
+            when(mockIter.next()).thenReturn(mockResult);
+            when(mockFeClient.doAction(any(org.apache.arrow.flight.Action.class), any()))
+                    .thenReturn(mockIter);
+
+            FlightSql.ActionCreatePreparedStatementRequest createReq =
+                    FlightSql.ActionCreatePreparedStatementRequest.newBuilder()
+                            .setQuery("SELECT 1").build();
+            FlightProducer.StreamListener<Result> listener = mock(FlightProducer.StreamListener.class);
+
+            testService.createPreparedStatement(createReq, callContext, listener);
+            Thread.sleep(500);
+
+            verify(mockFeClient).doAction(any(org.apache.arrow.flight.Action.class), any());
+            verify(listener).onNext(mockResult);
+            verify(listener).onCompleted();
+        }
+    }
+
+    @Test
+    public void testProxyForwarding_closePreparedStatement_withTestableService() throws Exception {
+        try (MockedStatic<ArrowFlightSqlSessionManager> mockedSessionMgr =
+                     mockStatic(ArrowFlightSqlSessionManager.class)) {
+            TestableArrowFlightSqlServiceImpl testService =
+                    new TestableArrowFlightSqlServiceImpl(sessionManager,
+                            Location.forGrpcInsecure("localhost", 1234));
+            testService.setProxyEnabled(true);
+
+            String remoteToken = "remote-fe|some-uuid-token";
+            FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
+            when(callContext.peerIdentity()).thenReturn(remoteToken);
+            when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
+            mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost(remoteToken))
+                    .thenReturn("remote-fe");
+
+            FlightClient mockFeClient = mock(FlightClient.class);
+            Config.arrow_flight_port = 9408;
+            testService.addToCacheForTesting("remote-fe:9408", mockFeClient);
+
+            java.util.Iterator<Result> emptyIter = mock(java.util.Iterator.class);
+            when(emptyIter.hasNext()).thenReturn(false);
+            when(mockFeClient.doAction(any(org.apache.arrow.flight.Action.class), any()))
+                    .thenReturn(emptyIter);
+
+            FlightSql.ActionClosePreparedStatementRequest closeReq =
+                    FlightSql.ActionClosePreparedStatementRequest.newBuilder()
+                            .setPreparedStatementHandle(ByteString.copyFromUtf8("stmt-id")).build();
+            FlightSqlProducer.StreamListener<Result> listener = mock(FlightSqlProducer.StreamListener.class);
+
+            testService.closePreparedStatement(closeReq, callContext, listener);
+            Thread.sleep(500);
+
+            verify(mockFeClient).doAction(any(org.apache.arrow.flight.Action.class), any());
+            verify(listener).onCompleted();
+        }
+    }
+
+    @Test
+    public void testProxyForwarding_setSessionOptions_withTestableService() throws Exception {
+        try (MockedStatic<ArrowFlightSqlSessionManager> mockedSessionMgr =
+                     mockStatic(ArrowFlightSqlSessionManager.class)) {
+            TestableArrowFlightSqlServiceImpl testService =
+                    new TestableArrowFlightSqlServiceImpl(sessionManager,
+                            Location.forGrpcInsecure("localhost", 1234));
+            testService.setProxyEnabled(true);
+
+            String remoteToken = "remote-fe|some-uuid-token";
+            FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
+            when(callContext.peerIdentity()).thenReturn(remoteToken);
+            when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
+            mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost(remoteToken))
+                    .thenReturn("remote-fe");
+
+            FlightClient mockFeClient = mock(FlightClient.class);
+            Config.arrow_flight_port = 9408;
+            testService.addToCacheForTesting("remote-fe:9408", mockFeClient);
+
+            SetSessionOptionsResult mockResult = new SetSessionOptionsResult(new HashMap<>());
+            when(mockFeClient.setSessionOptions(any(SetSessionOptionsRequest.class), any()))
+                    .thenReturn(mockResult);
+
+            SetSessionOptionsRequest setReq = mock(SetSessionOptionsRequest.class);
+            FlightProducer.StreamListener<SetSessionOptionsResult> listener =
+                    mock(FlightProducer.StreamListener.class);
+
+            testService.setSessionOptions(setReq, callContext, listener);
+            Thread.sleep(500);
+
+            verify(mockFeClient).setSessionOptions(any(SetSessionOptionsRequest.class), any());
+            verify(listener).onNext(any(SetSessionOptionsResult.class));
+            verify(listener).onCompleted();
+        }
+    }
+
+    @Test
+    public void testProxyForwarding_invalidToken_withTestableService() throws Exception {
+        try (MockedStatic<ArrowFlightSqlSessionManager> mockedSessionMgr =
+                     mockStatic(ArrowFlightSqlSessionManager.class)) {
+            TestableArrowFlightSqlServiceImpl testService =
+                    new TestableArrowFlightSqlServiceImpl(sessionManager,
+                            Location.forGrpcInsecure("localhost", 1234));
+            testService.setProxyEnabled(true);
+
+            String invalidToken = "invalid-token";
+            FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
+            when(callContext.peerIdentity()).thenReturn(invalidToken);
+            when(sessionManager.isLocalToken(invalidToken)).thenReturn(false);
+            mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost(invalidToken))
+                    .thenReturn(null);
+
+            FlightSql.ActionCreatePreparedStatementRequest createReq =
+                    FlightSql.ActionCreatePreparedStatementRequest.newBuilder()
+                            .setQuery("SELECT 1").build();
+            FlightProducer.StreamListener<Result> createListener = mock(FlightProducer.StreamListener.class);
+            testService.createPreparedStatement(createReq, callContext, createListener);
+            Thread.sleep(500);
+            verify(createListener).onError(any(FlightRuntimeException.class));
+
+            SetSessionOptionsRequest setReq = mock(SetSessionOptionsRequest.class);
+            FlightProducer.StreamListener<SetSessionOptionsResult> setListener =
+                    mock(FlightProducer.StreamListener.class);
+            testService.setSessionOptions(setReq, callContext, setListener);
+            Thread.sleep(500);
+            verify(setListener).onError(any(FlightRuntimeException.class));
+        }
+    }
+
+    @Test
+    public void testProxyForwarding_remoteException_withTestableService() throws Exception {
+        try (MockedStatic<ArrowFlightSqlSessionManager> mockedSessionMgr =
+                     mockStatic(ArrowFlightSqlSessionManager.class)) {
+            TestableArrowFlightSqlServiceImpl testService =
+                    new TestableArrowFlightSqlServiceImpl(sessionManager,
+                            Location.forGrpcInsecure("localhost", 1234));
+            testService.setProxyEnabled(true);
+
+            String remoteToken = "remote-fe|some-uuid-token";
+            FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
+            when(callContext.peerIdentity()).thenReturn(remoteToken);
+            when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
+            mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost(remoteToken))
+                    .thenReturn("remote-fe");
+
+            FlightClient mockFeClient = mock(FlightClient.class);
+            Config.arrow_flight_port = 9408;
+            testService.addToCacheForTesting("remote-fe:9408", mockFeClient);
+
+            when(mockFeClient.doAction(any(org.apache.arrow.flight.Action.class), any()))
+                    .thenThrow(new RuntimeException("Network error"));
+
+            FlightSql.ActionCreatePreparedStatementRequest createReq =
+                    FlightSql.ActionCreatePreparedStatementRequest.newBuilder()
+                            .setQuery("SELECT 1").build();
+            FlightProducer.StreamListener<Result> listener = mock(FlightProducer.StreamListener.class);
+            testService.createPreparedStatement(createReq, callContext, listener);
+            Thread.sleep(500);
+            verify(listener).onError(any(FlightRuntimeException.class));
+        }
+    }
+
+    @Test
+    public void testProxyForwarding_metadataRequests_forwardToRemoteFE() throws Exception {
+        try (MockedStatic<ArrowFlightSqlSessionManager> mockedSessionMgr =
+                     mockStatic(ArrowFlightSqlSessionManager.class)) {
+            TestableArrowFlightSqlServiceImpl testService =
+                    new TestableArrowFlightSqlServiceImpl(sessionManager,
+                            Location.forGrpcInsecure("localhost", 1234));
+            testService.setProxyEnabled(true);
+
+            String remoteToken = "remote-fe|550e8400-e29b-41d4-a716-446655440000";
+            FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
+            when(callContext.peerIdentity()).thenReturn(remoteToken);
+            when(sessionManager.isLocalToken(remoteToken)).thenReturn(false);
+            mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost(remoteToken))
+                    .thenReturn("remote-fe");
+
+            FlightClient mockFeClient = mock(FlightClient.class);
+            FlightInfo mockFlightInfo = mock(FlightInfo.class);
+            when(mockFeClient.getInfo(any(FlightDescriptor.class), any())).thenReturn(mockFlightInfo);
+
+            Config.arrow_flight_port = 9408;
+            testService.addToCacheForTesting("remote-fe:9408", mockFeClient);
+
+            FlightDescriptor descriptor = FlightDescriptor.command("".getBytes());
+
+            FlightSql.CommandGetCatalogs catalogsCmd = FlightSql.CommandGetCatalogs.newBuilder().build();
+            FlightInfo catalogsResult = testService.getFlightInfoCatalogs(catalogsCmd, callContext, descriptor);
+            assertEquals(mockFlightInfo, catalogsResult);
+
+            FlightSql.CommandGetDbSchemas schemasCmd = FlightSql.CommandGetDbSchemas.newBuilder().build();
+            FlightInfo schemasResult = testService.getFlightInfoSchemas(schemasCmd, callContext, descriptor);
+            assertEquals(mockFlightInfo, schemasResult);
+
+            FlightSql.CommandGetTables tablesCmd = FlightSql.CommandGetTables.newBuilder()
+                    .setIncludeSchema(true).build();
+            FlightInfo tablesResult = testService.getFlightInfoTables(tablesCmd, callContext, descriptor);
+            assertEquals(mockFlightInfo, tablesResult);
+
+            FlightSql.CommandGetSqlInfo sqlInfoCmd = FlightSql.CommandGetSqlInfo.newBuilder().build();
+            FlightInfo sqlInfoResult = testService.getFlightInfoSqlInfo(sqlInfoCmd, callContext, descriptor);
+            assertEquals(mockFlightInfo, sqlInfoResult);
+
+            FlightSql.CommandGetXdbcTypeInfo typeInfoCmd = FlightSql.CommandGetXdbcTypeInfo.newBuilder().build();
+            FlightInfo typeInfoResult = testService.getFlightInfoTypeInfo(typeInfoCmd, callContext, descriptor);
+            assertEquals(mockFlightInfo, typeInfoResult);
+
+            verify(mockFeClient, org.mockito.Mockito.atLeast(5)).getInfo(any(FlightDescriptor.class), any());
+        }
+    }
+
+    @Test
+    public void testProxyForwarding_metadataRequests_invalidToken() throws Exception {
+        try (MockedStatic<ArrowFlightSqlSessionManager> mockedSessionMgr =
+                     mockStatic(ArrowFlightSqlSessionManager.class)) {
+            TestableArrowFlightSqlServiceImpl testService =
+                    new TestableArrowFlightSqlServiceImpl(sessionManager,
+                            Location.forGrpcInsecure("localhost", 1234));
+            testService.setProxyEnabled(true);
+
+            String invalidToken = "invalid-token-format";
+            FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
+            when(callContext.peerIdentity()).thenReturn(invalidToken);
+            when(sessionManager.isLocalToken(invalidToken)).thenReturn(false);
+            mockedSessionMgr.when(() -> ArrowFlightSqlSessionManager.extractFeHost(invalidToken))
+                    .thenReturn(null);
+
+            FlightDescriptor descriptor = FlightDescriptor.command("".getBytes());
+
+            FlightSql.CommandGetCatalogs catalogsCmd = FlightSql.CommandGetCatalogs.newBuilder().build();
+            FlightRuntimeException ex = assertThrows(FlightRuntimeException.class, () ->
+                    testService.getFlightInfoCatalogs(catalogsCmd, callContext, descriptor));
+            assertTrue(ex.getMessage().contains("Invalid token format"));
+        }
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlSessionManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlSessionManagerTest.java
@@ -23,23 +23,31 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectScheduler;
+import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.service.arrow.flight.sql.session.ArrowFlightSqlSessionManager;
+import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TUniqueId;
 import org.apache.arrow.flight.FlightRuntimeException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -65,7 +73,8 @@ public class ArrowFlightSqlSessionManagerTest {
         GlobalStateMgr mockGlobalState = mock(GlobalStateMgr.class);
         VariableMgr mockVariableMgr = mock(VariableMgr.class);
         SessionVariable mockSessionVariable = mock(SessionVariable.class);
-        com.starrocks.authorization.AuthorizationMgr mockAuthMgr = mock(com.starrocks.authorization.AuthorizationMgr.class);
+        com.starrocks.authorization.AuthorizationMgr mockAuthMgr =
+                mock(com.starrocks.authorization.AuthorizationMgr.class);
 
         mockedGlobalState.when(GlobalStateMgr::getCurrentState).thenReturn(mockGlobalState);
         when(mockGlobalState.getVariableMgr()).thenReturn(mockVariableMgr);
@@ -76,6 +85,10 @@ public class ArrowFlightSqlSessionManagerTest {
         } catch (PrivilegeException e) {
             throw new RuntimeException(e);
         }
+
+        NodeMgr mockNodeMgr = mock(NodeMgr.class);
+        when(mockGlobalState.getNodeMgr()).thenReturn(mockNodeMgr);
+        when(mockNodeMgr.getSelfNode()).thenReturn(Pair.create("localhost", 9010));
     }
 
     private void mockAuthentication(MockedStatic<AuthenticationHandler> mockedAuth) {
@@ -139,7 +152,7 @@ public class ArrowFlightSqlSessionManagerTest {
     }
 
     @Test
-    public void testValidateToken_success() {
+    public void testValidateToken() {
         try (MockedStatic<ExecuteEnv> mockedEnv = mockStatic(ExecuteEnv.class);
                 MockedStatic<UUIDUtil> mockedUUID = mockStatic(UUIDUtil.class);
                 MockedStatic<GlobalStateMgr> mockedGlobalState = mockStatic(GlobalStateMgr.class);
@@ -160,18 +173,11 @@ public class ArrowFlightSqlSessionManagerTest {
 
             String token = sessionManager.initializeSession("testUser", "127.0.0.1", "testPassword");
             assertDoesNotThrow(() -> sessionManager.validateToken(token));
+
+            assertThrows(IllegalArgumentException.class, () -> sessionManager.validateToken(null));
+            assertThrows(IllegalArgumentException.class, () -> sessionManager.validateToken(""));
+            assertThrows(IllegalArgumentException.class, () -> sessionManager.validateToken("non-exist-token"));
         }
-    }
-
-    @Test
-    public void testValidateToken_emptyOrNull() {
-        assertThrows(IllegalArgumentException.class, () -> sessionManager.validateToken(null));
-        assertThrows(IllegalArgumentException.class, () -> sessionManager.validateToken(""));
-    }
-
-    @Test
-    public void testValidateToken_invalidToken() {
-        assertThrows(IllegalArgumentException.class, () -> sessionManager.validateToken("non-exist-token"));
     }
 
     @Test
@@ -224,6 +230,129 @@ public class ArrowFlightSqlSessionManagerTest {
             when(mockScheduler.getArrowFlightSqlConnectContext(mockToken)).thenReturn(null);
 
             assertThrows(FlightRuntimeException.class, () -> sessionManager.validateAndGetConnectContext(mockToken));
+        }
+    }
+
+    @Test
+    public void testExtractFeHost() {
+        assertEquals("fe1.example.com",
+                ArrowFlightSqlSessionManager.extractFeHost("fe1.example.com|123e4567-e89b-12d3-a456-426614174000"));
+        assertEquals("127.0.0.1",
+                ArrowFlightSqlSessionManager.extractFeHost("127.0.0.1|123e4567-e89b-12d3-a456-426614174000"));
+        assertEquals("2001:db8::1",
+                ArrowFlightSqlSessionManager.extractFeHost("2001:db8::1|123e4567-e89b-12d3-a456-426614174000"));
+        assertNull(ArrowFlightSqlSessionManager.extractFeHost("123e4567-e89b-12d3-a456-426614174000"));
+        assertNull(ArrowFlightSqlSessionManager.extractFeHost("simpletoken"));
+        assertNull(ArrowFlightSqlSessionManager.extractFeHost(""));
+        assertNull(ArrowFlightSqlSessionManager.extractFeHost(null));
+    }
+
+    @Test
+    public void testIsLocalToken_proxyDisabled() {
+        try (MockedStatic<GlobalVariable> mockedGlobalVar = mockStatic(GlobalVariable.class)) {
+            mockedGlobalVar.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(false);
+
+            // When proxy is disabled, all tokens are considered local
+            assertTrue(sessionManager.isLocalToken("any-token"));
+            assertTrue(sessionManager.isLocalToken("fe1.example.com|some-uuid"));
+        }
+    }
+
+    @Test
+    public void testIsLocalToken_proxyEnabled() {
+        try (MockedStatic<GlobalVariable> mockedGlobalVar = mockStatic(GlobalVariable.class);
+                MockedStatic<GlobalStateMgr> mockedGlobalState = mockStatic(GlobalStateMgr.class)) {
+
+            mockedGlobalVar.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+
+            GlobalStateMgr mockGlobalState = mock(GlobalStateMgr.class);
+            NodeMgr mockNodeMgr = mock(NodeMgr.class);
+            mockedGlobalState.when(GlobalStateMgr::getCurrentState).thenReturn(mockGlobalState);
+            when(mockGlobalState.getNodeMgr()).thenReturn(mockNodeMgr);
+            when(mockNodeMgr.getSelfNode()).thenReturn(Pair.create("127.0.0.1", 9010));
+
+            assertTrue(sessionManager.isLocalToken("127.0.0.1|123e4567-e89b-12d3-a456-426614174000"));
+            assertFalse(sessionManager.isLocalToken("127.0.0.2|123e4567-e89b-12d3-a456-426614174000"));
+            assertTrue(sessionManager.isLocalToken("simpletoken"));
+        }
+    }
+
+    @Test
+    public void testIsValidFeHost() {
+        try (MockedStatic<GlobalStateMgr> mockedGlobalState = mockStatic(GlobalStateMgr.class)) {
+            GlobalStateMgr mockGlobalState = mock(GlobalStateMgr.class);
+            NodeMgr mockNodeMgr = mock(NodeMgr.class);
+            Frontend mockFe1 = mock(Frontend.class);
+            Frontend mockFe2 = mock(Frontend.class);
+            Frontend mockFe3 = mock(Frontend.class);
+
+            mockedGlobalState.when(GlobalStateMgr::getCurrentState).thenReturn(mockGlobalState);
+            when(mockGlobalState.getNodeMgr()).thenReturn(mockNodeMgr);
+            when(mockNodeMgr.getFrontends(null)).thenReturn(List.of(mockFe1, mockFe2, mockFe3));
+            when(mockFe1.getHost()).thenReturn("127.0.0.1");
+            when(mockFe2.getHost()).thenReturn("127.0.0.2");
+            when(mockFe3.getHost()).thenReturn("127.0.0.3");
+
+            assertTrue(ArrowFlightSqlSessionManager.isValidFeHost("127.0.0.1"));
+            assertTrue(ArrowFlightSqlSessionManager.isValidFeHost("127.0.0.2"));
+            assertTrue(ArrowFlightSqlSessionManager.isValidFeHost("127.0.0.3"));
+            assertFalse(ArrowFlightSqlSessionManager.isValidFeHost("malicious.host.com"));
+            assertFalse(ArrowFlightSqlSessionManager.isValidFeHost("127.0.0.99"));
+            assertFalse(ArrowFlightSqlSessionManager.isValidFeHost(""));
+            assertFalse(ArrowFlightSqlSessionManager.isValidFeHost(null));
+        }
+    }
+
+    @Test
+    public void testInitializeSession_tokenFormat() {
+        try (MockedStatic<ExecuteEnv> mockedEnv = mockStatic(ExecuteEnv.class);
+                MockedStatic<UUIDUtil> mockedUUID = mockStatic(UUIDUtil.class);
+                MockedStatic<GlobalStateMgr> mockedGlobalState = mockStatic(GlobalStateMgr.class);
+                MockedStatic<GlobalVariable> mockedGlobalVar = mockStatic(GlobalVariable.class);
+                MockedStatic<AuthenticationHandler> mockedAuth = mockStatic(AuthenticationHandler.class)) {
+
+            mockAuthentication(mockedAuth);
+
+            ExecuteEnv mockEnv = mock(ExecuteEnv.class);
+            mockedEnv.when(ExecuteEnv::getInstance).thenReturn(mockEnv);
+            when(mockEnv.getScheduler()).thenReturn(mockScheduler);
+            when(mockScheduler.getNextConnectionId()).thenReturn(123);
+            when(mockScheduler.registerConnection(any())).thenReturn(Pair.create(true, ""));
+
+            mockedUUID.when(UUIDUtil::genUUID).thenReturn(mockUUID);
+            mockedUUID.when(() -> UUIDUtil.toTUniqueId(mockUUID)).thenReturn(mockTUniqueId);
+
+            GlobalStateMgr mockGlobalState = mock(GlobalStateMgr.class);
+            NodeMgr mockNodeMgr = mock(NodeMgr.class);
+            VariableMgr mockVariableMgr = mock(VariableMgr.class);
+            SessionVariable mockSessionVariable = mock(SessionVariable.class);
+            com.starrocks.authorization.AuthorizationMgr mockAuthMgr =
+                    mock(com.starrocks.authorization.AuthorizationMgr.class);
+
+            mockedGlobalState.when(GlobalStateMgr::getCurrentState).thenReturn(mockGlobalState);
+            when(mockGlobalState.getNodeMgr()).thenReturn(mockNodeMgr);
+            when(mockNodeMgr.getSelfNode()).thenReturn(Pair.create("127.0.0.1", 9010));
+            when(mockGlobalState.getVariableMgr()).thenReturn(mockVariableMgr);
+            when(mockVariableMgr.newSessionVariable()).thenReturn(mockSessionVariable);
+            when(mockGlobalState.getAuthorizationMgr()).thenReturn(mockAuthMgr);
+            try {
+                when(mockAuthMgr.getDefaultRoleIdsByUser(any())).thenReturn(Set.of(1L, 2L, 3L));
+            } catch (PrivilegeException e) {
+                throw new RuntimeException(e);
+            }
+
+            // Test with proxy enabled - token includes FE host prefix
+            mockedGlobalVar.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            String tokenWithProxy = sessionManager.initializeSession("testUser", "127.0.0.1", "testPassword");
+            assertNotNull(tokenWithProxy);
+            assertTrue(tokenWithProxy.startsWith("127.0.0.1|"), "Token should include FE host prefix");
+            assertTrue(tokenWithProxy.contains(mockUUID.toString()), "Token should contain UUID");
+
+            // Test with proxy disabled - token is plain UUID
+            mockedGlobalVar.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(false);
+            String tokenWithoutProxy = sessionManager.initializeSession("testUser", "127.0.0.1", "testPassword");
+            assertNotNull(tokenWithoutProxy);
+            assertEquals(mockUUID.toString(), tokenWithoutProxy, "Token should be plain UUID when proxy disabled");
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlTicketManagerTest.java
@@ -1,0 +1,321 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.service.arrow.flight.sql;
+
+import com.google.protobuf.ByteString;
+import com.starrocks.common.InvalidConfException;
+import com.starrocks.common.Pair;
+import com.starrocks.qe.GlobalVariable;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TUniqueId;
+import org.apache.arrow.flight.FlightRuntimeException;
+import org.apache.arrow.flight.Location;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+public class ArrowFlightSqlTicketManagerTest {
+
+    private ArrowFlightSqlTicketManager ticketManager;
+    private Location feEndpoint;
+
+    @BeforeEach
+    public void setUp() {
+        feEndpoint = Location.forGrpcInsecure("localhost", 1234);
+        ticketManager = new ArrowFlightSqlTicketManager(feEndpoint);
+    }
+
+    @Test
+    public void testParseTicketValidFormats() {
+        ArrowFlightSqlTicketManager.ParsedTicket feLocal = ticketManager.parseTicket("token123|queryId456");
+        assertEquals(ArrowFlightSqlTicketManager.TicketType.FE_LOCAL, feLocal.getType());
+        assertEquals("token123", feLocal.getToken());
+        assertEquals("queryId456", feLocal.getQueryId());
+        assertNull(feLocal.getFragmentInstanceId());
+        assertNull(feLocal.getHost());
+        assertEquals(0, feLocal.getPort());
+
+        ArrowFlightSqlTicketManager.ParsedTicket feProxy = ticketManager.parseTicket("token123|queryId456|fe-host:9408");
+        assertEquals(ArrowFlightSqlTicketManager.TicketType.FE_PROXY, feProxy.getType());
+        assertEquals("token123", feProxy.getToken());
+        assertEquals("queryId456", feProxy.getQueryId());
+        assertNull(feProxy.getFragmentInstanceId());
+        assertEquals("fe-host", feProxy.getHost());
+        assertEquals(9408, feProxy.getPort());
+
+        ArrowFlightSqlTicketManager.ParsedTicket beProxy = ticketManager.parseTicket("queryId|fragmentId|be-host|8815");
+        assertEquals(ArrowFlightSqlTicketManager.TicketType.BE_PROXY, beProxy.getType());
+        assertNull(beProxy.getToken());
+        assertEquals("queryId", beProxy.getQueryId());
+        assertEquals("fragmentId", beProxy.getFragmentInstanceId());
+        assertEquals("be-host", beProxy.getHost());
+        assertEquals(8815, beProxy.getPort());
+    }
+
+    @Test
+    public void testParseTicketInvalidFormats() {
+        FlightRuntimeException ex1 = assertThrows(FlightRuntimeException.class,
+                () -> ticketManager.parseTicket("just-one-part"));
+        assertTrue(ex1.getMessage().contains("expected 2, 3, or 4 parts, got [1]"));
+
+        FlightRuntimeException ex5 = assertThrows(FlightRuntimeException.class,
+                () -> ticketManager.parseTicket("a|b|c|d|e"));
+        assertTrue(ex5.getMessage().contains("expected 2, 3, or 4 parts, got [5]"));
+
+        FlightRuntimeException exFeHost = assertThrows(FlightRuntimeException.class,
+                () -> ticketManager.parseTicket("token123|queryId|invalid_host_port"));
+        assertTrue(exFeHost.getMessage().contains("Invalid FE host:port format"));
+
+        FlightRuntimeException exFePort = assertThrows(FlightRuntimeException.class,
+                () -> ticketManager.parseTicket("token123|queryId|hostname:abc"));
+        assertTrue(exFePort.getMessage().contains("Invalid FE port"));
+
+        FlightRuntimeException exBePort = assertThrows(FlightRuntimeException.class,
+                () -> ticketManager.parseTicket("queryId|fragmentId|hostname|non-numeric"));
+        assertTrue(exBePort.getMessage().contains("expected numerical port"));
+    }
+
+    @Test
+    public void testIsLocalFE() {
+        ArrowFlightSqlTicketManager.ParsedTicket localMatch = ticketManager.parseTicket("token|query|localhost:1234");
+        assertTrue(ticketManager.isLocalFE(localMatch));
+
+        ArrowFlightSqlTicketManager.ParsedTicket diffHost = ticketManager.parseTicket("token|query|remote-host:1234");
+        assertFalse(ticketManager.isLocalFE(diffHost));
+
+        ArrowFlightSqlTicketManager.ParsedTicket diffPort = ticketManager.parseTicket("token|query|localhost:9999");
+        assertFalse(ticketManager.isLocalFE(diffPort));
+
+        ArrowFlightSqlTicketManager.ParsedTicket notProxy = ticketManager.parseTicket("token|query");
+        assertFalse(ticketManager.isLocalFE(notProxy));
+    }
+
+    @Test
+    public void testBuildTickets() {
+        ByteString beTicketStr = ticketManager.buildBETicket("queryId", "fragmentId");
+        assertEquals("queryId:fragmentId", beTicketStr.toStringUtf8());
+
+        ByteString beTicketId = ticketManager.buildBETicket(new TUniqueId(0x1234L, 0x5678L), new TUniqueId(0xABCDL, 0xEF01L));
+        assertEquals("1234-5678:abcd-ef01", beTicketId.toStringUtf8());
+
+        ByteString feLocal = ticketManager.buildFELocalTicket("test-token", new TUniqueId(5L, 6L));
+        assertEquals("test-token|00000000-0000-0005-0000-000000000006", feLocal.toStringUtf8());
+
+        ByteString feProxy = ticketManager.buildFEProxyTicket("test-token", new TUniqueId(5L, 6L));
+        assertEquals("test-token|00000000-0000-0005-0000-000000000006|localhost:1234", feProxy.toStringUtf8());
+
+        ComputeNode worker = mock(ComputeNode.class);
+        when(worker.getHost()).thenReturn("be-host");
+        when(worker.getArrowFlightPort()).thenReturn(8815);
+        ByteString feProxyBe = ticketManager.buildFEProxyTicketForBE(new TUniqueId(3L, 4L), new TUniqueId(1L, 2L), worker);
+        assertEquals("3-4|1-2|be-host|8815", feProxyBe.toStringUtf8());
+    }
+
+    @Test
+    public void testValidateProxyFormatValid() throws InvalidConfException {
+        // All valid formats should not throw
+        ticketManager.validateProxyFormat("hostname:9408");
+        ticketManager.validateProxyFormat("grpc://hostname:9408");
+        ticketManager.validateProxyFormat("grpcs://hostname:443");
+        ticketManager.validateProxyFormat("hostname:1");
+        ticketManager.validateProxyFormat("hostname:65535");
+        ticketManager.validateProxyFormat("");
+    }
+
+    @Test
+    public void testValidateProxyFormatInvalid() {
+        InvalidConfException noPort = assertThrows(InvalidConfException.class,
+                () -> ticketManager.validateProxyFormat("hostname-only"));
+        assertTrue(noPort.getMessage().contains("Expected format 'hostname:port'"));
+
+        InvalidConfException emptyHost = assertThrows(InvalidConfException.class,
+                () -> ticketManager.validateProxyFormat(":9408"));
+        assertTrue(emptyHost.getMessage().contains("Hostname cannot be empty"));
+
+        InvalidConfException nonNumeric = assertThrows(InvalidConfException.class,
+                () -> ticketManager.validateProxyFormat("hostname:abc"));
+        assertTrue(nonNumeric.getMessage().contains("Port must be a valid integer"));
+
+        InvalidConfException portLow = assertThrows(InvalidConfException.class,
+                () -> ticketManager.validateProxyFormat("hostname:0"));
+        assertTrue(portLow.getMessage().contains("Port must be between 1 and 65535"));
+
+        InvalidConfException portHigh = assertThrows(InvalidConfException.class,
+                () -> ticketManager.validateProxyFormat("hostname:99999"));
+        assertTrue(portHigh.getMessage().contains("Port must be between 1 and 65535"));
+    }
+
+    @Test
+    public void testGetProxyLocation() throws InvalidConfException {
+        assertEquals(Location.forGrpcInsecure("proxy-host", 9408),
+                ticketManager.getProxyLocation("proxy-host:9408"));
+
+        assertEquals(Location.forGrpcInsecure("proxy-host", 9408),
+                ticketManager.getProxyLocation("grpc://proxy-host:9408"));
+
+        assertEquals(Location.forGrpcTls("proxy-host", 443),
+                ticketManager.getProxyLocation("grpcs://proxy-host:443"));
+
+        assertEquals(Location.forGrpcInsecure("::1", 9408),
+                ticketManager.getProxyLocation("[::1]:9408"));
+
+        assertEquals(Location.forGrpcTls("2001:db8::1", 443),
+                ticketManager.getProxyLocation("grpcs://[2001:db8::1]:443"));
+    }
+
+    @Test
+    public void testParseTicketWithIPv6() {
+        ArrowFlightSqlTicketManager.ParsedTicket ipv6Ticket =
+                ticketManager.parseTicket("token123|queryId456|[::1]:9408");
+        assertEquals(ArrowFlightSqlTicketManager.TicketType.FE_PROXY, ipv6Ticket.getType());
+        assertEquals("token123", ipv6Ticket.getToken());
+        assertEquals("queryId456", ipv6Ticket.getQueryId());
+        assertEquals("::1", ipv6Ticket.getHost());
+        assertEquals(9408, ipv6Ticket.getPort());
+    }
+
+    @Test
+    public void testBuildTicketsWithProxyToken() {
+        // When proxy is enabled, tokens have format "FE_HOST|UUID"
+        String proxyToken = "fe-host-1|550e8400-e29b-41d4-a716-446655440000";
+
+        ByteString feLocal = ticketManager.buildFELocalTicket(proxyToken, new TUniqueId(5L, 6L));
+        String feLocalStr = feLocal.toStringUtf8();
+        assertEquals("550e8400-e29b-41d4-a716-446655440000|00000000-0000-0005-0000-000000000006", feLocalStr);
+
+        ArrowFlightSqlTicketManager.ParsedTicket parsedFeLocal = ticketManager.parseTicket(feLocalStr);
+        assertEquals(ArrowFlightSqlTicketManager.TicketType.FE_LOCAL, parsedFeLocal.getType());
+        assertEquals("550e8400-e29b-41d4-a716-446655440000", parsedFeLocal.getToken());
+        assertEquals("00000000-0000-0005-0000-000000000006", parsedFeLocal.getQueryId());
+
+        ByteString feProxy = ticketManager.buildFEProxyTicket(proxyToken, new TUniqueId(7L, 8L));
+        String feProxyStr = feProxy.toStringUtf8();
+        assertEquals("550e8400-e29b-41d4-a716-446655440000|00000000-0000-0007-0000-000000000008|localhost:1234",
+                     feProxyStr);
+
+        ArrowFlightSqlTicketManager.ParsedTicket parsedFeProxy = ticketManager.parseTicket(feProxyStr);
+        assertEquals(ArrowFlightSqlTicketManager.TicketType.FE_PROXY, parsedFeProxy.getType());
+        assertEquals("550e8400-e29b-41d4-a716-446655440000", parsedFeProxy.getToken());
+        assertEquals("00000000-0000-0007-0000-000000000008", parsedFeProxy.getQueryId());
+        assertEquals("localhost", parsedFeProxy.getHost());
+        assertEquals(1234, parsedFeProxy.getPort());
+    }
+
+    @Test
+    public void testGetFEEndpoint() throws Exception {
+        ArrowFlightSqlConnectContext mockCtx = mock(ArrowFlightSqlConnectContext.class);
+        when(mockCtx.getArrowFlightSqlToken()).thenReturn("test-token");
+        when(mockCtx.getExecutionId()).thenReturn(new TUniqueId(5L, 6L));
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(false);
+
+            Pair<Location, ByteString> result = ticketManager.getFEEndpoint(mockCtx);
+            assertEquals(Location.forGrpcInsecure("localhost", 1234), result.first);
+            assertTrue(result.second.toStringUtf8().startsWith("test-token|"));
+            assertFalse(result.second.toStringUtf8().contains("localhost:1234"));
+        }
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mocked.when(GlobalVariable::getArrowFlightProxy).thenReturn("");
+
+            Pair<Location, ByteString> emptyProxy = ticketManager.getFEEndpoint(mockCtx);
+            assertEquals(Location.forGrpcInsecure("localhost", 1234), emptyProxy.first);
+            assertTrue(emptyProxy.second.toStringUtf8().contains("localhost:1234"));
+        }
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mocked.when(GlobalVariable::getArrowFlightProxy).thenReturn("proxy-host:9408");
+
+            Pair<Location, ByteString> withProxy = ticketManager.getFEEndpoint(mockCtx);
+            assertEquals(Location.forGrpcInsecure("proxy-host", 9408), withProxy.first);
+            assertTrue(withProxy.second.toStringUtf8().contains("localhost:1234"));
+        }
+    }
+
+    @Test
+    public void testGetBEEndpoint() throws Exception {
+        ComputeNode mockWorker = mock(ComputeNode.class);
+        when(mockWorker.getHost()).thenReturn("be-host");
+        when(mockWorker.getArrowFlightPort()).thenReturn(8815);
+        TUniqueId queryId = new TUniqueId(3L, 4L);
+        TUniqueId fragmentId = new TUniqueId(1L, 2L);
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(false);
+
+            Pair<Location, ByteString> result = ticketManager.getBEEndpoint(queryId, mockWorker, fragmentId);
+            assertEquals(Location.forGrpcInsecure("be-host", 8815), result.first);
+            assertEquals("3-4:1-2", result.second.toStringUtf8());
+        }
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mocked.when(GlobalVariable::getArrowFlightProxy).thenReturn("");
+
+            Pair<Location, ByteString> emptyProxy = ticketManager.getBEEndpoint(queryId, mockWorker, fragmentId);
+            assertEquals(Location.forGrpcInsecure("localhost", 1234), emptyProxy.first);
+            assertEquals("3-4|1-2|be-host|8815", emptyProxy.second.toStringUtf8());
+        }
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mocked.when(GlobalVariable::getArrowFlightProxy).thenReturn("proxy-host:9400");
+
+            Pair<Location, ByteString> withProxy = ticketManager.getBEEndpoint(queryId, mockWorker, fragmentId);
+            assertEquals(Location.forGrpcInsecure("proxy-host", 9400), withProxy.first);
+            assertEquals("3-4|1-2|be-host|8815", withProxy.second.toStringUtf8());
+        }
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mocked.when(GlobalVariable::getArrowFlightProxy).thenReturn("grpcs://proxy-host:443");
+
+            Pair<Location, ByteString> grpcs = ticketManager.getBEEndpoint(queryId, mockWorker, fragmentId);
+            assertEquals(Location.forGrpcTls("proxy-host", 443), grpcs.first);
+        }
+    }
+
+    @Test
+    public void testGetFELocation() throws Exception {
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(false);
+            assertEquals(Location.forGrpcInsecure("localhost", 1234), ticketManager.getFELocation());
+        }
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mocked.when(GlobalVariable::getArrowFlightProxy).thenReturn("");
+            assertEquals(Location.forGrpcInsecure("localhost", 1234), ticketManager.getFELocation());
+        }
+
+        try (MockedStatic<GlobalVariable> mocked = mockStatic(GlobalVariable.class)) {
+            mocked.when(GlobalVariable::isArrowFlightProxyEnabled).thenReturn(true);
+            mocked.when(GlobalVariable::getArrowFlightProxy).thenReturn("proxy-host:9408");
+            assertEquals(Location.forGrpcInsecure("proxy-host", 9408), ticketManager.getFELocation());
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: chris-celerdata <christopher.sapinski@celerdata.com>
(cherry picked from commit 0662e9c8a97cde27ae80e487b5b6ecef8b46336b)

# Conflicts:
#	fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java #	fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java

## Why I'm doing:
Fix the merge conflicts in #69423. 
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4