### PR TITLE
[Enhancement] Improve compression type selection for Iceberg delete operations

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2584,6 +2584,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return connectorSinkCompressionCodec;
     }
 
+    public void setConnectorSinkCompressionCodec(String connectorSinkCompressionCodec) {
+        this.connectorSinkCompressionCodec = connectorSinkCompressionCodec;
+    }
+
     @VariableMgr.VarAttr(name = CONNECTOR_SINK_TARGET_MAX_FILE_SIZE)
     private long connectorSinkTargetMaxFileSize = 1024L * 1024 * 1024;
 


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/issues/66944
## What I'm doing:
This pull request enhances how compression codecs are selected for Iceberg delete operations, ensuring that the correct priority is applied between table properties and session variables. Comprehensive tests have been added to verify this priority logic. Additionally, setter functionality for session compression codec has been introduced.

Compression codec selection improvements:

* Updated `IcebergDeleteSink` to prioritize `write.delete.parquet.compression-codec` over `write.parquet.compression-codec`, and fallback to the session variable if neither is set.
* Added imports for `DELETE_PARQUET_COMPRESSION` and `PARQUET_COMPRESSION` in `IcebergDeleteSink` for clearer property handling.

Testing enhancements:

* Added a comprehensive test method `testCompressionTypePriority` in `IcebergDeleteSinkTest` to validate the new priority logic across multiple scenarios, including both table properties and session variable cases.
* Included necessary imports for `TCompressionType` and utility classes in the test file to support new test cases.

Session variable improvements:

* Added a setter method `setConnectorSinkCompressionCodec` to `SessionVariable` for easier test setup and future configurability.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
