### PR TITLE
[BugFix] Disable creating mv with iceberg view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -378,7 +378,7 @@ public interface IcebergCatalog extends MemoryTrackable {
                                 "under snapshot [{}]", partitionName, nativeTable.name(), snapshotId, e);
             }
         }
-        if (lastUpdated ==  -1) {
+        if (lastUpdated == -1) {
             // Fallback to current snapshot's timestamp if last_updated_at is null due to snapshot expiration.
             lastUpdated = getTableLastestSnapshotTime(icebergTable, logger);
             logger.warn("The table [{}] last_updated_at is null (snapshot [{}] may have been expired), " +

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -665,6 +666,16 @@ public abstract class BaseMVRefreshProcessor {
                 // NOTE: DeepCopy.copyWithGson is very time costing, use `copyOnlyForQuery` to reduce the cost.
                 // TODO: Implement a `SnapshotTable` later which can use the copied table or transfer to the real table.
                 final Table table = tableOpt.get();
+
+                // Check if the table is an Iceberg table with partition evolution
+                if (table instanceof IcebergTable) {
+                    IcebergTable icebergTable = (IcebergTable) table;
+                    if (icebergTable.getNativeTable().specs().size() > 1) {
+                        throw new DmlException("Do not support refresh materialized view when base iceberg table " +
+                                table.getName() + " has done partition evolution");
+                    }
+                }
+
                 if (table.isNativeTableOrMaterializedView()) {
                     OlapTable copied = null;
                     if (table.isOlapOrCloudNativeTable()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -182,7 +182,6 @@ public class MaterializedViewAnalyzer {
                     Table.TableType.DELTALAKE,
                     Table.TableType.VIEW,
                     Table.TableType.HIVE_VIEW,
-                    Table.TableType.ICEBERG_VIEW,
                     Table.TableType.PAIMON_VIEW);
 
     public static void analyze(StatementBase stmt, ConnectContext session) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -217,6 +217,15 @@ public class MaterializedViewAnalyzer {
                 continue;
             }
 
+            // Check if the table is an Iceberg table with partition evolution
+            if (table instanceof IcebergTable) {
+                IcebergTable icebergTable = (IcebergTable) table;
+                if (icebergTable.getNativeTable().specs().size() > 1) {
+                    throw new SemanticException("Do not support create materialized view when base iceberg table " +
+                            table.getName() + " has done partition evolution", tableNameInfo.getPos());
+                }
+            }
+
             if (!FeConstants.isReplayFromQueryDump && !isSupportedExternalTables(table)) {
                 throw new SemanticException(
                         "Only supports creating materialized views based on the external table " +

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -502,7 +502,15 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     public com.starrocks.catalog.Table getTable(ConnectContext context, String dbName, String tblName) {
         readLock();
         try {
-            MockIcebergTable t = MOCK_TABLE_MAP.get(dbName).get(tblName).icebergTable;
+            Map<String, IcebergTableInfo> dbTables = MOCK_TABLE_MAP.get(dbName);
+            if (dbTables == null) {
+                return null;
+            }
+            IcebergTableInfo tableInfo = dbTables.get(tblName);
+            if (tableInfo == null) {
+                return null;
+            }
+            MockIcebergTable t = tableInfo.icebergTable;
             MockIcebergTable t1 = new MockIcebergTable(t.getId(), t.getName(), t.getCatalogName(), t.getResourceName(),
                         t.getCatalogDBName(), t.getCatalogTableName(),
                         t.getBaseSchema(), t.getNativeTable(), t.getIcebergProperties(),

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -504,11 +504,11 @@ public class MockIcebergMetadata implements ConnectorMetadata {
         try {
             Map<String, IcebergTableInfo> dbTables = MOCK_TABLE_MAP.get(dbName);
             if (dbTables == null) {
-                return null;
+                return getView(context, dbName, tblName);
             }
             IcebergTableInfo tableInfo = dbTables.get(tblName);
             if (tableInfo == null) {
-                return null;
+                return getView(context, dbName, tblName);
             }
             MockIcebergTable t = tableInfo.icebergTable;
             MockIcebergTable t1 = new MockIcebergTable(t.getId(), t.getName(), t.getCatalogName(), t.getResourceName(),
@@ -681,7 +681,7 @@ public class MockIcebergMetadata implements ConnectorMetadata {
                     new Column("date", DateType.DATE)
             );
             return new IcebergView(1, MOCKED_ICEBERG_CATALOG_NAME, dbName, viewName, schema,
-                    "SELECT id, data, date FROM t1", MOCKED_ICEBERG_CATALOG_NAME, dbName,
+                    "SELECT 1 as id, 'data' as data, CAST('2024-01-01' as DATE) as date", MOCKED_ICEBERG_CATALOG_NAME, dbName,
                     "view_location", Maps.newHashMap());
         }
         return null;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.IcebergView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.tvr.TvrDeltaStats;
 import com.starrocks.common.tvr.TvrTableDelta;
@@ -661,5 +662,21 @@ public class MockIcebergMetadata implements ConnectorMetadata {
 
     private void readUnlock() {
         lock.readLock().unlock();
+    }
+
+    @Override
+    public com.starrocks.catalog.Table getView(ConnectContext context, String dbName, String viewName) {
+        // Return a mock IcebergView for testing
+        if (dbName.equalsIgnoreCase("view_db") && viewName.equalsIgnoreCase("iceberg_view")) {
+            List<Column> schema = Lists.newArrayList(
+                    new Column("id", IntegerType.INT),
+                    new Column("data", VarcharType.createDefaultVarchar()),
+                    new Column("date", DateType.DEFAULT)
+            );
+            return new IcebergView(1, MOCKED_ICEBERG_CATALOG_NAME, dbName, viewName, schema,
+                    "SELECT id, data, date FROM t1", MOCKED_ICEBERG_CATALOG_NAME, dbName,
+                    "view_location", Maps.newHashMap());
+        }
+        return null;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -664,14 +664,13 @@ public class MockIcebergMetadata implements ConnectorMetadata {
         lock.readLock().unlock();
     }
 
-    @Override
     public com.starrocks.catalog.Table getView(ConnectContext context, String dbName, String viewName) {
         // Return a mock IcebergView for testing
         if (dbName.equalsIgnoreCase("view_db") && viewName.equalsIgnoreCase("iceberg_view")) {
             List<Column> schema = Lists.newArrayList(
                     new Column("id", IntegerType.INT),
-                    new Column("data", VarcharType.createDefaultVarchar()),
-                    new Column("date", DateType.DEFAULT)
+                    new Column("data", VarcharType.VARCHAR),
+                    new Column("date", DateType.DATE)
             );
             return new IcebergView(1, MOCKED_ICEBERG_CATALOG_NAME, dbName, viewName, schema,
                     "SELECT id, data, date FROM t1", MOCKED_ICEBERG_CATALOG_NAME, dbName,


### PR DESCRIPTION
## Why I'm doing:

`Iceberg view` is not support for mv create, disable it directly:
```
2026-02-09 14:25:28.711+08:00 ERROR (starrocks-mysql-nio-pool-1|433) [IcebergMetadata.getView():713] Failed to get iceberg view mv_iceberg_db_4f7da3deb804482ba88edebe0e2e1942.mv_iceberg_4f7da3deb804482ba88edebe0e2e1942.mv_iceberg_db_4f7da3deb804482ba88edebe0e2e1942.v_user_events
 org.apache.iceberg.exceptions.NoSuchViewException: View does not exist: mv_iceberg_db_4f7da3deb804482ba88edebe0e2e1942.mv_iceberg_4f7da3deb804482ba88edebe0e2e1942.mv_iceberg_db_4f7da3deb804482ba88edebe0e2e1942.v_user_events
        at org.apache.iceberg.view.BaseMetastoreViewCatalog.loadView(BaseMetastoreViewCatalog.java:61)
        at com.starrocks.connector.iceberg.hive.IcebergHiveCatalog.getView(IcebergHiveCatalog.java:232)
        at com.starrocks.connector.iceberg.CachingIcebergCatalog.getView(CachingIcebergCatalog.java:344)
        at com.starrocks.connector.iceberg.IcebergMetadata.getView(IcebergMetadata.java:710)
        at com.starrocks.connector.iceberg.IcebergMetadata.getTable(IcebergMetadata.java:640)
        at com.starrocks.connector.CatalogConnectorMetadata.getTable(CatalogConnectorMetadata.java:151)
        at com.starrocks.server.MetadataMgr.lambda$getTable$5(MetadataMgr.java:525)
        at java.base/java.util.Optional.map(Optional.java:260)
        at com.starrocks.server.MetadataMgr.getTable(MetadataMgr.java:525)
        at com.starrocks.server.MetadataMgr.getTable(MetadataMgr.java:581)
        at com.starrocks.server.MetadataMgr.getTableWithIdentifier(MetadataMgr.java:586)
        at com.starrocks.server.MetadataMgr.getTableChecked(MetadataMgr.java:600)
        at com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.getTableChecked(MvUtils.java:1519)
        at com.starrocks.mv.analyzer.MVPartitionExprResolver.getMVPartitionExprsChecked(MVPartitionExprResolver.java:597)
        at com.starrocks.server.LocalMetastore.createMaterializedView(LocalMetastore.java:3192)
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.lambda$visitCreateMaterializedViewStatement$12(DDLStmtExecutor.java:399)
        at com.starrocks.common.ErrorReport.wrapWithRuntimeException(ErrorReport.java:118)
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitCreateMaterializedViewStatement(DDLStmtExecutor.java:398)
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitCreateMaterializedViewStatement(DDLStmtExecutor.java:220)
        at com.starrocks.sql.ast.CreateMaterializedViewStatement.accept(CreateMaterializedViewStatement.java:402)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:94)
        at com.starrocks.qe.DDLStmtExecutor.execute(DDLStmtExecutor.java:205)
        at com.starrocks.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:2566)
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:1046)
        at com.starrocks.qe.ConnectProcessor.executeQueryAttempt(ConnectProcessor.java:556)
        at com.starrocks.qe.ConnectProcessor.runWithParserStageRetry(ConnectProcessor.java:450)
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:387)
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:767)
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:1149)
        at com.starrocks.mysql.nio.MySQLReadListener.handleRequest(MySQLReadListener.java:152)
        at com.starrocks.mysql.nio.MySQLReadListener.lambda$handleEvent$0(MySQLReadListener.java:92)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
```
## What I'm doing:
- Disable creating MV with Iceberg View or iceberg tables with partition evolution.
- Disable refreshing MV with Iceberg tables with partition evolution.

Fixes https://github.com/StarRocks/StarRocksTest/issues/10985

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
