### PR TITLE
[Enhancement] Push down loads table predicates to FE

### DIFF
--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -118,6 +118,11 @@ public:
 protected:
     Status _create_slot_descs(ObjectPool* pool);
 
+    // Parse scan conjuncts and extract the literal value from an equality predicate
+    // in the form of `col_name = <literal>` (or `<literal> = col_name`).
+    // NOTE: currently only supports STRING literal predicates.
+    // Returns true and fills `result` when a matched predicate is found; otherwise false.
+    // Intended for schema scanners to push simple equality filters to FE RPC requests.
     bool _parse_expr_predicate(const std::string& col_name, std::string& result);
     bool _parse_expr_predicate(Expr* conjunct, const std::string& col_name, std::string& result);
 

--- a/be/src/exec/schema_scanner/schema_loads_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_loads_scanner.cpp
@@ -14,11 +14,112 @@
 
 #include "exec/schema_scanner/schema_loads_scanner.h"
 
+#include <boost/algorithm/string.hpp>
+
 #include "exec/schema_scanner/schema_helper.h"
+#include "exprs/column_ref.h"
+#include "exprs/expr_context.h"
+#include "exprs/literal.h"
 #include "http/http_client.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks {
+namespace {
+bool _extract_literal_datetime_value(Expr* expr, std::string& result) {
+    auto* literal = dynamic_cast<VectorizedLiteral*>(expr);
+    if (literal == nullptr) {
+        return false;
+    }
+
+    auto literal_col_status = literal->evaluate_checked(nullptr, nullptr);
+    if (!literal_col_status.ok()) {
+        return false;
+    }
+
+    const auto literal_col = literal_col_status.value();
+    if (literal_col->is_null(0)) {
+        return false;
+    }
+
+    const auto datum = literal_col->get(0);
+    result = datum.get_timestamp().to_string(true);
+
+    return true;
+}
+
+bool _try_parse_datetime_range_predicate(const SchemaScannerParam* param, Expr* conjunct, const std::string& col_name,
+                                         std::string& literal_value, bool& is_lower_bound) {
+    const TExprNodeType::type& node_type = conjunct->node_type();
+    const TExprOpcode::type& op_type = conjunct->op();
+    if (node_type != TExprNodeType::BINARY_PRED || (op_type != TExprOpcode::GE && op_type != TExprOpcode::GT &&
+                                                    op_type != TExprOpcode::LE && op_type != TExprOpcode::LT)) {
+        return false;
+    }
+
+    Expr* slot_child = conjunct->get_child(0);
+    Expr* value_child = conjunct->get_child(1);
+    if (value_child->node_type() == TExprNodeType::SLOT_REF) {
+        std::swap(slot_child, value_child);
+        is_lower_bound = (op_type == TExprOpcode::LE || op_type == TExprOpcode::LT);
+    } else {
+        is_lower_bound = (op_type == TExprOpcode::GE || op_type == TExprOpcode::GT);
+    }
+
+    const SlotId slot_id = down_cast<const ColumnRef*>(slot_child)->slot_id();
+    auto& slot_id_mapping = param->slot_id_mapping;
+    if (const auto it = slot_id_mapping.find(slot_id);
+        it == slot_id_mapping.end() || !boost::iequals(it->second->col_name(), col_name)) {
+        return false;
+    }
+
+    if (!_extract_literal_datetime_value(value_child, literal_value)) {
+        return false;
+    }
+
+    return true;
+}
+
+void _update_range_bound(std::string& bound, bool& has_bound, const std::string& candidate, bool is_lower_bound) {
+    if (!has_bound) {
+        bound = candidate;
+        has_bound = true;
+        return;
+    }
+
+    if ((is_lower_bound && candidate > bound) || (!is_lower_bound && candidate < bound)) {
+        bound = candidate;
+    }
+}
+
+// Collect datetime range predicates on one column from schema scan conjuncts.
+// Usage:
+// 1. Pass a target column name, e.g. "LOAD_START_TIME".
+// 2. This function scans conjuncts and picks predicates with operators in {>, >=, <, <=}.
+// 3. It normalizes them into [lower_bound, upper_bound] (both inclusive for FE-side filtering).
+// Purpose: convert BE-side scan predicates into FE RPC parameters to reduce rows returned by getLoads().
+void _parse_datetime_range_predicates(const SchemaScannerParam* param, const std::string& col_name,
+                                      std::string& lower_bound, bool& has_lower_bound, std::string& upper_bound,
+                                      bool& has_upper_bound) {
+    if (param->expr_contexts == nullptr) {
+        return;
+    }
+
+    for (auto* expr_context : *(param->expr_contexts)) {
+        std::string literal_value;
+        bool is_lower_bound = false;
+        if (!_try_parse_datetime_range_predicate(param, expr_context->root(), col_name, literal_value,
+                                                 is_lower_bound)) {
+            continue;
+        }
+
+        if (is_lower_bound) {
+            _update_range_bound(lower_bound, has_lower_bound, literal_value, true);
+        } else {
+            _update_range_bound(upper_bound, has_upper_bound, literal_value, false);
+        }
+    }
+}
+} // namespace
 
 SchemaScanner::ColumnDesc SchemaLoadsScanner::_s_tbls_columns[] = {
         //   name,       type,          size,     is_null
@@ -60,6 +161,56 @@ Status SchemaLoadsScanner::start(RuntimeState* state) {
     if (nullptr != _param->db) {
         load_params.__set_db(*(_param->db));
     }
+
+    if (std::string table_name; _parse_expr_predicate("TABLE_NAME", table_name)) {
+        load_params.__set_table_name(table_name);
+    }
+    if (std::string user; _parse_expr_predicate("USER", user)) {
+        load_params.__set_user(user);
+    }
+    if (std::string state_str; _parse_expr_predicate("STATE", state_str)) {
+        load_params.__set_state(state_str);
+    }
+
+    std::string load_start_time_from;
+    std::string load_start_time_to;
+    bool has_load_start_time_from = false;
+    bool has_load_start_time_to = false;
+    _parse_datetime_range_predicates(_param, "LOAD_START_TIME", load_start_time_from, has_load_start_time_from,
+                                     load_start_time_to, has_load_start_time_to);
+    if (has_load_start_time_from) {
+        load_params.__set_load_start_time_from(load_start_time_from);
+    }
+    if (has_load_start_time_to) {
+        load_params.__set_load_start_time_to(load_start_time_to);
+    }
+
+    std::string load_finish_time_from;
+    std::string load_finish_time_to;
+    bool has_load_finish_time_from = false;
+    bool has_load_finish_time_to = false;
+    _parse_datetime_range_predicates(_param, "LOAD_FINISH_TIME", load_finish_time_from, has_load_finish_time_from,
+                                     load_finish_time_to, has_load_finish_time_to);
+    if (has_load_finish_time_from) {
+        load_params.__set_load_finish_time_from(load_finish_time_from);
+    }
+    if (has_load_finish_time_to) {
+        load_params.__set_load_finish_time_to(load_finish_time_to);
+    }
+
+    std::string create_time_from;
+    std::string create_time_to;
+    bool has_create_time_from = false;
+    bool has_create_time_to = false;
+    _parse_datetime_range_predicates(_param, "CREATE_TIME", create_time_from, has_create_time_from, create_time_to,
+                                     has_create_time_to);
+    if (has_create_time_from) {
+        load_params.__set_create_time_from(create_time_from);
+    }
+    if (has_create_time_to) {
+        load_params.__set_create_time_to(create_time_to);
+    }
+
     if (nullptr != _param->label) {
         load_params.__set_label(*(_param->label));
     }

--- a/be/src/exec/schema_scanner/schema_loads_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_loads_scanner.cpp
@@ -24,6 +24,7 @@
 #include "runtime/runtime_state.h"
 
 namespace starrocks {
+
 namespace {
 bool _extract_literal_datetime_value(Expr* expr, std::string& result) {
     auto* literal = dynamic_cast<VectorizedLiteral*>(expr);
@@ -63,6 +64,10 @@ bool _try_parse_datetime_range_predicate(const SchemaScannerParam* param, Expr* 
         is_lower_bound = (op_type == TExprOpcode::LE || op_type == TExprOpcode::LT);
     } else {
         is_lower_bound = (op_type == TExprOpcode::GE || op_type == TExprOpcode::GT);
+    }
+
+    if (slot_child->node_type() != TExprNodeType::SLOT_REF) {
+        return false;
     }
 
     const SlotId slot_id = down_cast<const ColumnRef*>(slot_child)->slot_id();
@@ -160,6 +165,8 @@ Status SchemaLoadsScanner::start(RuntimeState* state) {
     TGetLoadsParams load_params;
     if (nullptr != _param->db) {
         load_params.__set_db(*(_param->db));
+    } else if (std::string db_name; _parse_expr_predicate("DB_NAME", db_name)) {
+        load_params.__set_db(db_name);
     }
 
     if (std::string table_name; _parse_expr_predicate("TABLE_NAME", table_name)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadsSystemTable.java
@@ -13,20 +13,38 @@
 // limitations under the License.
 package com.starrocks.catalog.system.information;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.load.loadv2.LoadJob;
+import com.starrocks.load.loadv2.LoadMgr;
+import com.starrocks.load.streamload.AbstractStreamLoadTask;
+import com.starrocks.load.streamload.StreamLoadMgr;
+import com.starrocks.load.streamload.StreamLoadMultiStmtTask;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TGetLoadsParams;
+import com.starrocks.thrift.TGetLoadsResult;
+import com.starrocks.thrift.TLoadInfo;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.JsonType;
 import com.starrocks.type.TypeFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
 
 public class LoadsSystemTable {
     public static final String NAME = "loads";
+    private static final Logger LOG = LogManager.getLogger(LoadsSystemTable.class);
 
     public static SystemTable create() {
         return new SystemTable(SystemId.LOADS_ID,
@@ -61,4 +79,184 @@ public class LoadsSystemTable {
                         .column("JOB_ID", IntegerType.BIGINT)
                         .build(), TSchemaTableType.SCH_LOADS);
     }
+
+    public static TGetLoadsResult query(TGetLoadsParams request) {
+        TGetLoadsResult result = new TGetLoadsResult();
+        List<TLoadInfo> loads = Lists.newArrayList();
+        try {
+            LoadRequestFilter filter = LoadRequestFilter.from(request);
+
+            LoadMgr loadMgr = GlobalStateMgr.getCurrentState().getLoadMgr();
+            if (request.isSetJob_id()) {
+                LoadJob loadJob = loadMgr.getLoadJob(request.getJob_id());
+                appendLoadJob(loads, loadJob, request, filter);
+            } else if (filter.dbId != null) {
+                List<LoadJob> loadJobs;
+                if (request.isSetLabel()) {
+                    loadJobs = loadMgr.getLoadJobsByDb(filter.dbId, request.getLabel(), true);
+                } else {
+                    loadJobs = loadMgr.getLoadJobsByDb(filter.dbId, null, false);
+                }
+                for (LoadJob loadJob : loadJobs) {
+                    appendLoadJob(loads, loadJob, request, filter);
+                }
+            } else {
+                String label = request.isSetLabel() ? request.getLabel() : null;
+                List<LoadJob> loadJobs = loadMgr.getLoadJobs(label);
+                for (LoadJob loadJob : loadJobs) {
+                    appendLoadJob(loads, loadJob, request, filter);
+                }
+            }
+
+            StreamLoadMgr streamLoadMgr = GlobalStateMgr.getCurrentState().getStreamLoadMgr();
+            if (request.isSetJob_id()) {
+                AbstractStreamLoadTask streamLoadTask = streamLoadMgr.getTaskById(request.getJob_id());
+                appendStreamLoadTask(loads, streamLoadTask, request, filter);
+            } else {
+                List<AbstractStreamLoadTask> streamLoadTaskList = streamLoadMgr.getTaskByName(request.getLabel());
+                if (streamLoadTaskList != null) {
+                    for (AbstractStreamLoadTask streamLoadTask : streamLoadTaskList) {
+                        appendStreamLoadTask(loads, streamLoadTask, request, filter);
+                    }
+                }
+            }
+            result.setLoads(loads);
+        } catch (Exception e) {
+            LOG.warn("Failed to query information_schema.loads", e);
+            throw e;
+        }
+        return result;
+    }
+
+    public interface Job {
+        long getDbId();
+
+        String getUser();
+
+        String getStateName();
+
+        boolean matchTableName(String tableName);
+
+        Long getCreateTimeMs();
+
+        Long getLoadStartTimeMs();
+
+        Long getLoadFinishTimeMs();
+    }
+
+    private static void appendLoadJob(List<TLoadInfo> loads, LoadJob loadJob, TGetLoadsParams request,
+                                      LoadRequestFilter filter) {
+        if (loadJob == null || !matchFilter(loadJob, filter)) {
+            return;
+        }
+        loads.add(loadJob.toThrift());
+    }
+
+    private static void appendStreamLoadTask(List<TLoadInfo> loads, AbstractStreamLoadTask task, TGetLoadsParams request,
+                                             LoadRequestFilter filter) {
+        if (task == null) {
+            return;
+        }
+
+        if (!(task instanceof StreamLoadMultiStmtTask)) {
+            if (matchFilter(task, filter)) {
+                loads.addAll(task.toThrift());
+            }
+        } else {
+            StreamLoadMultiStmtTask multiTask = (StreamLoadMultiStmtTask) task;
+            for (AbstractStreamLoadTask childTask : multiTask.getTasks()) {
+                if (matchFilter(childTask, filter)) {
+                    loads.addAll(childTask.toThrift());
+                }
+            }
+        }
+    }
+
+    private static boolean matchFilter(Job job, LoadRequestFilter filter) {
+        if (filter.dbId != null && job.getDbId() != filter.dbId) {
+            return false;
+        }
+        if (filter.user != null && !filter.user.equals(job.getUser())) {
+            return false;
+        }
+        if (filter.state != null) {
+            String stateName = job.getStateName();
+            if (stateName != null && !filter.state.equalsIgnoreCase(stateName)) {
+                return false;
+            }
+        }
+        if (filter.tableName != null && !job.matchTableName(filter.tableName)) {
+            return false;
+        }
+        if (!matchTimeRange(job.getLoadStartTimeMs(), filter.loadStartTimeFrom, filter.loadStartTimeTo)) {
+            return false;
+        }
+        if (!matchTimeRange(job.getLoadFinishTimeMs(), filter.loadFinishTimeFrom, filter.loadFinishTimeTo)) {
+            return false;
+        }
+        return matchTimeRange(job.getCreateTimeMs(), filter.createTimeFrom, filter.createTimeTo);
+    }
+
+    private static boolean matchTimeRange(Long value, Long lowerBound, Long upperBound) {
+        if (lowerBound == null && upperBound == null) {
+            return true;
+        }
+        if (value == null || value < 0) {
+            return true;
+        }
+        if (lowerBound != null && value < lowerBound) {
+            return false;
+        }
+        return upperBound == null || value <= upperBound;
+    }
+
+    private static class LoadRequestFilter {
+        private Long dbId;
+        private String tableName;
+        private String user;
+        private String state;
+        private Long loadStartTimeFrom;
+        private Long loadStartTimeTo;
+        private Long loadFinishTimeFrom;
+        private Long loadFinishTimeTo;
+        private Long createTimeFrom;
+        private Long createTimeTo;
+
+        static LoadRequestFilter from(TGetLoadsParams request) {
+            LoadRequestFilter filter = new LoadRequestFilter();
+
+            if (request.isSetDb() && !Strings.isNullOrEmpty(request.getDb())) {
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(request.getDb());
+                if (db != null) {
+                    filter.dbId = db.getId();
+                }
+            }
+            if (request.isSetTable_name() && !Strings.isNullOrEmpty(request.getTable_name())) {
+                filter.tableName = request.getTable_name();
+            }
+            if (request.isSetUser()) {
+                filter.user = request.getUser();
+            }
+            if (request.isSetState()) {
+                filter.state = request.getState();
+            }
+            filter.loadStartTimeFrom = parseTime(request.isSetLoad_start_time_from() ? request.getLoad_start_time_from() : null);
+            filter.loadStartTimeTo = parseTime(request.isSetLoad_start_time_to() ? request.getLoad_start_time_to() : null);
+            filter.loadFinishTimeFrom =
+                    parseTime(request.isSetLoad_finish_time_from() ? request.getLoad_finish_time_from() : null);
+            filter.loadFinishTimeTo = parseTime(request.isSetLoad_finish_time_to() ? request.getLoad_finish_time_to() : null);
+            filter.createTimeFrom = parseTime(request.isSetCreate_time_from() ? request.getCreate_time_from() : null);
+            filter.createTimeTo = parseTime(request.isSetCreate_time_to() ? request.getCreate_time_to() : null);
+            return filter;
+        }
+
+        private static Long parseTime(String value) {
+            if (value == null) {
+                return null;
+            }
+            long ts = TimeUtils.timeStringToLong(value);
+            return ts >= 0 ? ts : null;
+        }
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
@@ -814,6 +814,11 @@ public class MergeCommitTask extends AbstractStreamLoadTask implements Runnable 
     }
 
     @Override
+    public String getUser() {
+        return user;
+    }
+
+    @Override
     public String getTableName() {
         return tableRef.getTableName();
     }
@@ -846,6 +851,11 @@ public class MergeCommitTask extends AbstractStreamLoadTask implements Runnable 
     @Override
     public long endTimeMs() {
         return loadTimeTrace.endTimeMs.get();
+    }
+
+    @Override
+    public Long getLoadStartTimeMs() {
+        return loadTimeTrace.startTimeMs.get();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/AbstractStreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/AbstractStreamLoadTask.java
@@ -8,6 +8,7 @@
 
 package com.starrocks.load.streamload;
 
+import com.starrocks.catalog.system.information.LoadsSystemTable;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.io.Writable;
 import com.starrocks.http.rest.TransactionResult;
@@ -27,7 +28,7 @@ import java.util.List;
  * Abstract base class for stream load tasks
  */
 public abstract class AbstractStreamLoadTask extends AbstractTxnStateChangeCallback
-        implements Writable, GsonPostProcessable, GsonPreProcessable, LoadJobWithWarehouse {
+        implements Writable, GsonPostProcessable, GsonPreProcessable, LoadJobWithWarehouse, LoadsSystemTable.Job {
 
     public abstract void beginTxnFromFrontend(TransactionResult resp);
     public abstract void beginTxnFromFrontend(int channelId, int channelNum, TransactionResult resp);
@@ -69,6 +70,7 @@ public abstract class AbstractStreamLoadTask extends AbstractTxnStateChangeCallb
     public abstract String getLabel();
     public abstract String getDBName();
     public abstract long getDBId();
+    public abstract String getUser();
     public abstract long getTxnId();
     public abstract String getTableName();
     public abstract String getStateName();
@@ -76,6 +78,26 @@ public abstract class AbstractStreamLoadTask extends AbstractTxnStateChangeCallb
     public abstract long createTimeMs();
     public abstract long endTimeMs();
     public abstract long getFinishTimestampMs();
+
+    @Override
+    public long getDbId() {
+        return getDBId();
+    }
+
+    @Override
+    public boolean matchTableName(String tableName) {
+        return tableName.equals(getTableName());
+    }
+
+    @Override
+    public Long getCreateTimeMs() {
+        return createTimeMs();
+    }
+
+    @Override
+    public Long getLoadFinishTimeMs() {
+        return getFinishTimestampMs();
+    }
 
     /**
      * Returns detailed information about the stream load task for SHOW STREAM LOAD statement.

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -280,6 +281,16 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
     }
 
     @Override
+    public String getUser() {
+        return user;
+    }
+
+    @Override
+    public Long getLoadStartTimeMs() {
+        return null;
+    }
+
+    @Override
     public String getDBName() {
         return dbName;
     }
@@ -488,5 +499,9 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
         for (StreamLoadTask task : taskMaps.values()) {
             task.replayOnVisible(txnState);
         }
+    }
+
+    public Collection<StreamLoadTask> getTasks() {
+        return taskMaps.values();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1481,6 +1481,16 @@ public class StreamLoadTask extends AbstractStreamLoadTask {
         return dbId;
     }
 
+    @Override
+    public Long getLoadStartTimeMs() {
+        return startLoadingTimeMs;
+    }
+
+    @Override
+    public String getUser() {
+        return user;
+    }
+
     public String getTableName() {
         return tableName;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1808,7 +1808,6 @@ public class PlanFragmentBuilder {
                         switch (columnRefOperator.getName()) {
                             case "TABLE_SCHEMA":
                             case "DATABASE_NAME":
-                            case "DB_NAME":
                                 scanNode.setSchemaDb(constantOperator.getVarchar());
                                 break;
                             case "TABLE_NAME":

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1808,6 +1808,7 @@ public class PlanFragmentBuilder {
                         switch (columnRefOperator.getName()) {
                             case "TABLE_SCHEMA":
                             case "DATABASE_NAME":
+                            case "DB_NAME":
                                 scanNode.setSchemaDb(constantOperator.getVarchar());
                                 break;
                             case "TABLE_NAME":

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -546,6 +546,15 @@ struct TGetLoadsParams {
     3: optional i64 txn_id
     4: optional string label
     5: optional string load_type
+    6: optional string table_name
+    7: optional string user
+    8: optional string state
+    9: optional string load_start_time_from
+    10: optional string load_start_time_to
+    11: optional string load_finish_time_from
+    12: optional string load_finish_time_to
+    13: optional string create_time_from
+    14: optional string create_time_to
 }
 
 struct TTrackingLoadInfo {
@@ -2425,4 +2434,3 @@ service FrontendService {
 
     TBatchGetTableSchemaResponse getTableSchema(1: TBatchGetTableSchemaRequest request)
 }
-

--- a/test/sql/test_information_schema/R/test_loads_predicate_pushdown
+++ b/test/sql/test_information_schema/R/test_loads_predicate_pushdown
@@ -1,0 +1,325 @@
+-- name: test_information_schema_loads_predicate_pushdown
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set enable_evaluate_schema_scan_rule=true;
+-- result:
+-- !result
+create table t_insert_${uuid0} (id int) distributed by hash(id) buckets 1 properties("replication_num" = "1");
+-- result:
+-- !result
+create table t_stream_${uuid0} (id int) distributed by hash(id) buckets 1 properties("replication_num" = "1");
+-- result:
+-- !result
+create table t_merge_${uuid0} (id int) primary key(id) distributed by hash(id) properties("replication_num" = "1");
+-- result:
+-- !result
+create table t_mstmt_${uuid0} (id int) distributed by hash(id) buckets 1 properties("replication_num" = "1");
+-- result:
+-- !result
+insert into t_insert_${uuid0} values (1);
+-- result:
+-- !result
+[UC]shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "label:sl_${uuid0}" -d '2' ${url}/api/db_${uuid0}/t_stream_${uuid0}/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:1" -d '{"id":3}' ${url}/api/db_${uuid0}/t_merge_${uuid0}/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:mstmt_${uuid0}" -H "db:db_${uuid0}" -H "source_type:12" -XPOST ${url}/api/transaction/begin
+-- result:
+0
+{
+  "Status": "OK",
+  "Message": ""
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:mstmt_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:t_mstmt_${uuid0}" -H "source_type:12" -H "format:json" -d '{"id":"4"}' -X PUT ${url}/api/transaction/load
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Db": "db_b46de9221a4647deb351901e173e0631",
+    "Table": "t_mstmt_b46de9221a4647deb351901e173e0631",
+    "Label": "mstmt_b46de9221a4647deb351901e173e0631",
+    "TxnId": 1012,
+    "LoadBytes": 10,
+    "StreamLoadPlanTimeMs": 0,
+    "ReceivedDataTimeMs": 0
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:mstmt_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:t_mstmt_${uuid0}" -H "source_type:12" -H "format:json" -d '{"id":"5"}' -X PUT ${url}/api/transaction/load
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Db": "db_b46de9221a4647deb351901e173e0631",
+    "Table": "t_mstmt_b46de9221a4647deb351901e173e0631",
+    "Label": "mstmt_b46de9221a4647deb351901e173e0631",
+    "TxnId": 1012,
+    "LoadBytes": 10,
+    "StreamLoadPlanTimeMs": 0,
+    "ReceivedDataTimeMs": 0
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:mstmt_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:t_mstmt_${uuid0}" -H "source_type:12" -H "format:json" -d '{"id":"6"}' -X PUT ${url}/api/transaction/load
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Db": "db_b46de9221a4647deb351901e173e0631",
+    "Table": "t_mstmt_b46de9221a4647deb351901e173e0631",
+    "Label": "mstmt_b46de9221a4647deb351901e173e0631",
+    "TxnId": 1012,
+    "LoadBytes": 10,
+    "StreamLoadPlanTimeMs": 0,
+    "ReceivedDataTimeMs": 0
+}
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:mstmt_${uuid0}" -H "db:db_${uuid0}" -H "source_type:12" -XPOST ${url}/api/transaction/commit
+-- result:
+0
+{
+  "Label": "mstmt_b46de9221a4647deb351901e173e0631",
+  "Status": "OK",
+  "TxnId": 1012,
+  "ChannelId": 0,
+  "Message": "",
+  "Prepared Channel Num": 1
+}
+-- !result
+function: wait_db_transaction_finish("db_${uuid0}", 60)
+-- result:
+None
+-- !result
+sync;
+-- result:
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_insert_${uuid0}';
+-- result:
+1
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_stream_${uuid0}';
+-- result:
+1
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_merge_${uuid0}';
+-- result:
+1
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_mstmt_${uuid0}';
+-- result:
+1
+-- !result
+select count(1) from information_schema.loads
+where db_name='db_${uuid0}'
+  and user='root'
+  and create_time >= date_sub(now(), interval 1 hour) and create_time <= date_add(now(), interval 1 hour)
+  and load_start_time >= date_sub(now(), interval 1 hour) and load_start_time <= date_add(now(), interval 1 hour)
+  and load_finish_time >= date_sub(now(), interval 1 hour) and load_finish_time <= date_add(now(), interval 1 hour);
+-- result:
+2
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}';
+-- result:
+4
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid1}' and load_start_time >= date_sub(now(), interval 1 hour) and load_start_time <= date_add(now(), interval 1 hour);
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_stream_${uuid0}';
+-- result:
+1
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='__no_such_table__';
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and user='root';
+-- result:
+3
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and user='__no_such_user__';
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and state='FINISHED';
+-- result:
+3
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and state='__NO_SUCH_STATE__';
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where table_name='t_stream_${uuid0}'
+and load_start_time >= date_sub(now(), interval 1 hour) and load_start_time <= date_add(now(), interval 1 hour);
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where table_name='__no_such_table__'
+and load_start_time >= date_sub(now(), interval 1 hour) and load_start_time <= date_add(now(), interval 1 hour);
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where user='__no_such_user__'
+and load_start_time >= date_sub(now(), interval 1 hour) and load_start_time <= date_add(now(), interval 1 hour);
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where state='__NO_SUCH_STATE__'
+and load_start_time >= date_sub(now(), interval 1 hour) and load_start_time <= date_add(now(), interval 1 hour);
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and create_time >= date_sub(now(), interval 1 hour) and create_time <= date_add(now(), interval 1 hour) and load_start_time >= date_sub(now(), interval 1 hour);
+-- result:
+3
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and create_time > date_add(now(), interval 1 hour) and load_start_time >= date_sub(now(), interval 1 hour);
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and load_start_time >= date_sub(now(), interval 1 hour) and load_start_time <= date_add(now(), interval 1 hour);
+-- result:
+3
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and load_start_time > date_add(now(), interval 1 hour);
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and load_finish_time >= date_sub(now(), interval 1 hour) and load_finish_time <= date_add(now(), interval 1 hour);
+-- result:
+3
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and load_finish_time > date_add(now(), interval 1 hour);
+-- result:
+0
+-- !result
+[UC]job_id=select id from information_schema.loads where db_name='db_${uuid0}' and table_name='t_insert_${uuid0}';
+-- result:
+12078
+-- !result
+select count(1) from information_schema.loads where id = '${job_id}';
+-- result:
+1
+-- !result
+[UC]job_id=select id from information_schema.loads where db_name='db_${uuid0}' and table_name='t_stream_${uuid0}';
+-- result:
+12081
+-- !result
+select count(1) from information_schema.loads where id = '${job_id}';
+-- result:
+1
+-- !result
+[UC]job_id=select id from information_schema.loads where db_name='db_${uuid0}' and table_name='t_merge_${uuid0}';
+-- result:
+12082
+-- !result
+select count(1) from information_schema.loads where id = '${job_id}';
+-- result:
+1
+-- !result
+[UC]job_id=select id from information_schema.loads where db_name='db_${uuid0}' and table_name='t_mstmt_${uuid0}';
+-- result:
+12084
+-- !result
+select count(1) from information_schema.loads where id = '${job_id}';
+-- result:
+0
+-- !result
+[UC]job_label=select label from information_schema.loads where db_name='db_${uuid0}' and table_name='t_insert_${uuid0}';
+-- result:
+insert_019c9379-1c40-792d-bc96-e9bdd29e3516
+-- !result
+select count(1) from information_schema.loads where label = '${job_label}';
+-- result:
+1
+-- !result
+select count(1) from information_schema.loads where label = '${job_label}' and db_name='db_${uuid0}';
+-- result:
+1
+-- !result
+select count(1) from information_schema.loads where label = 'no_exist_${job_label}';
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where label = 'no_exist_${job_label}' and db_name='db_${uuid0}';
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where label = 'sl_${uuid0}';
+-- result:
+1
+-- !result
+select count(1) from information_schema.loads where label = 'sl_${uuid0}' and db_name='db_${uuid0}';
+-- result:
+1
+-- !result
+select count(1) from information_schema.loads where label = 'no_exist_sl_${uuid0}';
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where label = 'no_exist_sl_${uuid0}' and db_name='db_${uuid0}';
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where label = 'mstmt_${uuid0}';
+-- result:
+1
+-- !result
+select count(1) from information_schema.loads where label = 'mstmt_${uuid0}' and db_name='db_${uuid0}';
+-- result:
+1
+-- !result
+select count(1) from information_schema.loads where label = 'no_exist_mstmt_${uuid0}';
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where label = 'no_exist_mstmt_${uuid0}' and db_name='db_${uuid0}';
+-- result:
+0
+-- !result
+select count(1) > 0 from information_schema.loads;
+-- result:
+1
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_insert_${uuid0}';
+-- result:
+0
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_stream_${uuid0}';
+-- result:
+1
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_merge_${uuid0}';
+-- result:
+1
+-- !result
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_mstmt_${uuid0}';
+-- result:
+1
+-- !result
+select count(1) > 0 from information_schema.loads;
+-- result:
+1
+-- !result

--- a/test/sql/test_information_schema/T/test_loads_predicate_pushdown
+++ b/test/sql/test_information_schema/T/test_loads_predicate_pushdown
@@ -1,0 +1,113 @@
+-- name: test_information_schema_loads_predicate_pushdown
+create database db_${uuid0};
+use db_${uuid0};
+set enable_evaluate_schema_scan_rule=true;
+
+create table t_insert_${uuid0} (id int) distributed by hash(id) buckets 1 properties("replication_num" = "1");
+create table t_stream_${uuid0} (id int) distributed by hash(id) buckets 1 properties("replication_num" = "1");
+create table t_merge_${uuid0} (id int) primary key(id) distributed by hash(id) properties("replication_num" = "1");
+create table t_mstmt_${uuid0} (id int) distributed by hash(id) buckets 1 properties("replication_num" = "1");
+
+-- insert into
+insert into t_insert_${uuid0} values (1);
+
+-- stream load
+[UC]shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "label:sl_${uuid0}" -d '2' ${url}/api/db_${uuid0}/t_stream_${uuid0}/_stream_load
+
+-- merge commit stream load (MergeCommitTask)
+[UC]shell: curl --location-trusted -u root: -X PUT -H "Expect:100-continue" -H "format:json" -H "enable_merge_commit:true" -H "merge_commit_interval_ms:3000" -H "merge_commit_parallel:1" -d '{"id":3}' ${url}/api/db_${uuid0}/t_merge_${uuid0}/_stream_load
+
+-- multi-statement stream load transaction (StreamLoadMultiStmtTask)
+[UC]shell: curl --location-trusted -u root: -H "label:mstmt_${uuid0}" -H "db:db_${uuid0}" -H "source_type:12" -XPOST ${url}/api/transaction/begin
+[UC]shell: curl --location-trusted -u root: -H "label:mstmt_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:t_mstmt_${uuid0}" -H "source_type:12" -H "format:json" -d '{"id":"4"}' -X PUT ${url}/api/transaction/load
+[UC]shell: curl --location-trusted -u root: -H "label:mstmt_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:t_mstmt_${uuid0}" -H "source_type:12" -H "format:json" -d '{"id":"5"}' -X PUT ${url}/api/transaction/load
+[UC]shell: curl --location-trusted -u root: -H "label:mstmt_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:t_mstmt_${uuid0}" -H "source_type:12" -H "format:json" -d '{"id":"6"}' -X PUT ${url}/api/transaction/load
+[UC]shell: curl --location-trusted -u root: -H "label:mstmt_${uuid0}" -H "db:db_${uuid0}" -H "source_type:12" -XPOST ${url}/api/transaction/commit
+
+function: wait_db_transaction_finish("db_${uuid0}", 60)
+sync;
+
+-- verify 4 load methods are all visible in information_schema.loads
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_insert_${uuid0}';
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_stream_${uuid0}';
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_merge_${uuid0}';
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_mstmt_${uuid0}';
+
+-- all pushdown predicates combined (hit)
+select count(1) from information_schema.loads
+where db_name='db_${uuid0}'
+  and user='root'
+  and create_time >= date_sub(now(), interval 1 hour) and create_time <= date_add(now(), interval 1 hour)
+  and load_start_time >= date_sub(now(), interval 1 hour) and load_start_time <= date_add(now(), interval 1 hour)
+  and load_finish_time >= date_sub(now(), interval 1 hour) and load_finish_time <= date_add(now(), interval 1 hour);
+
+-- equality predicates: DB_NAME/TABLE_NAME/USER/STATE (hit + miss)
+select count(1) from information_schema.loads where db_name='db_${uuid0}';
+select count(1) from information_schema.loads where db_name='db_${uuid1}' and load_start_time >= date_sub(now(), interval 1 hour) and load_start_time <= date_add(now(), interval 1 hour);
+
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_stream_${uuid0}';
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='__no_such_table__';
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and user='root';
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and user='__no_such_user__';
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and state='FINISHED';
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and state='__NO_SUCH_STATE__';
+
+select count(1) from information_schema.loads where table_name='t_stream_${uuid0}'
+and load_start_time >= date_sub(now(), interval 1 hour) and load_start_time <= date_add(now(), interval 1 hour);
+
+select count(1) from information_schema.loads where table_name='__no_such_table__'
+and load_start_time >= date_sub(now(), interval 1 hour) and load_start_time <= date_add(now(), interval 1 hour);
+
+select count(1) from information_schema.loads where user='__no_such_user__'
+and load_start_time >= date_sub(now(), interval 1 hour) and load_start_time <= date_add(now(), interval 1 hour);
+
+select count(1) from information_schema.loads where state='__NO_SUCH_STATE__'
+and load_start_time >= date_sub(now(), interval 1 hour) and load_start_time <= date_add(now(), interval 1 hour);
+
+-- range predicates: CREATE_TIME/LOAD_START_TIME/LOAD_FINISH_TIME (hit + miss)
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and create_time >= date_sub(now(), interval 1 hour) and create_time <= date_add(now(), interval 1 hour) and load_start_time >= date_sub(now(), interval 1 hour);
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and create_time > date_add(now(), interval 1 hour) and load_start_time >= date_sub(now(), interval 1 hour);
+
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and load_start_time >= date_sub(now(), interval 1 hour) and load_start_time <= date_add(now(), interval 1 hour);
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and load_start_time > date_add(now(), interval 1 hour);
+
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and load_finish_time >= date_sub(now(), interval 1 hour) and load_finish_time <= date_add(now(), interval 1 hour);
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and load_finish_time > date_add(now(), interval 1 hour);
+
+-- job_id
+[UC]job_id=select id from information_schema.loads where db_name='db_${uuid0}' and table_name='t_insert_${uuid0}';
+select count(1) from information_schema.loads where id = '${job_id}';
+[UC]job_id=select id from information_schema.loads where db_name='db_${uuid0}' and table_name='t_stream_${uuid0}';
+select count(1) from information_schema.loads where id = '${job_id}';
+[UC]job_id=select id from information_schema.loads where db_name='db_${uuid0}' and table_name='t_merge_${uuid0}';
+select count(1) from information_schema.loads where id = '${job_id}';
+[UC]job_id=select id from information_schema.loads where db_name='db_${uuid0}' and table_name='t_mstmt_${uuid0}';
+select count(1) from information_schema.loads where id = '${job_id}';
+
+-- label
+[UC]job_label=select label from information_schema.loads where db_name='db_${uuid0}' and table_name='t_insert_${uuid0}';
+select count(1) from information_schema.loads where label = '${job_label}';
+select count(1) from information_schema.loads where label = '${job_label}' and db_name='db_${uuid0}';
+select count(1) from information_schema.loads where label = 'no_exist_${job_label}';
+select count(1) from information_schema.loads where label = 'no_exist_${job_label}' and db_name='db_${uuid0}';
+
+select count(1) from information_schema.loads where label = 'sl_${uuid0}';
+select count(1) from information_schema.loads where label = 'sl_${uuid0}' and db_name='db_${uuid0}';
+select count(1) from information_schema.loads where label = 'no_exist_sl_${uuid0}';
+select count(1) from information_schema.loads where label = 'no_exist_sl_${uuid0}' and db_name='db_${uuid0}';
+
+select count(1) from information_schema.loads where label = 'mstmt_${uuid0}';
+select count(1) from information_schema.loads where label = 'mstmt_${uuid0}' and db_name='db_${uuid0}';
+select count(1) from information_schema.loads where label = 'no_exist_mstmt_${uuid0}';
+select count(1) from information_schema.loads where label = 'no_exist_mstmt_${uuid0}' and db_name='db_${uuid0}';
+
+select count(1) > 0 from information_schema.loads;
+
+drop database db_${uuid0} force;
+
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_insert_${uuid0}';
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_stream_${uuid0}';
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_merge_${uuid0}';
+select count(1) from information_schema.loads where db_name='db_${uuid0}' and table_name='t_mstmt_${uuid0}';
+
+select count(1) > 0 from information_schema.loads;


### PR DESCRIPTION
## Why I'm doing:

Querying `information_schema.loads` requires the BE’s `SchemaScanOperator` to send an RPC request to the FE to retrieve information for **all** load tasks.

When there are a large number of load tasks, this RPC can fail with the error:

“FE RPC failure, address=TNetworkAddress(hostname=xxxx, port=xxxx), reason=MaxMessageSize reached”.

## What I'm doing:

1. Push down the following predicates to be handled on the FE side during the RPC:
   - Equality predicates on `DB_NAME`, `TABLE_NAME`, `USER`, `LABEL`, and `STATE` (one side is the column ref, the other side is a constant).
   - Range predicates on `CREATE_TIME`, `LOAD_START_TIME`, and `LOAD_FINISH_TIME` (one side is the column ref, the other side is a constant).

2. On the FE side, apply the pushed-down filters before `toThrift`, so we can avoid doing unnecessary `toThrift` conversions for a large number of load jobs.

3. Fix the previous issue where `DB_NAME` was not pushed down to the FE RPC, because before the schema scan we only pushed down predicates when the column name was `DATABASE_NAME`.

4. Move the above logic from `FrontendServiceImpl` into `LoadsSystemTable`.

### Test
With 1,000,000 load jobs, only a small number of rows remain after filtering:

- Before: fails with an error
- After: < 1s

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
