### PR TITLE
[Enhancement] Prevent crashes when deserialization mismatches occur

### DIFF
--- a/be/src/column/chunk_extra_data.cpp
+++ b/be/src/column/chunk_extra_data.cpp
@@ -108,11 +108,13 @@ StatusOr<uint8_t*> ChunkExtraColumnsData::serialize(uint8_t* buff, bool sorted, 
     return buff;
 }
 
-StatusOr<const uint8_t*> ChunkExtraColumnsData::deserialize(const uint8_t* buff, bool sorted, const int encode_level) {
+StatusOr<const uint8_t*> ChunkExtraColumnsData::deserialize(const uint8_t* buff, const uint8_t* end, bool sorted,
+                                                            const int encode_level) {
     DCHECK_EQ(encode_level, 0);
     for (auto& column : _columns) {
         auto mutable_col = column->as_mutable_ptr();
-        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::deserialize(buff, mutable_col.get(), sorted, encode_level));
+        using Serd = serde::ColumnArraySerde;
+        ASSIGN_OR_RETURN(buff, Serd::deserialize(buff, end, mutable_col.get(), sorted, encode_level));
         column = std::move(mutable_col);
     }
     return buff;

--- a/be/src/column/chunk_extra_data.h
+++ b/be/src/column/chunk_extra_data.h
@@ -59,7 +59,8 @@ public:
 
     int64_t max_serialized_size(const int encode_level = 0);
     StatusOr<uint8_t*> serialize(uint8_t* buff, bool sorted = false, const int encode_level = 0);
-    StatusOr<const uint8_t*> deserialize(const uint8_t* buff, bool sorted = false, const int encode_level = 0);
+    StatusOr<const uint8_t*> deserialize(const uint8_t* buff, const uint8_t* end, bool sorted = false,
+                                         const int encode_level = 0);
 
     static ChunkExtraColumnsData* as_raw(const ChunkExtraDataPtr& extra_data);
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1020,6 +1020,9 @@ CONF_Bool(pipeline_analytic_enable_streaming_process, "true");
 CONF_mBool(pipeline_analytic_enable_removable_cumulative_process, "true");
 CONF_Int32(pipline_limit_max_delivery, "4096");
 
+// only used in DCHECK
+CONF_mBool(enable_dcheck_on_serde_failure, "false");
+
 CONF_mBool(use_default_dop_when_shared_scan, "true");
 /// For parallel scan on the single tablet.
 // These three configs are used to calculate the minimum number of rows picked up from a segment at one time.

--- a/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
+++ b/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
@@ -518,13 +518,14 @@ Status MemLimitedChunkQueue::_load(Block* block) {
 
     // 2. deserialize data
     uint8_t* buf = reinterpret_cast<uint8_t*>(buffer.data());
+    const auto* end = buf + buffer.size();
     const uint8_t* read_cursor = buf;
     std::vector<ChunkPtr> chunks(flush_chunks);
     for (auto& chunk : chunks) {
         chunk = _chunk_builder->clone_empty();
         for (auto& column : chunk->columns()) {
             ASSIGN_OR_RETURN(read_cursor,
-                             serde::ColumnArraySerde::deserialize(read_cursor, column->as_mutable_raw_ptr(), false,
+                             serde::ColumnArraySerde::deserialize(read_cursor, end, column->as_mutable_raw_ptr(), false,
                                                                   _opts.encode_level));
         }
     }

--- a/be/src/exec/pipeline/fetch_task.cpp
+++ b/be/src/exec/pipeline/fetch_task.cpp
@@ -114,7 +114,7 @@ Status FetchTask::_submit_remote_task(RuntimeState* state) {
                 const SlotDescriptor* slot_desc = ctx->processor->_slot_id_to_desc.at(slot_id);
                 auto column = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
                 const uint8_t* buff = reinterpret_cast<const uint8_t*>(buffer.data());
-                auto ret = serde::ColumnArraySerde::deserialize(buff, column.get());
+                auto ret = serde::ColumnArraySerde::deserialize(buff, buff + buffer.size(), column.get());
                 if (!ret.ok()) {
                     auto msg = fmt::format("deserialize column error, slot_id: {}", slot_id);
                     LOG(WARNING) << msg;

--- a/be/src/exec/pipeline/lookup_request.cpp
+++ b/be/src/exec/pipeline/lookup_request.cpp
@@ -78,7 +78,8 @@ Status RemoteLookUpRequestContext::collect_input_columns(ChunkPtr chunk) {
         VLOG_FILE << "deserialize column, slot_id: " << slot_id << ", data_size: " << data_size
                   << ", column: " << col->get_name();
         const uint8_t* buff = reinterpret_cast<const uint8_t*>(pcolumn.data().data());
-        auto ret = serde::ColumnArraySerde::deserialize(buff, col.get());
+        const auto* end = buff + data_size;
+        auto ret = serde::ColumnArraySerde::deserialize(buff, end, col.get());
         if (!ret.ok()) {
             auto msg = fmt::format("deserialize column failed, slot_id: {}, data_size: {}", slot_id, data_size);
             LOG(WARNING) << msg;

--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -379,7 +379,8 @@ StatusOr<int> RuntimeFilterHelper::deserialize_runtime_filter_for_skew_broadcast
     auto columnPtr = ColumnHelper::create_column(type_descriptor, is_null, is_const, num_rows);
 
     const uint8_t* cur = data + offset;
-    ASSIGN_OR_RETURN(cur, serde::ColumnArraySerde::deserialize(cur, columnPtr.get()));
+    const uint8_t* end = data + size;
+    ASSIGN_OR_RETURN(cur, serde::ColumnArraySerde::deserialize(cur, end, columnPtr.get()));
     offset += (cur - (data + offset));
 
     DCHECK(offset == size);

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -139,6 +139,7 @@ Status DataStreamMgr::transmit_chunk(const PTransmitChunkParams& request, ::goog
     t_finst_id.hi = finst_id.hi();
     t_finst_id.lo = finst_id.lo();
     SCOPED_SET_TRACE_INFO({}, {}, t_finst_id)
+    SCOPED_SET_TRACE_PLAN_NODE_ID(request.node_id());
     DUMP_TRACE_IF_TIMEOUT(config::pipeline_datastream_timeout_guard_ms);
 
     std::shared_ptr<DataStreamRecvr> recvr = find_recvr(t_finst_id, request.node_id());

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -18,7 +18,12 @@
 #include <streamvbyte.h>
 #include <streamvbytedelta.h>
 
+#include <cstdint>
+#include <limits>
+
 #include "base/coding.h"
+#include "base/status.h"
+#include "base/statusor.h"
 #include "column/array_column.h"
 #include "column/binary_column.h"
 #include "column/column_visitor_adapter.h"
@@ -31,9 +36,8 @@
 #include "column/object_column.h"
 #include "column/struct_column.h"
 #include "column/variant_column.h"
+#include "column/vectorized_fwd.h"
 #include "common/statusor.h"
-#include "gutil/strings/substitute.h"
-#include "runtime/descriptors.h"
 #include "serde/protobuf_serde.h"
 #include "types/hll.h"
 #include "types/json_value.h"
@@ -42,34 +46,48 @@
 #include "util/compression/compression_headers.h"
 
 namespace starrocks::serde {
-namespace {
+
+static Status check_remaining_size(const uint8_t* current, const uint8_t* end, size_t expected_remains) {
+    if (expected_remains > static_cast<size_t>(end - current)) {
+        if (config::enable_dcheck_on_serde_failure) {
+            DCHECK(false);
+        }
+        return Status::InternalError(
+                fmt::format("Expected remains size {}, but get {}", expected_remains, end - current));
+    }
+    return Status::OK();
+}
+
 constexpr int ENCODE_SIZE_LIMIT = 256;
-uint8_t* write_little_endian_32(uint32_t value, uint8_t* buff) {
+static uint8_t* write_little_endian_32(uint32_t value, uint8_t* buff) {
     encode_fixed32_le(buff, value);
     return buff + sizeof(value);
 }
 
-const uint8_t* read_little_endian_32(const uint8_t* buff, uint32_t* value) {
+static StatusOr<const uint8_t*> read_little_endian_32(const uint8_t* buff, const uint8_t* end, uint32_t* value) {
+    RETURN_IF_ERROR(check_remaining_size(buff, end, sizeof(uint32_t)));
     *value = decode_fixed32_le(buff);
     return buff + sizeof(*value);
 }
 
-uint8_t* write_little_endian_64(uint64_t value, uint8_t* buff) {
+static uint8_t* write_little_endian_64(uint64_t value, uint8_t* buff) {
     encode_fixed64_le(buff, value);
     return buff + sizeof(value);
 }
 
-const uint8_t* read_little_endian_64(const uint8_t* buff, uint64_t* value) {
+static StatusOr<const uint8_t*> read_little_endian_64(const uint8_t* buff, const uint8_t* end, uint64_t* value) {
+    RETURN_IF_ERROR(check_remaining_size(buff, end, sizeof(uint64_t)));
     *value = decode_fixed64_le(buff);
     return buff + sizeof(*value);
 }
 
-uint8_t* write_raw(const void* data, size_t size, uint8_t* buff) {
+static uint8_t* write_raw(const void* data, size_t size, uint8_t* buff) {
     strings::memcpy_inlined(buff, data, size);
     return buff + size;
 }
 
-const uint8_t* read_raw(const uint8_t* buff, void* target, size_t size) {
+static StatusOr<const uint8_t*> read_raw(const uint8_t* buff, const uint8_t* end, void* target, size_t size) {
+    RETURN_IF_ERROR(check_remaining_size(buff, end, size));
     strings::memcpy_inlined(target, buff, size);
     return buff + size;
 }
@@ -96,17 +114,43 @@ uint8_t* encode_integers(const void* data, size_t size, uint8_t* buff, int encod
 }
 
 template <bool sorted_32ints>
-const uint8_t* decode_integers(const uint8_t* buff, void* target, size_t size) {
+StatusOr<const uint8_t*> decode_integers(const uint8_t* buff, const uint8_t* end, void* target, size_t size) {
     uint64_t encode_size = 0;
-    buff = read_little_endian_64(buff, &encode_size);
+
+    ASSIGN_OR_RETURN(buff, read_little_endian_64(buff, end, &encode_size));
+
+    const uint64_t count64 = upper_int32(size);
+    if (UNLIKELY(count64 > std::numeric_limits<uint32_t>::max())) {
+        return Status::InternalError(
+                fmt::format("streamvbyte count overflow, count = {}, raw size = {}", count64, size));
+    }
+
+    const uint32_t count = static_cast<uint32_t>(count64);
+    const uint64_t key_len = (static_cast<uint64_t>(count) + 3) / 4;
+    if (UNLIKELY(encode_size < key_len)) {
+        return Status::InternalError(fmt::format(
+                "invalid streamvbyte payload, encoded size {} is smaller than key size {} (count = {}, raw size = {})",
+                encode_size, key_len, count, size));
+    }
+
+    const uint64_t max_compressed = streamvbyte_max_compressedbytes(count);
+    if (UNLIKELY(encode_size > max_compressed)) {
+        return Status::InternalError(
+                fmt::format("invalid streamvbyte payload, encoded size {} exceeds max compressed size {} (count = {}, "
+                            "raw size = {})",
+                            encode_size, max_compressed, count, size));
+    }
+
+    RETURN_IF_ERROR(check_remaining_size(buff, end, encode_size));
+
     uint64_t decode_size = 0;
     if (sorted_32ints) {
-        decode_size = streamvbyte_delta_decode(buff, (uint32_t*)target, upper_int32(size), 0);
+        decode_size = streamvbyte_delta_decode(buff, (uint32_t*)target, count, 0);
     } else {
-        decode_size = streamvbyte_decode(buff, (uint32_t*)target, upper_int32(size));
+        decode_size = streamvbyte_decode(buff, (uint32_t*)target, count);
     }
     if (encode_size != decode_size) {
-        throw std::runtime_error(fmt::format(
+        return Status::InternalError(fmt::format(
                 "encode size does not equal when decoding, encode size = {}, but decode get size = {}, raw size = {}.",
                 encode_size, decode_size, size));
     }
@@ -133,20 +177,22 @@ uint8_t* encode_string_lz4(const void* data, size_t size, uint8_t* buff, int enc
     return buff + encode_size;
 }
 
-const uint8_t* decode_string_lz4(const uint8_t* buff, void* target, size_t size) {
+StatusOr<const uint8_t*> decode_string_lz4(const uint8_t* buff, const uint8_t* end, void* target, size_t size) {
     uint64_t encode_size = 0;
-    buff = read_little_endian_64(buff, &encode_size);
+    ASSIGN_OR_RETURN(buff, read_little_endian_64(buff, end, &encode_size));
+
+    RETURN_IF_ERROR(check_remaining_size(buff, end, encode_size));
     auto decode_size = LZ4_decompress_safe(reinterpret_cast<const char*>(buff), reinterpret_cast<char*>(target),
                                            encode_size, size);
     if (decode_size <= 0) {
-        throw std::runtime_error(fmt::format(
+        return Status::InternalError(fmt::format(
                 "lz4 decompress failed: encode size = {}, raw size = {}, decompressed get decode size = {}.",
                 encode_size, size, decode_size));
     }
     if (size != decode_size) {
-        throw std::runtime_error(
-                fmt::format("lz4 encode size does not equal when decoding, encode size = {}, but decode get size = "
-                            "{}, raw size = {}.",
+        return Status::InternalError(
+                fmt::format("lz4 encode size does not equal when decoding, encode size = {}, but decode get size = {}, "
+                            "raw size = {}.",
                             encode_size, decode_size, size));
     }
     return buff + encode_size;
@@ -171,30 +217,25 @@ public:
         uint32_t size = sizeof(T) * column.size();
         buff = write_little_endian_32(size, buff);
         if (EncodeContext::enable_encode_integer(encode_level) && size >= ENCODE_SIZE_LIMIT) {
-            if (sizeof(T) == 4 && sorted) { // only support sorted 32-bit integers
-                buff = encode_integers<true>(column.raw_data(), size, buff, encode_level);
-            } else {
-                buff = encode_integers<false>(column.raw_data(), size, buff, encode_level);
-            }
+            // sorted 32-bit integers have a better optimize branch
+            buff = encode_integers<(sizeof(T) == 4 && sorted)>(column.raw_data(), size, buff, encode_level);
         } else {
             buff = write_raw(column.raw_data(), size, buff);
         }
         return buff;
     }
 
-    static const uint8_t* deserialize(const uint8_t* buff, FixedLengthColumnBase<T>* column, const int encode_level) {
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, const uint8_t* end,
+                                                FixedLengthColumnBase<T>* column, const int encode_level) {
         uint32_t size = 0;
-        buff = read_little_endian_32(buff, &size);
+        ASSIGN_OR_RETURN(buff, read_little_endian_32(buff, end, &size));
         auto& data = column->get_data();
         raw::make_room(&data, size / sizeof(T));
         if (EncodeContext::enable_encode_integer(encode_level) && size >= ENCODE_SIZE_LIMIT) {
-            if (sizeof(T) == 4 && sorted) { // only support sorted 32-bit integers
-                buff = decode_integers<true>(buff, data.data(), size);
-            } else {
-                buff = decode_integers<false>(buff, data.data(), size);
-            }
+            constexpr bool is_sorted_i32 = sizeof(T) == 4 && sorted;
+            ASSIGN_OR_RETURN(buff, decode_integers<is_sorted_i32>(buff, end, data.data(), size));
         } else {
-            buff = read_raw(buff, data.data(), size);
+            ASSIGN_OR_RETURN(buff, read_raw(buff, end, data.data(), size));
         }
         return buff;
     }
@@ -260,36 +301,38 @@ public:
     }
 
     template <typename T>
-    static const uint8_t* deserialize(const uint8_t* buff, BinaryColumnBase<T>* column, const int encode_level) {
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, const uint8_t* end, BinaryColumnBase<T>* column,
+                                                const int encode_level) {
+        // deserialize bytes
         T bytes_size = 0;
         if constexpr (std::is_same_v<T, uint32_t>) {
-            buff = read_little_endian_32(buff, &bytes_size);
+            ASSIGN_OR_RETURN(buff, read_little_endian_32(buff, end, &bytes_size));
         } else {
-            buff = read_little_endian_64(buff, &bytes_size);
+            ASSIGN_OR_RETURN(buff, read_little_endian_64(buff, end, &bytes_size));
         }
         column->get_bytes().resize(bytes_size);
+
+        auto* bytes_data = column->get_bytes().data();
         if (EncodeContext::enable_encode_string(encode_level) && bytes_size >= ENCODE_SIZE_LIMIT &&
             bytes_size <= LZ4_MAX_INPUT_SIZE) {
-            buff = decode_string_lz4(buff, column->get_bytes().data(), bytes_size);
+            ASSIGN_OR_RETURN(buff, decode_string_lz4(buff, end, bytes_data, bytes_size));
         } else {
-            buff = read_raw(buff, column->get_bytes().data(), bytes_size);
+            ASSIGN_OR_RETURN(buff, read_raw(buff, end, bytes_data, bytes_size));
         }
 
-        T offsets_size = 0;
+        T offset_bytes_size = 0;
         if constexpr (std::is_same_v<T, uint32_t>) {
-            buff = read_little_endian_32(buff, &offsets_size);
+            ASSIGN_OR_RETURN(buff, read_little_endian_32(buff, end, &offset_bytes_size));
         } else {
-            buff = read_little_endian_64(buff, &offsets_size);
+            ASSIGN_OR_RETURN(buff, read_little_endian_64(buff, end, &offset_bytes_size));
         }
-        raw::make_room(&column->get_offset(), offsets_size / sizeof(typename BinaryColumnBase<T>::Offset));
-        if (EncodeContext::enable_encode_integer(encode_level) && offsets_size >= ENCODE_SIZE_LIMIT) {
-            if (sizeof(T) == 4) { // only support sorted 32-bit integers
-                buff = decode_integers<true>(buff, column->get_offset().data(), offsets_size);
-            } else {
-                buff = decode_integers<false>(buff, column->get_offset().data(), offsets_size);
-            }
+        raw::make_room(&column->get_offset(), offset_bytes_size / sizeof(typename BinaryColumnBase<T>::Offset));
+
+        if (EncodeContext::enable_encode_integer(encode_level) && offset_bytes_size >= ENCODE_SIZE_LIMIT) {
+            constexpr bool is_i32 = sizeof(T) == 4;
+            ASSIGN_OR_RETURN(buff, decode_integers<is_i32>(buff, end, column->get_offset().data(), offset_bytes_size));
         } else {
-            buff = read_raw(buff, column->get_offset().data(), offsets_size);
+            ASSIGN_OR_RETURN(buff, read_raw(buff, end, column->get_offset().data(), offset_bytes_size));
         }
         return buff;
     }
@@ -318,15 +361,16 @@ public:
         return buff;
     }
 
-    static const uint8_t* deserialize(const uint8_t* buff, ObjectColumn<T>* column) {
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, const uint8_t* end, ObjectColumn<T>* column) {
         uint32_t num_objects = 0;
-        buff = read_little_endian_32(buff, &num_objects);
+
+        ASSIGN_OR_RETURN(buff, read_little_endian_32(buff, end, &num_objects));
         column->reset_column();
         auto& pool = column->get_pool();
         pool.reserve(num_objects);
         for (int i = 0; i < num_objects; i++) {
             uint64_t serialized_size = 0;
-            buff = read_little_endian_64(buff, &serialized_size);
+            ASSIGN_OR_RETURN(buff, read_little_endian_64(buff, end, &serialized_size));
             pool.emplace_back(Slice(buff, serialized_size));
             buff += serialized_size;
         }
@@ -367,18 +411,19 @@ public:
         return buff;
     }
 
-    static const uint8_t* deserialize(const uint8_t* buff, JsonColumn* column) {
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, const uint8_t* end, JsonColumn* column) {
         uint32_t actual_version = 0;
         uint32_t num_objects = 0;
-        buff = read_little_endian_32(buff, &actual_version);
-        buff = read_little_endian_32(buff, &num_objects);
+        ASSIGN_OR_RETURN(buff, read_little_endian_32(buff, end, &actual_version));
+        RETURN_IF_DCHECK_EQ_FAILED(actual_version, kJsonMetaDefaultFormatVersion);
+        ASSIGN_OR_RETURN(buff, read_little_endian_32(buff, end, &num_objects));
 
         column->reset_column();
         auto& pool = column->get_pool();
         pool.reserve(num_objects);
         for (int i = 0; i < num_objects; i++) {
             uint64_t serialized_size = 0;
-            buff = read_little_endian_64(buff, &serialized_size);
+            ASSIGN_OR_RETURN(buff, read_little_endian_64(buff, end, &serialized_size));
             pool.emplace_back(Slice(buff, serialized_size));
             buff += serialized_size;
         }
@@ -412,15 +457,15 @@ public:
         return buff;
     }
 
-    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, VariantColumn* column) {
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, const uint8_t* end, VariantColumn* column) {
         uint32_t num_objects = 0;
-        buff = read_little_endian_32(buff, &num_objects);
+        ASSIGN_OR_RETURN(buff, read_little_endian_32(buff, end, &num_objects));
         column->reset_column();
         auto& pool = column->get_pool();
         pool.reserve(num_objects);
         for (int i = 0; i < num_objects; ++i) {
             uint64_t serialized_size = 0;
-            buff = read_little_endian_64(buff, &serialized_size);
+            ASSIGN_OR_RETURN(buff, read_little_endian_64(buff, end, &serialized_size));
             auto variant = VariantRowValue::create(Slice(buff, serialized_size));
             if (!variant.ok()) {
                 return Status::Corruption(fmt::format("Failed to deserialize VariantRowValue at index {}: {}", i,
@@ -437,22 +482,22 @@ public:
 
 class NullableColumnSerde {
 public:
+    using Serde = serde::ColumnArraySerde;
     static int64_t max_serialized_size(const NullableColumn& column, const int encode_level) {
-        return serde::ColumnArraySerde::max_serialized_size(*column.null_column(), encode_level) +
-               serde::ColumnArraySerde::max_serialized_size(*column.data_column(), encode_level);
+        return Serde::max_serialized_size(*column.null_column(), encode_level) +
+               Serde::max_serialized_size(*column.data_column(), encode_level);
     }
 
     static StatusOr<uint8_t*> serialize(const NullableColumn& column, uint8_t* buff, const int encode_level) {
-        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(*column.null_column(), buff, false, encode_level));
-        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(*column.data_column(), buff, false, encode_level));
+        ASSIGN_OR_RETURN(buff, Serde::serialize(*column.null_column(), buff, false, encode_level));
+        ASSIGN_OR_RETURN(buff, Serde::serialize(*column.data_column(), buff, false, encode_level));
         return buff;
     }
 
-    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, NullableColumn* column, const int encode_level) {
-        ASSIGN_OR_RETURN(
-                buff, serde::ColumnArraySerde::deserialize(buff, column->null_column_raw_ptr(), false, encode_level));
-        ASSIGN_OR_RETURN(
-                buff, serde::ColumnArraySerde::deserialize(buff, column->data_column_raw_ptr(), false, encode_level));
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, const uint8_t* end, NullableColumn* column,
+                                                const int encode_level) {
+        ASSIGN_OR_RETURN(buff, Serde::deserialize(buff, end, column->null_column_raw_ptr(), false, encode_level));
+        ASSIGN_OR_RETURN(buff, Serde::deserialize(buff, end, column->data_column_raw_ptr(), false, encode_level));
         column->update_has_null();
         return buff;
     }
@@ -460,73 +505,73 @@ public:
 
 class ArrayColumnSerde {
 public:
+    using Serde = serde::ColumnArraySerde;
     static int64_t max_serialized_size(const ArrayColumn& column, const int encode_level) {
-        return serde::ColumnArraySerde::max_serialized_size(column.offsets(), encode_level) +
-               serde::ColumnArraySerde::max_serialized_size(column.elements(), encode_level);
+        return Serde::max_serialized_size(column.offsets(), encode_level) +
+               Serde::max_serialized_size(column.elements(), encode_level);
     }
 
     static StatusOr<uint8_t*> serialize(const ArrayColumn& column, uint8_t* buff, const int encode_level) {
-        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(column.offsets(), buff, true, encode_level));
-        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(column.elements(), buff, false, encode_level));
+        ASSIGN_OR_RETURN(buff, Serde::serialize(column.offsets(), buff, true, encode_level));
+        ASSIGN_OR_RETURN(buff, Serde::serialize(column.elements(), buff, false, encode_level));
         return buff;
     }
 
-    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, ArrayColumn* column, const int encode_level) {
-        ASSIGN_OR_RETURN(
-                buff, serde::ColumnArraySerde::deserialize(buff, column->offsets_column_raw_ptr(), true, encode_level));
-        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::deserialize(buff, column->elements_column_raw_ptr(), false,
-                                                                    encode_level));
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, const uint8_t* end, ArrayColumn* column,
+                                                const int encode_level) {
+        ASSIGN_OR_RETURN(buff, Serde::deserialize(buff, end, column->offsets_column_raw_ptr(), true, encode_level));
+        ASSIGN_OR_RETURN(buff, Serde::deserialize(buff, end, column->elements_column_raw_ptr(), false, encode_level));
         return buff;
     }
 };
 
 class MapColumnSerde {
 public:
+    using Serde = serde::ColumnArraySerde;
     static int64_t max_serialized_size(const MapColumn& column, const int encode_level) {
-        return serde::ColumnArraySerde::max_serialized_size(column.offsets(), encode_level) +
-               serde::ColumnArraySerde::max_serialized_size(column.keys(), encode_level) +
-               serde::ColumnArraySerde::max_serialized_size(column.values(), encode_level);
+        return Serde::max_serialized_size(column.offsets(), encode_level) +
+               Serde::max_serialized_size(column.keys(), encode_level) +
+               Serde::max_serialized_size(column.values(), encode_level);
     }
 
     static StatusOr<uint8_t*> serialize(const MapColumn& column, uint8_t* buff, const int encode_level) {
-        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(column.offsets(), buff, true, encode_level));
-        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(column.keys(), buff, false, encode_level));
-        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(column.values(), buff, false, encode_level));
+        ASSIGN_OR_RETURN(buff, Serde::serialize(column.offsets(), buff, true, encode_level));
+        ASSIGN_OR_RETURN(buff, Serde::serialize(column.keys(), buff, false, encode_level));
+        ASSIGN_OR_RETURN(buff, Serde::serialize(column.values(), buff, false, encode_level));
         return buff;
     }
 
-    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, MapColumn* column, const int encode_level) {
-        ASSIGN_OR_RETURN(
-                buff, serde::ColumnArraySerde::deserialize(buff, column->offsets_column_raw_ptr(), true, encode_level));
-        ASSIGN_OR_RETURN(
-                buff, serde::ColumnArraySerde::deserialize(buff, column->keys_column_raw_ptr(), false, encode_level));
-        ASSIGN_OR_RETURN(
-                buff, serde::ColumnArraySerde::deserialize(buff, column->values_column_raw_ptr(), false, encode_level));
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, const uint8_t* end, MapColumn* column,
+                                                const int encode_level) {
+        ASSIGN_OR_RETURN(buff, Serde::deserialize(buff, end, column->offsets_column_raw_ptr(), true, encode_level));
+        ASSIGN_OR_RETURN(buff, Serde::deserialize(buff, end, column->keys_column_raw_ptr(), false, encode_level));
+        ASSIGN_OR_RETURN(buff, Serde::deserialize(buff, end, column->values_column_raw_ptr(), false, encode_level));
         return buff;
     }
 };
 
 class StructColumnSerde {
 public:
+    using Serde = serde::ColumnArraySerde;
     static int64_t max_serialized_size(const StructColumn& column, const int encode_level) {
         int64_t size = 0;
         for (const auto& field : column.fields()) {
-            size += serde::ColumnArraySerde::max_serialized_size(*field, encode_level);
+            size += Serde::max_serialized_size(*field, encode_level);
         }
         return size;
     }
 
     static StatusOr<uint8_t*> serialize(const StructColumn& column, uint8_t* buff, const int encode_level) {
         for (const auto& field : column.fields()) {
-            ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(*field, buff, false, encode_level));
+            ASSIGN_OR_RETURN(buff, Serde::serialize(*field, buff, false, encode_level));
         }
         return buff;
     }
 
-    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, StructColumn* column, const int encode_level) {
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, const uint8_t* end, StructColumn* column,
+                                                const int encode_level) {
         for (auto& field : column->fields()) {
-            ASSIGN_OR_RETURN(
-                    buff, serde::ColumnArraySerde::deserialize(buff, field->as_mutable_raw_ptr(), false, encode_level));
+            ASSIGN_OR_RETURN(buff, Serde::deserialize(buff, end, field->as_mutable_raw_ptr(), false, encode_level));
         }
         return buff;
     }
@@ -534,22 +579,22 @@ public:
 
 class ConstColumnSerde {
 public:
+    using Serde = serde::ColumnArraySerde;
     static int64_t max_serialized_size(const ConstColumn& column, const int encode_level) {
-        return /*sizeof(uint64_t)=*/8 +
-               serde::ColumnArraySerde::max_serialized_size(*column.data_column(), encode_level);
+        return /*sizeof(uint64_t)=*/8 + Serde::max_serialized_size(*column.data_column(), encode_level);
     }
 
     static StatusOr<uint8_t*> serialize(const ConstColumn& column, uint8_t* buff, const int encode_level) {
         buff = write_little_endian_64(column.size(), buff);
-        ASSIGN_OR_RETURN(buff, serde::ColumnArraySerde::serialize(*column.data_column(), buff, false, encode_level));
+        ASSIGN_OR_RETURN(buff, Serde::serialize(*column.data_column(), buff, false, encode_level));
         return buff;
     }
 
-    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, ConstColumn* column, const int encode_level) {
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, const uint8_t* end, ConstColumn* column,
+                                                const int encode_level) {
         uint64_t size = 0;
-        buff = read_little_endian_64(buff, &size);
-        ASSIGN_OR_RETURN(
-                buff, serde::ColumnArraySerde::deserialize(buff, column->data_column_raw_ptr(), false, encode_level));
+        ASSIGN_OR_RETURN(buff, read_little_endian_64(buff, end, &size));
+        ASSIGN_OR_RETURN(buff, Serde::deserialize(buff, end, column->data_column_raw_ptr(), false, encode_level));
         column->resize(size);
         return buff;
     }
@@ -695,72 +740,70 @@ private:
 
 class ColumnDeserializingVisitor final : public ColumnVisitorMutableAdapter<ColumnDeserializingVisitor> {
 public:
-    explicit ColumnDeserializingVisitor(const uint8_t* buff, bool sorted, const int encode_level)
+    explicit ColumnDeserializingVisitor(const uint8_t* buff, const uint8_t* end, bool sorted, const int encode_level)
             : ColumnVisitorMutableAdapter(this),
               _buff(buff),
+              _end(end),
               _cur(buff),
               _sorted(sorted),
               _encode_level(encode_level) {}
 
     Status do_visit(NullableColumn* column) {
-        ASSIGN_OR_RETURN(_cur, NullableColumnSerde::deserialize(_cur, column, _encode_level));
+        ASSIGN_OR_RETURN(_cur, NullableColumnSerde::deserialize(_cur, _end, column, _encode_level));
         return Status::OK();
     }
 
     Status do_visit(ConstColumn* column) {
-        ASSIGN_OR_RETURN(_cur, ConstColumnSerde::deserialize(_cur, column, _encode_level));
+        ASSIGN_OR_RETURN(_cur, ConstColumnSerde::deserialize(_cur, _end, column, _encode_level));
         return Status::OK();
     }
 
     Status do_visit(ArrayColumn* column) {
-        ASSIGN_OR_RETURN(_cur, ArrayColumnSerde::deserialize(_cur, column, _encode_level));
+        ASSIGN_OR_RETURN(_cur, ArrayColumnSerde::deserialize(_cur, _end, column, _encode_level));
         return Status::OK();
     }
 
     Status do_visit(MapColumn* column) {
-        ASSIGN_OR_RETURN(_cur, MapColumnSerde::deserialize(_cur, column, _encode_level));
+        ASSIGN_OR_RETURN(_cur, MapColumnSerde::deserialize(_cur, _end, column, _encode_level));
         return Status::OK();
     }
 
     Status do_visit(StructColumn* column) {
-        ASSIGN_OR_RETURN(_cur, StructColumnSerde::deserialize(_cur, column, _encode_level));
+        ASSIGN_OR_RETURN(_cur, StructColumnSerde::deserialize(_cur, _end, column, _encode_level));
         return Status::OK();
     }
 
     template <typename T>
     Status do_visit(BinaryColumnBase<T>* column) {
-        _cur = BinaryColumnSerde::deserialize(_cur, column, _encode_level);
+        ASSIGN_OR_RETURN(_cur, BinaryColumnSerde::deserialize(_cur, _end, column, _encode_level));
         return Status::OK();
     }
 
     template <typename T>
     Status do_visit(FixedLengthColumnBase<T>* column) {
         if (_sorted) {
-            _cur = FixedLengthColumnSerde<T, true>::deserialize(_cur, column, _encode_level);
+            using Serd = FixedLengthColumnSerde<T, true>;
+            ASSIGN_OR_RETURN(_cur, Serd::deserialize(_cur, _end, column, _encode_level));
         } else {
-            _cur = FixedLengthColumnSerde<T, false>::deserialize(_cur, column, _encode_level);
+            using Serd = FixedLengthColumnSerde<T, false>;
+            ASSIGN_OR_RETURN(_cur, Serd::deserialize(_cur, _end, column, _encode_level));
         }
         return Status::OK();
     }
 
     template <typename T>
     Status do_visit(ObjectColumn<T>* column) {
-        _cur = ObjectColumnSerde<T>::deserialize(_cur, column);
+        ASSIGN_OR_RETURN(_cur, ObjectColumnSerde<T>::deserialize(_cur, _end, column));
         return Status::OK();
     }
 
     Status do_visit(JsonColumn* column) {
-        _cur = JsonColumnSerde::deserialize(_cur, column);
+        ASSIGN_OR_RETURN(_cur, JsonColumnSerde::deserialize(_cur, _end, column));
         return Status::OK();
     }
 
     Status do_visit(VariantColumn* column) {
-        auto v = VariantColumnSerde::deserialize(_cur, column);
-        if (!v.ok()) {
-            return v.status();
-        }
-
-        _cur = v.value();
+        ASSIGN_OR_RETURN(_cur, VariantColumnSerde::deserialize(_cur, _end, column));
         return Status::OK();
     }
 
@@ -770,12 +813,11 @@ public:
 
 private:
     const uint8_t* _buff;
+    const uint8_t* _end;
     const uint8_t* _cur;
     bool _sorted;
     int _encode_level;
 };
-
-} // namespace
 
 int64_t ColumnArraySerde::max_serialized_size(const Column& column, const int encode_level) {
     ColumnSerializedSizeVisitor visitor(0, encode_level);
@@ -791,10 +833,13 @@ StatusOr<uint8_t*> ColumnArraySerde::serialize(const Column& column, uint8_t* bu
     return visitor.cur();
 }
 
-StatusOr<const uint8_t*> ColumnArraySerde::deserialize(const uint8_t* data, Column* column, bool sorted,
-                                                       const int encode_level) {
-    ColumnDeserializingVisitor visitor(data, sorted, encode_level);
+StatusOr<const uint8_t*> ColumnArraySerde::deserialize(const uint8_t* buff, const uint8_t* end, Column* column,
+                                                       bool sorted, const int encode_level) {
+    ColumnDeserializingVisitor visitor(buff, end, sorted, encode_level);
     RETURN_IF_ERROR(column->accept_mutable(&visitor));
+    if (visitor.cur() > end) {
+        return Status::InvalidArgument("Buffer overflow");
+    }
     return visitor.cur();
 }
 

--- a/be/src/serde/column_array_serde.h
+++ b/be/src/serde/column_array_serde.h
@@ -34,13 +34,11 @@ public:
     // 0 means does not support the type of column
     static int64_t max_serialized_size(const Column& column, const int encode_level = 0);
 
-    // Return nullptr on error.
     static StatusOr<uint8_t*> serialize(const Column& column, uint8_t* buff, bool sorted = false,
                                         const int encode_level = 0);
 
-    // Return nullptr on error.
-    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, Column* column, bool sorted = false,
-                                                const int encode_level = 0);
+    static StatusOr<const uint8_t*> deserialize(const uint8_t* buff, const uint8_t* end, Column* column,
+                                                bool sorted = false, const int encode_level = 0);
 };
 
 } //  namespace starrocks::serde

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -868,7 +868,9 @@ Status RowsetUpdateState::load_delete(uint32_t del_id, const RowsetUpdateStatePa
     ASSIGN_OR_RETURN(auto read_buffer, read_file->read_all());
     auto col = pk_column->clone();
     using Serd = serde::ColumnArraySerde;
-    RETURN_IF_ERROR(Serd::deserialize(reinterpret_cast<const uint8_t*>(read_buffer.data()), col.get()));
+    const auto* begin = reinterpret_cast<const uint8_t*>(read_buffer.data());
+    const auto* end = begin + read_buffer.size();
+    RETURN_IF_ERROR(Serd::deserialize(begin, end, col.get()));
     col->raw_data();
     _memory_usage += col->memory_usage();
     _deletes[del_id] = std::move(col);

--- a/be/src/storage/primary_key_recover.cpp
+++ b/be/src/storage/primary_key_recover.cpp
@@ -66,7 +66,8 @@ Status PrimaryKeyRecover::recover() {
                         std::vector<uint8_t> read_buffer(file_size);
                         RETURN_IF_ERROR(read_file->read_at_fully(0, read_buffer.data(), read_buffer.size()));
                         auto col = pk_column->clone();
-                        RETURN_IF_ERROR(serde::ColumnArraySerde::deserialize(read_buffer.data(), col.get()));
+                        const auto* end = read_buffer.data() + read_buffer.size();
+                        RETURN_IF_ERROR(serde::ColumnArraySerde::deserialize(read_buffer.data(), end, col.get()));
                         RETURN_IF_ERROR(index.erase(*col, &new_deletes));
                         del_index++;
                     } else {

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -86,7 +86,8 @@ Status RowsetUpdateState::_load_deletes(Rowset* rowset, uint32_t idx, Column* pk
     TRY_CATCH_BAD_ALLOC(read_buffer.resize(file_size));
     RETURN_IF_ERROR(read_file->read_at_fully(0, read_buffer.data(), read_buffer.size()));
     auto col = pk_column->clone();
-    RETURN_IF_ERROR(serde::ColumnArraySerde::deserialize(read_buffer.data(), col.get()));
+    const auto* end = read_buffer.data() + read_buffer.size();
+    RETURN_IF_ERROR(serde::ColumnArraySerde::deserialize(read_buffer.data(), end, col.get()));
     TRY_CATCH_BAD_ALLOC(col->raw_data());
     _memory_usage += col != nullptr ? col->memory_usage() : 0;
     _deletes[idx] = std::move(col);

--- a/be/test/exec/exec_factory_test.cpp
+++ b/be/test/exec/exec_factory_test.cpp
@@ -159,6 +159,7 @@ TEST_F(ExecFactoryTest, test_create_tree_valid_simple_tree) {
     ASSERT_EQ(root->children().size(), 1);
     ASSERT_NE(root->children()[0], nullptr);
     ASSERT_EQ(root->children()[0]->type(), TPlanNodeType::EMPTY_SET_NODE);
+    root->close(&_runtime_state);
 }
 
 TEST_F(ExecFactoryTest, test_create_tree_invalid_tuple_id) {


### PR DESCRIPTION
## Why I'm doing:

Deserialization previously relied only on a buffer pointer without boundary awareness.
When serialized data is corrupted, truncated, or mismatched with the expected format, this may lead to:

1. out-of-bound memory access
2. undefined behavior
3. process crashes

This PR makes deserialization buffer-bound aware by introducing boundary checks and proper error propagation, so the system returns errors instead of crashing.

This improves system robustness and safety when handling corrupted or incompatible serialized data.

## What I'm doing:

1. Add buffer boundary (end pointer) validation to deserialization interfaces
2. Add safety checks to prevent out-of-bound reads

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
