### PR TITLE
[BugFix] [FOLLOWUP] Fix mv force refresh bugs for partition tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BaseMVRefreshProcessor.java
@@ -415,15 +415,14 @@ public abstract class BaseMVRefreshProcessor {
                     if (!mv.isPartitionedTable() || mvRefreshParams.isCompleteRefresh()) {
                         mv.getRefreshScheme().getAsyncRefreshContext().clearVisibleVersionMap();
                     } else {
-                        for (PCellWithName partName : toRefreshPartitions.getPartitions()) {
-                            mvRefreshPartitioner.dropPartition(db, mv, partName.name());
-                        }
+                        mv.getRefreshScheme().getAsyncRefreshContext().clearVisibleVersionMapByMVPartitions(
+                                toRefreshPartitions.getPartitionNames());
                     }
                 } catch (Exception e) {
-                    logger.warn("failed to drop partitions or clear version map {} for force refresh",
+                    logger.warn("failed to clear version map {} for force refresh",
                             Joiner.on(",").join(toRefreshPartitions.getPartitionNames()),
                             DebugUtil.getRootStackTrace(e));
-                    throw new AnalysisException("failed to drop partitions for force refresh: " + e.getMessage());
+                    throw new AnalysisException("failed to clear version map for force refresh: " + e.getMessage());
                 } finally {
                     locker.unLockTableWithIntensiveDbLock(db.getId(), this.mv.getId(), LockType.WRITE);
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -1246,10 +1246,11 @@ public class MaterializedViewTest extends StarRocksTestBase {
 
         List<Table> baseTables = mv.getBaseTables();
         Assertions.assertEquals(2, baseTables.size());
-        Assertions.assertEquals("base_view1", baseTables.get(0).getName());
-        Assertions.assertEquals(baseView, baseTables.get(0));
-        Assertions.assertEquals("base_table1", baseTables.get(1).getName());
-        Assertions.assertEquals(baseTable, baseTables.get(1));
+        // Check that both base table and base view are present, regardless of order
+        Assertions.assertTrue(baseTables.stream().anyMatch(t -> t.getName().equals("base_view1")));
+        Assertions.assertTrue(baseTables.stream().anyMatch(t -> t.getName().equals("base_table1")));
+        Assertions.assertTrue(baseTables.contains(baseView));
+        Assertions.assertTrue(baseTables.contains(baseTable));
 
         List<BaseTableInfo> baseTablesWithView = mv.getBaseTableInfosWithoutView();
         Assertions.assertEquals(1, baseTablesWithView.size());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -17,6 +17,7 @@ package com.starrocks.catalog;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.alter.AlterJobV2;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
 import com.starrocks.common.Config;
@@ -64,6 +65,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.starrocks.sql.optimizer.MVTestUtils.waitForSchemaChangeAlterJobFinish;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -1573,5 +1575,50 @@ public class MaterializedViewTest extends StarRocksTestBase {
                 "lastSchemaUpdateTime should be updated after force dropping partition");
         Assertions.assertTrue(afterDropSchemaUpdateTime >= beforeDropTime,
                 "lastSchemaUpdateTime should be >= time before force drop");
+    }
+
+    @Test
+    public void testClearVisibleVersionMapByMVPartitions() {
+        MaterializedView.AsyncRefreshContext context = new MaterializedView.AsyncRefreshContext();
+        Map<String, MaterializedView.BasePartitionInfo> olapPartitionInfo = Maps.newHashMap();
+        olapPartitionInfo.put("p1", new MaterializedView.BasePartitionInfo(1, 1, -1));
+        olapPartitionInfo.put("p2", new MaterializedView.BasePartitionInfo(2, 1, -1));
+        olapPartitionInfo.put("bp1", new MaterializedView.BasePartitionInfo(3, 1, -1));
+        olapPartitionInfo.put("bp2", new MaterializedView.BasePartitionInfo(4, 1, -1));
+        olapPartitionInfo.put("keep", new MaterializedView.BasePartitionInfo(5, 1, -1));
+        context.getBaseTableVisibleVersionMap().put(100L, olapPartitionInfo);
+
+        BaseTableInfo externalBaseTableInfo = new BaseTableInfo("hive0", "partitioned_db", "lineitem_par", "lineitem_par");
+        Map<String, MaterializedView.BasePartitionInfo> externalPartitionInfo = Maps.newHashMap();
+        externalPartitionInfo.put("p1", new MaterializedView.BasePartitionInfo(11, 1, -1));
+        externalPartitionInfo.put("p2", new MaterializedView.BasePartitionInfo(12, 1, -1));
+        externalPartitionInfo.put("bp1", new MaterializedView.BasePartitionInfo(13, 1, -1));
+        externalPartitionInfo.put("bp2", new MaterializedView.BasePartitionInfo(14, 1, -1));
+        externalPartitionInfo.put("keep", new MaterializedView.BasePartitionInfo(15, 1, -1));
+        context.getBaseTableInfoVisibleVersionMap().put(externalBaseTableInfo, externalPartitionInfo);
+
+        context.getMvPartitionNameRefBaseTablePartitionMap().put("p1", Sets.newHashSet("bp1"));
+        context.getMvPartitionNameRefBaseTablePartitionMap().put("p2", Sets.newHashSet("bp2"));
+
+        context.clearVisibleVersionMapByMVPartitions(Sets.newHashSet("p1"));
+
+        Assertions.assertFalse(context.getMvPartitionNameRefBaseTablePartitionMap().containsKey("p1"));
+        Assertions.assertTrue(context.getMvPartitionNameRefBaseTablePartitionMap().containsKey("p2"));
+
+        Assertions.assertFalse(olapPartitionInfo.containsKey("p1"));
+        Assertions.assertFalse(olapPartitionInfo.containsKey("bp1"));
+        Assertions.assertTrue(olapPartitionInfo.containsKey("p2"));
+        Assertions.assertTrue(olapPartitionInfo.containsKey("bp2"));
+        Assertions.assertTrue(olapPartitionInfo.containsKey("keep"));
+
+        Assertions.assertFalse(externalPartitionInfo.containsKey("p1"));
+        Assertions.assertFalse(externalPartitionInfo.containsKey("bp1"));
+        Assertions.assertTrue(externalPartitionInfo.containsKey("p2"));
+        Assertions.assertTrue(externalPartitionInfo.containsKey("bp2"));
+        Assertions.assertTrue(externalPartitionInfo.containsKey("keep"));
+
+        Set<String> beforeNoOp = Sets.newHashSet(olapPartitionInfo.keySet());
+        context.clearVisibleVersionMapByMVPartitions(Sets.newHashSet());
+        Assertions.assertEquals(beforeNoOp, olapPartitionInfo.keySet());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
@@ -239,7 +239,7 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVTestBase {
                             .collect(Collectors.toList());
             Assertions.assertEquals(Arrays.asList("p000101_202308", "p202308_202309"), partitions);
             // mv partition p202308_202309 is force refreshed and visible version is increased
-            Assertions.assertEquals(partitionVersionMap.get("p202308_202309"),
+            Assertions.assertTrue(partitionVersionMap.get("p202308_202309") <
                     materializedView.getPartition("p202308_202309")
                             .getDefaultPhysicalPartition().getVisibleVersion());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -386,6 +386,8 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
 
     @Test
     public void testRangePartitionRefresh() throws Exception {
+        // Clean up tbl4 to ensure test isolation from previous tests
+        starRocksAssert.getCtx().executeSql("TRUNCATE TABLE tbl4");
         MaterializedView materializedView = refreshMaterializedView("mv2", "2022-01-03", "2022-02-05");
 
         String insertSql = "insert into tbl4 partition(p1) values('2022-01-02',2,10);";
@@ -400,7 +402,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                 .getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(1, materializedView.getPartition("p202203_202204")
                 .getDefaultPhysicalPartition().getVisibleVersion());
-        Assertions.assertEquals(2, materializedView.getPartition("p202204_202205")
+        Assertions.assertEquals(1, materializedView.getPartition("p202204_202205")
                 .getDefaultPhysicalPartition().getVisibleVersion());
 
         refreshMVRange(materializedView.getName(), "2021-12-03", "2022-04-05", false);
@@ -412,7 +414,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                 .getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(1, materializedView.getPartition("p202203_202204")
                 .getDefaultPhysicalPartition().getVisibleVersion());
-        Assertions.assertEquals(2, materializedView.getPartition("p202204_202205")
+        Assertions.assertEquals(1, materializedView.getPartition("p202204_202205")
                 .getDefaultPhysicalPartition().getVisibleVersion());
 
         insertSql = "insert into tbl4 partition(p3) values('2022-03-02',21,102);";
@@ -429,13 +431,13 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                 .getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(1, materializedView.getPartition("p202203_202204")
                 .getDefaultPhysicalPartition().getVisibleVersion());
-        Assertions.assertEquals(2, materializedView.getPartition("p202204_202205")
+        Assertions.assertEquals(1, materializedView.getPartition("p202204_202205")
                 .getDefaultPhysicalPartition().getVisibleVersion());
 
         refreshMVRange(materializedView.getName(), "2021-12-03", "2022-05-06", true);
-        Assertions.assertEquals(2, materializedView.getPartition("p202112_202201")
+        Assertions.assertEquals(3, materializedView.getPartition("p202112_202201")
                 .getDefaultPhysicalPartition().getVisibleVersion());
-        Assertions.assertEquals(2, materializedView.getPartition("p202201_202202")
+        Assertions.assertEquals(3, materializedView.getPartition("p202201_202202")
                 .getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(2, materializedView.getPartition("p202202_202203")
                 .getDefaultPhysicalPartition().getVisibleVersion());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -400,7 +400,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                 .getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(1, materializedView.getPartition("p202203_202204")
                 .getDefaultPhysicalPartition().getVisibleVersion());
-        Assertions.assertEquals(1, materializedView.getPartition("p202204_202205")
+        Assertions.assertEquals(2, materializedView.getPartition("p202204_202205")
                 .getDefaultPhysicalPartition().getVisibleVersion());
 
         refreshMVRange(materializedView.getName(), "2021-12-03", "2022-04-05", false);
@@ -412,7 +412,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                 .getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(1, materializedView.getPartition("p202203_202204")
                 .getDefaultPhysicalPartition().getVisibleVersion());
-        Assertions.assertEquals(1, materializedView.getPartition("p202204_202205")
+        Assertions.assertEquals(2, materializedView.getPartition("p202204_202205")
                 .getDefaultPhysicalPartition().getVisibleVersion());
 
         insertSql = "insert into tbl4 partition(p3) values('2022-03-02',21,102);";
@@ -429,13 +429,13 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                 .getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(1, materializedView.getPartition("p202203_202204")
                 .getDefaultPhysicalPartition().getVisibleVersion());
-        Assertions.assertEquals(1, materializedView.getPartition("p202204_202205")
+        Assertions.assertEquals(2, materializedView.getPartition("p202204_202205")
                 .getDefaultPhysicalPartition().getVisibleVersion());
 
         refreshMVRange(materializedView.getName(), "2021-12-03", "2022-05-06", true);
-        Assertions.assertEquals(3, materializedView.getPartition("p202112_202201")
+        Assertions.assertEquals(2, materializedView.getPartition("p202112_202201")
                 .getDefaultPhysicalPartition().getVisibleVersion());
-        Assertions.assertEquals(3, materializedView.getPartition("p202201_202202")
+        Assertions.assertEquals(2, materializedView.getPartition("p202201_202202")
                 .getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(2, materializedView.getPartition("p202202_202203")
                 .getDefaultPhysicalPartition().getVisibleVersion());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -400,7 +400,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                 .getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(1, materializedView.getPartition("p202203_202204")
                 .getDefaultPhysicalPartition().getVisibleVersion());
-        Assertions.assertEquals(2, materializedView.getPartition("p202204_202205")
+        Assertions.assertEquals(1, materializedView.getPartition("p202204_202205")
                 .getDefaultPhysicalPartition().getVisibleVersion());
 
         refreshMVRange(materializedView.getName(), "2021-12-03", "2022-04-05", false);
@@ -412,7 +412,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                 .getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(1, materializedView.getPartition("p202203_202204")
                 .getDefaultPhysicalPartition().getVisibleVersion());
-        Assertions.assertEquals(2, materializedView.getPartition("p202204_202205")
+        Assertions.assertEquals(1, materializedView.getPartition("p202204_202205")
                 .getDefaultPhysicalPartition().getVisibleVersion());
 
         insertSql = "insert into tbl4 partition(p3) values('2022-03-02',21,102);";
@@ -429,13 +429,13 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                 .getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(1, materializedView.getPartition("p202203_202204")
                 .getDefaultPhysicalPartition().getVisibleVersion());
-        Assertions.assertEquals(2, materializedView.getPartition("p202204_202205")
+        Assertions.assertEquals(1, materializedView.getPartition("p202204_202205")
                 .getDefaultPhysicalPartition().getVisibleVersion());
 
         refreshMVRange(materializedView.getName(), "2021-12-03", "2022-05-06", true);
-        Assertions.assertEquals(2, materializedView.getPartition("p202112_202201")
+        Assertions.assertEquals(3, materializedView.getPartition("p202112_202201")
                 .getDefaultPhysicalPartition().getVisibleVersion());
-        Assertions.assertEquals(2, materializedView.getPartition("p202201_202202")
+        Assertions.assertEquals(3, materializedView.getPartition("p202201_202202")
                 .getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(2, materializedView.getPartition("p202202_202203")
                 .getDefaultPhysicalPartition().getVisibleVersion());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -2985,6 +2985,79 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                 });
     }
 
+    @Test
+    public void testForceRefreshSpecificPartitionDoesNotRecreatePartition() throws Exception {
+        starRocksAssert.withTable(new MTable("tt_partial_force_refresh", "k2",
+                        List.of(
+                                "k1 date",
+                                "k2 int",
+                                "v1 int"
+                        ),
+                        "k1",
+                        List.of(
+                                "PARTITION p0 values [('2021-12-01'),('2022-01-01'))",
+                                "PARTITION p1 values [('2022-01-01'),('2022-02-01'))",
+                                "PARTITION p2 values [('2022-02-01'),('2022-03-01'))"
+                        )
+                ).withValues(List.of(
+                        "('2021-12-02',2,10)",
+                        "('2022-01-02',2,10)",
+                        "('2022-02-02',2,10)"
+                )),
+                () -> {
+                    starRocksAssert.withRefreshedMaterializedView("create materialized view test_mv_partial_force_refresh \n" +
+                            "partition by k1 \n" +
+                            "distributed by random \n" +
+                            "refresh deferred manual\n" +
+                            "properties('partition_refresh_strategy' = 'force')\n" +
+                            "as select * from tt_partial_force_refresh;");
+                    MaterializedView mv = getMv("test_mv_partial_force_refresh");
+
+                    long p0IdBefore = mv.getPartition("p0").getId();
+                    long p1IdBefore = mv.getPartition("p1").getId();
+                    long p2IdBefore = mv.getPartition("p2").getId();
+                    long p0VersionBefore = mv.getPartition("p0").getDefaultPhysicalPartition().getVisibleVersion();
+                    long p1VersionBefore = mv.getPartition("p1").getDefaultPhysicalPartition().getVisibleVersion();
+                    long p2VersionBefore = mv.getPartition("p2").getDefaultPhysicalPartition().getVisibleVersion();
+
+                    executeInsertSql(connectContext, "insert into tt_partial_force_refresh partition(p1) " +
+                            "values('2022-01-15',3,20);");
+
+                    starRocksAssert.refreshMV("REFRESH MATERIALIZED VIEW test_mv_partial_force_refresh " +
+                            "PARTITION START ('2022-01-01') END ('2022-02-01') FORCE");
+
+                    String mvTaskName = TaskBuilder.getMvTaskName(mv.getId());
+                    TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
+                    long taskId = tm.getTask(mvTaskName).getId();
+                    int waitCount = 0;
+                    while (waitCount++ < 120 && (tm.getTaskRunScheduler().getRunnableTaskRun(taskId) != null
+                            || tm.listMVRefreshedTaskRunStatus(DB_NAME, Set.of(mvTaskName)).isEmpty())) {
+                        Thread.sleep(1000);
+                    }
+
+                    Map<String, List<TaskRunStatus>> statusMap =
+                            tm.listMVRefreshedTaskRunStatus(DB_NAME, Set.of(mvTaskName));
+                    Assertions.assertNotNull(statusMap, "Status map should not be null");
+                    Assertions.assertFalse(statusMap.isEmpty() || statusMap.get(mvTaskName) == null
+                                    || statusMap.get(mvTaskName).isEmpty(),
+                            "Timed out waiting for MV refresh to produce a TaskRunStatus entry");
+                    TaskRunStatus status = statusMap.get(mvTaskName).get(0);
+                    Assertions.assertEquals(Constants.TaskRunState.SUCCESS, status.getState(),
+                            "Force refresh for a specific partition should succeed");
+
+                    Assertions.assertEquals(p0IdBefore, mv.getPartition("p0").getId());
+                    Assertions.assertEquals(p1IdBefore, mv.getPartition("p1").getId());
+                    Assertions.assertEquals(p2IdBefore, mv.getPartition("p2").getId());
+
+                    Assertions.assertEquals(p0VersionBefore,
+                            mv.getPartition("p0").getDefaultPhysicalPartition().getVisibleVersion());
+                    Assertions.assertTrue(
+                            mv.getPartition("p1").getDefaultPhysicalPartition().getVisibleVersion() > p1VersionBefore);
+                    Assertions.assertEquals(p2VersionBefore,
+                            mv.getPartition("p2").getDefaultPhysicalPartition().getVisibleVersion());
+                });
+    }
+
     /**
      * Test that force refresh for non-partitioned MV clears the visible version map directly.
      * Verifies the refresh succeeds without dropping partitions.


### PR DESCRIPTION
## Why I'm doing:

This is a follow up for https://github.com/StarRocks/starrocks/pull/69428.

Only clear the specific partitions from the visible map to avoid dropping partitions to implement `force refresh.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
