### PR TITLE
[BugFix] Avoid individual get_partition RPCs per cached partition on cache reload

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -155,9 +155,11 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
                     @GwtIncompatible
                     public ListenableFuture<Partition> reload(
                             @NotNull HivePartitionName key, @NotNull Partition oldValue) {
-                        if (isCachedExternalTable(key.getDatabaseTableName())) {
-                            return Futures.immediateFuture(loadPartition(key));
-                        }
+                        // Do not reload partitions individually on cache refresh.
+                        // Guava Cache's refreshAfterWrite calls reload() per key, which would
+                        // trigger one get_partition RPC per cached partition (e.g. 7000+ RPCs/min
+                        // for large tables), overwhelming HMS. Batch refresh is handled by
+                        // refreshTableBackground() via loadPartitionsByNames() instead.
                         return Futures.immediateFuture(oldValue);
                     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -514,6 +514,6 @@ public class CachingHiveMetastoreTest {
             Thread.sleep(1000);
         }
         Assertions.assertEquals(partition.getParameters().get(TASK), mangedTableMark);
-        Assertions.assertNotEquals(externalPartition.getParameters().get(TASK), externalTableMark);
+        Assertions.assertEquals(externalPartition.getParameters().get(TASK), externalTableMark);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Fixes #69490

After PR #54596 introduced HMS External Table auto-refresh, `partitionCache` was changed from `NEVER_REFRESH` to `refreshIntervalSec` (default: 60s). The `CacheLoader.reload()` was overridden to call `loadPartition(key)` for HMS external tables.

Guava Cache's `refreshAfterWrite` triggers `reload()` **independently for each cached key** — it does NOT invoke `loadAll()` as a batch. So for a table with 7,395 cached partitions, every 60 seconds StarRocks fires **7,395 individual `get_partition` RPCs** to HMS instead of one batched `getPartitionsByNames` call.

**Observed impact in production (StarRocks 4.0.4):**
- `server_request_log`: 7,395 partitions → **7,395 individual `get_partition` calls every 60s**
- `utm_data`: 3,065 partitions → **3,065 individual `get_partition` calls every 60s**
- HMS audit log: **8.57 million `get_partition` calls in a single day**, peaking at **35,000+ calls/minute**

## What I'm doing:

Make `reload()` return `oldValue` for all cases instead of calling `loadPartition(key)` per partition. Partition data is already correctly refreshed in batch via `refreshTableBackground()` → `loadPartitionsByNames()` → `getPartitionsByNames` (one RPC for all partitions).

**Root cause:**
```java
// reload() is called per-key by refreshAfterWrite, NOT batched
@Override
public ListenableFuture<Partition> reload(
        @NotNull HivePartitionName key, @NotNull Partition oldValue) {
    if (isCachedExternalTable(key.getDatabaseTableName())) {
        return Futures.immediateFuture(loadPartition(key)); // 1 RPC per partition!
    }
    return Futures.immediateFuture(oldValue);
}

// loadAll() does batch correctly, but refreshAfterWrite never calls it
@Override
public Map<HivePartitionName, Partition> loadAll(...) {
    return loadPartitionsByNames(partitionKeys); // batch, but unused by refresh
}
```

**Fix:**
```java
@Override
public ListenableFuture<Partition> reload(
        @NotNull HivePartitionName key, @NotNull Partition oldValue) {
    // Do not reload partitions individually. Batch refresh is handled by
    // refreshTableBackground() via loadPartitionsByNames() instead.
    return Futures.immediateFuture(oldValue);
}
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
