### PR TITLE
[BugFix] Catch all exceptions of the ParquetFileWriter::close

### DIFF
--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -119,7 +119,7 @@ protected:
     std::unique_ptr<parquet::ParquetOutputStream> _output_stream;
     RuntimeState* _runtime_state = nullptr;
     ObjectPool _pool;
-    std::atomic<int> _lazy_column_coalesce_counter;
+    std::atomic<int> _lazy_column_coalesce_counter = 0;
     std::shared_ptr<ParquetWriterOptions> _writer_options;
     TCompressionType::type _compression_type = TCompressionType::NO_COMPRESSION;
 };

--- a/test/sql/test_sink/R/test_file_sink_commit_failed
+++ b/test/sql/test_sink/R/test_file_sink_commit_failed
@@ -26,6 +26,21 @@ insert into files(
 admin disable failpoint 'parquet_writer_close_failed';
 -- result:
 -- !result
+admin enable failpoint 'parquet_writer_throw_exception';
+-- result:
+-- !result
+insert into files(
+    "path" = "s3://${oss_bucket}/test_sink/test_file_sink_commit_failed/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}") select * from t1;
+-- result:
+[REGEX].*close file error: Parquet writer throws exception by fail point.*
+-- !result
+admin disable failpoint 'parquet_writer_throw_exception';
+-- result:
+-- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_file_sink_commit_failed/${uuid0} >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0

--- a/test/sql/test_sink/T/test_file_sink_commit_failed
+++ b/test/sql/test_sink/T/test_file_sink_commit_failed
@@ -17,4 +17,15 @@ insert into files(
 
 admin disable failpoint 'parquet_writer_close_failed';
 
+admin enable failpoint 'parquet_writer_throw_exception';
+
+insert into files(
+    "path" = "s3://${oss_bucket}/test_sink/test_file_sink_commit_failed/${uuid0}/",
+    "format" = "parquet",
+    "aws.s3.endpoint" = "${oss_endpoint}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}") select * from t1;
+
+admin disable failpoint 'parquet_writer_throw_exception';
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_file_sink_commit_failed/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:

If `_writer->Close()` throws an exception other than `ParquetStatusException`, the stream will not be closed, which will cause the pipeline to block or crash.

```
*** SIGABRT (@0x74ee) received by PID 29934 (TID 0x2ad55605e700) from PID 29934; stack trace: ***
    @     0x2ad416033e20 __GI___pthread_once
    @          0x7d2b0c0 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x2ad4160365e0 (/usr/lib64/libpthread-2.17.so+0xf5df)
    @     0x2ad416ba01f7 __GI_raise
    @     0x2ad416ba18e8 __GI_abort
    @          0x330c327 __gnu_cxx::__verbose_terminate_handler() [clone .cold]
    @          0xc408c86 __cxxabiv1::__terminate(void (*)())
    @          0xc408cf1 std::terminate()
    @          0xc408e44 __cxa_throw
    @          0x36faf61 __wrap___cxa_throw
    @          0x8bf930e parquet::ThrowRowsMisMatchError(int, long, long)
    @          0x8bfa9e8 parquet::FileSerializer::Close()
    @          0x8bf7ad0 parquet::ParquetFileWriter::Close() [clone .localalias]
    @          0x7183400 starrocks::formats::ParquetFileWriter::commit()
    @          0x6f6e7df starrocks::connector::ConnectorChunkSink::finish()
    @          0x6fd6714 starrocks::pipeline::ConnectorSinkOperator::set_finishing(starrocks::RuntimeState*)
    @          0x44b4154 starrocks::pipeline::PipelineDriver::_mark_operator_finishing(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)
    @          0x44b43ac starrocks::pipeline::PipelineDriver::_mark_operator_finished(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)
    @          0x44b4b03 starrocks::pipeline::PipelineDriver::_mark_operator_cancelled(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*)
    @          0x44b5025 starrocks::pipeline::PipelineDriver::cancel_operators(starrocks::RuntimeState*)
    @          0x477b524 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x3966ca3 starrocks::ThreadPool::dispatch_thread()
    @          0x395e326 starrocks::Thread::supervise_thread(void*)
    @     0x2ad41602ee25 start_thread
    @     0x2ad416c6334d __clone
```

## What I'm doing:

Catch all exceptions of the ParquetFileWriter::close

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
