### PR TITLE
[Doc] Updated translation for the FE Config docs

### DIFF
--- a/docs/en/_assets/commonMarkdown/Edition_Specific_FE_Item.mdx
+++ b/docs/en/_assets/commonMarkdown/Edition_Specific_FE_Item.mdx
@@ -1,5 +1,5 @@
 
-##### enable_auth_check
+##### `enable_auth_check`
 
 - Default: true
 - Type: Boolean

--- a/docs/ja/_assets/commonMarkdown/Edition_Specific_FE_Item.mdx
+++ b/docs/ja/_assets/commonMarkdown/Edition_Specific_FE_Item.mdx
@@ -1,5 +1,5 @@
 
-##### enable_auth_check
+##### `enable_auth_check`
 
 - デフォルト: true
 - タイプ: Boolean

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -16,23 +16,23 @@ import EditionSpecificFEItem from '../../_assets/commonMarkdown/Edition_Specific
 
 ## FE 設定項目の表示
 
-FE の起動後、MySQL クライアントで ADMIN SHOW FRONTEND CONFIG コマンドを実行して、パラメーター設定を確認できます。特定のパラメーターの設定をクエリするには、次のコマンドを実行します。
+FEが起動した後、MySQLクライアントでADMIN SHOW FRONTEND CONFIGコマンドを実行して、パラメータ設定を確認できます。特定のパラメータの設定をクエリしたい場合は、以下のコマンドを実行します。
 
 ```SQL
 ADMIN SHOW FRONTEND CONFIG [LIKE "pattern"];
 ```
 
-返されるフィールドの詳細な説明については、[`ADMIN SHOW CONFIG`](../../sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SHOW_CONFIG.md) を参照してください。
+返されるフィールドの詳細については、[`ADMIN SHOW CONFIG`](../../sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SHOW_CONFIG.md)を参照してください。
 
 :::note
-クラスター管理関連コマンドを実行するには、管理者権限が必要です。
+クラスター管理関連のコマンドを実行するには、管理者権限が必要です。
 :::
 
-## FE パラメーターの設定
+## FE パラメータの設定
 
-### FE 動的パラメーターの設定
+### FE動的パラメータの設定
 
-[`ADMIN SET FRONTEND CONFIG`](../../sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SET_CONFIG.md) を使用して、FE 動的パラメーターの設定を構成または変更できます。
+FE動的パラメータの設定は、[`ADMIN SET FRONTEND CONFIG`](../../sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SET_CONFIG.md)を使用して構成または変更できます。
 
 ```SQL
 ADMIN SET FRONTEND CONFIG ("key" = "value");
@@ -40,13 +40,13 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 <AdminSetFrontendNote />
 
-### FE 静的パラメーターの設定
+### FE静的パラメータを設定する
 
 <StaticFEConfigNote />
 
-## FE パラメーターについて
+## FEパラメータを理解する
 
-### ロギング
+### ログ
 
 ##### `audit_log_delete_age`
 
@@ -54,7 +54,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: 監査ログファイルの保持期間。デフォルト値 `30d` は、各監査ログファイルが 30 日間保持できることを指定します。StarRocks は各監査ログファイルをチェックし、30 日以上前に生成されたファイルを削除します。
+- Description: 監査ログファイルの保持期間。デフォルト値 `30d` は、各監査ログファイルが30日間保持されることを指定します。StarRocks は各監査ログファイルをチェックし、30日前に生成されたファイルを削除します。
 - Introduced in: -
 
 ##### `audit_log_dir`
@@ -63,7 +63,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: 監査ログファイルを格納するディレクトリ。
+- Description: 監査ログファイルを保存するディレクトリ。
 - Introduced in: -
 
 ##### `audit_log_enable_compress`
@@ -72,7 +72,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: N/A
 - Is mutable: No
-- Description: true の場合、生成された Log4j2 設定は、ローテーションされた監査ログファイル名 (fe.audit.log.*) に ".gz" 接尾辞を追加し、Log4j2 がロールオーバー時に圧縮された (.gz) アーカイブ監査ログファイルを生成するようにします。この設定は、FE 起動時に Log4jConfig.initLogging で読み込まれ、監査ログの RollingFile アペンダーに適用されます。アクティブな監査ログではなく、ローテーション/アーカイブされたファイルにのみ影響します。値は起動時に初期化されるため、変更を有効にするには FE の再起動が必要です。監査ログのローテーション設定 (`audit_log_dir`、`audit_log_roll_interval`、`audit_roll_maxsize`、`audit_log_roll_num`) とともに使用します。
+- Description: true の場合、生成された Log4j2 設定は、ローテーションされた監査ログファイル名 (fe.audit.log.*) に ".gz" 接尾辞を追加し、Log4j2 がロールオーバー時に圧縮された (.gz) アーカイブ監査ログファイルを生成するようにします。この設定は、FE 起動時に Log4jConfig.initLogging で読み取られ、監査ログの RollingFile アペンダーに適用されます。これは、アクティブな監査ログではなく、ローテーション/アーカイブされたファイルのみに影響します。値は起動時に初期化されるため、変更を有効にするには FE の再起動が必要です。監査ログのローテーション設定 (`audit_log_dir`、`audit_log_roll_interval`、`audit_roll_maxsize`、`audit_log_roll_num`) と併用してください。
 - Introduced in: 3.2.12
 
 ##### `audit_log_json_format`
@@ -81,7 +81,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: N/A
 - Is mutable: Yes
-- Description: true の場合、FE 監査イベントは、デフォルトのパイプ区切り "key=value" 文字列ではなく、構造化された JSON (Jackson ObjectMapper が注釈付き AuditEvent フィールドの Map をシリアル化) として出力されます。この設定は、AuditLogBuilder が処理するすべての組み込み監査シンクに影響します。接続監査、クエリ監査、大容量クエリ監査 (イベントが条件を満たす場合、大容量クエリしきい値フィールドが JSON に追加されます)、および低速監査出力です。大容量クエリしきい値および "features" フィールドに注釈が付けられたフィールドは特別に扱われます (通常の監査エントリから除外され、該当する場合、大容量クエリまたは機能ログに含まれます)。これを有効にすると、ログコレクターまたは SIEM のログが機械で解析可能になります。ログ形式が変更されるため、従来のパイプ区切り形式を期待する既存のパーサーを更新する必要がある場合があります。
+- Description: true の場合、FE 監査イベントは、デフォルトのパイプ区切り "key=value" 文字列ではなく、構造化された JSON (Jackson ObjectMapper が注釈付き AuditEvent フィールドの Map をシリアル化) として出力されます。この設定は、AuditLogBuilder が処理するすべての組み込み監査シンクに影響します。接続監査、クエリ監査、ビッグクエリ監査 (イベントが条件を満たす場合、ビッグクエリしきい値フィールドが JSON に追加されます)、およびスロー監査出力です。ビッグクエリしきい値と "features" フィールドに注釈が付けられたフィールドは特別に扱われます (通常の監査エントリから除外され、該当する場合にビッグクエリまたは機能ログに含まれます)。ログコレクターまたは SIEMs がログを機械で解析できるようにするには、これを有効にしてください。ログ形式が変更され、従来のパイプ区切り形式を期待する既存のパーサーの更新が必要になる場合があることに注意してください。
 - Introduced in: 3.2.7
 
 ##### `audit_log_modules`
@@ -90,7 +90,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String[]
 - Unit: -
 - Is mutable: No
-- Description: StarRocks が監査ログエントリを生成するモジュール。デフォルトでは、StarRocks は `slow_query` モジュールと `query` モジュールの監査ログを生成します。`connection` モジュールは v3.0 以降でサポートされています。モジュール名をコンマ (,) とスペースで区切ります。
+- Description: StarRocks が監査ログエントリを生成するモジュール。デフォルトでは、StarRocks は `slow_query` モジュールと `query` モジュールに対して監査ログを生成します。`connection` モジュールは v3.0 からサポートされています。モジュール名をコンマ (,) とスペースで区切ってください。
 - Introduced in: -
 
 ##### `audit_log_roll_interval`
@@ -100,8 +100,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Unit: -
 - Is mutable: No
 - Description: StarRocks が監査ログエントリをローテーションする時間間隔。有効な値: `DAY` と `HOUR`。
-  - このパラメーターが `DAY` に設定されている場合、監査ログファイル名に `yyyyMMdd` 形式のサフィックスが追加されます。
-  - このパラメーターが `HOUR` に設定されている場合、監査ログファイル名に `yyyyMMddHH` 形式のサフィックスが追加されます。
+  - このパラメータが `DAY` に設定されている場合、監査ログファイル名に `yyyyMMdd` 形式のサフィックスが追加されます。
+  - このパラメータが `HOUR` に設定されている場合、監査ログファイル名に `yyyyMMddHH` 形式のサフィックスが追加されます。
 - Introduced in: -
 
 ##### `audit_log_roll_num`
@@ -110,7 +110,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: `audit_log_roll_interval` パラメーターで指定された各保持期間内に保持できる監査ログファイルの最大数。
+- Description: `audit_log_roll_interval` パラメータで指定された各保持期間内に保持できる監査ログファイルの最大数。
 - Introduced in: -
 
 ##### `bdbje_log_level`
@@ -119,7 +119,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: StarRocks で Berkeley DB Java Edition (BDB JE) が使用するロギングレベルを制御します。BDB 環境の初期化中に BDBEnvironment.initConfigs() は、この値を `com.sleepycat.je` パッケージの Java ロガーと BDB JE 環境ファイルロギングレベル (`EnvironmentConfig.FILE_LOGGING_LEVEL`) に適用します。SEVERE、WARNING、INFO、CONFIG、FINE、FINER、FINEST、ALL、OFF などの標準的な java.util.logging.Level 名を受け入れます。ALL に設定すると、すべてのログメッセージが有効になります。詳細度を上げると、ログのボリュームが増加し、ディスク I/O とパフォーマンスに影響を与える可能性があります。この値は BDB 環境が初期化されるときに読み込まれるため、環境の (再) 初期化後にのみ有効になります。
+- Description: StarRocks で Berkeley DB Java Edition (BDB JE) が使用するロギングレベルを制御します。BDB 環境の初期化中に BDBEnvironment.initConfigs() はこの値を `com.sleepycat.je` パッケージの Java ロガーと BDB JE 環境ファイルロギングレベル (`EnvironmentConfig.FILE_LOGGING_LEVEL`) に適用します。SEVERE、WARNING、INFO、CONFIG、FINE、FINER、FINEST、ALL、OFF などの標準的な java.util.logging.Level 名を受け入れます。ALL に設定すると、すべてのログメッセージが有効になります。詳細度を上げるとログ量が増加し、ディスク I/O とパフォーマンスに影響を与える可能性があります。この値は BDB 環境が初期化されるときに読み取られるため、環境の (再) 初期化後にのみ有効になります。
 - Introduced in: v3.2.0
 
 ##### `big_query_log_delete_age`
@@ -128,7 +128,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: FE の大容量クエリログファイル (`fe.big_query.log.*`) が自動削除されるまでの保持期間を制御します。この値は、Log4j の削除ポリシーに IfLastModified age として渡されます。最終更新時刻がこの値よりも古いローテーションされた大容量クエリログは削除されます。`d` (日)、`h` (時間)、`m` (分)、`s` (秒) などの接尾辞をサポートしています。例: `7d` (7 日間)、`10h` (10 時間)、`60m` (60 分)、`120s` (120 秒)。この項目は `big_query_log_roll_interval` および `big_query_log_roll_num` と連携して、どのファイルを保持またはパージするかを決定します。
+- Description: FE ビッグクエリログファイル (`fe.big_query.log.*`) が自動削除されるまでの保持期間を制御します。この値は Log4j の削除ポリシーに IfLastModified age として渡されます。最終変更時刻がこの値よりも古いローテーションされたビッグクエリログは削除されます。`d` (日)、`h` (時間)、`m` (分)、`s` (秒) のサフィックスをサポートします。例: `7d` (7日間)、`10h` (10時間)、`60m` (60分)、`120s` (120秒)。この項目は `big_query_log_roll_interval` および `big_query_log_roll_num` と連携して、どのファイルを保持またはパージするかを決定します。
 - Introduced in: v3.2.0
 
 ##### `big_query_log_dir`
@@ -137,7 +137,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: FE が大容量クエリダンプログ (`fe.big_query.log.*`) を書き込むディレクトリ。Log4j 設定はこのパスを使用して、`fe.big_query.log` とそのローテーションされたファイル用の RollingFile アペンダーを作成します。ローテーションと保持は、`big_query_log_roll_interval` (時刻ベースのサフィックス)、`log_roll_size_mb` (サイズトリガー)、`big_query_log_roll_num` (最大ファイル数)、および `big_query_log_delete_age` (年齢ベースの削除) によって管理されます。大容量クエリレコードは、`big_query_log_cpu_second_threshold`、`big_query_log_scan_rows_threshold`、または `big_query_log_scan_bytes_threshold` などのユーザー定義のしきい値を超えるクエリに対してログに記録されます。このファイルにログを記録するモジュールを制御するには、`big_query_log_modules` を使用します。
+- Description: FE がビッグクエリダンプログ (`fe.big_query.log.*`) を書き込むディレクトリ。Log4j 設定はこのパスを使用して `fe.big_query.log` とそのローテーションされたファイル用の RollingFile アペンダーを作成します。ローテーションと保持は、`big_query_log_roll_interval` (時間ベースのサフィックス)、`log_roll_size_mb` (サイズトリガー)、`big_query_log_roll_num` (最大ファイル数)、および `big_query_log_delete_age` (年齢ベースの削除) によって管理されます。ビッグクエリレコードは、`big_query_log_cpu_second_threshold`、`big_query_log_scan_rows_threshold`、または `big_query_log_scan_bytes_threshold` などのユーザー定義のしきい値を超えるクエリに対してログに記録されます。`big_query_log_modules` を使用して、どのモジュールがこのファイルにログを記録するかを制御します。
 - Introduced in: v3.2.0
 
 ##### `big_query_log_modules`
@@ -146,7 +146,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String[]
 - Unit: -
 - Is mutable: No
-- Description: モジュールごとの大容量クエリロギングを有効にするモジュール名サフィックスのリスト。一般的な値は論理コンポーネント名です。たとえば、デフォルトの `query` は `big_query.query` を生成します。
+- Description: モジュールごとのビッグクエリロギングを有効にするモジュール名サフィックスのリスト。一般的な値は論理コンポーネント名です。たとえば、デフォルトの `query` は `big_query.query` を生成します。
 - Introduced in: v3.2.0
 
 ##### `big_query_log_roll_interval`
@@ -155,7 +155,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: `big_query` ログアペンダーのローリングファイル名の日付コンポーネントを構築するために使用される時間間隔を指定します。有効な値 (大文字と小文字を区別しない) は `DAY` (デフォルト) と `HOUR` です。`DAY` は日次パターン (`"%d{yyyyMMdd}"`) を生成し、`HOUR` は時間別パターン (`"%d{yyyyMMddHH}"`) を生成します。この値は、サイズベースのロールオーバー (`big_query_roll_maxsize`) およびインデックスベースのロールオーバー (`big_query_log_roll_num`) と組み合わせて、RollingFile の filePattern を形成します。無効な値は、ログ設定の生成が失敗し (IOException)、ログの初期化または再構成を妨げる可能性があります。`big_query_log_dir`、`big_query_roll_maxsize`、`big_query_log_roll_num`、および `big_query_log_delete_age` とともに使用します。
+- Description: `big_query` ログアペンダーのローリングファイル名の日付コンポーネントを構築するために使用される時間間隔を指定します。有効な値 (大文字と小文字を区別しない) は `DAY` (デフォルト) と `HOUR` です。`DAY` は日次パターン (`"%d{yyyyMMdd}"`) を生成し、`HOUR` は時間パターン (`"%d{yyyyMMddHH}"`) を生成します。この値は、サイズベースのロールオーバー (`big_query_roll_maxsize`) およびインデックスベースのロールオーバー (`big_query_log_roll_num`) と組み合わされて RollingFile の filePattern を形成します。無効な値はログ設定の生成を失敗させ (IOException)、ログの初期化または再設定を妨げる可能性があります。`big_query_log_dir`、`big_query_roll_maxsize`、`big_query_log_roll_num`、および `big_query_log_delete_age` と併用してください。
 - Introduced in: v3.2.0
 
 ##### `big_query_log_roll_num`
@@ -164,7 +164,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: `big_query_log_roll_interval` ごとに保持するローテーションされた FE 大容量クエリログファイルの最大数。この値は、`fe.big_query.log` の RollingFile アペンダーの DefaultRolloverStrategy `max` 属性にバインドされます。ログが (時間または `log_roll_size_mb` によって) ロールオーバーすると、StarRocks は `big_query_log_roll_num` 個のインデックス付きファイル (filePattern は時刻サフィックスとインデックスを使用) を保持します。この数よりも古いファイルはロールオーバーによって削除される可能性があり、`big_query_log_delete_age` は最終更新時刻によってさらにファイルを削除できます。
+- Description: `big_query_log_roll_interval` ごとに保持するローテーションされた FE ビッグクエリログファイルの最大数。この値は、`fe.big_query.log` の RollingFile アペンダーの DefaultRolloverStrategy `max` 属性にバインドされます。ログがロール (時間または `log_roll_size_mb` によって) されると、StarRocks は最大 `big_query_log_roll_num` 個のインデックス付きファイル (filePattern は時間サフィックスとインデックスを使用) を保持します。この数よりも古いファイルはロールオーバーによって削除される可能性があり、`big_query_log_delete_age` は最終変更時刻によってファイルをさらに削除できます。
 - Introduced in: v3.2.0
 
 ##### `dump_log_delete_age`
@@ -173,7 +173,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: ダンプログファイルの保持期間。デフォルト値 `7d` は、各ダンプログファイルが 7 日間保持できることを指定します。StarRocks は各ダンプログファイルをチェックし、7 日以上前に生成されたファイルを削除します。
+- Description: ダンプログファイルの保持期間。デフォルト値 `7d` は、各ダンプログファイルが7日間保持されることを指定します。StarRocks は各ダンプログファイルをチェックし、7日前に生成されたファイルを削除します。
 - Introduced in: -
 
 ##### `dump_log_dir`
@@ -182,7 +182,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: ダンプログファイルを格納するディレクトリ。
+- Description: ダンプログファイルを保存するディレクトリ。
 - Introduced in: -
 
 ##### `dump_log_modules`
@@ -191,7 +191,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String[]
 - Unit: -
 - Is mutable: No
-- Description: StarRocks がダンプログエントリを生成するモジュール。デフォルトでは、StarRocks はクエリモジュールのダンプログを生成します。モジュール名をコンマ (,) とスペースで区切ります。
+- Description: StarRocks がダンプログエントリを生成するモジュール。デフォルトでは、StarRocks はクエリモジュールに対してダンプログを生成します。モジュール名をコンマ (,) とスペースで区切ってください。
 - Introduced in: -
 
 ##### `dump_log_roll_interval`
@@ -201,8 +201,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Unit: -
 - Is mutable: No
 - Description: StarRocks がダンプログエントリをローテーションする時間間隔。有効な値: `DAY` と `HOUR`。
-  - このパラメーターが `DAY` に設定されている場合、ダンプログファイル名に `yyyyMMdd` 形式のサフィックスが追加されます。
-  - このパラメーターが `HOUR` に設定されている場合、ダンプログファイル名に `yyyyMMddHH` 形式のサフィックスが追加されます。
+  - このパラメータが `DAY` に設定されている場合、ダンプログファイル名に `yyyyMMdd` 形式のサフィックスが追加されます。
+  - このパラメータが `HOUR` に設定されている場合、ダンプログファイル名に `yyyyMMddHH` 形式のサフィックスが追加されます。
 - Introduced in: -
 
 ##### `dump_log_roll_num`
@@ -211,7 +211,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: `dump_log_roll_interval` パラメーターで指定された各保持期間内に保持できるダンプログファイルの最大数。
+- Description: `dump_log_roll_interval` パラメータで指定された各保持期間内に保持できるダンプログファイルの最大数。
 - Introduced in: -
 
 ##### `edit_log_write_slow_log_threshold_ms`
@@ -220,7 +220,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Milliseconds
 - Is mutable: Yes
-- Description: JournalWriter が低速な編集ログバッチ書き込みを検出してログに記録するために使用するしきい値 (ミリ秒)。バッチコミット後、バッチ期間がこの値を超えると、JournalWriter はバッチサイズ、期間、現在のジャーナルキューサイズを伴う WARN を出力します (約 2 秒に 1 回にレート制限)。この設定は、FE リーダーでの潜在的な I/O またはレプリケーションの遅延に対するロギング/アラートのみを制御します。コミットまたはロールの動作は変更しません (`edit_log_roll_num` およびコミット関連の設定を参照)。このしきい値に関係なく、メトリック更新は引き続き発生します。
+- Description: JournalWriter が遅い編集ログバッチ書き込みを検出してログに記録するために使用するしきい値 (ミリ秒単位)。バッチコミット後、バッチ期間がこの値を超えると、JournalWriter はバッチサイズ、期間、および現在のジャーナルキューサイズを含む WARN を出力します (約2秒に1回にレート制限されます)。この設定は、FE リーダーでの潜在的な IO またはレプリケーションの遅延に関するロギング/アラートのみを制御します。コミットまたはロールの動作は変更しません (`edit_log_roll_num` およびコミット関連の設定を参照)。このしきい値に関係なく、メトリックの更新は引き続き行われます。
 - Introduced in: v3.2.3
 
 ##### `enable_audit_sql`
@@ -229,7 +229,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: No
-- Description: この項目が `true` に設定されている場合、FE 監査サブシステムは、ConnectProcessor によって処理されたステートメントの SQL テキストを FE 監査ログ (`fe.audit.log`) に記録します。格納されたステートメントは、他の制御に従います。暗号化されたステートメントは編集され (`AuditEncryptionChecker`)、`enable_sql_desensitize_in_log` が設定されている場合、機密性の高い資格情報は編集または非機密化される可能性があり、ダイジェストレコーディングは `enable_sql_digest` によって制御されます。`false` に設定されている場合、ConnectProcessor は監査イベントのステートメントテキストを "?" に置き換えます。他の監査フィールド (ユーザー、ホスト、期間、ステータス、`qe_slow_log_ms` を介した低速クエリ検出、およびメトリック) は引き続き記録されます。SQL 監査を有効にすると、フォレンジックとトラブルシューティングの可視性が向上しますが、機密性の高い SQL コンテンツが公開され、ログのボリュームと I/O が増加する可能性があります。無効にすると、監査ログでの完全なステートメントの可視性を失う代わりにプライバシーが向上します。
+- Description: この項目が `true` に設定されている場合、FE 監査サブシステムは、ConnectProcessor によって処理される FE 監査ログ (`fe.audit.log`) にステートメントの SQL テキストを記録します。保存されるステートメントは他の制御を尊重します。暗号化されたステートメントは編集され (`AuditEncryptionChecker`)、`enable_sql_desensitize_in_log` が設定されている場合、機密性の高い資格情報は編集または非機密化され、ダイジェスト記録は `enable_sql_digest` によって制御されます。`false` に設定されている場合、ConnectProcessor は監査イベントのステートメントテキストを "?" に置き換えます。他の監査フィールド (ユーザー、ホスト、期間、ステータス、`qe_slow_log_ms` を介したスロークエリ検出、およびメトリック) は引き続き記録されます。SQL 監査を有効にすると、フォレンジックおよびトラブルシューティングの可視性が向上しますが、機密性の高い SQL コンテンツが公開され、ログ量と I/O が増加する可能性があります。無効にすると、監査ログでの完全なステートメントの可視性が失われる代わりにプライバシーが向上します。
 - Introduced in: -
 
 ##### `enable_profile_log`
@@ -238,7 +238,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: No
-- Description: プロファイルロギングを有効にするかどうか。この機能が有効になっている場合、FE はクエリごとのプロファイルログ (ProfileManager によって生成されたシリアル化された `queryDetail` JSON) をプロファイルログシンクに書き込みます。このロギングは `enable_collect_query_detail_info` も有効になっている場合にのみ実行されます。`enable_profile_log_compress` が有効になっている場合、JSON はロギング前に gzipped されることがあります。プロファイルログファイルは `profile_log_dir`、`profile_log_roll_num`、`profile_log_roll_interval` によって管理され、`profile_log_delete_age` ( `7d`、`10h`、`60m`、`120s` などの形式をサポート) に従ってローテーション/削除されます。この機能を無効にすると、プロファイルログの書き込みが停止します (ディスク I/O、圧縮 CPU、ストレージ使用量の削減)。
+- Description: プロファイルロギングを有効にするかどうか。この機能が有効になっている場合、FE はクエリごとのプロファイルログ (ProfileManager によって生成されるシリアル化された `queryDetail` JSON) をプロファイルログシンクに書き込みます。このロギングは、`enable_collect_query_detail_info` も有効になっている場合にのみ実行されます。`enable_profile_log_compress` が有効になっている場合、JSON はロギング前に gzip 圧縮される場合があります。プロファイルログファイルは、`profile_log_dir`、`profile_log_roll_num`、`profile_log_roll_interval` によって管理され、`profile_log_delete_age` ( `7d`、`10h`、`60m`、`120s` などの形式をサポート) に従ってローテーション/削除されます。この機能を無効にすると、プロファイルログの書き込みが停止します (ディスク I/O、圧縮 CPU、ストレージ使用量が削減されます)。
 - Introduced in: v3.2.5
 
 ##### `enable_qe_slow_log`
@@ -247,7 +247,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: N/A
 - Is mutable: Yes
-- Description: 有効にすると、FE 組み込み監査プラグイン (AuditLogBuilder) は、測定された実行時間 ("Time" フィールド) が `qe_slow_log_ms` で設定されたしきい値を超えるクエリイベントを低速クエリ監査ログ (AuditLog.getSlowAudit) に書き込みます。無効にすると、これらの低速クエリエントリは抑制されます (通常のクエリおよび接続監査ログは影響を受けません)。低速監査エントリは、グローバルな `audit_log_json_format` 設定 (JSON とプレーン文字列) に従います。このフラグを使用して、通常の監査ロギングとは独立して低速クエリ監査ボリュームの生成を制御します。無効にすると、`qe_slow_log_ms` が低い場合やワークロードが多くの長時間実行クエリを生成する場合にログ I/O を削減できます。
+- Description: 有効にすると、FE 組み込み監査プラグイン (AuditLogBuilder) は、測定された実行時間 ("Time" フィールド) が `qe_slow_log_ms` で設定されたしきい値を超えるクエリイベントをスロークエリ監査ログ (AuditLog.getSlowAudit) に書き込みます。無効にすると、これらのスロークエリエントリは抑制されます (通常のクエリおよび接続監査ログは影響を受けません)。スロー監査エントリは、グローバルな `audit_log_json_format` 設定 (JSON vs. プレーン文字列) に従います。このフラグを使用して、通常の監査ロギングとは独立してスロークエリ監査量を制御します。`qe_slow_log_ms` が低い場合や、ワークロードが多くの長時間実行クエリを生成する場合に、これをオフにするとログ I/O を削減できます。
 - Introduced in: 3.2.11
 
 ##### `enable_sql_desensitize_in_log`
@@ -256,7 +256,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: No
-- Description: この項目が `true` に設定されている場合、システムはログとクエリ詳細レコードに書き込まれる前に機密性の高い SQL コンテンツを置き換えるか隠します。この設定を尊重するコードパスには、ConnectProcessor.formatStmt (監査ログ)、StmtExecutor.addRunningQueryDetail (クエリ詳細)、および SimpleExecutor.formatSQL (内部エクゼキュータログ) が含まれます。この機能が有効になっている場合、無効な SQL は固定の非機密化メッセージに置き換えられる可能性があり、資格情報 (ユーザー/パスワード) は隠され、SQL フォーマッターはサニタイズされた表現を生成する必要があります (ダイジェスト形式の出力を有効にすることもできます)。これにより、監査/内部ログでの機密リテラルや資格情報の漏洩が減少しますが、ログとクエリ詳細に元の完全な SQL テキストが含まれなくなることになります (これは再生やデバッグに影響する可能性があります)。
+- Description: この項目が `true` に設定されている場合、システムは機密性の高い SQL コンテンツをログおよびクエリ詳細レコードに書き込む前に置き換えたり非表示にしたりします。この設定を尊重するコードパスには、ConnectProcessor.formatStmt (監査ログ)、StmtExecutor.addRunningQueryDetail (クエリ詳細)、および SimpleExecutor.formatSQL (内部エグゼキュータログ) が含まれます。この機能が有効になっている場合、無効な SQL は固定の非機密化メッセージに置き換えられる可能性があり、資格情報 (ユーザー/パスワード) は非表示になり、SQL フォーマッターはサニタイズされた表現を生成する必要があります (ダイジェスト形式の出力を有効にすることもできます)。これにより、監査/内部ログでの機密リテラルや資格情報の漏洩が減少しますが、ログやクエリ詳細に元の完全な SQL テキストが含まれなくなることも意味します (これはリプレイやデバッグに影響を与える可能性があります)。
 - Introduced in: -
 
 ##### `internal_log_delete_age`
@@ -265,7 +265,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: FE 内部ログファイル (`internal_log_dir` に書き込まれます) の保持期間を指定します。値は期間文字列です。サポートされている接尾辞: `d` (日)、`h` (時間)、`m` (分)、`s` (秒)。例: `7d` (7 日間)、`10h` (10 時間)、`60m` (60 分)、`120s` (120 秒)。この項目は、RollingFile Delete ポリシーで使用される `<IfLastModified age="..."/>` 述語として log4j 設定に代入されます。最終変更時刻がこの期間よりも古いファイルは、ログのロールオーバー中に削除されます。この値を増やすとディスク領域をより早く解放できます。減らすと内部マテリアライズドビューまたは統計ログをより長く保持できます。
+- Description: FE 内部ログファイル (`internal_log_dir` に書き込まれる) の保持期間を指定します。値は期間文字列です。サポートされるサフィックス: `d` (日)、`h` (時間)、`m` (分)、`s` (秒)。例: `7d` (7日間)、`10h` (10時間)、`60m` (60分)、`120s` (120秒)。この項目は、Log4j 設定に RollingFile Delete ポリシーで使用される `<IfLastModified age="..."/>` 述語として代入されます。最終変更時刻がこの期間よりも古いファイルは、ログロールオーバー中に削除されます。この値を増やすとディスクスペースが早く解放され、減らすと内部マテリアライズドビューまたは統計ログをより長く保持できます。
 - Introduced in: v3.2.4
 
 ##### `internal_log_dir`
@@ -274,7 +274,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: FE ロギングサブシステムが内部ログ (`fe.internal.log`) を保存するために使用するディレクトリ。この設定は Log4j 設定に代入され、InternalFile アペンダーが内部/マテリアライズドビュー/統計ログを書き込む場所、および `internal.<module>` の下にあるモジュールごとのロガーがファイルを配置する場所を決定します。ディレクトリが存在し、書き込み可能であり、十分なディスク容量があることを確認してください。このディレクトリ内のファイルのログローテーションと保持は、`log_roll_size_mb`、`internal_log_roll_num`、`internal_log_delete_age`、および `internal_log_roll_interval` によって制御されます。`sys_log_to_console` が有効になっている場合、内部ログはこのディレクトリではなくコンソールに書き込まれることがあります。
+- Description: FE ロギングサブシステムが内部ログ (`fe.internal.log`) を保存するために使用するディレクトリ。この設定は Log4j 設定に代入され、InternalFile アペンダーが内部/マテリアライズドビュー/統計ログを書き込む場所、および `internal.<module>` の下のモジュールごとのロガーがファイルを配置する場所を決定します。ディレクトリが存在し、書き込み可能であり、十分なディスクスペースがあることを確認してください。このディレクトリ内のファイルのログローテーションと保持は、`log_roll_size_mb`、`internal_log_roll_num`、`internal_log_delete_age`、および `internal_log_roll_interval` によって制御されます。`sys_log_to_console` が有効になっている場合、内部ログはこのディレクトリではなくコンソールに書き込まれる場合があります。
 - Introduced in: v3.2.4
 
 ##### `internal_log_json_format`
@@ -283,7 +283,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: この項目が `true` に設定されている場合、内部統計/監査エントリはコンパクトな JSON オブジェクトとして統計監査ロガーに書き込まれます。JSON には、"executeType" (InternalType: QUERY または DML)、"queryId"、"sql"、および "time" (経過ミリ秒) のキーが含まれます。`false` に設定されている場合、同じ情報は単一のフォーマットされたテキスト行 ("statistic execute: ... | QueryId: [...] | SQL: ...") としてログに記録されます。JSON を有効にすると、機械解析とログプロセッサとの統合が向上しますが、生の SQL テキストがログに含まれるため、機密情報が公開され、ログサイズが増加する可能性があります。
+- Description: この項目が `true` に設定されている場合、内部統計/監査エントリはコンパクトな JSON オブジェクトとして統計監査ロガーに書き込まれます。JSON には、キー "executeType" (InternalType: QUERY または DML)、"queryId"、"sql"、および "time" (経過ミリ秒) が含まれます。`false` に設定されている場合、同じ情報は単一のフォーマットされたテキスト行 ("statistic execute: ... | QueryId: [...] | SQL: ...") としてログに記録されます。JSON を有効にすると、機械解析とログプロセッサとの統合が向上しますが、生の SQL テキストがログに含まれるため、機密情報が公開され、ログサイズが増加する可能性があります。
 - Introduced in: -
 
 ##### `internal_log_modules`
@@ -292,7 +292,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String[]
 - Unit: -
 - Is mutable: No
-- Description: 専用の内部ロギングを受け取るモジュール識別子のリスト。各エントリ X について、Log4j はレベル INFO と additivity="false" の `internal.<X>` という名前のロガーを作成します。これらのロガーは、内部アペンダー ( `fe.internal.log` に書き込まれます) または `sys_log_to_console` が有効になっている場合はコンソールにルーティングされます。必要に応じて短い名前またはパッケージフラグメントを使用します。正確なロガー名は `internal.` + 構成された文字列になります。内部ログファイルのローテーションと保持は、`internal_log_dir`、`internal_log_roll_num`、`internal_log_delete_age`、`internal_log_roll_interval`、および `log_roll_size_mb` に従います。モジュールを追加すると、実行時メッセージが内部ロガーストリームに分離され、デバッグと監査が容易になります。
+- Description: 専用の内部ロギングを受け取るモジュール識別子のリスト。各エントリ X について、Log4j はレベル INFO および additivity="false" の `internal.<X>` という名前のロガーを作成します。これらのロガーは、内部アペンダー (`fe.internal.log` に書き込まれる) または `sys_log_to_console` が有効になっている場合はコンソールにルーティングされます。必要に応じて短い名前またはパッケージフラグメントを使用してください。正確なロガー名は `internal.` + 設定された文字列になります。内部ログファイルのローテーションと保持は、`internal_log_dir`、`internal_log_roll_num`、`internal_log_delete_age`、`internal_log_roll_interval`、および `log_roll_size_mb` に従います。モジュールを追加すると、そのランタイムメッセージが内部ロガーストリームに分離され、デバッグと監査が容易になります。
 - Introduced in: v3.2.4
 
 ##### `internal_log_roll_interval`
@@ -301,7 +301,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: FE 内部ログアペンダーの時刻ベースのロール間隔を制御します。受け入れられる値 (大文字と小文字を区別しない) は `HOUR` と `DAY` です。`HOUR` は時間別ファイルパターン (`"%d{yyyyMMddHH}"`) を生成し、`DAY` は日別ファイルパターン (`"%d{yyyyMMdd}"`) を生成します。これらは RollingFile TimeBasedTriggeringPolicy によってローテーションされた `fe.internal.log` ファイルに名前を付けるために使用されます。無効な値は、初期化の失敗 (アクティブな Log4j 設定の構築時に IOException がスローされます) を引き起こします。ロール動作は、`internal_log_dir`、`internal_roll_maxsize` (ソースにタイプミス、おそらく `log_roll_size_mb`)、`internal_log_roll_num`、および `internal_log_delete_age` などの関連設定にも依存します。
+- Description: FE 内部ログアペンダーの時間ベースのロール間隔を制御します。受け入れられる値 (大文字と小文字を区別しない) は `HOUR` と `DAY` です。`HOUR` は時間ごとのファイルパターン (`"%d{yyyyMMddHH}"`) を生成し、`DAY` は日ごとのファイルパターン (`"%d{yyyyMMdd}"`) を生成します。これらは RollingFile TimeBasedTriggeringPolicy によってローテーションされた `fe.internal.log` ファイルの名前付けに使用されます。無効な値は初期化を失敗させます (アクティブな Log4j 設定を構築するときに IOException がスローされます)。ロール動作は、`internal_log_dir`、`internal_roll_maxsize`、`internal_log_roll_num`、および `internal_log_delete_age` などの関連設定にも依存します。
 - Introduced in: v3.2.4
 
 ##### `internal_log_roll_num`
@@ -310,7 +310,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: 内部アペンダー (`fe.internal.log`) に対して保持するローテーションされた内部 FE ログファイルの最大数。この値は Log4j DefaultRolloverStrategy の `max` 属性として使用されます。ロールオーバーが発生すると、StarRocks は最大で `internal_log_roll_num` 個のアーカイブファイルを保持し、古いファイルを削除します (`internal_log_delete_age` によって管理されます)。値を小さくするとディスク使用量が減りますが、ログ履歴が短くなります。値を大きくすると、より多くの履歴内部ログが保持されます。この項目は、`internal_log_dir`、`internal_log_roll_interval`、および `internal_roll_maxsize` (ソースにタイプミス、おそらく `log_roll_size_mb`) と連携して機能します。
+- Description: 内部アペンダー (`fe.internal.log`) のために保持するローテーションされた内部 FE ログファイルの最大数。この値は Log4j DefaultRolloverStrategy の `max` 属性として使用されます。ロールオーバーが発生すると、StarRocks は最大 `internal_log_roll_num` 個のアーカイブファイルを保持し、古いファイルを削除します (`internal_log_delete_age` によっても管理されます)。値が低いとディスク使用量が削減されますが、ログ履歴が短くなります。値が高いと、より多くの履歴内部ログが保持されます。この項目は `internal_log_dir`、`internal_log_roll_interval`、および `internal_roll_maxsize` と連携して機能します。
 - Introduced in: v3.2.4
 
 ##### `log_cleaner_audit_log_min_retention_days`
@@ -319,7 +319,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Days
 - Is mutable: Yes
-- Description: 監査ログファイルの最小保持日数。これよりも新しい監査ログファイルは、ディスク使用量が高くても削除されません。これにより、監査ログがコンプライアンスとトラブルシューティングの目的で保持されます。
+- Description: 監査ログファイルの最小保持日数。これより新しい監査ログファイルは、ディスク使用量が高くても削除されません。これにより、監査ログがコンプライアンスおよびトラブルシューティングの目的で保持されることが保証されます。
 - Introduced in: -
 
 ##### `log_cleaner_check_interval_second`
@@ -328,7 +328,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
-- Description: ディスク使用量をチェックし、ログをクリーンアップする間隔 (秒単位)。クリーナーは、各ログディレクトリのディスク使用量を定期的にチェックし、必要に応じてクリーンアップをトリガーします。デフォルトは 300 秒 (5 分) です。
+- Description: ディスク使用量をチェックし、ログをクリーンアップする間隔 (秒単位)。クリーナーは定期的に各ログディレクトリのディスク使用量をチェックし、必要に応じてクリーンアップをトリガーします。デフォルトは300秒 (5分) です。
 - Introduced in: -
 
 ##### `log_cleaner_disk_usage_target`
@@ -337,7 +337,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Percentage
 - Is mutable: Yes
-- Description: ログクリーンアップ後の目標ディスク使用量 (パーセンテージ)。ディスク使用量がこのしきい値を下回るまでログクリーンアップが続行されます。クリーナーは、目標に達するまで最も古いログファイルを 1 つずつ削除します。
+- Description: ログクリーンアップ後の目標ディスク使用量 (パーセンテージ)。ログクリーンアップは、ディスク使用量がこのしきい値を下回るまで続行されます。クリーナーは、目標に達するまで最も古いログファイルを1つずつ削除します。
 - Introduced in: -
 
 ##### `log_cleaner_disk_usage_threshold`
@@ -346,7 +346,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Percentage
 - Is mutable: Yes
-- Description: ログクリーンアップをトリガーするディスク使用量しきい値 (パーセンテージ)。ディスク使用量がこのしきい値を超えると、ログクリーンアップが開始されます。クリーナーは、設定された各ログディレクトリを独立してチェックし、このしきい値を超えるディレクトリを処理します。
+- Description: ログクリーンアップをトリガーするディスク使用量しきい値 (パーセンテージ)。ディスク使用量がこのしきい値を超えると、ログクリーンアップが開始されます。クリーナーは、設定された各ログディレクトリを個別にチェックし、このしきい値を超えるディレクトリを処理します。
 - Introduced in: -
 
 ##### `log_cleaner_disk_util_based_enable`
@@ -355,7 +355,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: ディスク使用量に基づく自動ログクリーンアップを有効にします。有効にすると、ディスク使用量がしきい値を超えたときにログがクリーンアップされます。ログクリーナーは FE ノードのバックグラウンドデーモンとして実行され、ログファイルの蓄積によるディスク領域の枯渇を防ぐのに役立ちます。
+- Description: ディスク使用量に基づく自動ログクリーンアップを有効にします。有効にすると、ディスク使用量がしきい値を超えたときにログがクリーンアップされます。ログクリーナーは FE ノードでバックグラウンドデーモンとして実行され、ログファイルの蓄積によるディスクスペースの枯渇を防ぐのに役立ちます。
 - Introduced in: -
 
 ##### `log_plan_cancelled_by_crash_be`
@@ -364,7 +364,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: boolean
 - Unit: -
 - Is mutable: Yes
-- Description: BE クラッシュまたは RPC 例外によりクエリがキャンセルされた場合に、クエリ実行計画のロギングを有効にするかどうか。この機能が有効になっている場合、BE クラッシュまたは `RpcException` によりクエリがキャンセルされたときに、StarRocks はクエリ実行計画 ( `TExplainLevel.COSTS` レベル) を WARN エントリとしてログに記録します。ログエントリには QueryId、SQL、および COSTS 計画が含まれ、ExecuteExceptionHandler パスでは例外スタックトレースもログに記録されます。ロギングは `enable_collect_query_detail_info` が有効になっている場合はスキップされます (その場合、計画はクエリ詳細に格納されます)。コードパスでは、クエリ詳細が null であることを検証することでチェックが実行されます。ExecuteExceptionHandler では、計画は最初のリトライ (`retryTime == 0`) のみでログに記録されることに注意してください。これを有効にすると、完全な COSTS 計画が大きくなる可能性があるため、ログのボリュームが増加する可能性があります。
+- Description: BE クラッシュまたは RPC 例外によりクエリがキャンセルされたときに、クエリ実行計画のロギングを有効にするかどうか。この機能が有効になっている場合、StarRocks は、BE クラッシュまたは `RpcException` によりクエリがキャンセルされたときに、クエリ実行計画 (`TExplainLevel.COSTS` レベル) を WARN エントリとしてログに記録します。ログエントリには QueryId、SQL、および COSTS プランが含まれます。ExecuteExceptionHandler パスでは、例外スタックトレースもログに記録されます。`enable_collect_query_detail_info` が有効になっている場合 (プランはクエリ詳細に保存される)、ロギングはスキップされます。コードパスでは、クエリ詳細が null であることを確認することでチェックが実行されます。ExecuteExceptionHandler では、プランは最初の再試行 (`retryTime == 0`) でのみログに記録されることに注意してください。これを有効にすると、完全な COSTS プランが大きくなる可能性があるため、ログ量が増加する可能性があります。
 - Introduced in: v3.2.0
 
 ##### `log_register_and_unregister_query_id`
@@ -373,7 +373,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: FE が QeProcessorImpl からのクエリ登録および登録解除メッセージ (例: `"register query id = {}"` および `"deregister query id = {}"`) をログに記録することを許可するかどうか。ログは、クエリに null 以外の ConnectContext があり、コマンドが `COM_STMT_EXECUTE` でないか、セッション変数 `isAuditExecuteStmt()` が true の場合にのみ出力されます。これらのメッセージはすべてのクエリライフサイクルイベントに対して書き込まれるため、この機能を有効にすると、ログのボリュームが大きくなり、高並行環境ではスループットのボトルネックになる可能性があります。デバッグまたは監査のために有効にし、ロギングのオーバーヘッドを減らしてパフォーマンスを向上させるために無効にします。
+- Description: FE が QeProcessorImpl からクエリ登録および登録解除メッセージ (例: `"register query id = {}"` および `"deregister query id = {}"`) をログに記録することを許可するかどうか。ログは、クエリが null ではない ConnectContext を持ち、コマンドが `COM_STMT_EXECUTE` ではないか、セッション変数 `isAuditExecuteStmt()` が true の場合にのみ出力されます。これらのメッセージはすべてのクエリライフサイクルイベントに対して書き込まれるため、この機能を有効にすると、高並行環境で高いログ量が発生し、スループットのボトルネックになる可能性があります。デバッグまたは監査のために有効にし、ロギングオーバーヘッドを削減し、パフォーマンスを向上させるために無効にしてください。
 - Introduced in: v3.3.0, v3.4.0, v3.5.0
 
 ##### `log_roll_size_mb`
@@ -391,7 +391,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Days
 - Is mutable: Yes
-- Description: `sys_log_dir/proc_profile` 以下に生成されたプロセスプロファイリングファイル (CPU およびメモリ) の保持日数。ProcProfileCollector は、現在時刻から `proc_profile_file_retained_days` 日を差し引いて (yyyyMMdd-HHmmss 形式で) カットオフを計算し、タイムスタンプ部分がそのカットオフよりも辞書順で早いプロファイルファイル (`timePart.compareTo(timeToDelete) < 0` の場合) を削除します。ファイル削除は、`proc_profile_file_retained_size_bytes` によって制御されるサイズベースのカットオフも尊重します。プロファイルファイルは `cpu-profile-` と `mem-profile-` というプレフィックスを使用し、収集後に圧縮されます。
+- Description: `sys_log_dir/proc_profile` の下に生成されたプロセスプロファイリングファイル (CPU およびメモリ) を保持する日数。ProcProfileCollector は、現在時刻から `proc_profile_file_retained_days` 日を引いたカットオフ (yyyyMMdd-HHmmss 形式) を計算し、タイムスタンプ部分がそのカットオフよりも辞書順で早いプロファイルファイル (つまり、`timePart.compareTo(timeToDelete) < 0`) を削除します。ファイルの削除は、`proc_profile_file_retained_size_bytes` によって制御されるサイズベースのカットオフも尊重します。プロファイルファイルは `cpu-profile-` および `mem-profile-` のプレフィックスを使用し、収集後に圧縮されます。
 - Introduced in: v3.2.12
 
 ##### `proc_profile_file_retained_size_bytes`
@@ -400,7 +400,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Long
 - Unit: Bytes
 - Is mutable: Yes
-- Description: プロファイルディレクトリ下に保持される、収集された CPU およびメモリプロファイルファイル (`cpu-profile-` および `mem-profile-` というプレフィックスを持つファイル) の合計バイト数の最大値。有効なプロファイルファイルの合計が `proc_profile_file_retained_size_bytes` を超えると、コレクターは、残りの合計サイズが `proc_profile_file_retained_size_bytes` 以下になるまで、最も古いプロファイルファイルを削除します。`proc_profile_file_retained_days` よりも古いファイルもサイズに関係なく削除されます。この設定はプロファイルアーカイブのディスク使用量を制御し、`proc_profile_file_retained_days` と相互作用して削除順序と保持を決定します。
+- Description: プロファイルディレクトリの下に保持する収集された CPU およびメモリプロファイルファイル (`cpu-profile-` および `mem-profile-` のプレフィックスを持つファイル) の最大合計バイト数。有効なプロファイルファイルの合計が `proc_profile_file_retained_size_bytes` を超えると、コレクターは残りの合計サイズが `proc_profile_file_retained_size_bytes` 以下になるまで最も古いプロファイルファイルを削除します。`proc_profile_file_retained_days` よりも古いファイルもサイズに関係なく削除されます。この設定はプロファイルアーカイブのディスク使用量を制御し、`proc_profile_file_retained_days` と連携して削除順序と保持を決定します。
 - Introduced in: v3.2.12
 
 ##### `profile_log_delete_age`
@@ -409,7 +409,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: FE プロファイルログファイルが削除対象となるまでの保持期間を制御します。この値は Log4j の `<IfLastModified age="..."/>` ポリシー (`Log4jConfig` 経由) に注入され、`profile_log_roll_interval` や `profile_log_roll_num` などのローテーション設定と組み合わせて適用されます。サポートされる接尾辞: `d` (日)、`h` (時間)、`m` (分)、`s` (秒)。例: `7d` (7 日間)、`10h` (10 時間)、`60m` (60 分)、`120s` (120 秒)。
+- Description: FE プロファイルログファイルが削除の対象となるまでの保持期間を制御します。この値は Log4j の `<IfLastModified age="..."/>` ポリシー ( `Log4jConfig` 経由) に挿入され、`profile_log_roll_interval` や `profile_log_roll_num` などのローテーション設定と併せて適用されます。サポートされるサフィックス: `d` (日)、`h` (時間)、`m` (分)、`s` (秒)。例: `7d` (7日間)、`10h` (10時間)、`60m` (60分)、`120s` (120秒)。
 - Introduced in: v3.2.5
 
 ##### `profile_log_dir`
@@ -418,7 +418,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: FE プロファイルログが書き込まれるディレクトリ。Log4jConfig はこの値を使用して、プロファイル関連のアペンダーを配置します (このディレクトリの下に `fe.profile.log` や `fe.features.log` のようなファイルを作成します)。これらのファイルのローテーションと保持は、`profile_log_roll_size_mb`、`profile_log_roll_num`、`profile_log_delete_age` によって管理されます。タイムスタンプのサフィックス形式は `profile_log_roll_interval` (DAY または HOUR をサポート) によって制御されます。デフォルトのディレクトリは `STARROCKS_HOME_DIR` の下にあるため、FE プロセスがこのディレクトリへの書き込みおよびローテーション/削除の権限を持っていることを確認してください。
+- Description: FE プロファイルログが書き込まれるディレクトリ。Log4jConfig はこの値を使用してプロファイル関連のアペンダーを配置します (このディレクトリの下に `fe.profile.log` や `fe.features.log` などのファイルを作成します)。これらのファイルのローテーションと保持は、`profile_log_roll_size_mb`、`profile_log_roll_num`、および `profile_log_delete_age` によって管理されます。タイムスタンプサフィックス形式は `profile_log_roll_interval` (DAY または HOUR をサポート) によって制御されます。デフォルトのディレクトリは `STARROCKS_HOME_DIR` の下にあるため、FE プロセスがこのディレクトリに対する書き込みおよびローテーション/削除権限を持っていることを確認してください。
 - Introduced in: v3.2.5
 
 ##### `profile_log_roll_interval`
@@ -427,7 +427,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: プロファイルログファイル名の日付部分を生成するために使用される時間粒度を制御します。有効な値 (大文字と小文字を区別しない) は `HOUR` と `DAY` です。`HOUR` は `"%d{yyyyMMddHH}"` (時間ごとの時間バケット) のパターンを生成し、`DAY` は `"%d{yyyyMMdd}"` (日ごとの時間バケット) を生成します。この値は Log4j 設定で `profile_file_pattern` を計算する際に使用され、ロールオーバーファイル名の時間ベースのコンポーネントのみに影響します。サイズベースのロールオーバーは `profile_log_roll_size_mb` によって引き続き制御され、保持は `profile_log_roll_num` / `profile_log_delete_age` によって制御されます。無効な値は、ロギング初期化中に IOException を引き起こします (エラーメッセージ: `"profile_log_roll_interval config error: <value>"` )。高ボリュームプロファイリングの場合は `HOUR` を選択して 1 時間あたりのファイルサイズを制限するか、日次集計の場合は `DAY` を選択します。
+- Description: プロファイルログファイル名の日付部分を生成するために使用される時間粒度を制御します。有効な値 (大文字と小文字を区別しない) は `HOUR` と `DAY` です。`HOUR` は `"%d{yyyyMMddHH}"` (時間ごとのタイムバケット) のパターンを生成し、`DAY` は `"%d{yyyyMMdd}"` (日ごとのタイムバケット) を生成します。この値は Log4j 設定で `profile_file_pattern` を計算するときに使用され、ロールオーバーファイル名の時間ベースのコンポーネントのみに影響します。サイズベースのロールオーバーは `profile_log_roll_size_mb` によって、保持は `profile_log_roll_num` / `profile_log_delete_age` によって引き続き制御されます。無効な値はロギング初期化中に IOException を引き起こします (エラーメッセージ: `"profile_log_roll_interval config error: <value>"`)。大量のプロファイリングを行う場合は、ファイルごとのサイズを時間ごとに制限するために `HOUR` を選択し、日ごとの集計には `DAY` を選択してください。
 - Introduced in: v3.2.5
 
 ##### `profile_log_roll_num`
@@ -436,7 +436,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: プロファイルロガーの Log4j DefaultRolloverStrategy が保持するローテーションされたプロファイルログファイルの最大数を指定します。この値は、ロギング XML に `${profile_log_roll_num}` として注入されます (例: `<DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min">`)。ローテーションは `profile_log_roll_size_mb` または `profile_log_roll_interval` によってトリガーされます。ローテーションが発生すると、Log4j は最大でこれらのインデックス付きファイルを保持し、古いインデックスファイルは削除対象となります。ディスク上での実際の保持は、`profile_log_delete_age` と `profile_log_dir` の場所にも影響されます。値が小さいとディスク使用量が減りますが、保持される履歴が制限されます。値が大きいと、より多くの履歴プロファイルログが保持されます。
+- Description: プロファイルロガーの Log4j の DefaultRolloverStrategy によって保持されるローテーションされたプロファイルログファイルの最大数を指定します。この値は、ロギング XML に `${profile_log_roll_num}` として挿入されます (例: `<DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min">`)。ローテーションは `profile_log_roll_size_mb` または `profile_log_roll_interval` によってトリガーされます。ローテーションが発生すると、Log4j は最大でこれらのインデックス付きファイルを保持し、古いインデックスファイルは削除の対象となります。ディスク上の実際の保持は、`profile_log_delete_age` および `profile_log_dir` の場所にも影響されます。値が低いとディスク使用量が削減されますが、保持される履歴が制限されます。値が高いと、より多くの履歴プロファイルログが保持されます。
 - Introduced in: v3.2.5
 
 ##### `profile_log_roll_size_mb`
@@ -445,7 +445,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: MB
 - Is mutable: No
-- Description: FE プロファイルログファイルのサイズベースのロールオーバーをトリガーするサイズしきい値 (メガバイト単位) を設定します。この値は、`ProfileFile` アペンダーの Log4j RollingFile SizeBasedTriggeringPolicy によって使用されます。プロファイルログが `profile_log_roll_size_mb` を超えると、ローテーションされます。ローテーションは、`profile_log_roll_interval` に達したときに時間によっても発生する可能性があります。いずれかの条件がロールオーバーをトリガーします。`profile_log_roll_num` と `profile_log_delete_age` と組み合わせることで、この項目は保持される履歴プロファイルファイルの数と古いファイルの削除時期を制御します。ローテーションされたファイルの圧縮は `enable_profile_log_compress` によって制御されます。
+- Description: FE プロファイルログファイルのサイズベースのロールオーバーをトリガーするサイズしきい値 (メガバイト単位) を設定します。この値は、`ProfileFile` アペンダーの Log4j RollingFile SizeBasedTriggeringPolicy によって使用されます。プロファイルログが `profile_log_roll_size_mb` を超えると、ローテーションされます。`profile_log_roll_interval` に達すると、時間によってもローテーションが発生する可能性があります。どちらの条件もロールオーバーをトリガーします。`profile_log_roll_num` および `profile_log_delete_age` と組み合わせて、この項目は保持される履歴プロファイルファイルの数と古いファイルが削除される時期を制御します。ローテーションされたファイルの圧縮は `enable_profile_log_compress` によって制御されます。
 - Introduced in: v3.2.5
 
 ##### `qe_slow_log_ms`
@@ -454,7 +454,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Long
 - Unit: Milliseconds
 - Is mutable: Yes
-- Description: クエリが遅いクエリかどうかを判断するために使用されるしきい値。クエリの応答時間がこのしきい値を超えると、**fe.audit.log** に遅いクエリとして記録されます。
+- Description: クエリがスロークエリであるかどうかを判断するために使用されるしきい値。クエリの応答時間がこのしきい値を超えると、**fe.audit.log** にスロークエリとして記録されます。
 - Introduced in: -
 
 ##### `slow_lock_log_every_ms`
@@ -463,7 +463,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Long
 - Unit: Milliseconds
 - Is mutable: Yes
-- Description: 同じ SlowLockLogStats インスタンスに対して別の「低速ロック」警告を発行するまでに待機する最小間隔 (ミリ秒)。LockUtils は、ロック待機が `slow_lock_threshold_ms` を超えた後にこの値をチェックし、最後のログに記録された低速ロックイベントから `slow_lock_log_every_ms` ミリ秒が経過するまで追加の警告を抑制します。長期的な競合中にログのボリュームを減らすには値を大きくし、より頻繁な診断を得るには値を小さくします。変更は、その後のチェックに対して実行時に有効になります。
+- Description: 同じ SlowLockLogStats インスタンスに対して別の「スローロック」警告を出力するまでに待機する最小間隔 (ミリ秒単位)。LockUtils は、ロック待機が `slow_lock_threshold_ms` を超えた後にこの値をチェックし、最後にログに記録されたスローロックイベントから `slow_lock_log_every_ms` ミリ秒が経過するまで追加の警告を抑制します。長時間の競合中にログ量を減らすには大きな値を、より頻繁な診断を得るには小さな値を使用してください。変更は、その後のチェックに対して実行時に有効になります。
 - Introduced in: v3.2.0
 
 ##### `slow_lock_print_stack`
@@ -472,7 +472,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: LockManager が `logSlowLockTrace` によって出力される低速ロック警告の JSON ペイロードに、所有スレッドの完全なスタックトレースを含めることを許可するかどうか ("stack" 配列は `LogUtil.getStackTraceToJsonArray` を使用して `start=0` および `max=Short.MAX_VALUE` で設定されます)。この設定は、ロック取得が `slow_lock_threshold_ms` で設定されたしきい値を超えたときに表示されるロック所有者に関する追加のスタック情報のみを制御します。この機能を有効にすると、ロックを保持している正確なスレッドスタックを提供することでデバッグに役立ちます。無効にすると、高並行環境でスタックトレースをキャプチャしてシリアル化することによるログのボリュームと CPU/メモリのオーバーヘッドが減少します。
+- Description: LockManager が `logSlowLockTrace` によって出力されるスローロック警告の JSON ペイロードに、所有スレッドの完全なスタックトレースを含めることを許可するかどうか ("stack" 配列は `LogUtil.getStackTraceToJsonArray` を使用して `start=0` および `max=Short.MAX_VALUE` で設定されます)。この設定は、ロック取得が `slow_lock_threshold_ms` で設定されたしきい値を超えたときに表示されるロック所有者の追加のスタック情報のみを制御します。この機能を有効にすると、ロックを保持している正確なスレッドスタックが提供されるため、デバッグに役立ちます。無効にすると、高並行環境でスタックトレースをキャプチャしてシリアル化することによって発生するログ量と CPU/メモリオーバーヘッドが削減されます。
 - Introduced in: v3.3.16, v3.4.5, v3.5.1
 
 ##### `slow_lock_threshold_ms`
@@ -481,7 +481,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: long
 - Unit: Milliseconds
 - Is mutable: Yes
-- Description: ロック操作または保持されているロックを「遅い」と分類するために使用されるしきい値 (ミリ秒)。ロックの経過待機時間または保持時間がこの値を超えると、StarRocks は (コンテキストに応じて) 診断ログを出力し、スタックトレースまたは待機者/所有者情報を含め、LockManager ではこの遅延後にデッドロック検出を開始します。これは LockUtils (低速ロックロギング)、QueryableReentrantReadWriteLock (低速リーダーのフィルタリング)、LockManager (デッドロック検出遅延と低速ロックトレース)、LockChecker (定期的な低速ロック検出)、およびその他の呼び出し元 (例: DiskAndTabletLoadReBalancer ロギング) によって使用されます。値を下げると感度とロギング/診断のオーバーヘッドが増加します。0 または負の数に設定すると、初期の待機ベースのデッドロック検出遅延動作が無効になります。`slow_lock_log_every_ms`、`slow_lock_print_stack`、および `slow_lock_stack_trace_reserve_levels` と一緒に調整します。
+- Description: ロック操作または保持されているロックを「スロー」として分類するために使用されるしきい値 (ミリ秒単位)。ロックの経過待機時間または保持時間がこの値を超えると、StarRocks は (コンテキストに応じて) 診断ログを出力し、スタックトレースまたは待機者/所有者情報を含め、LockManager ではこの遅延後にデッドロック検出を開始します。これは LockUtils (スローロックロギング)、QueryableReentrantReadWriteLock (スローリーダーのフィルタリング)、LockManager (デッドロック検出遅延とスローロックトレース)、LockChecker (定期的なスローロック検出)、およびその他の呼び出し元 (例: DiskAndTabletLoadReBalancer ロギング) によって使用されます。値を下げると感度とロギング/診断オーバーヘッドが増加します。0 または負の値を設定すると、初期の待機ベースのデッドロック検出遅延動作が無効になります。`slow_lock_log_every_ms`、`slow_lock_print_stack`、および `slow_lock_stack_trace_reserve_levels` と組み合わせて調整してください。
 - Introduced in: 3.2.0
 
 ##### `sys_log_delete_age`
@@ -490,7 +490,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: システムログファイルの保持期間。デフォルト値 `7d` は、各システムログファイルが 7 日間保持できることを指定します。StarRocks は各システムログファイルをチェックし、7 日以上前に生成されたファイルを削除します。
+- Description: システムログファイルの保持期間。デフォルト値 `7d` は、各システムログファイルが7日間保持されることを指定します。StarRocks は各システムログファイルをチェックし、7日前に生成されたファイルを削除します。
 - Introduced in: -
 
 ##### `sys_log_dir`
@@ -499,7 +499,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: システムログファイルを格納するディレクトリ。
+- Description: システムログファイルを保存するディレクトリ。
 - Introduced in: -
 
 ##### `sys_log_enable_compress`
@@ -508,7 +508,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: boolean
 - Unit: -
 - Is mutable: No
-- Description: この項目が `true` に設定されている場合、システムはローテーションされたシステムログファイル名に ".gz" 接尾辞を追加し、Log4j が gzip 圧縮されたローテーションされた FE システムログ (例: fe.log.*) を生成するようにします。この値は Log4j 設定生成時 (Log4jConfig.initLogging / generateActiveLog4jXmlConfig) に読み取られ、RollingFile の filePattern で使用される `sys_file_postfix` プロパティを制御します。この機能を有効にすると、保持されるログのディスク使用量は減少しますが、ロールオーバー時の CPU と I/O が増加し、ログファイル名が変更されるため、ログを読み取るツールやスクリプトは .gz ファイルを処理できる必要があります。監査ログは圧縮に別の設定 (`audit_log_enable_compress`) を使用することに注意してください。
+- Description: この項目が `true` に設定されている場合、システムはローテーションされたシステムログファイル名に ".gz" 接尾辞を追加し、Log4j が gzip 圧縮されたローテーションされた FE システムログ (例: fe.log.*) を生成するようにします。この値は Log4j 設定生成中 (Log4jConfig.initLogging / generateActiveLog4jXmlConfig) に読み取られ、RollingFile の filePattern で使用される `sys_file_postfix` プロパティを制御します。この機能を有効にすると、保持されるログのディスク使用量が削減されますが、ロールオーバー中の CPU と I/O が増加し、ログファイル名が変更されるため、ログを読み取るツールやスクリプトは .gz ファイルを処理できる必要があります。監査ログは圧縮に別の設定 (`audit_log_enable_compress`) を使用することに注意してください。
 - Introduced in: v3.2.12
 
 ##### `sys_log_format`
@@ -517,7 +517,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: FE ログに使用される Log4j レイアウトを選択します。有効な値: `"plaintext"` (デフォルト) と `"json"`。値は大文字と小文字を区別しません。`"plaintext"` は、人間が読めるタイムスタンプ、レベル、スレッド、class.method:line、および WARN/ERROR のスタックトレースを持つ PatternLayout を構成します。`"json"` は JsonTemplateLayout を構成し、ログアグリゲーター (ELK、Splunk) に適した構造化 JSON イベント (UTC タイムスタンプ、レベル、スレッド ID/名、ソースファイル/メソッド/行、メッセージ、例外スタックトレース) を出力します。JSON 出力は、`sys_log_json_max_string_length` および `sys_log_json_profile_max_string_length` の最大文字列長に準拠します。
+- Description: FE ログに使用される Log4j レイアウトを選択します。有効な値: `"plaintext"` (デフォルト) と `"json"`。値は大文字と小文字を区別しません。`"plaintext"` は、人間が読めるタイムスタンプ、レベル、スレッド、クラス.メソッド:行、および WARN/ERROR のスタックトレースを含む PatternLayout を設定します。`"json"` は JsonTemplateLayout を設定し、ログアグリゲーター (ELK、Splunk) に適した構造化 JSON イベント (UTC タイムスタンプ、レベル、スレッド ID/名前、ソースファイル/メソッド/行、メッセージ、例外スタックトレース) を出力します。JSON 出力は、最大文字列長について `sys_log_json_max_string_length` および `sys_log_json_profile_max_string_length` に従います。
 - Introduced in: v3.2.10
 
 ##### `sys_log_json_max_string_length`
@@ -526,7 +526,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Bytes
 - Is mutable: No
-- Description: JSON 形式のシステムログに使用される JsonTemplateLayout の "maxStringLength" 値を設定します。`sys_log_format` が `"json"` に設定されている場合、文字列値のフィールド (たとえば "message" や文字列化された例外スタックトレース) は、長さがこの制限を超えると切り捨てられます。この値は、生成された Log4j XML ( `Log4jConfig.generateActiveLog4jXmlConfig()` 内) に注入され、デフォルト、警告、監査、ダンプ、および大容量クエリレイアウトに適用されます。プロファイルレイアウトは別の設定 (`sys_log_json_profile_max_string_length`) を使用します。この値を小さくするとログサイズは減りますが、有用な情報が切り捨てられる可能性があります。
+- Description: JSON 形式のシステムログに使用される JsonTemplateLayout の "maxStringLength" 値を設定します。`sys_log_format` が `"json"` に設定されている場合、文字列値フィールド (例: "message" および文字列化された例外スタックトレース) は、その長さがこの制限を超えると切り捨てられます。この値は、生成された Log4j XML の `Log4jConfig.generateActiveLog4jXmlConfig()` に挿入され、デフォルト、警告、監査、ダンプ、およびビッグクエリのレイアウトに適用されます。プロファイルレイアウトは別の設定 (`sys_log_json_profile_max_string_length`) を使用します。この値を下げるとログサイズは削減されますが、有用な情報が切り捨てられる可能性があります。
 - Introduced in: 3.2.11
 
 ##### `sys_log_json_profile_max_string_length`
@@ -535,7 +535,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Bytes
 - Is mutable: No
-- Description: `sys_log_format` が "json" の場合、プロファイル (および関連機能) ログアペンダーの JsonTemplateLayout の maxStringLength を設定します。JSON 形式のプロファイルログ内の文字列フィールド値は、このバイト長に切り捨てられます。非文字列フィールドは影響を受けません。この項目は Log4jConfig の `JsonTemplateLayout maxStringLength` に適用され、プレーンテキストロギングが使用されている場合は無視されます。必要な完全なメッセージに対して十分な大きさに保ちますが、値が大きいとログサイズと I/O が増加することに注意してください。
+- Description: `sys_log_format` が "json" の場合、プロファイル (および関連機能) ログアペンダーの JsonTemplateLayout の maxStringLength を設定します。JSON 形式のプロファイルログの文字列フィールド値は、このバイト長に切り捨てられます。非文字列フィールドは影響を受けません。この項目は Log4jConfig の `JsonTemplateLayout maxStringLength` に適用され、`plaintext` ロギングが使用されている場合は無視されます。必要な完全なメッセージに対して十分な大きさの値を保持しますが、値が大きいほどログサイズと I/O が増加することに注意してください。
 - Introduced in: v3.2.11
 
 ##### `sys_log_level`
@@ -554,8 +554,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Unit: -
 - Is mutable: No
 - Description: StarRocks がシステムログエントリをローテーションする時間間隔。有効な値: `DAY` と `HOUR`。
-  - このパラメーターが `DAY` に設定されている場合、システムログファイル名に `yyyyMMdd` 形式のサフィックスが追加されます。
-  - このパラメーターが `HOUR` に設定されている場合、システムログファイル名に `yyyyMMddHH` 形式のサフィックスが追加されます。
+  - このパラメータが `DAY` に設定されている場合、システムログファイル名に `yyyyMMdd` 形式のサフィックスが追加されます。
+  - このパラメータが `HOUR` に設定されている場合、システムログファイル名に `yyyyMMddHH` 形式のサフィックスが追加されます。
 - Introduced in: -
 
 ##### `sys_log_roll_num`
@@ -564,7 +564,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: `sys_log_roll_interval` パラメーターで指定された各保持期間内に保持できるシステムログファイルの最大数。
+- Description: `sys_log_roll_interval` パラメータで指定された各保持期間内に保持できるシステムログファイルの最大数。
 - Introduced in: -
 
 ##### `sys_log_to_console`
@@ -573,7 +573,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: No
-- Description: この項目が `true` に設定されている場合、システムは Log4j を設定して、すべてのログをファイルベースのアペンダーではなくコンソール (ConsoleErr アペンダー) に送信します。この値はアクティブな Log4j XML 設定を生成する際に読み取られ (ルートロガーおよびモジュールごとのロガーアペンダーの選択に影響します)、プロセス起動時に `SYS_LOG_TO_CONSOLE` 環境変数から取得されます。実行時に変更しても効果はありません。この設定は、stdout/stderr ログ収集がログファイルの書き込みよりも優先されるコンテナ化された環境や CI 環境で一般的に使用されます。
+- Description: この項目が `true` に設定されている場合、システムは Log4j を設定して、すべてのログをファイルベースのアペンダーではなくコンソール (ConsoleErr アペンダー) に送信します。この値は、アクティブな Log4j XML 設定を生成するときに読み取られ (ルートロガーとモジュールごとのロガーアペンダーの選択に影響します)、プロセス起動時に `SYS_LOG_TO_CONSOLE` 環境変数から取得されます。実行時に変更しても効果はありません。この設定は、stdout/stderr ログ収集がログファイルの書き込みよりも優先されるコンテナ化された環境や CI 環境で一般的に使用されます。
 - Introduced in: v3.2.0
 
 ##### `sys_log_verbose_modules`
@@ -582,7 +582,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String[]
 - Unit: -
 - Is mutable: No
-- Description: StarRocks がシステムログを生成するモジュール。このパラメーターが `org.apache.starrocks.catalog` に設定されている場合、StarRocks はカタログモジュールのみのシステムログを生成します。モジュール名をコンマ (,) とスペースで区切ります。
+- Description: StarRocks がシステムログを生成するモジュール。このパラメータが `org.apache.starrocks.catalog` に設定されている場合、StarRocks はカタログモジュールに対してのみシステムログを生成します。モジュール名をコンマ (,) とスペースで区切ってください。
 - Introduced in: -
 
 ##### `sys_log_warn_modules`
@@ -591,7 +591,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String[]
 - Unit: -
 - Is mutable: No
-- Description: システムが起動時に WARN レベルのロガーとして設定し、警告アペンダー (SysWF) (`fe.warn.log` ファイル) にルーティングするロガー名またはパッケージプレフィックスのリスト。エントリは生成された Log4j 設定 (org.apache.kafka、org.apache.hudi、org.apache.hadoop.io.compress などの組み込み警告モジュールとともに) に挿入され、`<Logger name="... " level="WARN"><AppenderRef ref="SysWF"/></Logger>` のようなロガー要素を生成します。完全修飾パッケージおよびクラスプレフィックス (例: "com.example.lib") は、通常のログへのノイズの多い INFO/DEBUG 出力を抑制し、警告を個別にキャプチャできるようにするために推奨されます。
+- Description: システムが起動時に WARN レベルのロガーとして設定し、警告アペンダー (SysWF) — `fe.warn.log` ファイルにルーティングするロガー名またはパッケージプレフィックスのリスト。エントリは生成された Log4j 設定 (org.apache.kafka、org.apache.hudi、org.apache.hadoop.io.compress などの組み込み警告モジュールと共に) に挿入され、`<Logger name="... " level="WARN"><AppenderRef ref="SysWF"/></Logger>` のようなロガー要素を生成します。完全修飾パッケージおよびクラスプレフィックス (例: "com.example.lib") は、通常のログへのノイズの多い INFO/DEBUG 出力を抑制し、警告を個別にキャプチャできるようにするために推奨されます。
 - Introduced in: v3.2.13
 
 ### サーバー
@@ -601,8 +601,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 10000
 - Type: Int
 - Unit: ms
-- Is mutable: No
-- Description: bRPC クライアントがアイドル状態で待機する最大時間。
+- Is mutable: いいえ
+- Description: bRPCクライアントがアイドル状態で待機する最大時間。
 - Introduced in: -
 
 ##### `brpc_inner_reuse_pool`
@@ -610,17 +610,17 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: boolean
 - Unit: -
-- Is mutable: No
-- Description: 下層の BRPC クライアントが接続/チャネルに内部共有再利用プールを使用するかどうかを制御します。StarRocks は BrpcProxy で RpcClientOptions を構築するときに `brpc_inner_reuse_pool` を読み取ります ( `rpcOptions.setInnerResuePool(...)` 経由)。有効な場合 (true)、RPC クライアントは内部プールを再利用して、呼び出しごとの接続作成を減らし、FE-to-BE / LakeService RPC の接続チャーン、メモリ、ファイルディスクリプタの使用量を削減します。無効な場合 (false)、クライアントはより多くの分離されたプールを作成する可能性があります (リソース使用量が増える代わりに並行性分離を向上させます)。この値を変更するには、プロセスを再起動して有効にする必要があります。
+- Is mutable: いいえ
+- Description: 基盤となるBRPCクライアントが接続/チャネルに内部共有再利用プールを使用するかどうかを制御します。StarRocksは、RpcClientOptionsを構築する際にBrpcProxyで`brpc_inner_reuse_pool`を読み取ります（`rpcOptions.setInnerResuePool(...)`経由）。有効（true）の場合、RPCクライアントは内部プールを再利用して、呼び出しごとの接続作成を減らし、FE-to-BE / LakeService RPCの接続チャーン、メモリ、ファイルディスクリプタの使用量を削減します。無効（false）の場合、クライアントはより分離されたプールを作成する可能性があります（より高いリソース使用量を犠牲にして並行性分離を増加させます）。この値を変更するには、プロセスを再起動して適用する必要があります。
 - Introduced in: v3.3.11, v3.4.1, v3.5.0
 
 ##### `brpc_min_evictable_idle_time_ms`
 
 - Default: 120000
 - Type: Int
-- Unit: Milliseconds
-- Is mutable: No
-- Description: アイドル状態の BRPC 接続が、接続プールで立ち退きの対象になるまでに残っている必要のある時間 (ミリ秒単位)。`BrpcProxy` が使用する RpcClientOptions に適用されます (RpcClientOptions.setMinEvictableIdleTime 経由)。この値を上げるとアイドル接続を長く保持でき (再接続のチャーンを減らす)、下げると未使用のソケットをより速く解放できます (リソース使用量を減らす)。接続の再利用、プールの成長、立ち退きの動作のバランスを取るために、`brpc_connection_pool_size` および `brpc_idle_wait_max_time` とともに調整します。
+- Unit: ミリ秒
+- Is mutable: いいえ
+- Description: アイドル状態のBRPC接続が接続プールに留まり、削除の対象となるまでのミリ秒単位の時間。`BrpcProxy`が使用するRpcClientOptionsに適用されます（RpcClientOptions.setMinEvictableIdleTime経由）。この値を上げると、アイドル接続を長く保持できます（再接続のチャーンを減らします）。この値を下げると、未使用のソケットをより速く解放できます（リソース使用量を減らします）。`brpc_connection_pool_size`および`brpc_idle_wait_max_time`と合わせて調整し、接続の再利用、プールの成長、および削除動作のバランスを取ります。
 - Introduced in: v3.3.11, v3.4.1, v3.5.0
 
 ##### `brpc_reuse_addr`
@@ -628,26 +628,26 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: No
-- Description: true の場合、StarRocks は、brpc RpcClient によって作成されたクライアントソケットにローカルアドレスの再利用を許可するソケットオプションを設定します (RpcClientOptions.setReuseAddress 経由)。これを有効にすると、バインドの失敗が減り、ソケットが閉じられた後にローカルポートの再バインドが高速化され、高レートの接続チャーンや迅速な再起動に役立ちます。false の場合、アドレス/ポートの再利用は無効になり、意図しないポート共有の可能性を減らすことができますが、一時的なバインドエラーが増加する可能性があります。このオプションは、`brpc_connection_pool_size` および `brpc_short_connection` によって設定される接続動作と相互作用します。これは、クライアントソケットを再バインドして再利用できる速度に影響するためです。
+- Is mutable: いいえ
+- Description: trueの場合、StarRocksはbrpc RpcClientによって作成されたクライアントソケットのローカルアドレス再利用を許可するようにソケットオプションを設定します（RpcClientOptions.setReuseAddress経由）。これを有効にすると、バインドの失敗が減り、ソケットが閉じられた後のローカルポートの再バインドが速くなるため、高レートの接続チャーンや迅速な再起動に役立ちます。falseの場合、アドレス/ポートの再利用は無効になり、意図しないポート共有の可能性を減らすことができますが、一時的なバインドエラーが増加する可能性があります。このオプションは、クライアントソケットがどれだけ迅速に再バインドおよび再利用できるかに影響するため、`brpc_connection_pool_size`および`brpc_short_connection`によって構成される接続動作と相互作用します。
 - Introduced in: v3.3.11, v3.4.1, v3.5.0
 
 ##### `cluster_name`
 
-- Default: StarRocks Cluster
+- Default: StarRocks クラスター
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: FE が属する StarRocks クラスターの名前。クラスター名は Web ページの `Title` に表示されます。
+- Is mutable: いいえ
+- Description: FEが属するStarRocksクラスターの名前。クラスター名はウェブページの`Title`に表示されます。
 - Introduced in: -
 
 ##### `dns_cache_ttl_seconds`
 
 - Default: 60
 - Type: Int
-- Unit: Seconds
-- Is mutable: No
-- Description: 成功した DNS ルックアップの DNS キャッシュ TTL (Time-To-Live) (秒単位)。これにより、JVM が成功した DNS ルックアップをキャッシュする期間を制御する Java セキュリティプロパティ `networkaddress.cache.ttl` が設定されます。システムが常に情報をキャッシュできるようにするにはこの項目を `-1` に設定し、キャッシュを無効にするには `0` に設定します。これは、Kubernetes デプロイメントや動的 DNS が使用されている場合など、IP アドレスが頻繁に変更される環境で特に役立ちます。
+- Unit: 秒
+- Is mutable: いいえ
+- Description: 成功したDNSルックアップのDNSキャッシュTTL（Time-To-Live）を秒単位で指定します。これは、JVMが成功したDNSルックアップをキャッシュする期間を制御するJavaセキュリティプロパティ`networkaddress.cache.ttl`を設定します。システムが常に情報をキャッシュするようにするにはこの項目を`-1`に設定し、キャッシュを無効にするには`0`に設定します。これは、Kubernetesデプロイメントや動的DNSが使用されている場合など、IPアドレスが頻繁に変更される環境で特に役立ちます。
 - Introduced in: v3.5.11, v4.0.4
 
 ##### `enable_http_async_handler`
@@ -655,8 +655,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: システムが HTTP リクエストを非同期で処理することを許可するかどうか。この機能が有効になっている場合、Netty ワーカー スレッドによって受信された HTTP リクエストは、HTTP サーバーのブロックを避けるために、サービスロジック処理のために別のスレッドプールに送信されます。無効になっている場合、Netty ワーカーがサービスロジックを処理します。
+- Is mutable: はい
+- Description: システムがHTTPリクエストを非同期で処理することを許可するかどうか。この機能が有効になっている場合、Nettyワーカー スレッドによって受信されたHTTPリクエストは、HTTPサーバーのブロックを回避するために、サービスロジック処理用の別のスレッドプールに送信されます。無効になっている場合、Nettyワーカーがサービスロジックを処理します。
 - Introduced in: 4.0.0
 
 ##### `enable_http_validate_headers`
@@ -664,8 +664,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: false
 - Type: Boolean
 - Unit: -
-- Is mutable: No
-- Description: Netty の HttpServerCodec が厳密な HTTP ヘッダー検証を実行するかどうかを制御します。この値は、HttpServer の HTTP パイプラインが初期化されるときに HttpServerCodec に渡されます (UseLocations を参照)。新しい Netty バージョンではより厳密なヘッダー規則が適用されるため (https://github.com/netty/netty/pull/12760)、下位互換性のためにデフォルトは false です。RFC 準拠のヘッダーチェックを強制するには true に設定します。そうすると、レガシークライアントやプロキシからの不正な形式の要求や非準拠の要求が拒否される可能性があります。変更を有効にするには HTTP サーバーの再起動が必要です。
+- Is mutable: いいえ
+- Description: NettyのHttpServerCodecが厳密なHTTPヘッダー検証を実行するかどうかを制御します。この値は、`HttpServer`でHTTPパイプラインが初期化されるときにHttpServerCodecに渡されます（UseLocationsを参照）。新しいNettyバージョンではより厳密なヘッダー規則が適用されるため（https://github.com/netty/netty/pull/12760）、後方互換性のためにデフォルトはfalseです。RFC準拠のヘッダーチェックを強制するにはtrueに設定します。そうすると、レガシーなクライアントやプロキシからの不正な形式または非準拠のリクエストが拒否される可能性があります。変更を有効にするにはHTTPサーバーの再起動が必要です。
 - Introduced in: v3.3.0, v3.4.0, v3.5.0
 
 ##### `enable_https`
@@ -673,8 +673,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: false
 - Type: Boolean
 - Unit: -
-- Is mutable: No
-- Description: FE ノードで HTTP サーバーと HTTPS サーバーを同時に有効にするかどうか。
+- Is mutable: いいえ
+- Description: FEノードでHTTPサーバーと並行してHTTPSサーバーを有効にするかどうか。
 - Introduced in: v4.0
 
 ##### `frontend_address`
@@ -682,8 +682,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 0.0.0.0
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: FE ノードの IP アドレス。
+- Is mutable: いいえ
+- Description: FEノードのIPアドレス。
 - Introduced in: -
 
 ##### `http_async_threads_num`
@@ -691,8 +691,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 4096
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: 非同期 HTTP リクエスト処理用のスレッドプールのサイズ。エイリアスは `max_http_sql_service_task_threads_num` です。
+- Is mutable: はい
+- Description: 非同期HTTPリクエスト処理用のスレッドプールのサイズ。エイリアスは`max_http_sql_service_task_threads_num`です。
 - Introduced in: 4.0.0
 
 ##### `http_backlog_num`
@@ -700,35 +700,35 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 1024
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: FE ノードの HTTP サーバーが保持するバックログキューの長さ。
+- Is mutable: いいえ
+- Description: FEノードのHTTPサーバーが保持するバックログキューの長さ。
 - Introduced in: -
 
 ##### `http_max_chunk_size`
 
 - Default: 8192
 - Type: Int
-- Unit: Bytes
-- Is mutable: No
-- Description: FE HTTP サーバーの Netty の HttpServerCodec によって処理される単一の HTTP チャンクの最大許容サイズ (バイト単位) を設定します。これは HttpServerCodec に 3 番目の引数として渡され、チャンク転送またはストリーミング要求/応答中のチャンクの長さを制限します。受信チャンクがこの値を超えると、Netty はフレームが大きすぎるエラー (TooLongFrameException など) を発生させ、要求が拒否される可能性があります。正当な大規模チャンクアップロードの場合はこれを増やし、メモリ圧力を減らしたり、DoS 攻撃の攻撃対象領域を減らしたりするために小さく保ちます。この設定は、`http_max_initial_line_length`、`http_max_header_size`、および `enable_http_validate_headers` とともに使用されます。
+- Unit: バイト
+- Is mutable: いいえ
+- Description: FE HTTPサーバーのNettyのHttpServerCodecによって処理される単一のHTTPチャンクの最大許容サイズ（バイト単位）を設定します。これはHttpServerCodecの3番目の引数として渡され、チャンク転送またはストリーミングリクエスト/レスポンス中のチャンクの長さを制限します。受信チャンクがこの値を超えると、Nettyはフレームが大きすぎるエラー（例：TooLongFrameException）を発生させ、リクエストが拒否される可能性があります。正当な大きなチャンクアップロードの場合はこれを増やし、メモリ負荷とDoS攻撃の表面積を減らすために小さく保ちます。この設定は、`http_max_initial_line_length`、`http_max_header_size`、および`enable_http_validate_headers`と併用されます。
 - Introduced in: v3.2.0
 
 ##### `http_max_header_size`
 
 - Default: 32768
 - Type: Int
-- Unit: Bytes
-- Is mutable: No
-- Description: Netty の `HttpServerCodec` によって解析される HTTP 要求ヘッダーブロックの最大許容サイズ (バイト単位)。StarRocks はこの値を `HttpServerCodec` に渡します ( `Config.http_max_header_size` 経由)。受信要求のヘッダー (名前と値の組み合わせ) がこの制限を超えると、コーデックは要求を拒否し (デコーダー例外)、接続/要求は失敗します。クライアントが非常に大きなヘッダー (大きな Cookie または多くのカスタムヘッダー) を正当に送信する場合にのみ増やしてください。値が大きいほど、接続ごとのメモリ使用量が増加します。`http_max_initial_line_length` および `http_max_chunk_size` と合わせて調整してください。変更には FE の再起動が必要です。
+- Unit: バイト
+- Is mutable: いいえ
+- Description: Nettyの`HttpServerCodec`によって解析されるHTTPリクエストヘッダーブロックの最大許容サイズ（バイト単位）。StarRocksはこの値を`HttpServerCodec`に渡します（`Config.http_max_header_size`として）。受信リクエストのヘッダー（名前と値の組み合わせ）がこの制限を超えると、コーデックはリクエストを拒否し（デコーダー例外）、接続/リクエストは失敗します。クライアントが正当に非常に大きなヘッダー（大きなCookieまたは多数のカスタムヘッダー）を送信する場合にのみ増やしてください。値が大きいほど、接続ごとのメモリ使用量が増加します。`http_max_initial_line_length`および`http_max_chunk_size`と組み合わせて調整してください。変更にはFEの再起動が必要です。
 - Introduced in: v3.2.0
 
 ##### `http_max_initial_line_length`
 
 - Default: 4096
 - Type: Int
-- Unit: Bytes
-- Is mutable: No
-- Description: HttpServer で使用される Netty `HttpServerCodec` が受け入れる HTTP 初期リクエスト行 (メソッド + リクエストターゲット + HTTP バージョン) の最大許容長 (バイト単位) を設定します。この値は Netty のデコーダーに渡され、この長さよりも長い初期行を持つリクエストは拒否されます (TooLongFrameException)。非常に長いリクエスト URI をサポートする必要がある場合にのみ、これを増やしてください。値が大きいほどメモリ使用量が増加し、不正な形式の/リクエスト乱用のリスクが高まる可能性があります。`http_max_header_size` および `http_max_chunk_size` と合わせて調整してください。
+- Unit: バイト
+- Is mutable: いいえ
+- Description: HttpServerで使用されるNetty `HttpServerCodec`が受け入れるHTTP初期リクエストライン（メソッド + リクエストターゲット + HTTPバージョン）の最大許容長（バイト単位）を設定します。この値はNettyのデコーダーに渡され、これより長い初期ラインを持つリクエストは拒否されます（TooLongFrameException）。非常に長いリクエストURIをサポートする必要がある場合にのみこれを増やしてください。値が大きいほどメモリ使用量が増加し、不正な形式のリクエスト/リクエスト乱用への露出が高まる可能性があります。`http_max_header_size`および`http_max_chunk_size`と組み合わせて調整してください。
 - Introduced in: v3.2.0
 
 ##### `http_port`
@@ -736,8 +736,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 8030
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: FE ノードの HTTP サーバーがリッスンするポート。
+- Is mutable: いいえ
+- Description: FEノードのHTTPサーバーがリッスンするポート。
 - Introduced in: -
 
 ##### `http_web_page_display_hardware`
@@ -745,8 +745,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: true の場合、HTTP インデックスページ (/index) に oshi ライブラリ (CPU、メモリ、プロセス、ディスク、ファイルシステム、ネットワークなど) を介して入力されたハードウェア情報セクションが含まれます。oshi は、システムユーティリティを呼び出したり、間接的にシステムファイルを読み取ったりする場合があります (たとえば、`getent passwd` などのコマンドを実行する可能性があります)。これにより、機密性の高いシステムデータが表面化する可能性があります。より厳格なセキュリティが必要な場合、またはホストでこれらの間接コマンドの実行を回避したい場合は、この設定を false にして、Web UI でのハードウェア詳細の収集と表示を無効にします。
+- Is mutable: はい
+- Description: trueの場合、HTTPインデックスページ（/index）には、oshiライブラリ（CPU、メモリ、プロセス、ディスク、ファイルシステム、ネットワークなど）を介して入力されたハードウェア情報セクションが含まれます。oshiはシステムユーティリティを呼び出したり、システムファイルを間接的に読み取ったりする可能性があり（たとえば、`getent passwd`などのコマンドを実行できます）、機密性の高いシステムデータが表面化する可能性があります。より厳格なセキュリティが必要な場合、またはホストでこれらの間接コマンドの実行を避けたい場合は、この設定をfalseに設定して、Web UIでのハードウェア詳細の収集と表示を無効にしてください。
 - Introduced in: v3.2.0
 
 ##### `http_worker_threads_num`
@@ -754,8 +754,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 0
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: HTTP リクエストを処理する HTTP サーバーのワーカー スレッドの数。負の値または 0 の場合、スレッド数は CPU コア数の 2 倍になります。
+- Is mutable: いいえ
+- Description: HTTPリクエストを処理するためのHTTPサーバーのワーカー スレッド数。負の値または0の場合、スレッド数はCPUコア数の2倍になります。
 - Introduced in: v2.5.18, v3.0.10, v3.1.7, v3.2.2
 
 ##### `https_port`
@@ -763,8 +763,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 8443
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: FE ノードの HTTPS サーバーがリッスンするポート。
+- Is mutable: いいえ
+- Description: FEノードのHTTPSサーバーがリッスンするポート。
 - Introduced in: v4.0
 
 ##### `max_mysql_service_task_threads_num`
@@ -772,17 +772,17 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 4096
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: FE ノードの MySQL サーバーがタスクを処理するために実行できる最大スレッド数。
+- Is mutable: いいえ
+- Description: FEノードのMySQLサーバーがタスクを処理するために実行できるスレッドの最大数。
 - Introduced in: -
 
 ##### `max_task_runs_threads_num`
 
 - Default: 512
 - Type: Int
-- Unit: Threads
-- Is mutable: No
-- Description: タスク実行エグゼキュータースレッドプールの最大スレッド数を制御します。この値は同時タスク実行の上限であり、増やすと並行性が高まりますが、CPU、メモリ、ネットワーク使用量も増加し、減らすとタスク実行のバックログと待ち時間が長くなる可能性があります。この値は、予想される同時スケジュールジョブと利用可能なシステムリソースに応じて調整してください。
+- Unit: スレッド
+- Is mutable: いいえ
+- Description: タスク実行エグゼキュータースレッドプール内の最大スレッド数を制御します。この値は、同時タスク実行の上限です。これを増やすと並列処理が向上しますが、CPU、メモリ、ネットワークの使用量も増加します。一方、これを減らすと、タスク実行のバックログとレイテンシの増加を引き起こす可能性があります。この値は、予想される同時スケジュール済みジョブと利用可能なシステムリソースに応じて調整してください。
 - Introduced in: v3.2.0
 
 ##### `memory_tracker_enable`
@@ -790,17 +790,17 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: FE メモリートラッカーサブシステムを有効にします。`memory_tracker_enable` が `true` に設定されている場合、`MemoryUsageTracker` は定期的に登録されたメタデータモジュールをスキャンし、メモリ内の `MemoryUsageTracker.MEMORY_USAGE` マップを更新し、合計をログに記録し、`MetricRepo` がメモリー使用量とオブジェクト数ゲージをメトリック出力に公開するようにします。サンプリング間隔を制御するには `memory_tracker_interval_seconds` を使用します。この機能を有効にすると、メモリー消費の監視とデバッグに役立ちますが、CPU と I/O のオーバーヘッド、および追加のメトリックカーディナリティが発生します。
+- Is mutable: はい
+- Description: FEメモリトラッカーサブシステムを有効にします。`memory_tracker_enable`が`true`に設定されている場合、`MemoryUsageTracker`は登録されたメタデータモジュールを定期的にスキャンし、インメモリの`MemoryUsageTracker.MEMORY_USAGE`マップを更新し、合計をログに記録し、`MetricRepo`がメトリクス出力でメモリ使用量とオブジェクト数ゲージを公開するようにします。サンプリング間隔を制御するには`memory_tracker_interval_seconds`を使用します。この機能を有効にすると、メモリ消費量の監視とデバッグに役立ちますが、CPUとI/Oのオーバーヘッド、および追加のメトリクスカーディナリティが発生します。
 - Introduced in: v3.2.4
 
 ##### `memory_tracker_interval_seconds`
 
 - Default: 60
 - Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: FE の `MemoryUsageTracker` デーモンが FE プロセスと登録された `MemoryTrackable` モジュールのメモリ使用量をポーリングして記録する間隔 (秒単位)。`memory_tracker_enable` が `true` に設定されている場合、トラッカーはこの周期で実行され、`MEMORY_USAGE` を更新し、集計された JVM および追跡対象モジュールの使用状況をログに記録します。
+- Unit: 秒
+- Is mutable: はい
+- Description: FE `MemoryUsageTracker`デーモンがFEプロセスおよび登録された`MemoryTrackable`モジュールのメモリ使用量をポーリングして記録する間隔（秒単位）。`memory_tracker_enable`が`true`に設定されている場合、トラッカーはこの周期で実行され、`MEMORY_USAGE`を更新し、集計されたJVMおよび追跡対象モジュールの使用量をログに記録します。
 - Introduced in: v3.2.4
 
 ##### `mysql_nio_backlog_num`
@@ -808,8 +808,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 1024
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: FE ノードの MySQL サーバーが保持するバックログキューの長さ。
+- Is mutable: いいえ
+- Description: FEノードのMySQLサーバーが保持するバックログキューの長さ。
 - Introduced in: -
 
 ##### `mysql_server_version`
@@ -817,11 +817,11 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 8.0.33
 - Type: String
 - Unit: -
-- Is mutable: Yes
-- Description: クライアントに返される MySQL サーバーバージョン。このパラメーターを変更すると、以下の状況でバージョン情報に影響します。
+- Is mutable: はい
+- Description: クライアントに返されるMySQLサーバーのバージョン。このパラメータを変更すると、以下の状況でバージョン情報に影響します。
   1. `select version();`
-  2. ハンドシェイクパケットバージョン
-  3. グローバル変数 `version` の値 (`show variables like 'version';`)
+  2. ハンドシェイクパケットのバージョン
+  3. グローバル変数`version`の値（`show variables like 'version';`）
 - Introduced in: -
 
 ##### `mysql_service_io_threads_num`
@@ -829,8 +829,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 4
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: FE ノードの MySQL サーバーが I/O イベントを処理するために実行できる最大スレッド数。
+- Is mutable: いいえ
+- Description: FEノードのMySQLサーバーがI/Oイベントを処理するために実行できるスレッドの最大数。
 - Introduced in: -
 
 ##### `mysql_service_kill_after_disconnect`
@@ -838,8 +838,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: No
-- Description: MySQL TCP 接続が閉じられたと検出された場合 (読み取りで EOF) のサーバーによるセッションの処理方法を制御します。`true` に設定されている場合、サーバーはその接続で実行中のクエリを直ちに停止し、即座にクリーンアップを実行します。`false` の場合、サーバーは切断時に実行中のクエリを停止せず、保留中の要求タスクがない場合にのみクリーンアップを実行し、クライアントが切断された後も長時間実行中のクエリを続行できるようにします。注: TCP キープアライブを示唆する簡単なコメントにもかかわらず、このパラメーターは特に切断後の停止動作を管理し、孤立したクエリを終了させるか (信頼性の低い/負荷分散されたクライアントの背後で推奨)、完了させるかを希望するかどうかに応じて設定する必要があります。
+- Is mutable: いいえ
+- Description: MySQL TCP接続が閉じられたと検出された場合（読み取り時のEOF）、サーバーがセッションをどのように処理するかを制御します。`true`に設定されている場合、サーバーはその接続で実行中のクエリを直ちに終了し、即座にクリーンアップを実行します。`false`の場合、サーバーは切断時に実行中のクエリを終了せず、保留中のリクエストタスクがない場合にのみクリーンアップを実行し、クライアントが切断した後も長時間実行されるクエリを続行できるようにします。注：TCPキープアライブを示唆する短いコメントにもかかわらず、このパラメータは切断後の終了動作を具体的に管理しており、孤立したクエリを終了させるか（信頼性の低い/ロードバランスされたクライアントの背後で推奨）、完了させるかを希望するかどうかに応じて設定する必要があります。
 - Introduced in: -
 
 ##### `mysql_service_nio_enable_keep_alive`
@@ -847,8 +847,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: No
-- Description: MySQL 接続で TCP Keep-Alive を有効にします。ロードバランサーの背後にある長時間アイドル状態の接続に役立ちます。
+- Is mutable: いいえ
+- Description: MySQL接続のTCP Keep-Aliveを有効にします。ロードバランサーの背後にある長時間アイドル状態の接続に役立ちます。
 - Introduced in: -
 
 ##### `net_use_ipv6_when_priority_networks_empty`
@@ -856,17 +856,17 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: false
 - Type: Boolean
 - Unit: -
-- Is mutable: No
-- Description: `priority_networks` が指定されていない場合に IPv6 アドレスを優先的に使用するかどうかを制御するブール値。`true` は、ノードをホストするサーバーに IPv4 と IPv6 アドレスの両方があり、`priority_networks` が指定されていない場合に、システムが IPv6 アドレスを優先的に使用することを許可することを示します。
+- Is mutable: いいえ
+- Description: `priority_networks`が指定されていない場合にIPv6アドレスを優先的に使用するかどうかを制御するブール値。`true`は、ノードをホストするサーバーがIPv4とIPv6の両方のアドレスを持ち、`priority_networks`が指定されていない場合に、システムがIPv6アドレスを優先的に使用することを許可することを示します。
 - Introduced in: v3.3.0
 
 ##### `priority_networks`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: 複数の IP アドレスを持つサーバーの選択戦略を宣言します。このパラメーターで指定されたリストと一致する IP アドレスは最大 1 つである必要があることに注意してください。このパラメーターの値は、CIDR 表記でセミコロン (;) で区切られたエントリ (例: 10.10.10.0/24) で構成されるリストです。このリストのエントリに一致する IP アドレスがない場合、サーバーの使用可能な IP アドレスがランダムに選択されます。v3.3.0 から、StarRocks は IPv6 に基づくデプロイメントをサポートしています。サーバーに IPv4 と IPv6 アドレスの両方があり、このパラメーターが指定されていない場合、システムはデフォルトで IPv4 アドレスを使用します。`net_use_ipv6_when_priority_networks_empty` を `true` に設定することで、この動作を変更できます。
+- Is mutable: いいえ
+- Description: 複数のIPアドレスを持つサーバーの選択戦略を宣言します。このパラメータで指定されたリストには、最大で1つのIPアドレスが一致する必要があることに注意してください。このパラメータの値は、CIDR表記でセミコロン（;）で区切られたエントリ（例：10.10.10.0/24）で構成されるリストです。このリストのエントリに一致するIPアドレスがない場合、サーバーの利用可能なIPアドレスがランダムに選択されます。v3.3.0以降、StarRocksはIPv6ベースのデプロイメントをサポートしています。サーバーがIPv4とIPv6の両方のアドレスを持ち、このパラメータが指定されていない場合、システムはデフォルトでIPv4アドレスを使用します。`net_use_ipv6_when_priority_networks_empty`を`true`に設定することで、この動作を変更できます。
 - Introduced in: -
 
 ##### `proc_profile_cpu_enable`
@@ -874,8 +874,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: この項目が `true` に設定されている場合、バックグラウンドの `ProcProfileCollector` は `AsyncProfiler` を使用して CPU プロファイルを収集し、HTML レポートを `sys_log_dir/proc_profile` に書き込みます。各収集実行では、`proc_profile_collect_time_s` で設定された期間 CPU スタックを記録し、Java スタック深度に `proc_profile_jstack_depth` を使用します。生成されたプロファイルは圧縮され、古いファイルは `proc_profile_file_retained_days` および `proc_profile_file_retained_size_bytes` に従ってパージされます。`AsyncProfiler` にはネイティブライブラリ (`libasyncProfiler.so`) が必要です。`/tmp` の noexec 問題を回避するために `one.profiler.extractPath` は `STARROCKS_HOME_DIR/bin` に設定されています。
+- Is mutable: はい
+- Description: この項目が`true`に設定されている場合、バックグラウンドの`ProcProfileCollector`は`AsyncProfiler`を使用してCPUプロファイルを収集し、`sys_log_dir/proc_profile`の下にHTMLレポートを書き込みます。各収集実行は、`proc_profile_collect_time_s`で構成された期間のCPUスタックを記録し、Javaスタック深度には`proc_profile_jstack_depth`を使用します。生成されたプロファイルは圧縮され、古いファイルは`proc_profile_file_retained_days`および`proc_profile_file_retained_size_bytes`に従って削除されます。`AsyncProfiler`にはネイティブライブラリ（`libasyncProfiler.so`）が必要です。`/tmp`でのnoexecの問題を回避するために、`one.profiler.extractPath`は`STARROCKS_HOME_DIR/bin`に設定されています。
 - Introduced in: v3.2.12
 
 ##### `qe_max_connection`
@@ -883,8 +883,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 4096
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: FE ノードへのすべてのユーザーが確立できる最大接続数。v3.1.12 および v3.2.7 以降、デフォルト値が `1024` から `4096` に変更されました。
+- Is mutable: いいえ
+- Description: すべてのユーザーがFEノードに確立できる接続の最大数。v3.1.12およびv3.2.7以降、デフォルト値は`1024`から`4096`に変更されました。
 - Introduced in: -
 
 ##### `query_port`
@@ -892,8 +892,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 9030
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: FE ノードの MySQL サーバーがリッスンするポート。
+- Is mutable: いいえ
+- Description: FEノードのMySQLサーバーがリッスンするポート。
 - Introduced in: -
 
 ##### `rpc_port`
@@ -901,8 +901,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 9020
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: FE ノードの Thrift サーバーがリッスンするポート。
+- Is mutable: いいえ
+- Description: FEノードのThriftサーバーがリッスンするポート。
 - Introduced in: -
 
 ##### `slow_lock_stack_trace_reserve_levels`
@@ -910,26 +910,26 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 15
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: StarRocks が遅いロックまたは保持されているロックのロックデバッグ情報をダンプする際に、いくつのスタックトレースフレームをキャプチャして出力するかを制御します。この値は、排他ロック所有者、現在のスレッド、および最古/共有リーダーの JSON を生成する際に `QueryableReentrantReadWriteLock` によって `LogUtil.getStackTraceToJsonArray` に渡されます。この値を増やすと、遅いロックまたはデッドロックの問題の診断に役立つより多くのコンテキストが得られますが、JSON ペイロードが大きくなり、スタックキャプチャの CPU/メモリがわずかに増加します。減らすとオーバーヘッドが減少します。注: リーダーエントリは、低速ロックのみをログに記録する場合、`slow_lock_threshold_ms` によってフィルタリングできます。
+- Is mutable: はい
+- Description: StarRocksが遅いロックまたは保持されているロックのロックデバッグ情報をダンプするときに、いくつのスタックトレースフレームがキャプチャされ出力されるかを制御します。この値は、排他ロック所有者、現在のスレッド、および最も古い/共有リーダーのJSONを生成する際に、`QueryableReentrantReadWriteLock`によって`LogUtil.getStackTraceToJsonArray`に渡されます。この値を増やすと、より大きなJSONペイロードとスタックキャプチャのためのわずかに高いCPU/メモリを犠牲にして、遅いロックまたはデッドロックの問題を診断するためのより多くのコンテキストが提供されます。減らすとオーバーヘッドが削減されます。注：遅いロックのみをログに記録する場合、リーダーエントリは`slow_lock_threshold_ms`でフィルタリングできます。
 - Introduced in: v3.4.0, v3.5.0
 
 ##### `ssl_cipher_blacklist`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: IANA 名で SSL 暗号スイートをブラックリストに登録するための、正規表現をサポートするコンマ区切りリスト。ホワイトリストとブラックリストの両方が設定されている場合、ブラックリストが優先されます。
+- Is mutable: いいえ
+- Description: IANA名でSSL暗号スイートをブラックリスト化するための、正規表現をサポートするカンマ区切りのリスト。ホワイトリストとブラックリストの両方が設定されている場合、ブラックリストが優先されます。
 - Introduced in: v4.0
 
 ##### `ssl_cipher_whitelist`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: IANA 名で SSL 暗号スイートをホワイトリストに登録するための、正規表現をサポートするコンマ区切りリスト。ホワイトリストとブラックリストの両方が設定されている場合、ブラックリストが優先されます。
+- Is mutable: いいえ
+- Description: IANA名でSSL暗号スイートをホワイトリスト化するための、正規表現をサポートするカンマ区切りのリスト。ホワイトリストとブラックリストの両方が設定されている場合、ブラックリストが優先されます。
 - Introduced in: v4.0
 
 ##### `task_runs_concurrency`
@@ -937,8 +937,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 4
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: 同時に実行される TaskRun インスタンスのグローバル制限。`TaskRunScheduler` は、現在の実行数が `task_runs_concurrency` 以上の場合、新しい実行のスケジュールを停止するため、この値はスケジューラー全体で並行 TaskRun 実行を制限します。これは `MVPCTRefreshPartitioner` によって TaskRun ごとのパーティション更新粒度を計算するためにも使用されます。値を増やすと並行性とリソース使用量が増加し、減らすと並行性が減少し、実行ごとのパーティション更新が大きくなります。意図的にスケジューリングを無効にする場合を除き、0 または負の値に設定しないでください。0 (または負の値) は、`TaskRunScheduler` による新しい TaskRun のスケジューリングを事実上妨げます。
+- Is mutable: はい
+- Description: 同時に実行されるTaskRunインスタンスのグローバル制限。現在の実行数が`task_runs_concurrency`以上の場合、`TaskRunScheduler`は新しい実行のスケジュールを停止するため、この値はスケジューラー全体での並列TaskRun実行を制限します。また、`MVPCTRefreshPartitioner`によって、TaskRunごとのパーティション更新粒度を計算するためにも使用されます。値を増やすと並列処理とリソース使用量が増加し、減らすと並行処理が減少し、実行ごとのパーティション更新が大きくなります。意図的にスケジューリングを無効にする場合を除き、0または負の値に設定しないでください。0（または負の値）は、`TaskRunScheduler`による新しいTaskRunのスケジュールを事実上妨げます。
 - Introduced in: v3.2.0
 
 ##### `task_runs_queue_length`
@@ -946,8 +946,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 500
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: 保留中のキューに保持される保留中の TaskRun 項目の最大数を制限します。`TaskRunManager` は現在の保留中の数をチェックし、有効な保留中の TaskRun の数が `task_runs_queue_length` 以上の場合、新しい送信を拒否します。マージ/承認された TaskRun が追加される前に同じ制限が再チェックされます。メモリとスケジューリングのバックログのバランスをとるためにこの値を調整します。拒否を回避するために、大規模でバースト性の高いワークロードの場合は高く設定し、メモリを制限して保留中のバックログを減らす場合は低く設定します。
+- Is mutable: はい
+- Description: 保留中のキューに保持される保留中のTaskRunアイテムの最大数を制限します。`TaskRunManager`は現在の保留中の数をチェックし、有効な保留中のTaskRun数が`task_runs_queue_length`以上の場合、新しい送信を拒否します。マージ/承認されたTaskRunが追加される前に、同じ制限が再チェックされます。メモリとスケジューリングのバックログのバランスを取るためにこの値を調整してください。大量のバースト的なワークロードの場合は拒否を避けるために高く設定し、メモリを制限し保留中のバックログを減らすために低く設定します。
 - Introduced in: v3.2.0
 
 ##### `thrift_backlog_num`
@@ -955,16 +955,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 1024
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: FE ノードの Thrift サーバーが保持するバックログキューの長さ。
+- Is mutable: いいえ
+- Description: FEノードのThriftサーバーが保持するバックログキューの長さ。
 - Introduced in: -
 
 ##### `thrift_client_timeout_ms`
 
 - Default: 5000
 - Type: Int
-- Unit: Milliseconds
-- Is mutable: No
+- Unit: ミリ秒
+- Is mutable: いいえ
 - Description: アイドル状態のクライアント接続がタイムアウトするまでの時間。
 - Introduced in: -
 
@@ -972,9 +972,9 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - Default: -1
 - Type: Int
-- Unit: Bytes
-- Is mutable: No
-- Description: サーバーの Thrift プロトコルを構築するときに使用される Thrift RPC メッセージ本文の最大許容サイズ (バイト単位) を制御します ( `ThriftServer` の TBinaryProtocol.Factory に渡されます)。値が `-1` の場合、制限が無効になります (無制限)。正の値を設定すると、上限が適用され、これより大きいメッセージは Thrift レイヤーによって拒否され、メモリ使用量を制限し、サイズ超過の要求や DoS のリスクを軽減するのに役立ちます。正当な要求の拒否を避けるために、予想されるペイロード (大きな構造体やバッチデータ) に十分な大きさに設定してください。
+- Unit: バイト
+- Is mutable: いいえ
+- Description: サーバーのThriftプロトコルを構築する際に使用されるThrift RPCメッセージボディの最大許容サイズ（バイト単位）を制御します（`ThriftServer`のTBinaryProtocol.Factoryに渡されます）。`-1`の値は制限を無効にします（無制限）。正の値を設定すると上限が強制され、これより大きいメッセージはThriftレイヤーによって拒否されます。これにより、メモリ使用量を制限し、過大なリクエストやDoSのリスクを軽減するのに役立ちます。正当なリクエストが拒否されないように、予想されるペイロード（大きな構造体やバッチデータ）に十分な大きさに設定してください。
 - Introduced in: v3.2.0
 
 ##### `thrift_server_max_worker_threads`
@@ -982,8 +982,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 4096
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: FE ノードの Thrift サーバーがサポートするワーカー スレッドの最大数。
+- Is mutable: はい
+- Description: FEノードのThriftサーバーがサポートするワーカー スレッドの最大数。
 - Introduced in: -
 
 ##### `thrift_server_queue_size`
@@ -991,8 +991,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 4096
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: 要求が保留されているキューの長さ。Thrift サーバーで処理されているスレッドの数が `thrift_server_max_worker_threads` で指定された値を超えると、新しい要求が保留中のキューに追加されます。
+- Is mutable: いいえ
+- Description: リクエストが保留されているキューの長さ。Thriftサーバーで処理されているスレッドの数が`thrift_server_max_worker_threads`で指定された値を超えると、新しいリクエストが保留中のキューに追加されます。
 - Introduced in: -
 
 ### メタデータとクラスター管理
@@ -1003,7 +1003,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Tasks
 - Is mutable: No
-- Description: alter サブシステムで使用される内部ワーカー スレッド プール キューの容量を制御します。これは `AlterHandler` で `ThreadPoolManager.newDaemonCacheThreadPool` に `alter_max_worker_threads` とともに渡されます。保留中の alter タスクの数が `alter_max_worker_queue_size` を超えると、新しい送信は拒否され、`RejectedExecutionException` がスローされる可能性があります ( `AlterHandler.handleFinishAlterTask` を参照)。この値を調整して、メモリ使用量と、同時 alter タスクに対して許可するバックログの量のバランスを取ります。
+- Description: alterサブシステムが使用する内部ワーカー スレッド プール キューの容量を制御します。`AlterHandler`の`ThreadPoolManager.newDaemonCacheThreadPool`に`alter_max_worker_threads`とともに渡されます。保留中のalterタスクの数が`alter_max_worker_queue_size`を超えると、新しい送信は拒否され、`RejectedExecutionException`がスローされる可能性があります（`AlterHandler.handleFinishAlterTask`を参照）。この値を調整して、メモリ使用量と同時alterタスクに許可するバックログの量のバランスを取ります。
 - Introduced in: v3.2.0
 
 ##### `alter_max_worker_threads`
@@ -1012,7 +1012,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Threads
 - Is mutable: No
-- Description: AlterHandler のスレッドプールの最大ワーカー スレッド数を設定します。AlterHandler はこの値を使用してエクゼキューターを構築し、alter 関連のタスクを実行および完了します (例: handleFinishAlterTask 経由で `AlterReplicaTask` を送信)。この値は alter 操作の同時実行を制限します。値を上げると並行性とリソース使用量が増加し、下げると同時 alter が制限され、ボトルネックになる可能性があります。エクゼキューターは `alter_max_worker_queue_size` とともに作成され、ハンドラーのスケジューリングは `alter_scheduler_interval_millisecond` を使用します。
+- Description: AlterHandlerのスレッドプールにおけるワーカー スレッドの最大数を設定します。AlterHandlerはこの値を使用してエグゼキュータを構築し、alter関連タスク（例: `handleFinishAlterTask`を介した`AlterReplicaTask`の送信）を実行および完了します。この値はalter操作の同時実行を制限します。値を上げると並列処理とリソース使用量が増加し、値を下げると同時alterが制限され、ボトルネックになる可能性があります。エグゼキュータは`alter_max_worker_queue_size`とともに作成され、ハンドラ スケジューリングは`alter_scheduler_interval_millisecond`を使用します。
 - Introduced in: v3.2.0
 
 ##### `automated_cluster_snapshot_interval_seconds`
@@ -1030,7 +1030,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Milliseconds
 - Is mutable: Yes
-- Description: 連続する 2 回の Hive メタデータ キャッシュ更新の間隔。
+- Description: 2つの連続するHiveメタデータ キャッシュ更新の間隔。
 - Introduced in: v2.5.5
 
 ##### `background_refresh_metadata_time_secs_since_last_access_secs`
@@ -1039,7 +1039,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Long
 - Unit: Seconds
 - Is mutable: Yes
-- Description: Hive メタデータキャッシュ更新タスクの有効期限。アクセスされた Hive カタログの場合、指定された時間以上アクセスされていない場合、StarRocks はそのキャッシュされたメタデータの更新を停止します。アクセスされていない Hive カタログの場合、StarRocks はそのキャッシュされたメタデータを更新しません。
+- Description: Hiveメタデータ キャッシュ更新タスクの有効期限。アクセスされたHiveカタログの場合、指定された時間以上アクセスされていない場合、StarRocksはそのキャッシュされたメタデータの更新を停止します。アクセスされていないHiveカタログの場合、StarRocksはそのキャッシュされたメタデータを更新しません。
 - Introduced in: v2.5.5
 
 ##### `bdbje_cleaner_threads`
@@ -1048,7 +1048,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: StarRocks ジャーナルで使用される Berkeley DB Java Edition (JE) 環境のバックグラウンドクリーナースレッドの数。この値は `BDBEnvironment.initConfigs` で環境初期化中に読み取られ、`Config.bdbje_cleaner_threads` を使用して `EnvironmentConfig.CLEANER_THREADS` に適用されます。これは JE ログクリーニングとスペース再利用の並行性を制御します。値を増やすとクリーニングが高速化される可能性がありますが、追加の CPU とフォアグラウンド操作との I/O 干渉が発生する可能性があります。変更は BDB 環境が (再) 初期化された場合にのみ有効になるため、新しい値を適用するにはフロントエンドの再起動が必要です。
+- Description: StarRocksジャーナルが使用するBerkeley DB Java Edition (JE) 環境のバックグラウンド クリーナー スレッド数。この値は`BDBEnvironment.initConfigs`での環境初期化中に読み取られ、`Config.bdbje_cleaner_threads`を使用して`EnvironmentConfig.CLEANER_THREADS`に適用されます。JEログのクリーンアップとスペース再利用の並列処理を制御します。値を増やすと、フォアグラウンド操作との追加のCPUおよびI/O干渉を犠牲にして、クリーンアップを高速化できます。変更はBDB環境が(再)初期化されたときにのみ有効になるため、新しい値を適用するにはフロントエンドの再起動が必要です。
 - Introduced in: v3.2.0
 
 ##### `bdbje_heartbeat_timeout_second`
@@ -1057,7 +1057,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Seconds
 - Is mutable: No
-- Description: StarRocks クラスター内のリーダー、フォロワー、オブザーバー FE 間でハートビートがタイムアウトするまでの時間。
+- Description: StarRocksクラスター内のリーダー、フォロワー、オブザーバーFE間のハートビートがタイムアウトするまでの時間。
 - Introduced in: -
 
 ##### `bdbje_lock_timeout_second`
@@ -1066,7 +1066,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Seconds
 - Is mutable: No
-- Description: BDB JE ベースの FE のロックがタイムアウトするまでの時間。
+- Description: BDB JEベースのFEにおけるロックがタイムアウトするまでの時間。
 - Introduced in: -
 
 ##### `bdbje_replay_cost_percent`
@@ -1075,7 +1075,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Percent
 - Is mutable: No
-- Description: BDB JE ログからのトランザクションのリプレイとネットワーク復元による同じデータの取得の相対コスト (パーセンテージ) を設定します。この値は基盤となる JE レプリケーションパラメーター `REPLAY_COST_PERCENT` に提供され、通常 `>100` であり、リプレイが通常ネットワーク復元よりも高価であることを示します。システムは、潜在的なリプレイのためにクリーンアップされたログファイルを保持するかどうかを決定する際に、リプレイコストにログサイズを掛けたものとネットワーク復元のコストを比較します。ネットワーク復元の方が効率的であると判断された場合、ファイルは削除されます。値が 0 の場合、このコスト比較に基づく保持は無効になります。`REP_STREAM_TIMEOUT` 内のレプリカまたはアクティブなレプリケーションに必要なログファイルは常に保持されます。
+- Description: BDB JEログからトランザクションをリプレイする相対コスト（パーセンテージ）と、ネットワーク リストアを介して同じデータを取得するコストを設定します。この値は、基盤となるJEレプリケーション パラメータ`REPLAY_COST_PERCENT`に供給され、通常は`>100`であり、リプレイがネットワーク リストアよりも高価であることを示します。潜在的なリプレイのためにクリーンアップされたログファイルを保持するかどうかを決定する際、システムはリプレイ コストにログ サイズを乗じたものをネットワーク リストアのコストと比較します。ネットワーク リストアの方が効率的と判断された場合、ファイルは削除されます。値が0の場合、このコスト比較に基づく保持は無効になります。`REP_STREAM_TIMEOUT`内のレプリカ、またはアクティブなレプリケーションに必要なログファイルは常に保持されます。
 - Introduced in: v3.2.0
 
 ##### `bdbje_replica_ack_timeout_second`
@@ -1084,7 +1084,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Seconds
 - Is mutable: No
-- Description: メタデータがリーダー FE からフォロワー FE に書き込まれるときに、リーダー FE が指定された数のフォロワー FE から ACK メッセージを待機できる最大時間。単位: 秒。大量のメタデータが書き込まれている場合、フォロワー FE がリーダー FE に ACK メッセージを返すまでに長い時間がかかり、ACK タイムアウトが発生する可能性があります。この状況では、メタデータ書き込みが失敗し、FE プロセスが終了します。この状況を防ぐために、このパラメーターの値を増やすことをお勧めします。
+- Description: リーダーFEからフォロワーFEにメタデータが書き込まれる際に、リーダーFEが指定された数のフォロワーFEからのACKメッセージを待機できる最大時間。単位: 秒。大量のメタデータが書き込まれている場合、フォロワーFEがリーダーFEにACKメッセージを返すまでに時間がかかり、ACKタイムアウトが発生する可能性があります。この状況では、メタデータの書き込みが失敗し、FEプロセスが終了します。この状況を防ぐために、このパラメータの値を増やすことをお勧めします。
 - Introduced in: -
 
 ##### `bdbje_reserved_disk_size`
@@ -1093,7 +1093,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Long
 - Unit: Bytes
 - Is mutable: No
-- Description: Berkeley DB JE が「保護されていない」(削除可能) ログ/データファイルとして予約するバイト数を制限します。StarRocks はこの値を BDBEnvironment の `EnvironmentConfig.RESERVED_DISK` 経由で JE に渡します。JE の組み込みデフォルトは 0 (無制限) です。StarRocks のデフォルト (512 MiB) は、JE が保護されていないファイルに過剰なディスクスペースを予約するのを防ぎつつ、古いファイルを安全にクリーンアップできるようにします。ディスクが制限されているシステムでこの値を調整します。値を減らすと JE はより多くのファイルをより早く解放でき、増やすと JE はより多くの予約スペースを保持できます。変更を有効にするにはプロセスを再起動する必要があります。
+- Description: Berkeley DB JEが「保護されていない」（削除可能な）ログ/データファイルとして予約するバイト数を制限します。StarRocksはこの値をBDBEnvironmentの`EnvironmentConfig.RESERVED_DISK`を介してJEに渡します。JEの組み込みデフォルトは0（無制限）です。StarRocksのデフォルト（512 MiB）は、JEが保護されていないファイルのために過剰なディスクスペースを予約するのを防ぎつつ、古いファイルを安全にクリーンアップできるようにします。ディスク容量が制約されているシステムではこの値を調整してください。値を減らすとJEはより早くファイルを解放でき、値を増やすとJEはより多くの予約スペースを保持できます。変更を有効にするにはプロセスの再起動が必要です。
 - Introduced in: v3.2.0
 
 ##### `bdbje_reset_election_group`
@@ -1102,7 +1102,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: BDBJE レプリケーショングループをリセットするかどうか。このパラメーターが `TRUE` に設定されている場合、FE は BDBJE レプリケーショングループをリセットし (つまり、すべての選挙可能な FE ノードの情報を削除し)、リーダー FE として起動します。リセット後、この FE はクラスター内の唯一のメンバーとなり、他の FE は `ALTER SYSTEM ADD/DROP FOLLOWER/OBSERVER 'xxx'` を使用してこのクラスターに再参加できます。ほとんどのフォロワー FE のデータが破損しているためにリーダー FE を選出できない場合にのみこの設定を使用してください。`reset_election_group` は `metadata_failure_recovery` の代替として使用されます。
+- Description: BDBJEレプリケーション グループをリセットするかどうか。このパラメータが`TRUE`に設定されている場合、FEはBDBJEレプリケーション グループをリセットし（つまり、すべての選出可能なFEノードの情報を削除し）、リーダーFEとして起動します。リセット後、このFEはクラスター内の唯一のメンバーとなり、他のFEは`ALTER SYSTEM ADD/DROP FOLLOWER/OBSERVER 'xxx'`を使用してこのクラスターに再参加できます。この設定は、ほとんどのフォロワーFEのデータが破損しているためにリーダーFEを選出できない場合にのみ使用してください。`reset_election_group`は`metadata_failure_recovery`を置き換えるために使用されます。
 - Introduced in: -
 
 ##### `black_host_connect_failures_within_time`
@@ -1111,7 +1111,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: ブラックリストに登録された BE ノードに許可される接続失敗のしきい値。BE ノードが自動的に BE ブラックリストに追加された場合、StarRocks はその接続性を評価し、BE ブラックリストから削除できるかどうかを判断します。`black_host_history_sec` 内で、ブラックリストに登録された BE ノードが `black_host_connect_failures_within_time` で設定されたしきい値よりも少ない接続失敗である場合にのみ、BE ブラックリストから削除できます。
+- Description: ブラックリストに登録されたBEノードに許可される接続失敗のしきい値。BEノードが自動的にBEブラックリストに追加された場合、StarRocksはその接続性を評価し、BEブラックリストから削除できるかどうかを判断します。`black_host_history_sec`内で、ブラックリストに登録されたBEノードの接続失敗が`black_host_connect_failures_within_time`で設定されたしきい値よりも少ない場合にのみ、BEブラックリストから削除できます。
 - Introduced in: v3.3.0
 
 ##### `black_host_history_sec`
@@ -1120,7 +1120,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
-- Description: BE ブラックリストに登録された BE ノードの過去の接続失敗を保持する期間。BE ノードが自動的に BE ブラックリストに追加された場合、StarRocks はその接続性を評価し、BE ブラックリストから削除できるかどうかを判断します。`black_host_history_sec` 内で、ブラックリストに登録された BE ノードが `black_host_connect_failures_within_time` で設定されたしきい値よりも少ない接続失敗である場合にのみ、BE ブラックリストから削除できます。
+- Description: BEブラックリスト内のBEノードの過去の接続失敗を保持する期間。BEノードが自動的にBEブラックリストに追加された場合、StarRocksはその接続性を評価し、BEブラックリストから削除できるかどうかを判断します。`black_host_history_sec`内で、ブラックリストに登録されたBEノードの接続失敗が`black_host_connect_failures_within_time`で設定されたしきい値よりも少ない場合にのみ、BEブラックリストから削除できます。
 - Introduced in: v3.3.0
 
 ##### `brpc_connection_pool_size`
@@ -1129,7 +1129,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Connections
 - Is mutable: No
-- Description: FE の BrpcProxy がエンドポイントごとに使用する BRPC 接続プールの最大数。この値は `setMaxTotoal` および `setMaxIdleSize` を介して RpcClientOptions に適用されるため、各要求はプールから接続を借りる必要があるため、同時発信 BRPC 要求を直接制限します。高並行シナリオでは、要求キューイングを回避するためにこれを増やしてください。増やすとソケットとメモリの使用量が増加し、リモートサーバーの負荷が増加する可能性があります。調整する際には、`brpc_idle_wait_max_time`、`brpc_short_connection`、`brpc_inner_reuse_pool`、`brpc_reuse_addr`、および `brpc_min_evictable_idle_time_ms` などの関連設定を考慮してください。この値を変更することはホットリロード可能ではなく、再起動が必要です。
+- Description: FEのBrpcProxyが使用するエンドポイントごとのプールされたBRPC接続の最大数。この値は`setMaxTotoal`と`setMaxIdleSize`を介してRpcClientOptionsに適用されるため、各リクエストがプールから接続を借りる必要があるため、同時発信BRPCリクエストを直接制限します。高並列シナリオでは、リクエストのキューイングを避けるためにこれを増やしてください。増やすとソケットとメモリの使用量が増加し、リモートサーバーの負荷が増加する可能性があります。調整する際は、`brpc_idle_wait_max_time`、`brpc_short_connection`、`brpc_inner_reuse_pool`、`brpc_reuse_addr`、`brpc_min_evictable_idle_time_ms`などの関連設定を考慮してください。この値の変更はホットリロード可能ではなく、再起動が必要です。
 - Introduced in: v3.2.0
 
 ##### `brpc_short_connection`
@@ -1138,7 +1138,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: boolean
 - Unit: -
 - Is mutable: No
-- Description: 下層の brpc RpcClient が短命の接続を使用するかどうかを制御します。有効な場合 (`true`)、RpcClientOptions.setShortConnection が設定され、要求完了後に接続が閉じられ、接続設定のオーバーヘッドが増加し、レイテンシーが増加する代わりに、長命のソケットの数が減少します。無効な場合 (`false`、デフォルト)、永続的な接続と接続プールが使用されます。このオプションを有効にすると、接続プール動作に影響するため、`brpc_connection_pool_size`、`brpc_idle_wait_max_time`、`brpc_min_evictable_idle_time_ms`、`brpc_reuse_addr`、および `brpc_inner_reuse_pool` と合わせて検討する必要があります。一般的な高スループットデプロイメントでは無効のままにし、ソケットのライフタイムを制限する必要がある場合や、ネットワークポリシーによって短命の接続が要求される場合にのみ有効にします。
+- Description: 基盤となるbrpc RpcClientが短命の接続を使用するかどうかを制御します。有効（`true`）にすると、RpcClientOptions.setShortConnectionが設定され、リクエスト完了後に接続が閉じられ、接続設定のオーバーヘッド増加とレイテンシ増加を犠牲にして、長寿命ソケットの数を減らします。無効（`false`、デフォルト）にすると、永続接続と接続プールが使用されます。このオプションを有効にすると接続プールの動作に影響するため、`brpc_connection_pool_size`、`brpc_idle_wait_max_time`、`brpc_min_evictable_idle_time_ms`、`brpc_reuse_addr`、`brpc_inner_reuse_pool`と合わせて考慮する必要があります。一般的な高スループット展開では無効のままにしてください。ソケットの寿命を制限する場合、またはネットワークポリシーによって短命接続が必要な場合にのみ有効にしてください。
 - Introduced in: v3.3.11, v3.4.1, v3.5.0
 
 ##### `catalog_try_lock_timeout_ms`
@@ -1156,7 +1156,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: `true` の場合、CheckpointController はリーダー FE のみをチェックポイントワーカーとして選択します。`false` の場合、コントローラーは任意のフロントエンドを選択し、ヒープ使用量が少ないノードを優先します。`false` の場合、ワーカーは最近の失敗時間と `heapUsedPercent` でソートされます (リーダーは無限のヒープ使用量を持つものとして扱われ、選択されないようにします)。クラスターのスナップショットメタデータを必要とする操作の場合、コントローラーはこのフラグに関係なくリーダーの選択を強制します。`true` を有効にすると、チェックポイント作業がリーダーに集中します (単純ですが、リーダーの CPU/メモリとネットワーク負荷が増加します)。`false` のままにすると、負荷の少ない FE にチェックポイント負荷が分散されます。この設定は、ワーカーの選択と、`checkpoint_timeout_seconds` などのタイムアウトや `thrift_rpc_timeout_ms` などの RPC 設定との相互作用に影響します。
+- Description: `true`の場合、CheckpointControllerはリーダーFEのみをチェックポイントワーカーとして選択します。`false`の場合、コントローラーは任意のフロントエンドを選択でき、ヒープ使用量が少ないノードを優先します。`false`の場合、ワーカーは最近の失敗時間と`heapUsedPercent`でソートされます（リーダーは選択を避けるために無限の使用量を持つものとして扱われます）。クラスター スナップショット メタデータを必要とする操作の場合、コントローラーはこのフラグに関係なくリーダー選択を強制します。`true`を有効にすると、チェックポイント作業がリーダーに集中します（より単純ですが、リーダーのCPU/メモリとネットワーク負荷が増加します）。`false`のままにすると、チェックポイント負荷が負荷の少ないFEに分散されます。この設定は、ワーカーの選択と、`checkpoint_timeout_seconds`などのタイムアウトや`thrift_rpc_timeout_ms`などのRPC設定との相互作用に影響します。
 - Introduced in: v3.4.0, v3.5.0
 
 ##### `checkpoint_timeout_seconds`
@@ -1165,7 +1165,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Long
 - Unit: Seconds
 - Is mutable: Yes
-- Description: リーダーの CheckpointController がチェックポイントワーカーがチェックポイントを完了するのを待つ最大時間 (秒単位)。コントローラーはこの値をナノ秒に変換し、ワーカーの結果キューをポーリングします。このタイムアウト内に成功した完了が受信されない場合、チェックポイントは失敗と見なされ、createImage は失敗を返します。この値を増やすと、長時間実行されるチェックポイントに対応できますが、失敗検出と後続のイメージ伝播が遅れます。値を減らすと、より高速なフェイルオーバー/再試行が発生しますが、低速なワーカーに対して誤ったタイムアウトが発生する可能性があります。この設定は、チェックポイント作成中の `CheckpointController` での待機期間のみを制御し、ワーカーの内部チェックポイント動作は変更しません。
+- Description: リーダーのCheckpointControllerがチェックポイントワーカーがチェックポイントを完了するのを待機する最大時間（秒単位）。コントローラーはこの値をナノ秒に変換し、ワーカーの結果キューをポーリングします。このタイムアウト内に正常な完了が受信されない場合、チェックポイントは失敗と見なされ、`createImage`は失敗を返します。この値を増やすと、実行時間の長いチェックポイントに対応できますが、障害検出とそれに続くイメージ伝播が遅れます。値を減らすと、より高速なフェイルオーバー/再試行が発生しますが、遅いワーカーに対して誤ったタイムアウトを生成する可能性があります。この設定は、チェックポイント作成中の`CheckpointController`での待機期間のみを制御し、ワーカーの内部チェックポイント動作は変更しません。
 - Introduced in: v3.4.0, v3.5.0
 
 ##### `db_used_data_quota_update_interval_secs`
@@ -1174,7 +1174,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
-- Description: データベース使用データクォータが更新される間隔。StarRocks は、ストレージ消費量を追跡するために、すべてのデータベースの使用データクォータを定期的に更新します。この値はクォータ強制とメトリック収集に使用されます。過剰なシステム負荷を防ぐため、許容される最小間隔は 30 秒です。30 未満の値は拒否されます。
+- Description: データベースの使用済みデータクォータが更新される間隔。StarRocksは、ストレージ消費を追跡するために、すべてのデータベースの使用済みデータクォータを定期的に更新します。この値は、クォータの適用とメトリクスの収集に使用されます。過剰なシステム負荷を防ぐため、許可される最小間隔は30秒です。30未満の値は拒否されます。
 - Introduced in: -
 
 ##### `drop_backend_after_decommission`
@@ -1183,7 +1183,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: BE が停止解除された後に BE を削除するかどうか。`TRUE` は、BE が停止解除された直後に削除されることを示します。`FALSE` は、BE が停止解除された後も削除されないことを示します。
+- Description: BEが廃止された後にBEを削除するかどうか。`TRUE`は、BEが廃止された直後に削除されることを示します。`FALSE`は、BEが廃止された後に削除されないことを示します。
 - Introduced in: -
 
 ##### `edit_log_port`
@@ -1192,7 +1192,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: クラスター内のリーダー、フォロワー、オブザーバー FE 間で通信に使用されるポート。
+- Description: クラスター内のリーダー、フォロワー、オブザーバーFE間の通信に使用されるポート。
 - Introduced in: -
 
 ##### `edit_log_roll_num`
@@ -1201,7 +1201,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: メタデータログエントリの最大数。この数に達すると、これらのログエントリ用のログファイルが作成されます。このパラメーターは、ログファイルのサイズを制御するために使用されます。新しいログファイルは BDBJE データベースに書き込まれます。
+- Description: メタデータログエントリのログファイルが作成されるまでに書き込むことができるメタデータログエントリの最大数。このパラメータはログファイルのサイズを制御するために使用されます。新しいログファイルはBDBJEデータベースに書き込まれます。
 - Introduced in: -
 
 ##### `edit_log_type`
@@ -1210,7 +1210,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: 生成できる編集ログの種類。値を `BDB` に設定します。
+- Description: 生成できる編集ログのタイプ。値を`BDB`に設定します。
 - Introduced in: -
 
 ##### `enable_background_refresh_connector_metadata`
@@ -1219,7 +1219,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 定期的な Hive メタデータキャッシュ更新を有効にするかどうか。有効にすると、StarRocks は Hive クラスターのメタストア (Hive Metastore または AWS Glue) をポーリングし、頻繁にアクセスされる Hive カタログのキャッシュされたメタデータを更新してデータ変更を認識します。`true` は Hive メタデータキャッシュ更新を有効にすることを示し、`false` は無効にすることを示します。
+- Description: 定期的なHiveメタデータ キャッシュ更新を有効にするかどうか。有効にすると、StarRocksはHiveクラスターのメタストア（Hive MetastoreまたはAWS Glue）をポーリングし、頻繁にアクセスされるHiveカタログのキャッシュされたメタデータを更新してデータ変更を認識します。`true`はHiveメタデータ キャッシュ更新を有効にすることを示し、`false`は無効にすることを示します。
 - Introduced in: v2.5.5
 
 ##### `enable_collect_query_detail_info`
@@ -1228,7 +1228,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: クエリのプロファイルを収集するかどうか。このパラメーターが `TRUE` に設定されている場合、システムはクエリのプロファイルを収集します。このパラメーターが `FALSE` に設定されている場合、システムはクエリのプロファイルを収集しません。
+- Description: クエリのプロファイルを収集するかどうか。このパラメータが`TRUE`に設定されている場合、システムはクエリのプロファイルを収集します。このパラメータが`FALSE`に設定されている場合、システムはクエリのプロファイルを収集しません。
 - Introduced in: -
 
 ##### `enable_create_partial_partition_in_batch`
@@ -1237,7 +1237,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: boolean
 - Unit: -
 - Is mutable: Yes
-- Description: この項目が `false` (デフォルト) に設定されている場合、StarRocks は、バッチ作成された範囲パーティションが標準の時刻単位境界に揃うことを強制します。穴の作成を避けるために、非整列の範囲は拒否されます。この項目を `true` に設定すると、そのアラインメントチェックが無効になり、バッチで部分的な (非標準の) パーティションを作成できるようになります。これにより、ギャップや誤ったパーティション範囲が生成される可能性があります。意図的に部分的なバッチパーティションが必要であり、関連するリスクを受け入れる場合にのみ `true` に設定する必要があります。
+- Description: この項目が`false`（デフォルト）に設定されている場合、StarRocksはバッチ作成された範囲パーティションが標準の時間単位境界に揃うように強制します。穴の作成を避けるために、非アラインメント範囲は拒否されます。この項目を`true`に設定すると、そのアラインメントチェックが無効になり、バッチで部分的な（非標準の）パーティションを作成できるようになります。これにより、ギャップやアラインメントされていないパーティション範囲が生成される可能性があります。部分的なバッチパーティションが意図的に必要であり、関連するリスクを受け入れる場合にのみ、これを`true`に設定してください。
 - Introduced in: v3.2.0
 
 ##### `enable_internal_sql`
@@ -1246,7 +1246,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: No
-- Description: この項目が `true` に設定されている場合、内部コンポーネント (例: SimpleExecutor) によって実行される内部 SQL ステートメントは、内部監査またはログメッセージに保持および書き込まれます ( `enable_sql_desensitize_in_log` が設定されている場合、さらに非機密化できます)。`false` に設定されている場合、内部 SQL テキストは抑制されます。フォーマットコード (SimpleExecutor.formatSQL) は "?" を返し、実際のステートメントは内部監査またはログメッセージに出力されません。この設定は、内部ステートメントの実行セマンティクスを変更しません。プライバシーまたはセキュリティのために内部 SQL のロギングと可視性のみを制御します。
+- Description: この項目が`true`に設定されている場合、内部コンポーネント（例: SimpleExecutor）によって実行される内部SQLステートメントは保持され、内部監査またはログメッセージに書き込まれます（`enable_sql_desensitize_in_log`が設定されている場合はさらに非機密化できます）。`false`に設定されている場合、内部SQLテキストは抑制されます。フォーマットコード（SimpleExecutor.formatSQL）は「?」を返し、実際のステートメントは内部監査またはログメッセージに出力されません。この設定は内部ステートメントの実行セマンティクスを変更しません。プライバシーまたはセキュリティのために内部SQLのログ記録と可視性を制御するだけです。
 - Introduced in: -
 
 ##### `enable_legacy_compatibility_for_replication`
@@ -1255,7 +1255,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: レプリケーションのレガシー互換性を有効にするかどうか。StarRocks は、以前のバージョンと新しいバージョンで異なる動作をする可能性があり、クロスクラスターデータ移行中に問題を引き起こすことがあります。したがって、データ移行前にターゲットクラスターでレガシー互換性を有効にし、データ移行完了後に無効にする必要があります。`true` はこのモードを有効にすることを示します。
+- Description: レプリケーションのレガシー互換性を有効にするかどうか。StarRocksは旧バージョンと新バージョンで動作が異なる場合があり、クラスター間のデータ移行中に問題を引き起こす可能性があります。そのため、データ移行前にターゲットクラスターのレガシー互換性を有効にし、データ移行完了後に無効にする必要があります。`true`はこのモードを有効にすることを示します。
 - Introduced in: v3.1.10, v3.2.6
 
 ##### `enable_show_materialized_views_include_all_task_runs`
@@ -1264,7 +1264,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: SHOW MATERIALIZED VIEWS コマンドに TaskRuns が返される方法を制御します。この項目が `false` に設定されている場合、StarRocks はタスクごとに最新の TaskRun のみを返します (互換性のためのレガシー動作)。`true` (デフォルト) に設定されている場合、`TaskManager` は、同じ開始 TaskRun ID を共有する場合 (たとえば、同じジョブに属する場合) にのみ、同じタスクの追加の TaskRun を含めることができ、無関係な重複実行が表示されるのを防ぎながら、1 つのジョブに紐付けられた複数のステータスを表示できます。単一実行の出力を復元したり、デバッグと監視のために複数実行ジョブの履歴を表示したりするには、この項目を `false` に設定します。
+- Description: `SHOW MATERIALIZED VIEWS`コマンドにTaskRunsがどのように返されるかを制御します。この項目が`false`に設定されている場合、StarRocksはタスクごとに最新のTaskRunのみを返します（互換性のためのレガシー動作）。`true`（デフォルト）に設定されている場合、`TaskManager`は、同じ開始TaskRun IDを共有する場合にのみ（たとえば、同じジョブに属する場合）、同じタスクの追加のTaskRunを含めることができ、無関係な重複実行が表示されるのを防ぎながら、1つのジョブに関連付けられた複数のステータスを表示できます。単一実行の出力を復元するため、またはデバッグと監視のために複数実行のジョブ履歴を表示するには、この項目を`false`に設定します。
 - Introduced in: v3.3.0, v3.4.0, v3.5.0
 
 ##### `enable_statistics_collect_profile`
@@ -1273,7 +1273,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 統計クエリのプロファイルを生成するかどうか。この項目を `true` に設定すると、StarRocks がシステム統計に関するクエリのクエリプロファイルを生成できるようになります。
+- Description: 統計クエリのプロファイルを生成するかどうか。この項目を`true`に設定すると、StarRocksがシステム統計に関するクエリのクエリプロファイルを生成できるようになります。
 - Introduced in: v3.1.5
 
 ##### `enable_table_name_case_insensitive`
@@ -1282,10 +1282,10 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: No
-- Description: カタログ名、データベース名、テーブル名、ビュー名、マテリアライズドビュー名の大文字小文字を区別しない処理を有効にするかどうか。現在、テーブル名は大文字小文字を区別します。
-  - この機能を有効にすると、関連するすべての名前は小文字で格納され、これらの名前を含むすべての SQL コマンドは自動的に小文字に変換されます。
-  - この機能は、クラスター作成時にのみ有効にできます。**クラスター起動後、この設定の値をいかなる方法でも変更することはできません**。変更しようとするとエラーが発生します。FE は、この設定アイテムの値がクラスターが最初に起動されたときと一致しないことを検出すると、起動に失敗します。
-  - 現在、この機能は JDBC カタログおよびテーブル名をサポートしていません。JDBC または ODBC データソースで大文字小文字を区別しない処理を実行する場合は、この機能を有効にしないでください。
+- Description: カタログ名、データベース名、テーブル名、ビュー名、マテリアライズドビュー名の大文字と小文字を区別しない処理を有効にするかどうか。現在、テーブル名は大文字と小文字を区別します（デフォルト）。
+  - この機能を有効にすると、関連するすべての名前は小文字で保存され、これらの名前を含むすべてのSQLコマンドは自動的に小文字に変換されます。
+  - この機能は、クラスターの作成時にのみ有効にできます。**クラスターが起動した後、この設定の値をいかなる方法でも変更することはできません**。変更しようとするとエラーが発生します。FEは、この設定項目の値がクラスターが最初に起動したときと矛盾していることを検出すると、起動に失敗します。
+  - 現在、この機能はJDBCカタログおよびテーブル名をサポートしていません。JDBCまたはODBCデータソースに対して大文字と小文字を区別しない処理を実行したい場合は、この機能を有効にしないでください。
 - Introduced in: v4.0
 
 ##### `enable_task_history_archive`
@@ -1294,7 +1294,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 有効にすると、完了したタスク実行レコードは永続的なタスク実行履歴テーブルにアーカイブされ、編集ログに記録されるため、ルックアップ (例: `lookupHistory`、`lookupHistoryByTaskNames`、`lookupLastJobOfTasks`) にアーカイブされた結果が含まれます。アーカイブは FE リーダーによって実行され、単体テスト中 (`FeConstants.runningUnitTest`) はスキップされます。有効にすると、インメモリの有効期限と強制 GC パスはバイパスされ (コードは `removeExpiredRuns` と `forceGC` から早期にリターンします)、保持/削除は `task_runs_ttl_second` と `task_runs_max_history_number` ではなく永続アーカイブによって処理されます。無効にすると、履歴はメモリ内に残り、これらの設定によってプルーニングされます。
+- Description: 有効にすると、完了したタスク実行レコードは永続的なタスク実行履歴テーブルにアーカイブされ、編集ログに記録されるため、ルックアップ（例: `lookupHistory`、`lookupHistoryByTaskNames`、`lookupLastJobOfTasks`）にはアーカイブされた結果が含まれます。アーカイブはFEリーダーによって実行され、単体テスト（`FeConstants.runningUnitTest`）中はスキップされます。有効にすると、インメモリの有効期限と強制GCパスはバイパスされ（コードは`removeExpiredRuns`と`forceGC`から早期にリターンします）、保持/削除は`task_runs_ttl_second`と`task_runs_max_history_number`ではなく永続アーカイブによって処理されます。無効にすると、履歴はメモリに残り、これらの設定によって剪定されます。
 - Introduced in: v3.3.1, v3.4.0, v3.5.0
 
 ##### `enable_task_run_fe_evaluation`
@@ -1303,7 +1303,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 有効にすると、FE は `TaskRunsSystemTable.supportFeEvaluation` でシステムテーブル `task_runs` のローカル評価を実行します。FE 側の評価は、列と定数を比較する結合等価述語にのみ許可され、列 `QUERY_ID` と `TASK_NAME` に制限されます。これを有効にすると、対象を絞ったルックアップのパフォーマンスが向上し、より広範なスキャンや追加のリモート処理が回避されます。無効にすると、プランナーは `task_runs` の FE 評価をスキップするため、述語のプルーニングが減少し、これらのフィルターのクエリレイテンシーに影響する可能性があります。
+- Description: 有効にすると、FEは`TaskRunsSystemTable.supportFeEvaluation`内のシステムテーブル`task_runs`に対してローカル評価を実行します。FE側の評価は、列を定数と比較する結合等価述語にのみ許可され、`QUERY_ID`と`TASK_NAME`列に限定されます。これを有効にすると、より広範なスキャンや追加のリモート処理を回避することで、ターゲットを絞ったルックアップのパフォーマンスが向上します。無効にすると、プランナーは`task_runs`のFE評価をスキップせざるを得なくなり、述語の剪定が減少し、これらのフィルターのクエリレイテンシに影響を与える可能性があります。
 - Introduced in: v3.3.13, v3.4.3, v3.5.0
 
 ##### `heartbeat_mgr_blocking_queue_size`
@@ -1312,7 +1312,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: Heartbeat Manager によって実行されるハートビートタスクを格納するブロッキングキューのサイズ。
+- Description: ハートビートマネージャーによって実行されるハートビートタスクを格納するブロッキングキューのサイズ。
 - Introduced in: -
 
 ##### `heartbeat_mgr_threads_num`
@@ -1321,7 +1321,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: Heartbeat Manager がハートビートタスクを実行するために実行できるスレッド数。
+- Description: ハートビートマネージャーがハートビートタスクを実行できるスレッド数。
 - Introduced in: -
 
 ##### `ignore_materialized_view_error`
@@ -1330,7 +1330,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: FE がマテリアライズドビューエラーによって引き起こされたメタデータ例外を無視するかどうか。マテリアライズドビューエラーによって引き起こされたメタデータ例外のために FE の起動に失敗した場合、このパラメーターを `true` に設定して FE が例外を無視できるようにすることができます。
+- Description: FEがマテリアライズドビューエラーによって引き起こされるメタデータ例外を無視するかどうか。マテリアライズドビューエラーによって引き起こされるメタデータ例外のためにFEが起動に失敗した場合、このパラメータを`true`に設定してFEが例外を無視できるようにすることができます。
 - Introduced in: v2.5.10
 
 ##### `ignore_meta_check`
@@ -1339,7 +1339,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 非リーダー FE がリーダー FE からのメタデータギャップを無視するかどうか。値が TRUE の場合、非リーダー FE はリーダー FE からのメタデータギャップを無視し、データ読み取りサービスを継続して提供します。このパラメーターは、リーダー FE を長期間停止した場合でも継続的なデータ読み取りサービスを保証します。値が FALSE の場合、非リーダー FE はリーダー FE からのメタデータギャップを無視せず、データ読み取りサービスの提供を停止します。
+- Description: 非リーダーFEがリーダーFEからのメタデータギャップを無視するかどうか。値が`TRUE`の場合、非リーダーFEはリーダーFEからのメタデータギャップを無視し、データ読み取りサービスを提供し続けます。このパラメータは、リーダーFEを長期間停止した場合でも、継続的なデータ読み取りサービスを保証します。値が`FALSE`の場合、非リーダーFEはリーダーFEからのメタデータギャップを無視せず、データ読み取りサービスを停止します。
 - Introduced in: -
 
 ##### `ignore_task_run_history_replay_error`
@@ -1348,7 +1348,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: StarRocks が `information_schema.task_runs` の TaskRun 履歴行を逆シリアル化する際、破損または無効な JSON 行は通常、逆シリアル化が警告をログに記録し、RuntimeException をスローします。この項目が `true` に設定されている場合、システムは逆シリアル化エラーをキャッチし、不正な形式のレコードをスキップし、クエリを失敗させるのではなく、残りの行の処理を続行します。これにより、`information_schema.task_runs` クエリは `_statistics_.task_run_history` テーブル内の不正なエントリに対して寛容になります。ただし、これを有効にすると、破損した履歴レコードが明示的なエラーを表面化する代わりにサイレントにドロップされることになります (潜在的なデータ損失)。
+- Description: StarRocksが`information_schema.task_runs`のTaskRun履歴行を逆シリアル化する際、破損または無効なJSON行は通常、逆シリアル化が警告をログに記録し、RuntimeExceptionをスローする原因となります。この項目が`true`に設定されている場合、システムは逆シリアル化エラーをキャッチし、不正な形式のレコードをスキップして、クエリを失敗させる代わりに残りの行の処理を続行します。これにより、`information_schema.task_runs`クエリは`_statistics_.task_run_history`テーブル内の不正なエントリに対して耐性を持つようになります。ただし、これを有効にすると、明示的なエラーを表示する代わりに、破損した履歴レコードがサイレントに破棄される可能性があることに注意してください（潜在的なデータ損失）。
 - Introduced in: v3.3.3, v3.4.0, v3.5.0
 
 ##### `lock_checker_interval_second`
@@ -1357,7 +1357,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: long
 - Unit: Seconds
 - Is mutable: Yes
-- Description: LockChecker フロントエンドデーモン ("deadlock-checker" という名前) の実行間の間隔 (秒単位)。デーモンはデッドロック検出と低速ロックのスキャンを実行します。設定値はミリ秒でタイマーを設定するために 1000 倍されます。この値を減らすと検出レイテンシーが短くなりますが、スケジューリングと CPU オーバーヘッドが増加します。増やすとオーバーヘッドが減少しますが、検出と低速ロックレポートが遅れます。変更は、デーモンが実行ごとに間隔をリセットするため、実行時に有効になります。この設定は、`lock_checker_enable_deadlock_check` (デッドロックチェックを有効にする) と `slow_lock_threshold_ms` (低速ロックを構成するものを定義する) と相互作用します。
+- Description: LockCheckerフロントエンドデーモン（「deadlock-checker」という名前）の実行間隔（秒単位）。デーモンはデッドロック検出とスローロック スキャンを実行します。設定された値は1000倍されてタイマーがミリ秒単位で設定されます。この値を減らすと検出レイテンシは減少しますが、スケジューリングとCPUオーバーヘッドが増加します。値を増やすとオーバーヘッドは減少しますが、検出とスローロックの報告が遅れます。デーモンは実行ごとに間隔をリセットするため、変更は実行時に有効になります。この設定は`lock_checker_enable_deadlock_check`（デッドロックチェックを有効にする）および`slow_lock_threshold_ms`（スローロックを構成するものを定義する）と相互作用します。
 - Introduced in: v3.2.0
 
 ##### `master_sync_policy`
@@ -1366,12 +1366,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: リーダー FE がログをディスクにフラッシュするポリシー。このパラメーターは、現在の FE がリーダー FE の場合にのみ有効です。有効な値:
+- Description: リーダーFEがログをディスクにフラッシュするポリシー。このパラメータは、現在のFEがリーダーFEである場合にのみ有効です。有効な値:
   - `SYNC`: トランザクションがコミットされると、ログエントリが生成され、同時にディスクにフラッシュされます。
-  - `NO_SYNC`: トランザクションがコミットされると、ログエントリの生成とフラッシュは同時に発生しません。
+  - `NO_SYNC`: トランザクションがコミットされるときに、ログエントリの生成とフラッシュが同時に行われません。
   - `WRITE_NO_SYNC`: トランザクションがコミットされると、ログエントリが同時に生成されますが、ディスクにはフラッシュされません。
 
-  フォロワー FE を 1 つだけデプロイしている場合、このパラメーターを `SYNC` に設定することをお勧めします。フォロワー FE を 3 つ以上デプロイしている場合、このパラメーターと `replica_sync_policy` の両方を `WRITE_NO_SYNC` に設定することをお勧めします。
+  フォロワーFEを1つだけデプロイしている場合は、このパラメータを`SYNC`に設定することをお勧めします。フォロワーFEを3つ以上デプロイしている場合は、このパラメータと`replica_sync_policy`の両方を`WRITE_NO_SYNC`に設定することをお勧めします。
 
 - Introduced in: -
 
@@ -1381,7 +1381,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Long
 - Unit: Milliseconds
 - Is mutable: No
-- Description: StarRocks クラスター内のリーダー FE とフォロワーまたはオブザーバー FE 間で許可される最大クロックオフセット。
+- Description: StarRocksクラスター内のリーダーFEとフォロワーまたはオブザーバーFE間で許容される最大クロックオフセット。
 - Introduced in: -
 
 ##### `meta_delay_toleration_second`
@@ -1390,7 +1390,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
-- Description: フォロワー FE およびオブザーバー FE のメタデータがリーダー FE のメタデータよりも遅延できる最大期間。単位: 秒。この期間を超えると、非リーダー FE はサービスの提供を停止します。
+- Description: フォロワーFEおよびオブザーバーFE上のメタデータがリーダーFE上のメタデータから遅延できる最大期間。単位: 秒。この期間を超えると、非リーダーFEはサービスの提供を停止します。
 - Introduced in: -
 
 ##### `meta_dir`
@@ -1408,7 +1408,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 未知のログ ID を無視するかどうか。FE がロールバックされた場合、以前のバージョンの FE は一部のログ ID を認識できない可能性があります。値が `TRUE` の場合、FE は未知のログ ID を無視します。値が `FALSE` の場合、FE は終了します。
+- Description: 不明なログIDを無視するかどうか。FEがロールバックされると、以前のバージョンのFEは一部のログIDを認識できない場合があります。値が`TRUE`の場合、FEは不明なログIDを無視します。値が`FALSE`の場合、FEは終了します。
 - Introduced in: -
 
 ##### `profile_info_format`
@@ -1417,7 +1417,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: Yes
-- Description: システムが出力するプロファイルの形式。有効な値: `default` と `json`。`default` に設定すると、プロファイルはデフォルトの形式になります。`json` に設定すると、システムはプロファイルを JSON 形式で出力します。
+- Description: システムが出力するプロファイルの形式。有効な値: `default`と`json`。`default`に設定すると、プロファイルはデフォルト形式になります。`json`に設定すると、システムはプロファイルをJSON形式で出力します。
 - Introduced in: v2.5
 
 ##### `replica_ack_policy`
@@ -1426,7 +1426,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: ログエントリが有効であると見なされるポリシー。デフォルト値 `SIMPLE_MAJORITY` は、ログエントリがフォロワー FE の過半数が ACK メッセージを返した場合に有効であると見なされることを指定します。
+- Description: ログエントリが有効と見なされるポリシー。デフォルト値`SIMPLE_MAJORITY`は、フォロワーFEの過半数がACKメッセージを返した場合にログエントリが有効と見なされることを指定します。
 - Introduced in: -
 
 ##### `replica_sync_policy`
@@ -1435,9 +1435,9 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: フォロワー FE がログをディスクにフラッシュするポリシー。このパラメーターは、現在の FE がフォロワー FE の場合にのみ有効です。有効な値:
+- Description: フォロワーFEがログをディスクにフラッシュするポリシー。このパラメータは、現在のFEがフォロワーFEである場合にのみ有効です。有効な値:
   - `SYNC`: トランザクションがコミットされると、ログエントリが生成され、同時にディスクにフラッシュされます。
-  - `NO_SYNC`: トランザクションがコミットされると、ログエントリの生成とフラッシュは同時に発生しません。
+  - `NO_SYNC`: トランザクションがコミットされるときに、ログエントリの生成とフラッシュが同時に行われません。
   - `WRITE_NO_SYNC`: トランザクションがコミットされると、ログエントリが同時に生成されますが、ディスクにはフラッシュされません。
 - Introduced in: -
 
@@ -1447,7 +1447,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: boolean
 - Unit: -
 - Is mutable: No
-- Description: true の場合、FE はイメージデータが存在するが Berkeley DB JE (BDB) ログファイルが欠落または破損している場合に起動を許可します。`MetaHelper.checkMetaDir()` はこのフラグを使用して、対応する BDB ログのないイメージからの起動を防ぐ安全チェックをバイパスします。この方法で起動すると、古いまたは矛盾したメタデータが生成される可能性があり、緊急復旧にのみ使用する必要があります。`RestoreClusterSnapshotMgr` はクラスターのスナップショットを復元する際に一時的にこのフラグを true に設定し、その後ロールバックします。このコンポーネントは復元中に `bdbje_reset_election_group` も切り替えます。通常の操作では有効にしないでください。破損した BDB データから復旧する場合、またはイメージベースのスナップショットを明示的に復元する場合にのみ有効にしてください。
+- Description: `true`の場合、イメージデータは存在するがBerkeley DB JE (BDB) ログファイルが欠落または破損している場合に、FEは起動を許可します。`MetaHelper.checkMetaDir()`はこのフラグを使用して、対応するBDBログなしでイメージから起動するのを防ぐ安全チェックをバイパスします。この方法で起動すると、古いまたは一貫性のないメタデータが生成される可能性があり、緊急復旧にのみ使用すべきです。`RestoreClusterSnapshotMgr`はクラスター スナップショットを復元する際に一時的にこのフラグを`true`に設定し、その後ロールバックします。このコンポーネントは復元中に`bdbje_reset_election_group`も切り替えます。通常の操作では有効にしないでください。破損したBDBデータから回復する場合、またはイメージベースのスナップショットを明示的に復元する場合にのみ有効にしてください。
 - Introduced in: v3.2.0
 
 ##### `table_keeper_interval_second`
@@ -1456,7 +1456,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
-- Description: TableKeeper デーモンの実行間の間隔 (秒単位)。TableKeeperDaemon はこの値 (1000 倍) を使用して内部タイマーを設定し、履歴テーブルが存在すること、正しいテーブルプロパティ (レプリケーション番号) があること、パーティション TTL を更新することを保証するキーパータスクを定期的に実行します。デーモンはリーダーノードでのみ作業を実行し、`table_keeper_interval_second` が変更されると `setInterval` を介して実行時間隔を更新します。スケジューリング頻度と負荷を減らすには値を増やし、欠落または古い履歴テーブルへの反応を速くするには値を減らします。
+- Description: TableKeeperデーモンの実行間隔（秒単位）。TableKeeperDaemonはこの値（1000倍）を使用して内部タイマーを設定し、履歴テーブルの存在確認、テーブルプロパティ（レプリケーション数）の修正、パーティションTTLの更新を行うキーパータスクを定期的に実行します。デーモンはリーダーノードでのみ作業を実行し、`table_keeper_interval_second`が変更されたときに`setInterval`を介して実行時間隔を更新します。スケジューリング頻度と負荷を減らすには値を増やし、欠落または古い履歴テーブルへのより迅速な反応のためには値を減らします。
 - Introduced in: v3.3.1, v3.4.0, v3.5.0
 
 ##### `task_runs_ttl_second`
@@ -1465,7 +1465,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
-- Description: タスク実行履歴の Time-To-Live (TTL) を制御します。この値を小さくすると履歴の保持期間が短くなり、メモリ/ディスク使用量が減ります。値を大きくすると履歴が長く保持されますが、リソース使用量が増加します。予測可能な保持とストレージ動作のために、`task_runs_max_history_number` と `enable_task_history_archive` と一緒に調整してください。
+- Description: タスク実行履歴の有効期間（TTL）を制御します。この値を下げると履歴の保持期間が短くなり、メモリ/ディスク使用量が減少します。値を上げると履歴が長く保持されますが、リソース使用量が増加します。予測可能な保持とストレージ動作のために、`task_runs_max_history_number`および`enable_task_history_archive`と合わせて調整してください。
 - Introduced in: v3.2.0
 
 ##### `task_ttl_second`
@@ -1474,7 +1474,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
-- Description: タスクの Time-to-live (TTL)。手動タスク (スケジュールが設定されていない場合)、TaskBuilder はこの値を使用してタスクの `expireTime` を計算します (`expireTime = now + task_ttl_second * 1000L`)。TaskRun も、実行のタイムアウトを計算する際にこの値を上限として使用します。実質的な実行タイムアウトは `min(task_runs_timeout_second, task_runs_ttl_second, task_ttl_second)` です。この値を調整すると、手動で作成されたタスクが有効な期間が変更され、タスク実行の最大許容実行時間を間接的に制限できます。
+- Description: タスクの有効期間（TTL）。手動タスク（スケジュールが設定されていない場合）の場合、TaskBuilderはこの値を使用してタスクの`expireTime`を計算します（`expireTime = now + task_ttl_second * 1000L`）。TaskRunも、実行の実行タイムアウトを計算する際の上限としてこの値を使用します。有効な実行タイムアウトは`min(task_runs_timeout_second, task_runs_ttl_second, task_ttl_second)`です。この値を調整すると、手動で作成されたタスクが有効なままである期間が変更され、タスク実行の最大許容実行時間を間接的に制限できます。
 - Introduced in: v3.2.0
 
 ##### `thrift_rpc_retry_times`
@@ -1483,7 +1483,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: Thrift RPC 呼び出しが行う合計試行回数を制御します。この値は `ThriftRPCRequestExecutor` (および `NodeMgr` や `VariableMgr` などの呼び出し元) によって再試行のループカウントとして使用されます。つまり、値 3 は初期試行を含めて最大 3 回の試行を許可します。`TTransportException` の場合、エグゼキューターは接続を再開してこの回数まで再試行します。原因が `SocketTimeoutException` の場合や再開が失敗した場合は再試行しません。各試行は `thrift_rpc_timeout_ms` で設定された試行ごとのタイムアウトの対象となります。この値を増やすと、一時的な接続障害に対する回復力は向上しますが、全体の RPC レイテンシーとリソース使用量が増加する可能性があります。
+- Description: Thrift RPC呼び出しが行う試行の合計回数を制御します。この値は`ThriftRPCRequestExecutor`（および`NodeMgr`や`VariableMgr`などの呼び出し元）によって再試行のループカウントとして使用されます。つまり、値が3の場合、最初の試行を含めて最大3回の試行が許可されます。`TTransportException`が発生した場合、エグゼキュータはこの回数まで接続を再オープンして再試行します。原因が`SocketTimeoutException`である場合、または再オープンが失敗した場合は再試行しません。各試行は`thrift_rpc_timeout_ms`で設定された試行ごとのタイムアウトの対象となります。この値を増やすと、一時的な接続障害に対する回復力が向上しますが、RPC全体のレイテンシとリソース使用量が増加する可能性があります。
 - Introduced in: v3.2.0
 
 ##### `thrift_rpc_strict_mode`
@@ -1492,7 +1492,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: No
-- Description: Thrift サーバーで使用される TBinaryProtocol の「厳密読み取り」モードを制御します。この値は Thrift サーバーのスタックにある org.apache.thrift.protocol.TBinaryProtocol.Factory に最初の引数として渡され、受信 Thrift メッセージの解析と検証方法に影響します。`true` (デフォルト) の場合、サーバーは厳密な Thrift エンコーディング/バージョンチェックを強制し、設定された `thrift_rpc_max_body_size` 制限を尊重します。`false` の場合、サーバーは非厳密な (レガシー/寛容な) メッセージ形式を受け入れます。これにより、古いクライアントとの互換性は向上する可能性がありますが、一部のプロトコル検証がバイパスされる可能性があります。これは変更不可能であり、相互運用性と解析の安全性に影響するため、稼働中のクラスターでこれを変更する場合は注意してください。
+- Description: Thriftサーバーが使用するTBinaryProtocolの「厳密読み取り」モードを制御します。この値はThriftサーバー スタックのorg.apache.thrift.protocol.TBinaryProtocol.Factoryの最初の引数として渡され、受信Thriftメッセージの解析と検証方法に影響します。`true`（デフォルト）の場合、サーバーは厳密なThriftエンコーディング/バージョンチェックを強制し、設定された`thrift_rpc_max_body_size`制限を尊重します。`false`の場合、サーバーは非厳密な（レガシー/寛容な）メッセージ形式を受け入れます。これは古いクライアントとの互換性を向上させる可能性がありますが、一部のプロトコル検証をバイパスする可能性があります。実行中のクラスターでこれを変更する際は注意が必要です。これは変更不可であり、相互運用性と解析の安全性に影響するためです。
 - Introduced in: v3.2.0
 
 ##### `thrift_rpc_timeout_ms`
@@ -1501,7 +1501,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Milliseconds
 - Is mutable: Yes
-- Description: Thrift RPC 呼び出しのデフォルトのネットワーク/ソケットタイムアウトとして使用されるタイムアウト (ミリ秒単位)。`ThriftConnectionPool` (フロントエンドおよびバックエンドプールで使用) で Thrift クライアントを作成するときに TSocket に渡され、また `ConfigBase`、`LeaderOpExecutor`、`GlobalStateMgr`、`NodeMgr`、`VariableMgr`、`CheckpointWorker` などの場所で RPC 呼び出しのタイムアウトを計算するときに操作の実行タイムアウトに追加されます (例: ExecTimeout*1000 + `thrift_rpc_timeout_ms`)。この値を増やすと、RPC 呼び出しは長いネットワークまたはリモート処理の遅延を許容できます。減らすと、低速なネットワークでのフェイルオーバーが高速化されます。この値を変更すると、Thrift RPC を実行する FE コードパス全体で接続作成と要求の期限に影響します。
+- Description: Thrift RPC呼び出しのデフォルトのネットワーク/ソケットタイムアウトとして使用されるタイムアウト（ミリ秒単位）。`ThriftConnectionPool`（フロントエンドおよびバックエンドプールで使用）でThriftクライアントを作成する際にTSocketに渡され、`ConfigBase`、`LeaderOpExecutor`、`GlobalStateMgr`、`NodeMgr`、`VariableMgr`、`CheckpointWorker`などの場所でRPC呼び出しタイムアウトを計算する際に、操作の実行タイムアウト（例: ExecTimeout*1000 + `thrift_rpc_timeout_ms`）にも追加されます。この値を増やすと、RPC呼び出しがより長いネットワークまたはリモート処理の遅延を許容できるようになります。値を減らすと、低速ネットワークでのフェイルオーバーが高速化されます。この値を変更すると、Thrift RPCを実行するFEコードパス全体で接続作成とリクエストの期限に影響します。
 - Introduced in: v3.2.0
 
 ##### `txn_latency_metric_report_groups`
@@ -1510,7 +1510,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: Yes
-- Description: レポートするトランザクションレイテンシーメトリックグループのコンマ区切りリスト。ロードタイプは監視のために論理グループに分類されます。グループが有効になっている場合、その名前はトランザクションメトリックに「type」ラベルとして追加されます。有効な値: `stream_load`、`routine_load`、`broker_load`、`insert`、および `compaction` (共有データクラスターでのみ利用可能)。例: `"stream_load,routine_load"`。
+- Description: 報告するトランザクションレイテンシメトリックグループのコンマ区切りリスト。ロードタイプは監視のために論理グループに分類されます。グループが有効になっている場合、その名前はトランザクションメトリックに「type」ラベルとして追加されます。有効な値: `stream_load`、`routine_load`、`broker_load`、`insert`、および`compaction`（共有データクラスターでのみ利用可能）。例: `"stream_load,routine_load"`。
 - Introduced in: v4.0
 
 ##### `txn_rollback_limit`
@@ -1522,34 +1522,34 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: ロールバックできるトランザクションの最大数。
 - Introduced in: -
 
-### ユーザー、ロール、権限
+### ユーザー、ロール、および権限
 
 ##### `enable_task_info_mask_credential`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: true の場合、StarRocks は `information_schema.tasks` および `information_schema.task_runs` で返される前に、タスク SQL 定義から資格情報を編集します。これは、DEFINITION 列に SqlCredentialRedactor.redact を適用することで行われます。`information_schema.task_runs` では、定義がタスク実行ステータスから来るか、空の場合にタスク定義ルックアップから来るかに関係なく、同じ編集が適用されます。false の場合、生のタスク定義が返されます (資格情報が公開される可能性があります)。マスキングは CPU/文字列処理作業であり、タスクまたは `task_runs` の数が大きい場合は時間がかかる場合があります。非編集定義が必要であり、セキュリティリスクを受け入れる場合にのみ無効にしてください。
-- Introduced in: v3.5.6
+- デフォルト: true
+- タイプ: ブール
+- 単位: -
+- 変更可能: はい
+- 説明: trueの場合、StarRocksは`information_schema.tasks`および`information_schema.task_runs`で資格情報を返す前に、`DEFINITION`列に`SqlCredentialRedactor.redact`を適用して、タスクSQL定義から資格情報を編集（秘匿）します。`information_schema.task_runs`では、定義がタスク実行ステータスから来るか、または空の場合にタスク定義ルックアップから来るかにかかわらず、同じ編集が適用されます。falseの場合、生のタスク定義が返されます（資格情報が公開される可能性があります）。マスキングはCPU/文字列処理作業であり、タスクまたは`task_runs`の数が多い場合は時間がかかることがあります。編集されていない定義が必要で、セキュリティリスクを受け入れる場合にのみ無効にしてください。
+- 導入バージョン: v3.5.6
 
 ##### `privilege_max_role_depth`
 
-- Default: 16
-- Type: Int
-- Unit:
-- Is mutable: Yes
-- Description: ロールの最大ロール深度 (継承レベル)。
-- Introduced in: v3.0.0
+- デフォルト: 16
+- タイプ: 整数
+- 単位:
+- 変更可能: はい
+- 説明: ロールの最大ロール深度（継承レベル）。
+- 導入バージョン: v3.0.0
 
 ##### `privilege_max_total_roles_per_user`
 
-- Default: 64
-- Type: Int
-- Unit:
-- Is mutable: Yes
-- Description: ユーザーが持つことができるロールの最大数。
-- Introduced in: v3.0.0
+- デフォルト: 64
+- タイプ: 整数
+- 単位:
+- 変更可能: はい
+- 説明: ユーザーが持つことができるロールの最大数。
+- 導入バージョン: v3.0.0
 
 ### クエリエンジン
 
@@ -1557,18 +1557,18 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - Default: 60000
 - Type: Int
-- Unit: Milliseconds
+- Unit: ミリ秒
 - Is mutable: Yes
-- Description: プランフラグメントを送信する前に BRPC TalkTimeoutController に適用されるタイムアウト (ミリ秒単位)。`BackendServiceClient.sendPlanFragmentAsync` は、バックエンド `execPlanFragmentAsync` を呼び出す前にこの値を設定します。これは、BRPC がアイドル接続を接続プールから借りる際や送信を実行する際に待機する期間を管理します。超過した場合、RPC は失敗し、メソッドの再試行ロジックをトリガーする可能性があります。競合時に迅速に失敗させるにはこれを低く設定し、一時的なプール枯渇や低速ネットワークを許容するには高く設定します。注意: 非常に大きな値は、失敗検出を遅延させ、要求スレッドをブロックする可能性があります。
+- Description: プランフラグメントを送信する前にBRPC TalkTimeoutControllerに適用されるミリ秒単位のタイムアウト。`BackendServiceClient.sendPlanFragmentAsync` は、バックエンドの `execPlanFragmentAsync` を呼び出す前にこの値を設定します。これは、BRPCが接続プールからアイドル接続を借りる際、および送信を実行する際に待機する時間を制御します。この値を超えると、RPCは失敗し、メソッドのリトライロジックがトリガーされる可能性があります。競合下で迅速に失敗させるにはこの値を低く設定し、一時的なプール枯渇や低速ネットワークを許容するには高く設定してください。注意: 非常に大きな値は、障害検出を遅らせ、リクエストスレッドをブロックする可能性があります。
 - Introduced in: v3.3.11, v3.4.1, v3.5.0
 
 ##### `connector_table_query_trigger_analyze_large_table_interval`
 
 - Default: 12 * 3600
 - Type: Int
-- Unit: Second
+- Unit: 秒
 - Is mutable: Yes
-- Description: 大規模テーブルのクエリトリガー ANALYZE タスクの間隔。
+- Description: 大規模テーブルのクエリトリガー `ANALYZE` タスクの間隔。
 - Introduced in: v3.4.0
 
 ##### `connector_table_query_trigger_analyze_max_pending_task_num`
@@ -1577,7 +1577,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: FE で保留状態にあるクエリトリガー ANALYZE タスクの最大数。
+- Description: FE上でPending状態にあるクエリトリガー `ANALYZE` タスクの最大数。
 - Introduced in: v3.4.0
 
 ##### `connector_table_query_trigger_analyze_max_running_task_num`
@@ -1586,16 +1586,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: FE で実行状態にあるクエリトリガー ANALYZE タスクの最大数。
+- Description: FE上でRunning状態にあるクエリトリガー `ANALYZE` タスクの最大数。
 - Introduced in: v3.4.0
 
 ##### `connector_table_query_trigger_analyze_small_table_interval`
 
 - Default: 2 * 3600
 - Type: Int
-- Unit: Second
+- Unit: 秒
 - Is mutable: Yes
-- Description: 小規模テーブルのクエリトリガー ANALYZE タスクの間隔。
+- Description: 小規模テーブルのクエリトリガー `ANALYZE` タスクの間隔。
 - Introduced in: v3.4.0
 
 ##### `connector_table_query_trigger_analyze_small_table_rows`
@@ -1604,16 +1604,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: クエリトリガー ANALYZE タスクのテーブルが小規模テーブルであるかどうかを判断するためのしきい値。
+- Description: クエリトリガー `ANALYZE` タスクにおいて、テーブルが小規模テーブルであるかどうかを判断するためのしきい値。
 - Introduced in: v3.4.0
 
 ##### `connector_table_query_trigger_task_schedule_interval`
 
 - Default: 30
 - Type: Int
-- Unit: Second
+- Unit: 秒
 - Is mutable: Yes
-- Description: スケジューラースレッドがクエリトリガーバックグラウンドタスクをスケジュールする間隔。この項目は v3.4.0 で導入された `connector_table_query_trigger_analyze_schedule_interval` を置き換えるものです。ここで、バックグラウンドタスクとは v3.4 の `ANALYZE` タスクと、v3.4 以降の低カーディナリティ列の辞書収集タスクを指します。
+- Description: スケジューラスレッドがクエリトリガーバックグラウンドタスクをスケジュールする間隔。この項目は、v3.4.0で導入された `connector_table_query_trigger_analyze_schedule_interval` を置き換えるものです。ここでいうバックグラウンドタスクとは、v3.4では `ANALYZE` タスクを指し、v3.4以降のバージョンでは低カーディナリティ列の辞書収集タスクを指します。
 - Introduced in: v3.4.2
 
 ##### `create_table_max_serial_replicas`
@@ -1622,7 +1622,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: シリアルに作成するレプリカの最大数。実際のレプリカ数がこの値を超えると、レプリカは並行して作成されます。テーブル作成に時間がかかりすぎる場合は、この値を減らしてみてください。
+- Description: シリアルに作成されるレプリカの最大数。実際のレプリカ数がこの値を超えると、レプリカは並行して作成されます。テーブル作成に時間がかかっている場合は、この値を減らしてみてください。
 - Introduced in: -
 
 ##### `default_mv_partition_refresh_number`
@@ -1631,8 +1631,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: マテリアライズドビューの更新が複数のパーティションを伴う場合、このパラメーターは、デフォルトで 1 つのバッチで更新されるパーティションの数を制御します。
-バージョン 3.3.0 以降、システムはデフォルトで一度に 1 つのパーティションを更新して、潜在的なメモリ不足 (OOM) の問題を回避します。以前のバージョンでは、デフォルトですべてのパーティションが一度に更新され、メモリ枯渇やタスク障害につながる可能性がありました。ただし、マテリアライズドビューの更新が多数のパーティションを伴う場合、一度に 1 つのパーティションのみを更新すると、スケジューリングのオーバーヘッドが過剰になり、全体の更新時間が長くなり、大量の更新レコードが生成される可能性があることに注意してください。そのような場合は、更新効率を向上させ、スケジューリングコストを削減するために、このパラメーターを適切に調整することをお勧めします。
+- Description: マテリアライズドビューの更新が複数のパーティションに関わる場合、このパラメータはデフォルトで1つのバッチでいくつのパーティションが更新されるかを制御します。
+バージョン3.3.0以降、システムは潜在的なメモリ不足 (OOM) の問題を避けるため、一度に1つのパーティションを更新することをデフォルトとしています。以前のバージョンでは、デフォルトですべてのパーティションが一度に更新され、メモリ枯渇やタスク失敗につながる可能性がありました。ただし、マテリアライズドビューの更新が多数のパーティションに関わる場合、一度に1つのパーティションのみを更新すると、過剰なスケジューリングオーバーヘッド、全体の更新時間の延長、および多数の更新レコードが発生する可能性があります。このような場合は、更新効率を向上させ、スケジューリングコストを削減するために、このパラメータを適切に調整することをお勧めします。
 - Introduced in: v3.3.0
 
 ##### `default_mv_refresh_immediate`
@@ -1641,16 +1641,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 非同期マテリアライズドビューの作成後すぐに更新するかどうか。この項目が `true` に設定されている場合、新しく作成されたマテリアライズドビューはすぐに更新されます。
+- Description: 非同期マテリアライズドビューを、作成後すぐに更新するかどうか。この項目が `true` に設定されている場合、新しく作成されたマテリアライズドビューはすぐに更新されます。
 - Introduced in: v3.2.3
 
 ##### `dynamic_partition_check_interval_seconds`
 
 - Default: 600
 - Type: Long
-- Unit: Seconds
+- Unit: 秒
 - Is mutable: Yes
-- Description: 新しいデータがチェックされる間隔。新しいデータが検出された場合、StarRocks は自動的にデータ用のパーティションを作成します。
+- Description: 新しいデータがチェックされる間隔。新しいデータが検出されると、StarRocksはそのデータのために自動的にパーティションを作成します。
 - Introduced in: -
 
 ##### `dynamic_partition_enable`
@@ -1659,7 +1659,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 動的パーティショニング機能を有効にするかどうか。この機能が有効になっている場合、StarRocks は新しいデータ用のパーティションを動的に作成し、期限切れのパーティションを自動的に削除してデータの鮮度を保証します。
+- Description: 動的パーティショニング機能を有効にするかどうか。この機能が有効な場合、StarRocksは新しいデータのために動的にパーティションを作成し、期限切れのパーティションを自動的に削除して、データの鮮度を確保します。
 - Introduced in: -
 
 ##### `enable_active_materialized_view_schema_strict_check`
@@ -1668,7 +1668,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 非アクティブなマテリアライズドビューをアクティブ化するときに、データ型の長さの一貫性を厳密にチェックするかどうか。この項目が `false` に設定されている場合、基底テーブルでデータ型の長さが変更されても、マテリアライズドビューのアクティブ化は影響を受けません。
+- Description: 非アクティブなマテリアライズドビューをアクティブ化する際に、データ型の長さの一貫性を厳密にチェックするかどうか。この項目が `false` に設定されている場合、ベーステーブルでデータ型の長さが変更されても、マテリアライズドビューのアクティブ化には影響しません。
 - Introduced in: v3.3.4
 
 ##### `enable_auto_collect_array_ndv`
@@ -1677,7 +1677,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: ARRAY 型の NDV 情報の自動収集を有効にするかどうか。
+- Description: `ARRAY` 型の `NDV` 情報の自動収集を有効にするかどうか。
 - Introduced in: v4.0
 
 ##### `enable_backup_materialized_view`
@@ -1686,7 +1686,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 特定のデータベースをバックアップまたは復元する際に、非同期マテリアライズドビューの BACKUP と RESTORE を有効にするかどうか。この項目が `false` に設定されている場合、StarRocks は非同期マテリアライズドビューのバックアップをスキップします。
+- Description: 特定のデータベースをバックアップまたは復元する際に、非同期マテリアライズドビューの `BACKUP` および `RESTORE` を有効にするかどうか。この項目が `false` に設定されている場合、StarRocksは非同期マテリアライズドビューのバックアップをスキップします。
 - Introduced in: v3.2.0
 
 ##### `enable_collect_full_statistic`
@@ -1695,7 +1695,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 自動完全統計収集を有効にするかどうか。この機能はデフォルトで有効になっています。
+- Description: 自動的な完全統計収集を有効にするかどうか。この機能はデフォルトで有効です。
 - Introduced in: -
 
 ##### `enable_colocate_mv_index`
@@ -1704,7 +1704,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 同期マテリアライズドビューを作成するときに、同期マテリアライズドビューインデックスを基底テーブルとコロケートすることをサポートするかどうか。この項目が `true` に設定されている場合、タブレットシンクは同期マテリアライズドビューの書き込みパフォーマンスを高速化します。
+- Description: 同期マテリアライズドビューを作成する際に、同期マテリアライズドビューインデックスをベーステーブルとコロケートすることをサポートするかどうか。この項目が `true` に設定されている場合、タブレットシンクは同期マテリアライズドビューの書き込みパフォーマンスを高速化します。
 - Introduced in: v3.2.0
 
 ##### `enable_decimal_v3`
@@ -1713,7 +1713,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: DECIMAL V3 データ型をサポートするかどうか。
+- Description: `DECIMAL V3` データ型をサポートするかどうか。
 - Introduced in: -
 
 ##### `enable_experimental_mv`
@@ -1722,7 +1722,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 非同期マテリアライズドビュー機能を有効にするかどうか。TRUE はこの機能が有効であることを示します。v2.5.2 以降、この機能はデフォルトで有効になっています。v2.5.2 以前のバージョンでは、この機能はデフォルトで無効になっています。
+- Description: 非同期マテリアライズドビュー機能を有効にするかどうか。`TRUE` はこの機能が有効であることを示します。v2.5.2以降、この機能はデフォルトで有効です。v2.5.2より前のバージョンでは、この機能はデフォルトで無効です。
 - Introduced in: v2.4
 
 ##### `enable_local_replica_selection`
@@ -1731,7 +1731,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: クエリのためにローカルレプリカを選択するかどうか。ローカルレプリカはネットワーク転送コストを削減します。このパラメーターが TRUE に設定されている場合、CBO は現在の FE と同じ IP アドレスを持つ BE 上のタブレットレプリカを優先的に選択します。このパラメーターが `FALSE` に設定されている場合、ローカルレプリカと非ローカルレプリカの両方を選択できます。
+- Description: クエリに対してローカルレプリカを選択するかどうか。ローカルレプリカはネットワーク転送コストを削減します。このパラメータが `TRUE` に設定されている場合、`CBO` は現在の `FE` と同じIPアドレスを持つ `BE` 上のタブレットレプリカを優先的に選択します。このパラメータが `FALSE` に設定されている場合、ローカルレプリカと非ローカルレプリカの両方を選択できます。
 - Introduced in: -
 
 ##### `enable_manual_collect_array_ndv`
@@ -1740,7 +1740,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: ARRAY 型の NDV 情報の手動収集を有効にするかどうか。
+- Description: `ARRAY` 型の `NDV` 情報の手動収集を有効にするかどうか。
 - Introduced in: v4.0
 
 ##### `enable_materialized_view`
@@ -1758,7 +1758,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 基底テーブルが外部 (クラウドネイティブではない) テーブルである場合に、マテリアライズドビューの更新のための内部最適化を有効にするには、この項目を `true` に設定します。有効にすると、マテリアライズドビューの更新プロセッサは候補パーティションを計算し、すべてのパーティションではなく影響を受ける基底テーブルパーティションのみを更新し、I/O と更新コストを削減します。外部テーブルの完全パーティション更新を強制するには `false` に設定します。
+- Description: ベーステーブルが外部（非クラウドネイティブ）テーブルである場合に、マテリアライズドビューの更新に対する内部最適化を有効にするには、この項目を `true` に設定します。有効にすると、マテリアライズドビューの更新プロセッサは候補パーティションを計算し、すべてのパーティションではなく、影響を受けるベーステーブルパーティションのみを更新するため、I/Oと更新コストが削減されます。外部テーブルの全パーティション更新を強制するには、`false` に設定します。
 - Introduced in: v3.2.9
 
 ##### `enable_materialized_view_metrics_collect`
@@ -1767,7 +1767,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 非同期マテリアライズドビューの監視メトリックをデフォルトで収集するかどうか。
+- Description: デフォルトで非同期マテリアライズドビューの監視メトリクスを収集するかどうか。
 - Introduced in: v3.1.11, v3.2.5
 
 ##### `enable_materialized_view_spill`
@@ -1776,7 +1776,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: マテリアライズドビュー更新タスクの途中結果スピルを有効にするかどうか。
+- Description: マテリアライズドビューの更新タスクに対して中間結果のスピルを有効にするかどうか。
 - Introduced in: v3.1.1
 
 ##### `enable_materialized_view_text_based_rewrite`
@@ -1785,7 +1785,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: デフォルトでテキストベースのクエリ書き換えを有効にするかどうか。この項目が `true` に設定されている場合、システムは非同期マテリアライズドビューの作成中に抽象構文ツリーを構築します。
+- Description: デフォルトでテキストベースのクエリ書き換えを有効にするかどうか。この項目が `true` に設定されている場合、システムは非同期マテリアライズドビューの作成中に抽象構文木を構築します。
 - Introduced in: v3.2.5
 
 ##### `enable_mv_automatic_active_check`
@@ -1794,7 +1794,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: スキーマ変更または基底テーブル (ビュー) の削除と再作成によって非アクティブになった非同期マテリアライズドビューを、システムが自動的にチェックして再アクティブ化する機能を有効にするかどうか。この機能は、ユーザーが手動で非アクティブに設定したマテリアライズドビューを再アクティブ化しないことに注意してください。
+- Description: ベーステーブル（ビュー）が `Schema Change` を受けた、または削除されて再作成されたために非アクティブに設定された非同期マテリアライズドビューを、システムが自動的にチェックして再アクティブ化することを有効にするかどうか。この機能は、ユーザーによって手動で非アクティブに設定されたマテリアライズドビューを再アクティブ化しないことに注意してください。
 - Introduced in: v3.1.6
 
 ##### `enable_mv_automatic_repairing_for_broken_base_tables`
@@ -1803,7 +1803,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: この項目が `true` に設定されている場合、StarRocks は、基底外部テーブルが削除され再作成されたり、テーブル識別子が変更されたりした場合に、マテリアライズドビューの基底テーブルメタデータを自動的に修復しようとします。修復フローは、マテリアライズドビューの基底テーブル情報を更新し、外部テーブルパーティションのパーティションレベルの修復情報を収集し、`autoRefreshPartitionsLimit` を尊重しながら非同期自動更新マテリアライズドビューのパーティション更新決定を駆動することができます。現在、自動修復は Hive 外部テーブルをサポートしています。サポートされていないテーブルタイプでは、マテリアライズドビューが非アクティブに設定され、修復例外が発生します。パーティション情報収集は非ブロッキングであり、失敗はログに記録されます。
+- Description: この項目が `true` に設定されている場合、ベースの外部テーブルが削除されて再作成されたり、そのテーブル識別子が変更されたりしたときに、StarRocksはマテリアライズドビューのベーステーブルメタデータを自動的に修復しようとします。修復フローは、マテリアライズドビューのベーステーブル情報を更新し、外部テーブルパーティションのパーティションレベルの修復情報を収集し、`autoRefreshPartitionsLimit` を尊重しながら、非同期自動更新マテリアライズドビューのパーティション更新決定を駆動できます。現在、自動修復は `Hive` 外部テーブルをサポートしています。サポートされていないテーブルタイプは、マテリアライズドビューが非アクティブに設定され、修復例外が発生します。パーティション情報収集は非ブロッキングであり、失敗はログに記録されます。
 - Introduced in: v3.3.19, v3.4.8, v3.5.6
 
 ##### `enable_predicate_columns_collection`
@@ -1812,7 +1812,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 述語列収集を有効にするかどうか。無効にすると、クエリオプティマイゼーション中に述語列は記録されません。
+- Description: 述語列の収集を有効にするかどうか。無効にすると、クエリ最適化中に述語列は記録されません。
 - Introduced in: -
 
 ##### `enable_query_queue_v2`
@@ -1821,7 +1821,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: boolean
 - Unit: -
 - Is mutable: No
-- Description: true の場合、FE のスロットベースクエリスケジューラを Query Queue V2 に切り替えます。このフラグはスロットマネージャーとトラッカー (例: `BaseSlotManager.isEnableQueryQueueV2` と `SlotTracker#createSlotSelectionStrategy`) によって読み取られ、レガシー戦略ではなく `SlotSelectionStrategyV2` を選択します。`query_queue_v2_xxx` 構成オプションと `QueryQueueOptions` は、このフラグが有効な場合にのみ有効になります。v4.1 以降、デフォルト値は `false` から `true` に変更されました。
+- Description: `true` の場合、`FE` のスロットベースのクエリスケジューラを `Query Queue V2` に切り替えます。このフラグは、スロットマネージャーとトラッカー（例: `BaseSlotManager.isEnableQueryQueueV2` および `SlotTracker#createSlotSelectionStrategy`）によって読み取られ、従来の戦略ではなく `SlotSelectionStrategyV2` を選択します。`query_queue_v2_xxx` 設定オプションと `QueryQueueOptions` は、このフラグが有効な場合にのみ有効になります。v4.1以降、デフォルト値は `false` から `true` に変更されました。
 - Introduced in: v3.3.4, v3.4.0, v3.5.0
 
 ##### `enable_sql_blacklist`
@@ -1830,7 +1830,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: SQL クエリのブラックリストチェックを有効にするかどうか。この機能が有効になっている場合、ブラックリスト内のクエリは実行できません。
+- Description: `SQL` クエリのブラックリストチェックを有効にするかどうか。この機能が有効な場合、ブラックリスト内のクエリは実行できません。
 - Introduced in: -
 
 ##### `enable_statistic_collect`
@@ -1839,7 +1839,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: CBO の統計情報を収集するかどうか。この機能はデフォルトで有効になっています。
+- Description: `CBO` の統計情報を収集するかどうか。この機能はデフォルトで有効です。
 - Introduced in: -
 
 ##### `enable_statistic_collect_on_first_load`
@@ -1849,29 +1849,29 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Unit: -
 - Is mutable: Yes
 - Description: データロード操作によってトリガーされる自動統計収集とメンテナンスを制御します。これには以下が含まれます。
-  - データがパーティションに最初にロードされたとき (パーティションバージョンが 2 のとき) の統計収集。
+  - データがパーティションに初めてロードされたとき（パーティションバージョンが2の場合）の統計収集。
   - マルチパーティションテーブルの空のパーティションにデータがロードされたときの統計収集。
-  - INSERT OVERWRITE 操作の統計コピーと更新。
+  - `INSERT OVERWRITE` 操作のための統計のコピーと更新。
 
   **統計収集タイプの決定ポリシー:**
   
-  - INSERT OVERWRITE の場合: `deltaRatio = |targetRows - sourceRows| / (sourceRows + 1)`
+  - `INSERT OVERWRITE` の場合: `deltaRatio = |targetRows - sourceRows| / (sourceRows + 1)`
     - `deltaRatio < statistic_sample_collect_ratio_threshold_of_first_load` (デフォルト: 0.1) の場合、統計収集は実行されません。既存の統計のみがコピーされます。
-    - それ以外の場合、`targetRows > statistic_sample_collect_rows` (デフォルト: 200000) の場合、SAMPLE 統計収集が使用されます。
-    - それ以外の場合、FULL 統計収集が使用されます。
+    - それ以外で、`targetRows > statistic_sample_collect_rows` (デフォルト: 200000) の場合、`SAMPLE` 統計収集が使用されます。
+    - それ以外の場合、`FULL` 統計収集が使用されます。
   
-  - 最初のロードの場合: `deltaRatio = loadRows / (totalRows + 1)`
+  - 初回ロードの場合: `deltaRatio = loadRows / (totalRows + 1)`
     - `deltaRatio < statistic_sample_collect_ratio_threshold_of_first_load` (デフォルト: 0.1) の場合、統計収集は実行されません。
-    - それ以外の場合、`loadRows > statistic_sample_collect_rows` (デフォルト: 200000) の場合、SAMPLE 統計収集が使用されます。
-    - それ以外の場合、FULL 統計収集が使用されます。
+    - それ以外で、`loadRows > statistic_sample_collect_rows` (デフォルト: 200000) の場合、`SAMPLE` 統計収集が使用されます。
+    - それ以外の場合、`FULL` 統計収集が使用されます。
   
   **同期動作:**
   
-  - DML ステートメント (INSERT INTO/INSERT OVERWRITE) の場合: テーブルロックを使用した同期モード。ロード操作は統計収集が完了するまで待機します (最大 `semi_sync_collect_statistic_await_seconds` まで)。
-  - ストリームロードとブローカーロードの場合: ロックなしの非同期モード。統計収集はバックグラウンドで実行され、ロード操作をブロックしません。
+  - `DML` ステートメント (`INSERT INTO`/`INSERT OVERWRITE`) の場合: テーブルロックを伴う同期モード。ロード操作は統計収集が完了するまで待機します（最大 `semi_sync_collect_statistic_await_seconds`）。
+  - `Stream Load` および `Broker Load` の場合: ロックなしの非同期モード。統計収集はロード操作をブロックせずにバックグラウンドで実行されます。
   
   :::note
-  この設定を無効にすると、ロードトリガー統計操作がすべて防止されます。これには INSERT OVERWRITE の統計メンテナンスも含まれ、テーブルに統計が不足する可能性があります。新しいテーブルが頻繁に作成され、データが頻繁にロードされる場合、この機能を有効にするとメモリと CPU のオーバーヘッドが増加します。
+  この設定を無効にすると、`INSERT OVERWRITE` の統計メンテナンスを含む、ロードによってトリガーされるすべての統計操作が防止され、テーブルに統計が不足する可能性があります。新しいテーブルが頻繁に作成され、データが頻繁にロードされる場合、この機能を有効にするとメモリとCPUのオーバーヘッドが増加します。
   :::
 
 - Introduced in: v3.1
@@ -1882,7 +1882,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: UPDATE ステートメントが自動統計収集をトリガーできるかどうかを制御します。有効にすると、テーブルデータを変更する UPDATE 操作は、`enable_statistic_collect_on_first_load` によって制御される同じインジェストベースの統計フレームワークを通じて統計収集をスケジュールする可能性があります。この設定を無効にすると、UPDATE ステートメントの統計収集はスキップされますが、ロードトリガー統計収集の動作は変更されません。
+- Description: `UPDATE` ステートメントが自動統計収集をトリガーできるかどうかを制御します。有効にすると、テーブルデータを変更する `UPDATE` 操作は、`enable_statistic_collect_on_first_load` によって制御されるのと同じ取り込みベースの統計フレームワークを通じて統計収集をスケジュールする場合があります。この設定を無効にすると、`UPDATE` ステートメントの統計収集はスキップされますが、ロードによってトリガーされる統計収集の動作は変更されません。
 - Introduced in: v3.5.11, v4.0.4
 
 ##### `enable_udf`
@@ -1891,7 +1891,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: No
-- Description: UDF を有効にするかどうか。
+- Description: `UDF` を有効にするかどうか。
 - Introduced in: -
 
 ##### `expr_children_limit`
@@ -1918,7 +1918,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Long
 - Unit: -
 - Is mutable: Yes
-- Description: ヒストグラムで収集する最大行数。
+- Description: ヒストグラムのために収集する最大行数。
 - Introduced in: -
 
 ##### `histogram_mcv_size`
@@ -1927,7 +1927,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Long
 - Unit: -
 - Is mutable: Yes
-- Description: ヒストグラムの最頻値 (MCV) の数。
+- Description: ヒストグラムの最頻値（MCV）の数。
 - Introduced in: -
 
 ##### `histogram_sample_ratio`
@@ -1943,9 +1943,9 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - Default: 5000
 - Type: Int
-- Unit: Milliseconds
+- Unit: ミリ秒
 - Is mutable: Yes
-- Description: HTTP リクエストの応答時間がこのパラメーターで指定された値を超えると、そのリクエストを追跡するためのログが生成されます。
+- Description: HTTPリクエストの応答時間がこのパラメータで指定された値を超えた場合、このリクエストを追跡するためのログが生成されます。
 - Introduced in: v2.5.15, v3.1.5
 
 ##### `lock_checker_enable_deadlock_check`
@@ -1954,7 +1954,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: 有効にすると、LockChecker スレッドは ThreadMXBean.findDeadlockedThreads() を使用して JVM レベルのデッドロック検出を実行し、問題のあるスレッドのスタックトレースをログに記録します。このチェックは LockChecker デーモン内で実行され (その頻度は `lock_checker_interval_second` で制御されます)、詳細なスタック情報をログに書き込みます。これは CPU および I/O を集中的に行う可能性があります。このオプションは、ライブまたは再現可能なデッドロック問題のトラブルシューティングにのみ有効にしてください。通常の操作で有効のままにすると、オーバーヘッドとログのボリュームが増加する可能性があります。
+- Description: 有効にすると、`LockChecker` スレッドは `ThreadMXBean.findDeadlockedThreads()` を使用して `JVM` レベルのデッドロック検出を実行し、問題のあるスレッドのスタックトレースをログに記録します。このチェックは `LockChecker` デーモン（その頻度は `lock_checker_interval_second` によって制御されます）内で実行され、詳細なスタック情報をログに書き込みますが、これはCPUとI/Oを大量に消費する可能性があります。このオプションは、ライブまたは再現可能なデッドロック問題のトラブルシューティングのためにのみ有効にしてください。通常の操作で有効にしたままにすると、オーバーヘッドとログ量が増加する可能性があります。
 - Introduced in: v3.2.0
 
 ##### `low_cardinality_threshold`
@@ -1970,9 +1970,9 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - Default: 60
 - Type: Int
-- Unit: Seconds
+- Unit: 秒
 - Is mutable: Yes
-- Description: 非同期マテリアライズドビューのスケジュールで許可される最小更新間隔 (秒単位)。マテリアライズドビューが時間ベースの間隔で作成された場合、その間隔は秒に変換され、この値以上でなければなりません。そうでない場合、CREATE/ALTER 操作は DDL エラーで失敗します。この値が 0 より大きい場合、チェックが強制されます。TaskManager の過剰なスケジューリングと、頻繁すぎる更新による FE のメモリ/CPU 使用率の高さを防ぐため、制限を無効にするには 0 または負の値に設定します。この項目は `EVENT_TRIGGERED` の更新には適用されません。
+- Description: 非同期マテリアライズドビューのスケジュールで許可される最小更新間隔（秒単位）。時間ベースの間隔でマテリアライズドビューが作成される場合、その間隔は秒に変換され、この値より小さくてはなりません。そうでない場合、`CREATE`/`ALTER` 操作は `DDL` エラーで失敗します。この値が0より大きい場合、チェックが強制されます。制限を無効にするには0または負の値を設定します。これにより、過度な `TaskManager` スケジューリングや、頻繁すぎる更新による `FE` の高いメモリ/CPU使用率が防止されます。この項目は `EVENT_TRIGGERED` 更新には適用されません。
 - Introduced in: v3.3.0, v3.4.0, v3.5.0
 
 ##### `materialized_view_refresh_ascending`
@@ -1981,7 +1981,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: この項目が `true` に設定されている場合、マテリアライズドビューのパーティション更新は昇順のパーティションキー順 (最も古いものから最も新しいものへ) でパーティションを反復処理します。`false` (デフォルト) に設定されている場合、システムは降順 (最も新しいものから最も古いものへ) で反復処理します。StarRocks は、パーティション更新制限が適用される場合に処理するパーティションを選択し、後続の TaskRun 実行の次の開始/終了パーティション境界を計算するために、リストパーティションおよび範囲パーティションのマテリアライズドビュー更新ロジックの両方でこの項目を使用します。この項目を変更すると、最初に更新されるパーティションと、次のパーティション範囲がどのように導出されるかが変わります。範囲パーティションのマテリアライズドビューの場合、スケジューラは新しい開始/終了を検証し、変更によって繰り返される境界 (デッドループ) が作成される場合はエラーを発生させるため、この項目は注意して設定してください。
+- Description: この項目が `true` に設定されている場合、マテリアライズドビューのパーティション更新は、パーティションキーの昇順（最も古いものから最も新しいものへ）でパーティションを反復処理します。`false`（デフォルト）に設定されている場合、システムは降順（最も新しいものから最も古いものへ）で反復処理します。StarRocksは、パーティション更新制限が適用される場合に処理するパーティションを選択し、後続の `TaskRun` 実行のための次の開始/終了パーティション境界を計算するために、リストパーティションおよび範囲パーティションのマテリアライズドビュー更新ロジックの両方でこの項目を使用します。この項目を変更すると、どのパーティションが最初に更新されるか、および次のパーティション範囲がどのように導出されるかが変わります。範囲パーティションのマテリアライズドビューの場合、スケジューラは新しい開始/終了を検証し、変更が繰り返される境界（デッドループ）を作成する場合にエラーを発生させるため、この項目は注意して設定してください。
 - Introduced in: v3.3.1, v3.4.0, v3.5.0
 
 ##### `max_allowed_in_element_num_of_delete`
@@ -1990,14 +1990,14 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: DELETE ステートメントの IN 述語で許可される要素の最大数。
+- Description: `DELETE` ステートメントの `IN` 述語で許可される要素の最大数。
 - Introduced in: -
 
 ##### `max_create_table_timeout_second`
 
 - Default: 600
 - Type: Int
-- Unit: Seconds
+- Unit: 秒
 - Is mutable: Yes
 - Description: テーブル作成の最大タイムアウト期間。
 - Introduced in: -
@@ -2008,7 +2008,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: パーティションプルーナーによって許可される最大再帰深度。再帰深度を増やすと、より多くの要素をプルーニングできますが、CPU 消費量も増加します。
+- Description: パーティションプルーナーによって許可される最大再帰深度。再帰深度を増やすと、より多くの要素をプルーニングできますが、CPU消費も増加します。
 - Introduced in: -
 
 ##### `max_partitions_in_one_batch`
@@ -2017,7 +2017,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Long
 - Unit: -
 - Is mutable: Yes
-- Description: 複数のパーティションを一括作成する際に作成できる最大パーティション数。
+- Description: パーティションを一括作成する際に作成できるパーティションの最大数。
 - Introduced in: -
 
 ##### `max_planner_scalar_rewrite_num`
@@ -2026,16 +2026,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Long
 - Unit: -
 - Is mutable: Yes
-- Description: オプティマイザがスカラー演算子を書き換えできる最大回数。
+- Description: オプティマイザがスカラー演算子を書き換えられる最大回数。
 - Introduced in: -
 
 ##### `max_query_queue_history_slots_number`
 
 - Default: 0
 - Type: Int
-- Unit: Slots
+- Unit: スロット
 - Is mutable: Yes
-- Description: 監視および可観測性のために、クエリキューごとに保持される最近解放された (履歴) 割り当てスロットの数を制御します。`max_query_queue_history_slots_number` が `> 0` の値に設定されている場合、BaseSlotTracker は、その数の最も最近解放された LogicalSlot エントリをメモリ内キューに保持し、制限を超えると最も古いエントリを削除します。これを有効にすると、getSlots() にこれらの履歴エントリ (最新のものが最初) が含まれるようになり、BaseSlotTracker はより豊富な ExtraMessage データのために ConnectContext にスロットを登録しようとすることができ、LogicalSlot.ConnectContextListener はクエリ完了メタデータを履歴スロットにアタッチできます。`max_query_queue_history_slots_number` が `<= 0` の場合、履歴メカニズムは無効になります (余分なメモリは使用されません)。可観測性とメモリオーバーヘッドのバランスを取るために、適切な値を使用してください。
+- Description: 監視と可観測性のために、クエリキューごとに最近解放された（履歴）割り当てスロットをいくつ保持するかを制御します。`max_query_queue_history_slots_number` が `> 0` の値に設定されている場合、`BaseSlotTracker` は、その数の最も最近解放された `LogicalSlot` エントリをインメモリキューに保持し、制限を超えると最も古いものを削除します。これを有効にすると、`getSlots()` がこれらの履歴エントリ（最新のものが最初）を含むようになり、`BaseSlotTracker` がより豊富な `ExtraMessage` データのために `ConnectContext` にスロットを登録しようとすることを許可し、`LogicalSlot.ConnectContextListener` がクエリ完了メタデータを履歴スロットに添付できるようになります。`max_query_queue_history_slots_number` が `<= 0` の場合、履歴メカニズムは無効になります（追加のメモリは使用されません）。可観測性とメモリオーバーヘッドのバランスを取るために、適切な値を使用してください。
 - Introduced in: v3.5.0
 
 ##### `max_query_retry_time`
@@ -2044,7 +2044,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: FE でのクエリ再試行の最大数。
+- Description: `FE` でのクエリ再試行の最大回数。
 - Introduced in: -
 
 ##### `max_running_rollup_job_num_per_table`
@@ -2062,7 +2062,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type：Int
 - Unit：-
 - Is mutable: Yes
-- Description：ScalarOperator のフラットな子の最大数。オプティマイザが過剰なメモリを使用するのを防ぐために、この制限を設定できます。
+- Description：`ScalarOperator` のフラットな子要素の最大数。この制限を設定することで、オプティマイザが過剰なメモリを使用するのを防ぐことができます。
 - Introduced in: -
 
 ##### `max_scalar_operator_optimize_depth`
@@ -2071,16 +2071,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type：Int
 - Unit：-
 - Is mutable: Yes
-- Description: ScalarOperator 最適化が適用できる最大深度。
+- Description: `ScalarOperator` の最適化が適用できる最大深度。
 - Introduced in: -
 
 ##### `mv_active_checker_interval_seconds`
 
 - Default: 60
 - Type: Long
-- Unit: Seconds
+- Unit: 秒
 - Is mutable: Yes
-- Description: バックグラウンドの `active_checker` スレッドが有効な場合、システムは定期的に、スキーマ変更または基底テーブル (ビュー) の再構築によって非アクティブになったマテリアライズドビューを検出して自動的に再アクティブ化します。このパラメーターは、チェッカー スレッドのスケジューリング間隔を秒単位で制御します。デフォルト値はシステム定義です。
+- Description: バックグラウンドの `active_checker` スレッドが有効な場合、システムは定期的に、ベーステーブル（またはビュー）のスキーマ変更や再構築により非アクティブになったマテリアライズドビューを検出し、自動的に再アクティブ化します。このパラメータは、チェッカースレッドのスケジューリング間隔を秒単位で制御します。デフォルト値はシステム定義です。
 - Introduced in: v3.1.6
 
 ##### `mv_rewrite_consider_data_layout_mode`
@@ -2089,18 +2089,18 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: Yes
-- Description: 最適なマテリアライズドビューを選択する際に、マテリアライズドビューの書き換えで基底テーブルのデータレイアウトを考慮するかどうかを制御します。有効な値:
-  - `disable`: 候補マテリアライズドビューを選択する際に、データレイアウト基準を使用しない。
-  - `enable`: クエリがレイアウトを意識していると認識された場合にのみ、データレイアウト基準を使用する。
-  - `force`: 最適なマテリアライズドビューを選択する際に、常にデータレイアウト基準を適用する。
-  この項目を変更すると、`BestMvSelector` の動作に影響し、物理的なレイアウトが計画の正確性やパフォーマンスに影響するかどうかに応じて、書き換えの適用範囲を改善または拡大することができます。
+- Description: 最適なマテリアライズドビューを選択する際に、マテリアライズドビューの書き換えがベーステーブルのデータレイアウトを考慮すべきかどうかを制御します。有効な値:
+  - `disable`: 候補となるマテリアライズドビューを選択する際に、データレイアウト基準を一切使用しません。
+  - `enable`: クエリがレイアウトセンシティブであると認識された場合にのみ、データレイアウト基準を使用します。
+  - `force`: 最適なマテリアライズドビューを選択する際に、常にデータレイアウト基準を適用します。
+  この項目を変更すると、`BestMvSelector` の動作に影響を与え、物理レイアウトがプランの正確性やパフォーマンスに影響するかどうかに応じて、書き換えの適用性を改善または拡大できます。
 - Introduced in: -
 
 ##### `publish_version_interval_ms`
 
 - Default: 10
 - Type: Int
-- Unit: Milliseconds
+- Unit: ミリ秒
 - Is mutable: No
 - Description: リリース検証タスクが発行される時間間隔。
 - Introduced in: -
@@ -2111,7 +2111,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: Yes
-- Description: `enable_query_queue_v2` が true の場合に、キューベースクエリに使用されるスロット推定戦略を選択します。有効な値は、MBE (メモリベース)、PBE (並行性ベース)、MAX (MBE と PBE の最大値を取る)、MIN (MBE と PBE の最小値を取る) です。MBE は、予測されたメモリまたは計画コストをスロットあたりのメモリターゲットで割ってスロットを推定し、`totalSlots` で上限が設定されます。PBE は、フラグメントの並行性 (スキャン範囲のカウントまたはカーディナリティ / スロットあたりの行数) と CPU コストベースの計算 (スロットあたりの CPU コストを使用) からスロットを導出し、結果を [numSlots/2, numSlots] の範囲内に制限します。MAX と MIN は、MBE と PBE の最大値または最小値を取ることによってそれらを結合します。設定された値が無効な場合、デフォルト (`MAX`) が使用されます。
+- Description: `enable_query_queue_v2` が `true` の場合に、キューベースのクエリに使用されるスロット推定戦略を選択します。有効な値: `MBE` (メモリベース)、`PBE` (並列性ベース)、`MAX` (`MBE` と `PBE` の最大値を取る)、`MIN` (`MBE` と `PBE` の最小値を取る)。`MBE` は、予測メモリまたはプランコストをスロットあたりのメモリターゲットで割ってスロットを推定し、`totalSlots` で上限が設定されます。`PBE` は、フラグメントの並列性（スキャン範囲のカウントまたはカーディナリティ / スロットあたりの行数）とCPUコストベースの計算（スロットあたりのCPUコストを使用）からスロットを導出し、結果を [numSlots/2, numSlots] の範囲内に制限します。`MAX` と `MIN` は、それぞれ最大値または最小値を取ることによって `MBE` と `PBE` を組み合わせます。設定値が無効な場合、デフォルト (`MAX`) が使用されます。
 - Introduced in: v3.5.0
 
 ##### `query_queue_v2_concurrency_level`
@@ -2120,25 +2120,25 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: システムの総クエリスロットを計算する際に使用される論理的な並行性「レイヤー」の数を制御します。Shared-nothing モードでは、総スロット = `query_queue_v2_concurrency_level` * BE の数 * BE ごとのコア数 (BackendResourceStat から派生)。マルチウェアハウスモードでは、実効並行性は max(1, `query_queue_v2_concurrency_level` / 4) にスケーリングされます。設定値が非正の場合、`4` として扱われます。この値を変更すると、totalSlots (したがって同時クエリ容量) が増減し、スロットごとのリソースに影響します。memBytesPerSlot はワーカーごとのメモリを (ワーカーごとのコア数 * 並行性) で割って導出され、CPU アカウンティングは `query_queue_v2_cpu_costs_per_slot` を使用します。クラスターサイズに比例して設定してください。非常に大きな値はスロットごとのメモリを減らし、リソースの断片化を引き起こす可能性があります。
+- Description: システムの総クエリスロットを計算する際に、いくつの論理的な並列性「レイヤー」が使用されるかを制御します。シェアードナッシングモードでは、総スロット = `query_queue_v2_concurrency_level` * `BE` の数 * `BE` あたりのコア数（`BackendResourceStat` から導出されます）。マルチウェアハウスモードでは、実効並列性は `max(1, query_queue_v2_concurrency_level / 4)` にスケールダウンされます。設定値が非正の場合、`4` として扱われます。この値を変更すると、`totalSlots`（したがって同時クエリ容量）が増減し、スロットあたりのリソースに影響します。`memBytesPerSlot` は、ワーカーあたりのメモリを（ワーカーあたりのコア数 * 並列性）で割って導出され、CPUアカウンティングは `query_queue_v2_cpu_costs_per_slot` を使用します。クラスターサイズに比例して設定してください。非常に大きな値は、スロットあたりのメモリを減らし、リソースの断片化を引き起こす可能性があります。
 - Introduced in: v3.3.4, v3.4.0, v3.5.0
 
 ##### `query_queue_v2_cpu_costs_per_slot`
 
 - Default: 1000000000
 - Type: Long
-- Unit: planner CPU cost units
+- Unit: プランナーCPUコスト単位
 - Is mutable: Yes
-- Description: プランナー CPU コストからクエリが必要とするスロット数を推定するために使用されるスロットごとの CPU コストしきい値。スケジューラーは、スロットを整数 (`plan_cpu_costs` / `query_queue_v2_cpu_costs_per_slot`) として計算し、結果を [1, totalSlots] の範囲にクランプします (totalSlots はクエリキュー V2 `V2` パラメーターから派生)。V2 コードは非正の設定を 1 に正規化するため (Math.max(1, value))、非正の値は事実上 `1` になります。この値を増やすと、クエリごとに割り当てられるスロットが減少し (より少ない、より大きなスロットのクエリを優先)、減らすとクエリごとのスロットが増加します。並行性対リソースの粒度を制御するために、`query_queue_v2_num_rows_per_slot` および並行性設定と合わせて調整してください。
+- Description: クエリがそのプランナーCPUコストから必要とするスロット数を推定するために使用される、スロットあたりのCPUコストしきい値。スケジューラは、スロットを整数(`plan_cpu_costs` / `query_queue_v2_cpu_costs_per_slot`)として計算し、結果を [1, totalSlots] の範囲にクランプします（`totalSlots` はクエリキュー `V2` パラメータから導出されます）。`V2` コードは非正の設定を1に正規化するため（`Math.max(1, value)`）、非正の値は実質的に `1` になります。この値を増やすと、クエリごとに割り当てられるスロットが減少し（より少ない、より大きなスロットのクエリを優先）、減らすとクエリごとのスロットが増加します。並列性とリソースの粒度を制御するために、`query_queue_v2_num_rows_per_slot` および並列性設定と合わせて調整してください。
 - Introduced in: v3.3.4, v3.4.0, v3.5.0
 
 ##### `query_queue_v2_num_rows_per_slot`
 
 - Default: 4096
 - Type: Int
-- Unit: Rows
+- Unit: 行
 - Is mutable: Yes
-- Description: クエリごとのスロット数を推定する際に、単一のスケジューリングスロットに割り当てられるターゲットのソース行レコード数。StarRocks は、`estimated_slots` = (ソースノードのカーディナリティ) / `query_queue_v2_num_rows_per_slot` を計算し、その結果を [1, totalSlots] の範囲にクランプし、計算された値が非正の場合は最低 1 を強制します。totalSlots は利用可能なリソース (おおよそ DOP * `query_queue_v2_concurrency_level` * ワーカー/BE の数) から導出され、したがってクラスター/コア数に依存します。この値を増やすと、スロット数が減少し (各スロットがより多くの行を処理)、スケジューリングオーバーヘッドが減少します。減らすと、並行性が増加し (より多くの、より小さいスロット)、リソース制限まで増加します。
+- Description: クエリごとのスロット数を推定する際に、単一のスケジューリングスロットに割り当てられるソース行レコードの目標数。StarRocksは `estimated_slots` = (ソースノードのカーディナリティ) / `query_queue_v2_num_rows_per_slot` を計算し、結果を [1, totalSlots] の範囲にクランプし、計算値が非正の場合は最小値1を強制します。`totalSlots` は利用可能なリソース（おおよそ `DOP` * `query_queue_v2_concurrency_level` * ワーカー/`BE` の数）から導出されるため、クラスター/コア数に依存します。この値を増やすと、スロット数が減少し（各スロットがより多くの行を処理）、スケジューリングオーバーヘッドが低減されます。減らすと、リソース制限まで並列性が増加します（より多くの、より小さなスロット）。
 - Introduced in: v3.3.4, v3.4.0, v3.5.0
 
 ##### `query_queue_v2_schedule_strategy`
@@ -2147,34 +2147,34 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: Yes
-- Description: Query Queue V2 が保留中のクエリを並べ替えるために使用するスケジューリングポリシーを選択します。サポートされている値 (大文字と小文字を区別しない) は `SWRR` (Smooth Weighted Round Robin) - デフォルトで、公平な重み付き共有が必要な混合/ハイブリッドワークロードに適しています - と `SJF` (Short Job First + Aging) - 短いジョブを優先し、エージングを使用してスタベーションを回避します。値は大文字と小文字を区別しない enum ルックアップで解析されます。認識されない値はエラーとしてログに記録され、デフォルトポリシーが使用されます。この設定は Query Queue V2 が有効な場合にのみ動作に影響し、`query_queue_v2_concurrency_level` などの V2 サイジング設定と相互作用します。
+- Description: `Query Queue V2` が保留中のクエリを順序付けるために使用するスケジューリングポリシーを選択します。サポートされる値（大文字小文字を区別しない）は、`SWRR` (Smooth Weighted Round Robin) — デフォルトであり、公平な重み付き共有が必要な混合/ハイブリッドワークロードに適しています — と `SJF` (Short Job First + Aging) — 短いジョブを優先し、エージングを使用して飢餓状態を回避します — です。値は大文字小文字を区別しない列挙型ルックアップで解析されます。認識されない値はエラーとしてログに記録され、デフォルトポリシーが使用されます。この設定は、`Query Queue V2` が有効な場合にのみ動作に影響し、`query_queue_v2_concurrency_level` などの `V2` サイジング設定と相互作用します。
 - Introduced in: v3.3.12, v3.4.2, v3.5.0
 
 ##### `semi_sync_collect_statistic_await_seconds`
 
 - Default: 30
 - Type: Int
-- Unit: Seconds
+- Unit: 秒
 - Is mutable: Yes
-- Description: DML 操作 (INSERT INTO および INSERT OVERWRITE ステートメント) 中の半同期統計収集の最大待機時間。ストリームロードおよびブローカーロードは非同期モードを使用するため、この設定の影響を受けません。統計収集時間がこの値を超えると、ロード操作は収集完了を待たずに続行します。この設定は `enable_statistic_collect_on_first_load` と連携して機能します。
+- Description: `DML` 操作（`INSERT INTO` および `INSERT OVERWRITE` ステートメント）中の半同期統計収集の最大待機時間。`Stream Load` および `Broker Load` は非同期モードを使用するため、この設定の影響を受けません。統計収集時間がこの値を超えると、ロード操作は収集の完了を待たずに続行されます。この設定は `enable_statistic_collect_on_first_load` と連携して機能します。
 - Introduced in: v3.1
 
 ##### `slow_query_analyze_threshold`
 
 - Default: 5
 - Type: Int
-- Unit: Seconds
+- Unit: 秒
 - Is mutable: Yes
-- Description: クエリフィードバックの分析をトリガーするクエリの実行時間しきい値。
+- Description: クエリフィードバックの分析をトリガーするためのクエリの実行時間しきい値。
 - Introduced in: v3.4.0
 
 ##### `statistic_analyze_status_keep_second`
 
 - Default: 3 * 24 * 3600
 - Type: Long
-- Unit: Seconds
+- Unit: 秒
 - Is mutable: Yes
-- Description: 収集タスクの履歴を保持する期間。デフォルト値は 3 日間です。
+- Description: 収集タスクの履歴を保持する期間。デフォルト値は3日間です。
 - Introduced in: -
 
 ##### `statistic_auto_analyze_end_time`
@@ -2201,7 +2201,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Double
 - Unit: -
 - Is mutable: Yes
-- Description: 自動収集の統計が健全であるかどうかを判断するためのしきい値。統計の健全性がこのしきい値よりも低い場合、自動収集がトリガーされます。
+- Description: 自動収集の統計が健全であるかどうかを判断するためのしきい値。統計の健全性がこのしきい値を下回ると、自動収集がトリガーされます。
 - Introduced in: -
 
 ##### `statistic_auto_collect_small_table_rows`
@@ -2210,7 +2210,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Long
 - Unit: -
 - Is mutable: Yes
-- Description: 自動収集中に、外部データソース (Hive、Iceberg、Hudi) のテーブルが小さいテーブルであるかどうかを判断するためのしきい値。テーブルの行数がこの値より少ない場合、そのテーブルは小さいテーブルと見なされます。
+- Description: 自動収集中に、外部データソース（`Hive`、`Iceberg`、`Hudi`）内のテーブルが小規模テーブルであるかどうかを判断するためのしきい値。テーブルの行数がこの値より少ない場合、そのテーブルは小規模テーブルと見なされます。
 - Introduced in: v3.2
 
 ##### `statistic_cache_columns`
@@ -2219,7 +2219,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Long
 - Unit: -
 - Is mutable: No
-- Description: 統計テーブルにキャッシュできる行数。
+- Description: 統計テーブルのためにキャッシュできる行数。
 - Introduced in: -
 
 ##### `statistic_cache_thread_pool_size`
@@ -2235,18 +2235,18 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - Default: 5 * 60
 - Type: Long
-- Unit: Seconds
+- Unit: 秒
 - Is mutable: Yes
-- Description: 自動収集中にデータ更新をチェックする間隔。
+- Description: 自動収集中のデータ更新をチェックする間隔。
 - Introduced in: -
 
 ##### `statistic_max_full_collect_data_size`
 
 - Default: 100 * 1024 * 1024 * 1024
 - Type: Long
-- Unit: bytes
+- Unit: バイト
 - Is mutable: Yes
-- Description: 統計の自動収集のデータサイズしきい値。合計サイズがこの値を超えると、完全収集ではなくサンプリング収集が実行されます。
+- Description: 統計の自動収集におけるデータサイズしきい値。合計サイズがこの値を超えると、完全収集ではなくサンプリング収集が実行されます。
 - Introduced in: -
 
 ##### `statistic_sample_collect_rows`
@@ -2255,14 +2255,14 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Long
 - Unit: -
 - Is mutable: Yes
-- Description: ロードトリガー統計操作中に SAMPLE 統計収集と FULL 統計収集のどちらかを決定するための行数しきい値。ロードまたは変更された行数がこのしきい値 (デフォルト 200,000) を超える場合、SAMPLE 統計収集が使用されます。そうでない場合、FULL 統計収集が使用されます。この設定は、`enable_statistic_collect_on_first_load` および `statistic_sample_collect_ratio_threshold_of_first_load` と連携して機能します。
+- Description: ロードによってトリガーされる統計操作中に、`SAMPLE` 統計収集と `FULL` 統計収集のどちらを選択するかを決定するための行数しきい値。ロードまたは変更された行数がこのしきい値（デフォルト200,000）を超えると、`SAMPLE` 統計収集が使用されます。それ以外の場合は、`FULL` 統計収集が使用されます。この設定は、`enable_statistic_collect_on_first_load` および `statistic_sample_collect_ratio_threshold_of_first_load` と連携して機能します。
 - Introduced in: -
 
 ##### `statistic_update_interval_sec`
 
 - Default: 24 * 60 * 60
 - Type: Long
-- Unit: Seconds
+- Unit: 秒
 - Is mutable: Yes
 - Description: 統計情報のキャッシュが更新される間隔。
 - Introduced in: -
@@ -2271,530 +2271,530 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - Default: 60
 - Type: Int
-- Unit: Seconds
+- Unit: 秒
 - Is mutable: Yes
-- Description: タスクバックグラウンドジョブの実行間隔。GlobalStateMgr はこの値を使用して `doTaskBackgroundJob()` を呼び出す TaskCleaner FrontendDaemon をスケジュールします。この値はデーモン間隔をミリ秒単位で設定するために 1000 倍されます。値を減らすとバックグラウンドメンテナンス (タスククリーンアップ、チェック) の実行頻度が高まり、反応が速くなりますが、CPU/IO オーバーヘッドが増加します。値を増やすとオーバーヘッドが減少しますが、クリーンアップと古いタスクの検出が遅れます。この値を調整して、メンテナンスの応答性とリソース使用量のバランスを取ります。
+- Description: タスクバックグラウンドジョブの実行間隔。`GlobalStateMgr` はこの値を使用して、`doTaskBackgroundJob()` を呼び出す `TaskCleaner FrontendDaemon` をスケジュールします。この値は1000倍されて、デーモン間隔がミリ秒単位で設定されます。値を減らすと、バックグラウンドメンテナンス（タスククリーンアップ、チェック）がより頻繁に実行され、より迅速に反応しますが、CPU/IOオーバーヘッドが増加します。値を増やすと、オーバーヘッドは減少しますが、クリーンアップと古いタスクの検出が遅れます。この値を調整して、メンテナンスの応答性とリソース使用量のバランスを取ってください。
 - Introduced in: v3.2.0
 
 ##### `task_min_schedule_interval_s`
 
 - Default: 10
 - Type: Int
-- Unit: Seconds
+- Unit: 秒
 - Is mutable: Yes
-- Description: SQL レイヤーによってチェックされるタスクスケジュールの最小許容スケジュール間隔 (秒単位)。タスクが送信されると、TaskAnalyzer はスケジュール期間を秒に変換し、期間が `task_min_schedule_interval_s` より小さい場合、`ERR_INVALID_PARAMETER` で送信を拒否します。これにより、頻繁すぎる実行タスクの作成が防止され、スケジューラーが高頻度タスクから保護されます。スケジュールに明示的な開始時間がない場合、TaskAnalyzer は開始時間を現在のエポック秒に設定します。
+- Description: `SQL` レイヤーによってチェックされるタスクスケジュールの最小許容スケジュール間隔（秒単位）。タスクが送信されると、`TaskAnalyzer` はスケジュール期間を秒に変換し、期間が `task_min_schedule_interval_s` より小さい場合、`ERR_INVALID_PARAMETER` で送信を拒否します。これにより、頻繁に実行されるタスクの作成が防止され、スケジューラが高頻度タスクから保護されます。スケジュールに明示的な開始時刻がない場合、`TaskAnalyzer` は開始時刻を現在のエポック秒に設定します。
 - Introduced in: v3.3.0, v3.4.0, v3.5.0
 
 ##### `task_runs_timeout_second`
 
 - Default: 4 * 3600
 - Type: Int
-- Unit: Seconds
+- Unit: 秒
 - Is mutable: Yes
-- Description: TaskRun のデフォルトの実行タイムアウト (秒単位)。この項目は TaskRun 実行の基準タイムアウトとして使用されます。タスク実行のプロパティに、正の整数値を持つセッション変数 `query_timeout` または `insert_timeout` が含まれている場合、実行時はそのセッションタイムアウトと `task_runs_timeout_second` のうち大きい方の値を使用します。その後、実質的なタイムアウトは、設定された `task_runs_ttl_second` および `task_ttl_second` を超えないように制限されます。タスク実行の最大実行時間を制限するには、この項目を設定します。非常に大きな値は、タスク/タスク実行の TTL 設定によって切り捨てられる可能性があります。
+- Description: `TaskRun` のデフォルトの実行タイムアウト（秒単位）。この項目は、`TaskRun` 実行のベースラインタイムアウトとして使用されます。タスク実行のプロパティに、正の整数値を持つセッション変数 `query_timeout` または `insert_timeout` が含まれている場合、ランタイムは、そのセッションタイムアウトと `task_runs_timeout_second` のうち大きい方の値を使用します。実効タイムアウトは、設定された `task_runs_ttl_second` および `task_ttl_second` を超えないように制限されます。この項目を設定して、タスク実行が実行できる期間を制限します。非常に大きな値は、タスク/タスク実行の `TTL` 設定によって切り詰められる場合があります。
 - Introduced in: -
 
 ### ロードとアンロード
 
 ##### `broker_load_default_timeout_second`
 
-- Default: 14400
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: Broker Load ジョブのタイムアウト期間。
-- Introduced in: -
+- デフォルト: 14400
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: Broker Load ジョブのタイムアウト期間。
+- 導入バージョン: -
 
 ##### `desired_max_waiting_jobs`
 
-- Default: 1024
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: FE での保留中のジョブの最大数。この数は、テーブル作成、ロード、スキーマ変更ジョブなど、すべてのジョブを指します。FE での保留中のジョブの数がこの値に達すると、FE は新しいロード要求を拒否します。このパラメーターは、非同期ロードにのみ有効です。v2.5 以降、デフォルト値は 100 から 1024 に変更されました。
-- Introduced in: -
+- デフォルト: 1024
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: FE 内の保留中のジョブの最大数。この数は、テーブル作成、ロード、スキーマ変更ジョブなど、すべてのジョブを指します。FE 内の保留中のジョブの数がこの値に達すると、FE は新しいロードリクエストを拒否します。このパラメーターは、非同期ロードにのみ有効です。v2.5 以降、デフォルト値は 100 から 1024 に変更されました。
+- 導入バージョン: -
 
 ##### `disable_load_job`
 
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: クラスターでエラーが発生した場合にロードを無効にするかどうか。これにより、クラスターエラーによる損失を防ぎます。デフォルト値は `FALSE` で、ロードが無効になっていないことを示します。`TRUE` はロードが無効になっており、クラスターが読み取り専用状態であることを示します。
-- Introduced in: -
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: クラスターがエラーに遭遇したときにロードを無効にするかどうか。これにより、クラスターエラーによって引き起こされる損失を防ぎます。デフォルト値は `FALSE` で、ロードが無効になっていないことを示します。`TRUE` はロードが無効になっており、クラスターが読み取り専用状態であることを示します。
+- 導入バージョン: -
 
 ##### `empty_load_as_error`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: データがロードされない場合にエラーメッセージ「すべてのパーティションにロードデータがありません」を返すかどうか。有効な値:
-  - `true`: データがロードされない場合、システムは失敗メッセージを表示し、エラー「すべてのパーティションにロードデータがありません」を返します。
-  - `false`: データがロードされない場合、システムは成功メッセージを表示し、エラーではなく OK を返します。
-- Introduced in: -
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: データがロードされなかった場合に、「すべてのパーティションにロードデータがありません」というエラーメッセージを返すかどうか。有効な値:
+  - `true`: データがロードされなかった場合、システムは失敗メッセージを表示し、「すべてのパーティションにロードデータがありません」というエラーを返します。
+  - `false`: データがロードされなかった場合、システムは成功メッセージを表示し、エラーではなく OK を返します。
+- 導入バージョン: -
 
 ##### `enable_file_bundling`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: クラウドネイティブテーブルのファイルバンドル最適化を有効にするかどうか。この機能が有効 ( `true` に設定) の場合、システムはロード、コンパクション、または公開操作によって生成されたデータファイルを自動的にバンドルし、それによって外部ストレージシステムへの高頻度アクセスによって発生する API コストを削減します。この動作は、CREATE TABLE プロパティ `file_bundling` を使用してテーブルレベルで制御することもできます。詳細な手順については、[CREATE TABLE](../../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md) を参照してください。
-- Introduced in: v4.0
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: クラウドネイティブテーブルの File Bundling 最適化を有効にするかどうか。この機能が有効になっている場合 (`true` に設定されている場合)、システムはロード、Compaction、または Publish 操作によって生成されたデータファイルを自動的にバンドルし、外部ストレージシステムへの高頻度アクセスによって発生する API コストを削減します。この動作は、CREATE TABLE プロパティ `file_bundling` を使用してテーブルレベルで制御することもできます。詳細な手順については、[CREATE TABLE](../../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md) を参照してください。
+- 導入バージョン: v4.0
 
 ##### `enable_routine_load_lag_metrics`
 
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: ルーチンロード Kafka パーティションオフセットラグメトリックを収集するかどうか。この項目を `true` に設定すると、Kafka API が呼び出されてパーティションの最新オフセットが取得されることに注意してください。
-- Introduced in: -
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: Routine Load Kafka パーティションオフセットラグメトリクスを収集するかどうか。この項目を `true` に設定すると、Kafka API を呼び出してパーティションの最新オフセットを取得することに注意してください。
+- 導入バージョン: -
 
 ##### `enable_sync_publish`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: ロードトランザクションの公開フェーズで適用タスクを同期的に実行するかどうか。このパラメーターは主キーテーブルにのみ適用されます。有効な値:
-  - `TRUE` (デフォルト): 適用タスクはロードトランザクションの公開フェーズで同期的に実行されます。これは、適用タスクが完了し、ロードされたデータが実際にクエリ可能になった後にのみ、ロードトランザクションが成功として報告されることを意味します。タスクが一度に大量のデータをロードしたり、頻繁にデータをロードしたりする場合、このパラメーターを `true` に設定するとクエリパフォーマンスと安定性が向上しますが、ロードレイテンシーが増加する可能性があります。
-  - `FALSE`: 適用タスクはロードトランザクションの公開フェーズで非同期的に実行されます。これは、適用タスクが送信された後にロードトランザクションが成功として報告されますが、ロードされたデータはすぐにクエリできないことを意味します。この場合、同時クエリは適用タスクが完了するかタイムアウトするまで待機してから続行する必要があります。タスクが一度に大量のデータをロードしたり、頻繁にデータをロードしたりしたりする場合、このパラメーターを `false` に設定すると、クエリパフォーマンスと安定性に影響する可能性があります。
-- Introduced in: v3.2.0
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: ロードトランザクションのパブリッシュフェーズで適用タスクを同期的に実行するかどうか。このパラメーターは Primary Key テーブルにのみ適用されます。有効な値:
+  - `TRUE` (デフォルト): ロードトランザクションのパブリッシュフェーズで適用タスクが同期的に実行されます。これは、適用タスクが完了した後にのみロードトランザクションが成功として報告され、ロードされたデータが実際にクエリ可能になることを意味します。タスクが一度に大量のデータをロードする場合、または頻繁にデータをロードする場合、このパラメーターを `true` に設定すると、クエリのパフォーマンスと安定性が向上しますが、ロードのレイテンシーが増加する可能性があります。
+  - `FALSE`: ロードトランザクションのパブリッシュフェーズで適用タスクが非同期的に実行されます。これは、適用タスクが送信された後にロードトランザクションが成功として報告されますが、ロードされたデータはすぐにクエリできないことを意味します。この場合、同時クエリは、適用タスクが完了するかタイムアウトするまで待機してから続行する必要があります。タスクが一度に大量のデータをロードする場合、または頻繁にデータをロードする場合、このパラメーターを `false` に設定すると、クエリのパフォーマンスと安定性に影響を与える可能性があります。
+- 導入バージョン: v3.2.0
 
 ##### `export_checker_interval_second`
 
-- Default: 5
-- Type: Int
-- Unit: Seconds
-- Is mutable: No
-- Description: ロードジョブがスケジュールされる時間間隔。
-- Introduced in: -
+- デフォルト: 5
+- タイプ: Int
+- 単位: 秒
+- 変更可能: No
+- 説明: ロードジョブがスケジュールされる時間間隔。
+- 導入バージョン: -
 
 ##### `export_max_bytes_per_be_per_task`
 
-- Default: 268435456
-- Type: Long
-- Unit: Bytes
-- Is mutable: Yes
-- Description: 単一の BE から単一のデータアンロードタスクによってエクスポートできる最大データ量。
-- Introduced in: -
+- デフォルト: 268435456
+- タイプ: Long
+- 単位: バイト
+- 変更可能: Yes
+- 説明: 単一のデータアンロードタスクによって単一の BE からエクスポートできるデータの最大量。
+- 導入バージョン: -
 
 ##### `export_running_job_num_limit`
 
-- Default: 5
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: 並行して実行できるデータエクスポートタスクの最大数。
-- Introduced in: -
+- デフォルト: 5
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: 並行して実行できるデータエクスポートタスクの最大数。
+- 導入バージョン: -
 
 ##### `export_task_default_timeout_second`
 
-- Default: 2 * 3600
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: データエクスポートタスクのタイムアウト期間。
-- Introduced in: -
+- デフォルト: 2 * 3600
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: データエクスポートタスクのタイムアウト期間。
+- 導入バージョン: -
 
 ##### `export_task_pool_size`
 
-- Default: 5
-- Type: Int
-- Unit: -
-- Is mutable: No
-- Description: アンロードタスクのスレッドプールのサイズ。
-- Introduced in: -
+- デフォルト: 5
+- タイプ: Int
+- 単位: -
+- 変更可能: No
+- 説明: アンロードタスクスレッドプールのサイズ。
+- 導入バージョン: -
 
 ##### `external_table_commit_timeout_ms`
 
-- Default: 10000
-- Type: Int
-- Unit: Milliseconds
-- Is mutable: Yes
-- Description: StarRocks 外部テーブルへの書き込みトランザクションをコミット (公開) するためのタイムアウト期間。デフォルト値 `10000` は 10 秒のタイムアウト期間を示します。
-- Introduced in: -
+- デフォルト: 10000
+- タイプ: Int
+- 単位: ミリ秒
+- 変更可能: Yes
+- 説明: StarRocks 外部テーブルへの書き込みトランザクションをコミット (パブリッシュ) する際のタイムアウト期間。デフォルト値 `10000` は 10 秒のタイムアウト期間を示します。
+- 導入バージョン: -
 
 ##### `finish_transaction_default_lock_timeout_ms`
 
-- Default: 1000
-- Type: Int
-- Unit: MilliSeconds
-- Is mutable: Yes
-- Description: トランザクション完了中の db およびテーブルロック取得のデフォルトタイムアウト。
-- Introduced in: v4.0.0, v3.5.8
+- デフォルト: 1000
+- タイプ: Int
+- 単位: ミリ秒
+- 変更可能: Yes
+- 説明: トランザクション完了中に DB およびテーブルロックを取得するためのデフォルトのタイムアウト。
+- 導入バージョン: v4.0.0, v3.5.8
 
 ##### `history_job_keep_max_second`
 
-- Default: 7 * 24 * 3600
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: スキーマ変更ジョブなど、履歴ジョブが保持できる最大期間。
-- Introduced in: -
+- デフォルト: 7 * 24 * 3600
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: スキーマ変更ジョブなど、履歴ジョブを保持できる最大期間。
+- 導入バージョン: -
 
 ##### `insert_load_default_timeout_second`
 
-- Default: 3600
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: データをロードするために使用される INSERT INTO ステートメントのタイムアウト期間。
-- Introduced in: -
+- デフォルト: 3600
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: データをロードするために使用される INSERT INTO ステートメントのタイムアウト期間。
+- 導入バージョン: -
 
 ##### `label_clean_interval_second`
 
-- Default: 4 * 3600
-- Type: Int
-- Unit: Seconds
-- Is mutable: No
-- Description: ラベルがクリーンアップされる時間間隔。単位: 秒。履歴ラベルがタイムリーにクリーンアップされるように、短い時間間隔を指定することをお勧めします。
-- Introduced in: -
+- デフォルト: 4 * 3600
+- タイプ: Int
+- 単位: 秒
+- 変更可能: No
+- 説明: ラベルがクリーンアップされる時間間隔。単位: 秒。履歴ラベルがタイムリーにクリーンアップされるように、短い時間間隔を指定することをお勧めします。
+- 導入バージョン: -
 
 ##### `label_keep_max_num`
 
-- Default: 1000
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: 一定期間内に保持できるロードジョブの最大数。この数を超えると、履歴ジョブの情報は削除されます。
-- Introduced in: -
+- デフォルト: 1000
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: 一定期間内に保持できるロードジョブの最大数。この数を超えると、履歴ジョブの情報は削除されます。
+- 導入バージョン: -
 
 ##### `label_keep_max_second`
 
-- Default: 3 * 24 * 3600
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: 完了し、FINISHED または CANCELLED 状態にあるロードジョブのラベルを保持する最大期間 (秒単位)。デフォルト値は 3 日間です。この期間が経過すると、ラベルは削除されます。このパラメーターはすべてのタイプのロードジョブに適用されます。値が大きすぎると大量のメモリを消費します。
-- Introduced in: -
+- デフォルト: 3 * 24 * 3600
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: 完了し、FINISHED または CANCELLED 状態にあるロードジョブのラベルを保持する最大期間 (秒単位)。デフォルト値は 3 日です。この期間が経過すると、ラベルは削除されます。このパラメーターは、すべての種類のロードジョブに適用されます。値が大きすぎると、多くのメモリを消費します。
+- 導入バージョン: -
 
 ##### `load_checker_interval_second`
 
-- Default: 5
-- Type: Int
-- Unit: Seconds
-- Is mutable: No
-- Description: ロードジョブがローリングベースで処理される時間間隔。
-- Introduced in: -
+- デフォルト: 5
+- タイプ: Int
+- 単位: 秒
+- 変更可能: No
+- 説明: ロードジョブがローリングベースで処理される時間間隔。
+- 導入バージョン: -
 
 ##### `load_parallel_instance_num`
 
-- Default: 1
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: ブローカーおよびストリームロードの単一ホストで作成される並行ロードフラグメントインスタンスの数を制御します。LoadPlanner は、セッションがアダプティブシンク DOP を有効にしない限り、この値をホストごとの並行度として使用します。セッション変数 `enable_adaptive_sink_dop` が true の場合、セッションの `sink_degree_of_parallelism` がこの設定を上書きします。シャッフルが必要な場合、この値はフラグメント並行実行 (スキャンフラグメントおよびシンクフラグメント並行実行インスタンス) に適用されます。シャッフルが不要な場合、シンクパイプライン DOP として使用されます。注: ローカルファイルからのロードは、ローカルディスク競合を避けるため、単一インスタンスに強制されます (パイプライン DOP = 1、並行実行 = 1)。この数を増やすと、ホストごとの並行性とスループットが向上しますが、CPU、メモリ、I/O 競合が増加する可能性があります。
-- Introduced in: v3.2.0
+- デフォルト: 1
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: Broker および Stream Load の単一ホストで作成される並列ロードフラグメントインスタンスの数を制御します。セッションが適応型シンク DOP を有効にしない限り、LoadPlanner はこの値をホストごとの並列度として使用します。セッション変数 `enable_adaptive_sink_dop` が true の場合、セッションの `sink_degree_of_parallelism` がこの設定を上書きします。シャッフルが必要な場合、この値はフラグメントの並列実行 (スキャンフラグメントとシンクフラグメントの並列実行インスタンス) に適用されます。シャッフルが不要な場合、シンクパイプライン DOP として使用されます。注: ローカルディスクの競合を避けるため、ローカルファイルからのロードは単一インスタンス (パイプライン DOP = 1、並列実行 = 1) に強制されます。この数を増やすと、ホストごとの同時実行性とスループットが向上しますが、CPU、メモリ、I/O の競合が増加する可能性があります。
+- 導入バージョン: v3.2.0
 
 ##### `load_straggler_wait_second`
 
-- Default: 300
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: BE レプリカが許容できる最大ロード遅延。この値を超えると、他のレプリカからデータをクローンするクローニングが実行されます。
-- Introduced in: -
+- デフォルト: 300
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: BE レプリカが許容できる最大ロード遅延。この値を超えると、他のレプリカからデータをクローンするためにクローニングが実行されます。
+- 導入バージョン: -
 
 ##### `loads_history_retained_days`
 
-- Default: 30
-- Type: Int
-- Unit: Days
-- Is mutable: Yes
-- Description: 内部 `_statistics_.loads_history` テーブルにロード履歴を保持する日数。この値はテーブル作成時にテーブルプロパティ `partition_live_number` を設定するために使用され、`TableKeeper` (最小値 1 にクランプ) に渡されて、保持する日次パーティションの数を決定します。この値を増減すると、完了したロードジョブが日次パーティションに保持される期間が調整されます。新しいテーブルの作成とキーパーのプルーニング動作に影響しますが、過去のパーティションを自動的に再作成することはありません。`LoadsHistorySyncer` は、ロード履歴のライフサイクルを管理する際にこの保持に依存します。その同期頻度は `loads_history_sync_interval_second` によって制御されます。
-- Introduced in: v3.3.6, v3.4.0, v3.5.0
+- デフォルト: 30
+- タイプ: Int
+- 単位: 日
+- 変更可能: Yes
+- 説明: 内部 `_statistics_.loads_history` テーブルにロード履歴を保持する日数。この値は、テーブル作成時にテーブルプロパティ `partition_live_number` を設定するために使用され、`TableKeeper` (最小 1 にクランプ) に渡されて、保持する日次パーティションの数を決定します。この値を増減すると、完了したロードジョブが日次パーティションに保持される期間が調整されます。これは新しいテーブル作成とキーパーのプルーニング動作に影響しますが、過去のパーティションを自動的に再作成することはありません。`LoadsHistorySyncer` は、ロード履歴のライフサイクルを管理する際にこの保持に依存します。その同期頻度は `loads_history_sync_interval_second` によって制御されます。
+- 導入バージョン: v3.3.6, v3.4.0, v3.5.0
 
 ##### `loads_history_sync_interval_second`
 
-- Default: 60
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: LoadsHistorySyncer が `information_schema.loads` から内部 `_statistics_.loads_history` テーブルに完了したロードジョブを定期的に同期する間隔 (秒単位)。この値は、FrontendDaemon の間隔を設定するためにコンストラクターで 1000 倍されます。シンカーは最初の実行をスキップし (テーブル作成を許可するため)、1 分以上前に完了したロードのみをインポートします。値が小さいと DML とエクゼキュータの負荷が増加し、値が大きいと履歴ロードレコードの可用性が遅延します。ターゲットテーブルの保持/パーティショニング動作については `loads_history_retained_days` を参照してください。
-- Introduced in: v3.3.6, v3.4.0, v3.5.0
+- デフォルト: 60
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: LoadsHistorySyncer が `information_schema.loads` から内部 `_statistics_.loads_history` テーブルへの完了したロードジョブの定期的な同期をスケジュールするために使用する間隔 (秒単位)。この値はコンストラクタで 1000 倍され、FrontendDaemon の間隔を設定します。シンクロナイザーは最初の実行をスキップし (テーブル作成を許可するため)、1 分以上前に完了したロードのみをインポートします。小さい値は DML とエグゼキュータの負荷を増加させ、大きい値は履歴ロードレコードの可用性を遅らせます。ターゲットテーブルの保持/パーティショニング動作については、`loads_history_retained_days` を参照してください。
+- 導入バージョン: v3.3.6, v3.4.0, v3.5.0
 
 ##### `max_broker_load_job_concurrency`
 
-- Default: 5
-- Alias: `async_load_task_pool_size`
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: StarRocks クラスター内で許可される同時 Broker Load ジョブの最大数。このパラメーターは Broker Load にのみ有効です。このパラメーターの値は、`max_running_txn_num_per_db` の値よりも小さくなければなりません。v2.5 以降、デフォルト値は `10` から `5` に変更されました。
-- Introduced in: -
+- デフォルト: 5
+- エイリアス: `async_load_task_pool_size`
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: StarRocks クラスター内で許可される同時 Broker Load ジョブの最大数。このパラメーターは Broker Load にのみ有効です。このパラメーターの値は、`max_running_txn_num_per_db` の値よりも小さくなければなりません。v2.5 以降、デフォルト値は `10` から `5` に変更されました。
+- 導入バージョン: -
 
 ##### `max_load_timeout_second`
 
-- Default: 259200
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: ロードジョブに許可される最大タイムアウト期間。この制限を超えると、ロードジョブは失敗します。この制限はすべての種類のロードジョブに適用されます。
-- Introduced in: -
+- デフォルト: 259200
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: ロードジョブに許可される最大タイムアウト期間。この制限を超えると、ロードジョブは失敗します。この制限は、すべての種類のロードジョブに適用されます。
+- 導入バージョン: -
 
 ##### `max_routine_load_batch_size`
 
-- Default: 4294967296
-- Type: Long
-- Unit: Bytes
-- Is mutable: Yes
-- Description: ルーチンロードタスクでロードできる最大データ量。
-- Introduced in: -
+- デフォルト: 4294967296
+- タイプ: Long
+- 単位: バイト
+- 変更可能: Yes
+- 説明: Routine Load タスクによってロードできるデータの最大量。
+- 導入バージョン: -
 
 ##### `max_routine_load_task_concurrent_num`
 
-- Default: 5
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: 各ルーチンロードジョブの同時実行タスクの最大数。
-- Introduced in: -
+- デフォルト: 5
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: 各 Routine Load ジョブの同時タスクの最大数。
+- 導入バージョン: -
 
 ##### `max_routine_load_task_num_per_be`
 
-- Default: 16
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: 各 BE での同時ルーチンロードタスクの最大数。v3.1.0 以降、このパラメーターのデフォルト値は 5 から 16 に増加され、BE 静的パラメーター `routine_load_thread_pool_size` (非推奨) の値以下である必要はなくなりました。
-- Introduced in: -
+- デフォルト: 16
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: 各 BE での同時 Routine Load タスクの最大数。v3.1.0 以降、このパラメーターのデフォルト値は 5 から 16 に増加し、BE 静的パラメーター `routine_load_thread_pool_size` (非推奨) の値以下である必要はなくなりました。
+- 導入バージョン: -
 
 ##### `max_running_txn_num_per_db`
 
-- Default: 1000
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: StarRocks クラスター内の各データベースで実行できるロードトランザクションの最大数。デフォルト値は `1000` です。v3.1 以降、デフォルト値は `100` から `1000` に変更されました。データベースで実行されているロードトランザクションの実際の数がこのパラメーターの値を超えると、新しいロード要求は処理されません。同期ロードジョブの新しい要求は拒否され、非同期ロードジョブの新しい要求はキューに配置されます。この値を増やすことはシステム負荷を増加させるため、お勧めしません。
-- Introduced in: -
+- デフォルト: 1000
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: StarRocks クラスター内の各データベースで実行が許可されるロードトランザクションの最大数。デフォルト値は `1000` です。v3.1 以降、デフォルト値は `100` から `1000` に変更されました。データベースで実行中のロードトランザクションの実際の数がこのパラメーターの値を超えると、新しいロードリクエストは処理されません。同期ロードジョブの新しいリクエストは拒否され、非同期ロードジョブの新しいリクエストはキューに入れられます。このパラメーターの値を増やすとシステム負荷が増加するため、増やすことはお勧めしません。
+- 導入バージョン: -
 
 ##### `max_stream_load_timeout_second`
 
-- Default: 259200
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: Stream Load ジョブに許可される最大タイムアウト期間。
-- Introduced in: -
+- デフォルト: 259200
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: Stream Load ジョブに許可される最大タイムアウト期間。
+- 導入バージョン: -
 
 ##### `max_tolerable_backend_down_num`
 
-- Default: 0
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: 許可される BE ノードの最大障害数。この数を超えると、ルーチンロードジョブは自動的に回復できません。
-- Introduced in: -
+- デフォルト: 0
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: 許容される障害のある BE ノードの最大数。この数を超えると、Routine Load ジョブは自動的に回復できません。
+- 導入バージョン: -
 
 ##### `min_bytes_per_broker_scanner`
 
-- Default: 67108864
-- Type: Long
-- Unit: Bytes
-- Is mutable: Yes
-- Description: Broker Load インスタンスによって処理できる最小データ量。
-- Introduced in: -
+- デフォルト: 67108864
+- タイプ: Long
+- 単位: バイト
+- 変更可能: Yes
+- 説明: Broker Load インスタンスによって処理できるデータの最小許容量。
+- 導入バージョン: -
 
 ##### `min_load_timeout_second`
 
-- Default: 1
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: ロードジョブに許可される最小タイムアウト期間。この制限はすべての種類のロードジョブに適用されます。
-- Introduced in: -
+- デフォルト: 1
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: ロードジョブに許可される最小タイムアウト期間。この制限は、すべての種類のロードジョブに適用されます。
+- 導入バージョン: -
 
 ##### `min_routine_load_lag_for_metrics`
 
-- Default: 10000
-- Type: INT
-- Unit: -
-- Is mutable: Yes
-- Description: 監視メトリックに表示されるルーチンロードジョブの最小オフセットラグ。オフセットラグがこの値よりも大きいルーチンロードジョブがメトリックに表示されます。
-- Introduced in: -
+- デフォルト: 10000
+- タイプ: INT
+- 単位: -
+- 変更可能: Yes
+- 説明: 監視メトリクスに表示される Routine Load ジョブの最小オフセットラグ。オフセットラグがこの値よりも大きい Routine Load ジョブは、メトリクスに表示されます。
+- 導入バージョン: -
 
 ##### `period_of_auto_resume_min`
 
-- Default: 5
-- Type: Int
-- Unit: Minutes
-- Is mutable: Yes
-- Description: ルーチンロードジョブが自動的に回復される間隔。
-- Introduced in: -
+- デフォルト: 5
+- タイプ: Int
+- 単位: 分
+- 変更可能: Yes
+- 説明: Routine Load ジョブが自動的に回復される間隔。
+- 導入バージョン: -
 
 ##### `prepared_transaction_default_timeout_second`
 
-- Default: 86400
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: 準備されたトランザクションのデフォルトのタイムアウト期間。
-- Introduced in: -
+- デフォルト: 86400
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: 準備済みトランザクションのデフォルトのタイムアウト期間。
+- 導入バージョン: -
 
 ##### `routine_load_task_consume_second`
 
-- Default: 15
-- Type: Long
-- Unit: Seconds
-- Is mutable: Yes
-- Description: クラスター内の各ルーチンロードタスクがデータを消費する最大時間。v3.1.0 以降、ルーチンロードジョブは [`job_properties`](../../sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md#job_properties) に新しいパラメーター `task_consume_second` をサポートしています。このパラメーターはルーチンロードジョブ内の個々のロードタスクに適用され、より柔軟です。
-- Introduced in: -
+- デフォルト: 15
+- タイプ: Long
+- 単位: 秒
+- 変更可能: Yes
+- 説明: クラスター内の各 Routine Load タスクがデータを消費する最大時間。v3.1.0 以降、Routine Load ジョブは [`job_properties`](../../sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md#job_properties) に新しいパラメーター `task_consume_second` をサポートしています。このパラメーターは、Routine Load ジョブ内の個々のロードタスクに適用され、より柔軟です。
+- 導入バージョン: -
 
 ##### `routine_load_task_timeout_second`
 
-- Default: 60
-- Type: Long
-- Unit: Seconds
-- Is mutable: Yes
-- Description: クラスター内の各ルーチンロードタスクのタイムアウト期間。v3.1.0 以降、ルーチンロードジョブは [`job_properties`](../../sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md#job_properties) に新しいパラメーター `task_timeout_second` をサポートしています。このパラメーターはルーチンロードジョブ内の個々のロードタスクに適用され、より柔軟です。
-- Introduced in: -
+- デフォルト: 60
+- タイプ: Long
+- 単位: 秒
+- 変更可能: Yes
+- 説明: クラスター内の各 Routine Load タスクのタイムアウト期間。v3.1.0 以降、Routine Load ジョブは [`job_properties`](../../sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md#job_properties) に新しいパラメーター `task_timeout_second` をサポートしています。このパラメーターは、Routine Load ジョブ内の個々のロードタスクに適用され、より柔軟です。
+- 導入バージョン: -
 
 ##### `routine_load_unstable_threshold_second`
 
-- Default: 3600
-- Type: Long
-- Unit: Seconds
-- Is mutable: Yes
-- Description: ルーチンロードジョブ内のいずれかのタスクが遅延した場合に、ルーチンロードジョブが UNSTABLE 状態に設定されます。具体的には、消費されているメッセージのタイムスタンプと現在時刻の差がこのしきい値を超え、データソースに未消費のメッセージが存在する場合です。
-- Introduced in: -
+- デフォルト: 3600
+- タイプ: Long
+- 単位: 秒
+- 変更可能: Yes
+- 説明: Routine Load ジョブ内のいずれかのタスクが遅延した場合、Routine Load ジョブは UNSTABLE 状態に設定されます。具体的には、消費されているメッセージのタイムスタンプと現在の時刻との差がこのしきい値を超え、データソースに未消費のメッセージが存在する場合です。
+- 導入バージョン: -
 
 ##### `spark_dpp_version`
 
-- Default: 1.0.0
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: 使用される Spark Dynamic Partition Pruning (DPP) のバージョン。
-- Introduced in: -
+- デフォルト: 1.0.0
+- タイプ: String
+- 単位: -
+- 変更可能: No
+- 説明: 使用される Spark Dynamic Partition Pruning (DPP) のバージョン。
+- 導入バージョン: -
 
 ##### `spark_home_default_dir`
 
-- Default: `StarRocksFE.STARROCKS_HOME_DIR` + "/lib/spark2x"
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: Spark クライアントのルートディレクトリ。
-- Introduced in: -
+- デフォルト: `StarRocksFE.STARROCKS_HOME_DIR` + "/lib/spark2x"
+- タイプ: String
+- 単位: -
+- 変更可能: No
+- 説明: Spark クライアントのルートディレクトリ。
+- 導入バージョン: -
 
 ##### `spark_launcher_log_dir`
 
-- Default: `sys_log_dir` + "/spark_launcher_log"
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: Spark ログファイルを格納するディレクトリ。
-- Introduced in: -
+- デフォルト: `sys_log_dir` + "/spark_launcher_log"
+- タイプ: String
+- 単位: -
+- 変更可能: No
+- 説明: Spark ログファイルを保存するディレクトリ。
+- 導入バージョン: -
 
 ##### `spark_load_default_timeout_second`
 
-- Default: 86400
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: 各 Spark Load ジョブのタイムアウト期間。
-- Introduced in: -
+- デフォルト: 86400
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: 各 Spark Load ジョブのタイムアウト期間。
+- 導入バージョン: -
 
 ##### `spark_load_submit_timeout_second`
 
-- Default: 300
-- Type: long
-- Unit: Seconds
-- Is mutable: No
-- Description: Spark アプリケーションの送信後、YARN 応答を待機する最大時間 (秒単位)。`SparkLauncherMonitor.LogMonitor` はこの値をミリ秒に変換し、ジョブが UNKNOWN/CONNECTED/SUBMITTED 状態のままこのタイムアウトを超えると、監視を停止し、Spark ランチャープロセスを強制終了します。`SparkLoadJob` はこの設定をデフォルトとして読み取り、`LoadStmt.SPARK_LOAD_SUBMIT_TIMEOUT` プロパティを使用してロードごとのオーバーライドを許可します。YARN キューイングの遅延に対応するのに十分な大きさに設定してください。低く設定しすぎると、正当にキューに入れられたジョブが中止される可能性があり、高く設定しすぎると、障害処理とリソースクリーンアップが遅れる可能性があります。
-- Introduced in: v3.2.0
+- デフォルト: 300
+- タイプ: long
+- 単位: 秒
+- 変更可能: No
+- 説明: Spark アプリケーションを送信した後、YARN の応答を待機する最大時間 (秒単位)。`SparkLauncherMonitor.LogMonitor` はこの値をミリ秒に変換し、ジョブがこのタイムアウトよりも長く UNKNOWN/CONNECTED/SUBMITTED 状態のままである場合、監視を停止し、Spark ランチャープロセスを強制終了します。`SparkLoadJob` はこの設定をデフォルトとして読み取り、`LoadStmt.SPARK_LOAD_SUBMIT_TIMEOUT` プロパティを介してロードごとの上書きを許可します。YARN のキューイング遅延に対応できる十分な高さに設定してください。低すぎると正当にキューに入れられたジョブが中止される可能性があり、高すぎると障害処理とリソースクリーンアップが遅れる可能性があります。
+- 導入バージョン: v3.2.0
 
 ##### `spark_resource_path`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: Spark 依存関係パッケージのルートディレクトリ。
-- Introduced in: -
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: No
+- 説明: Spark 依存関係パッケージのルートディレクトリ。
+- 導入バージョン: -
 
 ##### `stream_load_default_timeout_second`
 
-- Default: 600
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: 各 Stream Load ジョブのデフォルトのタイムアウト期間。
-- Introduced in: -
+- デフォルト: 600
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: 各 Stream Load ジョブのデフォルトのタイムアウト期間。
+- 導入バージョン: -
 
 ##### `stream_load_max_txn_num_per_be`
 
-- Default: -1
-- Type: Int
-- Unit: Transactions
-- Is mutable: Yes
-- Description: 単一の BE (バックエンド) ホストから受け入れられる同時ストリームロードトランザクションの数を制限します。非負の整数に設定されている場合、FrontendServiceImpl は BE (クライアント IP 別) の現在のトランザクション数をチェックし、数がこの制限を `>=` 超える場合、新しいストリームロード開始要求を拒否します。値が `< 0` の場合、制限は無効になります (無制限)。このチェックはストリームロード開始時に発生し、超過すると `streamload txn num per be exceeds limit` エラーが発生する可能性があります。関連する実行時動作では、`stream_load_default_timeout_second` を使用して要求タイムアウトのフォールバックが行われます。
-- Introduced in: v3.3.0, v3.4.0, v3.5.0
+- デフォルト: -1
+- タイプ: Int
+- 単位: トランザクション
+- 変更可能: Yes
+- 説明: 単一の BE (バックエンド) ホストから受け入れられる同時ストリームロードトランザクションの数を制限します。非負の整数に設定すると、FrontendServiceImpl は BE (クライアント IP 別) の現在のトランザクション数をチェックし、カウントがこの制限 `>=` を超える場合、新しいストリームロード開始リクエストを拒否します。`< 0` の値は制限を無効にします (無制限)。このチェックはストリームロード開始時に発生し、超過すると `streamload txn num per be exceeds limit` エラーを引き起こす可能性があります。関連するランタイム動作では、リクエストタイムアウトのフォールバックに `stream_load_default_timeout_second` を使用します。
+- 導入バージョン: v3.3.0, v3.4.0, v3.5.0
 
 ##### `stream_load_task_keep_max_num`
 
-- Default: 1000
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: StreamLoadMgr がメモリに保持する Stream Load タスクの最大数 (すべてのデータベースにわたるグローバル)。追跡されたタスク (`idToStreamLoadTask`) の数がこのしきい値を超えると、StreamLoadMgr はまず `cleanSyncStreamLoadTasks()` を呼び出して完了した同期ストリームロードタスクを削除します。サイズがまだこのしきい値の半分より大きい場合、`cleanOldStreamLoadTasks(true)` を呼び出して古いまたは完了したタスクを強制的に削除します。メモリにさらにタスク履歴を保持するにはこの値を増やし、メモリ使用量を減らしてクリーンアップをより積極的するには減らします。この値はインメモリ保持のみを制御し、永続化/再生されたタスクには影響しません。
-- Introduced in: v3.2.0
+- デフォルト: 1000
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: StreamLoadMgr がメモリに保持する Stream Load タスクの最大数 (すべてのデータベースでグローバル)。追跡されるタスク (`idToStreamLoadTask`) の数がこのしきい値を超えると、StreamLoadMgr はまず `cleanSyncStreamLoadTasks()` を呼び出して完了した同期ストリームロードタスクを削除します。サイズがこのしきい値の半分よりも大きいままである場合、`cleanOldStreamLoadTasks(true)` を呼び出して、古いタスクまたは完了したタスクの削除を強制します。この値を増やすと、より多くのタスク履歴をメモリに保持できます。減らすと、メモリ使用量が削減され、クリーンアップがより積極的になります。この値はメモリ内保持のみを制御し、永続化/リプレイされたタスクには影響しません。
+- 導入バージョン: v3.2.0
 
 ##### `stream_load_task_keep_max_second`
 
-- Default: 3 * 24 * 3600
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: 完了またはキャンセルされた Stream Load タスクの保持ウィンドウ。タスクが最終状態に達し、その終了タイムスタンプがこのしきい値 (`currentMs - endTimeMs > stream_load_task_keep_max_second * 1000`) より古い場合、`StreamLoadMgr.cleanOldStreamLoadTasks` による削除の対象となり、永続化された状態のロード時に破棄されます。`StreamLoadTask` と `StreamLoadMultiStmtTask` の両方に適用されます。合計タスク数が `stream_load_task_keep_max_num` を超える場合、クリーンアップが早期にトリガーされる可能性があります (同期タスクは `cleanSyncStreamLoadTasks` によって優先されます)。履歴/デバッグ可能性とメモリ使用量のバランスを取るためにこれを設定します。
-- Introduced in: v3.2.0
+- デフォルト: 3 * 24 * 3600
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: 完了またはキャンセルされた Stream Load タスクの保持期間。タスクが最終状態に達し、その終了タイムスタンプがこのしきい値 (`currentMs - endTimeMs > stream_load_task_keep_max_second * 1000`) よりも早い場合、`StreamLoadMgr.cleanOldStreamLoadTasks` による削除の対象となり、永続化された状態をロードする際に破棄されます。`StreamLoadTask` と `StreamLoadMultiStmtTask` の両方に適用されます。合計タスク数が `stream_load_task_keep_max_num` を超える場合、クリーンアップが早期にトリガーされる可能性があります (同期タスクは `cleanSyncStreamLoadTasks` によって優先されます)。履歴/デバッグ可能性とメモリ使用量のバランスを取るためにこれを設定してください。
+- 導入バージョン: v3.2.0
 
 ##### `transaction_clean_interval_second`
 
-- Default: 30
-- Type: Int
-- Unit: Seconds
-- Is mutable: No
-- Description: 完了したトランザクションがクリーンアップされる時間間隔。単位: 秒。完了したトランザクションがタイムリーにクリーンアップされるように、短い時間間隔を指定することをお勧めします。
-- Introduced in: -
+- デフォルト: 30
+- タイプ: Int
+- 単位: 秒
+- 変更可能: No
+- 説明: 完了したトランザクションがクリーンアップされる時間間隔。単位: 秒。完了したトランザクションがタイムリーにクリーンアップされるように、短い時間間隔を指定することをお勧めします。
+- 導入バージョン: -
 
 ##### `transaction_stream_load_coordinator_cache_capacity`
 
-- Default: 4096
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: トランザクションラベルからコーディネーターノードへのマッピングを格納するキャッシュの容量。
-- Introduced in: -
+- デフォルト: 4096
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: トランザクションラベルからコーディネーターノードへのマッピングを格納するキャッシュの容量。
+- 導入バージョン: -
 
 ##### `transaction_stream_load_coordinator_cache_expire_seconds`
 
-- Default: 900
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: キャッシュ内のコーディネーターマッピングを削除するまでの時間 (TTL)。
-- Introduced in: -
+- デフォルト: 900
+- タイプ: Int
+- 単位: 秒
+- 変更可能: Yes
+- 説明: コーディネーターマッピングがキャッシュから削除されるまでの保持時間 (TTL)。
+- 導入バージョン: -
 
 ##### `yarn_client_path`
 
-- Default: `StarRocksFE.STARROCKS_HOME_DIR` + "/lib/yarn-client/hadoop/bin/yarn"
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: Yarn クライアントパッケージのルートディレクトリ。
-- Introduced in: -
+- デフォルト: `StarRocksFE.STARROCKS_HOME_DIR` + "/lib/yarn-client/hadoop/bin/yarn"
+- タイプ: String
+- 単位: -
+- 変更可能: No
+- 説明: Yarn クライアントパッケージのルートディレクトリ。
+- 導入バージョン: -
 
 ##### `yarn_config_dir`
 
-- Default: `StarRocksFE.STARROCKS_HOME_DIR` + "/lib/yarn-config"
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: Yarn 設定ファイルを格納するディレクトリ。
-- Introduced in: -
+- デフォルト: `StarRocksFE.STARROCKS_HOME_DIR` + "/lib/yarn-config"
+- タイプ: String
+- 単位: -
+- 変更可能: No
+- 説明: Yarn 設定ファイルを保存するディレクトリ。
+- 導入バージョン: -
 
 ### 統計レポート
 
@@ -2803,8 +2803,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: この項目が `true` に設定されている場合、システムはウェアハウスごとのメトリックを収集してエクスポートします。これを有効にすると、ウェアハウスレベルのメトリック (スロット/使用量/可用性) がメトリック出力に追加され、メトリックのカーディナリティと収集オーバーヘッドが増加します。ウェアハウス固有のメトリックを省略し、CPU/ネットワークと監視ストレージコストを削減するには無効にします。
+- Is mutable: はい
+- Description: この項目が`true`に設定されている場合、システムはウェアハウスごとのメトリクスを収集し、エクスポートします。これを有効にすると、ウェアハウスレベルのメトリクス（スロット/使用量/可用性）がメトリクス出力に追加され、メトリクスのカーディナリティと収集オーバーヘッドが増加します。無効にすると、ウェアハウス固有のメトリクスが省略され、CPU/ネットワークおよび監視ストレージのコストが削減されます。
 - Introduced in: v3.5.0
 
 ##### `enable_http_detail_metrics`
@@ -2812,1013 +2812,1013 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: false
 - Type: boolean
 - Unit: -
-- Is mutable: Yes
-- Description: true の場合、HTTP サーバーは詳細な HTTP ワーカーメトリック (特に `HTTP_WORKER_PENDING_TASKS_NUM` ゲージ) を計算して公開します。これを有効にすると、サーバーは Netty ワーカーエクゼキューターを反復処理し、各 `NioEventLoop` で `pendingTasks()` を呼び出して保留中のタスクカウントを合計します。無効の場合、ゲージはコストを回避するために 0 を返します。この追加の収集は CPU およびレイテンシーに敏感である可能性があるため、デバッグまたは詳細な調査のためにのみ有効にしてください。
+- Is mutable: はい
+- Description: `true`の場合、HTTPサーバーは詳細なHTTPワーカーメトリクス（特に`HTTP_WORKER_PENDING_TASKS_NUM`ゲージ）を計算し、公開します。これを有効にすると、サーバーはNettyワーカーエグゼキュータを反復処理し、各`NioEventLoop`で`pendingTasks()`を呼び出して保留中のタスク数を合計します。無効にすると、そのコストを避けるためにゲージは0を返します。この追加の収集はCPUおよびレイテンシに影響を与える可能性があるため、デバッグまたは詳細な調査のためにのみ有効にしてください。
 - Introduced in: v3.2.3
 
 ##### `proc_profile_collect_time_s`
 
 - Default: 120
 - Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: 単一プロセスプロファイル収集の期間 (秒単位)。`proc_profile_cpu_enable` または `proc_profile_mem_enable` が `true` に設定されている場合、AsyncProfiler が起動し、コレクタースレッドはこの期間だけスリープし、その後プロファイラーが停止してプロファイルが書き込まれます。値が大きいほどサンプルカバレッジとファイルサイズは増加しますが、プロファイラーの実行時間が長くなり、その後の収集が遅れます。値が小さいほどオーバーヘッドは減少しますが、不十分なサンプルが生成される可能性があります。`proc_profile_file_retained_days` や `proc_profile_file_retained_size_bytes` などの保持設定とこの値が一致していることを確認してください。
+- Unit: 秒
+- Is mutable: はい
+- Description: 単一のプロセスプロファイル収集の期間を秒単位で指定します。`proc_profile_cpu_enable`または`proc_profile_mem_enable`が`true`に設定されている場合、AsyncProfilerが開始され、コレクタースレッドはこの期間スリープし、その後プロファイラーが停止されてプロファイルが書き込まれます。値が大きいほどサンプルカバレッジとファイルサイズは増加しますが、プロファイラーの実行時間が長くなり、後続の収集が遅れます。値が小さいほどオーバーヘッドは減少しますが、十分なサンプルが得られない可能性があります。この値が`proc_profile_file_retained_days`や`proc_profile_file_retained_size_bytes`などの保持設定と一致していることを確認してください。
 - Introduced in: v3.2.12
 
 ### ストレージ
 
 ##### `alter_table_timeout_second`
 
-- Default: 86400
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: スキーマ変更操作 (ALTER TABLE) のタイムアウト期間。
-- Introduced in: -
+- デフォルト: 86400
+- タイプ: Int
+- 単位: 秒
+- 変更可能: はい
+- 説明: スキーマ変更操作 (ALTER TABLE) のタイムアウト期間。
+- 導入バージョン: -
 
 ##### `capacity_used_percent_high_water`
 
-- Default: 0.75
-- Type: double
-- Unit: Fraction (0.0–1.0)
-- Is mutable: Yes
-- Description: バックエンド負荷スコアを計算する際に使用されるディスク容量使用率 (総容量に対する割合) の高水位しきい値。`BackendLoadStatistic.calcSore` は `capacity_used_percent_high_water` を使用して `LoadScore.capacityCoefficient` を設定します。バックエンドの使用率が 0.5 未満の場合、係数は 0.5 になります。使用率が `capacity_used_percent_high_water` を超える場合、係数は 1.0 になります。それ以外の場合、係数は使用率に応じて線形に推移します (2 * usedPercent - 0.5)。係数が 1.0 の場合、負荷スコアは完全に容量比率によって決定されます。値が低いほどレプリカ数の重みが増加します。この値を調整すると、バランサーがディスク使用率の高いバックエンドにペナルティを課す積極性が変わります。
-- Introduced in: v3.2.0
+- デフォルト: 0.75
+- タイプ: double
+- 単位: 割合 (0.0–1.0)
+- 変更可能: はい
+- 説明: バックエンドの負荷スコアを計算する際に使用される、ディスク使用容量の割合（総容量に対する割合）のハイウォーターしきい値です。`BackendLoadStatistic.calcSore` は `capacity_used_percent_high_water` を使用して `LoadScore.capacityCoefficient` を設定します。バックエンドの使用率が 0.5 未満の場合、係数は 0.5 になります。使用率が `capacity_used_percent_high_water` を超える場合、係数は 1.0 になります。それ以外の場合、係数は (2 * usedPercent - 0.5) を介して使用率と線形に変化します。係数が 1.0 の場合、負荷スコアは完全に容量の割合によって決定されます。値が低いほど、レプリカ数の重みが増加します。この値を調整すると、バランサーが高ディスク使用率のバックエンドにペナルティを課す積極性が変わります。
+- 導入バージョン: v3.2.0
 
 ##### `catalog_trash_expire_second`
 
-- Default: 86400
-- Type: Long
-- Unit: Seconds
-- Is mutable: Yes
-- Description: データベース、テーブル、またはパーティションが削除された後にメタデータが保持される最長期間。この期間が経過すると、データは削除され、[RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) コマンドで回復することはできません。
-- Introduced in: -
+- デフォルト: 86400
+- タイプ: Long
+- 単位: 秒
+- 変更可能: はい
+- 説明: データベース、テーブル、またはパーティションが削除された後、メタデータを保持できる最長期間です。この期間が経過すると、データは削除され、[RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) コマンドで復元することはできません。
+- 導入バージョン: -
 
 ##### `check_consistency_default_timeout_second`
 
-- Default: 600
-- Type: Long
-- Unit: Seconds
-- Is mutable: Yes
-- Description: レプリカの一貫性チェックのタイムアウト期間。タブレットのサイズに基づいてこのパラメーターを設定できます。
-- Introduced in: -
+- デフォルト: 600
+- タイプ: Long
+- 単位: 秒
+- 変更可能: はい
+- 説明: レプリカの一貫性チェックのタイムアウト期間です。このパラメータは、タブレットのサイズに基づいて設定できます。
+- 導入バージョン: -
 
 ##### `consistency_check_cooldown_time_second`
 
-- Default: 24 * 3600
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: 同じタブレットの一貫性チェック間で必要な最小間隔 (秒単位) を制御します。タブレット選択中、タブレットは `tablet.getLastCheckTime()` が `(currentTimeMillis - consistency_check_cooldown_time_second * 1000)` 未満の場合にのみ適格と見なされます。デフォルト値 (24 * 3600) は、バックエンドのディスク I/O を減らすために、タブレットごとに約 1 日に 1 回のチェックを強制します。この値を減らすとチェック頻度とリソース使用量が増加し、増やすと不整合の検出が遅れる代わりに I/O が減少します。この値は、インデックスのタブレットリストからクールダウンしたタブレットをフィルタリングする際にグローバルに適用されます。
-- Introduced in: v3.5.5
+- デフォルト: 24 * 3600
+- タイプ: Int
+- 単位: 秒
+- 変更可能: はい
+- 説明: 同じタブレットの一貫性チェック間に必要な最小間隔（秒単位）を制御します。タブレット選択中、`tablet.getLastCheckTime()` が `(currentTimeMillis - consistency_check_cooldown_time_second * 1000)` より小さい場合にのみ、タブレットは適格と見なされます。デフォルト値 (24 * 3600) は、バックエンドのディスク I/O を削減するために、1日あたり約1回のタブレットチェックを強制します。この値を下げるとチェック頻度とリソース使用量が増加し、上げると一貫性の検出が遅くなる代わりに I/O が減少します。この値は、インデックスのタブレットリストからクールダウンされたタブレットをフィルタリングする際にグローバルに適用されます。
+- 導入バージョン: v3.5.5
 
 ##### `consistency_check_end_time`
 
-- Default: "4"
-- Type: String
-- Unit: Hour of day (0-23)
-- Is mutable: No
-- Description: ConsistencyChecker の作業ウィンドウの終了時間 (時、0-23) を指定します。値はシステムタイムゾーンの SimpleDateFormat("HH") で解析され、0-23 (1 桁または 2 桁) として受け入れられます。StarRocks はこれを `consistency_check_start_time` とともに使用して、一貫性チェックジョブをスケジュールして追加する時期を決定します。`consistency_check_start_time` が `consistency_check_end_time` より大きい場合、ウィンドウは深夜をまたぎます (たとえば、デフォルトは `consistency_check_start_time` = "23" から `consistency_check_end_time` = "4")。`consistency_check_start_time` が `consistency_check_end_time` と等しい場合、チェッカーは実行されません。解析に失敗すると FE の起動がエラーをログに記録して終了するため、有効な時刻文字列を指定してください。
-- Introduced in: v3.2.0
+- デフォルト: "4"
+- タイプ: String
+- 単位: 時刻 (0-23)
+- 変更可能: いいえ
+- 説明: ConsistencyChecker の作業ウィンドウの終了時刻（時）を指定します。この値はシステムタイムゾーンで SimpleDateFormat("HH") を使用して解析され、0～23（1桁または2桁）として受け入れられます。StarRocks は `consistency_check_start_time` とともにこれを使用して、一貫性チェックジョブをいつスケジュールし、追加するかを決定します。`consistency_check_start_time` が `consistency_check_end_time` より大きい場合、ウィンドウは深夜をまたぎます（例：デフォルトは `consistency_check_start_time` = "23" から `consistency_check_end_time` = "4"）。`consistency_check_start_time` が `consistency_check_end_time` と等しい場合、チェッカーは実行されません。解析に失敗すると、FE の起動時にエラーがログに記録され、終了するため、有効な時刻文字列を指定してください。
+- 導入バージョン: v3.2.0
 
 ##### `consistency_check_start_time`
 
-- Default: "23"
-- Type: String
-- Unit: Hour of day (00-23)
-- Is mutable: No
-- Description: ConsistencyChecker の作業ウィンドウの開始時間 (時、00-23) を指定します。値はシステムタイムゾーンの SimpleDateFormat("HH") で解析され、0-23 (1 桁または 2 桁) として受け入れられます。StarRocks はこれを `consistency_check_end_time` とともに使用して、一貫性チェックジョブをスケジュールして追加する時期を決定します。`consistency_check_start_time` が `consistency_check_end_time` より大きい場合、ウィンドウは深夜をまたぎます (たとえば、デフォルトは `consistency_check_start_time` = "23" から `consistency_check_end_time` = "4")。`consistency_check_start_time` が `consistency_check_end_time` と等しい場合、チェッカーは実行されません。解析に失敗すると FE の起動がエラーをログに記録して終了するため、有効な時刻文字列を指定してください。
-- Introduced in: v3.2.0
+- デフォルト: "23"
+- タイプ: String
+- 単位: 時刻 (00-23)
+- 変更可能: いいえ
+- 説明: ConsistencyChecker の作業ウィンドウの開始時刻（時）を指定します。この値はシステムタイムゾーンで SimpleDateFormat("HH") を使用して解析され、0～23（1桁または2桁）として受け入れられます。StarRocks は `consistency_check_end_time` とともにこれを使用して、一貫性チェックジョブをいつスケジュールし、追加するかを決定します。`consistency_check_start_time` が `consistency_check_end_time` より大きい場合、ウィンドウは深夜をまたぎます（例：デフォルトは `consistency_check_start_time` = "23" から `consistency_check_end_time` = "4"）。`consistency_check_start_time` が `consistency_check_end_time` と等しい場合、チェッカーは実行されません。解析に失敗すると、FE の起動時にエラーがログに記録され、終了するため、有効な時刻文字列を指定してください。
+- 導入バージョン: v3.2.0
 
 ##### `consistency_tablet_meta_check_interval_ms`
 
-- Default: 2 * 3600 * 1000
-- Type: Int
-- Unit: Milliseconds
-- Is mutable: Yes
-- Description: ConsistencyChecker が `TabletInvertedIndex` と `LocalMetastore` の間の完全なタブレットメタの一貫性スキャンを実行するために使用する間隔 (ミリ秒)。`runAfterCatalogReady` のデーモンは、`現在の時間 - lastTabletMetaCheckTime` がこの値を超えたときに checkTabletMetaConsistency をトリガーします。無効なタブレットが最初に検出された場合、その `toBeCleanedTime` は `now + (consistency_tablet_meta_check_interval_ms / 2)` に設定されるため、実際の削除は後続のスキャンまで遅延されます。この値を増やすとスキャン頻度と負荷が減少し (クリーンアップが遅くなる)、減らすと古いタブレットの検出と削除が高速化されます (オーバーヘッドが増加する)。
-- Introduced in: v3.2.0
+- デフォルト: 2 * 3600 * 1000
+- タイプ: Int
+- 単位: ミリ秒
+- 変更可能: はい
+- 説明: ConsistencyChecker が `TabletInvertedIndex` と `LocalMetastore` の間で完全なタブレットメタ一貫性スキャンを実行するために使用する間隔です。`runAfterCatalogReady` のデーモンは、`current time - lastTabletMetaCheckTime` がこの値を超えたときに `checkTabletMetaConsistency` をトリガーします。無効なタブレットが最初に検出されると、その `toBeCleanedTime` は `now + (consistency_tablet_meta_check_interval_ms / 2)` に設定され、実際の削除は後続のスキャンまで遅延されます。この値を増やすとスキャン頻度と負荷が減少し（クリーンアップが遅くなる）、減らすと古いタブレットの検出と削除が速くなります（オーバーヘッドが増加する）。
+- 導入バージョン: v3.2.0
 
 ##### `default_replication_num`
 
-- Default: 3
-- Type: Short
-- Unit: -
-- Is mutable: Yes
-- Description: StarRocks でテーブルを作成する際に、各データパーティションのレプリカのデフォルト数を設定します。この設定は、CREATE TABLE DDL で `replication_num=x` を指定することで、テーブル作成時に上書きできます。
-- Introduced in: -
+- デフォルト: 3
+- タイプ: Short
+- 単位: -
+- 変更可能: はい
+- 説明: StarRocks でテーブルを作成する際に、各データパーティションのデフォルトのレプリカ数を設定します。この設定は、CREATE TABLE DDL で `replication_num=x` を指定することで、テーブル作成時に上書きできます。
+- 導入バージョン: -
 
 ##### `enable_auto_tablet_distribution`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: バケット数を自動的に設定するかどうか。
-  - このパラメーターが `TRUE` に設定されている場合、テーブルを作成したりパーティションを追加したりする際にバケット数を指定する必要はありません。StarRocks は自動的にバケット数を決定します。
-  - このパラメーターが `FALSE` に設定されている場合、テーブルを作成したりパーティションを追加したりする際にバケット数を手動で指定する必要があります。テーブルに新しいパーティションを追加する際にバケット数を指定しない場合、新しいパーティションはテーブル作成時に設定されたバケット数を継承します。ただし、新しいパーティションにバケット数を手動で指定することもできます。
-- Introduced in: v2.5.7
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: バケット数を自動的に設定するかどうか。
+  - このパラメータが `TRUE` に設定されている場合、テーブルを作成したりパーティションを追加したりする際に、バケット数を指定する必要はありません。StarRocks が自動的にバケット数を決定します。
+  - このパラメータが `FALSE` に設定されている場合、テーブルを作成したりパーティションを追加したりする際に、バケット数を手動で指定する必要があります。テーブルに新しいパーティションを追加する際にバケット数を指定しない場合、新しいパーティションはテーブル作成時に設定されたバケット数を継承します。ただし、新しいパーティションのバケット数を手動で指定することもできます。
+- 導入バージョン: v2.5.7
 
 ##### `enable_experimental_rowstore`
 
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: [ハイブリッド行指向・列指向ストレージ](../../table_design/hybrid_table.md) 機能を有効にするかどうか。
-- Introduced in: v3.2.3
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: [ハイブリッド行・列ストレージ](../../table_design/hybrid_table.md) 機能を有効にするかどうか。
+- 導入バージョン: v3.2.3
 
 ##### `enable_fast_schema_evolution`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: StarRocks クラスター内のすべてのテーブルで高速スキーマ進化を有効にするかどうか。有効な値は `TRUE` と `FALSE` (デフォルト) です。高速スキーマ進化を有効にすると、スキーマ変更の速度が向上し、列の追加または削除時のリソース使用量が削減されます。
-- Introduced in: v3.2.0
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: StarRocks クラスター内のすべてのテーブルで高速スキーマ進化を有効にするかどうか。有効な値は `TRUE` と `FALSE`（デフォルト）です。高速スキーマ進化を有効にすると、スキーマ変更の速度が向上し、列の追加または削除時のリソース使用量を削減できます。
+- 導入バージョン: v3.2.0
 
-> **NOTE**
+> **注記**
 >
-> - StarRocks Shared-data クラスターは v3.3.0 以降でこのパラメーターをサポートしています。
-> - 特定のテーブルの高速スキーマ進化を設定する必要がある場合 (特定のテーブルの高速スキーマ進化を無効にするなど) は、テーブル作成時にテーブルプロパティ [`fast_schema_evolution`](../../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md#set-fast-schema-evolution) を設定できます。
+> - StarRocks shared-data クラスターは、v3.3.0 以降でこのパラメータをサポートしています。
+> - 特定のテーブルに対して高速スキーマ進化を設定する必要がある場合（例：特定のテーブルの高速スキーマ進化を無効にする場合）、テーブル作成時にテーブルプロパティ [`fast_schema_evolution`](../../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md#set-fast-schema-evolution) を設定できます。
 
 ##### `enable_online_optimize_table`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: 最適化ジョブ作成時に StarRocks が非ブロッキングのオンライン最適化パスを使用するかどうかを制御します。`enable_online_optimize_table` が true で、ターゲットテーブルが互換性チェックを満たす場合 (パーティション/キー/ソート指定なし、分散が `RandomDistributionDesc` でない、ストレージタイプが `COLUMN_WITH_ROW` でない、レプリケートストレージが有効、テーブルがクラウドネイティブテーブルまたはマテリアライズドビューでない)、プランナーは書き込みをブロックせずに最適化を実行するために `OnlineOptimizeJobV2` を作成します。false の場合、または互換性条件が失敗した場合、StarRocks は `OptimizeJobV2` にフォールバックします。これは、最適化中に書き込み操作をブロックする可能性があります。
-- Introduced in: v3.3.3, v3.4.0, v3.5.0
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: 最適化ジョブを作成する際に、StarRocks が非ブロッキングのオンライン最適化パスを使用するかどうかを制御します。`enable_online_optimize_table` が true で、ターゲットテーブルが互換性チェック（パーティション/キー/ソート指定なし、ディストリビューションが `RandomDistributionDesc` ではない、ストレージタイプが `COLUMN_WITH_ROW` ではない、レプリケートストレージが有効、かつテーブルがクラウドネイティブテーブルまたはマテリアライズドビューではない）を満たす場合、プランナーは書き込みをブロックせずに最適化を実行するために `OnlineOptimizeJobV2` を作成します。false の場合、または互換性条件のいずれかが失敗した場合、StarRocks は `OptimizeJobV2` にフォールバックし、最適化中に書き込み操作をブロックする可能性があります。
+- 導入バージョン: v3.3.3, v3.4.0, v3.5.0
 
 ##### `enable_strict_storage_medium_check`
 
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: ユーザーがテーブルを作成する際に、FE が BE のストレージメディアを厳密にチェックするかどうか。このパラメーターが `TRUE` に設定されている場合、FE はユーザーがテーブルを作成する際に BE のストレージメディアをチェックし、BE のストレージメディアが CREATE TABLE ステートメントで指定された `storage_medium` パラメーターと異なる場合、エラーを返します。例えば、CREATE TABLE ステートメントで指定されたストレージメディアが SSD であるのに、BE の実際のストレージメディアが HDD である場合、テーブル作成は失敗します。このパラメーターが `FALSE` の場合、FE はユーザーがテーブルを作成する際に BE のストレージメディアをチェックしません。
-- Introduced in: -
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: ユーザーがテーブルを作成する際に、FE が BE のストレージメディアを厳密にチェックするかどうか。このパラメータが `TRUE` に設定されている場合、FE はユーザーがテーブルを作成する際に BE のストレージメディアをチェックし、BE のストレージメディアが CREATE TABLE ステートメントで指定された `storage_medium` パラメータと異なる場合、エラーを返します。例えば、CREATE TABLE ステートメントで指定されたストレージメディアが SSD であっても、BE の実際のストレージメディアが HDD の場合、テーブル作成は失敗します。このパラメータが `FALSE` の場合、FE はユーザーがテーブルを作成する際に BE のストレージメディアをチェックしません。
+- 導入バージョン: -
 
 ##### `max_bucket_number_per_partition`
 
-- Default: 1024
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: パーティション内に作成できるバケットの最大数。
-- Introduced in: v3.3.2
+- デフォルト: 1024
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: 1つのパーティションで作成できるバケットの最大数。
+- 導入バージョン: v3.3.2
 
 ##### `max_column_number_per_table`
 
-- Default: 10000
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: テーブル内に作成できる列の最大数。
-- Introduced in: v3.3.2
+- デフォルト: 10000
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: 1つのテーブルで作成できる列の最大数。
+- 導入バージョン: v3.3.2
 
 ##### `max_dynamic_partition_num`
 
-- Default: 500
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: 動的パーティションテーブルの分析または作成時に一度に作成できる最大パーティション数を制限します。動的パーティションプロパティ検証中、`systemtask_runs_max_history_number` は予想されるパーティション (終了オフセット + 履歴パーティション番号) を計算し、合計が `max_dynamic_partition_num` を超える場合、DDL エラーをスローします。正当に大きなパーティション範囲を予想する場合にのみこの値を増やしてください。増やすとより多くのパーティションを作成できますが、メタデータサイズ、スケジューリング作業、および運用上の複雑さが増加する可能性があります。
-- Introduced in: v3.2.0
+- デフォルト: 500
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: 動的パーティションテーブルを分析または作成する際に、一度に作成できるパーティションの最大数を制限します。動的パーティションプロパティの検証中、`systemtask_runs_max_history_number` は予想されるパーティション数（終了オフセット + 履歴パーティション数）を計算し、その合計が `max_dynamic_partition_num` を超える場合、DDL エラーをスローします。正当に大きなパーティション範囲を期待する場合にのみこの値を増やしてください。増やすとより多くのパーティションを作成できますが、メタデータサイズ、スケジューリング作業、および運用上の複雑さが増加する可能性があります。
+- 導入バージョン: v3.2.0
 
 ##### `max_partition_number_per_table`
 
-- Default: 100000
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: テーブル内に作成できるパーティションの最大数。
-- Introduced in: v3.3.2
+- デフォルト: 100000
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: 1つのテーブルで作成できるパーティションの最大数。
+- 導入バージョン: v3.3.2
 
 ##### `max_task_consecutive_fail_count`
 
-- Default: 10
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: タスクが自動的に停止されるまでに発生する可能性のある連続失敗の最大数。`TaskSource.MV.equals(task.getSource())` が `true` で `max_task_consecutive_fail_count` が 0 より大きい場合、タスクの連続失敗カウンターが `max_task_consecutive_fail_count` に達するか超えると、タスクは TaskManager を介して停止され、マテリアライズドビュータスクの場合はマテリアライズドビューが非アクティブ化されます。停止と再アクティブ化の方法を示す例外がスローされます (例: `ALTER MATERIALIZED VIEW <mv_name> ACTIVE`)。自動停止を無効にするには、この項目を 0 または負の値に設定します。
-- Introduced in: -
+- デフォルト: 10
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: スケジューラがタスクを自動的に中断するまでに、タスクが連続して失敗する可能性のある最大回数。`TaskSource.MV.equals(task.getSource())` であり、`max_task_consecutive_fail_count` が 0 より大きい場合、タスクの連続失敗カウンタが `max_task_consecutive_fail_count` に達するか超えると、タスクは TaskManager を介して中断され、マテリアライズドビュータスクの場合、マテリアライズドビューは非アクティブ化されます。中断と再アクティブ化の方法（例：`ALTER MATERIALIZED VIEW <mv_name> ACTIVE`）を示す例外がスローされます。自動中断を無効にするには、この項目を 0 または負の値に設定します。
+- 導入バージョン: -
 
 ##### `partition_recycle_retention_period_secs`
 
-- Default: 1800
-- Type: Long
-- Unit: Seconds
-- Is mutable: Yes
-- Description: INSERT OVERWRITE またはマテリアライズドビュー更新操作によって削除されたパーティションのメタデータ保持時間。このようなメタデータは、[RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) の実行によって回復できないことに注意してください。
-- Introduced in: v3.5.9
+- デフォルト: 1800
+- タイプ: Long
+- 単位: 秒
+- 変更可能: はい
+- 説明: INSERT OVERWRITE またはマテリアライズドビューの更新操作によって削除されたパーティションのメタデータ保持期間です。このようなメタデータは、[RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) を実行しても復元できないことに注意してください。
+- 導入バージョン: v3.5.9
 
 ##### `recover_with_empty_tablet`
 
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: 失われたまたは破損したタブレットレプリカを空のレプリカに置き換えるかどうか。タブレットレプリカが失われたり破損したりした場合、このタブレットまたは他の健全なタブレットのデータクエリは失敗する可能性があります。失われたまたは破損したタブレットレプリカを空のタブレットに置き換えることで、クエリは引き続き実行できます。ただし、データが失われているため、結果が正しくない可能性があります。デフォルト値は `FALSE` で、失われたまたは破損したタブレットレプリカは空のレプリカに置き換えられず、クエリは失敗します。
-- Introduced in: -
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: 紛失または破損したタブレットレプリカを空のレプリカに置き換えるかどうか。タブレットレプリカが紛失または破損した場合、このタブレットまたは他の正常なタブレットに対するデータクエリが失敗する可能性があります。紛失または破損したタブレットレプリカを空のタブレットに置き換えることで、クエリは引き続き実行できます。ただし、データが失われるため、結果が正しくない可能性があります。デフォルト値は `FALSE` であり、紛失または破損したタブレットレプリカは空のレプリカに置き換えられず、クエリは失敗します。
+- 導入バージョン: -
 
 ##### `storage_usage_hard_limit_percent`
 
-- Default: 95
-- Alias: `storage_flood_stage_usage_percent`
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: BE ディレクトリのストレージ使用率のハードリミット。BE ストレージディレクトリのストレージ使用率 (パーセンテージ) がこの値を超え、残りのストレージスペースが `storage_usage_hard_limit_reserve_bytes` 未満の場合、ロードおよび復元ジョブは拒否されます。この設定を有効にするには、BE 設定項目 `storage_flood_stage_usage_percent` と合わせてこの項目を設定する必要があります。
-- Introduced in: -
+- デフォルト: 95
+- エイリアス: `storage_flood_stage_usage_percent`
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: BE ディレクトリ内のストレージ使用率のハードリミット。BE ストレージディレクトリのストレージ使用率（パーセンテージ）がこの値を超え、かつ残りのストレージスペースが `storage_usage_hard_limit_reserve_bytes` 未満の場合、ロードおよびリストアジョブは拒否されます。この項目は、BE 設定項目 `storage_flood_stage_usage_percent` とともに設定して、設定を有効にする必要があります。
+- 導入バージョン: -
 
 ##### `storage_usage_hard_limit_reserve_bytes`
 
-- Default: 100 * 1024 * 1024 * 1024
-- Alias: `storage_flood_stage_left_capacity_bytes`
-- Type: Long
-- Unit: Bytes
-- Is mutable: Yes
-- Description: BE ディレクトリの残りストレージスペースのハードリミット。BE ストレージディレクトリの残りストレージスペースがこの値未満で、ストレージ使用率 (パーセンテージ) が `storage_usage_hard_limit_percent` を超える場合、ロードおよび復元ジョブは拒否されます。この設定を有効にするには、BE 設定項目 `storage_flood_stage_left_capacity_bytes` と合わせてこの項目を設定する必要があります。
-- Introduced in: -
+- デフォルト: 100 * 1024 * 1024 * 1024
+- エイリアス: `storage_flood_stage_left_capacity_bytes`
+- タイプ: Long
+- 単位: バイト
+- 変更可能: はい
+- 説明: BE ディレクトリ内の残りのストレージスペースのハードリミット。BE ストレージディレクトリ内の残りのストレージスペースがこの値より少なく、かつストレージ使用率（パーセンテージ）が `storage_usage_hard_limit_percent` を超える場合、ロードおよびリストアジョブは拒否されます。この項目は、BE 設定項目 `storage_flood_stage_left_capacity_bytes` とともに設定して、設定を有効にする必要があります。
+- 導入バージョン: -
 
 ##### `storage_usage_soft_limit_percent`
 
-- Default: 90
-- Alias: `storage_high_watermark_usage_percent`
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: BE ディレクトリのストレージ使用率のソフトリミット。BE ストレージディレクトリのストレージ使用率 (パーセンテージ) がこの値を超え、残りのストレージスペースが `storage_usage_soft_limit_reserve_bytes` 未満の場合、タブレットは このディレクトリにクローンできません。
-- Introduced in: -
+- デフォルト: 90
+- エイリアス: `storage_high_watermark_usage_percent`
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: BE ディレクトリ内のストレージ使用率のソフトリミット。BE ストレージディレクトリのストレージ使用率（パーセンテージ）がこの値を超え、かつ残りのストレージスペースが `storage_usage_soft_limit_reserve_bytes` 未満の場合、タブレットはこのディレクトリにクローンできません。
+- 導入バージョン: -
 
 ##### `storage_usage_soft_limit_reserve_bytes`
 
-- Default: 200 * 1024 * 1024 * 1024
-- Alias: `storage_min_left_capacity_bytes`
-- Type: Long
-- Unit: Bytes
-- Is mutable: Yes
-- Description: BE ディレクトリの残りストレージスペースのソフトリミット。BE ストレージディレクトリの残りストレージスペースがこの値未満で、ストレージ使用率 (パーセンテージ) が `storage_usage_soft_limit_percent` を超える場合、タブレットはこのディレクトリにクローンできません。
-- Introduced in: -
+- デフォルト: 200 * 1024 * 1024 * 1024
+- エイリアス: `storage_min_left_capacity_bytes`
+- タイプ: Long
+- 単位: バイト
+- 変更可能: はい
+- 説明: BE ディレクトリ内の残りのストレージスペースのソフトリミット。BE ストレージディレクトリ内の残りのストレージスペースがこの値より少なく、かつストレージ使用率（パーセンテージ）が `storage_usage_soft_limit_percent` を超える場合、タブレットはこのディレクトリにクローンできません。
+- 導入バージョン: -
 
 ##### `tablet_checker_lock_time_per_cycle_ms`
 
-- Default: 1000
-- Type: Int
-- Unit: Milliseconds
-- Is mutable: Yes
-- Description: テーブルロックを解放して再取得するまでの、タブレットチェッカーがサイクルごとにロックを保持する最大時間。100 未満の値は 100 として扱われます。
-- Introduced in: v3.5.9, v4.0.2
+- デフォルト: 1000
+- タイプ: Int
+- 単位: ミリ秒
+- 変更可能: はい
+- 説明: タブレットチェッカーがテーブルロックを解放して再取得するまでの、サイクルあたりの最大ロック保持時間。100 未満の値は 100 として扱われます。
+- 導入バージョン: v3.5.9, v4.0.2
 
 ##### `tablet_create_timeout_second`
 
-- Default: 10
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: タブレット作成のタイムアウト期間。v3.1 以降、デフォルト値は 1 から 10 に変更されました。
-- Introduced in: -
+- デフォルト: 10
+- タイプ: Int
+- 単位: 秒
+- 変更可能: はい
+- 説明: タブレット作成のタイムアウト期間。デフォルト値は v3.1 以降、1 から 10 に変更されました。
+- 導入バージョン: -
 
 ##### `tablet_delete_timeout_second`
 
-- Default: 2
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: タブレット削除のタイムアウト期間。
-- Introduced in: -
+- デフォルト: 2
+- タイプ: Int
+- 単位: 秒
+- 変更可能: はい
+- 説明: タブレット削除のタイムアウト期間。
+- 導入バージョン: -
 
 ##### `tablet_sched_balance_load_disk_safe_threshold`
 
-- Default: 0.5
-- Alias: `balance_load_disk_safe_threshold`
-- Type: Double
-- Unit: -
-- Is mutable: Yes
-- Description: BE のディスク使用量がバランスしているかどうかを判断するためのパーセンテージしきい値。すべての BE のディスク使用量がこの値よりも低い場合、バランスしていると見なされます。ディスク使用量がこの値よりも大きく、最高と最低の BE ディスク使用量の差が 10% を超える場合、ディスク使用量はバランスしていないと見なされ、タブレットの再バランシングがトリガーされます。
-- Introduced in: -
+- デフォルト: 0.5
+- エイリアス: `balance_load_disk_safe_threshold`
+- タイプ: Double
+- 単位: -
+- 変更可能: はい
+- 説明: BE のディスク使用率がバランスしているかどうかを判断するためのパーセンテージしきい値。すべての BE のディスク使用率がこの値より低い場合、バランスしていると見なされます。ディスク使用率がこの値より大きく、かつ最高と最低の BE ディスク使用率の差が 10% を超える場合、ディスク使用率はアンバランスと見なされ、タブレットのリバランスがトリガーされます。
+- 導入バージョン: -
 
 ##### `tablet_sched_balance_load_score_threshold`
 
-- Default: 0.1
-- Alias: `balance_load_score_threshold`
-- Type: Double
-- Unit: -
-- Is mutable: Yes
-- Description: BE の負荷がバランスしているかどうかを判断するためのパーセンテージしきい値。BE の負荷がすべての BE の平均負荷よりも低く、その差がこの値よりも大きい場合、その BE は低負荷状態にあります。逆に、BE の負荷が平均負荷よりも高く、その差がこの値よりも大きい場合、その BE は高負荷状態にあります。
-- Introduced in: -
+- デフォルト: 0.1
+- エイリアス: `balance_load_score_threshold`
+- タイプ: Double
+- 単位: -
+- 変更可能: はい
+- 説明: BE の負荷がバランスしているかどうかを判断するためのパーセンテージしきい値。BE の負荷がすべての BE の平均負荷よりも低く、その差がこの値より大きい場合、この BE は低負荷状態にあります。逆に、BE の負荷が平均負荷よりも高く、その差がこの値より大きい場合、この BE は高負荷状態にあります。
+- 導入バージョン: -
 
 ##### `tablet_sched_be_down_tolerate_time_s`
 
-- Default: 900
-- Type: Long
-- Unit: Seconds
-- Is mutable: Yes
-- Description: スケジューラが BE ノードを非アクティブのままにする最大期間。この時間しきい値に達すると、その BE ノード上のタブレットは他のアクティブな BE ノードに移行されます。
-- Introduced in: v2.5.7
+- デフォルト: 900
+- タイプ: Long
+- 単位: 秒
+- 変更可能: はい
+- 説明: スケジューラが BE ノードが非アクティブ状態を維持することを許可する最大期間。この時間しきい値に達すると、その BE ノード上のタブレットは他のアクティブな BE ノードに移行されます。
+- 導入バージョン: v2.5.7
 
 ##### `tablet_sched_disable_balance`
 
-- Default: false
-- Alias: `disable_balance`
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: タブレットバランシングを無効にするかどうか。`TRUE` はタブレットバランシングが無効になっていることを示します。`FALSE` はタブレットバランシングが有効になっていることを示します。
-- Introduced in: -
+- デフォルト: false
+- エイリアス: `disable_balance`
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: タブレットのバランシングを無効にするかどうか。`TRUE` はタブレットのバランシングが無効であることを示します。`FALSE` はタブレットのバランシングが有効であることを示します。
+- 導入バージョン: -
 
 ##### `tablet_sched_disable_colocate_balance`
 
-- Default: false
-- Alias: `disable_colocate_balance`
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: コロケーションテーブルのレプリカバランシングを無効にするかどうか。`TRUE` はレプリカバランシングが無効になっていることを示します。`FALSE` はレプリカバランシングが有効になっていることを示します。
-- Introduced in: -
+- デフォルト: false
+- エイリアス: `disable_colocate_balance`
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: Colocate Table のレプリカバランシングを無効にするかどうか。`TRUE` はレプリカバランシングが無効であることを示します。`FALSE` はレプリカバランシングが有効であることを示します。
+- 導入バージョン: -
 
 ##### `tablet_sched_max_balancing_tablets`
 
-- Default: 500
-- Alias: `max_balancing_tablets`
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: 同時にバランスできるタブレットの最大数。この値を超えると、タブレットの再バランシングはスキップされます。
-- Introduced in: -
+- デフォルト: 500
+- エイリアス: `max_balancing_tablets`
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: 同時にバランスできるタブレットの最大数。この値を超えると、タブレットのリバランスはスキップされます。
+- 導入バージョン: -
 
 ##### `tablet_sched_max_clone_task_timeout_sec`
 
-- Default: 2 * 60 * 60
-- Alias: `max_clone_task_timeout_sec`
-- Type: Long
-- Unit: Seconds
-- Is mutable: Yes
-- Description: タブレットのクローン作成の最大タイムアウト期間。
-- Introduced in: -
+- デフォルト: 2 * 60 * 60
+- エイリアス: `max_clone_task_timeout_sec`
+- タイプ: Long
+- 単位: 秒
+- 変更可能: はい
+- 説明: タブレットをクローンする際の最大タイムアウト期間。
+- 導入バージョン: -
 
 ##### `tablet_sched_max_not_being_scheduled_interval_ms`
 
-- Default: 15 * 60 * 1000
-- Type: Long
-- Unit: Milliseconds
-- Is mutable: Yes
-- Description: タブレットクローンタスクがスケジュールされている場合、このパラメーターで指定された時間の間タブレットがスケジュールされていない場合、StarRocks はそのタブレットに高い優先度を与え、できるだけ早くスケジュールします。
-- Introduced in: -
+- デフォルト: 15 * 60 * 1000
+- タイプ: Long
+- 単位: ミリ秒
+- 変更可能: はい
+- 説明: タブレットクローンタスクがスケジュールされている際に、このパラメータで指定された時間、タブレットがスケジュールされていない場合、StarRocks はそのタブレットをできるだけ早くスケジュールするために高い優先度を与えます。
+- 導入バージョン: -
 
 ##### `tablet_sched_max_scheduling_tablets`
 
-- Default: 10000
-- Alias: `max_scheduling_tablets`
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: 同時にスケジュールできるタブレットの最大数。この値を超えると、タブレットのバランシングと修復チェックはスキップされます。
-- Introduced in: -
+- デフォルト: 10000
+- エイリアス: `max_scheduling_tablets`
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: 同時にスケジュールできるタブレットの最大数。この値を超えると、タブレットのバランシングと修復チェックはスキップされます。
+- 導入バージョン: -
 
 ##### `tablet_sched_min_clone_task_timeout_sec`
 
-- Default: 3 * 60
-- Alias: `min_clone_task_timeout_sec`
-- Type: Long
-- Unit: Seconds
-- Is mutable: Yes
-- Description: タブレットのクローン作成の最小タイムアウト期間。
-- Introduced in: -
+- デフォルト: 3 * 60
+- エイリアス: `min_clone_task_timeout_sec`
+- タイプ: Long
+- 単位: 秒
+- 変更可能: はい
+- 説明: タブレットをクローンする際の最小タイムアウト期間。
+- 導入バージョン: -
 
 ##### `tablet_sched_num_based_balance_threshold_ratio`
 
-- Default: 0.5
-- Alias: -
-- Type: Double
-- Unit: -
-- Is mutable: Yes
-- Description: 数ベースのバランシングはディスクサイズバランスを損なう可能性がありますが、ディスク間の最大ギャップは `tablet_sched_num_based_balance_threshold_ratio` * `tablet_sched_balance_load_score_threshold` を超えることはできません。クラスター内に A から B へ、そして B から A へと常にバランシングしているタブレットがある場合、この値を減らしてください。タブレットの分散をよりバランスさせたい場合、この値を増やしてください。
-- Introduced in: - 3.1
+- デフォルト: 0.5
+- エイリアス: -
+- タイプ: Double
+- 単位: -
+- 変更可能: はい
+- 説明: 数値ベースのバランシングを行うとディスクサイズのバランスが崩れる可能性がありますが、ディスク間の最大ギャップは `tablet_sched_num_based_balance_threshold_ratio` * `tablet_sched_balance_load_score_threshold` を超えることはできません。クラスター内でタブレットが常に A から B、B から A へとバランシングを繰り返している場合、この値を減らしてください。タブレットの分散をよりバランスさせたい場合は、この値を増やしてください。
+- 導入バージョン: - 3.1
 
 ##### `tablet_sched_repair_delay_factor_second`
 
-- Default: 60
-- Alias: `tablet_repair_delay_factor_second`
-- Type: Long
-- Unit: Seconds
-- Is mutable: Yes
-- Description: レプリカが修復される間隔 (秒単位)。
-- Introduced in: -
+- デフォルト: 60
+- エイリアス: `tablet_repair_delay_factor_second`
+- タイプ: Long
+- 単位: 秒
+- 変更可能: はい
+- 説明: レプリカが修復される間隔（秒単位）。
+- 導入バージョン: -
 
 ##### `tablet_sched_slot_num_per_path`
 
-- Default: 8
-- Alias: `schedule_slot_num_per_path`
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: BE ストレージディレクトリで同時に実行できるタブレット関連タスクの最大数。v2.5 以降、このパラメーターのデフォルト値は `4` から `8` に変更されました。
-- Introduced in: -
+- デフォルト: 8
+- エイリアス: `schedule_slot_num_per_path`
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: BE ストレージディレクトリで同時に実行できるタブレット関連タスクの最大数。v2.5 以降、このパラメータのデフォルト値は `4` から `8` に変更されました。
+- 導入バージョン: -
 
 ##### `tablet_sched_storage_cooldown_second`
 
-- Default: -1
-- Alias: `storage_cooldown_second`
-- Type: Long
-- Unit: Seconds
-- Is mutable: Yes
-- Description: テーブル作成時からの自動冷却の遅延時間。デフォルト値 `-1` は自動冷却が無効になっていることを指定します。自動冷却を有効にするには、このパラメーターを `-1` より大きい値に設定します。
-- Introduced in: -
+- デフォルト: -1
+- エイリアス: `storage_cooldown_second`
+- タイプ: Long
+- 単位: 秒
+- 変更可能: はい
+- 説明: テーブル作成時から始まる自動冷却の遅延時間。デフォルト値 `-1` は、自動冷却が無効であることを指定します。自動冷却を有効にするには、このパラメータを `-1` より大きい値に設定してください。
+- 導入バージョン: -
 
 ##### `tablet_stat_update_interval_second`
 
-- Default: 300
-- Type: Int
-- Unit: Seconds
-- Is mutable: No
-- Description: FE が各 BE からタブレット統計を取得する時間間隔。
-- Introduced in: -
+- デフォルト: 300
+- タイプ: Int
+- 単位: 秒
+- 変更可能: いいえ
+- 説明: FE が各 BE からタブレット統計を取得する時間間隔。
+- 導入バージョン: -
 
 ### 共有データ
 
 ##### `aws_s3_access_key`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: S3 バケットにアクセスするために使用するアクセスキー ID。
-- Introduced in: v3.0
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: S3バケットにアクセスするために使用されるアクセスキーID。
+- 導入バージョン: v3.0
 
 ##### `aws_s3_endpoint`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: S3 バケットにアクセスするために使用するエンドポイント。例: `https://s3.us-west-2.amazonaws.com`。
-- Introduced in: v3.0
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: S3バケットにアクセスするために使用されるエンドポイント。例: `https://s3.us-west-2.amazonaws.com`。
+- 導入バージョン: v3.0
 
 ##### `aws_s3_external_id`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: S3 バケットへのクロスアカウントアクセスに使用される AWS アカウントの外部 ID。
-- Introduced in: v3.0
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: S3バケットへのクロスアカウントアクセスに使用されるAWSアカウントの外部ID。
+- 導入バージョン: v3.0
 
 ##### `aws_s3_iam_role_arn`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: データファイルが格納されている S3 バケットに対する権限を持つ IAM ロールの ARN。
-- Introduced in: v3.0
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: データファイルが保存されているS3バケットに対する権限を持つIAMロールのARN。
+- 導入バージョン: v3.0
 
 ##### `aws_s3_path`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: データを格納するために使用される S3 パス。S3 バケットの名前とその下のサブパス (存在する場合) で構成されます。例: `testbucket/subpath`。
-- Introduced in: v3.0
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: データを保存するために使用されるS3パス。S3バケットの名前と、その下のサブパス（もしあれば）で構成されます。例: `testbucket/subpath`。
+- 導入バージョン: v3.0
 
 ##### `aws_s3_region`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: S3 バケットが存在するリージョン。例: `us-west-2`。
-- Introduced in: v3.0
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: S3バケットが存在するリージョン。例: `us-west-2`。
+- 導入バージョン: v3.0
 
 ##### `aws_s3_secret_key`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: S3 バケットにアクセスするために使用するシークレットアクセスキー。
-- Introduced in: v3.0
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: S3バケットにアクセスするために使用されるシークレットアクセスキー。
+- 導入バージョン: v3.0
 
 ##### `aws_s3_use_aws_sdk_default_behavior`
 
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: No
-- Description: AWS SDK のデフォルトの認証資格情報を使用するかどうか。有効な値: true および false (デフォルト)。
-- Introduced in: v3.0
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 変更可能: いいえ
+- 説明: AWS SDKのデフォルト認証情報を使用するかどうか。有効な値: trueおよびfalse（デフォルト）。
+- 導入バージョン: v3.0
 
 ##### `aws_s3_use_instance_profile`
 
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: No
-- Description: S3 にアクセスするための認証方法としてインスタンスプロファイルと引き受けロールを使用するかどうか。有効な値: true および false (デフォルト)。
-  - IAM ユーザーベースの認証情報 (アクセスキーとシークレットキー) を使用して S3 にアクセスする場合、この項目を `false` に指定し、`aws_s3_access_key` と `aws_s3_secret_key` を指定する必要があります。
-  - インスタンスプロファイルを使用して S3 にアクセスする場合、この項目を `true` に指定する必要があります。
-  - 引き受けロールを使用して S3 にアクセスする場合、この項目を `true` に指定し、`aws_s3_iam_role_arn` を指定する必要があります。
-  - 外部 AWS アカウントを使用する場合、`aws_s3_external_id` も指定する必要があります。
-- Introduced in: v3.0
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 変更可能: いいえ
+- 説明: S3にアクセスするための認証方法としてInstance ProfileとAssumed Roleを使用するかどうか。有効な値: trueおよびfalse（デフォルト）。
+  - IAMユーザーベースの認証情報（Access KeyとSecret Key）を使用してS3にアクセスする場合、この項目を`false`に設定し、`aws_s3_access_key`と`aws_s3_secret_key`を指定する必要があります。
+  - Instance Profileを使用してS3にアクセスする場合、この項目を`true`に設定する必要があります。
+  - Assumed Roleを使用してS3にアクセスする場合、この項目を`true`に設定し、`aws_s3_iam_role_arn`を指定する必要があります。
+  - 外部AWSアカウントを使用する場合、`aws_s3_external_id`も指定する必要があります。
+- 導入バージョン: v3.0
 
 ##### `azure_adls2_endpoint`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: Azure Data Lake Storage Gen2 アカウントのエンドポイント。例: `https://test.dfs.core.windows.net`。
-- Introduced in: v3.4.1
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: Azure Data Lake Storage Gen2アカウントのエンドポイント。例: `https://test.dfs.core.windows.net`。
+- 導入バージョン: v3.4.1
 
 ##### `azure_adls2_oauth2_client_id`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: Azure Data Lake Storage Gen2 の要求を承認するために使用されるマネージド ID のクライアント ID。
-- Introduced in: v3.4.4
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: Azure Data Lake Storage Gen2へのリクエストを認証するために使用されるManaged IdentityのクライアントID。
+- 導入バージョン: v3.4.4
 
 ##### `azure_adls2_oauth2_tenant_id`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: Azure Data Lake Storage Gen2 の要求を承認するために使用されるマネージド ID のテナント ID。
-- Introduced in: v3.4.4
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: Azure Data Lake Storage Gen2へのリクエストを認証するために使用されるManaged IdentityのテナントID。
+- 導入バージョン: v3.4.4
 
 ##### `azure_adls2_oauth2_use_managed_identity`
 
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: No
-- Description: Azure Data Lake Storage Gen2 の要求を承認するためにマネージド ID を使用するかどうか。
-- Introduced in: v3.4.4
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 変更可能: いいえ
+- 説明: Azure Data Lake Storage Gen2へのリクエストを認証するためにManaged Identityを使用するかどうか。
+- 導入バージョン: v3.4.4
 
 ##### `azure_adls2_path`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: データを格納するために使用される Azure Data Lake Storage Gen2 パス。ファイルシステム名とディレクトリ名で構成されます。例: `testfilesystem/starrocks`。
-- Introduced in: v3.4.1
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: データを保存するために使用されるAzure Data Lake Storage Gen2パス。ファイルシステム名とディレクトリ名で構成されます。例: `testfilesystem/starrocks`。
+- 導入バージョン: v3.4.1
 
 ##### `azure_adls2_sas_token`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: Azure Data Lake Storage Gen2 の要求を承認するために使用される共有アクセスシグネチャ (SAS)。
-- Introduced in: v3.4.1
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: Azure Data Lake Storage Gen2へのリクエストを認証するために使用されるShared Access Signatures (SAS)。
+- 導入バージョン: v3.4.1
 
 ##### `azure_adls2_shared_key`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: Azure Data Lake Storage Gen2 の要求を承認するために使用される共有キー。
-- Introduced in: v3.4.1
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: Azure Data Lake Storage Gen2へのリクエストを認証するために使用されるShared Key。
+- 導入バージョン: v3.4.1
 
 ##### `azure_blob_endpoint`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: Azure Blob Storage アカウントのエンドポイント。例: `https://test.blob.core.windows.net`。
-- Introduced in: v3.1
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: Azure Blob Storageアカウントのエンドポイント。例: `https://test.blob.core.windows.net`。
+- 導入バージョン: v3.1
 
 ##### `azure_blob_path`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: データを格納するために使用される Azure Blob Storage パス。ストレージアカウント内のコンテナーの名前とコンテナー内のサブパス (存在する場合) で構成されます。例: `testcontainer/subpath`。
-- Introduced in: v3.1
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: データを保存するために使用されるAzure Blob Storageパス。ストレージアカウント内のコンテナ名と、その下のサブパス（もしあれば）で構成されます。例: `testcontainer/subpath`。
+- 導入バージョン: v3.1
 
 ##### `azure_blob_sas_token`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: Azure Blob Storage の要求を承認するために使用される共有アクセスシグネチャ (SAS)。
-- Introduced in: v3.1
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: Azure Blob Storageへのリクエストを認証するために使用されるShared Access Signatures (SAS)。
+- 導入バージョン: v3.1
 
 ##### `azure_blob_shared_key`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: Azure Blob Storage の要求を承認するために使用される共有キー。
-- Introduced in: v3.1
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: Azure Blob Storageへのリクエストを認証するために使用されるShared Key。
+- 導入バージョン: v3.1
 
 ##### `azure_use_native_sdk`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: Azure Blob Storage にアクセスするためにネイティブ SDK を使用するかどうか。これにより、マネージド ID およびサービスプリンシパルでの認証が可能になります。この項目が `false` に設定されている場合、共有キーと SAS トークンでの認証のみが許可されます。
-- Introduced in: v3.4.4
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: Azure Blob StorageにアクセスするためにネイティブSDKを使用するかどうか。これにより、Managed IdentitiesとService Principalsによる認証が可能になります。この項目が`false`に設定されている場合、Shared KeyとSAS Tokenによる認証のみが許可されます。
+- 導入バージョン: v3.4.4
 
 ##### `cloud_native_hdfs_url`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: HDFS ストレージの URL。例: `hdfs://127.0.0.1:9000/user/xxx/starrocks/`。
-- Introduced in: -
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: HDFSストレージのURL。例: `hdfs://127.0.0.1:9000/user/xxx/starrocks/`。
+- 導入バージョン: -
 
 ##### `cloud_native_meta_port`
 
-- Default: 6090
-- Type: Int
-- Unit: -
-- Is mutable: No
-- Description: FE クラウドネイティブメタデータサーバー RPC リッスンポート。
-- Introduced in: -
+- デフォルト: 6090
+- タイプ: Int
+- 単位: -
+- 変更可能: いいえ
+- 説明: FEクラウドネイティブメタデータサーバーのRPCリスニングポート。
+- 導入バージョン: -
 
 ##### `cloud_native_storage_type`
 
-- Default: S3
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: 使用するオブジェクトストレージのタイプ。共有データモードでは、StarRocks は HDFS、Azure Blob (v3.1.1 以降でサポート)、Azure Data Lake Storage Gen2 (v3.4.1 以降でサポート)、Google Storage (ネイティブ SDK、v3.5.1 以降でサポート)、および S3 プロトコルと互換性のあるオブジェクトストレージシステム (AWS S3、MinIO など) にデータを格納することをサポートしています。有効な値: `S3` (デフォルト)、`HDFS`、`AZBLOB`、`ADLS2`、および `GS`。このパラメーターを `S3` に指定した場合、`aws_s3` で始まるパラメーターを追加する必要があります。`AZBLOB` に指定した場合、`azure_blob` で始まるパラメーターを追加する必要があります。`ADLS2` に指定した場合、`azure_adls2` で始まるパラメーターを追加する必要があります。`GS` に指定した場合、`gcp_gcs` で始まるパラメーターを追加する必要があります。`HDFS` に指定した場合、`cloud_native_hdfs_url` のみを指定する必要があります。
-- Introduced in: -
+- デフォルト: S3
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: 使用するオブジェクトストレージのタイプ。shared-dataモードでは、StarRocksはHDFS、Azure Blob（v3.1.1以降でサポート）、Azure Data Lake Storage Gen2（v3.4.1以降でサポート）、Google Storage（ネイティブSDKを使用、v3.5.1以降でサポート）、およびS3プロトコルと互換性のあるオブジェクトストレージシステム（AWS S3、MinIOなど）にデータを保存することをサポートしています。有効な値: `S3`（デフォルト）、`HDFS`、`AZBLOB`、`ADLS2`、および`GS`。このパラメータを`S3`として指定する場合、`aws_s3`で始まるパラメータを追加する必要があります。このパラメータを`AZBLOB`として指定する場合、`azure_blob`で始まるパラメータを追加する必要があります。このパラメータを`ADLS2`として指定する場合、`azure_adls2`で始まるパラメータを追加する必要があります。このパラメータを`GS`として指定する場合、`gcp_gcs`で始まるパラメータを追加する必要があります。このパラメータを`HDFS`として指定する場合、`cloud_native_hdfs_url`のみを指定する必要があります。
+- 導入バージョン: -
 
 ##### `enable_load_volume_from_conf`
 
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: No
-- Description: StarRocks が FE 設定ファイルで指定されたオブジェクトストレージ関連プロパティを使用して、組み込みストレージボリュームを作成することを許可するかどうか。デフォルト値は v3.4.1 以降 `true` から `false` に変更されました。
-- Introduced in: v3.1.0
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 変更可能: いいえ
+- 説明: StarRocksがFE設定ファイルで指定されたオブジェクトストレージ関連のプロパティを使用して、組み込みストレージボリュームを作成することを許可するかどうか。デフォルト値はv3.4.1以降、`true`から`false`に変更されました。
+- 導入バージョン: v3.1.0
 
 ##### `gcp_gcs_impersonation_service_account`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: Google Storage にアクセスするために、偽装ベースの認証を使用する場合に偽装するサービスアカウント。
-- Introduced in: v3.5.1
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: Google Storageにアクセスするために偽装ベースの認証を使用する場合に偽装するService Account。
+- 導入バージョン: v3.5.1
 
 ##### `gcp_gcs_path`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: データを格納するために使用される Google Cloud パス。Google Cloud バケットの名前とその下のサブパス (存在する場合) で構成されます。例: `testbucket/subpath`。
-- Introduced in: v3.5.1
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: データを保存するために使用されるGoogle Cloudパス。Google Cloudバケットの名前と、その下のサブパス（もしあれば）で構成されます。例: `testbucket/subpath`。
+- 導入バージョン: v3.5.1
 
 ##### `gcp_gcs_service_account_email`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: サービスアカウント作成時に生成された JSON ファイル内のメールアドレス。例: `user@hello.iam.gserviceaccount.com`。
-- Introduced in: v3.5.1
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: Service Account作成時に生成されるJSONファイル内のメールアドレス。例: `user@hello.iam.gserviceaccount.com`。
+- 導入バージョン: v3.5.1
 
 ##### `gcp_gcs_service_account_private_key`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: サービスアカウント作成時に生成された JSON ファイル内の秘密鍵。例: `-----BEGIN PRIVATE KEY----xxxx-----END PRIVATE KEY-----\n`。
-- Introduced in: v3.5.1
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: Service Account作成時に生成されるJSONファイル内の秘密鍵。例: `-----BEGIN PRIVATE KEY----xxxx-----END PRIVATE KEY-----\n`。
+- 導入バージョン: v3.5.1
 
 ##### `gcp_gcs_service_account_private_key_id`
 
-- Default: Empty string
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: サービスアカウント作成時に生成された JSON ファイル内の秘密鍵 ID。
-- Introduced in: v3.5.1
+- デフォルト: 空の文字列
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: Service Account作成時に生成されるJSONファイル内の秘密鍵ID。
+- 導入バージョン: v3.5.1
 
 ##### `gcp_gcs_use_compute_engine_service_account`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: No
-- Description: Compute Engine にバインドされているサービスアカウントを使用するかどうか。
-- Introduced in: v3.5.1
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: いいえ
+- 説明: Compute EngineにバインドされているService Accountを使用するかどうか。
+- 導入バージョン: v3.5.1
 
 ##### `hdfs_file_system_expire_seconds`
 
-- Default: 300
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: HdfsFsManager が管理する未使用のキャッシュ HDFS/ObjectStore FileSystem の Time-to-live (秒単位)。FileSystemExpirationChecker (60 秒ごとに実行) はこの値を使用して各 HdfsFs.isExpired(...) を呼び出します。期限切れになるとマネージャーは基盤となる FileSystem を閉じ、キャッシュから削除します。アクセサーメソッド (例: `HdfsFs.getDFSFileSystem`、`getUserName`、`getConfiguration`) は最終アクセス時刻を更新するため、有効期限は非アクティブに基づいています。値が小さいとアイドルリソースの保持は減りますが、再オープンオーバーヘッドが増加します。値が大きいとハンドルが長く保持され、より多くのリソースを消費する可能性があります。
-- Introduced in: v3.2.0
+- デフォルト: 300
+- タイプ: Int
+- 単位: 秒
+- 変更可能: はい
+- 説明: HdfsFsManagerによって管理される未使用のキャッシュされたHDFS/ObjectStore FileSystemの生存期間（秒単位）。FileSystemExpirationChecker（60秒ごとに実行）は、この値を使用して各HdfsFs.isExpired(...)を呼び出します。期限切れになると、マネージャーは基になるFileSystemを閉じ、キャッシュから削除します。アクセサーメソッド（例: `HdfsFs.getDFSFileSystem`、`getUserName`、`getConfiguration`）は最終アクセス時刻を更新するため、有効期限は非アクティブ状態に基づいています。値が低いとアイドルリソースの保持は減りますが、再オープンのオーバーヘッドが増加します。値が高いとハンドルを長く保持し、より多くのリソースを消費する可能性があります。
+- 導入バージョン: v3.2.0
 
 ##### `lake_autovacuum_grace_period_minutes`
 
-- Default: 30
-- Type: Long
-- Unit: Minutes
-- Is mutable: Yes
-- Description: 共有データクラスターで履歴データバージョンを保持する時間範囲。この時間範囲内の履歴データバージョンは、コンパクション後に AutoVacuum によって自動的にクリーンアップされません。実行中のクエリによってアクセスされるデータがクエリ完了前に削除されることを避けるため、この値を最大クエリ時間よりも大きく設定する必要があります。v3.3.0、v3.2.5、および v3.1.10 以降、デフォルト値は `5` から `30` に変更されました。
-- Introduced in: v3.1.0
+- デフォルト: 30
+- タイプ: Long
+- 単位: 分
+- 変更可能: はい
+- 説明: shared-dataクラスターで履歴データバージョンを保持する時間範囲。この時間範囲内の履歴データバージョンは、Compaction後にAutoVacuumによって自動的にクリーンアップされません。実行中のクエリによってアクセスされるデータがクエリ完了前に削除されるのを避けるために、この値を最大クエリ時間よりも大きく設定する必要があります。デフォルト値はv3.3.0、v3.2.5、v3.1.10以降、`5`から`30`に変更されました。
+- 導入バージョン: v3.1.0
 
 ##### `lake_autovacuum_parallel_partitions`
 
-- Default: 8
-- Type: Int
-- Unit: -
-- Is mutable: No
-- Description: 共有データクラスターで同時に AutoVacuum を実行できるパーティションの最大数。AutoVacuum はコンパクション後のガベージコレクションです。
-- Introduced in: v3.1.0
+- デフォルト: 8
+- タイプ: Int
+- 単位: -
+- 変更可能: いいえ
+- 説明: shared-dataクラスターでAutoVacuumを同時に実行できるパーティションの最大数。AutoVacuumはCompaction後のガベージコレクションです。
+- 導入バージョン: v3.1.0
 
 ##### `lake_autovacuum_partition_naptime_seconds`
 
-- Default: 180
-- Type: Long
-- Unit: Seconds
-- Is mutable: Yes
-- Description: 共有データクラスターで同じパーティションに対する AutoVacuum 操作間の最小間隔。
-- Introduced in: v3.1.0
+- デフォルト: 180
+- タイプ: Long
+- 単位: 秒
+- 変更可能: はい
+- 説明: shared-dataクラスターで同じパーティションに対するAutoVacuum操作間の最小間隔。
+- 導入バージョン: v3.1.0
 
 ##### `lake_autovacuum_stale_partition_threshold`
 
-- Default: 12
-- Type: Long
-- Unit: Hours
-- Is mutable: Yes
-- Description: この時間範囲内にパーティションが更新されていない場合 (ロード、DELETE、またはコンパクション)、システムはこのパーティションに対して AutoVacuum を実行しません。
-- Introduced in: v3.1.0
+- デフォルト: 12
+- タイプ: Long
+- 単位: 時間
+- 変更可能: はい
+- 説明: この時間範囲内にパーティションに更新（ロード、DELETE、またはCompaction）がない場合、システムはこのパーティションに対してAutoVacuumを実行しません。
+- 導入バージョン: v3.1.0
 
 ##### `lake_compaction_allow_partial_success`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: この項目が `true` に設定されている場合、サブタスクの 1 つが成功した場合、システムは共有データクラスターでのコンパクション操作を成功と見なします。
-- Introduced in: v3.5.2
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: この項目が`true`に設定されている場合、shared-dataクラスターでのCompaction操作は、サブタスクのいずれかが成功したときに成功と見なされます。
+- 導入バージョン: v3.5.2
 
 ##### `lake_compaction_disable_ids`
 
-- Default: ""
-- Type: String
-- Unit: -
-- Is mutable: Yes
-- Description: 共有データモードでコンパクションが無効になっているテーブルまたはパーティションのリスト。形式はセミコロンで区切られた `tableId1;partitionId2` です。例: `12345;98765`。
-- Introduced in: v3.4.4
+- デフォルト: ""
+- タイプ: String
+- 単位: -
+- 変更可能: はい
+- 説明: shared-dataモードでCompactionが無効になっているテーブルまたはパーティションのリスト。フォーマットはセミコロンで区切られた`tableId1;partitionId2`です。例: `12345;98765`。
+- 導入バージョン: v3.4.4
 
 ##### `lake_compaction_history_size`
 
-- Default: 20
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: 共有データクラスターのリーダー FE ノードのメモリに保持される最近の成功したコンパクションタスクレコードの数。`SHOW PROC '/compactions'` コマンドを使用して、最近の成功したコンパクションタスクレコードを表示できます。コンパクション履歴は FE プロセスメモリに格納され、FE プロセスが再起動されると失われることに注意してください。
-- Introduced in: v3.1.0
+- デフォルト: 20
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: shared-dataクラスターのLeader FEノードのメモリに保持する最近成功したCompactionタスクレコードの数。`SHOW PROC '/compactions'`コマンドを使用して、最近成功したCompactionタスクレコードを表示できます。Compaction履歴はFEプロセスメモリに保存されるため、FEプロセスが再起動されると失われることに注意してください。
+- 導入バージョン: v3.1.0
 
 ##### `lake_compaction_max_tasks`
 
-- Default: -1
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: 共有データクラスターで許可される同時コンパクションタスクの最大数。この項目を `-1` に設定すると、同時タスク数が適応的に計算されることを示します。この値を `0` に設定すると、コンパクションが無効になります。
-- Introduced in: v3.1.0
+- デフォルト: -1
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: shared-dataクラスターで許可される同時Compactionタスクの最大数。この項目を`-1`に設定すると、同時タスク数が適応的に計算されることを示します。この値を`0`に設定すると、Compactionが無効になります。
+- 導入バージョン: v3.1.0
 
 ##### `lake_compaction_score_selector_min_score`
 
-- Default: 10.0
-- Type: Double
-- Unit: -
-- Is mutable: Yes
-- Description: 共有データクラスターでコンパクション操作をトリガーするコンパクションスコアのしきい値。パーティションのコンパクションスコアがこの値以上の場合、システムはそのパーティションでコンパクションを実行します。
-- Introduced in: v3.1.0
+- デフォルト: 10.0
+- タイプ: Double
+- 単位: -
+- 変更可能: はい
+- 説明: shared-dataクラスターでCompaction操作をトリガーするCompaction Scoreのしきい値。パーティションのCompaction Scoreがこの値以上の場合、システムはそのパーティションに対してCompactionを実行します。
+- 導入バージョン: v3.1.0
 
 ##### `lake_compaction_score_upper_bound`
 
-- Default: 2000
-- Type: Long
-- Unit: -
-- Is mutable: Yes
-- Description: 共有データクラスターのパーティションのコンパクションスコアの上限。`0` は上限がないことを示します。この項目は `lake_enable_ingest_slowdown` が `true` に設定されている場合にのみ有効になります。パーティションのコンパクションスコアがこの上限に達するか超えると、受信ロードタスクは拒否されます。v3.3.6 以降、デフォルト値は `0` から `2000` に変更されました。
-- Introduced in: v3.2.0
+- デフォルト: 2000
+- タイプ: Long
+- 単位: -
+- 変更可能: はい
+- 説明: shared-dataクラスターにおけるパーティションのCompaction Scoreの上限。`0`は上限なしを示します。この項目は`lake_enable_ingest_slowdown`が`true`に設定されている場合にのみ有効です。パーティションのCompaction Scoreがこの上限に達するか超えると、受信するロードタスクは拒否されます。v3.3.6以降、デフォルト値は`0`から`2000`に変更されました。
+- 導入バージョン: v3.2.0
 
 ##### `lake_enable_balance_tablets_between_workers`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: 共有データクラスターでクラウドネイティブテーブルのタブレット移行中に、Compute ノード間でタブレットの数をバランスさせるかどうか。`true` は Compute ノード間でタブレットをバランスさせることを示し、`false` はこの機能を無効にすることを示します。
-- Introduced in: v3.3.4
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: shared-dataクラスターにおけるクラウドネイティブテーブルのタブレット移行中に、Compute Node間でタブレットの数をバランスさせるかどうか。`true`はCompute Node間でタブレットをバランスさせることを示し、`false`はこの機能を無効にすることを示します。
+- 導入バージョン: v3.3.4
 
 ##### `lake_enable_ingest_slowdown`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: 共有データクラスターでデータ取り込みの減速を有効にするかどうか。データ取り込みの減速が有効になっている場合、パーティションのコンパクションスコアが `lake_ingest_slowdown_threshold` を超えると、そのパーティションでのロードタスクがスロットルダウンされます。この設定は `run_mode` が `shared_data` に設定されている場合にのみ有効になります。v3.3.6 以降、デフォルト値は `false` から `true` に変更されました。
-- Introduced in: v3.2.0
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: shared-dataクラスターでData Ingestion Slowdownを有効にするかどうか。Data Ingestion Slowdownが有効になっている場合、パーティションのCompaction Scoreが`lake_ingest_slowdown_threshold`を超えると、そのパーティションでのロードタスクはスロットリングされます。この設定は、`run_mode`が`shared_data`に設定されている場合にのみ有効です。v3.3.6以降、デフォルト値は`false`から`true`に変更されました。
+- 導入バージョン: v3.2.0
 
 ##### `lake_ingest_slowdown_threshold`
 
-- Default: 100
-- Type: Long
-- Unit: -
-- Is mutable: Yes
-- Description: 共有データクラスターでデータ取り込みの減速をトリガーするコンパクションスコアのしきい値。この設定は `lake_enable_ingest_slowdown` が `true` に設定されている場合にのみ有効になります。
-- Introduced in: v3.2.0
+- デフォルト: 100
+- タイプ: Long
+- 単位: -
+- 変更可能: はい
+- 説明: shared-dataクラスターでData Ingestion SlowdownをトリガーするCompaction Scoreのしきい値。この設定は、`lake_enable_ingest_slowdown`が`true`に設定されている場合にのみ有効です。
+- 導入バージョン: v3.2.0
 
 ##### `lake_publish_version_max_threads`
 
-- Default: 512
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: 共有データクラスターでのバージョン公開タスクの最大スレッド数。
-- Introduced in: v3.2.0
+- デフォルト: 512
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: shared-dataクラスターにおけるVersion Publishタスクの最大スレッド数。
+- 導入バージョン: v3.2.0
 
 ##### `meta_sync_force_delete_shard_meta`
 
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: 共有データクラスターのメタデータを直接削除し、リモートストレージファイルのクリーンアップをバイパスすることを許可するかどうか。クリーンアップするシャードが過剰に多く、FE JVM のメモリ圧力が極端に高くなる場合にのみ、この項目を `true` に設定することをお勧めします。この機能を有効にすると、シャードまたはタブレットに属するデータファイルが自動的にクリーンアップされないことに注意してください。
-- Introduced in: v3.2.10, v3.3.3
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: リモートストレージファイルのクリーンアップをバイパスして、shared-dataクラスターのメタデータを直接削除することを許可するかどうか。この項目は、クリーンアップするシャードが過剰に多く、FE JVMに極端なメモリ負荷がかかる場合にのみ`true`に設定することをお勧めします。この機能が有効になった後、シャードまたはタブレットに属するデータファイルは自動的にクリーンアップされないことに注意してください。
+- 導入バージョン: v3.2.10, v3.3.3
 
 ##### `run_mode`
 
-- Default: `shared_nothing`
-- Type: String
-- Unit: -
-- Is mutable: No
-- Description: StarRocks クラスターの実行モード。有効な値: `shared_data` および `shared_nothing` (デフォルト)。
-  - `shared_data` は StarRocks を共有データモードで実行することを示します。
-  - `shared_nothing` は StarRocks を共有なしモードで実行することを示します。
+- デフォルト: `shared_nothing`
+- タイプ: String
+- 単位: -
+- 変更可能: いいえ
+- 説明: StarRocksクラスターの実行モード。有効な値: `shared_data`および`shared_nothing`（デフォルト）。
+  - `shared_data`は、StarRocksをshared-dataモードで実行することを示します。
+  - `shared_nothing`は、StarRocksをshared-nothingモードで実行することを示します。
 
-  > **CAUTION**
+  > **注意**
   >
-  > - StarRocks クラスターで `shared_data` と `shared_nothing` モードを同時に採用することはできません。混合デプロイメントはサポートされていません。
-  > - クラスターのデプロイ後に `run_mode` を変更しないでください。そうしないと、クラスターの再起動に失敗します。共有なしクラスターから共有データクラスターへの変換、またはその逆の変換はサポートされていません。
+  > - StarRocksクラスターで`shared_data`モードと`shared_nothing`モードを同時に採用することはできません。混合デプロイメントはサポートされていません。
+  > - クラスターがデプロイされた後で`run_mode`を変更しないでください。そうしないと、クラスターの再起動に失敗します。shared-nothingクラスターからshared-dataクラスターへの変換、またはその逆はサポートされていません。
 
-- Introduced in: -
+- 導入バージョン: -
 
 ##### `shard_group_clean_threshold_sec`
 
-- Default: 3600
-- Type: Long
-- Unit: Seconds
-- Is mutable: Yes
-- Description: FE が共有データクラスターで未使用のタブレットおよびシャードグループをクリーンアップするまでの時間。このしきい値内に作成されたタブレットおよびシャードグループはクリーンアップされません。
-- Introduced in: -
+- デフォルト: 3600
+- タイプ: Long
+- 単位: 秒
+- 変更可能: はい
+- 説明: shared-dataクラスターでFEが未使用のタブレットとシャードグループをクリーンアップするまでの時間。このしきい値内で作成されたタブレットとシャードグループはクリーンアップされません。
+- 導入バージョン: -
 
 ##### `star_mgr_meta_sync_interval_sec`
 
-- Default: 600
-- Type: Long
-- Unit: Seconds
-- Is mutable: No
-- Description: FE が共有データクラスターで StarMgr と定期的なメタデータ同期を実行する間隔。
-- Introduced in: -
+- デフォルト: 600
+- タイプ: Long
+- 単位: 秒
+- 変更可能: いいえ
+- 説明: shared-dataクラスターでFEがStarMgrとの定期的なメタデータ同期を実行する間隔。
+- 導入バージョン: -
 
 ##### `starmgr_grpc_server_max_worker_threads`
 
-- Default: 1024
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: FE の starmgr モジュールの grpc サーバーが使用するワーカー スレッドの最大数。
-- Introduced in: v4.0.0, v3.5.8
+- デフォルト: 1024
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: FE starmgrモジュールのgrpcサーバーによって使用されるワーカー最大スレッド数。
+- 導入バージョン: v4.0.0, v3.5.8
 
 ##### `starmgr_grpc_timeout_seconds`
 
-- Default: 5
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description:
-- Introduced in: -
+- デフォルト: 5
+- タイプ: Int
+- 単位: 秒
+- 変更可能: はい
+- 説明:
+- 導入バージョン: -
 
 ### データレイク
 
 ##### `files_enable_insert_push_down_schema`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: 有効にすると、アナライザは INSERT ... FROM files() 操作のためにターゲットテーブルスキーマを `files()` テーブル関数にプッシュしようとします。これは、ソースが FileTableFunctionRelation であり、ターゲットがネイティブテーブルであり、SELECT リストにそれに対応するスロット参照列 (または *) が含まれている場合にのみ適用されます。アナライザは選択された列をターゲット列に一致させ (カウントが一致する必要があります)、ターゲットテーブルを一時的にロックし、ファイル列の型を非複合型 (Parquet JSON -> `array<varchar>` のような複合型はスキップされます) のディープコピーされたターゲット列型で置き換えます。元のファイルテーブルからの列名は保持されます。これにより、取り込み中のファイルベースの型推論による型ミスマッチと緩さが軽減されます。
-- Introduced in: v3.4.0, v3.5.0
+- デフォルト: true
+- 型: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: 有効にすると、アナライザーは `INSERT ... FROM files()` 操作のために、ターゲットテーブルのスキーマを `files()` テーブル関数にプッシュしようとします。これは、ソースが FileTableFunctionRelation であり、ターゲットがネイティブテーブルであり、SELECT リストに対応するスロット参照カラム (または *) が含まれている場合にのみ適用されます。アナライザーは、選択されたカラムをターゲットカラムに一致させ (カウントが一致する必要がある)、ターゲットテーブルを一時的にロックし、非複合型 (Parquet JSON `->` `array<varchar>` のような複合型はスキップされます) のファイルカラム型をディープコピーされたターゲットカラム型に置き換えます。元のファイルテーブルのカラム名は保持されます。これにより、取り込み時のファイルベースの型推論による型不一致と緩さが軽減されます。
+- 導入バージョン: v3.4.0, v3.5.0
 
 ##### `hdfs_read_buffer_size_kb`
 
-- Default: 8192
-- Type: Int
-- Unit: Kilobytes
-- Is mutable: Yes
-- Description: HDFS 読み取りバッファのサイズ (キロバイト単位)。StarRocks はこの値をバイト (`<< 10`) に変換し、`HdfsFsManager` で HDFS 読み取りバッファを初期化したり、ブローカーアクセスが使用されていない場合に BE タスク (例: `TBrokerScanRangeParams`、`TDownloadReq`) に送信される thrift フィールド `hdfs_read_buffer_size_kb` を設定したりするために使用します。`hdfs_read_buffer_size_kb` を増やすと、シーケンシャル読み取りスループットが向上し、システムコールオーバーヘッドが減少しますが、ストリームごとのメモリ使用量が増加します。減らすとメモリフットプリントが減少しますが、I/O 効率が低下する可能性があります。調整時にはワークロード (多くの小さなストリームと少数の大きなシーケンシャル読み取り) を考慮してください。
-- Introduced in: v3.2.0
+- デフォルト: 8192
+- 型: Int
+- 単位: Kilobytes
+- 変更可能: Yes
+- 説明: HDFS 読み取りバッファのサイズをキロバイト単位で指定します。StarRocks はこの値をバイト (`<< 10`) に変換し、`HdfsFsManager` で HDFS 読み取りバッファを初期化するために使用し、ブローカーアクセスが使用されない場合に BE タスク (例: `TBrokerScanRangeParams`、`TDownloadReq`) に送信される Thrift フィールド `hdfs_read_buffer_size_kb` を設定します。`hdfs_read_buffer_size_kb` を増やすと、ストリームあたりのメモリ使用量が増加する代わりに、シーケンシャル読み取りスループットが向上し、システムコールオーバーヘッドが削減されます。減らすとメモリフットプリントは減少しますが、IO 効率が低下する可能性があります。チューニング時にはワークロード (多数の小さなストリームか、少数の大きなシーケンシャル読み取りか) を考慮してください。
+- 導入バージョン: v3.2.0
 
 ##### `hdfs_write_buffer_size_kb`
 
-- Default: 1024
-- Type: Int
-- Unit: Kilobytes
-- Is mutable: Yes
-- Description: ブローカーを使用しない HDFS またはオブジェクトストレージへの直接書き込みに使用される HDFS 書き込みバッファサイズ (KB 単位) を設定します。FE はこの値をバイト (`<< 10`) に変換し、`HdfsFsManager` でローカル書き込みバッファを初期化します。また、Thrift リクエスト (例: TUploadReq、TExportSink、シンクオプション) に伝播され、バックエンド/エージェントが同じバッファサイズを使用するようにします。この値を増やすと、大きなシーケンシャル書き込みのスループットが向上しますが、ライターごとのメモリが増加します。減らすと、ストリームごとのメモリ使用量が減少し、小さな書き込みのレイテンシーが低下する可能性があります。`hdfs_read_buffer_size_kb` と並行して調整し、利用可能なメモリと同時ライターを考慮してください。
-- Introduced in: v3.2.0
+- デフォルト: 1024
+- 型: Int
+- 単位: Kilobytes
+- 変更可能: Yes
+- 説明: ブローカーを使用しない場合に HDFS またはオブジェクトストレージへの直接書き込みに使用される HDFS 書き込みバッファサイズ (KB 単位) を設定します。FE はこの値をバイト (`<< 10`) に変換し、HdfsFsManager でローカル書き込みバッファを初期化します。また、Thrift リクエスト (例: TUploadReq、TExportSink、シンクオプション) で伝播されるため、バックエンド/エージェントは同じバッファサイズを使用します。この値を増やすと、ライターあたりのメモリが増加する代わりに、大規模なシーケンシャル書き込みのスループットが向上します。減らすとストリームあたりのメモリ使用量が減少し、小さな書き込みのレイテンシが低下する可能性があります。`hdfs_read_buffer_size_kb` と合わせてチューニングし、利用可能なメモリと同時ライター数を考慮してください。
+- 導入バージョン: v3.2.0
 
 ##### `lake_batch_publish_max_version_num`
 
-- Default: 10
-- Type: Int
-- Unit: Count
-- Is mutable: Yes
-- Description: レイク (クラウドネイティブ) テーブルの公開バッチを構築する際に、連続するトランザクションバージョンをいくつのグループにまとめるかの上限を設定します。この値はトランザクショングラフバッチ処理ルーチン (getReadyToPublishTxnListBatch を参照) に渡され、`lake_batch_publish_min_version_num` と連携して TransactionStateBatch の候補範囲サイズを決定します。値が大きいほど、より多くのコミットをバッチ処理することで公開スループットが向上しますが、アトミック公開の範囲が広がり (可視性レイテンシーが長く、ロールバック対象が大きくなる)、バージョンが連続していない場合、実行時に制限される可能性があります。ワークロードと可視性/レイテンシー要件に応じて調整してください。
-- Introduced in: v3.2.0
+- デフォルト: 10
+- 型: Int
+- 単位: Count
+- 変更可能: Yes
+- 説明: レイク (クラウドネイティブ) テーブルのパブリッシュバッチを構築する際に、いくつの連続したトランザクションバージョンをグループ化できるかの上限を設定します。この値はトランザクショングラフのバッチ処理ルーチン (getReadyToPublishTxnListBatch を参照) に渡され、`lake_batch_publish_min_version_num` と連携して TransactionStateBatch の候補範囲サイズを決定します。値が大きいほど、より多くのコミットをバッチ処理することでパブリッシュスループットを向上させることができますが、アトミックなパブリッシュの範囲が広がり (可視性レイテンシが長くなり、ロールバックの対象が大きくなる)、バージョンが連続していない場合は実行時に制限される可能性があります。ワークロードと可視性/レイテンシの要件に応じてチューニングしてください。
+- 導入バージョン: v3.2.0
 
 ##### `lake_batch_publish_min_version_num`
 
-- Default: 1
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: レイクテーブルの公開バッチを形成するために必要な連続するトランザクションバージョンの最小数を設定します。DatabaseTransactionMgr.getReadyToPublishTxnListBatch は、依存トランザクションを選択するためにこの値を `lake_batch_publish_max_version_num` とともに transactionGraph.getTxnsWithTxnDependencyBatch に渡します。値が `1` の場合、単一トランザクションの公開が許可されます (バッチ処理なし)。値が `>1` の場合、少なくともその数の連続したバージョンを持つ単一テーブル、非レプリケーショントランザクションが利用可能である必要があります。バージョンが連続していない場合、レプリケーショントランザクションが出現した場合、またはスキーマ変更がバージョンを消費した場合、バッチ処理は中止されます。この値を増やすと、コミットをグループ化することで公開スループットが向上する可能性がありますが、十分な連続トランザクションを待機している間に公開が遅延する可能性があります。
-- Introduced in: v3.2.0
+- デフォルト: 1
+- 型: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: レイクテーブルのパブリッシュバッチを形成するために必要な連続したトランザクションバージョンの最小数を設定します。DatabaseTransactionMgr.getReadyToPublishTxnListBatch は、この値を `lake_batch_publish_max_version_num` とともに transactionGraph.getTxnsWithTxnDependencyBatch に渡し、依存するトランザクションを選択します。値が `1` の場合、単一トランザクションのパブリッシュ (バッチ処理なし) が許可されます。値が `>1` の場合、少なくともその数の連続したバージョンを持つ、単一テーブルの非レプリケーショントランザクションが利用可能である必要があります。バージョンが連続していない場合、レプリケーショントランザクションが出現した場合、またはスキーマ変更がバージョンを消費した場合、バッチ処理は中止されます。この値を増やすと、コミットをグループ化することでパブリッシュスループットを向上させることができますが、十分な連続トランザクションを待つ間、パブリッシュが遅延する可能性があります。
+- 導入バージョン: v3.2.0
 
 ##### `lake_enable_batch_publish_version`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: 有効にすると、PublishVersionDaemon は同じ Lake (共有データ) テーブル/パーティションの準備完了トランザクションをバッチ処理し、トランザクションごとの公開を発行するのではなく、まとめてバージョンを公開します。RunMode shared-data では、デーモンは getReadyPublishTransactionsBatch() を呼び出し、publishVersionForLakeTableBatch(...) を使用してグループ化された公開操作を実行します (RPC を削減し、スループットを向上させます)。無効の場合、デーモンは publishVersionForLakeTable(...) を介してトランザクションごとの公開にフォールバックします。実装は、スイッチが切り替えられたときに重複公開を避けるために内部セットを使用して進行中の作業を調整し、`lake_publish_version_max_threads` を介したスレッドプールサイズ設定の影響を受けます。
-- Introduced in: v3.2.0
+- デフォルト: true
+- 型: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: 有効にすると、PublishVersionDaemon は同じレイク (共有データ) テーブル/パーティションの準備ができたトランザクションをバッチ処理し、トランザクションごとのパブリッシュを発行する代わりに、それらのバージョンをまとめてパブリッシュします。RunMode shared-data では、デーモンは getReadyPublishTransactionsBatch() を呼び出し、publishVersionForLakeTableBatch(...) を使用してグループ化されたパブリッシュ操作を実行します (RPC を削減し、スループットを向上させます)。無効にすると、デーモンは publishVersionForLakeTable(...) を介したトランザクションごとのパブリッシュにフォールバックします。実装は、スイッチが切り替えられたときに重複するパブリッシュを避けるために内部セットを使用して進行中の作業を調整し、`lake_publish_version_max_threads` を介したスレッドプールサイズの影響を受けます。
+- 導入バージョン: v3.2.0
 
 ##### `lake_enable_tablet_creation_optimization`
 
-- Default: false
-- Type: boolean
-- Unit: -
-- Is mutable: Yes
-- Description: 有効にすると、StarRocks は共有データモードのクラウドネイティブテーブルおよびマテリアライズドビューのタブレット作成を最適化し、タブレットごとに個別のメタデータではなく、物理パーティション下のすべてのタブレットに単一の共有タブレットメタデータを作成します。これにより、テーブル作成、ロールアップ、スキーマ変更ジョブ中に作成されるタブレット作成タスクとメタデータ/ファイルの数が削減されます。この最適化はクラウドネイティブテーブル/マテリアライズドビューにのみ適用され、`file_bundling` と組み合わせて使用されます (後者は同じ最適化ロジックを再利用します)。注: スキーマ変更およびロールアップジョブは、同じ名前のファイルが上書きされるのを避けるため、`file_bundling` を使用するテーブルでは明示的に最適化を無効にします。注意して有効にしてください。作成されるタブレットメタデータの粒度が変更され、レプリカ作成とファイル命名の動作に影響する可能性があります。
-- Introduced in: v3.3.1, v3.4.0, v3.5.0
+- デフォルト: false
+- 型: boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: 有効にすると、StarRocks は共有データモードのクラウドネイティブテーブルおよびマテリアライズドビューのタブレット作成を最適化し、タブレットごとに個別のメタデータを作成する代わりに、物理パーティション下のすべてのタブレットに対して単一の共有タブレットメタデータを作成します。これにより、テーブル作成、ロールアップ、スキーマ変更ジョブ中に生成されるタブレット作成タスクとメタデータ/ファイルの数が削減されます。この最適化はクラウドネイティブテーブル/マテリアライズドビューにのみ適用され、`file_bundling` (後者は同じ最適化ロジックを再利用します) と組み合わされます。注: スキーマ変更およびロールアップジョブは、`file_bundling` を使用するテーブルに対して、同一名のファイルを上書きしないようにこの最適化を明示的に無効にします。慎重に有効にしてください — 作成されるタブレットメタデータの粒度が変更され、レプリカ作成とファイル命名の動作に影響を与える可能性があります。
+- 導入バージョン: v3.3.1, v3.4.0, v3.5.0
 
 ##### `lake_use_combined_txn_log`
 
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: この項目が `true` に設定されている場合、システムは Lake テーブルが関連トランザクションの結合トランザクションログパスを使用することを許可します。共有データクラスターでのみ利用可能です。
-- Introduced in: v3.3.7, v3.4.0, v3.5.0
+- デフォルト: false
+- 型: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: この項目が `true` に設定されている場合、システムはレイクテーブルが関連するトランザクションに対して結合されたトランザクションログパスを使用することを許可します。共有データクラスターでのみ利用可能です。
+- 導入バージョン: v3.3.7, v3.4.0, v3.5.0
 
 ##### `enable_iceberg_commit_queue`
 
-- Default: true
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: Iceberg テーブルのコミットキューを有効にして、同時コミット競合を回避するかどうか。Iceberg は、メタデータコミットに楽観的並行性制御 (OCC) を使用します。複数のスレッドが同じテーブルに同時にコミットすると、「Cannot commit: Base metadata location is not same as the current table metadata location」のようなエラーで競合が発生する可能性があります。有効にすると、各 Iceberg テーブルにはコミット操作用の単一スレッドエクゼキューターがあり、同じテーブルへのコミットがシリアル化され、OCC 競合が防止されます。異なるテーブルは同時にコミットでき、全体のスループットを維持します。これは信頼性を向上させるためのシステムレベルの最適化であり、デフォルトで有効にする必要があります。無効にすると、楽観的ロック競合により同時コミットが失敗する可能性があります。
-- Introduced in: v4.1.0
+- デフォルト: true
+- 型: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: Iceberg テーブルのコミットキューを有効にして、同時コミットの競合を回避するかどうか。Iceberg はメタデータコミットに楽観的並行性制御 (OCC) を使用します。複数のスレッドが同じテーブルに同時にコミットすると、「Cannot commit: Base metadata location is not same as the current table metadata location」のようなエラーで競合が発生する可能性があります。有効にすると、各 Iceberg テーブルはコミット操作用に独自のシングルスレッドエグゼキュータを持ち、同じテーブルへのコミットがシリアル化され、OCC 競合が防止されます。異なるテーブルは同時にコミットでき、全体のスループットを維持します。これは信頼性を向上させるためのシステムレベルの最適化であり、デフォルトで有効にする必要があります。無効にすると、楽観的ロックの競合により同時コミットが失敗する可能性があります。
+- 導入バージョン: v4.1.0
 
 ##### `iceberg_commit_queue_timeout_seconds`
 
-- Default: 300
-- Type: Int
-- Unit: Seconds
-- Is mutable: Yes
-- Description: Iceberg コミット操作が完了するまでの待機タイムアウト (秒単位)。コミットキュー (`enable_iceberg_commit_queue=true`) を使用する場合、各コミット操作はこのタイムアウト内で完了する必要があります。コミットがこのタイムアウトよりも長くかかる場合、キャンセルされ、エラーが発生します。コミット時間に影響する要因には、コミットされるデータファイルの数、テーブルのメタデータサイズ、基盤となるストレージ (S3、HDFS など) のパフォーマンスが含まれます。
-- Introduced in: v4.1.0
+- デフォルト: 300
+- 型: Int
+- 単位: Seconds
+- 変更可能: Yes
+- 説明: Iceberg コミット操作が完了するのを待つタイムアウトを秒単位で指定します。コミットキュー (`enable_iceberg_commit_queue=true`) を使用する場合、各コミット操作はこのタイムアウト内に完了する必要があります。コミットがこのタイムアウトよりも長くかかった場合、キャンセルされ、エラーが発生します。コミット時間に影響を与える要因には、コミットされるデータファイルの数、テーブルのメタデータサイズ、基盤となるストレージ (例: S3、HDFS) のパフォーマンスなどがあります。
+- 導入バージョン: v4.1.0
 
 ##### `iceberg_commit_queue_max_size`
 
-- Default: 1000
-- Type: Int
-- Unit: Count
-- Is mutable: No
-- Description: Iceberg テーブルごとの保留中のコミット操作の最大数。コミットキュー (`enable_iceberg_commit_queue=true`) を使用する場合、これは単一テーブルのキューに入れられるコミット操作の数を制限します。制限に達すると、追加のコミット操作は呼び出し元のスレッドで実行されます (容量が利用可能になるまでブロックします)。この設定は FE 起動時に読み取られ、新しく作成されたテーブルエクゼキューターに適用されます。有効にするには FE の再起動が必要です。同じテーブルへの同時コミットが多いと予想される場合は、この値を増やしてください。この値が低すぎると、高並行時に呼び出し元スレッドでコミットがブロックされる可能性があります。
-- Introduced in: v4.1.0
+- デフォルト: 1000
+- 型: Int
+- 単位: Count
+- 変更可能: No
+- 説明: Iceberg テーブルあたりの保留中のコミット操作の最大数。コミットキュー (`enable_iceberg_commit_queue=true`) を使用する場合、これは単一のテーブルに対してキューに入れられるコミット操作の数を制限します。制限に達すると、追加のコミット操作は呼び出し元のスレッドで実行されます (容量が利用可能になるまでブロックされます)。この設定は FE 起動時に読み込まれ、新しく作成されるテーブルエグゼキュータに適用されます。有効にするには FE の再起動が必要です。同じテーブルへの同時コミットが多数発生すると予想される場合は、この値を増やしてください。この値が低すぎると、高並行性時にコミットが呼び出し元のスレッドでブロックされる可能性があります。
+- 導入バージョン: v4.1.0
 
 ### その他
 
@@ -3826,9 +3826,9 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - Default: 5000
 - Type: Long
-- Unit: Milliseconds
-- Is mutable: Yes
-- Description: FE がエージェントタスクを再送信するまでに待機する必要がある期間。エージェントタスクは、タスク作成時間と現在時刻の間のギャップがこのパラメーターの値を超えた場合にのみ再送信できます。このパラメーターは、エージェントタスクの繰り返し送信を防ぐために使用されます。
+- Unit: ミリ秒
+- Is mutable: はい
+- Description: FEがエージェントタスクを再送信する前に待機しなければならない期間。エージェントタスクは、タスク作成時間と現在時間の間のギャップがこのパラメータの値を超えた場合にのみ再送信できます。このパラメータは、エージェントタスクの繰り返し送信を防ぐために使用されます。
 - Introduced in: -
 
 ##### `allow_system_reserved_names`
@@ -3836,53 +3836,53 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: false
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: ユーザーが `__op` と `__row` で始まる名前の列を作成することを許可するかどうか。この機能を有効にするには、このパラメーターを `TRUE` に設定します。これらの名前形式は StarRocks の特殊な目的のために予約されており、そのような列を作成すると未定義の動作になる可能性があるため、この機能はデフォルトで無効になっています。
+- Is mutable: はい
+- Description: ユーザーが`__op`および`__row`で始まる名前の列を作成することを許可するかどうか。この機能を有効にするには、このパラメータを`TRUE`に設定します。これらの名前形式はStarRocksで特別な目的のために予約されており、そのような列を作成すると未定義の動作を引き起こす可能性があることに注意してください。そのため、この機能はデフォルトで無効になっています。
 - Introduced in: v3.2.0
 
 ##### `auth_token`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: FE が属する StarRocks クラスター内で ID 認証に使用されるトークン。このパラメーターが指定されていない場合、StarRocks はクラスターのリーダー FE が最初に起動されたときに、クラスターのランダムなトークンを生成します。
+- Is mutable: いいえ
+- Description: FEが属するStarRocksクラスター内でID認証に使用されるトークン。このパラメータが指定されていない場合、StarRocksはクラスターのリーダーFEが初めて起動されたときに、クラスター用のランダムなトークンを生成します。
 - Introduced in: -
 
 ##### `authentication_ldap_simple_bind_base_dn`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: Yes
-- Description: LDAP サーバーがユーザーの認証情報の検索を開始する基底 DN。
+- Is mutable: はい
+- Description: LDAPサーバーがユーザーの認証情報の検索を開始する基点となるベースDN。
 - Introduced in: -
 
 ##### `authentication_ldap_simple_bind_root_dn`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: Yes
-- Description: ユーザーの認証情報を検索するために使用される管理者 DN。
+- Is mutable: はい
+- Description: ユーザーの認証情報を検索するために使用される管理者DN。
 - Introduced in: -
 
 ##### `authentication_ldap_simple_bind_root_pwd`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: Yes
+- Is mutable: はい
 - Description: ユーザーの認証情報を検索するために使用される管理者のパスワード。
 - Introduced in: -
 
 ##### `authentication_ldap_simple_server_host`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: Yes
-- Description: LDAP サーバーが実行されているホスト。
+- Is mutable: はい
+- Description: LDAPサーバーが実行されているホスト。
 - Introduced in: -
 
 ##### `authentication_ldap_simple_server_port`
@@ -3890,8 +3890,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 389
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: LDAP サーバーのポート。
+- Is mutable: はい
+- Description: LDAPサーバーのポート。
 - Introduced in: -
 
 ##### `authentication_ldap_simple_user_search_attr`
@@ -3899,16 +3899,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: uid
 - Type: String
 - Unit: -
-- Is mutable: Yes
-- Description: LDAP オブジェクトでユーザーを識別する属性の名前。
+- Is mutable: はい
+- Description: LDAPオブジェクトでユーザーを識別する属性の名前。
 - Introduced in: -
 
 ##### `backup_job_default_timeout_ms`
 
 - Default: 86400 * 1000
 - Type: Int
-- Unit: Milliseconds
-- Is mutable: Yes
+- Unit: ミリ秒
+- Is mutable: はい
 - Description: バックアップジョブのタイムアウト期間。この値を超えると、バックアップジョブは失敗します。
 - Introduced in: -
 
@@ -3917,8 +3917,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: `SHOW PROC /BACKENDS/{id}` コマンドで各ディスクのタブレット数を収集することを有効にするかどうか。
+- Is mutable: はい
+- Description: `SHOW PROC /BACKENDS/{id}`コマンドで各ディスクのタブレット数の収集を有効にするかどうか。
 - Introduced in: v4.0.1, v3.5.8
 
 ##### `enable_colocate_restore`
@@ -3926,8 +3926,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: false
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: コロケーションテーブルのバックアップと復元を有効にするかどうか。`true` はコロケーションテーブルのバックアップと復元を有効にすることを示し、`false` は無効にすることを示します。
+- Is mutable: はい
+- Description: Colocate Tableのバックアップと復元を有効にするかどうか。`true`はColocate Tableのバックアップと復元を有効にすることを意味し、`false`は無効にすることを意味します。
 - Introduced in: v3.2.10, v3.3.3
 
 ##### `enable_materialized_view_concurrent_prepare`
@@ -3935,7 +3935,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit:
-- Is mutable: Yes
+- Is mutable: はい
 - Description: パフォーマンスを向上させるために、マテリアライズドビューを並行して準備するかどうか。
 - Introduced in: v3.4.4
 
@@ -3944,8 +3944,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: No
-- Description: メトリックを定期的に収集する機能を有効にするかどうかを指定します。有効な値: `TRUE` および `FALSE`。`TRUE` はこの機能を有効にすることを指定し、`FALSE` はこの機能を無効にすることを指定します。
+- Is mutable: いいえ
+- Description: メトリクスを定期的に収集する機能を有効にするかどうかを指定します。有効な値は`TRUE`と`FALSE`です。`TRUE`はこの機能を有効にし、`FALSE`はこの機能を無効にします。
 - Introduced in: -
 
 ##### `enable_table_metrics_collect`
@@ -3953,8 +3953,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: FE でテーブルレベルのメトリックをエクスポートするかどうか。無効にすると、FE はテーブルメトリック (テーブルスキャン/ロードカウンターやテーブルサイズメトリックなど) のエクスポートをスキップしますが、カウンターはメモリに記録されます。
+- Is mutable: はい
+- Description: FEでテーブルレベルのメトリクスをエクスポートするかどうか。無効にすると、FEはテーブルメトリクス（テーブルスキャン/ロードカウンターやテーブルサイズメトリクスなど）のエクスポートをスキップしますが、カウンターはメモリに記録されます。
 - Introduced in: -
 
 ##### `enable_mv_post_image_reload_cache`
@@ -3962,8 +3962,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: FE がイメージをロードした後、リロードフラグチェックを実行するかどうか。ベースマテリアライズドビューに対してチェックが実行された場合、それに関連する他のマテリアライズドビューに対しては不要です。
+- Is mutable: はい
+- Description: FEがイメージをロードした後、リロードフラグのチェックを実行するかどうか。ベースマテリアライズドビューに対してチェックが実行された場合、それに関連する他のマテリアライズドビューに対しては不要です。
 - Introduced in: v3.5.0
 
 ##### `enable_mv_query_context_cache`
@@ -3971,8 +3971,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: クエリ書き換えパフォーマンスを向上させるために、クエリレベルのマテリアライズドビュー書き換えキャッシュを有効にするかどうか。
+- Is mutable: はい
+- Description: クエリ書き換えのパフォーマンスを向上させるために、クエリレベルのマテリアライズドビュー書き換えキャッシュを有効にするかどうか。
 - Introduced in: v3.3
 
 ##### `enable_mv_refresh_collect_profile`
@@ -3980,8 +3980,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: false
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: すべてのマテリアライズドビューに対して、デフォルトでマテリアライズドビューの更新時にプロファイルを有効にするかどうか。
+- Is mutable: はい
+- Description: すべてのマテリアライズドビューについて、デフォルトでマテリアライズドビューのリフレッシュ時にプロファイルを有効にするかどうか。
 - Introduced in: v3.3.0
 
 ##### `enable_mv_refresh_extra_prefix_logging`
@@ -3989,8 +3989,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: デバッグを容易にするために、ログにマテリアライズドビュー名をプレフィックスとして含めることを有効にするかどうか。
+- Is mutable: はい
+- Description: デバッグを容易にするために、ログにマテリアライズドビュー名を含むプレフィックスを有効にするかどうか。
 - Introduced in: v3.4.0
 
 ##### `enable_mv_refresh_query_rewrite`
@@ -3998,8 +3998,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: false
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: マテリアライズドビューの更新中にクエリ書き換えを有効にして、クエリパフォーマンスを向上させるために基底テーブルではなく書き換えられた MV を直接使用できるようにするかどうか。
+- Is mutable: はい
+- Description: マテリアライズドビューのリフレッシュ中にクエリ書き換えを有効にするかどうか。これにより、クエリはベーステーブルではなく書き換えられたMVを直接使用してクエリパフォーマンスを向上させることができます。
 - Introduced in: v3.3
 
 ##### `enable_trace_historical_node`
@@ -4007,71 +4007,71 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: false
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: システムが履歴ノードをトレースすることを許可するかどうか。この項目を `true` に設定することで、キャッシュ共有機能を有効にし、エラスティック スケーリング中にシステムが適切なキャッシュノードを選択できるようにすることができます。
+- Is mutable: はい
+- Description: システムが履歴ノードをトレースすることを許可するかどうか。この項目を`true`に設定することで、キャッシュ共有機能を有効にし、システムがエラスティック・スケーリング中に適切なキャッシュノードを選択できるようにします。
 - Introduced in: v3.5.1
 
 ##### `es_state_sync_interval_second`
 
 - Default: 10
 - Type: Long
-- Unit: Seconds
-- Is mutable: No
-- Description: FE が Elasticsearch インデックスを取得し、StarRocks 外部テーブルのメタデータを同期する時間間隔。
+- Unit: 秒
+- Is mutable: いいえ
+- Description: FEがElasticsearchインデックスを取得し、StarRocks外部テーブルのメタデータを同期する時間間隔。
 - Introduced in: -
 
 ##### `hive_meta_cache_refresh_interval_s`
 
 - Default: 3600 * 2
 - Type: Long
-- Unit: Seconds
-- Is mutable: No
-- Description: Hive 外部テーブルのキャッシュされたメタデータが更新される時間間隔。
+- Unit: 秒
+- Is mutable: いいえ
+- Description: Hive外部テーブルのキャッシュされたメタデータが更新される時間間隔。
 - Introduced in: -
 
 ##### `hive_meta_store_timeout_s`
 
 - Default: 10
 - Type: Long
-- Unit: Seconds
-- Is mutable: No
-- Description: Hive メタストアへの接続がタイムアウトするまでの時間。
+- Unit: 秒
+- Is mutable: いいえ
+- Description: Hive metastoreへの接続がタイムアウトするまでの時間。
 - Introduced in: -
 
 ##### `jdbc_connection_idle_timeout_ms`
 
 - Default: 600000
 - Type: Int
-- Unit: Milliseconds
-- Is mutable: No
-- Description: JDBC カタログへのアクセス接続がタイムアウトするまでの最大時間。タイムアウトした接続はアイドル状態と見なされます。
+- Unit: ミリ秒
+- Is mutable: いいえ
+- Description: JDBCカタログにアクセスするための接続がタイムアウトするまでの最大時間。タイムアウトした接続はアイドル状態と見なされます。
 - Introduced in: -
 
 ##### `jdbc_connection_timeout_ms`
 
 - Default: 10000
 - Type: Long
-- Unit: Milliseconds
-- Is mutable: No
-- Description: HikariCP コネクションプールが接続を取得するまでのタイムアウト (ミリ秒単位)。この時間内にプールから接続を取得できない場合、操作は失敗します。
+- Unit: ミリ秒
+- Is mutable: いいえ
+- Description: HikariCP接続プールが接続を取得するためのミリ秒単位のタイムアウト。この時間内にプールから接続を取得できない場合、操作は失敗します。
 - Introduced in: v3.5.13
 
 ##### `jdbc_query_timeout_ms`
 
 - Default: 30000
 - Type: Long
-- Unit: Milliseconds
-- Is mutable: Yes
-- Description: JDBC ステートメントのクエリ実行のタイムアウト (ミリ秒単位)。このタイムアウトは、JDBC カタログを通じて実行されるすべての SQL クエリ (パーティションメタデータクエリなど) に適用されます。この値は、JDBC ドライバーに渡されるときに秒に変換されます。
+- Unit: ミリ秒
+- Is mutable: はい
+- Description: JDBCステートメントクエリ実行のミリ秒単位のタイムアウト。このタイムアウトは、JDBCカタログを介して実行されるすべてのSQLクエリ（パーティションメタデータクエリなど）に適用されます。値はJDBCドライバーに渡されるときに秒に変換されます。
 - Introduced in: v3.5.13
 
 ##### `jdbc_network_timeout_ms`
 
 - Default: 30000
 - Type: Long
-- Unit: Milliseconds
-- Is mutable: Yes
-- Description: JDBC ネットワーク操作 (ソケット読み取り) のタイムアウト (ミリ秒単位)。このタイムアウトは、外部データベースが応答しない場合に無期限のブロッキングを防ぐために、データベースメタデータ呼び出し (getSchemas()、getTables()、getColumns() など) に適用されます。
+- Unit: ミリ秒
+- Is mutable: はい
+- Description: JDBCネットワーク操作（ソケット読み取り）のミリ秒単位のタイムアウト。このタイムアウトは、外部データベースが応答しない場合に無期限のブロックを防ぐために、データベースメタデータ呼び出し（getSchemas()、getTables()、getColumns()など）に適用されます。
 - Introduced in: v3.5.13
 
 ##### `jdbc_connection_pool_size`
@@ -4079,8 +4079,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 8
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: JDBC カタログにアクセスするための JDBC 接続プールの最大容量。
+- Is mutable: いいえ
+- Description: JDBCカタログにアクセスするためのJDBC接続プールの最大容量。
 - Introduced in: -
 
 ##### `jdbc_meta_default_cache_enable`
@@ -4088,17 +4088,17 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: false
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: JDBC カタログのメタデータキャッシュが有効になっているかどうかのデフォルト値。true に設定すると、新しく作成された JDBC カタログはデフォルトでメタデータキャッシュが有効になります。
+- Is mutable: はい
+- Description: JDBCカタログのメタデータキャッシュが有効になっているかどうかのデフォルト値。Trueに設定すると、新しく作成されたJDBCカタログはデフォルトでメタデータキャッシュが有効になります。
 - Introduced in: -
 
 ##### `jdbc_meta_default_cache_expire_sec`
 
 - Default: 600
 - Type: Long
-- Unit: Seconds
-- Is mutable: Yes
-- Description: JDBC カタログのメタデータキャッシュのデフォルトの有効期限。`jdbc_meta_default_cache_enable` が true に設定されている場合、新しく作成された JDBC カタログはデフォルトでメタデータキャッシュの有効期限を設定します。
+- Unit: 秒
+- Is mutable: はい
+- Description: JDBCカタログのメタデータキャッシュのデフォルトの有効期限。`jdbc_meta_default_cache_enable`がtrueに設定されている場合、新しく作成されたJDBCカタログはデフォルトでメタデータキャッシュの有効期限を設定します。
 - Introduced in: -
 
 ##### `jdbc_minimum_idle_connections`
@@ -4106,44 +4106,44 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 1
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: JDBC カタログにアクセスするための JDBC 接続プールのアイドル接続の最小数。
+- Is mutable: いいえ
+- Description: JDBCカタログにアクセスするためのJDBC接続プール内のアイドル接続の最小数。
 - Introduced in: -
 
 ##### `jwt_jwks_url`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: JSON Web Key Set (JWKS) サービスの URL、または `fe/conf` ディレクトリ下の公開鍵ローカルファイルへのパス。
+- Is mutable: いいえ
+- Description: JSON Web Key Set (JWKS) サービスへのURL、または`fe/conf`ディレクトリ下の公開鍵ローカルファイルへのパス。
 - Introduced in: v3.5.0
 
 ##### `jwt_principal_field`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: JWT のサブジェクト (`sub`) を示すフィールドを識別するために使用される文字列。デフォルト値は `sub` です。このフィールドの値は StarRocks へのログインに使用するユーザー名と同一である必要があります。
+- Is mutable: いいえ
+- Description: JWTでサブジェクト (`sub`) を示すフィールドを識別するために使用される文字列。デフォルト値は`sub`です。このフィールドの値は、StarRocksにログインするためのユーザー名と同一である必要があります。
 - Introduced in: v3.5.0
 
 ##### `jwt_required_audience`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: JWT のオーディエンス (`aud`) を識別するために使用される文字列のリスト。JWT が有効であると見なされるのは、リスト内の値のいずれかが JWT のオーディエンスと一致する場合のみです。
+- Is mutable: いいえ
+- Description: JWTでオーディエンス (`aud`) を識別するために使用される文字列のリスト。JWTは、リスト内のいずれかの値がJWTオーディエンスと一致する場合にのみ有効と見なされます。
 - Introduced in: v3.5.0
 
 ##### `jwt_required_issuer`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: JWT の発行者 (`iss`) を識別するために使用される文字列のリスト。JWT が有効であると見なされるのは、リスト内の値のいずれかが JWT の発行者と一致する場合のみです。
+- Is mutable: いいえ
+- Description: JWTで発行者 (`iss`) を識別するために使用される文字列のリスト。JWTは、リスト内のいずれかの値がJWT発行者と一致する場合にのみ有効と見なされます。
 - Introduced in: v3.5.0
 
 ##### locale
@@ -4151,8 +4151,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: `zh_CN.UTF-8`
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: FE が使用する文字セット。
+- Is mutable: いいえ
+- Description: FEが使用する文字セット。
 - Introduced in: -
 
 ##### `max_agent_task_threads_num`
@@ -4160,7 +4160,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 4096
 - Type: Int
 - Unit: -
-- Is mutable: No
+- Is mutable: いいえ
 - Description: エージェントタスクスレッドプールで許可されるスレッドの最大数。
 - Introduced in: -
 
@@ -4169,8 +4169,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 0
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: 各 RESTORE 操作において、StarRocks が BE ノードに割り当てるダウンロードタスクの最大数。この項目が 0 以下に設定されている場合、タスク数に制限は課されません。
+- Is mutable: はい
+- Description: 各RESTORE操作において、StarRocksがBEノードに割り当てるダウンロードタスクの最大数。この項目が0以下に設定されている場合、タスク数に制限は課されません。
 - Introduced in: v3.1.0
 
 ##### `max_mv_check_base_table_change_retry_times`
@@ -4178,8 +4178,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 10
 - Type: -
 - Unit: -
-- Is mutable: Yes
-- Description: マテリアライズドビューの更新時に、基底テーブルの変更を検出するための最大再試行回数。
+- Is mutable: はい
+- Description: マテリアライズドビューのリフレッシュ時にベーステーブルの変更を検出するための最大再試行回数。
 - Introduced in: v3.3.0
 
 ##### `max_mv_refresh_failure_retry_times`
@@ -4187,8 +4187,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 1
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: マテリアライズドビューの更新が失敗した場合の最大再試行回数。
+- Is mutable: はい
+- Description: マテリアライズドビューのリフレッシュが失敗した場合の最大再試行回数。
 - Introduced in: v3.3.0
 
 ##### `max_mv_refresh_try_lock_failure_retry_times`
@@ -4196,8 +4196,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 3
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: マテリアライズドビューの更新が失敗した場合の、ロック試行の最大再試行回数。
+- Is mutable: はい
+- Description: マテリアライズドビューのリフレッシュが失敗した場合のロック試行の最大再試行回数。
 - Introduced in: v3.3.0
 
 ##### `max_small_file_number`
@@ -4205,17 +4205,17 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 100
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: FE ディレクトリに格納できる小型ファイルの最大数。
+- Is mutable: はい
+- Description: FEディレクトリに保存できる小さなファイルの最大数。
 - Introduced in: -
 
 ##### `max_small_file_size_bytes`
 
 - Default: 1024 * 1024
 - Type: Int
-- Unit: Bytes
-- Is mutable: Yes
-- Description: 小型ファイルの最大サイズ。
+- Unit: バイト
+- Is mutable: はい
+- Description: 小さなファイルの最大サイズ。
 - Introduced in: -
 
 ##### `max_upload_task_per_be`
@@ -4223,17 +4223,17 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 0
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: 各 BACKUP 操作において、StarRocks が BE ノードに割り当てるアップロードタスクの最大数。この項目が 0 以下に設定されている場合、タスク数に制限は課されません。
+- Is mutable: はい
+- Description: 各BACKUP操作において、StarRocksがBEノードに割り当てるアップロードタスクの最大数。この項目が0以下に設定されている場合、タスク数に制限は課されません。
 - Introduced in: v3.1.0
 
 ##### `mv_create_partition_batch_interval_ms`
 
 - Default: 1000
 - Type: Int
-- Unit: ms
-- Is mutable: Yes
-- Description: マテリアライズドビューの更新中、複数のパーティションを一括作成する必要がある場合、システムはそれらをそれぞれ 64 パーティションのバッチに分割します。頻繁なパーティション作成による障害のリスクを軽減するため、作成頻度を制御するために各バッチ間にデフォルトの間隔 (ミリ秒単位) が設定されます。
+- Unit: ミリ秒
+- Is mutable: はい
+- Description: マテリアライズドビューのリフレッシュ中に、複数のパーティションを一括で作成する必要がある場合、システムはそれらをそれぞれ64パーティションのバッチに分割します。頻繁なパーティション作成による障害のリスクを軽減するため、各バッチ間にデフォルトの間隔（ミリ秒単位）が設定され、作成頻度を制御します。
 - Introduced in: v3.3
 
 ##### `mv_plan_cache_max_size`
@@ -4241,8 +4241,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 1000
 - Type: Long
 - Unit:
-- Is mutable: Yes
-- Description: マテリアライズドビュー計画キャッシュの最大サイズ (マテリアライズドビューの書き換えに使用されます)。透過的クエリ書き換えに多くのマテリアライズドビューが使用されている場合、この値を増やすことができます。
+- Is mutable: はい
+- Description: マテリアライズドビュープランキャッシュ（マテリアライズドビューの書き換えに使用される）の最大サイズ。透過的なクエリ書き換えに使用されるマテリアライズドビューが多い場合、この値を増やすことができます。
 - Introduced in: v3.2
 
 ##### `mv_plan_cache_thread_pool_size`
@@ -4250,8 +4250,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 3
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: マテリアライズドビュー計画キャッシュのデフォルトスレッドプールサイズ (マテリアライズドビュー書き換えに使用されます)。
+- Is mutable: はい
+- Description: マテリアライズドビュープランキャッシュ（マテリアライズドビューの書き換えに使用される）のデフォルトのスレッドプールサイズ。
 - Introduced in: v3.2
 
 ##### `mv_refresh_default_planner_optimize_timeout`
@@ -4259,8 +4259,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 30000
 - Type: -
 - Unit: -
-- Is mutable: Yes
-- Description: マテリアライズドビュー更新時のオプティマイザの計画フェーズのデフォルトタイムアウト。
+- Is mutable: はい
+- Description: マテリアライズドビューのリフレッシュ時に、オプティマイザの計画フェーズのデフォルトのタイムアウト。
 - Introduced in: v3.3.0
 
 ##### `mv_refresh_fail_on_filter_data`
@@ -4268,98 +4268,98 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: 更新時にフィルタリングされたデータがある場合、マテリアライズドビューの更新は失敗します (デフォルトは true)。そうでない場合、フィルタリングされたデータを無視して成功を返します。
+- Is mutable: はい
+- Description: リフレッシュ中にフィルタリングされたデータがある場合、MVのリフレッシュは失敗します（デフォルトはtrue）。そうでない場合は、フィルタリングされたデータを無視して成功を返します。
 - Introduced in: -
 
 ##### `mv_refresh_try_lock_timeout_ms`
 
 - Default: 30000
 - Type: Int
-- Unit: Milliseconds
-- Is mutable: Yes
-- Description: マテリアライズドビューの更新が、基底テーブル/マテリアライズドビューの DB ロックを試行するデフォルトの試行ロックタイムアウト。
+- Unit: ミリ秒
+- Is mutable: はい
+- Description: マテリアライズドビューのリフレッシュが、そのベーステーブル/マテリアライズドビューのDBロックを試行する際のデフォルトのロック試行タイムアウト。
 - Introduced in: v3.3.0
 
 ##### `oauth2_auth_server_url`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: 認証 URL。OAuth 2.0 認証プロセスを開始するためにユーザーのブラウザがリダイレクトされる URL。
+- Is mutable: いいえ
+- Description: 認証URL。OAuth 2.0認証プロセスを開始するために、ユーザーのブラウザがリダイレクトされるURL。
 - Introduced in: v3.5.0
 
 ##### `oauth2_client_id`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: StarRocks クライアントの公開識別子。
+- Is mutable: いいえ
+- Description: StarRocksクライアントの公開識別子。
 - Introduced in: v3.5.0
 
 ##### `oauth2_client_secret`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: StarRocks クライアントを認証サーバーで認証するために使用されるシークレット。
+- Is mutable: いいえ
+- Description: 認証サーバーでStarRocksクライアントを認証するために使用されるシークレット。
 - Introduced in: v3.5.0
 
 ##### `oauth2_jwks_url`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: JSON Web Key Set (JWKS) サービスの URL、または `conf` ディレクトリ下のローカルファイルへのパス。
+- Is mutable: いいえ
+- Description: JSON Web Key Set (JWKS) サービスへのURL、または`conf`ディレクトリ下のローカルファイルへのパス。
 - Introduced in: v3.5.0
 
 ##### `oauth2_principal_field`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: JWT のサブジェクト (`sub`) を示すフィールドを識別するために使用される文字列。デフォルト値は `sub` です。このフィールドの値は StarRocks へのログインに使用するユーザー名と同一である必要があります。
+- Is mutable: いいえ
+- Description: JWTでサブジェクト (`sub`) を示すフィールドを識別するために使用される文字列。デフォルト値は`sub`です。このフィールドの値は、StarRocksにログインするためのユーザー名と同一である必要があります。
 - Introduced in: v3.5.0
 
 ##### `oauth2_redirect_url`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: OAuth 2.0 認証が成功した後にユーザーのブラウザがリダイレクトされる URL。認証コードはこの URL に送信されます。ほとんどの場合、`http://<starrocks_fe_url>:<fe_http_port>/api/oauth2` として設定する必要があります。
+- Is mutable: いいえ
+- Description: OAuth 2.0認証が成功した後、ユーザーのブラウザがリダイレクトされるURL。認証コードはこのURLに送信されます。ほとんどの場合、`http://<starrocks_fe_url>:<fe_http_port>/api/oauth2`として設定する必要があります。
 - Introduced in: v3.5.0
 
 ##### `oauth2_required_audience`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: JWT のオーディエンス (`aud`) を識別するために使用される文字列のリスト。JWT が有効であると見なされるのは、リスト内の値のいずれかが JWT のオーディエンスと一致する場合のみです。
+- Is mutable: いいえ
+- Description: JWTでオーディエンス (`aud`) を識別するために使用される文字列のリスト。JWTは、リスト内のいずれかの値がJWTオーディエンスと一致する場合にのみ有効と見なされます。
 - Introduced in: v3.5.0
 
 ##### `oauth2_required_issuer`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: JWT の発行者 (`iss`) を識別するために使用される文字列のリスト。JWT が有効であると見なされるのは、リスト内の値のいずれかが JWT の発行者と一致する場合のみです。
+- Is mutable: いいえ
+- Description: JWTで発行者 (`iss`) を識別するために使用される文字列のリスト。JWTは、リスト内のいずれかの値がJWT発行者と一致する場合にのみ有効と見なされます。
 - Introduced in: v3.5.0
 
 ##### `oauth2_token_server_url`
 
-- Default: Empty string
+- Default: 空の文字列
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: StarRocks がアクセストークンを取得する認証サーバーのエンドポイントの URL。
+- Is mutable: いいえ
+- Description: StarRocksがアクセストークンを取得する認証サーバー上のエンドポイントのURL。
 - Introduced in: v3.5.0
 
 ##### `plugin_dir`
@@ -4367,8 +4367,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: `System.getenv("STARROCKS_HOME")` + "/plugins"
 - Type: String
 - Unit: -
-- Is mutable: No
-- Description: プラグインインストールパッケージを格納するディレクトリ。
+- Is mutable: いいえ
+- Description: プラグインインストールパッケージを保存するディレクトリ。
 - Introduced in: -
 
 ##### `plugin_enable`
@@ -4376,8 +4376,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: プラグインを FE にインストールできるかどうか。プラグインはリーダー FE にのみインストールまたはアンインストールできます。
+- Is mutable: はい
+- Description: FEにプラグインをインストールできるかどうか。プラグインはLeader FEにのみインストールまたはアンインストールできます。
 - Introduced in: -
 
 ##### `proc_profile_jstack_depth`
@@ -4385,8 +4385,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 128
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: システムが CPU およびメモリプロファイルを収集する際の最大 Java スタック深度。この値は、サンプリングされた各スタックについていくつの Java スタックフレームがキャプチャされるかを制御します。値が大きいほどトレースの詳細と出力サイズが増加し、プロファイリングのオーバーヘッドが追加される可能性があります。値が小さいほど詳細は減少します。この設定は CPU およびメモリプロファイリングの両方でプロファイラーが起動されるときに使用されるため、診断のニーズとパフォーマンスへの影響のバランスをとるように調整してください。
+- Is mutable: はい
+- Description: システムがCPUおよびメモリプロファイルを収集する際のJavaスタックの最大深度。この値は、サンプリングされた各スタックに対してキャプチャされるJavaスタックフレームの数を制御します。値が大きいほどトレースの詳細度と出力サイズが増加し、プロファイリングのオーバーヘッドが増える可能性がありますが、値が小さいほど詳細度が減少します。この設定は、CPUとメモリの両方のプロファイリングでプロファイラが開始されるときに使用されるため、診断の必要性とパフォーマンスへの影響のバランスを取るように調整してください。
 - Introduced in: -
 
 ##### `proc_profile_mem_enable`
@@ -4394,8 +4394,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: Yes
-- Description: プロセスメモリ割り当てプロファイルの収集を有効にするかどうか。この項目が `true` に設定されている場合、システムは `sys_log_dir/proc_profile` に `mem-profile-<timestamp>.html` という名前の HTML プロファイルを生成し、`proc_profile_collect_time_s` 秒間サンプリングしながらスリープし、Java スタック深度に `proc_profile_jstack_depth` を使用します。生成されたファイルは `proc_profile_file_retained_days` および `proc_profile_file_retained_size_bytes` に従って圧縮され、パージされます。ネイティブ抽出パスは `/tmp` の noexec 問題を回避するために `STARROCKS_HOME_DIR` を使用します。この項目はメモリ割り当てホットスポットのトラブルシューティングを目的としています。これを有効にすると CPU、I/O、ディスク使用量が増加し、大きなファイルが生成される可能性があります。
+- Is mutable: はい
+- Description: プロセスメモリ割り当てプロファイルの収集を有効にするかどうか。この項目が`true`に設定されている場合、システムは`sys_log_dir/proc_profile`の下に`mem-profile-<timestamp>.html`という名前のHTMLプロファイルを生成し、サンプリング中に`proc_profile_collect_time_s`秒間スリープし、Javaスタック深度に`proc_profile_jstack_depth`を使用します。生成されたファイルは`proc_profile_file_retained_days`と`proc_profile_file_retained_size_bytes`に従って圧縮およびパージされます。ネイティブ抽出パスは`/tmp`のnoexec問題を回避するために`STARROCKS_HOME_DIR`を使用します。この項目は、メモリ割り当てのホットスポットのトラブルシューティングを目的としています。これを有効にすると、CPU、I/O、ディスク使用量が増加し、大きなファイルが生成される可能性があります。
 - Introduced in: v3.2.12
 
 ##### `query_detail_explain_level`
@@ -4403,8 +4403,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: COSTS
 - Type: String
 - Unit: -
-- Is mutable: true
-- Description: EXPLAIN ステートメントによって返されるクエリ計画の詳細レベル。有効な値: COSTS, NORMAL, VERBOSE。
+- Is mutable: はい
+- Description: EXPLAINステートメントによって返されるクエリプランの詳細レベル。有効な値：COSTS、NORMAL、VERBOSE。
 - Introduced in: v3.2.12, v3.3.5
 
 ##### `replication_interval_ms`
@@ -4412,7 +4412,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 100
 - Type: Int
 - Unit: -
-- Is mutable: No
+- Is mutable: いいえ
 - Description: レプリケーションタスクがスケジュールされる最小時間間隔。
 - Introduced in: v3.3.5
 
@@ -4420,8 +4420,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - Default: 1048576
 - Type: Int
-- Unit: MB
-- Is mutable: Yes
+- Unit: メガバイト
+- Is mutable: はい
 - Description: 同時同期に許可されるデータの最大サイズ。
 - Introduced in: v3.3.5
 
@@ -4430,7 +4430,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 10240
 - Type: Int
 - Unit: -
-- Is mutable: Yes
+- Is mutable: はい
 - Description: 同時同期に許可されるタブレットレプリカの最大数。
 - Introduced in: v3.3.5
 
@@ -4439,16 +4439,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 100
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: 許可される同時データ同期タスクの最大数。StarRocks はテーブルごとに 1 つの同期タスクを作成します。
+- Is mutable: はい
+- Description: 許可される同時データ同期タスクの最大数。StarRocksはテーブルごとに1つの同期タスクを作成します。
 - Introduced in: v3.3.5
 
 ##### `replication_transaction_timeout_sec`
 
 - Default: 86400
 - Type: Int
-- Unit: Seconds
-- Is mutable: Yes
+- Unit: 秒
+- Is mutable: はい
 - Description: 同期タスクのタイムアウト期間。
 - Introduced in: v3.3.5
 
@@ -4457,5 +4457,44 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Default: 5
 - Type: Int
 - Unit: -
-- Is mutable: Yes
-- Description: 関連するマテリアライズドビューを持つテーブルに「非ロック」最適化を StarRocks がいつ適用するかを制御します。この項目
+- Is mutable: はい
+- Description: 関連するマテリアライズドビューを持つテーブルに対してStarRocksが「非ロック」最適化を適用するタイミングを制御します。この項目が0未満に設定されている場合、システムは常に非ロック最適化を適用し、クエリのために関連するマテリアライズドビューをコピーしません（FEのメモリ使用量とメタデータのコピー/ロック競合は減少しますが、メタデータの同時実行性の問題のリスクが増加する可能性があります）。0に設定されている場合、非ロック最適化は無効になります（システムは常に安全なコピーアンドロックパスを使用します）。0より大きい値に設定されている場合、非ロック最適化は、関連するマテリアライズドビューの数が設定されたしきい値以下であるテーブルにのみ適用されます。さらに、値が0以上の場合、プランナーはクエリOLAPテーブルをオプティマイザコンテキストに記録して、マテリアライズドビュー関連の書き換えパスを有効にします。0未満の場合、このステップはスキップされます。
+- Introduced in: v3.2.1
+
+##### `small_file_dir`
+
+- Default: `StarRocksFE.STARROCKS_HOME_DIR` + "/small_files"
+- Type: String
+- Unit: -
+- Is mutable: いいえ
+- Description: 小さなファイルのルートディレクトリ。
+- Introduced in: -
+
+##### `task_runs_max_history_number`
+
+- Default: 10000
+- Type: Int
+- Unit: -
+- Is mutable: はい
+- Description: メモリに保持し、アーカイブされたタスク実行履歴をクエリする際のデフォルトのLIMITとして使用するタスク実行レコードの最大数。`enable_task_history_archive`がfalseの場合、この値はメモリ内履歴を制限します。強制GCは古いエントリを削除し、最新の`task_runs_max_history_number`のみが残ります。アーカイブ履歴がクエリされた場合（明示的なLIMITが提供されていない場合）、この値が0より大きい場合、`TaskRunHistoryTable.lookup`は`"ORDER BY create_time DESC LIMIT <value>"`を使用します。注：これを0に設定すると、クエリ側のLIMITは無効になりますが（上限なし）、メモリ内履歴はゼロに切り詰められます（アーカイブが有効でない限り）。
+- Introduced in: v3.2.0
+
+##### `tmp_dir`
+
+- Default: `StarRocksFE.STARROCKS_HOME_DIR` + "/temp_dir"
+- Type: String
+- Unit: -
+- Is mutable: いいえ
+- Description: バックアップおよび復元手順中に生成されるファイルなどの一時ファイルを保存するディレクトリ。これらの手順が完了すると、生成された一時ファイルは削除されます。
+- Introduced in: -
+
+##### `transform_type_prefer_string_for_varchar`
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: はい
+- Description: マテリアライズドビューの作成およびCTAS操作において、固定長varchar列に文字列型を優先するかどうか。
+- Introduced in: v4.0.0
+
+<EditionSpecificFEItem />

--- a/docs/zh/_assets/commonMarkdown/Edition_Specific_FE_Item.mdx
+++ b/docs/zh/_assets/commonMarkdown/Edition_Specific_FE_Item.mdx
@@ -1,5 +1,5 @@
 
-##### enable_auth_check
+##### `enable_auth_check`
 
 - 默认值：true
 - 类型：Boolean

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -16,7 +16,7 @@ import EditionSpecificFEItem from '../../_assets/commonMarkdown/Edition_Specific
 
 ## 查看 FE 配置项
 
-FE 启动后，您可以在 MySQL 客户端运行 ADMIN SHOW FRONTEND CONFIG 命令查看参数配置。如果要查询特定参数的配置，请运行以下命令：
+FE 启动后，您可以在 MySQL 客户端上运行 ADMIN SHOW FRONTEND CONFIG 命令来检查参数配置。如果您想查询特定参数的配置，请运行以下命令：
 
 ```SQL
 ADMIN SHOW FRONTEND CONFIG [LIKE "pattern"];
@@ -25,14 +25,14 @@ ADMIN SHOW FRONTEND CONFIG [LIKE "pattern"];
 有关返回字段的详细说明，请参阅 [`ADMIN SHOW CONFIG`](../../sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SHOW_CONFIG.md)。
 
 :::note
-您必须具有管理员权限才能运行集群管理相关命令。
+您必须拥有管理员权限才能运行集群管理相关命令。
 :::
 
 ## 配置 FE 参数
 
 ### 配置 FE 动态参数
 
-您可以使用 [`ADMIN SET FRONTEND CONFIG`](../../sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SET_CONFIG.md) 命令配置或修改 FE 动态参数。
+您可以使用 [`ADMIN SET FRONTEND CONFIG`](../../sql-reference/sql-statements/cluster-management/config_vars/ADMIN_SET_CONFIG.md) 配置或修改 FE 动态参数的设置。
 
 ```SQL
 ADMIN SET FRONTEND CONFIG ("key" = "value");
@@ -53,8 +53,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 30d
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: 审计日志文件的保留期限。默认值 `30d` 指定每个审计日志文件可以保留 30 天。StarRocks 会检查每个审计日志文件，并删除 30 天前生成的那些。
+- 是否可变: 否
+- 描述: 审计日志文件的保留期限。默认值 `30d` 表示每个审计日志文件可以保留 30 天。StarRocks 会检查每个审计日志文件，并删除 30 天前生成的日志文件。
 - 引入版本: -
 
 ##### `audit_log_dir`
@@ -62,7 +62,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: `StarRocksFE.STARROCKS_HOME_DIR` + "/log"
 - 类型: String
 - 单位: -
-- 是否可变: No
+- 是否可变: 否
 - 描述: 存储审计日志文件的目录。
 - 引入版本: -
 
@@ -71,8 +71,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: false
 - 类型: Boolean
 - 单位: N/A
-- 是否可变: No
-- 描述: 当为 true 时，生成的 Log4j2 配置会将 ".gz" 后缀附加到轮转的审计日志文件名 (fe.audit.log.*) 中，以便 Log4j2 在轮转时生成压缩的 (.gz) 归档审计日志文件。此设置在 FE 启动期间在 Log4jConfig.initLogging 中读取，并应用于审计日志的 RollingFile appender；它仅影响轮转/归档文件，而不影响活动审计日志。由于该值在启动时初始化，因此更改它需要重启 FE 才能生效。与审计日志轮转设置 (`audit_log_dir`、`audit_log_roll_interval`、`audit_roll_maxsize`、`audit_log_roll_num`) 一起使用。
+- 是否可变: 否
+- 描述: 当设置为 true 时，生成的 Log4j2 配置会在轮转的审计日志文件名 (fe.audit.log.*) 后附加 ".gz" 后缀，以便 Log4j2 在日志轮转时生成压缩的 (.gz) 归档审计日志文件。此设置在 FE 启动时由 Log4jConfig.initLogging 读取，并应用于审计日志的 RollingFile appender；它只影响轮转/归档文件，不影响活动的审计日志。由于该值在启动时初始化，因此更改它需要重启 FE 才能生效。请与审计日志轮转设置 (`audit_log_dir`、`audit_log_roll_interval`、`audit_roll_maxsize`、`audit_log_roll_num`) 一起使用。
 - 引入版本: 3.2.12
 
 ##### `audit_log_json_format`
@@ -80,8 +80,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: false
 - 类型: Boolean
 - 单位: N/A
-- 是否可变: Yes
-- 描述: 当为 true 时，FE 审计事件将以结构化 JSON (Jackson ObjectMapper 序列化带注解的 AuditEvent 字段的 Map) 的形式发出，而不是默认的管道分隔的 "key=value" 字符串。此设置会影响 AuditLogBuilder 处理的所有内置审计接收器：连接审计、查询审计、大查询审计（当事件符合条件时，大查询阈值字段会添加到 JSON 中）和慢审计输出。用于大查询阈值的字段和 "features" 字段会进行特殊处理（从普通审计条目中排除；根据适用情况包含在大查询或功能日志中）。启用此功能可使日志可供日志收集器或 SIEM 机器解析；请注意，它会更改日志格式，可能需要更新任何期望旧版管道分隔格式的现有解析器。
+- 是否可变: 是
+- 描述: 当设置为 true 时，FE 审计事件将以结构化 JSON 格式（Jackson ObjectMapper 序列化带注解的 AuditEvent 字段的 Map）发出，而不是默认的管道分隔的 "key=value" 字符串。此设置影响 AuditLogBuilder 处理的所有内置审计接收器：连接审计、查询审计、大查询审计（当事件符合条件时，大查询阈值字段会添加到 JSON 中）和慢查询审计输出。针对大查询阈值注解的字段和 "features" 字段会特殊处理（从普通审计条目中排除；根据适用情况包含在大查询或特性日志中）。启用此功能可使日志易于日志收集器或 SIEMs 进行机器解析；请注意，它会更改日志格式，可能需要更新任何期望旧版管道分隔格式的现有解析器。
 - 引入版本: 3.2.7
 
 ##### `audit_log_modules`
@@ -89,8 +89,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: `slow_query`, query
 - 类型: String[]
 - 单位: -
-- 是否可变: No
-- 描述: StarRocks 为其生成审计日志条目的模块。默认情况下，StarRocks 为 `slow_query` 模块和 `query` 模块生成审计日志。`connection` 模块从 v3.0 版本开始支持。模块名称用逗号 (,) 和空格分隔。
+- 是否可变: 否
+- 描述: StarRocks 生成审计日志条目的模块。默认情况下，StarRocks 为 `slow_query` 模块和 `query` 模块生成审计日志。`connection` 模块从 v3.0 版本开始支持。模块名称之间用逗号 (,) 和空格分隔。
 - 引入版本: -
 
 ##### `audit_log_roll_interval`
@@ -98,10 +98,10 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: DAY
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: StarRocks 轮转审计日志条目的时间间隔。有效值：`DAY` 和 `HOUR`。
-  - 如果此参数设置为 `DAY`，则在审计日志文件名称中添加 `yyyyMMdd` 格式的后缀。
-  - 如果此参数设置为 `HOUR`，则在审计日志文件名称中添加 `yyyyMMddHH` 格式的后缀。
+- 是否可变: 否
+- 描述: StarRocks 轮转审计日志条目的时间间隔。有效值: `DAY` 和 `HOUR`。
+  - 如果此参数设置为 `DAY`，则审计日志文件名称中会添加 `yyyyMMdd` 格式的后缀。
+  - 如果此参数设置为 `HOUR`，则审计日志文件名称中会添加 `yyyyMMddHH` 格式的后缀。
 - 引入版本: -
 
 ##### `audit_log_roll_num`
@@ -109,7 +109,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 90
 - 类型: Int
 - 单位: -
-- 是否可变: No
+- 是否可变: 否
 - 描述: 在 `audit_log_roll_interval` 参数指定的每个保留期内，可以保留的审计日志文件的最大数量。
 - 引入版本: -
 
@@ -118,8 +118,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: INFO
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: 控制 StarRocks 中 Berkeley DB Java Edition (BDB JE) 使用的日志级别。在 BDB 环境初始化 BDBEnvironment.initConfigs() 期间，此值将应用于 `com.sleepycat.je` 包的 Java 日志记录器和 BDB JE 环境文件日志记录级别 (`EnvironmentConfig.FILE_LOGGING_LEVEL`)。接受标准的 java.util.logging.Level 名称，例如 SEVERE、WARNING、INFO、CONFIG、FINE、FINER、FINEST、ALL、OFF。设置为 ALL 可启用所有日志消息。增加详细程度将提高日志量，并可能影响磁盘 I/O 和性能；该值在 BDB 环境初始化时读取，因此仅在环境（重新）初始化后生效。
+- 是否可变: 否
+- 描述: 控制 StarRocks 中 Berkeley DB Java Edition (BDB JE) 使用的日志级别。在 BDB 环境初始化期间，BDBEnvironment.initConfigs() 将此值应用于 `com.sleepycat.je` 包的 Java 日志记录器和 BDB JE 环境文件日志级别 (`EnvironmentConfig.FILE_LOGGING_LEVEL`)。接受标准的 java.util.logging.Level 名称，例如 SEVERE、WARNING、INFO、CONFIG、FINE、FINER、FINEST、ALL、OFF。设置为 ALL 将启用所有日志消息。增加详细程度会提高日志量，并可能影响磁盘 I/O 和性能；该值在 BDB 环境初始化时读取，因此仅在环境（重新）初始化后生效。
 - 引入版本: v3.2.0
 
 ##### `big_query_log_delete_age`
@@ -127,8 +127,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 7d
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: 控制 FE 大查询日志文件 (`fe.big_query.log.*`) 在自动删除前的保留时间。该值作为 IfLastModified age 传递给 Log4j 的删除策略 — 任何最后修改时间早于此值的轮转大查询日志都将被删除。支持的后缀包括 `d`（天）、`h`（小时）、`m`（分钟）和 `s`（秒）。示例：`7d`（7 天）、`10h`（10 小时）、`60m`（60 分钟）和 `120s`（120 秒）。此项与 `big_query_log_roll_interval` 和 `big_query_log_roll_num` 共同决定哪些文件被保留或清除。
+- 是否可变: 否
+- 描述: 控制 FE 大查询日志文件 (`fe.big_query.log.*`) 在自动删除前保留多长时间。该值作为 IfLastModified age 传递给 Log4j 的删除策略——任何最后修改时间早于此值的轮转大查询日志都将被删除。支持的后缀包括 `d`（天）、`h`（小时）、`m`（分钟）和 `s`（秒）。示例: `7d`（7 天）、`10h`（10 小时）、`60m`（60 分钟）和 `120s`（120 秒）。此项与 `big_query_log_roll_interval` 和 `big_query_log_roll_num` 协同工作，以确定哪些文件被保留或清除。
 - 引入版本: v3.2.0
 
 ##### `big_query_log_dir`
@@ -136,8 +136,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: `Config.STARROCKS_HOME_DIR + "/log"`
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: FE 写入大查询 dump 日志 (`fe.big_query.log.*`) 的目录。Log4j 配置使用此路径为 `fe.big_query.log` 及其轮转文件创建 RollingFile appender。轮转和保留由 `big_query_log_roll_interval`（基于时间的后缀）、`log_roll_size_mb`（大小触发器）、`big_query_log_roll_num`（最大文件数）和 `big_query_log_delete_age`（基于年龄的删除）控制。对于超过用户定义阈值（例如 `big_query_log_cpu_second_threshold`、`big_query_log_scan_rows_threshold` 或 `big_query_log_scan_bytes_threshold`）的查询，会记录大查询记录。使用 `big_query_log_modules` 控制哪些模块记录到此文件中。
+- 是否可变: 否
+- 描述: FE 写入大查询转储日志 (`fe.big_query.log.*`) 的目录。Log4j 配置使用此路径为 `fe.big_query.log` 及其轮转文件创建 RollingFile appender。轮转和保留由 `big_query_log_roll_interval`（基于时间的后缀）、`log_roll_size_mb`（大小触发器）、`big_query_log_roll_num`（最大文件数）和 `big_query_log_delete_age`（基于年龄的删除）控制。对于超过用户定义阈值（例如 `big_query_log_cpu_second_threshold`、`big_query_log_scan_rows_threshold` 或 `big_query_log_scan_bytes_threshold`）的查询，会记录大查询记录。使用 `big_query_log_modules` 控制哪些模块记录到此文件。
 - 引入版本: v3.2.0
 
 ##### `big_query_log_modules`
@@ -145,8 +145,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: `{"query"}`
 - 类型: String[]
 - 单位: -
-- 是否可变: No
-- 描述: 启用每个模块大查询日志记录的模块名称后缀列表。典型值是逻辑组件名称。例如，默认的 `query` 会生成 `big_query.query`。
+- 是否可变: 否
+- 描述: 启用每个模块大查询日志记录的模块名称后缀列表。典型值为逻辑组件名称。例如，默认的 `query` 会生成 `big_query.query`。
 - 引入版本: v3.2.0
 
 ##### `big_query_log_roll_interval`
@@ -154,8 +154,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: `"DAY"`
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: 指定用于构建 `big_query` 日志 appender 滚动文件名称日期部分的时间间隔。有效值（不区分大小写）为 `DAY`（默认）和 `HOUR`。`DAY` 生成每日模式 (`"%d{yyyyMMdd}"`)，`HOUR` 生成每小时模式 (`"%d{yyyyMMddHH}"`)。该值与基于大小的轮转 (`big_query_roll_maxsize`) 和基于索引的轮转 (`big_query_log_roll_num`) 结合，形成 RollingFile filePattern。无效值会导致日志配置生成失败 (IOException)，并可能阻止日志初始化或重新配置。与 `big_query_log_dir`、`big_query_roll_maxsize`、`big_query_log_roll_num` 和 `big_query_log_delete_age` 一起使用。
+- 是否可变: 否
+- 描述: 指定用于构建 `big_query` 日志 appender 轮转文件名日期组件的时间间隔。有效值（不区分大小写）为 `DAY`（默认）和 `HOUR`。`DAY` 生成每日模式 (`"%d{yyyyMMdd}"`)，`HOUR` 生成每小时模式 (`"%d{yyyyMMddHH}"`)。该值与基于大小的轮转 (`big_query_roll_maxsize`) 和基于索引的轮转 (`big_query_log_roll_num`) 结合，形成 RollingFile 的 filePattern。无效值会导致日志配置生成失败 (IOException)，并可能阻止日志初始化或重新配置。请与 `big_query_log_dir`、`big_query_roll_maxsize`、`big_query_log_roll_num` 和 `big_query_log_delete_age` 一起使用。
 - 引入版本: v3.2.0
 
 ##### `big_query_log_roll_num`
@@ -163,8 +163,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 10
 - 类型: Int
 - 单位: -
-- 是否可变: No
-- 描述: 每个 `big_query_log_roll_interval` 保留的轮转 FE 大查询日志文件的最大数量。此值绑定到 RollingFile appender 的 DefaultRolloverStrategy `max` 属性，用于 `fe.big_query.log`；当日志轮转时（按时间或按 `log_roll_size_mb`），StarRocks 最多保留 `big_query_log_roll_num` 个索引文件（filePattern 使用时间后缀加索引）。超过此数量的文件可能会被轮转删除，`big_query_log_delete_age` 还可以根据最后修改时间删除文件。
+- 是否可变: 否
+- 描述: 每个 `big_query_log_roll_interval` 保留的轮转 FE 大查询日志文件的最大数量。此值绑定到 RollingFile appender 的 DefaultRolloverStrategy `max` 属性，用于 `fe.big_query.log`；当日志轮转时（按时间或按 `log_roll_size_mb`），StarRocks 最多保留 `big_query_log_roll_num` 个带索引的文件（filePattern 使用时间后缀加索引）。超过此计数的文件可能会被轮转删除，`big_query_log_delete_age` 还可以根据最后修改时间删除文件。
 - 引入版本: v3.2.0
 
 ##### `dump_log_delete_age`
@@ -172,8 +172,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 7d
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: dump 日志文件的保留期限。默认值 `7d` 指定每个 dump 日志文件可以保留 7 天。StarRocks 会检查每个 dump 日志文件，并删除 7 天前生成的那些。
+- 是否可变: 否
+- 描述: 转储日志文件的保留期限。默认值 `7d` 表示每个转储日志文件可以保留 7 天。StarRocks 会检查每个转储日志文件，并删除 7 天前生成的日志文件。
 - 引入版本: -
 
 ##### `dump_log_dir`
@@ -181,8 +181,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: `StarRocksFE.STARROCKS_HOME_DIR` + "/log"
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: 存储 dump 日志文件的目录。
+- 是否可变: 否
+- 描述: 存储转储日志文件的目录。
 - 引入版本: -
 
 ##### `dump_log_modules`
@@ -190,8 +190,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: query
 - 类型: String[]
 - 单位: -
-- 是否可变: No
-- 描述: StarRocks 为其生成 dump 日志条目的模块。默认情况下，StarRocks 为 query 模块生成 dump 日志。模块名称用逗号 (,) 和空格分隔。
+- 是否可变: 否
+- 描述: StarRocks 生成转储日志条目的模块。默认情况下，StarRocks 为 query 模块生成转储日志。模块名称之间用逗号 (,) 和空格分隔。
 - 引入版本: -
 
 ##### `dump_log_roll_interval`
@@ -199,10 +199,10 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: DAY
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: StarRocks 轮转 dump 日志条目的时间间隔。有效值：`DAY` 和 `HOUR`。
-  - 如果此参数设置为 `DAY`，则在 dump 日志文件名称中添加 `yyyyMMdd` 格式的后缀。
-  - 如果此参数设置为 `HOUR`，则在 dump 日志文件名称中添加 `yyyyMMddHH` 格式的后缀。
+- 是否可变: 否
+- 描述: StarRocks 轮转转储日志条目的时间间隔。有效值: `DAY` 和 `HOUR`。
+  - 如果此参数设置为 `DAY`，则转储日志文件名称中会添加 `yyyyMMdd` 格式的后缀。
+  - 如果此参数设置为 `HOUR`，则转储日志文件名称中会添加 `yyyyMMddHH` 格式的后缀。
 - 引入版本: -
 
 ##### `dump_log_roll_num`
@@ -210,8 +210,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 10
 - 类型: Int
 - 单位: -
-- 是否可变: No
-- 描述: 在 `dump_log_roll_interval` 参数指定的每个保留期内，可以保留的 dump 日志文件的最大数量。
+- 是否可变: 否
+- 描述: 在 `dump_log_roll_interval` 参数指定的每个保留期内，可以保留的转储日志文件的最大数量。
 - 引入版本: -
 
 ##### `edit_log_write_slow_log_threshold_ms`
@@ -219,8 +219,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 2000
 - 类型: Int
 - 单位: 毫秒
-- 是否可变: Yes
-- 描述: JournalWriter 用于检测和记录慢速 edit-log 批量写入的阈值（单位为毫秒）。批量提交后，如果批量持续时间超过此值，JournalWriter 将发出 WARN 日志，其中包含批量大小、持续时间和当前 Journal 队列大小（以每约 2 秒一次的速率限制）。此设置仅控制 FE Leader 上潜在 IO 或复制延迟的日志记录/警报；它不改变提交或轮转行为（请参阅 `edit_log_roll_num` 和与提交相关的设置）。无论此阈值如何，指标更新仍会发生。
+- 是否可变: 是
+- 描述: JournalWriter 用于检测和记录慢速编辑日志批次写入的阈值（单位：毫秒）。在批次提交后，如果批次持续时间超过此值，JournalWriter 将发出 WARN 消息，其中包含批次大小、持续时间和当前日志队列大小（限速为大约每 2 秒一次）。此设置仅控制 FE Leader 上潜在的 IO 或复制延迟的日志记录/警报；它不改变提交或轮转行为（参见 `edit_log_roll_num` 和与提交相关的设置）。无论此阈值如何，指标更新仍会发生。
 - 引入版本: v3.2.3
 
 ##### `enable_audit_sql`
@@ -228,8 +228,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: true
 - 类型: Boolean
 - 单位: -
-- 是否可变: No
-- 描述: 当此项设置为 `true` 时，FE 审计子系统会将 ConnectProcessor 处理的 SQL 语句文本记录到 FE 审计日志 (`fe.audit.log`) 中。存储的语句遵循其他控制：加密语句将被 redacted (`AuditEncryptionChecker`)，如果设置了 `enable_sql_desensitize_in_log`，敏感凭据可能会被 redacted 或脱敏，并且 digest 记录由 `enable_sql_digest` 控制。当设置为 `false` 时，ConnectProcessor 会在审计事件中将语句文本替换为 "?" — 其他审计字段（用户、主机、持续时间、状态、通过 `qe_slow_log_ms` 进行的慢查询检测以及指标）仍会记录。启用 SQL 审计会增加取证和故障排除的可见性，但可能会暴露敏感的 SQL 内容并增加日志量和 I/O；禁用它会提高隐私性，但代价是审计日志中会丢失完整的语句可见性。
+- 是否可变: 否
+- 描述: 当此项设置为 `true` 时，FE 审计子系统会将 ConnectProcessor 处理的语句的 SQL 文本记录到 FE 审计日志 (`fe.audit.log`) 中。存储的语句遵循其他控制：加密语句会被编辑 (`AuditEncryptionChecker`)，如果设置了 `enable_sql_desensitize_in_log`，敏感凭据可能会被编辑或脱敏，摘要记录由 `enable_sql_digest` 控制。当设置为 `false` 时，ConnectProcessor 会在审计事件中将语句文本替换为 "?"——其他审计字段（用户、主机、持续时间、状态、通过 `qe_slow_log_ms` 进行的慢查询检测以及指标）仍会被记录。启用 SQL 审计会增加取证和故障排除的可见性，但可能会暴露敏感的 SQL 内容并增加日志量和 I/O；禁用它会提高隐私性，但代价是审计日志中会丢失完整的语句可见性。
 - 引入版本: -
 
 ##### `enable_profile_log`
@@ -237,8 +237,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: true
 - 类型: Boolean
 - 单位: -
-- 是否可变: No
-- 描述: 是否启用 profile 日志。启用此功能后，FE 会将每个查询的 profile 日志（由 `ProfileManager` 生成的序列化 `queryDetail` JSON）写入 profile 日志接收器。此日志记录仅在 `enable_collect_query_detail_info` 也启用时执行；当 `enable_profile_log_compress` 启用时，JSON 可能会在日志记录前进行 gzip 压缩。Profile 日志文件由 `profile_log_dir`、`profile_log_roll_num`、`profile_log_roll_interval` 管理，并根据 `profile_log_delete_age` 进行轮转/删除（支持 `7d`、`10h`、`60m`、`120s` 等格式）。禁用此功能会停止写入 profile 日志（减少磁盘 I/O、压缩 CPU 和存储使用）。
+- 是否可变: 否
+- 描述: 是否启用 Profile 日志记录。启用此功能后，FE 会将每个查询的 Profile 日志（由 `ProfileManager` 生成的序列化 `queryDetail` JSON）写入 Profile 日志接收器。仅当 `enable_collect_query_detail_info` 也启用时才执行此日志记录；当 `enable_profile_log_compress` 启用时，JSON 可能会在记录前进行 gzip 压缩。Profile 日志文件由 `profile_log_dir`、`profile_log_roll_num`、`profile_log_roll_interval` 管理，并根据 `profile_log_delete_age` 进行轮转/删除（支持 `7d`、`10h`、`60m`、`120s` 等格式）。禁用此功能会停止写入 Profile 日志（减少磁盘 I/O、压缩 CPU 和存储使用）。
 - 引入版本: v3.2.5
 
 ##### `enable_qe_slow_log`
@@ -246,8 +246,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: true
 - 类型: Boolean
 - 单位: N/A
-- 是否可变: Yes
-- 描述: 当启用时，FE 内置审计插件 (AuditLogBuilder) 将把其测量执行时间（"Time" 字段）超过 `qe_slow_log_ms` 配置阈值的查询事件写入慢查询审计日志 (AuditLog.getSlowAudit)。如果禁用，这些慢查询条目将被抑制（常规查询和连接审计日志不受影响）。慢审计条目遵循全局 `audit_log_json_format` 设置（JSON 与纯字符串）。使用此标志可以独立于常规审计日志记录控制慢查询审计生成量；当 `qe_slow_log_ms` 较低或工作负载产生许多长时间运行的查询时，关闭它可能会减少日志 I/O。
+- 是否可变: 是
+- 描述: 启用后，FE 内置审计插件 (AuditLogBuilder) 会将执行时间（"Time" 字段）超过 `qe_slow_log_ms` 配置阈值的查询事件写入慢查询审计日志 (AuditLog.getSlowAudit)。如果禁用，这些慢查询条目将被抑制（常规查询和连接审计日志不受影响）。慢查询审计条目遵循全局 `audit_log_json_format` 设置（JSON 或纯字符串）。使用此标志可以独立于常规审计日志记录来控制慢查询审计量的生成；当 `qe_slow_log_ms` 较低或工作负载产生许多长时间运行的查询时，关闭它可以减少日志 I/O。
 - 引入版本: 3.2.11
 
 ##### `enable_sql_desensitize_in_log`
@@ -255,8 +255,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: false
 - 类型: Boolean
 - 单位: -
-- 是否可变: No
-- 描述: 当此项设置为 `true` 时，系统会在将敏感 SQL 内容写入日志和查询详细记录之前替换或隐藏这些内容。遵循此配置的代码路径包括 ConnectProcessor.formatStmt（审计日志）、StmtExecutor.addRunningQueryDetail（查询详细信息）和 SimpleExecutor.formatSQL（内部执行器日志）。启用此功能后，无效的 SQL 可能会被替换为固定的脱敏消息，凭据（用户/密码）将被隐藏，并且 SQL 格式化程序必须生成 sanitized 表示（它还可以启用摘要式输出）。这减少了审计/内部日志中敏感文字和凭据的泄露，但也意味着日志和查询详细信息不再包含原始完整 SQL 文本（这可能会影响回放或调试）。
+- 是否可变: 否
+- 描述: 当此项设置为 `true` 时，系统会在敏感 SQL 内容写入日志和查询详情记录之前对其进行替换或隐藏。遵循此配置的代码路径包括 ConnectProcessor.formatStmt（审计日志）、StmtExecutor.addRunningQueryDetail（查询详情）和 SimpleExecutor.formatSQL（内部执行器日志）。启用此功能后，无效 SQL 可能会被替换为固定的脱敏消息，凭据（用户/密码）会被隐藏，并且 SQL 格式化程序需要生成一个清理后的表示（它还可以启用摘要式输出）。这减少了审计/内部日志中敏感字面量和凭据的泄露，但也意味着日志和查询详情不再包含原始的完整 SQL 文本（这可能会影响重放或调试）。
 - 引入版本: -
 
 ##### `internal_log_delete_age`
@@ -264,8 +264,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 7d
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: 指定 FE 内部日志文件（写入 `internal_log_dir`）的保留期限。该值是一个持续时间字符串。支持的后缀：`d`（天）、`h`（小时）、`m`（分钟）、`s`（秒）。示例：`7d`（7 天）、`10h`（10 小时）、`60m`（60 分钟）、`120s`（120 秒）。此项作为 `<IfLastModified age="..."/>` 谓词替换到 Log4j 配置中，该谓词由 RollingFile Delete 策略使用。最后修改时间早于此持续时间的文件将在日志轮转期间删除。增加此值可更快释放磁盘空间，或减少此值可更长时间保留内部物化视图或统计信息日志。
+- 是否可变: 否
+- 描述: 指定 FE 内部日志文件（写入 `internal_log_dir`）的保留期限。该值是一个持续时间字符串。支持的后缀: `d`（天）、`h`（小时）、`m`（分钟）、`s`（秒）。示例: `7d`（7 天）、`10h`（10 小时）、`60m`（60 分钟）、`120s`（120 秒）。此项作为 `<IfLastModified age="..."/>` 谓词替换到 log4j 配置中，由 RollingFile Delete 策略使用。在日志轮转期间，最后修改时间早于此持续时间的文件将被删除。增加此值可以更快地释放磁盘空间，或减少此值以更长时间地保留内部物化视图或统计日志。
 - 引入版本: v3.2.4
 
 ##### `internal_log_dir`
@@ -273,8 +273,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: `Config.STARROCKS_HOME_DIR` + "/log"
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: FE 日志记录子系统用于存储内部日志 (`fe.internal.log`) 的目录。此配置将替换到 Log4j 配置中，并决定 InternalFile appender 在何处写入内部/物化视图/统计信息日志，以及 `internal.<module>` 下的每个模块日志记录器在何处放置其文件。确保目录存在、可写并具有足够的磁盘空间。此目录中文件的日志轮转和保留由 `log_roll_size_mb`、`internal_log_roll_num`、`internal_log_delete_age` 和 `internal_log_roll_interval` 控制。如果 `sys_log_to_console` 启用，内部日志可能会写入控制台而不是此目录。
+- 是否可变: 否
+- 描述: FE 日志子系统用于存储内部日志 (`fe.internal.log`) 的目录。此配置被替换到 Log4j 配置中，并决定 InternalFile appender 写入内部/物化视图/统计日志的位置，以及 `internal.<module>` 下的每个模块日志记录器放置其文件的位置。确保目录存在、可写且有足够的磁盘空间。此目录中文件的日志轮转和保留由 `log_roll_size_mb`、`internal_log_roll_num`、`internal_log_delete_age` 和 `internal_log_roll_interval` 控制。如果 `sys_log_to_console` 启用，内部日志可能会写入控制台而不是此目录。
 - 引入版本: v3.2.4
 
 ##### `internal_log_json_format`
@@ -282,8 +282,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: false
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 当此项设置为 `true` 时，内部统计/审计条目将作为紧凑的 JSON 对象写入统计审计日志记录器。JSON 包含键 "executeType" (InternalType: QUERY 或 DML)、"queryId"、"sql" 和 "time"（已用毫秒）。当设置为 `false` 时，相同的信息将记录为单个格式化文本行（"statistic execute: ... | QueryId: [...] | SQL: ..."）。启用 JSON 可改进机器解析并与日志处理器集成，但也会导致原始 SQL 文本包含在日志中，这可能会暴露敏感信息并增加日志大小。
+- 是否可变: 是
+- 描述: 当此项设置为 `true` 时，内部统计/审计条目将作为紧凑的 JSON 对象写入统计审计日志记录器。JSON 包含键 "executeType" (InternalType: QUERY 或 DML)、"queryId"、"sql" 和 "time"（经过的毫秒数）。当设置为 `false` 时，相同的信息将作为单个格式化文本行 ("statistic execute: ... | QueryId: [...] | SQL: ...") 记录。启用 JSON 改进了机器解析和与日志处理器的集成，但也会导致原始 SQL 文本包含在日志中，这可能会暴露敏感信息并增加日志大小。
 - 引入版本: -
 
 ##### `internal_log_modules`
@@ -291,8 +291,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: `{"base", "statistic"}`
 - 类型: String[]
 - 单位: -
-- 是否可变: No
-- 描述: 将接收专用内部日志记录的模块标识符列表。对于每个条目 X，Log4j 将创建一个名为 `internal.<X>` 的日志记录器，其级别为 INFO，并且 additivity="false"。这些日志记录器被路由到内部 appender（写入 `fe.internal.log`），或者在 `sys_log_to_console` 启用时路由到控制台。根据需要使用短名称或包片段 — 确切的日志记录器名称变为 `internal.` + 配置的字符串。内部日志文件轮转和保留遵循 `internal_log_dir`、`internal_log_roll_num`、`internal_log_delete_age`、`internal_log_roll_interval` 和 `log_roll_size_mb`。添加模块会导致其运行时消息分离到内部日志记录器流中，以便于调试和审计。
+- 是否可变: 否
+- 描述: 将接收专用内部日志记录的模块标识符列表。对于每个条目 X，Log4j 会创建一个名为 `internal.<X>` 的日志记录器，其级别为 INFO 且 additivity="false"。这些日志记录器被路由到内部 appender（写入 `fe.internal.log`），或者当 `sys_log_to_console` 启用时路由到控制台。根据需要使用短名称或包片段——确切的日志记录器名称变为 `internal.` + 配置的字符串。内部日志文件轮转和保留遵循 `internal_log_dir`、`internal_log_roll_num`、`internal_log_delete_age`、`internal_log_roll_interval` 和 `log_roll_size_mb`。添加模块会导致其运行时消息分离到内部日志流中，以便于调试和审计。
 - 引入版本: v3.2.4
 
 ##### `internal_log_roll_interval`
@@ -300,8 +300,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: DAY
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: 控制 FE 内部日志 appender 的基于时间的滚动间隔。接受的值（不区分大小写）为 `HOUR` 和 `DAY`。`HOUR` 生成每小时的文件模式 (`"%d{yyyyMMddHH}"`)，`DAY` 生成每日文件模式 (`"%d{yyyyMMdd}"`)，这些模式由 RollingFile TimeBasedTriggeringPolicy 用于命名轮转的 `fe.internal.log` 文件。无效值会导致初始化失败（构建活动 Log4j 配置时抛出 IOException）。滚动行为还取决于相关设置，例如 `internal_log_dir`、`internal_roll_maxsize`、`internal_log_roll_num` 和 `internal_log_delete_age`。
+- 是否可变: 否
+- 描述: 控制 FE 内部日志 appender 的基于时间的轮转间隔。接受的值（不区分大小写）为 `HOUR` 和 `DAY`。`HOUR` 生成每小时文件模式 (`"%d{yyyyMMddHH}"`)，`DAY` 生成每日文件模式 (`"%d{yyyyMMdd}"`)，这些模式由 RollingFile TimeBasedTriggeringPolicy 用于命名轮转的 `fe.internal.log` 文件。无效值会导致初始化失败（在构建活动 Log4j 配置时抛出 IOException）。轮转行为还取决于相关设置，例如 `internal_log_dir`、`internal_roll_maxsize`、`internal_log_roll_num` 和 `internal_log_delete_age`。
 - 引入版本: v3.2.4
 
 ##### `internal_log_roll_num`
@@ -309,8 +309,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 90
 - 类型: Int
 - 单位: -
-- 是否可变: No
-- 描述: 为内部 appender (`fe.internal.log`) 保留的轮转 FE 内部日志文件的最大数量。此值用作 Log4j DefaultRolloverStrategy `max` 属性；当发生轮转时，StarRocks 最多保留 `internal_log_roll_num` 个归档文件并删除旧文件（也受 `internal_log_delete_age` 控制）。较低的值会减少磁盘使用，但会缩短日志历史记录；较高的值会保留更多的历史内部日志。此项与 `internal_log_dir`、`internal_log_roll_interval` 和 `internal_roll_maxsize` 协同工作。
+- 是否可变: 否
+- 描述: 内部 appender (`fe.internal.log`) 保留的轮转内部 FE 日志文件的最大数量。此值用作 Log4j DefaultRolloverStrategy 的 `max` 属性；当发生轮转时，StarRocks 最多保留 `internal_log_roll_num` 个归档文件并删除旧文件（也受 `internal_log_delete_age` 控制）。较低的值会减少磁盘使用量但缩短日志历史记录；较高的值会保留更多历史内部日志。此项与 `internal_log_dir`、`internal_log_roll_interval` 和 `internal_roll_maxsize` 协同工作。
 - 引入版本: v3.2.4
 
 ##### `log_cleaner_audit_log_min_retention_days`
@@ -318,8 +318,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 3
 - 类型: Int
 - 单位: 天
-- 是否可变: Yes
-- 描述: 审计日志文件的最小保留天数。早于此时间的审计日志文件即使磁盘使用率很高也不会被删除。这确保了审计日志为合规性和故障排除目的而保留。
+- 是否可变: 是
+- 描述: 审计日志文件的最小保留天数。即使磁盘使用率很高，早于此日期的审计日志文件也不会被删除。这确保了审计日志用于合规性和故障排除目的而得到保留。
 - 引入版本: -
 
 ##### `log_cleaner_check_interval_second`
@@ -327,7 +327,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 300
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
+- 是否可变: 是
 - 描述: 检查磁盘使用情况和清理日志的间隔（秒）。清理器会定期检查每个日志目录的磁盘使用情况，并在必要时触发清理。默认值为 300 秒（5 分钟）。
 - 引入版本: -
 
@@ -336,7 +336,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 60
 - 类型: Int
 - 单位: 百分比
-- 是否可变: Yes
+- 是否可变: 是
 - 描述: 日志清理后的目标磁盘使用率（百分比）。日志清理将持续进行，直到磁盘使用率降至此阈值以下。清理器会逐个删除最旧的日志文件，直到达到目标。
 - 引入版本: -
 
@@ -345,8 +345,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 80
 - 类型: Int
 - 单位: 百分比
-- 是否可变: Yes
-- 描述: 触发日志清理的磁盘使用率阈值（百分比）。当磁盘使用率超过此阈值时，日志清理将开始。清理器会独立检查每个配置的日志目录，并处理超过此阈值的目录。
+- 是否可变: 是
+- 描述: 触发日志清理的磁盘使用率阈值（百分比）。当磁盘使用率超过此阈值时，将开始日志清理。清理器会独立检查每个配置的日志目录，并处理超过此阈值的目录。
 - 引入版本: -
 
 ##### `log_cleaner_disk_util_based_enable`
@@ -354,8 +354,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: false
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 启用基于磁盘使用率的自动日志清理。启用后，当磁盘使用率超过阈值时，将清理日志。日志清理器作为 FE 节点上的后台守护程序运行，有助于防止日志文件累积导致磁盘空间耗尽。
+- 是否可变: 是
+- 描述: 启用基于磁盘使用率的自动日志清理。启用后，当磁盘使用率超过阈值时，将清理日志。日志清理器作为 FE 节点上的后台守护进程运行，有助于防止日志文件堆积导致磁盘空间耗尽。
 - 引入版本: -
 
 ##### `log_plan_cancelled_by_crash_be`
@@ -363,8 +363,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: true
 - 类型: boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 当查询因 BE 崩溃或 RPC 异常而取消时，是否启用查询执行计划日志记录。启用此功能后，当查询因 BE 崩溃或 `RpcException` 而取消时，StarRocks 会将查询执行计划（`TExplainLevel.COSTS` 级别）记录为 WARN 条目。日志条目包括 QueryId、SQL 和 COSTS 计划；在 ExecuteExceptionHandler 路径中，还会记录异常堆栈跟踪。当 `enable_collect_query_detail_info` 启用时，日志记录会被跳过（计划随后存储在查询详细信息中）—— 在代码路径中，通过验证查询详细信息是否为 null 来执行检查。请注意，在 ExecuteExceptionHandler 中，计划仅在第一次重试时 (`retryTime == 0`) 记录。启用此功能可能会增加日志量，因为完整的 COSTS 计划可能很大。
+- 是否可变: 是
+- 描述: 当查询因 BE 崩溃或 RPC 异常而取消时，是否启用查询执行计划日志记录。启用此功能后，当查询因 BE 崩溃或 `RpcException` 而取消时，StarRocks 会将查询执行计划（`TExplainLevel.COSTS` 级别）作为 WARN 条目记录。日志条目包括 QueryId、SQL 和 COSTS 计划；在 ExecuteExceptionHandler 路径中，还会记录异常堆栈跟踪。当 `enable_collect_query_detail_info` 启用时，日志记录会被跳过（计划此时存储在查询详情中）——在代码路径中，通过验证查询详情是否为 null 来执行检查。请注意，在 ExecuteExceptionHandler 中，计划仅在第一次重试 (`retryTime == 0`) 时记录。启用此功能可能会增加日志量，因为完整的 COSTS 计划可能很大。
 - 引入版本: v3.2.0
 
 ##### `log_register_and_unregister_query_id`
@@ -372,8 +372,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: false
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否允许 FE 记录来自 QeProcessorImpl 的查询注册和注销消息（例如，`"register query id = {}"` 和 `"deregister query id = {}"`）。仅当查询具有非空 ConnectContext 且命令不是 `COM_STMT_EXECUTE` 或会话变量 `isAuditExecuteStmt()` 为 true 时才发出日志。由于这些消息是为每个查询生命周期事件写入的，因此启用此功能可能会产生大量日志并成为高并发环境中的吞吐量瓶颈。启用它用于调试或审计；禁用它以减少日志记录开销并提高性能。
+- 是否可变: 是
+- 描述: 是否允许 FE 记录来自 QeProcessorImpl 的查询注册和注销消息（例如，`"register query id = {}"` 和 `"deregister query id = {}"`）。仅当查询具有非空 ConnectContext 且命令不是 `COM_STMT_EXECUTE` 或会话变量 `isAuditExecuteStmt()` 为 true 时，才会发出日志。由于这些消息是为每个查询生命周期事件写入的，因此启用此功能可能会产生大量日志，并在高并发环境中成为吞吐量瓶颈。启用它用于调试或审计；禁用它以减少日志记录开销并提高性能。
 - 引入版本: v3.3.0, v3.4.0, v3.5.0
 
 ##### `log_roll_size_mb`
@@ -381,7 +381,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1024
 - 类型: Int
 - 单位: MB
-- 是否可变: No
+- 是否可变: 否
 - 描述: 系统日志文件或审计日志文件的最大大小。
 - 引入版本: -
 
@@ -390,8 +390,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1
 - 类型: Int
 - 单位: 天
-- 是否可变: Yes
-- 描述: 保留 `sys_log_dir/proc_profile` 下生成的进程分析文件（CPU 和内存）的天数。ProcProfileCollector 通过将 `proc_profile_file_retained_days` 天数从当前时间（格式为 yyyyMMdd-HHmmss）中减去来计算截止时间，并删除时间戳部分在字典序上早于该截止时间的分析文件（即 `timePart.compareTo(timeToDelete) < 0`）。文件删除还遵循由 `proc_profile_file_retained_size_bytes` 控制的基于大小的截止时间。分析文件使用 `cpu-profile-` 和 `mem-profile-` 前缀，并在收集后进行压缩。
+- 是否可变: 是
+- 描述: 保留在 `sys_log_dir/proc_profile` 下生成的进程分析文件（CPU 和内存）的天数。ProcProfileCollector 通过从当前时间（格式为 yyyyMMdd-HHmmss）减去 `proc_profile_file_retained_days` 天来计算截止日期，并删除时间戳部分按字典顺序早于该截止日期的分析文件（即 `timePart.compareTo(timeToDelete) < 0`）。文件删除也遵循由 `proc_profile_file_retained_size_bytes` 控制的基于大小的截止日期。分析文件使用 `cpu-profile-` 和 `mem-profile-` 前缀，并在收集后进行压缩。
 - 引入版本: v3.2.12
 
 ##### `proc_profile_file_retained_size_bytes`
@@ -399,8 +399,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 2L * 1024 * 1024 * 1024 (2147483648)
 - 类型: Long
 - 单位: 字节
-- 是否可变: Yes
-- 描述: 在分析目录下保留的收集到的 CPU 和内存分析文件（文件名前缀为 `cpu-profile-` 和 `mem-profile-`）的最大总字节数。当有效分析文件的总和超过 `proc_profile_file_retained_size_bytes` 时，收集器将删除最旧的分析文件，直到剩余总大小小于或等于 `proc_profile_file_retained_size_bytes`。早于 `proc_profile_file_retained_days` 的文件也将被删除，无论大小如何。此设置控制分析归档的磁盘使用情况，并与 `proc_profile_file_retained_days` 交互以确定删除顺序和保留。
+- 是否可变: 是
+- 描述: 在分析目录下保留的已收集 CPU 和内存分析文件（文件名前缀为 `cpu-profile-` 和 `mem-profile-`）的最大总字节数。当有效分析文件的总和超过 `proc_profile_file_retained_size_bytes` 时，收集器会删除最旧的分析文件，直到剩余总大小小于或等于 `proc_profile_file_retained_size_bytes`。早于 `proc_profile_file_retained_days` 的文件也会被删除，无论大小如何。此设置控制分析归档的磁盘使用量，并与 `proc_profile_file_retained_days` 交互以确定删除顺序和保留。
 - 引入版本: v3.2.12
 
 ##### `profile_log_delete_age`
@@ -408,8 +408,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1d
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: 控制 FE profile 日志文件在符合删除条件之前保留多长时间。该值注入到 Log4j 的 `<IfLastModified age="..."/>` 策略（通过 `Log4jConfig`）中，并与轮转设置（如 `profile_log_roll_interval` 和 `profile_log_roll_num`）一起应用。支持的后缀：`d`（天）、`h`（小时）、`m`（分钟）、`s`（秒）。例如：`7d`（7 天）、`10h`（10 小时）、`60m`（60 分钟）、`120s`（120 秒）。
+- 是否可变: 否
+- 描述: 控制 FE Profile 日志文件在符合删除条件之前保留多长时间。该值通过 `Log4jConfig` 注入到 Log4j 的 `<IfLastModified age="..."/>` 策略中，并与 `profile_log_roll_interval` 和 `profile_log_roll_num` 等轮转设置一起应用。支持的后缀: `d`（天）、`h`（小时）、`m`（分钟）、`s`（秒）。例如: `7d`（7 天）、`10h`（10 小时）、`60m`（60 分钟）、`120s`（120 秒）。
 - 引入版本: v3.2.5
 
 ##### `profile_log_dir`
@@ -417,8 +417,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: `Config.STARROCKS_HOME_DIR` + "/log"
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: FE profile 日志的写入目录。Log4jConfig 使用此值放置与 profile 相关的 appender（在此目录下创建 `fe.profile.log` 和 `fe.features.log` 等文件）。这些文件的轮转和保留由 `profile_log_roll_size_mb`、`profile_log_roll_num` 和 `profile_log_delete_age` 控制；时间戳后缀格式由 `profile_log_roll_interval` 控制（支持 DAY 或 HOUR）。由于默认目录位于 `STARROCKS_HOME_DIR` 下，请确保 FE 进程对此目录具有写入和轮转/删除权限。
+- 是否可变: 否
+- 描述: FE Profile 日志的写入目录。Log4jConfig 使用此值来放置与 Profile 相关的 appender（在此目录下创建 `fe.profile.log` 和 `fe.features.log` 等文件）。这些文件的轮转和保留由 `profile_log_roll_size_mb`、`profile_log_roll_num` 和 `profile_log_delete_age` 控制；时间戳后缀格式由 `profile_log_roll_interval` 控制（支持 DAY 或 HOUR）。由于默认目录在 `STARROCKS_HOME_DIR` 下，请确保 FE 进程对此目录具有写入和轮转/删除权限。
 - 引入版本: v3.2.5
 
 ##### `profile_log_roll_interval`
@@ -426,8 +426,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: DAY
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: 控制用于生成 profile 日志文件名日期部分的时间粒度。有效值（不区分大小写）为 `HOUR` 和 `DAY`。`HOUR` 生成模式 `"%d{yyyyMMddHH}"`（每小时时间桶），`DAY` 生成 `"%d{yyyyMMdd}"`（每日时间桶）。此值在 Log4j 配置中计算 `profile_file_pattern` 时使用，并且仅影响轮转文件名称中基于时间的组件；基于大小的轮转仍由 `profile_log_roll_size_mb` 控制，保留由 `profile_log_roll_num` / `profile_log_delete_age` 控制。无效值会导致日志初始化期间发生 IOException（错误消息：`"profile_log_roll_interval config error: <value>"`）。对于高容量 profiling，选择 `HOUR` 以限制每小时的文件大小，或选择 `DAY` 进行每日聚合。
+- 是否可变: 否
+- 描述: 控制用于生成 Profile 日志文件名日期部分的时间粒度。有效值（不区分大小写）为 `HOUR` 和 `DAY`。`HOUR` 生成 `"%d{yyyyMMddHH}"` 模式（每小时时间桶），`DAY` 生成 `"%d{yyyyMMdd}"` 模式（每日时间桶）。此值在 Log4j 配置中计算 `profile_file_pattern` 时使用，并且仅影响轮转文件名的基于时间的组件；基于大小的轮转仍由 `profile_log_roll_size_mb` 控制，保留由 `profile_log_roll_num` / `profile_log_delete_age` 控制。无效值会导致日志初始化期间抛出 IOException（错误消息: `"profile_log_roll_interval config error: <value>"`）。对于高容量分析，选择 `HOUR` 以限制每小时的文件大小，或选择 `DAY` 进行每日聚合。
 - 引入版本: v3.2.5
 
 ##### `profile_log_roll_num`
@@ -435,8 +435,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 5
 - 类型: Int
 - 单位: -
-- 是否可变: No
-- 描述: 指定 Log4j 的 DefaultRolloverStrategy 为 profile 日志记录器保留的最大轮转 profile 日志文件数。此值作为 `${profile_log_roll_num}` 注入到日志 XML 中（例如 `<DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min">`）。轮转由 `profile_log_roll_size_mb` 或 `profile_log_roll_interval` 触发；当发生轮转时，Log4j 最多保留这些索引文件，旧的索引文件将符合删除条件。磁盘上的实际保留也受 `profile_log_delete_age` 和 `profile_log_dir` 位置的影响。较低的值会减少磁盘使用，但会限制保留的历史记录；较高的值会保留更多的历史 profile 日志。
+- 是否可变: 否
+- 描述: 指定 Log4j 的 DefaultRolloverStrategy 为 Profile 日志记录器保留的轮转 Profile 日志文件的最大数量。此值作为 `${profile_log_roll_num}` 注入到日志 XML 中（例如 `<DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min">`）。轮转由 `profile_log_roll_size_mb` 或 `profile_log_roll_interval` 触发；当发生轮转时，Log4j 最多保留这些带索引的文件，旧的索引文件将符合删除条件。磁盘上的实际保留也受 `profile_log_delete_age` 和 `profile_log_dir` 位置的影响。较低的值会减少磁盘使用量但限制保留历史记录；较高的值会保留更多历史 Profile 日志。
 - 引入版本: v3.2.5
 
 ##### `profile_log_roll_size_mb`
@@ -444,8 +444,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1024
 - 类型: Int
 - 单位: MB
-- 是否可变: No
-- 描述: 设置触发 FE profile 日志文件基于大小轮转的大小阈值（以兆字节为单位）。此值由 Log4j RollingFile SizeBasedTriggeringPolicy 用于 `ProfileFile` appender；当 profile 日志超过 `profile_log_roll_size_mb` 时，它将被轮转。当达到 `profile_log_roll_interval` 时，也可以按时间进行轮转——任一条件都会触发轮转。结合 `profile_log_roll_num` 和 `profile_log_delete_age`，此项控制保留多少历史 profile 文件以及何时删除旧文件。轮转文件的压缩由 `enable_profile_log_compress` 控制。
+- 是否可变: 否
+- 描述: 设置触发 FE Profile 日志文件基于大小轮转的大小阈值（单位：兆字节）。此值由 Log4j RollingFile SizeBasedTriggeringPolicy 用于 `ProfileFile` appender；当 Profile 日志超过 `profile_log_roll_size_mb` 时，它将被轮转。当达到 `profile_log_roll_interval` 时，也可以按时间进行轮转——任一条件都会触发轮转。结合 `profile_log_roll_num` 和 `profile_log_delete_age`，此项控制保留多少历史 Profile 文件以及何时删除旧文件。轮转文件的压缩由 `enable_profile_log_compress` 控制。
 - 引入版本: v3.2.5
 
 ##### `qe_slow_log_ms`
@@ -453,8 +453,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 5000
 - 类型: Long
 - 单位: 毫秒
-- 是否可变: Yes
-- 描述: 用于判断查询是否为慢查询的阈值。如果查询的响应时间超过此阈值，则会在 **fe.audit.log** 中记录为慢查询。
+- 是否可变: 是
+- 描述: 用于判断查询是否为慢查询的阈值。如果查询的响应时间超过此阈值，则将其记录为 **fe.audit.log** 中的慢查询。
 - 引入版本: -
 
 ##### `slow_lock_log_every_ms`
@@ -462,8 +462,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 3000L
 - 类型: Long
 - 单位: 毫秒
-- 是否可变: Yes
-- 描述: 在为同一 SlowLockLogStats 实例发出另一个“慢锁”警告之前，等待的最短间隔（以毫秒为单位）。LockUtils 在锁等待超过 `slow_lock_threshold_ms` 后检查此值，并会抑制额外的警告，直到自上次记录慢锁事件以来已过去 `slow_lock_log_every_ms` 毫秒。使用更大的值可在长时间争用期间减少日志量，或使用更小的值以获得更频繁的诊断。更改在运行时对后续检查生效。
+- 是否可变: 是
+- 描述: 在为同一 SlowLockLogStats 实例发出另一个“慢锁”警告之前等待的最小间隔（单位：毫秒）。在锁等待超过 `slow_lock_threshold_ms` 后，LockUtils 会检查此值，并会抑制额外的警告，直到自上次记录慢锁事件以来已过去 `slow_lock_log_every_ms` 毫秒。使用较大的值可以在长时间争用期间减少日志量，或使用较小的值以获得更频繁的诊断。更改在运行时对后续检查生效。
 - 引入版本: v3.2.0
 
 ##### `slow_lock_print_stack`
@@ -471,8 +471,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: true
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否允许 LockManager 在 `logSlowLockTrace` 发出的慢锁警告的 JSON 负载中包含拥有线程的完整堆栈跟踪（"stack" 数组通过 `LogUtil.getStackTraceToJsonArray` 填充，`start=0` 且 `max=Short.MAX_VALUE`）。此配置仅控制当锁获取超过由 `slow_lock_threshold_ms` 配置的阈值时显示的锁所有者的额外堆栈信息。启用此功能通过提供持有锁的精确线程堆栈来帮助调试；禁用它可减少日志量和在高并发环境中捕获和序列化堆栈跟踪导致的 CPU/内存开销。
+- 是否可变: 是
+- 描述: 是否允许 LockManager 在 `logSlowLockTrace` 发出的慢锁警告的 JSON 负载中包含持有线程的完整堆栈跟踪（"stack" 数组通过 `LogUtil.getStackTraceToJsonArray` 填充，`start=0` 且 `max=Short.MAX_VALUE`）。此配置仅控制当锁获取超过 `slow_lock_threshold_ms` 配置的阈值时显示的锁持有者的额外堆栈信息。启用此功能通过提供精确的持有锁的线程堆栈来帮助调试；禁用它会减少日志量以及在高并发环境中捕获和序列化堆栈跟踪所导致的 CPU/内存开销。
 - 引入版本: v3.3.16, v3.4.5, v3.5.1
 
 ##### `slow_lock_threshold_ms`
@@ -480,8 +480,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 3000L
 - 类型: long
 - 单位: 毫秒
-- 是否可变: Yes
-- 描述: 用于将锁操作或持有的锁分类为“慢”的阈值（以毫秒为单位）。当锁的等待或持有时间超过此值时，StarRocks 将（根据上下文）发出诊断日志，包括堆栈跟踪或等待/所有者信息，并在 LockManager 中在此延迟后开始死锁检测。它由 LockUtils（慢锁日志记录）、QueryableReentrantReadWriteLock（过滤慢速读取器）、LockManager（死锁检测延迟和慢锁跟踪）、LockChecker（周期性慢锁检测）和其他调用者（例如 DiskAndTabletLoadReBalancer 日志记录）使用。降低此值会增加敏感性和日志记录/诊断开销；将其设置为 0 或负值会禁用初始基于等待的死锁检测延迟行为。与 `slow_lock_log_every_ms`、`slow_lock_print_stack` 和 `slow_lock_stack_trace_reserve_levels` 一起调整。
+- 是否可变: 是
+- 描述: 用于将锁操作或持有的锁归类为“慢”的阈值（单位：毫秒）。当锁的等待或持有时间超过此值时，StarRocks 将（根据上下文）发出诊断日志，包含堆栈跟踪或等待者/持有者信息，并且——在 LockManager 中——在此延迟后启动死锁检测。它被 LockUtils（慢锁日志记录）、QueryableReentrantReadWriteLock（过滤慢速读取器）、LockManager（死锁检测延迟和慢锁跟踪）、LockChecker（周期性慢锁检测）以及其他调用者（例如 DiskAndTabletLoadReBalancer 日志记录）使用。降低此值会增加敏感度和日志记录/诊断开销；将其设置为 0 或负值会禁用初始的基于等待的死锁检测延迟行为。请与 `slow_lock_log_every_ms`、`slow_lock_print_stack` 和 `slow_lock_stack_trace_reserve_levels` 一起调整。
 - 引入版本: 3.2.0
 
 ##### `sys_log_delete_age`
@@ -489,8 +489,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 7d
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: 系统日志文件的保留期限。默认值 `7d` 指定每个系统日志文件可以保留 7 天。StarRocks 会检查每个系统日志文件，并删除 7 天前生成的那些。
+- 是否可变: 否
+- 描述: 系统日志文件的保留期限。默认值 `7d` 表示每个系统日志文件可以保留 7 天。StarRocks 会检查每个系统日志文件，并删除 7 天前生成的日志文件。
 - 引入版本: -
 
 ##### `sys_log_dir`
@@ -498,7 +498,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: `StarRocksFE.STARROCKS_HOME_DIR` + "/log"
 - 类型: String
 - 单位: -
-- 是否可变: No
+- 是否可变: 否
 - 描述: 存储系统日志文件的目录。
 - 引入版本: -
 
@@ -507,8 +507,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: false
 - 类型: boolean
 - 单位: -
-- 是否可变: No
-- 描述: 当此项设置为 `true` 时，系统会将 ".gz" 后缀附加到轮转的系统日志文件名中，以便 Log4j 会生成 gzip 压缩的轮转 FE 系统日志（例如，fe.log.*）。此值在 Log4j 配置生成期间（Log4jConfig.initLogging / generateActiveLog4jXmlConfig）读取，并控制 RollingFile filePattern 中使用的 `sys_file_postfix` 属性。启用此功能可减少保留日志的磁盘使用，但会增加轮转期间的 CPU 和 I/O，并更改日志文件名，因此读取日志的工具或脚本必须能够处理 .gz 文件。请注意，审计日志使用单独的压缩配置，即 `audit_log_enable_compress`。
+- 是否可变: 否
+- 描述: 当此项设置为 `true` 时，系统会在轮转的系统日志文件名后附加 ".gz" 后缀，以便 Log4j 生成 gzip 压缩的轮转 FE 系统日志（例如 fe.log.*）。此值在 Log4j 配置生成期间（Log4jConfig.initLogging / generateActiveLog4jXmlConfig）读取，并控制 RollingFile filePattern 中使用的 `sys_file_postfix` 属性。启用此功能可减少保留日志的磁盘使用量，但会增加轮转期间的 CPU 和 I/O，并更改日志文件名，因此读取日志的工具或脚本必须能够处理 .gz 文件。请注意，审计日志使用单独的压缩配置，即 `audit_log_enable_compress`。
 - 引入版本: v3.2.12
 
 ##### `sys_log_format`
@@ -516,8 +516,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: "plaintext"
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: 选择 FE 日志使用的 Log4j 布局。有效值：`"plaintext"`（默认）和 `"json"`。值不区分大小写。`"plaintext"` 配置 PatternLayout，具有人类可读的时间戳、级别、线程、类.方法:行，以及 WARN/ERROR 的堆栈跟踪。`"json"` 配置 JsonTemplateLayout 并发出结构化 JSON 事件（UTC 时间戳、级别、线程 ID/名称、源文件/方法/行、消息、异常堆栈跟踪），适用于日志聚合器（ELK、Splunk）。JSON 输出遵循 `sys_log_json_max_string_length` 和 `sys_log_json_profile_max_string_length` 以获取最大字符串长度。
+- 是否可变: 否
+- 描述: 选择用于 FE 日志的 Log4j 布局。有效值: `"plaintext"`（默认）和 `"json"`。这些值不区分大小写。`"plaintext"` 配置 PatternLayout，具有人类可读的时间戳、级别、线程、类.方法:行以及 WARN/ERROR 的堆栈跟踪。`"json"` 配置 JsonTemplateLayout 并发出结构化 JSON 事件（UTC 时间戳、级别、线程 ID/名称、源文件/方法/行、消息、异常堆栈跟踪），适用于日志聚合器（ELK、Splunk）。JSON 输出遵循 `sys_log_json_max_string_length` 和 `sys_log_json_profile_max_string_length` 以限制最大字符串长度。
 - 引入版本: v3.2.10
 
 ##### `sys_log_json_max_string_length`
@@ -525,8 +525,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1048576
 - 类型: Int
 - 单位: 字节
-- 是否可变: No
-- 描述: 设置用于 JSON 格式系统日志的 JsonTemplateLayout "maxStringLength" 值。当 `sys_log_format` 设置为 `"json"` 时，如果字符串值字段（例如 "message" 和字符串化的异常堆栈跟踪）的长度超过此限制，它们将被截断。该值注入到 `Log4jConfig.generateActiveLog4jXmlConfig()` 中生成的 Log4j XML 中，并应用于默认、警告、审计、dump 和大查询布局。profile 布局使用单独的配置 (`sys_log_json_profile_max_string_length`)。降低此值会减小日志大小，但可能会截断有用信息。
+- 是否可变: 否
+- 描述: 设置用于 JSON 格式系统日志的 JsonTemplateLayout "maxStringLength" 值。当 `sys_log_format` 设置为 `"json"` 时，如果字符串类型字段（例如 "message" 和字符串化的异常堆栈跟踪）的长度超过此限制，它们将被截断。该值被注入到 Log4jConfig.generateActiveLog4jXmlConfig() 中生成的 Log4j XML 中，并应用于默认、警告、审计、转储和大查询布局。Profile 布局使用单独的配置 (`sys_log_json_profile_max_string_length`)。降低此值会减少日志大小，但可能会截断有用信息。
 - 引入版本: 3.2.11
 
 ##### `sys_log_json_profile_max_string_length`
@@ -534,8 +534,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 104857600 (100 MB)
 - 类型: Int
 - 单位: 字节
-- 是否可变: No
-- 描述: 当 `sys_log_format` 为 "json" 时，设置 profile（及相关功能）日志 appender 的 JsonTemplateLayout 的 maxStringLength。JSON 格式 profile 日志中的字符串字段值将被截断为此外字节长度；非字符串字段不受影响。此项应用于 Log4jConfig `JsonTemplateLayout maxStringLength`，并在使用 `plaintext` 日志记录时被忽略。保持足够大的值以获取您需要的完整消息，但请注意，较大的值会增加日志大小和 I/O。
+- 是否可变: 否
+- 描述: 当 `sys_log_format` 为 "json" 时，设置 Profile（及相关功能）日志 appender 的 JsonTemplateLayout 的 maxStringLength。JSON 格式 Profile 日志中的字符串字段值将被截断为此字节长度；非字符串字段不受影响。此项应用于 Log4jConfig `JsonTemplateLayout maxStringLength`，并在使用 `plaintext` 日志记录时被忽略。保持该值足够大以容纳您需要的完整消息，但请注意，较大的值会增加日志大小和 I/O。
 - 引入版本: v3.2.11
 
 ##### `sys_log_level`
@@ -543,8 +543,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: INFO
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: 系统日志条目分类的严重性级别。有效值：`INFO`、`WARN`、`ERROR` 和 `FATAL`。
+- 是否可变: 否
+- 描述: 系统日志条目分类的严重性级别。有效值: `INFO`、`WARN`、`ERROR` 和 `FATAL`。
 - 引入版本: -
 
 ##### `sys_log_roll_interval`
@@ -552,10 +552,10 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: DAY
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: StarRocks 轮转系统日志条目的时间间隔。有效值：`DAY` 和 `HOUR`。
-  - 如果此参数设置为 `DAY`，则在系统日志文件名称中添加 `yyyyMMdd` 格式的后缀。
-  - 如果此参数设置为 `HOUR`，则在系统日志文件名称中添加 `yyyyMMddHH` 格式的后缀。
+- 是否可变: 否
+- 描述: StarRocks 轮转系统日志条目的时间间隔。有效值: `DAY` 和 `HOUR`。
+  - 如果此参数设置为 `DAY`，则系统日志文件名称中会添加 `yyyyMMdd` 格式的后缀。
+  - 如果此参数设置为 `HOUR`，则系统日志文件名称中会添加 `yyyyMMddHH` 格式的后缀。
 - 引入版本: -
 
 ##### `sys_log_roll_num`
@@ -563,17 +563,17 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 10
 - 类型: Int
 - 单位: -
-- 是否可变: No
+- 是否可变: 否
 - 描述: 在 `sys_log_roll_interval` 参数指定的每个保留期内，可以保留的系统日志文件的最大数量。
 - 引入版本: -
 
 ##### `sys_log_to_console`
 
-- 默认值: false（除非环境变量 `SYS_LOG_TO_CONSOLE` 设置为 "1"）
+- 默认值: false (除非环境变量 `SYS_LOG_TO_CONSOLE` 设置为 "1")
 - 类型: Boolean
 - 单位: -
-- 是否可变: No
-- 描述: 当此项设置为 `true` 时，系统会将 Log4j 配置为将所有日志发送到控制台 (ConsoleErr appender)，而不是基于文件的 appender。此值在生成活动 Log4j XML 配置时读取（这会影响根日志记录器和每个模块日志记录器 appender 的选择）。其值在进程启动时从 `SYS_LOG_TO_CONSOLE` 环境变量中捕获。在运行时更改它无效。此配置通常用于容器化或 CI 环境中，其中 stdout/stderr 日志收集优于写入日志文件。
+- 是否可变: 否
+- 描述: 当此项设置为 `true` 时，系统会将 Log4j 配置为将所有日志发送到控制台 (ConsoleErr appender)，而不是基于文件的 appender。此值在生成活动 Log4j XML 配置时读取（这会影响根日志记录器和每个模块日志记录器 appender 的选择）。其值在进程启动时从 `SYS_LOG_TO_CONSOLE` 环境变量中捕获。在运行时更改它无效。此配置通常用于容器化或 CI 环境中，这些环境更倾向于 stdout/stderr 日志收集，而不是写入日志文件。
 - 引入版本: v3.2.0
 
 ##### `sys_log_verbose_modules`
@@ -581,8 +581,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 空字符串
 - 类型: String[]
 - 单位: -
-- 是否可变: No
-- 描述: StarRocks 为其生成系统日志的模块。如果此参数设置为 `org.apache.starrocks.catalog`，则 StarRocks 仅为 catalog 模块生成系统日志。模块名称用逗号 (,) 和空格分隔。
+- 是否可变: 否
+- 描述: StarRocks 生成系统日志的模块。如果此参数设置为 `org.apache.starrocks.catalog`，StarRocks 将仅为 catalog 模块生成系统日志。模块名称之间用逗号 (,) 和空格分隔。
 - 引入版本: -
 
 ##### `sys_log_warn_modules`
@@ -590,964 +590,964 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: {}
 - 类型: String[]
 - 单位: -
-- 是否可变: No
-- 描述: 启动时系统将配置为 WARN 级别日志记录器并路由到警告 appender (SysWF) — `fe.warn.log` 文件的日志记录器名称或包前缀列表。条目插入到生成的 Log4j 配置中（与内置警告模块如 org.apache.kafka、org.apache.hudi 和 org.apache.hadoop.io.compress 一起），并生成类似 `<Logger name="... " level="WARN"><AppenderRef ref="SysWF"/></Logger>` 的日志记录器元素。建议使用完全限定的包和类前缀（例如 "com.example.lib"），以抑制常规日志中的嘈杂 INFO/DEBUG 输出，并允许单独捕获警告。
+- 是否可变: 否
+- 描述: 一个日志记录器名称或包前缀列表，系统将在启动时将其配置为 WARN 级别日志记录器，并路由到警告 appender (SysWF)——即 `fe.warn.log` 文件。条目被插入到生成的 Log4j 配置中（与 org.apache.kafka、org.apache.hudi 和 org.apache.hadoop.io.compress 等内置警告模块一起），并生成 `<Logger name="... " level="WARN"><AppenderRef ref="SysWF"/></Logger>` 这样的日志记录器元素。建议使用完全限定的包和类前缀（例如 "com.example.lib"），以抑制常规日志中嘈杂的 INFO/DEBUG 输出，并允许单独捕获警告。
 - 引入版本: v3.2.13
 
-### 服务
+### Server
 
 ##### `brpc_idle_wait_max_time`
 
-- 默认值: 10000
-- 类型: Int
-- 单位: 毫秒
-- 是否可变: No
-- 描述: bRPC 客户端在空闲状态下等待的最长时间。
-- 引入版本: -
+- Default: 10000
+- Type: Int
+- Unit: ms
+- Is mutable: No
+- Description: bRPC 客户端在空闲状态下等待的最长时间。
+- Introduced in: -
 
 ##### `brpc_inner_reuse_pool`
 
-- 默认值: true
-- 类型: boolean
-- 单位: -
-- 是否可变: No
-- 描述: 控制底层 BRPC 客户端是否为连接/通道使用内部共享重用池。StarRocks 在 BrpcProxy 构造 RpcClientOptions 时（通过 `rpcOptions.setInnerResuePool(...)`）读取 `brpc_inner_reuse_pool`。启用时 (true)，RPC 客户端重用内部池以减少每次调用的连接创建，降低 FE 到 BE / LakeService RPC 的连接 churn、内存和文件描述符使用量。禁用时 (false)，客户端可能会创建更隔离的池（以更高的资源使用量为代价增加并发隔离）。更改此值需要重启进程才能生效。
-- 引入版本: v3.3.11, v3.4.1, v3.5.0
+- Default: true
+- Type: boolean
+- Unit: -
+- Is mutable: No
+- Description: 控制底层 BRPC 客户端是否使用内部共享复用池进行连接/通道。StarRocks 在通过 `rpcOptions.setInnerResuePool(...)` 构造 RpcClientOptions 时，会在 BrpcProxy 中读取 `brpc_inner_reuse_pool`。启用（true）时，RPC 客户端会复用内部池，以减少每次调用的连接创建，从而降低 FE 到 BE / LakeService RPC 的连接流失、内存和文件描述符使用量。禁用（false）时，客户端可能会创建更多隔离的池（以更高的资源使用量为代价增加并发隔离）。更改此值需要重启进程才能生效。
+- Introduced in: v3.3.11, v3.4.1, v3.5.0
 
 ##### `brpc_min_evictable_idle_time_ms`
 
-- 默认值: 120000
-- 类型: Int
-- 单位: 毫秒
-- 是否可变: No
-- 描述: 空闲的 BRPC 连接在连接池中必须保持空闲状态才能被驱逐的时间（毫秒）。应用于 `BrpcProxy` 使用的 RpcClientOptions（通过 RpcClientOptions.setMinEvictableIdleTime）。增加此值以保持空闲连接更长时间（减少重新连接的 churn）；降低此值可更快释放未使用的套接字（减少资源使用）。与 `brpc_connection_pool_size` 和 `brpc_idle_wait_max_time` 一起调整，以平衡连接重用、池增长和驱逐行为。
-- 引入版本: v3.3.11, v3.4.1, v3.5.0
+- Default: 120000
+- Type: Int
+- Unit: Milliseconds
+- Is mutable: No
+- Description: 空闲 BRPC 连接在连接池中必须保持的毫秒数，之后才能被驱逐。此设置应用于 `BrpcProxy` 使用的 RpcClientOptions（通过 RpcClientOptions.setMinEvictableIdleTime）。提高此值可以使空闲连接保持更长时间（减少重新连接的流失）；降低此值可以更快地释放未使用的套接字（减少资源使用）。与 `brpc_connection_pool_size` 和 `brpc_idle_wait_max_time` 一起调整，以平衡连接复用、池增长和驱逐行为。
+- Introduced in: v3.3.11, v3.4.1, v3.5.0
 
 ##### `brpc_reuse_addr`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 当为 true 时，StarRocks 会设置 socket 选项，允许 brpc RpcClient 创建的客户端 socket（通过 RpcClientOptions.setReuseAddress）重用本地地址。启用此选项可减少绑定失败，并允许在套接字关闭后更快地重新绑定本地端口，这对于高速率连接 churn 或快速重启非常有用。当为 false 时，地址/端口重用被禁用，这可以降低意外端口共享的可能性，但可能会增加瞬时绑定错误。此选项与 `brpc_connection_pool_size` 和 `brpc_short_connection` 配置的连接行为交互，因为它会影响客户端套接字可以多快地重新绑定和重用。
-- 引入版本: v3.3.11, v3.4.1, v3.5.0
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: 当为 true 时，StarRocks 会设置套接字选项，允许 brpc RpcClient 创建的客户端套接字（通过 RpcClientOptions.setReuseAddress）复用本地地址。启用此功能可减少绑定失败，并允许在套接字关闭后更快地重新绑定本地端口，这对于高连接流失率或快速重启很有帮助。当为 false 时，地址/端口复用被禁用，这可以减少意外端口共享的可能性，但可能会增加瞬时绑定错误。此选项与 `brpc_connection_pool_size` 和 `brpc_short_connection` 配置的连接行为相互作用，因为它会影响客户端套接字重新绑定和复用的速度。
+- Introduced in: v3.3.11, v3.4.1, v3.5.0
 
 ##### `cluster_name`
 
-- 默认值: StarRocks Cluster
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: FE 所属的 StarRocks 集群的名称。集群名称显示在网页的 `Title` 上。
-- 引入版本: -
+- Default: StarRocks 集群
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: FE 节点所属的 StarRocks 集群的名称。该集群名称显示在网页的 `Title` 位置。
+- Introduced in: -
 
 ##### `dns_cache_ttl_seconds`
 
-- 默认值: 60
-- 类型: Int
-- 单位: 秒
-- 是否可变: No
-- 描述: 成功 DNS 查找的 DNS 缓存 TTL（存活时间，Time-To-Live），单位为秒。这设置了 Java 安全属性 `networkaddress.cache.ttl`，它控制 JVM 缓存成功 DNS 查找的时间。将此项设置为 `-1` 以允许系统始终缓存信息，或设置为 `0` 以禁用缓存。这在 IP 地址经常变化的环境中特别有用，例如 Kubernetes 部署或使用动态 DNS 时。
-- 引入版本: v3.5.11, v4.0.4
+- Default: 60
+- Type: Int
+- Unit: 秒
+- Is mutable: No
+- Description: 成功 DNS 查询的 DNS 缓存 TTL（Time-To-Live），单位为秒。此项设置 Java 安全属性 `networkaddress.cache.ttl`，它控制 JVM 缓存成功 DNS 查询的时长。将此项设置为 `-1` 以允许系统始终缓存信息，或设置为 `0` 以禁用缓存。这在 IP 地址频繁变化的环境中特别有用，例如 Kubernetes 部署或使用动态 DNS 时。
+- Introduced in: v3.5.11, v4.0.4
 
 ##### `enable_http_async_handler`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否允许系统异步处理 HTTP 请求。如果启用此功能，Netty 工作线程收到的 HTTP 请求将提交到单独的线程池进行服务逻辑处理，以避免阻塞 HTTP 服务器。如果禁用，Netty 工作线程将处理服务逻辑。
-- 引入版本: 4.0.0
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 是否允许系统异步处理 HTTP 请求。如果启用此功能，Netty worker 线程接收到的 HTTP 请求将被提交到单独的线程池进行服务逻辑处理，以避免阻塞 HTTP 服务器。如果禁用，Netty worker 将直接处理服务逻辑。
+- Introduced in: 4.0.0
 
 ##### `enable_http_validate_headers`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 控制 Netty 的 HttpServerCodec 是否执行严格的 HTTP 头部验证。该值在 `HttpServer` 初始化 HTTP 管道时传递给 HttpServerCodec（参见 UseLocations）。默认值为 false 以保持向后兼容性，因为较新的 Netty 版本强制执行更严格的头部规则 (https://github.com/netty/netty/pull/12760)。设置为 true 以强制执行符合 RFC 的头部检查；这样做可能会导致来自旧客户端或代理的格式错误或不符合规范的请求被拒绝。更改需要重启 HTTP 服务器才能生效。
-- 引入版本: v3.3.0, v3.4.0, v3.5.0
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: 控制 Netty 的 HttpServerCodec 是否执行严格的 HTTP 头部验证。在 `HttpServer` 中初始化 HTTP 管道时，该值会传递给 HttpServerCodec（参见 UseLocations）。默认值为 false 是为了向后兼容，因为较新的 Netty 版本强制执行更严格的头部规则 (https://github.com/netty/netty/pull/12760)。设置为 true 以强制执行符合 RFC 的头部检查；这样做可能会导致来自旧客户端或代理的格式错误或不符合规范的请求被拒绝。更改此设置需要重启 HTTP 服务器才能生效。
+- Introduced in: v3.3.0, v3.4.0, v3.5.0
 
 ##### `enable_https`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 是否在 FE 节点中与 HTTP 服务器一起启用 HTTPS 服务器。
-- 引入版本: v4.0
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: 是否在 FE 节点中同时启用 HTTPS 服务器和 HTTP 服务器。
+- Introduced in: v4.0
 
 ##### `frontend_address`
 
-- 默认值: 0.0.0.0
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: FE 节点的 IP 地址。
-- 引入版本: -
+- Default: 0.0.0.0
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: FE 节点的 IP 地址。
+- Introduced in: -
 
 ##### `http_async_threads_num`
 
-- 默认值: 4096
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 异步 HTTP 请求处理的线程池大小。别名为 `max_http_sql_service_task_threads_num`。
-- 引入版本: 4.0.0
+- Default: 4096
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: 异步 HTTP 请求处理的线程池大小。别名为 `max_http_sql_service_task_threads_num`。
+- Introduced in: 4.0.0
 
 ##### `http_backlog_num`
 
-- 默认值: 1024
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: FE 节点中 HTTP 服务器持有的 backlog 队列的长度。
-- 引入版本: -
+- Default: 1024
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: FE 节点中 HTTP 服务器持有的积压队列的长度。
+- Introduced in: -
 
 ##### `http_max_chunk_size`
 
-- 默认值: 8192
-- 类型: Int
-- 单位: 字节
-- 是否可变: No
-- 描述: 设置 FE HTTP 服务器中 Netty 的 HttpServerCodec 处理的单个 HTTP 块的最大允许大小（以字节为单位）。它作为第三个参数传递给 HttpServerCodec，并限制分块传输或流式请求/响应期间的块长度。如果传入块超过此值，Netty 将引发帧过大错误（例如 TooLongFrameException），并且请求可能会被拒绝。对于合法的分块上传，请增加此值；保持较小以减少内存压力并减小 DoS 攻击的表面积。此设置与 `http_max_initial_line_length`、`http_max_header_size` 和 `enable_http_validate_headers` 一起使用。
-- 引入版本: v3.2.0
+- Default: 8192
+- Type: Int
+- Unit: 字节
+- Is mutable: No
+- Description: 设置 FE HTTP 服务器中 Netty 的 HttpServerCodec 处理的单个 HTTP 块的最大允许大小（以字节为单位）。它作为第三个参数传递给 HttpServerCodec，并限制分块传输或流式请求/响应期间块的长度。如果传入的块超过此值，Netty 将引发帧过大错误（例如 TooLongFrameException），并且请求可能会被拒绝。对于合法的分块上传，请增加此值；保持较小以减少内存压力和 DoS 攻击的受攻击面。此设置与 `http_max_initial_line_length`、`http_max_header_size` 和 `enable_http_validate_headers` 一起使用。
+- Introduced in: v3.2.0
 
 ##### `http_max_header_size`
 
-- 默认值: 32768
-- 类型: Int
-- 单位: 字节
-- 是否可变: No
-- 描述: Netty 的 `HttpServerCodec` 解析的 HTTP 请求头块的最大允许大小（以字节为单位）。StarRocks 将此值传递给 `HttpServerCodec`（作为 `Config.http_max_header_size`）；如果传入请求的头（名称和值组合）超过此限制，编解码器将拒绝该请求（解码器异常），并且连接/请求将失败。仅当客户端合法发送非常大的头（大型 cookie 或许多自定义头）时才增加此值；较大的值会增加每个连接的内存使用。与 `http_max_initial_line_length` 和 `http_max_chunk_size` 一起调整。更改需要重启 FE。
-- 引入版本: v3.2.0
+- Default: 32768
+- Type: Int
+- Unit: 字节
+- Is mutable: No
+- Description: Netty 的 `HttpServerCodec` 解析的 HTTP 请求头部块的最大允许大小（以字节为单位）。StarRocks 将此值传递给 `HttpServerCodec`（作为 `Config.http_max_header_size`）；如果传入请求的头部（名称和值组合）超过此限制，编解码器将拒绝该请求（解码器异常），并且连接/请求将失败。仅当客户端合法发送非常大的头部（大型 cookie 或许多自定义头部）时才增加此值；较大的值会增加每个连接的内存使用量。与 `http_max_initial_line_length` 和 `http_max_chunk_size` 结合调整。更改需要重启 FE。
+- Introduced in: v3.2.0
 
 ##### `http_max_initial_line_length`
 
-- 默认值: 4096
-- 类型: Int
-- 单位: 字节
-- 是否可变: No
-- 描述: 设置 HttpServer 中使用的 Netty `HttpServerCodec` 接受的 HTTP 初始请求行（方法 + 请求目标 + HTTP 版本）的最大允许长度（以字节为单位）。该值传递给 Netty 的解码器，并且初始行长于此值的请求将被拒绝 (TooLongFrameException)。仅当您必须支持非常长的请求 URI 时才增加此值；较大的值会增加内存使用，并可能增加暴露于格式错误/请求滥用的风险。与 `http_max_header_size` 和 `http_max_chunk_size` 一起调整。
-- 引入版本: v3.2.0
+- Default: 4096
+- Type: Int
+- Unit: 字节
+- Is mutable: No
+- Description: 设置 HttpServer 中使用的 Netty `HttpServerCodec` 接受的 HTTP 初始请求行（方法 + 请求目标 + HTTP 版本）的最大允许长度（以字节为单位）。该值传递给 Netty 的解码器，初始行长度超过此值的请求将被拒绝（TooLongFrameException）。仅当您必须支持非常长的请求 URI 时才增加此值；较大的值会增加内存使用量，并可能增加遭受格式错误/请求滥用的风险。与 `http_max_header_size` 和 `http_max_chunk_size` 一起调整。
+- Introduced in: v3.2.0
 
 ##### `http_port`
 
-- 默认值: 8030
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: FE 节点中 HTTP 服务器监听的端口。
-- 引入版本: -
+- Default: 8030
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: FE 节点中 HTTP 服务器监听的端口。
+- Introduced in: -
 
 ##### `http_web_page_display_hardware`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 当为 true 时，HTTP 索引页面 (/index) 将包含一个通过 oshi 库填充的硬件信息部分（CPU、内存、进程、磁盘、文件系统、网络等）。oshi 可能会间接调用系统工具或读取系统文件（例如，它可以执行 `getent passwd` 等命令），这可能会暴露敏感的系统数据。如果您需要更严格的安全性或希望避免在主机上执行这些间接命令，请将此配置设置为 false 以禁用 Web UI 上硬件详细信息的收集和显示。
-- 引入版本: v3.2.0
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 当为 true 时，HTTP 索引页面 (/index) 将包含一个通过 oshi 库（CPU、内存、进程、磁盘、文件系统、网络等）填充的硬件信息部分。oshi 可能会间接调用系统实用程序或读取系统文件（例如，它可以执行 `getent passwd` 等命令），这可能会暴露敏感的系统数据。如果您需要更严格的安全性或希望避免在主机上执行这些间接命令，请将此配置设置为 false 以禁用在 Web UI 上收集和显示硬件详细信息。
+- Introduced in: v3.2.0
 
 ##### `http_worker_threads_num`
 
-- 默认值: 0
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: HTTP 服务器处理 HTTP 请求的工作线程数。如果为负值或 0，则线程数将是 CPU 核心数的两倍。
-- 引入版本: v2.5.18, v3.0.10, v3.1.7, v3.2.2
+- Default: 0
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: HTTP 服务器处理 HTTP 请求的工作线程数。如果值为负数或 0，线程数将是 CPU 核心数的两倍。
+- Introduced in: v2.5.18, v3.0.10, v3.1.7, v3.2.2
 
 ##### `https_port`
 
-- 默认值: 8443
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: FE 节点中 HTTPS 服务器监听的端口。
-- 引入版本: v4.0
+- Default: 8443
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: FE 节点中 HTTPS 服务器监听的端口。
+- Introduced in: v4.0
 
 ##### `max_mysql_service_task_threads_num`
 
-- 默认值: 4096
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: FE 节点中 MySQL 服务器可运行以处理任务的最大线程数。
-- 引入版本: -
+- Default: 4096
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: FE 节点中 MySQL 服务器可用于处理任务的最大线程数。
+- Introduced in: -
 
 ##### `max_task_runs_threads_num`
 
-- 默认值: 512
-- 类型: Int
-- 单位: 线程
-- 是否可变: No
-- 描述: 控制任务运行执行器线程池中的最大线程数。此值是并发任务运行执行的上限；增加它会提高并行度，但也会增加 CPU、内存和网络使用率，而减少它可能导致任务运行积压和更高的延迟。根据预期的并发调度作业和可用的系统资源调整此值。
-- 引入版本: v3.2.0
+- Default: 512
+- Type: Int
+- Unit: 线程
+- Is mutable: No
+- Description: 控制任务运行执行器线程池中的最大线程数。此值是并发任务运行执行的上限；增加它会提高并行度，但也会增加 CPU、内存和网络使用量，而减少它可能导致任务运行积压和更高的延迟。根据预期的并发调度作业和可用的系统资源调整此值。
+- Introduced in: v3.2.0
 
 ##### `memory_tracker_enable`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 启用 FE 内存跟踪器子系统。当 `memory_tracker_enable` 设置为 `true` 时，`MemoryUsageTracker` 定期扫描注册的元数据模块，更新内存中的 `MemoryUsageTracker.MEMORY_USAGE` map，记录总计，并使 `MetricRepo` 在指标输出中暴露内存使用和对象计数 gauge。使用 `memory_tracker_interval_seconds` 控制采样间隔。启用此功能有助于监控和调试内存消耗，但会引入 CPU 和 I/O 开销以及额外的指标基数。
-- 引入版本: v3.2.4
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 启用 FE 内存跟踪器子系统。当 `memory_tracker_enable` 设置为 `true` 时，`MemoryUsageTracker` 会定期扫描注册的元数据模块，更新内存中的 `MemoryUsageTracker.MEMORY_USAGE` 映射，记录总计，并使 `MetricRepo` 在指标输出中暴露内存使用量和对象计数仪表。使用 `memory_tracker_interval_seconds` 控制采样间隔。启用此功能有助于监控和调试内存消耗，但会引入 CPU 和 I/O 开销以及额外的指标基数。
+- Introduced in: v3.2.4
 
 ##### `memory_tracker_interval_seconds`
 
-- 默认值: 60
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述: FE `MemoryUsageTracker` 守护程序轮询和记录 FE 进程和已注册 `MemoryTrackable` 模块内存使用情况的间隔（秒）。当 `memory_tracker_enable` 设置为 `true` 时，跟踪器以此频率运行，更新 `MEMORY_USAGE`，并记录聚合的 JVM 和跟踪模块使用情况。
-- 引入版本: v3.2.4
+- Default: 60
+- Type: Int
+- Unit: 秒
+- Is mutable: Yes
+- Description: FE `MemoryUsageTracker` 守护进程轮询和记录 FE 进程以及注册的 `MemoryTrackable` 模块内存使用情况的间隔（秒）。当 `memory_tracker_enable` 设置为 `true` 时，跟踪器会以此频率运行，更新 `MEMORY_USAGE`，并记录聚合的 JVM 和跟踪模块使用情况。
+- Introduced in: v3.2.4
 
 ##### `mysql_nio_backlog_num`
 
-- 默认值: 1024
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: FE 节点中 MySQL 服务器持有的 backlog 队列的长度。
-- 引入版本: -
+- Default: 1024
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: FE 节点中 MySQL 服务器持有的积压队列的长度。
+- Introduced in: -
 
 ##### `mysql_server_version`
 
-- 默认值: 8.0.33
-- 类型: String
-- 单位: -
-- 是否可变: Yes
-- 描述: 返回给客户端的 MySQL 服务器版本。修改此参数将影响以下情况的版本信息：
+- Default: 8.0.33
+- Type: String
+- Unit: -
+- Is mutable: Yes
+- Description: 返回给客户端的 MySQL 服务器版本。修改此参数将影响以下情况下的版本信息：
   1. `select version();`
   2. 握手包版本
   3. 全局变量 `version` 的值 (`show variables like 'version';`)
-- 引入版本: -
+- Introduced in: -
 
 ##### `mysql_service_io_threads_num`
 
-- 默认值: 4
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: FE 节点中 MySQL 服务器可运行以处理 I/O 事件的最大线程数。
-- 引入版本: -
+- Default: 4
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: FE 节点中 MySQL 服务器可用于处理 I/O 事件的最大线程数。
+- Introduced in: -
 
 ##### `mysql_service_kill_after_disconnect`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 控制当检测到 MySQL TCP 连接关闭（读取时 EOF）时服务器如何处理会话。如果设置为 `true`，服务器会立即杀死该连接的所有正在运行的查询并立即执行清理。如果设置为 `false`，服务器在断开连接时不会杀死正在运行的查询，并且仅在没有待处理请求任务时执行清理，允许长时间运行的查询在客户端断开连接后继续。注意：尽管有一条简短的注释建议 TCP keep-alive，但此参数专门管理断开连接后的杀死行为，应根据您是希望终止孤立查询（在不可靠/负载均衡客户端后推荐）还是允许其完成进行设置。
-- 引入版本: -
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: 控制当检测到 MySQL TCP 连接关闭（读取时 EOF）时服务器如何处理会话。如果设置为 `true`，服务器会立即终止该连接的任何正在运行的查询并立即执行清理。如果设置为 `false`，服务器在断开连接时不会终止正在运行的查询，并且仅在没有待处理请求任务时才执行清理，从而允许长时间运行的查询在客户端断开连接后继续执行。注意：尽管有一个简短的注释建议 TCP keep-alive，但此参数专门管理断开连接后的终止行为，应根据您是希望终止孤立查询（建议在不可靠/负载均衡客户端后面使用）还是允许其完成来设置。
+- Introduced in: -
 
 ##### `mysql_service_nio_enable_keep_alive`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 启用 MySQL 连接的 TCP Keep-Alive。对于负载均衡器后面的长时间空闲连接很有用。
-- 引入版本: -
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: 为 MySQL 连接启用 TCP Keep-Alive。对于负载均衡器后面的长时间空闲连接很有用。
+- Introduced in: -
 
 ##### `net_use_ipv6_when_priority_networks_empty`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 一个布尔值，用于控制在未指定 `priority_networks` 时是否优先使用 IPv6 地址。`true` 表示当托管节点的服务器同时具有 IPv4 和 IPv6 地址且未指定 `priority_networks` 时，允许系统优先使用 IPv6 地址。
-- 引入版本: v3.3.0
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: 一个布尔值，用于控制当未指定 `priority_networks` 时是否优先使用 IPv6 地址。`true` 表示当托管节点的服务器同时具有 IPv4 和 IPv6 地址且未指定 `priority_networks` 时，允许系统优先使用 IPv6 地址。
+- Introduced in: v3.3.0
 
 ##### `priority_networks`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 声明具有多个 IP 地址的服务器的选择策略。请注意，最多一个 IP 地址必须与此参数指定的列表匹配。此参数的值是一个列表，由 CIDR 表示法中用分号 (;) 分隔的条目组成，例如 10.10.10.0/24。如果没有 IP 地址与此列表中的条目匹配，则将随机选择服务器的可用 IP 地址。从 v3.3.0 开始，StarRocks 支持基于 IPv6 的部署。如果服务器同时具有 IPv4 和 IPv6 地址，并且未指定此参数，则系统默认使用 IPv4 地址。您可以将 `net_use_ipv6_when_priority_networks_empty` 设置为 `true` 来更改此行为。
-- 引入版本: -
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: 声明具有多个 IP 地址的服务器的选择策略。请注意，最多只能有一个 IP 地址与此参数指定的列表匹配。此参数的值是一个列表，由以分号 (;) 分隔的 CIDR 表示法条目组成，例如 10.10.10.0/24。如果没有 IP 地址与此列表中的条目匹配，则将随机选择服务器的一个可用 IP 地址。从 v3.3.0 开始，StarRocks 支持基于 IPv6 的部署。如果服务器同时具有 IPv4 和 IPv6 地址，并且未指定此参数，系统默认使用 IPv4 地址。您可以通过将 `net_use_ipv6_when_priority_networks_empty` 设置为 `true` 来更改此行为。
+- Introduced in: -
 
 ##### `proc_profile_cpu_enable`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 当此项设置为 `true` 时，后台 `ProcProfileCollector` 将使用 `AsyncProfiler` 收集 CPU profile，并将 HTML 报告写入 `sys_log_dir/proc_profile` 下。每次收集运行都会记录 `proc_profile_collect_time_s` 配置持续时间内的 CPU 堆栈，并使用 `proc_profile_jstack_depth` 作为 Java 堆栈深度。生成的 profile 会被压缩，并根据 `proc_profile_file_retained_days` 和 `proc_profile_file_retained_size_bytes` 清理旧文件。`AsyncProfiler` 需要原生库 (`libasyncProfiler.so`)；`one.profiler.extractPath` 设置为 `STARROCKS_HOME_DIR/bin` 以避免 `/tmp` 上的 noexec 问题。
-- 引入版本: v3.2.12
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 当此项设置为 `true` 时，后台 `ProcProfileCollector` 将使用 `AsyncProfiler` 收集 CPU 配置文件，并将 HTML 报告写入 `sys_log_dir/proc_profile` 下。每次收集运行都会记录由 `proc_profile_collect_time_s` 配置的持续时间的 CPU 堆栈，并使用 `proc_profile_jstack_depth` 作为 Java 堆栈深度。生成的配置文件会根据 `proc_profile_file_retained_days` 和 `proc_profile_file_retained_size_bytes` 进行压缩和旧文件修剪。`AsyncProfiler` 需要本地库 (`libasyncProfiler.so`)；`one.profiler.extractPath` 设置为 `STARROCKS_HOME_DIR/bin` 以避免 `/tmp` 上的 noexec 问题。
+- Introduced in: v3.2.12
 
 ##### `qe_max_connection`
 
-- 默认值: 4096
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: 所有用户可以与 FE 节点建立的最大连接数。从 v3.1.12 和 v3.2.7 开始，默认值已从 `1024` 更改为 `4096`。
-- 引入版本: -
+- Default: 4096
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: 所有用户可以与 FE 节点建立的最大连接数。从 v3.1.12 和 v3.2.7 开始，默认值已从 `1024` 更改为 `4096`。
+- Introduced in: -
 
 ##### `query_port`
 
-- 默认值: 9030
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: FE 节点中 MySQL 服务器监听的端口。
-- 引入版本: -
+- Default: 9030
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: FE 节点中 MySQL 服务器监听的端口。
+- Introduced in: -
 
 ##### `rpc_port`
 
-- 默认值: 9020
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: FE 节点中 Thrift 服务器监听的端口。
-- 引入版本: -
+- Default: 9020
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: FE 节点中 Thrift 服务器监听的端口。
+- Introduced in: -
 
 ##### `slow_lock_stack_trace_reserve_levels`
 
-- 默认值: 15
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 控制 StarRocks 为慢速或持有的锁转储锁调试信息时捕获和发出的堆栈跟踪帧数。此值由 `QueryableReentrantReadWriteLock` 在生成排他锁所有者、当前线程和最旧/共享读取器的 JSON 时传递给 `LogUtil.getStackTraceToJsonArray`。增加此值可为诊断慢锁或死锁问题提供更多上下文，但代价是 JSON 负载更大，并且堆栈捕获的 CPU/内存略高；减少此值可降低开销。注意：当只记录慢锁时，读取器条目可以通过 `slow_lock_threshold_ms` 过滤。
-- 引入版本: v3.4.0, v3.5.0
+- Default: 15
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: 控制 StarRocks 在为慢锁或持有锁转储锁调试信息时捕获和发出的堆栈跟踪帧数。当 `QueryableReentrantReadWriteLock` 为排他锁所有者、当前线程和最旧/共享读取器生成 JSON 时，此值会传递给 `LogUtil.getStackTraceToJsonArray`。增加此值可以为诊断慢锁或死锁问题提供更多上下文，但代价是更大的 JSON 有效负载和略高的 CPU/内存用于堆栈捕获；减少此值可以降低开销。注意：当仅记录慢锁时，读取器条目可以通过 `slow_lock_threshold_ms` 进行过滤。
+- Introduced in: v3.4.0, v3.5.0
 
 ##### `ssl_cipher_blacklist`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 以逗号分隔的列表，支持正则表达式，用于通过 IANA 名称将 SSL 密码套件列入黑名单。如果同时设置了白名单和黑名单，则黑名单优先。
-- 引入版本: v4.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: 逗号分隔列表，支持正则表达式，用于通过 IANA 名称将 SSL 密码套件列入黑名单。如果同时设置了白名单和黑名单，则黑名单优先。
+- Introduced in: v4.0
 
 ##### `ssl_cipher_whitelist`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 以逗号分隔的列表，支持正则表达式，用于通过 IANA 名称将 SSL 密码套件列入白名单。如果同时设置了白名单和黑名单，则黑名单优先。
-- 引入版本: v4.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: 逗号分隔列表，支持正则表达式，用于通过 IANA 名称将 SSL 密码套件列入白名单。如果同时设置了白名单和黑名单，则黑名单优先。
+- Introduced in: v4.0
 
 ##### `task_runs_concurrency`
 
-- 默认值: 4
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 并发运行的 TaskRun 实例的全局限制。当当前运行计数大于或等于 `task_runs_concurrency` 时，`TaskRunScheduler` 会停止调度新运行，因此此值限制了调度器中并行 TaskRun 执行的上限。它还被 `MVPCTRefreshPartitioner` 用于计算每个 TaskRun 分区刷新粒度。增加该值会提高并行度并增加资源使用；减少它会降低并发并使分区刷新在每次运行中更大。除非有意禁用调度，否则不要设置为 0 或负值：0（或负值）将有效地阻止 `TaskRunScheduler` 调度新的 TaskRun。
-- 引入版本: v3.2.0
+- Default: 4
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: 并发运行的 TaskRun 实例的全局限制。当当前运行计数大于或等于 `task_runs_concurrency` 时，`TaskRunScheduler` 会停止调度新的运行，因此此值限制了调度器中 TaskRun 的并行执行。它也被 `MVPCTRefreshPartitioner` 用于计算每个 TaskRun 的分区刷新粒度。增加此值会提高并行度和资源使用量；减少此值会降低并发性并使每次运行的分区刷新更大。除非有意禁用调度，否则不要设置为 0 或负数：0（或负数）将有效地阻止 `TaskRunScheduler` 调度新的 TaskRun。
+- Introduced in: v3.2.0
 
 ##### `task_runs_queue_length`
 
-- 默认值: 500
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 限制待处理队列中保留的待处理 TaskRun 项的最大数量。`TaskRunManager` 检查当前待处理计数，并在有效待处理 TaskRun 计数大于或等于 `task_runs_queue_length` 时拒绝新的提交。在添加合并/接受的 TaskRun 之前，会重新检查相同的限制。调整此值以平衡内存和调度积压：对于大量突发工作负载，设置为较高值以避免拒绝，或设置为较低值以限制内存并减少待处理积压。
-- 引入版本: v3.2.0
+- Default: 500
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: 限制待处理队列中保留的待处理 TaskRun 项的最大数量。当有效的待处理 TaskRun 计数大于或等于 `task_runs_queue_length` 时，`TaskRunManager` 会检查当前待处理计数并拒绝新的提交。在添加合并/接受的 TaskRun 之前，会重新检查相同的限制。调整此值以平衡内存和调度积压：对于大型突发工作负载，将其设置得更高以避免拒绝；或将其设置得更低以限制内存并减少待处理积压。
+- Introduced in: v3.2.0
 
 ##### `thrift_backlog_num`
 
-- 默认值: 1024
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: FE 节点中 Thrift 服务器持有的 backlog 队列的长度。
-- 引入版本: -
+- Default: 1024
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: FE 节点中 Thrift 服务器持有的积压队列的长度。
+- Introduced in: -
 
 ##### `thrift_client_timeout_ms`
 
-- 默认值: 5000
-- 类型: Int
-- 单位: 毫秒
-- 是否可变: No
-- 描述: 空闲客户端连接超时的时间长度。
-- 引入版本: -
+- Default: 5000
+- Type: Int
+- Unit: 毫秒
+- Is mutable: No
+- Description: 空闲客户端连接超时的时间长度。
+- Introduced in: -
 
 ##### `thrift_rpc_max_body_size`
 
-- 默认值: -1
-- 类型: Int
-- 单位: 字节
-- 是否可变: No
-- 描述: 控制构建服务器 Thrift 协议时使用的 Thrift RPC 消息体最大允许大小（以字节为单位）（传递给 `ThriftServer` 中的 TBinaryProtocol.Factory）。值为 `-1` 表示禁用限制（无界）。设置正值会强制执行上限，以便大于此值的消息被 Thrift 层拒绝，这有助于限制内存使用并缓解超大请求或 DoS 风险。将其设置为足够大的值以适应预期负载（大型结构或批量数据），以避免拒绝合法请求。
-- 引入版本: v3.2.0
+- Default: -1
+- Type: Int
+- Unit: 字节
+- Is mutable: No
+- Description: 控制构建服务器 Thrift 协议时（传递给 `ThriftServer` 中的 TBinaryProtocol.Factory）允许的最大 Thrift RPC 消息体大小（以字节为单位）。值为 `-1` 表示禁用限制（无限制）。设置正值会强制执行上限，以便大于此值的消息会被 Thrift 层拒绝，这有助于限制内存使用并减轻超大请求或 DoS 风险。将其设置为足够大的值以适应预期的有效负载（大型结构体或批量数据）以避免拒绝合法请求。
+- Introduced in: v3.2.0
 
 ##### `thrift_server_max_worker_threads`
 
-- 默认值: 4096
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: FE 节点中 Thrift 服务器支持的最大工作线程数。
-- 引入版本: -
+- Default: 4096
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: FE 节点中 Thrift 服务器支持的最大工作线程数。
+- Introduced in: -
 
 ##### `thrift_server_queue_size`
 
-- 默认值: 4096
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: 请求待处理队列的长度。如果 Thrift 服务器中正在处理的线程数超过 `thrift_server_max_worker_threads` 中指定的值，则新请求将添加到待处理队列。
-- 引入版本: -
+- Default: 4096
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: 请求待处理队列的长度。如果 Thrift 服务器中正在处理的线程数超过 `thrift_server_max_worker_threads` 中指定的值，则新请求将添加到待处理队列中。
+- Introduced in: -
 
 ### 元数据和集群管理
 
 ##### `alter_max_worker_queue_size`
 
-- 默认值: 4096
-- 类型: Int
-- 单位: 任务数
-- 是否可变: No
-- 描述: 控制 alter 子系统使用的内部工作线程池队列的容量。它与 `alter_max_worker_threads` 一起传递给 `AlterHandler` 中的 `ThreadPoolManager.newDaemonCacheThreadPool`。当待处理的 alter 任务数超过 `alter_max_worker_queue_size` 时，新的提交将被拒绝，并可能抛出 `RejectedExecutionException`（参见 `AlterHandler.handleFinishAlterTask`）。调整此值以平衡内存使用和允许并发 alter 任务的积压量。
-- 引入版本: v3.2.0
+- Default: 4096
+- Type: Int
+- Unit: 任务
+- Is mutable: No
+- Description: 控制 alter 子系统使用的内部工作线程池队列的容量。它与 `alter_max_worker_threads` 一起传递给 `AlterHandler` 中的 `ThreadPoolManager.newDaemonCacheThreadPool`。当待处理的 alter 任务数量超过 `alter_max_worker_queue_size` 时，新的提交将被拒绝，并可能抛出 `RejectedExecutionException`（参见 `AlterHandler.handleFinishAlterTask`）。调整此值以平衡内存使用和允许并发 alter 任务的积压量。
+- Introduced in: v3.2.0
 
 ##### `alter_max_worker_threads`
 
-- 默认值: 4
-- 类型: Int
-- 单位: 线程
-- 是否可变: No
-- 描述: 设置 AlterHandler 线程池中的最大工作线程数。AlterHandler 使用此值构造执行器来运行和完成与 alter 相关的任务（例如，通过 handleFinishAlterTask 提交 `AlterReplicaTask`）。此值限制了 alter 操作的并发执行；增加它会提高并行度并增加资源使用，降低它会限制并发 alters 并可能成为瓶颈。执行器与 `alter_max_worker_queue_size` 一起创建，并且处理程序调度使用 `alter_scheduler_interval_millisecond`。
-- 引入版本: v3.2.0
+- Default: 4
+- Type: Int
+- Unit: 线程
+- Is mutable: No
+- Description: 设置 AlterHandler 线程池中工作线程的最大数量。AlterHandler 使用此值构建执行器，以运行和完成与 alter 相关的任务（例如，通过 handleFinishAlterTask 提交 `AlterReplicaTask`）。此值限制了 alter 操作的并发执行；提高它会增加并行度和资源使用，降低它会限制并发 alter 并可能成为瓶颈。执行器与 `alter_max_worker_queue_size` 一起创建，处理程序调度使用 `alter_scheduler_interval_millisecond`。
+- Introduced in: v3.2.0
 
 ##### `automated_cluster_snapshot_interval_seconds`
 
-- 默认值: 600
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 触发自动化集群快照任务的间隔。
-- 引入版本: v3.4.2
+- Default: 600
+- Type: Int
+- Unit: 秒
+- Is mutable: Yes
+- Description: 触发自动集群快照任务的时间间隔。
+- Introduced in: v3.4.2
 
 ##### `background_refresh_metadata_interval_millis`
 
-- 默认值: 600000
-- 类型: Int
-- 单位: 毫秒
-- 是否可变: Yes
-- 描述: 两次 Hive 元数据缓存刷新之间的间隔。
-- 引入版本: v2.5.5
+- Default: 600000
+- Type: Int
+- Unit: 毫秒
+- Is mutable: Yes
+- Description: 两次连续 Hive 元数据缓存刷新的时间间隔。
+- Introduced in: v2.5.5
 
 ##### `background_refresh_metadata_time_secs_since_last_access_secs`
 
-- 默认值: 3600 * 24
-- 类型: Long
-- 单位: 秒
-- 是否可变: Yes
-- 描述: Hive 元数据缓存刷新任务的过期时间。对于已访问的 Hive Catalog，如果超过指定时间未访问，StarRocks 将停止刷新其缓存的元数据。对于未访问的 Hive Catalog，StarRocks 不会刷新其缓存的元数据。
-- 引入版本: v2.5.5
+- Default: 3600 * 24
+- Type: Long
+- Unit: 秒
+- Is mutable: Yes
+- Description: Hive 元数据缓存刷新任务的过期时间。对于已访问的 Hive Catalog，如果超过指定时间未被访问，StarRocks 将停止刷新其缓存的元数据。对于未访问的 Hive Catalog，StarRocks 将不会刷新其缓存的元数据。
+- Introduced in: v2.5.5
 
 ##### `bdbje_cleaner_threads`
 
-- 默认值: 1
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: StarRocks journal 使用的 Berkeley DB Java Edition (JE) 环境的后台清理线程数。此值在 `BDBEnvironment.initConfigs` 中的环境初始化期间读取，并使用 `Config.bdbje_cleaner_threads` 应用于 `EnvironmentConfig.CLEANER_THREADS`。它控制 JE 日志清理和空间回收的并行度；增加它可以加快清理速度，但代价是会增加额外的 CPU 和 I/O 干扰前台操作。更改仅在 BDB 环境（重新）初始化时生效，因此需要重启前端才能应用新值。
-- 引入版本: v3.2.0
+- Default: 1
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: StarRocks 日志使用的 Berkeley DB Java Edition (JE) 环境的后台清理线程数。此值在 `BDBEnvironment.initConfigs` 中的环境初始化期间读取，并使用 `Config.bdbje_cleaner_threads` 应用于 `EnvironmentConfig.CLEANER_THREADS`。它控制 JE 日志清理和空间回收的并行度；增加它可以加快清理速度，但会以额外的 CPU 和 I/O 干扰前台操作为代价。更改仅在 BDB 环境（重新）初始化时生效，因此需要重新启动前端以应用新值。
+- Introduced in: v3.2.0
 
 ##### `bdbje_heartbeat_timeout_second`
 
-- 默认值: 30
-- 类型: Int
-- 单位: 秒
-- 是否可变: No
-- 描述: StarRocks 集群中 Leader、Follower 和 Observer FE 之间心跳超时的时间。
-- 引入版本: -
+- Default: 30
+- Type: Int
+- Unit: 秒
+- Is mutable: No
+- Description: StarRocks 集群中 Leader、Follower 和 Observer FE 之间心跳超时的时间。
+- Introduced in: -
 
 ##### `bdbje_lock_timeout_second`
 
-- 默认值: 1
-- 类型: Int
-- 单位: 秒
-- 是否可变: No
-- 描述: 基于 BDB JE 的 FE 中的锁超时时间。
-- 引入版本: -
+- Default: 1
+- Type: Int
+- Unit: 秒
+- Is mutable: No
+- Description: 基于 BDB JE 的 FE 中锁超时的时间。
+- Introduced in: -
 
 ##### `bdbje_replay_cost_percent`
 
-- 默认值: 150
-- 类型: Int
-- 单位: 百分比
-- 是否可变: No
-- 描述: 设置从 BDB JE 日志重放事务相对于通过网络恢复相同数据的相对成本（以百分比表示）。该值提供给底层 JE 复制参数 `REPLAY_COST_PERCENT`，通常 `>100` 表示重放通常比网络恢复更昂贵。当决定是否保留清理过的日志文件以进行潜在重放时，系统会将重放成本乘以日志大小与网络恢复成本进行比较；如果判断网络恢复更有效，则将删除文件。值为 0 禁用基于此成本比较的保留。`REP_STREAM_TIMEOUT` 内的副本或任何活动复制所需的日志文件始终保留。
-- 引入版本: v3.2.0
+- Default: 150
+- Type: Int
+- Unit: 百分比
+- Is mutable: No
+- Description: 设置从 BDB JE 日志重放事务与通过网络恢复获取相同数据的相对成本（以百分比表示）。该值提供给底层 JE 复制参数 `REPLAY_COST_PERCENT`，通常 `>100` 表示重放通常比网络恢复更昂贵。在决定是否保留已清理的日志文件以进行潜在重放时，系统会将重放成本乘以日志大小与网络恢复成本进行比较；如果网络恢复被认为更有效，则将删除文件。值为 0 会禁用基于此成本比较的保留。`REP_STREAM_TIMEOUT` 内的副本或任何活动复制所需的日志文件始终保留。
+- Introduced in: v3.2.0
 
 ##### `bdbje_replica_ack_timeout_second`
 
-- 默认值: 10
-- 类型: Int
-- 单位: 秒
-- 是否可变: No
-- 描述: 当元数据从 Leader FE 写入 Follower FE 时，Leader FE 等待指定数量的 Follower FE 返回 ACK 消息的最长时间。单位：秒。如果正在写入大量元数据，Follower FE 需要很长时间才能向 Leader FE 返回 ACK 消息，从而导致 ACK 超时。在这种情况下，元数据写入失败，FE 进程退出。建议您增加此参数的值以防止这种情况。
-- 引入版本: -
+- Default: 10
+- Type: Int
+- Unit: 秒
+- Is mutable: No
+- Description: Leader FE 将元数据写入 Follower FE 时，Leader FE 等待指定数量的 Follower FE 返回 ACK 消息的最长时间。单位：秒。如果写入大量元数据，Follower FE 需要很长时间才能向 Leader FE 返回 ACK 消息，从而导致 ACK 超时。在这种情况下，元数据写入失败，FE 进程退出。建议您增加此参数的值以防止这种情况发生。
+- Introduced in: -
 
 ##### `bdbje_reserved_disk_size`
 
-- 默认值: 512 * 1024 * 1024 (536870912)
-- 类型: Long
-- 单位: 字节
-- 是否可变: No
-- 描述: 限制 Berkeley DB JE 将保留的“非保护”（可删除）日志/数据文件的字节数。StarRocks 通过 `BDBEnvironment` 中的 `EnvironmentConfig.RESERVED_DISK` 将此值传递给 JE；JE 的内置默认值为 0（无限制）。StarRocks 默认值（512 MiB）可防止 JE 为非保护文件保留过多的磁盘空间，同时允许安全清理过时文件。在磁盘受限的系统上调整此值：减小它可让 JE 更早释放更多文件，增加它可让 JE 保留更多保留空间。更改需要重启进程才能生效。
-- 引入版本: v3.2.0
+- Default: 512 * 1024 * 1024 (536870912)
+- Type: Long
+- Unit: 字节
+- Is mutable: No
+- Description: 限制 Berkeley DB JE 将保留为“未受保护”（可删除）日志/数据文件的字节数。StarRocks 通过 BDBEnvironment 中的 `EnvironmentConfig.RESERVED_DISK` 将此值传递给 JE；JE 的内置默认值为 0（无限制）。StarRocks 的默认值（512 MiB）可防止 JE 为未受保护的文件保留过多的磁盘空间，同时允许安全清理过时文件。在磁盘受限的系统上调整此值：减小它可让 JE 更早释放更多文件，增加它可让 JE 保留更多预留空间。更改需要重新启动进程才能生效。
+- Introduced in: v3.2.0
 
 ##### `bdbje_reset_election_group`
 
-- 默认值: false
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 是否重置 BDBJE 复制组。如果此参数设置为 `TRUE`，FE 将重置 BDBJE 复制组（即移除所有可选举 FE 节点的信息）并作为 Leader FE 启动。重置后，此 FE 将是集群中唯一的成员，其他 FE 可以通过使用 `ALTER SYSTEM ADD/DROP FOLLOWER/OBSERVER 'xxx'` 重新加入此集群。仅当由于大多数 Follower FE 的数据已损坏而无法选举 Leader FE 时才使用此设置。`reset_election_group` 用于替换 `metadata_failure_recovery`。
-- 引入版本: -
+- Default: false
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: 是否重置 BDBJE 复制组。如果此参数设置为 `TRUE`，FE 将重置 BDBJE 复制组（即，删除所有可选举 FE 节点的信息）并作为 Leader FE 启动。重置后，此 FE 将是集群中唯一的成员，其他 FE 可以通过使用 `ALTER SYSTEM ADD/DROP FOLLOWER/OBSERVER 'xxx'` 重新加入此集群。仅当大多数 Follower FE 的数据已损坏导致无法选举 Leader FE 时才使用此设置。`reset_election_group` 用于替换 `metadata_failure_recovery`。
+- Introduced in: -
 
 ##### `black_host_connect_failures_within_time`
 
-- 默认值: 5
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 黑名单 BE 节点允许的连接失败阈值。如果 BE 节点自动添加到 BE 黑名单，StarRocks 将评估其连接性并判断是否可以将其从 BE 黑名单中删除。在 `black_host_history_sec` 内，只有当黑名单 BE 节点的连接失败次数少于 `black_host_connect_failures_within_time` 中设置的阈值时，才能将其从 BE 黑名单中删除。
-- 引入版本: v3.3.0
+- Default: 5
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: 允许列入黑名单的 BE 节点的连接失败阈值。如果 BE 节点自动添加到 BE 黑名单，StarRocks 将评估其连接性并判断是否可以从 BE 黑名单中移除。在 `black_host_history_sec` 内，只有当列入黑名单的 BE 节点的连接失败次数少于 `black_host_connect_failures_within_time` 中设置的阈值时，才能将其从 BE 黑名单中移除。
+- Introduced in: v3.3.0
 
 ##### `black_host_history_sec`
 
-- 默认值: 2 * 60
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 保留 BE 节点历史连接失败的持续时间（BE 黑名单中）。如果 BE 节点自动添加到 BE 黑名单，StarRocks 将评估其连接性并判断是否可以将其从 BE 黑名单中删除。在 `black_host_history_sec` 内，只有当黑名单 BE 节点的连接失败次数少于 `black_host_connect_failures_within_time` 中设置的阈值时，才能将其从 BE 黑名单中删除。
-- 引入版本: v3.3.0
+- Default: 2 * 60
+- Type: Int
+- Unit: 秒
+- Is mutable: Yes
+- Description: 在 BE 黑名单中保留 BE 节点历史连接失败的时间长度。如果 BE 节点自动添加到 BE 黑名单，StarRocks 将评估其连接性并判断是否可以从 BE 黑名单中移除。在 `black_host_history_sec` 内，只有当列入黑名单的 BE 节点的连接失败次数少于 `black_host_connect_failures_within_time` 中设置的阈值时，才能将其从 BE 黑名单中移除。
+- Introduced in: v3.3.0
 
 ##### `brpc_connection_pool_size`
 
-- 默认值: 16
-- 类型: Int
-- 单位: 连接数
-- 是否可变: No
-- 描述: FE 的 BrpcProxy 使用的每个端点的最大池化 BRPC 连接数。此值通过 `setMaxTotoal` 和 `setMaxIdleSize` 应用于 RpcClientOptions，因此它直接限制并发传出 BRPC 请求，因为每个请求必须从池中借用一个连接。在高并发场景中，增加此值以避免请求排队；增加它会增加套接字和内存使用量，并可能增加远程服务器负载。调整时，请考虑相关设置，例如 `brpc_idle_wait_max_time`、`brpc_short_connection`、`brpc_inner_reuse_pool`、`brpc_reuse_addr` 和 `brpc_min_evictable_idle_time_ms`。更改此值不可热重载，需要重启。
-- 引入版本: v3.2.0
+- Default: 16
+- Type: Int
+- Unit: 连接
+- Is mutable: No
+- Description: FE 的 BrpcProxy 每个端点使用的最大 BRPC 连接池数量。此值通过 `setMaxTotoal` 和 `setMaxIdleSize` 应用于 RpcClientOptions，因此它直接限制了并发的出站 BRPC 请求，因为每个请求都必须从连接池中借用一个连接。在高并发场景中，增加此值以避免请求排队；增加它会提高套接字和内存使用率，并可能增加远程服务器负载。调整时，请考虑相关设置，例如 `brpc_idle_wait_max_time`、`brpc_short_connection`、`brpc_inner_reuse_pool`、`brpc_reuse_addr` 和 `brpc_min_evictable_idle_time_ms`。更改此值不可热加载，需要重新启动。
+- Introduced in: v3.2.0
 
 ##### `brpc_short_connection`
 
-- 默认值: false
-- 类型: boolean
-- 单位: -
-- 是否可变: No
-- 描述: 控制底层 brpc RpcClient 是否使用短连接。启用时 (`true`)，设置 RpcClientOptions.setShortConnection，并且连接在请求完成后关闭，从而减少长时间连接套接字的数量，但代价是更高的连接设置开销和增加的延迟。禁用时 (`false`，默认值) 使用持久连接和连接池。启用此选项会影响连接池行为，应与 `brpc_connection_pool_size`、`brpc_idle_wait_max_time`、`brpc_min_evictable_idle_time_ms`、`brpc_reuse_addr` 和 `brpc_inner_reuse_pool` 一起考虑。对于典型的高吞吐量部署，保持禁用；仅在需要限制套接字生命周期或网络策略需要短连接时才启用。
-- 引入版本: v3.3.11, v3.4.1, v3.5.0
+- Default: false
+- Type: boolean
+- Unit: -
+- Is mutable: No
+- Description: 控制底层 brpc RpcClient 是否使用短连接。启用时 (`true`)，将设置 RpcClientOptions.setShortConnection，并在请求完成后关闭连接，从而减少长连接套接字的数量，但代价是更高的连接建立开销和增加的延迟。禁用时 (`false`，默认值) 使用持久连接和连接池。启用此选项会影响连接池行为，应与 `brpc_connection_pool_size`、`brpc_idle_wait_max_time`、`brpc_min_evictable_idle_time_ms`、`brpc_reuse_addr` 和 `brpc_inner_reuse_pool` 一起考虑。对于典型的高吞吐量部署，请保持禁用状态；仅在限制套接字生命周期或网络策略要求短连接时启用。
+- Introduced in: v3.3.11, v3.4.1, v3.5.0
 
 ##### `catalog_try_lock_timeout_ms`
 
-- 默认值: 5000
-- 类型: Long
-- 单位: 毫秒
-- 是否可变: Yes
-- 描述: 获取全局锁的超时时长。
-- 引入版本: -
+- Default: 5000
+- Type: Long
+- Unit: 毫秒
+- Is mutable: Yes
+- Description: 获取全局锁的超时时长。
+- Introduced in: -
 
 ##### `checkpoint_only_on_leader`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 当 `true` 时，CheckpointController 将仅选择 Leader FE 作为 checkpoint worker；当 `false` 时，控制器可能会选择任何前端，并优先选择堆使用率较低的节点。当为 `false` 时，worker 按最近的失败时间和 `heapUsedPercent` 排序（Leader 被视为具有无限使用率以避免选择它）。对于需要集群快照元数据的操作，控制器无论此标志如何都已强制选择 Leader。启用 `true` 会将 checkpoint 工作集中在 Leader 上（更简单，但增加了 Leader 的 CPU/内存和网络负载）；保持 `false` 会将 checkpoint 负载分配到负载较低的 FE。此设置影响 worker 选择以及与 `checkpoint_timeout_seconds` 等超时和 `thrift_rpc_timeout_ms` 等 RPC 设置的交互。
-- 引入版本: v3.4.0, v3.5.0
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 当为 `true` 时，CheckpointController 将只选择 Leader FE 作为检查点工作节点；当为 `false` 时，控制器可以选择任何前端，并优先选择堆使用率较低的节点。当为 `false` 时，工作节点按最近失败时间和 `heapUsedPercent` 排序（Leader 被视为具有无限使用率以避免选择它）。对于需要集群快照元数据的操作，控制器无论此标志如何，都已强制选择 Leader。启用 `true` 将检查点工作集中在 Leader 上（更简单，但会增加 Leader 的 CPU/内存和网络负载）；保持 `false` 将检查点负载分配给负载较低的 FE。此设置影响工作节点选择以及与 `checkpoint_timeout_seconds` 等超时和 `thrift_rpc_timeout_ms` 等 RPC 设置的交互。
+- Introduced in: v3.4.0, v3.5.0
 
 ##### `checkpoint_timeout_seconds`
 
-- 默认值: 24 * 3600
-- 类型: Long
-- 单位: 秒
-- 是否可变: Yes
-- 描述: Leader 的 CheckpointController 将等待 checkpoint worker 完成 checkpoint 的最长时间（以秒为单位）。控制器将此值转换为纳秒并轮询 worker 结果队列；如果在此超时内未收到成功完成，则 checkpoint 被视为失败，并且 createImage 返回失败。增加此值可适应更长时间运行的 checkpoint，但会延迟故障检测和随后的镜像传播；减少此值会导致更快的故障转移/重试，但可能会因慢速 worker 而产生误报超时。此设置仅控制 `CheckpointController` 在 checkpoint 创建期间的等待时间，不改变 worker 的内部 checkpointing 行为。
-- 引入版本: v3.4.0, v3.5.0
+- Default: 24 * 3600
+- Type: Long
+- Unit: 秒
+- Is mutable: Yes
+- Description: Leader 的 CheckpointController 等待检查点工作节点完成检查点的最长时间（以秒为单位）。控制器将此值转换为纳秒并轮询工作节点结果队列；如果在此超时时间内未收到成功完成，则检查点被视为失败，并且 createImage 返回失败。增加此值可以适应运行时间更长的检查点，但会延迟故障检测和后续镜像传播；减小它会导致更快的故障转移/重试，但可能会为慢速工作节点产生错误的超时。此设置仅控制 `CheckpointController` 在检查点创建期间的等待时间，不改变工作节点的内部检查点行为。
+- Introduced in: v3.4.0, v3.5.0
 
 ##### `db_used_data_quota_update_interval_secs`
 
-- 默认值: 300
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 数据库已用数据配额更新的间隔。StarRocks 会定期更新所有数据库的已用数据配额，以跟踪存储消耗。此值用于配额强制执行和指标收集。允许的最小间隔为 30 秒，以防止过高的系统负载。小于 30 的值将被拒绝。
-- 引入版本: -
+- Default: 300
+- Type: Int
+- Unit: 秒
+- Is mutable: Yes
+- Description: 数据库已用数据配额的更新间隔。StarRocks 定期更新所有数据库的已用数据配额以跟踪存储消耗。此值用于配额强制执行和指标收集。允许的最小间隔为 30 秒，以防止系统负载过高。小于 30 的值将被拒绝。
+- Introduced in: -
 
 ##### `drop_backend_after_decommission`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: BE 下线后是否删除 BE。`TRUE` 表示 BE 下线后立即删除 BE。`FALSE` 表示 BE 下线后不删除 BE。
-- 引入版本: -
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: BE 下线后是否删除 BE。`TRUE` 表示 BE 下线后立即删除。`FALSE` 表示 BE 下线后不删除。
+- Introduced in: -
 
 ##### `edit_log_port`
 
-- 默认值: 9010
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: 集群中 Leader、Follower 和 Observer FE 之间通信使用的端口。
-- 引入版本: -
+- Default: 9010
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: 集群中 Leader、Follower 和 Observer FE 之间用于通信的端口。
+- Introduced in: -
 
 ##### `edit_log_roll_num`
 
-- 默认值: 50000
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 在为日志条目创建日志文件之前可以写入的元数据日志条目的最大数量。此参数用于控制日志文件的大小。新的日志文件写入 BDBJE 数据库。
-- 引入版本: -
+- Default: 50000
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: 在为这些日志条目创建日志文件之前可以写入的最大元数据日志条目数。此参数用于控制日志文件的大小。新日志文件写入 BDBJE 数据库。
+- Introduced in: -
 
 ##### `edit_log_type`
 
-- 默认值: BDB
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 可以生成的 edit log 类型。将值设置为 `BDB`。
-- 引入版本: -
+- Default: BDB
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: 可以生成的编辑日志类型。将值设置为 `BDB`。
+- Introduced in: -
 
 ##### `enable_background_refresh_connector_metadata`
 
-- 默认值: v3.0 及更高版本为 true，v2.5 为 false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否启用周期性 Hive 元数据缓存刷新。启用后，StarRocks 会轮询 Hive 集群的 metastore（Hive Metastore 或 AWS Glue），并刷新频繁访问的 Hive Catalog 的缓存元数据，以感知数据变化。`true` 表示启用 Hive 元数据缓存刷新，`false` 表示禁用。
-- 引入版本: v2.5.5
+- Default: v3.0 及更高版本为 true，v2.5 为 false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 是否启用周期性 Hive 元数据缓存刷新。启用后，StarRocks 会轮询您的 Hive 集群的 metastore（Hive Metastore 或 AWS Glue），并刷新频繁访问的 Hive Catalog 的缓存元数据以感知数据变化。`true` 表示启用 Hive 元数据缓存刷新，`false` 表示禁用。
+- Introduced in: v2.5.5
 
 ##### `enable_collect_query_detail_info`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否收集查询的 profile。如果此参数设置为 `TRUE`，系统将收集查询的 profile。如果此参数设置为 `FALSE`，系统将不收集查询的 profile。
-- 引入版本: -
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 是否收集查询的 Profile。如果此参数设置为 `TRUE`，系统将收集查询的 Profile。如果此参数设置为 `FALSE`，系统将不收集查询的 Profile。
+- Introduced in: -
 
 ##### `enable_create_partial_partition_in_batch`
 
-- 默认值: false
-- 类型: boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 当此项设置为 `false`（默认）时，StarRocks 会强制批量创建的范围分区与标准时间单位边界对齐。它将拒绝非对齐的范围以避免创建空洞。将此项设置为 `true` 会禁用该对齐检查，并允许批量创建部分（非标准）分区，这可能会产生间隙或错位的分区范围。仅当您有意需要部分批量分区并接受相关风险时才应将其设置为 `true`。
-- 引入版本: v3.2.0
+- Default: false
+- Type: boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 当此项设置为 `false`（默认值）时，StarRocks 强制批量创建的范围分区与标准时间单位边界对齐。它将拒绝非对齐范围以避免创建空洞。将此项设置为 `true` 会禁用该对齐检查，并允许批量创建部分（非标准）分区，这可能会产生间隙或错位的分区范围。您只应在有意需要部分批量分区并接受相关风险时将其设置为 `true`。
+- Introduced in: v3.2.0
 
 ##### `enable_internal_sql`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 当此项设置为 `true` 时，内部组件（例如 SimpleExecutor）执行的内部 SQL 语句将保留并写入内部审计或日志消息中（如果设置了 `enable_sql_desensitize_in_log`，还可以进一步脱敏）。当设置为 `false` 时，内部 SQL 文本将被抑制：格式化代码 (SimpleExecutor.formatSQL) 返回 "?"，并且实际语句不会发出到内部审计或日志消息中。此配置不改变内部语句的执行语义——它仅控制内部 SQL 的日志记录和可见性，用于隐私或安全目的。
-- 引入版本: -
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: 当此项设置为 `true` 时，内部组件（例如 SimpleExecutor）执行的内部 SQL 语句将被保留并写入内部审计或日志消息中（如果设置了 `enable_sql_desensitize_in_log`，还可以进一步脱敏）。当设置为 `false` 时，内部 SQL 文本将被抑制：格式化代码 (SimpleExecutor.formatSQL) 返回“?”，并且实际语句不会发送到内部审计或日志消息。此配置不改变内部语句的执行语义——它仅控制内部 SQL 的日志记录和可见性，以实现隐私或安全。
+- Introduced in: -
 
 ##### `enable_legacy_compatibility_for_replication`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否启用 Legacy 复制兼容性。StarRocks 在新旧版本之间可能表现不同，导致跨集群数据迁移时出现问题。因此，在数据迁移之前，您必须为目标集群启用 Legacy 兼容性，并在数据迁移完成后禁用它。`true` 表示启用此模式。
-- 引入版本: v3.1.10, v3.2.6
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 是否启用复制的旧版兼容性。StarRocks 在新旧版本之间可能行为不同，导致跨集群数据迁移期间出现问题。因此，您必须在数据迁移之前为目标集群启用旧版兼容性，并在数据迁移完成后禁用它。`true` 表示启用此模式。
+- Introduced in: v3.1.10, v3.2.6
 
 ##### `enable_show_materialized_views_include_all_task_runs`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 控制 SHOW MATERIALIZED VIEWS 命令如何返回 TaskRun。当此项设置为 `false` 时，StarRocks 只返回每个任务的最新 TaskRun（为兼容性而保留的旧行为）。当设置为 `true`（默认）时，`TaskManager` 可能会为同一任务包含额外的 TaskRun，但仅当它们共享相同的启动 TaskRun ID（例如，属于同一作业）时，从而防止出现不相关的重复运行，同时允许显示与一个作业相关的多个状态。将此项设置为 `false` 可恢复单次运行输出，或用于调试和监控的多运行作业历史记录。
-- 引入版本: v3.3.0, v3.4.0, v3.5.0
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 控制 `SHOW MATERIALIZED VIEWS` 命令如何返回 TaskRuns。当此项设置为 `false` 时，StarRocks 只返回每个任务的最新 TaskRun（为了兼容性的旧行为）。当设置为 `true`（默认值）时，`TaskManager` 可能会为同一任务包含额外的 TaskRuns，但仅当它们共享相同的启动 TaskRun ID（例如，属于同一作业）时，这可以防止出现不相关的重复运行，同时允许显示与一个作业相关的多个状态。将此项设置为 `false` 以恢复单次运行输出，或显示多次运行的作业历史以进行调试和监控。
+- Introduced in: v3.3.0, v3.4.0, v3.5.0
 
 ##### `enable_statistics_collect_profile`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否为统计信息查询生成 profile。您可以将此项设置为 `true`，以允许 StarRocks 为系统统计信息查询生成查询 profile。
-- 引入版本: v3.1.5
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 是否为统计信息查询生成 Profile。您可以将此项设置为 `true`，以允许 StarRocks 为系统统计信息查询生成查询 Profile。
+- Introduced in: v3.1.5
 
 ##### `enable_table_name_case_insensitive`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 是否对 catalog 名称、数据库名称、表名称、视图名称和物化视图名称启用不区分大小写的处理。当前，表名称默认区分大小写。
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: 是否对 Catalog 名称、数据库名称、表名称、视图名称和物化视图名称启用不区分大小写处理。目前，表名称默认区分大小写。
   - 启用此功能后，所有相关名称将以小写形式存储，并且所有包含这些名称的 SQL 命令将自动将其转换为小写。
-  - 您只能在创建集群时启用此功能。**集群启动后，此配置的值无法通过任何方式修改**。任何修改尝试都将导致错误。FE 在检测到此配置项的值与集群首次启动时不一致时将无法启动。
-  - 当前，此功能不支持 JDBC catalog 和表名称。如果您想对 JDBC 或 ODBC 数据源执行不区分大小写的处理，请不要启用此功能。
-- 引入版本: v4.0
+  - 您只能在创建集群时启用此功能。**集群启动后，此配置的值不能以任何方式修改**。任何修改尝试都将导致错误。当 FE 检测到此配置项的值与集群首次启动时不一致时，FE 将无法启动。
+  - 目前，此功能不支持 JDBC Catalog 和表名称。如果您想对 JDBC 或 ODBC 数据源执行不区分大小写处理，请勿启用此功能。
+- Introduced in: v4.0
 
 ##### `enable_task_history_archive`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 启用后，已完成的任务运行记录将存档到持久的任务运行历史表中，并记录到 edit log 中，以便查找（例如，`lookupHistory`、`lookupHistoryByTaskNames`、`lookupLastJobOfTasks`）包含存档结果。存档由 FE Leader 执行，并在单元测试 (`FeConstants.runningUnitTest`) 期间跳过。启用后，会绕过内存中的过期和强制 GC 路径（代码从 `removeExpiredRuns` 和 `forceGC` 中提前返回），因此保留/驱逐由持久存档处理，而不是 `task_runs_ttl_second` 和 `task_runs_max_history_number`。禁用后，历史记录保留在内存中，并由这些配置进行清理。
-- 引入版本: v3.3.1, v3.4.0, v3.5.0
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 启用后，已完成的任务运行记录将归档到持久任务运行历史表并记录到编辑日志中，以便查找（例如 `lookupHistory`、`lookupHistoryByTaskNames`、`lookupLastJobOfTasks`）包含归档结果。归档由 FE Leader 执行，并在单元测试 (`FeConstants.runningUnitTest`) 期间跳过。启用后，内存中的过期和强制 GC 路径将被绕过（代码从 `removeExpiredRuns` 和 `forceGC` 提前返回），因此保留/逐出由持久归档处理，而不是 `task_runs_ttl_second` 和 `task_runs_max_history_number`。禁用时，历史记录保留在内存中并由这些配置进行修剪。
+- Introduced in: v3.3.1, v3.4.0, v3.5.0
 
 ##### `enable_task_run_fe_evaluation`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 启用后，FE 将在 `TaskRunsSystemTable.supportFeEvaluation` 中对系统表 `task_runs` 执行本地评估。FE 侧评估仅允许用于将列与常量进行比较的合取相等谓词，并且仅限于 `QUERY_ID` 和 `TASK_NAME` 列。启用此功能可提高定向查找的性能，避免更广泛的扫描或额外的远程处理；禁用它会强制规划器跳过对 `task_runs` 的 FE 评估，这可能会减少谓词剪枝并影响这些过滤器的查询延迟。
-- 引入版本: v3.3.13, v3.4.3, v3.5.0
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 启用后，FE 将在 `TaskRunsSystemTable.supportFeEvaluation` 中对系统表 `task_runs` 执行本地评估。FE 侧评估仅允许用于将列与常量进行比较的合取相等谓词，并且仅限于 `QUERY_ID` 和 `TASK_NAME` 列。启用此功能可以通过避免更广泛的扫描或额外的远程处理来提高目标查找的性能；禁用它会强制规划器跳过 `task_runs` 的 FE 评估，这可能会减少谓词修剪并影响这些过滤器的查询延迟。
+- Introduced in: v3.3.13, v3.4.3, v3.5.0
 
 ##### `heartbeat_mgr_blocking_queue_size`
 
-- 默认值: 1024
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: 存储 Heartbeat Manager 运行的心跳任务的阻塞队列的大小。
-- 引入版本: -
+- Default: 1024
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: 存储由心跳管理器运行的心跳任务的阻塞队列的大小。
+- Introduced in: -
 
 ##### `heartbeat_mgr_threads_num`
 
-- 默认值: 8
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: Heartbeat Manager 可运行以运行心跳任务的线程数。
-- 引入版本: -
+- Default: 8
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: 心跳管理器可以运行心跳任务的线程数。
+- Introduced in: -
 
 ##### `ignore_materialized_view_error`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: FE 是否忽略物化视图错误导致的元数据异常。如果 FE 因物化视图错误导致的元数据异常而无法启动，您可以将此参数设置为 `true` 以允许 FE 忽略该异常。
-- 引入版本: v2.5.10
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: FE 是否忽略由物化视图错误引起的元数据异常。如果 FE 因物化视图错误引起的元数据异常而无法启动，您可以将此参数设置为 `true` 以允许 FE 忽略该异常。
+- Introduced in: v2.5.10
 
 ##### `ignore_meta_check`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 非 Leader FE 是否忽略 Leader FE 的元数据差距。如果值为 TRUE，非 Leader FE 忽略 Leader FE 的元数据差距并继续提供数据读取服务。此参数确保即使您长时间停止 Leader FE，也能持续提供数据读取服务。如果值为 FALSE，非 Leader FE 不忽略 Leader FE 的元数据差距并停止提供数据读取服务。
-- 引入版本: -
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 非 Leader FE 是否忽略与 Leader FE 的元数据差距。如果值为 TRUE，非 Leader FE 将忽略与 Leader FE 的元数据差距并继续提供数据读取服务。此参数确保即使您长时间停止 Leader FE，也能提供连续的数据读取服务。如果值为 FALSE，非 Leader FE 将不忽略与 Leader FE 的元数据差距并停止提供数据读取服务。
+- Introduced in: -
 
 ##### `ignore_task_run_history_replay_error`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 当 StarRocks 反序列化 `information_schema.task_runs` 的 TaskRun 历史行时，损坏或无效的 JSON 行通常会导致反序列化记录警告并抛出 RuntimeException。如果此项设置为 `true`，系统将捕获反序列化错误，跳过格式错误的记录，并继续处理剩余行而不是使查询失败。这将使 `information_schema.task_runs` 查询能够容忍 `_statistics_.task_run_history` 表中的错误条目。请注意，启用它将静默丢弃损坏的历史记录（潜在数据丢失），而不是显式报错。
-- 引入版本: v3.3.3, v3.4.0, v3.5.0
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 当 StarRocks 为 `information_schema.task_runs` 反序列化 TaskRun 历史行时，损坏或无效的 JSON 行通常会导致反序列化记录警告并抛出 RuntimeException。如果此项设置为 `true`，系统将捕获反序列化错误，跳过格式错误的记录，并继续处理剩余的行，而不是使查询失败。这将使 `information_schema.task_runs` 查询能够容忍 `_statistics_.task_run_history` 表中的错误条目。请注意，启用它将静默丢弃损坏的历史记录（潜在数据丢失），而不是显示明确的错误。
+- Introduced in: v3.3.3, v3.4.0, v3.5.0
 
 ##### `lock_checker_interval_second`
 
-- 默认值: 30
-- 类型: long
-- 单位: 秒
-- 是否可变: Yes
-- 描述: LockChecker 前端守护程序（名为 "deadlock-checker"）执行的间隔（秒）。守护程序执行死锁检测和慢锁扫描；配置值乘以 1000 以设置计时器（毫秒）。减小此值可减少检测延迟但增加调度和 CPU 开销；增加此值可减少开销但延迟检测和慢锁报告。更改在运行时生效，因为守护程序每次运行都会重置其间隔。此设置与 `lock_checker_enable_deadlock_check`（启用死锁检查）和 `slow_lock_threshold_ms`（定义慢锁的构成）交互。
-- 引入版本: v3.2.0
+- Default: 30
+- Type: long
+- Unit: 秒
+- Is mutable: Yes
+- Description: LockChecker 前端守护程序（名为“deadlock-checker”）执行之间的间隔，以秒为单位。该守护程序执行死锁检测和慢锁扫描；配置的值乘以 1000 以毫秒为单位设置计时器。减小此值可减少检测延迟，但会增加调度和 CPU 开销；增加它可减少开销，但会延迟检测和慢锁报告。更改在运行时生效，因为守护程序每次运行时都会重置其间隔。此设置与 `lock_checker_enable_deadlock_check`（启用死锁检查）和 `slow_lock_threshold_ms`（定义慢锁的构成）交互。
+- Introduced in: v3.2.0
 
 ##### `master_sync_policy`
 
-- 默认值: SYNC
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: Leader FE 将日志刷新到磁盘的策略。此参数仅当当前 FE 是 Leader FE 时有效。有效值：
-  - `SYNC`: 事务提交时，日志条目同时生成并刷新到磁盘。
-  - `NO_SYNC`: 事务提交时，日志条目的生成和刷新不同时发生。
-  - `WRITE_NO_SYNC`: 事务提交时，日志条目同时生成但不刷新到磁盘。
+- Default: SYNC
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: Leader FE 将日志刷新到磁盘的策略。此参数仅在当前 FE 是 Leader FE 时有效。有效值：
+  - `SYNC`：事务提交时，日志条目同时生成并刷新到磁盘。
+  - `NO_SYNC`：事务提交时，日志条目的生成和刷新不同时发生。
+  - `WRITE_NO_SYNC`：事务提交时，日志条目同时生成但不刷新到磁盘。
 
   如果您只部署了一个 Follower FE，建议您将此参数设置为 `SYNC`。如果您部署了三个或更多 Follower FE，建议您将此参数和 `replica_sync_policy` 都设置为 `WRITE_NO_SYNC`。
 
-- 引入版本: -
+- Introduced in: -
 
 ##### `max_bdbje_clock_delta_ms`
 
-- 默认值: 5000
-- 类型: Long
-- 单位: 毫秒
-- 是否可变: No
-- 描述: StarRocks 集群中 Leader FE 与 Follower 或 Observer FE 之间允许的最大时钟偏移量。
-- 引入版本: -
+- Default: 5000
+- Type: Long
+- Unit: 毫秒
+- Is mutable: No
+- Description: StarRocks 集群中 Leader FE 与 Follower 或 Observer FE 之间允许的最大时钟偏移。
+- Introduced in: -
 
 ##### `meta_delay_toleration_second`
 
-- 默认值: 300
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述: Follower 和 Observer FE 上的元数据可以比 Leader FE 上的元数据落后最长时间。单位：秒。如果超过此持续时间，非 Leader FE 将停止提供服务。
-- 引入版本: -
+- Default: 300
+- Type: Int
+- Unit: 秒
+- Is mutable: Yes
+- Description: Follower 和 Observer FE 上的元数据落后于 Leader FE 上的元数据的最大持续时间。单位：秒。如果超过此持续时间，非 Leader FE 将停止提供服务。
+- Introduced in: -
 
 ##### `meta_dir`
 
-- 默认值: `StarRocksFE.STARROCKS_HOME_DIR` + "/meta"
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 存储元数据的目录。
-- 引入版本: -
+- Default: `StarRocksFE.STARROCKS_HOME_DIR` + "/meta"
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: 存储元数据的目录。
+- Introduced in: -
 
 ##### `metadata_ignore_unknown_operation_type`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否忽略未知日志 ID。当 FE 回滚时，早期版本的 FE 可能无法识别某些日志 ID。如果值为 `TRUE`，FE 将忽略未知日志 ID。如果值为 `FALSE`，FE 将退出。
-- 引入版本: -
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: 是否忽略未知日志 ID。当 FE 回滚时，早期版本的 FE 可能无法识别某些日志 ID。如果值为 `TRUE`，FE 将忽略未知日志 ID。如果值为 `FALSE`，FE 将退出。
+- Introduced in: -
 
 ##### `profile_info_format`
 
-- 默认值: default
-- 类型: String
-- 单位: -
-- 是否可变: Yes
-- 描述: 系统输出的 Profile 格式。有效值：`default` 和 `json`。设置为 `default` 时，Profile 为默认格式。设置为 `json` 时，系统输出 JSON 格式的 Profile。
-- 引入版本: v2.5
+- Default: default
+- Type: String
+- Unit: -
+- Is mutable: Yes
+- Description: 系统输出的 Profile 格式。有效值：`default` 和 `json`。当设置为 `default` 时，Profile 为默认格式。当设置为 `json` 时，系统以 JSON 格式输出 Profile。
+- Introduced in: v2.5
 
 ##### `replica_ack_policy`
 
-- 默认值: `SIMPLE_MAJORITY`
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 日志条目被认为有效的策略。默认值 `SIMPLE_MAJORITY` 指定如果大多数 Follower FE 返回 ACK 消息，则日志条目被认为有效。
-- 引入版本: -
+- Default: `SIMPLE_MAJORITY`
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: 判断日志条目是否有效的策略。默认值 `SIMPLE_MAJORITY` 指定如果大多数 Follower FE 返回 ACK 消息，则日志条目被认为是有效的。
+- Introduced in: -
 
 ##### `replica_sync_policy`
 
-- 默认值: SYNC
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: Follower FE 将日志刷新到磁盘的策略。此参数仅当当前 FE 是 Follower FE 时有效。有效值：
-  - `SYNC`: 事务提交时，日志条目同时生成并刷新到磁盘。
-  - `NO_SYNC`: 事务提交时，日志条目的生成和刷新不同时发生。
-  - `WRITE_NO_SYNC`: 事务提交时，日志条目同时生成但不刷新到磁盘。
-- 引入版本: -
+- Default: SYNC
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: Follower FE 将日志刷新到磁盘的策略。此参数仅在当前 FE 是 Follower FE 时有效。有效值：
+  - `SYNC`：事务提交时，日志条目同时生成并刷新到磁盘。
+  - `NO_SYNC`：事务提交时，日志条目的生成和刷新不同时发生。
+  - `WRITE_NO_SYNC`：事务提交时，日志条目同时生成但不刷新到磁盘。
+- Introduced in: -
 
 ##### `start_with_incomplete_meta`
 
-- 默认值: false
-- 类型: boolean
-- 单位: -
-- 是否可变: No
-- 描述: 当为 true 时，如果镜像数据存在但 Berkeley DB JE (BDB) 日志文件丢失或损坏，FE 将允许启动。`MetaHelper.checkMetaDir()` 使用此标志绕过安全检查，否则会阻止从没有相应 BDB 日志的镜像启动；以这种方式启动可能会产生陈旧或不一致的元数据，应仅用于紧急恢复。`RestoreClusterSnapshotMgr` 在恢复集群快照时暂时将此标志设置为 true，然后将其回滚；该组件在恢复期间也会切换 `bdbje_reset_election_group`。在正常操作中不要启用它 — 仅在从损坏的 BDB 数据恢复或显式恢复基于镜像的快照时启用。
-- 引入版本: v3.2.0
+- Default: false
+- Type: boolean
+- Unit: -
+- Is mutable: No
+- Description: 当为 true 时，如果镜像数据存在但 Berkeley DB JE (BDB) 日志文件丢失或损坏，FE 将允许启动。`MetaHelper.checkMetaDir()` 使用此标志绕过安全检查，否则该检查会阻止在没有相应 BDB 日志的情况下从镜像启动；以这种方式启动可能会产生陈旧或不一致的元数据，并且只能用于紧急恢复。`RestoreClusterSnapshotMgr` 在恢复集群快照时暂时将此标志设置为 true，然后将其回滚；该组件在恢复期间还会切换 `bdbje_reset_election_group`。请勿在正常操作中启用——仅在从损坏的 BDB 数据恢复或明确恢复基于镜像的快照时启用。
+- Introduced in: v3.2.0
 
 ##### `table_keeper_interval_second`
 
-- 默认值: 30
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述: TableKeeper 守护程序执行的间隔（秒）。TableKeeperDaemon 使用此值（乘以 1000）设置其内部计时器，并定期运行 keeper 任务，以确保历史表存在、正确的表属性（复制数量）并更新分区 TTL。守护程序仅在 Leader 节点上执行工作，并在 `table_keeper_interval_second` 更改时通过 setInterval 更新其运行时间隔。增加此值可减少调度频率和负载；减少此值可更快响应缺失或陈旧的历史表。
-- 引入版本: v3.3.1, v3.4.0, v3.5.0
+- Default: 30
+- Type: Int
+- Unit: 秒
+- Is mutable: Yes
+- Description: TableKeeper 守护程序执行之间的间隔，以秒为单位。TableKeeperDaemon 使用此值（乘以 1000）设置其内部计时器，并定期运行 keeper 任务，以确保历史表存在、更正表属性（副本数）并更新分区 TTL。守护程序仅在 Leader 节点上执行工作，并在 `table_keeper_interval_second` 更改时通过 setInterval 更新其运行时间隔。增加此值可降低调度频率和负载；减小此值可更快地响应缺失或陈旧的历史表。
+- Introduced in: v3.3.1, v3.4.0, v3.5.0
 
 ##### `task_runs_ttl_second`
 
-- 默认值: 7 * 24 * 3600
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 控制任务运行历史记录的存活时间 (TTL)。降低此值会缩短历史记录保留时间并减少内存/磁盘使用；提高此值会保留更长时间的历史记录，但会增加资源使用。与 `task_runs_max_history_number` 和 `enable_task_history_archive` 一起调整，以实现可预测的保留和存储行为。
-- 引入版本: v3.2.0
+- Default: 7 * 24 * 3600
+- Type: Int
+- Unit: 秒
+- Is mutable: Yes
+- Description: 控制任务运行历史记录的生存时间 (TTL)。降低此值会缩短历史记录保留时间并减少内存/磁盘使用；提高此值会延长历史记录保留时间但增加资源使用。与 `task_runs_max_history_number` 和 `enable_task_history_archive` 一起调整，以实现可预测的保留和存储行为。
+- Introduced in: v3.2.0
 
 ##### `task_ttl_second`
 
-- 默认值: 24 * 3600
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 任务的存活时间 (TTL)。对于手动任务（未设置调度），TaskBuilder 使用此值计算任务的 `expireTime` (`expireTime = now + task_ttl_second * 1000L`)。TaskRun 也将此值用作计算运行执行超时的上限 — 有效执行超时为 `min(task_runs_timeout_second, task_runs_ttl_second, task_ttl_second)`。调整此值会更改手动创建任务的有效时间，并可以间接限制任务运行的最大允许执行时间。
-- 引入版本: v3.2.0
+- Default: 24 * 3600
+- Type: Int
+- Unit: 秒
+- Is mutable: Yes
+- Description: 任务的生存时间 (TTL)。对于手动任务（未设置调度时），TaskBuilder 使用此值计算任务的 `expireTime` (`expireTime = now + task_ttl_second * 1000L`)。TaskRun 在计算运行的执行超时时也使用此值作为上限——有效的执行超时是 `min(task_runs_timeout_second, task_runs_ttl_second, task_ttl_second)`。调整此值会改变手动创建任务的有效时间，并可以间接限制任务运行的最大允许执行时间。
+- Introduced in: v3.2.0
 
 ##### `thrift_rpc_retry_times`
 
-- 默认值: 3
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 控制 Thrift RPC 调用将尝试的总次数。此值由 `ThriftRPCRequestExecutor`（以及 `NodeMgr` 和 `VariableMgr` 等调用者）用作重试的循环计数 — 即，值为 3 允许最多三次尝试，包括初始尝试。在 `TTransportException` 上，执行器将尝试重新打开连接并重试此计数；当原因是 `SocketTimeoutException` 或重新打开失败时，它不会重试。每次尝试都受 `thrift_rpc_timeout_ms` 配置的每次尝试超时限制。增加此值可提高对瞬时连接失败的弹性，但会增加整体 RPC 延迟和资源使用。
-- 引入版本: v3.2.0
+- Default: 3
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: 控制 Thrift RPC 调用将尝试的总次数。此值由 `ThriftRPCRequestExecutor`（以及 `NodeMgr` 和 `VariableMgr` 等调用者）用作重试的循环计数——即，值为 3 允许最多三次尝试，包括初始尝试。在 `TTransportException` 上，执行器将尝试重新打开连接并重试达到此计数；当原因是 `SocketTimeoutException` 或重新打开失败时，它将不会重试。每次尝试都受 `thrift_rpc_timeout_ms` 配置的每次尝试超时限制。增加此值可提高对瞬态连接故障的弹性，但可能会增加整体 RPC 延迟和资源使用。
+- Introduced in: v3.2.0
 
 ##### `thrift_rpc_strict_mode`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 控制 Thrift 服务器使用的 TBinaryProtocol“严格读取”模式。此值作为第一个参数传递给 Thrift 服务器堆栈中的 org.apache.thrift.protocol.TBinaryProtocol.Factory，并影响如何解析和验证传入的 Thrift 消息。当 `true`（默认）时，服务器强制执行严格的 Thrift 编码/版本检查并遵守配置的 `thrift_rpc_max_body_size` 限制；当 `false` 时，服务器接受非严格（旧版/宽松）消息格式，这可以提高与旧客户端的兼容性，但可能会绕过某些协议验证。在运行中的集群上更改此值请谨慎，因为它不可变并影响互操作性和解析安全性。
-- 引入版本: v3.2.0
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: 控制 Thrift 服务器使用的 TBinaryProtocol“严格读取”模式。此值作为第一个参数传递给 Thrift 服务器堆栈中的 org.apache.thrift.protocol.TBinaryProtocol.Factory，并影响传入 Thrift 消息的解析和验证方式。当为 `true`（默认值）时，服务器强制执行严格的 Thrift 编码/版本检查并遵守配置的 `thrift_rpc_max_body_size` 限制；当为 `false` 时，服务器接受非严格（旧版/宽松）消息格式，这可以提高与旧客户端的兼容性，但可能会绕过一些协议验证。在运行中的集群上更改此设置时请谨慎，因为它不可变且会影响互操作性和解析安全性。
+- Introduced in: v3.2.0
 
 ##### `thrift_rpc_timeout_ms`
 
-- 默认值: 10000
-- 类型: Int
-- 单位: 毫秒
-- 是否可变: Yes
-- 描述: 用作 Thrift RPC 调用默认网络/套接字超时的持续时间（毫秒）。它在 `ThriftConnectionPool`（前端和后端池使用）创建 Thrift 客户端时传递给 TSocket，并且在 `ConfigBase`、`LeaderOpExecutor`、`GlobalStateMgr`、`NodeMgr`、`VariableMgr` 和 `CheckpointWorker` 等地方计算 RPC 调用超时时也添加到操作的执行超时（例如 ExecTimeout*1000 + `thrift_rpc_timeout_ms`）。增加此值会使 RPC 调用能够容忍更长的网络或远程处理延迟；减少此值会导致慢速网络上的故障转移更快。更改此值会影响执行 Thrift RPC 的 FE 代码路径中的连接创建和请求截止日期。
-- 引入版本: v3.2.0
+- Default: 10000
+- Type: Int
+- Unit: 毫秒
+- Is mutable: Yes
+- Description: 用作 Thrift RPC 调用的默认网络/套接字超时时间（以毫秒为单位）。在 `ThriftConnectionPool` 中创建 Thrift 客户端时（由前端和后端池使用）会将其传递给 TSocket，并且在 `ConfigBase`、`LeaderOpExecutor`、`GlobalStateMgr`、`NodeMgr`、`VariableMgr` 和 `CheckpointWorker` 等地方计算 RPC 调用超时时，也会将其添加到操作的执行超时（例如，ExecTimeout*1000 + `thrift_rpc_timeout_ms`）。增加此值可使 RPC 调用容忍更长的网络或远程处理延迟；减小此值可在慢速网络上实现更快的故障转移。更改此值会影响执行 Thrift RPC 的 FE 代码路径中的连接创建和请求截止时间。
+- Introduced in: v3.2.0
 
 ##### `txn_latency_metric_report_groups`
 
-- 默认值: 一个空字符串
-- 类型: String
-- 单位: -
-- 是否可变: Yes
-- 描述: 逗号分隔的事务延迟指标组列表，用于报告。加载类型被归类为逻辑组以进行监控。当启用某个组时，其名称将作为“类型”标签添加到事务指标中。有效值：`stream_load`、`routine_load`、`broker_load`、`insert` 和 `compaction`（仅适用于共享数据集群）。示例：`"stream_load,routine_load"`。
-- 引入版本: v4.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: Yes
+- Description: 要报告的事务延迟指标组的逗号分隔列表。加载类型被分类为逻辑组以进行监控。当启用一个组时，其名称将作为“type”标签添加到事务指标中。有效值：`stream_load`、`routine_load`、`broker_load`、`insert` 和 `compaction`（仅适用于共享数据集群）。示例：`"stream_load,routine_load"`。
+- Introduced in: v4.0
 
 ##### `txn_rollback_limit`
 
-- 默认值: 100
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: 可回滚的最大事务数。
-- 引入版本: -
+- Default: 100
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: 可以回滚的最大事务数。
+- Introduced in: -
 
 ### 用户、角色和权限
 
 ##### `enable_task_info_mask_credential`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔
 - 单位: -
-- 是否可变: Yes
-- 描述: 当为 true 时，StarRocks 会在将凭据从任务 SQL 定义返回到 `information_schema.tasks` 和 `information_schema.task_runs` 之前，通过对 DEFINITION 列应用 SqlCredentialRedactor.redact 来屏蔽凭据。在 `information_schema.task_runs` 中，无论定义是来自任务运行状态还是在为空时来自任务定义查找，都应用相同的屏蔽。当为 false 时，返回原始任务定义（可能会暴露凭据）。屏蔽是 CPU/字符串处理工作，当任务或 `task_runs` 数量很大时可能非常耗时；仅当您需要未屏蔽的定义并接受安全风险时才禁用。
+- 可变: 是
+- 描述: 当为 true 时，StarRocks 会在将任务 SQL 定义返回到 `information_schema.tasks` 和 `information_schema.task_runs` 之前，通过对 DEFINITION 列应用 SqlCredentialRedactor.redact 来编辑凭证。在 `information_schema.task_runs` 中，无论定义是来自任务运行状态，还是在为空时来自任务定义查找，都会应用相同的编辑。当为 false 时，将返回原始任务定义（可能会暴露凭证）。掩码是 CPU/字符串处理工作，当任务或 `task_runs` 的数量很大时，可能会非常耗时；仅当您需要未编辑的定义并接受安全风险时才禁用。
 - 引入版本: v3.5.6
 
 ##### `privilege_max_role_depth`
 
 - 默认值: 16
-- 类型: Int
+- 类型: 整型
 - 单位:
-- 是否可变: Yes
-- 描述: 角色的最大角色深度（继承级别）。
+- 可变: 是
+- 描述: 角色的最大深度（继承级别）。
 - 引入版本: v3.0.0
 
 ##### `privilege_max_total_roles_per_user`
 
 - 默认值: 64
-- 类型: Int
+- 类型: 整型
 - 单位:
-- 是否可变: Yes
+- 可变: 是
 - 描述: 用户可以拥有的最大角色数量。
 - 引入版本: v3.0.0
 
@@ -1556,322 +1556,322 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 ##### `brpc_send_plan_fragment_timeout_ms`
 
 - 默认值: 60000
-- 类型: Int
+- 类型: 整型
 - 单位: 毫秒
-- 是否可变: Yes
-- 描述: 在发送计划片段之前应用于 BRPC TalkTimeoutController 的超时（毫秒）。`BackendServiceClient.sendPlanFragmentAsync` 在调用后端 `execPlanFragmentAsync` 之前设置此值。它控制 BRPC 在从连接池借用空闲连接以及执行发送时将等待多长时间；如果超过，RPC 将失败并可能触发该方法的重试逻辑。在争用情况下，将此值设置得更低以快速失败，或提高它以容忍瞬时池耗尽或慢速网络。请谨慎：非常大的值可能会延迟故障检测并阻塞请求线程。
+- 可变: 是
+- 描述: 在发送计划片段之前，应用于 BRPC TalkTimeoutController 的超时时间（毫秒）。`BackendServiceClient.sendPlanFragmentAsync` 在调用后端 `execPlanFragmentAsync` 之前设置此值。它控制 BRPC 在从连接池借用空闲连接以及执行发送操作时将等待多长时间；如果超出此时间，RPC 将失败并可能触发方法的重试逻辑。将其设置得更低可以在争用情况下快速失败，或者提高它以容忍瞬时连接池耗尽或慢速网络。请注意：非常大的值可能会延迟故障检测并阻塞请求线程。
 - 引入版本: v3.3.11, v3.4.1, v3.5.0
 
 ##### `connector_table_query_trigger_analyze_large_table_interval`
 
 - 默认值: 12 * 3600
-- 类型: Int
+- 类型: 整型
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 大型表的查询触发 ANALYZE 任务的间隔。
+- 可变: 是
+- 描述: 大表的查询触发 ANALYZE 任务的间隔。
 - 引入版本: v3.4.0
 
 ##### `connector_table_query_trigger_analyze_max_pending_task_num`
 
 - 默认值: 100
-- 类型: Int
+- 类型: 整型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: FE 上处于 Pending 状态的查询触发 ANALYZE 任务的最大数量。
 - 引入版本: v3.4.0
 
 ##### `connector_table_query_trigger_analyze_max_running_task_num`
 
 - 默认值: 2
-- 类型: Int
+- 类型: 整型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: FE 上处于 Running 状态的查询触发 ANALYZE 任务的最大数量。
 - 引入版本: v3.4.0
 
 ##### `connector_table_query_trigger_analyze_small_table_interval`
 
 - 默认值: 2 * 3600
-- 类型: Int
+- 类型: 整型
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 小型表的查询触发 ANALYZE 任务的间隔。
+- 可变: 是
+- 描述: 小表的查询触发 ANALYZE 任务的间隔。
 - 引入版本: v3.4.0
 
 ##### `connector_table_query_trigger_analyze_small_table_rows`
 
 - 默认值: 10000000
-- 类型: Int
+- 类型: 整型
 - 单位: -
-- 是否可变: Yes
-- 描述: 用于确定查询触发 ANALYZE 任务的表是否为小型表的阈值。
+- 可变: 是
+- 描述: 用于查询触发 ANALYZE 任务，判断表是否为小表的阈值。
 - 引入版本: v3.4.0
 
 ##### `connector_table_query_trigger_task_schedule_interval`
 
 - 默认值: 30
-- 类型: Int
+- 类型: 整型
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 调度器线程调度查询触发后台任务的间隔。此项旨在取代 v3.4.0 中引入的 `connector_table_query_trigger_analyze_schedule_interval`。在此处，后台任务指 v3.4 中的 `ANALYZE` 任务，以及 v3.4 之后版本中低基数列字典的收集任务。
+- 可变: 是
+- 描述: 调度器线程调度查询触发后台任务的间隔。此项用于替换 v3.4.0 中引入的 `connector_table_query_trigger_analyze_schedule_interval`。这里，后台任务在 v3.4 中指 `ANALYZE` 任务，在 v3.4 之后的版本中指低基数列字典的收集任务。
 - 引入版本: v3.4.2
 
 ##### `create_table_max_serial_replicas`
 
 - 默认值: 128
-- 类型: Int
+- 类型: 整型
 - 单位: -
-- 是否可变: Yes
-- 描述: 串行创建副本的最大数量。如果实际副本数量超过此值，则将并发创建副本。如果表创建时间过长，请尝试减小此值。
+- 可变: 是
+- 描述: 串行创建副本的最大数量。如果实际副本数量超过此值，副本将并发创建。如果表创建时间过长，请尝试减小此值。
 - 引入版本: -
 
 ##### `default_mv_partition_refresh_number`
 
 - 默认值: 1
-- 类型: Int
+- 类型: 整型
 - 单位: -
-- 是否可变: Yes
-- 描述: 当物化视图刷新涉及多个分区时，此参数控制默认情况下单个批次中刷新多少个分区。
+- 可变: 是
+- 描述: 当物化视图刷新涉及多个分区时，此参数默认控制单批次刷新多少个分区。
 从 3.3.0 版本开始，系统默认一次刷新一个分区，以避免潜在的内存溢出 (OOM) 问题。在早期版本中，所有分区默认一次刷新，这可能导致内存耗尽和任务失败。但是，请注意，当物化视图刷新涉及大量分区时，一次只刷新一个分区可能会导致过多的调度开销、更长的整体刷新时间以及大量的刷新记录。在这种情况下，建议适当调整此参数以提高刷新效率并降低调度成本。
 - 引入版本: v3.3.0
 
 ##### `default_mv_refresh_immediate`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否在创建后立即刷新异步物化视图。当此项设置为 `true` 时，新创建的物化视图将立即刷新。
+- 可变: 是
+- 描述: 是否在创建异步物化视图后立即刷新。当此项设置为 `true` 时，新创建的物化视图将立即刷新。
 - 引入版本: v3.2.3
 
 ##### `dynamic_partition_check_interval_seconds`
 
 - 默认值: 600
-- 类型: Long
+- 类型: 长整型
 - 单位: 秒
-- 是否可变: Yes
+- 可变: 是
 - 描述: 检查新数据的间隔。如果检测到新数据，StarRocks 会自动为数据创建分区。
 - 引入版本: -
 
 ##### `dynamic_partition_enable`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否启用动态分区功能。启用此功能后，StarRocks 会为新数据动态创建分区，并自动删除过期分区以确保数据的及时性。
+- 可变: 是
+- 描述: 是否启用动态分区功能。启用此功能后，StarRocks 会为新数据动态创建分区，并自动删除过期分区以确保数据的时效性。
 - 引入版本: -
 
 ##### `enable_active_materialized_view_schema_strict_check`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 激活非活动物化视图时是否严格检查数据类型的长度一致性。当此项设置为 `false` 时，如果基表中的数据类型长度发生变化，物化视图的激活不受影响。
+- 可变: 是
+- 描述: 激活非活跃物化视图时是否严格检查数据类型长度一致性。当此项设置为 `false` 时，如果基表中的数据类型长度发生变化，物化视图的激活不受影响。
 - 引入版本: v3.3.4
 
 ##### `enable_auto_collect_array_ndv`
 
 - 默认值: false
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: 是否启用 ARRAY 类型 NDV 信息的自动收集。
 - 引入版本: v4.0
 
 ##### `enable_backup_materialized_view`
 
 - 默认值: false
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: 在备份或恢复特定数据库时，是否启用异步物化视图的 BACKUP 和 RESTORE。如果此项设置为 `false`，StarRocks 将跳过备份异步物化视图。
 - 引入版本: v3.2.0
 
 ##### `enable_collect_full_statistic`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: 是否启用自动全量统计信息收集。此功能默认启用。
 - 引入版本: -
 
 ##### `enable_colocate_mv_index`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 创建同步物化视图时是否支持将同步物化视图索引与基表进行 Colocate。如果此项设置为 `true`，tablet sink 将加速同步物化视图的写入性能。
+- 可变: 是
+- 描述: 创建同步物化视图时是否支持将同步物化视图索引与基表进行 Colocate。如果此项设置为 `true`，tablet sink 将加快同步物化视图的写入性能。
 - 引入版本: v3.2.0
 
 ##### `enable_decimal_v3`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: 是否支持 DECIMAL V3 数据类型。
 - 引入版本: -
 
 ##### `enable_experimental_mv`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否启用异步物化视图功能。TRUE 表示启用此功能。从 v2.5.2 开始，此功能默认启用。对于 v2.5.2 之前的版本，此功能默认禁用。
+- 可变: 是
+- 描述: 是否启用异步物化视图功能。TRUE 表示此功能已启用。从 v2.5.2 版本开始，此功能默认启用。对于 v2.5.2 之前的版本，此功能默认禁用。
 - 引入版本: v2.4
 
 ##### `enable_local_replica_selection`
 
 - 默认值: false
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否为查询选择本地副本。本地副本可降低网络传输成本。如果此参数设置为 TRUE，CBO 优先选择与当前 FE 具有相同 IP 地址的 BE 上的 tablet 副本。如果此参数设置为 `FALSE`，则可以选择本地副本和非本地副本。
+- 可变: 是
+- 描述: 是否为查询选择本地副本。本地副本可降低网络传输成本。如果此参数设置为 TRUE，CBO 优先选择与当前 FE 具有相同 IP 地址的 BE 上的 tablet 副本。如果此参数设置为 `FALSE`，则本地副本和非本地副本都可以选择。
 - 引入版本: -
 
 ##### `enable_manual_collect_array_ndv`
 
 - 默认值: false
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: 是否启用 ARRAY 类型 NDV 信息的手动收集。
 - 引入版本: v4.0
 
 ##### `enable_materialized_view`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否允许创建物化视图。
+- 可变: 是
+- 描述: 是否启用物化视图的创建。
 - 引入版本: -
 
 ##### `enable_materialized_view_external_table_precise_refresh`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 将此项设置为 `true` 可为物化视图刷新启用内部优化，当基表是外部（非云原生）表时。启用后，物化视图刷新处理器会计算候选分区并仅刷新受影响的基表分区，而不是所有分区，从而减少 I/O 和刷新成本。将其设置为 `false` 以强制对外部表进行全分区刷新。
+- 可变: 是
+- 描述: 将此项设置为 `true` 以启用物化视图刷新时的内部优化，当基表是外部（非云原生）表时。启用后，物化视图刷新处理器会计算候选分区并仅刷新受影响的基表分区，而不是所有分区，从而减少 I/O 和刷新成本。将其设置为 `false` 以强制对外部表进行全分区刷新。
 - 引入版本: v3.2.9
 
 ##### `enable_materialized_view_metrics_collect`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: 是否默认收集异步物化视图的监控指标。
 - 引入版本: v3.1.11, v3.2.5
 
 ##### `enable_materialized_view_spill`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否为物化视图刷新任务启用中间结果 spilling。
+- 可变: 是
+- 描述: 是否为物化视图刷新任务启用中间结果溢出。
 - 引入版本: v3.1.1
 
 ##### `enable_materialized_view_text_based_rewrite`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否默认启用基于文本的查询重写。如果此项设置为 `true`，系统将在创建异步物化视图时构建抽象语法树。
+- 可变: 是
+- 描述: 是否默认启用基于文本的查询重写。如果此项设置为 `true`，系统在创建异步物化视图时会构建抽象语法树。
 - 引入版本: v3.2.5
 
 ##### `enable_mv_automatic_active_check`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否启用系统自动检查和重新激活那些因基表（视图）进行 Schema Change 或被删除和重新创建而变为 Inactive 的异步物化视图。请注意，此功能不会重新激活用户手动设置为 Inactive 的物化视图。
+- 可变: 是
+- 描述: 是否启用系统自动检查并重新激活因基表（视图）发生 Schema Change 或被删除并重新创建而设置为非活跃的异步物化视图。请注意，此功能不会重新激活用户手动设置为非活跃的物化视图。
 - 引入版本: v3.1.6
 
 ##### `enable_mv_automatic_repairing_for_broken_base_tables`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 当此项设置为 `true` 时，StarRocks 将尝试在基外部表被删除并重新创建或其表标识符更改时自动修复物化视图基表元数据。修复流程可以更新物化视图的基表信息，收集外部表分区的分区级修复信息，并推动异步自动刷新物化视图的分区刷新决策，同时遵守 `autoRefreshPartitionsLimit`。目前自动修复支持 Hive 外部表；不支持的表类型将导致物化视图设置为非活动状态并引发修复异常。分区信息收集是非阻塞的，失败将被记录。
+- 可变: 是
+- 描述: 当此项设置为 `true` 时，当基外部表被删除并重新创建或其表标识符发生变化时，StarRocks 将尝试自动修复物化视图基表元数据。修复流程可以更新物化视图的基表信息，收集外部表分区的分区级修复信息，并根据 `autoRefreshPartitionsLimit` 驱动异步自动刷新物化视图的分区刷新决策。目前，自动修复支持 Hive 外部表；不支持的表类型将导致物化视图被设置为非活跃状态并引发修复异常。分区信息收集是非阻塞的，失败将被记录。
 - 引入版本: v3.3.19, v3.4.8, v3.5.6
 
 ##### `enable_predicate_columns_collection`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: 是否启用谓词列收集。如果禁用，谓词列在查询优化期间将不会被记录。
 - 引入版本: -
 
 ##### `enable_query_queue_v2`
 
 - 默认值: true
-- 类型: boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: No
-- 描述: 当为 true 时，将 FE 基于槽位的查询调度器切换到查询队列 V2。槽位管理器和跟踪器（例如 `BaseSlotManager.isEnableQueryQueueV2` 和 `SlotTracker#createSlotSelectionStrategy`）会读取此标志以选择 `SlotSelectionStrategyV2` 而不是旧版策略。`query_queue_v2_xxx` 配置选项和 `QueryQueueOptions` 仅在此标志启用时生效。从 v4.1 开始，默认值从 `false` 更改为 `true`。
+- 可变: 否
+- 描述: 当为 true 时，将基于 FE slot 的查询调度器切换到 Query Queue V2。该标志由 slot 管理器和跟踪器（例如，`BaseSlotManager.isEnableQueryQueueV2` 和 `SlotTracker#createSlotSelectionStrategy`）读取，以选择 `SlotSelectionStrategyV2` 而不是旧版策略。`query_queue_v2_xxx` 配置选项和 `QueryQueueOptions` 仅在此标志启用时生效。从 v4.1 开始，默认值从 `false` 更改为 `true`。
 - 引入版本: v3.3.4, v3.4.0, v3.5.0
 
 ##### `enable_sql_blacklist`
 
 - 默认值: false
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否启用 SQL 查询的黑名单检查。启用此功能后，黑名单中的查询无法执行。
+- 可变: 是
+- 描述: 是否启用 SQL 查询黑名单检查。启用此功能后，黑名单中的查询无法执行。
 - 引入版本: -
 
 ##### `enable_statistic_collect`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否收集 CBO 的统计信息。此功能默认启用。
+- 可变: 是
+- 描述: 是否为 CBO 收集统计信息。此功能默认启用。
 - 引入版本: -
 
 ##### `enable_statistic_collect_on_first_load`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: 控制由数据加载操作触发的自动统计信息收集和维护。这包括：
-  - 当数据首次加载到分区时（分区版本等于 2）的统计信息收集。
-  - 当数据加载到多分区表的空分区时（分区版本等于 2）的统计信息收集。
+  - 首次将数据加载到分区时（分区版本等于 2）的统计信息收集。
+  - 将数据加载到多分区表的空分区时的统计信息收集。
   - INSERT OVERWRITE 操作的统计信息复制和更新。
 
   **统计信息收集类型决策策略：**
   
-  - 对于 INSERT OVERWRITE：`deltaRatio = |targetRows - sourceRows| / (sourceRows + 1)`
+  - 对于 INSERT OVERWRITE: `deltaRatio = |targetRows - sourceRows| / (sourceRows + 1)`
     - 如果 `deltaRatio < statistic_sample_collect_ratio_threshold_of_first_load` (默认值: 0.1)，则不执行统计信息收集。仅复制现有统计信息。
     - 否则，如果 `targetRows > statistic_sample_collect_rows` (默认值: 200000)，则使用 SAMPLE 统计信息收集。
     - 否则，使用 FULL 统计信息收集。
   
-  - 对于首次加载：`deltaRatio = loadRows / (totalRows + 1)`
+  - 对于首次加载: `deltaRatio = loadRows / (totalRows + 1)`
     - 如果 `deltaRatio < statistic_sample_collect_ratio_threshold_of_first_load` (默认值: 0.1)，则不执行统计信息收集。
     - 否则，如果 `loadRows > statistic_sample_collect_rows` (默认值: 200000)，则使用 SAMPLE 统计信息收集。
     - 否则，使用 FULL 统计信息收集。
   
   **同步行为：**
   
-  - 对于 DML 语句（INSERT INTO/INSERT OVERWRITE）：同步模式，带表锁。加载操作等待统计信息收集完成（最长 `semi_sync_collect_statistic_await_seconds`）。
-  - 对于 Stream Load 和 Broker Load：异步模式，无锁。统计信息收集在后台运行，不阻塞加载操作。
+  - 对于 DML 语句 (INSERT INTO/INSERT OVERWRITE): 同步模式，带表锁。加载操作等待统计信息收集完成（最长 `semi_sync_collect_statistic_await_seconds`）。
+  - 对于 Stream Load 和 Broker Load: 异步模式，无锁。统计信息收集在后台运行，不阻塞加载操作。
   
   :::note
-  禁用此配置将阻止所有加载触发的统计信息操作，包括 INSERT OVERWRITE 的统计信息维护，这可能导致表缺少统计信息。如果经常创建新表并频繁加载数据，启用此功能将增加内存和 CPU 开销。
+  禁用此配置将阻止所有加载触发的统计信息操作，包括 INSERT OVERWRITE 的统计信息维护，这可能导致表缺少统计信息。如果频繁创建新表并频繁加载数据，启用此功能将增加内存和 CPU 开销。
   :::
 
 - 引入版本: v3.1
@@ -1879,429 +1879,429 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 ##### `enable_statistic_collect_on_update`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 控制 UPDATE 语句是否可以触发自动统计信息收集。启用后，修改表数据的 UPDATE 操作可能会通过与 `enable_statistic_collect_on_first_load` 控制的基于摄取统计信息框架调度统计信息收集。禁用此配置会跳过 UPDATE 语句的统计信息收集，同时保持加载触发的统计信息收集行为不变。
+- 可变: 是
+- 描述: 控制 UPDATE 语句是否可以触发自动统计信息收集。启用后，修改表数据的 UPDATE 操作可能会通过与 `enable_statistic_collect_on_first_load` 控制的基于摄取的统计信息框架相同的机制调度统计信息收集。禁用此配置将跳过 UPDATE 语句的统计信息收集，同时保持加载触发的统计信息收集行为不变。
 - 引入版本: v3.5.11, v4.0.4
 
 ##### `enable_udf`
 
 - 默认值: false
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: No
+- 可变: 否
 - 描述: 是否启用 UDF。
 - 引入版本: -
 
 ##### `expr_children_limit`
 
 - 默认值: 10000
-- 类型: Int
+- 类型: 整型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: 表达式中允许的最大子表达式数量。
 - 引入版本: -
 
 ##### `histogram_buckets_size`
 
 - 默认值: 64
-- 类型: Long
+- 类型: 长整型
 - 单位: -
-- 是否可变: Yes
-- 描述: 直方图的默认 bucket 数量。
+- 可变: 是
+- 描述: 直方图的默认桶数量。
 - 引入版本: -
 
 ##### `histogram_max_sample_row_count`
 
 - 默认值: 10000000
-- 类型: Long
+- 类型: 长整型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: 直方图收集的最大行数。
 - 引入版本: -
 
 ##### `histogram_mcv_size`
 
 - 默认值: 100
-- 类型: Long
+- 类型: 长整型
 - 单位: -
-- 是否可变: Yes
-- 描述: 直方图的最常见值 (MCV) 数量。
+- 可变: 是
+- 描述: 直方图中最常见值 (MCV) 的数量。
 - 引入版本: -
 
 ##### `histogram_sample_ratio`
 
 - 默认值: 0.1
-- 类型: Double
+- 类型: 双精度浮点型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: 直方图的采样率。
 - 引入版本: -
 
 ##### `http_slow_request_threshold_ms`
 
 - 默认值: 5000
-- 类型: Int
+- 类型: 整型
 - 单位: 毫秒
-- 是否可变: Yes
-- 描述: 如果 HTTP 请求的响应时间超过此参数指定的值，则生成日志以跟踪此请求。
+- 可变: 是
+- 描述: 如果 HTTP 请求的响应时间超过此参数指定的值，则会生成日志以跟踪此请求。
 - 引入版本: v2.5.15, v3.1.5
 
 ##### `lock_checker_enable_deadlock_check`
 
 - 默认值: false
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 启用后，LockChecker 线程使用 ThreadMXBean.findDeadlockedThreads() 执行 JVM 级死锁检测，并记录违规线程的堆栈跟踪。检查在 LockChecker 守护程序（其频率由 `lock_checker_interval_second` 控制）内部运行，并将详细的堆栈信息写入日志，这可能耗费 CPU 和 I/O。仅在调试实时或可重现的死锁问题时才启用此选项；在正常操作中保持启用状态可能会增加开销和日志量。
+- 可变: 是
+- 描述: 启用后，LockChecker 线程使用 ThreadMXBean.findDeadlockedThreads() 执行 JVM 级别的死锁检测，并记录违规线程的堆栈跟踪。检查在 LockChecker 守护进程（其频率由 `lock_checker_interval_second` 控制）内部运行，并将详细的堆栈信息写入日志，这可能会占用 CPU 和 I/O 资源。仅在排查实时或可重现的死锁问题时启用此选项；在正常操作中保持启用状态可能会增加开销和日志量。
 - 引入版本: v3.2.0
 
 ##### `low_cardinality_threshold`
 
 - 默认值: 255
-- 类型: Int
+- 类型: 整型
 - 单位: -
-- 是否可变: No
+- 可变: 否
 - 描述: 低基数字典的阈值。
 - 引入版本: v3.5.0
 
 ##### `materialized_view_min_refresh_interval`
 
 - 默认值: 60
-- 类型: Int
+- 类型: 整型
 - 单位: 秒
-- 是否可变: Yes
-- 描述: ASYNC 物化视图调度的最小允许刷新间隔（以秒为单位）。当以基于时间的间隔创建物化视图时，该间隔将转换为秒，并且不得小于此值；否则 CREATE/ALTER 操作将因 DDL 错误而失败。如果此值大于 0，则强制执行检查；将其设置为 0 或负值以禁用限制，这可以防止TaskManager 过度调度和因刷新过于频繁而导致 FE 内存/CPU 使用率过高。此项不适用于 `EVENT_TRIGGERED` 刷新。
+- 可变: 是
+- 描述: ASYNC 物化视图调度允许的最小刷新间隔（秒）。当创建具有基于时间的间隔的物化视图时，该间隔将转换为秒，并且不得小于此值；否则 CREATE/ALTER 操作将因 DDL 错误而失败。如果此值大于 0，则强制执行检查；将其设置为 0 或负值以禁用此限制，这可以防止因过于频繁的刷新而导致过多的 TaskManager 调度和高 FE 内存/CPU 使用率。此项不适用于 `EVENT_TRIGGERED` 刷新。
 - 引入版本: v3.3.0, v3.4.0, v3.5.0
 
 ##### `materialized_view_refresh_ascending`
 
 - 默认值: false
-- 类型: Boolean
+- 类型: 布尔型
 - 单位: -
-- 是否可变: Yes
-- 描述: 当此项设置为 `true` 时，物化视图分区刷新将以升序分区键顺序（从最旧到最新）迭代分区。当设置为 `false`（默认）时，系统以降序（从最新到最旧）迭代。StarRocks 在列表分区和范围分区物化视图刷新逻辑中都使用此项来选择在应用分区刷新限制时要处理的分区，并计算后续 TaskRun 执行的下一个开始/结束分区边界。更改此项会改变首先刷新哪些分区以及如何导出下一个分区范围；对于范围分区物化视图，调度器会验证新的开始/结束，如果更改会创建重复边界（死循环），则会引发错误，因此请谨慎设置此项。
+- 可变: 是
+- 描述: 当此项设置为 `true` 时，物化视图分区刷新将按分区键升序（从最旧到最新）迭代分区。当设置为 `false`（默认值）时，系统按降序（从最新到最旧）迭代。StarRocks 在列表分区和范围分区物化视图刷新逻辑中都使用此项，以在应用分区刷新限制时选择要处理的分区，并计算后续 TaskRun 执行的下一个开始/结束分区边界。更改此项会改变首先刷新哪些分区以及如何派生下一个分区范围；对于范围分区物化视图，调度器会验证新的开始/结束，如果更改会创建重复边界（死循环），则会引发错误，因此请谨慎设置此项。
 - 引入版本: v3.3.1, v3.4.0, v3.5.0
 
 ##### `max_allowed_in_element_num_of_delete`
 
 - 默认值: 10000
-- 类型: Int
+- 类型: 整型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: DELETE 语句中 IN 谓词允许的最大元素数量。
 - 引入版本: -
 
 ##### `max_create_table_timeout_second`
 
 - 默认值: 600
-- 类型: Int
+- 类型: 整型
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 创建表的超时时长上限。
+- 可变: 是
+- 描述: 创建表的最大超时时间。
 - 引入版本: -
 
 ##### `max_distribution_pruner_recursion_depth`
 
 - 默认值: 100
-- 类型: Int
+- 类型: 整型
 - 单位: -
-- 是否可变: Yes
-- 描述: 分区剪枝器允许的最大递归深度。增加递归深度可以剪枝更多元素，但也会增加 CPU 消耗。
+- 可变: 是
+- 描述:: 分区剪枝器允许的最大递归深度。增加递归深度可以剪枝更多元素，但也会增加 CPU 消耗。
 - 引入版本: -
 
 ##### `max_partitions_in_one_batch`
 
 - 默认值: 4096
-- 类型: Long
+- 类型: 长整型
 - 单位: -
-- 是否可变: Yes
-- 描述: 批量创建分区时可创建的最大分区数。
+- 可变: 是
+- 描述: 批量创建分区时可以创建的最大分区数量。
 - 引入版本: -
 
 ##### `max_planner_scalar_rewrite_num`
 
 - 默认值: 100000
-- 类型: Long
+- 类型: 长整型
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: 优化器可以重写标量操作符的最大次数。
 - 引入版本: -
 
 ##### `max_query_queue_history_slots_number`
 
 - 默认值: 0
-- 类型: Int
-- 单位: 槽位
-- 是否可变: Yes
-- 描述: 控制每个查询队列保留多少最近释放的（历史）已分配槽位用于监控和可观察性。当 `max_query_queue_history_slots_number` 设置为 `> 0` 的值时，BaseSlotTracker 在内存队列中保留最多指定数量的最新释放的 LogicalSlot 条目，当超出限制时驱逐最旧的条目。启用此功能会导致 getSlots() 包含这些历史条目（最新的在前），允许 BaseSlotTracker 尝试使用 ConnectContext 注册槽位以获取更丰富的 ExtraMessage 数据，并允许 LogicalSlot.ConnectContextListener 将查询完成元数据附加到历史槽位。当 `max_query_queue_history_slots_number` `<= 0` 时，历史机制被禁用（不使用额外的内存）。使用合理的值来平衡可观察性和内存开销。
+- 类型: 整型
+- 单位: Slots
+- 可变: 是
+- 描述: 控制每个查询队列保留多少最近释放（历史）的已分配 slot 用于监控和可观测性。当 `max_query_queue_history_slots_number` 设置为 `> 0` 的值时，BaseSlotTracker 会在内存队列中保留最多指定数量的最近释放的 LogicalSlot 条目，当超出限制时，会逐出最旧的条目。启用此功能会导致 getSlots() 包含这些历史条目（最新优先），允许 BaseSlotTracker 尝试向 ConnectContext 注册 slot 以获取更丰富的 ExtraMessage 数据，并允许 LogicalSlot.ConnectContextListener 将查询完成元数据附加到历史 slot。当 `max_query_queue_history_slots_number` `<= 0` 时，历史机制被禁用（不使用额外内存）。使用合理的值来平衡可观测性和内存开销。
 - 引入版本: v3.5.0
 
 ##### `max_query_retry_time`
 
 - 默认值: 2
-- 类型: Int
+- 类型: 整型
 - 单位: -
-- 是否可变: Yes
-- 描述: FE 上查询重试的最大次数。
+- 可变: 是
+- 描述: FE 上查询的最大重试次数。
 - 引入版本: -
 
 ##### `max_running_rollup_job_num_per_table`
 
 - 默认值: 1
-- 类型: Int
+- 类型: 整型
 - 单位: -
-- 是否可变: Yes
-- 描述: 每张表可以并行运行的 rollup 作业的最大数量。
+- 可变: 是
+- 描述: 单个表可以并行运行的 rollup 任务的最大数量。
 - 引入版本: -
 
 ##### `max_scalar_operator_flat_children`
 
-- 默认值: 10000
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: ScalarOperator 的最大扁平子节点数。您可以设置此限制以防止优化器使用过多内存。
+- 默认值：10000
+- 类型：整型
+- 单位：-
+- 可变: 是
+- 描述：ScalarOperator 的最大扁平子节点数量。您可以设置此限制以防止优化器使用过多内存。
 - 引入版本: -
 
 ##### `max_scalar_operator_optimize_depth`
 
-- 默认值: 256
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
+- 默认值：256
+- 类型：整型
+- 单位：-
+- 可变: 是
 - 描述: ScalarOperator 优化可以应用的最大深度。
 - 引入版本: -
 
 ##### `mv_active_checker_interval_seconds`
 
 - 默认值: 60
-- 类型: Long
+- 类型: 长整型
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 当后台 `active_checker` 线程启用时，系统会定期检测并自动重新激活因其基表（或视图）的 schema 变更或重建而变为 Inactive 的物化视图。此参数以秒为单位控制检查器线程的调度间隔。默认值由系统定义。
+- 可变: 是
+- 描述: 当后台 `active_checker` 线程启用时，系统将定期检测并自动重新激活因基表（或视图）的 Schema Change 或重建而变为 Inactive 的物化视图。此参数控制检查器线程的调度间隔，以秒为单位。默认值由系统定义。
 - 引入版本: v3.1.6
 
 ##### `mv_rewrite_consider_data_layout_mode`
 
 - 默认值: `enable`
-- 类型: String
+- 类型: 字符串
 - 单位: -
-- 是否可变: Yes
-- 描述: 控制物化视图重写在选择最佳物化视图时是否应考虑基表数据布局。有效值：
-  - `disable`: 在选择候选物化视图时，从不使用数据布局标准。
-  - `enable`: 仅当查询被识别为布局敏感时才使用数据布局标准。
+- 可变: 是
+- 描述: 控制物化视图重写在选择最佳物化视图时是否考虑基表数据布局。有效值：
+  - `disable`: 在候选物化视图之间选择时，从不使用数据布局标准。
+  - `enable`: 仅当查询被识别为对布局敏感时才使用数据布局标准。
   - `force`: 在选择最佳物化视图时始终应用数据布局标准。
-  更改此项会影响 `BestMvSelector` 的行为，并可以根据物理布局是否影响计划正确性或性能来改进或扩大重写的适用性。
+  更改此项会影响 `BestMvSelector` 的行为，并根据物理布局是否对计划正确性或性能重要来改进或拓宽重写适用性。
 - 引入版本: -
 
 ##### `publish_version_interval_ms`
 
 - 默认值: 10
-- 类型: Int
+- 类型: 整型
 - 单位: 毫秒
-- 是否可变: No
-- 描述: 发布验证任务发出的时间间隔。
+- 可变: 否
+- 描述: 发布验证任务的发出时间间隔。
 - 引入版本: -
 
 ##### `query_queue_slots_estimator_strategy`
 
 - 默认值: MAX
-- 类型: String
+- 类型: 字符串
 - 单位: -
-- 是否可变: Yes
-- 描述: 当 `enable_query_queue_v2` 为 true 时，选择用于基于队列的查询的槽位估算策略。有效值：MBE（基于内存）、PBE（基于并行度）、MAX（取 MBE 和 PBE 的最大值）和 MIN（取 MBE 和 PBE 的最小值）。MBE 根据预测内存或计划成本除以每个槽位内存目标来估算槽位，并受 `totalSlots` 限制。PBE 根据片段并行度（扫描范围计数或基数/每槽位行数）和基于 CPU 成本的计算（使用每槽位 CPU 成本）推导出槽位，然后将结果限制在 [numSlots/2, numSlots] 范围内。MAX 和 MIN 通过取其最大值或最小值来组合 MBE 和 PBE。如果配置值无效，则使用默认值 (`MAX`)。
+- 可变: 是
+- 描述: 当 `enable_query_queue_v2` 为 true 时，选择用于基于队列的查询的 slot 估算策略。有效值：MBE（基于内存）、PBE（基于并行度）、MAX（取 MBE 和 PBE 的最大值）和 MIN（取 MBE 和 PBE 的最小值）。MBE 根据预测内存或计划成本除以每个 slot 的内存目标来估算 slot，并受 `totalSlots` 限制。PBE 根据片段并行度（扫描范围计数或基数 / 每 slot 行数）和基于 CPU 成本的计算（使用每个 slot 的 CPU 成本）推导 slot，然后将结果限制在 [numSlots/2, numSlots] 范围内。MAX 和 MIN 通过分别取 MBE 和 PBE 的最大值或最小值来组合它们。如果配置值无效，则使用默认值 (`MAX`)。
 - 引入版本: v3.5.0
 
 ##### `query_queue_v2_concurrency_level`
 
 - 默认值: 4
-- 类型: Int
+- 类型: 整型
 - 单位: -
-- 是否可变: Yes
-- 描述: 控制计算系统总查询槽位时使用的逻辑并发“层数”。在 shared-nothing 模式下，总槽位 = `query_queue_v2_concurrency_level` * BE 数量 * 每个 BE 的核心数（来自 BackendResourceStat）。在多仓库模式下，有效并发会缩减为 max(1, `query_queue_v2_concurrency_level` / 4)。如果配置值为非正数，则视为 `4`。更改此值会增加或减少 totalSlots（以及因此的并发查询容量），并影响每个槽位的资源：memBytesPerSlot 通过将每个 worker 内存除以（每个 worker 的核心数 * 并发）得出，并且 CPU 记账使用 `query_queue_v2_cpu_costs_per_slot`。将其设置为与集群大小成比例；非常大的值可能会减少每个槽位的内存并导致资源碎片。
+- 可变: 是
+- 描述: 控制在计算系统总查询 slot 时使用的逻辑并发“层”数量。在 shared-nothing 模式下，总 slot = `query_queue_v2_concurrency_level` * BE 数量 * 每个 BE 的核心数（从 BackendResourceStat 派生）。在多仓库模式下，有效并发会按比例缩小到 max(1, `query_queue_v2_concurrency_level` / 4)。如果配置值为非正数，则视为 `4`。更改此值会增加或减少 totalSlots（从而增加或减少并发查询容量）并影响每个 slot 的资源：memBytesPerSlot 是通过将每个 worker 的内存除以 (cores_per_worker * concurrency) 得出的，CPU 记账使用 `query_queue_v2_cpu_costs_per_slot`。将其设置为与集群大小成比例；非常大的值可能会减少每个 slot 的内存并导致资源碎片化。
 - 引入版本: v3.3.4, v3.4.0, v3.5.0
 
 ##### `query_queue_v2_cpu_costs_per_slot`
 
 - 默认值: 1000000000
-- 类型: Long
-- 单位: 规划器 CPU 成本单位
-- 是否可变: Yes
-- 描述: 每个槽位的 CPU 成本阈值，用于根据查询的规划器 CPU 成本估算查询所需的槽位数量。调度器计算槽位为整数（`plan_cpu_costs` / `query_queue_v2_cpu_costs_per_slot`），然后将结果限制在 [1, totalSlots] 范围内（totalSlots 来自查询队列 V2 `V2` 参数）。V2 代码将非正值规范化为 1 (Math.max(1, value))，因此非正值实际上变为 `1`。增加此值会减少每个查询分配的槽位（有利于更少、更大槽位的查询）；减少此值会增加每个查询的槽位。与 `query_queue_v2_num_rows_per_slot` 和并发设置一起调整，以控制并行度与资源粒度。
+- 类型: 长整型
+- 单位: planner CPU cost units
+- 可变: 是
+- 描述: 每个 slot 的 CPU 成本阈值，用于根据查询的 planner CPU 成本估算查询所需的 slot 数量。调度器将 slot 计算为整数(`plan_cpu_costs` / `query_queue_v2_cpu_costs_per_slot`)，然后将结果限制在 [1, totalSlots] 范围内（totalSlots 从查询队列 V2 `V2` 参数派生）。V2 代码将非正设置规范化为 1 (Math.max(1, value))，因此非正值实际上变为 `1`。增加此值会减少每个查询分配的 slot（倾向于更少、更大 slot 的查询）；减少此值会增加每个查询的 slot。与 `query_queue_v2_num_rows_per_slot` 和并发设置一起调整，以控制并行度与资源粒度。
 - 引入版本: v3.3.4, v3.4.0, v3.5.0
 
 ##### `query_queue_v2_num_rows_per_slot`
 
 - 默认值: 4096
-- 类型: Int
+- 类型: 整型
 - 单位: 行
-- 是否可变: Yes
-- 描述: 当估算每个查询的槽位计数时，分配给单个调度槽位的目标源行记录数。StarRocks 计算 `estimated_slots` = (源节点的基数) / `query_queue_v2_num_rows_per_slot`，然后将结果限制在 [1, totalSlots] 范围内，如果计算值为非正数，则强制最小值为 1。totalSlots 来自可用资源（大致为 DOP * `query_queue_v2_concurrency_level` * worker/BE 数量），因此取决于集群/核心计数。增加此值以减少槽位计数（每个槽位处理更多行）并降低调度开销；减少此值以增加并行度（更多、更小的槽位），直至达到资源限制。
+- 可变: 是
+- 描述: 在估算每个查询的 slot 数量时，分配给单个调度 slot 的目标源行记录数。StarRocks 计算 `estimated_slots` = (Source Node 的基数) / `query_queue_v2_num_rows_per_slot`，然后将结果限制在 [1, totalSlots] 范围内，如果计算值为非正数，则强制最小值为 1。totalSlots 从可用资源（大致为 DOP * `query_queue_v2_concurrency_level` * worker/BE 数量）派生，因此取决于集群/核心计数。增加此值以减少 slot 计数（每个 slot 处理更多行）并降低调度开销；减少此值以增加并行度（更多、更小的 slot），直至达到资源限制。
 - 引入版本: v3.3.4, v3.4.0, v3.5.0
 
 ##### `query_queue_v2_schedule_strategy`
 
 - 默认值: SWRR
-- 类型: String
+- 类型: 字符串
 - 单位: -
-- 是否可变: Yes
-- 描述: 选择 Query Queue V2 用于对待处理查询进行排序的调度策略。支持的值（不区分大小写）为 `SWRR` (Smooth Weighted Round Robin) - 默认值，适用于需要公平加权共享的混合/混合工作负载 - 和 `SJF` (Short Job First + Aging) - 优先处理短作业，同时使用老化机制避免饥饿。该值通过不区分大小写的枚举查找进行解析；无法识别的值将记录为错误并使用默认策略。此配置仅在 Query Queue V2 启用时影响行为，并与 V2 大小设置（如 `query_queue_v2_concurrency_level`）交互。
+- 可变: 是
+- 描述: 选择 Query Queue V2 用于对待处理查询进行排序的调度策略。支持的值（不区分大小写）有 `SWRR` (Smooth Weighted Round Robin) — 默认值，适用于需要公平加权共享的混合/混合工作负载 — 和 `SJF` (Short Job First + Aging) — 优先处理短作业，同时使用老化机制避免饥饿。该值通过不区分大小写的枚举查找进行解析；无法识别的值将记录为错误并使用默认策略。此配置仅在 Query Queue V2 启用时影响行为，并与 V2 大小设置（例如 `query_queue_v2_concurrency_level`）交互。
 - 引入版本: v3.3.12, v3.4.2, v3.5.0
 
 ##### `semi_sync_collect_statistic_await_seconds`
 
 - 默认值: 30
-- 类型: Int
+- 类型: 整型
 - 单位: 秒
-- 是否可变: Yes
+- 可变: 是
 - 描述: DML 操作（INSERT INTO 和 INSERT OVERWRITE 语句）期间半同步统计信息收集的最大等待时间。Stream Load 和 Broker Load 使用异步模式，不受此配置影响。如果统计信息收集时间超过此值，加载操作将继续，而不等待收集完成。此配置与 `enable_statistic_collect_on_first_load` 协同工作。
 - 引入版本: v3.1
 
 ##### `slow_query_analyze_threshold`
 
 - 默认值: 5
-- 类型: Int
+- 类型: 整型
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 查询执行时间阈值，用于触发查询反馈分析。
+- 可变: 是
+- 描述:: 查询触发查询反馈分析的执行时间阈值。
 - 引入版本: v3.4.0
 
 ##### `statistic_analyze_status_keep_second`
 
 - 默认值: 3 * 24 * 3600
-- 类型: Long
+- 类型: 长整型
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 保留收集任务历史记录的持续时间。默认值为 3 天。
+- 可变: 是
+- 描述: 收集任务历史记录的保留时长。默认值为 3 天。
 - 引入版本: -
 
 ##### `statistic_auto_analyze_end_time`
 
 - 默认值: 23:59:59
-- 类型: String
+- 类型: 字符串
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: 自动收集的结束时间。取值范围：`00:00:00` - `23:59:59`。
 - 引入版本: -
 
 ##### `statistic_auto_analyze_start_time`
 
 - 默认值: 00:00:00
-- 类型: String
+- 类型: 字符串
 - 单位: -
-- 是否可变: Yes
+- 可变: 是
 - 描述: 自动收集的开始时间。取值范围：`00:00:00` - `23:59:59`。
 - 引入版本: -
 
 ##### `statistic_auto_collect_ratio`
 
 - 默认值: 0.8
-- 类型: Double
+- 类型: 双精度浮点型
 - 单位: -
-- 是否可变: Yes
-- 描述: 用于判断自动收集统计信息是否健康的阈值。如果统计信息健康度低于此阈值，将触发自动收集。
+- 可变: 是
+- 描述: 判断自动收集的统计信息是否健康的阈值。如果统计信息健康度低于此阈值，则触发自动收集。
 - 引入版本: -
 
 ##### `statistic_auto_collect_small_table_rows`
 
 - 默认值: 10000000
-- 类型: Long
+- 类型: 长整型
 - 单位: -
-- 是否可变: Yes
-- 描述: 自动收集期间，判断外部数据源（Hive、Iceberg、Hudi）中的表是否为小型表的阈值。如果表的行数小于此值，则认为该表为小型表。
+- 可变: 是
+- 描述: 在自动收集期间，判断外部数据源（Hive, Iceberg, Hudi）中的表是否为小表的阈值。如果表的行数小于此值，则该表被视为小表。
 - 引入版本: v3.2
 
 ##### `statistic_cache_columns`
 
 - 默认值: 100000
-- 类型: Long
+- 类型: 长整型
 - 单位: -
-- 是否可变: No
-- 描述: 统计信息表可缓存的行数。
+- 可变: 否
+- 描述: 统计信息表可以缓存的行数。
 - 引入版本: -
 
 ##### `statistic_cache_thread_pool_size`
 
 - 默认值: 10
-- 类型: Int
+- 类型: 整型
 - 单位: -
-- 是否可变: No
+- 可变: 否
 - 描述: 用于刷新统计信息缓存的线程池大小。
 - 引入版本: -
 
 ##### `statistic_collect_interval_sec`
 
 - 默认值: 5 * 60
-- 类型: Long
+- 类型: 长整型
 - 单位: 秒
-- 是否可变: Yes
+- 可变: 是
 - 描述: 自动收集期间检查数据更新的间隔。
 - 引入版本: -
 
 ##### `statistic_max_full_collect_data_size`
 
 - 默认值: 100 * 1024 * 1024 * 1024
-- 类型: Long
+- 类型: 长整型
 - 单位: 字节
-- 是否可变: Yes
+- 可变: 是
 - 描述: 统计信息自动收集的数据大小阈值。如果总大小超过此值，则执行采样收集而不是全量收集。
 - 引入版本: -
 
 ##### `statistic_sample_collect_rows`
 
 - 默认值: 200000
-- 类型: Long
+- 类型: 长整型
 - 单位: -
-- 是否可变: Yes
-- 描述: 在加载触发的统计信息操作期间，用于决定 SAMPLE 和 FULL 统计信息收集之间的行数阈值。如果加载或更改的行数超过此阈值（默认 200,000），则使用 SAMPLE 统计信息收集；否则，使用 FULL 统计信息收集。此设置与 `enable_statistic_collect_on_first_load` 和 `statistic_sample_collect_ratio_threshold_of_first_load` 协同工作。
+- 可变: 是
+- 描述: 在加载触发的统计信息操作期间，用于决定 SAMPLE 和 FULL 统计信息收集的行数阈值。如果加载或更改的行数超过此阈值（默认 200,000），则使用 SAMPLE 统计信息收集；否则，使用 FULL 统计信息收集。此设置与 `enable_statistic_collect_on_first_load` 和 `statistic_sample_collect_ratio_threshold_of_first_load` 协同工作。
 - 引入版本: -
 
 ##### `statistic_update_interval_sec`
 
 - 默认值: 24 * 60 * 60
-- 类型: Long
+- 类型: 长整型
 - 单位: 秒
-- 是否可变: Yes
+- 可变: 是
 - 描述: 统计信息缓存的更新间隔。
 - 引入版本: -
 
 ##### `task_check_interval_second`
 
 - 默认值: 60
-- 类型: Int
+- 类型: 整型
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 任务后台作业执行之间的间隔。GlobalStateMgr 使用此值调度 TaskCleaner FrontendDaemon，该守护程序调用 `doTaskBackgroundJob()`；该值乘以 1000 以设置守护程序间隔（毫秒）。减小此值可使后台维护（任务清理、检查）运行更频繁并更快响应，但会增加 CPU/IO 开销；增加此值可减少开销，但会延迟清理和陈旧任务的检测。调整此值以平衡维护响应性和资源使用。
+- 可变: 是
+- 描述: 任务后台作业执行之间的间隔。GlobalStateMgr 使用此值调度 TaskCleaner FrontendDaemon，该守护进程调用 `doTaskBackgroundJob()`；该值乘以 1000 以设置守护进程的间隔（毫秒）。减小该值会使后台维护（任务清理、检查）运行更频繁，响应更快，但会增加 CPU/IO 开销；增加该值会减少开销，但会延迟清理和陈旧任务的检测。调整此值以平衡维护响应能力和资源使用。
 - 引入版本: v3.2.0
 
 ##### `task_min_schedule_interval_s`
 
 - 默认值: 10
-- 类型: Int
+- 类型: 整型
 - 单位: 秒
-- 是否可变: Yes
-- 描述: SQL 层检查的任务调度的最小允许调度间隔（以秒为单位）。提交任务时，TaskAnalyzer 将调度周期转换为秒，如果周期小于 `task_min_schedule_interval_s`，则以 `ERR_INVALID_PARAMETER` 拒绝提交。这可以防止创建运行过于频繁的任务，并保护调度器免受高频任务的影响。如果调度没有显式开始时间，TaskAnalyzer 会将开始时间设置为当前纪元秒。
+- 可变: 是
+- 描述: SQL 层检查的任务调度允许的最小调度间隔（秒）。提交任务时，TaskAnalyzer 将调度周期转换为秒，如果周期小于 `task_min_schedule_interval_s`，则以 `ERR_INVALID_PARAMETER` 拒绝提交。这可以防止创建运行过于频繁的任务，并保护调度器免受高频任务的影响。如果调度没有明确的开始时间，TaskAnalyzer 会将开始时间设置为当前纪元秒。
 - 引入版本: v3.3.0, v3.4.0, v3.5.0
 
 ##### `task_runs_timeout_second`
 
 - 默认值: 4 * 3600
-- 类型: Int
+- 类型: 整型
 - 单位: 秒
-- 是否可变: Yes
-- 描述: TaskRun 的默认执行超时（以秒为单位）。此项用作 TaskRun 执行的基线超时。如果任务运行的属性包含会话变量 `query_timeout` 或 `insert_timeout` 且具有正整数值，则运行时使用会话超时和 `task_runs_timeout_second` 之间的较大值。有效超时随后被限制为不超过配置的 `task_runs_ttl_second` 和 `task_ttl_second`。设置此项以限制任务运行的执行时间。非常大的值可能会被任务/任务运行 TTL 设置截断。
+- 可变: 是
+- 描述: TaskRun 的默认执行超时时间（秒）。此项用作 TaskRun 执行的基线超时。如果任务运行的属性包含会话变量 `query_timeout` 或 `insert_timeout`，且其值为正整数，则运行时使用该会话超时和 `task_runs_timeout_second` 中较大的值。然后，有效超时将被限制，不得超过配置的 `task_runs_ttl_second` 和 `task_ttl_second`。设置此项以限制任务运行的执行时间。非常大的值可能会被任务/任务运行 TTL 设置截断。
 - 引入版本: -
 
-### 加载和卸载
+### 加载与卸载
 
 ##### `broker_load_default_timeout_second`
 
 - 默认值: 14400
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
+- 是否可变: 是
 - 描述: Broker Load 作业的超时时长。
 - 引入版本: -
 
@@ -2310,8 +2310,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1024
 - 类型: Int
 - 单位: -
-- 是否可变: Yes
-- 描述: FE 中待处理作业的最大数量。该数量指的是所有作业，例如表创建、加载和 schema 变更作业。如果 FE 中待处理作业的数量达到此值，FE 将拒绝新的加载请求。此参数仅对异步加载生效。从 v2.5 开始，默认值从 100 更改为 1024。
+- 是否可变: 是
+- 描述: FE 中待处理作业的最大数量。该数量指所有作业，例如表创建、加载和 Schema 变更作业。如果 FE 中待处理作业的数量达到此值，FE 将拒绝新的加载请求。此参数仅对异步加载生效。从 v2.5 版本开始，默认值从 100 更改为 1024。
 - 引入版本: -
 
 ##### `disable_load_job`
@@ -2319,8 +2319,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: false
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 集群发生错误时是否禁用加载。这可以防止因集群错误造成的任何损失。默认值为 `FALSE`，表示不禁用加载。`TRUE` 表示禁用加载，集群处于只读状态。
+- 是否可变: 是
+- 描述: 当集群遇到错误时是否禁用加载。这可以防止集群错误造成的任何损失。默认值为 `FALSE`，表示未禁用加载。`TRUE` 表示禁用加载，集群处于只读状态。
 - 引入版本: -
 
 ##### `empty_load_as_error`
@@ -2328,10 +2328,10 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: true
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 如果没有数据加载，是否返回错误消息 "all partitions have no load data"。有效值：
-  - `true`: 如果没有数据加载，系统会显示失败消息并返回错误 "all partitions have no load data"。
-  - `false`: 如果没有数据加载，系统会显示成功消息并返回 OK，而不是错误。
+- 是否可变: 是
+- 描述: 如果没有加载任何数据，是否返回错误消息 "all partitions have no load data"。有效值：
+  - `true`: 如果没有加载任何数据，系统将显示失败消息并返回错误 "all partitions have no load data"。
+  - `false`: 如果没有加载任何数据，系统将显示成功消息并返回 OK，而不是错误。
 - 引入版本: -
 
 ##### `enable_file_bundling`
@@ -2339,8 +2339,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: true
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否为云原生表启用 File Bundling 优化。启用此功能 (设置为 `true`) 后，系统会自动捆绑加载、Compaction 或 Publish 操作生成的数据文件，从而降低因频繁访问外部存储系统而产生的 API 成本。您还可以使用 CREATE TABLE 属性 `file_bundling` 在表级别控制此行为。有关详细说明，请参阅 [CREATE TABLE](../../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md)。
+- 是否可变: 是
+- 描述: 是否为云原生表启用 File Bundling 优化。当此功能启用（设置为 `true`）时，系统会自动捆绑加载、Compaction 或 Publish 操作生成的数据文件，从而降低高频访问外部存储系统造成的 API 成本。您还可以使用 CREATE TABLE 属性 `file_bundling` 在表级别控制此行为。有关详细说明，请参阅 [CREATE TABLE](../../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md)。
 - 引入版本: v4.0
 
 ##### `enable_routine_load_lag_metrics`
@@ -2348,8 +2348,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: false
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否收集 Routine Load Kafka 分区偏移量滞后指标。请注意，将此项设置为 `true` 将调用 Kafka API 以获取分区的最新偏移量。
+- 是否可变: 是
+- 描述: 是否收集 Routine Load Kafka 分区偏移量滞后指标。请注意，将此项设置为 `true` 将调用 Kafka API 获取分区的最新偏移量。
 - 引入版本: -
 
 ##### `enable_sync_publish`
@@ -2357,10 +2357,10 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: true
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否在加载事务的发布阶段同步执行应用任务。此参数仅适用于 Primary Key 表。有效值：
-  - `TRUE`（默认）：应用任务在加载事务的发布阶段同步执行。这意味着只有在应用任务完成后，加载事务才会被报告为成功，并且加载的数据才能真正被查询。当任务一次加载大量数据或频繁加载数据时，将此参数设置为 `true` 可以提高查询性能和稳定性，但可能会增加加载延迟。
-  - `FALSE`: 应用任务在加载事务的发布阶段异步执行。这意味着在应用任务提交后，加载事务被报告为成功，但加载的数据不能立即被查询。在这种情况下，并发查询需要等待应用任务完成或超时才能继续。当任务一次加载大量数据或频繁加载数据时，将此参数设置为 `false` 可能会影响查询性能和稳定性。
+- 是否可变: 是
+- 描述: 是否在加载事务的发布阶段同步执行 apply 任务。此参数仅适用于主键表。有效值：
+  - `TRUE` (默认值): apply 任务在加载事务的发布阶段同步执行。这意味着只有在 apply 任务完成后，加载事务才会被报告为成功，并且加载的数据才能真正被查询。当任务一次加载大量数据或频繁加载数据时，将此参数设置为 `true` 可以提高查询性能和稳定性，但可能会增加加载延迟。
+  - `FALSE`: apply 任务在加载事务的发布阶段异步执行。这意味着在 apply 任务提交后，加载事务即被报告为成功，但加载的数据不能立即被查询。在这种情况下，并发查询需要等待 apply 任务完成或超时后才能继续。当任务一次加载大量数据或频繁加载数据时，将此参数设置为 `false` 可能会影响查询性能和稳定性。
 - 引入版本: v3.2.0
 
 ##### `export_checker_interval_second`
@@ -2368,8 +2368,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 5
 - 类型: Int
 - 单位: 秒
-- 是否可变: No
-- 描述: 调度加载作业的时间间隔。
+- 是否可变: 否
+- 描述: 加载作业的调度时间间隔。
 - 引入版本: -
 
 ##### `export_max_bytes_per_be_per_task`
@@ -2377,8 +2377,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 268435456
 - 类型: Long
 - 单位: 字节
-- 是否可变: Yes
-- 描述: 单个数据卸载任务从单个 BE 导出的最大数据量。
+- 是否可变: 是
+- 描述: 单个数据卸载任务可从单个 BE 导出的最大数据量。
 - 引入版本: -
 
 ##### `export_running_job_num_limit`
@@ -2386,7 +2386,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 5
 - 类型: Int
 - 单位: -
-- 是否可变: Yes
+- 是否可变: 是
 - 描述: 可并行运行的数据导出任务的最大数量。
 - 引入版本: -
 
@@ -2395,7 +2395,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 2 * 3600
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
+- 是否可变: 是
 - 描述: 数据导出任务的超时时长。
 - 引入版本: -
 
@@ -2404,7 +2404,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 5
 - 类型: Int
 - 单位: -
-- 是否可变: No
+- 是否可变: 否
 - 描述: 卸载任务线程池的大小。
 - 引入版本: -
 
@@ -2413,8 +2413,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 10000
 - 类型: Int
 - 单位: 毫秒
-- 是否可变: Yes
-- 描述: 提交（发布）写入事务到 StarRocks 外部表的超时时长。默认值 `10000` 表示 10 秒超时时长。
+- 是否可变: 是
+- 描述: 将写入事务提交（发布）到 StarRocks 外部表的超时时长。默认值 `10000` 表示 10 秒的超时时长。
 - 引入版本: -
 
 ##### `finish_transaction_default_lock_timeout_ms`
@@ -2422,8 +2422,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1000
 - 类型: Int
 - 单位: 毫秒
-- 是否可变: Yes
-- 描述: 完成事务期间获取数据库和表锁的默认超时。
+- 是否可变: 是
+- 描述: 在完成事务期间获取数据库和表锁的默认超时时间。
 - 引入版本: v4.0.0, v3.5.8
 
 ##### `history_job_keep_max_second`
@@ -2431,8 +2431,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 7 * 24 * 3600
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 历史作业（例如 schema 变更作业）可保留的最长时间。
+- 是否可变: 是
+- 描述: 历史作业（例如 Schema 变更作业）可保留的最长时间。
 - 引入版本: -
 
 ##### `insert_load_default_timeout_second`
@@ -2440,7 +2440,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 3600
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
+- 是否可变: 是
 - 描述: 用于加载数据的 INSERT INTO 语句的超时时长。
 - 引入版本: -
 
@@ -2449,8 +2449,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 4 * 3600
 - 类型: Int
 - 单位: 秒
-- 是否可变: No
-- 描述: 标签清理的时间间隔。单位：秒。建议您指定较短的时间间隔，以确保可以及时清理历史标签。
+- 是否可变: 否
+- 描述: 清理标签的时间间隔。单位：秒。建议您指定较短的时间间隔，以确保历史标签能够及时清理。
 - 引入版本: -
 
 ##### `label_keep_max_num`
@@ -2458,8 +2458,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1000
 - 类型: Int
 - 单位: -
-- 是否可变: Yes
-- 描述: 在一段时间内可以保留的最大加载作业数。如果超过此数量，将删除历史作业信息。
+- 是否可变: 是
+- 描述: 在一段时间内可保留的加载作业的最大数量。如果超出此数量，历史作业的信息将被删除。
 - 引入版本: -
 
 ##### `label_keep_max_second`
@@ -2467,8 +2467,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 3 * 24 * 3600
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 已完成且处于 FINISHED 或 CANCELLED 状态的加载作业标签的最长保留时间（秒）。默认值为 3 天。此持续时间过后，标签将被删除。此参数适用于所有类型的加载作业。值过大会消耗大量内存。
+- 是否可变: 是
+- 描述: 保留已完成且处于 FINISHED 或 CANCELLED 状态的加载作业标签的最长持续时间（秒）。默认值为 3 天。此持续时间到期后，标签将被删除。此参数适用于所有类型的加载作业。值过大会消耗大量内存。
 - 引入版本: -
 
 ##### `load_checker_interval_second`
@@ -2476,7 +2476,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 5
 - 类型: Int
 - 单位: 秒
-- 是否可变: No
+- 是否可变: 否
 - 描述: 加载作业滚动处理的时间间隔。
 - 引入版本: -
 
@@ -2485,8 +2485,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1
 - 类型: Int
 - 单位: -
-- 是否可变: Yes
-- 描述: 控制为单个主机上的 broker 和 stream loads 创建的并行加载片段实例的数量。LoadPlanner 将此值用作每个主机的并行度，除非会话启用自适应 sink DOP；如果会话变量 `enable_adaptive_sink_dop` 为 true，则会话的 `sink_degree_of_parallelism` 将覆盖此配置。当需要 shuffle 时，此值应用于片段并行执行（扫描片段和 sink 片段并行执行实例）。当不需要 shuffle 时，它用作 sink 管道 DOP。注意：从本地文件加载被强制为单个实例（管道 DOP = 1，并行执行 = 1）以避免本地磁盘争用。增加此数字会提高每个主机的并发性和吞吐量，但可能会增加 CPU、内存和 I/O 争用。
+- 是否可变: 是
+- 描述: 控制为 Broker Load 和 Stream Load 在单个主机上创建的并行加载片段实例的数量。LoadPlanner 使用此值作为每主机的并行度，除非会话启用自适应 sink DOP；如果会话变量 `enable_adaptive_sink_dop` 为 true，则会话的 `sink_degree_of_parallelism` 将覆盖此配置。当需要 shuffle 时，此值应用于片段并行执行（扫描片段和 sink 片段并行执行实例）。当不需要 shuffle 时，它用作 sink pipeline DOP。注意：从本地文件加载时，强制使用单个实例（pipeline DOP = 1，parallel exec = 1）以避免本地磁盘争用。增加此数量会提高每主机的并发性和吞吐量，但可能会增加 CPU、内存和 I/O 争用。
 - 引入版本: v3.2.0
 
 ##### `load_straggler_wait_second`
@@ -2494,8 +2494,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 300
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
-- 描述: BE 副本可容忍的最大加载延迟。如果超过此值，将执行克隆以从其他副本克隆数据。
+- 是否可变: 是
+- 描述: BE 副本可容忍的最大加载延迟。如果超过此值，将执行克隆操作以从其他副本克隆数据。
 - 引入版本: -
 
 ##### `loads_history_retained_days`
@@ -2503,8 +2503,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 30
 - 类型: Int
 - 单位: 天
-- 是否可变: Yes
-- 描述: 内部 `_statistics_.loads_history` 表中加载历史记录的保留天数。此值用于表创建以设置表属性 `partition_live_number`，并传递给 `TableKeeper`（最小值为 1）以确定要保留多少个每日分区。增加或减少此值可调整完成的加载作业在每日分区中保留的时间；它会影响新表创建和 keeper 的清理行为，但不会自动重新创建过去的分区。`LoadsHistorySyncer` 在管理加载历史生命周期时依赖此保留；其同步节奏由 `loads_history_sync_interval_second` 控制。
+- 是否可变: 是
+- 描述: 在内部 `_statistics_.loads_history` 表中保留加载历史记录的天数。此值用于表创建，以设置表属性 `partition_live_number`，并传递给 `TableKeeper`（最小值为 1）以确定要保留多少个每日分区。增加或减少此值会调整已完成的加载作业在每日分区中保留的时间；它会影响新表的创建和 keeper 的修剪行为，但不会自动重新创建过去的 partitions。`LoadsHistorySyncer` 在管理加载历史记录生命周期时依赖此保留策略；其同步频率由 `loads_history_sync_interval_second` 控制。
 - 引入版本: v3.3.6, v3.4.0, v3.5.0
 
 ##### `loads_history_sync_interval_second`
@@ -2512,8 +2512,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 60
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
-- 描述: LoadsHistorySyncer 用于调度从 `information_schema.loads` 到内部 `_statistics_.loads_history` 表的周期性同步的间隔（以秒为单位）。该值在构造函数中乘以 1000 以设置 FrontendDaemon 间隔。同步器跳过第一次运行（以允许表创建），并且仅导入一分钟前完成的加载；较小的值会增加 DML 和执行器负载，而较大的值会延迟历史加载记录的可用性。有关目标表的保留/分区行为，请参阅 `loads_history_retained_days`。
+- 是否可变: 是
+- 描述: `LoadsHistorySyncer` 用于调度从 `information_schema.loads` 到内部 `_statistics_.loads_history` 表的已完成加载作业的定期同步的时间间隔（秒）。该值在构造函数中乘以 1000 以设置 FrontendDaemon 间隔。同步器跳过第一次运行（以允许表创建），并且只导入一分钟前完成的加载；较小的值会增加 DML 和执行器负载，而较大的值会延迟历史加载记录的可用性。有关目标表的保留/分区行为，请参阅 `loads_history_retained_days`。
 - 引入版本: v3.3.6, v3.4.0, v3.5.0
 
 ##### `max_broker_load_job_concurrency`
@@ -2522,8 +2522,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 别名: `async_load_task_pool_size`
 - 类型: Int
 - 单位: -
-- 是否可变: Yes
-- 描述: StarRocks 集群中允许的最大并发 Broker Load 作业数。此参数仅对 Broker Load 有效。此参数的值必须小于 `max_running_txn_num_per_db` 的值。从 v2.5 开始，默认值从 `10` 更改为 `5`。
+- 是否可变: 是
+- 描述: StarRocks 集群中允许的最大并发 Broker Load 作业数量。此参数仅对 Broker Load 有效。此参数的值必须小于 `max_running_txn_num_per_db` 的值。从 v2.5 版本开始，默认值从 `10` 更改为 `5`。
 - 引入版本: -
 
 ##### `max_load_timeout_second`
@@ -2531,8 +2531,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 259200
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 加载作业允许的最大超时时长。如果超过此限制，加载作业将失败。此限制适用于所有类型的加载作业。
+- 是否可变: 是
+- 描述: 加载作业允许的最大超时时长。如果超出此限制，加载作业将失败。此限制适用于所有类型的加载作业。
 - 引入版本: -
 
 ##### `max_routine_load_batch_size`
@@ -2540,7 +2540,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 4294967296
 - 类型: Long
 - 单位: 字节
-- 是否可变: Yes
+- 是否可变: 是
 - 描述: Routine Load 任务可加载的最大数据量。
 - 引入版本: -
 
@@ -2549,8 +2549,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 5
 - 类型: Int
 - 单位: -
-- 是否可变: Yes
-- 描述: 每个 Routine Load 作业的最大并发任务数。
+- 是否可变: 是
+- 描述: 每个 Routine Load 作业的最大并发任务数量。
 - 引入版本: -
 
 ##### `max_routine_load_task_num_per_be`
@@ -2558,8 +2558,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 16
 - 类型: Int
 - 单位: -
-- 是否可变: Yes
-- 描述: 每个 BE 上的最大并发 Routine Load 任务数。从 v3.1.0 开始，此参数的默认值从 5 增加到 16，并且不再需要小于或等于 BE 静态参数 `routine_load_thread_pool_size`（已弃用）的值。
+- 是否可变: 是
+- 描述: 每个 BE 上最大并发 Routine Load 任务数量。从 v3.1.0 版本开始，此参数的默认值从 5 增加到 16，并且不再需要小于或等于 BE 静态参数 `routine_load_thread_pool_size`（已弃用）的值。
 - 引入版本: -
 
 ##### `max_running_txn_num_per_db`
@@ -2567,8 +2567,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1000
 - 类型: Int
 - 单位: -
-- 是否可变: Yes
-- 描述: StarRocks 集群中每个数据库允许运行的最大加载事务数。默认值为 `1000`。从 v3.1 开始，默认值从 `100` 更改为 `1000`。当数据库的实际运行加载事务数超过此参数的值时，新的加载请求将不会被处理。同步加载作业的新请求将被拒绝，异步加载作业的新请求将排队。不建议您增加此参数的值，因为这会增加系统负载。
+- 是否可变: 是
+- 描述: StarRocks 集群中每个数据库允许运行的最大加载事务数量。默认值为 `1000`。从 v3.1 版本开始，默认值从 `100` 更改为 `1000`。当数据库实际运行的加载事务数量超过此参数的值时，新的加载请求将不会被处理。同步加载作业的新请求将被拒绝，异步加载作业的新请求将被放入队列。我们不建议您增加此参数的值，因为这会增加系统负载。
 - 引入版本: -
 
 ##### `max_stream_load_timeout_second`
@@ -2576,7 +2576,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 259200
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
+- 是否可变: 是
 - 描述: Stream Load 作业允许的最大超时时长。
 - 引入版本: -
 
@@ -2585,8 +2585,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 0
 - 类型: Int
 - 单位: -
-- 是否可变: Yes
-- 描述: 允许的最大故障 BE 节点数。如果超过此数量，Routine Load 作业无法自动恢复。
+- 是否可变: 是
+- 描述: 允许的最大故障 BE 节点数量。如果超过此数量，Routine Load 作业将无法自动恢复。
 - 引入版本: -
 
 ##### `min_bytes_per_broker_scanner`
@@ -2594,7 +2594,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 67108864
 - 类型: Long
 - 单位: 字节
-- 是否可变: Yes
+- 是否可变: 是
 - 描述: Broker Load 实例可处理的最小数据量。
 - 引入版本: -
 
@@ -2603,7 +2603,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
+- 是否可变: 是
 - 描述: 加载作业允许的最小超时时长。此限制适用于所有类型的加载作业。
 - 引入版本: -
 
@@ -2612,7 +2612,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 10000
 - 类型: INT
 - 单位: -
-- 是否可变: Yes
+- 是否可变: 是
 - 描述: 在监控指标中显示的 Routine Load 作业的最小偏移量滞后。偏移量滞后大于此值的 Routine Load 作业将显示在指标中。
 - 引入版本: -
 
@@ -2621,8 +2621,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 5
 - 类型: Int
 - 单位: 分钟
-- 是否可变: Yes
-- 描述: Routine Load 作业自动恢复的间隔。
+- 是否可变: 是
+- 描述: Routine Load 作业自动恢复的时间间隔。
 - 引入版本: -
 
 ##### `prepared_transaction_default_timeout_second`
@@ -2630,8 +2630,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 86400
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 准备事务的默认超时时长。
+- 是否可变: 是
+- 描述: 预处理事务的默认超时时长。
 - 引入版本: -
 
 ##### `routine_load_task_consume_second`
@@ -2639,8 +2639,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 15
 - 类型: Long
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 集群中每个 Routine Load 任务消耗数据的最大时间。从 v3.1.0 开始，Routine Load 作业在 [`job_properties`](../../sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md#job_properties) 中支持一个新的参数 `task_consume_second`。此参数适用于 Routine Load 作业中的单个加载任务，更加灵活。
+- 是否可变: 是
+- 描述: 集群中每个 Routine Load 任务消耗数据的最长时间。从 v3.1.0 版本开始，Routine Load 作业在 [`job_properties`](../../sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md#job_properties) 中支持一个新的参数 `task_consume_second`。此参数适用于 Routine Load 作业中的单个加载任务，这更灵活。
 - 引入版本: -
 
 ##### `routine_load_task_timeout_second`
@@ -2648,8 +2648,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 60
 - 类型: Long
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 集群中每个 Routine Load 任务的超时时长。从 v3.1.0 开始，Routine Load 作业在 [`job_properties`](../../sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md#job_properties) 中支持一个新的参数 `task_timeout_second`。此参数适用于 Routine Load 作业中的单个加载任务，更加灵活。
+- 是否可变: 是
+- 描述: 集群中每个 Routine Load 任务的超时时长。从 v3.1.0 版本开始，Routine Load 作业在 [`job_properties`](../../sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md#job_properties) 中支持一个新的参数 `task_timeout_second`。此参数适用于 Routine Load 作业中的单个加载任务，这更灵活。
 - 引入版本: -
 
 ##### `routine_load_unstable_threshold_second`
@@ -2657,8 +2657,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 3600
 - 类型: Long
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 如果 Routine Load 作业中的任何任务滞后，则将其设置为 UNSTABLE 状态。具体来说，消耗的消息时间戳与当前时间的差值超过此阈值，并且数据源中存在未消耗的消息。
+- 是否可变: 是
+- 描述: 如果 Routine Load 作业中的任何任务滞后，则 Routine Load 作业将设置为 UNSTABLE 状态。具体来说，如果正在消费的消息的时间戳与当前时间之间的差值超过此阈值，并且数据源中存在未消费的消息。
 - 引入版本: -
 
 ##### `spark_dpp_version`
@@ -2666,8 +2666,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1.0.0
 - 类型: String
 - 单位: -
-- 是否可变: No
-- 描述: 使用的 Spark 动态分区剪枝 (DPP) 版本。
+- 是否可变: 否
+- 描述: 使用的 Spark 动态分区裁剪 (DPP) 版本。
 - 引入版本: -
 
 ##### `spark_home_default_dir`
@@ -2675,7 +2675,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: `StarRocksFE.STARROCKS_HOME_DIR` + "/lib/spark2x"
 - 类型: String
 - 单位: -
-- 是否可变: No
+- 是否可变: 否
 - 描述: Spark 客户端的根目录。
 - 引入版本: -
 
@@ -2684,7 +2684,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: `sys_log_dir` + "/spark_launcher_log"
 - 类型: String
 - 单位: -
-- 是否可变: No
+- 是否可变: 否
 - 描述: 存储 Spark 日志文件的目录。
 - 引入版本: -
 
@@ -2693,7 +2693,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 86400
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
+- 是否可变: 是
 - 描述: 每个 Spark Load 作业的超时时长。
 - 引入版本: -
 
@@ -2702,8 +2702,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 300
 - 类型: long
 - 单位: 秒
-- 是否可变: No
-- 描述: 提交 Spark 应用程序后等待 YARN 响应的最大时间（秒）。`SparkLauncherMonitor.LogMonitor` 将此值转换为毫秒，如果作业在 UNKNOWN/CONNECTED/SUBMITTED 状态停留时间超过此超时，它将停止监控并强制杀死 Spark 启动器进程。`SparkLoadJob` 将此配置作为默认值读取，并允许通过 `LoadStmt.SPARK_LOAD_SUBMIT_TIMEOUT` 属性进行按加载覆盖。将其设置得足够高以适应 YARN 排队延迟；设置得过低可能会中止合法排队的作业，而设置得过高可能会延迟故障处理和资源清理。
+- 是否可变: 否
+- 描述: 提交 Spark 应用程序后等待 YARN 响应的最长时间（秒）。`SparkLauncherMonitor.LogMonitor` 将此值转换为毫秒，如果作业在 UNKNOWN/CONNECTED/SUBMITTED 状态停留时间超过此超时，将停止监控并强制终止 Spark 启动器进程。`SparkLoadJob` 将此配置作为默认值读取，并允许通过 `LoadStmt.SPARK_LOAD_SUBMIT_TIMEOUT` 属性进行每个加载的覆盖。将其设置得足够高以适应 YARN 队列延迟；设置过低可能会中止合法排队的作业，而设置过高可能会延迟故障处理和资源清理。
 - 引入版本: v3.2.0
 
 ##### `spark_resource_path`
@@ -2711,7 +2711,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 空字符串
 - 类型: String
 - 单位: -
-- 是否可变: No
+- 是否可变: 否
 - 描述: Spark 依赖包的根目录。
 - 引入版本: -
 
@@ -2720,7 +2720,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 600
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
+- 是否可变: 是
 - 描述: 每个 Stream Load 作业的默认超时时长。
 - 引入版本: -
 
@@ -2728,9 +2728,9 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - 默认值: -1
 - 类型: Int
-- 单位: 事务数
-- 是否可变: Yes
-- 描述: 限制从单个 BE（后端）主机接受的并发 Stream Load 事务数。当设置为非负整数时，FrontendServiceImpl 检查 BE（按客户端 IP）的当前事务计数，如果计数 `>=` 此限制，则拒绝新的 Stream Load 开始请求。值 `< 0` 禁用限制（无限制）。此检查发生在 Stream Load 开始期间，当超出限制时可能会导致 `streamload txn num per be exceeds limit` 错误。相关的运行时行为使用 `stream_load_default_timeout_second` 作为请求超时回退。
+- 单位: 事务
+- 是否可变: 是
+- 描述: 限制单个 BE（后端）主机接受的并发 Stream Load 事务的数量。当设置为非负整数时，FrontendServiceImpl 会检查 BE（按客户端 IP）的当前事务计数，如果计数 `>=` 此限制，则拒绝新的 Stream Load 开始请求。值 `< 0` 会禁用此限制（无限制）。此检查发生在 Stream Load 开始期间，超出时可能会导致 `streamload txn num per be exceeds limit` 错误。相关的运行时行为使用 `stream_load_default_timeout_second` 作为请求超时回退。
 - 引入版本: v3.3.0, v3.4.0, v3.5.0
 
 ##### `stream_load_task_keep_max_num`
@@ -2738,8 +2738,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1000
 - 类型: Int
 - 单位: -
-- 是否可变: Yes
-- 描述: StreamLoadMgr 在内存中保留的 Stream Load 任务的最大数量（全局范围，跨所有数据库）。当跟踪的任务数量 (`idToStreamLoadTask`) 超过此阈值时，StreamLoadMgr 首先调用 `cleanSyncStreamLoadTasks()` 删除已完成的同步 Stream Load 任务；如果大小仍然大于此阈值的一半，它会调用 `cleanOldStreamLoadTasks(true)` 强制删除较旧或已完成的任务。增加此值可在内存中保留更多任务历史记录；减少此值可减少内存使用并使清理更具侵略性。此值仅控制内存中的保留，不影响持久化/重放的任务。
+- 是否可变: 是
+- 描述: `StreamLoadMgr` 在内存中保留的 Stream Load 任务的最大数量（跨所有数据库全局）。当跟踪任务的数量 (`idToStreamLoadTask`) 超过此阈值时，`StreamLoadMgr` 首先调用 `cleanSyncStreamLoadTasks()` 来删除已完成的同步 Stream Load 任务；如果大小仍然大于此阈值的一半，它会调用 `cleanOldStreamLoadTasks(true)` 来强制删除较旧或已完成的任务。增加此值可在内存中保留更多任务历史记录；减小此值可减少内存使用并使清理更积极。此值仅控制内存中的保留，不影响持久化/重放的任务。
 - 引入版本: v3.2.0
 
 ##### `stream_load_task_keep_max_second`
@@ -2747,8 +2747,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 3 * 24 * 3600
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 已完成或取消的 Stream Load 任务的保留窗口。当任务达到最终状态且其结束时间戳早于此阈值（`currentMs - endTimeMs > stream_load_task_keep_max_second * 1000`）时，它就有资格由 `StreamLoadMgr.cleanOldStreamLoadTasks` 删除，并在加载持久化状态时被丢弃。适用于 `StreamLoadTask` 和 `StreamLoadMultiStmtTask`。如果总任务计数超过 `stream_load_task_keep_max_num`，清理可能会更早触发（同步任务由 `cleanSyncStreamLoadTasks` 优先处理）。设置此值以平衡历史/可调试性与内存使用。
+- 是否可变: 是
+- 描述: 已完成或已取消的 Stream Load 任务的保留窗口。当任务达到最终状态且其结束时间戳早于此阈值 (`currentMs - endTimeMs > stream_load_task_keep_max_second * 1000`) 时，它将有资格被 `StreamLoadMgr.cleanOldStreamLoadTasks` 删除，并在加载持久化状态时被丢弃。适用于 `StreamLoadTask` 和 `StreamLoadMultiStmtTask`。如果总任务计数超过 `stream_load_task_keep_max_num`，清理可能会提前触发（同步任务由 `cleanSyncStreamLoadTasks` 优先处理）。设置此值以平衡历史记录/可调试性与内存使用。
 - 引入版本: v3.2.0
 
 ##### `transaction_clean_interval_second`
@@ -2756,8 +2756,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 30
 - 类型: Int
 - 单位: 秒
-- 是否可变: No
-- 描述: 已完成事务清理的时间间隔。单位：秒。建议您指定较短的时间间隔，以确保可以及时清理已完成的事务。
+- 是否可变: 否
+- 描述: 清理已完成事务的时间间隔。单位：秒。建议您指定较短的时间间隔，以确保已完成的事务能够及时清理。
 - 引入版本: -
 
 ##### `transaction_stream_load_coordinator_cache_capacity`
@@ -2765,8 +2765,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 4096
 - 类型: Int
 - 单位: -
-- 是否可变: Yes
-- 描述: 存储事务标签到协调器节点映射的缓存容量。
+- 是否可变: 是
+- 描述: 存储从事务标签到协调器节点映射的缓存容量。
 - 引入版本: -
 
 ##### `transaction_stream_load_coordinator_cache_expire_seconds`
@@ -2774,8 +2774,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 900
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 在协调器映射被驱逐（TTL）之前，在缓存中保留的时间。
+- 是否可变: 是
+- 描述: 协调器映射在缓存中保留的时间（TTL），之后将被逐出。
 - 引入版本: -
 
 ##### `yarn_client_path`
@@ -2783,7 +2783,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: `StarRocksFE.STARROCKS_HOME_DIR` + "/lib/yarn-client/hadoop/bin/yarn"
 - 类型: String
 - 单位: -
-- 是否可变: No
+- 是否可变: 否
 - 描述: Yarn 客户端包的根目录。
 - 引入版本: -
 
@@ -2792,7 +2792,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: `StarRocksFE.STARROCKS_HOME_DIR` + "/lib/yarn-config"
 - 类型: String
 - 单位: -
-- 是否可变: No
+- 是否可变: 否
 - 描述: 存储 Yarn 配置文件的目录。
 - 引入版本: -
 
@@ -2801,923 +2801,923 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 ##### `enable_collect_warehouse_metrics`
 
 - 默认值: true
-- 类型: Boolean
+- 类型: 布尔
 - 单位: -
-- 是否可变: Yes
-- 描述: 当此项设置为 `true` 时，系统将收集并导出每个仓库的指标。启用它会将仓库级别的指标（槽位/使用率/可用性）添加到指标输出中，并增加指标基数和收集开销。禁用它可省略仓库特定指标，并减少 CPU/网络和监控存储成本。
+- 可变: 是
+- 描述: 当此项设置为 `true` 时，系统将收集并导出每个仓库的指标。启用它会将仓库级别的指标（slot/usage/availability）添加到指标输出中，并增加指标基数和收集开销。禁用它将省略特定于仓库的指标，并减少 CPU/网络和监控存储成本。
 - 引入版本: v3.5.0
 
 ##### `enable_http_detail_metrics`
 
 - 默认值: false
-- 类型: boolean
+- 类型: 布尔
 - 单位: -
-- 是否可变: Yes
-- 描述: 当为 true 时，HTTP 服务器计算并暴露详细的 HTTP worker 指标（特别是 `HTTP_WORKER_PENDING_TASKS_NUM` gauge）。启用此功能会导致服务器迭代 Netty worker 执行器并调用每个 `NioEventLoop` 上的 `pendingTasks()` 以汇总待处理任务计数；禁用时，gauge 返回 0 以避免此成本。这种额外的收集可能会耗费 CPU 和延迟 — 仅在调试或详细调查时启用。
+- 可变: 是
+- 描述: 当为 true 时，HTTP 服务器会计算并公开详细的 HTTP worker 指标（特别是 `HTTP_WORKER_PENDING_TASKS_NUM` 仪表）。启用此功能会导致服务器遍历 Netty worker 执行器，并在每个 `NioEventLoop` 上调用 `pendingTasks()` 以汇总待处理任务计数；禁用时，仪表返回 0 以避免此开销。这种额外的收集可能对 CPU 和延迟敏感——仅在调试或详细调查时启用。
 - 引入版本: v3.2.3
 
 ##### `proc_profile_collect_time_s`
 
 - 默认值: 120
-- 类型: Int
+- 类型: 整型
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 单次进程 profile 收集的持续时间（秒）。当 `proc_profile_cpu_enable` 或 `proc_profile_mem_enable` 设置为 `true` 时，AsyncProfiler 启动，收集器线程休眠此持续时间，然后 profiler 停止并写入 profile。较大的值会增加样本覆盖率和文件大小，但会延长 profiler 运行时并延迟后续收集；较小的值会减少开销，但可能会产生不足的样本。确保此值与 `proc_profile_file_retained_days` 和 `proc_profile_file_retained_size_bytes` 等保留设置对齐。
+- 可变: 是
+- 描述: 单次进程配置文件收集的持续时间（秒）。当 `proc_profile_cpu_enable` 或 `proc_profile_mem_enable` 设置为 `true` 时，AsyncProfiler 启动，收集器线程休眠此持续时间，然后分析器停止并写入配置文件。较大的值会增加样本覆盖率和文件大小，但会延长分析器运行时并延迟后续收集；较小的值会减少开销，但可能产生不足的样本。确保此值与保留设置（例如 `proc_profile_file_retained_days` 和 `proc_profile_file_retained_size_bytes`）保持一致。
 - 引入版本: v3.2.12
 
 ### 存储
 
 ##### `alter_table_timeout_second`
 
-- 默认值: 86400
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述: schema 变更操作 (ALTER TABLE) 的超时时长。
-- 引入版本: -
+- Default: 86400
+- Type: Int
+- Unit: 秒
+- Is mutable: 是
+- Description: 模式变更操作 (ALTER TABLE) 的超时时长。
+- Introduced in: -
 
 ##### `capacity_used_percent_high_water`
 
-- 默认值: 0.75
-- 类型: double
-- 单位: 分数 (0.0–1.0)
-- 是否可变: Yes
-- 描述: 计算后端负载分数时使用的磁盘容量使用百分比（总容量的百分比）的高水位阈值。`BackendLoadStatistic.calcSore` 使用 `capacity_used_percent_high_water` 设置 `LoadScore.capacityCoefficient`：如果后端的使用百分比小于 0.5，则系数等于 0.5；如果使用百分比 `>` `capacity_used_percent_high_water`，则系数 = 1.0；否则，系数通过 (2 * usedPercent - 0.5) 随使用百分比线性变化。当系数为 1.0 时，负载分数完全由容量比例决定；较低的值会增加副本计数的权重。调整此值会改变平衡器惩罚磁盘利用率高的后端的积极程度。
-- 引入版本: v3.2.0
+- Default: 0.75
+- Type: double
+- Unit: 分数 (0.0–1.0)
+- Is mutable: 是
+- Description: 计算 BE 负载分数时使用的磁盘容量使用百分比（总容量的百分比）的高水位阈值。`BackendLoadStatistic.calcSore` 使用 `capacity_used_percent_high_water` 来设置 `LoadScore.capacityCoefficient`：如果 BE 的使用百分比小于 0.5，则系数等于 0.5；如果使用百分比 `>` `capacity_used_percent_high_water`，则系数等于 1.0；否则，系数通过 (2 * usedPercent - 0.5) 与使用百分比线性过渡。当系数为 1.0 时，负载分数完全由容量比例决定；较低的值会增加副本数量的权重。调整此值会改变均衡器惩罚磁盘利用率高的 BE 的激进程度。
+- Introduced in: v3.2.0
 
 ##### `catalog_trash_expire_second`
 
-- 默认值: 86400
-- 类型: Long
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 数据库、表或分区删除后，元数据可保留的最长时间。如果此持续时间过期，数据将被删除，并且无法通过 [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) 命令恢复。
-- 引入版本: -
+- Default: 86400
+- Type: Long
+- Unit: 秒
+- Is mutable: 是
+- Description: 数据库、表或分区被删除后，元数据可以保留的最长时间。如果此持续时间过期，数据将被删除，并且无法通过 [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) 命令恢复。
+- Introduced in: -
 
 ##### `check_consistency_default_timeout_second`
 
-- 默认值: 600
-- 类型: Long
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 副本一致性检查的超时时长。您可以根据 tablet 的大小设置此参数。
-- 引入版本: -
+- Default: 600
+- Type: Long
+- Unit: 秒
+- Is mutable: 是
+- Description: 副本一致性检查的超时时长。您可以根据 tablet 的大小设置此参数。
+- Introduced in: -
 
 ##### `consistency_check_cooldown_time_second`
 
-- 默认值: 24 * 3600
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 控制同一 tablet 两次一致性检查之间的最小间隔（以秒为单位）。在 tablet 选择期间，只有当 `tablet.getLastCheckTime()` 小于 `(currentTimeMillis - consistency_check_cooldown_time_second * 1000)` 时，tablet 才被视为符合条件。默认值 (24 * 3600) 强制每个 tablet 大约每天检查一次，以减少后端磁盘 I/O。降低此值会增加检查频率和资源使用；提高此值会以更慢地检测不一致为代价减少 I/O。该值在从索引的 tablet 列表中过滤冷却的 tablet 时全局应用。
-- 引入版本: v3.5.5
+- Default: 24 * 3600
+- Type: Int
+- Unit: 秒
+- Is mutable: 是
+- Description: 控制同一 tablet 之间一致性检查所需的最小间隔（秒）。在 tablet 选择期间，只有当 `tablet.getLastCheckTime()` 小于 `(currentTimeMillis - consistency_check_cooldown_time_second * 1000)` 时，tablet 才被视为符合条件。默认值 (24 * 3600) 大致强制每个 tablet 每天检查一次，以减少 BE 磁盘 I/O。降低此值会增加检查频率和资源使用；提高此值会减少 I/O，但会以较慢地检测不一致为代价。在从索引的 tablet 列表中过滤掉冷却中的 tablet 时，此值是全局应用的。
+- Introduced in: v3.5.5
 
 ##### `consistency_check_end_time`
 
-- 默认值: "4"
-- 类型: String
-- 单位: 一天中的小时 (0-23)
-- 是否可变: No
-- 描述: 指定 ConsistencyChecker 工作窗口的结束小时（一天中的小时）。该值使用 SimpleDateFormat("HH") 在系统时区中解析，并接受 0-23（一位或两位数）。StarRocks 将其与 `consistency_check_start_time` 一起使用，以决定何时调度和添加一致性检查作业。当 `consistency_check_start_time` 大于 `consistency_check_end_time` 时，窗口跨越午夜（例如，默认 `consistency_check_start_time` = "23" 到 `consistency_check_end_time` = "4"）。当 `consistency_check_start_time` 等于 `consistency_check_end_time` 时，检查器从不运行。解析失败将导致 FE 启动记录错误并退出，因此请提供有效的小时字符串。
-- 引入版本: v3.2.0
+- Default: "4"
+- Type: String
+- Unit: 一天中的小时 (0-23)
+- Is mutable: 否
+- Description: 指定 ConsistencyChecker 工作窗口的结束小时（一天中的小时）。该值使用系统时区中的 SimpleDateFormat("HH") 进行解析，并接受 0-23（一位或两位数字）。StarRocks 将其与 `consistency_check_start_time` 一起使用，以决定何时调度和添加一致性检查作业。当 `consistency_check_start_time` 大于 `consistency_check_end_time` 时，窗口会跨越午夜（例如，默认值为 `consistency_check_start_time` = "23" 到 `consistency_check_end_time` = "4"）。当 `consistency_check_start_time` 等于 `consistency_check_end_time` 时，检查器永远不会运行。解析失败将导致 FE 启动时记录错误并退出，因此请提供一个有效的小时字符串。
+- Introduced in: v3.2.0
 
 ##### `consistency_check_start_time`
 
-- 默认值: "23"
-- 类型: String
-- 单位: 一天中的小时 (00-23)
-- 是否可变: No
-- 描述: 指定 ConsistencyChecker 工作窗口的开始小时（一天中的小时）。该值使用 SimpleDateFormat("HH") 在系统时区中解析，并接受 0-23（一位或两位数）。StarRocks 将其与 `consistency_check_end_time` 一起使用，以决定何时调度和添加一致性检查作业。当 `consistency_check_start_time` 大于 `consistency_check_end_time` 时，窗口跨越午夜（例如，默认 `consistency_check_start_time` = "23" 到 `consistency_check_end_time` = "4"）。当 `consistency_check_start_time` 等于 `consistency_check_end_time` 时，检查器从不运行。解析失败将导致 FE 启动记录错误并退出，因此请提供有效的小时字符串。
-- 引入版本: v3.2.0
+- Default: "23"
+- Type: String
+- Unit: 一天中的小时 (00-23)
+- Is mutable: 否
+- Description: 指定 ConsistencyChecker 工作窗口的开始小时（一天中的小时）。该值使用系统时区中的 SimpleDateFormat("HH") 进行解析，并接受 0-23（一位或两位数字）。StarRocks 将其与 `consistency_check_end_time` 一起使用，以决定何时调度和添加一致性检查作业。当 `consistency_check_start_time` 大于 `consistency_check_end_time` 时，窗口会跨越午夜（例如，默认值为 `consistency_check_start_time` = "23" 到 `consistency_check_end_time` = "4"）。当 `consistency_check_start_time` 等于 `consistency_check_end_time` 时，检查器永远不会运行。解析失败将导致 FE 启动时记录错误并退出，因此请提供一个有效的小时字符串。
+- Introduced in: v3.2.0
 
 ##### `consistency_tablet_meta_check_interval_ms`
 
-- 默认值: 2 * 3600 * 1000
-- 类型: Int
-- 单位: 毫秒
-- 是否可变: Yes
-- 描述: ConsistencyChecker 用于在 `TabletInvertedIndex` 和 `LocalMetastore` 之间运行完整 tablet 元数据一致性扫描的间隔。`runAfterCatalogReady` 中的守护程序在 `current time - lastTabletMetaCheckTime` 超过此值时触发 checkTabletMetaConsistency。当首次检测到无效 tablet 时，其 `toBeCleanedTime` 设置为 `now + (consistency_tablet_meta_check_interval_ms / 2)`，因此实际删除会延迟到后续扫描。增加此值可减少扫描频率和负载（清理较慢）；减少此值可更快检测和删除陈旧 tablet（开销较高）。
-- 引入版本: v3.2.0
+- Default: 2 * 3600 * 1000
+- Type: Int
+- Unit: 毫秒
+- Is mutable: 是
+- Description: ConsistencyChecker 用于在 `TabletInvertedIndex` 和 `LocalMetastore` 之间运行完整 tablet 元数据一致性扫描的间隔。`runAfterCatalogReady` 中的守护进程在 `current time - lastTabletMetaCheckTime` 超过此值时触发 checkTabletMetaConsistency。当首次检测到无效 tablet 时，其 `toBeCleanedTime` 设置为 `now + (consistency_tablet_meta_check_interval_ms / 2)`，因此实际删除会延迟到后续扫描。增加此值可减少扫描频率和负载（清理速度较慢）；减少此值可更快地检测和删除过时 tablet（开销较高）。
+- Introduced in: v3.2.0
 
 ##### `default_replication_num`
 
-- 默认值: 3
-- 类型: Short
-- 单位: -
-- 是否可变: Yes
-- 描述: 设置在 StarRocks 中创建表时每个数据分区的默认副本数。此设置可以在创建表时通过在 CREATE TABLE DDL 中指定 `replication_num=x` 来覆盖。
-- 引入版本: -
+- Default: 3
+- Type: Short
+- Unit: -
+- Is mutable: 是
+- Description: 在 StarRocks 中创建表时，设置每个数据分区的默认副本数。在创建表时，可以通过在 CREATE TABLE DDL 中指定 `replication_num=x` 来覆盖此设置。
+- Introduced in: -
 
 ##### `enable_auto_tablet_distribution`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否自动设置 bucket 数量。
-  - 如果此参数设置为 `TRUE`，您在创建表或添加分区时无需指定 bucket 数量。StarRocks 会自动确定 bucket 数量。
-  - 如果此参数设置为 `FALSE`，您在创建表或添加分区时需要手动指定 bucket 数量。如果您在向表添加新分区时不指定 bucket 数量，新分区将继承表创建时设置的 bucket 数量。但是，您也可以手动为新分区指定 bucket 数量。
-- 引入版本: v2.5.7
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否自动设置分桶数量。
+  - 如果此参数设置为 `TRUE`，则在创建表或添加分区时无需指定分桶数量。StarRocks 会自动确定分桶数量。
+  - 如果此参数设置为 `FALSE`，则在创建表或添加分区时需要手动指定分桶数量。如果为表添加新分区时未指定分桶数量，则新分区将继承表创建时设置的分桶数量。但是，您也可以手动为新分区指定分桶数量。
+- Introduced in: v2.5.7
 
 ##### `enable_experimental_rowstore`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否启用 [混合行存和列存](../../table_design/hybrid_table.md) 功能。
-- 引入版本: v3.2.3
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否启用 [行存列存混合存储](../../table_design/hybrid_table.md) 功能。
+- Introduced in: v3.2.3
 
 ##### `enable_fast_schema_evolution`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否为 StarRocks 集群中的所有表启用快速 schema 演进。有效值为 `TRUE` 和 `FALSE`（默认）。启用快速 schema 演进可以提高 schema 变更的速度，并在添加或删除列时减少资源使用。
-- 引入版本: v3.2.0
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否为 StarRocks 集群中的所有表启用快速 Schema 变更。有效值为 `TRUE` 和 `FALSE`（默认）。启用快速 Schema 变更可以提高 Schema 变更的速度，并在添加或删除列时减少资源使用。
+- Introduced in: v3.2.0
 
-> **NOTE**
+> **注意**
 >
-> - StarRocks 共享数据集群从 v3.3.0 开始支持此参数。
-> - 如果您需要为特定表配置快速 schema 演进，例如禁用特定表的快速 schema 演进，您可以在表创建时设置表属性 [`fast_schema_evolution`](../../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md#set-fast-schema-evolution)。
+> - StarRocks 存算分离集群从 v3.3.0 开始支持此参数。
+> - 如果您需要为特定表配置快速 Schema 变更，例如禁用特定表的快速 Schema 变更，您可以在表创建时设置表属性 [`fast_schema_evolution`](../../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md#set-fast-schema-evolution)。
 
 ##### `enable_online_optimize_table`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 控制 StarRocks 在创建优化作业时是否使用非阻塞在线优化路径。当 `enable_online_optimize_table` 为 true 且目标表满足兼容性检查（无分区/键/排序规范，分布不是 `RandomDistributionDesc`，存储类型不是 `COLUMN_WITH_ROW`，已启用复制存储，且该表不是云原生表或物化视图）时，规划器会创建一个 `OnlineOptimizeJobV2` 以在不阻塞写入的情况下执行优化。如果为 false 或任何兼容性条件失败，StarRocks 将回退到 `OptimizeJobV2`，这可能会在优化期间阻塞写入操作。
-- 引入版本: v3.3.3, v3.4.0, v3.5.0
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 控制 StarRocks 在创建优化作业时是否使用非阻塞的在线优化路径。当 `enable_online_optimize_table` 为 true 且目标表满足兼容性检查（没有分区/键/排序规范，分布不是 `RandomDistributionDesc`，存储类型不是 `COLUMN_WITH_ROW`，启用了副本存储，并且该表不是云原生表或物化视图）时，规划器会创建一个 `OnlineOptimizeJobV2` 来执行优化而不会阻塞写入。如果为 false 或任何兼容性条件失败，StarRocks 将回退到 `OptimizeJobV2`，这可能会在优化期间阻塞写入操作。
+- Introduced in: v3.3.3, v3.4.0, v3.5.0
 
 ##### `enable_strict_storage_medium_check`
 
 - Default: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: FE 在用户创建表时是否严格检查 BE 的存储介质。如果此参数设置为 `TRUE`，FE 会在用户创建表时检查 BE 的存储介质，如果 BE 的存储介质与 CREATE TABLE 语句中指定的 `storage_medium` 参数不同，则返回错误。例如，CREATE TABLE 语句中指定的存储介质是 SSD，但 BE 的实际存储介质是 HDD。因此，表创建失败。如果此参数为 `FALSE`，FE 在用户创建表时不会检查 BE 的存储介质。
-- 引入版本: -
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 用户创建表时，FE 是否严格检查 BE 的存储介质。如果此参数设置为 `TRUE`，则 FE 在用户创建表时会检查 BE 的存储介质，如果 BE 的存储介质与 CREATE TABLE 语句中指定的 `storage_medium` 参数不同，则返回错误。例如，CREATE TABLE 语句中指定的存储介质是 SSD，但 BE 的实际存储介质是 HDD。结果，表创建失败。如果此参数为 `FALSE`，则 FE 在用户创建表时不会检查 BE 的存储介质。
+- Introduced in: -
 
 ##### `max_bucket_number_per_partition`
 
-- 默认值: 1024
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 一个分区中可以创建的最大 bucket 数量。
-- 引入版本: v3.3.2
+- Default: 1024
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 一个分区中可以创建的最大分桶数量。
+- Introduced in: v3.3.2
 
 ##### `max_column_number_per_table`
 
-- 默认值: 10000
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 一个表中可以创建的最大列数。
-- 引入版本: v3.3.2
+- Default: 10000
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 一个表中可以创建的最大列数。
+- Introduced in: v3.3.2
 
 ##### `max_dynamic_partition_num`
 
-- 默认值: 500
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 限制分析或创建动态分区表时可一次性创建的最大分区数。在动态分区属性验证期间，`systemtask_runs_max_history_number` 计算预期分区（结束偏移量 + 历史分区号），如果总数超过 `max_dynamic_partition_num`，则抛出 DDL 错误。仅当您预期合法的大分区范围时才增加此值；增加它允许创建更多分区，但会增加元数据大小、调度工作和操作复杂性。
-- 引入版本: v3.2.0
+- Default: 500
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 限制在分析或创建动态分区表时一次可以创建的最大分区数量。在动态分区属性验证期间，`systemtask_runs_max_history_number` 计算预期分区（结束偏移量 + 历史分区数量），如果总数超过 `max_dynamic_partition_num`，则抛出 DDL 错误。仅当您预期有合法的大分区范围时才提高此值；增加此值允许创建更多分区，但会增加元数据大小、调度工作和操作复杂性。
+- Introduced in: v3.2.0
 
 ##### `max_partition_number_per_table`
 
-- 默认值: 100000
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 一个表中可以创建的最大分区数。
-- 引入版本: v3.3.2
+- Default: 100000
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 一个表中可以创建的最大分区数量。
+- Introduced in: v3.3.2
 
 ##### `max_task_consecutive_fail_count`
 
-- 默认值: 10
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 任务在调度器自动暂停它之前可能连续失败的最大次数。当 `TaskSource.MV.equals(task.getSource())` 且 `max_task_consecutive_fail_count` 大于 0 时，如果任务的连续失败计数达到或超过 `max_task_consecutive_fail_count`，任务将通过 TaskManager 暂停，并且对于物化视图任务，物化视图将失效。抛出异常，指示暂停以及如何重新激活（例如，`ALTER MATERIALIZED VIEW <mv_name> ACTIVE`）。将此项设置为 0 或负值以禁用自动暂停。
-- 引入版本: -
+- Default: 10
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 任务在调度器自动暂停之前可能连续失败的最大次数。当 `TaskSource.MV.equals(task.getSource())` 且 `max_task_consecutive_fail_count` 大于 0 时，如果任务的连续失败计数器达到或超过 `max_task_consecutive_fail_count`，则该任务将通过 TaskManager 暂停，对于物化视图任务，物化视图将被停用。将抛出异常，指示暂停以及如何重新激活（例如，`ALTER MATERIALIZED VIEW <mv_name> ACTIVE`）。将此项设置为 0 或负值以禁用自动暂停。
+- Introduced in: -
 
 ##### `partition_recycle_retention_period_secs`
 
-- 默认值: 1800
-- 类型: Long
-- 单位: 秒
-- 是否可变: Yes
-- 描述: INSERT OVERWRITE 或物化视图刷新操作删除的分区的元数据保留时间。请注意，此类元数据无法通过执行 [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) 恢复。
-- 引入版本: v3.5.9
+- Default: 1800
+- Type: Long
+- Unit: 秒
+- Is mutable: 是
+- Description: 通过 INSERT OVERWRITE 或物化视图刷新操作删除的分区的元数据保留时间。请注意，此类元数据无法通过执行 [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) 恢复。
+- Introduced in: v3.5.9
 
 ##### `recover_with_empty_tablet`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否用空的 tablet 替换丢失或损坏的 tablet 副本。如果 tablet 副本丢失或损坏，对此 tablet 或其他健康 tablet 的数据查询可能会失败。用空的 tablet 替换丢失或损坏的 tablet 副本可确保查询仍能执行。但是，由于数据丢失，结果可能不正确。默认值为 `FALSE`，这意味着丢失或损坏的 tablet 副本不会被空的副本替换，并且查询失败。
-- 引入版本: -
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否用空 tablet 替换丢失或损坏的 tablet 副本。如果 tablet 副本丢失或损坏，对此 tablet 或其他健康 tablet 的数据查询可能会失败。用空 tablet 替换丢失或损坏的 tablet 副本可确保查询仍能执行。但是，结果可能不正确，因为数据已丢失。默认值为 `FALSE`，这意味着丢失或损坏的 tablet 副本不会被空 tablet 替换，并且查询会失败。
+- Introduced in: -
 
 ##### `storage_usage_hard_limit_percent`
 
-- 默认值: 95
-- 别名: `storage_flood_stage_usage_percent`
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: BE 目录中存储使用率的硬限制（百分比）。如果 BE 存储目录的存储使用率（百分比）超过此值，并且剩余存储空间小于 `storage_usage_hard_limit_reserve_bytes`，则加载和恢复作业将被拒绝。您需要将此项与 BE 配置项 `storage_flood_stage_usage_percent` 一起设置，以使配置生效。
-- 引入版本: -
+- Default: 95
+- Alias: `storage_flood_stage_usage_percent`
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: BE 目录中存储使用百分比的硬限制。如果 BE 存储目录的存储使用率（百分比）超过此值且剩余存储空间小于 `storage_usage_hard_limit_reserve_bytes`，则 Load 和 Restore 作业将被拒绝。您需要将此项与 BE 配置项 `storage_flood_stage_usage_percent` 一起设置，以使配置生效。
+- Introduced in: -
 
 ##### `storage_usage_hard_limit_reserve_bytes`
 
-- 默认值: 100 * 1024 * 1024 * 1024
-- 别名: `storage_flood_stage_left_capacity_bytes`
-- 类型: Long
-- 单位: 字节
-- 是否可变: Yes
-- 描述: BE 目录中剩余存储空间的硬限制。如果 BE 存储目录中剩余存储空间小于此值，并且存储使用率（百分比）超过 `storage_usage_hard_limit_percent`，则加载和恢复作业将被拒绝。您需要将此项与 BE 配置项 `storage_flood_stage_left_capacity_bytes` 一起设置，以使配置生效。
-- 引入版本: -
+- Default: 100 * 1024 * 1024 * 1024
+- Alias: `storage_flood_stage_left_capacity_bytes`
+- Type: Long
+- Unit: 字节
+- Is mutable: 是
+- Description: BE 目录中剩余存储空间的硬限制。如果 BE 存储目录中剩余存储空间小于此值且存储使用率（百分比）超过 `storage_usage_hard_limit_percent`，则 Load 和 Restore 作业将被拒绝。您需要将此项与 BE 配置项 `storage_flood_stage_left_capacity_bytes` 一起设置，以使配置生效。
+- Introduced in: -
 
 ##### `storage_usage_soft_limit_percent`
 
-- 默认值: 90
-- 别名: `storage_high_watermark_usage_percent`
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: BE 目录中存储使用率的软限制（百分比）。如果 BE 存储目录的存储使用率（百分比）超过此值，并且剩余存储空间小于 `storage_usage_soft_limit_reserve_bytes`，则 tablet 无法克隆到此目录。
-- 引入版本: -
+- Default: 90
+- Alias: `storage_high_watermark_usage_percent`
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: BE 目录中存储使用百分比的软限制。如果 BE 存储目录的存储使用率（百分比）超过此值且剩余存储空间小于 `storage_usage_soft_limit_reserve_bytes`，则 tablet 无法克隆到此目录。
+- Introduced in: -
 
 ##### `storage_usage_soft_limit_reserve_bytes`
 
-- 默认值: 200 * 1024 * 1024 * 1024
-- 别名: `storage_min_left_capacity_bytes`
-- 类型: Long
-- 单位: 字节
-- 是否可变: Yes
-- 描述: BE 目录中剩余存储空间的软限制。如果 BE 存储目录中剩余存储空间小于此值，并且存储使用率（百分比）超过 `storage_usage_soft_limit_percent`，则 tablet 无法克隆到此目录。
-- 引入版本: -
+- Default: 200 * 1024 * 1024 * 1024
+- Alias: `storage_min_left_capacity_bytes`
+- Type: Long
+- Unit: 字节
+- Is mutable: 是
+- Description: BE 目录中剩余存储空间的软限制。如果 BE 存储目录中剩余存储空间小于此值且存储使用率（百分比）超过 `storage_usage_soft_limit_percent`，则 tablet 无法克隆到此目录。
+- Introduced in: -
 
 ##### `tablet_checker_lock_time_per_cycle_ms`
 
-- 默认值: 1000
-- 类型: Int
-- 单位: 毫秒
-- 是否可变: Yes
-- 描述: tablet 检查器在释放并重新获取表锁之前，每个周期最大锁持有时间。小于 100 的值将被视为 100。
-- 引入版本: v3.5.9, v4.0.2
+- Default: 1000
+- Type: Int
+- Unit: 毫秒
+- Is mutable: 是
+- Description: tablet 检查器在释放并重新获取表锁之前，每个周期最大持有锁的时间。小于 100 的值将被视为 100。
+- Introduced in: v3.5.9, v4.0.2
 
 ##### `tablet_create_timeout_second`
 
-- 默认值: 10
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 创建 tablet 的超时时长。从 v3.1 开始，默认值从 1 更改为 10。
-- 引入版本: -
+- Default: 10
+- Type: Int
+- Unit: 秒
+- Is mutable: 是
+- Description: 创建 tablet 的超时时长。从 v3.1 开始，默认值从 1 更改为 10。
+- Introduced in: -
 
 ##### `tablet_delete_timeout_second`
 
-- 默认值: 2
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 删除 tablet 的超时时长。
-- 引入版本: -
+- Default: 2
+- Type: Int
+- Unit: 秒
+- Is mutable: 是
+- Description: 删除 tablet 的超时时长。
+- Introduced in: -
 
 ##### `tablet_sched_balance_load_disk_safe_threshold`
 
-- 默认值: 0.5
-- 别名: `balance_load_disk_safe_threshold`
-- 类型: Double
-- 单位: -
-- 是否可变: Yes
-- 描述: 用于判断 BE 磁盘使用率是否平衡的百分比阈值。如果所有 BE 的磁盘使用率都低于此值，则认为平衡。如果磁盘使用率大于此值，并且最高和最低 BE 磁盘使用率之间的差异大于 10%，则认为磁盘使用率不平衡，并触发 tablet 重新平衡。
-- 引入版本: -
+- Default: 0.5
+- Alias: `balance_load_disk_safe_threshold`
+- Type: Double
+- Unit: -
+- Is mutable: 是
+- Description: 判断 BE 磁盘使用率是否均衡的百分比阈值。如果所有 BE 的磁盘使用率都低于此值，则认为均衡。如果磁盘使用率高于此值，并且最高和最低 BE 磁盘使用率之间的差异大于 10%，则认为磁盘使用率不均衡，并触发 tablet 重新均衡。
+- Introduced in: -
 
 ##### `tablet_sched_balance_load_score_threshold`
 
-- 默认值: 0.1
-- 别名: `balance_load_score_threshold`
-- 类型: Double
-- 单位: -
-- 是否可变: Yes
-- 描述: 用于判断 BE 负载是否平衡的百分比阈值。如果 BE 的负载低于所有 BE 的平均负载，并且差异大于此值，则此 BE 处于低负载状态。相反，如果 BE 的负载高于平均负载，并且差异大于此值，则此 BE 处于高负载状态。
-- 引入版本: -
+- Default: 0.1
+- Alias: `balance_load_score_threshold`
+- Type: Double
+- Unit: -
+- Is mutable: 是
+- Description: 判断 BE 负载是否均衡的百分比阈值。如果 BE 的负载低于所有 BE 的平均负载且差异大于此值，则该 BE 处于低负载状态。相反，如果 BE 的负载高于平均负载且差异大于此值，则该 BE 处于高负载状态。
+- Introduced in: -
 
 ##### `tablet_sched_be_down_tolerate_time_s`
 
-- 默认值: 900
-- 类型: Long
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 调度器允许 BE 节点保持非活动状态的最大持续时间。达到时间阈值后，该 BE 节点上的 tablet 将迁移到其他活动 BE 节点。
-- 引入版本: v2.5.7
+- Default: 900
+- Type: Long
+- Unit: 秒
+- Is mutable: 是
+- Description: 调度器允许 BE 节点保持非活动状态的最长时间。达到时间阈值后，该 BE 节点上的 tablet 将迁移到其他活动 BE 节点。
+- Introduced in: v2.5.7
 
 ##### `tablet_sched_disable_balance`
 
-- 默认值: false
-- 别名: `disable_balance`
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否禁用 tablet 平衡。`TRUE` 表示禁用 tablet 平衡。`FALSE` 表示启用 tablet 平衡。
-- 引入版本: -
+- Default: false
+- Alias: `disable_balance`
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否禁用 tablet 均衡。`TRUE` 表示禁用 tablet 均衡。`FALSE` 表示启用 tablet 均衡。
+- Introduced in: -
 
 ##### `tablet_sched_disable_colocate_balance`
 
-- 默认值: false
-- 别名: `disable_colocate_balance`
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否禁用 Colocate 表的副本平衡。`TRUE` 表示禁用副本平衡。`FALSE` 表示启用副本平衡。
-- 引入版本: -
+- Default: false
+- Alias: `disable_colocate_balance`
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否禁用 Colocate Table 的副本均衡。`TRUE` 表示禁用副本均衡。`FALSE` 表示启用副本均衡。
+- Introduced in: -
 
 ##### `tablet_sched_max_balancing_tablets`
 
-- 默认值: 500
-- 别名: `max_balancing_tablets`
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 可同时平衡的最大 tablet 数量。如果超过此值，将跳过 tablet 重新平衡。
-- 引入版本: -
+- Default: 500
+- Alias: `max_balancing_tablets`
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 可以同时进行均衡的 tablet 的最大数量。如果超过此值，将跳过 tablet 重新均衡。
+- Introduced in: -
 
 ##### `tablet_sched_max_clone_task_timeout_sec`
 
-- 默认值: 2 * 60 * 60
-- 别名: `max_clone_task_timeout_sec`
-- 类型: Long
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 克隆 tablet 的最大超时时长。
-- 引入版本: -
+- Default: 2 * 60 * 60
+- Alias: `max_clone_task_timeout_sec`
+- Type: Long
+- Unit: 秒
+- Is mutable: 是
+- Description: 克隆 tablet 的最大超时时长。
+- Introduced in: -
 
 ##### `tablet_sched_max_not_being_scheduled_interval_ms`
 
-- 默认值: 15 * 60 * 1000
-- 类型: Long
-- 单位: 毫秒
-- 是否可变: Yes
-- 描述: 当 tablet 克隆任务正在调度时，如果 tablet 在此参数指定的时间内未被调度，StarRocks 会给予其更高的优先级，以便尽快调度。
-- 引入版本: -
+- Default: 15 * 60 * 1000
+- Type: Long
+- Unit: 毫秒
+- Is mutable: 是
+- Description: 当 tablet 克隆任务正在调度时，如果一个 tablet 在此参数指定的时间内未被调度，StarRocks 会赋予它更高的优先级，以便尽快调度。
+- Introduced in: -
 
 ##### `tablet_sched_max_scheduling_tablets`
 
-- 默认值: 10000
-- 别名: `max_scheduling_tablets`
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 可同时调度的最大 tablet 数量。如果超过此值，将跳过 tablet 平衡和修复检查。
-- 引入版本: -
+- Default: 10000
+- Alias: `max_scheduling_tablets`
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 可以同时调度的 tablet 的最大数量。如果超过此值，将跳过 tablet 均衡和修复检查。
+- Introduced in: -
 
 ##### `tablet_sched_min_clone_task_timeout_sec`
 
-- 默认值: 3 * 60
-- 别名: `min_clone_task_timeout_sec`
-- 类型: Long
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 克隆 tablet 的最小超时时长。
-- 引入版本: -
+- Default: 3 * 60
+- Alias: `min_clone_task_timeout_sec`
+- Type: Long
+- Unit: 秒
+- Is mutable: 是
+- Description: 克隆 tablet 的最小超时时长。
+- Introduced in: -
 
 ##### `tablet_sched_num_based_balance_threshold_ratio`
 
-- 默认值: 0.5
-- 别名: -
-- 类型: Double
-- 单位: -
-- 是否可变: Yes
-- 描述: 基于数量的平衡可能会破坏磁盘大小平衡，但磁盘之间的最大差距不能超过 `tablet_sched_num_based_balance_threshold_ratio` * `tablet_sched_balance_load_score_threshold`。如果集群中有 tablet 不断从 A 平衡到 B，又从 B 平衡到 A，请减小此值。如果您希望 tablet 分布更平衡，请增加此值。
-- 引入版本: - 3.1
+- Default: 0.5
+- Alias: -
+- Type: Double
+- Unit: -
+- Is mutable: 是
+- Description: 基于数量的均衡可能会破坏磁盘大小均衡，但磁盘之间的最大差距不能超过 `tablet_sched_num_based_balance_threshold_ratio` * `tablet_sched_balance_load_score_threshold`。如果集群中存在 tablet 不断从 A 均衡到 B，又从 B 均衡到 A 的情况，请减小此值。如果您希望 tablet 分布更均衡，请增大此值。
+- Introduced in: - 3.1
 
 ##### `tablet_sched_repair_delay_factor_second`
 
-- 默认值: 60
-- 别名: `tablet_repair_delay_factor_second`
-- 类型: Long
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 副本修复的间隔，单位为秒。
-- 引入版本: -
+- Default: 60
+- Alias: `tablet_repair_delay_factor_second`
+- Type: Long
+- Unit: 秒
+- Is mutable: 是
+- Description: 副本修复的间隔时间，单位为秒。
+- Introduced in: -
 
 ##### `tablet_sched_slot_num_per_path`
 
-- 默认值: 8
-- 别名: `schedule_slot_num_per_path`
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 单个 BE 存储目录中可并发运行的 tablet 相关任务的最大数量。从 v2.5 开始，此参数的默认值从 `4` 更改为 `8`。
-- 引入版本: -
+- Default: 8
+- Alias: `schedule_slot_num_per_path`
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: BE 存储目录中可以同时运行的 tablet 相关任务的最大数量。从 v2.5 开始，此参数的默认值从 `4` 更改为 `8`。
+- Introduced in: -
 
 ##### `tablet_sched_storage_cooldown_second`
 
-- 默认值: -1
-- 别名: `storage_cooldown_second`
-- 类型: Long
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 从表创建时间开始的自动冷却延迟。默认值 `-1` 表示禁用自动冷却。如果需要启用自动冷却，请将此参数设置为大于 `-1` 的值。
-- 引入版本: -
+- Default: -1
+- Alias: `storage_cooldown_second`
+- Type: Long
+- Unit: 秒
+- Is mutable: 是
+- Description: 从表创建时间开始的自动冷却延迟。默认值 `-1` 表示禁用自动冷却。如果要启用自动冷却，请将此参数设置为大于 `-1` 的值。
+- Introduced in: -
 
 ##### `tablet_stat_update_interval_second`
 
-- 默认值: 300
-- 类型: Int
-- 单位: 秒
-- 是否可变: No
-- 描述: FE 从每个 BE 获取 tablet 统计信息的时间间隔。
-- 引入版本: -
+- Default: 300
+- Type: Int
+- Unit: 秒
+- Is mutable: 否
+- Description: FE 从每个 BE 获取 tablet 统计信息的时间间隔。
+- Introduced in: -
 
 ### 共享数据
 
 ##### `aws_s3_access_key`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于访问 S3 存储桶的 Access Key ID。
-- 引入版本: v3.0
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：用于访问您的 S3 存储桶的 Access Key ID。
+- 引入版本：v3.0
 
 ##### `aws_s3_endpoint`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于访问 S3 存储桶的 endpoint，例如 `https://s3.us-west-2.amazonaws.com`。
-- 引入版本: v3.0
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：用于访问您的 S3 存储桶的端点，例如 `https://s3.us-west-2.amazonaws.com`。
+- 引入版本：v3.0
 
 ##### `aws_s3_external_id`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于跨账户访问 S3 存储桶的 AWS 账户的外部 ID。
-- 引入版本: v3.0
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：用于跨账号访问您的 S3 存储桶的 AWS 账号的外部 ID。
+- 引入版本：v3.0
 
 ##### `aws_s3_iam_role_arn`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 对存储数据文件的 S3 存储桶具有权限的 IAM 角色的 ARN。
-- 引入版本: v3.0
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：具有访问您的 S3 存储桶（存储数据文件）权限的 IAM 角色的 ARN。
+- 引入版本：v3.0
 
 ##### `aws_s3_path`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于存储数据的 S3 路径。它由 S3 存储桶的名称和其下的子路径（如果有）组成，例如 `testbucket/subpath`。
-- 引入版本: v3.0
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：用于存储数据的 S3 路径。它由您的 S3 存储桶名称及其下的子路径（如果有）组成，例如 `testbucket/subpath`。
+- 引入版本：v3.0
 
 ##### `aws_s3_region`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: S3 存储桶所在的区域，例如 `us-west-2`。
-- 引入版本: v3.0
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：您的 S3 存储桶所在的区域，例如 `us-west-2`。
+- 引入版本：v3.0
 
 ##### `aws_s3_secret_key`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于访问 S3 存储桶的 Secret Access Key。
-- 引入版本: v3.0
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：用于访问您的 S3 存储桶的 Secret Access Key。
+- 引入版本：v3.0
 
 ##### `aws_s3_use_aws_sdk_default_behavior`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 是否使用 AWS SDK 的默认认证凭据。有效值：true 和 false (默认)。
-- 引入版本: v3.0
+- 默认值：false
+- 类型：Boolean
+- 单位：-
+- 是否可变：否
+- 描述：是否使用 AWS SDK 的默认认证凭证。有效值：true 和 false（默认）。
+- 引入版本：v3.0
 
 ##### `aws_s3_use_instance_profile`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 是否使用实例配置文件和 assumed role 作为访问 S3 的凭证方法。有效值：true 和 false (默认)。
-  - 如果您使用基于 IAM 用户（Access Key 和 Secret Key）的凭证访问 S3，则必须将此项指定为 `false`，并指定 `aws_s3_access_key` 和 `aws_s3_secret_key`。
-  - 如果您使用实例配置文件访问 S3，则必须将此项指定为 `true`。
-  - 如果您使用 assumed role 访问 S3，则必须将此项指定为 `true`，并指定 `aws_s3_iam_role_arn`。
-  - 如果您使用外部 AWS 账户，则还必须指定 `aws_s3_external_id`。
-- 引入版本: v3.0
+- 默认值：false
+- 类型：Boolean
+- 单位：-
+- 是否可变：否
+- 描述：是否使用 Instance Profile 和 Assumed Role 作为访问 S3 的凭证方法。有效值：true 和 false（默认）。
+  - 如果您使用基于 IAM 用户的凭证（Access Key 和 Secret Key）访问 S3，则必须将此项指定为 `false`，并指定 `aws_s3_access_key` 和 `aws_s3_secret_key`。
+  - 如果您使用 Instance Profile 访问 S3，则必须将此项指定为 `true`。
+  - 如果您使用 Assumed Role 访问 S3，则必须将此项指定为 `true`，并指定 `aws_s3_iam_role_arn`。
+  - 如果您使用外部 AWS 账号，则还必须指定 `aws_s3_external_id`。
+- 引入版本：v3.0
 
 ##### `azure_adls2_endpoint`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: Azure Data Lake Storage Gen2 账户的 endpoint，例如 `https://test.dfs.core.windows.net`。
-- 引入版本: v3.4.1
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：您的 Azure Data Lake Storage Gen2 账号的端点，例如 `https://test.dfs.core.windows.net`。
+- 引入版本：v3.4.1
 
 ##### `azure_adls2_oauth2_client_id`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于授权 Azure Data Lake Storage Gen2 请求的托管标识的客户端 ID。
-- 引入版本: v3.4.4
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：用于授权对您的 Azure Data Lake Storage Gen2 请求的 Managed Identity 的客户端 ID。
+- 引入版本：v3.4.4
 
 ##### `azure_adls2_oauth2_tenant_id`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于授权 Azure Data Lake Storage Gen2 请求的托管标识的租户 ID。
-- 引入版本: v3.4.4
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：用于授权对您的 Azure Data Lake Storage Gen2 请求的 Managed Identity 的租户 ID。
+- 引入版本：v3.4.4
 
 ##### `azure_adls2_oauth2_use_managed_identity`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 是否使用托管标识授权 Azure Data Lake Storage Gen2 请求。
-- 引入版本: v3.4.4
+- 默认值：false
+- 类型：Boolean
+- 单位：-
+- 是否可变：否
+- 描述：是否使用 Managed Identity 授权对您的 Azure Data Lake Storage Gen2 的请求。
+- 引入版本：v3.4.4
 
 ##### `azure_adls2_path`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于存储数据的 Azure Data Lake Storage Gen2 路径。它由文件系统名称和目录名称组成，例如 `testfilesystem/starrocks`。
-- 引入版本: v3.4.1
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：用于存储数据的 Azure Data Lake Storage Gen2 路径。它由文件系统名称和目录名称组成，例如 `testfilesystem/starrocks`。
+- 引入版本：v3.4.1
 
 ##### `azure_adls2_sas_token`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于授权 Azure Data Lake Storage Gen2 请求的共享访问签名 (SAS)。
-- 引入版本: v3.4.1
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：用于授权对您的 Azure Data Lake Storage Gen2 请求的共享访问签名 (SAS)。
+- 引入版本：v3.4.1
 
 ##### `azure_adls2_shared_key`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于授权 Azure Data Lake Storage Gen2 请求的共享密钥。
-- 引入版本: v3.4.1
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：用于授权对您的 Azure Data Lake Storage Gen2 请求的共享密钥。
+- 引入版本：v3.4.1
 
 ##### `azure_blob_endpoint`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: Azure Blob Storage 账户的 endpoint，例如 `https://test.blob.core.windows.net`。
-- 引入版本: v3.1
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：您的 Azure Blob Storage 账号的端点，例如 `https://test.blob.core.windows.net`。
+- 引入版本：v3.1
 
 ##### `azure_blob_path`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于存储数据的 Azure Blob Storage 路径。它由存储账户中容器的名称和容器下的子路径（如果有）组成，例如 `testcontainer/subpath`。
-- 引入版本: v3.1
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：用于存储数据的 Azure Blob Storage 路径。它由您的存储账号中的容器名称及其下的子路径（如果有）组成，例如 `testcontainer/subpath`。
+- 引入版本：v3.1
 
 ##### `azure_blob_sas_token`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于授权 Azure Blob Storage 请求的共享访问签名 (SAS)。
-- 引入版本: v3.1
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：用于授权对您的 Azure Blob Storage 请求的共享访问签名 (SAS)。
+- 引入版本：v3.1
 
 ##### `azure_blob_shared_key`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于授权 Azure Blob Storage 请求的共享密钥。
-- 引入版本: v3.1
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：用于授权对您的 Azure Blob Storage 请求的共享密钥。
+- 引入版本：v3.1
 
 ##### `azure_use_native_sdk`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否使用原生 SDK 访问 Azure Blob Storage，从而允许使用托管标识和服务主体进行身份验证。如果此项设置为 `false`，则仅允许使用共享密钥和 SAS Token 进行身份验证。
-- 引入版本: v3.4.4
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否可变：是
+- 描述：是否使用原生 SDK 访问 Azure Blob Storage，从而允许使用 Managed Identities 和 Service Principals 进行身份验证。如果此项设置为 `false`，则只允许使用 Shared Key 和 SAS Token 进行身份验证。
+- 引入版本：v3.4.4
 
 ##### `cloud_native_hdfs_url`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: HDFS 存储的 URL，例如 `hdfs://127.0.0.1:9000/user/xxx/starrocks/`。
-- 引入版本: -
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：HDFS 存储的 URL，例如 `hdfs://127.0.0.1:9000/user/xxx/starrocks/`。
+- 引入版本：-
 
 ##### `cloud_native_meta_port`
 
-- 默认值: 6090
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: FE 云原生元数据服务器 RPC 监听端口。
-- 引入版本: -
+- 默认值：6090
+- 类型：Int
+- 单位：-
+- 是否可变：否
+- 描述：FE 云原生元数据服务器 RPC 监听端口。
+- 引入版本：-
 
 ##### `cloud_native_storage_type`
 
-- 默认值: S3
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 您使用的对象存储类型。在共享数据模式下，StarRocks 支持将数据存储在 HDFS、Azure Blob（v3.1.1 起支持）、Azure Data Lake Storage Gen2（v3.4.1 起支持）、Google Storage（带原生 SDK，v3.5.1 起支持）以及与 S3 协议兼容的对象存储系统（如 AWS S3 和 MinIO）中。有效值：`S3`（默认）、`HDFS`、`AZBLOB`、`ADLS2` 和 `GS`。如果您将此参数指定为 `S3`，则必须添加以 `aws_s3` 为前缀的参数。如果您将此参数指定为 `AZBLOB`，则必须添加以 `azure_blob` 为前缀的参数。如果您将此参数指定为 `ADLS2`，则必须添加以 `azure_adls2` 为前缀的参数。如果您将此参数指定为 `GS`，则必须添加以 `gcp_gcs` 为前缀的参数。如果您将此参数指定为 `HDFS`，则只需指定 `cloud_native_hdfs_url`。
-- 引入版本: -
+- 默认值：S3
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：您使用的对象存储类型。在共享数据模式下，StarRocks 支持将数据存储在 HDFS、Azure Blob（v3.1.1 及更高版本支持）、Azure Data Lake Storage Gen2（v3.4.1 及更高版本支持）、Google Storage（使用原生 SDK，v3.5.1 及更高版本支持）以及与 S3 协议兼容的对象存储系统（如 AWS S3 和 MinIO）中。有效值：`S3`（默认）、`HDFS`、`AZBLOB`、`ADLS2` 和 `GS`。如果您将此参数指定为 `S3`，则必须添加以 `aws_s3` 为前缀的参数。如果您将此参数指定为 `AZBLOB`，则必须添加以 `azure_blob` 为前缀的参数。如果您将此参数指定为 `ADLS2`，则必须添加以 `azure_adls2` 为前缀的参数。如果您将此参数指定为 `GS`，则必须添加以 `gcp_gcs` 为前缀的参数。如果您将此参数指定为 `HDFS`，则只需指定 `cloud_native_hdfs_url`。
+- 引入版本：-
 
 ##### `enable_load_volume_from_conf`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 是否允许 StarRocks 使用 FE 配置文件中指定的对象存储相关属性创建内置存储卷。从 v3.4.1 开始，默认值从 `true` 更改为 `false`。
-- 引入版本: v3.1.0
+- 默认值：false
+- 类型：Boolean
+- 单位：-
+- 是否可变：否
+- 描述：是否允许 StarRocks 使用 FE 配置文件中指定的对象存储相关属性创建内置存储卷。从 v3.4.1 起，默认值从 `true` 更改为 `false`。
+- 引入版本：v3.1.0
 
 ##### `gcp_gcs_impersonation_service_account`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 如果您使用基于模拟的身份验证访问 Google Storage，则要模拟的服务账户。
-- 引入版本: v3.5.1
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：如果您使用基于模拟的身份验证访问 Google Storage，则要模拟的 Service Account。
+- 引入版本：v3.5.1
 
 ##### `gcp_gcs_path`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于存储数据的 Google Cloud 路径。它由 Google Cloud 存储桶的名称和其下的子路径（如果有）组成，例如 `testbucket/subpath`。
-- 引入版本: v3.5.1
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：用于存储数据的 Google Cloud 路径。它由您的 Google Cloud 存储桶名称及其下的子路径（如果有）组成，例如 `testbucket/subpath`。
+- 引入版本：v3.5.1
 
 ##### `gcp_gcs_service_account_email`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 服务账户创建时生成的 JSON 文件中的电子邮件地址，例如 `user@hello.iam.gserviceaccount.com`。
-- 引入版本: v3.5.1
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：在创建 Service Account 时生成的 JSON 文件中的电子邮件地址，例如 `user@hello.iam.gserviceaccount.com`。
+- 引入版本：v3.5.1
 
 ##### `gcp_gcs_service_account_private_key`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 服务账户创建时生成的 JSON 文件中的私钥，例如 `-----BEGIN PRIVATE KEY----xxxx-----END PRIVATE KEY-----\n`。
-- 引入版本: v3.5.1
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：在创建 Service Account 时生成的 JSON 文件中的私钥，例如 `-----BEGIN PRIVATE KEY----xxxx-----END PRIVATE KEY-----\n`。
+- 引入版本：v3.5.1
 
 ##### `gcp_gcs_service_account_private_key_id`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 服务账户创建时生成的 JSON 文件中的私钥 ID。
-- 引入版本: v3.5.1
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：在创建 Service Account 时生成的 JSON 文件中的私钥 ID。
+- 引入版本：v3.5.1
 
 ##### `gcp_gcs_use_compute_engine_service_account`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 是否使用绑定到 Compute Engine 的服务账户。
-- 引入版本: v3.5.1
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否可变：否
+- 描述：是否使用绑定到您的 Compute Engine 的 Service Account。
+- 引入版本：v3.5.1
 
 ##### `hdfs_file_system_expire_seconds`
 
-- 默认值: 300
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 由 HdfsFsManager 管理的未使用的缓存 HDFS/ObjectStore FileSystem 的存活时间（秒）。FileSystemExpirationChecker（每 60 秒运行一次）使用此值调用每个 HdfsFs.isExpired(...)；过期时，管理器关闭底层 FileSystem 并将其从缓存中删除。访问器方法（例如 `HdfsFs.getDFSFileSystem`、`getUserName`、`getConfiguration`）更新最后访问时间戳，因此过期基于不活动。较低的值会减少空闲资源占用，但会增加重新打开的开销；较高的值会保持句柄更长时间，并可能消耗更多资源。
-- 引入版本: v3.2.0
+- 默认值：300
+- 类型：Int
+- 单位：秒
+- 是否可变：是
+- 描述：由 HdfsFsManager 管理的未使用的缓存 HDFS/ObjectStore FileSystem 的存活时间（秒）。FileSystemExpirationChecker（每 60 秒运行一次）使用此值调用每个 HdfsFs.isExpired(...)；当过期时，管理器会关闭底层 FileSystem 并将其从缓存中移除。访问器方法（例如 `HdfsFs.getDFSFileSystem`、`getUserName`、`getConfiguration`）会更新上次访问时间戳，因此过期是基于不活动时间。较低的值会减少空闲资源占用，但会增加重新打开的开销；较高的值会使句柄保持更长时间，并可能消耗更多资源。
+- 引入版本：v3.2.0
 
 ##### `lake_autovacuum_grace_period_minutes`
 
-- 默认值: 30
-- 类型: Long
-- 单位: 分钟
-- 是否可变: Yes
-- 描述: 共享数据集群中保留历史数据版本的时间范围。在此时间范围内的历史数据版本不会在 Compactions 后通过 AutoVacuum 自动清理。您需要将此值设置得大于最大查询时间，以避免正在运行的查询访问的数据在查询完成之前被删除。从 v3.3.0、v3.2.5 和 v3.1.10 开始，默认值已从 `5` 更改为 `30`。
-- 引入版本: v3.1.0
+- 默认值：30
+- 类型：Long
+- 单位：分钟
+- 是否可变：是
+- 描述：共享数据集群中保留历史数据版本的时间范围。在此时间范围内的历史数据版本在 Compactions 后不会通过 AutoVacuum 自动清理。您需要将此值设置得大于最大查询时间，以避免正在运行的查询访问的数据在查询完成之前被删除。从 v3.3.0、v3.2.5 和 v3.1.10 起，默认值已从 `5` 更改为 `30`。
+- 引入版本：v3.1.0
 
 ##### `lake_autovacuum_parallel_partitions`
 
-- 默认值: 8
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: 共享数据集群中可同时进行 AutoVacuum 的分区最大数量。AutoVacuum 是 Compactions 后的垃圾回收。
-- 引入版本: v3.1.0
+- 默认值：8
+- 类型：Int
+- 单位：-
+- 是否可变：否
+- 描述：共享数据集群中可以同时进行 AutoVacuum 的最大分区数。AutoVacuum 是 Compactions 后的垃圾回收。
+- 引入版本：v3.1.0
 
 ##### `lake_autovacuum_partition_naptime_seconds`
 
-- 默认值: 180
-- 类型: Long
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 共享数据集群中同一分区两次 AutoVacuum 操作之间的最小间隔。
-- 引入版本: v3.1.0
+- 默认值：180
+- 类型：Long
+- 单位：秒
+- 是否可变：是
+- 描述：共享数据集群中同一分区上 AutoVacuum 操作之间的最小间隔。
+- 引入版本：v3.1.0
 
 ##### `lake_autovacuum_stale_partition_threshold`
 
-- 默认值: 12
-- 类型: Long
-- 单位: 小时
-- 是否可变: Yes
-- 描述: 如果分区在此时间范围内没有更新（加载、DELETE 或 Compactions），系统将不会对此分区执行 AutoVacuum。
-- 引入版本: v3.1.0
+- 默认值：12
+- 类型：Long
+- 单位：小时
+- 是否可变：是
+- 描述：如果分区在此时间范围内没有更新（加载、DELETE 或 Compactions），系统将不会对此分区执行 AutoVacuum。
+- 引入版本：v3.1.0
 
 ##### `lake_compaction_allow_partial_success`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 如果此项设置为 `true`，则在共享数据集群中，当子任务之一成功时，系统将认为 Compaction 操作成功。
-- 引入版本: v3.5.2
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否可变：是
+- 描述：如果此项设置为 `true`，当共享数据集群中的 Compaction 操作的其中一个子任务成功时，系统将认为该 Compaction 操作成功。
+- 引入版本：v3.5.2
 
 ##### `lake_compaction_disable_ids`
 
-- 默认值: ""
-- 类型: String
-- 单位: -
-- 是否可变: Yes
-- 描述: 在共享数据模式下禁用 Compaction 的表或分区列表。格式为 `tableId1;partitionId2`，以分号分隔，例如 `12345;98765`。
-- 引入版本: v3.4.4
+- 默认值：""
+- 类型：String
+- 单位：-
+- 是否可变：是
+- 描述：在共享数据模式下禁用 Compaction 的表或分区列表。格式为 `tableId1;partitionId2`，以分号分隔，例如 `12345;98765`。
+- 引入版本：v3.4.4
 
 ##### `lake_compaction_history_size`
 
-- 默认值: 20
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 在共享数据集群中，Leader FE 内存中保留的最近成功 Compaction 任务记录数。您可以使用 `SHOW PROC '/compactions'` 命令查看最近成功的 Compaction 任务记录。请注意，Compaction 历史记录存储在 FE 进程内存中，如果 FE 进程重启，它将丢失。
-- 引入版本: v3.1.0
+- 默认值：20
+- 类型：Int
+- 单位：-
+- 是否可变：是
+- 描述：共享数据集群中 Leader FE 节点内存中保留的最近成功 Compaction 任务记录的数量。您可以使用 `SHOW PROC '/compactions'` 命令查看最近成功的 Compaction 任务记录。请注意，Compaction 历史记录存储在 FE 进程内存中，如果 FE 进程重启，它将丢失。
+- 引入版本：v3.1.0
 
 ##### `lake_compaction_max_tasks`
 
-- 默认值: -1
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 共享数据集群中允许的最大并发 Compaction 任务数。将此项设置为 `-1` 表示以自适应方式计算并发任务数。将此值设置为 `0` 将禁用 Compaction。
-- 引入版本: v3.1.0
+- 默认值：-1
+- 类型：Int
+- 单位：-
+- 是否可变：是
+- 描述：共享数据集群中允许的最大并发 Compaction 任务数。将此项设置为 `-1` 表示以自适应方式计算并发任务数。将此值设置为 `0` 将禁用 Compaction。
+- 引入版本：v3.1.0
 
 ##### `lake_compaction_score_selector_min_score`
 
-- 默认值: 10.0
-- 类型: Double
-- 单位: -
-- 是否可变: Yes
-- 描述: 触发共享数据集群中 Compaction 操作的 Compaction Score 阈值。当分区的 Compaction Score 大于或等于此值时，系统会对该分区执行 Compaction。
-- 引入版本: v3.1.0
+- 默认值：10.0
+- 类型：Double
+- 单位：-
+- 是否可变：是
+- 描述：触发共享数据集群中 Compaction 操作的 Compaction Score 阈值。当分区的 Compaction Score 大于或等于此值时，系统将对该分区执行 Compaction。
+- 引入版本：v3.1.0
 
 ##### `lake_compaction_score_upper_bound`
 
-- 默认值: 2000
-- 类型: Long
-- 单位: -
-- 是否可变: Yes
-- 描述: 共享数据集群中分区的 Compaction Score 上限。`0` 表示无上限。此项仅在 `lake_enable_ingest_slowdown` 设置为 `true` 时生效。当分区的 Compaction Score 达到或超过此上限时，传入的加载任务将被拒绝。从 v3.3.6 开始，默认值从 `0` 更改为 `2000`。
-- 引入版本: v3.2.0
+- 默认值：2000
+- 类型：Long
+- 单位：-
+- 是否可变：是
+- 描述：共享数据集群中分区的 Compaction Score 上限。`0` 表示没有上限。此项仅在 `lake_enable_ingest_slowdown` 设置为 `true` 时生效。当分区的 Compaction Score 达到或超过此上限时，传入的加载任务将被拒绝。从 v3.3.6 起，默认值从 `0` 更改为 `2000`。
+- 引入版本：v3.2.0
 
 ##### `lake_enable_balance_tablets_between_workers`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 在共享数据集群中，云原生表 tablet 迁移期间是否平衡计算节点之间的 tablet 数量。`true` 表示在计算节点之间平衡 tablet，`false` 表示禁用此功能。
-- 引入版本: v3.3.4
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否可变：是
+- 描述：在共享数据集群中云原生表的 Tablet 迁移期间，是否在 Compute Node 之间平衡 Tablet 数量。`true` 表示在 Compute Node 之间平衡 Tablet，`false` 表示禁用此功能。
+- 引入版本：v3.3.4
 
 ##### `lake_enable_ingest_slowdown`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否在共享数据集群中启用数据摄取减速。当数据摄取减速启用时，如果分区的 Compaction Score 超过 `lake_ingest_slowdown_threshold`，则该分区上的加载任务将受到限制。此配置仅在 `run_mode` 设置为 `shared_data` 时生效。从 v3.3.6 开始，默认值从 `false` 更改为 `true`。
-- 引入版本: v3.2.0
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否可变：是
+- 描述：是否在共享数据集群中启用数据摄取减速 (Data Ingestion Slowdown)。当启用数据摄取减速时，如果分区的 Compaction Score 超过 `lake_ingest_slowdown_threshold`，则该分区上的加载任务将被限流。此配置仅在 `run_mode` 设置为 `shared_data` 时生效。从 v3.3.6 起，默认值从 `false` 更改为 `true`。
+- 引入版本：v3.2.0
 
 ##### `lake_ingest_slowdown_threshold`
 
-- 默认值: 100
-- 类型: Long
-- 单位: -
-- 是否可变: Yes
-- 描述: 触发共享数据集群中数据摄取减速的 Compaction Score 阈值。此配置仅在 `lake_enable_ingest_slowdown` 设置为 `true` 时生效。
-- 引入版本: v3.2.0
+- 默认值：100
+- 类型：Long
+- 单位：-
+- 是否可变：是
+- 描述：触发共享数据集群中数据摄取减速的 Compaction Score 阈值。此配置仅在 `lake_enable_ingest_slowdown` 设置为 `true` 时生效。
+- 引入版本：v3.2.0
 
 ##### `lake_publish_version_max_threads`
 
-- 默认值: 512
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 共享数据集群中版本发布任务的最大线程数。
-- 引入版本: v3.2.0
+- 默认值：512
+- 类型：Int
+- 单位：-
+- 是否可变：是
+- 描述：共享数据集群中版本发布任务的最大线程数。
+- 引入版本：v3.2.0
 
 ##### `meta_sync_force_delete_shard_meta`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否允许直接删除共享数据集群的元数据，绕过清理远程存储文件。建议仅在存在大量待清理分片，导致 FE JVM 内存压力过大时才将此项设置为 `true`。请注意，启用此功能后，属于分片或 tablet 的数据文件无法自动清理。
-- 引入版本: v3.2.10, v3.3.3
+- 默认值：false
+- 类型：Boolean
+- 单位：-
+- 是否可变：是
+- 描述：是否允许直接删除共享数据集群的元数据，绕过清理远程存储文件。建议仅在需要清理的 shard 数量过多，导致 FE JVM 内存压力过大时，才将此项设置为 `true`。请注意，启用此功能后，属于 shard 或 tablet 的数据文件无法自动清理。
+- 引入版本：v3.2.10, v3.3.3
 
 ##### `run_mode`
 
-- 默认值: `shared_nothing`
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: StarRocks 集群的运行模式。有效值：`shared_data` 和 `shared_nothing`（默认）。
+- 默认值：`shared_nothing`
+- 类型：String
+- 单位：-
+- 是否可变：否
+- 描述：StarRocks 集群的运行模式。有效值：`shared_data` 和 `shared_nothing`（默认）。
   - `shared_data` 表示以共享数据模式运行 StarRocks。
   - `shared_nothing` 表示以共享无数据模式运行 StarRocks。
 
-  > **CAUTION**
+  > **注意**
   >
   > - StarRocks 集群不能同时采用 `shared_data` 和 `shared_nothing` 模式。不支持混合部署。
   > - 集群部署后，请勿更改 `run_mode`。否则，集群将无法重启。不支持从共享无数据集群转换为共享数据集群，反之亦然。
 
-- 引入版本: -
+- 引入版本：-
 
 ##### `shard_group_clean_threshold_sec`
 
-- 默认值: 3600
-- 类型: Long
-- 单位: 秒
-- 是否可变: Yes
-- 描述: FE 清理共享数据集群中未使用的 tablet 和 shard 组的时间。在此阈值内创建的 tablet 和 shard 组将不会被清理。
-- 引入版本: -
+- 默认值：3600
+- 类型：Long
+- 单位：秒
+- 是否可变：是
+- 描述：FE 清理共享数据集群中未使用的 Tablet 和 shard 组之前的时间。在此阈值内创建的 Tablet 和 shard 组将不会被清理。
+- 引入版本：-
 
 ##### `star_mgr_meta_sync_interval_sec`
 
-- 默认值: 600
-- 类型: Long
-- 单位: 秒
-- 是否可变: No
-- 描述: FE 在共享数据集群中与 StarMgr 进行周期性元数据同步的间隔。
-- 引入版本: -
+- 默认值：600
+- 类型：Long
+- 单位：秒
+- 是否可变：否
+- 描述：FE 在共享数据集群中与 StarMgr 进行周期性元数据同步的间隔。
+- 引入版本：-
 
 ##### `starmgr_grpc_server_max_worker_threads`
 
-- 默认值: 1024
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: FE starmgr 模块中 grpc 服务器使用的最大工作线程数。
-- 引入版本: v4.0.0, v3.5.8
+- 默认值：1024
+- 类型：Int
+- 单位：-
+- 是否可变：是
+- 描述：FE starmgr 模块中 grpc 服务器使用的最大工作线程数。
+- 引入版本：v4.0.0, v3.5.8
 
 ##### `starmgr_grpc_timeout_seconds`
 
-- 默认值: 5
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述:
-- 引入版本: -
+- 默认值：5
+- 类型：Int
+- 单位：秒
+- 是否可变：是
+- 描述：
+- 引入版本：-
 
 ### 数据湖
 
@@ -3726,8 +3726,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: true
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 启用后，分析器将尝试将目标表 schema 推送到 `files()` 表函数中，用于 INSERT ... FROM files() 操作。这仅适用于源是 FileTableFunctionRelation、目标是原生表且 SELECT 列表中包含相应的 slot-ref 列（或 *）的情况。分析器会将选择的列与目标列匹配（计数必须匹配），短暂锁定目标表，并用非复杂类型（Parquet JSON 等复杂类型 `->` `array<varchar>` 会跳过）的深拷贝目标列类型替换文件列类型。原始文件表中的列名会保留。这减少了摄取期间文件类型推断引起的类型不匹配和松散性。
+- 可变: 是
+- 描述: 启用此项后，分析器将尝试在 `INSERT ... FROM files()` 操作中，将目标表 schema 推送到 `files()` 表函数中。这仅适用于源为 `FileTableFunctionRelation`、目标为原生表，且 `SELECT` 列表中包含相应的 `slot-ref` 列（或 `*`）的情况。分析器会将 `SELECT` 列与目标列进行匹配（数量必须一致），短暂锁定目标表，并用深拷贝的目标列类型替换非复杂类型的文件列类型（`Parquet JSON -> array<varchar>` 等复杂类型会被跳过）。原始 `files` 表中的列名将保留。这减少了摄取过程中因基于文件的类型推断导致的类型不匹配和松散性。
 - 引入版本: v3.4.0, v3.5.0
 
 ##### `hdfs_read_buffer_size_kb`
@@ -3735,8 +3735,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 8192
 - 类型: Int
 - 单位: 千字节
-- 是否可变: Yes
-- 描述: HDFS 读取缓冲区的大小（以千字节为单位）。StarRocks 将此值转换为字节（`<< 10`），并用它来初始化 `HdfsFsManager` 中的 HDFS 读取缓冲区，并在不使用 broker 访问时填充发送给 BE 任务的 thrift 字段 `hdfs_read_buffer_size_kb`（例如 `TBrokerScanRangeParams`、`TDownloadReq`）。增加 `hdfs_read_buffer_size_kb` 可以提高顺序读取吞吐量并减少系统调用开销，但代价是每个流的内存使用量更高；减小它会减少内存占用，但可能会降低 I/O 效率。调整时请考虑工作负载（许多小流与少数大型顺序读取）。
+- 可变: 是
+- 描述: HDFS 读取缓冲区的大小，单位为千字节。StarRocks 会将此值转换为字节（`<< 10`），并用它来初始化 `HdfsFsManager` 中的 HDFS 读取缓冲区，以及在不使用 broker 访问时，填充发送给 BE 任务的 Thrift 字段 `hdfs_read_buffer_size_kb`（例如 `TBrokerScanRangeParams`、`TDownloadReq`）。增加 `hdfs_read_buffer_size_kb` 可以提高顺序读取吞吐量并减少系统调用开销，但会增加每个流的内存使用量；减小此值会减少内存占用，但可能会降低 IO 效率。在调优时请考虑工作负载（许多小流与少量大顺序读取）。
 - 引入版本: v3.2.0
 
 ##### `hdfs_write_buffer_size_kb`
@@ -3744,17 +3744,17 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1024
 - 类型: Int
 - 单位: 千字节
-- 是否可变: Yes
-- 描述: 设置用于直接写入 HDFS 或对象存储时（不使用 broker）的 HDFS 写入缓冲区大小（以 KB 为单位）。FE 将此值转换为字节（`<< 10`），并初始化 HdfsFsManager 中的本地写入缓冲区，并在 Thrift 请求中传播（例如 TUploadReq、TExportSink、sink options），以便后端/代理使用相同的缓冲区大小。增加此值可以提高大型顺序写入的吞吐量，但代价是每个写入器占用更多内存；减小此值可以减少每个流的内存使用量，并可能降低小型写入的延迟。与 `hdfs_read_buffer_size_kb` 一起调整，并考虑可用内存和并发写入器。
+- 可变: 是
+- 描述: 设置 HDFS 写入缓冲区的大小（单位为 KB），用于在不使用 broker 时直接写入 HDFS 或对象存储。FE 会将此值转换为字节（`<< 10`）并初始化 `HdfsFsManager` 中的本地写入缓冲区，并通过 Thrift 请求（例如 `TUploadReq`、`TExportSink`、`sink options`）进行传播，以便后端/代理使用相同的缓冲区大小。增加此值可以提高大型顺序写入的吞吐量，但会增加每个写入器的内存消耗；减小此值会减少每个流的内存使用量，并可能降低小型写入的延迟。请与 `hdfs_read_buffer_size_kb` 一起调优，并考虑可用内存和并发写入器。
 - 引入版本: v3.2.0
 
 ##### `lake_batch_publish_max_version_num`
 
 - 默认值: 10
 - 类型: Int
-- 单位: 计数
-- 是否可变: Yes
-- 描述: 设置在为 lake（云原生）表构建发布批次时，可能分组的连续事务版本的上限。该值传递给事务图批处理例程（参见 getReadyToPublishTxnListBatch），并与 `lake_batch_publish_min_version_num` 一起确定 TransactionStateBatch 的候选范围大小。较大的值可以通过批处理更多提交来提高发布吞吐量，但会增加原子发布的范围（更长的可见性延迟和更大的回滚表面），并且当版本不连续时可能会在运行时受到限制。根据工作负载和可见性/延迟要求进行调整。
+- 单位: 数量
+- 可变: 是
+- 描述: 设置为 Lake（云原生）表构建发布批次时，可以分组的连续事务版本的上限。此值会传递给事务图批处理例程（参见 `getReadyToPublishTxnListBatch`），并与 `lake_batch_publish_min_version_num` 协同工作，以确定 `TransactionStateBatch` 的候选范围大小。较大的值可以通过批处理更多提交来提高发布吞吐量，但会增加原子发布的范围（更长的可见性延迟和更大的回滚面），并且在版本不连续时可能会在运行时受到限制。请根据工作负载和可见性/延迟要求进行调优。
 - 引入版本: v3.2.0
 
 ##### `lake_batch_publish_min_version_num`
@@ -3762,8 +3762,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 1
 - 类型: Int
 - 单位: -
-- 是否可变: Yes
-- 描述: 设置构成 lake 表发布批次所需的最小连续事务版本数。DatabaseTransactionMgr.getReadyToPublishTxnListBatch 将此值与 `lake_batch_publish_max_version_num` 一起传递给 transactionGraph.getTxnsWithTxnDependencyBatch 以选择依赖事务。值为 `1` 允许单事务发布（不批处理）。值 `>1` 要求至少有相同数量的连续版本、单表、非复制事务可用；如果版本不连续，出现复制事务，或 schema 更改消耗版本，则批处理中止。增加此值可以通过分组提交来提高发布吞吐量，但可能会在等待足够连续的事务时延迟发布。
+- 可变: 是
+- 描述: 设置为 Lake 表形成发布批次所需的最小连续事务版本数。`DatabaseTransactionMgr.getReadyToPublishTxnListBatch` 会将此值与 `lake_batch_publish_max_version_num` 一起传递给 `transactionGraph.getTxnsWithTxnDependencyBatch` 以选择依赖事务。值为 `1` 允许单个事务发布（不进行批处理）。值 `>1` 要求至少有相同数量的连续版本、单表、非复制事务可用；如果版本不连续、出现复制事务或 schema 变更消耗了一个版本，则批处理将被中止。增加此值可以通过分组提交来提高发布吞吐量，但可能会因等待足够的连续事务而延迟发布。
 - 引入版本: v3.2.0
 
 ##### `lake_enable_batch_publish_version`
@@ -3771,8 +3771,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: true
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 启用后，PublishVersionDaemon 会为同一个 Lake（共享数据）表/分区批处理就绪事务，并将其版本一起发布，而不是为每个事务单独发布。在 RunMode shared-data 中，守护进程调用 getReadyPublishTransactionsBatch() 并使用 publishVersionForLakeTableBatch(...) 执行分组发布操作（减少 RPC 并提高吞吐量）。禁用时，守护进程回退到通过 publishVersionForLakeTable(...) 进行的逐事务发布。实现通过内部集合协调进行中的工作，以避免在切换开关时重复发布，并且受 `lake_publish_version_max_threads` 的线程池大小影响。
+- 可变: 是
+- 描述: 启用此项后，`PublishVersionDaemon` 会将同一 Lake（共享数据）表/分区的就绪事务进行批处理，并将其版本一起发布，而不是逐个事务发布。在 `RunMode shared-data` 模式下，守护进程会调用 `getReadyPublishTransactionsBatch()` 并使用 `publishVersionForLakeTableBatch(...)` 执行分组发布操作（减少 RPC 并提高吞吐量）。禁用时，守护进程会通过 `publishVersionForLakeTable(...)` 回退到逐个事务发布。该实现通过内部集合协调正在进行的工作，以避免在开关切换时重复发布，并受 `lake_publish_version_max_threads` 配置的线程池大小影响。
 - 引入版本: v3.2.0
 
 ##### `lake_enable_tablet_creation_optimization`
@@ -3780,8 +3780,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: false
 - 类型: boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 启用后，StarRocks 在共享数据模式下优化云原生表和物化视图的 tablet 创建，通过为物理分区下的所有 tablet 创建单个共享 tablet 元数据，而不是为每个 tablet 创建不同的元数据。这减少了表创建、rollup 和 schema 变更作业期间创建的 tablet 任务和元数据/文件数量。优化仅适用于云原生表/物化视图，并与 `file_bundling` 结合（后者重用相同的优化逻辑）。注意：schema 变更和 rollup 作业明确禁用使用 `file_bundling` 的表的优化，以避免使用相同名称的文件被覆盖。谨慎启用——它改变了创建的 tablet 元数据的粒度，并可能影响副本创建和文件命名行为。
+- 可变: 是
+- 描述: 启用此项后，StarRocks 会在共享数据模式下优化云原生表和物化视图的 tablet 创建，通过为物理分区下的所有 tablet 创建一个共享的 tablet 元数据，而不是为每个 tablet 创建独立的元数据。这减少了表创建、rollup 和 schema 变更作业期间生成的 tablet 创建任务和元数据/文件数量。此优化仅适用于云原生表/物化视图，并与 `file_bundling` 结合使用（后者重用相同的优化逻辑）。注意：schema 变更和 rollup 作业会明确禁用使用 `file_bundling` 的表的此优化，以避免覆盖同名文件。请谨慎启用——它会改变创建的 tablet 元数据的粒度，并可能影响副本创建和文件命名行为。
 - 引入版本: v3.3.1, v3.4.0, v3.5.0
 
 ##### `lake_use_combined_txn_log`
@@ -3789,8 +3789,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: false
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 当此项设置为 `true` 时，系统允许 Lake 表使用组合事务日志路径进行相关事务。仅适用于共享数据集群。
+- 可变: 是
+- 描述: 当此项设置为 `true` 时，系统允许 Lake 表对相关事务使用组合事务日志路径。仅适用于共享数据集群。
 - 引入版本: v3.3.7, v3.4.0, v3.5.0
 
 ##### `enable_iceberg_commit_queue`
@@ -3798,8 +3798,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: true
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 是否为 Iceberg 表启用提交队列以避免并发提交冲突。Iceberg 使用乐观并发控制 (OCC) 进行元数据提交。当多个线程同时提交到同一表时，可能会发生冲突，并出现诸如“无法提交：基元数据位置与当前表元数据位置不同”之类的错误。启用后，每个 Iceberg 表都有自己的单线程执行器用于提交操作，确保对同一表的提交是序列化的，并防止 OCC 冲突。不同的表可以并发提交，从而保持整体吞吐量。这是一项系统级优化，旨在提高可靠性，应默认启用。如果禁用，并发提交可能会因乐观锁定冲突而失败。
+- 可变: 是
+- 描述: 是否为 Iceberg 表启用提交队列以避免并发提交冲突。Iceberg 使用乐观并发控制（OCC）进行元数据提交。当多个线程并发提交到同一个表时，可能会发生冲突，并出现类似“Cannot commit: Base metadata location is not same as the current table metadata location”的错误。启用此项后，每个 Iceberg 表都有自己的单线程执行器用于提交操作，确保对同一表的提交是序列化的，从而防止 OCC 冲突。不同的表可以并发提交，从而保持整体吞吐量。这是一项系统级优化，旨在提高可靠性，应默认启用。如果禁用，并发提交可能会因乐观锁冲突而失败。
 - 引入版本: v4.1.0
 
 ##### `iceberg_commit_queue_timeout_seconds`
@@ -3807,694 +3807,694 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 300
 - 类型: Int
 - 单位: 秒
-- 是否可变: Yes
-- 描述: 等待 Iceberg 提交操作完成的超时时间（秒）。当使用提交队列 (`enable_iceberg_commit_queue=true`) 时，每个提交操作必须在此超时时间内完成。如果提交时间超过此超时，它将被取消并引发错误。影响提交时间的因素包括：正在提交的数据文件数量、表的元数据大小、底层存储（例如 S3、HDFS）的性能。
+- 可变: 是
+- 描述: 等待 Iceberg 提交操作完成的超时时间，单位为秒。当使用提交队列（`enable_iceberg_commit_queue=true`）时，每个提交操作必须在此超时时间内完成。如果提交时间超过此超时，它将被取消并引发错误。影响提交时间的因素包括：提交的数据文件数量、表的元数据大小、底层存储（例如 S3、HDFS）的性能。
 - 引入版本: v4.1.0
 
 ##### `iceberg_commit_queue_max_size`
 
 - 默认值: 1000
 - 类型: Int
-- 单位: 计数
-- 是否可变: No
-- 描述: 每个 Iceberg 表待处理提交操作的最大数量。当使用提交队列 (`enable_iceberg_commit_queue=true`) 时，这限制了可以为一个表排队的提交操作的数量。当达到限制时，额外的提交操作将在调用者线程中执行（阻塞直到容量可用）。此配置在 FE 启动时读取，并应用于新创建的表执行器。需要重启 FE 才能生效。如果您预期对同一表有许多并发提交，请增加此值。如果此值过低，在高并发期间提交可能会在调用者线程中阻塞。
+- 单位: 数量
+- 可变: 否
+- 描述: 每个 Iceberg 表的最大待处理提交操作数。当使用提交队列（`enable_iceberg_commit_queue=true`）时，此项限制了单个表可以排队的提交操作数量。当达到限制时，额外的提交操作将在调用者线程中执行（阻塞直到有可用容量）。此配置在 FE 启动时读取，并适用于新创建的表执行器。需要重启 FE 才能生效。如果您预计对同一表有许多并发提交，请增加此值。如果此值过低，在高并发期间提交可能会在调用者线程中阻塞。
 - 引入版本: v4.1.0
 
 ### 其他
 
 ##### `agent_task_resend_wait_time_ms`
 
-- 默认值: 5000
-- 类型: Long
-- 单位: 毫秒
-- 是否可变: Yes
-- 描述: FE 在重新发送 agent 任务之前必须等待的持续时间。仅当任务创建时间与当前时间之间的间隔超过此参数的值时，才能重新发送 agent 任务。此参数用于防止重复发送 agent 任务。
-- 引入版本: -
+- Default: 5000
+- Type: Long
+- Unit: 毫秒
+- Is mutable: 是
+- Description: FE 在重新发送 Agent 任务之前必须等待的时长。只有当任务创建时间与当前时间之间的间隔超过此参数的值时，才能重新发送 Agent 任务。此参数用于防止重复发送 Agent 任务。
+- Introduced in: -
 
 ##### `allow_system_reserved_names`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否允许用户创建以 `__op` 和 `__row` 开头的列名。要启用此功能，请将此参数设置为 `TRUE`。请注意，这些名称格式在 StarRocks 中保留用于特殊目的，创建此类列可能导致未定义的行为。因此，此功能默认禁用。
-- 引入版本: v3.2.0
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否允许用户创建以 `__op` 和 `__row` 开头的列。要启用此功能，请将此参数设置为 `TRUE`。请注意，这些名称格式在 StarRocks 中保留用于特殊目的，创建此类列可能会导致未定义的行为。因此，此功能默认禁用。
+- Introduced in: v3.2.0
 
 ##### `auth_token`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于 StarRocks 集群内部身份验证的令牌。如果未指定此参数，StarRocks 会在集群 Leader FE 首次启动时为集群生成一个随机令牌。
-- 引入版本: -
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: 用于 FE 所属 StarRocks 集群内身份验证的令牌。如果未指定此参数，StarRocks 会在集群的 Leader FE 首次启动时为集群生成一个随机令牌。
+- Introduced in: -
 
 ##### `authentication_ldap_simple_bind_base_dn`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: Yes
-- 描述: LDAP 服务器开始搜索用户身份验证信息的基准 DN。
-- 引入版本: -
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 是
+- Description: 基本 DN，LDAP 服务器从该点开始搜索用户的认证信息。
+- Introduced in: -
 
 ##### `authentication_ldap_simple_bind_root_dn`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: Yes
-- 描述: 用于搜索用户身份验证信息的管理员 DN。
-- 引入版本: -
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 是
+- Description: 用于搜索用户认证信息的管理员 DN。
+- Introduced in: -
 
 ##### `authentication_ldap_simple_bind_root_pwd`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: Yes
-- 描述: 用于搜索用户身份验证信息的管理员密码。
-- 引入版本: -
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 是
+- Description: 用于搜索用户认证信息的管理员密码。
+- Introduced in: -
 
 ##### `authentication_ldap_simple_server_host`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: Yes
-- 描述: LDAP 服务器运行的主机。
-- 引入版本: -
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 是
+- Description: LDAP 服务器运行的主机。
+- Introduced in: -
 
 ##### `authentication_ldap_simple_server_port`
 
-- 默认值: 389
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: LDAP 服务器的端口。
-- 引入版本: -
+- Default: 389
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: LDAP 服务器的端口。
+- Introduced in: -
 
 ##### `authentication_ldap_simple_user_search_attr`
 
-- 默认值: uid
-- 类型: String
-- 单位: -
-- 是否可变: Yes
-- 描述: 在 LDAP 对象中标识用户的属性名称。
-- 引入版本: -
+- Default: uid
+- Type: String
+- Unit: -
+- Is mutable: 是
+- Description: 在 LDAP 对象中标识用户的属性名称。
+- Introduced in: -
 
 ##### `backup_job_default_timeout_ms`
 
-- 默认值: 86400 * 1000
-- 类型: Int
-- 单位: 毫秒
-- 是否可变: Yes
-- 描述: 备份作业的超时时长。如果超过此值，备份作业将失败。
-- 引入版本: -
+- Default: 86400 * 1000
+- Type: Int
+- Unit: 毫秒
+- Is mutable: 是
+- Description: 备份作业的超时时长。如果超过此值，备份作业将失败。
+- Introduced in: -
 
 ##### `enable_collect_tablet_num_in_show_proc_backend_disk_path`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否在 `SHOW PROC /BACKENDS/{id}` 命令中启用收集每个磁盘的 tablet 数量。
-- 引入版本: v4.0.1, v3.5.8
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否在 `SHOW PROC /BACKENDS/{id}` 命令中启用收集每个磁盘的 tablet 数量。
+- Introduced in: v4.0.1, v3.5.8
 
 ##### `enable_colocate_restore`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否为 Colocate 表启用备份和恢复。`true` 表示为 Colocate 表启用备份和恢复，`false` 表示禁用。
-- 引入版本: v3.2.10, v3.3.3
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否为 Colocate 表启用备份和恢复。`true` 表示启用 Colocate 表的备份和恢复，`false` 表示禁用。
+- Introduced in: v3.2.10, v3.3.3
 
 ##### `enable_materialized_view_concurrent_prepare`
 
-- 默认值: true
-- 类型: Boolean
-- 单位:
-- 是否可变: Yes
-- 描述: 是否并发准备物化视图以提高性能。
-- 引入版本: v3.4.4
+- Default: true
+- Type: Boolean
+- Unit:
+- Is mutable: 是
+- Description: 是否并发准备物化视图以提高性能。
+- Introduced in: v3.4.4
 
 ##### `enable_metric_calculator`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: No
-- 描述: 指定是否启用用于定期收集指标的功能。有效值：`TRUE` 和 `FALSE`。`TRUE` 指定启用此功能，`FALSE` 指定禁用此功能。
-- 引入版本: -
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: 否
+- Description: 指定是否启用用于定期收集指标的功能。有效值：`TRUE` 和 `FALSE`。`TRUE` 表示启用此功能，`FALSE` 表示禁用此功能。
+- Introduced in: -
 
 ##### `enable_table_metrics_collect`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: FE 中是否导出表级别指标。禁用后，FE 将跳过导出表指标（如表扫描/加载计数器和表大小指标），但仍将计数器记录在内存中。
-- 引入版本: -
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否在 FE 中导出表级别指标。禁用时，FE 将跳过导出表指标（例如表扫描/加载计数器和表大小指标），但仍会在内存中记录计数器。
+- Introduced in: -
 
 ##### `enable_mv_post_image_reload_cache`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: FE 加载镜像后是否执行重新加载标志检查。如果对一个基本物化视图执行检查，则对于其他与之相关的物化视图则不需要。
-- 引入版本: v3.5.0
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: FE 加载镜像后是否执行重载标志检查。如果对基础物化视图执行了检查，则与其相关的其他物化视图无需再次检查。
+- Introduced in: v3.5.0
 
 ##### `enable_mv_query_context_cache`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否启用查询级别物化视图重写缓存以提高查询重写性能。
-- 引入版本: v3.3
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否启用查询级别的物化视图重写缓存以提高查询重写性能。
+- Introduced in: v3.3
 
 ##### `enable_mv_refresh_collect_profile`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否默认对所有物化视图在刷新时启用 profile。
-- 引入版本: v3.3.0
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否默认对所有物化视图在刷新时启用 profile。
+- Introduced in: v3.3.0
 
 ##### `enable_mv_refresh_extra_prefix_logging`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否在日志中启用带有物化视图名称的前缀，以便更好地调试。
-- 引入版本: v3.4.0
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否在日志中启用物化视图名称前缀以便更好地调试。
+- Introduced in: v3.4.0
 
 ##### `enable_mv_refresh_query_rewrite`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否在物化视图刷新期间启用重写查询，以便查询可以直接使用重写的物化视图而不是基表来提高查询性能。
-- 引入版本: v3.3
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否在物化视图刷新期间启用查询重写，以便查询可以直接使用重写的物化视图而不是基表来提高查询性能。
+- Introduced in: v3.3
 
 ##### `enable_trace_historical_node`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否允许系统跟踪历史节点。通过将此项设置为 `true`，您可以启用缓存共享功能，并允许系统在弹性伸缩期间选择正确的缓存节点。
-- 引入版本: v3.5.1
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否允许系统跟踪历史节点。通过将此项设置为 `true`，您可以启用缓存共享功能，并允许系统在弹性伸缩期间选择正确的缓存节点。
+- Introduced in: v3.5.1
 
 ##### `es_state_sync_interval_second`
 
-- 默认值: 10
-- 类型: Long
-- 单位: 秒
-- 是否可变: No
-- 描述: FE 获取 Elasticsearch 索引并同步 StarRocks 外部表元数据的时间间隔。
-- 引入版本: -
+- Default: 10
+- Type: Long
+- Unit: 秒
+- Is mutable: 否
+- Description: FE 获取 Elasticsearch 索引并同步 StarRocks 外部表元数据的时间间隔。
+- Introduced in: -
 
 ##### `hive_meta_cache_refresh_interval_s`
 
-- 默认值: 3600 * 2
-- 类型: Long
-- 单位: 秒
-- 是否可变: No
-- 描述: Hive 外部表缓存元数据的更新时间间隔。
-- 引入版本: -
+- Default: 3600 * 2
+- Type: Long
+- Unit: 秒
+- Is mutable: 否
+- Description: Hive 外部表的缓存元数据更新的时间间隔。
+- Introduced in: -
 
 ##### `hive_meta_store_timeout_s`
 
-- 默认值: 10
-- 类型: Long
-- 单位: 秒
-- 是否可变: No
-- 描述: 连接 Hive metastore 的超时时长。
-- 引入版本: -
+- Default: 10
+- Type: Long
+- Unit: 秒
+- Is mutable: 否
+- Description: 连接到 Hive metastore 超时的时间。
+- Introduced in: -
 
 ##### `jdbc_connection_idle_timeout_ms`
 
-- 默认值: 600000
-- 类型: Int
-- 单位: 毫秒
-- 是否可变: No
-- 描述: 访问 JDBC Catalog 的连接超时最长时间。超时连接被视为空闲。
-- 引入版本: -
+- Default: 600000
+- Type: Int
+- Unit: 毫秒
+- Is mutable: 否
+- Description: 访问 JDBC Catalog 的连接超时后的最大时长。超时连接被视为空闲连接。
+- Introduced in: -
 
 ##### `jdbc_connection_timeout_ms`
 
-- 默认值: 10000
-- 类型: Long
-- 单位: 毫秒
-- 是否可变: No
-- 描述: HikariCP 连接池获取连接的超时时间（毫秒）。如果在此时限内无法从池中获取连接，则操作将失败。
-- 引入版本: v3.5.13
+- Default: 10000
+- Type: Long
+- Unit: 毫秒
+- Is mutable: 否
+- Description: HikariCP 连接池获取连接的超时时间（毫秒）。如果在此时间内无法从连接池获取连接，操作将失败。
+- Introduced in: v3.5.13
 
 ##### `jdbc_query_timeout_ms`
 
-- 默认值: 30000
-- 类型: Long
-- 单位: 毫秒
-- 是否可变: Yes
-- 描述: JDBC 语句查询执行的超时时间（毫秒）。此超时应用于通过 JDBC Catalog 执行的所有 SQL 查询（例如，分区元数据查询）。该值在传递给 JDBC 驱动程序时转换为秒。
-- 引入版本: v3.5.13
+- Default: 30000
+- Type: Long
+- Unit: 毫秒
+- Is mutable: 是
+- Description: JDBC 语句查询执行的超时时间（毫秒）。此超时适用于通过 JDBC Catalog 执行的所有 SQL 查询（例如，分区元数据查询）。该值在传递给 JDBC 驱动程序时会转换为秒。
+- Introduced in: v3.5.13
 
 ##### `jdbc_network_timeout_ms`
 
-- 默认值: 30000
-- 类型: Long
-- 单位: 毫秒
-- 是否可变: Yes
-- 描述: JDBC 网络操作（套接字读取）的超时时间（毫秒）。此超时应用于数据库元数据调用（例如，getSchemas()、getTables()、getColumns()），以防止外部数据库无响应时无限期阻塞。
-- 引入版本: v3.5.13
+- Default: 30000
+- Type: Long
+- Unit: 毫秒
+- Is mutable: 是
+- Description: JDBC 网络操作（socket 读取）的超时时间（毫秒）。此超时适用于数据库元数据调用（例如，getSchemas()、getTables()、getColumns()），以防止外部数据库无响应时无限期阻塞。
+- Introduced in: v3.5.13
 
 ##### `jdbc_connection_pool_size`
 
-- 默认值: 8
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: 访问 JDBC Catalog 的 JDBC 连接池的最大容量。
-- 引入版本: -
+- Default: 8
+- Type: Int
+- Unit: -
+- Is mutable: 否
+- Description: 访问 JDBC Catalog 的 JDBC 连接池的最大容量。
+- Introduced in: -
 
 ##### `jdbc_meta_default_cache_enable`
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: JDBC Catalog 元数据缓存是否启用的默认值。设置为 True 时，新创建的 JDBC Catalog 将默认启用元数据缓存。
-- 引入版本: -
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: JDBC Catalog 元数据缓存是否启用的默认值。当设置为 True 时，新创建的 JDBC Catalog 将默认启用元数据缓存。
+- Introduced in: -
 
 ##### `jdbc_meta_default_cache_expire_sec`
 
-- 默认值: 600
-- 类型: Long
-- 单位: 秒
-- 是否可变: Yes
-- 描述: JDBC Catalog 元数据缓存的默认过期时间。当 `jdbc_meta_default_cache_enable` 设置为 true 时，新创建的 JDBC Catalog 将默认设置元数据缓存的过期时间。
-- 引入版本: -
+- Default: 600
+- Type: Long
+- Unit: 秒
+- Is mutable: 是
+- Description: JDBC Catalog 元数据缓存的默认过期时间。当 `jdbc_meta_default_cache_enable` 设置为 true 时，新创建的 JDBC Catalog 将默认设置元数据缓存的过期时间。
+- Introduced in: -
 
 ##### `jdbc_minimum_idle_connections`
 
-- 默认值: 1
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: 访问 JDBC Catalog 的 JDBC 连接池中的最小空闲连接数。
-- 引入版本: -
+- Default: 1
+- Type: Int
+- Unit: -
+- Is mutable: 否
+- Description: 访问 JDBC Catalog 的 JDBC 连接池中的最小空闲连接数。
+- Introduced in: -
 
 ##### `jwt_jwks_url`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: JSON Web Key Set (JWKS) 服务的 URL 或 `fe/conf` 目录下公共密钥本地文件的路径。
-- 引入版本: v3.5.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: JSON Web Key Set (JWKS) 服务的 URL 或 `fe/conf` 目录下公钥本地文件的路径。
+- Introduced in: v3.5.0
 
 ##### `jwt_principal_field`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于标识 JWT 中指示 subject (`sub`) 的字段的字符串。默认值为 `sub`。此字段的值必须与登录 StarRocks 的用户名相同。
-- 引入版本: v3.5.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: 用于标识 JWT 中表示主题 (`sub`) 的字段的字符串。默认值为 `sub`。此字段的值必须与登录 StarRocks 的用户名相同。
+- Introduced in: v3.5.0
 
 ##### `jwt_required_audience`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于标识 JWT 中 audience (`aud`) 的字符串列表。只有当列表中一个值与 JWT audience 匹配时，JWT 才被视为有效。
-- 引入版本: v3.5.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: 用于标识 JWT 中受众 (`aud`) 的字符串列表。只有当列表中的一个值与 JWT 受众匹配时，JWT 才被视为有效。
+- Introduced in: v3.5.0
 
 ##### `jwt_required_issuer`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于标识 JWT 中 issuer (`iss`) 的字符串列表。只有当列表中一个值与 JWT issuer 匹配时，JWT 才被视为有效。
-- 引入版本: v3.5.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: 用于标识 JWT 中颁发者 (`iss`) 的字符串列表。只有当列表中的一个值与 JWT 颁发者匹配时，JWT 才被视为有效。
+- Introduced in: v3.5.0
 
 ##### locale
 
-- 默认值: `zh_CN.UTF-8`
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: FE 使用的字符集。
-- 引入版本: -
+- Default: `zh_CN.UTF-8`
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: FE 使用的字符集。
+- Introduced in: -
 
 ##### `max_agent_task_threads_num`
 
-- 默认值: 4096
-- 类型: Int
-- 单位: -
-- 是否可变: No
-- 描述: agent 任务线程池中允许的最大线程数。
-- 引入版本: -
+- Default: 4096
+- Type: Int
+- Unit: -
+- Is mutable: 否
+- Description: Agent 任务线程池中允许的最大线程数。
+- Introduced in: -
 
 ##### `max_download_task_per_be`
 
-- 默认值: 0
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 在每个 RESTORE 操作中，StarRocks 分配给 BE 节点的最大下载任务数。当此项设置为小于或等于 0 时，任务数量不受限制。
-- 引入版本: v3.1.0
+- Default: 0
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 在每次 RESTORE 操作中，StarRocks 分配给 BE 节点的最大下载任务数。当此项设置为小于或等于 0 时，对任务数量不施加限制。
+- Introduced in: v3.1.0
 
 ##### `max_mv_check_base_table_change_retry_times`
 
-- 默认值: 10
-- 类型: -
-- 单位: -
-- 是否可变: Yes
-- 描述: 刷新物化视图时检测基表变更的最大重试次数。
-- 引入版本: v3.3.0
+- Default: 10
+- Type: -
+- Unit: -
+- Is mutable: 是
+- Description: 刷新物化视图时检测基表更改的最大重试次数。
+- Introduced in: v3.3.0
 
 ##### `max_mv_refresh_failure_retry_times`
 
-- 默认值: 1
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 物化视图刷新失败时的最大重试次数。
-- 引入版本: v3.3.0
+- Default: 1
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 物化视图刷新失败时的最大重试次数。
+- Introduced in: v3.3.0
 
 ##### `max_mv_refresh_try_lock_failure_retry_times`
 
-- 默认值: 3
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 物化视图刷新失败时尝试锁定的最大重试次数。
-- 引入版本: v3.3.0
+- Default: 3
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 物化视图刷新失败时尝试获取锁的最大重试次数。
+- Introduced in: v3.3.0
 
 ##### `max_small_file_number`
 
-- 默认值: 100
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 可存储在 FE 目录中的小型文件最大数量。
-- 引入版本: -
+- Default: 100
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: FE 目录下可以存储的小文件最大数量。
+- Introduced in: -
 
 ##### `max_small_file_size_bytes`
 
-- 默认值: 1024 * 1024
-- 类型: Int
-- 单位: 字节
-- 是否可变: Yes
-- 描述: 小型文件的最大大小。
-- 引入版本: -
+- Default: 1024 * 1024
+- Type: Int
+- Unit: 字节
+- Is mutable: 是
+- Description: 小文件的最大大小。
+- Introduced in: -
 
 ##### `max_upload_task_per_be`
 
-- 默认值: 0
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 在每个 BACKUP 操作中，StarRocks 分配给 BE 节点的最大上传任务数。当此项设置为小于或等于 0 时，任务数量不受限制。
-- 引入版本: v3.1.0
+- Default: 0
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 在每次 BACKUP 操作中，StarRocks 分配给 BE 节点的最大上传任务数。当此项设置为小于或等于 0 时，对任务数量不施加限制。
+- Introduced in: v3.1.0
 
 ##### `mv_create_partition_batch_interval_ms`
 
-- 默认值: 1000
-- 类型: Int
-- 单位: 毫秒
-- 是否可变: Yes
-- 描述: 在物化视图刷新期间，如果需要批量创建多个分区，系统会将其分为每批 64 个分区。为降低频繁创建分区导致失败的风险，每个批次之间设置了默认间隔（以毫秒为单位）以控制创建频率。
-- 引入版本: v3.3
+- Default: 1000
+- Type: Int
+- Unit: 毫秒
+- Is mutable: 是
+- Description: 在物化视图刷新期间，如果需要批量创建多个分区，系统会将其分成每批 64 个分区。为了降低频繁创建分区导致失败的风险，在每个批次之间设置了一个默认间隔（毫秒），以控制创建频率。
+- Introduced in: v3.3
 
 ##### `mv_plan_cache_max_size`
 
-- 默认值: 1000
-- 类型: Long
-- 单位:
-- 是否可变: Yes
-- 描述: 物化视图计划缓存的最大大小（用于物化视图重写）。如果有很多物化视图用于透明查询重写，您可以增加此值。
-- 引入版本: v3.2
+- Default: 1000
+- Type: Long
+- Unit:
+- Is mutable: 是
+- Description: 物化视图计划缓存的最大大小（用于物化视图重写）。如果有很多物化视图用于透明查询重写，您可以增加此值。
+- Introduced in: v3.2
 
 ##### `mv_plan_cache_thread_pool_size`
 
-- 默认值: 3
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 物化视图计划缓存的默认线程池大小（用于物化视图重写）。
-- 引入版本: v3.2
+- Default: 3
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 物化视图计划缓存的默认线程池大小（用于物化视图重写）。
+- Introduced in: v3.2
 
 ##### `mv_refresh_default_planner_optimize_timeout`
 
-- 默认值: 30000
-- 类型: -
-- 单位: -
-- 是否可变: Yes
-- 描述: 刷新物化视图时优化器规划阶段的默认超时。
-- 引入版本: v3.3.0
+- Default: 30000
+- Type: -
+- Unit: -
+- Is mutable: 是
+- Description: 刷新物化视图时优化器规划阶段的默认超时时间。
+- Introduced in: v3.3.0
 
 ##### `mv_refresh_fail_on_filter_data`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 如果刷新过程中存在过滤数据，物化视图刷新失败，默认为 true，否则忽略过滤数据并返回成功。
-- 引入版本: -
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 如果刷新时存在过滤数据，物化视图刷新将失败，默认为 true；否则，通过忽略过滤数据返回成功。
+- Introduced in: -
 
 ##### `mv_refresh_try_lock_timeout_ms`
 
-- 默认值: 30000
-- 类型: Int
-- 单位: 毫秒
-- 是否可变: Yes
-- 描述: 物化视图刷新尝试对其基表/物化视图进行数据库锁定的默认尝试锁定超时。
-- 引入版本: v3.3.0
+- Default: 30000
+- Type: Int
+- Unit: 毫秒
+- Is mutable: 是
+- Description: 物化视图刷新尝试获取其基表/物化视图的 DB 锁的默认尝试锁超时时间。
+- Introduced in: v3.3.0
 
 ##### `oauth2_auth_server_url`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 授权 URL。用户浏览器将被重定向到此 URL，以开始 OAuth 2.0 授权过程。
-- 引入版本: v3.5.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: 授权 URL。用户的浏览器将被重定向到此 URL 以开始 OAuth 2.0 授权过程。
+- Introduced in: v3.5.0
 
 ##### `oauth2_client_id`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: StarRocks 客户端的公共标识符。
-- 引入版本: v3.5.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: StarRocks 客户端的公共标识符。
+- Introduced in: v3.5.0
 
 ##### `oauth2_client_secret`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于授权 StarRocks 客户端与授权服务器通信的密钥。
-- 引入版本: v3.5.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: 用于授权 StarRocks 客户端与授权服务器通信的密钥。
+- Introduced in: v3.5.0
 
 ##### `oauth2_jwks_url`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: JSON Web Key Set (JWKS) 服务的 URL 或 `conf` 目录下本地文件的路径。
-- 引入版本: v3.5.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: JSON Web Key Set (JWKS) 服务的 URL 或 `conf` 目录下本地文件的路径。
+- Introduced in: v3.5.0
 
 ##### `oauth2_principal_field`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于标识 JWT 中指示 subject (`sub`) 的字段的字符串。默认值为 `sub`。此字段的值必须与登录 StarRocks 的用户名相同。
-- 引入版本: v3.5.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: 用于标识 JWT 中表示主题 (`sub`) 的字段的字符串。默认值为 `sub`。此字段的值必须与登录 StarRocks 的用户名相同。
+- Introduced in: v3.5.0
 
 ##### `oauth2_redirect_url`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: OAuth 2.0 认证成功后，用户浏览器将被重定向到的 URL。授权码将发送到此 URL。在大多数情况下，需要将其配置为 `http://<starrocks_fe_url>:<fe_http_port>/api/oauth2`。
-- 引入版本: v3.5.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: OAuth 2.0 认证成功后，用户的浏览器将被重定向到的 URL。授权码将发送到此 URL。在大多数情况下，需要将其配置为 `http://<starrocks_fe_url>:<fe_http_port>/api/oauth2`。
+- Introduced in: v3.5.0
 
 ##### `oauth2_required_audience`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于标识 JWT 中 audience (`aud`) 的字符串列表。只有当列表中一个值与 JWT audience 匹配时，JWT 才被视为有效。
-- 引入版本: v3.5.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: 用于标识 JWT 中受众 (`aud`) 的字符串列表。只有当列表中的一个值与 JWT 受众匹配时，JWT 才被视为有效。
+- Introduced in: v3.5.0
 
 ##### `oauth2_required_issuer`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 用于标识 JWT 中 issuer (`iss`) 的字符串列表。只有当列表中一个值与 JWT issuer 匹配时，JWT 才被视为有效。
-- 引入版本: v3.5.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: 用于标识 JWT 中颁发者 (`iss`) 的字符串列表。只有当列表中的一个值与 JWT 颁发者匹配时，JWT 才被视为有效。
+- Introduced in: v3.5.0
 
 ##### `oauth2_token_server_url`
 
-- 默认值: 空字符串
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 授权服务器上 StarRocks 获取访问令牌的 endpoint 的 URL。
-- 引入版本: v3.5.0
+- Default: 空字符串
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: 授权服务器上 StarRocks 获取访问令牌的端点 URL。
+- Introduced in: v3.5.0
 
 ##### `plugin_dir`
 
-- 默认值: `System.getenv("STARROCKS_HOME")` + "/plugins"
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 存储插件安装包的目录。
-- 引入版本: -
+- Default: `System.getenv("STARROCKS_HOME")` + "/plugins"
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: 存储插件安装包的目录。
+- Introduced in: -
 
 ##### `plugin_enable`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否允许在 FE 上安装插件。插件只能在 Leader FE 上安装或卸载。
-- 引入版本: -
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否可以在 FE 上安装插件。插件只能在 Leader FE 上安装或卸载。
+- Introduced in: -
 
 ##### `proc_profile_jstack_depth`
 
-- 默认值: 128
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 系统收集 CPU 和内存 profile 时的最大 Java 堆栈深度。此值控制每个采样堆栈捕获的 Java 堆栈帧数：较大的值会增加跟踪详细信息和输出大小，并可能增加 profiling 开销，而较小的值会减少详细信息。此设置在 CPU 和内存 profiling 启动 profiler 时使用，因此请根据诊断需求和性能影响进行调整。
-- 引入版本: -
+- Default: 128
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 系统收集 CPU 和内存 profile 时 Java 堆栈的最大深度。此值控制每个采样堆栈捕获的 Java 堆栈帧数量：较大的值会增加跟踪细节和输出大小，并可能增加 profile 开销，而较小的值会减少细节。此设置在启动 CPU 和内存 profile 时使用，因此请调整它以平衡诊断需求和性能影响。
+- Introduced in: -
 
 ##### `proc_profile_mem_enable`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 是否启用进程内存分配 profile 收集。当此项设置为 `true` 时，系统会在 `sys_log_dir/proc_profile` 下生成名为 `mem-profile-<timestamp>.html` 的 HTML profile，在采样期间休眠 `proc_profile_collect_time_s` 秒，并使用 `proc_profile_jstack_depth` 作为 Java 堆栈深度。生成的文件会根据 `proc_profile_file_retained_days` 和 `proc_profile_file_retained_size_bytes` 进行压缩和清除。原生提取路径使用 `STARROCKS_HOME_DIR` 以避免 `/tmp` noexec 问题。此项旨在用于故障排除内存分配热点。启用它会增加 CPU、I/O 和磁盘使用率，并可能生成大文件。
-- 引入版本: v3.2.12
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 是否启用收集进程内存分配 profile。当此项设置为 `true` 时，系统会在 `sys_log_dir/proc_profile` 下生成一个名为 `mem-profile-<timestamp>.html` 的 HTML profile，在采样期间休眠 `proc_profile_collect_time_s` 秒，并使用 `proc_profile_jstack_depth` 作为 Java 堆栈深度。生成的文件会根据 `proc_profile_file_retained_days` 和 `proc_profile_file_retained_size_bytes` 进行压缩和清除。原生提取路径使用 `STARROCKS_HOME_DIR` 以避免 `/tmp` noexec 问题。此项旨在解决内存分配热点问题。启用它会增加 CPU、I/O 和磁盘使用率，并可能生成大文件。
+- Introduced in: v3.2.12
 
 ##### `query_detail_explain_level`
 
-- 默认值: COSTS
-- 类型: String
-- 单位: -
-- 是否可变: true
-- 描述: EXPLAIN 语句返回的查询计划的详细级别。有效值：COSTS, NORMAL, VERBOSE。
-- 引入版本: v3.2.12, v3.3.5
+- Default: COSTS
+- Type: String
+- Unit: -
+- Is mutable: 是
+- Description: EXPLAIN 语句返回的查询计划的详细级别。有效值：COSTS, NORMAL, VERBOSE。
+- Introduced in: v3.2.12, v3.3.5
 
 ##### `replication_interval_ms`
 
-- 默认值: 100
-- 类型: Int
-- 单位: 毫秒
-- 是否可变: No
-- 描述: 调度复制任务的最小时间间隔。
-- 引入版本: v3.3.5
+- Default: 100
+- Type: Int
+- Unit: -
+- Is mutable: 否
+- Description: 调度复制任务的最小时间间隔。
+- Introduced in: v3.3.5
 
 ##### `replication_max_parallel_data_size_mb`
 
-- 默认值: 1048576
-- 类型: Int
-- 单位: MB
-- 是否可变: Yes
-- 描述: 允许并发同步的最大数据大小。
-- 引入版本: v3.3.5
+- Default: 1048576
+- Type: Int
+- Unit: MB
+- Is mutable: 是
+- Description: 允许并发同步的最大数据大小。
+- Introduced in: v3.3.5
 
 ##### `replication_max_parallel_replica_count`
 
-- 默认值: 10240
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 允许并发同步的 tablet 副本的最大数量。
-- 引入版本: v3.3.5
+- Default: 10240
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 允许并发同步的 tablet 副本的最大数量。
+- Introduced in: v3.3.5
 
 ##### `replication_max_parallel_table_count`
 
-- 默认值: 100
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 允许的最大并发数据同步任务数。StarRocks 为每张表创建一个同步任务。
-- 引入版本: v3.3.5
+- Default: 100
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 允许的最大并发数据同步任务数。StarRocks 为每个表创建一个同步任务。
+- Introduced in: v3.3.5
 
 ##### `replication_transaction_timeout_sec`
 
-- 默认值: 86400
-- 类型: Int
-- 单位: 秒
-- 是否可变: Yes
-- 描述: 同步任务的超时时长。
-- 引入版本: v3.3.5
+- Default: 86400
+- Type: Int
+- Unit: 秒
+- Is mutable: 是
+- Description: 同步任务的超时时长。
+- Introduced in: v3.3.5
 
 ##### `skip_whole_phase_lock_mv_limit`
 
-- 默认值: 5
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 控制 StarRocks 何时对具有相关物化视图的表应用“无锁”优化。当此项设置为小于 0 时，系统始终应用无锁优化，并且不为查询复制相关物化视图（减少 FE 内存使用和元数据复制/锁争用，但可能增加元数据并发问题的风险）。当设置为 0 时，禁用无锁优化（系统始终使用安全的复制和锁定路径）。当设置为大于 0 时，仅当相关物化视图的数量小于或等于配置阈值时才应用无锁优化。此外，当值大于或等于 0 时，规划器会将查询 OLAP 表记录到优化器上下文中以启用与物化视图相关的重写路径；当值小于 0 时，此步骤将被跳过。
-- 引入版本: v3.2.1
+- Default: 5
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 控制 StarRocks 何时对具有相关物化视图的表应用“无锁”优化。当此项设置为小于 0 时，系统始终应用无锁优化，并且不为查询复制相关的物化视图（FE 内存使用和元数据复制/锁争用减少，但元数据并发问题的风险可能增加）。当设置为 0 时，无锁优化被禁用（系统始终使用安全的复制和加锁路径）。当设置为大于 0 时，无锁优化仅适用于相关物化视图数量小于或等于配置阈值的表。此外，当值大于或等于 0 时，规划器会将查询 OLAP 表记录到优化器上下文中，以启用物化视图相关的重写路径；当值小于 0 时，此步骤将被跳过。
+- Introduced in: v3.2.1
 
 ##### `small_file_dir`
 
-- 默认值: `StarRocksFE.STARROCKS_HOME_DIR` + "/small_files"
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 小型文件的根目录。
-- 引入版本: -
+- Default: `StarRocksFE.STARROCKS_HOME_DIR` + "/small_files"
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: 小文件的根目录。
+- Introduced in: -
 
 ##### `task_runs_max_history_number`
 
-- 默认值: 10000
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 在内存中保留的任务运行记录的最大数量，并用作查询存档任务运行历史记录时的默认 LIMIT。当 `enable_task_history_archive` 为 false 时，此值限制内存中的历史记录：强制 GC 会修剪较旧的条目，因此只保留最新的 `task_runs_max_history_number`。当查询存档历史记录时（且未提供显式 LIMIT），如果此值大于 0，`TaskRunHistoryTable.lookup` 将使用 `"ORDER BY create_time DESC LIMIT <value>"`。注意：将此值设置为 0 会禁用查询侧的 LIMIT（无上限），但会导致内存中的历史记录被截断为零（除非启用了存档）。
-- 引入版本: v3.2.0
+- Default: 10000
+- Type: Int
+- Unit: -
+- Is mutable: 是
+- Description: 在内存中保留的任务运行记录的最大数量，以及在查询归档任务运行历史记录时用作默认 LIMIT 的值。当 `enable_task_history_archive` 为 false 时，此值限制内存中的历史记录：强制 GC 会修剪较旧的条目，只保留最新的 `task_runs_max_history_number`。当查询归档历史记录（且未提供显式 LIMIT）时，如果此值大于 0，`TaskRunHistoryTable.lookup` 将使用 `"ORDER BY create_time DESC LIMIT <value>"`。注意：将其设置为 0 会禁用查询侧的 LIMIT（无上限），但会导致内存中的历史记录被截断为零（除非启用了归档）。
+- Introduced in: v3.2.0
 
 ##### `tmp_dir`
 
-- 默认值: `StarRocksFE.STARROCKS_HOME_DIR` + "/temp_dir"
-- 类型: String
-- 单位: -
-- 是否可变: No
-- 描述: 存储临时文件的目录，例如备份和恢复过程中生成的文件。这些过程完成后，生成的临时文件将被删除。
-- 引入版本: -
+- Default: `StarRocksFE.STARROCKS_HOME_DIR` + "/temp_dir"
+- Type: String
+- Unit: -
+- Is mutable: 否
+- Description: 存储临时文件的目录，例如在备份和恢复过程中生成的文件。这些过程完成后，生成的临时文件将被删除。
+- Introduced in: -
 
 ##### `transform_type_prefer_string_for_varchar`
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 在物化视图创建和 CTAS 操作中，是否更倾向于为固定长度的 varchar 列使用 string 类型。
-- 引入版本: v4.0.0
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: 是
+- Description: 在物化视图创建和 CTAS 操作中，是否优先为定长 varchar 列选择 string 类型。
+- Introduced in: v4.0.0
 
 <EditionSpecificFEItem />


### PR DESCRIPTION
## Why I'm doing:

The FE Configuration docs are not consistent across languages, and config parameters should be in backticks.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
