### PR TITLE
[BugFix] Allow incremental ingest with replace snapshots in iceberg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -775,6 +775,10 @@ public class IcebergMetadata implements ConnectorMetadata {
         final Iterable<Snapshot> snapshots = SnapshotUtil.ancestorsBetween(
                 toSnapshotIdInclusive, fromSnapshotIdExclusive, nativeTable::snapshot);
         for (Snapshot snapshot : snapshots) {
+            // replace operations are the result of iceberg maintenance and do not change table data. Skip them.
+            if (snapshot.operation() != null && snapshot.operation().equals(DataOperations.REPLACE)) {
+                continue;
+            }
             long currentSnapshotId = snapshot.snapshotId();
             TvrTableDelta delta = TvrTableDelta.of(currentSnapshotId, lastSnapshotId);
             TvrDeltaStats stats = TvrDeltaStats.of(snapshot);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -132,6 +132,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DataOperations;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetricsModes;
@@ -2146,6 +2147,56 @@ public class IcebergMetadataTest extends TableTestBase {
                 TvrTableSnapshot.of(TvrVersion.of(0)), tvrTableSnapshot);
         Assertions.assertNotNull(deltas);
         Assertions.assertTrue(deltas.isEmpty());
+    }
+
+    @Test
+    public void testListTableDeltaTraitsSkipReplaceSnapshot(@Mocked Snapshot appendSnapshot,
+                                                            @Mocked Snapshot replaceSnapshot) {
+        new Expectations() {
+            {
+                appendSnapshot.snapshotId();
+                result = 2L;
+                minTimes = 0;
+
+                appendSnapshot.operation();
+                result = DataOperations.APPEND;
+                minTimes = 0;
+
+                replaceSnapshot.snapshotId();
+                result = 1L;
+                minTimes = 0;
+
+                replaceSnapshot.operation();
+                result = DataOperations.REPLACE;
+                minTimes = 0;
+            }
+        };
+
+        new MockUp<org.apache.iceberg.util.SnapshotUtil>() {
+            @Mock
+            public Iterable<Snapshot> ancestorsBetween(long latestSnapshotId,
+                                                       long oldestSnapshotId,
+                                                       java.util.function.Function<Long, Snapshot> lookup) {
+                return Lists.newArrayList(appendSnapshot, replaceSnapshot);
+            }
+
+            @Mock
+            public Iterable<Snapshot> ancestorsBetween(long latestSnapshotId,
+                                                       Long oldestSnapshotId,
+                                                       java.util.function.Function<Long, Snapshot> lookup) {
+                return Lists.newArrayList(appendSnapshot, replaceSnapshot);
+            }
+        };
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, null,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "db_name",
+                "table_name", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+        List<TvrTableDeltaTrait> deltas = metadata.listTableDeltaTraits("db", icebergTable,
+                TvrTableSnapshot.of(TvrVersion.of(0)), TvrTableSnapshot.of(TvrVersion.of(2)));
+
+        Assertions.assertEquals(1, deltas.size());
+        Assertions.assertTrue(deltas.stream().allMatch(TvrTableDeltaTrait::isAppendOnly));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
Replace snapshots do not change table data and are very common operations that are the result of iceberg maintenance procedures. Skipping incremental ingest because these snapshots exist will result in large tables which require frequent maintenance runs never being able to incrementally refresh even if they are append only. These are also the tables that would benefit the most from this feature.

## What I'm doing:
Allow incremental ingest when the snapshots are append || replace only. Overwrite snapshots will still avoid the incremental path and trigger a normal partition based refresh.

Fixes #69493

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

