### PR TITLE
[Enhancement] add iceberg compact metrics

### DIFF
--- a/docs/en/administration/management/monitoring/metrics.md
+++ b/docs/en/administration/management/monitoring/metrics.md
@@ -2004,3 +2004,38 @@ Latency metrics expose percentile series such as `merge_commit_request_latency_9
 - Type: Cumulative
 - Labels: `delete_type` (`position` or `metadata`)
 - Description: Total deleted rows from Iceberg `DELETE` tasks. For `metadata` delete, this represents the number of rows in deleted data files. For `position` delete, this represents the number of position deletes created.
+
+### iceberg_compaction_total
+
+- Unit: Count
+- Type: Cumulative
+- Labels: `compaction_type` (`manual` or `auto`)
+- Description: Total number of Iceberg compaction (`rewrite_data_files`) tasks.
+
+### iceberg_compaction_duration_ms_total
+
+- Unit: Millisecond
+- Type: Cumulative
+- Labels: `compaction_type` (`manual` or `auto`)
+- Description: Total time spent running Iceberg compaction tasks.
+
+### iceberg_compaction_input_files_total
+
+- Unit: Count
+- Type: Cumulative
+- Labels: `compaction_type` (`manual` or `auto`)
+- Description: Total number of data files read by Iceberg compaction tasks.
+
+### iceberg_compaction_output_files_total
+
+- Unit: Count
+- Type: Cumulative
+- Labels: `compaction_type` (`manual` or `auto`)
+- Description: Total number of data files produced by Iceberg compaction tasks.
+
+### iceberg_compaction_removed_delete_files_total
+
+- Unit: Count
+- Type: Cumulative
+- Labels: `compaction_type` (`manual` or `auto`)
+- Description: Total number of delete files removed by Iceberg manual compaction tasks.

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -35,6 +35,7 @@ import com.starrocks.connector.metadata.MetadataTableType;
 import com.starrocks.connector.metadata.TableMetaMetadata;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AlterTableCommentClause;
@@ -304,8 +305,8 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
-        normal.alterTable(context, stmt);
+    public ShowResultSet alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
+        return normal.alterTable(context, stmt);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorAlterTableExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorAlterTableExecutor.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.TableName;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
@@ -30,6 +31,7 @@ public class ConnectorAlterTableExecutor implements AstVisitorExtendInterface<Vo
     protected AlterTableStmt stmt;
     protected final TableName tableName;
     protected List<Runnable> actions;
+    protected ShowResultSet resultSet;
 
     public ConnectorAlterTableExecutor(AlterTableStmt stmt) {
         this.stmt = stmt;
@@ -48,8 +50,9 @@ public class ConnectorAlterTableExecutor implements AstVisitorExtendInterface<Vo
         }
     }
 
-    public void execute() throws DdlException {
+    public ShowResultSet execute() throws DdlException {
         applyClauses();
+        return resultSet;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -33,6 +33,7 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.metadata.MetadataTableType;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AlterTableCommentClause;
@@ -303,7 +304,7 @@ public interface ConnectorMetadata {
     default void abortSink(String dbName, String table, List<TSinkCommitInfo> commitInfos) {
     }
 
-    default void alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
+    default ShowResultSet alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
         throw new StarRocksConnectorException("This connector doesn't support alter table");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -49,6 +49,7 @@ import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.AlterClause;
@@ -522,7 +523,7 @@ public class HiveMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
+    public ShowResultSet alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
         // (FIXME) add this api just for tests of external table
         List<AlterClause> alterClauses = stmt.getAlterClauseList();
         for (AlterClause alterClause : alterClauses) {
@@ -533,6 +534,7 @@ public class HiveMetadata implements ConnectorMetadata {
                         alterClause.getClass().getSimpleName());
             }
         }
+        return null;
     }
 
     private void addPartition(ConnectContext context, AlterTableStmt stmt, AlterClause alterClause) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
@@ -443,8 +443,9 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
         IcebergTableProcedureContext tableProcedureContext =
                 new IcebergTableProcedureContext(icebergCatalog, table, context != null ? context : ConnectContext.get(),
                         transaction, hdfsEnvironment, stmt, clause);
-        actions.add(() -> tableProcedure.execute(tableProcedureContext, args));
-
+        actions.add(() -> {
+            super.resultSet = tableProcedure.execute(tableProcedureContext, args);
+        });
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -73,6 +73,7 @@ import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.metric.IcebergMetricsMgr;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.AlterViewStmt;
@@ -395,7 +396,7 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
+    public ShowResultSet alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
         org.apache.iceberg.Table table = icebergCatalog.getTable(context, dbName, tableName);
@@ -413,7 +414,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
 
         IcebergAlterTableExecutor executor = new IcebergAlterTableExecutor(stmt, table, icebergCatalog, context, hdfsEnvironment);
-        executor.execute();
+        ShowResultSet resultSet = executor.execute();
 
         synchronized (this) {
             tables.remove(TableIdentifier.of(dbName, tableName));
@@ -425,6 +426,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             }
             asyncRefreshOthersFeMetadataCache(dbName, tableName);
         }
+        return resultSet;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/AddFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/AddFilesProcedure.java
@@ -24,6 +24,7 @@ import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergPartitionData;
 import com.starrocks.connector.iceberg.IcebergTableOperation;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.ast.ParseNode;
@@ -108,7 +109,7 @@ public class AddFilesProcedure extends IcebergTableProcedure {
     }
 
     @Override
-    public void execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args) {
+    public ShowResultSet execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args) {
         // Validate arguments - either source_table or location must be provided, but not both
         ConstantOperator sourceTableArg = args.get(SOURCE_TABLE);
         ConstantOperator tableLocationArg = args.get(LOCATION);
@@ -167,6 +168,8 @@ public class AddFilesProcedure extends IcebergTableProcedure {
             LOGGER.error("Failed to execute add_files procedure", e);
             throw new StarRocksConnectorException("Failed to add files: %s", e.getMessage(), e);
         }
+
+        return null;
     }
 
     private void addFilesFromLocation(IcebergTableProcedureContext context, Table table, Transaction transaction,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/CherryPickSnapshotProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/CherryPickSnapshotProcedure.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.iceberg.procedure;
 
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergTableOperation;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.type.IntegerType;
 
@@ -44,7 +45,7 @@ public class CherryPickSnapshotProcedure extends IcebergTableProcedure {
     }
 
     @Override
-    public void execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args) {
+    public ShowResultSet execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args) {
         if (args.size() != 1) {
             throw new StarRocksConnectorException("invalid args. cherrypick snapshot must contain `snapshot id`");
         }
@@ -57,5 +58,6 @@ public class CherryPickSnapshotProcedure extends IcebergTableProcedure {
                 .orElseThrow(() -> new StarRocksConnectorException("invalid argument type for %s, expected BIGINT", SNAPSHOT_ID));
 
         context.transaction().manageSnapshots().cherrypick(snapshotId).commit();
+        return null;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/ExpireSnapshotsProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/ExpireSnapshotsProcedure.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.iceberg.procedure;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergTableOperation;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
@@ -51,7 +52,7 @@ public class ExpireSnapshotsProcedure extends IcebergTableProcedure {
     }
 
     @Override
-    public void execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args) {
+    public ShowResultSet execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args) {
         if (args.size() > 2) {
             throw new StarRocksConnectorException(
                     "invalid args. only support `older_than` and `retain_last` in the expire snapshot operation");
@@ -88,5 +89,6 @@ public class ExpireSnapshotsProcedure extends IcebergTableProcedure {
             expireSnapshots = expireSnapshots.retainLast(retainLast);
         }
         expireSnapshots.commit();
+        return null;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/FastForwardProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/FastForwardProcedure.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.iceberg.procedure;
 
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergTableOperation;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.type.VarcharType;
 
@@ -46,7 +47,7 @@ public class FastForwardProcedure extends IcebergTableProcedure {
     }
 
     @Override
-    public void execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args) {
+    public ShowResultSet execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args) {
         if (args.size() != 2) {
             throw new StarRocksConnectorException("invalid args. fast forward must contain `from branch` and `to branch`");
         }
@@ -68,5 +69,6 @@ public class FastForwardProcedure extends IcebergTableProcedure {
                         TO_BRANCH));
 
         context.transaction().manageSnapshots().fastForwardBranch(from, to).commit();
+        return null;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/IcebergTableProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/IcebergTableProcedure.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector.iceberg.procedure;
 
 import com.starrocks.connector.iceberg.IcebergTableOperation;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 
 import java.util.List;
@@ -44,5 +45,5 @@ public abstract class IcebergTableProcedure {
         return this.operation;
     }
 
-    public abstract void execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args);
+    public abstract ShowResultSet execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
@@ -19,6 +19,7 @@ import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergTableOperation;
 import com.starrocks.connector.iceberg.IcebergUtil;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.type.DateType;
 import com.starrocks.type.VarcharType;
@@ -81,7 +82,7 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
     }
 
     @Override
-    public void execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args) {
+    public ShowResultSet execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args) {
         if (args.size() > 2) {
             throw new StarRocksConnectorException("invalid args. only support " +
                     "`older_than` and `location` in the remove orphan files operation");
@@ -101,7 +102,7 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
 
         Table table = context.table();
         if (table.currentSnapshot() == null) {
-            return;
+            return null;
         }
         if (table.location() == null || table.location().isEmpty()) {
             throw new StarRocksConnectorException("table location is empty");
@@ -150,6 +151,7 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
         validFileNames.add("version-hint.text");
 
         scanAndDeleteInvalidFiles(location, olderThanMillis, validFileNames, context.hdfsEnvironment());
+        return null;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RollbackToSnapshotProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RollbackToSnapshotProcedure.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.iceberg.procedure;
 
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergTableOperation;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.type.IntegerType;
 
@@ -45,7 +46,7 @@ public class RollbackToSnapshotProcedure extends IcebergTableProcedure {
     }
 
     @Override
-    public void execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args) {
+    public ShowResultSet execute(IcebergTableProcedureContext context, Map<String, ConstantOperator> args) {
         if (args.size() != 1) {
             throw new StarRocksConnectorException("invalid args. rollback snapshot must contain `snapshot id`");
         }
@@ -57,5 +58,6 @@ public class RollbackToSnapshotProcedure extends IcebergTableProcedure {
                         new StarRocksConnectorException("invalid argument type for %s, expected BIGINT", SNAPSHOT_ID));
 
         context.transaction().manageSnapshots().rollbackTo(snapshotId).commit();
+        return null;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -444,10 +444,11 @@ public class DDLStmtExecutor {
 
         @Override
         public ShowResultSet visitAlterTableStatement(AlterTableStmt stmt, ConnectContext context) {
-            ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().getMetadataMgr().alterTable(context, stmt);
-            });
-            return null;
+            try {
+                return context.getGlobalStateMgr().getMetadataMgr().alterTable(context, stmt);
+            } catch (StarRocksException e) {
+                throw new RuntimeException(e);
+            }
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -176,6 +176,7 @@ import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockWriter;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.Task;
@@ -2985,9 +2986,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
      * including SchemaChangeHandler and RollupHandler
      */
     @Override
-    public void alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
+    public ShowResultSet alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
         AlterJobExecutor alterJobExecutor = new AlterJobExecutor();
         alterJobExecutor.process(stmt, context);
+        return null;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -69,6 +69,7 @@ import com.starrocks.connector.metadata.MetadataTableType;
 import com.starrocks.connector.statistics.ConnectorTableColumnStats;
 import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.sql.analyzer.FeNameFormat;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.AlterViewStmt;
@@ -377,7 +378,7 @@ public class MetadataMgr {
         }
     }
 
-    public void alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
+    public ShowResultSet alterTable(ConnectContext context, AlterTableStmt stmt) throws StarRocksException {
         String catalogName = stmt.getCatalogName();
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
 
@@ -392,7 +393,7 @@ public class MetadataMgr {
                 throw new DdlException("Table '" + tableName + "' does not exist in database '" + dbName + "'");
             }
 
-            connectorMetadata.get().alterTable(context, stmt);
+            return connectorMetadata.get().alterTable(context, stmt);
         } else {
             throw new DdlException("Invalid catalog " + catalogName + " , ConnectorMetadata doesn't exist");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRewriteDataJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRewriteDataJobTest.java
@@ -124,7 +124,9 @@ public class IcebergRewriteDataJobTest {
         IcebergScanNode scanNode = mock(IcebergScanNode.class);
         Deencapsulation.setField(job, "scanNodes", Collections.singletonList(scanNode));
 
-        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> job.execute());
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> {
+            job.execute();
+        });
         assertEquals("Must call prepare() before execute()", ex.getMessage());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/metric/IcebergMetricsMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/IcebergMetricsMgrTest.java
@@ -1,0 +1,128 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.metric;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.utframe.StarRocksTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class IcebergMetricsMgrTest extends StarRocksTestBase {
+
+    @BeforeAll
+    public static void setUp() {
+        FeConstants.runningUnitTest = true;
+        MetricRepo.init();
+    }
+
+    @Test
+    public void testCompactionTotalMetrics() {
+        LongCounterMetric successBefore = findCounter("iceberg_compaction_total",
+                "compaction_type", "manual", "status", "success", "reason", "none");
+        long successBase = successBefore == null ? 0 : successBefore.getValue();
+
+        IcebergMetricsMgr.increaseIcebergCompactionTotalSuccess();
+
+        LongCounterMetric successAfter = findCounter("iceberg_compaction_total",
+                "compaction_type", "manual", "status", "success", "reason", "none");
+        Assertions.assertNotNull(successAfter);
+        Assertions.assertEquals(successBase + 1, successAfter.getValue());
+
+        LongCounterMetric failBefore = findCounter("iceberg_compaction_total",
+                "compaction_type", "auto", "status", "failed", "reason", "timeout");
+        long failBase = failBefore == null ? 0 : failBefore.getValue();
+
+        IcebergMetricsMgr.increaseIcebergCompactionTotal("failed", "timeout", "auto");
+
+        LongCounterMetric failAfter = findCounter("iceberg_compaction_total",
+                "compaction_type", "auto", "status", "failed", "reason", "timeout");
+        Assertions.assertNotNull(failAfter);
+        Assertions.assertEquals(failBase + 1, failAfter.getValue());
+    }
+
+    @Test
+    public void testCompactionFileAndDurationMetrics() {
+        LongCounterMetric durationBefore = findCounter("iceberg_compaction_duration_ms_total",
+                "compaction_type", "manual");
+        long durationBase = durationBefore == null ? 0 : durationBefore.getValue();
+
+        LongCounterMetric inputBefore = findCounter("iceberg_compaction_input_files_total",
+                "compaction_type", "manual");
+        long inputBase = inputBefore == null ? 0 : inputBefore.getValue();
+
+        LongCounterMetric outputBefore = findCounter("iceberg_compaction_output_files_total",
+                "compaction_type", "manual");
+        long outputBase = outputBefore == null ? 0 : outputBefore.getValue();
+
+        LongCounterMetric removedBefore = findCounter("iceberg_compaction_removed_delete_files_total",
+                "compaction_type", "manual");
+        long removedBase = removedBefore == null ? 0 : removedBefore.getValue();
+
+        IcebergMetricsMgr.increaseIcebergCompactionDurationMs(120L, "manual");
+        IcebergMetricsMgr.increaseIcebergCompactionInputFiles(3L, "manual");
+        IcebergMetricsMgr.increaseIcebergCompactionOutputFiles(2L, "manual");
+        IcebergMetricsMgr.increaseIcebergCompactionRemovedDeleteFiles(1L, "manual");
+
+        LongCounterMetric durationAfter = findCounter("iceberg_compaction_duration_ms_total",
+                "compaction_type", "manual");
+        LongCounterMetric inputAfter = findCounter("iceberg_compaction_input_files_total",
+                "compaction_type", "manual");
+        LongCounterMetric outputAfter = findCounter("iceberg_compaction_output_files_total",
+                "compaction_type", "manual");
+        LongCounterMetric removedAfter = findCounter("iceberg_compaction_removed_delete_files_total",
+                "compaction_type", "manual");
+
+        Assertions.assertNotNull(durationAfter);
+        Assertions.assertEquals(durationBase + 120L, durationAfter.getValue());
+
+        Assertions.assertNotNull(inputAfter);
+        Assertions.assertEquals(inputBase + 3L, inputAfter.getValue());
+
+        Assertions.assertNotNull(outputAfter);
+        Assertions.assertEquals(outputBase + 2L, outputAfter.getValue());
+
+        Assertions.assertNotNull(removedAfter);
+        Assertions.assertEquals(removedBase + 1L, removedAfter.getValue());
+    }
+
+    private LongCounterMetric findCounter(String name, String... labels) {
+        List<Metric> metrics = MetricRepo.getMetricsByName(name);
+        for (Metric<?> metric : metrics) {
+            if (!(metric instanceof LongCounterMetric)) {
+                continue;
+            }
+            Map<String, String> labelMap = metric.getLabels().stream()
+                    .collect(Collectors.toMap(MetricLabel::getKey, MetricLabel::getValue));
+            boolean match = true;
+            for (int i = 0; i < labels.length; i += 2) {
+                String key = labels[i];
+                String value = labels[i + 1];
+                if (!value.equals(labelMap.get(key))) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) {
+                return (LongCounterMetric) metric;
+            }
+        }
+        return null;
+    }
+}

--- a/test/sql/test_iceberg/R/test_iceberg_rewrite
+++ b/test/sql/test_iceberg/R/test_iceberg_rewrite
@@ -1,0 +1,69 @@
+-- name: test_iceberg_rewrite
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/iceberg_db_${uuid0}/test_iceberg_rewrite/${uuid0}"
+);
+-- result:
+-- !result
+set connector_sink_shuffle_mode = 'force';
+-- result:
+-- !result
+CREATE TABLE iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.`test_table` (
+    `name` VARCHAR(1048576),
+    `tenant` VARCHAR(1048576),
+    `p_year` INT
+)
+PARTITION BY (`tenant`, `p_year`);
+-- result:
+-- !result
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_1', 'tenant_A', 2025);
+-- result:
+-- !result
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_2', 'tenant_A', 2025);
+-- result:
+-- !result
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_3', 'tenant_B', 2025);
+-- result:
+-- !result
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_4', 'tenant_B', 2025);
+-- result:
+-- !result
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_5', 'tenant_A', 2024);
+-- result:
+-- !result
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_6', 'tenant_A', 2024);
+-- result:
+-- !result
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_7', 'tenant_B', 2024);
+-- result:
+-- !result
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_7', 'tenant_B', 2024);
+-- result:
+-- !result
+[UC]ALTER TABLE iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.`test_table` EXECUTE rewrite_data_files("min_file_size_bytes"= "134217728") where p_year=2025;
+-- result:
+iceberg_db_6ac612949bbf4ac7b0812f6a380a5fa1	test_table	4	2	0	22306	success
+-- !result
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table$files;
+-- result:
+6
+-- !result
+[UC]ALTER TABLE iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.`test_table` EXECUTE rewrite_data_files("min_file_size_bytes"= "134217728");
+-- result:
+iceberg_db_6ac612949bbf4ac7b0812f6a380a5fa1	test_table	6	4	0	25140	success
+-- !result
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table$files;
+-- result:
+4
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table;
+-- result:
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/R/test_iceberg_rewrite_manifests
+++ b/test/sql/test_iceberg/R/test_iceberg_rewrite_manifests
@@ -24,8 +24,9 @@ select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uui
 -- result:
 4
 -- !result
-alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute rewrite_data_files();
+[UC]alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute rewrite_data_files();
 -- result:
+iceberg_db_a24f06304e304a83905ca3d62c1a54d5	ice_tbl_a24f06304e304a83905ca3d62c1a54d5	4	1	0	14519	success
 -- !result
 select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests;
 -- result:

--- a/test/sql/test_iceberg/T/test_iceberg_rewrite
+++ b/test/sql/test_iceberg/T/test_iceberg_rewrite
@@ -1,0 +1,37 @@
+-- name: test_iceberg_rewrite
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/iceberg_db_${uuid0}/test_iceberg_rewrite/${uuid0}"
+);
+
+set connector_sink_shuffle_mode = 'force';
+
+CREATE TABLE iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.`test_table` (
+    `name` VARCHAR(1048576),
+    `tenant` VARCHAR(1048576),
+    `p_year` INT
+)
+PARTITION BY (`tenant`, `p_year`);
+
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_1', 'tenant_A', 2025);
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_2', 'tenant_A', 2025);
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_3', 'tenant_B', 2025);
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_4', 'tenant_B', 2025);
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_5', 'tenant_A', 2024);
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_6', 'tenant_A', 2024);
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_7', 'tenant_B', 2024);
+INSERT INTO iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table VALUES ('log_entry_7', 'tenant_B', 2024);
+
+[UC]ALTER TABLE iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.`test_table` EXECUTE rewrite_data_files("min_file_size_bytes"= "134217728") where p_year=2025;
+
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table$files;
+
+[UC]ALTER TABLE iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.`test_table` EXECUTE rewrite_data_files("min_file_size_bytes"= "134217728");
+
+select count(*) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table$files;
+
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_table;
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+drop catalog iceberg_sql_test_${uuid0};

--- a/test/sql/test_iceberg/T/test_iceberg_rewrite_manifests
+++ b/test/sql/test_iceberg/T/test_iceberg_rewrite_manifests
@@ -10,7 +10,7 @@ insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} selec
 
 select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests;
 
-alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute rewrite_data_files();
+[UC]alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute rewrite_data_files();
 select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests;
 
 alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute rewrite_manifests();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. add query result for iceberg compaction
2. add metrics for iceberg compaction

This pull request introduces several improvements and refactorings to the handling of table alteration operations and Iceberg compaction metrics in the codebase. The most significant changes are the standardization of the `alterTable` method to return a `ShowResultSet`, the addition of new Iceberg compaction metrics, and the enhancement of the Iceberg rewrite data job to provide detailed metrics. These updates improve consistency, observability, and extensibility for external table operations, especially for Iceberg.

**Alter Table API Standardization and Refactoring:**

* The `alterTable` method in `ConnectorMetadata` and its implementations (`HiveMetadata`, `IcebergMetadata`, and `CatalogConnectorMetadata`) now return a `ShowResultSet` instead of `void`, enabling more consistent and informative responses for external table alterations. [[1]](diffhunk://#diff-fb163407084572dcd46e9cc5a3ba160e79d086110cbeac3087f91b3eda7ece31L306-R307) [[2]](diffhunk://#diff-f4eb61e8d68a4b9d62ea3d4a983ac32e80871b1d13cb9ea0b181e5babb4fcb9eL525-R526) [[3]](diffhunk://#diff-f4eb61e8d68a4b9d62ea3d4a983ac32e80871b1d13cb9ea0b181e5babb4fcb9eR537) [[4]](diffhunk://#diff-6c25423f964e0e7910311e2cb6fba148f1def8754ce9e8a292e1c906ec3f14c2L398-R399) [[5]](diffhunk://#diff-6c25423f964e0e7910311e2cb6fba148f1def8754ce9e8a292e1c906ec3f14c2L416-R417) [[6]](diffhunk://#diff-6c25423f964e0e7910311e2cb6fba148f1def8754ce9e8a292e1c906ec3f14c2R429) [[7]](diffhunk://#diff-94124f39edb8940e4a70ade02c7e3b7ab96ef20346bc989713f506bc6bbafe57L307-R309)
* `ConnectorAlterTableExecutor.execute()` now returns a `ShowResultSet`, and result handling is updated throughout the Iceberg alter table execution flow. [[1]](diffhunk://#diff-e56a18ee125e7ca41ead6aff75714eb7e932bd0733087272e93ef73dd5c93f3bL51-R55) [[2]](diffhunk://#diff-e56a18ee125e7ca41ead6aff75714eb7e932bd0733087272e93ef73dd5c93f3bR34) [[3]](diffhunk://#diff-945d1a4febbf25e17e64b4ef578025f77f2b22e50dda50629debe989719fd137L446-R448)

**Iceberg Compaction Metrics Enhancements:**

* Documentation is updated to include several new Iceberg compaction metrics, such as `iceberg_compaction_total`, `iceberg_compaction_duration_ms_total`, `iceberg_compaction_input_files_total`, `iceberg_compaction_output_files_total`, and `iceberg_compaction_removed_delete_files_total`, improving observability of compaction operations.

**Iceberg Rewrite Data Job Improvements:**

* The `IcebergRewriteDataJob` class introduces a `RewriteMetrics` inner class and updates its `execute()` method to return detailed metrics about rewritten and added files, enhancing reporting and monitoring capabilities for rewrite operations. [[1]](diffhunk://#diff-4f2c1f424e9569c9e331281a3c8f559fa1467a412bc4dc43b73874f94d54681bR65-R92) [[2]](diffhunk://#diff-4f2c1f424e9569c9e331281a3c8f559fa1467a412bc4dc43b73874f94d54681bL189-R220) [[3]](diffhunk://#diff-4f2c1f424e9569c9e331281a3c8f559fa1467a412bc4dc43b73874f94d54681bL252-R279) [[4]](diffhunk://#diff-4f2c1f424e9569c9e331281a3c8f559fa1467a412bc4dc43b73874f94d54681bR292) [[5]](diffhunk://#diff-4f2c1f424e9569c9e331281a3c8f559fa1467a412bc4dc43b73874f94d54681bR307-R319)

**Procedure API Consistency:**

* The `execute` methods in Iceberg table procedures (e.g., `AddFilesProcedure`, `CherryPickSnapshotProcedure`) are refactored to return a `ShowResultSet`, aligning their signatures with the new standard. [[1]](diffhunk://#diff-2272b08ea5d93f2110d895c0db26b411fe681cba15915bf6e224a45fe28e19ebL111-R112) [[2]](diffhunk://#diff-2272b08ea5d93f2110d895c0db26b411fe681cba15915bf6e224a45fe28e19ebR171-R172) [[3]](diffhunk://#diff-a61b7c9437c583066b47b6da753f7011202708b2fc4652d616bdf790f5315461L47-R48) [[4]](diffhunk://#diff-a61b7c9437c583066b47b6da753f7011202708b2fc4652d616bdf790f5315461R61)

**Imports and Minor Cleanups:**

* Necessary imports for `ShowResultSet` are added across multiple files to support the new method signatures. [[1]](diffhunk://#diff-94124f39edb8940e4a70ade02c7e3b7ab96ef20346bc989713f506bc6bbafe57R38) [[2]](diffhunk://#diff-e56a18ee125e7ca41ead6aff75714eb7e932bd0733087272e93ef73dd5c93f3bR21) [[3]](diffhunk://#diff-fb163407084572dcd46e9cc5a3ba160e79d086110cbeac3087f91b3eda7ece31R36) [[4]](diffhunk://#diff-f4eb61e8d68a4b9d62ea3d4a983ac32e80871b1d13cb9ea0b181e5babb4fcb9eR52) [[5]](diffhunk://#diff-6c25423f964e0e7910311e2cb6fba148f1def8754ce9e8a292e1c906ec3f14c2R76) [[6]](diffhunk://#diff-2272b08ea5d93f2110d895c0db26b411fe681cba15915bf6e224a45fe28e19ebR27) [[7]](diffhunk://#diff-a61b7c9437c583066b47b6da753f7011202708b2fc4652d616bdf790f5315461R19)
* Minor code style and logic cleanups (e.g., streamlining filter logic in `IcebergRewriteDataJob`).

These changes collectively improve the maintainability, extensibility, and monitoring of external table operations, especially for Iceberg connectors.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [x] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
