### PR TITLE
[Enhancement] Support query queue in ETL mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -79,6 +79,9 @@ public final class GlobalVariable {
     public static final String ENABLE_TDE = "enable_tde";
     public static final String MAX_UNKNOWN_STRING_META_LENGTH = "max_unknown_string_meta_length";
 
+    // ETL mode variables
+    public static final String ETL_EXEC_ENABLE_QUEUE_ALL_WORKLOADS = "etl_exec_enable_queue_all_workloads";
+
     // cngroup
     public static final String CNGROUP_RESOURCE_USAGE_FRESH_RATIO = "cngroup_resource_usage_fresh_ratio";
     public static final String CNGROUP_LOW_WATERMARK_RUNNING_QUERY_COUNT  = "cngroup_low_watermark_running_query_count";
@@ -225,6 +228,9 @@ public final class GlobalVariable {
 
     @VariableMgr.VarAttr(name = MAX_UNKNOWN_STRING_META_LENGTH, flag = VariableMgr.GLOBAL)
     private static int maxUnknownStringMetaLength = 64;
+
+    @VariableMgr.VarAttr(name = ETL_EXEC_ENABLE_QUEUE_ALL_WORKLOADS, flag = VariableMgr.GLOBAL)
+    public static boolean enableEtlExecQueueAllWorkloads = true;
 
     @VariableMgr.VarAttr(name = CNGROUP_RESOURCE_USAGE_FRESH_RATIO)
     private static double cngroupResourceUsageFreshRatio = 0.5;
@@ -399,6 +405,10 @@ public final class GlobalVariable {
             return 64;
         }
         return maxUnknownStringMetaLength;
+    }
+
+    public static boolean isEnableEtlExecQueueAllWorkloads() {
+        return enableEtlExecQueueAllWorkloads;
     }
 
     public static void setCngroupResourceUsageFreshRatio(double value) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
@@ -172,7 +172,7 @@ public class QueryQueueManager {
 
         return new LogicalSlot(coord.getQueryId(), frontend.getNodeName(), warehouseId,
                 groupId, numSlots, expiredPendingTimeMs, expiredAllocatedTimeMs,
-                frontend.getStartTime(), numFragments, pipelineDop);
+                frontend.getStartTime(), numFragments, pipelineDop, context.getSessionVariable().getExecMode());
     }
 
     private int estimateNumSlots(ConnectContext context, DefaultCoordinator coord) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2014,7 +2014,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     // DEFAULT/ETL
     @VarAttr(name = EXEC_MODE)
-    private String execMode = SessionVariableConstants.DEFAULT;
+    private String execMode = SessionVariableConstants.ExecMode.DEFAULT.name();
 
     // 1: sort based, 2: hash based
     @VarAttr(name = WINDOW_PARTITION_MODE, flag = VariableMgr.INVISIBLE)
@@ -2453,20 +2453,45 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return windowPartitionMode;
     }
 
+    public SessionVariableConstants.ExecMode getExecMode() {
+        return SessionVariableConstants.ExecMode.parse(execMode);
+    }
+
+    public boolean isETLExecMode() {
+        return SessionVariableConstants.ETL.equalsIgnoreCase(execMode);
+    }
+
     public void setExecMode(String execMode) {
-        final SessionVariable sv = DEFAULT_SESSION_VARIABLE;
-        if (execMode.equalsIgnoreCase(SessionVariableConstants.ETL)) {
-            setEnableWaitDependentEvent(true);
-            setEnablePhasedScheduler(true);
-            setEnableSpill(true);
-            setEnableQueryQueue(Config.enable_query_queue_v2);
-        } else {
-            setEnableWaitDependentEvent(sv.enableWaitDependentEvent);
-            setEnablePhasedScheduler(sv.enablePhasedScheduler);
-            setEnableSpill(sv.enableSpill);
-            setEnableQueryQueue(sv.enableQueryQueue);
+        SessionVariableConstants.ExecMode result =
+                Enums.getIfPresent(SessionVariableConstants.ExecMode.class, StringUtils.upperCase(execMode))
+                        .orNull();
+        if (result == null) {
+            String legalValues = Joiner.on(" | ").join(SessionVariableConstants.ExecMode.values());
+            throw new IllegalArgumentException("Legal values of exec_mode are " + legalValues);
         }
-        this.execMode = execMode;
+        switch (result) {
+            case ETL: {
+                setEnableWaitDependentEvent(true);
+                setEnablePhasedScheduler(true);
+                setEnableSpill(true);
+                setEnableQueryQueue(Config.enable_query_queue_v2);
+                break;
+            }
+            case DEFAULT: {
+                // Reset ETL-tuned session flags to their default values when switching back from ETL mode
+                setEnableWaitDependentEvent(DEFAULT_SESSION_VARIABLE.enableWaitDependentEvent);
+                setEnablePhasedScheduler(DEFAULT_SESSION_VARIABLE.enablePhasedScheduler);
+                setEnableSpill(DEFAULT_SESSION_VARIABLE.enableSpill);
+                setEnableQueryQueue(DEFAULT_SESSION_VARIABLE.enableQueryQueue);
+                setSpillPartitionWiseAgg(DEFAULT_SESSION_VARIABLE.spillPartitionWiseAgg);
+                break;
+            }
+            default: {
+                // do nothing
+                break;
+            }
+        }
+        this.execMode = execMode.toUpperCase();
     }
 
     public void setEnableSortAggregate(boolean enableSortAggregate) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -45,6 +45,26 @@ public class SessionVariableConstants {
     public static final String ETL = "etl";
     public static final String DEFAULT = "default";
 
+    public enum ExecMode {
+        DEFAULT,
+        ETL;
+
+        public static ExecMode getDefault() {
+            return DEFAULT;
+        }
+
+        public boolean isETL() {
+            return this == ETL;
+        }
+
+        public static ExecMode parse(String str) {
+            try {
+                return EnumUtils.getEnumIgnoreCase(ExecMode.class, str);
+            } catch (Exception e) {
+                return getDefault();
+            }
+        }
+    }
 
     public enum ChooseInstancesMode {
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotManager.java
@@ -166,6 +166,12 @@ public abstract class BaseSlotManager {
                 !connectContext.getSessionVariable().isEnableQueryQueue()) {
             return false;
         }
+
+        // for etl mode, always enable query queue
+        if (GlobalVariable.isEnableEtlExecQueueAllWorkloads() && connectContext.getSessionVariable().isETLExecMode()) {
+            return true;
+        }
+
         if (instance.isStatisticsJob()) {
             return GlobalVariable.isEnableQueryQueueStatistic();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/LogicalSlot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/LogicalSlot.java
@@ -23,6 +23,7 @@ import com.starrocks.plugin.AuditEvent;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.QueryState;
+import com.starrocks.qe.SessionVariableConstants;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
@@ -74,11 +75,22 @@ public class LogicalSlot {
     private Optional<ExtraMessage> extraMessage = Optional.empty();
 
     private State state = State.CREATED;
+    private final SessionVariableConstants.ExecMode execMode;
 
     public LogicalSlot(TUniqueId slotId, String requestFeName,
                        long warehouseId, long groupId, int numPhysicalSlots,
                        long expiredPendingTimeMs, long expiredAllocatedTimeMs, long feStartTimeMs,
                        int numFragments, int pipelineDop) {
+        this(slotId, requestFeName, warehouseId, groupId, numPhysicalSlots,
+                expiredPendingTimeMs, expiredAllocatedTimeMs, feStartTimeMs,
+                numFragments, pipelineDop, SessionVariableConstants.ExecMode.getDefault());
+    }
+
+    public LogicalSlot(TUniqueId slotId, String requestFeName,
+                       long warehouseId, long groupId, int numPhysicalSlots,
+                       long expiredPendingTimeMs, long expiredAllocatedTimeMs, long feStartTimeMs,
+                       int numFragments, int pipelineDop,
+                       SessionVariableConstants.ExecMode execMode) {
         this.slotId = slotId;
         this.requestFeName = requestFeName;
         this.warehouseId = warehouseId;
@@ -90,6 +102,7 @@ public class LogicalSlot {
         this.startTimeMs = System.currentTimeMillis();
         this.numFragments = numFragments;
         this.pipelineDop = pipelineDop;
+        this.execMode = execMode;
     }
 
     public State getState() {
@@ -226,6 +239,10 @@ public class LogicalSlot {
         return warehouseName.orElse("");
     }
 
+    public boolean isETLExec() {
+        return execMode == SessionVariableConstants.ExecMode.ETL;
+    }
+
     @Override
     public String toString() {
         return "LogicalSlot{" +
@@ -238,6 +255,7 @@ public class LogicalSlot {
                 ", expiredAllocatedTimeMs=" + TimeUtils.longToTimeString(expiredAllocatedTimeMs) +
                 ", feStartTimeMs=" + TimeUtils.longToTimeString(feStartTimeMs) +
                 ", startTimeMs=" + TimeUtils.longToTimeString(startTimeMs) +
+                ", execMode=" + execMode +
                 ", state=" + state +
                 '}';
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorTest.java
@@ -78,6 +78,10 @@ public class StmtExecutorTest {
                 minTimes = 0;
                 result = state;
 
+                GlobalStateMgr.getServingState();
+                minTimes = 0;
+                result = state;
+
                 state.getSqlParser();
                 minTimes = 0;
                 result = new SqlParser(AstBuilder.getInstance());
@@ -89,6 +93,10 @@ public class StmtExecutorTest {
                 state.isInTransferringToLeader();
                 minTimes = 0;
                 result = false;
+
+                state.isReady();
+                minTimes = 0;
+                result = true;
 
                 ctx.getSerializer();
                 minTimes = 0;


### PR DESCRIPTION
## Why I'm doing:

This pull request introduces an "ETL execution mode" to the query engine, along with related session and global configuration changes. The main goal is to support ETL workloads with specific session flags and ensure the query queue is always enabled for ETL mode. The changes include new session variables, logic for handling ETL mode, and propagation of execution mode in slot management.

**Session and execution mode enhancements:**

* Added a new `exec_mode` session variable with an enum type (`DEFAULT` or `ETL`), including parsing logic and helper methods in `SessionVariableConstants` and `SessionVariable` to manage ETL-specific session flags and reset them when switching modes. [[1]](diffhunk://#diff-51d52fea9afc299a4b03db6f3e9f91a5d4dff64df863dda0ec61f67a561800edR48-R67) [[2]](diffhunk://#diff-727d043183218b8a4cbbc92d0fc2796a9e1637cd2f21219c7c26add24b13972dL2017-R2017) [[3]](diffhunk://#diff-727d043183218b8a4cbbc92d0fc2796a9e1637cd2f21219c7c26add24b13972dR2456-R2494)

* Introduced the `isETLExecMode()` method to easily check if a session is in ETL mode, and updated logic to throw an error for invalid `exec_mode` values.

**Global and session variables:**

* Added a global variable `etl_exec_enable_queue_all_workloads` to always enable the query queue for ETL workloads, including getter/setter and annotation for variable management. [[1]](diffhunk://#diff-ae4a3a834f121b138e3cac85726b37ac5322beb8db5106e5d779f148aa647074R82-R84) [[2]](diffhunk://#diff-ae4a3a834f121b138e3cac85726b37ac5322beb8db5106e5d779f148aa647074R232-R234) [[3]](diffhunk://#diff-ae4a3a834f121b138e3cac85726b37ac5322beb8db5106e5d779f148aa647074R410-R413)

**Query queue and slot management:**

* Updated `BaseSlotManager` to always enable the query queue for ETL mode if the global flag is set.

* Modified `LogicalSlot` to include the execution mode, propagate it from `QueryQueueManager`, and provide a helper method `isETLExec()`. Updated the `toString()` method for easier debugging. [[1]](diffhunk://#diff-036bd17e91f986e0083d948b7ab307a33f9486115eb8ccfca146b1012033423eR26) [[2]](diffhunk://#diff-036bd17e91f986e0083d948b7ab307a33f9486115eb8ccfca146b1012033423eR78-R93) [[3]](diffhunk://#diff-036bd17e91f986e0083d948b7ab307a33f9486115eb8ccfca146b1012033423eR105) [[4]](diffhunk://#diff-036bd17e91f986e0083d948b7ab307a33f9486115eb8ccfca146b1012033423eR242-R245) [[5]](diffhunk://#diff-036bd17e91f986e0083d948b7ab307a33f9486115eb8ccfca146b1012033423eR258) [[6]](diffhunk://#diff-80b412909b09d40099f70eb44c2458a7af02b9cef33ce5b087dd4cc78a0b9922L175-R175)

**Testing and maintenance:**

* Minor updates to test mocks in `StmtExecutorTest` to accommodate the new logic. [[1]](diffhunk://#diff-40337aee8d8b44b973e64d9a48cb602a405d99169981e98636e53ac0a476f68fR81-R84) [[2]](diffhunk://#diff-40337aee8d8b44b973e64d9a48cb602a405d99169981e98636e53ac0a476f68fR97-R100)


## What I'm doing:

- Enable query queue for all stmts which is etl mode.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
